### PR TITLE
Revert "Remove maintainership"

### DIFF
--- a/pkgs/applications/misc/buku/default.nix
+++ b/pkgs/applications/misc/buku/default.nix
@@ -69,7 +69,7 @@ with python3.pkgs; buildPythonApplication rec {
     homepage = https://github.com/jarun/Buku;
     license = licenses.gpl3;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ infinisil ];
+    maintainers = with maintainers; [ matthiasbeyer infinisil ];
   };
 }
 

--- a/pkgs/applications/misc/cataract/build.nix
+++ b/pkgs/applications/misc/cataract/build.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     homepage = http://cgg.bzatek.net/;
     description = "a simple static web photo gallery, designed to be clean and easily usable";
     license = stdenv.lib.licenses.gpl2;
-    maintainers = with stdenv.lib.maintainers; [ ];
+    maintainers = [ stdenv.lib.maintainers.matthiasbeyer ];
     platforms = with stdenv.lib.platforms; linux ++ darwin;
   };
 }

--- a/pkgs/applications/misc/cli-visualizer/default.nix
+++ b/pkgs/applications/misc/cli-visualizer/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/dpayne/cli-visualizer;
     description = "CLI based audio visualizer";
     license = stdenv.lib.licenses.mit;
-    maintainers = with stdenv.lib.maintainers; [ ];
+    maintainers = [ stdenv.lib.maintainers.matthiasbeyer ];
     platforms = with stdenv.lib.platforms; linux;
   };
 }

--- a/pkgs/applications/misc/ctodo/default.nix
+++ b/pkgs/applications/misc/ctodo/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     homepage = http://ctodo.apakoh.dk/;
     description = "A simple ncurses-based task list manager";
     license = stdenv.lib.licenses.mit;
-    maintainers = with stdenv.lib.maintainers; [ ];
+    maintainers = [ stdenv.lib.maintainers.matthiasbeyer ];
     platforms = stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/applications/misc/haxor-news/default.nix
+++ b/pkgs/applications/misc/haxor-news/default.nix
@@ -38,7 +38,7 @@ buildPythonApplication rec {
     homepage = https://github.com/donnemartin/haxor-news;
     description = "Browse Hacker News like a haxor";
     license = licenses.asl20;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ matthiasbeyer ];
   };
 
 }

--- a/pkgs/applications/misc/hr/default.nix
+++ b/pkgs/applications/misc/hr/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/LuRsT/hr;
     description = "A horizontal bar for your terminal";
     license = licenses.mit;
-    maintainers = [ ];
+    maintainers = [ maintainers.matthiasbeyer ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/applications/misc/hstr/default.nix
+++ b/pkgs/applications/misc/hstr/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/dvorka/hstr;
     description = "Shell history suggest box - easily view, navigate, search and use your command history";
     license = stdenv.lib.licenses.asl20;
-    maintainers = with stdenv.lib.maintainers; [ ];
+    maintainers = [ stdenv.lib.maintainers.matthiasbeyer ];
     platforms = with stdenv.lib.platforms; linux; # Cannot test others
   };
 

--- a/pkgs/applications/misc/khard/default.nix
+++ b/pkgs/applications/misc/khard/default.nix
@@ -50,6 +50,6 @@ in with python.pkgs; buildPythonApplication rec {
     homepage = https://github.com/scheibler/khard;
     description = "Console carddav client";
     license = stdenv.lib.licenses.gpl3;
-    maintainers = with stdenv.lib.maintainers; [ ];
+    maintainers = with stdenv.lib.maintainers; [ matthiasbeyer ];
   };
 }

--- a/pkgs/applications/misc/mdp/default.nix
+++ b/pkgs/applications/misc/mdp/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = https://github.com/visit1985/mdp;
     description = "A command-line based markdown presentation tool";
-    maintainers = with maintainers; [ vrthra ];
+    maintainers = with maintainers; [ matthiasbeyer vrthra ];
     license = licenses.gpl3;
     platforms = with platforms; unix;
   };

