### PR TITLE
LanguageClient-neovim: 2018-09-07 -> 0.1.140

### DIFF
--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -1,6 +1,7 @@
 { lib, stdenv
 , python, cmake, vim, ruby
-, which, fetchgit, llvmPackages, rustPlatform
+, which, fetchgit, fetchurl
+, llvmPackages, rustPlatform
 , xkb-switch, fzf, skim
 , python3, boost, icu, ncurses
 , ycmd, rake
@@ -39,16 +40,15 @@ self: super: {
   };
 
   LanguageClient-neovim = let
-    LanguageClient-neovim-src = fetchgit {
-      url = "https://github.com/autozimu/LanguageClient-neovim";
-      rev = "59f0299e8f7d7edd0653b5fc005eec74c4bf4aba";
-      sha256 = "0x6729w7v3bxlpvm8jz1ybn23qa0zqfgxl88q2j0bbs6rvp0w1jq";
+    LanguageClient-neovim-src = fetchurl {
+      url = "https://github.com/autozimu/LanguageClient-neovim/archive/0.1.140.tar.gz";
+      sha256 = "0cixwm9wnn6vlam6mp57j436n92c4bvj5rs6j2qcv7qip8d2ggyw";
     };
     LanguageClient-neovim-bin = rustPlatform.buildRustPackage {
       name = "LanguageClient-neovim-bin";
       src = LanguageClient-neovim-src;
 
-      cargoSha256 = "1afmz14j7ma2nrsx0njcqbh2wa430dr10hds78c031286ppgwjls";
+      cargoSha256 = "0f591zv4f7spks2hx22nkq78sj42259gi7flnnpr1nfs40d7n13n";
       buildInputs = stdenv.lib.optionals stdenv.isDarwin [ CoreServices ];
 
       # FIXME: Use impure version of CoreFoundation because of missing symbols.
@@ -59,7 +59,7 @@ self: super: {
     };
   in buildVimPluginFrom2Nix {
     pname = "LanguageClient-neovim";
-    version = "2018-09-07";
+    version = "0.1.140";
     src = LanguageClient-neovim-src;
 
     propogatedBuildInputs = [ LanguageClient-neovim-bin ];


### PR DESCRIPTION
###### Motivation for this change
Use the latest release instead of a rev.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

