### PR TITLE
sympow: fix patch url to working revision

### DIFF
--- a/pkgs/development/libraries/science/math/sympow/default.nix
+++ b/pkgs/development/libraries/science/math/sympow/default.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
     })
     (fetchpatch {
       name = "fix_pointer_initialization2.patch";
-      url = "https://git.archlinux.org/svntogit/community.git/plain/trunk/sympow-datafiles.patch?h=packages/sympow";
+      url = "https://git.archlinux.org/svntogit/community.git/plain/trunk/sympow-datafiles.patch?h=packages/sympow&id=5088e641a45b23d0385d8e63be65315129b4cf58";
       sha256 = "1m0vz048layb47r1jjf7fplw650ccc9x0w3l322iqmppzmv3022a";
     })
   ];


### PR DESCRIPTION
fix_pointer_initialization2.patch no longer exists on trunk in arch repo -- download from a fixed older revision where it did.

###### Motivation for this change

Building sympow fails with 404 for patch download.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

