### PR TITLE
 aws-sdk-cpp: 1.6.52 -> 1.7.49; add aws-checksums, aws-c-common, aws-c-event-stream

### DIFF
--- a/pkgs/development/libraries/aws-c-common/default.nix
+++ b/pkgs/development/libraries/aws-c-common/default.nix
@@ -13,6 +13,11 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
+  NIX_CFLAGS_COMPILE = lib.optionals stdenv.isDarwin [
+    "-Wno-nullability-extension"
+    "-Wno-typedef-redefinition"
+  ];
+
   meta = with lib; {
     description = "AWS SDK for C common core";
     homepage = https://github.com/awslabs/aws-c-common;

--- a/pkgs/development/libraries/aws-c-common/default.nix
+++ b/pkgs/development/libraries/aws-c-common/default.nix
@@ -1,0 +1,23 @@
+{ lib, stdenv, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "aws-c-common";
+  version = "0.3.2";
+
+  src = fetchFromGitHub {
+    owner = "awslabs";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "169ha105qgcvj93hf1bhlya2nlwh8g5fvypd6whfjs9k0hqddi0c";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with lib; {
+    description = "AWS SDK for C common core";
+    homepage = https://github.com/awslabs/aws-c-common;
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ orivej eelco ];
+  };
+}

--- a/pkgs/development/libraries/aws-c-event-stream/default.nix
+++ b/pkgs/development/libraries/aws-c-event-stream/default.nix
@@ -1,0 +1,29 @@
+{ lib, stdenv, fetchFromGitHub, cmake, aws-c-common, aws-checksums }:
+
+stdenv.mkDerivation rec {
+  pname = "aws-c-event-stream";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "awslabs";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0anjynfghk3inysy21wqvhxha33xsswh3lm8pr7nx7cpj6cmr37m";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ aws-c-common aws-checksums ];
+
+  cmakeFlags = [
+    "-DCMAKE_MODULE_PATH=${aws-c-common}/lib/cmake"
+  ];
+
+  meta = with lib; {
+    description = "C99 implementation of the vnd.amazon.eventstream content-type";
+    homepage = https://github.com/awslabs/aws-c-event-stream;
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ orivej eelco ];
+  };
+}

--- a/pkgs/development/libraries/aws-checksums/default.nix
+++ b/pkgs/development/libraries/aws-checksums/default.nix
@@ -1,0 +1,23 @@
+{ lib, stdenv, fetchFromGitHub, cmake }:
+
+stdenv.mkDerivation rec {
+  pname = "aws-checksums";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "awslabs";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1r21sfs1ik6cb8bz17w6gp6y2xa9rbjxjka0p6airb3qds094iv5";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with lib; {
+    description = "HW accelerated CRC32c and CRC32";
+    homepage = https://github.com/awslabs/aws-checksums;
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ orivej eelco ];
+  };
+}

--- a/pkgs/development/libraries/aws-sdk-cpp/default.nix
+++ b/pkgs/development/libraries/aws-sdk-cpp/default.nix
@@ -1,4 +1,5 @@
 { lib, stdenv, fetchFromGitHub, cmake, curl, openssl, zlib
+, aws-c-common, aws-c-event-stream, aws-checksums
 , CoreAudio, AudioToolbox
 , # Allow building a limited set of APIs, e.g. ["s3" "ec2"].
   apis ? ["*"]
@@ -6,22 +7,15 @@
   customMemoryManagement ? true
 }:
 
-let
-  loaderVar =
-    if stdenv.isLinux
-      then "LD_LIBRARY_PATH"
-      else if stdenv.isDarwin
-        then "DYLD_LIBRARY_PATH"
-        else throw "Unsupported system!";
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   name = "aws-sdk-cpp-${version}";
-  version = "1.6.52";
+  version = "1.7.49";
 
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "aws-sdk-cpp";
     rev = version;
-    sha256 = "17hyq6rv1xl3f70p2pfkkxm86gbfimq2pwpakv1wv3xjibmppbrf";
+    sha256 = "09j1y82jvi69mj7h751wg0zlyf3n8s2zgfn5p85v4659pl4jgqmf";
   };
 
   # FIXME: might be nice to put different APIs in different outputs
