### PR TITLE
mbed-cli: 1.8.3 -> 1.9.1

### DIFF
--- a/pkgs/development/tools/mbed-cli/default.nix
+++ b/pkgs/development/tools/mbed-cli/default.nix
@@ -4,14 +4,14 @@ with python3Packages;
 
 buildPythonApplication rec {
   pname = "mbed-cli";
-  version = "1.8.3";
+  version = "1.9.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "04vn2v0d7y3vmm8cswzvn2z85balgp3095n5flvgf3r60fdlhlmp";
+    sha256 = "1228plh55id03qywsw0ai88ypdpbh9iz18jfcyhn21pci7mj77fv";
   };
 
-  doCheck = false; # no tests available in Pypi
+  doCheck = false; # Tests cannot import mbed.
 
   meta = with lib; {
     homepage = https://github.com/ARMmbed/mbed-cli;

--- a/pkgs/development/tools/mbed-cli/default.nix
+++ b/pkgs/development/tools/mbed-cli/default.nix
@@ -1,4 +1,4 @@
-{ lib, python3Packages }:
+{ lib, python3Packages, git, mercurial }:
 
 with python3Packages;
 
@@ -11,7 +11,18 @@ buildPythonApplication rec {
     sha256 = "1228plh55id03qywsw0ai88ypdpbh9iz18jfcyhn21pci7mj77fv";
   };
 
-  doCheck = false; # Tests cannot import mbed.
+  checkInputs = [
+    git
+    mercurial
+    pytest
+  ];
+
+  checkPhase = ''
+    export GIT_COMMITTER_NAME=nixbld
+    export EMAIL=nixbld@localhost
+    export GIT_COMMITTER_DATE=$SOURCE_DATE_EPOCH
+    pytest test
+  '';
 
   meta = with lib; {
     homepage = https://github.com/ARMmbed/mbed-cli;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I tried to enable tests, but they fail, saying that `main` cannot be imported from `mbed`.
I believe this file is the reason: https://github.com/ARMmbed/mbed-cli/blob/1.9.1/mbed/__main__.py