### PR TITLE
aptly: 1.2.0 -> 1.3.0

### DIFF
--- a/pkgs/tools/misc/aptly/default.nix
+++ b/pkgs/tools/misc/aptly/default.nix
@@ -2,14 +2,14 @@
 
 let
 
-  version = "1.2.0";
+  version = "1.3.0";
   rev = "v${version}";
 
   aptlySrc = fetchFromGitHub {
     inherit rev;
-    owner = "smira";
+    owner = "aptly-dev";
     repo = "aptly";
-    sha256 = "1acnkmgarz9rp0skkh7zzwkhisjlmbl74jqjmqd3mn42y528c34b";
+    sha256 = "032gw8qkxcgc0jyrvzqh7jkbmk4k0gf7j74hyhclfnjmd9548f5l";
   };
 
   aptlyCompletionSrc = fetchFromGitHub {
@@ -26,7 +26,7 @@ buildGoPackage {
 
   src = aptlySrc;
 
-  goPackagePath = "github.com/smira/aptly";
+  goPackagePath = "github.com/aptly-dev/aptly";
 
   nativeBuildInputs = [ makeWrapper ];
 


### PR DESCRIPTION
###### Motivation for this change
New release available


###### Things done
The GitHub repository moved from `smira` to `aptly-dev`. This was changed with the version bump.
@montag451 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

