### PR TITLE
linux: Enable support for Self-Encrypting Drives

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -592,6 +592,8 @@ let
 
       BLK_DEV_INTEGRITY       = yes;
 
+      BLK_SED_OPAL = whenAtLeast "4.14" yes;
+
       BSD_PROCESS_ACCT_V3 = yes;
 
       BT_HCIUART_BCSP = option yes;


### PR DESCRIPTION
###### Motivation for this change

To quote `block/Kconfig`:

> Builds Logic for interfacing with Opal enabled controllers.
> Enabling this option enables users to setup/unlock/lock
> Locking ranges for SED devices using the Opal protocol.

Without `BLK_SED_OPAL`, it is impossible to resume from sleep when using a locked self-encrypting drive.

This configuration option appeared in earlier kernels, but only reached maturity in 4.14 according to discussion at:

- https://github.com/Drive-Trust-Alliance/sedutil/issues/90 and
- https://github.com/Drive-Trust-Alliance/sedutil/pull/190

This kernel option is enabled in the default kernels shipped with Fedora, Debian, and other mainstream Linux distributions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

