### PR TITLE
vimpc: 0.09.1 -> 0.09.2

### DIFF
--- a/pkgs/applications/audio/vimpc/default.nix
+++ b/pkgs/applications/audio/vimpc/default.nix
@@ -1,19 +1,19 @@
 { stdenv, fetchFromGitHub, autoreconfHook, mpd_clientlib, ncurses, pcre, pkgconfig
-, taglib }:
+, taglib, curl }:
 
 stdenv.mkDerivation rec {
-  version = "0.09.1";
+  version = "0.09.2";
   name = "vimpc-${version}";
 
   src = fetchFromGitHub {
     owner = "boysetsfrog";
     repo = "vimpc";
     rev = "v${version}";
-    sha256 = "1495a702df4nja8mlxq98mkbic2zv88sjiinimf9qddrfb38jxk6";
+    sha256 = "0lswzkap2nm7v5h7ppb6a64cb35rajysd09nb204rxgrkij4m6nx";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
-  buildInputs = [ mpd_clientlib ncurses pcre taglib ];
+  buildInputs = [ mpd_clientlib ncurses pcre taglib curl ];
 
   postInstall = ''
     mkdir -p $out/etc


### PR DESCRIPTION
###### Motivation for this change


   * Fix lyrics fetching
    * Allow XDG base configuration folder
    * Various bugfixes



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

