### PR TITLE
undefined-medium: init at 1.0

### DIFF
--- a/pkgs/data/fonts/undefined-medium/default.nix
+++ b/pkgs/data/fonts/undefined-medium/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchzip }:
+
+fetchzip rec {
+  name = "undefined-medium-1.0";
+
+  url = https://github.com/andirueckel/undefined-medium/archive/v1.0.zip;
+
+  postFetch = ''
+    mkdir -p $out/share/fonts
+    unzip -j $downloadedFile ${name}/fonts/otf/\*.otf -d $out/share/fonts/opentype
+  '';
+
+  sha256 = "0v3p1g9f1c0d6b9lhrvm1grzivm7ddk7dvn96zl5hdzr2y60y1rw";
+
+  meta = with stdenv.lib; {
+    homepage = https://undefined-medium.com/;
+    description = "A pixel grid-based monospace typeface";
+    longDescription = ''
+      undefined medium is a free and open-source pixel grid-based
+      monospace typeface suitable for programming, writing, and
+      whatever else you can think of … it’s pretty undefined.
+    '';
+    license = licenses.ofl;
+    maintainers = [ maintainers.rycee ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15944,6 +15944,8 @@ in
 
   ultimate-oldschool-pc-font-pack = callPackage ../data/fonts/ultimate-oldschool-pc-font-pack { };
 
+  undefined-medium = callPackage ../data/fonts/undefined-medium { };
+
   uni-vga = callPackage ../data/fonts/uni-vga { };
 
   unifont = callPackage ../data/fonts/unifont { };


### PR DESCRIPTION
###### Motivation for this change

Adds new font package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).