### PR TITLE
perlPackages.TermReadKey: add workarounds for cross compilation

### DIFF
--- a/pkgs/development/perl-modules/generic/default.nix
+++ b/pkgs/development/perl-modules/generic/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, perl }:
+{ lib, stdenv, perl, buildPackages }:
 
 { nativeBuildInputs ? [], name, ... } @ attrs:
 
@@ -37,6 +37,6 @@ stdenv.mkDerivation (
     name = "perl${perl.version}-${name}";
     builder = ./builder.sh;
     nativeBuildInputs = nativeBuildInputs ++ [ (perl.dev or perl) ];
-    inherit perl;
+    perl = buildPackages.perl;
   }
 )


### PR DESCRIPTION
###### Motivation for this change

Allows this package to be cross-compiled, which is a dependency for many other more well-known packages (e.g. `git`).

Fixes #54510 

One can test that these are now working:
```
nix build -f . pkgsCross.armv7l-hf-multiplatform.perlPackages.TermReadKey
nix build -f . pkgsCross.armv7l-hf-multiplatform.git
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

