### PR TITLE
qt511.qtwebkit: fix on darwin

### DIFF
--- a/pkgs/development/libraries/qt-5/5.11/default.nix
+++ b/pkgs/development/libraries/qt-5/5.11/default.nix
@@ -65,7 +65,11 @@ let
     qtwebengine = [ ./qtwebengine-no-build-skip.patch ]
       ++ optional stdenv.cc.isClang ./qtwebengine-clang-fix.patch
       ++ optional stdenv.isDarwin ./qtwebengine-darwin-sdk-10.10.patch;
-    qtwebkit = [ ./qtwebkit.patch ];
+    qtwebkit = [ ./qtwebkit.patch ]
+      ++ optionals stdenv.isDarwin [
+        ./qtwebkit-darwin-no-readline.patch
+        ./qtwebkit-darwin-no-qos-classes.patch
+      ];
   };
 
   mkDerivation =

--- a/pkgs/development/libraries/qt-5/5.11/qtwebkit-darwin-no-qos-classes.patch
+++ b/pkgs/development/libraries/qt-5/5.11/qtwebkit-darwin-no-qos-classes.patch
@@ -1,0 +1,11 @@
+diff --git a/Source/cmake/OptionsQt.cmake b/Source/cmake/OptionsQt.cmake
+--- a/Source/cmake/OptionsQt.cmake
++++ b/Source/cmake/OptionsQt.cmake
+@@ -683,7 +683,6 @@ if (WIN32 AND COMPILER_IS_GCC_OR_CLANG)
+ endif ()
+ 
+ if (APPLE)
+-    SET_AND_EXPOSE_TO_BUILD(HAVE_QOS_CLASSES 1)
+ endif ()
+ 
+ if (ENABLE_MATHML)

--- a/pkgs/development/libraries/qt-5/5.11/qtwebkit-darwin-no-readline.patch
+++ b/pkgs/development/libraries/qt-5/5.11/qtwebkit-darwin-no-readline.patch
@@ -1,0 +1,45 @@
+diff --git a/Source/JavaScriptCore/shell/CMakeLists.txt b/Source/JavaScriptCore/shell/CMakeLists.txt
+--- a/Source/JavaScriptCore/shell/CMakeLists.txt
++++ b/Source/JavaScriptCore/shell/CMakeLists.txt
+@@ -9,7 +9,6 @@ set(JSC_LIBRARIES
+ )
+ 
+ if (WTF_OS_MAC_OS_X)
+-    list(APPEND JSC_LIBRARIES edit)
+ endif ()
+ 
+ if ("${JavaScriptCore_LIBRARY_TYPE}" MATCHES "STATIC")
+diff --git a/Source/WTF/wtf/Platform.h b/Source/WTF/wtf/Platform.h
+--- a/Source/WTF/wtf/Platform.h
++++ b/Source/WTF/wtf/Platform.h
+@@ -563,7 +563,6 @@
+ #if PLATFORM(IOS)
+ 
+ #define HAVE_NETWORK_EXTENSION 1
+-#define HAVE_READLINE 1
+ #if USE(APPLE_INTERNAL_SDK)
+ #define USE_CFNETWORK 1
+ #endif
+@@ -650,7 +649,6 @@
+ #define HAVE_MADV_DONTNEED 1
+ #define HAVE_MERGESORT 1
+ #define HAVE_PTHREAD_SETNAME_NP 1
+-#define HAVE_READLINE 1
+ #define HAVE_SYS_TIMEB_H 1
+ 
+ #if !PLATFORM(GTK) && !PLATFORM(QT)
+diff --git a/Source/WTF/wtf/PlatformMac.cmake b/Source/WTF/wtf/PlatformMac.cmake
+--- a/Source/WTF/wtf/PlatformMac.cmake
++++ b/Source/WTF/wtf/PlatformMac.cmake
+@@ -2,11 +2,9 @@ set(WTF_LIBRARY_TYPE SHARED)
+ 
+ find_library(COCOA_LIBRARY Cocoa)
+ find_library(COREFOUNDATION_LIBRARY CoreFoundation)
+-find_library(READLINE_LIBRARY Readline)
+ list(APPEND WTF_LIBRARIES
+     ${COREFOUNDATION_LIBRARY}
+     ${COCOA_LIBRARY}
+-    ${READLINE_LIBRARY}
+     libicucore.dylib
+ )
+ 

--- a/pkgs/development/libraries/qt-5/5.12/default.nix
+++ b/pkgs/development/libraries/qt-5/5.12/default.nix
@@ -61,7 +61,11 @@ let
     qtscript = [ ./qtscript.patch ];
     qtserialport = [ ./qtserialport.patch ];
     qtwebengine = [ ./qtwebengine-no-build-skip.patch ];
-    qtwebkit = [ ./qtwebkit.patch ];
+    qtwebkit = [ ./qtwebkit.patch ]
+      ++ optionals stdenv.isDarwin [
+        ./qtwebkit-darwin-no-readline.patch
+        ./qtwebkit-darwin-no-qos-classes.patch
+      ];
   };
 
   mkDerivation =