@@ -30,43 +24,35 @@ in stdenv.mkDerivation rec {
   separateDebugInfo = stdenv.isLinux;
 
   nativeBuildInputs = [ cmake curl ];
-  buildInputs = [ zlib curl openssl ]
-    ++ lib.optionals (stdenv.isDarwin &&
+
+  buildInputs = [
+    curl openssl zlib
+    aws-c-common aws-c-event-stream aws-checksums
+  ] ++ lib.optionals (stdenv.isDarwin &&
                         ((builtins.elem "text-to-speech" apis) ||
                          (builtins.elem "*" apis)))
          [ CoreAudio AudioToolbox ];
 
-  cmakeFlags =
-       lib.optional (!customMemoryManagement) "-DCUSTOM_MEMORY_MANAGEMENT=0"
+  cmakeFlags = [
+    "-DBUILD_DEPS=OFF"
+    "-DCMAKE_SKIP_BUILD_RPATH=OFF"
+  ] ++ lib.optional (!customMemoryManagement) "-DCUSTOM_MEMORY_MANAGEMENT=0"
     ++ lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) "-DENABLE_TESTING=OFF"
     ++ lib.optional (apis != ["*"])
       "-DBUILD_ONLY=${lib.concatStringsSep ";" apis}";
-
-  enableParallelBuilding = true;
-
-  # Behold the escaping nightmare below on loaderVar o.O
-  preBuild =
-    ''
-      # Ensure that the unit tests can find the *.so files.
-      for i in testing-resources aws-cpp-sdk-*; do
-        export ${loaderVar}=$(pwd)/$i:''${${loaderVar}}
-      done
-    '';
 
   preConfigure =
     ''
       rm aws-cpp-sdk-core-tests/aws/auth/AWSCredentialsProviderTest.cpp
     '';
 
-  NIX_CFLAGS_COMPILE = [ "-Wno-error=noexcept-type" ];
-
   __darwinAllowLocalNetworking = true;
 
-  meta = {
+  meta = with lib; {
     description = "A C++ interface for Amazon Web Services";
     homepage = https://github.com/awslabs/aws-sdk-cpp;
-    license = lib.licenses.asl20;
-    platforms = lib.platforms.linux ++ lib.platforms.darwin;
-    maintainers = [ lib.maintainers.eelco ];
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ eelco orivej ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9345,6 +9345,8 @@ in
 
   aws-c-common = callPackage ../development/libraries/aws-c-common { };
 
+  aws-c-event-stream = callPackage ../development/libraries/aws-c-event-stream { };
+
   aws-checksums = callPackage ../development/libraries/aws-checksums { };
 
   aws-sdk-cpp = callPackage ../development/libraries/aws-sdk-cpp {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9345,6 +9345,8 @@ in
 
   aws-c-common = callPackage ../development/libraries/aws-c-common { };
 
+  aws-checksums = callPackage ../development/libraries/aws-checksums { };
+
   aws-sdk-cpp = callPackage ../development/libraries/aws-sdk-cpp {
     inherit (darwin.apple_sdk.frameworks) CoreAudio AudioToolbox;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9343,6 +9343,8 @@ in
     inherit (darwin.apple_sdk.frameworks) AudioUnit CoreServices;
   };
 
+  aws-c-common = callPackage ../development/libraries/aws-c-common { };
+
   aws-sdk-cpp = callPackage ../development/libraries/aws-sdk-cpp {
     inherit (darwin.apple_sdk.frameworks) CoreAudio AudioToolbox;
   };


### PR DESCRIPTION
###### Motivation for this change

Fixes #54546.

Since 1.7.0 it requires new aws-c* dependencies:
https://github.com/aws/aws-sdk-cpp/releases/tag/1.7.0
https://github.com/aws/aws-sdk-cpp/commit/ffd81252bec92f3e0587e144b07c05f8aed28eb1

New packages are single-output because they install only development files and small static libraries.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Please test on macOS!

/cc maintainer @edolstra