### PR TITLE
nixos/doc: Small updates about wireless configuration.

### DIFF
--- a/nixos/doc/manual/configuration/wireless.xml
+++ b/nixos/doc/manual/configuration/wireless.xml
@@ -33,8 +33,25 @@
  </para>
 
  <para>
-  If you are using WPA2 the <command>wpa_passphrase</command> tool might be
-  useful to generate the <literal>wpa_supplicant.conf</literal>.
+  If you are using WPA2 you can generate pskRaw key using
+  <command>wpa_passphrase</command>:
+<screen>
+$ wpa_passphrase ESSID PSK
+network={
+        ssid="echelon"
+        #psk="abcdefgh"
+        psk=dca6d6ed41f4ab5a984c9f55f6f66d4efdc720ebf66959810f4329bb391c5435
+}
+</screen>
+<programlisting>
+<xref linkend="opt-networking.wireless.networks"/> = {
+  echelon = {
+    pskRaw = "dca6d6ed41f4ab5a984c9f55f6f66d4efdc720ebf66959810f4329bb391c5435";
+  };
+}
+</programlisting>
+  or you can use it to directly generate the
+  <literal>wpa_supplicant.conf</literal>:
 <screen>
 # wpa_passphrase ESSID PSK > /etc/wpa_supplicant.conf</screen>
   After you have edited the <literal>wpa_supplicant.conf</literal>, you need to

--- a/nixos/doc/manual/installation/installing.xml
+++ b/nixos/doc/manual/installation/installing.xml
@@ -378,6 +378,10 @@
      the grub menu.
     </para>
     <para>
+     If you need to configure networking for your machine the configuration
+     options are described in <xref linkend="sec-networking"/>.
+    </para>
+    <para>
      Another critical option is <option>fileSystems</option>, specifying the
      file systems that need to be mounted by NixOS. However, you typically
      don’t need to set it yourself, because


### PR DESCRIPTION
* Reference networking section from installation
* Add info about pskRaw option in networking.wireless.networks

###### Motivation for this change
Those are the bits of documentation that would have greatly helped me on my first installation of NixOS.
I made a full writup at https://discourse.nixos.org/t/thoughts-from-a-new-nixos-user/2135

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

