### PR TITLE
[Demo] splice.nix: poor man's implementation of Gentoo-like use-flags

### DIFF
--- a/pkgs/top-level/splice.nix
+++ b/pkgs/top-level/splice.nix
@@ -21,7 +21,7 @@
 # For performance reasons, rather than uniformally splice in all cases, we only
 # do so when `pkgs` and `buildPackages` are distinct. The `actuallySplice`
 # parameter there the boolean value of that equality check.
-lib: pkgs: actuallySplice:
+lib: config: pkgs: actuallySplice:
 
 let
 
@@ -126,9 +126,9 @@ in
   # `newScope' for sets of packages in `pkgs' (see e.g. `gnome' below).
   callPackage = pkgs.newScope {};
 
-  callPackages = lib.callPackagesWith splicedPackagesWithXorg;
+  callPackages = lib.callPackagesWith (splicedPackagesWithXorg // (config.poorMansUseFlags or {}));
 
-  newScope = extra: lib.callPackageWith (splicedPackagesWithXorg // extra);
+  newScope = extra: lib.callPackageWith (splicedPackagesWithXorg // (config.poorMansUseFlags or {}) // extra);
 
   # Haskell package sets need this because they reimplement their own
   # `newScope`.

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -86,7 +86,7 @@ let
     inherit (hostPlatform) system;
   };
 
-  splice = self: super: import ./splice.nix lib self (buildPackages != null);
+  splice = self: super: import ./splice.nix lib config self (buildPackages != null);
 
   allPackages = self: super:
     let res = import ./all-packages.nix


### PR DESCRIPTION
# What? Why?

See #56110.

# `git log`

- splice.nix: poor man's implementation of Gentoo-like use-flags

  Now, instantiate `mpv`, add

  ```
  poorMansUseFlags = {
    pulseaudioSupport = false;
  };
  ```

  (Sure, there is `pulseaudio` option already, I wanted to propose to set `x11Support`, but setting it breaks evaluation ATM...)

  Instantiate `mpv` again. Compare drvs.

# `nix-instantiate` environment

- Host OS: Linux 4.9, SLNOS 19.03
- Nix: nix-env (Nix) 2.1.3
- Multi-user: yes
- Sandbox: yes
- NIXPKGS_CONFIG:

```nix
{
  checkMeta = true;
  doCheckByDefault = true;
}
```

# `nix-env -qaP` diffs

- On x86_64-linux: noop
- On aarch64-linux: noop
- On x86_64-darwin: noop
