### PR TITLE
pandoc: Enable distribution to fix master eval

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1225,7 +1225,7 @@ self: super: {
 
   # Use latest pandoc despite what LTS says.
   # Test suite fails in both 2.5 and 2.6: https://github.com/jgm/pandoc/issues/5309.
-  pandoc = dontCheck super.pandoc_2_6;
+  pandoc = doDistribute (dontCheck super.pandoc_2_6);
   pandoc-citeproc = self.pandoc-citeproc_0_16_1;
 
   # https://github.com/qfpl/tasty-hedgehog/issues/24


### PR DESCRIPTION
###### Motivation for this change
`pandoc_2_6` has `hydraPlatforms = stdenv.lib.platforms.none` so I think the hackage2nix generator (or some other component) needs some more information so that master evals and thus grahamcofborg don't fail on `nix-instantiate pkgs/top-level/release.nix -A pandoc.x86_64-linux`

This is a workaround to keep the spice flowing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

