### PR TITLE
murmur_git: Fix

### DIFF
--- a/pkgs/applications/networking/mumble/default.nix
+++ b/pkgs/applications/networking/mumble/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchFromGitHub, fetchpatch, pkgconfig
+{ stdenv, fetchurl, fetchFromGitHub, fetchpatch, makeWrapper, pkgconfig
 , qt4, qmake4Hook, qt5, avahi, boost, libopus, libsndfile, protobuf, speex, libcap
 , alsaLib, python
 , jackSupport ? false, libjack2 ? null
@@ -154,5 +154,12 @@ in {
   murmur     = server stableSource;
   murmur_git = (server gitSource).overrideAttrs (old: {
     meta = old.meta // { broken = iceSupport; };
+
+    nativeBuildInputs = old.nativeBuildInputs or [] ++ [ makeWrapper ];
+
+    installPhase = old.installPhase or "" + ''
+      wrapProgram $out/bin/murmurd --suffix QT_PLUGIN_PATH : \
+        ${getBin qt5.qtbase}/${qt5.qtbase.qtPluginPrefix}
+    '';
   });
 }


### PR DESCRIPTION
Was failing with the following error when running a service with it:

    ServerDB: Database driver QSQLITE not available

This fix is only needed for the git version of murmur.

Ping @jgeerds 

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after): **+0.0002%**
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

