### PR TITLE
hugo: 0.50 -> 0.54.0

### DIFF
--- a/pkgs/applications/misc/hugo/default.nix
+++ b/pkgs/applications/misc/hugo/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "hugo-${version}";
-  version = "0.50";
+  version = "0.54.0";
 
   goPackagePath = "github.com/gohugoio/hugo";
 
@@ -10,7 +10,7 @@ buildGoPackage rec {
     owner  = "gohugoio";
     repo   = "hugo";
     rev    = "v${version}";
-    sha256 = "1shrw7pxwrz9g5x9bq6k5qvhn3fqmwznadpw7i07msh97p8b3dyn";
+    sha256 = "01grfbr3kpd4qf5cbcmzc6yfq34cm0nkak4pqzgrn46r254y0ymv";
   };
 
   goDeps = ./deps.nix;

--- a/pkgs/applications/misc/hugo/deps.nix
+++ b/pkgs/applications/misc/hugo/deps.nix
@@ -1,5 +1,23 @@
+# file generated from go.mod using vgo2nix (https://github.com/adisbladis/vgo2nix)
 [
-
+  {
+    goPackagePath = "github.com/gobuffalo/envy";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gobuffalo/envy";
+      rev = "v1.6.8";
+      "sha256" = "1xh26j9bji8c4hr05f89kbc4fhqniba00bdcic4gs5xfnp2vj7gk";
+    };
+  }
+  {
+    goPackagePath = "github.com/joho/godotenv";
+    fetch = {
+      type = "git";
+      url = "https://github.com/joho/godotenv";
+      rev = "v1.3.0";
+      "sha256" = "0ri8if0pc3x6jg4c3i8wr58xyfpxkwmcjk3rp8gb398a1aa3gpjm";
+    };
+  }
   {
     goPackagePath = "github.com/BurntSushi/locker";
     fetch = {
@@ -9,7 +27,6 @@
       sha256 = "1xak4aync4klswq5217qvw191asgla51jr42y94vp109lirm5dzg";
     };
   }
-
   {
     goPackagePath = "github.com/BurntSushi/toml";
     fetch = {
@@ -19,7 +36,6 @@
       sha256 = "1sjxs2lwc8jpln80s4rlzp7nprbcljhy5mz4rf9995gq93wqnym5";
     };
   }
-
   {
     goPackagePath = "github.com/PuerkitoBio/purell";
     fetch = {
@@ -29,7 +45,6 @@
       sha256 = "0vsxyn1fbm7g873b8kf3hcsgqgncb5nmfq3zfsc35a9yhzarka91";
     };
   }
-
   {
     goPackagePath = "github.com/PuerkitoBio/urlesc";
     fetch = {
@@ -39,7 +54,6 @@
       sha256 = "0n0srpqwbaan1wrhh2b7ysz543pjs1xw2rghvqyffg9l0g8kzgcw";
     };
   }
-
   {
     goPackagePath = "github.com/alecthomas/assert";
     fetch = {
@@ -49,17 +63,15 @@
       sha256 = "1l567pi17k593nrd1qlbmiq8z9jy3qs60px2a16fdpzjsizwqx8l";
     };
   }
-
   {
     goPackagePath = "github.com/alecthomas/chroma";
     fetch = {
       type = "git";
       url = "https://github.com/alecthomas/chroma";
-      rev = "v0.5.0";
-      sha256 = "150jv4vhsdi1gj3liwkgicdrwnzgv5qkq2fwznlnzf64vmfb0b9f";
+      rev = "v0.6.2";
+      sha256 = "1bcppy1s148iikr78qjm0akahn01ywh83a8pw544prr9yc16jvmz";
     };
   }
-
   {
     goPackagePath = "github.com/alecthomas/colour";
     fetch = {
@@ -69,17 +81,33 @@
       sha256 = "0iq566534gbzkd16ixg7fk298wd766821vvs80838yifx9yml5vs";
     };
   }
