### PR TITLE
Add optional Jupyter kernelspec options from the spec

### DIFF
--- a/pkgs/applications/editors/jupyter/kernel.nix
+++ b/pkgs/applications/editors/jupyter/kernel.nix
@@ -39,13 +39,17 @@ in
 
       ${concatStringsSep "\n" (mapAttrsToList (kernelName: kernel:
         let
-          config = builtins.toJSON {
+          config = builtins.toJSON ({
             display_name = if (kernel.displayName != "")
               then kernel.displayName
               else kernelName;
             argv = kernel.argv;
             language = kernel.language;
-          };
+          }
+          // optionalAttrs (kernel ? env) { env = kernel.env; }
+          // optionalAttrs (kernel ? interrupt_mode) { env = kernel.interrupt_mode; }
+          // optionalAttrs (kernel ? metadata) { env = kernel.metadata; }
+          );
           logo32 =
             if (kernel.logo32 != null)
             then "ln -s ${kernel.logo32} 'kernels/${kernelName}/logo-32x32.png';"


### PR DESCRIPTION
###### Motivation for this change

The documentation for Jupyter kernels specifies that a few more keys can optionally be added to a kernel spec than are currently supported. This PR adds support for them.

Documentation is here: https://jupyter-client.readthedocs.io/en/stable/kernels.html#kernel-specs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [N/A] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [N/A] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [N/A?] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

