### PR TITLE
csound-qt 0.9.6-beta2 -> 0.9.6-beta3, plus python-qt include changes

### DIFF
--- a/pkgs/applications/audio/csound/csound-qt/default.nix
+++ b/pkgs/applications/audio/csound/csound-qt/default.nix
@@ -13,12 +13,14 @@ stdenv.mkDerivation rec {
     sha256 = "007jhkh0k6qk52r77i067999dwdiimazix6ggp2hvyc4pj6n5dip";
   };
 
-  patches = [(fetchpatch {
-               name = "examplepath.patch";
-               url = "https://github.com/CsoundQt/CsoundQt/commit/09f2d515bff638cbcacb450979d66e273a59fdec.diff";
-               sha256 = "0y23kf8m1mh9mklsvf908b2b8m2w2rji8qvws44paf1kpwnwdmgm";
-              })
-              ./rtmidipath.patch];
+  patches = [
+    (fetchpatch {
+      name = "examplepath.patch";
+      url = "https://github.com/CsoundQt/CsoundQt/commit/09f2d515bff638cbcacb450979d66e273a59fdec.diff";
+      sha256 = "0y23kf8m1mh9mklsvf908b2b8m2w2rji8qvws44paf1kpwnwdmgm";
+    })
+    ./rtmidipath.patch
+  ];
 
   nativeBuildInputs = [ qmake qtwebengine qtxmlpatterns ];
 

--- a/pkgs/applications/audio/csound/csound-qt/default.nix
+++ b/pkgs/applications/audio/csound/csound-qt/default.nix
@@ -1,43 +1,42 @@
 { stdenv, csound, desktop-file-utils,
   fetchFromGitHub, python, python-qt, qmake,
-  qtwebengine, rtmidi, unzip }:
+  qtwebengine, qtxmlpatterns, rtmidi, fetchpatch }:
 
 stdenv.mkDerivation rec {
   name = "csound-qt-${version}";
-  version = "0.9.6-beta2";
+  version = "0.9.6-beta3";
 
   src = fetchFromGitHub {
     owner = "CsoundQt";
     repo = "CsoundQt";
     rev = "${version}";
-    sha256 = "12jv7cvns3wj2npha0mvpn88kkkfsxsvhgzs2wrw04kbrvbhbffi";
+    sha256 = "007jhkh0k6qk52r77i067999dwdiimazix6ggp2hvyc4pj6n5dip";
   };
 
-  patches = [ ./rtmidipath.patch ];
+  patches = [(fetchpatch {
+               name = "examplepath.patch";
+               url = "https://github.com/CsoundQt/CsoundQt/commit/09f2d515bff638cbcacb450979d66e273a59fdec.diff";
+               sha256 = "0y23kf8m1mh9mklsvf908b2b8m2w2rji8qvws44paf1kpwnwdmgm";
+              })
+              ./rtmidipath.patch];
 
-  nativeBuildInputs = [ qmake qtwebengine ];
+  nativeBuildInputs = [ qmake qtwebengine qtxmlpatterns ];
 
-  buildInputs = [ csound desktop-file-utils rtmidi unzip ];
+  buildInputs = [ csound desktop-file-utils rtmidi ];
 
   qmakeFlags = [ "qcs.pro" "CONFIG+=rtmidi" "CONFIG+=pythonqt"
+                 "CONFIG+=record_support" "CONFIG+=html_webengine"
                  "CSOUND_INCLUDE_DIR=${csound}/include/csound"
                  "CSOUND_LIBRARY_DIR=${csound}/lib"
                  "RTMIDI_DIR=${rtmidi.src}"
-                 "PYTHONQT_SRC_DIR=${python-qt}/lib"
+                 "PYTHONQT_SRC_DIR=${python-qt}/include/PythonQt"
                  "PYTHONQT_LIB_DIR=${python-qt}/lib"
-                 "LIBS+=${python-qt}/lib/libPythonQt-Qt5-Python2.7.so"
-                 "LIBS+=${python-qt}/lib/libPythonQt_QtAll-Qt5-Python2.7.so"
+                 "LIBS+=-L${python-qt}/lib"
                  "INCLUDEPATH+=${python-qt}/include/PythonQt"
                  "INCLUDEPATH+=${python}/include/python2.7"
-                 "INSTALL_DIR=$(out)"
-                 "SHARE_DIR=$(out)/share"
+                 "INSTALL_DIR=${placeholder "out"}"
+                 "SHARE_DIR=${placeholder "out"}/share"
                  ];
-
-  installPhase = ''
-    mkdir -p $out
-    cp -r bin $out
-    make install
-  '';
 
   meta = with stdenv.lib; {
     description = "CsoundQt is a frontend for Csound with editor, integrated help, widgets and other features.";

--- a/pkgs/applications/audio/csound/csound-qt/rtmidipath.patch
+++ b/pkgs/applications/audio/csound/csound-qt/rtmidipath.patch
@@ -13,5 +13,5 @@ index e5e0c896..9a9fa513 100644
 +    SOURCES += "$${RTMIDI_DIR}/RtMidi.cpp"
 +    INCLUDEPATH += $${RTMIDI_DIR}
  }
-
+ 
  perfThread_build {

--- a/pkgs/development/libraries/python-qt/default.nix
+++ b/pkgs/development/libraries/python-qt/default.nix
@@ -28,8 +28,8 @@ stdenv.mkDerivation rec {
     mkdir -p $out/include/PythonQt
     cp -r ./lib $out
     cp -r ./src/* $out/include/PythonQt
-    cp extensions/PythonQt_QtAll/PythonQt_QtAll.h $out/include/PythonQt
-    cp extensions/PythonQt_QtAll/PythonQt_QtAll.cpp $out/include/PythonQt
+    cp -r ./build $out/include/PythonQt
+    cp -r ./extensions $out/include/PythonQt
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16528,10 +16528,8 @@ in
     pygments = python27Packages.pygments;
   };
 
-  csound-qt = callPackage ../applications/audio/csound/csound-qt {
+  csound-qt = libsForQt59.callPackage ../applications/audio/csound/csound-qt {
     python = python27;
-    qmake = qt59.qmake;
-    qtwebengine = qt59.qtwebengine;
   };
 
   cinepaint = callPackage ../applications/graphics/cinepaint {


### PR DESCRIPTION
###### Motivation for this change

to my surprise csound-qt didn't actually install properly, so I changed some qmake paths and bumped the version. I changed which source files are added to include in python-qt, I can seperate this into two PR's if that's urgent.

###### Things done

Bumped and added new qtlib dep (xmlpatterns).

- [ x ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ x ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

