### PR TITLE
xsel: 2016-09-02 -> 2018-01-10

### DIFF
--- a/pkgs/tools/misc/xsel/default.nix
+++ b/pkgs/tools/misc/xsel/default.nix
@@ -3,22 +3,17 @@
 stdenv.mkDerivation rec {
   name = "xsel-unstable-${version}";
 
-  version = "2016-09-02";
+  version = "2018-01-10";
 
   src = fetchFromGitHub {
     owner = "kfish";
     repo = "xsel";
-    rev = "aa7f57eed805adb09e9c59c8ea841870e8206b81";
-    sha256 = "04mrc8j0rr7iy1k6brfxnx26pmxm800gh4nqrxn6j2lz6vd5y9m5";
+    rev = "9bfc13d64b5acb92c6648c696a9d9260fcbecc65";
+    sha256 = "05ms34by5hxznnpvmvhgp6llvlkz0zw4sq6c4bgwr82lj140lscm";
   };
 
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ libX11 ];
-
-  # We need a README file, otherwise autoconf complains.
-  postUnpack = ''
-    mv $sourceRoot/README{.md,}
-  '';
 
   meta = with lib; {
     description = "Command-line program for getting and setting the contents of the X selection";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

