### PR TITLE
ipad_charge: enable installation udev rules

### DIFF
--- a/pkgs/tools/misc/ipad_charge/default.nix
+++ b/pkgs/tools/misc/ipad_charge/default.nix
@@ -16,14 +16,16 @@ stdenv.mkDerivation rec {
   postPatch = ''
     substituteInPlace Makefile \
       --replace " -o root -g root" "" \
+      --replace "/usr" "$out" \
+      --replace "/etc/udev" "$out/lib/udev"
+    substituteInPlace *.rules \
       --replace "/usr" "$out"
-    sed "/rules\.d/d" -i Makefile
   '';
 
   enableParallelBuilding = true;
 
   preInstall = ''
-    mkdir -p $out/bin
+    mkdir -p $out/{bin,lib/udev/rules.d}
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Note that you need to add this package to your
`services.udev.packages` list rather than your
`environment.systemPackages` for the udev rules to take effect.

It might be worthwhile giving this its own configuration option, which
could be documented in `man configuration.nix`.

###### Motivation for this change

The current package ignores the udev rules, but they are very useful for getting your iPads to charge automatically when connected via USB.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

