### PR TITLE
nixos/prometheus: support v2

### DIFF
--- a/nixos/tests/prometheus-2.nix
+++ b/nixos/tests/prometheus-2.nix
@@ -1,0 +1,35 @@
+import ./make-test.nix {
+  name = "prometheus-2";
+
+  nodes = {
+    one = { pkgs, ... }: {
+      services.prometheus = {
+        enable = true;
+        package = pkgs.prometheus_2;
+        scrapeConfigs = [{
+          job_name = "prometheus";
+          static_configs = [{
+            targets = [ "127.0.0.1:9090" ];
+            labels = { instance = "localhost"; };
+          }];
+        }];
+        rules = [
+          ''
+            groups:
+              - name: test
+                rules:
+                  - record: testrule
+                    expr: count(up{job="prometheus"})
+          ''
+        ];
+      };
+    };
+  };
+
+  testScript = ''
+    startAll;
+    $one->waitForUnit("prometheus.service");
+    $one->waitForOpenPort(9090);
+    $one->succeed("curl -s http://127.0.0.1:9090/metrics");
+  '';
+}

--- a/pkgs/servers/monitoring/prometheus/default.nix
+++ b/pkgs/servers/monitoring/prometheus/default.nix
@@ -7,6 +7,7 @@ let
     let attrs' = builtins.removeAttrs attrs ["version" "sha256"]; in
       buildGoPackage ({
         name = "prometheus-${version}";
+        inherit version;
 
         inherit goPackagePath;
 
@@ -50,7 +51,7 @@ in rec {
   };
 
   prometheus_2 = generic {
-    version = "2.6.0";
-    sha256 = "1d9zwzs280pw9zspqwp7xx3ji04lfg2v9l5qhrfy3y633ghcmpxz";
+    version = "2.7.1";
+    sha256 = "09dk2a9r34nw8qcfd25cyklx0q3gd1viib4dlir52sdvj2rc1ng7";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Be able to use prometheus v2 with the prometheus nixos module.

Since the alertmanager is configured differently between v1 and v2, there is different options for v1 and v2. Added assertions to check if the correct option is used depending on prometheus version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

