### PR TITLE
all-packages.nix: move defaults to package files continues^3

### DIFF
--- a/pkgs/applications/audio/openmpt123/default.nix
+++ b/pkgs/applications/audio/openmpt123/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, zlib, pkgconfig, mpg123, libogg, libvorbis, portaudio, libsndfile, flac
-, usePulseAudio ? false, libpulseaudio }:
+{ config, stdenv, fetchurl, zlib, pkgconfig, mpg123, libogg, libvorbis, portaudio, libsndfile, flac
+, usePulseAudio ? config.pulseaudio or false, libpulseaudio }:
 
 let
   version = "0.4.1";

--- a/pkgs/applications/graphics/ahoviewer/default.nix
+++ b/pkgs/applications/graphics/ahoviewer/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchFromGitHub, pkgconfig, libconfig,
-  gtkmm2, glibmm, libxml2, libsecret, curl, libzip,
-  librsvg, gst_all_1, autoreconfHook, makeWrapper,
-  useUnrar ? false, unrar
+{ config, stdenv, fetchFromGitHub, pkgconfig, libconfig
+, gtkmm2, glibmm, libxml2, libsecret, curl, libzip
+, librsvg, gst_all_1, autoreconfHook, makeWrapper
+, useUnrar ? config.ahoviewer.useUnrar or false, unrar
 }:
 
 assert useUnrar -> unrar != null;

