### PR TITLE
bazel: fix bash completion

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -245,6 +245,7 @@ stdenv.mkDerivation rec {
     scripts/generate_bash_completion.sh \
         --bazel=./output/bazel \
         --output=output/bazel-complete.bash \
+        --prepend=scripts/bazel-complete-header.bash \
         --prepend=scripts/bazel-complete-template.bash
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Fix bazel bash completion

###### Things done

bazel bash completion is generated running `generate_bash_completion.sh`. The line that runs that command was missing prepending `bazel-complete-header.bash`.

Reference: https://github.com/bazelbuild/bazel/blob/d8dde88207b4c739c74f855b2bc693f3233383b5/scripts/BUILD#L17

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

