### PR TITLE
gnome3.geary: 0.12.4 -> 0.13.1

### DIFF
--- a/pkgs/desktops/gnome-3/misc/geary/default.nix
+++ b/pkgs/desktops/gnome-3/misc/geary/default.nix
@@ -20,6 +20,12 @@ stdenv.mkDerivation rec {
       url = https://gitlab.gnome.org/GNOME/geary/commit/d2f1b1076aa942d140e83fdf03b66621c11229f5.patch;
       sha256 = "1dsj4ybnibpi572w9hafm0w90jbjv7wzdl6j8d4c2qg5h7knlvfk";
     })
+    # Fixes tests on Aarch64
+    # https://gitlab.gnome.org/GNOME/geary/issues/259
+    (fetchpatch {
+      url = https://gitlab.gnome.org/GNOME/geary/commit/9c3fdbfb5c792daeb9c3924f798fa83a15096d8a.patch;
+      sha256 = "1ihjxnaj0g6gx264kd8cbhs88yp37vwmmcd3lvmz44agf7qcv2ri";
+    })
   ];
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/misc/geary/default.nix
+++ b/pkgs/desktops/gnome-3/misc/geary/default.nix
@@ -1,60 +1,63 @@
-{ stdenv, fetchurl, intltool, pkgconfig, gtk3, vala_0_40, enchant
-, wrapGAppsHook, gdk_pixbuf, cmake, ninja, desktop-file-utils
-, libnotify, libcanberra-gtk3, libsecret, gmime, isocodes
-, gobject-introspection, libpthreadstubs, sqlite, gcr
-, gnome3, librsvg, gnome-doc-utils, webkitgtk, fetchpatch }:
+{ stdenv, fetchurl, fetchpatch, pkgconfig, gtk3, vala, enchant2, wrapGAppsHook, meson, ninja
+, desktop-file-utils, gnome-online-accounts, gsettings-desktop-schemas, adwaita-icon-theme
+, libnotify, libcanberra-gtk3, libsecret, gmime, isocodes, libxml2, gettext
+, sqlite, gcr, json-glib, itstool, libgee, gnome3, webkitgtk, python3
+, xvfb_run, dbus, shared-mime-info, libunwind, glib-networking }:
 
-let
-  pname = "geary";
-  version = "0.12.4";
-in
 stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
+  pname = "geary";
+  version = "0.13.1";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "01ykhkjfkprvh9kp4rzrl6xs2pqibiw44ckvqsn5cs3xy2rlq8mm";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "0h9pf2mdskq7mylib1m9hw86nwfmdzyngjl7ywangqipm1k5svjx";
   };
 
   patches = [
-    # Fix build with webkitgtk-2.22
+    # gobject-introspection is not needed
+    # https://gitlab.gnome.org/GNOME/geary/merge_requests/138
     (fetchpatch {
-      url = https://gitlab.gnome.org/GNOME/geary/commit/5d0f711426d76f878cf9b71f7e8f785199c7cde1.patch;
-      sha256 = "1yifng5lfsc6wp7irmi8gjdcfig1cr0chf7rdv3asrk567nmwrsi";
-    })
-    (fetchpatch {
-      url = https://gitlab.gnome.org/GNOME/geary/commit/0d966950a2cba888873cd3a7f4f42bb7a017dc6d.patch;
-      sha256 = "1y6v4fnik4w3paj9nl0yqs54998sx1zr9w3940d579p6dsa8f3fg";
-    })
-    (fetchpatch {
-      url = https://gitlab.gnome.org/GNOME/geary/commit/e091f24b00ec421e1aadd5e360d1550e658ad5ef.patch;
-      sha256 = "0d5hc4h9c1hnn2sk18nkpmzdvwm3h746n2zj8n22ax9rj6lxl38l";
-    })
-    # Fix build with vala 0.40.12
-    # See: https://gitlab.gnome.org/GNOME/vala/blob/0.40.12/NEWS#L22
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/geary/commit/088cb2c0aa35ad4b54ea5a0a2edaf0ff96c64b45.patch";
-      sha256 = "0cnjmbd3snm8ggmprqa32f7i3w86gs3ylab9p5ffj921dcpvvlb2";
+      url = https://gitlab.gnome.org/GNOME/geary/commit/d2f1b1076aa942d140e83fdf03b66621c11229f5.patch;
+      sha256 = "1dsj4ybnibpi572w9hafm0w90jbjv7wzdl6j8d4c2qg5h7knlvfk";
     })
   ];
 
-  nativeBuildInputs = [ vala_0_40 intltool pkgconfig wrapGAppsHook cmake ninja desktop-file-utils gnome-doc-utils gobject-introspection ];
+  nativeBuildInputs = [
+    desktop-file-utils gettext itstool libxml2 meson ninja
+    pkgconfig vala wrapGAppsHook python3
+  ];
+
   buildInputs = [
-    gtk3 enchant webkitgtk libnotify libcanberra-gtk3 gnome3.libgee libsecret gmime sqlite
-    libpthreadstubs gnome3.gsettings-desktop-schemas gcr isocodes
-    gdk_pixbuf librsvg gnome3.defaultIconTheme
+    adwaita-icon-theme enchant2 gcr gmime gnome-online-accounts
+    gsettings-desktop-schemas gtk3 isocodes json-glib libcanberra-gtk3
+    libgee libnotify libsecret sqlite webkitgtk glib-networking
+    libunwind
   ];
 
-  cmakeFlags = [
-    "-DISOCODES_DIRECTORY=${isocodes}/share/xml/iso-codes"
+  checkInputs = [ xvfb_run dbus ];
+
+  mesonFlags = [
+    "-Dcontractor=true" # install the contractor file (Pantheon specific)
   ];
 
-  # TODO: This is bad, upstream should fix their code.
-  PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR = "${webkitgtk.dev}/share/gir-1.0";
+  postPatch = ''
+    chmod +x build-aux/post_install.py
+    patchShebangs build-aux/post_install.py
+  '';
 
   preFixup = ''
     # Add geary to path for geary-attach
     gappsWrapperArgs+=(--prefix PATH : "$out/bin")
+  '';
+
+  doCheck = true;
+
+  checkPhase = ''
+    NO_AT_BRIDGE=1 \
+    XDG_DATA_DIRS=:$XDG_DATA_DIRS:${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${shared-mime-info}/share \
+    xvfb-run -s '-screen 0 800x600x24' dbus-run-session \
+      --config-file=${dbus.daemon}/share/dbus-1/session.conf \
+      meson test -v --no-stdsplit
   '';
 
   passthru = {
@@ -68,7 +71,7 @@ stdenv.mkDerivation rec {
     homepage = https://wiki.gnome.org/Apps/Geary;
     description = "Mail client for GNOME 3";
     maintainers = gnome3.maintainers;
-    license = licenses.lgpl2;
+    license = licenses.lgpl21Plus;
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Ends the litany of patches and other horrible things :smile:

[Link to News](https://gitlab.gnome.org/GNOME/geary/blob/8afe3c6f24abc580c05b047eba8198ba0ae987e9/NEWS)
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

