### PR TITLE
solc: make z3 dependency optional

### DIFF
--- a/pkgs/development/compilers/solc/default.nix
+++ b/pkgs/development/compilers/solc/default.nix
@@ -1,4 +1,8 @@
-{ stdenv, fetchzip, fetchFromGitHub, boost, cmake, z3 }:
+{ stdenv, fetchzip, fetchFromGitHub, boost, cmake
+, z3Support ? true, z3 ? null
+}:
+
+assert z3Support -> z3 != null;
 
 let
   version = "0.5.3";
@@ -33,6 +37,8 @@ stdenv.mkDerivation {
   cmakeFlags = [
     "-DBoost_USE_STATIC_LIBS=OFF"
     "-DBUILD_SHARED_LIBS=ON"
+  ] ++ stdenv.lib.optionals (!z3Support) [
+    "-DUSE_Z3=OFF"
   ];
 
   doCheck = stdenv.hostPlatform.isLinux && stdenv.hostPlatform == stdenv.buildPlatform;
@@ -40,7 +46,8 @@ stdenv.mkDerivation {
                "./test/soltest -p -- --no-ipc --no-smt --testpath ../test";
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ boost z3 ];
+  buildInputs = [ boost ]
+    ++ stdenv.lib.optionals z3Support [ z3 ];
 
   outputs = [ "out" "dev" ];
 


### PR DESCRIPTION
###### Motivation for this change

It is an optional dependency, which defaults to true.

https://solidity.readthedocs.io/en/latest/installing-solidity.html#smt-solvers

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

