### PR TITLE
openblas: adjust makeFlags handling

### DIFF
--- a/pkgs/development/libraries/science/math/openblas/default.nix
+++ b/pkgs/development/libraries/science/math/openblas/default.nix
@@ -126,7 +126,8 @@ stdenv.mkDerivation rec {
     NO_STATIC = true;
     CROSS = stdenv.hostPlatform != stdenv.buildPlatform;
     HOSTCC = "cc";
-    NO_BINARY_MODE = stdenv.hostPlatform != stdenv.buildPlatform;
+    # Makefile.system only checks defined status
+    NO_BINARY_MODE = toString (stdenv.hostPlatform != stdenv.buildPlatform);
   });
 
   doCheck = true;


### PR DESCRIPTION
###### Motivation for this change
Fixes arpack (octave) and maybe other builds. See #55628 or #53972.

###### Things done
The last change making false non-empty actually broke the `NO_BINARY_MODE` setting. While the cmake build checks the value, Makfile.system only uses ifdef/ifndef, which is now triggered even when `NO_BINARY_MODE=0`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

