### PR TITLE
Add new maps to sc2-headless

### DIFF
--- a/pkgs/applications/science/machine-learning/sc2-headless/default.nix
+++ b/pkgs/applications/science/machine-learning/sc2-headless/default.nix
@@ -33,8 +33,9 @@ in stdenv.mkDerivation rec {
     cp -r . "$out"
     rm -r $out/Libs
 
-    cp -r "${maps.minigames}"/* "${maps.melee}"/* "${maps.ladder2017season1}"/* "${maps.ladder2017season2}"/* "${maps.ladder2017season3}"/* \
-      "${maps.ladder2017season4}"/*  "${maps.ladder2018season1}"/* "${maps.ladder2018season2}"/* "$out"/Maps/
+    cp -ur "${maps.minigames}"/* "${maps.melee}"/* "${maps.ladder2017season1}"/* "${maps.ladder2017season2}"/* "${maps.ladder2017season3}"/* \
+      "${maps.ladder2017season4}"/* "${maps.ladder2018season1}"/* "${maps.ladder2018season2}"/* \
+      "${maps.ladder2018season3}"/*  "${maps.ladder2018season4}"/* "${maps.ladder2019season1}"/* "$out"/Maps/
   '';
 
   preFixup = ''

--- a/pkgs/applications/science/machine-learning/sc2-headless/maps.nix
+++ b/pkgs/applications/science/machine-learning/sc2-headless/maps.nix
@@ -1,7 +1,7 @@
-{ fetchzip
+{ fetchzip, unzip
 }:
 let
-  fetchzip' = args: (fetchzip args).overrideAttrs (old: { UNZIP = "-P iagreetotheeula"; });
+  fetchzip' = args: (fetchzip args).overrideAttrs (old: { UNZIP = "-j -P iagreetotheeula"; });
 in
 {
   minigames = fetchzip {
@@ -17,32 +17,47 @@ in
   };
   ladder2017season1 = fetchzip' {
     url = "http://blzdistsc2-a.akamaihd.net/MapPacks/Ladder2017Season1.zip";
-    sha256 = "194p0mb0bh63sjy84q21x4v5pb6d7hidivfi28aalr2gkwhwqfvh";
+    sha256 = "0ngg4g74s2ryhylny93fm8yq9rlrhphwnjg2s6f3qr85a2b3zdpd";
     stripRoot = false;
   };
   ladder2017season2 = fetchzip' {
     url = "http://blzdistsc2-a.akamaihd.net/MapPacks/Ladder2017Season2.zip";
-    sha256 = "1pvp7zi16326x3l45mk7s959ggnkg2j1w9rfmaxxa8mawr9c6i39";
+    sha256 = "01kycnvqagql9pkjkcgngfcnry2pc4kcygdkk511m0qr34909za5";
     stripRoot = false;
   };
   ladder2017season3 = fetchzip' {
     url = "http://blzdistsc2-a.akamaihd.net/MapPacks/Ladder2017Season3_Updated.zip";
-    sha256 = "1sjskfp6spmh7l2za1z55v7binx005qxw3w11xdvjpn20cyhkh8a";
+    sha256 = "0wix3lwmbyxfgh8ldg0n66i21p0dbavk2dxjngz79rx708m8qvld";
     stripRoot = false;
   };
   ladder2017season4 = fetchzip' {
     url = "http://blzdistsc2-a.akamaihd.net/MapPacks/Ladder2017Season4.zip";
-    sha256 = "1zf4mfq6r1ylf8bmd0qpv134dcrfgrsi4afxfqwnf39ijdq4z26g";
+    sha256 = "1sidnmk2rc9j5fd3a4623pvaika1mm1rwhznb2qklsqsq1x2qckp";
     stripRoot = false;
   };
   ladder2018season1 = fetchzip' {
     url = "http://blzdistsc2-a.akamaihd.net/MapPacks/Ladder2018Season1.zip";
-    sha256 = "0p51xj98qg816qm9ywv9zar5llqvqs6bcyns6d5fp2j39fg08v6f";
+    sha256 = "0mp0ilcq0gmd7ahahc5i8c7bdr3ivk6skx0b2cgb1z89l5d76irq";
     stripRoot = false;
   };
   ladder2018season2 = fetchzip' {
     url = "http://blzdistsc2-a.akamaihd.net/MapPacks/Ladder2018Season2_Updated.zip";
-    sha256 = "1wjn6vpbymjvjxqf10h7az34fnmhb5dpi878nsydlax25v9lgzqx";
+    sha256 = "176rs848cx5src7qbr6dnn81bv1i86i381fidk3v81q9bxlmc2rv";
+    stripRoot = false;
+  };
+  ladder2018season3 = fetchzip' {
+    url = "http://blzdistsc2-a.akamaihd.net/MapPacks/Ladder2018Season3.zip";
+    sha256 = "1r3wv4w53g9zq6073ajgv74prbdsd1x3zfpyhv1kpxbffyr0x0zp";
+    stripRoot = false;
+  };
+  ladder2018season4 = fetchzip' {
+    url = "http://blzdistsc2-a.akamaihd.net/MapPacks/Ladder2018Season4.zip";
+    sha256 = "0k47rr6pzxbanlqnhliwywkvf0w04c8hxmbanksbz6aj5wpkcn1s";
+    stripRoot = false;
+  };
+  ladder2019season1 = fetchzip' {
+    url = "http://blzdistsc2-a.akamaihd.net/MapPacks/Ladder2019Season1.zip";
+    sha256 = "1dlk9zza8h70lbjvg2ykc5wr9vsvvdk02szwrkgdw26mkssl2rg9";
     stripRoot = false;
   };
 }


### PR DESCRIPTION
Updating with 2018/2019 maps

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

