### PR TITLE
init automirror at v49

### DIFF
--- a/pkgs/tools/misc/automirror/default.nix
+++ b/pkgs/tools/misc/automirror/default.nix
@@ -1,0 +1,27 @@
+{stdenv, fetchFromGitHub, git, ronn}:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "automirror";
+  version = "49";
+
+  src = fetchFromGitHub {
+    owner = "schlomo";
+    repo = "automirror";
+    rev = "v${version}";
+    sha256 = "1syyf7dcm8fbyw31cpgmacg80h7pg036dayaaf0svvdsk0hqlsch";
+  };
+
+  patchPhase = "sed -i s#/usr##g Makefile";
+
+  buildInputs = [ git ronn ];
+
+  installFlags = "DESTDIR=$(out)";
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/schlomo/automirror;
+    description = "Automatic Display Mirror";
+    license = licenses.gpl3;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -638,6 +638,8 @@ in
 
   autorevision = callPackage ../tools/misc/autorevision { };
 
+  automirror = callPackage ../tools/misc/automirror { };
+
   bcachefs-tools = callPackage ../tools/filesystems/bcachefs-tools { };
 
   bitwarden-cli = callPackage ../tools/security/bitwarden-cli { };


### PR DESCRIPTION
###### Motivation for this change
- Make automirror available in nixos

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ x Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

