### PR TITLE
easysnap: 2018-11-20 -> 2019-02-17

### DIFF
--- a/pkgs/tools/backup/easysnap/default.nix
+++ b/pkgs/tools/backup/easysnap/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "easysnap-${version}";
-  version = "unstable-2018-11-20";
+  version = "unstable-2019-02-17";
 
   src = fetchFromGitHub {
     owner = "sjau";
     repo = "easysnap";
-    rev = "dbf58c06a339cb040dbdcaf7e6ffec5af4add3c7";
-    sha256 = "0rvikmj2k103ffgnvkway8n6ajq0vzwcxb4l5vhka1hqh8047lam";
+    rev = "9ef5d1ff51ccf9939a88b7b32b4959d27cf61ecc";
+    sha256 = "0m0217ni909nham15w5vxg8y7cw2zwjibnhvgnpxxsap8zkhv1m4";
   };
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Some bug fixes regarding removal of snapshots on backup media and better comments.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

