### PR TITLE
installer: Enable pulseaudio in all graphical iso's

### DIFF
--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-base.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-base.nix
@@ -31,6 +31,10 @@ with lib;
   # there is no power management backend such as upower).
   powerManagement.enable = true;
 
+  # Enable sound in graphical iso's.
+  hardware.pulseaudio.enable = true;
+  hardware.pulseaudio.systemWide = true; # Needed since we run plasma as root.
+
   environment.systemPackages = [
     # Include gparted for partitioning disks.
     pkgs.gparted

--- a/nixos/modules/profiles/graphical.nix
+++ b/nixos/modules/profiles/graphical.nix
@@ -14,5 +14,9 @@
     libinput.enable = true; # for touchpad support on many laptops
   };
 
+  # Enable sound in virtualbox appliances.
+  hardware.pulseaudio.enable = true;
+  hardware.pulseaudio.systemWide = true; # Needed since we run plasma as root.
+
   environment.systemPackages = [ pkgs.glxinfo pkgs.firefox ];
 }


### PR DESCRIPTION
###### Motivation for this change
I think this would help for a good first impression for people trying out the ISO. I've never reflected over this myself. But someone I chatted with (that has never heard of NixOS before) tried it pointed this out to me.

And I agree, it's weird to ship a graphical environment without audio enabled.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

I've built the ISO like this:
```
nix-build nixos/release.nix -A iso_graphical
```

And then I've wrote the image to an USB-stick and tried it on my thinkpad. And it works there at least.

- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

