### PR TITLE
lepton: init at 1.2.1

### DIFF
--- a/pkgs/tools/graphics/lepton/default.nix
+++ b/pkgs/tools/graphics/lepton/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, cmake, git, glibc }:
+
+stdenv.mkDerivation rec {
+  version = "1.2.1";
+  name = "lepton-${version}";
+
+  src = fetchFromGitHub {
+    repo = "lepton";
+    owner = "dropbox";
+    rev = "c378cbfa2daaa99e8828be7395013f94cedb1bcc";
+    sha256 = "1f2vyp0crj4yw27bs53vykf2fqk4w57gv3lh9dp89dh3y7wwh1ba";
+  };
+
+  nativeBuildInputs = [ cmake git ];
+  buildInputs = [ glibc.static ];
+
+  meta = {
+    homepage = https://github.com/dropbox/lepton;
+    description = "A tool to losslessly compress JPEGs";
+    license = stdenv.lib.licenses.asl20;
+    platforms = with stdenv.lib.platforms; linux;
+    maintainers = with stdenv.lib.maintainers; [ artemist ];
+  };
+}

--- a/pkgs/tools/graphics/lepton/default.nix
+++ b/pkgs/tools/graphics/lepton/default.nix
@@ -14,11 +14,11 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake git ];
   buildInputs = [ glibc.static ];
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://github.com/dropbox/lepton;
     description = "A tool to losslessly compress JPEGs";
-    license = stdenv.lib.licenses.asl20;
-    platforms = with stdenv.lib.platforms; linux;
-    maintainers = with stdenv.lib.maintainers; [ artemist ];
+    license = licenses.asl20;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ artemist ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1487,6 +1487,8 @@ in
 
   languagetool = callPackage ../tools/text/languagetool {  };
 
+  lepton = callPackage ../tools/graphics/lepton { };
+
   lief = callPackage ../development/libraries/lief {};
 
   libndtypes = callPackage ../development/libraries/libndtypes { };


### PR DESCRIPTION
###### Motivation for this change
Lepton is Dropbox's JPEG compression program. It was not previously packaged.


###### Things done
Add a lepton package for Linux. Note that it requires some Linux-specific things (glibc.static) and I do not have a Mac to test the required modifications

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

