### PR TITLE
kdevelop: added ability to include kdevelop plugins, kdev-php: init at 5.3.1, kdev-python: init at 5.3.1

### DIFF
--- a/pkgs/applications/editors/kdevelop5/kdev-php.nix
+++ b/pkgs/applications/editors/kdevelop5/kdev-php.nix
@@ -1,0 +1,29 @@
+{ stdenv, lib, fetchurl, cmake, extra-cmake-modules, threadweaver, ktexteditor, kdevelop-unwrapped, kdevelop-pg-qt }:
+
+let
+  pname = "kdev-php";
+  version = "5.3.1";
+in
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/KDE/${pname}/archive/v${version}.tar.gz";
+    sha256 = "1xiz4v6w30dsa7l4nk3jw3hxpkx71b0yaaj2k8s7xzgjif824bgl";
+  };
+
+  cmakeFlags = [
+    "-DBUILD_TESTING=OFF"
+  ];
+
+  nativeBuildInputs = [ cmake extra-cmake-modules ];
+  buildInputs = [ kdevelop-pg-qt threadweaver ktexteditor kdevelop-unwrapped ];
+
+  meta = with lib; {
+    maintainers = [ maintainers.aanderse ];
+    platforms = platforms.linux;
+    description = "PHP support for KDevelop";
+    homepage = https://www.kdevelop.org;
+    license = [ licenses.gpl2 ];
+  };
+}

--- a/pkgs/applications/editors/kdevelop5/kdev-python.nix
+++ b/pkgs/applications/editors/kdevelop5/kdev-python.nix
@@ -1,0 +1,30 @@
+{ stdenv, lib, fetchurl, cmake, extra-cmake-modules, threadweaver, ktexteditor, kdevelop-unwrapped, python }:
+
+let
+  pname = "kdev-python";
+  version = "5.3.1";
+in
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/KDE/${pname}/archive/v${version}.tar.gz";
+    sha256 = "11hf8n6vrlaz31c0p3xbnf0df2q5j6ykgc9ip0l5g33kadwn5b9j";
+  };
+
+  cmakeFlags = [
+    "-DBUILD_TESTING=OFF"
+    "-DPYTHON_EXECUTABLE=${python}/bin/python"
+  ];
+
+  nativeBuildInputs = [ cmake extra-cmake-modules ];
+  buildInputs = [ threadweaver ktexteditor kdevelop-unwrapped ];
+
+  meta = with lib; {
+    maintainers = [ maintainers.aanderse ];
+    platforms = platforms.linux;
+    description = "Python support for KDevelop";
+    homepage = https://www.kdevelop.org;
+    license = [ licenses.gpl2 ];
+  };
+}

--- a/pkgs/applications/editors/kdevelop5/kdevelop.nix
+++ b/pkgs/applications/editors/kdevelop5/kdevelop.nix
@@ -43,6 +43,13 @@ mkDerivation rec {
     "-DCLANG_BUILTIN_DIR=${llvmPackages.clang-unwrapped}/lib/clang/${(builtins.parseDrvName llvmPackages.clang.name).version}/include"
   ];
 
+  postPatch = ''
+    # FIXME: temporary until https://invent.kde.org/kde/kdevelop/merge_requests/8 is merged
+    substituteInPlace kdevplatform/language/backgroundparser/parsejob.cpp --replace \
+      'if (internalFilePath.startsWith(dataPath.canonicalPath() + QStringLiteral("/kdev"))) {' \
+      'if (internalFilePath.startsWith(dataPath.canonicalPath() + QStringLiteral("/kdev")) || localFile.startsWith(path + QStringLiteral("/kdev"))) {'
+  '';
+
   postInstall = ''
     # The kdevelop! script (shell environment) needs qdbus and kioclient5 in PATH.
     wrapProgram "$out/bin/kdevelop!" \

--- a/pkgs/applications/editors/kdevelop5/wrapper.nix
+++ b/pkgs/applications/editors/kdevelop5/wrapper.nix
@@ -1,0 +1,7 @@
+{ symlinkJoin, kdevelop-unwrapped, plugins ? null }:
+
+symlinkJoin {
+  name = "kdevelop-with-plugins";
+
+  paths = [ kdevelop-unwrapped ] ++ (if plugins != null then plugins else []);
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17879,11 +17879,18 @@ in
 
   inherit (kdeFrameworks) kdesu;
 
-  kdevelop-pg-qt = libsForQt5.callPackage ../applications/editors/kdevelop5/kdevelop-pg-qt.nix {};
+  kdevelop-pg-qt = libsForQt5.callPackage ../applications/editors/kdevelop5/kdevelop-pg-qt.nix { };
 
-  kdevelop = libsForQt5.callPackage ../applications/editors/kdevelop5/kdevelop.nix {
+  kdevelop-unwrapped = libsForQt5.callPackage ../applications/editors/kdevelop5/kdevelop.nix {
     llvmPackages = llvmPackages_7;
   };
+
+  kdev-php = libsForQt5.callPackage ../applications/editors/kdevelop5/kdev-php.nix { };
+  kdev-python = libsForQt5.callPackage ../applications/editors/kdevelop5/kdev-python.nix {
+    python = python3;
+  };
+
+  kdevelop = libsForQt5.callPackage ../applications/editors/kdevelop5/wrapper.nix { };
 
   keepnote = callPackage ../applications/office/keepnote { };
 


### PR DESCRIPTION
###### Motivation for this change
Added php and python support as optional plugins for kdevelop.

Note: There is a bug upstream which I have submitted a patch for to fix a problem in kdevelop on nixos. See https://invent.kde.org/kde/kdevelop/merge_requests/8 for details. The issue likely won't be resolved in kdevelop before 19.03 so I suggest this PR is merged as is.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