-
+  {
+    goPackagePath = "github.com/alecthomas/kong";
+    fetch = {
+      type = "git";
+      url = "https://github.com/alecthomas/kong";
+      rev = "v0.1.15";
+      sha256 = "1llxabcdzlb2hard0h931knqkdnyjyz8dp3k0nli0m0mags7l31b";
+    };
+  }
   {
     goPackagePath = "github.com/alecthomas/repr";
     fetch = {
       type = "git";
       url = "https://github.com/alecthomas/repr";
-      rev = "117648cd9897";
-      sha256 = "05v1rgzdqc8razf702laagrvhvx68xd9yxxmzd3dyz0d6425pdrp";
+      rev = "d37bc2a10ba1";
+      sha256 = "0jnx1ypdl4zi010ds2z857ajkr5cx51wkx950rfqb126hvql7svx";
     };
   }
-
+  {
+    goPackagePath = "github.com/armon/consul-api";
+    fetch = {
+      type = "git";
+      url = "https://github.com/armon/consul-api";
+      rev = "eb2c6b5be1b6";
+      sha256 = "1j6fdr1sg36qy4n4xjl7brq739fpm5npq98cmvklzjc9qrx98nk9";
+    };
+  }
   {
     goPackagePath = "github.com/bep/debounce";
     fetch = {
@@ -89,7 +117,6 @@
       sha256 = "1sh4zv0hv7f454mhzpl2mbv7ar5rm00wyy5qr78x1h84bgph87wy";
     };
   }
-
   {
     goPackagePath = "github.com/bep/gitmap";
     fetch = {
@@ -99,17 +126,15 @@
       sha256 = "0zqdl5h4ayi2gi5aqf35f1sjszhbcriksm2bf84fkrg7ngr48jn6";
     };
   }
-
   {
     goPackagePath = "github.com/bep/go-tocss";
     fetch = {
       type = "git";
       url = "https://github.com/bep/go-tocss";
-      rev = "v0.5.0";
-      sha256 = "12q7h6nydklq4kg65kcgd85209rx7zf64ba6nf3k7y16knj4233q";
+      rev = "v0.6.0";
+      sha256 = "0w5i3ig3bbdrwbrcwzx8xsxhlb8xr17jj3wdcb6klqglg7551yvm";
     };
   }
-
   {
     goPackagePath = "github.com/chaseadamsio/goorgeous";
     fetch = {
@@ -119,7 +144,42 @@
       sha256 = "07qdqi46klizq3wigxqbiksnlgbrdc8hvmizgzg0aas5iqy88dcb";
     };
   }
-
+  {
+    goPackagePath = "github.com/cheekybits/is";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cheekybits/is";
+      rev = "68e9c0620927";
+      sha256 = "1mkbyzhwq3rby832ikq00nxv3jnckxsm3949wkxd8ya9js2jmg4d";
+    };
+  }
+  {
+    goPackagePath = "github.com/coreos/etcd";
+    fetch = {
+      type = "git";
+      url = "https://github.com/coreos/etcd";
+      rev = "v3.3.10";
+      sha256 = "1x2ii1hj8jraba8rbxz6dmc03y3sjxdnzipdvg6fywnlq1f3l3wl";
+    };
+  }
+  {
+    goPackagePath = "github.com/coreos/go-etcd";
+    fetch = {
+      type = "git";
+      url = "https://github.com/coreos/go-etcd";
+      rev = "v2.0.0";
+      sha256 = "1xb34hzaa1lkbq5vkzy9vcz6gqwj7hp6cdbvyack2bf28dwn33jj";
+    };
+  }
+  {
+    goPackagePath = "github.com/coreos/go-semver";
+    fetch = {
+      type = "git";
+      url = "https://github.com/coreos/go-semver";
+      rev = "v0.2.0";
+      sha256 = "1gghi5bnqj50hfxhqc1cxmynqmh2yk9ii7ab9gsm75y5cp94ymk0";
+    };
+  }
   {
     goPackagePath = "github.com/cpuguy83/go-md2man";
     fetch = {
@@ -129,7 +189,6 @@
       sha256 = "1w22dfdamsq63b5rvalh9k2y7rbwfkkjs7vm9vd4a13h2ql70lg2";
     };
   }
