### PR TITLE
qscintilla: 2.9.4 -> 2.11.2 and sqlitebrowser: 3.11.2

### DIFF
--- a/pkgs/development/tools/database/sqlitebrowser/default.nix
+++ b/pkgs/development/tools/database/sqlitebrowser/default.nix
@@ -27,6 +27,6 @@ mkDerivation rec {
     homepage = http://sqlitebrowser.org/;
     license = licenses.gpl3;
     maintainers = with maintainers; [ ma27 ];
-    platforms = platforms.linux; # can only test on linux
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/tools/database/sqlitebrowser/default.nix
+++ b/pkgs/development/tools/database/sqlitebrowser/default.nix
@@ -1,25 +1,20 @@
 { mkDerivation, lib, fetchFromGitHub, cmake, antlr
-, qtbase, qttools, sqlite }:
+, qtbase, qttools, qscintilla, sqlite }:
 
 mkDerivation rec {
-  version = "3.11.2";
   pname = "sqlitebrowser";
+  version = "3.11.2";
 
   src = fetchFromGitHub {
-    repo   = pname;
     owner  = pname;
+    repo   = pname;
     rev    = "v${version}";
     sha256 = "0ydd5fg76d5d23byac1f7f8mzx3brmd0cnnkd58qpmlzi7p9hcvx";
   };
 
-  buildInputs = [ qtbase sqlite ];
+  buildInputs = [ antlr qtbase qscintilla sqlite ];
 
-  nativeBuildInputs = [ cmake antlr qttools ];
-
-  # Use internal `qscintilla` rather than our package to fix the build
-  # (https://github.com/sqlitebrowser/sqlitebrowser/issues/1348#issuecomment-374170936).
-  # This can probably be removed when https://github.com/NixOS/nixpkgs/pull/56034 is merged.
-  cmakeFlags = [ "-DFORCE_INTERNAL_QSCINTILLA=ON" ];
+  nativeBuildInputs = [ cmake qttools ];
 
   NIX_LDFLAGS = [
     "-lQt5PrintSupport"


### PR DESCRIPTION
###### Motivation for this change

sqlitebrowser needs a newer version of qscintilla to work which is included here.

The qt4 version is broken - I will have to run nix-review on this thing to assess the impact.

Anybody on mac who can help to verify on darwin?

Cc: @Ma27 @matthewbauer 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

