### PR TITLE
Add package tpm2-tools (+ deps) to nixpkgs

### DIFF
--- a/pkgs/development/libraries/tpm2-tss/default.nix
+++ b/pkgs/development/libraries/tpm2-tss/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, lib, fetchurl
+, cmocka, doxygen, ibm-sw-tpm2, iproute, openssl, perl, pkgconfig, procps
+, uthash, which }:
+
+stdenv.mkDerivation rec {
+  pname = "tpm2-tss";
+  version = "2.2.0";
+
+  src = fetchurl {
+    url = "https://github.com/tpm2-software/${pname}/releases/download/${version}/${pname}-${version}.tar.gz";
+    sha256 = "10r5wgrq21p0y700gh5iirh26pc5gsaib2b8b2nzmbr27apiw4y9";
+  };
+
+  nativeBuildInputs = [
+    doxygen perl pkgconfig
+    # For unit tests and integration tests.
+    ibm-sw-tpm2 iproute procps which
+  ];
+  buildInputs = [
+    openssl
+    # For unit tests and integration tests.
+    cmocka uthash
+  ];
+
+  postPatch = "patchShebangs script";
+
+  configureFlags = [
+    "--enable-unit"
+    "--enable-integration"
+  ];
+
+  doCheck = true;
+
+  postInstall = ''
+    # Do not install the upstream udev rules, they rely on specific
+    # users/groups which aren't guaranteed to exist on the system.
+    rm -R $out/lib/udev
+  '';
+
+  meta = with lib; {
+    description = "OSS implementation of the TCG TPM2 Software Stack (TSS2)";
+    homepage = https://github.com/tpm2-software/tpm2-tss;
+    license = licenses.bsd2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ delroth ];
+  };
+}

--- a/pkgs/tools/security/ibm-sw-tpm2/default.nix
+++ b/pkgs/tools/security/ibm-sw-tpm2/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchurl, lib, openssl }:
+
+stdenv.mkDerivation rec {
+  pname = "ibm-sw-tpm2";
+  version = "1332";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/ibmswtpm2/ibmtpm${version}.tar.gz";
+    sha256 = "1zdhi8acd4jfp1v7ibd86hcv0g39yk8qrnhxjmmgzn8i7npr70cf";
+  };
+
+  buildInputs = [ openssl ];
+
+  sourceRoot = "src";
+
+  prePatch = ''
+    # Fix hardcoded path to GCC.
+    substituteInPlace makefile --replace /usr/bin/gcc "${stdenv.cc}/bin/cc"
+
+    # Remove problematic default CFLAGS.
+    substituteInPlace makefile \
+      --replace -Werror "" \
+      --replace -O0 "" \
+      --replace -ggdb ""
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp tpm_server $out/bin
+  '';
+
+  meta = with lib; {
+    description = "IBM's Software TPM 2.0, an implementation of the TCG TPM 2.0 specification";
+    homepage = https://sourceforge.net/projects/ibmswtpm2/;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ delroth ];
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/tools/security/tpm2-tools/default.nix
+++ b/pkgs/tools/security/tpm2-tools/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchurl, fetchpatch, lib
+, cmocka, curl, pandoc, pkgconfig, openssl, tpm2-tss }:
+
+stdenv.mkDerivation rec {
+  pname = "tpm2-tools";
+  version = "3.1.3";
+
+  src = fetchurl {
+    url = "https://github.com/tpm2-software/${pname}/releases/download/${version}/${pname}-${version}.tar.gz";
+    sha256 = "05is1adwcg7y2p121yldd8m1gigdnzf9izbjazvsr6yg95pmg5fc";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "tests-tss-2.2.0-compat.patch";
+      url = "https://patch-diff.githubusercontent.com/raw/tpm2-software/tpm2-tools/pull/1322.patch";
+      sha256 = "0yy5qbgbd13d7cl8pzsji95a6qnwiik5s2cyqj35jd8blymikqxh";
+    })
+  ];
+
+  nativeBuildInputs = [ pandoc pkgconfig ];
+  buildInputs = [
+    curl openssl tpm2-tss
+    # For unit tests.
+    cmocka
+  ];
+
+  configureFlags = [ "--enable-unit" ];
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Command line tools that provide access to a TPM 2.0 compatible device";
+    homepage = https://github.com/tpm2-software/tpm2-tools;
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ delroth ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5829,6 +5829,8 @@ in
 
   tpm-luks = callPackage ../tools/security/tpm-luks { };
 
+  tpm2-tools = callPackage ../tools/security/tpm2-tools { };
+
   trezord = callPackage ../servers/trezord { };
 
   tthsum = callPackage ../applications/misc/tthsum { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12837,6 +12837,8 @@ in
 
   totem-pl-parser = callPackage ../development/libraries/totem-pl-parser { };
 
+  tpm2-tss = callPackage ../development/libraries/tpm2-tss { };
+
   tremor = callPackage ../development/libraries/tremor { };
 
   twolame = callPackage ../development/libraries/twolame { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3363,6 +3363,8 @@ in
 
   iannix = libsForQt5.callPackage ../applications/audio/iannix { };
 
+  ibm-sw-tpm2 = callPackage ../tools/security/ibm-sw-tpm2 { };
+
   ibniz = callPackage ../tools/graphics/ibniz { };
 
   icecast = callPackage ../servers/icecast { };


### PR DESCRIPTION
###### Motivation for this change
Nix doesn't have any tools to control TPM 2.0 devices, only TPM 1.2 (tpm-tools / trousers). This PR inits tpm2-tools, Intel's package for TPM 2.0 userland support.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

