### PR TITLE
python: qiskit: 0.6.1 -> 0.7.3

### DIFF
--- a/pkgs/development/python-modules/marshmallow-polyfield/default.nix
+++ b/pkgs/development/python-modules/marshmallow-polyfield/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, six
+, marshmallow
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "marshmallow-polyfield";
+  version = "3.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "72980cb9a43a7c750580b4b08e9d01a8cbd583e1f59360f1924a1ed60f065a4c";
+  };
+
+  propagatedBuildInputs = [
+    six
+    marshmallow
+  ];
+
+  checkInputs = [
+    pytest
+  ];
+
+  checkPhase = "py.test tests";
+
+  meta = {
+    homepage = "https://github.com/Bachmann1234/marshmallow-polyfield";
+    description = "An extension to marshmallow to allow for polymorphic fields";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      pandaman
+    ];
+  };
+}

--- a/pkgs/development/python-modules/qiskit-aer/default.nix
+++ b/pkgs/development/python-modules/qiskit-aer/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, isPy3k
+, buildPythonPackage
+, fetchFromGitHub
+, cmake
+, blas
+, liblapack
+, scikit-build
+, cython
+, numpy
+, qiskit-terra
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "qiskit-aer";
+  version = "0.1.1";
+
+  disabled = !isPy3k;
+
+  # PyPI has only binary wheels
+  src = fetchFromGitHub {
+    owner = "Qiskit";
+    repo = "qiskit-aer";
+    rev = "21fdd7e7503dc8ac7dfaee24b927f26d1eff42f8";
+    sha256 = "1p4w1jg6sl9xvmp98nrn5s6drp1rcl67vzi5xdh639kf498y49nz";
+  };
+
+  buildInputs = [
+    scikit-build
+    cython
+    cmake
+    blas
+    liblapack
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+  ];
+
+  checkInputs = [
+    qiskit-terra
+  ];
+
+  checkPhase = "${python.interpreter} -m unittest discover -s test";
+
+  meta = {
+    description = "A high performance simulator for quantum circuits that includes noise models";
+    homepage    = https://github.com/Qiskit/qiskit-aer;
+    license     = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      pandaman
+    ];
+  };
+}

--- a/pkgs/development/python-modules/qiskit-terra/default.nix
+++ b/pkgs/development/python-modules/qiskit-terra/default.nix
@@ -1,0 +1,66 @@
+{ lib
+, isPy3k
+, buildPythonPackage
+, fetchPypi
+, jsonschema
+, marshmallow
+, marshmallow-polyfield
+, networkx
+, numpy
+, pillow
+, ply
+, psutil
+, requests
+, requests_ntlm
+, scipy
+, sympy
+, IBMQuantumExperience
+, vcrpy
+, jupyter
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "qiskit-terra";
+  version = "0.7.0";
+
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "9cc57da08896627d0f34cf6ae76bd3358a5e6e155f612137ff343dd787134720";
+  };
+
+  propagatedBuildInputs = [
+    jsonschema
+    marshmallow
+    marshmallow-polyfield
+    networkx
+    numpy
+    pillow
+    ply
+    psutil
+    requests
+    requests_ntlm
+    scipy
+    sympy
+    IBMQuantumExperience
+  ];
+
+  checkInputs = [
+    vcrpy
+    jupyter
+  ];
+
+  checkPhase = "QISKIT_TESTS=skip_online ${python.interpreter} -m unittest discover -s test";
+
+  meta = {
+    description = "A library for creating, manipulating, and executing quantum circuits";
+    homepage = https://github.com/Qiskit/qiskit-terra;
+
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      pandaman
+    ];
+  };
+}

--- a/pkgs/development/python-modules/qiskit/default.nix
+++ b/pkgs/development/python-modules/qiskit/default.nix
@@ -2,59 +2,36 @@
 , isPy3k
 , buildPythonPackage
 , fetchPypi
-, numpy
-, scipy
-, sympy
-, matplotlib
-, networkx
-, ply
-, pillow
-, cffi
-, requests
-, requests_ntlm
-, IBMQuantumExperience
-, jsonschema
-, psutil
-, cmake
-, llvmPackages 
+, qiskit-aer
+, qiskit-terra
+, python
 }:
 
 buildPythonPackage rec {
   pname = "qiskit";
-  version = "0.6.1";
+  version = "0.7.3";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "601e8db4db470593b94a32495c6e90e2db11a9382817a34584520573a7b8cc38";
+    sha256 = "63e7a7c3033fe955d715cc825b3fb61d27c25ad66e1761493ca2243b5dbfb4f9";
   };
 
