### PR TITLE
pyo3-pack: 0.3.8 -> 0.5.0

### DIFF
--- a/pkgs/development/tools/rust/pyo3-pack/default.nix
+++ b/pkgs/development/tools/rust/pyo3-pack/default.nix
@@ -5,16 +5,16 @@ let
   inherit (darwin.apple_sdk.frameworks) Security;
 in rustPlatform.buildRustPackage rec {
   name = "pyo3-pack-${version}";
-  version = "0.3.8";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "PyO3";
     repo = "pyo3-pack";
     rev = "v${version}";
-    sha256 = "14343209w7wphkqh7pnw08pah09spjbwhk6l548g9ivra057gwaz";
+    sha256 = "0577v8nqjbb7l7fqvac706bg9zrcp8fbh9ca1mkj44db12v02kgb";
   };
 
-  cargoSha256 = "0n7z9p3v92ijqc2ix60wi74as5rql61k5qbqi8b1b02b71xmsp7j";
+  cargoSha256 = "1xrzz8c2pfb70i7ynv5lw0d89r284kvhkgjh8z8pgyk1j79ixv2v";
 
   nativeBuildInputs = [ pkgconfig ];
 


### PR DESCRIPTION
###### Motivation for this change

Update `pyo3-pack` to its latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

