### PR TITLE
ktlint: init at 0.30.0

### DIFF
--- a/pkgs/development/tools/ktlint/default.nix
+++ b/pkgs/development/tools/ktlint/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchurl, makeWrapper, jre }:
+
+stdenv.mkDerivation rec {
+  name = "ktlint-${version}";
+  version = "0.30.0";
+
+  src = fetchurl {
+    url = "https://github.com/shyiko/ktlint/releases/download/${version}/ktlint";
+    sha256 = "0l3h3q4qc7ij3sr9ij1mrhir18xic7qbzgb621fv16zgdk6rjghn";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  propagatedBuildInputs = [ jre ];
+
+  unpackCmd = ''
+    mkdir -p ${name}
+    cp $curSrc ${name}/ktlint
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv ktlint $out/bin/ktlint
+    chmod +x $out/bin/ktlint
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/ktlint --prefix PATH : "${jre}/bin"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "An anti-bikeshedding Kotlin linter with built-in formatter";
+    homepage = https://ktlint.github.io/;
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ tadfisher ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8832,6 +8832,8 @@ in
 
   kustomize = callPackage ../development/tools/kustomize { };
 
+  ktlint = callPackage ../development/tools/ktlint { };
+
   kythe = callPackage ../development/tools/kythe { };
 
   lazygit = callPackage ../development/tools/lazygit { };


### PR DESCRIPTION
###### Motivation for this change

Add `ktlint`, a useful code style linter and formatter for Kotlin source code.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

