### PR TITLE
digikam: fix media playback by adding ffmpeg to buildInputs

### DIFF
--- a/pkgs/applications/graphics/digikam/default.nix
+++ b/pkgs/applications/graphics/digikam/default.nix
@@ -23,6 +23,7 @@
 , boost
 , eigen
 , exiv2
+, ffmpeg
 , flex
 , jasper
 , lcms2
@@ -66,6 +67,7 @@ mkDerivation rec {
     boost
     eigen
     exiv2
+    ffmpeg
     flex
     jasper
     lcms2


### PR DESCRIPTION
###### Motivation for this change

Since Digikam 6.0.0, media playback requires `ffmpeg` as a direct dependency.

This shouldn't really change the closure size, as another of Digikam's dependencies, `libqtav`, already depends on `ffmpeg`.

The difference is evident during the `cmakeConfigurePhase`:

```patch
--- before.txt	2019-02-21 10:10:24.312731211 +0000
+++ after.txt	2019-02-21 10:01:43.642602245 +0000
@@ -1,13 +1,13 @@
--- Could NOT find FFmpeg (missing: FFMPEG_LIBRARIES FFMPEG_INCLUDE_DIRS AVCODEC_LIBRARIES AVCODEC_INCLUDE_DIRS AVFILTER_LIBRARIES AVFILTER_INCLUDE_DIRS AVFORMAT_LIBRARIES AVFORMAT_INCLUDE_DIRS AVUTIL_LIBRARIES AVUTIL_INCLUDE_DIRS SWSCALE_LIBRARIES SWSCALE_INCLUDE_DIRS) 
--- FFMPEG_FOUND        = FALSE
--- FFMPEG_INCLUDE_DIRS = 
--- FFMPEG_LIBRARIES    = 
--- FFMPEG_DEFINITIONS  = 
+-- Found FFmpeg: /nix/store/naf33s4w5kpxv060vmjv6cz5jvcqnxrb-ffmpeg-3.4.5/lib/libavcodec.so;/nix/store/naf33s4w5kpxv060vmjv6cz5jvcqnxrb-ffmpeg-3.4.5/lib/libavfilter.so;/nix/store/naf33s4w5kpxv060vmjv6cz5jvcqnxrb-ffmpeg-3.4.5/lib/libavformat.so;/nix/store/naf33s4w5kpxv060vmjv6cz5jvcqnxrb-ffmpeg-3.4.5/lib/libavutil.so;/nix/store/naf33s4w5kpxv060vmjv6cz5jvcqnxrb-ffmpeg-3.4.5/lib/libswscale.so
+-- FFMPEG_FOUND        = TRUE
+-- FFMPEG_INCLUDE_DIRS = /nix/store/bsgkvbqniycnf94xv8dmlszazqrlas7n-ffmpeg-3.4.5-dev/include
+-- FFMPEG_LIBRARIES    = /nix/store/naf33s4w5kpxv060vmjv6cz5jvcqnxrb-ffmpeg-3.4.5/lib/libavcodec.so;/nix/store/naf33s4w5kpxv060vmjv6cz5jvcqnxrb-ffmpeg-3.4.5/lib/libavfilter.so;/nix/store/naf33s4w5kpxv060vmjv6cz5jvcqnxrb-ffmpeg-3.4.5/lib/libavformat.so;/nix/store/naf33s4w5kpxv060vmjv6cz5jvcqnxrb-ffmpeg-3.4.5/lib/libavutil.so;/nix/store/naf33s4w5kpxv060vmjv6cz5jvcqnxrb-ffmpeg-3.4.5/lib/libswscale.so
+-- FFMPEG_DEFINITIONS  =
 -- QtAV search path: /nix/store/yjj7f7lypknwzbxvkvjkf8aa0av6ss0d-qtbase-5.12.0-dev/lib/cmake
 -- Found QtAV: /nix/store/ncxf8s0jlqmh1cvlp9day3byh45mxqb3-libqtav-1.12.0/lib/libQtAV.so;/nix/store/ncxf8s0jlqmh1cvlp9day3byh45mxqb3-libqtav-1.12.0/lib/libQtAVWidgets.so
 -- Found QtAV version 1.12.0
 -- QtAV_FOUND       = TRUE
 -- QtAV_INCLUDE_DIR = /nix/store/ncxf8s0jlqmh1cvlp9day3byh45mxqb3-libqtav-1.12.0/include/QtAV /nix/store/ncxf8s0jlqmh1cvlp9day3byh45mxqb3-libqtav-1.12.0/include/QtAVWidgets
 -- QtAV_LIBRARIES   = /nix/store/ncxf8s0jlqmh1cvlp9day3byh45mxqb3-libqtav-1.12.0/lib/libQtAV.so;/nix/store/ncxf8s0jlqmh1cvlp9day3byh45mxqb3-libqtav-1.12.0/lib/libQtAVWidgets.so
 -- QtAV_VERSION     = 1.12.0
--- ENABLE_MEDIAPLAYER option is enabled but FFMpeg cannot be found. Media player support is disabled.
+-- Media player support is enabled.
```

...and during program execution, in the Help → Components Information menu:

![digikam-ffmpeg](https://user-images.githubusercontent.com/24193/53161612-37f15080-35c2-11e9-8a74-8ea28799c332.png)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).