### PR TITLE
qjournalctl: init at 2018-11-25

### DIFF
--- a/pkgs/applications/misc/qjournalctl/default.nix
+++ b/pkgs/applications/misc/qjournalctl/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, qtbase, qmake }:
+
+stdenv.mkDerivation rec {
+  pname = "qjournalctl";
+  version = "unstable-2018-11-25";
+
+  src = fetchFromGitHub {
+    owner = "pentix";
+    repo = pname;
+    rev = "80463d38dc52e2fce457ab66114edf1fdf951e73";
+    sha256 = "10b76ywbnyvwik4apn0c1y0vjb6xg53ksxyzrh194z2ppw0c3r0r";
+  };
+
+  postPatch = ''
+    substituteInPlace qjournalctl.pro --replace /usr/ $out/
+  '';
+
+  nativeBuildInputs = [ qmake ];
+  buildInputs = [ qtbase ];
+
+  meta = with stdenv.lib; {
+    description = "Qt-based Graphical User Interface for systemd's journalctl command";
+    homepage = https://github.com/pentix/qjournalctl;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ dtzWill ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18961,6 +18961,8 @@ in
 
   qjackctl = libsForQt5.callPackage ../applications/audio/qjackctl { };
 
+  qjournalctl = libsForQt5.callPackage ../applications/misc/qjournalctl { };
+
   qmapshack = libsForQt5.callPackage ../applications/misc/qmapshack { };
 
   qmediathekview = libsForQt5.callPackage ../applications/video/qmediathekview { };


### PR DESCRIPTION
###### Motivation for this change

qt journalctl frontend :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---