### PR TITLE
gnome3.dconf: fix build on Darwin

### DIFF
--- a/pkgs/desktops/gnome-3/core/dconf/default.nix
+++ b/pkgs/desktops/gnome-3/core/dconf/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, meson, ninja, python3, vala, libxslt, pkgconfig, glib, bash-completion, dbus, gnome3
-, libxml2, gtk-doc, docbook_xsl, docbook_xml_dtd_42 }:
+, libxml2, gtk-doc, docbook_xsl, docbook_xml_dtd_42, fetchpatch }:
 
 let
   pname = "dconf";
@@ -12,6 +12,15 @@ stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "1dq2dn7qmxr4fxzx9wnag89ck24gxq17p2n4gl81h4w8qdy3m6jl";
   };
+
+  patches = [
+    # Fix the build on Darwin
+    # Issue: https://gitlab.gnome.org/GNOME/dconf/issues/47
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/dconf/commit/49f4d916e1151af3975df52c522c69de98ed2fbb.patch";
+      sha256 = "00klkr1jzli9ap0aj6399m1bj2bxxz48pmcj4r16dsy6dfdl6325";
+    })
+  ];
 
   postPatch = ''
     chmod +x meson_post_install.py


### PR DESCRIPTION
###### Motivation for this change

Fix the build on Darwin.

Please see https://gitlab.gnome.org/GNOME/dconf/issues/47

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

