### PR TITLE
dockerTools: mark store-path-to-layer.sh as executable

### DIFF
--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -283,6 +283,7 @@ rec {
     let
       storePathToLayer = substituteAll
       { inherit (stdenv) shell;
+        isExecutable = true;
         src = ./store-path-to-layer.sh;
       };
     in


### PR DESCRIPTION
bcf54ce5bbc8c325cfd2b6bcc5cec7661ef49183 introduced a treewide change to use ${stdenv.shell} where-ever possible. However, this broke a script used by dockerTools, store-path-to-layer.sh, as it did not preserve the +x mode bit. This meant the file got put into the store as mode 0444, resulting in a build-time error later on that looked like:

    xargs: /nix/store/jixivxhh3c8sncp9xlkc4ls3y5f2mmxh-store-path-to-layer.sh: Permission denied

However, in a twist of fate, bcf54ce5bbc8c325cfd2b6bcc5cec7661ef49183 not only introduced this regression but, in this particular instance, didn't even fix the original bug: the store-path-to-layer.sh script *still* uses /bin/sh as its shebang line, rather than an absolute path to stdenv. (Fixing this can be done in a separate commit.)

/cc @rnhmjoj 

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

