### PR TITLE
buildRustCrate support editions

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/build-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/build-crate.nix
@@ -8,11 +8,11 @@
   let
 
     deps = makeDeps dependencies;
-        rustcOpts =
-          lib.lists.foldl' (opts: opt: opts + " " + opt)
-            (if release then "-C opt-level=3" else "-C debuginfo=2")
-            (["-C codegen-units=1"] ++ extraRustcOpts);
-        rustcMeta = "-C metadata=${metadata} -C extra-filename=-${metadata}";
+    rustcOpts =
+      lib.lists.foldl' (opts: opt: opts + " " + opt)
+        (if release then "-C opt-level=3" else "-C debuginfo=2")
+        (["-C codegen-units=1"] ++ extraRustcOpts);
+    rustcMeta = "-C metadata=${metadata} -C extra-filename=-${metadata}";
 
     # Some platforms have different names for rustc.
     rustPlatform =

--- a/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
@@ -1,9 +1,27 @@
 { lib, stdenv, echo_build_heading, noisily, makeDeps }:
-{ build, buildDependencies, colors, completeBuildDeps, completeDeps, crateAuthors, crateFeatures, crateName, crateVersion, extraLinkFlags, libName, libPath, release, target_os, verbose, workspace_member }:
+{ build
+, buildDependencies
+, colors
+, completeBuildDeps
+, completeDeps
+, crateAuthors
+, crateFeatures
+, crateName
+, crateVersion
+, extraLinkFlags
+, extraRustcOpts
+, libName
+, libPath
+, release
+, target_os
+, verbose
+, workspace_member }:
 let version_ = lib.splitString "-" crateVersion;
     versionPre = if lib.tail version_ == [] then "" else builtins.elemAt version_ 1;
     version = lib.splitString "." (lib.head version_);
-    rustcOpts = (if release then "-C opt-level=3" else "-C debuginfo=2");
+    rustcOpts = lib.lists.foldl' (opts: opt: opts + " " + opt)
+        (if release then "-C opt-level=3" else "-C debuginfo=2")
+        (["-C codegen-units=1"] ++ extraRustcOpts);
     buildDeps = makeDeps buildDependencies;
     authors = lib.concatStringsSep ":" crateAuthors;
     optLevel = if release then 3 else 0;

--- a/pkgs/build-support/rust/build-rust-crate/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/default.nix
@@ -71,7 +71,7 @@ let crate = crate_ // (lib.attrByPath [ crate_.crateName ] (attr: {}) crateOverr
     processedAttrs = [
       "src" "buildInputs" "crateBin" "crateLib" "libName" "libPath"
       "buildDependencies" "dependencies" "features"
-      "crateName" "version" "build" "authors" "colors"
+      "crateName" "version" "build" "authors" "colors" "edition"
     ];
     extraDerivationAttrs = lib.filterAttrs (n: v: ! lib.elem n processedAttrs) crate;
     buildInputs_ = buildInputs;
@@ -136,7 +136,9 @@ stdenv.mkDerivation (rec {
         (crate.type or ["lib"]);
     colors = lib.attrByPath [ "colors" ] "always" crate;
     extraLinkFlags = builtins.concatStringsSep " " (crate.extraLinkFlags or []);
-    extraRustcOpts = (if crate ? extraRustcOpts then crate.extraRustcOpts else []) ++ extraRustcOpts_;
+    edition = crate.edition or null;
+    extraRustcOpts = (if crate ? extraRustcOpts then crate.extraRustcOpts else []) ++ extraRustcOpts_ ++ (lib.optional (edition != null) "--edition ${edition}");
+
     configurePhase = configureCrate {
       inherit crateName buildDependencies completeDeps completeBuildDeps
               crateFeatures libName build workspace_member release libPath crateVersion

--- a/pkgs/build-support/rust/build-rust-crate/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/default.nix
@@ -136,13 +136,13 @@ stdenv.mkDerivation (rec {
         (crate.type or ["lib"]);
     colors = lib.attrByPath [ "colors" ] "always" crate;
     extraLinkFlags = builtins.concatStringsSep " " (crate.extraLinkFlags or []);
+    extraRustcOpts = (if crate ? extraRustcOpts then crate.extraRustcOpts else []) ++ extraRustcOpts_;
     configurePhase = configureCrate {
       inherit crateName buildDependencies completeDeps completeBuildDeps
               crateFeatures libName build workspace_member release libPath crateVersion
-              extraLinkFlags
+              extraLinkFlags extraRustcOpts
               crateAuthors verbose colors target_os;
     };
-    extraRustcOpts = (if crate ? extraRustcOpts then crate.extraRustcOpts else []) ++ extraRustcOpts_;
     buildPhase = buildCrate {
       inherit crateName dependencies
               crateFeatures libName release libPath crateType


### PR DESCRIPTION
###### Motivation for this change

This is my initial version of editions support. I have a local change to `carnix` that also exposed the edition field (if availabe). I can finally build my private projects again that have dependencies with an `edition = 2018` field in the `Cargo.toml`. \o/



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I am currently unable to apply / upload / propose the changes to carnix since my account is never created (tried months ago, tried now, …). One of the patches I wrote is below (the one for this PR; the other one crashes pijul :/). (cc @P-E-Meunier)

```

$ pijul patch 8pcBAtmobyqgYGqkvTieAvQKnxshTwQL2XXPhxbASRPdUAuhUaSNASMjxpqUcbmQnKPkLrYZFYLKPrRWsbfRiaZK
In "["src", "krate.rs"]":
From line 39:
+     pub edition: Option<String>,
In "["src", "output.rs"]":
From line 1013:
+
+         if let Some(ref edition) = meta.edition {
+             writeln!(w, "{}  edition = {};", indent, edition)?;
+         }
In "["src", "prefetch.rs"]":
From line 101:
+         let edition = v.get("package").and_then(|p| p.get("edition").map(|s| s.to_string()));
In "["src", "prefetch.rs"]":
From line 134:
+             edition
```

