### PR TITLE
Reclassify printer drivers erroneously marked as GPL

### DIFF
--- a/pkgs/misc/cups/drivers/brgenml1lpr/default.nix
+++ b/pkgs/misc/cups/drivers/brgenml1lpr/default.nix
@@ -87,7 +87,7 @@ stdenv.mkDerivation rec {
     description = "Brother BrGenML1 LPR driver";
     homepage = http://www.brother.com;
     platforms = stdenv.lib.platforms.linux;
-    license = stdenv.lib.licenses.gpl2Plus;
+    license = stdenv.lib.licenses.unfreeRedistributable;
     maintainers = with stdenv.lib.maintainers; [ jraygauthier ];
   };
 }


### PR DESCRIPTION
Some CUPS printer drivers were marked as being GPL.
This changes them to reflect their actual, unfree licence.

###### Motivation for this change

The licence listed for some printer drivers was incorrect.