### PR TITLE
ktouch: fix build failure due to dependecy missing

### DIFF
--- a/pkgs/applications/kde/ktouch.nix
+++ b/pkgs/applications/kde/ktouch.nix
@@ -3,7 +3,7 @@
 , kconfig, kconfigwidgets, kcoreaddons, kdeclarative, ki18n
 , kitemviews, kcmutils, kio, knewstuff, ktexteditor, kwidgetsaddons
 , kwindowsystem, kxmlgui, qtscript, qtdeclarative, kqtquickcharts
-, qtx11extras, qtgraphicaleffects, xorg
+, qtx11extras, qtgraphicaleffects, qtxmlpatterns, xorg
 }:
 
 
@@ -19,7 +19,8 @@
       kconfig kconfigwidgets kcoreaddons kdeclarative ki18n
       kitemviews kcmutils kio knewstuff ktexteditor kwidgetsaddons
       kwindowsystem kxmlgui qtscript qtdeclarative kqtquickcharts
-      qtx11extras qtgraphicaleffects xorg.libxkbfile xorg.libxcb
+      qtx11extras qtgraphicaleffects qtxmlpatterns
+      xorg.libxkbfile xorg.libxcb
     ];
 
     enableParallelBuilding = true;


### PR DESCRIPTION
fixes #56097

###### Motivation for this change

ktouch failed to build on unstable due to a missing dependency

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

