### PR TITLE
libdislocator: init at 2.52b

### DIFF
--- a/pkgs/tools/security/afl/libdislocator.nix
+++ b/pkgs/tools/security/afl/libdislocator.nix
@@ -1,0 +1,34 @@
+{ stdenv, afl}:
+
+stdenv.mkDerivation rec {
+  version = (builtins.parseDrvName afl.name).version;
+  name = "libdislocator-${version}";
+
+  src = afl.src;
+  sourceRoot = "${afl.name}/libdislocator";
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  preInstall = ''
+    mkdir -p $out/lib/afl
+  '';
+  postInstall = ''
+    mkdir $out/bin
+    cat > $out/bin/get-libdislocator-so <<END
+    #!${stdenv.shell}
+    echo $out/lib/afl/libdislocator.so
+    END
+    chmod +x $out/bin/get-libdislocator-so
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "http://lcamtuf.coredump.cx/afl/";
+    description = ''
+      Drop-in replacement for the libc allocator which improves
+      the odds of bumping into heap-related security bugs in
+      several ways.
+    '';
+    license = stdenv.lib.licenses.asl20;
+    maintainers = with maintainers; [ ris ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -441,6 +441,8 @@ in
     stdenv = clangStdenv;
   };
 
+  libdislocator = callPackage ../tools/security/afl/libdislocator.nix { };
+
   afpfs-ng = callPackage ../tools/filesystems/afpfs-ng { };
 
   agrep = callPackage ../tools/text/agrep { };


### PR DESCRIPTION
###### Motivation for this change
`afl` comes bundled with this useful little `malloc`-wrapper which we don't currently build. Would be good to expose this to users. A few odd things about this package though where I don't know if I made the right decision:

 - The source being bundled with `afl`, it doesn't really have a version number of its own. So I made it inherit `afl`'s version.
 - I exposed the `libdislocator` package in the top-level namespace because it's usable (and useful) outside the context of `afl`, but the nix file lives in `afl`'s directory and directly pulls in `afl.src` instead of just being totally independent. Weird?
 - This being a raw `.so` library where the intended use is through e.g. `$ LD_PRELOAD=/path/to/libdislocator.so ...` I didn't know how to expose this to the user's environment. The most convenient thing seemed to be to add this tiny script `get-libdislocator-so` to live in the user's path and allow them to do `$ LD_PRELOAD=$(get-libdislocator-so) ...` in the same vein as `pkg-config` and similar tools.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

