### PR TITLE
fltrdr: init at 0.1.0

### DIFF
--- a/pkgs/tools/misc/fltrdr/default.nix
+++ b/pkgs/tools/misc/fltrdr/default.nix
@@ -1,21 +1,37 @@
 { stdenv
 , fetchFromGitHub
-, gcc8
+, gcc8Stdenv
 , cmake
+, gnumake
 }:
 
-stdenv.mkDerivation rec {
+gcc8Stdenv.mkDerivation rec {
   name = "fltrdr-${version}";
-  version = "0.1.0";
+  version = "0.1.1";
 
   src = fetchFromGitHub {
     repo   = "fltrdr";
     owner  = "octobanana";
     rev    = "${version}";
-    sha256 = "1qnlbw3r82hdppxprah933ycw6lddv54mb1jl6df0ikvxgqrjw3q";
+    sha256 = "1gglv7hwszk09ywjq6s169cdzr77sjklj89k5p24if24v93yffpf";
   };
 
-  buildInputs = [ gcc8 cmake ];
+  buildPhase = ''
+    BUILD_TYPE="release"
+
+    mkdir -p build/$BUILD_TYPE
+    cd build/$BUILD_TYPE
+    ${cmake}/bin/cmake ../../ -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+    cat Makefile
+    make
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp fltrdr $out/bin/
+  '';
+
+  buildInput = [ cmake gnumake ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/tools/misc/fltrdr/default.nix
+++ b/pkgs/tools/misc/fltrdr/default.nix
@@ -1,11 +1,9 @@
 { stdenv
 , fetchFromGitHub
-, gcc8Stdenv
 , cmake
-, gnumake
 }:
 
-gcc8Stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   name = "fltrdr-${version}";
   version = "0.1.1";
 
@@ -16,22 +14,7 @@ gcc8Stdenv.mkDerivation rec {
     sha256 = "1gglv7hwszk09ywjq6s169cdzr77sjklj89k5p24if24v93yffpf";
   };
 
-  buildPhase = ''
-    BUILD_TYPE="release"
-
-    mkdir -p build/$BUILD_TYPE
-    cd build/$BUILD_TYPE
-    ${cmake}/bin/cmake ../../ -DCMAKE_BUILD_TYPE=$BUILD_TYPE
-    cat Makefile
-    make
-  '';
-
-  installPhase = ''
-    mkdir -p $out/bin
-    cp fltrdr $out/bin/
-  '';
-
-  buildInput = [ cmake gnumake ];
+  nativeBuildInputs = [ cmake ];
 
   enableParallelBuilding = true;
 
@@ -51,7 +34,7 @@ gcc8Stdenv.mkDerivation rec {
 
     platforms   = platforms.linux; # can only test linux
     license     = licenses.mit;
-    maintainers = [ stdenv.maintainers.matthiasbeyer ];
+    maintainers = [ maintainers.matthiasbeyer ];
   };
 }
 

--- a/pkgs/tools/misc/fltrdr/default.nix
+++ b/pkgs/tools/misc/fltrdr/default.nix
@@ -1,0 +1,41 @@
+{ stdenv
+, fetchFromGitHub
+, gcc8
+, cmake
+}:
+
+stdenv.mkDerivation rec {
+  name = "fltrdr-${version}";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    repo   = "fltrdr";
+    owner  = "octobanana";
+    rev    = "${version}";
+    sha256 = "1qnlbw3r82hdppxprah933ycw6lddv54mb1jl6df0ikvxgqrjw3q";
+  };
+
+  buildInputs = [ gcc8 cmake ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = https://octobanana.com/software/fltrdr;
+    description = "A TUI text reader for the terminal";
+
+    longDescription = ''
+      Fltrdr, or flat-reader, is an interactive text reader for the terminal. It
+      is flat in the sense that the reader is word-based. It creates a
+      horizontal stream of words, ignoring all newline characters and reducing
+      extra whitespace. Its purpose is to facilitate reading, scanning, and
+      searching text. The program has a play mode that moves the reader forward
+      one word at a time, along with a configurable words per minute (WPM),
+      setting.
+    '';
+
+    platforms   = platforms.linux; # can only test linux
+    license     = licenses.mit;
+    maintainers = [ stdenv.maintainers.matthiasbeyer ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2633,6 +2633,8 @@ in
 
   flatpak-builder = callPackage ../development/tools/flatpak-builder { };
 
+  fltrdr = callPackage ../tools/misc/fltrdr { stdenv = gcc8Stdenv; };
+
   figlet = callPackage ../tools/misc/figlet { };
 
   file = callPackage ../tools/misc/file {


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

