### PR TITLE
shades-of-gray-theme: 1.1.4 -> 1.1.5

### DIFF
--- a/pkgs/data/themes/shades-of-gray/default.nix
+++ b/pkgs/data/themes/shades-of-gray/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "shades-of-gray-theme-${version}";
-  version = "1.1.4";
+  version = "1.1.5";
 
   src = fetchFromGitHub {
     owner = "WernerFP";
     repo = "Shades-of-gray-theme";
     rev = version;
-    sha256 = "1i5mra1ib3c8xqnhwjh8yzjcdnhvqdmccw5x52sfh9xq797px39l";
+    sha256 = "1ql8rkbm5l94b842hg53cwf02vbw2785rlrs4cr60d4kn2c0lj2y";
   };
 
   buildInputs = [ gtk_engines ];


### PR DESCRIPTION
###### Motivation for this change

Update to version [1.1.5](https://github.com/WernerFP/Shades-of-gray-theme/releases/tag/1.1.5)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).