### PR TITLE
qt5.qtwebengine: fail properly

### DIFF
--- a/pkgs/development/libraries/qt-5/5.11/default.nix
+++ b/pkgs/development/libraries/qt-5/5.11/default.nix
@@ -62,8 +62,8 @@ let
     qtscript = [ ./qtscript.patch ];
     qtserialport = [ ./qtserialport.patch ];
     qttools = [ ./qttools.patch ];
-    qtwebengine =
-         optional stdenv.cc.isClang ./qtwebengine-clang-fix.patch
+    qtwebengine = [ ./qtwebengine-no-build-skip.patch ]
+      ++ optional stdenv.cc.isClang ./qtwebengine-clang-fix.patch
       ++ optional stdenv.isDarwin ./qtwebengine-darwin-sdk-10.10.patch;
     qtwebkit = [ ./qtwebkit.patch ];
   };

--- a/pkgs/development/libraries/qt-5/5.11/qtwebengine-no-build-skip.patch
+++ b/pkgs/development/libraries/qt-5/5.11/qtwebengine-no-build-skip.patch
@@ -1,0 +1,12 @@
+diff --git a/qtwebengine.pro b/qtwebengine.pro
+--- a/qtwebengine.pro
++++ b/qtwebengine.pro
+@@ -5,7 +5,7 @@ runConfigure()
+ 
+ !isEmpty(skipBuildReason) {
+     SUBDIRS =
+-    log($${skipBuildReason}$${EOL})
++    error($${skipBuildReason}$${EOL})
+     log(QtWebEngine will not be built.$${EOL})
+ }
+ 

--- a/pkgs/development/libraries/qt-5/5.12/default.nix
+++ b/pkgs/development/libraries/qt-5/5.12/default.nix
@@ -60,6 +60,7 @@ let
     qtdeclarative = [ ./qtdeclarative.patch ];
     qtscript = [ ./qtscript.patch ];
     qtserialport = [ ./qtserialport.patch ];
+    qtwebengine = [ ./qtwebengine-no-build-skip.patch ];
     qtwebkit = [ ./qtwebkit.patch ];
   };
 

--- a/pkgs/development/libraries/qt-5/5.12/qtwebengine-no-build-skip.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtwebengine-no-build-skip.patch
@@ -1,0 +1,12 @@
+diff --git a/qtwebengine.pro b/qtwebengine.pro
+--- a/qtwebengine.pro
++++ b/qtwebengine.pro
+@@ -5,7 +5,7 @@ runConfigure()
+ 
+ !isEmpty(skipBuildReason) {
+     SUBDIRS =
+-    log($${skipBuildReason}$${EOL})
++    error($${skipBuildReason}$${EOL})
+     log(QtWebEngine will not be built.$${EOL})
+ }
+ 

--- a/pkgs/development/libraries/qt-5/5.9/default.nix
+++ b/pkgs/development/libraries/qt-5/5.9/default.nix
@@ -43,6 +43,7 @@ let
     qtscript = [ ./qtscript.patch ];
     qtserialport = [ ./qtserialport.patch ];
     qttools = [ ./qttools.patch ];
+    qtwebengine = [ ./qtwebengine-no-build-skip.patch ];
     qtwebkit = [ ./qtwebkit.patch ];
     qtvirtualkeyboard = [
       (fetchpatch {

--- a/pkgs/development/libraries/qt-5/5.9/qtwebengine-no-build-skip.patch
+++ b/pkgs/development/libraries/qt-5/5.9/qtwebengine-no-build-skip.patch
@@ -1,0 +1,12 @@
+diff --git a/qtwebengine.pro b/qtwebengine.pro
+--- a/qtwebengine.pro
++++ b/qtwebengine.pro
+@@ -5,7 +5,7 @@ runConfigure()
+ 
+ !isEmpty(skipBuildReason) {
+     SUBDIRS =
+-    log($${skipBuildReason}$${EOL})
++    error($${skipBuildReason}$${EOL})
+     log(QtWebEngine will not be built.$${EOL})
+ }
+ 


### PR DESCRIPTION
###### Motivation for this change

qtwebengine currently appears to build successfully on darwin, but in reality it fails to configure. The problem is not darwin-specific though.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS build fails as expected
   - [x] other Linux distributions, tested `qt511.qtwebengine` `qt512.qtwebengine` `qt59.qtwebengine` build fine
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

