### PR TITLE
python3Packages.imageio: 2.4.1 -> 2.5.0

### DIFF
--- a/pkgs/development/python-modules/imageio-ffmpeg/default.nix
+++ b/pkgs/development/python-modules/imageio-ffmpeg/default.nix
@@ -1,0 +1,26 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, isPy3k
+}:
+
+buildPythonPackage rec {
+  pname = "imageio-ffmpeg";
+  version = "0.2.0";
+
+  src = fetchPypi {
+    sha256 = "191k77hd69lfmd8p4w02c2ajjdsall6zijn01gyhqi11n48wpsib";
+    inherit pname version;
+  };
+
+  # No test infrastructure in repository.
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "FFMPEG wrapper for Python";
+    homepage = https://github.com/imageio/imageio-ffmpeg;
+    license = licenses.bsd2;
+    maintainers = [ maintainers.pmiddend ];
+  };
+
+}

--- a/pkgs/development/python-modules/imageio-ffmpeg/default.nix
+++ b/pkgs/development/python-modules/imageio-ffmpeg/default.nix
@@ -1,4 +1,4 @@
-{ stdenv
+{ lib
 , buildPythonPackage
 , fetchPypi
 , isPy3k
@@ -13,10 +13,12 @@ buildPythonPackage rec {
     inherit pname version;
   };
 
+  disabled = !isPy3k;
+
   # No test infrastructure in repository.
   doCheck = false;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "FFMPEG wrapper for Python";
     homepage = https://github.com/imageio/imageio-ffmpeg;
     license = licenses.bsd2;

--- a/pkgs/development/python-modules/imageio/default.nix
+++ b/pkgs/development/python-modules/imageio/default.nix
@@ -1,28 +1,34 @@
 { stdenv
 , buildPythonPackage
+, pathlib
 , fetchPypi
 , pillow
 , psutil
+, imageio-ffmpeg
 , pytest
 , numpy
 , isPy3k
+, ffmpeg
 , futures
 , enum34
 }:
 
 buildPythonPackage rec {
   pname = "imageio";
-  version = "2.4.1";
+  version = "2.5.0";
 
   src = fetchPypi {
-    sha256 = "0jjiwf6wjipmykh33prjh448qv8mpgngfi77ndc7mym5r1xhgf0n";
+    sha256 = "1bdcrr5190jvk0msw2lswj4pbdhrcggjpj8m6q2a2mrxzjnmmrj2";
     inherit pname version;
   };
 
-  checkInputs = [ pytest psutil ];
+  checkInputs = [ pytest psutil ] ++ stdenv.lib.optionals isPy3k [
+    imageio-ffmpeg ffmpeg
+    ];
   propagatedBuildInputs = [ numpy pillow ] ++ stdenv.lib.optionals (!isPy3k) [
     futures
     enum34
+    pathlib
   ];
 
   checkPhase = ''
@@ -34,8 +40,12 @@ buildPythonPackage rec {
 
   # For some reason, importing imageio also imports xml on Nix, see
   # https://github.com/imageio/imageio/issues/395
+
+  # Also, there are tests that test the downloading of ffmpeg if it's not installed.
+  # "Uncomment" those by renaming.
   postPatch = ''
-    substituteInPlace tests/test_meta.py --replace '"urllib",' "\"urllib\",\"xml\""
+    substituteInPlace tests/test_meta.py --replace '"urllib",' "\"urllib\",\"xml\","
+    substituteInPlace tests/test_ffmpeg.py --replace 'test_get_exe_installed' 'get_exe_installed'
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2794,6 +2794,8 @@ in {
 
   imageio = callPackage ../development/python-modules/imageio { };
 
+  imageio-ffmpeg = disabledIf isPy27 (callPackage ../development/python-modules/imageio-ffmpeg { });
+
   imgaug = callPackage ../development/python-modules/imgaug { };
 
   inflection = callPackage ../development/python-modules/inflection { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2794,7 +2794,7 @@ in {
 
   imageio = callPackage ../development/python-modules/imageio { };
 
-  imageio-ffmpeg = disabledIf isPy27 (callPackage ../development/python-modules/imageio-ffmpeg { });
+  imageio-ffmpeg = callPackage ../development/python-modules/imageio-ffmpeg { };
 
   imgaug = callPackage ../development/python-modules/imgaug { };
 


### PR DESCRIPTION
###### Motivation for this change

imageio now optionally needs imageio-ffmpeg, which I also put into this PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

