### PR TITLE
brasero: fix libdvdcss usage

### DIFF
--- a/pkgs/tools/cd-dvd/brasero/default.nix
+++ b/pkgs/tools/cd-dvd/brasero/default.nix
@@ -2,8 +2,6 @@
 , libcanberra-gtk3, intltool, dvdauthor, libburn, libisofs
 , vcdimager, wrapGAppsHook, hicolor-icon-theme }:
 
-# libdvdcss is "too old" (in fast "too new"), see https://bugs.launchpad.net/ubuntu/+source/brasero/+bug/611590
-
 let
   major = "3.12";
   minor = "2";

--- a/pkgs/tools/cd-dvd/brasero/wrapper.nix
+++ b/pkgs/tools/cd-dvd/brasero/wrapper.nix
@@ -1,4 +1,4 @@
-{ lib, symlinkJoin, brasero-original, cdrtools, makeWrapper }:
+{ lib, symlinkJoin, brasero-original, cdrtools, libdvdcss, makeWrapper }:
 
 let
   binPath = lib.makeBinPath [ cdrtools ];
@@ -10,8 +10,9 @@ in symlinkJoin {
 
   postBuild = ''
     wrapProgram $out/bin/brasero \
-      --prefix PATH ':' ${binPath}
+      --prefix PATH ':' ${binPath} \
+      --prefix LD_PRELOAD : ${lib.makeLibraryPath [ libdvdcss ]}/libdvdcss.so
   '';
-  
+
   inherit (brasero-original) meta;
 }


### PR DESCRIPTION
turns out, prefixing `LD_PRELOAD` with the path to libdvdcss works just
fine. Verified by creating an iso image of a owned DVD.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

