### PR TITLE
Allow using LLVM for cross compilation toolchain

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -101,7 +101,7 @@ rec {
       in
         if final.parsed.kernel.name == pkgs.stdenv.hostPlatform.parsed.kernel.name &&
            pkgs.stdenv.hostPlatform.isCompatible final
-        then pkgs.runtimeShell
+        then "${pkgs.runtimeShell} -c"
         else if final.isWindows
         then "${wine}/bin/${wine-name}"
         else if final.isLinux && pkgs.stdenv.hostPlatform.isLinux

--- a/pkgs/development/compilers/llvm/3.8/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.8/llvm.nix
@@ -79,8 +79,8 @@ in stdenv.mkDerivation rec {
     "-DLLVM_ENABLE_RTTI=ON"
 
     "-DLLVM_HOST_TRIPLE=${stdenv.hostPlatform.config}"
-    "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.targetPlatform.config}"
-    "-DTARGET_TRIPLE=${stdenv.targetPlatform.config}"
+    "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.hostPlatform.config}"
+    "-DTARGET_TRIPLE=${stdenv.hostPlatform.config}"
   ] ++ stdenv.lib.optional enableSharedLibraries [
     "-DLLVM_LINK_LLVM_DYLIB=ON"
   ] ++ stdenv.lib.optional (!isDarwin)

--- a/pkgs/development/compilers/llvm/3.9/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.9/llvm.nix
@@ -120,8 +120,8 @@ in stdenv.mkDerivation rec {
     "-DCOMPILER_RT_INCLUDE_TESTS=OFF" # FIXME: requires clang source code
 
     "-DLLVM_HOST_TRIPLE=${stdenv.hostPlatform.config}"
-    "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.targetPlatform.config}"
-    "-DTARGET_TRIPLE=${stdenv.targetPlatform.config}"
+    "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.hostPlatform.config}"
+    "-DTARGET_TRIPLE=${stdenv.hostPlatform.config}"
   ] ++ stdenv.lib.optional enableSharedLibraries [
     "-DLLVM_LINK_LLVM_DYLIB=ON"
   ] ++ stdenv.lib.optional (!isDarwin)

--- a/pkgs/development/compilers/llvm/4/llvm.nix
+++ b/pkgs/development/compilers/llvm/4/llvm.nix
@@ -100,8 +100,8 @@ in stdenv.mkDerivation (rec {
     "-DCOMPILER_RT_INCLUDE_TESTS=OFF" # FIXME: requires clang source code
 
     "-DLLVM_HOST_TRIPLE=${stdenv.hostPlatform.config}"
-    "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.targetPlatform.config}"
-    "-DTARGET_TRIPLE=${stdenv.targetPlatform.config}"
+    "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.hostPlatform.config}"
+    "-DTARGET_TRIPLE=${stdenv.hostPlatform.config}"
   ]
   ++ stdenv.lib.optional enableSharedLibraries
     "-DLLVM_LINK_LLVM_DYLIB=ON"

--- a/pkgs/development/compilers/llvm/6/llvm.nix
+++ b/pkgs/development/compilers/llvm/6/llvm.nix
@@ -94,7 +94,7 @@ in stdenv.mkDerivation (rec {
     "-DLLVM_ENABLE_FFI=ON"
     "-DLLVM_ENABLE_RTTI=ON"
     "-DLLVM_HOST_TRIPLE=${stdenv.hostPlatform.config}"
-    "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.targetPlatform.config}"
+    "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.hostPlatform.config}"
     "-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly"
     "-DLLVM_ENABLE_DUMP=ON"
   ] ++ optionals enableSharedLibraries [

--- a/pkgs/development/compilers/llvm/7/bintools.nix
+++ b/pkgs/development/compilers/llvm/7/bintools.nix
@@ -1,0 +1,19 @@
+{ runCommand, stdenv, llvm, lld, version }:
+
+let
+  prefix =
+    if stdenv.hostPlatform != stdenv.targetPlatform
+    then "${stdenv.targetPlatform.config}-"
+    else "";
+in runCommand "llvm-binutils-${version}" { preferLocalBuild = true; } ''
+   mkdir -p $out/bin
+   for prog in ${lld}/bin/*; do
+     ln -s $prog $out/bin/${prefix}$(basename $prog)
+   done
+   for prog in ${llvm}/bin/*; do
+     ln -s $prog $out/bin/${prefix}$(echo $(basename $prog) | sed -e "s|llvm-||")
+     ln -sf $prog $out/bin/${prefix}$(basename $prog)
+   done
+   rm -f $out/bin/${prefix}cat
+   ln -s ${lld}/bin/lld $out/bin/${prefix}ld
+''

--- a/pkgs/development/compilers/llvm/7/clang/default.nix
+++ b/pkgs/development/compilers/llvm/7/clang/default.nix
@@ -5,7 +5,6 @@
 }:
 
 let
-  gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
   self = stdenv.mkDerivation ({
     name = "clang-${version}";
 
@@ -81,8 +80,8 @@ let
     passthru = {
       isClang = true;
       inherit llvm;
-    } // stdenv.lib.optionalAttrs stdenv.targetPlatform.isLinux {
-      inherit gcc;
+    } // stdenv.lib.optionalAttrs (stdenv.targetPlatform.isLinux || (stdenv.cc.isGNU && stdenv.cc.cc ? gcc)) {
+      gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
     };
 
     meta = {

--- a/pkgs/development/compilers/llvm/7/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/7/compiler-rt.nix
@@ -7,8 +7,19 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake python llvm ];
   buildInputs = stdenv.lib.optional stdenv.hostPlatform.isDarwin libcxxabi;
 
-  configureFlags = [
+  cmakeFlags = [
     "-DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON"
+  ] ++ stdenv.lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) [
+    "-DCMAKE_C_FLAGS=-nodefaultlibs"
+    "-DCMAKE_CXX_COMPILER_WORKS=ON"
+    "-DCOMPILER_RT_BUILD_BUILTINS=ON"
+    "-DCOMPILER_RT_BUILD_SANITIZERS=OFF"
+    "-DCOMPILER_RT_BUILD_XRAY=OFF"
+    "-DCOMPILER_RT_BUILD_LIBFUZZER=OFF"
+    "-DCOMPILER_RT_BUILD_PROFILE=OFF"
+    "-DCMAKE_C_COMPILER_TARGET=${stdenv.hostPlatform.config}"
+    "-DCMAKE_ASM_COMPILER_TARGET=${stdenv.hostPlatform.config}"
+    "-DCOMPILER_RT_BAREMETAL_BUILD=ON"
   ];
 
   outputs = [ "out" "dev" ];
@@ -16,7 +27,8 @@ stdenv.mkDerivation rec {
   patches = [
     ./compiler-rt-codesign.patch # Revert compiler-rt commit that makes codesign mandatory
   ] ++ stdenv.lib.optional stdenv.hostPlatform.isMusl ./sanitizers-nongnu.patch
-  ++ stdenv.lib.optional stdenv.hostPlatform.isDarwin ./compiler-rt-clock_gettime.patch;
+    ++ stdenv.lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) ./crtbegin-and-end.patch
+    ++ stdenv.lib.optional stdenv.hostPlatform.isDarwin ./compiler-rt-clock_gettime.patch;
 
   # TSAN requires XPC on Darwin, which we have no public/free source files for. We can depend on the Apple frameworks
   # to get it, but they're unfree. Since LLVM is rather central to the stdenv, we patch out TSAN support so that Hydra
@@ -26,11 +38,23 @@ stdenv.mkDerivation rec {
   postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
     substituteInPlace cmake/config-ix.cmake \
       --replace 'set(COMPILER_RT_HAS_TSAN TRUE)' 'set(COMPILER_RT_HAS_TSAN FALSE)'
+  '' + stdenv.lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+    substituteInPlace lib/builtins/int_util.c \
+      --replace "#include <stdlib.h>" ""
+    substituteInPlace lib/builtins/clear_cache.c \
+      --replace "#include <assert.h>" ""
+    substituteInPlace lib/builtins/cpu_model.c \
+      --replace "#include <assert.h>" ""
   '';
 
   # Hack around weird upsream RPATH bug
   postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
     ln -s "$out/lib"/*/* "$out/lib"
+  '' + stdenv.lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+    ln -s $out/lib/*/clang_rt.crtbegin-*.o $out/lib/linux/crtbegin.o
+    ln -s $out/lib/*/cclang_rt.crtend-*.o $out/lib/linux/crtend.o
+    ln -s $out/lib/*/clang_rt.crtbegin_shared-*.o $out/lib/linux/crtbeginS.o
+    ln -s $out/lib/*/clang_rt.crtend_shared-*.o $out/lib/linux/crtendS.o
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/development/compilers/llvm/7/crtbegin-and-end.patch
+++ b/pkgs/development/compilers/llvm/7/crtbegin-and-end.patch
@@ -1,0 +1,595 @@
+Get crtbegin and crtend without compiler GCC! PR is at https://reviews.llvm.org/D28791
+
+Index: compiler-rt/CMakeLists.txt
+===================================================================
+--- compiler-rt/CMakeLists.txt
++++ compiler-rt/CMakeLists.txt
+@@ -29,6 +29,8 @@
+ 
+ option(COMPILER_RT_BUILD_BUILTINS "Build builtins" ON)
+ mark_as_advanced(COMPILER_RT_BUILD_BUILTINS)
++option(COMPILER_RT_BUILD_CRT "Build crtbegin.o/crtend.o" ON)
++mark_as_advanced(COMPILER_RT_BUILD_CRT)
+ option(COMPILER_RT_BUILD_SANITIZERS "Build sanitizers" ON)
+ mark_as_advanced(COMPILER_RT_BUILD_SANITIZERS)
+ option(COMPILER_RT_BUILD_XRAY "Build xray" ON)
+Index: compiler-rt/cmake/Modules/AddCompilerRT.cmake
+===================================================================
+--- compiler-rt/cmake/Modules/AddCompilerRT.cmake
++++ compiler-rt/cmake/Modules/AddCompilerRT.cmake
+@@ -132,7 +132,7 @@
+ # Adds static or shared runtime for a list of architectures and operating
+ # systems and puts it in the proper directory in the build and install trees.
+ # add_compiler_rt_runtime(<name>
+-#                         {STATIC|SHARED}
++#                         {OBJECT|STATIC|SHARED}
+ #                         ARCHS <architectures>
+ #                         OS <os list>
+ #                         SOURCES <source files>
+@@ -144,8 +144,8 @@
+ #                         PARENT_TARGET <convenience parent target>
+ #                         ADDITIONAL_HEADERS <header files>)
+ function(add_compiler_rt_runtime name type)
+-  if(NOT type MATCHES "^(STATIC|SHARED)$")
+-    message(FATAL_ERROR "type argument must be STATIC or SHARED")
++  if(NOT type MATCHES "^(OBJECT|STATIC|SHARED)$")
++    message(FATAL_ERROR "type argument must be OBJECT, STATIC or SHARED")
+     return()
+   endif()
+   cmake_parse_arguments(LIB
+@@ -204,7 +204,10 @@
+         message(FATAL_ERROR "Architecture ${arch} can't be targeted")
+         return()
+       endif()
+-      if(type STREQUAL "STATIC")
++      if(type STREQUAL "OBJECT")
++        set(libname "${name}-${arch}")
++        set(output_name_${libname} ${libname}${COMPILER_RT_OS_SUFFIX})
++      elseif(type STREQUAL "STATIC")
+         set(libname "${name}-${arch}")
+         set_output_name(output_name_${libname} ${name} ${arch})
+       else()
+@@ -270,12 +273,34 @@
+       set(COMPONENT_OPTION COMPONENT ${libname})
+     endif()
+ 
+-    add_library(${libname} ${type} ${sources_${libname}})
+-    set_target_compile_flags(${libname} ${extra_cflags_${libname}})
+-    set_target_link_flags(${libname} ${extra_link_flags_${libname}})
+-    set_property(TARGET ${libname} APPEND PROPERTY
+-                COMPILE_DEFINITIONS ${LIB_DEFS})
+-    set_target_output_directories(${libname} ${output_dir_${libname}})
++    if(type STREQUAL "OBJECT")
++      string(TOUPPER ${CMAKE_BUILD_TYPE} config)
++      get_property(cflags SOURCE ${sources_${libname}} PROPERTY COMPILE_FLAGS)
++      separate_arguments(cflags)
++      add_custom_command(
++          OUTPUT ${output_dir_${libname}}/${libname}.o
++          COMMAND ${CMAKE_C_COMPILER} ${sources_${libname}} ${cflags} ${extra_cflags_${libname}} -c -o ${output_dir_${libname}}/${libname}.o
++          DEPENDS ${sources_${libname}}
++          COMMENT "Building C object ${libname}.o")
++      add_custom_target(${libname} DEPENDS ${output_dir_${libname}}/${libname}.o)
++      install(FILES ${output_dir_${libname}}/${libname}.o
++        DESTINATION ${install_dir_${libname}}
++        ${COMPONENT_OPTION})
++    else()
++      add_library(${libname} ${type} ${sources_${libname}})
++      set_target_compile_flags(${libname} ${extra_cflags_${libname}})
++      set_target_link_flags(${libname} ${extra_link_flags_${libname}})
++      set_property(TARGET ${libname} APPEND PROPERTY
++                   COMPILE_DEFINITIONS ${LIB_DEFS})
++      set_target_output_directories(${libname} ${output_dir_${libname}})
++      install(TARGETS ${libname}
++        ARCHIVE DESTINATION ${install_dir_${libname}}
++                ${COMPONENT_OPTION}
++        LIBRARY DESTINATION ${install_dir_${libname}}
++                ${COMPONENT_OPTION}
++        RUNTIME DESTINATION ${install_dir_${libname}}
++                ${COMPONENT_OPTION})
++    endif()
+     set_target_properties(${libname} PROPERTIES
+         OUTPUT_NAME ${output_name_${libname}})
+     set_target_properties(${libname} PROPERTIES FOLDER "Compiler-RT Runtime")
+@@ -299,13 +324,6 @@
+         )
+       endif()
+     endif()
+-    install(TARGETS ${libname}
+-      ARCHIVE DESTINATION ${install_dir_${libname}}
+-              ${COMPONENT_OPTION}
+-      LIBRARY DESTINATION ${install_dir_${libname}}
+-              ${COMPONENT_OPTION}
+-      RUNTIME DESTINATION ${install_dir_${libname}}
+-              ${COMPONENT_OPTION})
+ 
+     # We only want to generate per-library install targets if you aren't using
+     # an IDE because the extra targets get cluttered in IDEs.
+Index: compiler-rt/cmake/config-ix.cmake
+===================================================================
+--- compiler-rt/cmake/config-ix.cmake
++++ compiler-rt/cmake/config-ix.cmake
+@@ -227,6 +227,7 @@
+     ${ARM32} ${ARM64} ${MIPS32} ${MIPS64} ${S390X})
+ set(ALL_ASAN_SUPPORTED_ARCH ${X86} ${X86_64} ${ARM32} ${ARM64}
+     ${MIPS32} ${MIPS64} ${PPC64} ${S390X})
++set(ALL_CRT_SUPPORTED_ARCH ${X86} ${X86_64} ${ARM32} ${ARM64})
+ set(ALL_DFSAN_SUPPORTED_ARCH ${X86_64} ${MIPS64} ${ARM64})
+ set(ALL_FUZZER_SUPPORTED_ARCH ${X86_64} ${ARM64})
+ 
+@@ -474,6 +475,7 @@
+     SANITIZER_COMMON_SUPPORTED_ARCH)
+ 
+ else()
++  filter_available_targets(CRT_SUPPORTED_ARCH ${ALL_CRT_SUPPORTED_ARCH})
+   # Architectures supported by compiler-rt libraries.
+   filter_available_targets(SANITIZER_COMMON_SUPPORTED_ARCH
+     ${ALL_SANITIZER_COMMON_SUPPORTED_ARCH})
+@@ -563,6 +565,12 @@
+ 
+ # TODO: Add builtins support.
+ 
++if (CRT_SUPPORTED_ARCH AND OS_NAME MATCHES "Linux")
++  set(COMPILER_RT_HAS_CRT TRUE)
++else()
++  set(COMPILER_RT_HAS_CRT FALSE)
++endif()
++
+ if (COMPILER_RT_HAS_SANITIZER_COMMON AND DFSAN_SUPPORTED_ARCH AND
+     OS_NAME MATCHES "Linux")
+   set(COMPILER_RT_HAS_DFSAN TRUE)
+Index: compiler-rt/lib/CMakeLists.txt
+===================================================================
+--- compiler-rt/lib/CMakeLists.txt
++++ compiler-rt/lib/CMakeLists.txt
+@@ -17,6 +17,10 @@
+   add_subdirectory(builtins)
+ endif()
+ 
++if(COMPILER_RT_BUILD_CRT)
++  add_subdirectory(crt)
++endif()
++
+ function(compiler_rt_build_runtime runtime)
+   string(TOUPPER ${runtime} runtime_uppercase)
+   if(COMPILER_RT_HAS_${runtime_uppercase})
+Index: compiler-rt/lib/crt/CMakeLists.txt
+===================================================================
+--- /dev/null
++++ compiler-rt/lib/crt/CMakeLists.txt
+@@ -0,0 +1,101 @@
++add_compiler_rt_component(crt)
++
++function(check_cxx_section_exists section output)
++  cmake_parse_arguments(ARG "" "" "SOURCE;FLAGS" ${ARGN})
++  if(NOT ARG_SOURCE)
++    set(ARG_SOURCE "int main() { return 0; }\n")
++  endif()
++
++  string(RANDOM TARGET_NAME)
++  set(TARGET_NAME "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/cmTC_${TARGET_NAME}.dir")
++  file(MAKE_DIRECTORY ${TARGET_NAME})
++
++  file(WRITE "${TARGET_NAME}/CheckSectionExists.c" "${ARG_SOURCE}\n")
++
++  string(REGEX MATCHALL "<[A-Za-z0-9_]*>" substitutions
++         ${CMAKE_C_COMPILE_OBJECT})
++
++  set(try_compile_flags "${ARG_FLAGS}")
++  if(CMAKE_C_COMPILER_ID MATCHES Clang AND CMAKE_C_COMPILER_TARGET)
++    list(APPEND try_compile_flags "-target ${CMAKE_C_COMPILER_TARGET}")
++  endif()
++
++  string(REPLACE ";" " " extra_flags "${try_compile_flags}")
++
++  set(test_compile_command "${CMAKE_C_COMPILE_OBJECT}")
++  foreach(substitution ${substitutions})
++    if(substitution STREQUAL "<CMAKE_C_COMPILER>")
++      string(REPLACE "<CMAKE_C_COMPILER>"
++             "${CMAKE_C_COMPILER}" test_compile_command ${test_compile_command})
++    elseif(substitution STREQUAL "<OBJECT>")
++      string(REPLACE "<OBJECT>" "${TARGET_NAME}/CheckSectionExists.o"
++             test_compile_command ${test_compile_command})
++    elseif(substitution STREQUAL "<SOURCE>")
++      string(REPLACE "<SOURCE>" "${TARGET_NAME}/CheckSectionExists.c"
++             test_compile_command ${test_compile_command})
++    elseif(substitution STREQUAL "<FLAGS>")
++      string(REPLACE "<FLAGS>" "${CMAKE_C_FLAGS} ${extra_flags}"
++             test_compile_command ${test_compile_command})
++    else()
++      string(REPLACE "${substitution}" "" test_compile_command
++             ${test_compile_command})
++    endif()
++  endforeach()
++
++  string(REPLACE " " ";" test_compile_command "${test_compile_command}")
++
++  execute_process(
++    COMMAND ${test_compile_command}
++    RESULT_VARIABLE TEST_RESULT
++    OUTPUT_VARIABLE TEST_OUTPUT
++    ERROR_VARIABLE TEST_ERROR
++  )
++
++  execute_process(
++    COMMAND ${CMAKE_OBJDUMP} -h "${TARGET_NAME}/CheckSectionExists.o"
++    RESULT_VARIABLE CHECK_RESULT
++    OUTPUT_VARIABLE CHECK_OUTPUT
++    ERROR_VARIABLE CHECK_ERROR
++  )
++  string(FIND ${CHECK_OUTPUT} ${section} SECTION_FOUND)
++
++  if(NOT SECTION_FOUND EQUAL -1)
++    set(${output} TRUE PARENT_SCOPE)
++  else()
++    set(${output} FALSE PARENT_SCOPE)
++  endif()
++
++  file(REMOVE_RECURSE ${TARGET_NAME})
++endfunction()
++
++check_cxx_section_exists(".init_array" COMPILER_RT_HAS_INITFINI_ARRAY
++  SOURCE "__attribute__((constructor)) void f() {}\nint main() { return 0; }\n")
++
++append_list_if(COMPILER_RT_HAS_INITFINI_ARRAY -DCRT_HAS_INITFINI_ARRAY CRT_CFLAGS)
++
++foreach(arch ${CRT_SUPPORTED_ARCH})
++  add_compiler_rt_runtime(clang_rt.crtbegin
++    OBJECT
++    ARCHS ${arch}
++    SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/crtbegin.c
++    CFLAGS ${CRT_CFLAGS}
++    PARENT_TARGET crt)
++  add_compiler_rt_runtime(clang_rt.crtbegin_shared
++    OBJECT
++    ARCHS ${arch}
++    SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/crtbegin.c
++    CFLAGS ${CRT_CFLAGS} -DCRT_SHARED -fPIC
++    PARENT_TARGET crt)
++  add_compiler_rt_runtime(clang_rt.crtend
++    OBJECT
++    ARCHS ${arch}
++    SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/crtend.c
++    CFLAGS ${CRT_CFLAGS}
++    PARENT_TARGET crt)
++  add_compiler_rt_runtime(clang_rt.crtend_shared
++    OBJECT
++    ARCHS ${arch}
++    SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/crtend.c
++    CFLAGS ${CRT_CFLAGS} -DCRT_SHARED -fPIC
++    PARENT_TARGET crt)
++endforeach()
+Index: compiler-rt/lib/crt/crtbegin.c
+===================================================================
+--- /dev/null
++++ compiler-rt/lib/crt/crtbegin.c
+@@ -0,0 +1,110 @@
++/* ===-- crtbegin.c - Start of constructors and destructors ----------------===
++ *
++ *      	       The LLVM Compiler Infrastructure
++ *
++ * This file is dual licensed under the MIT and the University of Illinois Open
++ * Source Licenses. See LICENSE.TXT for details.
++ *
++ * ===----------------------------------------------------------------------===
++ */
++
++#include <stddef.h>
++
++__attribute__((visibility("hidden")))
++#ifdef CRT_SHARED
++void *__dso_handle = &__dso_handle;
++#else
++void *__dso_handle = (void *)0;
++#endif
++
++static long __EH_FRAME_LIST__[] __attribute__((
++    section(".eh_frame"), aligned(sizeof(void *)), visibility("hidden"))) = {};
++
++extern void __register_frame_info(const void *, void *) __attribute__((weak));
++extern void *__deregister_frame_info(const void *) __attribute__((weak));
++
++#ifndef CRT_HAS_INITFINI_ARRAY
++typedef void (*fp)(void);
++
++static fp __CTOR_LIST__[]
++    __attribute__((section(".ctors"), aligned(sizeof(fp)), visibility("hidden"),
++                   used)) = {(fp)-1};
++extern fp __CTOR_LIST_END__[] __attribute__((visibility("hidden")));
++#endif
++
++#ifdef CRT_SHARED
++extern void __cxa_finalize(void *) __attribute__((weak));
++#endif
++
++static void __attribute__((used)) __do_init() {
++  static _Bool __initialized;
++  if (__builtin_expect(__initialized, 0))
++    return;
++  __initialized = 1;
++
++  static struct { void *p[8]; } __object;
++  if (__register_frame_info)
++    __register_frame_info(__EH_FRAME_LIST__, &__object);
++
++#ifndef CRT_HAS_INITFINI_ARRAY
++  const size_t n = __CTOR_LIST_END__ - __CTOR_LIST__ - 1;
++  for (size_t i = n; i >= 1; i--) __CTOR_LIST__[i]();
++#endif
++}
++
++#ifdef CRT_HAS_INITFINI_ARRAY
++__attribute__((section(".init_array"),
++               used)) static void (*__init)(void) = __do_init;
++#else  // CRT_HAS_INITFINI_ARRAY
++#if defined(__i386__) || defined(__x86_64__)
++asm(".pushsection .init,\"ax\",@progbits\n\t"
++    "call " __USER_LABEL_PREFIX__ "__do_init\n\t"
++    ".popsection");
++#elif defined(__arm__)
++asm(".pushsection .init,\"ax\",%progbits\n\t"
++    "bl " __USER_LABEL_PREFIX__ "__do_init\n\t"
++    ".popsection");
++#endif  // CRT_HAS_INITFINI_ARRAY
++#endif
++
++#ifndef CRT_HAS_INITFINI_ARRAY
++static fp __DTOR_LIST__[]
++    __attribute__((section(".dtors"), aligned(sizeof(fp)), visibility("hidden"),
++                   used)) = {(fp)-1};
++extern fp __DTOR_LIST_END__[] __attribute__((visibility("hidden")));
++#endif
++
++static void __attribute__((used)) __do_fini() {
++  static _Bool __finalized;
++  if (__builtin_expect(__finalized, 0))
++    return;
++  __finalized = 1;
++
++#ifdef CRT_SHARED
++  if (__cxa_finalize)
++    __cxa_finalize(__dso_handle);
++#endif
++
++#ifndef CRT_HAS_INITFINI_ARRAY
++  if (__deregister_frame_info)
++    __deregister_frame_info(__EH_FRAME_LIST__);
++
++  const size_t n = __DTOR_LIST_END__ - __DTOR_LIST__ - 1;
++  for (size_t i = 1; i < n; i++) __DTOR_LIST__[i]();
++#endif
++}
++
++#ifdef CRT_HAS_INITFINI_ARRAY
++__attribute__((section(".fini_array"),
++               used)) static void (*__fini)(void) = __do_fini;
++#else  // CRT_HAS_INITFINI_ARRAY
++#if defined(__i386__) || defined(__x86_64__)
++asm(".pushsection .fini,\"ax\",@progbits\n\t"
++    "call " __USER_LABEL_PREFIX__ "__do_fini\n\t"
++    ".popsection");
++#elif defined(__arm__)
++asm(".pushsection .fini,\"ax\",%progbits\n\t"
++    "bl " __USER_LABEL_PREFIX__ "__do_fini\n\t"
++    ".popsection");
++#endif
++#endif  // CRT_HAS_INIT_FINI_ARRAY
+Index: compiler-rt/lib/crt/crtend.c
+===================================================================
+--- /dev/null
++++ compiler-rt/lib/crt/crtend.c
+@@ -0,0 +1,23 @@
++/* ===-- crtend.c - End of constructors and destructors --------------------===
++ *
++ *      	       The LLVM Compiler Infrastructure
++ *
++ * This file is dual licensed under the MIT and the University of Illinois Open
++ * Source Licenses. See LICENSE.TXT for details.
++ *
++ * ===----------------------------------------------------------------------===
++ */
++
++#include <stdint.h>
++
++// Put 4-byte zero which is the length field in FDE at the end as a terminator.
++const int32_t __EH_FRAME_LIST_END__[]
++    __attribute__((section(".eh_frame"), aligned(sizeof(int32_t)), used)) = {0};
++
++#ifndef CRT_HAS_INITFINI_ARRAY
++typedef void (*fp)(void);
++fp __CTOR_LIST_END__[]
++    __attribute__((section(".ctors"), visibility("hidden"), used)) = {0};
++fp __DTOR_LIST_END__[]
++    __attribute__((section(".dtors"), visibility("hidden"), used)) = {0};
++#endif
+Index: compiler-rt/test/CMakeLists.txt
+===================================================================
+--- compiler-rt/test/CMakeLists.txt
++++ compiler-rt/test/CMakeLists.txt
+@@ -73,6 +73,9 @@
+   if(COMPILER_RT_BUILD_XRAY)
+     compiler_rt_test_runtime(xray)
+   endif()
++  if(COMPILER_RT_HAS_CRT)
++    add_subdirectory(crt)
++  endif()
+   # ShadowCallStack does not yet provide a runtime with compiler-rt, the tests
+   # include their own minimal runtime
+   add_subdirectory(shadowcallstack)
+Index: compiler-rt/test/crt/CMakeLists.txt
+===================================================================
+--- /dev/null
++++ compiler-rt/test/crt/CMakeLists.txt
+@@ -0,0 +1,31 @@
++set(CRT_LIT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
++
++set(CRT_TESTSUITES)
++
++set(CRT_TEST_DEPS "")
++
++if(NOT COMPILER_RT_STANDALONE_BUILD AND COMPILER_RT_BUILD_CRT AND
++   COMPILER_RT_HAS_CRT)
++  list(APPEND CRT_TEST_DEPS crt)
++endif()
++
++set(CRT_TEST_ARCH ${CRT_SUPPORTED_ARCH})
++if (COMPILER_RT_BUILD_CRT AND COMPILER_RT_HAS_CRT)
++  foreach(arch ${CRT_TEST_ARCH})
++    set(CRT_TEST_TARGET_ARCH ${arch})
++    string(TOLOWER "-${arch}-${OS_NAME}" CRT_TEST_CONFIG_SUFFIX)
++    get_test_cc_for_arch(${arch} CRT_TEST_TARGET_CC CRT_TEST_TARGET_CFLAGS)
++    string(TOUPPER ${arch} ARCH_UPPER_CASE)
++    set(CONFIG_NAME ${ARCH_UPPER_CASE}${OS_NAME}Config)
++
++    configure_lit_site_cfg(
++      ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in
++      ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}/lit.site.cfg)
++    list(APPEND CRT_TESTSUITES ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME})
++  endforeach()
++endif()
++
++add_lit_testsuite(check-crt "Running the CRT tests"
++  ${CRT_TESTSUITES}
++  DEPENDS ${CRT_TEST_DEPS})
++set_target_properties(check-crt PROPERTIES FOLDER "Compiler-RT Misc")
+Index: compiler-rt/test/crt/dso_handle.cpp
+===================================================================
+--- /dev/null
++++ compiler-rt/test/crt/dso_handle.cpp
+@@ -0,0 +1,33 @@
++// RUN: %clangxx -g -DCRT_SHARED -c %s -fPIC -o %tshared.o
++// RUN: %clangxx -g -c %s -fPIC -o %t.o
++// RUN: %clangxx -g -shared -o %t.so -nostdlib %crti %shared_crtbegin %tshared.o %libstdcxx -lc -lm -lgcc_s %shared_crtend %crtn
++// RUN: %clangxx -g -o %t -nostdlib %crt1 %crti %crtbegin %t.o %libstdcxx -lc -lm %libgcc %t.so %crtend %crtn
++// RUN: %run %t 2>&1 | FileCheck %s
++
++#include <stdio.h>
++
++// CHECK: 1
++// CHECK-NEXT: ~A()
++
++#ifdef CRT_SHARED
++bool G;
++void C() {
++  printf("%d\n", G);
++}
++
++struct A {
++  A() { G = true; }
++  ~A() {
++    printf("~A()\n");
++  }
++};
++
++A a;
++#else
++void C();
++
++int main() {
++  C();
++  return 0;
++}
++#endif
+Index: compiler-rt/test/crt/lit.cfg
+===================================================================
+--- /dev/null
++++ compiler-rt/test/crt/lit.cfg
+@@ -0,0 +1,80 @@
++# -*- Python -*-
++
++import os
++import subprocess
++
++# Setup config name.
++config.name = 'CRT' + config.name_suffix
++
++# Setup source root.
++config.test_source_root = os.path.dirname(__file__)
++
++
++def get_library_path(file):
++    cmd = subprocess.Popen([config.clang.strip(),
++                            config.target_cflags.strip(),
++                            '-print-file-name=%s' % file],
++                           stdout=subprocess.PIPE,
++                           env=config.environment)
++    if not cmd.stdout:
++      lit_config.fatal("Couldn't find the library path for '%s'" % file)
++    dir = cmd.stdout.read().strip()
++    if sys.platform in ['win32'] and execute_external:
++        # Don't pass dosish path separator to msys bash.exe.
++        dir = dir.replace('\\', '/')
++    # Ensure the result is an ascii string, across Python2.5+ - Python3.
++    return str(dir.decode('ascii'))
++
++
++def get_libgcc_file_name():
++    cmd = subprocess.Popen([config.clang.strip(),
++                            config.target_cflags.strip(),
++                            '-print-libgcc-file-name'],
++                           stdout=subprocess.PIPE,
++                           env=config.environment)
++    if not cmd.stdout:
++      lit_config.fatal("Couldn't find the library path for '%s'" % file)
++    dir = cmd.stdout.read().strip()
++    if sys.platform in ['win32'] and execute_external:
++        # Don't pass dosish path separator to msys bash.exe.
++        dir = dir.replace('\\', '/')
++    # Ensure the result is an ascii string, across Python2.5+ - Python3.
++    return str(dir.decode('ascii'))
++
++
++def build_invocation(compile_flags):
++    return ' ' + ' '.join([config.clang] + compile_flags) + ' '
++
++
++# Setup substitutions.
++config.substitutions.append(
++    ('%clang ', build_invocation([config.target_cflags])))
++config.substitutions.append(
++    ('%clangxx ',
++     build_invocation(config.cxx_mode_flags + [config.target_cflags])))
++
++base_lib = os.path.join(
++    config.compiler_rt_libdir, "clang_rt.%%s-%s.o" % config.target_arch)
++config.substitutions.append(('%crtbegin', base_lib % "crtbegin"))
++config.substitutions.append(('%shared_crtbegin', base_lib % "crtbegin_shared"))
++config.substitutions.append(('%crtend', base_lib % "crtend"))
++config.substitutions.append(('%shared_crtend', base_lib % "crtend_shared"))
++
++config.substitutions.append(
++    ('%crt1', get_library_path('crt1.o')))
++config.substitutions.append(
++    ('%crti', get_library_path('crti.o')))
++config.substitutions.append(
++    ('%crtn', get_library_path('crtn.o')))
++
++config.substitutions.append(
++    ('%libgcc', get_libgcc_file_name()))
++
++config.substitutions.append(
++    ('%libstdcxx', '-l' + config.sanitizer_cxx_lib.lstrip('lib')))
++
++# Default test suffixes.
++config.suffixes = ['.c', '.cc', '.cpp']
++
++if config.host_os not in ['Linux']:
++    config.unsupported = True
+Index: compiler-rt/test/crt/lit.site.cfg.in
+===================================================================
+--- /dev/null
++++ compiler-rt/test/crt/lit.site.cfg.in
+@@ -0,0 +1,14 @@
++@LIT_SITE_CFG_IN_HEADER@
++
++# Tool-specific config options.
++config.name_suffix = "@CRT_TEST_CONFIG_SUFFIX@"
++config.crt_lit_source_dir = "@CRT_LIT_SOURCE_DIR@"
++config.target_cflags = "@CRT_TEST_TARGET_CFLAGS@"
++config.target_arch = "@CRT_TEST_TARGET_ARCH@"
++config.sanitizer_cxx_lib = "@SANITIZER_TEST_CXX_LIBNAME@"
++
++# Load common config for all compiler-rt lit tests
++lit_config.load_config(config, "@COMPILER_RT_BINARY_DIR@/test/lit.common.configured")
++
++# Load tool-specific config that would do the real work.
++lit_config.load_config(config, "@CRT_LIT_SOURCE_DIR@/lit.cfg")

--- a/pkgs/development/compilers/llvm/7/llvm.nix
+++ b/pkgs/development/compilers/llvm/7/llvm.nix
@@ -106,7 +106,7 @@ in stdenv.mkDerivation (rec {
     "-DLLVM_ENABLE_FFI=ON"
     "-DLLVM_ENABLE_RTTI=ON"
     "-DLLVM_HOST_TRIPLE=${stdenv.hostPlatform.config}"
-    "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.targetPlatform.config}"
+    "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.hostPlatform.config}"
     "-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly"
     "-DLLVM_ENABLE_DUMP=ON"
   ] ++ optionals enableSharedLibraries [

--- a/pkgs/development/libraries/libpfm/default.nix
+++ b/pkgs/development/libraries/libpfm/default.nix
@@ -12,8 +12,8 @@ stdenv.mkDerivation rec {
   makeFlags = [
     "PREFIX=${placeholder "out"}"
     "LDCONFIG=true"
-    "ARCH=${stdenv.targetPlatform.uname.processor}"
-    "SYS=${stdenv.targetPlatform.uname.system}"
+    "ARCH=${stdenv.hostPlatform.uname.processor}"
+    "SYS=${stdenv.hostPlatform.uname.system}"
   ];
 
   NIX_CFLAGS_COMPILE = [ "-Wno-error" ];

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -54,6 +54,8 @@ in lib.init bootStages ++ [
              then buildPackages.darwin.iosSdkPkgs.clang
            else if crossSystem.useAndroidPrebuilt or false
              then buildPackages."androidndkPkgs_${crossSystem.ndkVer}".gcc
+           else if crossSystem.useLLVM or false
+             then buildPackages.llvmPackages_7.lldClang
            else buildPackages.gcc;
 
       extraNativeBuildInputs = old.extraNativeBuildInputs

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -86,7 +86,7 @@ rec {
       doCheck' = doCheck && stdenv.hostPlatform == stdenv.buildPlatform;
       doInstallCheck' = doInstallCheck && stdenv.hostPlatform == stdenv.buildPlatform;
 
-      separateDebugInfo' = separateDebugInfo && stdenv.hostPlatform.isLinux;
+      separateDebugInfo' = separateDebugInfo && stdenv.hostPlatform.isLinux && !(stdenv.hostPlatform.useLLVM or false);
       outputs' = outputs ++ lib.optional separateDebugInfo' "debug";
 
       fixedOutputDrv = attrs ? outputHash;

--- a/pkgs/test/cross/default.nix
+++ b/pkgs/test/cross/default.nix
@@ -26,13 +26,19 @@ let
     # We need to remove whitespace, unfortunately
     # Windows programs use \r but Unix programs use \n
 
+    echo Running native-built program natively
+
     # find expected value natively
     ${getExecutable hostPkgs pkgFun exec} ${args'} \
       | dos2unix > $out/expected
 
+    echo Running cross-built program in emulator
+
     # run emulator to get actual value
     ${emulator} ${getExecutable crossPkgs pkgFun exec} ${args'} \
       | dos2unix > $out/actual
+
+    echo Comparing results...
 
     if [ "$(cat $out/actual)" != "$(cat $out/expected)" ]; then
       echo "${pkgName} did not output expected value:"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6842,7 +6842,10 @@ in
     { substitutions = { gcc = gcc-unwrapped; }; }
     ../development/compilers/gcc/libstdc++-hook.sh;
 
-  crossLibcStdenv = overrideCC stdenv buildPackages.gccCrossStageStatic;
+  crossLibcStdenv = overrideCC stdenv
+    (if stdenv.targetPlatform.useLLVM or false
+     then buildPackages.llvmPackages_7.lldClangNoLibc
+     else buildPackages.gccCrossStageStatic);
 
   # The GCC used to build libc for the target platform. Normal gccs will be
   # built with, and use, that cross-compiled libc.
@@ -7384,13 +7387,11 @@ in
     stdenv = overrideCC stdenv buildPackages.gcc6; # with gcc-7: undefined reference to `__divmoddi4'
   });
 
-  llvmPackages_7 = callPackage ../development/compilers/llvm/7 ({
+  llvmPackages_7 = callPackage ../development/compilers/llvm/7 {
     inherit (stdenvAdapters) overrideCC;
     buildLlvmTools = buildPackages.llvmPackages_7.tools;
     targetLlvmLibraries = targetPackages.llvmPackages_7.libraries;
-  } // stdenv.lib.optionalAttrs (stdenv.cc.isGNU && stdenv.hostPlatform.isi686) {
-    stdenv = overrideCC stdenv buildPackages.gcc6; # with gcc-7: undefined reference to `__divmoddi4'
-  });
+  };
 
   llvmPackages_latest = llvmPackages_7;
 


### PR DESCRIPTION
###### Motivation for this change
The idea is to allow you to build with LLVM by passing something like this in Nixpkgs:

```
nix-build -A hello --arg crossSystem '{ config = "aarch64-unknown-linux-gnu"; useLLVM = true; }'
```

Lots of this is based on the approach taking in wasm-cross repo:

https://github.com/WebGHC/wasm-cross

Unfortunately I haven't gotten libc to cross compile without using GCC.