### PR TITLE
tt-rss-plugin-tumblr-gdpr: 1.2 -> 2.1

### DIFF
--- a/pkgs/servers/tt-rss/plugin-tumblr-gdpr/default.nix
+++ b/pkgs/servers/tt-rss/plugin-tumblr-gdpr/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchFromGitHub, ... }: stdenv.mkDerivation rec {
   name = "tt-rss-plugin-tumblr-gdpr-${version}";
-  version = "1.2";
+  version = "2.1";
 
   src = fetchFromGitHub {
     owner = "GregThib";
     repo = "ttrss-tumblr-gdpr";
     rev = "v${version}";
-    sha256 = "1qqnzysg1d0b169kr9fbgi50yjnvw7lrvgrl2zjx6px6z61jhv4j";
+    sha256 = "09cbghi5b6ww4i5677i39qc9rhpq70xmygp0d7x30239r3i23rpq";
   };
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

The old version doesn't work anymore since #54896 was merged.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

