### PR TITLE
Fixes for diod

### DIFF
--- a/nixos/modules/services/network-filesystems/diod.nix
+++ b/nixos/modules/services/network-filesystems/diod.nix
@@ -153,7 +153,6 @@ in
       after = [ "network.target" ];
       serviceConfig = {
         ExecStart = "${pkgs.diod}/sbin/diod -f -c ${diodConfig}";
-        CapabilityBoundingSet = "cap_net_bind_service+=ep";
       };
     };
   };

--- a/pkgs/servers/diod/default.nix
+++ b/pkgs/servers/diod/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, munge, lua, libcap, perl, ncurses }:
+{ stdenv, fetchurl, munge, lua,
+  libcap, perl, ncurses
+}:
 
 stdenv.mkDerivation rec {
   name = "diod-${version}";
@@ -9,12 +11,16 @@ stdenv.mkDerivation rec {
     sha256 = "17wckwfsqj61yixz53nwkc35z66arb1x3napahpi64m7q68jn7gl";
   };
 
+  postPatch = ''
+    substituteInPlace diod/xattr.c --replace attr/xattr.h sys/xattr.h
+  '';
+
   buildInputs = [ munge lua libcap perl ncurses ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "An I/O forwarding server that implements a variant of the 9P protocol";
-    maintainers = [ stdenv.lib.maintainers.rickynils];
-    platforms = stdenv.lib.platforms.linux;
-    license = stdenv.lib.licenses.gpl2Plus;
+    maintainers = with maintainers; [ rnhmjoj rickynils ];
+    platforms   = platforms.linux;
+    license     = licenses.gpl2Plus;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Wanted to create a NAS with a 9P filesystem.
This also fixes part of #53716.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I'm not sure why the capabilities has been restricted to `cap_net_bind_service`. The daemon needs to run as root and require almost every capability: at least `cap_net_bind_service`, `cap_setgid`, `cap_chown` and more that I couldn't figure out by trial and error.

cc @rickynils 