### PR TITLE
lektor: 2.3 -> 3.1.3

### DIFF
--- a/pkgs/development/python-modules/lektor/default.nix
+++ b/pkgs/development/python-modules/lektor/default.nix
@@ -1,4 +1,6 @@
 { stdenv
+, lib
+, isPy3k
 , buildPythonPackage
 , fetchFromGitHub
 , click
@@ -7,7 +9,9 @@
 , requests
 , mistune
 , inifile
+, enum34
 , Babel
+, functools32
 , jinja2
 , flask
 , pyopenssl
@@ -17,20 +21,20 @@
 
 buildPythonPackage rec {
   pname = "lektor";
-  version = "2.3";
+  version = "3.1.3";
 
   src = fetchFromGitHub {
     owner = "lektor";
     repo = "lektor";
-    rev = "${version}";
-    sha256 = "1n0ylh1sbpvi9li3g6a7j7m28njfibn10y6s2gayjxwm6fpphqxy";
+    rev = version;
+    sha256 = "16qw68rz5q77w84lwyhjpfd3bm4mfrhcjrnxwwnz3vmi610h68hx";
   };
 
   buildInputs = [ pkgs.glibcLocales ];
   propagatedBuildInputs = [
     click watchdog exifread requests mistune inifile Babel jinja2
     flask pyopenssl ndg-httpsclient
-  ];
+  ] ++ lib.optional (!isPy3k) [enum34 functools32];
 
   LC_ALL="en_US.UTF-8";
 

--- a/pkgs/development/python-modules/lektor/default.nix
+++ b/pkgs/development/python-modules/lektor/default.nix
@@ -1,6 +1,6 @@
 { stdenv
 , buildPythonPackage
-, fetchgit
+, fetchFromGitHub
 , click
 , watchdog
 , exifread
@@ -19,9 +19,10 @@ buildPythonPackage rec {
   pname = "lektor";
   version = "2.3";
 
-  src = fetchgit {
-    url = "https://github.com/lektor/lektor";
-    rev = "refs/tags/${version}";
+  src = fetchFromGitHub {
+    owner = "lektor";
+    repo = "lektor";
+    rev = "${version}";
     sha256 = "1n0ylh1sbpvi9li3g6a7j7m28njfibn10y6s2gayjxwm6fpphqxy";
   };
 


### PR DESCRIPTION
###### Motivation for this change

version bump (Lektor 3.0 [has been released in 2017](https://pypi.org/project/Lektor/#history), 3.1 in early 2018 and 3.1.3 on 2019-01-26.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Notes:

* The derivation seems to be missing the JavaScript part of Lektor, so editing through the web interface provided by `lektor server` doesn't work. This was already the case with the 2.3 version of the derivation, so isn't a regression of this version bump.
* Upstream [_does_ provide tests](https://github.com/lektor/lektor#want-to-develop-on-lektor), but we don't run them. Should we? If so, can someone help me implement that? If we shouldn't, should we at least remove or change the comment that (falsely) claims "No tests included in archive"?