### PR TITLE
pygmentex: add tlType attribute; install latex style and demo

### DIFF
--- a/pkgs/tools/typesetting/pygmentex/default.nix
+++ b/pkgs/tools/typesetting/pygmentex/default.nix
@@ -1,17 +1,18 @@
 { stdenv, fetchFromBitbucket, python2Packages }:
 
 python2Packages.buildPythonApplication rec {
-  name = "pygmentex-${version}";
+  pname = "pygmentex";
   version = "0.8";
+  tlType = "run";
 
   src = fetchFromBitbucket {
     owner = "romildo";
-    repo = "pygmentex";
+    repo = pname;
     rev = version;
     sha256 = "07dnv7hgppy15bda2kcbrlvfqzl6lhza80klc7133dwg8q92hm6m";
   };
 
-  pythonPath = [ python2Packages.pygments python2Packages.chardet ];
+  pythonPath = with python2Packages; [ pygments chardet ];
 
   dontBuild = true;
 
@@ -20,6 +21,15 @@ python2Packages.buildPythonApplication rec {
   installPhase = ''
     mkdir -p $out/bin
     cp -a pygmentex.py $out/bin
+
+    mkdir -p $out/scripts/pygmentex
+    ln -s $out/bin/pygmentex.py $out/scripts/pygmentex
+
+    mkdir -p $out/tex/latex/pygmentex
+    cp -a pygmentex.sty $out/tex/latex/pygmentex
+
+    mkdir -p $out/doc/latex/pygmentex
+    cp -a README demo.* blueshade.png Factorial.java $out/doc/latex/pygmentex
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

- Install LaTeX style file and example document.
- Set `pname` and `tlType` attributes, so that it can be used with `texlive.combine`. For instance one can put the following in `environment.systemPackages`:

``` nix
( texlive.combine {
     pygmentex = { pkgs = [pygmentex]; };
     inherit (texlive) scheme-basic;
} )
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).