### PR TITLE
qutebrowser: choose correct executable when restarting

### DIFF
--- a/pkgs/applications/networking/browsers/qutebrowser/default.nix
+++ b/pkgs/applications/networking/browsers/qutebrowser/default.nix
@@ -53,7 +53,13 @@ in python3Packages.buildPythonApplication rec {
     pyreadability pykeepass stem
   ];
 
+  patches = [
+    ./fix-restart.patch
+  ];
+
   postPatch = ''
+    substituteInPlace qutebrowser/app.py --subst-var-by qutebrowser "$out/bin/qutebrowser"
+
     sed -i "s,/usr/share/,$out/share/,g" qutebrowser/utils/standarddir.py
   '' + lib.optionalString withPdfReader ''
     sed -i "s,/usr/share/pdf.js,${pdfjs},g" qutebrowser/browser/pdfjs.py

--- a/pkgs/applications/networking/browsers/qutebrowser/fix-restart.patch
+++ b/pkgs/applications/networking/browsers/qutebrowser/fix-restart.patch
@@ -1,0 +1,29 @@
+diff --git a/qutebrowser/app.py b/qutebrowser/app.py
+index 2b6896b76..ee05f379d 100644
+--- a/qutebrowser/app.py
++++ b/qutebrowser/app.py
+@@ -555,22 +555,8 @@ class Quitter:
+                 args: The commandline as a list of strings.
+                 cwd: The current working directory as a string.
+         """
+-        if os.path.basename(sys.argv[0]) == 'qutebrowser':
+-            # Launched via launcher script
+-            args = [sys.argv[0]]
+-            cwd = None
+-        elif hasattr(sys, 'frozen'):
+-            args = [sys.executable]
+-            cwd = os.path.abspath(os.path.dirname(sys.executable))
+-        else:
+-            args = [sys.executable, '-m', 'qutebrowser']
+-            cwd = os.path.join(
+-                os.path.abspath(os.path.dirname(qutebrowser.__file__)), '..')
+-            if not os.path.isdir(cwd):
+-                # Probably running from a python egg. Let's fallback to
+-                # cwd=None and see if that works out.
+-                # See https://github.com/qutebrowser/qutebrowser/issues/323
+-                cwd = None
++        args = ['@qutebrowser@']
++        cwd = None
+ 
+         # Add all open pages so they get reopened.
+         page_args = []


### PR DESCRIPTION
###### Motivation for this change
fixes #25832

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @igsha @The-Compiler @abbradar 