### PR TITLE
thinkfan: 0.9.3 -> 1.0.1

### DIFF
--- a/pkgs/tools/system/thinkfan/default.nix
+++ b/pkgs/tools/system/thinkfan/default.nix
@@ -1,15 +1,25 @@
-{ stdenv, fetchurl, cmake }:
+{ stdenv, fetchFromGitHub, cmakeCurses, libyamlcpp, libatasmart, pkgconfig }:
 
 stdenv.mkDerivation rec {
   name = "thinkfan-${version}";
-  version = "0.9.3";
+  version = "1.0.1";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/thinkfan/thinkfan-${version}.tar.gz";
-    sha256 = "0nz4c48f0i0dljpk5y33c188dnnwg8gz82s4grfl8l64jr4n675n";
+  src = fetchFromGitHub {
+    owner = "vmatare";
+    repo = "thinkfan";
+    rev = "${version}";
+    sha256 = "1983p8aryfgpyhflh5r5xz27y136a4vvm7plgrg44q4aicqbcp8j";
   };
 
-  nativeBuildInputs = [ cmake ];
+  configureFlags = [
+    "-DCMAKE_INSTALL_DOCDIR==share/doc/${name}"
+    "-DUSE_NVML=OFF"
+    "-DUSE_ATASMART=ON"
+    "-DUSE_YAML=ON"
+  ];
+
+  nativeBuildInputs = [ cmakeCurses pkgconfig ];
+  buildInputs = [ libyamlcpp libatasmart ];
 
   installPhase = ''
     install -Dm755 {.,$out/bin}/thinkfan
@@ -22,7 +32,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     license = stdenv.lib.licenses.gpl3;
-    homepage = http://thinkfan.sourceforge.net/;
+    homepage = https://github.com/vmatare/thinkfan;
     maintainers = with stdenv.lib.maintainers; [ domenkozar ];
     platforms = stdenv.lib.platforms.linux;
   };


### PR DESCRIPTION
###### Motivation for this change

http://thinkfan.sourceforge.net/ is dead since latest release at 2016-05-05!
Repo https://github.com/vmatare/thinkfan is alive with active development.

As say https://github.com/vmatare/thinkfan/blob/master/README#L66 new version have options USE_NVML, USE_ATASMART, USE_YAML. I could not do the right switches. I would be grateful if someone make it more correctly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

