### PR TITLE
pythonPackages.sparse: init at 0.6.0

### DIFF
--- a/pkgs/development/python-modules/sparse/default.nix
+++ b/pkgs/development/python-modules/sparse/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, numpy
+, scipy
+, numba
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "sparse";
+  version = "0.6.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "2ac6fcbf68b38b999eae98467cf4880b942c13a72036868f78d65a10aeba808d";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [
+    numpy
+    scipy
+    numba
+  ];
+
+  checkPhase = ''
+    pytest sparse
+  '';
+
+  meta = with lib; {
+    description = "Sparse n-dimensional arrays computations";
+    homepage = https://github.com/pydata/sparse/;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -812,6 +812,8 @@ in {
 
   snapcast = callPackage ../development/python-modules/snapcast { };
 
+  sparse = callPackage ../development/python-modules/sparse { };
+
   spglib = callPackage ../development/python-modules/spglib { };
 
   sslib = callPackage ../development/python-modules/sslib { };


### PR DESCRIPTION
###### Motivation for this change

Package needed for testing some sparse linear algebra routines I am using. Might as well package it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

