### PR TITLE
Trunc

### DIFF
--- a/pkgs/os-specific/linux/kernel/interpreter-trunc.patch
+++ b/pkgs/os-specific/linux/kernel/interpreter-trunc.patch
@@ -1,0 +1,82 @@
+Reported-by: Samuel Dionne-Riel <samuel@dionne-riel.com>
+Fixes: 8099b047ecc4 ("exec: load_script: don't blindly truncate shebang string")
+Signed-off-by: Kees Cook <keescook@chromium.org>
+---
+ fs/binfmt_script.c | 37 +++++++++++++++++++++++++++++++------
+ 1 file changed, 31 insertions(+), 6 deletions(-)
+
+diff --git a/fs/binfmt_script.c b/fs/binfmt_script.c
+index d0078cbb718b..3db23528bb85 100644
+--- a/fs/binfmt_script.c
++++ b/fs/binfmt_script.c
+@@ -20,6 +20,7 @@ static int load_script(struct linux_binprm *bprm)
+ 	char *cp;
+ 	struct file *file;
+ 	int retval;
++	bool truncated = false, end_of_interp = false;
+
+ 	if ((bprm->buf[0] != '#') || (bprm->buf[1] != '!'))
+ 		return -ENOEXEC;
+@@ -42,32 +43,56 @@ static int load_script(struct linux_binprm *bprm)
+ 	fput(bprm->file);
+ 	bprm->file = NULL;
+
++	/*
++	 * Truncating interpreter arguments is okay: the interpreter
++	 * can re-read the script to parse them on its own. Truncating
++	 * the interpreter path itself, though, is bad. Note truncation
++	 * here, and check for either newline or start of arguments
++	 * below.
++	 */
+ 	for (cp = bprm->buf+2;; cp++) {
+-		if (cp >= bprm->buf + BINPRM_BUF_SIZE)
+-			return -ENOEXEC;
+-		if (!*cp || (*cp == '\n'))
++		if (cp == bprm->buf + BINPRM_BUF_SIZE - 1) {
++			truncated = true;
+ 			break;
++		}
++		if (!*cp || (*cp == '\n')) {
++			end_of_interp = true;
++			break;
++		}
+ 	}
+ 	*cp = '\0';
+
++	/* Truncate trailing whitespace */
+ 	while (cp > bprm->buf) {
+ 		cp--;
+-		if ((*cp == ' ') || (*cp == '\t'))
++		if ((*cp == ' ') || (*cp == '\t')) {
++			end_of_interp = true;
+ 			*cp = '\0';
+-		else
++		} else
+ 			break;
+ 	}
++	/* Skip leading whitespace */
+ 	for (cp = bprm->buf+2; (*cp == ' ') || (*cp == '\t'); cp++);
+ 	if (*cp == '\0')
+ 		return -ENOEXEC; /* No interpreter name found */
+ 	i_name = cp;
+ 	i_arg = NULL;
++	/*
++	 * Skip until end of string or finding whitespace which
++	 * signals the start of interpreter arguments.
++	 */
+ 	for ( ; *cp && (*cp != ' ') && (*cp != '\t'); cp++)
+ 		/* nothing */ ;
+-	while ((*cp == ' ') || (*cp == '\t'))
++	/* Truncate and skip any whitespace in front of arguments */
++	while ((*cp == ' ') || (*cp == '\t')) {
++		end_of_interp = true;
+ 		*cp++ = '\0';
++	}
+ 	if (*cp)
+ 		i_arg = cp;
++	/* Fail exec if the name of the interpreter was cut off. */
++	if (truncated && !end_of_interp)
++		return -ENOEXEC;
+ 	/*
+ 	 * OK, we've parsed out the interpreter name and
+ 	 * (optional) argument.

--- a/pkgs/os-specific/linux/kernel/linux-4.14.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.14.nix
@@ -3,7 +3,7 @@
 with stdenv.lib;
 
 buildLinux (args // rec {
-  version = "4.14.98";
+  version = "4.14.99";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
   modDirVersion = if (modDirVersionArg == null) then concatStrings (intersperse "." (take 3 (splitString "." "${version}.0"))) else modDirVersionArg;
@@ -13,6 +13,6 @@ buildLinux (args // rec {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
-    sha256 = "0pqc04ij6qdfhh3rpakas0qc0vqj8mm120z64q9v9vxin5qi20lg";
+    sha256 = "02pbi5jck6fp7y5lihn077i0j3hssxcrbsfbxlyp62xjsnp8rycg";
   };
 } // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -57,4 +57,9 @@ rec {
       sha256 = "1l8xq02rd7vakxg52xm9g4zng0ald866rpgm8kjlh88mwwyjkrwv";
     };
   };
+
+  interpreter-trunc = {
+    name = "interpreter-trunc";
+    patch = ./interpreter-trunc.patch;
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14562,55 +14562,61 @@ in
   };
 
   linux_4_9 = callPackage ../os-specific/linux/kernel/linux-4.9.nix {
-    kernelPatches =
-      [ kernelPatches.bridge_stp_helper
-        kernelPatches.cpu-cgroup-v2."4.9"
-        kernelPatches.modinst_arg_list_too_long
-      ];
+    kernelPatches = [
+      kernelPatches.bridge_stp_helper
+      kernelPatches.cpu-cgroup-v2."4.9"
+      kernelPatches.modinst_arg_list_too_long
+    ];
   };
 
   linux_4_14 = callPackage ../os-specific/linux/kernel/linux-4.14.nix {
-    kernelPatches =
-      [ kernelPatches.bridge_stp_helper
-        # See pkgs/os-specific/linux/kernel/cpu-cgroup-v2-patches/README.md
-        # when adding a new linux version
-        kernelPatches.cpu-cgroup-v2."4.11"
-        kernelPatches.modinst_arg_list_too_long
-      ];
+    kernelPatches = [
+      kernelPatches.bridge_stp_helper
+      # See pkgs/os-specific/linux/kernel/cpu-cgroup-v2-patches/README.md
+      # when adding a new linux version
+      kernelPatches.cpu-cgroup-v2."4.11"
+      kernelPatches.modinst_arg_list_too_long
+      kernelPatches.interpreter-trunc
+    ];
   };
 
   linux_4_19 = callPackage ../os-specific/linux/kernel/linux-4.19.nix {
-    kernelPatches =
-      [ kernelPatches.bridge_stp_helper
-        kernelPatches.modinst_arg_list_too_long
-      ];
+    kernelPatches = [
+      kernelPatches.bridge_stp_helper
+      kernelPatches.modinst_arg_list_too_long
+      kernelPatches.interpreter-trunc
+    ];
   };
 
   linux_4_20 = callPackage ../os-specific/linux/kernel/linux-4.20.nix {
-    kernelPatches =
-      [ kernelPatches.bridge_stp_helper
-        kernelPatches.modinst_arg_list_too_long
-      ];
+    kernelPatches = [
+      kernelPatches.bridge_stp_helper
+      kernelPatches.modinst_arg_list_too_long
+      kernelPatches.interpreter-trunc
+    ];
   };
 
   linux_testing = callPackage ../os-specific/linux/kernel/linux-testing.nix {
     kernelPatches = [
       kernelPatches.bridge_stp_helper
       kernelPatches.modinst_arg_list_too_long
+      kernelPatches.interpreter-trunc
     ];
   };
 
   linux_testing_bcachefs = callPackage ../os-specific/linux/kernel/linux-testing-bcachefs.nix {
-    kernelPatches =
-      [ kernelPatches.bridge_stp_helper
-        kernelPatches.modinst_arg_list_too_long
-      ];
+    kernelPatches = [
+      kernelPatches.bridge_stp_helper
+      kernelPatches.modinst_arg_list_too_long
+      kernelPatches.interpreter-trunc
+    ];
   };
 
   linux_hardkernel_4_14 = callPackage ../os-specific/linux/kernel/linux-hardkernel-4.14.nix {
     kernelPatches = [
       kernelPatches.bridge_stp_helper
       kernelPatches.modinst_arg_list_too_long
+      kernelPatches.interpreter-trunc
     ];
   };
 


### PR DESCRIPTION
###### Motivation for this change
#53672, temporarily use patch from https://lore.kernel.org/lkml/20190214012754.GA17326@beast/T/#u

Need to bring back 4.14.99

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @eadwu @grahamc @dtzWill @Laaas