-  buildInputs = [ cmake ]
-    ++ stdenv.lib.optional stdenv.isDarwin llvmPackages.openmp;
-
-  propagatedBuildInputs = [
-    numpy
-    matplotlib
-    networkx
-    ply
-    scipy
-    sympy
-    pillow
-    cffi
-    requests
-    requests_ntlm
-    IBMQuantumExperience
-    jsonschema
-    psutil
+  patches = [
+    # Qiskit overrides the installation to deal with misconfiguration of dependency,
+    # but we don't need it as Nix tracks the right dependency
+    ./no-override.patch
   ];
 
-  # Pypi's tarball doesn't contain tests
-  doCheck = false;
+  propagatedBuildInputs = [
+    qiskit-aer
+    qiskit-terra
+  ];
 
   meta = {
-    description = "Quantum Software Development Kit for writing quantum computing experiments, programs, and applications";
-    homepage    = https://github.com/QISKit/qiskit-terra;
+    description = "Software for developing quantum computing programs";
+    homepage    = https://github.com/Qiskit/qiskit;
     license     = stdenv.lib.licenses.asl20;
     maintainers = with stdenv.lib.maintainers; [
       pandaman

--- a/pkgs/development/python-modules/qiskit/no-override.patch
+++ b/pkgs/development/python-modules/qiskit/no-override.patch
@@ -1,0 +1,22 @@
+--- a/setup.py
++++ b/setup.py
+@@ -92,18 +92,4 @@ setup(
+     install_requires=requirements,
+     include_package_data=True,
+     python_requires=">=3.5",
+-    # qiskit 0.7 metapackage has a bug for which qiskit 0.6.1 cannot correctly
+-    # upgrade to 0.7: some Terra files are deleted when removing qiskit 0.6.1
+-    # before installing qiskit 0.7 but after installing its dependencies. More
+-    # detailed info is provided at:
+-    # https://github.com/Qiskit/qiskit/issues/27#issue-396844438
+-    # https://github.com/Qiskit/qiskit/issues/27#issuecomment-455598103
+-    #
+-    # The fix overrides 'install' and 'develop' setuptools commands to force
+-    # reinstalling 'qiskit-terra' after installation to restore the missing files.
+-    #
+-    # For this fix to work, we cannot distribute a wheel version of the metapackage
+-    # (which does not provide any advantage right now). We can remove the fix once
+-    # we don't support updating from 0.6.
+-    cmdclass=_COMMANDS
+ )
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5275,6 +5275,8 @@ in {
 
   qiskit-aer = callPackage ../development/python-modules/qiskit-aer { };
 
+  qiskit-terra = callPackage ../development/python-modules/qiskit-terra { };
+
   qasm2image = callPackage ../development/python-modules/qasm2image { };
 
   simpy = callPackage ../development/python-modules/simpy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5273,6 +5273,8 @@ in {
 
   qiskit = callPackage ../development/python-modules/qiskit { };
 
+  qiskit-aer = callPackage ../development/python-modules/qiskit-aer { };
+
   qasm2image = callPackage ../development/python-modules/qasm2image { };
 
   simpy = callPackage ../development/python-modules/simpy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3055,6 +3055,8 @@ in {
 
   marshmallow = callPackage ../development/python-modules/marshmallow { };
 
+  marshmallow-polyfield = callPackage ../development/python-modules/marshmallow-polyfield {};
+
   marshmallow-sqlalchemy = callPackage ../development/python-modules/marshmallow-sqlalchemy { };
 
   manuel = callPackage ../development/python-modules/manuel { };


### PR DESCRIPTION
###### Motivation for this change

Upgrade Qiskit.

###### Things done

I chose `staging` as the base because the latest version of Qiskit needs `scikit-build`, but I couldn't build one of the transitive dependency, `libxml2Python`, with the following error:
```
these derivations will be built:
  /nix/store/q414ay3n4g7302dhi4hkpry2b7d6hmyf-libxml2+py-2.9.9.drv
building '/nix/store/q414ay3n4g7302dhi4hkpry2b7d6hmyf-libxml2+py-2.9.9.drv'...
Path /nix/store/vdpzi7q32nkkr6bmka7cwhlr5p26pga1-libxml2-2.9.9-dev/bin/xml2-config is a file and can't be merged into an environment using pkgs.buildEnv! at /nix/store/hafzskpwv85wsz1f8c2ps6n5a87khac7-builder.pl line 88.
builder for '/nix/store/q414ay3n4g7302dhi4hkpry2b7d6hmyf-libxml2+py-2.9.9.drv' failed with exit code 2
error: build of '/nix/store/q414ay3n4g7302dhi4hkpry2b7d6hmyf-libxml2+py-2.9.9.drv' failed
```

When I rebased onto master and cherry-picked `scikit-build` and sysconfig fix, it worked.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

