### PR TITLE
all-packages.nix: move defaults to package files continues

### DIFF
--- a/pkgs/applications/audio/cmus/default.nix
+++ b/pkgs/applications/audio/cmus/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, runCommand, ncurses, pkgconfig
+{ config, stdenv, fetchFromGitHub, runCommand, ncurses, pkgconfig
 , libiconv, CoreAudio
 
 , alsaSupport ? stdenv.isLinux, alsaLib ? null
@@ -7,7 +7,7 @@
 , jackSupport ? false, libjack ? null
 , samplerateSupport ? jackSupport, libsamplerate ? null
 , ossSupport ? false, alsaOss ? null
-, pulseaudioSupport ? false, libpulseaudio ? null
+, pulseaudioSupport ? config.pulseaudio or false, libpulseaudio ? null
 
 # TODO: add these
 #, artsSupport

--- a/pkgs/applications/audio/deadbeef/default.nix
+++ b/pkgs/applications/audio/deadbeef/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, intltool, pkgconfig, jansson
+{ config, stdenv, fetchurl, intltool, pkgconfig, jansson
 # deadbeef can use either gtk2 or gtk3
 , gtk2Support ? false, gtk2 ? null
 , gtk3Support ? true, gtk3 ? null, gsettings-desktop-schemas ? null, wrapGAppsHook ? null
@@ -20,7 +20,7 @@
 , osdSupport ? true, dbus ? null
 # output plugins
 , alsaSupport ? true, alsaLib ? null
-, pulseSupport ? true, libpulseaudio ? null
+, pulseSupport ? config.pulseaudio or stdenv.isLinux, libpulseaudio ? null
 # effect plugins
 , resamplerSupport ? true, libsamplerate ? null
 , overloadSupport ? true, zlib ? null

--- a/pkgs/applications/audio/mimic/default.nix
+++ b/pkgs/applications/audio/mimic/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, autoreconfHook, fetchFromGitHub, pkgconfig
+{ config, stdenv, autoreconfHook, fetchFromGitHub, pkgconfig
 , alsaLib, libtool, icu
-, pulseaudioSupport ? true, libpulseaudio }:
+, pulseaudioSupport ? config.pulseaudio or false, libpulseaudio }:
 
 stdenv.mkDerivation rec {
   name = "mimic-${version}";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "1wkpbwk88lsahzkc7pzbznmyy0lc02vsp0vkj8f1ags1gh0lc52j";
   };
 
-  nativeBuildInputs = [ 
+  nativeBuildInputs = [
     autoreconfHook
     pkgconfig
   ];
@@ -21,15 +21,14 @@ stdenv.mkDerivation rec {
   buildInputs = [
     alsaLib
     libtool
-    icu 
+    icu
   ] ++ stdenv.lib.optional pulseaudioSupport libpulseaudio;
 
   meta = {
     description = "Mycroft's TTS engine, based on CMU's Flite (Festival Lite)";
-    homepage = https://mimic.mycroft.ai/; 
+    homepage = https://mimic.mycroft.ai/;
     license = stdenv.lib.licenses.free;
     platforms = stdenv.lib.platforms.linux;
-    maintainers = [ stdenv.lib.maintainers.noneucat ]; 
+    maintainers = [ stdenv.lib.maintainers.noneucat ];
   };
 }
-

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -1,4 +1,5 @@
-{ newScope, stdenv, llvmPackages, makeWrapper, makeDesktopItem, ed
+{ newScope, config, stdenv, llvmPackages, gcc8Stdenv, llvmPackages_7
+, makeWrapper, makeDesktopItem, ed
 , glib, gtk3, gnome3, gsettings-desktop-schemas
 
 # package customization
@@ -10,12 +11,17 @@
 , enablePepperFlash ? false
 , enableWideVine ? false
 , cupsSupport ? true
-, pulseSupport ? false
+, pulseSupport ? config.pulseaudio or stdenv.isLinux
 , commandLineArgs ? ""
 }:
 
-assert stdenv.cc.isClang -> (stdenv == llvmPackages.stdenv);
 let
+  stdenv_ = if stdenv.isAarch64 then gcc8Stdenv else llvmPackages_7.stdenv;
+  llvmPackages_ = if stdenv.isAarch64 then llvmPackages else llvmPackages_7;
+in let
+  stdenv = stdenv_;
+  llvmPackages = llvmPackages_;
+
   callPackage = newScope chromium;
 
   chromium = {

--- a/pkgs/applications/video/aegisub/default.nix
+++ b/pkgs/applications/video/aegisub/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl
+{ config, stdenv, fetchurl
 , libX11, wxGTK
 , libiconv, fontconfig, freetype
 , libGLU_combined
@@ -8,8 +8,8 @@
 , spellcheckSupport ? true, hunspell ? null
 , automationSupport ? true, lua ? null
 , openalSupport ? false, openal ? null
-, alsaSupport ? true, alsaLib ? null
-, pulseaudioSupport ? true, libpulseaudio ? null
+, alsaSupport ? stdenv.isLinux, alsaLib ? null
+, pulseaudioSupport ? config.pulseaudio or stdenv.isLinux, libpulseaudio ? null
 , portaudioSupport ? false, portaudio ? null }:
 
 assert spellcheckSupport -> (hunspell != null);

--- a/pkgs/applications/video/bomi/default.nix
+++ b/pkgs/applications/video/bomi/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchFromGitHub, fetchpatch, pkgconfig, perl, python, which
+{ config, stdenv, fetchFromGitHub
+, fetchpatch, pkgconfig, perl, python, which
 , libX11, libxcb, libGLU_combined
 , qtbase, qtdeclarative, qtquickcontrols, qttools, qtx11extras, qmake, makeWrapper
 , libchardet
@@ -15,7 +16,7 @@
 , libbluray
 , jackSupport ? false, jack ? null
 , portaudioSupport ? false, portaudio ? null
-, pulseSupport ? true, libpulseaudio ? null
+, pulseSupport ? config.pulseaudio or stdenv.isLinux, libpulseaudio ? null
 , cddaSupport ? false, libcdda ? null
 , youtubeSupport ? true, youtube-dl ? null
 }:

--- a/pkgs/applications/video/mplayer/default.nix
+++ b/pkgs/applications/video/mplayer/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, freetype, yasm, ffmpeg
+{ config, stdenv, fetchurl, pkgconfig, freetype, yasm, ffmpeg
 , aalibSupport ? true, aalib ? null
 , fontconfigSupport ? true, fontconfig ? null, freefont_ttf ? null
 , fribidiSupport ? true, fribidi ? null
@@ -19,7 +19,7 @@
 , theoraSupport ? true, libtheora ? null
 , x264Support ? false, x264 ? null
 , jackaudioSupport ? false, libjack2 ? null
-, pulseSupport ? false, libpulseaudio ? null
+, pulseSupport ? config.pulseaudio or false, libpulseaudio ? null
 , bs2bSupport ? false, libbs2b ? null
 # For screenshots
 , libpngSupport ? true, libpng ? null

--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, lib, fetchpatch, iasl, dev86, pam, libxslt, libxml2
+{ config, stdenv, fetchurl, lib, fetchpatch, iasl, dev86, pam, libxslt, libxml2
 , libX11, xorgproto, libXext, libXcursor, libXmu, qt5, libIDL, SDL, libcap
 , libpng, glib, lvm2, libXrandr, libXinerama, libopus
 , pkgconfig, which, docbook_xsl, docbook_xml_dtd_43
@@ -7,7 +7,7 @@
 , javaBindings ? false, jdk ? null
 , pythonBindings ? false, python2 ? null
 , extensionPack ? null, fakeroot ? null
-, pulseSupport ? false, libpulseaudio ? null
+, pulseSupport ? config.pulseaudio or stdenv.isLinux, libpulseaudio ? null
 , enableHardening ? false
 , headless ? false
 , enable32bitGuests ? true

--- a/pkgs/development/libraries/pcaudiolib/default.nix
+++ b/pkgs/development/libraries/pcaudiolib/default.nix
@@ -1,6 +1,7 @@
-{ stdenv, lib, fetchFromGitHub, autoconf, automake, which, libtool, pkgconfig,
-  alsaLib, portaudio, 
-  pulseaudioSupport ? true, libpulseaudio }:
+{ config, stdenv, lib, fetchFromGitHub
+, autoconf, automake, which, libtool, pkgconfig
+, portaudio, alsaLib
+, pulseaudioSupport ? config.pulseaudio or stdenv.isLinux, libpulseaudio }:
 
 stdenv.mkDerivation rec {
   name = "pcaudiolib-${version}";

--- a/pkgs/tools/misc/brltty/default.nix
+++ b/pkgs/tools/misc/brltty/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, pkgconfig, python3, alsaSupport, alsaLib ? null, bluez, systemdSupport, systemd ? null }:
+{ stdenv, fetchurl, pkgconfig, python3, bluez
+, alsaSupport ? stdenv.isLinux, alsaLib ? null
+, systemdSupport ? stdenv.isLinux, systemd ? null }:
 
 assert alsaSupport -> alsaLib != null;
 assert systemdSupport -> systemd != null;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16335,8 +16335,6 @@ in
     inherit (darwin.apple_sdk.frameworks) CoreAudio;
     libjack = libjack2;
     ffmpeg = ffmpeg_2;
-
-    pulseaudioSupport = config.pulseaudio or false;
   };
 
   cmusfm = callPackage ../applications/audio/cmusfm { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16295,18 +16295,7 @@ in
 
   bookworm = callPackage ../applications/office/bookworm { };
 
-  chromium = callPackage ../applications/networking/browsers/chromium ({
-    channel = "stable";
-    pulseSupport = config.pulseaudio or true;
-    enablePepperFlash = config.chromium.enablePepperFlash or false;
-    enableWideVine = config.chromium.enableWideVine or false;
-  } // (if stdenv.isAarch64 then {
-          stdenv = gcc8Stdenv;
-        } else {
-          llvmPackages = llvmPackages_7;
-          stdenv = llvmPackages_7.stdenv;
-        })
-   );
+  chromium = callPackage ../applications/networking/browsers/chromium (config.chromium or {});
 
   chronos = callPackage ../applications/networking/cluster/chronos { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16207,7 +16207,6 @@ in
   bombono = callPackage ../applications/video/bombono {};
 
   bomi = libsForQt5.callPackage ../applications/video/bomi {
-    pulseSupport = config.pulseaudio or true;
     ffmpeg = ffmpeg_2;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -406,15 +406,9 @@ in
 
   aefs = callPackage ../tools/filesystems/aefs { };
 
-  aegisub = callPackage ../applications/video/aegisub {
+  aegisub = callPackage ../applications/video/aegisub ({
     wxGTK = wxGTK30;
-    spellcheckSupport = config.aegisub.spellcheckSupport or true;
-    automationSupport = config.aegisub.automationSupport or true;
-    openalSupport     = config.aegisub.openalSupport or false;
-    alsaSupport       = config.aegisub.alsaSupport or true;
-    pulseaudioSupport = config.aegisub.pulseaudioSupport or true;
-    portaudioSupport  = config.aegisub.portaudioSupport or false;
-  };
+  } // (config.aegisub or {}));
 
   aerospike = callPackage ../servers/nosql/aerospike { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19726,7 +19726,6 @@ in
   virtualbox = callPackage ../applications/virtualization/virtualbox {
     stdenv = stdenv_32bit;
     inherit (gnome2) libIDL;
-    pulseSupport = config.pulseaudio or true;
   };
 
   virtualboxHardened = lowPrio (virtualbox.override {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18118,9 +18118,7 @@ in
 
   minitube = libsForQt5.callPackage ../applications/video/minitube { };
 
-  mimic = callPackage ../applications/audio/mimic {
-    pulseaudioSupport = config.pulseaudio or false;
-  };
+  mimic = callPackage ../applications/audio/mimic { };
 
   mimms = callPackage ../applications/audio/mimms {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11890,9 +11890,7 @@ in
 
   pangoxsl = callPackage ../development/libraries/pangoxsl { };
 
-  pcaudiolib = callPackage ../development/libraries/pcaudiolib {
-    pulseaudioSupport = config.pulseaudio or true;
-  };
+  pcaudiolib = callPackage ../development/libraries/pcaudiolib { };
 
   pcg_c = callPackage ../development/libraries/pcg-c { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16443,9 +16443,7 @@ in
 
   ddgr = callPackage ../applications/misc/ddgr { };
 
-  deadbeef = callPackage ../applications/audio/deadbeef {
-    pulseSupport = config.pulseaudio or true;
-  };
+  deadbeef = callPackage ../applications/audio/deadbeef { };
 
   deadbeefPlugins = {
     headerbar-gtk3 = callPackage ../applications/audio/deadbeef/plugins/headerbar-gtk3.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18278,7 +18278,6 @@ in
   mpc-qt = libsForQt5.callPackage ../applications/video/mpc-qt { };
 
   mplayer = callPackage ../applications/video/mplayer ({
-    pulseSupport = config.pulseaudio or false;
     libdvdnav = libdvdnav_4_2_1;
   } // (config.mplayer or {}));
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -967,10 +967,8 @@ in
 
   brigand = callPackage ../development/libraries/brigand { };
 
-  brltty = callPackage ../tools/misc/brltty {
-    alsaSupport = (!stdenv.isDarwin);
-    systemdSupport = stdenv.isLinux;
-  };
+  brltty = callPackage ../tools/misc/brltty { };
+
   bro = callPackage ../applications/networking/ids/bro { };
 
   bruteforce-luks = callPackage ../tools/security/bruteforce-luks { };


### PR DESCRIPTION
# What? Why?

A continuation of #55129. This one also integrates a bit of #35374.

# `git log`

- *: move defaults to package file

A bunch of these.

# `nix-instantiate` environment

- Host OS: Linux 4.9, SLNOS 19.03
- Nix: nix-env (Nix) 2.1.3
- Multi-user: yes
- Sandbox: yes
- NIXPKGS_CONFIG:

```nix
{
  checkMeta = true;
  doCheckByDefault = true;
}
```

# `nix-env -qaP` diffs

- On x86_64-linux: noop
- On aarch64-linux: noop
- On x86_64-darwin: noop

/cc @mic92 @ryantm @ericson2314 @infinisil @bendlas @jtojnar @pbogdan @abbradar from git-blame and @7c6f434c from #55129