### PR TITLE
bbe: init at 0.2.2

### DIFF
--- a/pkgs/tools/misc/bbe/default.nix
+++ b/pkgs/tools/misc/bbe/default.nix
@@ -1,0 +1,22 @@
+{ stdenv , fetchurl, autoreconfHook }:
+stdenv.mkDerivation rec {
+  name = "bbe-${version}";
+  version = "0.2.2";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/bbe-/${version}/bbe-${version}.tar.gz";
+    sha256 = "1nyxdqi4425sffjrylh7gl57lrssyk4018afb7mvrnd6fmbszbms";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  outputs = [ "out" "doc" ];
+
+  meta = with stdenv.lib; {
+    description = "A sed-like editor for binary files";
+    homepage = "http://bbe-.sourceforge.net/";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.hhm ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1726,6 +1726,8 @@ in
 
   bats = callPackage ../development/interpreters/bats { };
 
+  bbe = callPackage ../tools/misc/bbe { };
+
   bdsync = callPackage ../tools/backup/bdsync { };
 
   beanstalkd = callPackage ../servers/beanstalkd { };


### PR DESCRIPTION
###### Motivation for this change
Adds [bbe](http://bbe-.sourceforge.net/), a sed-like binary block editor.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