--- a/pkgs/applications/misc/mwic/default.nix
+++ b/pkgs/applications/misc/mwic/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     homepage = http://jwilk.net/software/mwic;
     description = "spell-checker that groups possible misspellings and shows them in their contexts";
     license = licenses.mit;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ matthiasbeyer ];
   };
 }
 

--- a/pkgs/applications/misc/rtv/default.nix
+++ b/pkgs/applications/misc/rtv/default.nix
@@ -41,6 +41,6 @@ buildPythonApplication rec {
     homepage = https://github.com/michael-lazar/rtv;
     description = "Browse Reddit from your Terminal";
     license = licenses.mit;
-    maintainers = with maintainers; [ jgeerds wedens ];
+    maintainers = with maintainers; [ matthiasbeyer jgeerds wedens ];
   };
 }

--- a/pkgs/applications/misc/sigal/default.nix
+++ b/pkgs/applications/misc/sigal/default.nix
@@ -29,6 +29,6 @@ python3Packages.buildPythonApplication rec {
     description = "Yet another simple static gallery generator";
     homepage    = http://sigal.saimon.org/en/latest/index.html;
     license     = licenses.mit;
-    maintainers = with maintainers; [ domenkozar ];
+    maintainers = with maintainers; [ domenkozar matthiasbeyer ];
   };
 }

--- a/pkgs/applications/misc/stag/default.nix
+++ b/pkgs/applications/misc/stag/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
     homepage = https://github.com/seenaburns/stag;
     description = "Terminal streaming bar graph passed through stdin";
     license = stdenv.lib.licenses.bsdOriginal;
-    maintainers = with stdenv.lib.maintainers; [ ];
+    maintainers = [ stdenv.lib.maintainers.matthiasbeyer ];
     platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/applications/misc/tasknc/default.nix
+++ b/pkgs/applications/misc/tasknc/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = https://github.com/lharding/tasknc;
     description = "A ncurses wrapper around taskwarrior";
-    maintainers = with maintainers; [ infinisil ];
+    maintainers = with maintainers; [ matthiasbeyer infinisil ];
     platforms = platforms.linux; # Cannot test others
     license = licenses.mit;
   };

--- a/pkgs/applications/misc/tasksh/default.nix
+++ b/pkgs/applications/misc/tasksh/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     description = "REPL for taskwarrior";
     homepage = http://tasktools.org;
     license = licenses.mit;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ matthiasbeyer ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/misc/timewarrior/default.nix
+++ b/pkgs/applications/misc/timewarrior/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     description = "A command-line time tracker";
     homepage = https://taskwarrior.org/docs/timewarrior;
     license = licenses.mit;
-    maintainers = with maintainers; [ mrVanDalo ];
+    maintainers = with maintainers; [ matthiasbeyer mrVanDalo ];
     platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/applications/misc/toot/default.nix
+++ b/pkgs/applications/misc/toot/default.nix
@@ -24,7 +24,7 @@ python3Packages.buildPythonApplication rec {
     description = "Mastodon CLI interface";
     homepage    = "https://github.com/ihabunek/toot";
     license     = licenses.mit;
-    maintainers = [ ];
+    maintainers = [ maintainers.matthiasbeyer ];
   };
 
 }

--- a/pkgs/applications/misc/weather/default.nix
+++ b/pkgs/applications/misc/weather/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
         homepage = http://fungi.yuggoth.org/weather;
         description = "Quick access to current weather conditions and forecasts";
         license = stdenv.lib.licenses.isc;
-        maintainers = with stdenv.lib.maintainers; [ ];
+        maintainers = [ stdenv.lib.maintainers.matthiasbeyer ];
         platforms = with stdenv.lib.platforms; linux; # my only platform
     };
 }

--- a/pkgs/applications/misc/yaft/default.nix
+++ b/pkgs/applications/misc/yaft/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/uobikiemukot/yaft;
     description = "Yet another framebuffer terminal";
     license = stdenv.lib.licenses.mit;
-    maintainers = with stdenv.lib.maintainers; [ ];
+    maintainers = [ stdenv.lib.maintainers.matthiasbeyer ];
     platforms = with stdenv.lib.platforms; linux;
   };
 }

