### PR TITLE
openjdk: 11.0.1 -> 11.0.2

### DIFF
--- a/pkgs/development/compilers/openjdk/11.nix
+++ b/pkgs/development/compilers/openjdk/11.nix
@@ -18,16 +18,15 @@ let
     else "amd64";
 
   major = "11";
-  update = ".0.1";
-  build = "13";
-  repover = "jdk-${major}${update}+${build}";
+  update = ".0.2";
+  repover = "jdk-${major}${update}-ga";
 
   openjdk = stdenv.mkDerivation {
-    name = "openjdk-${major}${update}-b${build}";
+    name = "openjdk-${major}${update}-ga";
 
     src = fetchurl {
       url = "http://hg.openjdk.java.net/jdk-updates/jdk${major}u/archive/${repover}.tar.gz";
-      sha256 = "1ri3fv67rvs9xxhc3ynklbprhxbdsgpwafbw6wqj950xy5crgysm";
+      sha256 = "0xcb0i6j3qrihmq4klx2lkwhd6xmk4xxcvk1dkc5z15vvh937l8b";
     };
 
     nativeBuildInputs = [ pkgconfig ];
@@ -53,9 +52,6 @@ let
 
       configureFlagsArray=(
         "--with-boot-jdk=${bootjdk.home}"
-        "--with-update-version=${major}${update}"
-        "--with-build-number=${build}"
-        "--with-milestone=fcs"
         "--enable-unlimited-crypto"
         "--disable-debug-symbols"
         "--with-zlib=system"


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).