### PR TITLE
 linux: allow for interpreter to be truncated

### DIFF
--- a/pkgs/os-specific/linux/kernel/interpreter-trunc.patch
+++ b/pkgs/os-specific/linux/kernel/interpreter-trunc.patch
@@ -1,0 +1,44 @@
+From cb5b020a8d38f77209d0472a0fea755299a8ec78 Mon Sep 17 00:00:00 2001
+From: Linus Torvalds <torvalds@linux-foundation.org>
+Date: Thu, 14 Feb 2019 15:02:18 -0800
+Subject: Revert "exec: load_script: don't blindly truncate shebang string"
+
+This reverts commit 8099b047ecc431518b9bb6bdbba3549bbecdc343.
+
+It turns out that people do actually depend on the shebang string being
+truncated, and on the fact that an interpreter (like perl) will often
+just re-interpret it entirely to get the full argument list.
+
+Reported-by: Samuel Dionne-Riel <samuel@dionne-riel.com>
+Acked-by: Kees Cook <keescook@chromium.org>
+Cc: Oleg Nesterov <oleg@redhat.com>
+Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>
+---
+ fs/binfmt_script.c | 10 +++-------
+ 1 file changed, 3 insertions(+), 7 deletions(-)
+
+diff --git a/fs/binfmt_script.c b/fs/binfmt_script.c
+index d0078cbb718b..7cde3f46ad26 100644
+--- a/fs/binfmt_script.c
++++ b/fs/binfmt_script.c
+@@ -42,14 +42,10 @@ static int load_script(struct linux_binprm *bprm)
+ 	fput(bprm->file);
+ 	bprm->file = NULL;
+ 
+-	for (cp = bprm->buf+2;; cp++) {
+-		if (cp >= bprm->buf + BINPRM_BUF_SIZE)
+-			return -ENOEXEC;
+-		if (!*cp || (*cp == '\n'))
+-			break;
+-	}
++	bprm->buf[BINPRM_BUF_SIZE - 1] = '\0';
++	if ((cp = strchr(bprm->buf, '\n')) == NULL)
++		cp = bprm->buf+BINPRM_BUF_SIZE-1;
+ 	*cp = '\0';
+-
+ 	while (cp > bprm->buf) {
+ 		cp--;
+ 		if ((*cp == ' ') || (*cp == '\t'))
+-- 
+cgit 1.2-0.3.lf.el7
+

--- a/pkgs/os-specific/linux/kernel/linux-4.14.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.14.nix
@@ -3,7 +3,7 @@
 with stdenv.lib;
 
 buildLinux (args // rec {
-  version = "4.14.98";
+  version = "4.14.99";
 
   # modDirVersion needs to be x.y.z, will automatically add .0 if needed
   modDirVersion = if (modDirVersionArg == null) then concatStrings (intersperse "." (take 3 (splitString "." "${version}.0"))) else modDirVersionArg;
@@ -13,6 +13,6 @@ buildLinux (args // rec {
 
   src = fetchurl {
     url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
-    sha256 = "0pqc04ij6qdfhh3rpakas0qc0vqj8mm120z64q9v9vxin5qi20lg";
+    sha256 = "02pbi5jck6fp7y5lihn077i0j3hssxcrbsfbxlyp62xjsnp8rycg";
   };
 } // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -57,4 +57,11 @@ rec {
       sha256 = "1l8xq02rd7vakxg52xm9g4zng0ald866rpgm8kjlh88mwwyjkrwv";
     };
   };
+
+  # https://github.com/NixOS/nixpkgs/issues/53672
+  # https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=cb5b020a8d38f77209d0472a0fea755299a8ec78
+  interpreter-trunc = {
+    name = "interpreter-trunc";
+    patch = ./interpreter-trunc.patch;
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14576,6 +14576,7 @@ in
         # when adding a new linux version
         kernelPatches.cpu-cgroup-v2."4.11"
         kernelPatches.modinst_arg_list_too_long
+        kernelPatches.interpreter-trunc
       ];
   };
 
@@ -14583,6 +14584,7 @@ in
     kernelPatches =
       [ kernelPatches.bridge_stp_helper
         kernelPatches.modinst_arg_list_too_long
+        kernelPatches.interpreter-trunc
       ];
   };
 
@@ -14590,6 +14592,7 @@ in
     kernelPatches =
       [ kernelPatches.bridge_stp_helper
         kernelPatches.modinst_arg_list_too_long
+        kernelPatches.interpreter-trunc
       ];
   };
 
@@ -14597,6 +14600,7 @@ in
     kernelPatches = [
       kernelPatches.bridge_stp_helper
       kernelPatches.modinst_arg_list_too_long
+      kernelPatches.interpreter-trunc
     ];
   };
 
@@ -14611,6 +14615,7 @@ in
     kernelPatches = [
       kernelPatches.bridge_stp_helper
       kernelPatches.modinst_arg_list_too_long
+      kernelPatches.interpreter-trunc
     ];
   };
 


### PR DESCRIPTION
###### Motivation for this change
Now just give me a few hours to compile using this specific patch taken from the git repository instead of my own.

Based off https://github.com/NixOS/nixpkgs/pull/55763, though I don't think `linux_testing_bcachefs` needs to be patched, as it's still based upon 4.20.0.

Resolves https://github.com/NixOS/nixpkgs/issues/53672.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @NeQuissimus @grahamc @dtzWill