### PR TITLE
dasht: init at v2.3.0

### DIFF
--- a/pkgs/tools/misc/dasht/default.nix
+++ b/pkgs/tools/misc/dasht/default.nix
@@ -13,12 +13,12 @@
 }:
 
 stdenv.mkDerivation rec {
+  pname   = "dasht";
   version = "2.3.0";
-  name    = "dasht-${version}";
 
   src = fetchFromGitHub {
     owner  = "sunaku";
-    repo   = "dasht";
+    repo   = pname;
     rev    = "v${version}";
     sha256 = "0d0pcjalba58nvxdgn39m4b6n9ifajf3ygyjaqgvzwxzgpzw0a60";
   };
@@ -56,10 +56,9 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Search API docs offline, in terminal or browser";
-    homepage    = https://sunaku.github.io/dasht/man;
+    homepage    = "https://sunaku.github.io/dasht/man";
     license     = stdenv.lib.licenses.isc;
     platforms   = stdenv.lib.platforms.unix; #cannot test other
     maintainers = with stdenv.lib.maintainers; [ matthiasbeyer ];
   };
 }
-

--- a/pkgs/tools/misc/dasht/default.nix
+++ b/pkgs/tools/misc/dasht/default.nix
@@ -1,0 +1,65 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, makeWrapper
+, coreutils
+, gnused
+, gnugrep
+, sqlite
+, wget
+, w3m
+, socat
+, gawk
+}:
+
+stdenv.mkDerivation rec {
+  version = "2.3.0";
+  name    = "dasht-${version}";
+
+  src = fetchFromGitHub {
+    owner  = "sunaku";
+    repo   = "dasht";
+    rev    = "v${version}";
+    sha256 = "0d0pcjalba58nvxdgn39m4b6n9ifajf3ygyjaqgvzwxzgpzw0a60";
+  };
+
+  deps = lib.makeBinPath [
+    coreutils
+    gnused
+    gnugrep
+    sqlite
+    wget
+    w3m
+    socat
+    gawk
+    (placeholder "out")
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp bin/* $out/bin/
+
+    mkdir -p $out/share/man/man1
+    cp man/man1/* $out/share/man/man1/
+
+    for i in $out/bin/*; do
+      echo "Wrapping $i"
+      wrapProgram $i --prefix PATH : ${deps};
+    done;
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Search API docs offline, in terminal or browser";
+    homepage    = https://sunaku.github.io/dasht/man;
+    license     = stdenv.lib.licenses.isc;
+    platforms   = stdenv.lib.platforms.unix; #cannot test other
+    maintainers = with stdenv.lib.maintainers; [ matthiasbeyer ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6535,6 +6535,8 @@ in
 
   dash = callPackage ../shells/dash { };
 
+  dasht = callPackage ../tools/misc/dasht { };
+
   dashing = callPackage ../tools/misc/dashing { };
 
   es = callPackage ../shells/es { };


### PR DESCRIPTION
Closes #55546

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Works for me, I downloaded the bash docset and ran a query on it... 