### PR TITLE
 rippled-validatior-keys-tool: init at d7774bcc

### DIFF
--- a/pkgs/servers/rippled/validator-keys-tool.nix
+++ b/pkgs/servers/rippled/validator-keys-tool.nix
@@ -1,0 +1,34 @@
+{ stdenv, lib, fetchgit, cmake, openssl, boost, zlib, rippled }:
+
+stdenv.mkDerivation rec {
+  name = "rippled-validator-keys-tool-20180927-${builtins.substring 0 7 rev}";
+  rev = "d7774bcc1dc9439c586ea1c175fcd5ff3960b15f";
+
+  src = fetchgit {
+    url = "https://github.com/ripple/validator-keys-tool.git";
+    inherit rev;
+    sha256 = "1hcbwwa21n692qpbm0vqy5jvvnf4aias309610m4kwdsnzfw0902";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ openssl boost zlib rippled ];
+
+  hardeningDisable = ["format"];
+
+  preConfigure = ''
+    export CXX="$(command -v $CXX)"
+    export CC="$(command -v $CC)"
+  '';
+
+  installPhase = ''
+    install -D validator-keys $out/bin/validator-keys
+  '';
+
+  meta = with lib; {
+    description = "Generate master and ephemeral rippled validator keys";
+    homepage = https://github.com/ripple/validator-keys-tool;
+    maintainers = with maintainers; [ offline ];
+    license = licenses.isc;
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13995,6 +13995,12 @@ in
     boost = boost167;
   };
 
+  rippled-validator-keys-tool = callPackage ../servers/rippled/validator-keys-tool.nix {
+    boost = boost167.override {
+      enableStatic = true;
+    };
+  };
+
   s6 = skawarePackages.s6;
 
   s6-rc = skawarePackages.s6-rc;


### PR DESCRIPTION
###### Motivation for this change

Tool needed to setup rippled validator, depends on https://github.com/NixOS/nixpkgs/pull/55772

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