-
   {
     goPackagePath = "github.com/danwakefield/fnmatch";
     fetch = {
@@ -139,7 +198,6 @@
       sha256 = "0cbf511ppsa6hf59mdl7nbyn2b2n71y0bpkzbmfkdqjhanqh1lqz";
     };
   }
-
   {
     goPackagePath = "github.com/davecgh/go-spew";
     fetch = {
@@ -149,7 +207,6 @@
       sha256 = "0hka6hmyvp701adzag2g26cxdj47g21x6jz4sc6jjz1mn59d474y";
     };
   }
-
   {
     goPackagePath = "github.com/disintegration/imaging";
     fetch = {
@@ -159,7 +216,6 @@
       sha256 = "1laxccmzi7q51zxn81ringmdwp8iaipivrl375yc3gq56d70sp0r";
     };
   }
-
   {
     goPackagePath = "github.com/dlclark/regexp2";
     fetch = {
@@ -169,7 +225,15 @@
       sha256 = "144s81ndviwhyy20ipxvvfvap8phv5p762glxrz6aqxprkxfarj5";
     };
   }
-
+  {
+    goPackagePath = "github.com/dustin/go-humanize";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dustin/go-humanize";
+      rev = "v1.0.0";
+      sha256 = "1kqf1kavdyvjk7f8kx62pnm7fbypn9z1vbf8v2qdh3y7z7a0cbl3";
+    };
+  }
   {
     goPackagePath = "github.com/eknkc/amber";
     fetch = {
@@ -179,7 +243,6 @@
       sha256 = "152w97yckwncgw7lwjvgd8d00wy6y0nxzlvx72kl7nqqxs9vhxd9";
     };
   }
-
   {
     goPackagePath = "github.com/fortytw2/leaktest";
     fetch = {
@@ -189,7 +252,6 @@
       sha256 = "1lf9l6zgzjbcc7hmcjhhg3blx0y8icyxvjmjqqwfbwdk502803ra";
     };
   }
-
   {
     goPackagePath = "github.com/fsnotify/fsnotify";
     fetch = {
@@ -199,7 +261,6 @@
       sha256 = "07va9crci0ijlivbb7q57d2rz9h27zgn2fsm60spjsqpdbvyrx4g";
     };
   }
-
   {
     goPackagePath = "github.com/gobwas/glob";
     fetch = {
@@ -209,7 +270,6 @@
       sha256 = "0jxk1x806zn5x86342s72dq2qy64ksb3zrvrlgir2avjhwb18n6z";
     };
   }
-
   {
     goPackagePath = "github.com/gorilla/websocket";
     fetch = {
@@ -219,7 +279,6 @@
       sha256 = "00i4vb31nsfkzzk7swvx3i75r2d960js3dri1875vypk3v2s0pzk";
     };
   }
-
   {
     goPackagePath = "github.com/hashicorp/go-immutable-radix";
     fetch = {
@@ -229,7 +288,6 @@
       sha256 = "1v3nmsnk1s8bzpclrhirz7iq0g5xxbw9q5gvrg9ss6w9crs72qr6";
     };
   }
-
   {
     goPackagePath = "github.com/hashicorp/go-uuid";
     fetch = {
@@ -239,7 +297,6 @@
       sha256 = "1jflywlani7583qm4ysph40hsgx3n66n5zr2k84i057fmwa1ypfy";
     };
   }
-
   {
     goPackagePath = "github.com/hashicorp/golang-lru";
     fetch = {
@@ -249,7 +306,6 @@
       sha256 = "12k2cp2k615fjvfa5hyb9k2alian77wivds8s65diwshwv41939f";
     };
   }
-
   {
     goPackagePath = "github.com/hashicorp/hcl";
     fetch = {
@@ -259,7 +315,6 @@
       sha256 = "0q6ml0qqs0yil76mpn4mdx4lp94id8vbv575qm60jzl1ijcl5i66";
     };
   }
-
   {
     goPackagePath = "github.com/inconshreveable/mousetrap";
     fetch = {
@@ -269,7 +324,6 @@
       sha256 = "1mn0kg48xkd74brf48qf5hzp0bc6g8cf5a77w895rl3qnlpfw152";
     };
   }
