### PR TITLE
system.requiredKernelConfig: packages contraints

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -52,6 +52,9 @@ let
     # back-compat aliases
     platforms = systems.forMeta;
 
+    # kernel
+    kernel = callLibs ./kernel.nix;
+
     inherit (builtins) add addErrorContext attrNames concatLists
       deepSeq elem elemAt filter genericClosure genList getAttr
       hasAttr head isAttrs isBool isInt isList isString length

--- a/lib/kernel.nix
+++ b/lib/kernel.nix
@@ -1,4 +1,4 @@
-{ lib, version }:
+{ lib, version ? null }:
 
 with lib;
 rec {
@@ -15,7 +15,42 @@ rec {
 
   yes      = { tristate    = "y"; };
   no       = { tristate    = "n"; };
+  enable   = { tristate    = "e"; };
   module   = { tristate    = "m"; };
   freeform = x: { freeform = x; };
+
+  # copy/pasted from boot/kernel.nix
+      isYes = option: {
+        assertion = config: config.isYes option;
+        message = "CONFIG_${option} is not yes!";
+        configLine = "CONFIG_${option}=y";
+      };
+
+      isNo = option: {
+        assertion = config: config.isNo option;
+        message = "CONFIG_${option} is not no!";
+        configLine = "CONFIG_${option}=n";
+      };
+
+      isModule = option: {
+        assertion = config: config.isModule option;
+        message = "CONFIG_${option} is not built as a module!";
+        configLine = "CONFIG_${option}=m";
+      };
+
+      ### Usually you will just want to use these two
+      # True if yes or module
+      isEnabled = option: {
+        assertion = config: config.isEnabled option;
+        message = "CONFIG_${option} is not enabled!";
+        configLine = "CONFIG_${option}=y";
+      };
+
+      # True if no or omitted
+      isDisabled = option: {
+        assertion = config: config.isDisabled option;
+        message = "CONFIG_${option} is not disabled!";
+        configLine = "CONFIG_${option}=n";
+      };
 
 }

--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -65,6 +65,27 @@ in
       '';
     };
 
+    boot.enforceRequiredConfig = mkOption {
+      type = types.listOf types.attrs;
+      default = [];
+      example = literalExample "[ pkgs.kernelPatches.ubuntu_fan_4_4 ]";
+      description = ''
+        '';
+    };
+
+    boot.kernelConfig = mkOption {
+      # for now use str but in the end should use kernelItem
+      type = types.attrsOf types.str;
+      default = {};
+      # example = literalExample "[ pkgs.kernelPatches.ubuntu_fan_4_4 ]";
+      description = ''
+        Declarative kernel configuration.
+        Also set by requiredKernelConfig when enforceRequiredConfig is set.
+        '';
+    };
+
+
+
     boot.kernelPatches = mkOption {
       type = types.listOf types.attrs;
       default = [];
@@ -297,6 +318,9 @@ in
         configLine = "CONFIG_${option}=n";
       };
     };
+
+
+    boot.kernelConfig = mkIf config.boot.enforceRequiredConfig config.system.requiredKernelConfig;
 
     # The config options that all modules can depend upon
     system.requiredKernelConfig = with config.lib.kernelConfig; [

--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -13,6 +13,11 @@ let
       ${concatStringsSep "\n" config.boot.kernelModules}
     '';
 
+  requiredKernelConfigFromPackages = pkgs:
+  let
+    requiredKernelConfigs = map (x: x.meta.requiredKernelConfig or []) pkgs;
+  in
+  foldr (a: b: a ++ b) [] requiredKernelConfigs;
 in
 
 {
@@ -298,7 +303,7 @@ in
       # !!! Should this really be needed?
       (isYes "MODULES")
       (isYes "BINFMT_ELF")
-    ];
+    ] ++ requiredKernelConfigFromPackages config.environment.systemPackages;
 
     # nixpkgs kernels are assumed to have all required features
     assertions = if config.boot.kernelPackages.kernel ? features then [] else

--- a/pkgs/os-specific/linux/bcc/default.nix
+++ b/pkgs/os-specific/linux/bcc/default.nix
@@ -70,6 +70,27 @@ python.pkgs.buildPythonApplication rec {
   '';
 
   meta = with stdenv.lib; {
+
+    # TODO adapt my own config
+  #bpfConfigStructured = {
+  #  #prev.pkgs.linuxPackages.bcc.kernelExtraConfig or
+  #  BPF = yes;
+  #  BPF_JIT_ALWAYS_ON = yes;
+  #  NETFILTER_XTABLES = yes;
+  #  NETFILTER_XT_MATCH_BPF = yes;
+  #  BPF_SYSCALL = yes;
+  #  NET_CLS_BPF = yes;
+  #  NET_ACT_BPF = yes;
+  #  HAVE_EBPF_JIT = yes;
+  #  BPF_JIT = yes;
+  #  BPF_EVENTS = yes;
+  #  KPROBES                = yes;
+  #  KPROBES_ON_FTRACE      = yes;
+  #  HAVE_KPROBES           = yes;
+  #  HAVE_KPROBES_ON_FTRACE = yes;
+  #  KPROBE_EVENTS          = yes;
+  #};
+    requiredKernelConfig = [ (stdenv.lib.kernel.isEnabled "OPENVSWITCH") ];
     description = "Dynamic Tracing Tools for Linux";
     homepage = https://iovisor.github.io/bcc/;
     license = licenses.asl20;

--- a/pkgs/os-specific/linux/openvswitch/default.nix
+++ b/pkgs/os-specific/linux/openvswitch/default.nix
@@ -59,6 +59,7 @@ in stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     platforms = platforms.linux;
+    requiredKernelConfig = [ (stdenv.lib.kernel.isEnabled "OPENVSWITCH") ];
     description = "A multilayer virtual switch";
     longDescription =
       ''

--- a/pkgs/os-specific/linux/powertop/default.nix
+++ b/pkgs/os-specific/linux/powertop/default.nix
@@ -29,6 +29,10 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Analyze power consumption on Intel-based laptops";
+    requiredKernelConfig = [
+      (stdenv.lib.kernel.isEnabled "CPU_FREQ_STAT" )
+      (stdenv.lib.kernel.isEnabled "CPU_FREQ" )
+    ];
     homepage = https://01.org/powertop;
     license = licenses.gpl2;
     maintainers = with maintainers; [ fpletz ];

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -185,6 +185,7 @@ let
 
     # Weirder stuff that doesn't appear in the documentation?
     knownVulnerabilities = listOf str;
+    requiredKernelConfig = listOf str;
     name = str;
     version = str;
     tag = str;

--- a/pkgs/tools/virtualization/mininet/default.nix
+++ b/pkgs/tools/virtualization/mininet/default.nix
@@ -44,5 +44,8 @@ stdenv.mkDerivation rec {
     };
     homepage = https://github.com/mininet/mininet;
     maintainers = with maintainers; [ teto ];
+    requiredKernelConfig = [
+      (stdenv.lib.kernel.isEnabled "NET_NS" )
+    ];
   };
 }


### PR DESCRIPTION
This lets packages define `meta.requiredKernelConfig` that is added to `system.requiredKernelConfig` when the package belongs to `environment.systemPackages`.
This checks if the package can work with the booted kernel.
(hopefully the check could be run against an arbitrary kernel).

The hope is to then add a knob that builds a kernel configuration satisfying the installed package constraints.

###### Motivation for this change
Long term goal is https://github.com/NixOS/nixpkgs/issues/41103. The intent with the PR is just to start with a smaller scope and concrete code. This is not the definite proposition but the main idea is visible and I hope to trigger some feedback.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

