### PR TITLE
beanstalkc: init at 0.4.0

### DIFF
--- a/pkgs/development/python-modules/beanstalkc/default.nix
+++ b/pkgs/development/python-modules/beanstalkc/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, fetchPypi, buildPythonPackage }:
+
+buildPythonPackage rec {
+  pname = "beanstalkc";
+  version = "0.4.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "98978e57797320146f4b233286d9a02f65d20bad0168424118839fc608085280";
+  };
+
+  meta = {
+    description = "A simple beanstalkd client library for Python";
+    maintainers = with stdenv.lib.maintainers; [ aanderse ];
+    license = with stdenv.lib.licenses; [ asl20 ];
+    homepage = https://github.com/earl/beanstalkc;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -268,6 +268,8 @@ in {
 
   bayespy = callPackage ../development/python-modules/bayespy { };
 
+  beanstalkc = disabledIf isPy3k (callPackage ../development/python-modules/beanstalkc {});
+
   bitarray = callPackage ../development/python-modules/bitarray { };
 
   bitcoinlib = callPackage ../development/python-modules/bitcoinlib { };


### PR DESCRIPTION
###### Motivation for this change
Package I require not in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

