### PR TITLE
bazel-watcher: 0.9.0 -> 0.9.1

### DIFF
--- a/pkgs/development/tools/bazel-watcher/default.nix
+++ b/pkgs/development/tools/bazel-watcher/default.nix
@@ -10,13 +10,13 @@
 
 buildBazelPackage rec {
   name = "bazel-watcher-${version}";
-  version = "0.9.0";
+  version = "0.9.1";
 
   src = fetchFromGitHub {
     owner = "bazelbuild";
     repo = "bazel-watcher";
     rev = "v${version}";
-    sha256 = "0yphks1qlp3xcbq5mg95lxrhl3q8pza5g3f9i2j6y7dsfz0s0l4v";
+    sha256 = "1gjbv67ydyb0mafpp59qr9n8f8vva2mwhgan6lxxl0i9yfx7qc6p";
   };
 
   nativeBuildInputs = [ go git python ];
@@ -49,7 +49,7 @@ buildBazelPackage rec {
       sed -e '/^FILE:@bazel_gazelle_go_repository_tools.*/d' -i $bazelOut/external/\@*.marker
     '';
 
-    sha256 = "14k1cpw4h78c2gk294xzq9a9nv09yabdrahbzgin8xizbgdxn1q8";
+    sha256 = "0p6yarz4wlb6h33n4slkczkdkaa93zc9jx55h8wl9vv81ahp0md5";
   };
 
   buildAttrs = {


### PR DESCRIPTION
###### Motivation for this change

Bazel watcher 0.9.1 was released 3 days ago. See changelog [here](https://github.com/bazelbuild/bazel-watcher/blob/master/CHANGELOG.md#v091-2019-02-17).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

