### PR TITLE
treewide: assemble all `fetchurlBoot` uses in overrides to `fetchurl`

### DIFF
--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurlBoot, buildPackages
+{ lib, stdenv, fetchurl, buildPackages
 , enableThreading ? stdenv ? glibc, makeWrapper
 }:
 
@@ -27,7 +27,7 @@ let
 
     name = "perl-${version}";
 
-    src = fetchurlBoot {
+    src = fetchurl {
       url = "mirror://cpan/src/5.0/${name}.tar.gz";
       inherit sha256;
     };
@@ -46,7 +46,7 @@ let
       ]
       ++ optional (versionOlder version "5.29.6")
         # Fix parallel building: https://rt.perl.org/Public/Bug/Display.html?id=132360
-        (fetchurlBoot {
+        (fetchurl {
           url = "https://rt.perl.org/Public/Ticket/Attachment/1502646/807252/0001-Fix-missing-build-dependency-for-pods.patch";
           sha256 = "1bb4mldfp8kq1scv480wm64n2jdsqa3ar46cjp1mjpby8h5dr2r0";
         })
@@ -156,7 +156,7 @@ let
   } // stdenv.lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) rec {
     crossVersion = "276849e62f472c1b241d9e7b38a28e4cc9f98563"; # Dez 02, 2018
 
-    perl-cross-src = fetchurlBoot {
+    perl-cross-src = fetchurl {
       url = "https://github.com/arsv/perl-cross/archive/${crossVersion}.tar.gz";
       sha256 = "1fpr1m9lgkwdp1vmdr0s6gvmcpd0m8q6jwn024bkczc2h37bdynd";
     };

--- a/pkgs/development/libraries/libssh2/default.nix
+++ b/pkgs/development/libraries/libssh2/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, fetchurlBoot, openssl, zlib, windows }:
+{ stdenv, fetchurl, openssl, zlib, windows }:
 
 stdenv.mkDerivation rec {
   name = "libssh2-1.8.0";
 
-  src = fetchurlBoot {
+  src = fetchurl {
     url = "${meta.homepage}/download/${name}.tar.gz";
     sha256 = "1m3n8spv79qhjq4yi0wgly5s5rc8783jb1pyra9bkx1md0plxwrr";
   };

--- a/pkgs/os-specific/darwin/apple-source-releases/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPackages, fetchurl, fetchzip, pkgs, fetchurlBoot }:
+{ stdenv, buildPackages, fetchurl, fetchzip, pkgs }:
 
 let
   # This attrset can in theory be computed automatically, but for that to work nicely we need
@@ -141,7 +141,7 @@ let
     # in an infinite recursion without this. It's not clear why this
     # worked fine when not cross-compiling
     fetch = if name == "libiconv"
-      then fetchurlBoot
+      then stdenv.fetchurlBoot
       else fetchurl;
   in fetch {
     url = "http://www.opensource.apple.com/tarballs/${name}/${name}-${versions.${version}.${name}}.tar.gz";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -239,9 +239,35 @@ in
   # `fetchurl' downloads a file from the network.
   fetchurl = import ../build-support/fetchurl {
     inherit lib stdenvNoCC;
-    # On darwin, libkrb5 needs bootstrap_cmds which would require
-    # converting many packages to fetchurl_boot to avoid evaluation cycles.
-    curl = buildPackages.curl.override (lib.optionalAttrs stdenv.isDarwin { gssSupport = false; });
+    curl = buildPackages.curl.override rec {
+      # break dependency cycles
+      fetchurl = stdenv.fetchurlBoot;
+      pkgconfig = buildPackages.pkgconfig.override { fetchurl = stdenv.fetchurlBoot; };
+      perl = buildPackages.perl.override { fetchurl = stdenv.fetchurlBoot; };
+      openssl = buildPackages.openssl.override {
+        fetchurl = stdenv.fetchurlBoot;
+        inherit perl;
+        buildPackages = { inherit perl; };
+      };
+      libssh2 = buildPackages.libssh2.override {
+        fetchurl = stdenv.fetchurlBoot;
+        inherit openssl;
+      };
+      # On darwin, libkrb5 needs bootstrap_cmds which would require
+      # converting many packages to fetchurl_boot to avoid evaluation cycles.
+      gssSupport = !stdenv.isDarwin && !stdenv.hostPlatform.isWindows;
+      libkrb5 = buildPackages.libkrb5.override {
+        fetchurl = stdenv.fetchurlBoot;
+        inherit pkgconfig perl openssl;
+        keyutils = buildPackages.keyutils.override { fetchurl = stdenv.fetchurlBoot; };
+      };
+      nghttp2 = buildPackages.nghttp2.override {
+        fetchurl = stdenv.fetchurlBoot;
+        inherit pkgconfig openssl;
+        c-ares = buildPackages.c-ares.override { fetchurl = stdenv.fetchurlBoot; };
+        libev = buildPackages.libev.override { fetchurl = stdenv.fetchurlBoot; };
+      };
+    };
   };
 
   fetchRepoProject = callPackage ../build-support/fetchrepoproject { };
@@ -249,13 +275,6 @@ in
   fetchipfs = import ../build-support/fetchipfs {
     inherit curl stdenv;
   };
-
-  # fetchurlBoot is used for curl and its dependencies in order to
-  # prevent a cyclic dependency (curl depends on curl.tar.bz2,
-  # curl.tar.bz2 depends on fetchurl, fetchurl depends on curl).  It
-  # uses the curl from the previous bootstrap phase (e.g. a statically
-  # linked curl in the case of stdenv-linux).
-  fetchurlBoot = stdenv.fetchurlBoot;
 
   fetchzip = callPackage ../build-support/fetchzip { };
 
@@ -2139,9 +2158,7 @@ in
     brotliSupport = true;
   };
 
-  curl = callPackage ../tools/networking/curl rec {
-    fetchurl = fetchurlBoot;
-  };
+  curl = callPackage ../tools/networking/curl { };
 
   curl_unix_socket = callPackage ../tools/networking/curl-unix-socket rec { };
 
@@ -8971,9 +8988,7 @@ in
 
   pkgconf = callPackage ../development/tools/misc/pkgconf {};
 
-  pkg-config = callPackage ../development/tools/misc/pkg-config {
-    fetchurl = fetchurlBoot;
-  };
+  pkg-config = callPackage ../development/tools/misc/pkg-config { };
   pkgconfig = pkg-config; # added 2018-02-02
 
   pkg-configUpstream = lowPrio (pkg-config.override { vanilla = true; });
@@ -9436,9 +9451,7 @@ in
 
   bzrtp = callPackage ../development/libraries/bzrtp { };
 
-  c-ares = callPackage ../development/libraries/c-ares {
-    fetchurl = fetchurlBoot;
-  };
+  c-ares = callPackage ../development/libraries/c-ares { };
 
   c-blosc = callPackage ../development/libraries/c-blosc { };
 
@@ -10499,10 +10512,7 @@ in
     inherit (buildPackages.darwin) bootstrap_cmds;
   };
   krb5Full = krb5;
-  libkrb5 = krb5.override {
-    fetchurl = fetchurlBoot;
-    type = "lib";
-  };
+  libkrb5 = krb5.override { type = "lib"; };
   kerberos = libkrb5; # TODO: move to aliases.nix
 
   languageMachines = recurseIntoAttrs (import ../development/libraries/languagemachines/packages.nix { inherit callPackage; });
@@ -10878,9 +10888,7 @@ in
 
   libechonest = callPackage ../development/libraries/libechonest { };
 
-  libev = callPackage ../development/libraries/libev {
-    fetchurl = fetchurlBoot;
-  };
+  libev = callPackage ../development/libraries/libev { };
 
   libevent = callPackage ../development/libraries/libevent { };
 
@@ -11099,9 +11107,7 @@ in
     ln -sv ${libcDev}/include/iconv.h $out/include
   '';
 
-  libiconvReal = callPackage ../development/libraries/libiconv {
-    fetchurl = fetchurlBoot;
-  };
+  libiconvReal = callPackage ../development/libraries/libiconv { };
 
   # On non-GNU systems we need GNU Gettext for libintl.
   libintl = if stdenv.hostPlatform.libc != "glibc" then gettext else null;
@@ -11771,9 +11777,7 @@ in
 
   newt = callPackage ../development/libraries/newt { };
 
-  nghttp2 = callPackage ../development/libraries/nghttp2 {
-    fetchurl = fetchurlBoot;
-  };
+  nghttp2 = callPackage ../development/libraries/nghttp2 { };
   libnghttp2 = nghttp2.lib;
 
   nix-plugins = callPackage ../development/libraries/nix-plugins {
@@ -11931,9 +11935,7 @@ in
 
   openssl = openssl_1_0_2;
 
-  inherit (callPackages ../development/libraries/openssl {
-      fetchurl = fetchurlBoot;
-    })
+  inherit (callPackages ../development/libraries/openssl { })
     openssl_1_0_2
     openssl_1_1;
 
@@ -13132,9 +13134,7 @@ in
 
   zeitgeist = callPackage ../development/libraries/zeitgeist { };
 
-  zlib = callPackage ../development/libraries/zlib {
-    fetchurl = fetchurlBoot;
-  };
+  zlib = callPackage ../development/libraries/zlib { };
 
   libdynd = callPackage ../development/libraries/libdynd { };
 
@@ -14913,8 +14913,7 @@ in
     kernel = null; # dpdk modules are in linuxPackages.dpdk.kmod
   };
 
-  # Using fetchurlBoot because this is used by kerberos (on Linux), which curl depends on
-  keyutils = callPackage ../os-specific/linux/keyutils { fetchurl = fetchurlBoot; };
+  keyutils = callPackage ../os-specific/linux/keyutils { };
 
   libselinux = callPackage ../os-specific/linux/libselinux { };
 


### PR DESCRIPTION
# What?

This kills top-level `fetchurlBoot` attribute and isolates rest of the uses to `stdenv`, normal `fetchurl` and one Darwin reference I don't touch because I can't test it.

Note that this change _is_ a noop for `nix-env -qaP --out-path` diff. `nix-env -qaP --drv-path` diff is huge because everything that depends on curl itself and anything curl itself depends on will evaluate to new derivations. I.e. this changes a lot of .drvs but does zero rebuilds.

Stuff referencing `pkgsCross` works as before, so I declare this not breaking anything. Before rebase I was running on top of this for 3 months or so.

# Why?

`fetchurlBoot` got in the way of clean breaking of dependency cycles for my `doCheckByDefault` thingy (#39464), I got pissed and (mostly) killed it.

# `git log`

- treewide: assemble all `fetchurlBoot` uses in overrides to `fetchurl` itself

  The only outside-curl uses of `fetchurlBoot` left are `stdenv`
  and `apple-source-releases`. The latter one can probably be removed
  too, but I can't test it.

  Pros:

  - Aggregates all behind-the-scenes insanity in a single place.

  Cons:

  - At the cost of 10 more derivations (but 0 new outpaths).

# `nix-instantiate` environment

- Host OS: Linux 4.9, SLNOS 19.03
- Nix: nix-env (Nix) 2.1.3
- Multi-user: yes
- Sandbox: yes
- NIXPKGS_CONFIG:

```nix
{
  checkMeta = true;
  doCheckByDefault = true;
}
```

# `nix-env -qaP --out-path` diffs

- On x86_64-linux: noop
- On aarch64-linux: noop
- On x86_64-darwin: noop

/cc @Ericson2314 @matthewbauer @7c6f434c
