### PR TITLE
wmfs: init at 201902

### DIFF
--- a/pkgs/applications/window-managers/wmfs/default.nix
+++ b/pkgs/applications/window-managers/wmfs/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchFromGitHub, gnumake,
+  libX11, libXinerama, libXrandr, libXpm, libXft, imlib2 }:
+stdenv.mkDerivation rec {
+  name = "wmfs-${version}";
+
+  version = "201902";
+
+  src = fetchFromGitHub {
+    owner = "xorg62";
+    repo = "wmfs";
+    sha256 = "sha256:1m7dsmmlhq2qipim659cp9aqlriz1cwrrgspl8baa5pncln0gd5c";
+    rev = "b7b8ff812d28c79cb22a73db2739989996fdc6c2";
+  };
+
+  nativeBuildInputs = [
+    gnumake
+  ];
+
+  buildInputs = [
+    imlib2
+    libX11
+    libXinerama
+    libXrandr
+    libXpm
+    libXft
+  ];
+
+  preConfigure = "substituteInPlace configure --replace '-lxft' '-lXft'";
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+    "XDG_CONFIG_DIR=${placeholder "out"}/etc/xdg"
+    "MANPREFIX=${placeholder "out"}/share/man"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Window manager from scratch";
+    license = licenses.bsd2;
+    maintainers = [ maintainers.balsoft ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17800,6 +17800,8 @@ in
 
   wmfocus = callPackage ../applications/window-managers/i3/wmfocus.nix { };
 
+  wmfs = callPackage ../applications/window-managers/wmfs/default.nix { };
+
   i810switch = callPackage ../os-specific/linux/i810switch { };
 
   icewm = callPackage ../applications/window-managers/icewm {};


### PR DESCRIPTION
###### Motivation for this change

This adds wmfs, Window Manager From Scratch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

