### PR TITLE
prometheus-pushgateway: 0.4.0 -> 0.7.0

### DIFF
--- a/pkgs/servers/monitoring/prometheus/pushgateway.nix
+++ b/pkgs/servers/monitoring/prometheus/pushgateway.nix
@@ -1,8 +1,8 @@
-{ stdenv, go, buildGoPackage, go-bindata, fetchFromGitHub }:
+{ stdenv, go, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
   name = "pushgateway-${version}";
-  version = "0.4.0";
+  version = "0.7.0";
   rev = "v${version}";
 
   goPackagePath = "github.com/prometheus/pushgateway";
@@ -11,33 +11,39 @@ buildGoPackage rec {
     inherit rev;
     owner = "prometheus";
     repo = "pushgateway";
-    sha256 = "19hsv42addcx4dsjdbh64y7ggjvaaay9gag0342gz7gyl9sr719f";
+    sha256 = "1sczg6vrpxv0jlqhkif8443v7mhbp3lp40g71ndqkf1s669m1pl4";
   };
 
-  buildInputs = [ go-bindata ];
-
-  preBuild = ''
-  (
-    cd "go/src/$goPackagePath"
-    go-bindata ./resources/
-  )
-  '';
+  buildUser = "nix@nixpkgs";
+  buildDate = "19700101-00:00:00";
 
   buildFlagsArray = ''
     -ldflags=
-        -X main.buildVersion=${version}
-        -X main.buildRev=${rev}
-        -X main.buildBranch=${rev}
-        -X main.buildUser=nix@nixpkgs
-        -X main.buildDate=19700101-00:00:00
+        -X github.com/prometheus/pushgateway/vendor/github.com/prometheus/common/version.Version=${version}
+        -X github.com/prometheus/pushgateway/vendor/github.com/prometheus/common/version.Revision=${rev}
+        -X github.com/prometheus/pushgateway/vendor/github.com/prometheus/common/version.Branch=${rev}
+        -X github.com/prometheus/pushgateway/vendor/github.com/prometheus/common/version.BuildUser=${buildUser}
+        -X github.com/prometheus/pushgateway/vendor/github.com/prometheus/common/version.BuildDate=${buildDate}
         -X main.goVersion=${stdenv.lib.getVersion go}
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    export PATH=$PATH:$bin/bin
+
+    pushgateway --help
+
+    # Make sure our -X options were included in the build
+    for s in ${version} ${rev} ${buildUser} ${buildDate}; do
+      pushgateway --version 2>&1 | fgrep -q -- "$s" || { echo "pushgateway --version output missing $s"; exit 1; }
+    done
   '';
 
   meta = with stdenv.lib; {
     description = "Allows ephemeral and batch jobs to expose metrics to Prometheus";
     homepage = https://github.com/prometheus/pushgateway;
     license = licenses.asl20;
-    maintainers = with maintainers; [ benley fpletz ];
+    maintainers = with maintainers; [ benley fpletz ivan ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

https://github.com/prometheus/pushgateway/blob/master/CHANGELOG.md

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I pushed a metric with a POST request and it was visible on the server running on :9091.