### PR TITLE
ocamlPackages.mlgmpidl: 1.2.7 -> 1.2.8

### DIFF
--- a/pkgs/development/ocaml-modules/mlgmpidl/default.nix
+++ b/pkgs/development/ocaml-modules/mlgmpidl/default.nix
@@ -2,25 +2,23 @@
 
 stdenv.mkDerivation rec {
   name = "ocaml${ocaml.version}-mlgmpidl-${version}";
-  version = "1.2.7";
+  version = "1.2.8";
   src = fetchFromGitHub {
     owner = "nberth";
     repo = "mlgmpidl";
     rev = version;
-    sha256 = "063hy1divbiabqm5x307iamw942sivzw9fr8vczy3kgndfp12nic";
+    sha256 = "1csqplyxi5gq6ma7g4la2x20mhz1plmjallsankv0mn0x69zb1id";
   };
 
   buildInputs = [ perl gmp mpfr ocaml findlib camlidl ];
 
-  configurePhase = ''
-    echo CAML_PREFIX = ${ocaml} > Makefile.config
-    cat Makefile.config.model >> Makefile.config
-    sed -i Makefile.config \
-      -e 's|^MLGMPIDL_PREFIX.*$|MLGMPIDL_PREFIX = $out|' \
-      -e 's|^GMP_PREFIX.*$|GMP_PREFIX = ${gmp.dev}|' \
-      -e 's|^MPFR_PREFIX.*$|MPFR_PREFIX = ${mpfr.dev}|' \
-      -e 's|^CAMLIDL_DIR.*$|CAMLIDL_DIR = ${camlidl}/lib/ocaml/${ocaml.version}/site-lib/camlidl|'
-    echo HAS_NATIVE_PLUGINS = 1 >> Makefile.config
+  prefixKey = "-prefix ";
+  configureFlags = [
+    "--gmp-prefix ${gmp.dev}"
+    "--mpfr-prefix ${mpfr.dev}"
+  ];
+
+  postConfigure = ''
     sed -i Makefile \
       -e 's|^	/bin/rm |	rm |'
   '';


### PR DESCRIPTION
This version builds even if profiling is not available (e.g., on Aarch).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

