### PR TITLE
Add optional manylinux1 (PEP 513) support for Python

### DIFF
--- a/pkgs/development/interpreters/python/cpython/2.7/default.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/default.nix
@@ -241,9 +241,6 @@ in with passthru; stdenv.mkDerivation ({
         ln -s $out/lib/${libPrefix}/pdb.py $out/bin/pdb${sourceVersion.major}.${sourceVersion.minor}
         ln -s $out/share/man/man1/{python2.7.1.gz,python.1.gz}
 
-        # Python on Nix is not manylinux1 compatible. https://github.com/NixOS/nixpkgs/issues/18484
-        echo "manylinux1_compatible=False" >> $out/lib/${libPrefix}/_manylinux.py
-
         rm "$out"/lib/python*/plat-*/regen # refers to glibc.dev
 
         # Determinism: Windows installers were not deterministic.

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -187,9 +187,6 @@ in with passthru; stdenv.mkDerivation {
 
     ln -s "$out/include/${executable}m" "$out/include/${executable}"
 
-    # Python on Nix is not manylinux1 compatible. https://github.com/NixOS/nixpkgs/issues/18484
-    echo "manylinux1_compatible=False" >> $out/lib/${libPrefix}/_manylinux.py
-
     # Determinism: Windows installers were not deterministic.
     # We're also not interested in building Windows installers.
     find "$out" -name 'wininst*.exe' | xargs -r rm -f

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -32,7 +32,11 @@ with pkgs;
         isPy3k = isPy3;
         isPyPy = interpreter == "pypy";
 
-        buildEnv = callPackage ./wrapper.nix { python = self; inherit (pythonPackages) requiredPythonModules; };
+        buildEnv = callPackage ./wrapper.nix {
+          python = self;
+          inherit libPrefix;
+          inherit (pythonPackages) requiredPythonModules toPythonModule;
+        };
         withPackages = import ./with-packages.nix { inherit buildEnv pythonPackages;};
         pkgs = pythonPackages;
         interpreter = "${self}/bin/${executable}";

--- a/pkgs/development/interpreters/python/manylinux1.nix
+++ b/pkgs/development/interpreters/python/manylinux1.nix
@@ -1,0 +1,63 @@
+{stdenv, pkgs}:
+
+with stdenv.lib;
+with pkgs;
+
+rec {
+  # To be manylinux1 compatible, we have to be able to link against any of the libraries below (PEP 513)
+  # https://www.python.org/dev/peps/pep-0513
+  # The map shows which libraries come from which packages.
+  libraryMap = {
+    "libpanelw.so.5" = ncurses5;
+    "libncursesw.so.5" = ncurses5;
+    "libgcc_s.so.1" = glibc;
+    "libstdc++.so.6" = gcc7.cc;
+    "libm.so.6" = glibc;
+    "libdl.so.2" = glibc;
+    "librt.so.1" = glibc;
+    "libcrypt.so.1" = glibc;
+    "libc.so.6" = glibc;
+    "libnsl.so.1" = glibc;
+    "libutil.so.1" = glibc;
+    "libpthread.so.0" = glibc;
+    "libresolv.so.2" = glibc;
+    "libX11.so.6" = xorg.libX11;
+    "libXext.so.6" = xorg.libXext;
+    "libXrender.so.1" = xorg.libXrender;
+    "libICE.so.6" = xorg.libICE;
+    "libSM.so.6" = xorg.libSM;
+    "libGL.so.1" = libGL;
+    "libgobject-2.0.so.0" = glib;
+    "libgthread-2.0.so.0" = glib;
+    "libglib-2.0.so.0" = glib;
+  };
+
+  libs = attrValues libraryMap;
+  desiredLibraries = attrNames libraryMap;
+
+  package = runCommand "manylinux1_libs" {buildInputs = libs;} ''
+    mkdir -p $out/lib
+    num_found=0
+
+    IFS=:
+    export DESIRED_LIBRARIES=${concatStringsSep ":" desiredLibraries}
+    export LIBRARY_PATH=${makeLibraryPath libs}
+    for desired in $DESIRED_LIBRARIES; do
+      for path in $LIBRARY_PATH; do
+        if [ -e $path/$desired ]; then
+          echo "FOUND $path/$desired"
+          ln -s $path/$desired $out/lib/$desired
+          num_found=$((num_found+1))
+          break
+        fi
+      done
+    done
+
+    num_desired=${toString (length desiredLibraries)}
+    echo "Found $num_found of $num_desired libraries"
+    if [ "$num_found" -ne "$num_desired" ]; then
+      echo "Error: not all desired libraries were found"
+      exit 1
+    fi
+  '';
+}

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -46,6 +46,10 @@
 # Skip wrapping of python programs altogether
 , dontWrapPythonPrograms ? false
 
+# Enable manylinux1 support in generated binaries, by providing the
+# libraries listed in PEP 513 in LD_LIBRARY_PATH
+, manylinux1 ? false
+
 # Remove bytecode from bin folder.
 # When a Python script has the extension `.py`, bytecode is generated
 # Typically, executables in bin have no extension, so no bytecode is generated.
@@ -67,7 +71,7 @@ then throw "${name} not supported for interpreter ${python.executable}"
 else
 
 let self = toPythonModule (python.stdenv.mkDerivation (builtins.removeAttrs attrs [
-    "disabled" "checkInputs" "doCheck" "doInstallCheck" "dontWrapPythonPrograms" "catchConflicts"
+    "disabled" "checkInputs" "doCheck" "doInstallCheck" "dontWrapPythonPrograms" "catchConflicts" "makeWrapperArgs"
   ] // {
 
   name = namePrefix + name;
@@ -91,6 +95,12 @@ let self = toPythonModule (python.stdenv.mkDerivation (builtins.removeAttrs attr
   doCheck = false;
   doInstallCheck = doCheck;
   installCheckInputs = checkInputs;
+
+  makeWrapperArgs = makeWrapperArgs ++ (lib.optionals manylinux1 [
+    "--set"
+    "LD_LIBRARY_PATH"
+    (lib.makeLibraryPath [(lib.callPackage ./manylinux1.nix {}).package])
+  ]);
 
   postFixup = lib.optionalString (!dontWrapPythonPrograms) ''
     wrapPythonPrograms

--- a/pkgs/development/interpreters/python/pypy/default.nix
+++ b/pkgs/development/interpreters/python/pypy/default.nix
@@ -130,9 +130,6 @@ in with passthru; stdenv.mkDerivation rec {
 
     # verify cffi modules
     $out/bin/${executable} -c ${if isPy3k then "'import tkinter;import sqlite3;import curses;import lzma'" else "'import Tkinter;import sqlite3;import curses'"}
-
-    # Python on Nix is not manylinux1 compatible. https://github.com/NixOS/nixpkgs/issues/18484
-    echo "manylinux1_compatible=False" >> $out/lib/${libPrefix}/_manylinux.py
   '';
 
   inherit passthru;


### PR DESCRIPTION
###### Motivation for this change

PEP 513 tries to make the task of distributing Python wheels easier by defining a list of "core" shared libraries that should be available on any Linux system. If your system contains these libraries, then you are considered `manylinux1` compliant and you can install these wheels.

Until now, Nix's Python distributions have not been `manylinux1` compliant, but it would be nice if it were possible. This is primarily useful if you are using Nix to install `pip` and then using `pip` to install additional packages outside of Nix. (cf. https://github.com/NixOS/nixpkgs/pull/51641)

This PR isn't entirely complete -- I'm not sure the right way to expose this option and looking for feedback. Currently the idea is that you can make a `manylinux1`-compliant `python.withPackages` like this:

```
myWithPackages = f: let packages = f pythonPackages; in
  python.buildEnv.override {
    extraLibs = packages;
    manylinux1 =true;    
};
```

There would also need to be a way to re-implement the restriction that prevents attempting to install `manylinux1` wheels when it isn't enabled; we can't just bake it into the Python build.

There's some discussion about this restriction in #18484.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] tested this idea on Ubuntu
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [N/A] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

