### PR TITLE
openafs_1_8: Include support for Linux 4.20

### DIFF
--- a/pkgs/servers/openafs/1.8/linux-4.20.patch
+++ b/pkgs/servers/openafs/1.8/linux-4.20.patch
@@ -1,0 +1,62 @@
+--- a/src/afs/LINUX/osi_machdep.h
++++ b/src/afs/LINUX/osi_machdep.h
+@@ -75,7 +75,14 @@
+ #if defined(HAVE_LINUX_CRED_H)
+ #include "h/cred.h"
+ #endif
+-#if defined(HAVE_LINUX_CURRENT_KERNEL_TIME)
++
++#if defined(HAVE_LINUX_KTIME_GET_COARSE_REAL_TS64)
++static inline time_t osi_Time(void) {
++    struct timespec64 xtime;
++    ktime_get_coarse_real_ts64(&xtime);
++    return xtime.tv_sec;
++}
++#elif defined(HAVE_LINUX_CURRENT_KERNEL_TIME)
+ static inline time_t osi_Time(void) {
+     struct timespec xtime;
+     xtime = current_kernel_time();
+--- a/src/cf/linux-kernel-func.m4
++++ b/src/cf/linux-kernel-func.m4
+@@ -72,6 +72,10 @@ AC_CHECK_LINUX_FUNC([iter_file_splice_write],
+ AC_CHECK_LINUX_FUNC([kernel_setsockopt],
+                     [#include <linux/net.h>],
+                     [kernel_setsockopt(NULL, 0, 0, NULL, 0);])
++AC_CHECK_LINUX_FUNC([ktime_get_coarse_real_ts64],
++                    [#include <linux/time.h>],
++                    [struct timespec64 *s;
++                    ktime_get_coarse_real_ts64(s);])
+ AC_CHECK_LINUX_FUNC([locks_lock_file_wait],
+                     [#include <linux/fs.h>],
+                     [locks_lock_file_wait(NULL, NULL);])
+--- a/src/afs/LINUX/osi_misc.c
++++ b/src/afs/LINUX/osi_misc.c
+@@ -28,18 +28,6 @@
+ int afs_osicred_initialized = 0;
+ afs_ucred_t afs_osi_cred;
+ 
+-void
+-afs_osi_SetTime(osi_timeval_t * tvp)
+-{
+-    struct timespec tv;
+-    tv.tv_sec = tvp->tv_sec;
+-    tv.tv_nsec = tvp->tv_usec * NSEC_PER_USEC;
+-
+-    AFS_STATCNT(osi_SetTime);
+-
+-    do_settimeofday(&tv);
+-}
+-
+ void
+ osi_linux_mask(void)
+ {
+--- a/src/afs/LINUX/osi_prototypes.h
++++ b/src/afs/LINUX/osi_prototypes.h
+@@ -45,7 +45,6 @@ extern void osi_ioctl_init(void);
+ extern void osi_ioctl_clean(void);
+ 
+ /* osi_misc.c */
+-extern void afs_osi_SetTime(osi_timeval_t * tvp);
+ extern int osi_lookupname_internal(char *aname, int followlink,
+ 				   struct vfsmount **mnt, struct dentry **dpp);
+ extern int osi_lookupname(char *aname, uio_seg_t seg, int followlink,

--- a/pkgs/servers/openafs/1.8/module.nix
+++ b/pkgs/servers/openafs/1.8/module.nix
@@ -11,6 +11,8 @@ in stdenv.mkDerivation rec {
   name = "openafs-${version}-${kernel.modDirVersion}";
   inherit version src;
 
+  patches = [ ./linux-4.20.patch ];
+
   nativeBuildInputs = [ autoconf automake flex libtool_2 perl which yacc ]
     ++ kernel.moduleBuildDependencies;
 


### PR DESCRIPTION
###### Motivation for this change
OpenAFS version 1.8.2 does not have support for Linux 4.20,
meaning that linuxPackages_latest.openafs_1_8 would fail
to build.

###### Things done

This patch adds patches taken from the OpenAFS git (via the Arch AUR) to
remove the references to deprecated functions. This has been
tested on Linux 4.20 and Linux 4.14

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

