### PR TITLE
sage: fix fetchSageDiff

### DIFF
--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -64,10 +64,10 @@ stdenv.mkDerivation rec {
     fetchSageDiff = { base, rev, name ? "sage-diff-${base}-${rev}.patch", ...}@args: (
       fetchpatch ({
         inherit name;
-        url = "https://git.sagemath.org/sage.git/rawdiff?id2=${base}&id=${rev}";
+        url = "https://git.sagemath.org/sage.git/patch?id2=${base}&id=${rev}";
         # We don't care about sage's own build system (which builds all its dependencies).
         # Exclude build system changes to avoid conflicts.
-        excludes = [ "/build/*" ];
+        excludes = [ "build/*" ];
       } // builtins.removeAttrs args [ "rev" "base" ])
     );
   in [


### PR DESCRIPTION
###### Motivation for this change

For some reason I changed it to use `cgit`s `rawdiff` instead of `patch`
in the update to sage 8.6. Probably commited that by accident, at least
I can't remember the reason. Also changed the excludes filter, the
leading slash prevented it from working.

As a result, the cypari2 patch changed. Only didn't notice because it
was cached.

Fixes #55780 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

