### PR TITLE
gnome-control-center: point to gnome-session's libexecdir properly

### DIFF
--- a/pkgs/desktops/gnome-3/core/gnome-control-center/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-control-center/default.nix
@@ -4,7 +4,7 @@
 , libxml2, polkit, libxslt, libgtop, libsoup, colord, colord-gtk
 , cracklib, libkrb5, networkmanagerapplet, networkmanager, glibc
 , libwacom, samba, shared-mime-info, tzdata, libtool, libgnomekbd
-, docbook_xsl, modemmanager, clutter, clutter-gtk, cheese
+, docbook_xsl, modemmanager, clutter, clutter-gtk, cheese, gnome-session
 , fontconfig, sound-theme-freedesktop, grilo, python3 }:
 
 let
@@ -45,6 +45,10 @@ in stdenv.mkDerivation rec {
     chmod +x build-aux/meson/meson_post_install.py # patchShebangs requires executable file
     patchShebangs build-aux/meson/meson_post_install.py
   '';
+
+  mesonFlags = [
+    "-Dgnome_session_libexecdir=${gnome-session}/libexec"
+  ];
 
   preFixup = ''
     gappsWrapperArgs+=(


### PR DESCRIPTION
###### Motivation for this change

Noticed while investigating some ultimately unrelated problem,
but seems like whatever it wants gnome-session libexecdir for
looking for it in a place that surely will not have those bits
is likely not the best.

(and if intentional should perhaps be documented)

If gnome3 maintainer thinks this is a clear win, great,
if it's a maze of questionableness then NP let's leave as-is :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---