### PR TITLE
beanstalkc: 0.4.0 -> 0.5.2

### DIFF
--- a/pkgs/development/python-modules/beanstalkc/default.nix
+++ b/pkgs/development/python-modules/beanstalkc/default.nix
@@ -1,13 +1,17 @@
-{ stdenv, fetchPypi, buildPythonPackage }:
+{ stdenv, fetchFromGitHub, buildPythonPackage }:
 
 buildPythonPackage rec {
   pname = "beanstalkc";
-  version = "0.4.0";
+  version = "0.5.2";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "98978e57797320146f4b233286d9a02f65d20bad0168424118839fc608085280";
+  src = fetchFromGitHub {
+    owner = "bosondata";
+    repo = "beanstalkc";
+    rev = "v${version}";
+    sha256 = "1dpb1yimp2pfnikmgsb2fr9x6h8riixlsx3xfqphnfvrid49vw5s";
   };
+
+  doCheck = false;
 
   meta = {
     description = "A simple beanstalkd client library for Python";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -268,7 +268,7 @@ in {
 
   bayespy = callPackage ../development/python-modules/bayespy { };
 
-  beanstalkc = disabledIf isPy3k (callPackage ../development/python-modules/beanstalkc {});
+  beanstalkc = callPackage ../development/python-modules/beanstalkc { };
 
   bitarray = callPackage ../development/python-modules/bitarray { };
 


### PR DESCRIPTION
###### Motivation for this change
Version bump which adds python3 support, requested by @flokli.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

