### PR TITLE
k6: init at 0.23.1

### DIFF
--- a/pkgs/development/tools/k6/default.nix
+++ b/pkgs/development/tools/k6/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage  rec {
+  name = "k6-${version}";
+  version = "0.23.1";
+
+  goPackagePath = "github.com/loadimpact/k6";
+
+  src = fetchFromGitHub {
+    owner = "loadimpact";
+    repo = "k6";
+    rev = "v${version}";
+    sha256 = "03krrpbb67h9hmrg5m94936kha667yh2lqzp9s7fv0b6khskr9r7";
+  };
+
+  subPackages = [ "./" ];
+
+  meta = with stdenv.lib; {
+    homepage = https://k6.io/;
+    description = "A modern load testing tool, using Go and JavaScript";
+    license = licenses.agpl3;
+    maintainers = with maintainers; [ offline ];
+  };
+}

--- a/pkgs/development/tools/k6/default.nix
+++ b/pkgs/development/tools/k6/default.nix
@@ -18,7 +18,7 @@ buildGoPackage  rec {
   meta = with stdenv.lib; {
     homepage = https://k6.io/;
     description = "A modern load testing tool, using Go and JavaScript";
-    license = licenses.agpl3;
+    license = licenses.agpl3Plus;
     maintainers = with maintainers; [ offline ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3660,6 +3660,8 @@ in
 
   kytea = callPackage ../tools/text/kytea { };
 
+  k6 = callPackage ../development/tools/k6 { };
+
   ldc = callPackage ../development/compilers/ldc { };
 
   lbreakout2 = callPackage ../games/lbreakout2 { };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

