### PR TITLE
nixos/ledger: init

### DIFF
--- a/nixos/modules/hardware/ledger.nix
+++ b/nixos/modules/hardware/ledger.nix
@@ -1,0 +1,14 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.hardware.ledger;
+
+in {
+  options.hardware.ledger.enable = mkEnableOption "udev rules for Ledger devices";
+
+  config = mkIf cfg.enable {
+    services.udev.packages = [ pkgs.ledger-udev-rules ];
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -44,6 +44,7 @@
   ./hardware/digitalbitbox.nix
   ./hardware/sensor/iio.nix
   ./hardware/ksm.nix
+  ./hardware/ledger.nix
   ./hardware/mcelog.nix
   ./hardware/network/b43.nix
   ./hardware/nitrokey.nix

--- a/pkgs/os-specific/linux/ledger-udev-rules/default.nix
+++ b/pkgs/os-specific/linux/ledger-udev-rules/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "ledger-udev-rules";
+  version = "unstable-2019-02-13";
+
+  src = fetchFromGitHub {
+    owner = "LedgerHQ";
+    repo = "udev-rules";
+    rev = "20cc1651eb551c4855aaa56628c77eaeb3031c22";
+    sha256 = "0riydkc4in10pv4qlrvbg3w78qsvxly5caa3zwyqcmsm5fmprqky";
+  };
+
+  dontBuild = true;
+  dontConfigure = true;
+
+  installPhase = ''
+    mkdir -p $out/lib/udev/rules.d
+    cp 20-hw1.rules $out/lib/udev/rules.d/20-ledger.rules
+  '';
+
+  meta = with stdenv.lib; {
+    description = "udev rules for Ledger devices";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ asymmetric ];
+    platforms = platforms.linux;
+    homepage = https://github.com/LedgerHQ/udev-rules;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15634,6 +15634,8 @@ in
 
   league-of-moveable-type = callPackage ../data/fonts/league-of-moveable-type {};
 
+  ledger-udev-rules = callPackage ../os-specific/linux/ledger-udev-rules {};
+
   inherit (callPackages ../data/fonts/redhat-liberation-fonts { })
     liberation_ttf_v1
     liberation_ttf_v2


### PR DESCRIPTION
###### Motivation for this change

Adds udev rules for Ledger.

Supersedes and closes #39950.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

