### PR TITLE
pythonPackages.sortedcontainers: 2.0.5 -> 2.1.0

### DIFF
--- a/pkgs/development/python-modules/sortedcontainers/default.nix
+++ b/pkgs/development/python-modules/sortedcontainers/default.nix
@@ -5,11 +5,11 @@
 
 buildPythonPackage rec {
   pname = "sortedcontainers";
-  version = "2.0.5";
+  version = "2.1.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "b74f2756fb5e23512572cc76f0fe0832fd86310f77dfee54335a35fb33f6b950";
+    sha256 = "0fm0w5id2yhqld95hg2m636vjgkz377rvgdfqaxc25vbylr9lklp";
   };
 
   # pypi tarball does not come with tests


### PR DESCRIPTION
###### Motivation for this change

Just a regular update. `doCheck = false` seems to be still relevant.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

