### PR TITLE
tcptrace: init at 6.6.7

### DIFF
--- a/pkgs/tools/networking/tcptrace/default.nix
+++ b/pkgs/tools/networking/tcptrace/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchurl, libpcap }:
+let
+  name        = "tcptrace";
+  origVersion = "6.6.7";
+  patch       = "5";
+
+  version      = "${origVersion}-${patch}";
+  srcTarball   = "${name}-${origVersion}.tar.gz";
+  patchTarball = "${name}_${version}.debian.tar.xz";
+  patchPath    = "${builtins.substring 0 1 name}/${name}/${patchTarball}";
+
+  debianPatches = fetchurl {
+    name   = "tcptrace-debian-patches.tar.xz";
+    url    = "mirror://debian/pool/main/${patchPath}";
+    sha256 = "0cx20064rw9v9jsh0fc91xy4sq8nzdn0wpp7fmg5d73fp544diyz";
+  };
+
+  origSrc = fetchurl {
+    url    = "http://www.tcptrace.org/download/${srcTarball}";
+    sha256 = "1g8hd6sqwf1f41am5m30kyy0i4wmdzy9ssj7g64s0g4ka500lf33";
+  };
+in stdenv.mkDerivation {
+  inherit name version;
+
+  srcs       = [ origSrc debianPatches ];
+  sourceRoot = "${name}-${origVersion}";
+  outputs    = [ "out" "man" ];
+
+  setOutputFlags = false;
+
+  patches  = [ ./fix-owners.patch ];
+  prePatch = ''
+    patches_deb=(../debian/patches/bug*)
+    patches+=" ''${patches_deb[*]}"
+  '';
+
+  buildInputs = [ libpcap ];
+  makeFlags   = [
+    "BINDIR=${placeholder "out"}/bin"
+    "MANDIR=${placeholder "man"}/share/man"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "a tool for analysis of TCP dump files";
+    license     = licenses.gpl2Plus;
+    maintainers = with maintainers; [ twey ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/tools/networking/tcptrace/fix-owners.patch
+++ b/pkgs/tools/networking/tcptrace/fix-owners.patch
@@ -1,0 +1,16 @@
+Index: tcptrace-6.6.1/Makefile.in
+===================================================================
+--- tcptrace-6.6.1.orig/Makefile.in
+--- tcptrace-6.6.1/Makefile.in
+@@ -286,9 +286,9 @@
+ # just a quick installation rule
+ INSTALL = ./install-sh -c
+ install: tcptrace install-man
+-	$(INSTALL) -m 755 -o bin -g bin tcptrace ${BINDIR}/tcptrace
++	$(INSTALL) -m 755 tcptrace ${BINDIR}/tcptrace
+ install-man: 
+-	$(INSTALL) -m 444 -o bin -g bin tcptrace.man $(MANDIR)/man1/tcptrace.1
++	$(INSTALL) -m 444 tcptrace.man $(MANDIR)/man1/tcptrace.1
+ 
+ 
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5704,6 +5704,8 @@ in
 
   tcpreplay = callPackage ../tools/networking/tcpreplay { };
 
+  tcptrace = callPackage ../tools/networking/tcptrace { };
+
   ted = callPackage ../tools/typesetting/ted { };
 
   teamviewer = libsForQt56.callPackage ../applications/networking/remote/teamviewer { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