--- a/pkgs/applications/misc/audio/sox/default.nix
+++ b/pkgs/applications/misc/audio/sox/default.nix
@@ -1,7 +1,7 @@
-{ lib, stdenv, fetchurl
+{ config, lib, stdenv, fetchurl
 , enableAlsa ? true, alsaLib ? null
 , enableLibao ? true, libao ? null
-, enableLame ? false, lame ? null
+, enableLame ? config.sox.enableLame or false, lame ? null
 , enableLibmad ? true, libmad ? null
 , enableLibogg ? true, libogg ? null, libvorbis ? null
 , enableFLAC ? true, flac ? null

--- a/pkgs/applications/misc/zathura/default.nix
+++ b/pkgs/applications/misc/zathura/default.nix
@@ -1,4 +1,6 @@
-{ pkgs, useMupdf ? true, synctexSupport ? true }:
+{ config, pkgs
+, useMupdf ? config.zathura.useMupdf or true
+, synctexSupport ? true }:
 
 let
   callPackage = pkgs.newScope self;

--- a/pkgs/applications/networking/mailreaders/claws-mail/default.nix
+++ b/pkgs/applications/networking/mailreaders/claws-mail/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, wrapGAppsHook, autoreconfHook
+{ config, fetchurl, stdenv, wrapGAppsHook, autoreconfHook
 , curl, dbus, dbus-glib, enchant, gtk2, gnutls, gnupg, gpgme, hicolor-icon-theme
 , libarchive, libcanberra-gtk2, libetpan, libnotify, libsoup, libxml2, networkmanager
 , openldap, perl, pkgconfig, poppler, python, shared-mime-info, webkitgtk24x-gtk2
@@ -10,7 +10,7 @@
 #         gdata requires libgdata
 #         geolocation requires libchamplain
 , enableLdap ? false
-, enableNetworkManager ? false
+, enableNetworkManager ? config.networking.networkmanager.enable or false
 , enablePgp ? true
 , enablePluginArchive ? false
 , enablePluginFancy ? false

--- a/pkgs/applications/science/machine-learning/sc2-headless/default.nix
+++ b/pkgs/applications/science/machine-learning/sc2-headless/default.nix
@@ -1,9 +1,9 @@
-{ stdenv
+{ config, stdenv
 , callPackage
 , lib
 , fetchurl
 , unzip
-, licenseAccepted ? false
+, licenseAccepted ? config.sc2-headless.accept_license or false
 }:
 
 if !licenseAccepted then throw ''

--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, fetchurl, fetchFromGitHub, makeWrapper
+{ config, stdenv, fetchurl, fetchFromGitHub, makeWrapper
 , docutils, perl, pkgconfig, python3, which, ffmpeg_4
 , freefont_ttf, freetype, libass, libpthreadstubs, mujs
 , lua, libuchardet, libiconv ? null, darwin
 
-, waylandSupport ? false
+, waylandSupport ? stdenv.isLinux
   , wayland           ? null
   , wayland-protocols ? null
   , libxkbcommon      ? null
@@ -24,30 +24,30 @@
   , vulkan-headers ? null
   , vulkan-loader ? null
 
-, alsaSupport        ? true,  alsaLib       ? null
-, bluraySupport      ? true,  libbluray     ? null
-, bs2bSupport        ? true,  libbs2b       ? null
-, cacaSupport        ? true,  libcaca       ? null
-, cmsSupport         ? true,  lcms2         ? null
-, drmSupport         ? true,  libdrm        ? null
-, dvdnavSupport      ? true,  libdvdnav     ? null
-, dvdreadSupport     ? true,  libdvdread    ? null
-, libpngSupport      ? true,  libpng        ? null
-, pulseSupport       ? true,  libpulseaudio ? null
-, rubberbandSupport  ? true,  rubberband    ? null
-, screenSaverSupport ? true,  libXScrnSaver ? null
-, sdl2Support        ? true,  SDL2          ? null
-, speexSupport       ? true,  speex         ? null
-, theoraSupport      ? true,  libtheora     ? null
-, vaapiSupport       ? true,  libva         ? null
-, vdpauSupport       ? true,  libvdpau      ? null
-, xineramaSupport    ? true,  libXinerama   ? null
-, xvSupport          ? true,  libXv         ? null
-, youtubeSupport     ? true,  youtube-dl    ? null
-, archiveSupport     ? false, libarchive    ? null
-, jackaudioSupport   ? false, libjack2      ? null
-, openalSupport      ? false, openalSoft    ? null
-, vapoursynthSupport ? false, vapoursynth   ? null
+, alsaSupport        ? stdenv.isLinux, alsaLib       ? null
+, bluraySupport      ? true,           libbluray     ? null
+, bs2bSupport        ? true,           libbs2b       ? null
+, cacaSupport        ? true,           libcaca       ? null
+, cmsSupport         ? true,           lcms2         ? null
+, drmSupport         ? stdenv.isLinux, libdrm        ? null
+, dvdnavSupport      ? stdenv.isLinux, libdvdnav     ? null
+, dvdreadSupport     ? stdenv.isLinux, libdvdread    ? null
+, libpngSupport      ? true,           libpng        ? null
+, pulseSupport       ? config.pulseaudio or stdenv.isLinux, libpulseaudio ? null
+, rubberbandSupport  ? stdenv.isLinux, rubberband ? null
+, screenSaverSupport ? true,           libXScrnSaver ? null
+, sdl2Support        ? true,           SDL2          ? null
+, speexSupport       ? true,           speex         ? null
+, theoraSupport      ? true,           libtheora     ? null
+, vaapiSupport       ? stdenv.isLinux, libva ? null
+, vdpauSupport       ? true,           libvdpau      ? null
+, xineramaSupport    ? stdenv.isLinux, libXinerama   ? null
+, xvSupport          ? stdenv.isLinux, libXv         ? null
+, youtubeSupport     ? true,           youtube-dl    ? null
+, archiveSupport     ? false,          libarchive    ? null
+, jackaudioSupport   ? false,          libjack2      ? null
+, openalSupport      ? false,          openalSoft    ? null
+, vapoursynthSupport ? false,          vapoursynth   ? null
 }:
 
 with stdenv.lib;
@@ -92,7 +92,7 @@ let
              "http://www.freehackers.org/~tnagy/release/waf-${wafVersion}" ];
     sha256 = "0j7sbn3w6bgslvwwh5v9527w3gi2sd08kskrgxamx693y0b0i3ia";
   };
-  luaEnv = lua.withPackages(ps: with ps; [ luasocket]);
+  luaEnv = lua.withPackages(ps: with ps; [ luasocket ]);
 
 in stdenv.mkDerivation rec {
   name = "mpv-${version}";

--- a/pkgs/applications/video/obs-studio/default.nix
+++ b/pkgs/applications/video/obs-studio/default.nix
@@ -1,4 +1,4 @@
-{ stdenv
+{ config, stdenv
 , fetchFromGitHub
 , fetchpatch
 , cmake
@@ -26,9 +26,9 @@
 , swig
 , python3
 
-, alsaSupport ? false
+, alsaSupport ? stdenv.isLinux
 , alsaLib
-, pulseaudioSupport ? false
+, pulseaudioSupport ? config.pulseaudio or stdenv.isLinux
 , libpulseaudio
 }:
 

--- a/pkgs/build-support/fetchsvn/default.nix
+++ b/pkgs/build-support/fetchsvn/default.nix
@@ -1,4 +1,4 @@
-{stdenvNoCC, subversion, glibcLocales, sshSupport ? false, openssh ? null}:
+{stdenvNoCC, subversion, glibcLocales, sshSupport ? true, openssh ? null}:
 {url, rev ? "HEAD", md5 ? "", sha256 ? ""
 , ignoreExternals ? false, ignoreKeywords ? false, name ? null
 , preferLocalBuild ? true }:

--- a/pkgs/development/compilers/coreclr/default.nix
+++ b/pkgs/development/compilers/coreclr/default.nix
@@ -1,4 +1,4 @@
-{ stdenv
+{ config, stdenv
 , fetchFromGitHub
 , fetchpatch
 , which
@@ -14,7 +14,7 @@
 , liburcu
 , libuuid
 , libkrb5
-, debug ? false
+, debug ? config.coreclr.debug or false
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
@@ -17,7 +17,8 @@
 , installjdk ? true
 , pluginSupport ? true
 , installjce ? false
-, licenseAccepted ? false
+, config
+, licenseAccepted ? config.oraclejdk.accept_license or false
 , glib
 , libxml2
 , libav_0_8

--- a/pkgs/development/libraries/gnutls-kdh/generic.nix
+++ b/pkgs/development/libraries/gnutls-kdh/generic.nix
@@ -1,5 +1,6 @@
-{ lib, stdenv, zlib, lzo, libtasn1, nettle, pkgconfig, lzip
-, guileBindings, guile, perl, gmp, autogen, libidn, p11-kit, unbound, libiconv
+{ config, lib, stdenv, zlib, lzo, libtasn1, nettle, pkgconfig, lzip
+, perl, gmp, autogen, libidn, p11-kit, unbound, libiconv
+, guileBindings ? config.gnutls.guile or false, guile
 , tpmSupport ? true, trousers, nettools, gperftools, gperf, gettext, automake
 , yacc, texinfo
 

--- a/pkgs/development/libraries/gnutls/generic.nix
+++ b/pkgs/development/libraries/gnutls/generic.nix
@@ -1,5 +1,6 @@
-{ lib, stdenv, zlib, lzo, libtasn1, nettle, pkgconfig, lzip
-, guileBindings, guile, perl, gmp, autogen, libidn, p11-kit, libiconv
+{ config, lib, stdenv, zlib, lzo, libtasn1, nettle, pkgconfig, lzip
+, perl, gmp, autogen, libidn, p11-kit, libiconv
+, guileBindings ? config.gnutls.guile or false, guile
 , tpmSupport ? false, trousers, which, nettools, libunistring
 , unbound, dns-root-data, gettext
 

--- a/pkgs/development/libraries/libiodbc/default.nix
+++ b/pkgs/development/libraries/libiodbc/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, pkgconfig, gtk2, Carbon, useGTK ? false }:
+{ config, stdenv, fetchurl, pkgconfig, gtk2, Carbon
+, useGTK ? config.libiodbc.gtk or false }:
 
 stdenv.mkDerivation rec {
   name = "libiodbc-3.52.12";

--- a/pkgs/development/libraries/opencv/3.x.nix
+++ b/pkgs/development/libraries/opencv/3.x.nix
@@ -8,13 +8,13 @@
 , enablePNG       ? true, libpng
 , enableTIFF      ? true, libtiff
 , enableWebP      ? true, libwebp
-, enableEXR ? (!stdenv.isDarwin), openexr, ilmbase
+, enableEXR ?     !stdenv.isDarwin, openexr, ilmbase
 , enableJPEG2K    ? true, jasper
 , enableEigen     ? true, eigen
 , enableOpenblas  ? true, openblas
 , enableContrib   ? true
 
-, enableCuda      ? (config.cudaSupport or false), cudatoolkit
+, enableCuda      ? config.cudaSupport or false, cudatoolkit
 
 , enableUnfree    ? false
 , enableIpp       ? false

--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -8,13 +8,13 @@
 , enablePNG       ? true, libpng
 , enableTIFF      ? true, libtiff
 , enableWebP      ? true, libwebp
-, enableEXR ? (!stdenv.isDarwin), openexr, ilmbase
+, enableEXR ?     !stdenv.isDarwin, openexr, ilmbase
 , enableJPEG2K    ? true, jasper
 , enableEigen     ? true, eigen
 , enableOpenblas  ? true, openblas
 , enableContrib   ? true
 
-, enableCuda      ? (config.cudaSupport or false), cudatoolkit
+, enableCuda      ? config.cudaSupport or false, cudatoolkit
 
 , enableUnfree    ? false
 , enableIpp       ? false

--- a/pkgs/development/libraries/qt-3/default.nix
+++ b/pkgs/development/libraries/qt-3/default.nix
@@ -6,7 +6,8 @@
 , cursorSupport ? true, libXcursor ? null
 , threadSupport ? true
 , mysqlSupport ? false, mysql ? null
-, openglSupport ? false, libGLU_combined ? null, libXmu ? null
+, libGLSupported
+, openglSupport ? libGLSupported, libGLU_combined ? null, libXmu ? null
 , xlibsWrapper, xorgproto, zlib, libjpeg, libpng, which
 }:
 

--- a/pkgs/development/libraries/wxwidgets/2.8/default.nix
+++ b/pkgs/development/libraries/wxwidgets/2.8/default.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchurl, pkgconfig, gtk2, libXinerama, libSM, libXxf86vm, xorgproto
 , gstreamer, gst-plugins-base, GConf, libX11, cairo
-, withMesa ? true, libGLU ? null, libGL ? null
+, libGLSupported
+, withMesa ? libGLSupported, libGLU ? null, libGL ? null
 , compat24 ? false, compat26 ? true, unicode ? true,
 }:
 

--- a/pkgs/development/libraries/wxwidgets/2.9/default.nix
+++ b/pkgs/development/libraries/wxwidgets/2.9/default.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchurl, pkgconfig, gtk2, libXinerama, libSM, libXxf86vm, xorgproto
 , gstreamer, gst-plugins-base, GConf, setfile
-, withMesa ? true, libGLU ? null, libGL ? null
+, libGLSupported
+, withMesa ? libGLSupported, libGLU ? null, libGL ? null
 , compat24 ? false, compat26 ? true, unicode ? true
 , Carbon ? null, Cocoa ? null, Kernel ? null, QuickTime ? null, AGL ? null
 }:

--- a/pkgs/development/libraries/wxwidgets/3.0/default.nix
+++ b/pkgs/development/libraries/wxwidgets/3.0/default.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchFromGitHub, fetchurl, fetchpatch, pkgconfig
 , gtk2, gtk3, libXinerama, libSM, libXxf86vm
 , xorgproto, gstreamer, gst-plugins-base, GConf, setfile
-, withMesa ? true, libGLU ? null, libGL ? null
+, libGLSupported
+, withMesa ? libGLSupported, libGLU ? null, libGL ? null
 , compat24 ? false, compat26 ? true, unicode ? true
 , withGtk2 ? true
 , withWebKit ? false, webkitgtk24x-gtk2 ? null, webkitgtk ? null

--- a/pkgs/development/mobile/androidenv/default.nix
+++ b/pkgs/development/mobile/androidenv/default.nix
@@ -1,6 +1,6 @@
-{ pkgs ? import <nixpkgs> {}
+{ config, pkgs ? import <nixpkgs> {}
 , pkgs_i686 ? import <nixpkgs> { system = "i686-linux"; }
-, licenseAccepted ? false
+, licenseAccepted ? config.android_sdk.accept_license or false
 }:
 
 rec {

--- a/pkgs/development/tools/analysis/radare2/default.nix
+++ b/pkgs/development/tools/analysis/radare2/default.nix
@@ -8,7 +8,10 @@
 , python3 ? null
 , ruby ? null
 , lua ? null
-, useX11, rubyBindings, pythonBindings, luaBindings
+, useX11 ? false
+, rubyBindings ? false
+, pythonBindings ? false
+, luaBindings ? false
 }:
 
 assert useX11 -> (gtk2 != null && vte != null && gtkdialog != null);

--- a/pkgs/games/steam/chrootenv.nix
+++ b/pkgs/games/steam/chrootenv.nix
@@ -1,11 +1,13 @@
-{ stdenv, lib, writeScript, buildFHSUserEnv, steam, glxinfo-i686
+{ config, stdenv, lib, writeScript, buildFHSUserEnv, steam, glxinfo-i686
 , steam-runtime-wrapped, steam-runtime-wrapped-i686 ? null
-, withJava ? false
-, withPrimus ? false
 , extraPkgs ? pkgs: [ ] # extra packages to add to targetPkgs
 , extraProfile ? "" # string to append to profile
 , nativeOnly ? false
 , runtimeOnly ? false
+
+# DEPRECATED
+, withJava ? config.steam.java or false
+, withPrimus ? config.steam.primus or false
 }:
 
 let

--- a/pkgs/os-specific/linux/conky/default.nix
+++ b/pkgs/os-specific/linux/conky/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pkgconfig, cmake
+{ config, stdenv, fetchFromGitHub, pkgconfig, cmake
 
 # dependencies
 , glib, libXinerama
@@ -27,7 +27,7 @@
 
 , wirelessSupport     ? true      , wirelesstools ? null
 , nvidiaSupport       ? false     , libXNVCtrl ? null
-, pulseSupport        ? false     , libpulseaudio ? null
+, pulseSupport        ? config.pulseaudio or false, libpulseaudio ? null
 
 , curlSupport         ? true      , curl ? null
 , rssSupport          ? curlSupport

--- a/pkgs/os-specific/linux/guvcview/default.nix
+++ b/pkgs/os-specific/linux/guvcview/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, intltool, pkgconfig
+{ config, stdenv, fetchurl, intltool, pkgconfig
 , gtk3, portaudio, SDL2, ffmpeg, udev, libusb1, libv4l, alsaLib, gsl
-, pulseaudioSupport ? true, libpulseaudio ? null }:
+, pulseaudioSupport ? config.pulseaudio or stdenv.isLinux, libpulseaudio ? null }:
 
 assert pulseaudioSupport -> libpulseaudio != null;
 

--- a/pkgs/os-specific/linux/lxcfs/default.nix
+++ b/pkgs/os-specific/linux/lxcfs/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, help2man, fuse
-, enableDebugBuild ? false }:
+{ config, stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, help2man, fuse
+, enableDebugBuild ? config.lxcfs.enableDebugBuild or false }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {

--- a/pkgs/servers/dns/bind/default.nix
+++ b/pkgs/servers/dns/bind/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, lib, fetchurl
+{ config, stdenv, lib, fetchurl
 , perl
 , libcap, libtool, libxml2, openssl
-, enablePython ? false, python3 ? null
+, enablePython ? config.bind.enablePython or false, python3 ? null
 , enableSeccomp ? false, libseccomp ? null, buildPackages
 }:
 
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ libtool libxml2 openssl ]
     ++ lib.optional stdenv.isLinux libcap
     ++ lib.optional enableSeccomp libseccomp
-    ++ lib.optional enablePython python3;
+    ++ lib.optional enablePython (python3.withPackages (ps: with ps; [ ply ]));
 
   STD_CDEFINES = [ "-DDIG_SIGCHASE=1" ]; # support +sigchase
 

--- a/pkgs/servers/plex/default.nix
+++ b/pkgs/servers/plex/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, rpmextract, glibc
+{ config, stdenv, fetchurl, rpmextract, glibc
 , dataDir ? "/var/lib/plex" # Plex's data directory must be baked into the package due to symlinks.
-, enablePlexPass ? false
+, enablePlexPass ? config.plex.enablePlexPass or false
 }:
 
 let

--- a/pkgs/tools/bluetooth/blueman/default.nix
+++ b/pkgs/tools/bluetooth/blueman/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, lib, fetchurl, intltool, pkgconfig, python3Packages, bluez, gtk3
+{ config, stdenv, lib, fetchurl, intltool, pkgconfig, python3Packages, bluez, gtk3
 , obex_data_server, xdg_utils, libnotify, dnsmasq, dhcp
 , hicolor-icon-theme, librsvg, wrapGAppsHook, gobject-introspection
-, withPulseAudio ? true, libpulseaudio }:
+, withPulseAudio ? config.pulseaudio or stdenv.isLinux, libpulseaudio }:
 
 let
   pythonPackages = python3Packages;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14326,8 +14326,7 @@ in
 
   conky = callPackage ../os-specific/linux/conky ({
     lua = lua5_3_compat;
-    libXNVCtrl = linuxPackages.nvidia_x11.settings.libXNVCtrl;
-    pulseSupport = config.pulseaudio or false;
+    inherit (linuxPackages.nvidia_x11.settings) libXNVCtrl;
   } // config.conky or {});
 
   conntrack-tools = callPackage ../os-specific/linux/conntrack-tools { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15445,9 +15445,7 @@ in
 
   comic-relief = callPackage ../data/fonts/comic-relief {};
 
-  coreclr = callPackage ../development/compilers/coreclr {
-    debug = config.coreclr.debug or false;
-  };
+  coreclr = callPackage ../development/compilers/coreclr { };
 
   corefonts = callPackage ../data/fonts/corefonts { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18382,19 +18382,8 @@ in
       # !!! should depend on MPlayer
     };
 
-  mpv = callPackage ../applications/video/mpv rec {
+  mpv = callPackage ../applications/video/mpv {
     inherit lua;
-    waylandSupport     = stdenv.isLinux;
-    alsaSupport        = !stdenv.isDarwin;
-    pulseSupport       = !stdenv.isDarwin;
-    rubberbandSupport  = !stdenv.isDarwin;
-    dvdreadSupport     = !stdenv.isDarwin;
-    dvdnavSupport      = !stdenv.isDarwin;
-    drmSupport         = !stdenv.isDarwin;
-    vaapiSupport       = !stdenv.isDarwin;
-    x11Support         = !stdenv.isDarwin;
-    xineramaSupport    = !stdenv.isDarwin;
-    xvSupport          = !stdenv.isDarwin;
   };
 
   mpv-with-scripts = callPackage ../applications/video/mpv/wrapper.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4036,9 +4036,7 @@ in
   ltris = callPackage ../games/ltris { };
 
   lxc = callPackage ../os-specific/linux/lxc { };
-  lxcfs = callPackage ../os-specific/linux/lxcfs {
-    enableDebugBuild = config.lxcfs.enableDebugBuild or false;
-  };
+  lxcfs = callPackage ../os-specific/linux/lxcfs { };
   lxd = callPackage ../tools/admin/lxd { };
 
   lzfse = callPackage ../tools/compression/lzfse { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10964,7 +10964,6 @@ in
   libinotify-kqueue = callPackage ../development/libraries/libinotify-kqueue { };
 
   libiodbc = callPackage ../development/libraries/libiodbc {
-    useGTK = config.libiodbc.gtk or false;
     inherit (darwin.apple_sdk.frameworks) Carbon;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7197,14 +7197,12 @@ in
     (if pluginSupport then appendToName "with-plugin" else x: x)
       (callPackage ../development/compilers/oraclejdk/jdk8cpu-linux.nix {
         inherit installjdk pluginSupport;
-        licenseAccepted = config.oraclejdk.accept_license or false;
       });
 
   oraclejdk8psu_distro = installjdk: pluginSupport:
     (if pluginSupport then appendToName "with-plugin" else x: x)
       (callPackage ../development/compilers/oraclejdk/jdk8psu-linux.nix {
         inherit installjdk pluginSupport;
-        licenseAccepted = config.oraclejdk.accept_license or false;
       });
 
   javacard-devkit = pkgsi686Linux.callPackage ../development/compilers/javacard-devkit { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16030,9 +16030,7 @@ in
 
   agedu = callPackage ../tools/misc/agedu { };
 
-  ahoviewer = callPackage ../applications/graphics/ahoviewer {
-    useUnrar = config.ahoviewer.useUnrar or false;
-  };
+  ahoviewer = callPackage ../applications/graphics/ahoviewer { };
 
   airwave = callPackage ../applications/audio/airwave { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21004,11 +21004,7 @@ in
 
   steamPackages = callPackage ../games/steam { };
 
-  steam = steamPackages.steam-chrootenv.override {
-    # DEPRECATED
-    withJava = config.steam.java or false;
-    withPrimus = config.steam.primus or false;
-  };
+  steam = steamPackages.steam-chrootenv;
 
   steam-run = steam.run;
   steam-run-native = (steam.override {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16386,7 +16386,6 @@ in
   claws-mail = callPackage ../applications/networking/mailreaders/claws-mail {
     inherit (gnome3) gsettings-desktop-schemas;
     inherit (xorg) libSM;
-    enableNetworkManager = config.networking.networkmanager.enable or false;
   };
 
   clfswm = callPackage ../applications/window-managers/clfswm { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19384,9 +19384,7 @@ in
 
   soulseekqt = libsForQt5.callPackage ../applications/networking/p2p/soulseekqt { };
 
-  sox = callPackage ../applications/misc/audio/sox {
-    enableLame = config.sox.enableLame or false;
-  };
+  sox = callPackage ../applications/misc/audio/sox { };
 
   soxr = callPackage ../applications/misc/audio/soxr { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13446,10 +13446,7 @@ in
 
   bftpd = callPackage ../servers/ftp/bftpd {};
 
-  bind = callPackage ../servers/dns/bind {
-    enablePython = config.bind.enablePython or false;
-    python3 = python3.withPackages (ps: with ps; [ ply ]);
-  };
+  bind = callPackage ../servers/dns/bind { };
   dnsutils = bind.dnsutils;
 
   inherit (callPackages ../servers/bird { })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20362,9 +20362,7 @@ in
     boost = boost160;
   };
 
-  zathura = callPackage ../applications/misc/zathura {
-    useMupdf = config.zathura.useMupdf or true;
-  };
+  zathura = callPackage ../applications/misc/zathura { };
 
   zeroc_ice = callPackage ../development/libraries/zeroc-ice {
     inherit (darwin.apple_sdk.frameworks) Security;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -226,9 +226,7 @@ in
 
   fetchs3 = callPackage ../build-support/fetchs3 { };
 
-  fetchsvn = callPackage ../build-support/fetchsvn {
-    sshSupport = true;
-  };
+  fetchsvn = callPackage ../build-support/fetchsvn { };
 
   fetchsvnrevision = import ../build-support/fetchsvnrevision runCommand subversion;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11868,7 +11868,6 @@ in
   };
 
   opencv3 = callPackage ../development/libraries/opencv/3.x.nix {
-    enableCuda = config.cudaSupport or false;
     inherit (darwin) cf-private;
     inherit (darwin.apple_sdk.frameworks) AVFoundation Cocoa QTKit VideoDecodeAcceleration;
   };
@@ -11878,7 +11877,6 @@ in
   };
 
   opencv4 = callPackage ../development/libraries/opencv/4.x.nix {
-    enableCuda = config.cudaSupport or false;
     inherit (darwin) cf-private;
     inherit (darwin.apple_sdk.frameworks) AVFoundation Cocoa QTKit VideoDecodeAcceleration;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4875,7 +4875,7 @@ in
 
   playbar2 = libsForQt5.callPackage ../applications/audio/playbar2 { };
 
-  plex = callPackage ../servers/plex { enablePlexPass = config.plex.enablePlexPass or false; };
+  plex = callPackage ../servers/plex { };
 
   plexpy = callPackage ../servers/plexpy { python = python2; };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18677,9 +18677,7 @@ in
 
   vivaldi-ffmpeg-codecs = callPackage ../applications/networking/browsers/vivaldi/ffmpeg-codecs.nix {};
 
-  openmpt123 = callPackage ../applications/audio/openmpt123 {
-    usePulseAudio = config.pulseaudio or false;
-  };
+  openmpt123 = callPackage ../applications/audio/openmpt123 { };
 
   opusfile = callPackage ../applications/audio/opusfile { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18634,10 +18634,7 @@ in
 
   obs-linuxbrowser = callPackage ../applications/video/obs-studio/linuxbrowser.nix { };
 
-  obs-studio = libsForQt5.callPackage ../applications/video/obs-studio {
-    alsaSupport = stdenv.isLinux;
-    pulseaudioSupport = config.pulseaudio or true;
-  };
+  obs-studio = libsForQt5.callPackage ../applications/video/obs-studio { };
 
   octoprint = callPackage ../applications/misc/octoprint { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13008,21 +13008,18 @@ in
 
   wxGTK28 = callPackage ../development/libraries/wxwidgets/2.8 {
     inherit (gnome2) GConf;
-    withMesa = lib.elem stdenv.hostPlatform.system lib.platforms.mesaPlatforms;
   };
 
   wxGTK29 = callPackage ../development/libraries/wxwidgets/2.9 {
     inherit (gnome2) GConf;
     inherit (darwin.stubs) setfile;
     inherit (darwin.apple_sdk.frameworks) AGL Carbon Cocoa Kernel QuickTime;
-    withMesa = lib.elem stdenv.hostPlatform.system lib.platforms.mesaPlatforms;
   };
 
   wxGTK30 = callPackage ../development/libraries/wxwidgets/3.0 {
     inherit (gnome2) GConf;
     inherit (darwin.stubs) setfile;
     inherit (darwin.apple_sdk.frameworks) AGL Carbon Cocoa Kernel QTKit;
-    withMesa = lib.elem stdenv.hostPlatform.system lib.platforms.mesaPlatforms;
   };
 
   wxGTK31 = callPackage ../development/libraries/wxwidgets/3.1 {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17534,9 +17534,7 @@ in
 
   gv = callPackage ../applications/misc/gv { };
 
-  guvcview = callPackage ../os-specific/linux/guvcview {
-    pulseaudioSupport = config.pulseaudio or true;
-  };
+  guvcview = callPackage ../os-specific/linux/guvcview { };
 
   gxmessage = callPackage ../applications/misc/gxmessage { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9007,14 +9007,10 @@ in
 
   r10k = callPackage ../tools/system/r10k { };
 
-  inherit (callPackages ../development/tools/analysis/radare2 {
+  inherit (callPackages ../development/tools/analysis/radare2 ({
     inherit (gnome2) vte;
     lua = lua5;
-    useX11 = config.radare.useX11 or false;
-    pythonBindings = config.radare.pythonBindings or false;
-    rubyBindings = config.radare.rubyBindings or false;
-    luaBindings = config.radare.luaBindings or false;
-  }) radare2 r2-for-cutter;
+  } // (config.radare or {}))) radare2 r2-for-cutter;
 
   radare2-cutter = libsForQt5.callPackage ../development/tools/analysis/radare2/cutter.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21536,9 +21536,7 @@ in
 
   ### SCIENCE/MACHINE LEARNING
 
-  sc2-headless = callPackage ../applications/science/machine-learning/sc2-headless {
-    licenseAccepted = (config.sc2-headless.accept_license or false);
-  };
+  sc2-headless = callPackage ../applications/science/machine-learning/sc2-headless { };
 
   ### SCIENCE/MATH
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -783,7 +783,6 @@ in
 
   androidenv = callPackage ../development/mobile/androidenv {
     pkgs_i686 = pkgsi686Linux;
-    licenseAccepted = config.android_sdk.accept_license or false;
   };
 
   androidndkPkgs = androidndkPkgs_18b;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10113,12 +10113,9 @@ in
       # https://github.com/NixOS/nixpkgs/commit/d6454e6a1
       then ../development/libraries/gnutls/3.5.10.nix
       else ../development/libraries/gnutls/3.6.nix)
-    {
-      guileBindings = config.gnutls.guile or false;
-    };
+    { };
 
   gnutls-kdh = callPackage ../development/libraries/gnutls-kdh/3.5.nix {
-    guileBindings = config.gnutls.guile or false;
     gperf = gperf_3_0;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12099,7 +12099,6 @@ in
   qolibri = libsForQt5.callPackage ../applications/misc/qolibri { };
 
   qt3 = callPackage ../development/libraries/qt-3 {
-    openglSupport = libGLSupported;
     libpng = libpng12;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1762,9 +1762,7 @@ in
     inherit (python27Packages) pillow;
   };
 
-  blueman = callPackage ../tools/bluetooth/blueman {
-    withPulseAudio = config.pulseaudio or true;
-  };
+  blueman = callPackage ../tools/bluetooth/blueman { };
 
   bmrsa = callPackage ../tools/security/bmrsa/11.nix { };
 


### PR DESCRIPTION
# What? Why?

A continuation of #55129, #55732, and #56026. Yet another noop.

# `git log`

- *: move defaults to package file

A whole bunch of these.

# `nix-instantiate` environment

- Host OS: Linux 4.9, SLNOS 19.03
- Nix: nix-env (Nix) 2.1.3
- Multi-user: yes
- Sandbox: yes
- NIXPKGS_CONFIG:

```nix
{
  checkMeta = true;
  doCheckByDefault = true;
}
```

# `nix-env -qaP` diffs

- On x86_64-linux: noop
- On aarch64-linux: noop
- On x86_64-darwin: noop

/cc @7c6f434c from #55129 and @bendlas, @volth, @samueldr from #55732
