### PR TITLE
cmake: 3.12.1 -> 3.13.4

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -16,10 +16,10 @@ with stdenv.lib;
 
 let
   os = stdenv.lib.optionalString;
-  majorVersion = "3.12";
-  minorVersion = "1";
-  # from https://cmake.org/files/v3.12/cmake-3.12.1-SHA-256.txt
-  sha256 = "1ckswlaid3p2is1a80fmr4hgwpfsiif66giyx1z9ayhxx0n5qgf5";
+  majorVersion = "3.13";
+  minorVersion = "4";
+  # from https://cmake.org/files/v3.13/cmake-3.13.4-SHA-256.txt for cmake-3.13.4.tar.gz
+  sha256 = "fdd928fee35f472920071d1c7f1a6a2b72c9b25e04f7a37b409349aef3f20e9b";
   version = "${majorVersion}.${minorVersion}";
 in
 


### PR DESCRIPTION
###### Motivation for this change
Bring cmake up-to-date (RE: #55060). This also fixes building magma with cudatoolkit-10 (see original #54836 PR).

Closes #55060.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Submitted to staging by request of @ttuegel (see #54836)
