### PR TITLE
ocamlPackages: disable a few libraries that do not build with old OCaml versions

### DIFF
--- a/pkgs/development/ocaml-modules/atd/default.nix
+++ b/pkgs/development/ocaml-modules/atd/default.nix
@@ -4,6 +4,8 @@ buildDunePackage rec {
   pname = "atd";
   version = "2.0.0";
 
+  minimumOCamlVersion = "4.02";
+
   src = fetchFromGitHub {
     owner = "mjambon";
     repo = pname;

--- a/pkgs/development/ocaml-modules/bisect_ppx-ocamlbuild/default.nix
+++ b/pkgs/development/ocaml-modules/bisect_ppx-ocamlbuild/default.nix
@@ -1,6 +1,7 @@
 { buildDunePackage, bisect_ppx, ocamlbuild }:
 
 buildDunePackage rec {
+  minimumOCamlVersion = "4.02";
   inherit (bisect_ppx) version src meta;
   pname = "bisect_ppx-ocamlbuild";
   propagatedBuildInputs = [ ocamlbuild ];

--- a/pkgs/development/ocaml-modules/dtoa/default.nix
+++ b/pkgs/development/ocaml-modules/dtoa/default.nix
@@ -4,7 +4,7 @@ buildDunePackage rec {
   pname = "dtoa";
   version = "0.3.1";
 
-  minimumOCamlVersion = "4.01";
+  minimumOCamlVersion = "4.02";
 
   src = fetchurl {
     url = "https://github.com/flowtype/ocaml-${pname}/releases/download/v${version}/${pname}-${version}.tbz";

--- a/pkgs/development/ocaml-modules/opti/default.nix
+++ b/pkgs/development/ocaml-modules/opti/default.nix
@@ -4,6 +4,8 @@ buildDunePackage rec {
   pname = "opti";
   version = "1.0.3";
 
+  minimumOCamlVersion = "4.02";
+
   src = fetchurl {
     url = "https://github.com/magnusjonsson/opti/releases/download/${version}/opti-${version}.tbz";
     sha256 = "ed9ba56dc06e9d2b1bf097964cc65ea37db787d4f239c13d0dd74693f5b50a1e";

--- a/pkgs/development/ocaml-modules/wtf8/default.nix
+++ b/pkgs/development/ocaml-modules/wtf8/default.nix
@@ -4,7 +4,7 @@ buildDunePackage rec {
   pname = "wtf8";
   version = "1.0.1";
 
-  minimumOCamlVersion = "4.01";
+  minimumOCamlVersion = "4.02";
 
   src = fetchurl {
     url = "https://github.com/flowtype/ocaml-${pname}/releases/download/v${version}/${pname}-${version}.tbz";

--- a/pkgs/development/tools/ocaml/utop/default.nix
+++ b/pkgs/development/tools/ocaml/utop/default.nix
@@ -2,7 +2,7 @@
 , lambdaTerm, cppo, makeWrapper
 }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.02"
+if !stdenv.lib.versionAtLeast ocaml.version "4.03"
 then throw "utop is not available for OCaml ${ocaml.version}"
 else
 


### PR DESCRIPTION
###### Motivation for this change

These libraries do not build with old versions of OCaml. This PR documents this fact. This makes future reviewing tasks easier.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