--- a/pkgs/development/libraries/qt-5/5.12/qtwebkit-darwin-no-qos-classes.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtwebkit-darwin-no-qos-classes.patch
@@ -1,0 +1,11 @@
+diff --git a/Source/cmake/OptionsQt.cmake b/Source/cmake/OptionsQt.cmake
+--- a/Source/cmake/OptionsQt.cmake
++++ b/Source/cmake/OptionsQt.cmake
+@@ -683,7 +683,6 @@ if (WIN32 AND COMPILER_IS_GCC_OR_CLANG)
+ endif ()
+ 
+ if (APPLE)
+-    SET_AND_EXPOSE_TO_BUILD(HAVE_QOS_CLASSES 1)
+ endif ()
+ 
+ if (ENABLE_MATHML)

--- a/pkgs/development/libraries/qt-5/5.12/qtwebkit-darwin-no-readline.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtwebkit-darwin-no-readline.patch
@@ -1,0 +1,45 @@
+diff --git a/Source/JavaScriptCore/shell/CMakeLists.txt b/Source/JavaScriptCore/shell/CMakeLists.txt
+--- a/Source/JavaScriptCore/shell/CMakeLists.txt
++++ b/Source/JavaScriptCore/shell/CMakeLists.txt
+@@ -9,7 +9,6 @@ set(JSC_LIBRARIES
+ )
+ 
+ if (WTF_OS_MAC_OS_X)
+-    list(APPEND JSC_LIBRARIES edit)
+ endif ()
+ 
+ if ("${JavaScriptCore_LIBRARY_TYPE}" MATCHES "STATIC")
+diff --git a/Source/WTF/wtf/Platform.h b/Source/WTF/wtf/Platform.h
+--- a/Source/WTF/wtf/Platform.h
++++ b/Source/WTF/wtf/Platform.h
+@@ -563,7 +563,6 @@
+ #if PLATFORM(IOS)
+ 
+ #define HAVE_NETWORK_EXTENSION 1
+-#define HAVE_READLINE 1
+ #if USE(APPLE_INTERNAL_SDK)
+ #define USE_CFNETWORK 1
+ #endif
+@@ -650,7 +649,6 @@
+ #define HAVE_MADV_DONTNEED 1
+ #define HAVE_MERGESORT 1
+ #define HAVE_PTHREAD_SETNAME_NP 1
+-#define HAVE_READLINE 1
+ #define HAVE_SYS_TIMEB_H 1
+ 
+ #if !PLATFORM(GTK) && !PLATFORM(QT)
+diff --git a/Source/WTF/wtf/PlatformMac.cmake b/Source/WTF/wtf/PlatformMac.cmake
+--- a/Source/WTF/wtf/PlatformMac.cmake
++++ b/Source/WTF/wtf/PlatformMac.cmake
+@@ -2,11 +2,9 @@ set(WTF_LIBRARY_TYPE SHARED)
+ 
+ find_library(COCOA_LIBRARY Cocoa)
+ find_library(COREFOUNDATION_LIBRARY CoreFoundation)
+-find_library(READLINE_LIBRARY Readline)
+ list(APPEND WTF_LIBRARIES
+     ${COREFOUNDATION_LIBRARY}
+     ${COCOA_LIBRARY}
+-    ${READLINE_LIBRARY}
+     libicucore.dylib
+ )
+ 