--- a/pkgs/applications/office/beancount/bean-add.nix
+++ b/pkgs/applications/office/beancount/bean-add.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     # The (only) source file states:
     #   License: "Do what you feel is right, but don't be a jerk" public license.
 
-    maintainers = with stdenv.lib.maintainers; [ ];
+    maintainers = with stdenv.lib.maintainers; [ matthiasbeyer ];
   };
 }
 

--- a/pkgs/applications/office/fava/default.nix
+++ b/pkgs/applications/office/fava/default.nix
@@ -32,6 +32,6 @@ buildPythonApplication rec {
     homepage = https://beancount.github.io/fava;
     description = "Web interface for beancount";
     license = stdenv.lib.licenses.mit;
-    maintainers = with stdenv.lib.maintainers; [ ];
+    maintainers = with stdenv.lib.maintainers; [ matthiasbeyer ];
   };
 }

--- a/pkgs/applications/office/wordgrinder/default.nix
+++ b/pkgs/applications/office/wordgrinder/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     description = "Text-based word processor";
     homepage = https://cowlark.com/wordgrinder;
     license = licenses.mit;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ matthiasbeyer ];
     platforms = with stdenv.lib.platforms; linux ++ darwin;
   };
 }

--- a/pkgs/applications/version-management/bugseverywhere/default.nix
+++ b/pkgs/applications/version-management/bugseverywhere/default.nix
@@ -28,7 +28,7 @@ pythonPackages.buildPythonApplication rec {
         homepage = http://www.bugseverywhere.org/;
         license = licenses.gpl2Plus;
         platforms = platforms.all;
-        maintainers = [ ];
+        maintainers = [ maintainers.matthiasbeyer ];
     };
 }
 

--- a/pkgs/applications/version-management/git-and-tools/git-dit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-dit/default.nix
@@ -49,6 +49,6 @@ buildRustPackage rec {
     inherit (src.meta) homepage;
     description = "Decentralized Issue Tracking for git";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ Profpatsch ];
+    maintainers = with maintainers; [ Profpatsch matthiasbeyer ];
   };
 }

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-mailwatch-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-mailwatch-plugin.nix
@@ -21,6 +21,6 @@ stdenv.mkDerivation rec {
     homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";
     description = "Mailwatch plugin for Xfce panel";
     platforms = platforms.linux;
-    maintainers = [ ];
+    maintainers = [ maintainers.matthiasbeyer ];
   };
 }

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-mpc-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-mpc-plugin.nix
@@ -21,6 +21,6 @@ stdenv.mkDerivation rec {
     homepage = "http://goodies.xfce.org/projects/panel-plugins/${p_name}";
     description = "MPD plugin for Xfce panel";
     platforms = platforms.linux;
-    maintainers = [ ];
+    maintainers = [ maintainers.matthiasbeyer ];
   };
 }

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-timer-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-timer-plugin.nix
@@ -25,6 +25,6 @@ stdenv.mkDerivation rec {
     description = "A simple XFCE panel plugin that lets the user run an alarm at a specified time or at the end of a specified countdown period";
     platforms = platforms.linux;
     license = licenses.gpl2;
-    maintainers = [ ];
+    maintainers = [ maintainers.matthiasbeyer ];
   };
 }

--- a/pkgs/development/libraries/zlog/default.nix
+++ b/pkgs/development/libraries/zlog/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     homepage = http://hardysimpson.github.com/zlog;
     license = licenses.lgpl21;
     platforms = platforms.linux; # cannot test on something else
-    maintainers = [ ];
+    maintainers = [ maintainers.matthiasbeyer ];
   };
 
 }

--- a/pkgs/development/python-modules/pygraphviz/default.nix
+++ b/pkgs/development/python-modules/pygraphviz/default.nix
@@ -32,6 +32,6 @@ buildPythonPackage rec {
     description = "Python interface to Graphviz graph drawing package";
     homepage = https://github.com/pygraphviz/pygraphviz;
     license = licenses.bsd3;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ matthiasbeyer ];
   };
 }

