### PR TITLE
protonmail-bridge: 1.1.0-1 -> 1.1.1-1

### DIFF
--- a/pkgs/applications/networking/protonmail-bridge/default.nix
+++ b/pkgs/applications/networking/protonmail-bridge/default.nix
@@ -2,7 +2,7 @@
   libsecret, libGL, libpulseaudio, glib, makeWrapper, makeDesktopItem }:
 
 let
-  version = "1.1.0-1";
+  version = "1.1.1-1";
 
   description = ''
     An application that runs on your computer in the background and seamlessly encrypts
@@ -12,9 +12,9 @@ let
   '';
 
   desktopItem = makeDesktopItem {
-    name = "Desktop-Bridge";
-    exec = "Desktop-Bridge";
-    icon = "desktop-bridge";
+    name = "protonmail-bridge";
+    exec = "protonmail-bridge";
+    icon = "protonmail-bridge";
     comment = stdenv.lib.replaceStrings ["\n"] [" "] description;
     desktopName = "ProtonMail Bridge";
     genericName = "ProtonMail Bridge for Linux";
@@ -25,7 +25,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://protonmail.com/download/protonmail-bridge_${version}_amd64.deb";
-    sha256 = "0l29z208krnd3dginc203m4p5dlmnxf08vpmbm9xzlckwmswizkb";
+    sha256 = "148syyz92yqxp2fw18fhflhmdrakxz7cc30va7h0pwysz97gni2p";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -40,11 +40,11 @@ in stdenv.mkDerivation rec {
     mkdir -p $out/{bin,lib,share/applications}
     mkdir -p $out/share/{applications,icons/hicolor/scalable/apps}
 
-    cp -r usr/lib/protonmail/bridge/Desktop-Bridge{,.sh} $out/lib
-    cp usr/share/icons/protonmail/Desktop-Bridge.svg $out/share/icons/hicolor/scalable/apps/desktop-bridge.svg
+    cp -r usr/lib/protonmail/bridge/protonmail-bridge{,.sh} $out/lib
+    cp usr/share/icons/protonmail/ProtonMail_Bridge.svg $out/share/icons/hicolor/scalable/apps/protonmail-bridge.svg
     cp ${desktopItem}/share/applications/* $out/share/applications
 
-    ln -s $out/lib/Desktop-Bridge $out/bin/Desktop-Bridge
+    ln -s $out/lib/protonmail-bridge $out/bin/protonmail-bridge
   '';
 
   postFixup = let
@@ -66,9 +66,9 @@ in stdenv.mkDerivation rec {
     patchelf \
       --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
       --set-rpath "${rpath}" \
-      $out/lib/Desktop-Bridge
+      $out/lib/protonmail-bridge
 
-    wrapProgram $out/lib/Desktop-Bridge \
+    wrapProgram $out/lib/protonmail-bridge \
       --set QT_PLUGIN_PATH "${qtPath qtbase.qtPluginPrefix}" \
       --set QML_IMPORT_PATH "${qtPath qtbase.qtQmlPrefix}" \
       --set QML2_IMPORT_PATH "${qtPath qtbase.qtQmlPrefix}" \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18880,7 +18880,7 @@ in
     python = python3;
   } // (config.profanity or {}));
 
-  protonmail-bridge = libsForQt5.callPackage ../applications/networking/protonmail-bridge { };
+  protonmail-bridge = libsForQt511.callPackage ../applications/networking/protonmail-bridge { };
 
   psi = callPackage ../applications/networking/instant-messengers/psi { };
 


### PR DESCRIPTION
###### Motivation for this change
- Update to newest version
- previous version segfaulted since it was not pinned to qt 5.11. no it runs again

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

