### PR TITLE
pythonPackages.pantable: init at 0.12.2

### DIFF
--- a/pkgs/development/python-modules/shutilwhich/default.nix
+++ b/pkgs/development/python-modules/shutilwhich/default.nix
@@ -1,0 +1,18 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "shutilwhich";
+  version = "1.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1ijdnvn101ixwhayd4x4khf73xwhj33vhyv1z8qgchhy8v33j7yv";
+  };
+
+  meta = with lib; {
+    homepage = https://github.com/mbr/shutilwhich;
+    description = "shutil.which for legacy below Python 3.3";
+    license = licenses.psfl;
+    maintainers = with maintainers; [ leenaars ];
+  };
+}

--- a/pkgs/tools/text/panflute/default.nix
+++ b/pkgs/tools/text/panflute/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, pythonAtLeast, isPy27, fetchPypi
+, pyyaml, future, click, shutilwhich }:
+
+buildPythonPackage rec {
+  pname = "panflute";
+  version = "1.11.2";
+
+  disabled = ! pythonAtLeast "3.5" && !isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1ybkqqamz3cpxla6jxs7wrnfs4hplb2r4gmbp5qqwfmym1iqa4b1";
+  };
+
+  propagatedBuildInputs = [ pyyaml future click shutilwhich ];
+
+  meta = with lib; {
+    description = "Pythonic pandocfilters with extra helper functions";
+    homepage = http://scorreia.com/software/panflute/;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ leenaars ];
+  };
+}

--- a/pkgs/tools/text/pantable/default.nix
+++ b/pkgs/tools/text/pantable/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, pythonAtLeast, isPy27, fetchPypi
+, panflute, backports_csv }:
+
+buildPythonPackage rec {
+  pname = "pantable";
+  version = "0.12.2";
+
+  disabled = ! pythonAtLeast "3.5" && !isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1wk3fff87jf3srx0q370ggblng0vxx0lphxhy8m2wypw7ap3q8xw";
+  };
+
+  propagatedBuildInputs = [ panflute backports_csv ];
+
+  meta = with lib; {
+    description = "CSV Tables in Markdown: Pandoc Filter for CSV Tables";
+    homepage = https://ickc.github.io/pantable/;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ leenaars ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4675,6 +4675,8 @@ in
 
   pal = callPackage ../tools/misc/pal { };
 
+  pamtester = callPackage ../tools/security/pamtester { };
+
   pandoc = haskell.lib.overrideCabal (haskell.lib.justStaticExecutables haskellPackages.pandoc) (drv: {
     configureFlags = drv.configureFlags or [] ++ ["-fembed_data_files"];
     buildDepends = drv.buildDepends or [] ++ [haskellPackages.file-embed];
@@ -4692,8 +4694,6 @@ in
   });
 
   pantable = python3Packages.callPackage ../tools/text/pantable { };
-
-  pamtester = callPackage ../tools/security/pamtester { };
 
   paper-gtk-theme = callPackage ../misc/themes/paper { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4691,6 +4691,8 @@ in
     '';
   });
 
+  pantable = python3Packages.callPackage ../tools/text/pantable { };
+
   pamtester = callPackage ../tools/security/pamtester { };
 
   paper-gtk-theme = callPackage ../misc/themes/paper { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3193,6 +3193,8 @@ in {
 
   neuronpy = callPackage ../development/python-modules/neuronpy { };
 
+  panflute = callPackage ../tools/text/panflute { };
+
   pint = callPackage ../development/python-modules/pint { };
 
   pygal = callPackage ../development/python-modules/pygal { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -786,6 +786,8 @@ in {
 
   shellingham = callPackage ../development/python-modules/shellingham {};
 
+  shutilwhich = callPackage ../development/python-modules/shutilwhich {};
+
   simpleeval = callPackage ../development/python-modules/simpleeval { };
 
   singledispatch = callPackage ../development/python-modules/singledispatch { };


### PR DESCRIPTION
###### Motivation for this change

Useful helper tool for working with pandoc tables + dependencies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

