### PR TITLE
dmd: Fix dmd.conf

### DIFF
--- a/pkgs/development/compilers/dmd/default.nix
+++ b/pkgs/development/compilers/dmd/default.nix
@@ -14,7 +14,7 @@ let
       name = "dmd.conf";
       text = (lib.generators.toINI {} {
         "Environment" = {
-          DFLAGS = ''-I$@out@/include/d2 -L-L$@out@/lib -fPIC ${stdenv.lib.optionalString (!targetPackages.stdenv.cc.isClang) "-L--export-dynamic"}'';
+          DFLAGS = ''-I@out@/include/dmd -L-L@out@/lib -fPIC ${stdenv.lib.optionalString (!targetPackages.stdenv.cc.isClang) "-L--export-dynamic"}'';
         };
       });
   };
@@ -135,15 +135,15 @@ stdenv.mkDerivation rec {
 
       cd ../druntime
       mkdir $out/include
-      mkdir $out/include/d2
-      cp -r import/* $out/include/d2
+      mkdir $out/include/dmd
+      cp -r import/* $out/include/dmd
 
       cd ../phobos
       mkdir $out/lib
       cp generated/${osname}/release/${bits}/libphobos2.* $out/lib
 
-      cp -r std $out/include/d2
-      cp -r etc $out/include/d2
+      cp -r std $out/include/dmd
+      cp -r etc $out/include/dmd
 
       wrapProgram $out/bin/dmd \
           --prefix PATH ":" "${targetPackages.stdenv.cc}/bin" \


### PR DESCRIPTION
###### Motivation for this change

This fixes the build for all packages depending on dmd.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

