### PR TITLE
update xhyve to tip of master

### DIFF
--- a/pkgs/applications/virtualization/xhyve/default.nix
+++ b/pkgs/applications/virtualization/xhyve/default.nix
@@ -1,15 +1,15 @@
-{ stdenv, lib, fetchurl, Hypervisor, vmnet, xpc, libobjc }:
+{ stdenv, lib, fetchurl, Hypervisor, vmnet, xpc, libobjc, zlib }:
 
 stdenv.mkDerivation rec {
   name    = "xhyve-${version}";
-  version = "1f1dbe305";
+  version = "20190124";
 
   src = fetchurl {
-    url    = "https://github.com/mist64/xhyve/archive/1f1dbe3059904f885e4ab2b3328f4bb350ea5c37.tar.gz";
-    sha256 = "0hfix8yr90szlv2yyqb2rlq5qsrxyam8kg52sly0adja0cpwfjvx";
+    url    = "https://github.com/machyve/xhyve/archive/1dd9a5165848c7ed56dafc41932c553ea56a12af.tar.gz";
+    sha256 = "18zd74pd0azf43csbqb14srbyclfgx28dpgm8ygjmbcazbnipc1k";
   };
 
-  buildInputs = [ Hypervisor vmnet xpc libobjc ];
+  buildInputs = [ Hypervisor vmnet xpc libobjc zlib ];
 
   # Don't use git to determine version
   prePatch = ''


### PR DESCRIPTION
###### Motivation for this change
run the latest xhyve 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

