### PR TITLE
evmdis: init at unstable-2018-03-23

### DIFF
--- a/pkgs/development/tools/analysis/evmdis/default.nix
+++ b/pkgs/development/tools/analysis/evmdis/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "evmdis-unstable-${version}";
+  version = "2018-03-23";
+  goPackagePath = "github.com/Arachnid/evmdis";
+
+  src = fetchFromGitHub {
+    owner = "Arachnid";
+    repo = "evmdis";
+    rev = "0d1406905c5fda6224651fa53260a21c907eb986";
+    sha256 = "09y4j7ipgv8yd99g3xk3f079w8fqfj7kl1y7ry81ainysn0qlqrg";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/Arachnid/evmdis;
+    description = "Ethereum EVM disassembler";
+    license = [ licenses.asl20 ];
+    maintainers = with maintainers; [ asymmetric ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8639,6 +8639,8 @@ in
 
   eresi = callPackage ../development/tools/analysis/eresi { };
 
+  evmdis = callPackage ../development/tools/analysis/evmdis { };
+
   eweb = callPackage ../development/tools/literate-programming/eweb { };
 
   eztrace = callPackage ../development/tools/profiling/EZTrace { };


### PR DESCRIPTION
###### Motivation for this change

Adds package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

