### PR TITLE
mautrix-whatsapp: init at 2019-02-11

### DIFF
--- a/pkgs/servers/mautrix-whatsapp/default.nix
+++ b/pkgs/servers/mautrix-whatsapp/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "mautrix-${version}";
+  version = "2019-02-11";
+
+  goPackagePath = "maunium.net/go/mautrix-whatsapp";
+
+  src = fetchFromGitHub {
+    owner = "tulir";
+    repo = "mautrix-whatsapp";
+    rev = "f689297ba6704265a938951f307b365e829fcfa1";
+    sha256 = "1658bika9ylhm64k9lxavp43dxilygn6vx7yn6y1l10j8by2akxk";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = with stdenv.lib; {
+    homepage = https://github/tulir/mautrix-whatsapp;
+    description = "Matrix <-> Whatsapp hybrid puppeting/relaybot bridge";
+    license = licenses.agpl3;
+    maintainers = with maintainers; [ vskilet ];
+  };
+}

--- a/pkgs/servers/mautrix-whatsapp/default.nix
+++ b/pkgs/servers/mautrix-whatsapp/default.nix
@@ -1,7 +1,7 @@
 { stdenv, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
-  name = "mautrix-${version}";
+  name = "mautrix-unstable-${version}";
   version = "2019-02-11";
 
   goPackagePath = "maunium.net/go/mautrix-whatsapp";

--- a/pkgs/servers/mautrix-whatsapp/default.nix
+++ b/pkgs/servers/mautrix-whatsapp/default.nix
@@ -16,7 +16,7 @@ buildGoPackage rec {
   goDeps = ./deps.nix;
 
   meta = with stdenv.lib; {
-    homepage = https://github/tulir/mautrix-whatsapp;
+    homepage = https://github.com/tulir/mautrix-whatsapp;
     description = "Matrix <-> Whatsapp hybrid puppeting/relaybot bridge";
     license = licenses.agpl3;
     maintainers = with maintainers; [ vskilet ];

--- a/pkgs/servers/mautrix-whatsapp/deps.nix
+++ b/pkgs/servers/mautrix-whatsapp/deps.nix
@@ -1,0 +1,201 @@
+# file generated from go.mod using vgo2nix (https://github.com/adisbladis/vgo2nix)
+[
+  {
+    goPackagePath = "github.com/Baozisoftware/qrcode-terminal-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/Baozisoftware/qrcode-terminal-go";
+      rev = "c0650d8dff0f";
+      sha256 = "166h9zy9y7ygayhybg7d080hpdcf1mvkf3rwnq5lqg8i3cg71s7b";
+    };
+  }
+  {
+    goPackagePath = "github.com/Rhymen/go-whatsapp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/Rhymen/go-whatsapp";
+      rev = "2ca6af00572c";
+      sha256 = "0lrscj59n9nmd5z0h9r2c952m0da672r3aj33bi443ap0h97w19i";
+    };
+  }
+  {
+    goPackagePath = "github.com/fatih/color";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fatih/color";
+      rev = "v1.7.0";
+      sha256 = "0v8msvg38r8d1iiq2i5r4xyfx0invhc941kjrsg5gzwvagv55inv";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/protobuf";
+      rev = "v1.2.0";
+      sha256 = "0kf4b59rcbb1cchfny2dm9jyznp8ri2hsb14n8iak1q8986xa0ab";
+    };
+  }
+  {
+    goPackagePath = "github.com/gorilla/mux";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gorilla/mux";
+      rev = "v1.6.2";
+      sha256 = "0pvzm23hklxysspnz52mih6h1q74vfrdhjfm1l3sa9r8hhqmmld2";
+    };
+  }
+  {
+    goPackagePath = "github.com/gorilla/websocket";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gorilla/websocket";
+      rev = "v1.4.0";
+      sha256 = "00i4vb31nsfkzzk7swvx3i75r2d960js3dri1875vypk3v2s0pzk";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-colorable";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-colorable";
+      rev = "v0.0.9";
+      sha256 = "1nwjmsppsjicr7anq8na6md7b1z84l9ppnlr045hhxjvbkqwalvx";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-isatty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-isatty";
+      rev = "v0.0.4";
+      sha256 = "0zs92j2cqaw9j8qx1sdxpv3ap0rgbs0vrvi72m40mg8aa36gd39w";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-sqlite3";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-sqlite3";
+      rev = "v1.10.0";
+      sha256 = "1zmz6asplixfihxhj11spgfs0v3xzb3nv0hlq6n6zsg781ni31xx";
+    };
+  }
+  {
+    goPackagePath = "github.com/russross/blackfriday";
+    fetch = {
+      type = "git";
+      url = "https://github.com/russross/blackfriday";
+      rev = "v2.0.1";
+      sha256 = "0nlz7isdd4rgnwzs68499hlwicxz34j2k2a0b8jy0y7ycd2bcr5j";
+    };
+  }
+  {
+    goPackagePath = "github.com/shurcooL/sanitized_anchor_name";
+    fetch = {
+      type = "git";
+      url = "https://github.com/shurcooL/sanitized_anchor_name";
+      rev = "v1.0.0";
+      sha256 = "1gv9p2nr46z80dnfjsklc6zxbgk96349sdsxjz05f3z6wb6m5l8f";
+    };
+  }
+  {
+    goPackagePath = "github.com/skip2/go-qrcode";
+    fetch = {
+      type = "git";
+      url = "https://github.com/skip2/go-qrcode";
+      rev = "dc11ecdae0a9";
+      sha256 = "0mc70hsn5x2a66a9sbwlq51cng2s1aq7rw4pr9pif4xdzflkl057";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev = "ff983b9c42bc";
+      sha256 = "1hpr06kzn8jnn3gvzp0p9zn4fz4l9h69f7x66idx142w4xdlaanz";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev = "915654e7eabc";
+      sha256 = "0fzd7n2yc4qnnf2wk21zxy6gb01xviq2z1dzrbqcn8p1s4fjsqw5";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sync";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sync";
+      rev = "37e7f081c4d4";
+      sha256 = "1bb0mw6ckb1k7z8v3iil2qlqwfj408fvvp8m1cik2b46p7snyjhm";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev = "48ac38b7c8cb";
+      sha256 = "037vs8sdvq310j3b6z9k62zlby1mzmsr9ha01rcy98dv5v8bkhin";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/check.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/check.v1";
+      rev = "788fd7840127";
+      sha256 = "0v3bim0j375z81zrpr5qv42knqs0y2qv2vkjiqi5axvb78slki1a";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/yaml.v2";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/yaml.v2";
+      rev = "v2.2.2";
+      sha256 = "01wj12jzsdqlnidpyjssmj0r4yavlqy7dwrg7adqd8dicjc4ncsa";
+    };
+  }
+  {
+    goPackagePath = "maunium.net/go/mauflag";
+    fetch = {
+      type = "git";
+      url = "https://github.com/tulir/mauflag.git";
+      rev = "v1.0.0";
+      sha256 = "09jv1819jwq5i29y6ngf4j4ii6qwlshydvprfvsfplc419dkz1vx";
+    };
+  }
+  {
+    goPackagePath = "maunium.net/go/maulogger";
+    fetch = {
+      type = "git";
+      url = "https://github.com/tulir/maulogger.git";
+      rev = "v2.0.0";
+      sha256 = "0qz4cpaqvcmrj3fb2bb6yrhw3k5h51crskricyqgg1b7aklphan5";
+    };
+  }
+  {
+    goPackagePath = "maunium.net/go/mautrix";
+    fetch = {
+      type = "git";
+      url = "https://github.com/tulir/mautrix-go.git";
+      rev = "v0.1.0-alpha.3";
+      sha256 = "12nlyij57ss2a5d1f1k1vsmjjvxp1fannlrbnp2jsj6rrsq0d2wr";
+    };
+  }
+  {
+    goPackagePath = "maunium.net/go/mautrix-appservice";
+    fetch = {
+      type = "git";
+      url = "https://github.com/tulir/mautrix-appservice-go.git";
+      rev = "v0.1.0-alpha.3";
+      sha256 = "17y11wgqbrafbq6bnn4rp2lzd50fjz9d6f8j3382jsara7ps95vr";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3751,6 +3751,8 @@ in
 
   mautrix-telegram = callPackage ../servers/mautrix-telegram { };
 
+  mautrix-whatsapp = callPackage ../servers/mautrix-whatsapp { };
+
   mdbook = callPackage ../tools/text/mdbook {
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };
@@ -21528,7 +21530,7 @@ in
 
   bftools = callPackage ../applications/science/biology/bftools { };
 
-  cmtk = callPackage ../applications/science/biology/cmtk { }; 
+  cmtk = callPackage ../applications/science/biology/cmtk { };
 
   conglomerate = callPackage ../applications/science/biology/conglomerate { };
 


### PR DESCRIPTION
###### Motivation for this change
Add a bridge Matrix <-> Whatsapp

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---