### PR TITLE
gnome3: stop using aliases

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/xfce.nix
+++ b/nixos/modules/services/x11/desktop-managers/xfce.nix
@@ -53,7 +53,7 @@ in
 
       # Supplies some abstract icons such as:
       # utilities-terminal, accessories-text-editor
-      gnome3.defaultIconTheme
+      gnome3.adwaita-icon-theme
 
       hicolor-icon-theme
       tango-icon-theme

--- a/nixos/modules/services/x11/display-managers/lightdm-greeters/gtk.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm-greeters/gtk.nix
@@ -95,8 +95,8 @@ in
 
         package = mkOption {
           type = types.package;
-          default = pkgs.gnome3.defaultIconTheme;
-          defaultText = "pkgs.gnome3.defaultIconTheme";
+          default = pkgs.gnome3.adwaita-icon-theme;
+          defaultText = "pkgs.gnome3.adwaita-icon-theme";
           description = ''
             The package path that contains the icon theme given in the name option.
           '';
@@ -115,8 +115,8 @@ in
       cursorTheme = {
 
         package = mkOption {
-          default = pkgs.gnome3.defaultIconTheme;
-          defaultText = "pkgs.gnome3.defaultIconTheme";
+          default = pkgs.gnome3.adwaita-icon-theme;
+          defaultText = "pkgs.gnome3.adwaita-icon-theme";
           description = ''
             The package path that contains the cursor theme given in the name option.
           '';

--- a/pkgs/applications/audio/audacious/default.nix
+++ b/pkgs/applications/audio/audacious/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     gettext glib gtk3 libmowgli dbus-glib libxml2
-    xorg.libXcomposite gnome3.defaultIconTheme alsaLib libjack2
+    xorg.libXcomposite gnome3.adwaita-icon-theme alsaLib libjack2
     libpulseaudio fluidsynth libmad libogg libvorbis libcdio
     libcddb flac ffmpeg mpg123 libcue libmms libbs2b libsndfile
     libmodplug libsamplerate soxr lirc curl wavpack neon faad2

--- a/pkgs/applications/audio/cozy-audiobooks/default.nix
+++ b/pkgs/applications/audio/cozy-audiobooks/default.nix
@@ -43,7 +43,7 @@ python3Packages.buildPythonApplication rec {
     gtk3
     cairo
     gettext
-    gnome3.defaultIconTheme
+    gnome3.adwaita-icon-theme
   ] ++ (with gst_all_1; [
     gstreamer
     gst-plugins-good

--- a/pkgs/applications/audio/easytag/default.nix
+++ b/pkgs/applications/audio/easytag/default.nix
@@ -19,7 +19,7 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig intltool itstool libxml2 wrapGAppsHook ];
   buildInputs = [
     gtk3 glib libid3tag id3lib taglib libvorbis libogg opusfile flac
-    gsettings-desktop-schemas gnome3.defaultIconTheme
+    gsettings-desktop-schemas gnome3.adwaita-icon-theme
   ];
 
   doCheck = false; # fails 1 out of 9 tests

--- a/pkgs/applications/audio/gpodder/default.nix
+++ b/pkgs/applications/audio/gpodder/default.nix
@@ -28,7 +28,7 @@ python3Packages.buildPythonApplication rec {
   buildInputs = [
     python3
     gobject-introspection
-    gnome3.defaultIconTheme
+    gnome3.adwaita-icon-theme
   ];
 
   checkInputs = with python3Packages; [

--- a/pkgs/applications/audio/gtkpod/default.nix
+++ b/pkgs/applications/audio/gtkpod/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     curl gettext
     flex libgpod libid3tag flac libvorbis gtk3 gdk_pixbuf
-    gdl gnome3.defaultIconTheme gnome3.anjuta
+    gdl gnome3.adwaita-icon-theme gnome3.anjuta
   ] ++ (with perlPackages; [ perl XMLParser ]);
 
   patchPhase = ''

--- a/pkgs/applications/audio/pavucontrol/default.nix
+++ b/pkgs/applications/audio/pavucontrol/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [ libpulseaudio gtkmm3 libcanberra-gtk3 makeWrapper
-                  gnome3.defaultIconTheme ];
+                  gnome3.adwaita-icon-theme ];
 
   nativeBuildInputs = [ pkgconfig intltool ];
 

--- a/pkgs/applications/audio/quodlibet/default.nix
+++ b/pkgs/applications/audio/quodlibet/default.nix
@@ -20,7 +20,7 @@ python3.pkgs.buildPythonApplication rec {
 
   checkInputs = with python3.pkgs; [ pytest pytest_xdist pyflakes pycodestyle polib xvfb_run dbus.daemon glibcLocales ];
 
-  buildInputs = [ gnome3.defaultIconTheme libsoup glib glib-networking gtk3 webkitgtk gdk_pixbuf keybinder3 gtksourceview libmodplug libappindicator-gtk3 kakasi gobject-introspection ]
+  buildInputs = [ gnome3.adwaita-icon-theme libsoup glib glib-networking gtk3 webkitgtk gdk_pixbuf keybinder3 gtksourceview libmodplug libappindicator-gtk3 kakasi gobject-introspection ]
     ++ (if xineBackend then [ xineLib ] else with gst_all_1;
     [ gstreamer gst-plugins-base ] ++ optionals withGstPlugins [ gst-plugins-good gst-plugins-ugly gst-plugins-bad ]);
 

--- a/pkgs/applications/audio/rhythmbox/default.nix
+++ b/pkgs/applications/audio/rhythmbox/default.nix
@@ -50,7 +50,7 @@ in stdenv.mkDerivation rec {
     gtk3
     gnome3.libpeas
     totem-pl-parser
-    gnome3.defaultIconTheme
+    gnome3.adwaita-icon-theme
 
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base

--- a/pkgs/applications/audio/sonata/default.nix
+++ b/pkgs/applications/audio/sonata/default.nix
@@ -19,7 +19,7 @@ in buildPythonApplication rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
     intltool wrapGAppsHook
-    gnome3.defaultIconTheme
+    gnome3.adwaita-icon-theme
     gnome3.gsettings-desktop-schemas
   ];
 

--- a/pkgs/applications/audio/sound-juicer/default.nix
+++ b/pkgs/applications/audio/sound-juicer/default.nix
@@ -15,7 +15,7 @@ in stdenv.mkDerivation rec{
 
   nativeBuildInputs = [ pkgconfig intltool itstool libxml2 wrapGAppsHook ];
   buildInputs = [
-    glib gtk3 brasero libcanberra-gtk3 gnome3.defaultIconTheme
+    glib gtk3 brasero libcanberra-gtk3 gnome3.adwaita-icon-theme
     gnome3.gsettings-desktop-schemas libmusicbrainz5 libdiscid isocodes
     gst_all_1.gstreamer gst_all_1.gst-plugins-base
     gst_all_1.gst-plugins-good gst_all_1.gst-plugins-bad

--- a/pkgs/applications/editors/bluefish/default.nix
+++ b/pkgs/applications/editors/bluefish/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ intltool pkgconfig wrapGAppsHook ];
-  buildInputs = [ gnome3.defaultIconTheme gtk libxml2
+  buildInputs = [ gnome3.adwaita-icon-theme gtk libxml2
     enchant gucharmap python ];
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/editors/gnome-latex/default.nix
+++ b/pkgs/applications/editors/gnome-latex/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, wrapGAppsHook
+{ stdenv, fetchurl, wrapGAppsHook, gsettings-desktop-schemas, gspell, gtksourceview4, libgee
 , tepl, amtk, gnome3, glib, pkgconfig, intltool, itstool, libxml2 }:
 let
   version = "3.30.2";
@@ -21,9 +21,9 @@ in stdenv.mkDerivation {
     intltool
   ];
 
-  buildInputs = with gnome3; [
+  buildInputs = [
     amtk
-    defaultIconTheme
+    gnome3.adwaita-icon-theme
     glib
     gsettings-desktop-schemas
     gspell

--- a/pkgs/applications/graphics/avocode/default.nix
+++ b/pkgs/applications/graphics/avocode/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "1slxxr3j0djqdnbk645sriwl99jp9imndyxiwd8aqggmmlp145a2";
   };
 
-  libPath = stdenv.lib.makeLibraryPath (with xorg; with gnome3; [
+  libPath = stdenv.lib.makeLibraryPath (with xorg; [
     stdenv.cc.cc.lib
     gdk_pixbuf
     glib

--- a/pkgs/applications/graphics/gthumb/default.nix
+++ b/pkgs/applications/graphics/gthumb/default.nix
@@ -1,5 +1,6 @@
 { stdenv,  fetchurl, gnome3, itstool, libxml2, pkgconfig, intltool,
   exiv2, libjpeg, libtiff, gst_all_1, libraw, libsoup, libsecret,
+  glib, gtk3, gsettings-desktop-schemas,
   libchamplain, librsvg, libwebp, json-glib, webkitgtk, lcms2, bison,
   flex, wrapGAppsHook, shared-mime-info }:
 
@@ -16,10 +17,10 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ itstool libxml2 intltool pkgconfig bison flex wrapGAppsHook ];
 
-  buildInputs = with gnome3; [
-    glib gtk gsettings-desktop-schemas gst_all_1.gstreamer gst_all_1.gst-plugins-base
+  buildInputs = [
+    glib gtk3 gsettings-desktop-schemas gst_all_1.gstreamer gst_all_1.gst-plugins-base
     exiv2 libjpeg libtiff libraw libsoup libsecret libchamplain
-    librsvg libwebp json-glib webkitgtk lcms2 defaultIconTheme
+    librsvg libwebp json-glib webkitgtk lcms2 gnome3.adwaita-icon-theme
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/applications/graphics/shotwell/default.nix
+++ b/pkgs/applications/graphics/shotwell/default.nix
@@ -25,7 +25,7 @@ in stdenv.mkDerivation rec {
     gst_all_1.gstreamer gst_all_1.gst-plugins-base gnome3.libgee
     libgudev gnome3.gexiv2 gnome3.gsettings-desktop-schemas
     libraw json-glib glib gdk_pixbuf librsvg gnome3.rest
-    gcr gnome3.defaultIconTheme libgdata
+    gcr gnome3.adwaita-icon-theme libgdata
   ];
 
   postPatch = ''

--- a/pkgs/applications/graphics/synfigstudio/default.nix
+++ b/pkgs/applications/graphics/synfigstudio/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, boost, cairo, gettext, glibmm, gtk3, gtkmm3
 , libjack2, libsigcxx, libxmlxx, makeWrapper, mlt-qt5, pango, pkgconfig
-, imagemagick, intltool, autoreconfHook, which, defaultIconTheme
+, imagemagick, intltool, autoreconfHook, which, gnome3
 }:
 
 let
@@ -105,7 +105,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     ETL boost cairo glibmm gtk3 gtkmm3 imagemagick intltool
     libjack2 libsigcxx libxmlxx makeWrapper mlt-qt5
-    synfig which defaultIconTheme
+    synfig which gnome3.adwaita-icon-theme
   ];
 
   postInstall = ''

--- a/pkgs/applications/graphics/vimiv/default.nix
+++ b/pkgs/applications/graphics/vimiv/default.nix
@@ -1,5 +1,5 @@
 { lib, python3Packages, fetchFromGitHub, imagemagick, librsvg, gtk3, jhead
-, hicolor-icon-theme, defaultIconTheme
+, hicolor-icon-theme, gnome3
 
 # Test requirements
 , dbus, xvfb_run, xdotool
@@ -38,7 +38,7 @@ python3Packages.buildPythonApplication rec {
   '';
 
   checkInputs = [ python3Packages.nose dbus.daemon xvfb_run xdotool ];
-  buildInputs = [ hicolor-icon-theme defaultIconTheme librsvg ];
+  buildInputs = [ hicolor-icon-theme gnome3.adwaita-icon-theme librsvg ];
   propagatedBuildInputs = with python3Packages; [ pillow pygobject3 gtk3 ];
 
   makeWrapperArgs = [

--- a/pkgs/applications/misc/font-manager/default.nix
+++ b/pkgs/applications/misc/font-manager/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     sqlite
     librsvg
     gnome3.gtk
-    gnome3.defaultIconTheme
+    gnome3.adwaita-icon-theme
   ];
 
   patches = [ ./correct-post-install.patch ];

--- a/pkgs/applications/misc/gnome-recipes/default.nix
+++ b/pkgs/applications/misc/gnome-recipes/default.nix
@@ -13,7 +13,7 @@
 , glib
 , libsoup
 , gnome-online-accounts
-, rest
+, librest
 , json-glib
 , gnome-autoar
 , gspell
@@ -46,7 +46,7 @@ in stdenv.mkDerivation rec {
     glib
     libsoup
     gnome-online-accounts
-    rest
+    librest
     json-glib
     gnome-autoar
     gspell

--- a/pkgs/applications/misc/gnome-usage/default.nix
+++ b/pkgs/applications/misc/gnome-usage/default.nix
@@ -15,7 +15,7 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ meson ninja pkgconfig vala gettext libxml2 desktop-file-utils wrapGAppsHook ];
 
-  buildInputs = [ glib gtk3 libgtop gnome3.defaultIconTheme ];
+  buildInputs = [ glib gtk3 libgtop gnome3.adwaita-icon-theme ];
 
   postPatch = ''
     chmod +x build-aux/meson/postinstall.sh

--- a/pkgs/applications/misc/gummi/default.nix
+++ b/pkgs/applications/misc/gummi/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   ];
   buildInputs = [
     glib gnome2.gtksourceview gnome2.pango gtk2-x11 gtkspell2 poppler
-    gnome3.defaultIconTheme
+    gnome3.adwaita-icon-theme
   ];
 
   preConfigure = ''

--- a/pkgs/applications/misc/pcmanfm/default.nix
+++ b/pkgs/applications/misc/pcmanfm/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "0mb8hg76x1z0szdyl0w7jpz0bdblc6a29is1vvnh79z37qxh8138";
   };
 
-  buildInputs = [ glib gtk libfm' libX11 pango gnome3.defaultIconTheme ];
+  buildInputs = [ glib gtk libfm' libX11 pango gnome3.adwaita-icon-theme ];
   nativeBuildInputs = [ pkgconfig wrapGAppsHook intltool ];
 
   configureFlags = optional withGtk3 "--with-gtk=3";

--- a/pkgs/applications/misc/safeeyes/default.nix
+++ b/pkgs/applications/misc/safeeyes/default.nix
@@ -17,7 +17,7 @@ in buildPythonApplication rec {
   buildInputs = [
     gtk3
     gobject-introspection
-    gnome3.defaultIconTheme
+    gnome3.adwaita-icon-theme
     gnome3.adwaita-icon-theme
   ];
 

--- a/pkgs/applications/misc/tootle/default.nix
+++ b/pkgs/applications/misc/tootle/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub
-, meson, ninja, pkgconfig, python3
+, meson, ninja, pkgconfig, python3, libgee, gsettings-desktop-schemas
 , gnome3, pantheon, gobject-introspection, wrapGAppsHook
 , gtk3, json-glib, glib, glib-networking, hicolor-icon-theme
 }:
@@ -28,7 +28,7 @@ in stdenv.mkDerivation rec {
   ];
   buildInputs = [
     gtk3 pantheon.granite json-glib glib glib-networking hicolor-icon-theme
-    gnome3.libgee gnome3.libsoup gnome3.gsettings-desktop-schemas
+    libgee gnome3.libsoup gsettings-desktop-schemas
   ];
 
   postPatch = ''

--- a/pkgs/applications/networking/browsers/brave/default.nix
+++ b/pkgs/applications/networking/browsers/brave/default.nix
@@ -89,7 +89,7 @@ in stdenv.mkDerivation rec {
 
     nativeBuildInputs = [ dpkg wrapGAppsHook ];
 
-    buildInputs = [ glib gnome3.gsettings_desktop_schemas gnome3.defaultIconTheme ];
+    buildInputs = [ glib gnome3.gsettings_desktop_schemas gnome3.adwaita-icon-theme ];
 
     unpackPhase = "dpkg-deb --fsys-tarfile $src | tar -x --no-same-permissions --no-same-owner";
 

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -78,7 +78,7 @@ in stdenv.mkDerivation {
     gsettings-desktop-schemas glib gtk3
 
     # needed for XDG_ICON_DIRS
-    gnome3.defaultIconTheme
+    gnome3.adwaita-icon-theme
   ];
 
   outputs = ["out" "sandbox"];

--- a/pkgs/applications/networking/browsers/firefox-bin/default.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/default.nix
@@ -31,7 +31,7 @@
 , libgnome
 , libgnomeui
 , libnotify
-, defaultIconTheme
+, gnome3
 , libGLU_combined
 , nspr
 , nss
@@ -141,7 +141,7 @@ stdenv.mkDerivation {
 
   inherit gtk3;
 
-  buildInputs = [ wrapGAppsHook gtk3 defaultIconTheme ];
+  buildInputs = [ wrapGAppsHook gtk3 gnome3.adwaita-icon-theme ];
 
   # "strip" after "patchelf" may break binaries.
   # See: https://github.com/NixOS/patchelf/issues/10

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -131,7 +131,7 @@ let
               --set GDK_BACKEND "wayland" \
             ''}${lib.optionalString (browser ? gtk3)
                 ''--prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH" \
-                  --suffix XDG_DATA_DIRS : '${gnome3.defaultIconTheme}/share'
+                  --suffix XDG_DATA_DIRS : '${gnome3.adwaita-icon-theme}/share'
                 ''
             }
 

--- a/pkgs/applications/networking/browsers/google-chrome/default.nix
+++ b/pkgs/applications/networking/browsers/google-chrome/default.nix
@@ -77,7 +77,7 @@ in stdenv.mkDerivation rec {
     gsettings-desktop-schemas glib gtk
 
     # needed for XDG_ICON_DIRS
-    gnome.defaultIconTheme
+    gnome.adwaita-icon-theme
   ];
 
   unpackPhase = ''

--- a/pkgs/applications/networking/browsers/midori/default.nix
+++ b/pkgs/applications/networking/browsers/midori/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, ninja, pkgconfig, intltool, vala, wrapGAppsHook, gcr
+{ stdenv, fetchurl, cmake, ninja, pkgconfig, intltool, vala, wrapGAppsHook, gcr, libpeas
 , gtk3, webkitgtk, sqlite, gsettings-desktop-schemas, libsoup, glib-networking, gnome3
 }:
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     gtk3 webkitgtk sqlite gsettings-desktop-schemas gcr
-    (libsoup.override { gnomeSupport = true; }) gnome3.libpeas
+    (libsoup.override { gnomeSupport = true; }) libpeas
     glib-networking
   ];
 

--- a/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser-bundle-bin/default.nix
@@ -39,7 +39,7 @@
 # Wrapper runtime
 , coreutils
 , glibcLocales
-, defaultIconTheme
+, gnome3
 , runtimeShell
 , shared-mime-info
 , gsettings-desktop-schemas
@@ -252,7 +252,7 @@ stdenv.mkDerivation rec {
     EOF
 
     WRAPPER_XDG_DATA_DIRS=${concatMapStringsSep ":" (x: "${x}/share") [
-      defaultIconTheme
+      gnome3.adwaita-icon-theme
       shared-mime-info
     ]}
     WRAPPER_XDG_DATA_DIRS+=":"${concatMapStringsSep ":" (x: "${x}/share/gsettings-schemas/${x.name}") [

--- a/pkgs/applications/networking/feedreaders/feedreader/default.nix
+++ b/pkgs/applications/networking/feedreaders/feedreader/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchFromGitHub, fetchpatch, meson, ninja, pkgconfig, vala_0_40, gettext, python3
 , appstream-glib, desktop-file-utils, glibcLocales, wrapGAppsHook
+, gtk3, libgee, libpeas, librest, webkitgtk, gsettings-desktop-schemas
 , curl, glib, gnome3, gst_all_1, json-glib, libnotify, libsecret, sqlite, gumbo
 }:
 
@@ -29,10 +30,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     curl glib json-glib libnotify libsecret sqlite gumbo
-  ] ++ (with gnome3; [
-    gtk libgee libpeas libsoup rest webkitgtk gnome-online-accounts
+    gtk3 libgee libpeas gnome3.libsoup librest webkitgtk gnome3.gnome-online-accounts
     gsettings-desktop-schemas
-  ]) ++ (with gst_all_1; [
+  ] ++ (with gst_all_1; [
     gstreamer gst-plugins-base gst-plugins-good
   ]);
 

--- a/pkgs/applications/networking/ftp/taxi/default.nix
+++ b/pkgs/applications/networking/ftp/taxi/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, pantheon, pkgconfig, meson, ninja, python3
-, gtk3, gnome3, libsoup, libsecret, gobject-introspection, wrapGAppsHook }:
+, gtk3, libgee, libsoup, libsecret, gobject-introspection, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "taxi";
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     pantheon.granite
-    gnome3.libgee
+    libgee
     gtk3
     libsecret
     libsoup

--- a/pkgs/applications/networking/instant-messengers/coyim/default.nix
+++ b/pkgs/applications/networking/instant-messengers/coyim/default.nix
@@ -1,5 +1,5 @@
 { stdenv, buildGoPackage, fetchFromGitHub, pkgconfig,
-  cairo, gdk_pixbuf, glib, gnome3, wrapGAppsHook  }:
+  cairo, gdk_pixbuf, glib, gnome3, wrapGAppsHook, gtk3 }:
 
 buildGoPackage rec {
   name = "coyim-${version}";
@@ -14,7 +14,7 @@ buildGoPackage rec {
     sha256 = "1sna1n9dz1crws6cb1yjhy2kznbngjlbiw2diycshvbfigf7y7xl";
   };
 
-  nativeBuildInputs = [ pkgconfig wrapGAppsHook glib cairo gdk_pixbuf gnome3.gtk gnome3.defaultIconTheme ];
+  nativeBuildInputs = [ pkgconfig wrapGAppsHook glib cairo gdk_pixbuf gtk3 gnome3.adwaita-icon-theme ];
 
   meta = with stdenv.lib; {
     description = "a safe and secure chat client";

--- a/pkgs/applications/networking/instant-messengers/dino/default.nix
+++ b/pkgs/applications/networking/instant-messengers/dino/default.nix
@@ -2,7 +2,7 @@
 , vala, cmake, ninja, wrapGAppsHook, pkgconfig, gettext
 , gobject-introspection, gnome3, glib, gdk_pixbuf, gtk3, glib-networking
 , xorg, libXdmcp, libxkbcommon
-, libnotify, libsoup
+, libnotify, libsoup, libgee
 , libgcrypt
 , epoxy
 , at-spi2-core
@@ -39,8 +39,8 @@ stdenv.mkDerivation rec {
     gobject-introspection
     glib-networking
     glib
-    gnome3.libgee
-    gnome3.defaultIconTheme
+    libgee
+    gnome3.adwaita-icon-theme
     sqlite
     gdk_pixbuf
     gtk3

--- a/pkgs/applications/networking/instant-messengers/ekiga/default.nix
+++ b/pkgs/applications/networking/instant-messengers/ekiga/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ cyrus_sasl gettext openldap ptlib opal libXv rarian intltool
                   evolution-data-server gnome-doc-utils avahi
                   libsigcxx gtk dbus-glib libnotify libXext xorgproto sqlite
-                  gnome3.libsoup glib gnome3.defaultIconTheme boost
+                  gnome3.libsoup glib gnome3.adwaita-icon-theme boost
                   autoreconfHook pkgconfig libxml2 unixODBC db nspr
                   nss zlib libsecret libXrandr which libxslt libtasn1
                   gmp nettle makeWrapper ]

--- a/pkgs/applications/networking/instant-messengers/gajim/default.nix
+++ b/pkgs/applications/networking/instant-messengers/gajim/default.nix
@@ -1,7 +1,7 @@
 { lib, fetchurl, gettext, wrapGAppsHook
 
 # Native dependencies
-, python3, gtk3, gobject-introspection, defaultIconTheme
+, python3, gtk3, gobject-introspection, gnome3
 
 # Test dependencies
 , xvfb_run, dbus
@@ -33,7 +33,7 @@ python3.pkgs.buildPythonApplication rec {
   '';
 
   buildInputs = [
-    gobject-introspection gtk3 defaultIconTheme
+    gobject-introspection gtk3 gnome3.adwaita-icon-theme
   ] ++ lib.optionals enableJingle [ farstream gstreamer gst-plugins-base gst-libav gst-plugins-ugly ]
     ++ lib.optional enableSecrets libsecret
     ++ lib.optional enableSpelling gspell

--- a/pkgs/applications/networking/mailreaders/astroid/default.nix
+++ b/pkgs/applications/networking/mailreaders/astroid/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig, gnome3, gmime3, webkitgtk
 , libsass, notmuch, boost, wrapGAppsHook, glib-networking, protobuf, vim_configurable
+, gtkmm3, libpeas, gsettings-desktop-schemas
 , makeWrapper, python3, python3Packages
 , vim ? vim_configurable.override {
                     features = "normal";
@@ -21,10 +22,12 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ronn pkgconfig wrapGAppsHook ];
 
-  buildInputs = [ gnome3.gtkmm gmime3 webkitgtk libsass gnome3.libpeas
-                  python3 python3Packages.pygobject3
-                  notmuch boost gnome3.gsettings-desktop-schemas gnome3.defaultIconTheme
-                  glib-networking protobuf ] ++ (if vim == null then [] else [ vim ]);
+  buildInputs = [
+    gtkmm3 gmime3 webkitgtk libsass libpeas
+    python3 python3Packages.pygobject3
+    notmuch boost gsettings-desktop-schemas gnome3.adwaita-icon-theme
+    glib-networking protobuf
+   ] ++ (if vim == null then [] else [ vim ]);
 
   postPatch = ''
     sed -i "s~gvim ~${vim}/bin/vim -g ~g" src/config.cc

--- a/pkgs/applications/networking/mailreaders/mailnag/default.nix
+++ b/pkgs/applications/networking/mailreaders/mailnag/default.nix
@@ -21,7 +21,7 @@ in pythonPackages.buildPythonApplication rec {
     gettext gtk3 gdk_pixbuf libnotify gst_all_1.gstreamer
     gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good
     gst_all_1.gst-plugins-bad
-    gnome3.defaultIconTheme
+    gnome3.adwaita-icon-theme
   ] ++ stdenv.lib.optional withGnomeKeyring libgnome-keyring3;
 
   nativeBuildInputs = [

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
@@ -30,7 +30,7 @@
 , libcanberra-gtk2
 , libgnome
 , libgnomeui
-, defaultIconTheme
+, gnome3
 , libGLU_combined
 , nspr
 , nss
@@ -117,7 +117,7 @@ stdenv.mkDerivation {
       stdenv.cc.cc
     ];
 
-  buildInputs = [ gtk3 defaultIconTheme ];
+  buildInputs = [ gtk3 gnome3.adwaita-icon-theme ];
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -42,7 +42,7 @@ in stdenv.mkDerivation rec {
       hunspell libevent libstartup_notification /* cairo */
       icu libpng jemalloc
     ]
-    ++ lib.optionals enableGTK3 [ gtk3 gnome3.defaultIconTheme ];
+    ++ lib.optionals enableGTK3 [ gtk3 gnome3.adwaita-icon-theme ];
 
   # from firefox + m4 + wrapperTool
   nativeBuildInputs = [ m4 autoconf213 which gnused pkgconfig perl python wrapperTool cargo rustc ];

--- a/pkgs/applications/networking/remote/remmina/default.nix
+++ b/pkgs/applications/networking/remote/remmina/default.nix
@@ -6,7 +6,7 @@
 , libsecret, libsoup, spice-protocol, spice-gtk, epoxy, at-spi2-core
 , openssl, gsettings-desktop-schemas, json-glib
 # The themes here are soft dependencies; only icons are missing without them.
-, hicolor-icon-theme, adwaita-icon-theme
+, hicolor-icon-theme, gnome3
 }:
 
 with stdenv.lib;
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     pcre libdbusmenu-gtk3 libappindicator-gtk3
     libvncserver libpthreadstubs libXdmcp libxkbcommon
     libsecret libsoup spice-protocol spice-gtk epoxy at-spi2-core
-    openssl hicolor-icon-theme adwaita-icon-theme json-glib
+    openssl hicolor-icon-theme gnome3.adwaita-icon-theme json-glib
   ];
 
   cmakeFlags = [

--- a/pkgs/applications/networking/weather/meteo/default.nix
+++ b/pkgs/applications/networking/weather/meteo/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitLab, vala, python3, pkgconfig, meson, ninja, gtk3
-, gnome3, json-glib, libsoup, clutter, clutter-gtk, libchamplain, webkitgtk
+, json-glib, libsoup, clutter, clutter-gtk, libchamplain, webkitgtk, geocode-glib
 , libappindicator, desktop-file-utils, appstream, gobject-introspection, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     clutter
     clutter-gtk
-    gnome3.geocode-glib
+    geocode-glib
     gtk3
     json-glib
     libappindicator

--- a/pkgs/applications/office/abiword/default.nix
+++ b/pkgs/applications/office/abiword/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, gtk3, fribidi
 , libpng, popt, libgsf, enchant, wv, librsvg, bzip2, libjpeg, perl
-, boost, libxslt, goffice, wrapGAppsHook, iconTheme
+, boost, libxslt, goffice, wrapGAppsHook, gnome3
 }:
 
 stdenv.mkDerivation rec {
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     gtk3 librsvg bzip2 fribidi libpng popt
-    libgsf enchant wv libjpeg perl boost libxslt goffice iconTheme
+    libgsf enchant wv libjpeg perl boost libxslt goffice gnome3.adwaita-icon-theme
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/office/gnumeric/default.nix
+++ b/pkgs/applications/office/gnumeric/default.nix
@@ -20,7 +20,7 @@ in stdenv.mkDerivation rec {
 
   # ToDo: optional libgda, introspection?
   buildInputs = [
-    goffice gtk3 gnome3.defaultIconTheme
+    goffice gtk3 gnome3.adwaita-icon-theme
     python pygobject3
   ] ++ (with perlPackages; [ perl XMLParser ]);
 

--- a/pkgs/applications/office/grisbi/default.nix
+++ b/pkgs/applications/office/grisbi/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig wrapGAppsHook ];
   buildInputs = [ gtk libofx intltool hicolor-icon-theme libsoup
-    gnome3.defaultIconTheme ];
+    gnome3.adwaita-icon-theme ];
 
   meta = with stdenv.lib; {
     description = "A personnal accounting application.";

--- a/pkgs/applications/office/homebank/default.nix
+++ b/pkgs/applications/office/homebank/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig wrapGAppsHook ];
   buildInputs = [ gtk libofx intltool hicolor-icon-theme libsoup
-    gnome3.defaultIconTheme ];
+    gnome3.adwaita-icon-theme ];
 
   meta = with stdenv.lib; {
     description = "Free, easy, personal accounting for everyone";

--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -12,7 +12,7 @@
 , libatomic_ops, graphite2, harfbuzz, libodfgen, libzmf
 , librevenge, libe-book, libmwaw, glm, glew, gst_all_1
 , gdb, commonsLogging, librdf_rasqal, wrapGAppsHook
-, defaultIconTheme, glib, ncurses, epoxy, gpgme
+, gnome3, glib, ncurses, epoxy, gpgme
 , langs ? [ "ca" "cs" "de" "en-GB" "en-US" "eo" "es" "fr" "hu" "it" "nl" "pl" "ru" "sl" "zh-CN" ]
 , withHelp ? true
 , kdeIntegration ? false
@@ -277,7 +277,7 @@ in stdenv.mkDerivation rec {
       mdds bluez5 libcmis libwps libabw libzmf libtool
       libxshmfence libatomic_ops graphite2 harfbuzz gpgme utillinux
       librevenge libe-book libmwaw glm glew ncurses epoxy
-      libodfgen CoinMP librdf_rasqal defaultIconTheme gettext
+      libodfgen CoinMP librdf_rasqal gnome3.adwaita-icon-theme gettext
     ]
     ++ lib.optional kdeIntegration kdelibs4;
   nativeBuildInputs = [ wrapGAppsHook gdb ];

--- a/pkgs/applications/office/libreoffice/still.nix
+++ b/pkgs/applications/office/libreoffice/still.nix
@@ -12,7 +12,7 @@
 , libatomic_ops, graphite2, harfbuzz, libodfgen, libzmf
 , librevenge, libe-book, libmwaw, glm, glew, gst_all_1
 , gdb, commonsLogging, librdf_rasqal, wrapGAppsHook
-, defaultIconTheme, glib, ncurses, epoxy, gpgme
+, gnome3, glib, ncurses, epoxy, gpgme
 , langs ? [ "ca" "cs" "de" "en-GB" "en-US" "eo" "es" "fr" "hu" "it" "nl" "pl" "ru" "sl" "zh-CN" ]
 , withHelp ? true
 , kdeIntegration ? false
@@ -272,7 +272,7 @@ in stdenv.mkDerivation rec {
       mdds bluez5 libcmis libwps libabw libzmf libtool
       libxshmfence libatomic_ops graphite2 harfbuzz gpgme utillinux
       librevenge libe-book libmwaw glm glew ncurses epoxy
-      libodfgen CoinMP librdf_rasqal defaultIconTheme gettext
+      libodfgen CoinMP librdf_rasqal gnome3.adwaita-icon-theme gettext
     ]
     ++ lib.optional kdeIntegration kdelibs4;
   nativeBuildInputs = [ wrapGAppsHook gdb ];

--- a/pkgs/applications/office/paperwork/default.nix
+++ b/pkgs/applications/office/paperwork/default.nix
@@ -12,7 +12,7 @@ python3Packages.buildPythonApplication rec {
 
   # Patch out a few paths that assume that we're using the FHS:
   postPatch = ''
-    themeDir="$(echo "${gnome3.defaultIconTheme}/share/icons/"*)"
+    themeDir="$(echo "${gnome3.adwaita-icon-theme}/share/icons/"*)"
     sed -i -e "s,/usr/share/icons/gnome,$themeDir," src/paperwork/deps.py
 
     sed -i -e 's,sys\.prefix,"",g' \
@@ -48,7 +48,7 @@ python3Packages.buildPythonApplication rec {
 
   checkInputs = [ xvfb_run dbus.daemon ];
   buildInputs = [
-    gnome3.defaultIconTheme hicolor-icon-theme libnotify librsvg
+    gnome3.adwaita-icon-theme hicolor-icon-theme libnotify librsvg
   ];
 
   # A few parts of chkdeps need to have a display and a dbus session, so we not

--- a/pkgs/applications/office/tryton/default.nix
+++ b/pkgs/applications/office/tryton/default.nix
@@ -32,7 +32,7 @@ python2Packages.buildPythonApplication rec {
   buildInputs = [
     atk
     gtk3
-    gnome3.defaultIconTheme
+    gnome3.adwaita-icon-theme
     gtkspell3
     goocanvas2
   ];

--- a/pkgs/applications/science/math/nasc/default.nix
+++ b/pkgs/applications/science/math/nasc/default.nix
@@ -4,6 +4,8 @@
 , gtk3
 , pantheon
 , gnome3
+, gtksourceview
+, libgee
 , cmake
 , libqalculate
 , gobject-introspection
@@ -35,8 +37,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     pantheon.elementary-icon-theme
-    gnome3.gtksourceview
-    gnome3.libgee
+    gtksourceview
+    libgee
     gnome3.libsoup
     pantheon.granite
     gtk3

--- a/pkgs/applications/science/math/wxmaxima/default.nix
+++ b/pkgs/applications/science/math/wxmaxima/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "0s7bdykc77slqix28cyaa6x8wvxrn8461mkdgxflvi2apwsl56aa";
   };
 
-  buildInputs = [ wxGTK maxima gnome3.defaultIconTheme ];
+  buildInputs = [ wxGTK maxima gnome3.adwaita-icon-theme ];
 
   nativeBuildInputs = [ wrapGAppsHook cmake gettext ];
 

--- a/pkgs/applications/version-management/meld/default.nix
+++ b/pkgs/applications/version-management/meld/default.nix
@@ -16,7 +16,7 @@ python3.pkgs.buildPythonApplication rec {
     intltool itstool libxml2 gobject-introspection wrapGAppsHook
   ];
   buildInputs = [
-    gtk3 gtksourceview gnome3.gsettings-desktop-schemas gnome3.defaultIconTheme
+    gtk3 gtksourceview gnome3.gsettings-desktop-schemas gnome3.adwaita-icon-theme
   ];
   propagatedBuildInputs = with python3.pkgs; [ pygobject3 pycairo ];
   checkInputs = [ xvfb_run python3.pkgs.pytest dbus ];

--- a/pkgs/applications/video/pitivi/default.nix
+++ b/pkgs/applications/video/pitivi/default.nix
@@ -48,7 +48,7 @@ in python3Packages.buildPythonApplication rec {
 
   buildInputs = [
     gobject-introspection gtk3 librsvg gnome3.gnome-desktop gsound
-    gnome3.defaultIconTheme
+    gnome3.adwaita-icon-theme
     gnome3.gsettings-desktop-schemas libnotify
     gst-transcoder
   ] ++ (with gst_all_1; [

--- a/pkgs/applications/video/screenkey/default.nix
+++ b/pkgs/applications/video/screenkey/default.nix
@@ -9,7 +9,7 @@
 , libX11
 , libXtst
 , wrapGAppsHook
-, defaultIconTheme
+, gnome3
 , hicolor-icon-theme
 }:
 buildPythonApplication rec {
@@ -39,7 +39,7 @@ buildPythonApplication rec {
   ];
 
   buildInputs = [
-    defaultIconTheme
+    gnome3.adwaita-icon-theme
     hicolor-icon-theme
   ];
 

--- a/pkgs/applications/virtualization/open-vm-tools/default.nix
+++ b/pkgs/applications/virtualization/open-vm-tools/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchFromGitHub, makeWrapper, autoreconfHook,
   fuse, libmspack, openssl, pam, xercesc, icu, libdnet, procps,
   libX11, libXext, libXinerama, libXi, libXrender, libXrandr, libXtst,
-  pkgconfig, glib, gtk, gtkmm, iproute, dbus, systemd, which,
+  pkgconfig, glib, gtk3, gtkmm3, iproute, dbus, systemd, which,
   withX ? true }:
 
 stdenv.mkDerivation rec {
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook makeWrapper pkgconfig ];
   buildInputs = [ fuse glib icu libdnet libmspack openssl pam procps xercesc ]
-      ++ lib.optionals withX [ gtk gtkmm libX11 libXext libXinerama libXi libXrender libXrandr libXtst ];
+      ++ lib.optionals withX [ gtk3 gtkmm3 libX11 libXext libXinerama libXi libXrender libXrandr libXtst ];
 
   patches = [ ./recognize_nixos.patch ];
   postPatch = ''

--- a/pkgs/applications/virtualization/virt-manager/default.nix
+++ b/pkgs/applications/virtualization/virt-manager/default.nix
@@ -24,7 +24,7 @@ python3Packages.buildPythonApplication rec {
   ];
 
   buildInputs =
-    [ libvirt-glib vte dconf gtk-vnc gnome3.defaultIconTheme avahi
+    [ libvirt-glib vte dconf gtk-vnc gnome3.adwaita-icon-theme avahi
       gsettings-desktop-schemas libosinfo gtk3
     ] ++ optional spiceSupport spice-gtk;
 

--- a/pkgs/desktops/gnome-3/apps/accerciser/default.nix
+++ b/pkgs/desktops/gnome-3/apps/accerciser/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     gtk3 libxml2 python3Packages.python python3Packages.pyatspi
     python3Packages.pygobject3 python3Packages.ipython
-    at-spi2-core dbus libwnck3 gnome3.defaultIconTheme
+    at-spi2-core dbus libwnck3 gnome3.adwaita-icon-theme
   ];
 
   wrapPrefixVariables = [ "PYTHONPATH" ];

--- a/pkgs/desktops/gnome-3/apps/evolution/default.nix
+++ b/pkgs/desktops/gnome-3/apps/evolution/default.nix
@@ -1,5 +1,7 @@
 { stdenv, cmake, ninja, intltool, fetchurl, libxml2, webkitgtk, highlight
-, pkgconfig, gtk3, glib, libnotify, gtkspell3
+, pkgconfig, gtk3, glib, libnotify, gtkspell3, evolution-data-server
+, adwaita-icon-theme, gnome-desktop, libgdata
+, libgweather, glib-networking, gsettings-desktop-schemas
 , wrapGAppsHook, itstool, shared-mime-info, libical, db, gcr, sqlite
 , gnome3, librsvg, gdk_pixbuf, libsecret, nss, nspr, icu
 , libcanberra-gtk3, bogofilter, gst_all_1, procps, p11-kit, openldap }:
@@ -14,17 +16,17 @@ in stdenv.mkDerivation rec {
     sha256 = "10dy08xpizvvj7r8xgs3lr6migm3ipr199yryqz7wgkycq6nf53b";
   };
 
-  propagatedUserEnvPkgs = [ gnome3.evolution-data-server ];
+  propagatedUserEnvPkgs = [ evolution-data-server ];
 
   buildInputs = [
-    gtk3 glib gdk_pixbuf gnome3.defaultIconTheme librsvg db icu
-    gnome3.evolution-data-server libsecret libical gcr
-    webkitgtk shared-mime-info gnome3.gnome-desktop gtkspell3
-    libcanberra-gtk3 bogofilter gnome3.libgdata sqlite
+    gtk3 glib gdk_pixbuf adwaita-icon-theme librsvg db icu
+    evolution-data-server libsecret libical gcr
+    webkitgtk shared-mime-info gnome-desktop gtkspell3
+    libcanberra-gtk3 bogofilter libgdata sqlite
     gst_all_1.gstreamer gst_all_1.gst-plugins-base p11-kit
-    nss nspr libnotify procps highlight gnome3.libgweather
-    gnome3.gsettings-desktop-schemas
-    gnome3.glib-networking openldap
+    nss nspr libnotify procps highlight libgweather
+    gsettings-desktop-schemas
+    glib-networking openldap
   ];
 
   nativeBuildInputs = [ cmake ninja intltool itstool libxml2 pkgconfig wrapGAppsHook ];

--- a/pkgs/desktops/gnome-3/apps/file-roller/default.nix
+++ b/pkgs/desktops/gnome-3/apps/file-roller/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, glib, gtk, meson, ninja, pkgconfig, gnome3, gettext, itstool, libxml2, libarchive
+{ stdenv, fetchurl, glib, gtk3, meson, ninja, pkgconfig, gnome3, gettext, itstool, libxml2, libarchive
 , file, json-glib, python3, wrapGAppsHook, desktop-file-utils, libnotify, nautilus, glibcLocales }:
 
 stdenv.mkDerivation rec {
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ meson ninja gettext itstool pkgconfig libxml2 python3 wrapGAppsHook glibcLocales desktop-file-utils ];
 
-  buildInputs = [ glib gtk json-glib libarchive file gnome3.defaultIconTheme libnotify nautilus ];
+  buildInputs = [ glib gtk3 json-glib libarchive file gnome3.adwaita-icon-theme libnotify nautilus ];
 
   PKG_CONFIG_LIBNAUTILUS_EXTENSION_EXTENSIONDIR = "${placeholder "out"}/lib/nautilus/extensions-3.0";
 

--- a/pkgs/desktops/gnome-3/apps/gedit/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gedit/default.nix
@@ -1,5 +1,6 @@
 { stdenv, intltool, fetchurl
-, pkgconfig, gtk3, glib
+, pkgconfig, gtk3, glib, adwaita-icon-theme
+, libpeas, gtksourceview, gsettings-desktop-schemas
 , wrapGAppsHook, itstool, libsoup, libxml2
 , gnome3, gspell }:
 
@@ -16,9 +17,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     gtk3 glib
-    gnome3.defaultIconTheme libsoup
-    gnome3.libpeas gnome3.gtksourceview
-    gnome3.gsettings-desktop-schemas gspell
+    adwaita-icon-theme libsoup
+    libpeas gtksourceview
+    gsettings-desktop-schemas gspell
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/desktops/gnome-3/apps/ghex/default.nix
+++ b/pkgs/desktops/gnome-3/apps/ghex/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, gnome3, intltool, itstool, libxml2,
+{ stdenv, fetchurl, pkgconfig, gnome3, intltool, itstool, libxml2, gtk3,
   wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
@@ -10,13 +10,16 @@ stdenv.mkDerivation rec {
     sha256 = "c67450f86f9c09c20768f1af36c11a66faf460ea00fbba628a9089a6804808d3";
   };
 
-  passthru = {
-    updateScript = gnome3.updateScript { packageName = "ghex"; attrPath = "gnome3.ghex"; };
-  };
-
   nativeBuildInputs = [ pkgconfig wrapGAppsHook ];
 
-  buildInputs = [ gnome3.gtk intltool itstool libxml2 ];
+  buildInputs = [ gtk3 intltool itstool libxml2 ];
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = "ghex";
+      attrPath = "gnome3.ghex";
+    };
+  };
 
   meta = with stdenv.lib; {
     homepage = https://wiki.gnome.org/Apps/Ghex;

--- a/pkgs/desktops/gnome-3/apps/glade/default.nix
+++ b/pkgs/desktops/gnome-3/apps/glade/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     gtk3 glib libxml2 python3 python3.pkgs.pygobject3
     gnome3.gsettings-desktop-schemas
-    gdk_pixbuf gnome3.defaultIconTheme
+    gdk_pixbuf gnome3.adwaita-icon-theme
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/desktops/gnome-3/apps/gnome-boxes/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-boxes/default.nix
@@ -31,7 +31,7 @@ in stdenv.mkDerivation rec {
     libvirt-glib glib gtk3 gtk-vnc freerdp libxml2
     libvirt spice-gtk spice-protocol libsoup json-glib webkitgtk libosinfo systemd
     tracker tracker-miners libcap yajl gmp gdbm cyrus_sasl libusb libarchive
-    gnome3.defaultIconTheme librsvg acl libgudev libsecret
+    gnome3.adwaita-icon-theme librsvg acl libgudev libsecret
     libcap_ng numactl xen libapparmor
   ];
 

--- a/pkgs/desktops/gnome-3/apps/gnome-calendar/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-calendar/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, meson, ninja, pkgconfig, wrapGAppsHook, libdazzle, libgweather, geoclue2, geocode-glib, python3
-, gettext, libxml2, gnome3, gtk, evolution-data-server, libsoup
+, gettext, libxml2, gnome3, gtk3, evolution-data-server, libsoup
 , glib, gnome-online-accounts, gsettings-desktop-schemas }:
 
 let
@@ -22,8 +22,8 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ meson ninja pkgconfig gettext libxml2 wrapGAppsHook python3 ];
   buildInputs = [
-    gtk evolution-data-server libsoup glib gnome-online-accounts libdazzle libgweather geoclue2 geocode-glib
-    gsettings-desktop-schemas gnome3.defaultIconTheme
+    gtk3 evolution-data-server libsoup glib gnome-online-accounts libdazzle libgweather geoclue2 geocode-glib
+    gsettings-desktop-schemas gnome3.adwaita-icon-theme
   ];
 
   postPatch = ''

--- a/pkgs/desktops/gnome-3/apps/gnome-characters/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-characters/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, meson, ninja, pkgconfig, gettext, gnome3, glib, gtk3, pango, wrapGAppsHook, python3
-, gobject-introspection, gjs, libunistring }:
+, gobject-introspection, gjs, libunistring, gsettings-desktop-schemas, adwaita-icon-theme, gnome-desktop }:
 
 stdenv.mkDerivation rec {
   name = "gnome-characters-${version}";
@@ -24,10 +24,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ meson ninja pkgconfig gettext wrapGAppsHook python3 gobject-introspection ];
   buildInputs = [
-    glib gtk3 gjs pango gnome3.gsettings-desktop-schemas
-    gnome3.defaultIconTheme libunistring
+    glib gtk3 gjs pango gsettings-desktop-schemas
+    adwaita-icon-theme libunistring
     # typelib
-    gnome3.gnome-desktop
+    gnome-desktop
   ];
 
   mesonFlags = [

--- a/pkgs/desktops/gnome-3/apps/gnome-clocks/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-clocks/default.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchurl
 , meson, ninja, gettext, pkgconfig, wrapGAppsHook, itstool, desktop-file-utils
 , vala, gobject-introspection, libxml2, gtk3, glib, gsound, sound-theme-freedesktop
+, gsettings-desktop-schemas, adwaita-icon-theme, gnome-desktop, geocode-glib
 , gnome3, gdk_pixbuf, geoclue2, libgweather }:
 
 stdenv.mkDerivation rec {
@@ -26,8 +27,8 @@ stdenv.mkDerivation rec {
     gobject-introspection # for finding vapi files
   ];
   buildInputs = [
-    gtk3 glib gnome3.gsettings-desktop-schemas gdk_pixbuf gnome3.defaultIconTheme
-    gnome3.gnome-desktop gnome3.geocode-glib geoclue2 libgweather gsound
+    gtk3 glib gsettings-desktop-schemas gdk_pixbuf adwaita-icon-theme
+    gnome-desktop geocode-glib geoclue2 libgweather gsound
   ];
 
   preFixup = ''

--- a/pkgs/desktops/gnome-3/apps/gnome-documents/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-documents/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   ];
   buildInputs = [
     gtk3 glib gnome3.gsettings-desktop-schemas
-    gdk_pixbuf gnome3.defaultIconTheme evince
+    gdk_pixbuf gnome3.adwaita-icon-theme evince
     libsoup webkitgtk gjs gobject-introspection
     tracker tracker-miners libgdata
     gnome-desktop libzapojit libgepub

--- a/pkgs/desktops/gnome-3/apps/gnome-logs/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-logs/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     meson ninja pkgconfig wrapGAppsHook gettext itstool desktop-file-utils
     libxml2 libxslt docbook_xsl docbook_xml_dtd_43
   ];
-  buildInputs = [ glib gtk3 systemd gnome3.gsettings-desktop-schemas gnome3.defaultIconTheme ];
+  buildInputs = [ glib gtk3 systemd gnome3.gsettings-desktop-schemas gnome3.adwaita-icon-theme ];
 
   postPatch = ''
     chmod +x meson_post_install.py

--- a/pkgs/desktops/gnome-3/apps/gnome-maps/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-maps/default.nix
@@ -23,7 +23,7 @@ in stdenv.mkDerivation rec {
     geocode-glib libchamplain libsoup
     gdk_pixbuf librsvg libgweather
     gnome3.gsettings-desktop-schemas evolution-data-server
-    gnome-online-accounts gnome3.defaultIconTheme
+    gnome-online-accounts gnome3.adwaita-icon-theme
     webkitgtk
   ];
 

--- a/pkgs/desktops/gnome-3/apps/gnome-music/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-music/default.nix
@@ -18,7 +18,7 @@ python3.pkgs.buildPythonApplication rec {
   nativeBuildInputs = [ meson ninja gettext itstool pkgconfig libxml2 wrapGAppsHook desktop-file-utils appstream-glib gobject-introspection ];
   buildInputs = with gst_all_1; [
     gtk3 glib libmediaart gnome-online-accounts
-    gdk_pixbuf gnome3.defaultIconTheme python3
+    gdk_pixbuf gnome3.adwaita-icon-theme python3
     grilo grilo-plugins libnotify libdazzle libsoup
     gnome3.gsettings-desktop-schemas tracker
     gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly

--- a/pkgs/desktops/gnome-3/apps/gnome-nettool/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-nettool/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
     gtk3 wrapGAppsHook libgtop intltool itstool libxml2
-    gnome3.defaultIconTheme
+    gnome3.adwaita-icon-theme
   ];
 
   propagatedUserEnvPkgs = [ nmap inetutils ];

--- a/pkgs/desktops/gnome-3/apps/gnome-notes/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-notes/default.nix
@@ -30,7 +30,7 @@ in stdenv.mkDerivation rec {
     gnome3.gnome-online-accounts zeitgeist
     gnome3.gsettings-desktop-schemas
     evolution-data-server
-    gnome3.defaultIconTheme
+    gnome3.adwaita-icon-theme
   ];
 
   mesonFlags = [

--- a/pkgs/desktops/gnome-3/apps/gnome-photos/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-photos/default.nix
@@ -23,7 +23,7 @@ in stdenv.mkDerivation rec {
   buildInputs = [
     gtk3 glib gegl babl libgdata libdazzle
     gnome3.gsettings-desktop-schemas
-    gdk_pixbuf gnome3.defaultIconTheme
+    gdk_pixbuf gnome3.adwaita-icon-theme
     gfbgraph grilo-plugins grilo
     gnome-online-accounts tracker
     gexiv2 geocode-glib dleyna-renderer

--- a/pkgs/desktops/gnome-3/apps/gnome-power-manager/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-power-manager/default.nix
@@ -47,7 +47,7 @@ in stdenv.mkDerivation rec {
     gtk3
     glib
     upower
-    gnome3.defaultIconTheme
+    gnome3.adwaita-icon-theme
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/desktops/gnome-3/apps/gnome-todo/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-todo/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, meson, ninja, pkgconfig, python3, wrapGAppsHook
-, gettext, gnome3, glib, gtk, libpeas
+, gettext, gnome3, glib, gtk3, libpeas
 , gnome-online-accounts, gsettings-desktop-schemas
-, evolution-data-server, libxml2, libsoup, libical, rest, json-glib }:
+, evolution-data-server, libxml2, libsoup, libical, librest, json-glib }:
 
 let
   pname = "gnome-todo";
@@ -18,11 +18,11 @@ in stdenv.mkDerivation rec {
     meson ninja pkgconfig gettext python3 wrapGAppsHook
   ];
   buildInputs = [
-    glib gtk libpeas gnome-online-accounts
-    gsettings-desktop-schemas gnome3.defaultIconTheme
+    glib gtk3 libpeas gnome-online-accounts
+    gsettings-desktop-schemas gnome3.adwaita-icon-theme
     # Plug-ins
     evolution-data-server libxml2 libsoup libical
-    rest json-glib
+    librest json-glib
   ];
 
   postPatch = ''

--- a/pkgs/desktops/gnome-3/apps/gnome-weather/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-weather/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig intltool itstool wrapGAppsHook ];
   buildInputs = [
     gtk3 gjs gobject-introspection gnome-desktop
-    libgweather gnome3.defaultIconTheme geoclue2 gnome3.gsettings-desktop-schemas
+    libgweather gnome3.adwaita-icon-theme geoclue2 gnome3.gsettings-desktop-schemas
   ];
 
   # The .service file isn't wrapped with the correct environment

--- a/pkgs/desktops/gnome-3/apps/seahorse/default.nix
+++ b/pkgs/desktops/gnome-3/apps/seahorse/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     gtk3 glib gcr
     gnome3.gsettings-desktop-schemas gnupg
-    gnome3.defaultIconTheme gpgme
+    gnome3.adwaita-icon-theme gpgme
     libsecret avahi libsoup p11-kit
     openssh openldap
   ];

--- a/pkgs/desktops/gnome-3/apps/vinagre/default.nix
+++ b/pkgs/desktops/gnome-3/apps/vinagre/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig intltool itstool wrapGAppsHook ];
   buildInputs = [
-    gtk3 vte libxml2 gtk-vnc libsecret gnome3.defaultIconTheme librsvg
+    gtk3 vte libxml2 gtk-vnc libsecret gnome3.adwaita-icon-theme librsvg
   ];
 
   NIX_CFLAGS_COMPILE = "-Wno-format-nonliteral";

--- a/pkgs/desktops/gnome-3/core/adwaita-icon-theme/default.nix
+++ b/pkgs/desktops/gnome-3/core/adwaita-icon-theme/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, intltool, gnome3
-, iconnamingutils, gtk, gdk_pixbuf, librsvg, hicolor-icon-theme }:
+, iconnamingutils, gtk3, gdk_pixbuf, librsvg, hicolor-icon-theme }:
 
 stdenv.mkDerivation rec {
   name = "adwaita-icon-theme-${version}";
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ gdk_pixbuf librsvg ];
 
-  nativeBuildInputs = [ pkgconfig intltool iconnamingutils gtk ];
+  nativeBuildInputs = [ pkgconfig intltool iconnamingutils gtk3 ];
 
   # remove a tree of dirs with no files within
   postInstall = '' rm -rf "$out/locale" '';

--- a/pkgs/desktops/gnome-3/core/baobab/default.nix
+++ b/pkgs/desktops/gnome-3/core/baobab/default.nix
@@ -14,7 +14,7 @@ in stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ meson ninja pkgconfig vala gettext itstool libxml2 desktop-file-utils wrapGAppsHook ];
-  buildInputs = [ gtk3 glib gnome3.defaultIconTheme ];
+  buildInputs = [ gtk3 glib gnome3.adwaita-icon-theme ];
 
   doCheck = true;
 

--- a/pkgs/desktops/gnome-3/core/caribou/default.nix
+++ b/pkgs/desktops/gnome-3/core/caribou/default.nix
@@ -1,6 +1,6 @@
 { fetchurl, stdenv, pkgconfig, gnome3, glib, gtk3, clutter, dbus, python3, libxml2
 , libxklavier, libXtst, gtk2, intltool, libxslt, at-spi2-core, autoreconfHook
-, wrapGAppsHook }:
+, wrapGAppsHook, libgee }:
 
 let
   pname = "caribou";
@@ -30,7 +30,7 @@ in stdenv.mkDerivation rec {
     libXtst gtk2
   ];
 
-  propagatedBuildInputs = [ gnome3.libgee libxklavier ];
+  propagatedBuildInputs = [ libgee libxklavier ];
 
   postPatch = ''
     patchShebangs .

--- a/pkgs/desktops/gnome-3/core/empathy/default.nix
+++ b/pkgs/desktops/gnome-3/core/empathy/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     gcr libsecret libpulseaudio gdk_pixbuf
     libnotify clutter libsoup gnutls libgee p11-kit
     libcanberra-gtk3 telepathy-farstream farstream
-    gnome3.defaultIconTheme gnome3.gsettings-desktop-schemas
+    gnome3.adwaita-icon-theme gnome3.gsettings-desktop-schemas
     librsvg
     # Spell-checking
     enchant isocodes

--- a/pkgs/desktops/gnome-3/core/epiphany/default.nix
+++ b/pkgs/desktops/gnome-3/core/epiphany/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, meson, ninja, gettext, fetchurl, pkgconfig, gtk, glib, icu
+{ stdenv, meson, ninja, gettext, fetchurl, pkgconfig, gtk3, glib, icu
 , wrapGAppsHook, gnome3, libxml2, libxslt, itstool
 , webkitgtk, libsoup, glib-networking, libsecret, gnome-desktop, libnotify, p11-kit
 , sqlite, gcr, isocodes, desktop-file-utils, python3
@@ -21,9 +21,9 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    gtk glib webkitgtk libsoup libxml2 libsecret gnome-desktop libnotify
+    gtk3 glib webkitgtk libsoup libxml2 libsecret gnome-desktop libnotify
     sqlite isocodes p11-kit icu
-    gdk_pixbuf gnome3.defaultIconTheme gcr
+    gdk_pixbuf gnome3.adwaita-icon-theme gcr
     glib-networking gst_all_1.gstreamer gst_all_1.gst-plugins-base
     gst_all_1.gst-plugins-good gst_all_1.gst-plugins-bad gst_all_1.gst-plugins-ugly
     gst_all_1.gst-libav json-glib libdazzle

--- a/pkgs/desktops/gnome-3/core/evince/default.nix
+++ b/pkgs/desktops/gnome-3/core/evince/default.nix
@@ -1,7 +1,8 @@
 { fetchurl, stdenv, pkgconfig, intltool, libxml2
 , glib, gtk3, pango, atk, gdk_pixbuf, shared-mime-info, itstool, gnome3
 , poppler, ghostscriptX, djvulibre, libspectre, libarchive, libsecret, wrapGAppsHook
-, librsvg, gobject-introspection, yelp-tools, gspell
+, librsvg, gobject-introspection, yelp-tools, gspell, adwaita-icon-theme, gsettings-desktop-schemas
+, libgxps
 , recentListSize ? null # 5 is not enough, allow passing a different number
 , supportXPS ? false    # Open XML Paper Specification via libgxps
 , autoreconfHook, pruneLibtoolFiles
@@ -26,10 +27,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     glib gtk3 pango atk gdk_pixbuf libxml2
-    gnome3.gsettings-desktop-schemas
+    gsettings-desktop-schemas
     poppler ghostscriptX djvulibre libspectre libarchive
-    libsecret librsvg gnome3.adwaita-icon-theme gspell
-  ] ++ stdenv.lib.optional supportXPS gnome3.libgxps;
+    libsecret librsvg adwaita-icon-theme gspell
+  ] ++ stdenv.lib.optional supportXPS libgxps;
 
   configureFlags = [
     "--disable-nautilus" # Do not build nautilus plugin
@@ -37,7 +38,7 @@ stdenv.mkDerivation rec {
     (if supportXPS then "--enable-xps" else "--disable-xps")
   ];
 
-  NIX_CFLAGS_COMPILE = "-I${gnome3.glib.dev}/include/gio-unix-2.0";
+  NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/gio-unix-2.0";
 
   preConfigure = stdenv.lib.optionalString (recentListSize != null) ''
     sed -i 's/\(gtk_recent_chooser_set_limit .*\)5)/\1${builtins.toString recentListSize})/' shell/ev-open-recent-action.c

--- a/pkgs/desktops/gnome-3/core/evolution-data-server/default.nix
+++ b/pkgs/desktops/gnome-3/core/evolution-data-server/default.nix
@@ -1,7 +1,8 @@
 { fetchurl, stdenv, substituteAll, pkgconfig, gnome3, python3, gobject-introspection
 , intltool, libsoup, libxml2, libsecret, icu, sqlite, tzdata, libcanberra-gtk3, gcr
 , p11-kit, db, nspr, nss, libical, gperf, wrapGAppsHook, glib-networking, pcre
-, vala, cmake, ninja, kerberos, openldap, webkitgtk, libaccounts-glib, json-glib }:
+, vala, cmake, ninja, kerberos, openldap, webkitgtk, libaccounts-glib, json-glib
+, glib, gtk3, gnome-online-accounts, libgweather, libgdata }:
 
 stdenv.mkDerivation rec {
   name = "evolution-data-server-${version}";
@@ -25,8 +26,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake ninja pkgconfig intltool python3 gperf wrapGAppsHook gobject-introspection vala
   ];
-  buildInputs = with gnome3; [
-    glib libsoup libxml2 gtk gnome-online-accounts
+  buildInputs = [
+    glib libsoup libxml2 gtk3 gnome-online-accounts
     gcr p11-kit libgweather libgdata libaccounts-glib json-glib
     icu sqlite kerberos openldap webkitgtk glib-networking
     libcanberra-gtk3 pcre

--- a/pkgs/desktops/gnome-3/core/gdm/default.nix
+++ b/pkgs/desktops/gnome-3/core/gdm/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, substituteAll, pkgconfig, glib, itstool, libxml2, xorg
 , accountsservice, libX11, gnome3, systemd, autoreconfHook
-, gtk, libcanberra-gtk3, pam, libtool, gobject-introspection, plymouth
+, gtk3, libcanberra-gtk3, pam, libtool, gobject-introspection, plymouth
 , librsvg, coreutils, xwayland, fetchpatch }:
 
 stdenv.mkDerivation rec {
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig libxml2 itstool autoreconfHook libtool gnome3.dconf ];
   buildInputs = [
     glib accountsservice systemd
-    gobject-introspection libX11 gtk
+    gobject-introspection libX11 gtk3
     libcanberra-gtk3 pam plymouth librsvg
   ];
 

--- a/pkgs/desktops/gnome-3/core/gnome-bluetooth/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-bluetooth/default.nix
@@ -22,7 +22,7 @@ in stdenv.mkDerivation rec {
   ];
   buildInputs = [
     glib gtk3 udev libnotify libcanberra-gtk3
-    gnome3.defaultIconTheme gnome3.gsettings-desktop-schemas
+    gnome3.adwaita-icon-theme gnome3.gsettings-desktop-schemas
   ];
 
   mesonFlags = [

--- a/pkgs/desktops/gnome-3/core/gnome-calculator/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-calculator/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     gtk3 glib libxml2 gtksourceview3 mpfr gmp
-    gnome3.defaultIconTheme
+    gnome3.adwaita-icon-theme
     gnome3.gsettings-desktop-schemas libsoup libmpc
   ];
 

--- a/pkgs/desktops/gnome-3/core/gnome-contacts/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-contacts/default.nix
@@ -24,7 +24,7 @@ in stdenv.mkDerivation rec {
     gtk3 glib evolution-data-server gnome3.gsettings-desktop-schemas
     folks gnome-desktop telepathy-glib
     libxml2 gnome-online-accounts cheese
-    gnome3.defaultIconTheme libchamplain clutter-gtk geocode-glib
+    gnome3.adwaita-icon-theme libchamplain clutter-gtk geocode-glib
   ];
 
   postPatch = ''

--- a/pkgs/desktops/gnome-3/core/gnome-control-center/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-control-center/default.nix
@@ -5,7 +5,10 @@
 , cracklib, libkrb5, networkmanagerapplet, networkmanager, glibc
 , libwacom, samba, shared-mime-info, tzdata, libtool, libgnomekbd
 , docbook_xsl, modemmanager, clutter, clutter-gtk, cheese
-, fontconfig, sound-theme-freedesktop, grilo, python3 }:
+, fontconfig, sound-theme-freedesktop, grilo, python3
+, gtk3, glib, glib-networking, gsettings-desktop-schemas
+, gnome-desktop, gnome-settings-daemon, gnome-online-accounts
+, vino, gnome-bluetooth, tracker, adwaita-icon-theme }:
 
 let
   pname = "gnome-control-center";
@@ -23,13 +26,13 @@ in stdenv.mkDerivation rec {
     shared-mime-info python3
   ];
 
-  buildInputs = with gnome3; [
-    ibus gtk glib glib-networking upower gsettings-desktop-schemas
+  buildInputs = [
+    ibus gtk3 glib glib-networking upower gsettings-desktop-schemas
     libxml2 gnome-desktop gnome-settings-daemon polkit libgtop
     gnome-online-accounts libsoup colord libpulseaudio fontconfig colord-gtk
     accountsservice libkrb5 networkmanagerapplet libwacom samba libnotify
     grilo libpwquality cracklib vino libcanberra-gtk3 libgudev libsecret
-    gdk_pixbuf defaultIconTheme librsvg clutter clutter-gtk cheese
+    gdk_pixbuf adwaita-icon-theme librsvg clutter clutter-gtk cheese
     networkmanager modemmanager gnome-bluetooth tracker
   ];
 

--- a/pkgs/desktops/gnome-3/core/gnome-dictionary/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-dictionary/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, meson, ninja, pkgconfig, desktop-file-utils, appstream-glib, libxslt
 , libxml2, gettext, itstool, wrapGAppsHook, docbook_xsl, docbook_xml_dtd_43
-, gnome3, gtk, glib }:
+, gnome3, gtk3, glib }:
 
 stdenv.mkDerivation rec {
   name = "gnome-dictionary-${version}";
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     meson ninja pkgconfig wrapGAppsHook libxml2 gettext itstool
     desktop-file-utils appstream-glib libxslt docbook_xsl docbook_xml_dtd_43
   ];
-  buildInputs = [ gtk glib gnome3.gsettings-desktop-schemas gnome3.defaultIconTheme ];
+  buildInputs = [ gtk3 glib gnome3.gsettings-desktop-schemas gnome3.adwaita-icon-theme ];
 
   passthru = {
     updateScript = gnome3.updateScript {

--- a/pkgs/desktops/gnome-3/core/gnome-disk-utility/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-disk-utility/default.nix
@@ -1,5 +1,5 @@
 { stdenv, gettext, fetchurl, pkgconfig, udisks2, libsecret, libdvdread
-, meson, ninja, gtk, glib, wrapGAppsHook, python3, libnotify
+, meson, ninja, gtk3, glib, wrapGAppsHook, python3, libnotify
 , itstool, gnome3, libxml2
 , libcanberra-gtk3, libxslt, docbook_xsl, libpwquality }:
 
@@ -12,17 +12,14 @@ stdenv.mkDerivation rec {
     sha256 = "1365fabz3q7n3bl775z82m1nzg18birxxyd7l2ssbbkqrx3h7wgi";
   };
 
-  passthru = {
-    updateScript = gnome3.updateScript { packageName = "gnome-disk-utility"; attrPath = "gnome3.gnome-disk-utility"; };
-  };
-
   nativeBuildInputs = [
     meson ninja pkgconfig gettext itstool libxslt docbook_xsl
     wrapGAppsHook python3 libxml2
   ];
+
   buildInputs = [
-    gtk glib libsecret libpwquality libnotify libdvdread libcanberra-gtk3
-    udisks2 gnome3.defaultIconTheme
+    gtk3 glib libsecret libpwquality libnotify libdvdread libcanberra-gtk3
+    udisks2 gnome3.adwaita-icon-theme
     gnome3.gnome-settings-daemon gnome3.gsettings-desktop-schemas
   ];
 
@@ -30,6 +27,13 @@ stdenv.mkDerivation rec {
     chmod +x meson_post_install.py # patchShebangs requires executable file
     patchShebangs meson_post_install.py
   '';
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = "gnome-disk-utility";
+      attrPath = "gnome3.gnome-disk-utility";
+    };
+  };
 
   meta = with stdenv.lib; {
     homepage = https://en.wikipedia.org/wiki/GNOME_Disks;

--- a/pkgs/desktops/gnome-3/core/gnome-font-viewer/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-font-viewer/default.nix
@@ -1,5 +1,5 @@
 { stdenv, meson, ninja, gettext, fetchurl
-, pkgconfig, gtk3, glib, libxml2
+, pkgconfig, gtk3, glib, libxml2, gnome-desktop, adwaita-icon-theme
 , wrapGAppsHook, gnome3 }:
 
 stdenv.mkDerivation rec {
@@ -11,17 +11,20 @@ stdenv.mkDerivation rec {
     sha256 = "1wwnx2zrlbd2d6np7m9s78alx6j6ranrnh1g2z6zrv9qcj8rpzz5";
   };
 
-  passthru = {
-    updateScript = gnome3.updateScript { packageName = "gnome-font-viewer"; attrPath = "gnome3.gnome-font-viewer"; };
-  };
-
   doCheck = true;
 
   nativeBuildInputs = [ meson ninja pkgconfig gettext wrapGAppsHook libxml2 ];
-  buildInputs = [ gtk3 glib gnome3.gnome-desktop gnome3.defaultIconTheme ];
+  buildInputs = [ gtk3 glib gnome-desktop adwaita-icon-theme ];
 
   # Do not run meson-postinstall.sh
   preConfigure = "sed -i '2,$ d'  meson-postinstall.sh";
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = "gnome-font-viewer";
+      attrPath = "gnome3.gnome-font-viewer";
+    };
+  };
 
   meta = with stdenv.lib; {
     description = "Program that can preview fonts and create thumbnails for fonts";

--- a/pkgs/desktops/gnome-3/core/gnome-online-accounts/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-online-accounts/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, pkgconfig, vala, glib, libxslt, gtk, wrapGAppsHook
-, webkitgtk, json-glib, rest, libsecret, gtk-doc, gobject-introspection
+{ stdenv, fetchurl, pkgconfig, vala, glib, libxslt, gtk3, wrapGAppsHook
+, webkitgtk, json-glib, librest, libsecret, gtk-doc, gobject-introspection
 , gettext, icu, glib-networking
 , libsoup, docbook_xsl, docbook_xml_dtd_412, gnome3, gcr, kerberos
 }:
@@ -33,7 +33,7 @@ in stdenv.mkDerivation rec {
     libxslt docbook_xsl docbook_xml_dtd_412 gtk-doc
   ];
   buildInputs = [
-    glib gtk webkitgtk json-glib rest libsecret glib-networking icu libsoup
+    glib gtk3 webkitgtk json-glib librest libsecret glib-networking icu libsoup
     gcr kerberos
   ];
 

--- a/pkgs/desktops/gnome-3/core/gnome-online-miners/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-online-miners/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchurl, pkgconfig, glib, gnome3, libxml2
-, libsoup, json-glib, gmp, openssl, dleyna-server, wrapGAppsHook }:
+, libgdata, grilo, libzapojit, grilo-plugins, gnome-online-accounts, libmediaart
+, tracker, gfbgraph, librest, libsoup, json-glib, gmp, openssl, dleyna-server, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "gnome-online-miners-${version}";
@@ -10,18 +11,23 @@ stdenv.mkDerivation rec {
     sha256 = "0pjamwwzn5wqgihyss357dyl2q70r0bngnqmwsqawchx5f9aja9c";
   };
 
-  passthru = {
-    updateScript = gnome3.updateScript { packageName = "gnome-online-miners"; attrPath = "gnome3.gnome-online-miners"; };
-  };
-
   nativeBuildInputs = [ pkgconfig wrapGAppsHook ];
-  buildInputs = [ glib gnome3.libgdata libxml2 libsoup gmp openssl
-                  gnome3.grilo gnome3.libzapojit gnome3.grilo-plugins
-                  gnome3.gnome-online-accounts gnome3.libmediaart
-                  gnome3.tracker gnome3.gfbgraph json-glib gnome3.rest
-                  dleyna-server ];
+  buildInputs = [
+    glib libgdata libxml2 libsoup gmp openssl
+    grilo libzapojit grilo-plugins
+    gnome-online-accounts libmediaart
+    tracker gfbgraph json-glib librest
+    dleyna-server
+  ];
 
   enableParallelBuilding = true;
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = "gnome-online-miners";
+      attrPath = "gnome3.gnome-online-miners";
+    };
+  };
 
   meta = with stdenv.lib; {
     homepage = https://wiki.gnome.org/Projects/GnomeOnlineMiners;

--- a/pkgs/desktops/gnome-3/core/gnome-screenshot/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-screenshot/default.nix
@@ -22,7 +22,7 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ meson ninja pkgconfig gettext appstream-glib libxml2 desktop-file-utils python3 wrapGAppsHook ];
   buildInputs = [
-    gtk3 glib libcanberra-gtk3 gnome3.defaultIconTheme
+    gtk3 glib libcanberra-gtk3 gnome3.adwaita-icon-theme
     gnome3.gsettings-desktop-schemas
   ];
 

--- a/pkgs/desktops/gnome-3/core/gnome-session/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-session/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, substituteAll, meson, ninja, pkgconfig, gnome3, glib, gtk, gsettings-desktop-schemas
+{ fetchurl, stdenv, substituteAll, meson, ninja, pkgconfig, gnome3, glib, gtk3, gsettings-desktop-schemas
 , gnome-desktop, dbus, json-glib, libICE, xmlto, docbook_xsl, docbook_xml_dtd_412, python3
 , libxslt, gettext, makeWrapper, systemd, xorg, epoxy, gnugrep, bash }:
 
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    glib gtk libICE gnome-desktop json-glib xorg.xtrans gnome3.defaultIconTheme
+    glib gtk3 libICE gnome-desktop json-glib xorg.xtrans gnome3.adwaita-icon-theme
     gnome3.gnome-settings-daemon gsettings-desktop-schemas systemd epoxy
   ];
 

--- a/pkgs/desktops/gnome-3/core/gnome-settings-daemon/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-settings-daemon/default.nix
@@ -1,7 +1,7 @@
-{ fetchurl, substituteAll, stdenv, meson, ninja, pkgconfig, gnome3, perl, gettext, glib, libnotify, lcms2, libXtst
-, libxkbfile, libpulseaudio, alsaLib, libcanberra-gtk3, upower, colord, libgweather, polkit
+{ fetchurl, substituteAll, stdenv, meson, ninja, pkgconfig, gnome3, perl, gettext, gtk3, glib, libnotify, lcms2, libXtst
+, libxkbfile, libpulseaudio, alsaLib, libcanberra-gtk3, upower, colord, libgweather, polkit, gsettings-desktop-schemas
 , geoclue2, librsvg, xf86_input_wacom, udev, libgudev, libwacom, libxslt, libxml2, networkmanager
-, docbook_xsl, wrapGAppsHook, python3, ibus, xkeyboard_config, tzdata, nss }:
+, gnome-desktop, geocode-glib, docbook_xsl, wrapGAppsHook, python3, ibus, xkeyboard_config, tzdata, nss }:
 
 stdenv.mkDerivation rec {
   name = "gnome-settings-daemon-${version}";
@@ -21,8 +21,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ meson ninja pkgconfig perl gettext libxml2 libxslt docbook_xsl wrapGAppsHook python3 ];
 
-  buildInputs = with gnome3; [
-    ibus gtk glib gsettings-desktop-schemas networkmanager
+  buildInputs = [
+    ibus gtk3 glib gsettings-desktop-schemas networkmanager
     libnotify gnome-desktop lcms2 libXtst libxkbfile libpulseaudio alsaLib
     libcanberra-gtk3 upower colord libgweather xkeyboard_config nss
     polkit geocode-glib geoclue2 librsvg xf86_input_wacom udev libgudev libwacom

--- a/pkgs/desktops/gnome-3/core/gnome-shell/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-shell/default.nix
@@ -2,9 +2,10 @@
 , python3Packages, libsoup, polkit, clutter, networkmanager, docbook_xsl , docbook_xsl_ns, at-spi2-core
 , libstartup_notification, telepathy-glib, telepathy-logger, libXtst, unzip, glibcLocales, shared-mime-info
 , libgweather, libcanberra-gtk3, librsvg, geoclue2, perl, docbook_xml_dtd_42, desktop-file-utils
-, libpulseaudio, libical, gobject-introspection, gstreamer, wrapGAppsHook, libxslt, gcr
-, accountsservice, gdk_pixbuf, gdm, upower, ibus, networkmanagerapplet, libgnomekbd
-, sassc, systemd, gst_all_1 }:
+, libpulseaudio, libical, gobject-introspection, gstreamer, wrapGAppsHook, libxslt, gcr, caribou
+, accountsservice, gdk_pixbuf, gdm, upower, ibus, networkmanagerapplet, libgnomekbd, gnome-desktop
+, gsettings-desktop-schemas, gnome-keyring, glib, gjs, mutter, evolution-data-server, gtk3
+, sassc, systemd, gst_all_1, adwaita-icon-theme, gnome-bluetooth, gnome-clocks, gnome-settings-daemon }:
 
 # http://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/gnome-base/gnome-shell/gnome-shell-3.10.2.1.ebuild?revision=1.3&view=markup
 
@@ -26,16 +27,16 @@ in stdenv.mkDerivation rec {
     meson ninja pkgconfig gettext docbook_xsl docbook_xsl_ns docbook_xml_dtd_42 perl wrapGAppsHook glibcLocales
     sassc desktop-file-utils libxslt.bin
   ];
-  buildInputs = with gnome3; [
+  buildInputs = [
     systemd caribou
     gsettings-desktop-schemas gnome-keyring glib gcr json-glib accountsservice
     libcroco libsecret libsoup polkit gdk_pixbuf librsvg
     clutter networkmanager libstartup_notification telepathy-glib
     libXtst gjs mutter libpulseaudio evolution-data-server
-    libical gtk gstreamer gdm libcanberra-gtk3 geoclue2
-    defaultIconTheme gnome3.gnome-bluetooth
-    gnome3.gnome-clocks # schemas needed
-    at-spi2-core upower ibus gnome-desktop telepathy-logger gnome3.gnome-settings-daemon
+    libical gtk3 gstreamer gdm libcanberra-gtk3 geoclue2
+    adwaita-icon-theme gnome-bluetooth
+    gnome-clocks # schemas needed
+    at-spi2-core upower ibus gnome-desktop telepathy-logger gnome-settings-daemon
     gst_all_1.gst-plugins-good # recording
     gobject-introspection
 
@@ -45,7 +46,7 @@ in stdenv.mkDerivation rec {
   propagatedUserEnvPkgs = [
     # Needed to support on-screen keyboard used with touch screen devices
     # see https://github.com/NixOS/nixpkgs/issues/25968
-    gnome3.caribou
+    caribou
   ];
 
   patches = [

--- a/pkgs/desktops/gnome-3/core/gnome-software/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-software/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchurl, substituteAll, pkgconfig, meson, ninja, gettext, gnome3, wrapGAppsHook, packagekit, ostree
 , glib, appstream-glib, libsoup, polkit, isocodes, gspell, libxslt, gobject-introspection, flatpak, fwupd
+, gtk3, gsettings-desktop-schemas, gnome-desktop
 , json-glib, libsecret, valgrind-light, docbook_xsl, docbook_xml_dtd_42, docbook_xml_dtd_43, gtk-doc, desktop-file-utils }:
 
 stdenv.mkDerivation rec {
@@ -24,8 +25,8 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    gnome3.gtk glib packagekit appstream-glib libsoup
-    gnome3.gsettings-desktop-schemas gnome3.gnome-desktop
+    gtk3 glib packagekit appstream-glib libsoup
+    gsettings-desktop-schemas gnome-desktop
     gspell json-glib libsecret ostree
     polkit flatpak fwupd
   ];

--- a/pkgs/desktops/gnome-3/core/gnome-system-monitor/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-system-monitor/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     polkit # for ITS file
   ];
   buildInputs = [
-    bash gtk3 glib libxml2 gtkmm3 libgtop gdk_pixbuf gnome3.defaultIconTheme librsvg
+    bash gtk3 glib libxml2 gtkmm3 libgtop gdk_pixbuf gnome3.adwaita-icon-theme librsvg
     gnome3.gsettings-desktop-schemas systemd
   ];
 

--- a/pkgs/desktops/gnome-3/core/gnome-terminal/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-terminal/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, libxml2, gnome3, dconf, nautilus
-, gtk, gsettings-desktop-schemas, vte, intltool, which, libuuid, vala
+, gtk3, gsettings-desktop-schemas, vte, intltool, which, libuuid, vala
 , desktop-file-utils, itstool, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    gtk gsettings-desktop-schemas vte libuuid dconf
+    gtk3 gsettings-desktop-schemas vte libuuid dconf
     # For extension
     nautilus
   ];

--- a/pkgs/desktops/gnome-3/core/gnome-themes-extra/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-themes-extra/default.nix
@@ -19,7 +19,7 @@ in stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig intltool ];
-  buildInputs = [ gtk3 librsvg pango atk gtk2 gdk_pixbuf gnome3.defaultIconTheme ];
+  buildInputs = [ gtk3 librsvg pango atk gtk2 gdk_pixbuf gnome3.adwaita-icon-theme ];
 
   postFixup = ''
     gtk-update-icon-cache "$out"/share/icons/HighContrast

--- a/pkgs/desktops/gnome-3/core/gnome-user-share/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-user-share/default.nix
@@ -1,5 +1,5 @@
 { stdenv, intltool, fetchurl, apacheHttpd, nautilus
-, pkgconfig, gtk3, glib, libxml2, systemd
+, pkgconfig, gtk3, glib, libxml2, systemd, adwaita-icon-theme
 , wrapGAppsHook, itstool, libnotify, libtool, mod_dnssd
 , gnome3, librsvg, gdk_pixbuf, file, libcanberra-gtk3 }:
 
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  NIX_CFLAGS_COMPILE = "-I${gnome3.glib.dev}/include/gio-unix-2.0";
+  NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/gio-unix-2.0";
 
   preConfigure = ''
     sed -e 's,^LoadModule dnssd_module.\+,LoadModule dnssd_module ${mod_dnssd}/modules/mod_dnssd.so,' \
@@ -26,15 +26,19 @@ stdenv.mkDerivation rec {
       -i data/dav_user_2.4.conf
   '';
 
-  configureFlags = [ "--with-httpd=${apacheHttpd.out}/bin/httpd"
-                     "--with-modules-path=${apacheHttpd.dev}/modules"
-                     "--with-systemduserunitdir=$(out)/etc/systemd/user"
-                     "--with-nautilusdir=$(out)/lib/nautilus/extensions-3.0" ];
+  configureFlags = [
+    "--with-httpd=${apacheHttpd.out}/bin/httpd"
+    "--with-modules-path=${apacheHttpd.dev}/modules"
+    "--with-systemduserunitdir=$(out)/etc/systemd/user"
+    "--with-nautilusdir=$(out)/lib/nautilus/extensions-3.0"
+  ];
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ gtk3 glib intltool itstool libxml2 libtool
-                  wrapGAppsHook file gdk_pixbuf gnome3.defaultIconTheme librsvg
-                  nautilus libnotify libcanberra-gtk3 systemd ];
+  buildInputs = [
+    gtk3 glib intltool itstool libxml2 libtool
+    wrapGAppsHook file gdk_pixbuf adwaita-icon-theme librsvg
+    nautilus libnotify libcanberra-gtk3 systemd
+  ];
 
   postInstall = ''
     mkdir -p $out/share/gsettings-schemas/$name

--- a/pkgs/desktops/gnome-3/core/grilo-plugins/default.nix
+++ b/pkgs/desktops/gnome-3/core/grilo-plugins/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, meson, ninja, pkgconfig, gettext, sqlite
-, gnome3, libxml2, gupnp, gssdp, lua5, liboauth, gupnp-av
+{ stdenv, fetchurl, meson, ninja, pkgconfig, gettext, sqlite, librest
+, gnome3, libxml2, gupnp, gssdp, lua5, liboauth, gupnp-av, libgdata, libmediaart
 , gmime, json-glib, avahi, tracker, dleyna-server, itstool, totem-pl-parser }:
 
 let
@@ -15,10 +15,10 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ meson ninja pkgconfig gettext itstool ];
   buildInputs = [
-    gnome3.grilo libxml2 gupnp gssdp gnome3.libgdata
+    gnome3.grilo libxml2 gupnp gssdp libgdata
     lua5 liboauth gupnp-av sqlite gnome3.gnome-online-accounts
-    totem-pl-parser gnome3.rest gmime json-glib
-    avahi gnome3.libmediaart tracker dleyna-server
+    totem-pl-parser librest gmime json-glib
+    avahi libmediaart tracker dleyna-server
   ];
 
   passthru = {

--- a/pkgs/desktops/gnome-3/core/gucharmap/default.nix
+++ b/pkgs/desktops/gnome-3/core/gucharmap/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, intltool, fetchFromGitLab, fetchpatch, pkgconfig, gtk3, defaultIconTheme
+{ stdenv, intltool, fetchFromGitLab, fetchpatch, pkgconfig, gtk3, adwaita-icon-theme
 , glib, desktop-file-utils, gtk-doc, autoconf, automake, libtool
 , wrapGAppsHook, gnome3, itstool, libxml2, yelp-tools
 , docbook_xsl, docbook_xml_dtd_412, gsettings-desktop-schemas
@@ -26,7 +26,7 @@ in stdenv.mkDerivation rec {
     yelp-tools libxml2 desktop-file-utils gobject-introspection
   ];
 
-  buildInputs = [ gtk3 glib gsettings-desktop-schemas defaultIconTheme ];
+  buildInputs = [ gtk3 glib gsettings-desktop-schemas adwaita-icon-theme ];
 
   configureFlags = [
     "--with-unicode-data=${unicode-data}"

--- a/pkgs/desktops/gnome-3/core/mutter/3.28.nix
+++ b/pkgs/desktops/gnome-3/core/mutter/3.28.nix
@@ -1,7 +1,8 @@
 { fetchurl, stdenv, fetchpatch, pkgconfig, gnome3, intltool, gobject-introspection, upower, cairo
-, pango, cogl, clutter, libstartup_notification, zenity, libcanberra-gtk3
+, glib, gtk3, pango, cogl, clutter, libstartup_notification, zenity, libcanberra-gtk3
+, gsettings-desktop-schemas, gnome-desktop
 , libtool, makeWrapper, xkeyboard_config, libxkbfile, libxkbcommon, libXtst, libinput
-, pipewire, libgudev, libwacom, xwayland, autoreconfHook }:
+, geocode-glib, pipewire, libgudev, libwacom, xwayland, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   name = "mutter-${version}";
@@ -32,10 +33,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook pkgconfig intltool libtool makeWrapper ];
 
-  buildInputs = with gnome3; [
-    glib gobject-introspection gtk gsettings-desktop-schemas upower
+  buildInputs = [
+    glib gobject-introspection gtk3 gsettings-desktop-schemas upower
     gnome-desktop cairo pango cogl clutter zenity libstartup_notification
-    gnome3.geocode-glib libinput libgudev libwacom
+    geocode-glib libinput libgudev libwacom
     libcanberra-gtk3 zenity xkeyboard_config libxkbfile
     libxkbcommon pipewire
   ];

--- a/pkgs/desktops/gnome-3/core/mutter/default.nix
+++ b/pkgs/desktops/gnome-3/core/mutter/default.nix
@@ -1,7 +1,8 @@
 { fetchurl, stdenv, pkgconfig, gnome3, intltool, gobject-introspection, upower, cairo
 , pango, cogl, clutter, libstartup_notification, zenity, libcanberra-gtk3
 , libtool, makeWrapper, xkeyboard_config, libxkbfile, libxkbcommon, libXtst, libinput
-, pipewire, libgudev, libwacom, xwayland, autoreconfHook }:
+, gsettings-desktop-schemas, glib, gtk3, gnome-desktop
+, geocode-glib, pipewire, libgudev, libwacom, xwayland, autoreconfHook }:
 
 stdenv.mkDerivation rec {
   name = "mutter-${version}";
@@ -10,10 +11,6 @@ stdenv.mkDerivation rec {
   src = fetchurl {
     url = "mirror://gnome/sources/mutter/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "0qr3w480p31nbiad49213rj9rk6p9fl82a68pzznpz36p30dq96z";
-  };
-
-  passthru = {
-    updateScript = gnome3.updateScript { packageName = "mutter"; attrPath = "gnome3.mutter"; };
   };
 
   configureFlags = [
@@ -36,10 +33,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook pkgconfig intltool libtool makeWrapper ];
 
-  buildInputs = with gnome3; [
-    glib gobject-introspection gtk gsettings-desktop-schemas upower
+  buildInputs = [
+    glib gobject-introspection gtk3 gsettings-desktop-schemas upower
     gnome-desktop cairo pango cogl clutter zenity libstartup_notification
-    gnome3.geocode-glib libinput libgudev libwacom
+    geocode-glib libinput libgudev libwacom
     libcanberra-gtk3 zenity xkeyboard_config libxkbfile
     libxkbcommon pipewire
   ];
@@ -50,6 +47,13 @@ stdenv.mkDerivation rec {
   '';
 
   enableParallelBuilding = true;
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = "mutter";
+      attrPath = "gnome3.mutter";
+    };
+  };
 
   meta = with stdenv.lib; {
     platforms = platforms.linux;

--- a/pkgs/desktops/gnome-3/core/nautilus/default.nix
+++ b/pkgs/desktops/gnome-3/core/nautilus/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, meson, ninja, pkgconfig, gettext, libxml2
-, desktop-file-utils, python3, wrapGAppsHook , gtk, gnome3, gnome-autoar
+, desktop-file-utils, python3, wrapGAppsHook , gtk3, gnome3, gnome-autoar
 , glib-networking, shared-mime-info, libnotify, libexif, libseccomp , exempi
 , librsvg, tracker, tracker-miners, gexiv2, libselinux, gdk_pixbuf
 , substituteAll, bubblewrap
@@ -22,7 +22,7 @@ in stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    glib-networking shared-mime-info libexif gtk exempi libnotify libselinux
+    glib-networking shared-mime-info libexif gtk3 exempi libnotify libselinux
     tracker tracker-miners gexiv2 libseccomp bubblewrap
     gnome3.adwaita-icon-theme gnome3.gsettings-desktop-schemas
   ];

--- a/pkgs/desktops/gnome-3/core/simple-scan/default.nix
+++ b/pkgs/desktops/gnome-3/core/simple-scan/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, meson, ninja, pkgconfig, gettext, itstool, python3, wrapGAppsHook
-, cairo, gdk_pixbuf, colord, glib, gtk, gusb, packagekit, libwebp
+, cairo, gdk_pixbuf, colord, glib, gtk3, gusb, packagekit, libwebp
 , libxml2, sane-backends, vala, gnome3, gobject-introspection }:
 
 stdenv.mkDerivation rec {
@@ -12,8 +12,8 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    cairo gdk_pixbuf colord glib gnome3.defaultIconTheme gusb
-    gtk libwebp packagekit sane-backends vala
+    cairo gdk_pixbuf colord glib gnome3.adwaita-icon-theme gusb
+    gtk3 libwebp packagekit sane-backends vala
   ];
   nativeBuildInputs = [
     meson ninja gettext itstool pkgconfig python3 wrapGAppsHook libxml2

--- a/pkgs/desktops/gnome-3/core/totem/default.nix
+++ b/pkgs/desktops/gnome-3/core/totem/default.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchurl, meson, ninja, intltool, gst_all_1
 , clutter-gtk, clutter-gst, python3Packages, shared-mime-info
 , pkgconfig, gtk3, glib, gobject-introspection, totem-pl-parser
-, wrapGAppsHook, itstool, libxml2, vala, gnome3
+, wrapGAppsHook, itstool, libxml2, vala, gnome3, grilo, grilo-plugins
+, libpeas, adwaita-icon-theme, gnome-desktop, gsettings-desktop-schemas
 , gdk_pixbuf, tracker, nautilus }:
 
 stdenv.mkDerivation rec {
@@ -15,15 +16,15 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  NIX_CFLAGS_COMPILE = "-I${gnome3.glib.dev}/include/gio-unix-2.0";
+  NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/gio-unix-2.0";
 
   nativeBuildInputs = [ meson ninja vala pkgconfig intltool python3Packages.python itstool gobject-introspection wrapGAppsHook ];
   buildInputs = [
-    gtk3 glib gnome3.grilo clutter-gtk clutter-gst totem-pl-parser gnome3.grilo-plugins
+    gtk3 glib grilo clutter-gtk clutter-gst totem-pl-parser grilo-plugins
     gst_all_1.gstreamer gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good gst_all_1.gst-plugins-bad
-    gst_all_1.gst-plugins-ugly gst_all_1.gst-libav gnome3.libpeas shared-mime-info
-    gdk_pixbuf libxml2 gnome3.defaultIconTheme gnome3.gnome-desktop
-    gnome3.gsettings-desktop-schemas tracker nautilus
+    gst_all_1.gst-plugins-ugly gst_all_1.gst-libav libpeas shared-mime-info
+    gdk_pixbuf libxml2 adwaita-icon-theme gnome-desktop
+    gsettings-desktop-schemas tracker nautilus
     python3Packages.pygobject3 python3Packages.dbus-python # for plug-ins
   ];
 

--- a/pkgs/desktops/gnome-3/core/tracker-miners/default.nix
+++ b/pkgs/desktops/gnome-3/core/tracker-miners/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, substituteAll, intltool, itstool, libxslt
+{ stdenv, fetchurl, substituteAll, intltool, itstool, libxslt, gexiv2, tracker
 , meson, ninja, pkgconfig, vala, wrapGAppsHook, bzip2, dbus, evolution-data-server
 , exempi, flac, giflib, glib, gnome3, gst_all_1, icu, json-glib, libcue, libexif
 , libgrss, libgsf, libiptcdata, libjpeg, libpng, libseccomp, libsoup, libtiff, libuuid
@@ -35,9 +35,9 @@ in stdenv.mkDerivation rec {
     flac
     giflib
     glib
-    gnome3.gexiv2
+    gexiv2
     totem-pl-parser
-    gnome3.tracker
+    tracker
     gst_all_1.gst-plugins-base
     gst_all_1.gstreamer
     icu

--- a/pkgs/desktops/gnome-3/core/vino/default.nix
+++ b/pkgs/desktops/gnome-3/core/vino/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ intltool wrapGAppsHook pkgconfig ];
 
   buildInputs = [
-    gnome3.defaultIconTheme gtk3 glib libXtst libnotify libsoup
+    gnome3.adwaita-icon-theme gtk3 glib libXtst libnotify libsoup
     libsecret gnutls libgcrypt avahi zlib libjpeg
     libXdamage libXfixes libXext networkmanager
   ] ++ optionals telepathySupport [ dbus-glib telepathy-glib ];

--- a/pkgs/desktops/gnome-3/core/yelp/default.nix
+++ b/pkgs/desktops/gnome-3/core/yelp/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     gtk3 glib webkitgtk sqlite
     libxml2 libxslt gnome3.yelp-xsl
-    gnome3.defaultIconTheme
+    gnome3.adwaita-icon-theme
     gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good
   ];
 

--- a/pkgs/desktops/gnome-3/core/zenity/default.nix
+++ b/pkgs/desktops/gnome-3/core/zenity/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, libxml2, libxslt, gnome3
+{ stdenv, fetchurl, pkgconfig, libxml2, libxslt, gnome3, gtk3
 , gnome-doc-utils, intltool, libX11, which, itstool, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
@@ -10,17 +10,20 @@ stdenv.mkDerivation rec {
     sha256 = "1wipnp46pd238z9ck5rsckbaw7yla6c936fswq5w94k4c6bgcplr";
   };
 
-  passthru = {
-    updateScript = gnome3.updateScript { packageName = "zenity"; attrPath = "gnome3.zenity"; };
-  };
-
   preBuild = ''
     mkdir -p $out/include
   '';
 
-  buildInputs = [ gnome3.gtk libxml2 libxslt libX11 itstool ];
+  buildInputs = [ gtk3 libxml2 libxslt libX11 itstool ];
 
   nativeBuildInputs = [ pkgconfig intltool gnome-doc-utils which wrapGAppsHook ];
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = "zenity";
+      attrPath = "gnome3.zenity";
+    };
+  };
 
   meta = with stdenv.lib; {
     platforms = platforms.linux;

--- a/pkgs/desktops/gnome-3/default.nix
+++ b/pkgs/desktops/gnome-3/default.nix
@@ -28,7 +28,7 @@ lib.makeScope pkgs.newScope (self: with self; {
     gtk3.out # for gtk-update-icon-cache
     glib-networking gvfs dconf gnome-backgrounds gnome-control-center
     gnome-menus gnome-settings-daemon gnome-shell
-    gnome-themes-extra defaultIconTheme gnome-shell-extensions
+    gnome-themes-extra adwaita-icon-theme gnome-shell-extensions
     pkgs.hicolor-icon-theme
   ];
 
@@ -51,22 +51,11 @@ lib.makeScope pkgs.newScope (self: with self; {
     hitori gnome-taquin
   ];
 
-  inherit (pkgs) atk glib gobject-introspection gspell webkitgtk gtk3 gtkmm3
-    libgtop libgudev libhttpseverywhere librsvg libsecret gdk_pixbuf gtksourceview gtksourceviewmm gtksourceview4
-    easytag meld orca rhythmbox shotwell gnome-usage
-    clutter clutter-gst clutter-gtk cogl gtk-vnc libdazzle libgda libgit2-glib libgxps libgdata libgepub libcroco libpeas libgee geocode-glib libgweather librest libzapojit libmediaart gfbgraph gexiv2 folks totem-pl-parser gcr gsound libgnomekbd vte vte_290 vte-ng gnome-menus gdl;
-
   libsoup = pkgs.libsoup.override { gnomeSupport = true; };
   libchamplain = pkgs.libchamplain.override { libsoup = libsoup; };
   gnome3 = self // { recurseForDerivations = false; };
-  gtk = gtk3;
-  gtkmm = gtkmm3;
   vala = pkgs.vala_0_42;
-  gegl_0_4 = pkgs.gegl_0_4.override { inherit gtk; };
-  rest = librest;
-
-# Simplify the nixos module and gnome packages
-  defaultIconTheme = adwaita-icon-theme;
+  gegl_0_4 = pkgs.gegl_0_4.override { gtk = pkgs.gtk3; };
 
 # ISO installer
 # installerIso = callPackage ./installer.nix {};
@@ -372,8 +361,8 @@ lib.makeScope pkgs.newScope (self: with self; {
 
   bijiben = gnome-notes; # added 2018-09-26
   evolution_data_server = evolution-data-server; # added 2018-02-25
-  geocode_glib = geocode-glib; # added 2018-02-25
-  glib_networking = glib-networking; # added 2018-02-25
+  geocode_glib = pkgs.geocode-glib; # added 2018-02-25
+  glib_networking = pkgs.glib-networking; # added 2018-02-25
   gnome_common = gnome-common; # added 2018-02-25
   gnome_control_center = gnome-control-center; # added 2018-02-25
   gnome_desktop = gnome-desktop; # added 2018-02-25
@@ -399,4 +388,13 @@ lib.makeScope pkgs.newScope (self: with self; {
   yelp_xsl = yelp-xsl; # added 2018-02-25
   yelp_tools = yelp-tools; # added 2018-02-25
 
+  # added 2019-02-08
+  inherit (pkgs) atk glib gobject-introspection gspell webkitgtk gtk3 gtkmm3
+      libgtop libgudev libhttpseverywhere librsvg libsecret gdk_pixbuf gtksourceview gtksourceviewmm gtksourceview4
+      easytag meld orca rhythmbox shotwell gnome-usage
+      clutter clutter-gst clutter-gtk cogl gtk-vnc libdazzle libgda libgit2-glib libgxps libgdata libgepub libcroco libpeas libgee geocode-glib libgweather librest libzapojit libmediaart gfbgraph gexiv2 folks totem-pl-parser gcr gsound libgnomekbd vte vte_290 vte-ng gnome-menus gdl;
+  defaultIconTheme = adwaita-icon-theme;
+  gtk = gtk3;
+  gtkmm = gtkmm3;
+  rest = librest;
 })

--- a/pkgs/desktops/gnome-3/devtools/devhelp/default.nix
+++ b/pkgs/desktops/gnome-3/devtools/devhelp/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ meson ninja pkgconfig gettext itstool wrapGAppsHook appstream-glib gobject-introspection python3 ];
   buildInputs = [
     glib gtk3 webkitgtk amtk
-    gnome3.defaultIconTheme gsettings-desktop-schemas
+    gnome3.adwaita-icon-theme gsettings-desktop-schemas
   ];
 
   doCheck = true;

--- a/pkgs/desktops/gnome-3/devtools/nemiver/default.nix
+++ b/pkgs/desktops/gnome-3/devtools/nemiver/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchpatch, pkgconfig, gnome3, gtk3, libxml2, intltool, itstool, gdb,
-  boost, sqlite, libgtop, glibmm, gtkmm, vte, gtksourceview, gsettings-desktop-schemas,
+  boost, sqlite, libgtop, glibmm, gtkmm3, vte, gtksourceview, gsettings-desktop-schemas,
   gtksourceviewmm, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     gtk3 gdb boost sqlite libgtop
-    glibmm gtkmm vte gtksourceview gtksourceviewmm
+    glibmm gtkmm3 vte gtksourceview gtksourceviewmm
     gsettings-desktop-schemas
   ];
 

--- a/pkgs/desktops/gnome-3/games/atomix/default.nix
+++ b/pkgs/desktops/gnome-3/games/atomix/default.nix
@@ -13,7 +13,7 @@ in stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ meson ninja pkgconfig gettext wrapGAppsHook python3 ];
-  buildInputs = [ glib gtk3 gdk_pixbuf libgnome-games-support gnome3.defaultIconTheme ];
+  buildInputs = [ glib gtk3 gdk_pixbuf libgnome-games-support gnome3.adwaita-icon-theme ];
 
   postPatch = ''
     chmod +x meson_post_install.py

--- a/pkgs/desktops/gnome-3/games/five-or-more/default.nix
+++ b/pkgs/desktops/gnome-3/games/five-or-more/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ meson ninja pkgconfig gettext itstool libxml2 python3 wrapGAppsHook ];
   buildInputs = [
-    gtk3 librsvg libgnome-games-support gnome3.defaultIconTheme
+    gtk3 librsvg libgnome-games-support gnome3.adwaita-icon-theme
   ];
 
   postPatch = ''

--- a/pkgs/desktops/gnome-3/games/four-in-a-row/default.nix
+++ b/pkgs/desktops/gnome-3/games/four-in-a-row/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig wrapGAppsHook gettext itstool libxml2 ];
-  buildInputs = [ gtk3 libcanberra-gtk3 librsvg gnome3.defaultIconTheme ];
+  buildInputs = [ gtk3 libcanberra-gtk3 librsvg gnome3.adwaita-icon-theme ];
 
   passthru = {
     updateScript = gnome3.updateScript {

--- a/pkgs/desktops/gnome-3/games/gnome-chess/default.nix
+++ b/pkgs/desktops/gnome-3/games/gnome-chess/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ meson ninja vala pkgconfig gettext itstool libxml2 python3 wrapGAppsHook gobject-introspection ];
-  buildInputs = [ glib gtk3 librsvg gnome3.defaultIconTheme ];
+  buildInputs = [ glib gtk3 librsvg gnome3.adwaita-icon-theme ];
 
   postPatch = ''
     chmod +x meson_post_install.py

--- a/pkgs/desktops/gnome-3/games/gnome-klotski/default.nix
+++ b/pkgs/desktops/gnome-3/games/gnome-klotski/default.nix
@@ -13,7 +13,7 @@ in stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig vala wrapGAppsHook intltool itstool libxml2 appstream-glib desktop-file-utils ];
-  buildInputs = [ glib gtk3 librsvg libgee libgnome-games-support gnome3.defaultIconTheme ];
+  buildInputs = [ glib gtk3 librsvg libgee libgnome-games-support gnome3.adwaita-icon-theme ];
 
   passthru = {
     updateScript = gnome3.updateScript {

--- a/pkgs/desktops/gnome-3/games/gnome-mahjongg/default.nix
+++ b/pkgs/desktops/gnome-3/games/gnome-mahjongg/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
     gtk3 wrapGAppsHook librsvg intltool itstool libxml2
-    gnome3.defaultIconTheme
+    gnome3.adwaita-icon-theme
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/desktops/gnome-3/games/gnome-mines/default.nix
+++ b/pkgs/desktops/gnome-3/games/gnome-mines/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   # gobject-introspection for finding vapi files
   nativeBuildInputs = [ meson ninja vala gobject-introspection pkgconfig gettext itstool python3 libxml2 wrapGAppsHook ];
-  buildInputs = [ gtk3 librsvg gnome3.defaultIconTheme libgnome-games-support libgee ];
+  buildInputs = [ gtk3 librsvg gnome3.adwaita-icon-theme libgnome-games-support libgee ];
 
   postPatch = ''
     chmod +x data/meson_compile_gschema.py # patchShebangs requires executable file

--- a/pkgs/desktops/gnome-3/games/gnome-nibbles/default.nix
+++ b/pkgs/desktops/gnome-3/games/gnome-nibbles/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig wrapGAppsHook intltool itstool libxml2 ];
   buildInputs = [
-    gtk3 librsvg libcanberra-gtk3 clutter-gtk gnome3.defaultIconTheme
+    gtk3 librsvg libcanberra-gtk3 clutter-gtk gnome3.adwaita-icon-theme
     libgee libgnome-games-support
   ];
 

--- a/pkgs/desktops/gnome-3/games/gnome-robots/default.nix
+++ b/pkgs/desktops/gnome-3/games/gnome-robots/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
     gtk3 wrapGAppsHook intltool itstool librsvg libcanberra-gtk3
-    libxml2 gnome3.defaultIconTheme libgnome-games-support libgee
+    libxml2 gnome3.adwaita-icon-theme libgnome-games-support libgee
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/desktops/gnome-3/games/gnome-sudoku/default.nix
+++ b/pkgs/desktops/gnome-3/games/gnome-sudoku/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, meson, ninja, vala, pkgconfig, gobject-introspection, gettext, gtk3, gnome3, wrapGAppsHook
-, json-glib, qqwing, itstool, libxml2, python3, desktop-file-utils }:
+, libgee, json-glib, qqwing, itstool, libxml2, python3, desktop-file-utils }:
 
 stdenv.mkDerivation rec {
   name = "gnome-sudoku-${version}";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ meson ninja vala pkgconfig gobject-introspection gettext itstool libxml2 python3 desktop-file-utils wrapGAppsHook ];
-  buildInputs = [ gtk3 gnome3.libgee json-glib qqwing ];
+  buildInputs = [ gtk3 libgee json-glib qqwing ];
 
   postPatch = ''
     chmod +x post_install.py # patchShebangs requires executable file

--- a/pkgs/desktops/gnome-3/games/gnome-taquin/default.nix
+++ b/pkgs/desktops/gnome-3/games/gnome-taquin/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
     gtk3 wrapGAppsHook librsvg libcanberra-gtk3
-    intltool itstool libxml2 gnome3.defaultIconTheme
+    intltool itstool libxml2 gnome3.adwaita-icon-theme
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/desktops/gnome-3/games/gnome-tetravex/default.nix
+++ b/pkgs/desktops/gnome-3/games/gnome-tetravex/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
-    gtk3 wrapGAppsHook intltool itstool libxml2 gnome3.defaultIconTheme
+    gtk3 wrapGAppsHook intltool itstool libxml2 gnome3.adwaita-icon-theme
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/desktops/gnome-3/games/hitori/default.nix
+++ b/pkgs/desktops/gnome-3/games/hitori/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
     gtk3 wrapGAppsHook intltool itstool libxml2
-    gnome3.defaultIconTheme
+    gnome3.adwaita-icon-theme
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/desktops/gnome-3/games/iagno/default.nix
+++ b/pkgs/desktops/gnome-3/games/iagno/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig wrapGAppsHook itstool libxml2 ];
-  buildInputs = [ gtk3 gnome3.defaultIconTheme gdk_pixbuf librsvg libcanberra-gtk3 ];
+  buildInputs = [ gtk3 gnome3.adwaita-icon-theme gdk_pixbuf librsvg libcanberra-gtk3 ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/desktops/gnome-3/games/lightsoff/default.nix
+++ b/pkgs/desktops/gnome-3/games/lightsoff/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     vala pkgconfig wrapGAppsHook itstool gettext appstream-glib libxml2
     meson ninja python3
   ];
-  buildInputs = [ gtk3 gnome3.defaultIconTheme gdk_pixbuf librsvg clutter clutter-gtk ];
+  buildInputs = [ gtk3 gnome3.adwaita-icon-theme gdk_pixbuf librsvg clutter clutter-gtk ];
 
   passthru = {
     updateScript = gnome3.updateScript {

--- a/pkgs/desktops/gnome-3/games/quadrapassel/default.nix
+++ b/pkgs/desktops/gnome-3/games/quadrapassel/default.nix
@@ -15,7 +15,7 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig itstool intltool wrapGAppsHook ];
   buildInputs = [
-    gtk3 gnome3.defaultIconTheme gdk_pixbuf librsvg
+    gtk3 gnome3.adwaita-icon-theme gdk_pixbuf librsvg
     libcanberra-gtk3 clutter libxml2 clutter-gtk
   ];
 

--- a/pkgs/desktops/gnome-3/games/swell-foop/default.nix
+++ b/pkgs/desktops/gnome-3/games/swell-foop/default.nix
@@ -20,7 +20,7 @@ in stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ meson ninja vala pkgconfig wrapGAppsHook python3 itstool gettext libxml2 desktop-file-utils ];
-  buildInputs = [ glib gtk3 gnome3.defaultIconTheme clutter clutter-gtk ];
+  buildInputs = [ glib gtk3 gnome3.adwaita-icon-theme clutter clutter-gtk ];
 
   postPatch = ''
     chmod +x meson_post_install.py # patchShebangs requires executable file

--- a/pkgs/desktops/gnome-3/games/tali/default.nix
+++ b/pkgs/desktops/gnome-3/games/tali/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ gtk3 gnome3.defaultIconTheme gdk_pixbuf librsvg
+  buildInputs = [ gtk3 gnome3.adwaita-icon-theme gdk_pixbuf librsvg
                   libxml2 itstool intltool wrapGAppsHook ];
 
   enableParallelBuilding = true;

--- a/pkgs/desktops/gnome-3/misc/geary/default.nix
+++ b/pkgs/desktops/gnome-3/misc/geary/default.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchurl, intltool, pkgconfig, gtk3, vala_0_40, enchant
 , wrapGAppsHook, gdk_pixbuf, cmake, ninja, desktop-file-utils
 , libnotify, libcanberra-gtk3, libsecret, gmime, isocodes
-, gobject-introspection, libpthreadstubs, sqlite, gcr
+, gobject-introspection, libpthreadstubs, sqlite, gcr, libgee
+, gsettings-desktop-schemas, adwaita-icon-theme
 , gnome3, librsvg, gnome-doc-utils, webkitgtk, fetchpatch }:
 
 let
@@ -40,9 +41,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ vala_0_40 intltool pkgconfig wrapGAppsHook cmake ninja desktop-file-utils gnome-doc-utils gobject-introspection ];
   buildInputs = [
-    gtk3 enchant webkitgtk libnotify libcanberra-gtk3 gnome3.libgee libsecret gmime sqlite
-    libpthreadstubs gnome3.gsettings-desktop-schemas gcr isocodes
-    gdk_pixbuf librsvg gnome3.defaultIconTheme
+    gtk3 enchant webkitgtk libnotify libcanberra-gtk3 libgee libsecret gmime sqlite
+    libpthreadstubs gsettings-desktop-schemas gcr isocodes
+    gdk_pixbuf librsvg adwaita-icon-theme
   ];
 
   cmakeFlags = [

--- a/pkgs/desktops/gnome-3/misc/gitg/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gitg/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchurl, fetchpatch, vala, intltool, pkgconfig, gtk3, glib
 , json-glib, wrapGAppsHook, libpeas, bash, gobject-introspection
+, libsoup, gtksourceview, gsettings-desktop-schemas, adwaita-icon-theme
 , gnome3, gtkspell3, shared-mime-info, libgee, libgit2-glib, libsecret
 , meson, ninja, python3
  }:
@@ -35,9 +36,9 @@ in stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   buildInputs = [
-    gtk3 glib json-glib libgee libpeas gnome3.libsoup
-    libgit2-glib gtkspell3 gnome3.gtksourceview gnome3.gsettings-desktop-schemas
-    libsecret gobject-introspection gnome3.adwaita-icon-theme
+    gtk3 glib json-glib libgee libpeas libsoup
+    libgit2-glib gtkspell3 gtksourceview gsettings-desktop-schemas
+    libsecret gobject-introspection adwaita-icon-theme
   ];
 
   nativeBuildInputs = [ meson ninja python3 vala wrapGAppsHook intltool pkgconfig ];

--- a/pkgs/desktops/gnome-3/misc/gnome-flashback/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gnome-flashback/default.nix
@@ -10,7 +10,7 @@
 , gnome-session
 , gnome3
 , gsettings-desktop-schemas
-, gtk
+, gtk3
 , ibus
 , intltool
 , libcanberra-gtk3
@@ -85,7 +85,7 @@ let
       gnome-bluetooth
       gnome-desktop
       gsettings-desktop-schemas
-      gtk
+      gtk3
       ibus
       libcanberra-gtk3
       libpulseaudio

--- a/pkgs/desktops/gnome-3/misc/gnome-packagekit/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gnome-packagekit/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, meson, ninja, gettext, gnome3, packagekit, polkit
-, systemd, wrapGAppsHook, desktop-file-utils }:
+, gtk3, systemd, wrapGAppsHook, desktop-file-utils }:
 
 stdenv.mkDerivation rec {
   name = "gnome-packagekit-${version}";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig meson ninja gettext wrapGAppsHook desktop-file-utils ];
-  buildInputs = [ gnome3.gtk packagekit systemd polkit ];
+  buildInputs = [ gtk3 packagekit systemd polkit ];
 
   postPatch = ''
     patchShebangs meson_post_install.sh

--- a/pkgs/desktops/gnome-3/misc/gnome-panel/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gnome-panel/default.nix
@@ -11,7 +11,7 @@
 , gnome-flashback
 , gnome-menus
 , gnome3
-, gtk
+, gtk3
 , itstool
 , libgweather
 , libsoup
@@ -77,7 +77,7 @@ in stdenv.mkDerivation rec {
     glib
     gnome-desktop
     gnome-menus
-    gtk
+    gtk3
     libgweather
     libsoup
     libwnck3

--- a/pkgs/desktops/gnome-3/misc/gnome-screensaver/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gnome-screensaver/default.nix
@@ -7,7 +7,7 @@
 , gnome-common
 , gnome-desktop
 , gnome3
-, gtk
+, gtk3
 , gsettings-desktop-schemas
 , pkgconfig
 , intltool
@@ -66,7 +66,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     glib
-    gtk
+    gtk3
     gnome-desktop
     dbus-glib
     pam

--- a/pkgs/desktops/gnome-3/misc/gnome-tweaks/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gnome-tweaks/default.nix
@@ -19,7 +19,7 @@ in stdenv.mkDerivation rec {
   ];
   buildInputs = [
     gtk3 glib gnome3.gsettings-desktop-schemas
-    gdk_pixbuf gnome3.defaultIconTheme
+    gdk_pixbuf gnome3.adwaita-icon-theme
     libnotify gnome3.gnome-shell python3Packages.pygobject3
     libsoup gnome3.gnome-settings-daemon gnome3.nautilus
     gnome3.mutter gnome3.gnome-desktop gobject-introspection

--- a/pkgs/desktops/gnome-3/misc/metacity/default.nix
+++ b/pkgs/desktops/gnome-3/misc/metacity/default.nix
@@ -4,7 +4,7 @@
 , glib
 , gnome3
 , gsettings-desktop-schemas
-, gtk
+, gtk3
 , libcanberra-gtk3
 , libgtop
 , libstartup_notification
@@ -42,7 +42,7 @@ in stdenv.mkDerivation rec {
   buildInputs = [
     glib
     gsettings-desktop-schemas
-    gtk
+    gtk3
     libcanberra-gtk3
     libgtop
     libstartup_notification

--- a/pkgs/desktops/gnome-3/misc/pomodoro/default.nix
+++ b/pkgs/desktops/gnome-3/misc/pomodoro/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     dbus-glib libcanberra gst_all_1.gstreamer
     gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good
     gnome3.gsettings-desktop-schemas
-    gnome3.gnome-shell gtk3 gnome3.defaultIconTheme
+    gnome3.gnome-shell gtk3 gnome3.adwaita-icon-theme
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/desktops/mate/pluma/default.nix
+++ b/pkgs/desktops/mate/pluma/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     python
     gnome3.gtksourceview
     gnome3.libpeas
-    gnome3.defaultIconTheme
+    gnome3.adwaita-icon-theme
     mate.mate-desktop
   ];
 

--- a/pkgs/desktops/pantheon/services/elementary-settings-daemon/default.nix
+++ b/pkgs/desktops/pantheon/services/elementary-settings-daemon/default.nix
@@ -1,5 +1,6 @@
 { fetchurl, fetchgit, substituteAll, stdenv, meson, ninja, pkgconfig, gnome3, perl, gettext, glib, libnotify, lcms2, libXtst
 , libxkbfile, libpulseaudio, alsaLib, libcanberra-gtk3, upower, colord, libgweather, polkit
+, geocode-glib, gtk3
 , geoclue2, librsvg, xf86_input_wacom, udev, libgudev, libwacom, libxslt, libxml2, networkmanager
 , docbook_xsl, wrapGAppsHook, python3, ibus, xkeyboard_config, tzdata, nss, pantheon, accountsservice }:
 
@@ -75,16 +76,16 @@ stdenv.mkDerivation rec {
     wrapGAppsHook
   ];
 
-  buildInputs = with gnome3; [
+  buildInputs = [
     accountsservice
     alsaLib
     colord
     geoclue2
     geocode-glib
     glib
-    gnome-desktop
-    gsettings-desktop-schemas
-    gtk
+    gnome3.gnome-desktop
+    gnome3.gsettings-desktop-schemas
+    gtk3
     ibus
     lcms2
     libXtst

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -286,7 +286,7 @@ self: super: builtins.intersectAttrs super {
   # Tries to run GUI in tests
   leksah = dontCheck (overrideCabal super.leksah (drv: {
     executableSystemDepends = (drv.executableSystemDepends or []) ++ (with pkgs; [
-      gnome3.defaultIconTheme # Fix error: Icon 'window-close' not present in theme ...
+      gnome3.adwaita-icon-theme # Fix error: Icon 'window-close' not present in theme ...
       wrapGAppsHook           # Fix error: GLib-GIO-ERROR **: No GSettings schemas are installed on the system
       gtk3                    # Fix error: GLib-GIO-ERROR **: Settings schema 'org.gtk.Settings.FileChooser' is not installed
     ]);

--- a/pkgs/development/libraries/amtk/default.nix
+++ b/pkgs/development/libraries/amtk/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl
+{ stdenv, fetchurl, gtk3
 , pkgconfig, gnome3, dbus, xvfb_run }:
 let
   version = "5.0.0";
@@ -17,7 +17,7 @@ in stdenv.mkDerivation {
   ];
 
   buildInputs = [
-    gnome3.gtk
+    gtk3
   ];
 
   doCheck = stdenv.isLinux;

--- a/pkgs/development/libraries/aravis/default.nix
+++ b/pkgs/development/libraries/aravis/default.nix
@@ -55,7 +55,7 @@ in
       ++ stdenv.lib.optional enableUsb libusb
       ++ stdenv.lib.optional enablePacketSocket audit
       ++ stdenv.lib.optionals (enableViewer || enableGstPlugin) [ gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad ]
-      ++ stdenv.lib.optionals (enableViewer) [ libnotify gnome3.gtk3 gnome3.defaultIconTheme ];
+      ++ stdenv.lib.optionals (enableViewer) [ libnotify gnome3.gtk3 gnome3.adwaita-icon-theme ];
 
     preAutoreconf = ''./autogen.sh'';
 

--- a/pkgs/development/libraries/gegl/4.0.nix
+++ b/pkgs/development/libraries/gegl/4.0.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, glib, babl, libpng, cairo, libjpeg, which
 , librsvg, pango, gtk, bzip2, json-glib, intltool, autoreconfHook, libraw
-, libwebp, gnome3, libintl }:
+, gexiv2, libwebp, gnome3, libintl }:
 
 let
   version = "0.4.12";
@@ -21,7 +21,7 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [
     libpng cairo libjpeg librsvg pango gtk bzip2
-    libraw libwebp gnome3.gexiv2
+    libraw libwebp gexiv2
   ];
 
   propagatedBuildInputs = [ glib json-glib babl ]; # for gegl-4.0.pc

--- a/pkgs/development/libraries/geocode-glib/default.nix
+++ b/pkgs/development/libraries/geocode-glib/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, meson, ninja, pkgconfig, gettext, gtk-doc, docbook_xsl, gobject-introspection, gnome3, libsoup, json-glib }:
+{ fetchurl, stdenv, meson, ninja, pkgconfig, gettext, gtk-doc, docbook_xsl, gobject-introspection, gnome3, libsoup, json-glib, glib }:
 
 stdenv.mkDerivation rec {
   pname = "geocode-glib";
@@ -11,8 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "1vmydxs5xizcmaxpkfrq75xpj6pqrpdjizxyb30m00h54yqqch7a";
   };
 
-  nativeBuildInputs = with gnome3; [ meson ninja pkgconfig gettext gtk-doc docbook_xsl gobject-introspection ];
-  buildInputs = with gnome3; [ glib libsoup json-glib ];
+  nativeBuildInputs = [ meson ninja pkgconfig gettext gtk-doc docbook_xsl gobject-introspection ];
+  buildInputs = [ glib libsoup json-glib ];
 
   patches = [
     ./installed-tests-path.patch

--- a/pkgs/development/libraries/libgda/default.nix
+++ b/pkgs/development/libraries/libgda/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, itstool, libxml2, gtk3, openssl, gnome3, gobject-introspection, vala
+{ stdenv, fetchurl, pkgconfig, intltool, itstool, libxml2, gtk3, openssl, gnome3, gobject-introspection, vala, libgee
 , overrideCC, gcc6
 , mysqlSupport ? false, mysql ? null
 , postgresSupport ? false, postgresql ? null
@@ -24,7 +24,7 @@ assert postgresSupport -> postgresql != null;
   hardeningDisable = [ "format" ];
 
   nativeBuildInputs = [ pkgconfig intltool itstool libxml2 gobject-introspection vala ];
-  buildInputs = with stdenv.lib; [ gtk3 openssl gnome3.libgee ]
+  buildInputs = with stdenv.lib; [ gtk3 openssl libgee ]
     ++ optional (mysqlSupport) mysql.connector-c
     ++ optional (postgresSupport) postgresql;
 

--- a/pkgs/development/libraries/libgdata/default.nix
+++ b/pkgs/development/libraries/libgdata/default.nix
@@ -14,8 +14,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig intltool gobject-introspection ];
 
-  buildInputs = with gnome3;
-    [ libsoup libxml2 glib liboauth gcr gnome-online-accounts p11-kit openssl uhttpmock ];
+  buildInputs = [ gnome3.libsoup libxml2 glib liboauth gcr gnome3.gnome-online-accounts p11-kit openssl uhttpmock ];
 
   propagatedBuildInputs = [ json-glib ];
 

--- a/pkgs/development/libraries/osm-gps-map/default.nix
+++ b/pkgs/development/libraries/osm-gps-map/default.nix
@@ -1,4 +1,4 @@
-{ cairo, fetchzip, glib, gnome3, gobject-introspection, pkgconfig, stdenv }:
+{ cairo, fetchzip, glib, gnome3, gtk3, gobject-introspection, pkgconfig, stdenv }:
 
 stdenv.mkDerivation rec {
   name = "osm-gps-map-${version}";
@@ -15,9 +15,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     cairo glib gobject-introspection
-  ] ++ (with gnome3; [
-    gnome-common gtk libsoup
-  ]);
+    gnome3.gnome-common gtk3 gnome3.libsoup
+  ];
 
   meta = with stdenv.lib; {
     description = "Gtk+ widget for displaying OpenStreetMap tiles";

--- a/pkgs/development/tools/misc/d-feet/default.nix
+++ b/pkgs/development/tools/misc/d-feet/default.nix
@@ -14,7 +14,7 @@ in python3Packages.buildPythonApplication rec {
   };
 
   nativeBuildInputs = [ pkgconfig itstool intltool wrapGAppsHook libxml2 ];
-  buildInputs = [ glib gtk3 gnome3.defaultIconTheme libwnck3 gobject-introspection ];
+  buildInputs = [ glib gtk3 gnome3.adwaita-icon-theme libwnck3 gobject-introspection ];
 
   propagatedBuildInputs = with python3Packages; [ pygobject3 pep8 ];
 

--- a/pkgs/development/tools/profiling/sysprof/default.nix
+++ b/pkgs/development/tools/profiling/sysprof/default.nix
@@ -38,7 +38,7 @@ in stdenv.mkDerivation rec {
     pkgconfig
     shared-mime-info
     wrapGAppsHook
-    gnome3.defaultIconTheme
+    gnome3.adwaita-icon-theme
   ];
   buildInputs = [ glib gtk3 pango polkit systemd.dev systemd.lib ];
 

--- a/pkgs/misc/emulators/cdemu/analyzer.nix
+++ b/pkgs/misc/emulators/cdemu/analyzer.nix
@@ -6,7 +6,7 @@ let pkg = import ./base.nix {
 };
 in callPackage pkg {
   buildInputs = [ glib gtk3 libxml2 gnuplot (callPackage ./libmirage.nix {}) makeWrapper
-                  gnome3.defaultIconTheme gdk_pixbuf librsvg intltool ];
+                  gnome3.adwaita-icon-theme gdk_pixbuf librsvg intltool ];
   drvParams = {
     postFixup = ''
       wrapProgram $out/bin/image-analyzer \

--- a/pkgs/misc/emulators/cdemu/gui.nix
+++ b/pkgs/misc/emulators/cdemu/gui.nix
@@ -8,7 +8,7 @@ let
   inherit (pythonPackages) python pygobject3;
 in callPackage pkg {
   buildInputs = [ python pygobject3 gtk3 glib libnotify intltool makeWrapper
-                  gnome3.defaultIconTheme gdk_pixbuf librsvg ];
+                  gnome3.adwaita-icon-theme gdk_pixbuf librsvg ];
   drvParams = {
     postFixup = ''
       wrapProgram $out/bin/gcdemu \

--- a/pkgs/os-specific/linux/piper/default.nix
+++ b/pkgs/os-specific/linux/piper/default.nix
@@ -16,7 +16,7 @@ python3.pkgs.buildPythonApplication rec {
   };
 
   nativeBuildInputs = [ meson ninja gettext pkgconfig wrapGAppsHook desktop-file-utils appstream-glib gobject-introspection ];
-  buildInputs = [ gtk3 glib gnome3.defaultIconTheme python3 ];
+  buildInputs = [ gtk3 glib gnome3.adwaita-icon-theme python3 ];
   propagatedBuildInputs = with python3.pkgs; [ lxml evdev pygobject3 ];
 
   postPatch = ''

--- a/pkgs/tools/audio/gvolicon/default.nix
+++ b/pkgs/tools/audio/gvolicon/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
-    makeWrapper alsaLib gnome3.gtk gdk_pixbuf gnome3.defaultIconTheme
+    makeWrapper alsaLib gnome3.gtk gdk_pixbuf gnome3.adwaita-icon-theme
     librsvg wrapGAppsHook
   ];
 

--- a/pkgs/tools/audio/pasystray/default.nix
+++ b/pkgs/tools/audio/pasystray/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig autoreconfHook wrapGAppsHook ];
   buildInputs = [
-    gnome3.defaultIconTheme
+    gnome3.adwaita-icon-theme
     avahi gtk3 libappindicator-gtk3 libnotify libpulseaudio xlibsWrapper
     gnome3.gsettings-desktop-schemas
   ];

--- a/pkgs/tools/graphics/luxcorerender/default.nix
+++ b/pkgs/tools/graphics/luxcorerender/default.nix
@@ -33,7 +33,7 @@ in stdenv.mkDerivation rec {
      # needed for GSETTINGS_SCHEMAS_PATH
      gsettings-desktop-schemas glib gnome3.gtk
      # needed for XDG_ICON_DIRS
-     gnome3.defaultIconTheme
+     gnome3.adwaita-icon-theme
      makeWrapper
      (stdenv.lib.getLib gnome3.dconf)
    ] ++ stdenv.lib.optionals withOpenCL [opencl-headers ocl-icd opencl-clhpp];
@@ -65,7 +65,7 @@ in stdenv.mkDerivation rec {
   preFixup = ''
     wrapProgram "$out/bin/luxcoreui" \
       --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH" \
-      --suffix XDG_DATA_DIRS : '${gnome3.defaultIconTheme}/share' \
+      --suffix XDG_DATA_DIRS : '${gnome3.adwaita-icon-theme}/share' \
       --prefix GIO_EXTRA_MODULES : "${stdenv.lib.getLib gnome3.dconf}/lib/gio/modules"
   '';
 

--- a/pkgs/tools/inputmethods/fcitx/fcitx-configtool.nix
+++ b/pkgs/tools/inputmethods/fcitx/fcitx-configtool.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ makeWrapper fcitx cmake isocodes gtk3
-    gnome3.defaultIconTheme ];
+    gnome3.adwaita-icon-theme ];
 
   preFixup = ''
     wrapProgram $out/bin/fcitx-config-gtk3 \

--- a/pkgs/tools/networking/gupnp-tools/default.nix
+++ b/pkgs/tools/networking/gupnp-tools/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ meson ninja pkgconfig gettext wrapGAppsHook ];
-  buildInputs = [ gupnp libuuid gssdp gtk3 gupnp-av gtksourceview4 gnome3.defaultIconTheme ];
+  buildInputs = [ gupnp libuuid gssdp gtk3 gupnp-av gtksourceview4 gnome3.adwaita-icon-theme ];
 
   passthru = {
     updateScript = gnome3.updateScript {

--- a/pkgs/tools/networking/network-manager/applet.nix
+++ b/pkgs/tools/networking/network-manager/applet.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, meson, ninja, intltool, gtk-doc, pkgconfig, networkmanager, gnome3
 , libnotify, libsecret, polkit, isocodes, modemmanager, libxml2, docbook_xsl, docbook_xml_dtd_43
 , mobile-broadband-provider-info, glib-networking, gsettings-desktop-schemas
-, libgudev, jansson, wrapGAppsHook, gobject-introspection, python3
+, libgudev, jansson, wrapGAppsHook, gobject-introspection, python3, gtk3
 , libappindicator-gtk3, withGnome ? false, gcr }:
 
 let
@@ -25,10 +25,10 @@ in stdenv.mkDerivation rec {
   outputs = [ "out" "lib" "dev" "devdoc" "man" ];
 
   buildInputs = [
-    gnome3.gtk networkmanager libnotify libsecret gsettings-desktop-schemas
+    gtk3 networkmanager libnotify libsecret gsettings-desktop-schemas
     polkit isocodes mobile-broadband-provider-info libgudev
     modemmanager jansson glib-networking
-    libappindicator-gtk3 gnome3.defaultIconTheme
+    libappindicator-gtk3 gnome3.adwaita-icon-theme
   ] ++ stdenv.lib.optionals withGnome [ gcr ]; # advanced certificate chooser
 
   nativeBuildInputs = [ meson ninja intltool pkgconfig wrapGAppsHook gobject-introspection python3 gtk-doc docbook_xsl docbook_xml_dtd_43 libxml2 ];

--- a/pkgs/tools/networking/network-manager/fortisslvpn/default.nix
+++ b/pkgs/tools/networking/network-manager/fortisslvpn/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, substituteAll, openfortivpn, intltool, pkgconfig,
+{ stdenv, fetchurl, substituteAll, openfortivpn, intltool, pkgconfig, gtk3,
 networkmanager, ppp, libsecret, withGnome ? true, gnome3 }:
 
 let
@@ -20,7 +20,7 @@ in stdenv.mkDerivation rec {
   ];
 
   buildInputs = [ openfortivpn networkmanager ppp ]
-    ++ stdenv.lib.optionals withGnome [ gnome3.gtk libsecret gnome3.networkmanagerapplet ];
+    ++ stdenv.lib.optionals withGnome [ gtk3 libsecret gnome3.networkmanagerapplet ];
 
   nativeBuildInputs = [ intltool pkgconfig ];
 

--- a/pkgs/tools/networking/network-manager/iodine/default.nix
+++ b/pkgs/tools/networking/network-manager/iodine/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, substituteAll, iodine, intltool, pkgconfig, networkmanager, libsecret
+{ stdenv, fetchurl, substituteAll, iodine, intltool, pkgconfig, networkmanager, libsecret, gtk3
 , withGnome ? true, gnome3 }:
 
 let
@@ -20,7 +20,7 @@ in stdenv.mkDerivation rec {
   ];
 
   buildInputs = [ iodine networkmanager ]
-    ++ stdenv.lib.optionals withGnome [ gnome3.gtk libsecret gnome3.networkmanagerapplet ];
+    ++ stdenv.lib.optionals withGnome [ gtk3 libsecret gnome3.networkmanagerapplet ];
 
   nativeBuildInputs = [ intltool pkgconfig ];
 

--- a/pkgs/tools/networking/network-manager/l2tp/default.nix
+++ b/pkgs/tools/networking/network-manager/l2tp/default.nix
@@ -1,5 +1,5 @@
 { stdenv, substituteAll, fetchFromGitHub, autoreconfHook, libtool, intltool, pkgconfig
-, networkmanager, ppp, xl2tpd, strongswan, libsecret
+, gtk3, networkmanager, ppp, xl2tpd, strongswan, libsecret
 , withGnome ? true, gnome3, networkmanagerapplet }:
 
 stdenv.mkDerivation rec {
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [ networkmanager ppp ]
-    ++ stdenv.lib.optionals withGnome [ gnome3.gtk libsecret networkmanagerapplet ];
+    ++ stdenv.lib.optionals withGnome [ gtk3 libsecret networkmanagerapplet ];
 
   nativeBuildInputs = [ autoreconfHook libtool intltool pkgconfig ];
 

--- a/pkgs/tools/networking/network-manager/openconnect/default.nix
+++ b/pkgs/tools/networking/network-manager/openconnect/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, substituteAll, openconnect, intltool, pkgconfig, networkmanager, libsecret
-, withGnome ? true, gnome3, kmod }:
+, gtk3, withGnome ? true, gnome3, kmod }:
 
 let
   pname   = "NetworkManager-openconnect";
@@ -20,7 +20,7 @@ in stdenv.mkDerivation rec {
   ];
 
   buildInputs = [ openconnect networkmanager ]
-    ++ stdenv.lib.optionals withGnome [ gnome3.gtk libsecret ];
+    ++ stdenv.lib.optionals withGnome [ gtk3 libsecret ];
 
   nativeBuildInputs = [ intltool pkgconfig ];
 

--- a/pkgs/tools/networking/network-manager/openvpn/default.nix
+++ b/pkgs/tools/networking/network-manager/openvpn/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, substituteAll, openvpn, intltool, libxml2, pkgconfig, file, networkmanager, libsecret
-, withGnome ? true, gnome3, kmod }:
+, gtk3, withGnome ? true, gnome3, kmod }:
 
 let
   pname = "NetworkManager-openvpn";
@@ -20,7 +20,7 @@ in stdenv.mkDerivation rec {
   ];
 
   buildInputs = [ openvpn networkmanager ]
-    ++ stdenv.lib.optionals withGnome [ gnome3.gtk libsecret gnome3.networkmanagerapplet ];
+    ++ stdenv.lib.optionals withGnome [ gtk3 libsecret gnome3.networkmanagerapplet ];
 
   nativeBuildInputs = [ intltool pkgconfig file libxml2 ];
 

--- a/pkgs/tools/networking/network-manager/vpnc/default.nix
+++ b/pkgs/tools/networking/network-manager/vpnc/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, substituteAll, vpnc, intltool, pkgconfig, networkmanager, libsecret
-, withGnome ? true, gnome3, kmod, file }:
+, gtk3, withGnome ? true, gnome3, kmod, file }:
 let
   pname = "NetworkManager-vpnc";
   version = "1.2.6";
@@ -19,7 +19,7 @@ in stdenv.mkDerivation rec {
   ];
 
   buildInputs = [ vpnc networkmanager ]
-    ++ stdenv.lib.optionals withGnome [ gnome3.gtk libsecret gnome3.networkmanagerapplet ];
+    ++ stdenv.lib.optionals withGnome [ gtk3 libsecret gnome3.networkmanagerapplet ];
 
   nativeBuildInputs = [ intltool pkgconfig file ];
 

--- a/pkgs/tools/security/onioncircuits/default.nix
+++ b/pkgs/tools/security/onioncircuits/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, pythonPackages, intltool, gtk3, gobject-introspection, defaultIconTheme }:
+{ stdenv, fetchgit, pythonPackages, intltool, gtk3, gobject-introspection, gnome3 }:
 
 pythonPackages.buildPythonApplication rec {
   name = "onioncircuits-${version}";
@@ -16,7 +16,7 @@ pythonPackages.buildPythonApplication rec {
   postFixup = ''
     wrapProgram "$out/bin/onioncircuits" \
       --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH" \
-      --prefix XDG_DATA_DIRS : "$out/share:${defaultIconTheme}/share"
+      --prefix XDG_DATA_DIRS : "$out/share:${gnome3.adwaita-icon-theme}/share"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1985,7 +1985,7 @@ in
 
   ibus = callPackage ../tools/inputmethods/ibus {
     gconf = gnome2.GConf;
-    inherit (gnome3) dconf glib;
+    inherit (gnome3) dconf;
   };
 
   ibus-qt = callPackage ../tools/inputmethods/ibus/ibus-qt.nix { };
@@ -4551,9 +4551,7 @@ in
 
   omping = callPackage ../applications/networking/omping { };
 
-  onioncircuits = callPackage ../tools/security/onioncircuits {
-    inherit (gnome3) defaultIconTheme;
-  };
+  onioncircuits = callPackage ../tools/security/onioncircuits { };
 
   openapi-generator-cli = callPackage ../tools/networking/openapi-generator-cli { };
 
@@ -5157,7 +5155,6 @@ in
   remind = callPackage ../tools/misc/remind { };
 
   remmina = callPackage ../applications/networking/remote/remmina {
-    adwaita-icon-theme = gnome3.adwaita-icon-theme;
     gsettings-desktop-schemas = gnome3.gsettings-desktop-schemas;
   };
 
@@ -5324,9 +5321,7 @@ in
     quazip = quazip_qt4;
   };
 
-  screenkey = python2Packages.callPackage ../applications/video/screenkey {
-    inherit (gnome3) defaultIconTheme;
-  };
+  screenkey = python2Packages.callPackage ../applications/video/screenkey { };
 
   quazip_qt4 = libsForQt5.quazip.override {
     qtbase = qt4; qmake = qmake4Hook;
@@ -5803,9 +5798,7 @@ in
 
   tor-arm = callPackage ../tools/security/tor/tor-arm.nix { };
 
-  tor-browser-bundle-bin = callPackage ../applications/networking/browsers/tor-browser-bundle-bin {
-    inherit (gnome3) defaultIconTheme;
-  };
+  tor-browser-bundle-bin = callPackage ../applications/networking/browsers/tor-browser-bundle-bin { };
 
   tor-browser-bundle = callPackage ../applications/networking/browsers/tor-browser-bundle {
     stdenv = stdenvNoCC;
@@ -12158,7 +12151,8 @@ in
       inherit perl;
       inherit (darwin) cf-private;
       inherit (gst_all_1) gstreamer gst-plugins-base;
-      inherit (gnome3) gtk3 dconf;
+      inherit gtk3;
+      inherit (gnome3) dconf;
     });
 
   libsForQt59 = lib.makeScope qt59.newScope mkLibsForQt5;
@@ -12173,7 +12167,8 @@ in
       inherit libGL;
       inherit perl;
       inherit (darwin) cf-private;
-      inherit (gnome3) gtk3 dconf;
+      inherit gtk3;
+      inherit (gnome3) dconf;
       inherit (gst_all_1) gstreamer gst-plugins-base;
     });
 
@@ -12189,7 +12184,8 @@ in
       inherit libGL;
       inherit perl;
       inherit (darwin) cf-private;
-      inherit (gnome3) gtk3 dconf;
+      inherit gtk3;
+      inherit (gnome3) dconf;
       inherit (gst_all_1) gstreamer gst-plugins-base;
     });
 
@@ -14983,9 +14979,7 @@ in
 
   nvme-cli = callPackage ../os-specific/linux/nvme-cli { };
 
-  open-vm-tools = callPackage ../applications/virtualization/open-vm-tools {
-    inherit (gnome3) gtk gtkmm;
-  };
+  open-vm-tools = callPackage ../applications/virtualization/open-vm-tools { };
   open-vm-tools-headless = open-vm-tools.override { withX = false; };
 
   delve = callPackage ../development/tools/delve { };
@@ -16022,9 +16016,7 @@ in
     inherit (pythonPackages) eyeD3;
   };
 
-  abiword = callPackage ../applications/office/abiword {
-    iconTheme = gnome3.defaultIconTheme;
-  };
+  abiword = callPackage ../applications/office/abiword { };
 
   abook = callPackage ../applications/misc/abook { };
 
@@ -16654,9 +16646,7 @@ in
 
   devede = callPackage ../applications/video/devede { };
 
-  denemo = callPackage ../applications/audio/denemo {
-    inherit (gnome3) gtksourceview;
-  };
+  denemo = callPackage ../applications/audio/denemo { };
 
   dvb_apps  = callPackage ../applications/video/dvb-apps { };
 
@@ -17246,7 +17236,6 @@ in
     generated = import ../applications/networking/browsers/firefox-bin/release_sources.nix;
     gconf = pkgs.gnome2.GConf;
     inherit (pkgs.gnome2) libgnome libgnomeui;
-    inherit (pkgs.gnome3) defaultIconTheme;
   };
 
   firefox-bin = wrapFirefox firefox-bin-unwrapped {
@@ -17261,7 +17250,6 @@ in
     generated = import ../applications/networking/browsers/firefox-bin/beta_sources.nix;
     gconf = pkgs.gnome2.GConf;
     inherit (pkgs.gnome2) libgnome libgnomeui;
-    inherit (pkgs.gnome3) defaultIconTheme;
   };
 
   firefox-beta-bin = res.wrapFirefox firefox-beta-bin-unwrapped {
@@ -17276,7 +17264,6 @@ in
     generated = import ../applications/networking/browsers/firefox-bin/devedition_sources.nix;
     gconf = pkgs.gnome2.GConf;
     inherit (pkgs.gnome2) libgnome libgnomeui;
-    inherit (pkgs.gnome3) defaultIconTheme;
   };
 
   firefox-devedition-bin = res.wrapFirefox firefox-devedition-bin-unwrapped {
@@ -17509,7 +17496,7 @@ in
   gnome-mpv = callPackage ../applications/video/gnome-mpv { };
 
   gnome-recipes = callPackage ../applications/misc/gnome-recipes {
-    inherit (gnome3) gnome-online-accounts rest gnome-autoar gspell;
+    inherit (gnome3) gnome-online-accounts gnome-autoar;
   };
 
   gollum = callPackage ../applications/misc/gollum { };
@@ -18033,7 +18020,6 @@ in
   libreoffice-args = {
     inherit (perlPackages) ArchiveZip IOCompress;
     inherit (gnome2) GConf ORBit2 gnome_vfs;
-    inherit (gnome3) defaultIconTheme;
     zip = zip.override { enableNLS = false; };
     fontsConf = makeFontsConf {
       fontDirectories = [
@@ -18555,7 +18541,6 @@ in
   };
 
   synfigstudio = callPackage ../applications/graphics/synfigstudio {
-    inherit (gnome3) defaultIconTheme;
     mlt-qt5 = libsForQt5.mlt;
   };
 
@@ -18891,9 +18876,7 @@ in
 
   pinfo = callPackage ../applications/misc/pinfo { };
 
-  pinpoint = callPackage ../applications/office/pinpoint {
-    inherit (gnome3) clutter clutter-gtk;
-  };
+  pinpoint = callPackage ../applications/office/pinpoint { };
 
   pinta = callPackage ../applications/graphics/pinta {
     gtksharp = gtk-sharp-2_0;
@@ -19091,7 +19074,7 @@ in
   quodlibet-xine = quodlibet.override { xineBackend = true; tag = "-xine"; };
 
   quodlibet-full = quodlibet.override {
-    inherit (gnome3) gtksourceview webkitgtk;
+    inherit gtksourceview webkitgtk;
     withDbusPython = true;
     withPyInotify = true;
     withMusicBrainzNgs = true;
@@ -19677,7 +19660,6 @@ in
   thunderbird-bin = callPackage ../applications/networking/mailreaders/thunderbird-bin {
     gconf = pkgs.gnome2.GConf;
     inherit (pkgs.gnome2) libgnome libgnomeui;
-    inherit (pkgs.gnome3) defaultIconTheme;
   };
 
   tig = gitAndTools.tig;
@@ -19838,9 +19820,7 @@ in
     inherit (darwin.apple_sdk.frameworks) Carbon Cocoa;
   };
 
-  vimiv = callPackage ../applications/graphics/vimiv {
-    inherit (gnome3) defaultIconTheme;
-  };
+  vimiv = callPackage ../applications/graphics/vimiv { };
 
   macvim = callPackage ../applications/editors/vim/macvim.nix { stdenv = clangStdenv; };
 
@@ -22115,9 +22095,7 @@ in
 
   bcal = callPackage ../applications/science/math/bcal { };
 
-  pspp = callPackage ../applications/science/math/pspp {
-    inherit (gnome3) gtksourceview;
-  };
+  pspp = callPackage ../applications/science/math/pspp { };
 
   pynac = callPackage ../applications/science/math/pynac { };
 
@@ -22432,7 +22410,6 @@ in
 
   gajim = callPackage ../applications/networking/instant-messengers/gajim {
     inherit (gst_all_1) gstreamer gst-plugins-base gst-libav gst-plugins-ugly;
-    inherit (gnome3) gspell defaultIconTheme;
   };
 
   gammu = callPackage ../applications/misc/gammu { };
@@ -23149,9 +23126,7 @@ in
 
   xosview2 = callPackage ../tools/X11/xosview2 { };
 
-  xpad = callPackage ../applications/misc/xpad {
-    inherit (gnome3) gtksourceview;
-  };
+  xpad = callPackage ../applications/misc/xpad { };
 
   xsane = callPackage ../applications/graphics/sane/xsane.nix {
     libpng = libpng12;
@@ -23262,9 +23237,7 @@ in
 
   iterm2 = callPackage ../applications/misc/iterm2 {};
 
-  sequeler = callPackage ../applications/misc/sequeler {
-    inherit (gnome3) gtksourceview libgda;
-  };
+  sequeler = callPackage ../applications/misc/sequeler { };
 
   sequelpro = callPackage ../applications/misc/sequelpro {};
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

