### PR TITLE
morph: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/tools/package-management/morph/default.nix
+++ b/pkgs/tools/package-management/morph/default.nix
@@ -2,19 +2,25 @@
 
 buildGoPackage rec {
   name = "morph-${version}";
-  version = "1.1.0";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "dbcdk";
     repo = "morph";
     rev = "v${version}";
-    sha256 = "0pixm48is9if9d2b4qc5mwwa4lzma6snkib6z2a1d4pmdx1lmpmm";
+    sha256 = "0jhypvj45yjg4cn4rvb2j9091pl6z5j541vcfaln5sb3ds14fkwf";
   };
 
   goPackagePath = "github.com/dbcdk/morph";
   goDeps = ./deps.nix;
 
   buildInputs = [ go-bindata ];
+
+  buildFlagsArray = ''
+    -ldflags=
+    -X
+    main.version=${version}
+  '';
 
   prePatch = ''
     go-bindata -pkg assets -o assets/assets.go data/


### PR DESCRIPTION
###### Motivation for this change

A new release of morph has been cut. Should be fully backwards compatible.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