-
   {
     goPackagePath = "github.com/jdkato/prose";
     fetch = {
@@ -279,7 +333,6 @@
       sha256 = "1gjqgrpc7wbqvnhgwyfhxng24qvx37qjy0x2mbikiw1vaygxqsmy";
     };
   }
-
   {
     goPackagePath = "github.com/kr/pretty";
     fetch = {
@@ -289,7 +342,6 @@
       sha256 = "18m4pwg2abd0j9cn5v3k2ksk9ig4vlwxmlw9rrglanziv9l967qp";
     };
   }
-
   {
     goPackagePath = "github.com/kr/pty";
     fetch = {
@@ -299,7 +351,6 @@
       sha256 = "0383f0mb9kqjvncqrfpidsf8y6ns5zlrc91c6a74xpyxjwvzl2y6";
     };
   }
-
   {
     goPackagePath = "github.com/kr/text";
     fetch = {
@@ -309,7 +360,6 @@
       sha256 = "1gm5bsl01apvc84bw06hasawyqm4q84vx1pm32wr9jnd7a8vjgj1";
     };
   }
-
   {
     goPackagePath = "github.com/kyokomi/emoji";
     fetch = {
@@ -319,7 +369,6 @@
       sha256 = "005rxyxlqcd2sfjn686xb52l11wn2w0g5jv042ka6pnsx24r812a";
     };
   }
-
   {
     goPackagePath = "github.com/magefile/mage";
     fetch = {
@@ -329,7 +378,6 @@
       sha256 = "177hzmmzhk7bcm3jj2cj6d5l9h5ql3cikvndhk4agkslrhwr3xka";
     };
   }
-
   {
     goPackagePath = "github.com/magiconair/properties";
     fetch = {
@@ -339,17 +387,33 @@
       sha256 = "1a10362wv8a8qwb818wygn2z48lgzch940hvpv81hv8gc747ajxn";
     };
   }
-
   {
     goPackagePath = "github.com/markbates/inflect";
     fetch = {
       type = "git";
       url = "https://github.com/markbates/inflect";
-      rev = "a12c3aec81a6";
-      sha256 = "0mawr6z9nav4f5j0nmjdxg9lbfhr7wz8zi34g7b6wndmzyf8jbsd";
+      rev = "v1.0.0";
+      sha256 = "072a73ij23mp8vabr8xwga2kj8dimya44ciiy9g4x4r9imm86psw";
     };
   }
-
+  {
+    goPackagePath = "github.com/matryer/try";
+    fetch = {
+      type = "git";
+      url = "https://github.com/matryer/try";
+      rev = "9ac251b645a2";
+      sha256 = "19fnqmpl3p54vmxgm1hmqvdc87brqx754wf3cdhq1bj04fcbb5h9";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-colorable";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-colorable";
+      rev = "v0.0.9";
+      sha256 = "1nwjmsppsjicr7anq8na6md7b1z84l9ppnlr045hhxjvbkqwalvx";
+    };
+  }
   {
     goPackagePath = "github.com/mattn/go-isatty";
     fetch = {
@@ -359,7 +423,6 @@
       sha256 = "0zs92j2cqaw9j8qx1sdxpv3ap0rgbs0vrvi72m40mg8aa36gd39w";
     };
   }
-
   {
     goPackagePath = "github.com/mattn/go-runewidth";
     fetch = {
@@ -369,7 +432,6 @@
       sha256 = "0lc39b6xrxv7h3v3y1kgz49cgi5qxwlygs715aam6ba35m48yi7g";
     };
   }
-
   {
     goPackagePath = "github.com/miekg/mmark";
     fetch = {
@@ -379,7 +441,6 @@
       sha256 = "0q2zrwa2vwk7a0zhmi000zpqrc01zssrj9c5n3573rg68fksg77m";
     };
   }
-
   {
     goPackagePath = "github.com/mitchellh/hashstructure";
     fetch = {
@@ -389,17 +450,15 @@
       sha256 = "0zgl5c03ip2yzkb9b7fq9ml08i7j8prgd46ha1fcg8c6r7k9xl3i";
     };
   }
