### PR TITLE
Fix thumbnails generation in nautilus

### DIFF
--- a/pkgs/desktops/gnome-3/core/gnome-desktop/bubblewrap-paths.patch
+++ b/pkgs/desktops/gnome-3/core/gnome-desktop/bubblewrap-paths.patch
@@ -1,16 +1,15 @@
 --- a/libgnome-desktop/gnome-desktop-thumbnail-script.c
 +++ b/libgnome-desktop/gnome-desktop-thumbnail-script.c
-@@ -536,10 +536,9 @@ add_bwrap (GPtrArray   *array,
+@@ -536,9 +536,9 @@ add_bwrap (GPtrArray   *array,
    g_return_val_if_fail (script->s_infile != NULL, FALSE);
  
    add_args (array,
 -	    "bwrap",
 -	    "--ro-bind", "/usr", "/usr",
 -	    "--ro-bind", "/etc/ld.so.cache", "/etc/ld.so.cache",
--	    NULL);
-+            "@bubblewrap_bin@",
-+            "--ro-bind", "/nix/store", "/nix/store",
-+      NULL);
++	    "@bubblewrap_bin@",
++	    "--ro-bind", "/nix/store", "/nix/store",
++	    "--ro-bind", "/run/current-system", "/run/current-system",
+ 	    NULL);
  
    /* These directories might be symlinks into /usr/... */
-   for (i = 0; i < G_N_ELEMENTS (usrmerged_dirs); i++)

--- a/pkgs/desktops/gnome-3/core/nautilus/bubblewrap-paths.patch
+++ b/pkgs/desktops/gnome-3/core/nautilus/bubblewrap-paths.patch
@@ -1,6 +1,6 @@
 ---   a/src/gnome-desktop/gnome-desktop-thumbnail-script.c
 +++   a/src/gnome-desktop/gnome-desktop-thumbnail-script.c
-@@ -514,14 +514,10 @@ add_bwrap (GPtrArray   *array,
+@@ -514,14 +514,11 @@ add_bwrap (GPtrArray   *array,
    g_return_val_if_fail (script->s_infile != NULL, FALSE);
  
    add_args (array,
@@ -8,8 +8,9 @@
 -	    "--ro-bind", "/usr", "/usr",
 -	    "--ro-bind", "/lib", "/lib",
 -	    "--ro-bind", "/lib64", "/lib64",
-+      "@bubblewrap_bin@",
-+      "--ro-bind", "@storeDir@", "@storeDir@",
++	    "@bubblewrap_bin@",
++	    "--ro-bind", "@storeDir@", "@storeDir@",
++	    "--ro-bind", "/run/current-system", "/run/current-system",
  	    "--proc", "/proc",
  	    "--dev", "/dev",
 -	    "--symlink", "usr/bin", "/bin",


### PR DESCRIPTION
###### Motivation for this change

PDF thumbnails (and possibly others) are not generated in nautilus
because the thumbnailers execution is sandboxed.
`/run/current-system` is not mounted in the sandbox, and system binaries
that rely on `$PATH` are not resolvable.

It turns out that .desktop files sometimes contain an absolute path, but
I think it better to just mount /run/current-system in the sandbox
rather than enforcing all the .desktop files to contain an absolute
path, especially since some (like firefox) break when an absolute path
is used there.

```
$ rg -L Exec= /run/current-system/sw/share/thumbnailers                     
/run/current-system/sw/share/thumbnailers/gnome-font-viewer.thumbnailer
2:TryExec=gnome-thumbnail-font
3:Exec=gnome-thumbnail-font --size %s %u %o

/run/current-system/sw/share/thumbnailers/evince.thumbnailer
2:TryExec=evince-thumbnailer
3:Exec=evince-thumbnailer -s %s %u %o

/run/current-system/sw/share/thumbnailers/totem.thumbnailer
2:TryExec=/nix/store/rdiavbwkm520l12c3shc0rjbxaqd8glz-totem-3.30.0/bin/totem-video-thumbnailer
3:Exec=/nix/store/rdiavbwkm520l12c3shc0rjbxaqd8glz-totem-3.30.0/bin/totem-video-thumbnailer -s %s %u %o
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested on NixOS
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---