### PR TITLE
nixos/icingaweb2-audit: Init both module and pkg

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -717,6 +717,7 @@
   ./services/web-apps/codimd.nix
   ./services/web-apps/frab.nix
   ./services/web-apps/icingaweb2/icingaweb2.nix
+  ./services/web-apps/icingaweb2/module-audit.nix
   ./services/web-apps/icingaweb2/module-monitoring.nix
   ./services/web-apps/mattermost.nix
   ./services/web-apps/nextcloud.nix

--- a/nixos/modules/services/web-apps/icingaweb2/module-audit.nix
+++ b/nixos/modules/services/web-apps/icingaweb2/module-audit.nix
@@ -1,0 +1,69 @@
+{ config, lib, pkgs, ... }: with lib; let
+  cfg = config.services.icingaweb2.modules.audit;
+
+  configIni = ''
+    [log]
+    type = "${cfg.log}"
+    ${optionalString (cfg.log == "syslog") ''
+      ident = "${cfg.syslogApplication}"
+      facility = "${cfg.syslogFacility}"
+    ''}
+    ${optionalString (cfg.log == "file") ''path = "${cfg.logFile}"''}
+
+    [stream]
+    format = "${if cfg.logJSON then "json" else "none"}"
+    path = "${cfg.logFileJSON}"
+  '';
+
+in {
+  options.services.icingaweb2.modules.audit = with types; {
+    enable = mkEnableOption "the icingaweb2 audit module";
+
+    mutableAuditConfig = mkOption {
+      type = bool;
+      default = false;
+      description = "Make config.ini of the audit module mutable (e.g. via the web interface).";
+    };
+
+    log = mkOption {
+      type = enum [ "none" "syslog" "file" ];
+      default = "none";
+      description = "Target of the human-readable log.";
+    };
+
+    syslogApplication = mkOption {
+      type = str;
+      default = "icingaweb2-audit";
+      description = "Application name to log under";
+    };
+
+    syslogFacility = mkOption {
+      type = enum [ "auth" "authpriv" "user" "local0" "local1" "local2" "local3" "local4" "local5" "local6" "local7" ];
+      default = "auth";
+      description = "Syslog facility to log to";
+    };
+
+    logFile = mkOption {
+      type = str;
+      default = "/var/log/icingaweb2/audit.log";
+      description = "Full path to the standard log file";
+    };
+
+    logJSON = mkOption {
+      type = bool;
+      default = false;
+      description = "Also log machine-parsable JSON objects";
+    };
+
+    logFileJSON = mkOption {
+      type = str;
+      default = "/var/log/icingaweb2/audit.json";
+      description = "Full path to the JSON log file";
+    };
+  };
+
+  config = mkIf (config.services.icingaweb2.enable && cfg.enable) {
+    environment.etc = { "icingaweb2/enabledModules/audit" = { source = "${pkgs.icingaweb2Modules.module-audit}"; }; }
+      // optionalAttrs (!cfg.mutableAuditConfig) { "icingaweb2/modules/audit/config.ini".text = configIni; };
+  };
+}

--- a/pkgs/servers/icingaweb2/module-audit/default.nix
+++ b/pkgs/servers/icingaweb2/module-audit/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, lib, fetchFromGitHub }: with lib; stdenv.mkDerivation rec {
+  name = "icingaweb2-module-audit";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "Icinga";
+    repo = name;
+    rev = "v${version}";
+    sha256 = "1klaxd60ba6yg227vjag1pqszdp358a7qr56vzhfp98yj36g4754";
+  };
+
+  installPhase = ''
+    mkdir -p "$out"
+    cp -r * "$out"
+  '';
+
+  meta = {
+    description = "Audit module for Icingaweb 2";
+    homepage = "https://github.com/Icinga/icingaweb2-module-audit";
+    license = licenses.gpl2;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ das_j ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13596,6 +13596,7 @@ in
 
   icingaweb2 = callPackage ../servers/icingaweb2 { };
   icingaweb2Modules = {
+    module-audit = callPackage ../servers/icingaweb2/module-audit { };
     theme-april = callPackage ../servers/icingaweb2/theme-april { };
     theme-lsd = callPackage ../servers/icingaweb2/theme-lsd { };
     theme-particles = callPackage ../servers/icingaweb2/theme-particles { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

