### PR TITLE
inter: 3.1 -> 3.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3222,6 +3222,11 @@
     github = "nathan-gs";
     name = "Nathan Bijnens";
   };
+  nathyong = {
+    email = "nathyong@gmail.com";
+    github = "nathyong";
+    name = "Nathan Yong";
+  };
   nckx = {
     email = "github@tobias.gr";
     github = "nckx";

--- a/pkgs/data/fonts/inter/default.nix
+++ b/pkgs/data/fonts/inter/default.nix
@@ -1,25 +1,25 @@
 { stdenv, fetchzip }:
 
 let
-  version = "3.1";
+  version = "3.3";
 in fetchzip {
-  name = "inter-ui-${version}";
+  name = "inter-${version}";
 
-  url = "https://github.com/rsms/inter/releases/download/v${version}/Inter-UI-${version}.zip";
+  url = "https://github.com/rsms/inter/releases/download/v${version}/Inter-${version}.zip";
 
   postFetch = ''
     mkdir -p $out/share/fonts/opentype
     unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
   '';
 
-  sha256 = "0cdjpwylynwmab0x5z5lw43k39vis74xj1ciqg8nw12ccprbmj60";
+  sha256 = "17fv33ryvbla4f4mfgw7m7gjlwyjlni90a8gpb7jws1qzn0vgazg";
 
   meta = with stdenv.lib; {
     homepage = https://rsms.me/inter/;
     description = "A typeface specially designed for user interfaces";
     license = licenses.ofl;
     platforms = platforms.all;
-    maintainers = with maintainers; [ demize ];
+    maintainers = with maintainers; [ demize nathyong ];
   };
 }
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15891,7 +15891,7 @@ in
 
   maligned = callPackage ../development/tools/maligned { };
 
-  inter-ui = callPackage ../data/fonts/inter-ui { };
+  inter = callPackage ../data/fonts/inter { };
 
   siji = callPackage ../data/fonts/siji { };
 


### PR DESCRIPTION
The name of this font has also changed from "Inter UI" to simply "Inter"
as of version 3.3.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

