### PR TITLE
emacs: avoid xorg build dependency

### DIFF
--- a/pkgs/build-support/emacs/wrapper.nix
+++ b/pkgs/build-support/emacs/wrapper.nix
@@ -32,7 +32,7 @@ in customEmacsPackages.emacsWithPackages (epkgs: [ epkgs.evil epkgs.magit ])
 
 */
 
-{ lib, lndir, makeWrapper, runCommand, stdenv }: self:
+{ lib, makeWrapper, runCommand, stdenv }: self:
 
 with lib; let inherit (self) emacs; in
 
@@ -47,13 +47,13 @@ in
 
 stdenv.mkDerivation {
   name = (appendToName "with-packages" emacs).name;
-  nativeBuildInputs = [ emacs lndir makeWrapper ];
+  nativeBuildInputs = [ emacs makeWrapper ];
   inherit emacs explicitRequires;
 
   # Store all paths we want to add to emacs here, so that we only need to add
   # one path to the load lists
   deps = runCommand "emacs-packages-deps"
-   { inherit explicitRequires lndir emacs; }
+   { inherit explicitRequires emacs; }
    ''
      findInputsOld() {
          local pkg="$1"; shift
@@ -105,7 +105,10 @@ stdenv.mkDerivation {
 
        # Add the path to the search path list, but only if it exists
        if [[ -d "$pkg/$origin_path" ]]; then
-         $lndir/bin/lndir -silent "$pkg/$origin_path" "$out/$dest_path"
+         for i in `cd "$pkg/$origin_path" && find . -not -type d | cut -c 3-` ; do
+           install -d `dirname "$out/$dest_path/$i"`
+           ln -sf "$pkg/$origin_path/$i" "$out/$dest_path/$i"
+         done
        fi
      }
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16917,7 +16917,6 @@ in
     inherit lib newScope stdenv;
     inherit fetchFromGitHub fetchgit fetchhg fetchurl fetchpatch;
     inherit emacs texinfo makeWrapper runCommand writeText;
-    inherit (xorg) lndir;
 
     trivialBuild = callPackage ../build-support/emacs/trivial.nix {
       inherit emacs;

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -34,7 +34,7 @@
 
 { lib, newScope, stdenv, fetchurl, fetchgit, fetchFromGitHub, fetchhg, fetchpatch, runCommand, writeText
 
-, emacs, texinfo, lndir, makeWrapper
+, emacs, texinfo, makeWrapper
 , trivialBuild
 , melpaBuild
 
@@ -60,7 +60,7 @@ let
   orgPackages = import ../applications/editors/emacs-modes/org-packages.nix { };
 
   emacsWithPackages = import ../build-support/emacs/wrapper.nix {
-    inherit lib lndir makeWrapper stdenv runCommand;
+    inherit lib makeWrapper stdenv runCommand;
   };
 
   packagesFun = self: with self; {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

