### PR TITLE
all-packages.nix: move defaults to package files continues^2

### DIFF
--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -1,10 +1,10 @@
-{ stdenv, lib, fetchurl, boost, cmake, ffmpeg, gettext, glew
+{ config, stdenv, lib, fetchurl, boost, cmake, ffmpeg, gettext, glew
 , ilmbase, libXi, libX11, libXext, libXrender
 , libjpeg, libpng, libsamplerate, libsndfile
 , libtiff, libGLU_combined, openal, opencolorio, openexr, openimageio, openjpeg_1, pythonPackages
 , zlib, fftw, opensubdiv, freetype, jemalloc, ocl-icd
 , jackaudioSupport ? false, libjack2
-, cudaSupport ? false, cudatoolkit
+, cudaSupport ? config.cudaSupport or false, cudatoolkit
 , colladaSupport ? true, opencollada
 , enableNumpy ? false, makeWrapper
 }:

--- a/pkgs/applications/science/math/caffe/default.nix
+++ b/pkgs/applications/science/math/caffe/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, runCommand
+{ config, stdenv, lib, runCommand
 , fetchFromGitHub
 , fetchurl
 , cmake
@@ -13,8 +13,8 @@
 , Accelerate, CoreGraphics, CoreVideo
 , lmdbSupport ? true, lmdb
 , leveldbSupport ? true, leveldb, snappy
-, cudaSupport ? stdenv.isLinux, cudatoolkit
-, cudnnSupport ? false, cudnn ? null
+, cudaSupport ? config.cudaSupport or false, cudatoolkit
+, cudnnSupport ? cudaSupport, cudnn ? null
 , ncclSupport ? false, nccl ? null
 , pythonSupport ? false, python ? null, numpy ? null
 }:

--- a/pkgs/applications/science/math/cntk/default.nix
+++ b/pkgs/applications/science/math/cntk/default.nix
@@ -1,8 +1,8 @@
-{ lib, stdenv, fetchgit, fetchFromGitHub, cmake
+{ config, lib, stdenv, fetchgit, fetchFromGitHub, cmake
 , openblas, opencv3, libzip, boost, protobuf, openmpi
 , onebitSGDSupport ? false
-, cudaSupport ? false, cudatoolkit, nvidia_x11
-, cudnnSupport ? false, cudnn
+, cudaSupport ? config.cudaSupport or false, cudatoolkit, nvidia_x11
+, cudnnSupport ? cudaSupport, cudnn
 }:
 
 assert cudnnSupport -> cudaSupport;

--- a/pkgs/applications/science/math/mxnet/default.nix
+++ b/pkgs/applications/science/math/mxnet/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, lib, fetchurl, bash, cmake
+{ config, stdenv, lib, fetchurl, bash, cmake
 , opencv, gtest, openblas, liblapack, perl
-, cudaSupport ? false, cudatoolkit, nvidia_x11
-, cudnnSupport ? false, cudnn
+, cudaSupport ? config.cudaSupport or false, cudatoolkit, nvidia_x11
+, cudnnSupport ? cudaSupport, cudnn
 }:
 
 assert cudnnSupport -> cudaSupport;

--- a/pkgs/applications/window-managers/xmonad/log-applet/default.nix
+++ b/pkgs/applications/window-managers/xmonad/log-applet/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, pkgconfig, autoreconfHook, glib, dbus-glib
-, desktopSupport, xorg
+, desktopSupport ? "gnomeflashback", xorg
 , gtk2
 , gtk3, gnome3, mate
 , libxfce4util, xfce4-panel

--- a/pkgs/development/compilers/gnu-smalltalk/default.nix
+++ b/pkgs/development/compilers/gnu-smalltalk/default.nix
@@ -1,5 +1,7 @@
-{ stdenv, fetchurl, pkgconfig, libtool, zip, libffi, libsigsegv, readline, gmp,
-gnutls, gnome2, cairo, SDL, sqlite, emacsSupport ? false, emacs ? null }:
+{ config, stdenv, fetchurl, pkgconfig, libtool
+, zip, libffi, libsigsegv, readline, gmp
+, gnutls, gnome2, cairo, SDL, sqlite
+, emacsSupport ? config.emacsSupport or false, emacs ? null }:
 
 assert emacsSupport -> (emacs != null);
 

--- a/pkgs/development/libraries/cairo/default.nix
+++ b/pkgs/development/libraries/cairo/default.nix
@@ -1,8 +1,10 @@
-{ stdenv, fetchurl, pkgconfig, libiconv
+{ config, stdenv, fetchurl, pkgconfig, libiconv
 , libintl, expat, zlib, libpng, pixman, fontconfig, freetype, xorg
 , gobjectSupport ? true, glib
 , xcbSupport ? true # no longer experimental since 1.12
-, glSupport ? true, libGL ? null # libGLU_combined is no longer a big dependency
+, libGLSupported
+, glSupport ? config.cairo.gl or (libGLSupported && stdenv.isLinux && !stdenv.isAarch32 && !stdenv.isMips)
+, libGL ? null # libGLU_combined is no longer a big dependency
 , pdfSupport ? true
 , darwin
 }:

--- a/pkgs/development/libraries/gtk+/2.x.nix
+++ b/pkgs/development/libraries/gtk+/2.x.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchurl, pkgconfig, gettext, glib, atk, pango, cairo, perl, xorg
+{ config, stdenv, fetchurl, pkgconfig, gettext, glib, atk, pango, cairo, perl, xorg
 , gdk_pixbuf, xlibsWrapper, gobject-introspection
 , xineramaSupport ? stdenv.isLinux
-, cupsSupport ? true, cups ? null
+, cupsSupport ? config.gtk2.cups or stdenv.isLinux, cups ? null
 , gdktarget ? if stdenv.isDarwin then "quartz" else "x11"
 , AppKit, Cocoa
 , fetchpatch

--- a/pkgs/development/libraries/libtensorflow/default.nix
+++ b/pkgs/development/libraries/libtensorflow/default.nix
@@ -1,7 +1,7 @@
-{ stdenv
+{ config, stdenv
 , fetchurl
 , patchelf
-, cudaSupport ? false, symlinkJoin, cudatoolkit, cudnn, nvidia_x11
+, cudaSupport ? config.cudaSupport or false, symlinkJoin, cudatoolkit, cudnn, nvidia_x11
 }:
 with stdenv.lib;
 let

--- a/pkgs/development/libraries/opensubdiv/default.nix
+++ b/pkgs/development/libraries/opensubdiv/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, cmake, pkgconfig, xorg, libGLU
+{ config, lib, stdenv, fetchFromGitHub, cmake, pkgconfig, xorg, libGLU
 , libGL, glew, ocl-icd, python3
-, cudaSupport ? false, cudatoolkit
+, cudaSupport ? config.cudaSupport or false, cudatoolkit
 , darwin
 }:
 

--- a/pkgs/development/libraries/xgboost/default.nix
+++ b/pkgs/development/libraries/xgboost/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, lib, fetchgit, cmake
-, cudaSupport ? false, cudatoolkit
+{ config, stdenv, lib, fetchgit, cmake
+, cudaSupport ? config.cudaSupport or false, cudatoolkit
 , ncclSupport ? false, nccl
 , llvmPackages
 }:

--- a/pkgs/os-specific/linux/pcmciautils/default.nix
+++ b/pkgs/os-specific/linux/pcmciautils/default.nix
@@ -1,10 +1,9 @@
-{ stdenv, fetchurl
+{ config, lib, stdenv, fetchurl
 , yacc, flex
 , sysfsutils, kmod, udev
-, firmware # Special pcmcia cards.
-, config   # Special hardware (map memory & port & irq)
-, lib      # used to generate postInstall script.
-}:
+, firmware   ? config.pcmciaUtils.firmware or [] # Special pcmcia cards.
+, configOpts ? config.pcmciaUtils.config or null # Special hardware (map memory & port & irq)
+}:                   # used to generate postInstall script.
 
 # FIXME: should add an option to choose between hotplug and udev.
 stdenv.mkDerivation rec {
@@ -28,8 +27,8 @@ stdenv.mkDerivation rec {
     " src/{startup.c,pcmcia-check-broken-cis.c} # fix-color */
   ''
   + (if firmware == [] then ''sed -i "s,STARTUP = true,STARTUP = false," Makefile'' else "")
-  + (if config == null then "" else ''
-    ln -sf ${config} ./config/config.opts'')
+  + (if configOpts == null then "" else ''
+    ln -sf ${configOpts} ./config/config.opts'')
   ;
 
   makeFlags = "LEX=flex";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10144,7 +10144,6 @@ in
   elementary-cmake-modules = callPackage ../development/libraries/elementary-cmake-modules { };
 
   gtk2 = callPackage ../development/libraries/gtk+/2.x.nix {
-    cupsSupport = config.gtk2.cups or stdenv.isLinux;
     inherit (darwin.apple_sdk.frameworks) AppKit Cocoa;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21850,20 +21850,16 @@ in
 
   ### SCIENCE / MATH
 
-  caffe = callPackage ../applications/science/math/caffe rec {
-    cudaSupport = config.caffe.cudaSupport or config.cudaSupport or false;
-    cudnnSupport = cudaSupport;
-    # Used only for image loading.
-    opencv3 = opencv3WithoutCuda;
+  caffe = callPackage ../applications/science/math/caffe ({
+    opencv3 = opencv3WithoutCuda; # Used only for image loading.
     inherit (darwin.apple_sdk.frameworks) Accelerate CoreGraphics CoreVideo;
-  };
+  } // (config.caffe or {}));
 
   caffe2 = callPackage ../development/libraries/science/math/caffe2 (rec {
     inherit (python36Packages) python future six numpy pydot;
     protobuf = protobuf3_1;
     python-protobuf = python36Packages.protobuf.override { inherit protobuf; };
-    # Used only for image loading.
-    opencv3 = opencv3WithoutCuda;
+    opencv3 = opencv3WithoutCuda; # Used only for image loading.
   });
 
   cntk = callPackage ../applications/science/math/cntk rec {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6905,9 +6905,7 @@ in
     inherit (gnome2) libart_lgpl;
   });
 
-  gnu-smalltalk = callPackage ../development/compilers/gnu-smalltalk {
-    emacsSupport = config.emacsSupport or false;
-  };
+  gnu-smalltalk = callPackage ../development/compilers/gnu-smalltalk { };
 
   gccgo = gccgo6;
   gccgo6 = wrapCC (gcc6.cc.override {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12993,9 +12993,7 @@ in
 
   xalanc = callPackage ../development/libraries/xalanc {};
 
-  xgboost = callPackage ../development/libraries/xgboost {
-    cudaSupport = config.cudaSupport or false;
-  };
+  xgboost = callPackage ../development/libraries/xgboost { };
 
   xgeometry-select = callPackage ../tools/X11/xgeometry-select { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20151,18 +20151,15 @@ in
   };
 
   xmonad_log_applet = callPackage ../applications/window-managers/xmonad/log-applet {
-    desktopSupport = "gnomeflashback";
     inherit (xfce) libxfce4util xfce4-panel;
   };
 
   xmonad_log_applet_mate = xmonad_log_applet.override {
     desktopSupport = "mate";
-    inherit (xfce) libxfce4util xfce4-panel;
   };
 
   xmonad_log_applet_xfce = xmonad_log_applet.override {
     desktopSupport = "xfce4";
-    inherit (xfce) libxfce4util xfce4-panel;
   };
 
   xmpp-client = callPackage ../applications/networking/instant-messengers/xmpp-client { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -915,7 +915,6 @@ in
   tensor = libsForQt5.callPackage ../applications/networking/instant-messengers/tensor { };
 
   libtensorflow = callPackage ../development/libraries/libtensorflow {
-    cudaSupport = config.cudaSupport or false;
     inherit (linuxPackages) nvidia_x11;
     cudatoolkit = cudatoolkit_9_0;
     cudnn = cudnn_cudatoolkit_9_0;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21862,12 +21862,9 @@ in
     opencv3 = opencv3WithoutCuda; # Used only for image loading.
   });
 
-  cntk = callPackage ../applications/science/math/cntk rec {
-    cudaSupport = pkgs.config.cudaSupport or false;
-    cudnnSupport = cudaSupport;
+  cntk = callPackage ../applications/science/math/cntk {
     inherit (linuxPackages) nvidia_x11;
-    # Used only for image loading.
-    opencv3 = opencv3WithoutCuda;
+    opencv3 = opencv3WithoutCuda; # Used only for image loading.
   };
 
   ecm = callPackage ../applications/science/math/ecm { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14992,10 +14992,7 @@ in
 
   pax-utils = callPackage ../os-specific/linux/pax-utils { };
 
-  pcmciaUtils = callPackage ../os-specific/linux/pcmciautils {
-    firmware = config.pcmciaUtils.firmware or [];
-    config = config.pcmciaUtils.config or null;
-  };
+  pcmciaUtils = callPackage ../os-specific/linux/pcmciautils { };
 
   pcstat = callPackage ../tools/system/pcstat { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11866,7 +11866,6 @@ in
   openssl-chacha = callPackage ../development/libraries/openssl/chacha.nix { };
 
   opensubdiv = callPackage ../development/libraries/opensubdiv {
-    cudaSupport = config.cudaSupport or false;
     cmake = cmake_2_8;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16183,7 +16183,6 @@ in
   bleachbit = callPackage ../applications/misc/bleachbit { };
 
   blender = callPackage  ../applications/misc/blender {
-    cudaSupport = config.cudaSupport or false;
     pythonPackages = python35Packages;
     stdenv = overrideCC stdenv gcc6;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21902,9 +21902,7 @@ in
     sbcl = null;
   };
 
-  mxnet = callPackage ../applications/science/math/mxnet rec {
-    cudaSupport = config.cudaSupport or false;
-    cudnnSupport = cudaSupport;
+  mxnet = callPackage ../applications/science/math/mxnet {
     inherit (linuxPackages) nvidia_x11;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10118,11 +10118,7 @@ in
 
   pixman = callPackage ../development/libraries/pixman { };
 
-  cairo = callPackage ../development/libraries/cairo {
-    glSupport = config.cairo.gl or (stdenv.isLinux &&
-      !stdenv.isAarch32 && !stdenv.isMips);
-  };
-
+  cairo = callPackage ../development/libraries/cairo { };
 
   cairomm = callPackage ../development/libraries/cairomm { };
 


### PR DESCRIPTION
# What? Why?

A continuation of #55129 and #55732. Another noop.

# `git log`

- *: move defaults to package file

A bunch of these.

- xmonad_log_applet: move defaults to package file, cleanup

  These are already inherited in the parent derivation.

# `nix-instantiate` environment

- Host OS: Linux 4.9, SLNOS 19.03
- Nix: nix-env (Nix) 2.1.3
- Multi-user: yes
- Sandbox: yes
- NIXPKGS_CONFIG:

```nix
{
  checkMeta = true;
  doCheckByDefault = true;
}
```

# `nix-env -qaP` diffs

- On x86_64-linux: noop
- On aarch64-linux: noop
- On x86_64-darwin: noop

/cc @7c6f434c from #55129 and @bendlas, @volth, @samueldr from #55732
