### PR TITLE
fondo, notes-up: init

### DIFF
--- a/pkgs/applications/graphics/fondo/default.nix
+++ b/pkgs/applications/graphics/fondo/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchFromGitHub, pantheon, pkgconfig, meson, ninja, python3, glib, gsettings-desktop-schemas, gtk3, libgee, json-glib, glib-networking, libsoup, libunity, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  pname = "fondo";
+  version = "1.2.1";
+
+  src = fetchFromGitHub {
+    owner = "calo001";
+    repo = pname;
+    rev = version;
+    sha256 = "0xczqkkq54gjay7wdl8mpil7klfrpvcw2a0n1brq7qrfhsmhc7pc";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pantheon.vala
+    pkgconfig
+    python3
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    glib
+    glib-networking
+    gsettings-desktop-schemas
+    gtk3
+    json-glib
+    libgee
+    libsoup
+    libunity
+    pantheon.granite
+  ];
+
+  postPatch = ''
+    chmod +x meson/post_install.py
+    patchShebangs meson/post_install.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Find the most beautiful wallpapers for your desktop";
+    homepage = https://github.com/calo001/fondo;
+    license = licenses.agpl3Plus;
+    maintainers = with maintainers; [ worldofpeace ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/office/notes-up/default.nix
+++ b/pkgs/applications/office/notes-up/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchFromGitHub, pantheon, pkgconfig, cmake, ninja, gtk3, gtksourceview3, webkitgtk, gtkspell3, glib, libgee, sqlite, discount, wrapGAppsHook }:
+{ stdenv, fetchFromGitHub, pantheon, pkgconfig, cmake, ninja, gtk3, gtksourceview3, webkitgtk, gtkspell3, glib, libgee, sqlite, discount, wrapGAppsHook
+, withPantheon ? false }:
 
 stdenv.mkDerivation rec {
   pname = "notes-up";
@@ -31,8 +32,12 @@ stdenv.mkDerivation rec {
     webkitgtk
   ];
 
+  # Whether to build with contractor support (Pantheon specific)
+  cmakeFlags = if withPantheon then null else [ "-Dnoele=yes" ];
+
   meta = with stdenv.lib; {
-    description = "Markdown notes editor and manager designed for elementary OS";
+    description = "Markdown notes editor and manager designed for elementary OS"
+    + stdenv.lib.optionalString withPantheon " - built with Contractor support";
     homepage = https://github.com/Philip-Scott/Notes-up;
     license = licenses.gpl2;
     maintainers = with maintainers; [ davidak worldofpeace ];

--- a/pkgs/applications/office/notes-up/default.nix
+++ b/pkgs/applications/office/notes-up/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchFromGitHub, pantheon, pkgconfig, cmake, ninja, gtk3, gtksourceview3, webkitgtk, gtkspell3, glib, libgee, sqlite, discount, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  pname = "notes-up";
+  version = "1.6.3";
+
+  src = fetchFromGitHub {
+    owner = "Philip-Scott";
+    repo = "Notes-up";
+    rev = version;
+    sha256 = "06fzdb823kkami0jch9ccblsvw3x7zd1d4xz8fv3giscl3f36x4q";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pantheon.vala
+    pkgconfig
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    discount
+    glib
+    gtk3
+    gtksourceview3
+    gtkspell3
+    libgee
+    pantheon.granite
+    sqlite
+    webkitgtk
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Markdown notes editor and manager designed for elementary OS";
+    homepage = https://github.com/Philip-Scott/Notes-up;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ davidak worldofpeace ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/desktops/pantheon/default.nix
+++ b/pkgs/desktops/pantheon/default.nix
@@ -62,6 +62,8 @@ lib.makeScope pkgs.newScope (self: with self; {
 
   elementary-gsettings-schemas = callPackage ./desktop/elementary-gsettings-schemas { };
 
+  notes-up = pkgs.notes-up.override { withPantheon = true; };
+
   #### APPS
 
   elementary-calculator = callPackage ./apps/elementary-calculator { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17016,6 +17016,8 @@ in
 
   focuswriter = libsForQt5.callPackage ../applications/editors/focuswriter { };
 
+  fondo = callPackage ../applications/graphics/fondo { };
+
   font-manager = callPackage ../applications/misc/font-manager { };
 
   foo-yc20 = callPackage ../applications/audio/foo-yc20 { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4497,6 +4497,8 @@ in
 
   notify-osd = callPackage ../applications/misc/notify-osd { };
 
+  notes-up = callPackage ../applications/office/notes-up { };
+
   notify-osd-customizable = callPackage ../applications/misc/notify-osd-customizable { };
 
   nox = callPackage ../tools/package-management/nox { };


### PR DESCRIPTION
###### Motivation for this change
@davidak wanted notes-up.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

