### PR TITLE
spotifyd: init at 0.2.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2209,6 +2209,11 @@
     github = "jmettes";
     name = "Jonathan Mettes";
   };
+  jmgrosen = {
+    email = "jmgrosen@gmail.com";
+    github = "jmgrosen";
+    name = "John Grosen";
+  };
   Jo = {
     email = "0x4A6F@shackspace.de";
     name = "Joachim Ernst";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -180,6 +180,7 @@
   ./services/audio/mpd.nix
   ./services/audio/mopidy.nix
   ./services/audio/slimserver.nix
+  ./services/audio/spotifyd.nix
   ./services/audio/squeezelite.nix
   ./services/audio/ympd.nix
   ./services/backup/bacula.nix

--- a/nixos/modules/services/audio/spotifyd.nix
+++ b/nixos/modules/services/audio/spotifyd.nix
@@ -1,0 +1,53 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.spotifyd;
+  spotifydConf = pkgs.writeText "spotifyd.conf" cfg.config;
+  spotifyd = pkgs.callPackage (import ../../../../pkgs/applications/audio/spotifyd/default.nix) { };
+in
+{
+  options = {
+    services.spotifyd = {
+      enable = mkEnableOption "spotifyd, a Spotify playing daemon";
+
+      dataDir = mkOption {
+        default = "/var/lib/spotifyd";
+        type = types.path;
+        description = "The directory where spotifyd stores its state.";
+      };
+
+      config = mkOption {
+        default = "";
+        type = types.lines;
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.spotifyd = {
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" "sound.target" ];
+      description = "spotifyd, a Spotify playing daemon";
+      preStart = ''mkdir -p "${cfg.dataDir}" && chown -R spotifyd:spotifyd "${cfg.dataDir}"'';
+      serviceConfig = {
+        ExecStart = "${spotifyd}/bin/spotifyd --no-daemon --config ${spotifydConf}";
+        Restart = "always";
+        RestartSec = 12;
+        User = "spotifyd";
+      };
+    };
+
+    users = {
+      users.spotifyd = {
+        description = "spotifyd user";
+        group = "spotifyd";
+        extraGroups = [ "audio" ];
+        home = cfg.dataDir;
+      };
+
+      groups.spotifyd = {};
+    };
+  };
+}

--- a/nixos/modules/services/audio/spotifyd.nix
+++ b/nixos/modules/services/audio/spotifyd.nix
@@ -5,7 +5,6 @@ with lib;
 let
   cfg = config.services.spotifyd;
   spotifydConf = pkgs.writeText "spotifyd.conf" cfg.config;
-  spotifyd = pkgs.callPackage (import ../../../../pkgs/applications/audio/spotifyd/default.nix) { };
 in
 {
   options = {
@@ -36,7 +35,7 @@ in
       description = "spotifyd, a Spotify playing daemon";
       preStart = ''mkdir -p "${cfg.dataDir}" && chown -R spotifyd:spotifyd "${cfg.dataDir}"'';
       serviceConfig = {
-        ExecStart = "${spotifyd}/bin/spotifyd --no-daemon --config ${spotifydConf}";
+        ExecStart = "${pkgs.spotifyd}/bin/spotifyd --no-daemon --config ${spotifydConf}";
         Restart = "always";
         RestartSec = 12;
         User = "spotifyd";

--- a/nixos/modules/services/audio/spotifyd.nix
+++ b/nixos/modules/services/audio/spotifyd.nix
@@ -12,9 +12,9 @@ in
       enable = mkEnableOption "spotifyd, a Spotify playing daemon";
 
       dataDir = mkOption {
-        default = "/var/lib/spotifyd";
-        type = types.path;
-        description = "The directory where spotifyd stores its state.";
+        default = "spotifyd";
+        type = types.str;
+        description = "The directory where spotifyd stores its state, relative to /var/lib/.";
       };
 
       config = mkOption {
@@ -33,24 +33,14 @@ in
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" "sound.target" ];
       description = "spotifyd, a Spotify playing daemon";
-      preStart = ''mkdir -p "${cfg.dataDir}" && chown -R spotifyd:spotifyd "${cfg.dataDir}"'';
       serviceConfig = {
         ExecStart = "${pkgs.spotifyd}/bin/spotifyd --no-daemon --config ${spotifydConf}";
         Restart = "always";
         RestartSec = 12;
-        User = "spotifyd";
+        DynamicUser = true;
+        StateDirectory = "${cfg.dataDir}";
+        Environment = "HOME=/var/lib/${cfg.dataDir}";
       };
-    };
-
-    users = {
-      users.spotifyd = {
-        description = "spotifyd user";
-        group = "spotifyd";
-        extraGroups = [ "audio" ];
-        home = cfg.dataDir;
-      };
-
-      groups.spotifyd = {};
     };
   };
 }

--- a/nixos/modules/services/audio/spotifyd.nix
+++ b/nixos/modules/services/audio/spotifyd.nix
@@ -21,6 +21,10 @@ in
       config = mkOption {
         default = "";
         type = types.lines;
+        description = ''
+          Configuration for Spotifyd. For syntax and directives, see
+          https://github.com/Spotifyd/spotifyd#Configuration.
+        '';
       };
     };
   };

--- a/pkgs/applications/audio/spotifyd/default.nix
+++ b/pkgs/applications/audio/spotifyd/default.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchFromGitHub, rustPlatform, pkgconfig, openssl
 , withALSA ? true, alsaLib ? null
 , withPulseAudio ? false, libpulseaudio ? null
+, withPortAudio ? false, portaudio ? null
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -14,6 +15,9 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0nmi33wvagmasxb59jwhlgdqlh8gfmqgwib16k1wx885qhx9yg30";
   };
 
+  # buildRustPackage currently seems to have some problems with [replace]
+  # directives in Cargo files (see #30742 and #47172), so don't use the
+  # replacement.
   cargoPatches = [ ./noavxcrypto.patch ];
 
   cargoSha256 = "09vial0psmh39j20ikmfldidl505jnpfnqa8ybszrf2pvrhszsgq";
@@ -21,15 +25,16 @@ rustPlatform.buildRustPackage rec {
   cargoBuildFlags = [
     "--no-default-features"
     "--features"
-    "${stdenv.lib.optionalString withALSA "alsa_backend,"}${stdenv.lib.optionalString withPulseAudio "pulseaudio_backend,"}"
+    "${stdenv.lib.optionalString withALSA "alsa_backend,"}${stdenv.lib.optionalString withPulseAudio "pulseaudio_backend,"}${stdenv.lib.optionalString withPortAudio "portaudio_backend,"}"
   ];
 
   buildInputs = [ pkgconfig openssl ]
     ++ stdenv.lib.optional withALSA alsaLib
-    ++ stdenv.lib.optional withPulseAudio libpulseaudio;
+    ++ stdenv.lib.optional withPulseAudio libpulseaudio
+    ++ stdenv.lib.optional withPortAudio portaudio;
 
   meta = with stdenv.lib; {
-    description = "An open source Spotify client running as a UNIX daemon.";
+    description = "An open source Spotify client running as a UNIX daemon";
     homepage = https://github.com/Spotifyd/spotifyd;
     license = with licenses; [ gpl3 ];
     maintainers = [ maintainers.jmgrosen ];

--- a/pkgs/applications/audio/spotifyd/default.nix
+++ b/pkgs/applications/audio/spotifyd/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, rustPlatform, pkgconfig, openssl
+, withALSA ? true, alsaLib ? null
+, withPulseAudio ? false, libpulseaudio ? null
+}:
+
+rustPlatform.buildRustPackage rec {
+  name = "spotifyd-${version}";
+  version = "0.2.4";
+
+  src = fetchFromGitHub {
+    owner = "Spotifyd";
+    repo = "spotifyd";
+    rev = "v${version}";
+    sha256 = "0nmi33wvagmasxb59jwhlgdqlh8gfmqgwib16k1wx885qhx9yg30";
+  };
+
+  cargoPatches = [ ./noavxcrypto.patch ];
+
+  cargoSha256 = "09vial0psmh39j20ikmfldidl505jnpfnqa8ybszrf2pvrhszsgq";
+
+  cargoBuildFlags = [
+    "--no-default-features"
+    "--features"
+    "${stdenv.lib.optionalString withALSA "alsa_backend,"}${stdenv.lib.optionalString withPulseAudio "pulseaudio_backend,"}"
+  ];
+
+  buildInputs = [ pkgconfig openssl ]
+    ++ stdenv.lib.optional withALSA alsaLib
+    ++ stdenv.lib.optional withPulseAudio libpulseaudio;
+
+  meta = with stdenv.lib; {
+    description = "An open source Spotify client running as a UNIX daemon.";
+    homepage = https://github.com/Spotifyd/spotifyd;
+    license = with licenses; [ gpl3 ];
+    maintainers = [ maintainers.jmgrosen ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/applications/audio/spotifyd/noavxcrypto.patch
+++ b/pkgs/applications/audio/spotifyd/noavxcrypto.patch
@@ -1,0 +1,48 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 3b44f66..71c7b2c 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -1672,7 +1672,7 @@ dependencies = [
+ [[package]]
+ name = "rust-crypto"
+ version = "0.2.36"
+-source = "git+https://github.com/awmath/rust-crypto.git?branch=avx2#394c247254dbe2ac5d44483232cf335d10cf0260"
++source = "registry+https://github.com/rust-lang/crates.io-index"
+ dependencies = [
+  "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
+  "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+@@ -1681,12 +1681,6 @@ dependencies = [
+  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ ]
+ 
+-[[package]]
+-name = "rust-crypto"
+-version = "0.2.36"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-replace = "rust-crypto 0.2.36 (git+https://github.com/awmath/rust-crypto.git?branch=avx2)"
+-
+ [[package]]
+ name = "rust-ini"
+ version = "0.10.3"
+@@ -2780,7 +2774,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ "checksum reqwest 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)" = "09d6e187a58d923ee132fcda141c94e716bcfe301c2ea2bef5c81536e0085376"
+ "checksum rpassword 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ec4bdede957362ec6fdd550f7e79c6d14cad2bc26b2d062786234c6ee0cb27bb"
+ "checksum rspotify 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "dee05e47d9aed6b35d9666d80c6b0d4d7ca6253e7a88464410a85dba1a8cd63d"
+-"checksum rust-crypto 0.2.36 (git+https://github.com/awmath/rust-crypto.git?branch=avx2)" = "<none>"
+ "checksum rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
+ "checksum rust-ini 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8a654c5bda722c699be6b0fe4c0d90de218928da5b724c3e467fc48865c37263"
+ "checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"
+diff --git a/Cargo.toml b/Cargo.toml
+index b10b164..9d6eccf 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -24,9 +24,6 @@ rspotify = "0.2.5"
+ chrono = "0.4"
+ alsa = { version = "0.2", optional = true }
+ 
+-[replace]
+-"rust-crypto:0.2.36" = { git = "https://github.com/awmath/rust-crypto.git", branch = "avx2" }
+-
+ [dependencies.librespot]
+ git = "https://github.com/librespot-org/librespot.git"
+ default-features = false

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19415,7 +19415,9 @@ in
   };
 
   spotifyd = callPackage ../applications/audio/spotifyd {
+    withALSA = stdenv.isLinux;
     withPulseAudio = config.pulseaudio or true;
+    withPortAudio = stdenv.isDarwin;
   };
 
   libspotify = callPackage ../development/libraries/libspotify (config.libspotify or {});

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19414,6 +19414,10 @@ in
     };
   };
 
+  spotifyd = callPackage ../applications/audio/spotifyd {
+    withPulseAudio = config.pulseaudio or true;
+  };
+
   libspotify = callPackage ../development/libraries/libspotify (config.libspotify or {});
 
   sourcetrail = callPackage ../development/tools/sourcetrail { };


### PR DESCRIPTION
###### Motivation for this change

Spotifyd is a nice spotify connect server. I worked around the issues in #47172 by just not using the avx version of rust-crypto (achieved through a patch).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

(Apologies if I've done something wrong, this is my first submitted PR.)