### PR TITLE
wkhtmltopdf: add qtxmlpatterns dependency

### DIFF
--- a/pkgs/tools/graphics/wkhtmltopdf/default.nix
+++ b/pkgs/tools/graphics/wkhtmltopdf/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     fontconfig freetype libpng zlib libjpeg openssl
     libX11 libXext libXrender
-    qt5.qtwebkit qt5.qtsvg
+    qt5.qtwebkit qt5.qtsvg qt5.qtxmlpatterns
   ];
 
   prePatch = ''


### PR DESCRIPTION
###### Motivation for this change

```
building '/nix/store/7n2cag47gl93wp3f0mv7fiq3dybq2a6l-wkhtmltopdf-0.12.5.drv'...
unpacking sources
unpacking source archive /nix/store/lv2zcapqqn1kjlc616ljap1ddlc2lvx8-source
source root is source
patching sources
configuring
Info: creating stash file /tmp/nix-build-wkhtmltopdf-0.12.5.drv-0/source/.qmake.stash
building
build flags: -j4 -l4 SHELL=/nix/store/i82x3x0yiijkgyqkzh8ni87gspas0f48-bash-4.4-p23/bin/bash
cd src/lib/ && ( test -e Makefile || /nix/store/334ck8czp3jhfy0ppy55sb6dxf7yxsdv-qtbase-5.12.0-dev/bin/qmake -o Makefile /tmp/nix-build-wkhtmltopdf-0.12.5.drv-0/source/src/lib/lib.pro INSTALLBASE=/nix/store/rc8z502xa3w0n2qm2vmr5d3l73v1lyyd-wkhtmltopdf-0.12.5 ) && make -f Makefile
Project ERROR: Unknown module(s) in QT: xmlpatterns
make: *** [Makefile:47: sub-src-lib-make_first-ordered] Error 3
builder for '/nix/store/7n2cag47gl93wp3f0mv7fiq3dybq2a6l-wkhtmltopdf-0.12.5.drv' failed with exit code 2
```


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
---

