### PR TITLE
profanity: Fix build

### DIFF
--- a/pkgs/applications/networking/instant-messengers/profanity/default.nix
+++ b/pkgs/applications/networking/instant-messengers/profanity/default.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, glib, openssl
 , glibcLocales, expect, ncurses, libotr, curl, readline, libuuid
 , cmocka, libmicrohttpd, stabber, expat, libmesode
+, autoconf-archive
 
 , autoAwaySupport ? true,       libXScrnSaver ? null, libX11 ? null
 , notifySupport ? true,         libnotify ? null, gdk_pixbuf ? null
@@ -32,7 +33,9 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [ autoreconfHook glibcLocales pkgconfig ];
+  nativeBuildInputs = [
+    autoreconfHook autoconf-archive glibcLocales pkgconfig
+  ];
 
   buildInputs = [
     expect readline libuuid glib openssl expat ncurses libotr
@@ -57,12 +60,6 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   LC_ALL = "en_US.utf8";
-
-  NIX_CFLAGS_COMPILE = [ ]
-    ++ optionals pythonPluginSupport [ "-I${python}/include/${python.libPrefix}" ];
-
-  LDFLAGS = [ ]
-    ++ optionals pythonPluginSupport [ "-L${python}/lib" "-l${python.libPrefix}" ];
 
   meta = {
     description = "A console based XMPP client";


### PR DESCRIPTION
###### Motivation for this change
Profanity hasn't been able to build since [1]. This patch addresses the
issue by introducing `autoconf-archive` and removing NIX_CFLAGS_COMPILE
as well as LDFLAGS as a consequence since `autoconf-archive` is able to
handle the AX_PYTHON extension used by Profanity's upstream autoconf
file.

Thanks to @aszlig for helping with this.

[1]: https://github.com/NixOS/nixpkgs/commit/efbe87f3ef769aac5e95512609b4759a43109307

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

