### PR TITLE
krb5: 1.15.2 -> 1.17

### DIFF
--- a/pkgs/development/libraries/kerberos/krb5.nix
+++ b/pkgs/development/libraries/kerberos/krb5.nix
@@ -15,11 +15,11 @@ with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "${type}krb5-${version}";
   majorVersion = "1.15";
-  version = "${majorVersion}.2";
+  version = "${majorVersion}.5";
 
   src = fetchurl {
-    url = "${meta.homepage}dist/krb5/${majorVersion}/krb5-${version}.tar.gz";
-    sha256 = "0zn8s7anb10hw3nzwjz7vg10fgmmgvwnibn2zrn3nppjxn9f6f8n";
+    url = "https://kerberos.org/dist/krb5/${majorVersion}/krb5-${version}.tar.gz";
+    sha256 = "1fiywc3daaqsvj09lymqd3qd5kz51w13krh60j93z18g78nix23q";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/kerberos/krb5.nix
+++ b/pkgs/development/libraries/kerberos/krb5.nix
@@ -14,12 +14,12 @@ in
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "${type}krb5-${version}";
-  majorVersion = "1.15";
-  version = "${majorVersion}.5";
+  majorVersion = "1.17";
+  version = "${majorVersion}";
 
   src = fetchurl {
     url = "https://kerberos.org/dist/krb5/${majorVersion}/krb5-${version}.tar.gz";
-    sha256 = "1fiywc3daaqsvj09lymqd3qd5kz51w13krh60j93z18g78nix23q";
+    sha256 = "1xc1ly09697b7g2vngvx76szjqy9769kpgn27lnp1r9xln224vjs";
   };
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
###### Motivation for this change

Not sure why this is so far behind, bump to latest release.

Review/testing requested-- will be doing at least basic build testing
but help appreciated beyond that :).

 * https://web.mit.edu/kerberos/krb5-1.17/
 * https://web.mit.edu/kerberos/krb5-1.16/krb5-1.16.2.html 
 * https://web.mit.edu/kerberos/krb5-1.16/krb5-1.16.1.html 
 * https://web.mit.edu/kerberos/krb5-1.16/krb5-1.16.html
 * https://web.mit.edu/kerberos/krb5-1.15/krb5-1.15.3.html 
 * https://web.mit.edu/kerberos/krb5-1.15/krb5-1.15.4.html 
 * https://web.mit.edu/kerberos/krb5-1.15/krb5-1.15.5.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---