### PR TITLE
nixos-nix-serve: Add some hint on howto get valid signing keys.

### DIFF
--- a/nixos/modules/services/networking/nix-serve.nix
+++ b/nixos/modules/services/networking/nix-serve.nix
@@ -31,6 +31,15 @@ in
         default = null;
         description = ''
           The path to the file used for signing derivation data.
+          Generate with:
+
+          ```
+          nix-store --generate-binary-cache-key key-name secret-key-file public-key-file
+          ```
+
+          Make sure user `nix-serve` has read access to the private key file.
+
+          For more details see <citerefentry><refentrytitle>nix-store</refentrytitle><manvolnum>1</manvolnum></citerefentry>.
         '';
       };
 


### PR DESCRIPTION
###### Motivation for this change

Usually enabling features on nixos is pretty easy, for nix-serve it was unnecessary hard as I had to find some stack overflow answer to figure out howto create signing keys.

###### Things done
Nothing - only doc fix.
