### PR TITLE
Revert cctools bump

### DIFF
--- a/pkgs/os-specific/darwin/cctools/ld-tbd-v2.patch
+++ b/pkgs/os-specific/darwin/cctools/ld-tbd-v2.patch
@@ -1,0 +1,98 @@
+diff --git a/cctools/ld64/src/ld/parsers/textstub_dylib_file.cpp b/cctools/ld64/src/ld/parsers/textstub_dylib_file.cpp
+index 09c0e12..ac6b085 100644
+--- a/cctools/ld64/src/ld/parsers/textstub_dylib_file.cpp
++++ b/cctools/ld64/src/ld/parsers/textstub_dylib_file.cpp
+@@ -187,6 +187,7 @@ struct DynamicLibrary {
+ 	ld::File::ObjcConstraint _objcConstraint;
+ 	Options::Platform _platform;
+ 	std::vector<Token> _allowedClients;
++	std::vector<Token> _allowableClients;
+ 	std::vector<Token> _reexportedLibraries;
+ 	std::vector<Token> _symbols;
+ 	std::vector<Token> _classes;
+@@ -246,6 +247,14 @@ class TBDFile {
+ 		});
+ 	}
+ 
++	void parseAllowableClients(DynamicLibrary& lib) {
++		if ( !hasOptionalToken("allowable-clients") )
++			return;
++		parseFlowSequence([&](Token name) {
++			lib._allowableClients.emplace_back(name);
++		});
++	}
++
+ 	void parseReexportedDylibs(DynamicLibrary& lib) {
+ 		if ( !hasOptionalToken("re-exports") )
+ 			return;
+@@ -306,6 +315,21 @@ class TBDFile {
+ 		return false;
+ 	}
+ 
++	void skipUUIDs(DynamicLibrary& lib) {
++		expectToken("uuids");
++		while ( true ) {
++			auto token = next();
++			if ( token == "]" )
++				break;
++		}
++	}
++
++	void skipParentUmbrella(DynamicLibrary& lib) {
++		if (!hasOptionalToken("parent-umbrella"))
++			return;
++		next();
++	}
++
+ 	void parsePlatform(DynamicLibrary& lib) {
+ 		expectToken("platform");
+ 
+@@ -410,6 +434,7 @@ class TBDFile {
+ 			}
+ 
+ 			parseAllowedClients(lib);
++			parseAllowableClients(lib);
+ 			parseReexportedDylibs(lib);
+ 			parseSymbols(lib);
+ 			if ( !hasOptionalToken("-") )
+@@ -455,17 +480,21 @@ class TBDFile {
+ 			return result.front();
+ 	}
+ 
+-	void parseDocument(DynamicLibrary& lib, std::string &requestedArchName) {
++	void parseDocument(DynamicLibrary& lib, std::string &requestedArchName, bool isTbdV2) {
+ 		auto selectedArchName = parseAndSelectArchitecture(requestedArchName);
+ 		if (selectedArchName.empty())
+ 			throwf("invalid arch");
+ 
++		if(isTbdV2)
++			skipUUIDs(lib);
+ 		parsePlatform(lib);
+ 		parseInstallName(lib);
+ 		parseCurrentVersion(lib);
+ 		parseCompatibilityVersion(lib);
+ 		parseSwiftVersion(lib);
+ 		parseObjCConstraint(lib);
++		if(isTbdV2)
++			skipParentUmbrella(lib);
+ 		parseExportsBlock(lib, selectedArchName);
+ 	}
+ 
+@@ -476,7 +505,8 @@ public:
+ 		_tokenizer.reset();
+ 		DynamicLibrary lib;
+ 		expectToken("---");
+-		parseDocument(lib, requestedArchName);
++		auto isTbdV2 = hasOptionalToken("!tapi-tbd-v2");
++		parseDocument(lib, requestedArchName, isTbdV2);
+ 		expectToken("...");
+ 		return lib;
+ 	}
+@@ -486,6 +516,7 @@ public:
+ 		auto token = next();
+ 		if ( token != "---" )
+ 			return false;
++		hasOptionalToken("!tapi-tbd-v2");
+ 		return !parseAndSelectArchitecture(requestedArchName).empty();
+ 	}
+ 

--- a/pkgs/os-specific/darwin/cctools/port.nix
+++ b/pkgs/os-specific/darwin/cctools/port.nix
@@ -1,9 +1,17 @@
-{ stdenv, fetchFromGitHub, autoconf, automake, libtool, autoreconfHook
+{ stdenv, fetchFromGitHub, autoconf, automake, libtool_2, autoreconfHook
 , libcxxabi, libuuid, llvm
 , libobjc ? null, maloader ? null
+, enableDumpNormalizedLibArgs ? false
 }:
 
 let
+
+  # We need to use an old version of cctools-port to support linking TBD files
+  # in the iOS SDK. Note that this only provides support for SDK versions up to
+  # 10.x. For 11.0 and higher we will need to upgrade to a newer cctools than the
+  # default version here, which can support the new TBD format via Apple's
+  # libtapi.
+  useOld = stdenv.targetPlatform.isiOS;
 
   # The targetPrefix prepended to binary names to allow multiple binuntils on the
   # PATH to both be usable.
@@ -15,27 +23,47 @@ in
 # Non-Darwin alternatives
 assert (!stdenv.hostPlatform.isDarwin) -> maloader != null;
 
+assert enableDumpNormalizedLibArgs -> (!useOld);
+
 let
   baseParams = rec {
     name = "${targetPrefix}cctools-port-${version}";
-    version = "895";
+    version = if useOld then "886" else "895";
 
-    src = fetchFromGitHub {
+    src = fetchFromGitHub (if enableDumpNormalizedLibArgs then {
       owner  = "tpoechtrager";
       repo   = "cctools-port";
-      rev    = "07619027f8311fa61b4a549c75994b88739a82d8";
-      sha256 = "12g94hhz5v5bmy2w0zb6fb4bjlmn992gygc60h9nai15kshj2spi";
-    };
+      # master with https://github.com/tpoechtrager/cctools-port/pull/34
+      rev    = "8395d4b2c3350356e2fb02f5e04f4f463c7388df";
+      sha256 = "10vbf1cfzx02q8chc77s84fp2kydjpx2y682mr6mrbb7sq5rwh8f";
+    } else if useOld then {
+      owner  = "tpoechtrager";
+      repo   = "cctools-port";
+      rev    = "02f0b8ecd87a3951653d838a321ae744815e21a5";
+      sha256 = "0bzyabzr5dvbxglr74d0kbrk2ij5x7s5qcamqi1v546q1had1wz1";
+    } else {
+      owner  = "tpoechtrager";
+      repo   = "cctools-port";
+      rev    = "2e569d765440b8cd6414a695637617521aa2375b"; # From branch 895-ld64-274.2
+      sha256 = "0l45mvyags56jfi24rawms8j2ihbc45mq7v13pkrrwppghqrdn52";
+    });
 
     outputs = [ "out" "dev" ];
 
-    nativeBuildInputs = [ autoconf automake libtool autoreconfHook ];
+    nativeBuildInputs = [ autoconf automake libtool_2 autoreconfHook ];
     buildInputs = [ libuuid ]
       ++ stdenv.lib.optionals stdenv.isDarwin [ libcxxabi libobjc ];
 
-    patches = [ ./ld-rpath-nonfinal.patch ./ld-ignore-rpath-link.patch ];
+    patches = [
+      ./ld-rpath-nonfinal.patch ./ld-ignore-rpath-link.patch
+    ] ++ stdenv.lib.optionals useOld [
+      # See https://github.com/tpoechtrager/cctools-port/issues/24. Remove when that's fixed.
+      ./undo-unknown-triple.patch
+      ./ld-tbd-v2.patch
+      ./support-ios.patch
+    ];
 
-    __propagatedImpureHostDeps = [
+    __propagatedImpureHostDeps = stdenv.lib.optionals (!useOld) [
       # As far as I can tell, otool from cctools is the only thing that depends on these two, and we should fix them
       "/usr/lib/libobjc.A.dylib"
       "/usr/lib/libobjc.dylib"
@@ -48,9 +76,7 @@ let
       ++ stdenv.lib.optional (stdenv.targetPlatform != stdenv.hostPlatform) "target";
     configureFlags = [ "--disable-clang-as" ];
 
-    postPatch = stdenv.lib.optionalString stdenv.hostPlatform.isDarwin ''
-      substituteInPlace cctools/Makefile.am --replace libobjc2 ""
-    '' + ''
+    postPatch = ''
       sed -i -e 's/addStandardLibraryDirectories = true/addStandardLibraryDirectories = false/' cctools/ld64/src/ld/Options.cpp
 
       # FIXME: there are far more absolute path references that I don't want to fix right now

--- a/pkgs/os-specific/darwin/cctools/port.nix
+++ b/pkgs/os-specific/darwin/cctools/port.nix
@@ -125,6 +125,7 @@ let
       homepage = http://www.opensource.apple.com/source/cctools/;
       description = "MacOS Compiler Tools (cross-platform port)";
       license = stdenv.lib.licenses.apsl20;
+      maintainers = with stdenv.lib.maintainers; [ matthewbauer ];
     };
   };
 in stdenv.mkDerivation baseParams

--- a/pkgs/os-specific/darwin/cctools/support-ios.patch
+++ b/pkgs/os-specific/darwin/cctools/support-ios.patch
@@ -1,0 +1,13 @@
+diff --git a/cctools/configure.ac b/cctools/configure.ac
+index 56e8f24..0b4b3ff 100644
+--- a/cctools/configure.ac
++++ b/cctools/configure.ac
+@@ -39,7 +39,7 @@ EXTRACXXFLAGS=""
+ WARNINGS=""
+ 
+ case $host_os in
+-  darwin* )
++  darwin* | ios*)
+     isdarwin=yes
+     AM_CONDITIONAL([ISDARWIN], [true])
+   ;;

--- a/pkgs/os-specific/darwin/cctools/undo-unknown-triple.patch
+++ b/pkgs/os-specific/darwin/cctools/undo-unknown-triple.patch
@@ -1,0 +1,17 @@
+diff --git a/cctools/as/driver.c b/cctools/as/driver.c
+index b06d085..c03397a 100644
+--- a/cctools/as/driver.c
++++ b/cctools/as/driver.c
+@@ -363,12 +363,6 @@ char **envp)
+ 	    /* Add -c or clang will run ld(1). */
+ 	    new_argv[j] = "-c";
+ 	    j++;
+-	    /* cctools-port start */
+-	    new_argv[j] = "-target";
+-	    j++;
+-	    new_argv[j] = "unknown-apple-darwin";
+-	    j++;
+-	    /* cctools-port end */
+ 	    new_argv[j] = NULL;
+ 	    if(execute(new_argv, verbose))
+ 		exit(0);

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6635,6 +6635,11 @@ in
     name = "clang-wrapper-with-reexport-hack";
     bintools = darwin.binutils.override {
       useMacosReexportHack = true;
+      bintools = darwin.binutils.bintools.override {
+        cctools = darwin.cctools.override {
+          enableDumpNormalizedLibArgs = true;
+        };
+      };
     };
   };
 


### PR DESCRIPTION
###### Motivation for this change

This broke iOS building on master. Even Xcode 8.2 comes with TAPI
librarises. We need these patches to support those .tbd files.
Eventually we will move to using libtapi directly, but I have not
finished work on this right now.

Unfortunately, this will mean cctools does not have my changes for building
manpages. We will have to do this update at some later time.

Also add myself as maintainer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