--- a/pkgs/development/python-modules/requests-toolbelt/default.nix
+++ b/pkgs/development/python-modules/requests-toolbelt/default.nix
@@ -26,6 +26,6 @@ buildPythonPackage rec {
   meta = {
     description = "A toolbelt of useful classes and functions to be used with python-requests";
     homepage = http://toolbelt.rtfd.org;
-    maintainers = with lib.maintainers; [ jgeerds ];
+    maintainers = with lib.maintainers; [ matthiasbeyer jgeerds ];
   };
 }

--- a/pkgs/misc/screensavers/pipes/default.nix
+++ b/pkgs/misc/screensavers/pipes/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/pipeseroni/pipes.sh;
     description = "Animated pipes terminal screensaver";
     license = licenses.mit;
-    maintainers = [ ];
+    maintainers = [ maintainers.matthiasbeyer ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/servers/misc/taskserver/default.nix
+++ b/pkgs/servers/misc/taskserver/default.nix
@@ -38,6 +38,6 @@ stdenv.mkDerivation rec {
     homepage = https://taskwarrior.org;
     license = stdenv.lib.licenses.mit;
     platforms = stdenv.lib.platforms.linux;
-    maintainers = with stdenv.lib.maintainers; [ makefu ];
+    maintainers = with stdenv.lib.maintainers; [ matthiasbeyer makefu ];
   };
 }

--- a/pkgs/tools/misc/mpdscribble/default.nix
+++ b/pkgs/tools/misc/mpdscribble/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     description = "A Music Player Daemon (MPD) client which submits information about tracks beeing played to a scrobbler (e.g. last.fm)";
     homepage = http://mpd.wikia.com/wiki/Client:mpdscribble;
     license = licenses.gpl2;
-    maintainers = [ ];
+    maintainers = [ maintainers.matthiasbeyer ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/misc/multitail/default.nix
+++ b/pkgs/tools/misc/multitail/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = http://www.vanheusden.com/multitail/;
     description = "tail on Steroids";
-    maintainers = with stdenv.lib.maintainers; [ ];
+    maintainers = with stdenv.lib.maintainers; [ matthiasbeyer ];
     platforms = stdenv.lib.platforms.unix;
     license = stdenv.lib.licenses.gpl2Plus;
   };

--- a/pkgs/tools/misc/smenu/default.nix
+++ b/pkgs/tools/misc/smenu/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
       your selection will be sent to standard output.
     '';
     license     = licenses.gpl2;
-    maintainers = [ ];
+    maintainers = [ maintainers.matthiasbeyer ];
     platforms   = platforms.linux;
   };
 }

--- a/pkgs/tools/misc/vdirsyncer/default.nix
+++ b/pkgs/tools/misc/vdirsyncer/default.nix
@@ -71,7 +71,7 @@ python3Packages.buildPythonApplication rec {
   meta = with stdenv.lib; {
     homepage = https://github.com/pimutils/vdirsyncer;
     description = "Synchronize calendars and contacts";
-    maintainers = with maintainers; [ jgeerds ];
+    maintainers = with maintainers; [ matthiasbeyer jgeerds ];
     platforms = platforms.all;
     license = licenses.mit;
   };

--- a/pkgs/tools/misc/vimer/default.nix
+++ b/pkgs/tools/misc/vimer/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
       in an existing instance of GVim or MacVim.
     '';
     license = licenses.mit;
-    maintainers = [ ];
+    maintainers = [ maintainers.matthiasbeyer ];
     platforms = platforms.linux;
   };
 

--- a/pkgs/tools/networking/http-prompt/default.nix
+++ b/pkgs/tools/networking/http-prompt/default.nix
@@ -29,7 +29,7 @@ pythonPackages.buildPythonApplication rec {
     description = "An interactive command-line HTTP client featuring autocomplete and syntax highlighting";
     homepage = https://github.com/eliangcs/http-prompt;
     license = licenses.mit;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ matthiasbeyer ];
     platforms = platforms.linux; # can only test on linux
   };
 }


### PR DESCRIPTION
I'm baaaaack!

This patch reverts my patch where I removed myself as maintainer because
of my traveling. I'm back now and I want to maintain these packages
again.

This reverts commit ce1c1e3093b9652fb3a3cdc1472afbc8a84dee68.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

