### PR TITLE
firefoxPackages.tor-browser: 8.0.5 -> 8.0.6

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -237,16 +237,16 @@ in rec {
   };
 
   tor-browser-8-0 = tbcommon rec {
-    ffversion = "60.5.0esr";
-    tbversion = "8.0.5";
+    ffversion = "60.5.1esr";
+    tbversion = "8.0.6";
 
     # FIXME: fetchFromGitHub is not ideal, unpacked source is >900Mb
     src = fetchFromGitHub {
       owner = "SLNOS";
       repo  = "tor-browser";
-      # branch "tor-browser-60.5.0esr-8.0-1-slnos"
-      rev   = "7f113a4ea0539bd2ea9687fe4296c880f2b006c4";
-      sha256 = "11qbhwy2q9rinfw8337b9f78x0r26lnxg25581z85vxshp2jszdq";
+      # branch "tor-browser-60.5.1esr-8.0-1-slnos"
+      rev   = "89be91fc7cbc420b7c4a3bfc36d2b0d500dd3ccf";
+      sha256 = "022zjfwsdl0dkg6ck2kha4nf91xm3j9ag5n21zna98szg3x82dj1";
     };
   };
 


### PR DESCRIPTION
# `git log`

- firefoxPackages.tor-browser: 8.0.5 -> 8.0.6

# `nix-instantiate` environment

- Host OS: Linux 4.9, SLNOS 19.03
- Nix: nix-env (Nix) 2.1.3
- Multi-user: yes
- Sandbox: yes
- NIXPKGS_CONFIG:

```nix
{
  checkMeta = true;
  doCheckByDefault = true;
}
```

# `nix-env -qaP` diffs

- On x86_64-linux:
  - Updated (2):
    - firefoxPackages.tor-browser
    - tor-browser-bundle

- On aarch64-linux:
  - Updated (1):
    - firefoxPackages.tor-browser

- On x86_64-darwin: ditto

/cc @joachifm