### PR TITLE
Restrict vim update.py to generated.nix

### DIFF
--- a/pkgs/misc/vim-plugins/update.py
+++ b/pkgs/misc/vim-plugins/update.py
@@ -111,16 +111,20 @@ class Plugin:
         return copy
 
 
-GET_PLUGINS = """(with import <localpkgs> {};
+GET_PLUGINS = f"""(with import <localpkgs> {{}};
 let
+  inherit (vimUtils.override {{inherit vim;}}) buildVimPluginFrom2Nix;
+  generated = callPackage {ROOT}/generated.nix {{
+    inherit buildVimPluginFrom2Nix;
+  }};
   hasChecksum = value: lib.isAttrs value && lib.hasAttrByPath ["src" "outputHash"] value;
   getChecksum = name: value:
-    if hasChecksum value then {
+    if hasChecksum value then {{
       submodules = value.src.fetchSubmodules or false;
       sha256 = value.src.outputHash;
       rev = value.src.rev;
-    } else null;
-  checksums = lib.mapAttrs getChecksum vimPlugins;
+    }} else null;
+  checksums = lib.mapAttrs getChecksum generated;
 in lib.filterAttrs (n: v: v != null) checksums)"""
 
 


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/55857 broke `pkgs/misc/vim-plugins/update.py`. (https://github.com/NixOS/nixpkgs/pull/55857#issuecomment-466348295).

###### Things done
This change modifies the script to only look for updates for plugins that are defined in `generated.nix`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

