### PR TITLE
cairo: apply patch for CVE-2018-19876

### DIFF
--- a/pkgs/development/libraries/cairo/default.nix
+++ b/pkgs/development/libraries/cairo/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, libiconv
+{ stdenv, fetchurl, fetchpatch, pkgconfig, libiconv
 , libintl, expat, zlib, libpng, pixman, fontconfig, freetype, xorg
 , gobjectSupport ? true, glib
 , xcbSupport ? true # no longer experimental since 1.12
@@ -19,6 +19,19 @@ in stdenv.mkDerivation rec {
     url = "https://cairographics.org/${if stdenv.lib.mod (builtins.fromJSON (stdenv.lib.versions.minor version)) 2 == 0 then "releases" else "snapshots"}/${name}.tar.xz";
     sha256 = "0c930mk5xr2bshbdljv005j3j8zr47gqmkry3q6qgvqky6rjjysy";
   };
+
+  patches = [
+    # Fixes CVE-2018-19876; see Nixpkgs issue #55384
+    # CVE information: https://nvd.nist.gov/vuln/detail/CVE-2018-19876
+    # Upstream PR: https://gitlab.freedesktop.org/cairo/cairo/merge_requests/5
+    #
+    # This patch is the merged commit from the above PR.
+    (fetchpatch {
+      name   = "CVE-2018-19876.patch";
+      url    = "https://gitlab.freedesktop.org/cairo/cairo/commit/6edf572ebb27b00d3c371ba5ae267e39d27d5b6d.patch";
+      sha256 = "112hgrrsmcwxh1r52brhi5lksq4pvrz4xhkzcf2iqp55jl2pb7n1";
+    })
+  ];
 
   outputs = [ "out" "dev" "devdoc" ];
   outputBin = "dev"; # very small


### PR DESCRIPTION
###### Motivation for this change

Security update; ref: #55384

This applies the patch from the following upstream merge request:
    https://gitlab.freedesktop.org/cairo/cairo/merge_requests/5

This resulted in the following merge commit, which we fetch as a patch
and apply:
    https://gitlab.freedesktop.org/cairo/cairo/commit/6edf572ebb27b00d3c371ba5ae267e39d27d5b6d

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @ckauhaus 