### PR TITLE
x2goclient: Use nx-libs instead of nxproxy

### DIFF
--- a/pkgs/applications/networking/remote/x2goclient/default.nix
+++ b/pkgs/applications/networking/remote/x2goclient/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, cups, libssh, libXpm, nxproxy, openldap, openssh
+{ stdenv, fetchgit, cups, libssh, libXpm, nx-libs, openldap, openssh
 , makeWrapper, qtbase, qtsvg, qtx11extras, qttools, phonon, pkgconfig }:
 
 stdenv.mkDerivation rec {
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
    sha256 = "05gfs11m259bchy3k0ihqpwg9wf8lp94rbca5dzla9fjzrb7pyy4";
   };
 
-  buildInputs = [ cups libssh libXpm nxproxy openldap openssh
+  buildInputs = [ cups libssh libXpm nx-libs openldap openssh
                   qtbase qtsvg qtx11extras qttools phonon pkgconfig ];
   nativeBuildInputs = [ makeWrapper ];
 
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   installTargets = [ "install_client" "install_man" ];
   postInstall = ''
-    wrapProgram "$out/bin/x2goclient" --suffix PATH : "${nxproxy}/bin:${openssh}/libexec";
+    wrapProgram "$out/bin/x2goclient" --suffix PATH : "${nx-libs}/bin:${openssh}/libexec";
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
nxproxy was removed in favour of nx-libs, causing an eval failure in gcofborg (and possibly Hydra as well?) This should probably be reverted (or at least the nxproxy name should be removed instead of using lib.warn,) but this package also needs to refer to the `nx-libs` instead.

No real testing has been done here aside from running the executable -- I don't know the software.

See also #55723

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