-
   {
     goPackagePath = "github.com/mitchellh/mapstructure";
     fetch = {
       type = "git";
       url = "https://github.com/mitchellh/mapstructure";
-      rev = "v1.0.0";
-      sha256 = "0f06q4fpzg0c370cvmpsl0iq2apl5nkbz5cd3nba5x5ysmshv1lm";
+      rev = "v1.1.2";
+      sha256 = "03bpv28jz9zhn4947saqwi328ydj7f6g6pf1m2d4m5zdh5jlfkrr";
     };
   }
-
   {
     goPackagePath = "github.com/muesli/smartcrop";
     fetch = {
@@ -409,7 +468,6 @@
       sha256 = "0xbv5wbn0z36nkw9ay3ly6z23lpsrs0khryl1w54fz85lvwh66gp";
     };
   }
-
   {
     goPackagePath = "github.com/nfnt/resize";
     fetch = {
@@ -419,7 +477,6 @@
       sha256 = "005cpiwq28krbjf0zjwpfh63rp4s4is58700idn24fs3g7wdbwya";
     };
   }
-
   {
     goPackagePath = "github.com/nicksnyder/go-i18n";
     fetch = {
@@ -429,7 +486,6 @@
       sha256 = "1nlvq85c232z5yjs86pxpmkv7hk6gb5pa6j4hhzgdz85adk2ma04";
     };
   }
-
   {
     goPackagePath = "github.com/olekukonko/tablewriter";
     fetch = {
@@ -439,7 +495,6 @@
       sha256 = "1274k5r9ardh1f6gsmadxmdds7zy8rkr55fb9swvnm0vazr3y01l";
     };
   }
-
   {
     goPackagePath = "github.com/pelletier/go-toml";
     fetch = {
@@ -449,7 +504,6 @@
       sha256 = "1fjzpcjng60mc3a4b2ql5a00d5gah84wj740dabv9kq67mpg8fxy";
     };
   }
-
   {
     goPackagePath = "github.com/pkg/errors";
     fetch = {
@@ -459,7 +513,6 @@
       sha256 = "001i6n71ghp2l6kdl3qq1v2vmghcz3kicv9a5wgcihrzigm75pp5";
     };
   }
-
   {
     goPackagePath = "github.com/pmezard/go-difflib";
     fetch = {
@@ -469,7 +522,6 @@
       sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
     };
   }
-
   {
     goPackagePath = "github.com/russross/blackfriday";
     fetch = {
@@ -479,7 +531,6 @@
       sha256 = "01z1jsdkac09cw95lqq4pahkw9xnini2mb956lvb772bby2x3dmj";
     };
   }
-
   {
     goPackagePath = "github.com/sanity-io/litter";
     fetch = {
@@ -489,7 +540,6 @@
       sha256 = "09nywwxxd6rmhxc7rsvs96ynjszmnvmhwr7dvh1n35hb6h9y7s2r";
     };
   }
-
   {
     goPackagePath = "github.com/sergi/go-diff";
     fetch = {
@@ -499,7 +549,6 @@
       sha256 = "0swiazj8wphs2zmk1qgq75xza6m19snif94h2m6fi8dqkwqdl7c7";
     };
   }
-
   {
     goPackagePath = "github.com/shurcooL/sanitized_anchor_name";
     fetch = {
@@ -509,17 +558,15 @@
       sha256 = "142m507s9971cl8qdmbcw7sqxnkgi3xqd8wzvfq15p0w7w8i4a3h";
     };
   }
-
   {
     goPackagePath = "github.com/spf13/afero";
     fetch = {
       type = "git";
       url = "https://github.com/spf13/afero";
-      rev = "v1.1.2";
-      sha256 = "0miv4faf5ihjfifb1zv6aia6f6ik7h1s4954kcb8n6ixzhx9ck6k";
+      rev = "v1.2.1";
+      sha256 = "14qqj0cz6a595vn4dp747vddx05fd77jdsyl85qjmf9baymaxlam";
     };
   }
-
   {
     goPackagePath = "github.com/spf13/cast";
     fetch = {
@@ -529,7 +576,6 @@
       sha256 = "0xq1ffqj8y8h7dcnm0m9lfrh0ga7pssnn2c1dnr09chqbpn4bdc5";
     };
   }
