### PR TITLE
planner: unstable-2018-03-25 -> unstable-2019-02-13

### DIFF
--- a/pkgs/applications/office/planner/default.nix
+++ b/pkgs/applications/office/planner/default.nix
@@ -7,10 +7,10 @@
 , libtool
 , gnome2
 , libxslt
-, python
+, python2
 }:
 
-let version = "unstable-2018-03-25";
+let version = "unstable-2019-02-13";
 
 in stdenv.mkDerivation {
   name = "planner-${version}";
@@ -19,12 +19,9 @@ in stdenv.mkDerivation {
     domain = "gitlab.gnome.org";
     owner = "GNOME";
     repo = "planner";
-    rev = "2a2bf11d96a7f5d64f05c9053661baa848e47797";
-    sha256 = "1bhh05kkbnhibldc1fc7kv7bwf8aa1vh4q379syqd3jbas8y521g";
+    rev = "76d31defae4979aa51dd37e8888f61e9a6a51367";
+    sha256 = "0lbch4drg6005216hgcys93rq92p7zd20968x0gk254kckd9ag5w";
   };
-
-  # planner-popup-button.c:81:2: error: 'g_type_class_add_private' is deprecated [-Werror=deprecated-declarations]
-  NIX_CFLAGS_COMPILE = "-Wno-error=deprecated-declarations";
 
   nativeBuildInputs = with gnome2; [
     pkgconfig
@@ -44,10 +41,14 @@ in stdenv.mkDerivation {
     libgnomeui
     libglade
     libxslt
-    python
+    python2.pkgs.pygtk
   ];
 
   preConfigure = ''./autogen.sh'';
+  configureFlags = [
+    "--enable-python"
+    "--enable-python-plugin"
+    ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
A yearly update.

###### Motivation for this change

- the warnings no longer need to be disabled, fixed upstream
- enable the Python 2 / PyGTK bindings and plugin, by the way

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

