### PR TITLE
metrics.nix: add nix-env.qaCountDrv metric

### DIFF
--- a/pkgs/top-level/metrics.nix
+++ b/pkgs/top-level/metrics.nix
@@ -55,6 +55,9 @@ runCommand "nixpkgs-metrics"
     num=$(nix-env -f ${nixpkgs} -qa | wc -l)
     echo "nix-env.qaCount $num" >> $out/nix-support/hydra-metrics
 
+    num=$(nix-env -f ${nixpkgs} -qa --drv-path | wc -l)
+    echo "nix-env.qaCountDrv $num" >> $out/nix-support/hydra-metrics
+
     # TODO: this has been ignored for some time
     # GC Warning: Bad initial heap size 128k - ignoring it.
     #export GC_INITIAL_HEAP_SIZE=128k


### PR DESCRIPTION
# `git log`

- metrics.nix: add nix-env.qaCountDrv metric

  Before ae16dd1a15dfbe29c6a1de61c4cc23e2cd6487f0 `nix-env.qaCount` and
  `nix-env.qaCountDrv` were equivalent, after that change that is no longer
  the case so this needs a separate metric now.

# `nix-instantiate` environment

- Host OS: Linux 4.9, SLNOS 19.03
- Nix: nix-env (Nix) 2.1.3
- Multi-user: yes
- Sandbox: yes
- NIXPKGS_CONFIG:

```nix
{
  checkMeta = true;
  doCheckByDefault = true;
}
```

# `nix-env -qaP` diffs

- On x86_64-linux: noop
- On aarch64-linux: noop
- On x86_64-darwin: noop

/cc @matthewbauer @7c6f434c