--- a/pkgs/development/libraries/qt-5/5.9/qtwebkit.patch
+++ b/pkgs/development/libraries/qt-5/5.9/qtwebkit.patch
@@ -1,16 +1,3 @@
-diff --git a/Source/WTF/WTF.pri b/Source/WTF/WTF.pri
-index 69e4cd1f3..3f729a75e 100644
---- a/Source/WTF/WTF.pri
-+++ b/Source/WTF/WTF.pri
-@@ -12,7 +12,7 @@ mac {
-     # Mac OS does ship libicu but not the associated header files.
-     # Therefore WebKit provides adequate header files.
-     INCLUDEPATH = $${ROOT_WEBKIT_DIR}/Source/WTF/icu $$INCLUDEPATH
--    LIBS += -licucore
-+    LIBS += /usr/lib/libicucore.dylib
- } else:!use?(wchar_unicode): {
-     win32 {
-         CONFIG(static, static|shared) {
 diff --git a/Source/WebCore/plugins/qt/PluginPackageQt.cpp b/Source/WebCore/plugins/qt/PluginPackageQt.cpp
 index a923d49aa..46772a4bb 100644
 --- a/Source/WebCore/plugins/qt/PluginPackageQt.cpp

--- a/pkgs/development/libraries/qt-5/modules/qtwebkit.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebkit.nix
@@ -8,7 +8,7 @@
 }:
 
 let
-  inherit (lib) optional optionals getLib;
+  inherit (lib) optional optionals getDev getLib;
   hyphen = stdenv.mkDerivation rec {
     name = "hyphen-2.8.8";
     src = fetchurl {
@@ -34,7 +34,12 @@ qtModule {
     bison2 flex gdb gperf perl pkgconfig python2 ruby
   ] ++ optional usingAnnulenWebkitFork cmake;
 
-  cmakeFlags = optional usingAnnulenWebkitFork "-DPORT=Qt";
+  cmakeFlags = optionals usingAnnulenWebkitFork ([ "-DPORT=Qt" ]
+    ++ optionals stdenv.isDarwin [
+      "-DQt5Multimedia_DIR=${getDev qtmultimedia}/lib/cmake/Qt5Multimedia"
+      "-DQt5MultimediaWidgets_DIR=${getDev qtmultimedia}/lib/cmake/Qt5MultimediaWidgets"
+      "-DMACOS_FORCE_SYSTEM_XML_LIBRARIES=OFF"
+    ]);
 
   # QtWebKit overrides qmake's default_pre and default_post features,
   # so its custom qmake files must be found first at the front of QMAKEPATH.

--- a/pkgs/development/libraries/qt-5/modules/qtwebkit.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebkit.nix
@@ -43,7 +43,7 @@ qtModule {
 
   # QtWebKit overrides qmake's default_pre and default_post features,
   # so its custom qmake files must be found first at the front of QMAKEPATH.
-  preConfigure = ''
+  preConfigure = stdenv.lib.optionalString (!usingAnnulenWebkitFork) ''
     QMAKEPATH="$PWD/Tools/qmake''${QMAKEPATH:+:}$QMAKEPATH"
     fixQtBuiltinPaths . '*.pr?'
     # Fix hydra's "Log limit exceeded"

--- a/pkgs/development/libraries/qt-5/modules/qtwebkit.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebkit.nix
@@ -27,17 +27,13 @@ qtModule {
     ++ optional (stdenv.isDarwin && lib.versionAtLeast qtbase.version "5.9.0") qtmultimedia
     ++ optional (lib.versionAtLeast qtbase.version "5.11.0") qtwebchannel;
   buildInputs = [ fontconfig libwebp libxml2 libxslt sqlite glib gst_all_1.gstreamer gst_all_1.gst-plugins-base ]
-    ++ optionals (stdenv.isDarwin) (with darwin; with apple_sdk.frameworks; [ cf-private OpenGL ])
+    ++ optionals (stdenv.isDarwin) (with darwin; with apple_sdk.frameworks; [ cf-private ICU OpenGL ])
     ++ optionals (lib.versionAtLeast qtbase.version "5.11.0") [ hyphen ];
   nativeBuildInputs = [
     bison2 flex gdb gperf perl pkgconfig python2 ruby
   ] ++ optionals (lib.versionAtLeast qtbase.version "5.11.0") [ cmake ];
 
   cmakeFlags = optionals (lib.versionAtLeast qtbase.version "5.11.0") [ "-DPORT=Qt" ];
-
-  __impureHostDeps = optionals (stdenv.isDarwin) [
-    "/usr/lib/libicucore.dylib"
-  ];
 
   # QtWebKit overrides qmake's default_pre and default_post features,
   # so its custom qmake files must be found first at the front of QMAKEPATH.

--- a/pkgs/development/libraries/qt-5/modules/qtwebkit.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebkit.nix
@@ -20,20 +20,21 @@ let
     '';
     buildInputs = [ perl ];
   };
+  usingAnnulenWebkitFork = lib.versionAtLeast qtbase.version "5.11.0";
 in
 qtModule {
   name = "qtwebkit";
   qtInputs = [ qtbase qtdeclarative qtlocation qtsensors ]
     ++ optional (stdenv.isDarwin && lib.versionAtLeast qtbase.version "5.9.0") qtmultimedia
-    ++ optional (lib.versionAtLeast qtbase.version "5.11.0") qtwebchannel;
+    ++ optional usingAnnulenWebkitFork qtwebchannel;
   buildInputs = [ fontconfig libwebp libxml2 libxslt sqlite glib gst_all_1.gstreamer gst_all_1.gst-plugins-base ]
     ++ optionals (stdenv.isDarwin) (with darwin; with apple_sdk.frameworks; [ cf-private ICU OpenGL ])
-    ++ optionals (lib.versionAtLeast qtbase.version "5.11.0") [ hyphen ];
+    ++ optional usingAnnulenWebkitFork hyphen;
   nativeBuildInputs = [
     bison2 flex gdb gperf perl pkgconfig python2 ruby
-  ] ++ optionals (lib.versionAtLeast qtbase.version "5.11.0") [ cmake ];
+  ] ++ optional usingAnnulenWebkitFork cmake;
 
-  cmakeFlags = optionals (lib.versionAtLeast qtbase.version "5.11.0") [ "-DPORT=Qt" ];
+  cmakeFlags = optional usingAnnulenWebkitFork "-DPORT=Qt";
 
   # QtWebKit overrides qmake's default_pre and default_post features,
   # so its custom qmake files must be found first at the front of QMAKEPATH.


### PR DESCRIPTION
`qt511.qtwebkit` is currently broken on darwin. This also prevents `qt5.full` from building #55892

###### Things done

* [x] `qt59.qtwebkit` builds
* [x] `qt511.qtwebkit` builds
* [ ] Tested

cc @alyssais who fixed `qt59.qtwebkit` earlier