### PR TITLE
mikutter: drop maintainership

### DIFF
--- a/pkgs/applications/networking/instant-messengers/mikutter/default.nix
+++ b/pkgs/applications/networking/instant-messengers/mikutter/default.nix
@@ -56,7 +56,6 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "An extensible Twitter client";
     homepage = https://mikutter.hachune.net;
-    maintainers = with maintainers; [ midchildan ];
     platforms = ruby.meta.platforms;
     license = licenses.mit;
   };


### PR DESCRIPTION
###### Motivation for this change
I'd like to remove myself as the maintainer of the `mikutter` package because I no longer use it due to loss of functionality caused by Twitter's removal of the streaming API. It should still work fine as a Twitter/Mastodon client, so I'd be grateful if anyone who sees this issue in the future is interested in taking over maintainership.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