-
   {
     goPackagePath = "github.com/spf13/cobra";
     fetch = {
@@ -539,7 +585,6 @@
       sha256 = "1q1nsx05svyv9fv3fy6xv6gs9ffimkyzsfm49flvl3wnvf1ncrkd";
     };
   }
-
   {
     goPackagePath = "github.com/spf13/fsync";
     fetch = {
@@ -549,7 +594,6 @@
       sha256 = "1vvbgxbbsc4mvi1axgqgn9pzjz1p495dsmwpc7mr8qxh8f6s0nhv";
     };
   }
-
   {
     goPackagePath = "github.com/spf13/jwalterweatherman";
     fetch = {
@@ -559,7 +603,6 @@
       sha256 = "1ywmkwci5zyd88ijym6f30fj5c0k2yayxarkmnazf5ybljv50q7b";
     };
   }
-
   {
     goPackagePath = "github.com/spf13/nitro";
     fetch = {
@@ -569,57 +612,51 @@
       sha256 = "143sbpx0jdgf8f8ayv51x6l4jg6cnv6nps6n60qxhx4vd90s6mib";
     };
   }
-
   {
     goPackagePath = "github.com/spf13/pflag";
     fetch = {
       type = "git";
       url = "https://github.com/spf13/pflag";
-      rev = "v1.0.2";
-      sha256 = "005598piihl3l83a71ahj10cpq9pbhjck4xishx1b4dzc02r9xr2";
+      rev = "v1.0.3";
+      sha256 = "1cj3cjm7d3zk0mf1xdybh0jywkbbw7a6yr3y22x9sis31scprswd";
     };
   }
-
   {
     goPackagePath = "github.com/spf13/viper";
     fetch = {
       type = "git";
       url = "https://github.com/spf13/viper";
-      rev = "v1.2.0";
-      sha256 = "0klv7dyllvv9jkyspy4ww5nrz24ngb3adlh884cbdjn7562bhi47";
+      rev = "v1.3.1";
+      sha256 = "1190mg04718r03qriav99sf4kx2n7wdgr8vdni15f74bpbzrdjrl";
     };
   }
-
   {
     goPackagePath = "github.com/stretchr/testify";
     fetch = {
       type = "git";
       url = "https://github.com/stretchr/testify";
-      rev = "f2347ac6c9c9";
-      sha256 = "0ns8zc2n8gpcsd1fdaqbq7a8d939lnaxraqx5nr2fi2zdxqyh7hm";
+      rev = "04af85275a5c";
+      sha256 = "1al7hgvg34xbajds99ss5wmlndxbzzmz5l0wrg6wchvvfaiwxlx0";
     };
   }
-
   {
     goPackagePath = "github.com/tdewolff/minify";
     fetch = {
       type = "git";
       url = "https://github.com/tdewolff/minify";
-      rev = "v2.3.6";
-      sha256 = "0p4v4ab49lm5y438k5aks06fpiagbjw2j2x7i8jaa273mkgicrbb";
+      rev = "v2.3.7";
+      sha256 = "1mj1lmd8s0mrg9cfj1ihvsqrbsbpzh3icm0pmayd2r6jp6rbffw6";
     };
   }
-
   {
     goPackagePath = "github.com/tdewolff/parse";
     fetch = {
       type = "git";
       url = "https://github.com/tdewolff/parse";
-      rev = "fced451e0bed";
-      sha256 = "1n6wcapk8xbck2zjxd4l5cgfn1v12rr7znrdpd5y2xp1nc3739c3";
+      rev = "v2.3.5";
+      sha256 = "05w859s31dx6525wrjryby601z9c0xpncilznk6shgqygpxda6cz";
     };
   }
-
   {
     goPackagePath = "github.com/tdewolff/test";
     fetch = {
@@ -629,17 +666,33 @@
       sha256 = "10vyp4bhanzg3yl9k8zqfdrxpsmx8yc53xv4lqxfymd7jjyqgssj";
     };
   }
