### PR TITLE
mirrors.nix: add https and http mirrors for gcc

### DIFF
--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -44,6 +44,8 @@ rec {
 
   # GCC.
   gcc = [
+    https://bigsearcher.com/mirrors/gcc/
+    http://mirror.koddos.net/gcc/
     ftp://ftp.nluug.nl/mirror/languages/gcc/
     ftp://ftp.fu-berlin.de/unix/languages/gcc/
     ftp://ftp.irisa.fr/pub/mirrors/gcc.gnu.org/gcc/


### PR DESCRIPTION
HTTP is never worse and often better than FTP, since many users may be on
networks that do not allow FTP traffic.

###### Motivation for this change
More variety of src fetching mechanisms.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

