### PR TITLE
td: init at 0.16.4

### DIFF
--- a/pkgs/tools/misc/td/Gemfile
+++ b/pkgs/tools/misc/td/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem 'td'

--- a/pkgs/tools/misc/td/Gemfile.lock
+++ b/pkgs/tools/misc/td/Gemfile.lock
@@ -1,0 +1,40 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    fluent-logger (0.8.0)
+      msgpack (>= 1.0.0, < 2)
+    hirb (0.7.3)
+    httpclient (2.8.3)
+    msgpack (1.2.6)
+    parallel (1.13.0)
+    ruby-progressbar (1.10.0)
+    rubyzip (1.2.2)
+    td (0.16.4)
+      hirb (>= 0.4.5)
+      msgpack
+      parallel (~> 1.8)
+      ruby-progressbar (~> 1.7)
+      rubyzip (>= 1.2.1)
+      td-client (>= 1.0.6, < 2)
+      td-logger (>= 0.3.21, < 2)
+      yajl-ruby (~> 1.1)
+      zip-zip (~> 0.3)
+    td-client (1.0.6)
+      httpclient (>= 2.7)
+      msgpack (>= 0.5.6, < 2)
+    td-logger (0.3.27)
+      fluent-logger (>= 0.5.0, < 2.0)
+      msgpack (>= 0.5.6, < 2.0)
+      td-client (>= 0.8.66, < 2.0)
+    yajl-ruby (1.4.1)
+    zip-zip (0.3)
+      rubyzip (>= 1.0.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  td
+
+BUNDLED WITH
+   1.16.3

--- a/pkgs/tools/misc/td/default.nix
+++ b/pkgs/tools/misc/td/default.nix
@@ -1,0 +1,15 @@
+{ lib, bundlerApp }:
+
+bundlerApp {
+  pname = "td";
+  gemdir = ./.;
+  exes = [ "td" ];
+
+  meta = with lib; {
+    description = "CLI to manage data on Treasure Data, the Hadoop-based cloud data warehousing.";
+    homepage    = https://github.com/treasure-data/td;
+    license     = licenses.asl20;
+    maintainers =  with maintainers; [ groodt ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/tools/misc/td/gemset.nix
+++ b/pkgs/tools/misc/td/gemset.nix
@@ -1,0 +1,103 @@
+{
+  fluent-logger = {
+    dependencies = ["msgpack"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1yr6vrai4fqajpzybmdlajf8wzsgy29kr1318amn21y9nhjlnys5";
+      type = "gem";
+    };
+    version = "0.8.0";
+  };
+  hirb = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0mzch3c2lvmf8gskgzlx6j53d10j42ir6ik2dkrl27sblhy76cji";
+      type = "gem";
+    };
+    version = "0.7.3";
+  };
+  httpclient = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "19mxmvghp7ki3klsxwrlwr431li7hm1lczhhj8z4qihl2acy8l99";
+      type = "gem";
+    };
+    version = "2.8.3";
+  };
+  msgpack = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0031gd2mjyba6jb7m97sqa149zjkr0vzn2s2gpb3m9nb67gqkm13";
+      type = "gem";
+    };
+    version = "1.2.6";
+  };
+  parallel = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "005shcy8dabc7lwydpkbhd3fx8bfqzvsj6g04r90mx0wky10lz84";
+      type = "gem";
+    };
+    version = "1.13.0";
+  };
+  ruby-progressbar = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1cv2ym3rl09svw8940ny67bav7b2db4ms39i4raaqzkf59jmhglk";
+      type = "gem";
+    };
+    version = "1.10.0";
+  };
+  rubyzip = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1n1lb2sdwh9h27y244hxzg1lrxxg2m53pk1vq7p33bna003qkyrj";
+      type = "gem";
+    };
+    version = "1.2.2";
+  };
+  td = {
+    dependencies = ["hirb" "msgpack" "parallel" "ruby-progressbar" "rubyzip" "td-client" "td-logger" "yajl-ruby" "zip-zip"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0nlxpc4nasgmv6mqanb6ag1q3wmryja2c174dzgwxngxa0y2j1yn";
+      type = "gem";
+    };
+    version = "0.16.4";
+  };
+  td-client = {
+    dependencies = ["httpclient" "msgpack"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0j5jcsgg020cm8xarbbw67mca4k8cx5pfyd2mm3wcqrnc1cl2bgp";
+      type = "gem";
+    };
+    version = "1.0.6";
+  };
+  td-logger = {
+    dependencies = ["fluent-logger" "msgpack" "td-client"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1y56gilaqk9a4lfhzb777ysmsq77pi1aqkr4q485a7f5dwnpwl1p";
+      type = "gem";
+    };
+    version = "0.3.27";
+  };
+  yajl-ruby = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "16v0w5749qjp13xhjgr2gcsvjv6mf35br7iqwycix1n2h7kfcckf";
+      type = "gem";
+    };
+    version = "1.4.1";
+  };
+  zip-zip = {
+    dependencies = ["rubyzip"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0ny3zv1sn9wasamykfkg7b7xgs6w7k5fy8kggiyjj9vrwfzzavqg";
+      type = "gem";
+    };
+    version = "0.3";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6121,6 +6121,8 @@ in
 
   rcm = callPackage ../tools/misc/rcm {};
 
+  td = callPackage ../tools/misc/td { };
+
   tegola = callPackage ../servers/tegola {};
 
   tftp-hpa = callPackage ../tools/networking/tftp-hpa {};


### PR DESCRIPTION
###### Motivation for this change
Init `td` CLI for Treasure Data

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