-
+  {
+    goPackagePath = "github.com/ugorji/go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ugorji/go";
+      rev = "d75b2dcb6bc8";
+      sha256 = "0di1k35gpq9bp958ywranpbskx2vdwlb38s22vl9rybm3wa5g3ps";
+    };
+  }
   {
     goPackagePath = "github.com/wellington/go-libsass";
     fetch = {
       type = "git";
       url = "https://github.com/wellington/go-libsass";
-      rev = "615eaa47ef79";
-      sha256 = "0imjiskn4vq7nml5jwb1scgl61jg53cfpkjnb9rsc6m8gsd8s16s";
+      rev = "c63644206701";
+      sha256 = "1ml0fk4wldnjlkmliydnig9f3rpp3cdzwgz331mlqyadvma3c0lf";
     };
   }
-
+  {
+    goPackagePath = "github.com/xordataexchange/crypt";
+    fetch = {
+      type = "git";
+      url = "https://github.com/xordataexchange/crypt";
+      rev = "b2862e3d0a77";
+      sha256 = "04q3856anpzl4gdfgmg7pbp9cx231nkz3ymq2xp27rnmmwhfxr8y";
+    };
+  }
   {
     goPackagePath = "github.com/yosssi/ace";
     fetch = {
@@ -649,7 +702,15 @@
       sha256 = "1kbvbc56grrpnl65grygd23gyn3nkkhxdg8awhzkjmd0cvki8w1f";
     };
   }
-
+  {
+    goPackagePath = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev = "505ab145d0a9";
+      sha256 = "1vbsvcvmjz6c00p5vf8ls533p52fx2y3gy6v4k5qrdlzl4wf0i5s";
+    };
+  }
   {
     goPackagePath = "golang.org/x/image";
     fetch = {
@@ -659,7 +720,6 @@
       sha256 = "1kkafy29vz5xf6r29ghbvvbwrgjxwxvzk6dsa2qhyp1ddk6l2vkz";
     };
   }
-
   {
     goPackagePath = "golang.org/x/net";
     fetch = {
@@ -669,7 +729,6 @@
       sha256 = "0254ld010iijygbzykib2vags1dc0wlmcmhgh4jl8iny159lhbcv";
     };
   }
-
   {
     goPackagePath = "golang.org/x/sync";
     fetch = {
@@ -679,17 +738,15 @@
       sha256 = "046jlanz2lkxq1r57x9bl6s4cvfqaic6p2xybsj8mq1120jv4rs6";
     };
   }
-
   {
     goPackagePath = "golang.org/x/sys";
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/sys";
-      rev = "d0be0721c37e";
-      sha256 = "081wyvfnlf842dqg03raxfz6lldlxpmyh1prix9lmrrm65arxb12";
+      rev = "b4a75ba826a6";
+      sha256 = "0kzrd2wywkcq35iakbzplqyma4bvf2ng3mzi7917kxcbdq3fflrj";
     };
   }
-
   {
     goPackagePath = "golang.org/x/text";
     fetch = {
@@ -699,7 +756,6 @@
       sha256 = "0r6x6zjzhr8ksqlpiwm5gdd7s209kwk5p4lw54xjvz10cs3qlq19";
     };
   }
-
   {
     goPackagePath = "gopkg.in/check.v1";
     fetch = {
@@ -709,14 +765,13 @@
       sha256 = "0v3bim0j375z81zrpr5qv42knqs0y2qv2vkjiqi5axvb78slki1a";
     };
   }
-
   {
     goPackagePath = "gopkg.in/yaml.v2";
     fetch = {
       type = "git";
       url = "https://gopkg.in/yaml.v2";
-      rev = "v2.2.1";
-      sha256 = "0dwjrs2lp2gdlscs7bsrmyc5yf6mm4fvgw71bzr9mv2qrd2q73s1";
+      rev = "v2.2.2";
+      sha256 = "01wj12jzsdqlnidpyjssmj0r4yavlqy7dwrg7adqd8dicjc4ncsa";
     };
   }
 ]


### PR DESCRIPTION
###### Motivation for this change

Upgrade Hugo from 0.50 to 0.54.0.

I had to do some manual adding of packages to the `deps.nix` file to get it to build, so I'm not really sure if the versions I've included for `gobuffalo/envy` or `joho/godotenv` are exactly correct, but it built and ran fine on my computer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

