### PR TITLE
ddgr: 1.1 -> 1.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -817,6 +817,11 @@
     github = "cdepillabout";
     name = "Dennis Gosnell";
   };
+  ceedubs = {
+    email = "ceedubs@gmail.com";
+    github = "ceedubs";
+    name = "Cody Allen";
+  };
   cfouche = {
     email = "chaddai.fouche@gmail.com";
     github = "Chaddai";

--- a/pkgs/applications/misc/ddgr/default.nix
+++ b/pkgs/applications/misc/ddgr/default.nix
@@ -1,29 +1,17 @@
-{stdenv, fetchpatch, fetchFromGitHub, python3Packages}:
+{stdenv, fetchpatch, fetchFromGitHub, python3}:
 
 stdenv.mkDerivation rec {
-  version = "1.1";
+  version = "1.6";
   name = "ddgr-${version}";
 
   src = fetchFromGitHub {
     owner = "jarun";
     repo = "ddgr";
     rev = "v${version}";
-    sha256 = "1q66kwip5y0kfkfldm1x54plz85mjyvv1xpxjqrs30r2lr0najgf";
+    sha256 = "04ybbjsf9hpn2p5cjjm15cwvv0mwrmdi19iifrym6ps3rmll0p3c";
   };
 
-  buildInputs = [
-    (python3Packages.python.withPackages (ps: with ps; [
-      requests
-    ]))
-  ];
-
-  patches = [
-    (fetchpatch {
-     sha256 = "1rxr3biq0mk4m0m7dsxr70dhz4fg5siil5x5fy9nymcmhvcm1cdc";
-     name = "Fix-zsh-completion.patch";
-     url = "https://github.com/jarun/ddgr/commit/10c1a911a3d5cbf3e96357c932b0211d3165c4b8.patch";
-    })
-  ];
+  buildInputs = [ python3 ];
 
   makeFlags = "PREFIX=$(out)";
 
@@ -40,7 +28,7 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/jarun/ddgr;
     description = "Search DuckDuckGo from the terminal";
     license = licenses.gpl3;
-    maintainers = with maintainers; [ markus1189 ];
+    maintainers = with maintainers; [ ceedubs markus1189 ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

ddgr (DuckDuckGo CLI) 1.6 no longer requires the `requests` Python
package and includes the commit that patched zsh-completion.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

