### PR TITLE
nixos: doc: include all modules in manual generation

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -141,7 +141,7 @@ rec {
         docOption = rec {
           loc = opt.loc;
           name = showOption opt.loc;
-          description = opt.description or (throw "Option `${name}' has no description.");
+          description = opt.description or (lib.warn "Option `${name}' has no description." "This option has no description.");
           declarations = filter (x: x != unknownModule) opt.declarations;
           internal = opt.internal or false;
           visible = opt.visible or true;

--- a/nixos/doc/manual/default.nix
+++ b/nixos/doc/manual/default.nix
@@ -327,6 +327,7 @@ in rec {
       # Generate manpages.
       mkdir -p $out/share/man
       xsltproc --nonet \
+        --maxdepth 6000 \
         --param man.output.in.separate.dir 1 \
         --param man.output.base.dir "'$out/share/man/'" \
         --param man.endnotes.are.numbered 0 \

--- a/nixos/doc/manual/release-notes/rl-1909.xml
+++ b/nixos/doc/manual/release-notes/rl-1909.xml
@@ -51,7 +51,17 @@
 
   <itemizedlist>
    <listitem>
-    <para />
+    <para>
+     The <option>documentation</option> module gained an option named
+     <option>documentation.nixos.includeAllModules</option> which makes the generated
+     <citerefentry><refentrytitle>configuration.nix</refentrytitle>
+     <manvolnum>5</manvolnum></citerefentry> manual page include all options from all NixOS modules
+     included in a given <literal>configuration.nix</literal> configuration file. Currently, it is
+     set to <literal>false</literal> by default as enabling it frequently prevents evaluation. But
+     the plan is to eventually have it set to <literal>true</literal> by default. Please set it to
+     <literal>true</literal> now in your <literal>configuration.nix</literal> and fix all the bugs
+     it uncovers.
+    </para>
    </listitem>
   </itemizedlist>
  </section>

--- a/nixos/lib/eval-config.nix
+++ b/nixos/lib/eval-config.nix
@@ -51,7 +51,7 @@ in rec {
   # system configuration.
   inherit (lib.evalModules {
     inherit prefix check;
-    modules = modules ++ extraModules ++ baseModules ++ [ pkgsModule ];
+    modules = baseModules ++ extraModules ++ [ pkgsModule ] ++ modules;
     args = extraArgs;
     specialArgs =
       { modulesPath = builtins.toString ../modules; } // specialArgs;
@@ -60,7 +60,7 @@ in rec {
   # These are the extra arguments passed to every module.  In
   # particular, Nixpkgs is passed through the "pkgs" argument.
   extraArgs = extraArgs_ // {
-    inherit modules baseModules;
+    inherit baseModules extraModules modules;
   };
 
   inherit (config._module.args) pkgs;


### PR DESCRIPTION
# What? Why?

An edited version of #47177. See commit messages below.

# `git log`

- nixos: doc: include all modules in manual generation

  Before this change `man 5 configuration.nix` would only show options of modules in
  the `baseModules` set, which consists only of the list of modules in
  `nixos/modules/module-list.nix`

  With this change applied all modules included in `configuration.nix` file will
  be used instead.

  This makes configurations with custom modules self-documenting. It also means
  that importing non-`baseModules` modules like `gce.nix` or `azure.nix`
  will make their documentation available in `man 5 configuration.nix`.

  This was originally implemented in #47177, edited for more configurability and
  rebased onto master by @oxij.

- nixos: doc: increase maxdepth for xsltproc

  See https://github.com/NixOS/nixpkgs/issues/37903#issuecomment-376618117
  for details. With the previous patch and some custom modules included in
  `configuration.nix` the above bug is very easy to trigger.

  This is a simplest workaround I have. A proper solution would look like
  https://github.com/NixOS/nixpkgs/issues/37903#issuecomment-376980838.

# `nix-instantiate` environment

- Host OS: Linux 4.9, SLNOS 19.03
- Nix: nix-env (Nix) 2.1.3
- Multi-user: yes
- Sandbox: yes
- NIXPKGS_CONFIG:

```nix
{
  checkMeta = true;
  doCheckByDefault = true;
}
```

# `nix-env -qaP` diffs

- On x86_64-linux:
  - Updated (2):
    - tests.nixos-functions.nixos-test
    - tests.nixos-functions.nixosTest-test

- On aarch64-linux: ditto
- On x86_64-darwin: noop

/cc original author of #47177 @arianvp, documentation aficionados @grahamc @vcunat