### PR TITLE
granite: 5.2.2 -> 5.2.3

### DIFF
--- a/pkgs/development/libraries/granite/default.nix
+++ b/pkgs/development/libraries/granite/default.nix
@@ -12,15 +12,6 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    # Add Meson support that hit after 5.2.2
-    (fetchpatch {
-      url = "https://github.com/elementary/granite/commit/2066b377226cf327cb2d5399b6b40a2d36d47b11.patch";
-      sha256 = "1bxjgq8wvl1sb79cwhmh9kwawnkkfn7c5q67cyz1fjxmamwyyi85";
-    })
-    (fetchpatch {
-      url = "https://github.com/elementary/granite/commit/f1b29f52e3aaf0f5d6bba44c42617da265f679c8.patch";
-      sha256 = "0cdp9ny6fj1lpcirab641p1qn1rbsvnsaa03hnr6zsdpim96jlvs";
-    })
     # Resolve the circular dependency between granite and the datetime wingpanel indicator
     # See: https://github.com/elementary/granite/pull/242
     ./02-datetime-clock-format-gsettings.patch

--- a/pkgs/development/libraries/granite/default.nix
+++ b/pkgs/development/libraries/granite/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "granite";
-  version = "5.2.2";
+  version = "5.2.3";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "1zp0pp5v3j8k6ail724p7h5jj2zmznj0a2ybwfw5sspfdw5bfydh";
+    sha256 = "10ddq1s2w4jvpzq813cylmqhh8pggzaz890fy3kzg07275i98gah";
   };
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---