### PR TITLE
gnash: 0.8.11-2017-03-08 -> 0.8.11-2019-02-16

### DIFF
--- a/pkgs/misc/gnash/default.nix
+++ b/pkgs/misc/gnash/default.nix
@@ -14,10 +14,10 @@
 , enableQt  ? false, qt4  ? null
 
 # media
-, enableFFmpeg    ? true,  ffmpeg_2 ? null
+, enableFFmpeg   ? true, ffmpeg_2 ? null
 
 # misc
-, enableJemalloc ? true, jemalloc  ? null
+, enableJemalloc ? true, jemalloc ? null
 , enableHwAccel  ? true
 , enablePlugins  ? false, xulrunner ? null, npapi_sdk ? null
 }:
@@ -66,12 +66,12 @@ assert length renderers == 0 -> throw "at least one renderer must be enabled";
 
 stdenv.mkDerivation rec {
   name = "gnash-${version}";
-  version = "0.8.11-2017-03-08";
+  version = "0.8.11-2019-30-01";
 
   src = fetchgit {
     url = "git://git.sv.gnu.org/gnash.git";
-    rev = "8a11e60585db4ed6bc4eafadfbd9b3123ced45d9";
-    sha256 = "1qas084gc4s9cb2jbwi2s1h4hk7m92xmrsb596sd14h0i44dai02";
+    rev = "583ccbc1275c7701dc4843ec12142ff86bb305b4";
+    sha256 = "0fh0bljn0i6ypyh6l99afi855p7ki7lm869nq1qj6k8hrrwhmfry";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change
The readme has been updated declaring the project officially unmaintained.
This is likely going to be the last commit ever.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

