### PR TITLE
[18.09] elasticsearch: Add zlib to buildInputs for unfree

### DIFF
--- a/pkgs/servers/search/elasticsearch/default.nix
+++ b/pkgs/servers/search/elasticsearch/default.nix
@@ -35,7 +35,8 @@ stdenv.mkDerivation (rec {
       "ES_CLASSPATH=\"\$ES_CLASSPATH:$out/\$additional_classpath_directory/\*\""
   '';
 
-  buildInputs = [ makeWrapper jre_headless utillinux ];
+  buildInputs = [ makeWrapper jre_headless utillinux ]
+             ++ optional enableUnfree zlib;
 
   installPhase = ''
     mkdir -p $out


### PR DESCRIPTION
###### Motivation for this change

Elasticsearch fails to build: #56055

On master, `autopatchElf` was improved (#47222) but with minor incompatibilities which were fixed on master. However autopatchElf was backported (#55538) without one of the fixes. This is the simple `git cherry-pick -x` backport.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

