### PR TITLE
darwin.architecture: fix sandbox build

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/architecture/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/architecture/default.nix
@@ -3,6 +3,12 @@
 appleDerivation {
   dontBuild = true;
 
+  postPatch = ''
+    substituteInPlace Makefile \
+        --replace '/bin/mkdir' 'mkdir' \
+        --replace '/usr/bin/install' 'install'
+  '';
+
   installFlags = [ "EXPORT_DSTDIR=/include/architecture" ];
 
   DSTROOT = "$(out)";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

