### PR TITLE
nixos/beanstalkd: update test to use python3 instead of python2

### DIFF
--- a/nixos/tests/beanstalkd.nix
+++ b/nixos/tests/beanstalkd.nix
@@ -1,23 +1,25 @@
 import ./make-test.nix ({ pkgs, lib, ... }:
 
 let
+  pythonEnv = pkgs.python3.withPackages (p: [p.beanstalkc]);
+
   produce = pkgs.writeScript "produce.py" ''
-    #!${pkgs.python2.withPackages (p: [p.beanstalkc])}/bin/python
+    #!${pythonEnv.interpreter}
     import beanstalkc
 
     queue = beanstalkc.Connection(host='localhost', port=11300, parse_yaml=False);
-    queue.put('this is a job')
-    queue.put('this is another job')
+    queue.put(b'this is a job')
+    queue.put(b'this is another job')
   '';
 
   consume = pkgs.writeScript "consume.py" ''
-    #!${pkgs.python2.withPackages (p: [p.beanstalkc])}/bin/python
+    #!${pythonEnv.interpreter}
     import beanstalkc
 
     queue = beanstalkc.Connection(host='localhost', port=11300, parse_yaml=False);
 
     job = queue.reserve(timeout=0)
-    print job.body
+    print(job.body.decode('utf-8'))
     job.delete()
   '';
 


### PR DESCRIPTION
###### Motivation for this change
As requested by @flokli in https://github.com/NixOS/nixpkgs/pull/56117

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

