### PR TITLE
quick patch to bump BINPRM_BUF_SIZE from 128 to 1024

### DIFF
--- a/pkgs/os-specific/linux/kernel/binprm-buf-size.patch
+++ b/pkgs/os-specific/linux/kernel/binprm-buf-size.patch
@@ -1,0 +1,16 @@
+diff --git a/include/uapi/linux/binfmts.h b/include/uapi/linux/binfmts.h
+index 4abad03..667179b 100644
+--- a/include/uapi/linux/binfmts.h
++++ b/include/uapi/linux/binfmts.h
+@@ -16,6 +16,7 @@ struct pt_regs;
+ #define MAX_ARG_STRINGS 0x7FFFFFFF
+ 
+ /* sizeof(linux_binprm->buf) */
+-#define BINPRM_BUF_SIZE 128
++/* 1024 bytes ought to be enough for anyone */
++#define BINPRM_BUF_SIZE 1024
+ 
+ #endif /* _UAPI_LINUX_BINFMTS_H */
+-- 
+2.21.0-rc0
+

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -57,4 +57,9 @@ rec {
       sha256 = "1l8xq02rd7vakxg52xm9g4zng0ald866rpgm8kjlh88mwwyjkrwv";
     };
   };
+
+  binprm_buf_size = rec {
+    name = "binprm_buf_size";
+    patch = ./binprm-buf-size.patch;
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14543,6 +14543,7 @@ in
   linux_rpi = callPackage ../os-specific/linux/kernel/linux-rpi.nix {
     kernelPatches = with kernelPatches; [
       bridge_stp_helper
+      binprm_buf_size
     ];
   };
 
@@ -14556,6 +14557,7 @@ in
         # upstream! Fixes https://github.com/NixOS/nixpkgs/issues/42755
         kernelPatches.xen-netfront_fix_mismatched_rtnl_unlock
         kernelPatches.xen-netfront_update_features_after_registering_netdev
+        kernelPatches.binprm_buf_size
       ];
   };
 
@@ -14564,6 +14566,7 @@ in
       [ kernelPatches.bridge_stp_helper
         kernelPatches.cpu-cgroup-v2."4.9"
         kernelPatches.modinst_arg_list_too_long
+        kernelPatches.binprm_buf_size
       ];
   };
 
@@ -14574,6 +14577,7 @@ in
         # when adding a new linux version
         kernelPatches.cpu-cgroup-v2."4.11"
         kernelPatches.modinst_arg_list_too_long
+        kernelPatches.binprm_buf_size
       ];
   };
 
@@ -14581,6 +14585,7 @@ in
     kernelPatches =
       [ kernelPatches.bridge_stp_helper
         kernelPatches.modinst_arg_list_too_long
+        kernelPatches.binprm_buf_size
       ];
   };
 
@@ -14588,6 +14593,7 @@ in
     kernelPatches =
       [ kernelPatches.bridge_stp_helper
         kernelPatches.modinst_arg_list_too_long
+        kernelPatches.binprm_buf_size
       ];
   };
 
@@ -14595,6 +14601,7 @@ in
     kernelPatches = [
       kernelPatches.bridge_stp_helper
       kernelPatches.modinst_arg_list_too_long
+      kernelPatches.binprm_buf_size
     ];
   };
 
@@ -14602,6 +14609,7 @@ in
     kernelPatches =
       [ kernelPatches.bridge_stp_helper
         kernelPatches.modinst_arg_list_too_long
+        kernelPatches.binprm_buf_size
       ];
   };
 
@@ -14609,6 +14617,7 @@ in
     kernelPatches = [
       kernelPatches.bridge_stp_helper
       kernelPatches.modinst_arg_list_too_long
+      kernelPatches.binprm_buf_size
     ];
   };
 
@@ -14823,7 +14832,7 @@ in
       inherit stdenv;
       inherit (kernel) version;
     };
-    kernelPatches = kernel.kernelPatches ++ [ kernelPatches.tag_hardened ];
+    kernelPatches = kernel.kernelPatches ++ [ kernelPatches.tag_hardened kernelPatches.binprm_buf_size];
     modDirVersionArg = kernel.modDirVersion + "-hardened";
   });
 


### PR DESCRIPTION
Doesn't fix the problem but fixes my/our machines for now.

I'm running 4.20.8 with this presently,
other kernels "should" patch okay but I haven't checked.

And I wasn't sure if hardening wanted this or not? Dunno.

https://github.com/NixOS/nixpkgs/issues/53672#issuecomment-463313587


###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---