### PR TITLE
vivaldi: 2.3.1440.41-1 -> 2.3.1440.48-1; vivaldi-ffmpeg-codecs: 72.0.3626.96 -> 72.0.3626.109

### DIFF
--- a/pkgs/applications/networking/browsers/vivaldi/default.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/default.nix
@@ -13,11 +13,11 @@
 stdenv.mkDerivation rec {
   name = "${product}-${version}";
   product = "vivaldi";
-  version = "2.3.1440.41-1";
+  version = "2.3.1440.48-1";
 
   src = fetchurl {
     url = "https://downloads.vivaldi.com/stable/${product}-stable_${version}_amd64.deb";
-    sha256 = "0wrq7c0sw1b41bshwgzji4pwl0raj0l5h2r7gkcg952rcn0wl9bs";
+    sha256 = "0zc9080np82qqqrfavg78vbjfl7w1b4p7f3s6h5wga9f6w1m078c";
   };
 
   unpackPhase = ''

--- a/pkgs/applications/networking/browsers/vivaldi/ffmpeg-codecs.nix
+++ b/pkgs/applications/networking/browsers/vivaldi/ffmpeg-codecs.nix
@@ -6,11 +6,11 @@
 stdenv.mkDerivation rec {
   name = "${product}-${version}";
   product = "vivaldi-ffmpeg-codecs";
-  version = "72.0.3626.96";
+  version = "72.0.3626.109";
 
   src = fetchurl {
     url = "https://commondatastorage.googleapis.com/chromium-browser-official/chromium-${version}.tar.xz";
-    sha512 = "2hawkyydcd0b6ipfigkf5n6c1ha1vknaqd4mgw381pi0ayq8skxbjazqabfcg9gcj84cnksi8j4dylfcrbgrmlnmc479fix0m0xx7cl";
+    sha512 = "0ffpzvamrzw71vfi12sdwqrxc42bhraai21zzx8rp5n12794rr687dzw9hn3735sc0h2bq7c59zc4hcx3ighr2i93iplz35hp883dhy";
   };
 
   buildInputs = [ ];


### PR DESCRIPTION
###### Motivation for this change

- vivaldi: 2.3.1440.41-1 -> 2.3.1440.48-1
- vivaldi-ffmpeg-codecs: 72.0.3626.96 -> 72.0.3626.109

[Minor update for Vivaldi 2.3](https://vivaldi.com/blog/minor-update-for-vivaldi-2-3)

[Minor update (2) for Vivaldi 2.3](https://vivaldi.com/blog/minor-update-2-for-vivaldi-2-3/)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).