### PR TITLE
writeC: fix finding of libraries

### DIFF
--- a/pkgs/build-support/writers/default.nix
+++ b/pkgs/build-support/writers/default.nix
@@ -94,8 +94,8 @@ rec {
         ]}
         gcc \
             ${optionalString (libraries != [])
-              "$(pkgs.pkgconfig}/bin/pkg-config --cflags --libs ${
-                concatMapStringsSep " " (lib: escapeShellArg (builtins.parseDrvName lib.name).name) (libraries)
+              "$(pkg-config --cflags --libs ${
+                concatMapStringsSep " " (pkg: "$(find ${escapeShellArg pkg}/lib/pkgsconfig -name \*.pc -exec basename {} \;)") libraries
               })"
             } \
             -O \


### PR DESCRIPTION
###### Motivation for this change

fix external libraries support in writers.writeC.

Sadly the tests are missing, since I don't know how to write a c program with an external library. help would be very appreciated.
