### PR TITLE
dict: fix datadir path

### DIFF
--- a/pkgs/servers/dict/default.nix
+++ b/pkgs/servers/dict/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   patchPhase = "patch -p0 < ${./buildfix.diff}";
   configureFlags = [
     "--enable-dictorg"
-    "--datadir=/run/current-systems/sw/share/dictd"
+    "--datadir=/run/current-system/sw/share/dictd"
   ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
I'm not actually sure what this does, but it certainly seems like it was a typo, because `/run/current-systems` isn't a thing?