### PR TITLE
antimony: 2018-07-17 -> 2018-10-20

### DIFF
--- a/pkgs/applications/graphics/antimony/default.nix
+++ b/pkgs/applications/graphics/antimony/default.nix
@@ -4,19 +4,19 @@
 }:
 
 let
-  gitRev    = "60a58688e552f12501980c4bdab034ab0f2ba059";
+  gitRev    = "c0038e3ea82fec6119de364bcbc3370955ed46a2";
   gitBranch = "develop";
   gitTag    = "0.9.3";
 in
   stdenv.mkDerivation rec {
     name    = "antimony-${version}";
-    version = "2018-07-17";
+    version = "2018-10-20";
 
     src = fetchFromGitHub {
       owner  = "mkeeter";
       repo   = "antimony";
       rev    = gitRev;
-      sha256 = "0pgf6kr23xw012xsil56j5gq78mlirmrlqdm09m5wlgcf4vr6xnl";
+      sha256 = "01cjcjppbb0gvh6npcsaidzpfcfzrqhhi07z4v0jkfyi0fl125v4";
     };
 
     patches = [ ./paths-fix.patch ];


### PR DESCRIPTION
###### Motivation for this change
Minor fixes

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change
- [x] Tested execution of all binary files
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

