### PR TITLE
Revert "libcxx: add linker scripts for libc++.a to ensure libc++abi.a…

### DIFF
--- a/pkgs/development/compilers/llvm/4/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/4/libc++/default.nix
@@ -44,11 +44,6 @@ stdenv.mkDerivation rec {
 
   linkCxxAbi = stdenv.isLinux;
 
-  postInstall = ''
-    mv $out/lib/libc++.a $out/lib/libc++_static.a
-    cp ${./libc++.a} $out/lib/libc++.a
-  '';
-
   setupHooks = [
     ../../../../../build-support/setup-hooks/role.bash
     ./setup-hook.sh

--- a/pkgs/development/compilers/llvm/4/libc++/libc++.a
+++ b/pkgs/development/compilers/llvm/4/libc++/libc++.a
@@ -1,1 +1,0 @@
-INPUT(-lc++_static -lc++abi)

--- a/pkgs/development/compilers/llvm/5/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/5/libc++/default.nix
@@ -38,11 +38,6 @@ stdenv.mkDerivation rec {
 
   linkCxxAbi = stdenv.isLinux;
 
-  postInstall = ''
-    mv $out/lib/libc++.a $out/lib/libc++_static.a
-    cp ${./libc++.a} $out/lib/libc++.a
-  '';
-
   setupHooks = [
     ../../../../../build-support/setup-hooks/role.bash
     ./setup-hook.sh

--- a/pkgs/development/compilers/llvm/5/libc++/libc++.a
+++ b/pkgs/development/compilers/llvm/5/libc++/libc++.a
@@ -1,1 +1,0 @@
-INPUT(-lc++_static -lc++abi)

--- a/pkgs/development/compilers/llvm/6/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/6/libc++/default.nix
@@ -38,11 +38,6 @@ stdenv.mkDerivation rec {
 
   linkCxxAbi = stdenv.isLinux;
 
-  postInstall = ''
-    mv $out/lib/libc++.a $out/lib/libc++_static.a
-    cp ${./libc++.a} $out/lib/libc++.a
-  '';
-
   setupHooks = [
     ../../../../../build-support/setup-hooks/role.bash
     ./setup-hook.sh

--- a/pkgs/development/compilers/llvm/6/libc++/libc++.a
+++ b/pkgs/development/compilers/llvm/6/libc++/libc++.a
@@ -1,1 +1,0 @@
-INPUT(-lc++_static -lc++abi)

--- a/pkgs/development/compilers/llvm/7/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/7/libc++/default.nix
@@ -36,11 +36,6 @@ stdenv.mkDerivation rec {
 
   linkCxxAbi = stdenv.isLinux;
 
-  postInstall = ''
-    mv $out/lib/libc++.a $out/lib/libc++_static.a
-    cp ${./libc++.a} $out/lib/libc++.a
-  '';
-
   setupHooks = [
     ../../../../../build-support/setup-hooks/role.bash
     ./setup-hook.sh

--- a/pkgs/development/compilers/llvm/7/libc++/libc++.a
+++ b/pkgs/development/compilers/llvm/7/libc++/libc++.a
@@ -1,1 +1,0 @@
-INPUT(-lc++_static -lc++abi)


### PR DESCRIPTION
… is properly linked"

This reverts commit 72e1764199805ab6e602fa3762a4d95bfdf80cb8.

This causes the GHC panic reported in issue #55848. Discussion on what's going on is available in that issue. This may not be needed if we can figure out how to patch GHC to avoid the panic.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

