### PR TITLE
pythonPackages.httpretty: fix darwin sandbox build

### DIFF
--- a/pkgs/development/python-modules/httpretty/default.nix
+++ b/pkgs/development/python-modules/httpretty/default.nix
@@ -30,6 +30,8 @@ buildPythonPackage rec {
   ];
   propagatedBuildInputs = [ six ];
 
+  __darwinAllowLocalNetworking = true;
+
   meta = with stdenv.lib; {
     homepage = "https://falcao.it/HTTPretty/";
     description = "HTTP client request mocking tool";


### PR DESCRIPTION
The tests use localhost networking and get stuck otherwise.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

