### PR TITLE
nasm: build from source

### DIFF
--- a/pkgs/development/compilers/nasm/default.nix
+++ b/pkgs/development/compilers/nasm/default.nix
@@ -1,15 +1,18 @@
-{ stdenv, fetchurl, perl }:
+{ stdenv, fetchFromRepoOrCz, autoreconfHook, perl, asciidoc, xmlto, docbook_xml_dtd_45, docbook_xsl }:
 
 stdenv.mkDerivation rec {
   name = "nasm-${version}";
   version = "2.14.02";
 
-  src = fetchurl {
-    url = "https://www.nasm.us/pub/nasm/releasebuilds/${version}/${name}.tar.bz2";
-    sha256 = "1g409sr1kj7v1089s9kv0i4azvddkcwcypnbakfryyi71b3jdz9l";
+  src = fetchFromRepoOrCz {
+    repo = "nasm";
+    rev = name;
+    sha256 = "15z6ybnzlsrqs2964h6czqhpmr7vc3ln4y4h0z9vrznk4mqcwbsa";
   };
 
-  nativeBuildInputs = [ perl ];
+  nativeBuildInputs = [ autoreconfHook perl asciidoc xmlto docbook_xml_dtd_45 docbook_xsl ];
+
+  postBuild = "make manpages";
 
   doCheck = true;
 


### PR DESCRIPTION
# `git log`

- nasm: build from source

  https://nasm.us is currently down. This way is also preferable, IMHO.

# `nix-instantiate` environment

- Host OS: Linux 4.9, SLNOS 19.03
- Nix: nix-env (Nix) 2.1.3
- Multi-user: yes
- Sandbox: yes
- NIXPKGS_CONFIG:

```nix
{
  checkMeta = true;
  doCheckByDefault = true;
}
```

# `nix-env -qaP` diffs

- On x86_64-linux:
  - Updated (5285)

- On aarch64-linux:
  - Updated (4526)

- On x86_64-darwin:
  - Updated (1627)

/cc @pbogdan @ryantm from git-blame

PR is made against staging because of the mass-rebuild, but nasm is currently broken on master too.