### PR TITLE
cmake: add ability to cross-compile cmake

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchurl, fetchpatch, pkgconfig
 , bzip2, curl, expat, libarchive, xz, zlib, libuv, rhash
+, buildPackages
 # darwin attributes
 , ps
 , isBootstrap ? false
@@ -61,6 +62,8 @@ stdenv.mkDerivation rec {
     ++ optional useQt4 qt4
     ++ optional withQt5 qtbase;
 
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+
   propagatedBuildInputs = optional stdenv.isDarwin ps;
 
   preConfigure = ''
@@ -71,7 +74,8 @@ stdenv.mkDerivation rec {
       --subst-var-by libc_lib ${getLib stdenv.cc.libc}
     substituteInPlace Modules/FindCxxTest.cmake \
       --replace "$""{PYTHON_EXECUTABLE}" ${stdenv.shell}
-    configureFlags="--parallel=''${NIX_BUILD_CORES:-1} $configureFlags"
+    # BUILD_CC and BUILD_CXX are used to bootstrap cmake
+    configureFlags="--parallel=''${NIX_BUILD_CORES:-1} CC=$BUILD_CC CXX=$BUILD_CXX $configureFlags"
   '';
 
   configureFlags = [
@@ -94,6 +98,11 @@ stdenv.mkDerivation rec {
   ]
     # Avoid depending on frameworks.
     ++ optional (!useNcurses) "-DBUILD_CursesDialog=OFF";
+
+  # make install attempts to use the just-built cmake
+  preInstall = optional (stdenv.hostPlatform != stdenv.buildPlatform) ''
+    sed -i 's|bin/cmake|${buildPackages.cmake}/bin/cmake|g' Makefile
+  '';
 
   dontUseCmakeConfigure = true;
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change

Allows `cmake` to be cross-compiled, this does not make a `cmake` that runs on the build platform and generates code for a different architecture, but a `cmake` that _runs_ on another architecture.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

