### PR TITLE
pythonPackages.fastparquet: init at 0.2.1

### DIFF
--- a/pkgs/development/python-modules/fastparquet/default.nix
+++ b/pkgs/development/python-modules/fastparquet/default.nix
@@ -5,8 +5,6 @@ buildPythonPackage rec {
   pname = "fastparquet";
   version = "0.2.1";
 
-  disabled = !isPy3k;
-
   src = fetchPypi {
     inherit pname version;
     sha256 = "183wdmhnhnlsd7908n3d2g4qnb49fcipqfshghwpbdwdzjpa0day";

--- a/pkgs/development/python-modules/fastparquet/default.nix
+++ b/pkgs/development/python-modules/fastparquet/default.nix
@@ -1,0 +1,28 @@
+{ lib, buildPythonPackage, isPy3k, fetchPypi, numba, numpy, pandas,
+pytestrunner, thrift }:
+
+buildPythonPackage rec {
+  pname = "fastparquet";
+  version = "0.2.1";
+
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "183wdmhnhnlsd7908n3d2g4qnb49fcipqfshghwpbdwdzjpa0day";
+  };
+
+  buildInputs = [ pytestrunner ];
+  propagatedBuildInputs = [ numba numpy pandas thrift ];
+
+  # Needs python-snappy and some patching to prevent tests from trying to
+  # download python packages
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A python implementation of the parquet format";
+    homepage = https://github.com/dask/fastparquet;
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ veprbl ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -374,6 +374,8 @@ in {
 
   face = callPackage ../development/python-modules/face { };
 
+  fastparquet = callPackage ../development/python-modules/fastparquet { };
+
   fastpbkdf2 = callPackage ../development/python-modules/fastpbkdf2 {  };
 
   favicon = callPackage ../development/python-modules/favicon {  };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

