### PR TITLE
charles: split into versions (major releases)

### DIFF
--- a/pkgs/applications/networking/charles/default.nix
+++ b/pkgs/applications/networking/charles/default.nix
@@ -1,48 +1,68 @@
-{ stdenv, fetchurl, makeDesktopItem, jre, makeWrapper }:
+{
+stdenv
+, makeWrapper
+, makeDesktopItem
+, fetchurl
+, jre
+}:
 
 let
-  desktopItem = makeDesktopItem {
-    categories = "Network;Development;WebDevelopment;Java;";
-    desktopName = "Charles";
-    exec = "charles %F";
-    genericName  = "Web Debugging Proxy";
-    icon = "charles-proxy";
-    mimeType = "application/x-charles-savedsession;application/x-charles-savedsession+xml;application/x-charles-savedsession+json;application/har+json;application/vnd.tcpdump.pcap;application/x-charles-trace";
-    name = "Charles";
-    startupNotify = "true";
-  };
+  generic = { version, sha256, ... }@attrs:
+  let
+    desktopItem = makeDesktopItem {
+      categories = "Network;Development;WebDevelopment;Java;";
+      desktopName = "Charles";
+      exec = "charles %F";
+      genericName  = "Web Debugging Proxy";
+      icon = "charles-proxy";
+      mimeType = "application/x-charles-savedsession;application/x-charles-savedsession+xml;application/x-charles-savedsession+json;application/har+json;application/vnd.tcpdump.pcap;application/x-charles-trace";
+      name = "Charles";
+      startupNotify = "true";
+    };
 
-in stdenv.mkDerivation rec {
-  name = "charles-${version}";
-  version = "4.2.7";
+    attrs' = builtins.removeAttrs attrs ["version" "sha256"];
+    in stdenv.mkDerivation rec {
+      name = "charles-${version}";
+      inherit version;
 
-  src = fetchurl {
-    url = "https://www.charlesproxy.com/assets/release/${version}/charles-proxy-${version}.tar.gz";
+      src = fetchurl {
+        url = "https://www.charlesproxy.com/assets/release/${version}/charles-proxy-${version}.tar.gz";
+        inherit sha256;
+      };
+      buildInputs = [ makeWrapper ];
+
+      installPhase = ''
+        makeWrapper ${jre}/bin/java $out/bin/charles \
+          --add-flags "-Xmx1024M -Dcharles.config='~/.charles.config' -jar $out/share/java/charles.jar"
+
+        for fn in lib/*.jar; do
+          install -D -m644 $fn $out/share/java/$(basename $fn)
+        done
+
+        mkdir -p $out/share/applications
+        ln -s ${desktopItem}/share/applications/* $out/share/applications/
+
+        mkdir -p $out/share/icons
+        cp -r icon $out/share/icons/hicolor
+      '';
+
+      meta = with stdenv.lib; {
+        description = "Web Debugging Proxy";
+        homepage = https://www.charlesproxy.com/;
+        maintainers = [ maintainers.kalbasit ];
+        license = stdenv.lib.licenses.unfree;
+        platforms = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;
+      };
+    };
+
+in rec {
+  charles4 = (generic {
+    version = "4.2.7";
     sha256 = "1nycw3wpbfwj4ijjaq5k0f4xipj8j605fs0yjzgl66gmv7r583rd";
-  };
-
-  buildInputs = [ makeWrapper ];
-
-  installPhase = ''
-    makeWrapper ${jre}/bin/java $out/bin/charles \
-      --add-flags "-Xmx1024M -Dcharles.config='~/.charles.config' -jar $out/share/java/charles.jar"
-
-    for fn in lib/*.jar; do
-      install -D -m644 $fn $out/share/java/$(basename $fn)
-    done
-
-    mkdir -p $out/share/applications
-    ln -s ${desktopItem}/share/applications/* $out/share/applications/
-
-    mkdir -p $out/share/icons
-    cp -r icon $out/share/icons/hicolor
-  '';
-
-  meta = with stdenv.lib; {
-    description = "Web Debugging Proxy";
-    homepage = https://www.charlesproxy.com/;
-    maintainers = [ maintainers.kalbasit ];
-    license = stdenv.lib.licenses.unfree;
-    platforms = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;
-  };
+  });
+  charles3 = (generic {
+    version = "3.12.3";
+    sha256 = "13zk82ny1w5zd9qcs9qkq0kdb22ni5byzajyshpxdfm4zv6p32ss";
+  });
 }
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -943,7 +943,11 @@ in
 
   bluemix-cli = callPackage ../tools/admin/bluemix-cli { };
 
-  charles = callPackage ../applications/networking/charles { };
+  charles = charles4;
+  inherit (callPackage ../applications/networking/charles {})
+    charles3
+    charles4
+  ;
 
   libqmatrixclient = libsForQt5.callPackage ../development/libraries/libqmatrixclient { };
 


### PR DESCRIPTION
###### Motivation for this change
Charles proxy requires a license and each license it bound to the major release version.
Therefor it makes sense to make the previous version available to the users.

###### Things done
I have created the following two files
```
charles-4.x.nix
charles-3.x.nix
```
Which are the most recent of these major versions.
Then there are the 3 following packages, to be able to pin/install them
```
charles -> charles-4.x.nix
charles4 -> charles-4.x.nix
charles3 ->charles-3.x.nix
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

