### PR TITLE
csound-manual: init at 6.12.0

### DIFF
--- a/pkgs/applications/audio/csound/csound-manual/default.nix
+++ b/pkgs/applications/audio/csound/csound-manual/default.nix
@@ -1,0 +1,44 @@
+{ 
+  stdenv, fetchurl, docbook_xsl,
+  docbook_xml_dtd_45, python, pygments, 
+  libxslt 
+}:
+
+stdenv.mkDerivation rec {
+  version = "6.12.0";
+  name = "csound-manual-${version}";
+  
+  src = fetchurl {
+    url = "https://github.com/csound/manual/archive/${version}.tar.gz";
+    sha256 = "1v1scp468rnfbcajnp020kdj8zigimc2mbcwzxxqi8sf8paccdrp";
+  };
+
+
+  prePatch = ''
+    substituteInPlace manual.xml \
+      --replace "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" \
+                "${docbook_xml_dtd_45}/xml/dtd/docbook/docbookx.dtd"
+  '';
+
+  nativeBuildInputs = [ libxslt.bin ];
+
+  buildInputs = [ docbook_xsl python pygments ];
+
+  buildPhase = ''
+    make XSL_BASE_PATH=${docbook_xsl}/share/xml/docbook-xsl html-dist
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/doc/csound
+    cp -r ./html $out/share/doc/csound
+  '';
+
+  meta = {
+    description = "The Csound Canonical Reference Manual";
+    homepage = "https://github.com/csound/manual";
+    license = stdenv.lib.licenses.fdl12Plus;
+    maintainers = [ stdenv.lib.maintainers.hlolli ];
+    platforms = stdenv.lib.platforms.all;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16436,6 +16436,11 @@ in
     fluidsynth = fluidsynth_1;
   };
 
+  csound-manual = callPackage ../applications/audio/csound/csound-manual {
+    python = python27;
+    pygments = python27Packages.pygments;
+  };
+
   csound-qt = callPackage ../applications/audio/csound/csound-qt {
     python = python27;
     qmake = qt59.qmake;


### PR DESCRIPTION
###### Motivation for this change

These generated html files can be used in conjunction with CsoundQt.

###### Things done

- [ x ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

