### PR TITLE
mdsh: init at 0.1.2

### DIFF
--- a/pkgs/development/tools/documentation/mdsh/default.nix
+++ b/pkgs/development/tools/documentation/mdsh/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  name = "mdsh-${version}";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "zimbatm";
+    repo = "mdsh";
+    rev = "v${version}";
+    sha256 = "0sggclzghm54g4wnbab00qw4ry49min4zyw3hjwi0v741aa51xb2";
+  };
+
+  cargoSha256 = "1hsnz4sj8kff9azcbw9pkr2ipxlymz4zcm4vhfwydfkdlvdncpxm";
+
+  meta = with stdenv.lib; {
+    description = "Markdown shell pre-processor";
+    homepage = https://github.com/zimbatm/mdsh;
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ zimbatm ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4104,6 +4104,8 @@ in
 
   mbuffer = callPackage ../tools/misc/mbuffer { };
 
+  mdsh = callPackage ../development/tools/documentation/mdsh { };
+
   mecab =
     let
       mecab-nodic = callPackage ../tools/text/mecab/nodic.nix { };


### PR DESCRIPTION
###### Motivation for this change

Publish https://github.com/zimbatm/mdsh

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

