### PR TITLE
tt-rss: Fix syntax error in config.php DB_PASS field

### DIFF
--- a/nixos/modules/services/web-apps/tt-rss.nix
+++ b/nixos/modules/services/web-apps/tt-rss.nix
@@ -40,7 +40,7 @@ let
         else if (cfg.database.passwordFile != null) then
           "file_get_contents('${cfg.database.passwordFile}')"
         else
-          ""
+          "''"
       });
       define('DB_PORT', '${toString dbPort}');
 


### PR DESCRIPTION
Empty password case would write `define('DB_PASS', )` instead of `define('DB_PASS', '')`.