### PR TITLE
buildPythonPackage: initial support for PEP 517

### DIFF
--- a/pkgs/development/interpreters/python/build-python-package-pyproject.nix
+++ b/pkgs/development/interpreters/python/build-python-package-pyproject.nix
@@ -1,0 +1,55 @@
+# This function provides specific bits for building a setuptools-based Python package.
+
+{ lib
+, python
+}:
+
+{
+# passed to "python setup.py build_ext"
+# https://github.com/pypa/pip/issues/881
+# Rename to `buildOptions` because it is not setuptools specific?
+  setupPyBuildFlags ? []
+# Execute before shell hook
+, preShellHook ? ""
+# Execute after shell hook
+, postShellHook ? ""
+, ... } @ attrs:
+
+let
+  options = lib.concatMapStringsSep " " (option: "--global-option ${option}") setupPyBuildFlags;
+in attrs // {
+  # we copy nix_run_setup over so it's executed relative to the root of the source
+  # many project make that assumption
+  buildPhase = attrs.buildPhase or ''
+    runHook preBuild
+    mkdir -p dist
+    echo "Creating a wheel..."
+    ${python.pythonForBuild.interpreter} -m pip wheel --no-index --no-deps --no-clean --no-build-isolation --wheel-dir dist ${options} .
+    echo "Finished creating a wheel..."
+    runHook postBuild
+  '';
+
+  installCheckPhase = attrs.checkPhase or ''
+    runHook preCheck
+    ${python.interpreter} -m unittest discover
+    runHook postCheck
+  '';
+
+  # With Python it's a common idiom to run the tests
+  # after the software has been installed.
+  doCheck = attrs.doCheck or true;
+
+  shellHook = attrs.shellHook or ''
+    ${preShellHook}
+    # Long-term setup.py should be dropped.
+    if [ -e pyproject.toml ] || [ -e setup.py ]; then
+      tmp_path=$(mktemp -d)
+      export PATH="$tmp_path/bin:$PATH"
+      export PYTHONPATH="$tmp_path/${python.pythonForBuild.sitePackages}:$PYTHONPATH"
+      mkdir -p $tmp_path/${python.pythonForBuild.sitePackages}
+      ${python.pythonForBuild.pkgs.bootstrapped-pip}/bin/pip install -e . --prefix $tmp_path >&2
+    fi
+    ${postShellHook}
+  '';
+
+}

--- a/pkgs/development/interpreters/python/build-python-package.nix
+++ b/pkgs/development/interpreters/python/build-python-package.nix
@@ -17,6 +17,7 @@
 
 let
   setuptools-specific = import ./build-python-package-setuptools.nix { inherit lib python; };
+  pyproject-specific = import ./build-python-package-pyproject.nix { inherit lib python; };
   flit-specific = import ./build-python-package-flit.nix { inherit python flit; };
   wheel-specific = import ./build-python-package-wheel.nix { };
   common = import ./build-python-package-common.nix { inherit python; };
@@ -32,12 +33,13 @@ in
 # "wheel" : Install from a pre-compiled wheel.
 # "flit" : Install a flit package. This builds a wheel.
 # "other" : Provide your own buildPhase and installPhase.
-format ? "setuptools"
+format ? "pyproject"
 , ... } @ attrs:
 
 let
   formatspecific =
-    if format == "setuptools" then common (setuptools-specific attrs)
+    if format == "pyproject" then common (pyproject-specific attrs)
+    else if format == "setuptools" then common (setuptools-specific attrs)
     else if format == "flit" then common (flit-specific attrs)
     else if format == "wheel" then common (wheel-specific attrs)
     else if format == "other" then {}


### PR DESCRIPTION
###### Motivation for this change

Implements https://github.com/NixOS/nixpkgs/issues/55961.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

to do:

- [ ] documentation (use `nativeBuildInputs` for `requires`)
- [ ] changelog. Default is now `pyproject`, which runs `python -m unitest discover` instead of `python setup.py test`
- [ ] deprecate `setuptools` and `flit` formats, although they could simply append their `requires` to `nativeBuildInputs`
