### PR TITLE
acpilight: init at 1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4313,6 +4313,15 @@
     github = "sleexyz";
     name = "Sean Lee";
   };
+  smakarov = {
+    email = "setser200018@gmail.com";
+    github = "setser";
+    name = "Sergey Makarov";
+    keys = [{
+      longkeyid = "rsa2048/6AA23A1193B7064B";
+      fingerprint = "6F8A 18AE 4101 103F 3C54  24B9 6AA2 3A11 93B7 064B";
+    }];
+  };
   smaret = {
     email = "sebastien.maret@icloud.com";
     github = "smaret";

--- a/nixos/modules/hardware/acpilight.nix
+++ b/nixos/modules/hardware/acpilight.nix
@@ -1,0 +1,24 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.hardware.acpilight;
+in
+{
+  options = {
+    hardware.acpilight = {
+      enable = mkOption {
+        default = false;
+        type = types.bool;
+        description = ''
+          Enable acpilight.
+          This will allow brightness control via xbacklight from users in the video group
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.udev.packages = with pkgs; [ acpilight ];
+  };
+}

--- a/pkgs/misc/acpilight/default.nix
+++ b/pkgs/misc/acpilight/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchgit, python36, udev, coreutils }:
+
+stdenv.mkDerivation rec {
+  pname = "acpilight";
+  version = "1.1";
+
+  src = fetchgit {
+    url = "https://gitlab.com/wavexx/acpilight.git";
+    rev = "v${version}";
+    sha256 = "0kykrl71fb146vaq8207c3qp03h2djkn8hn6psryykk8gdzkv3xd";
+  };
+
+  pyenv = python36.withPackages (pythonPackages: with pythonPackages; [
+    ConfigArgParse
+  ]);
+
+  postConfigure = ''
+    substituteInPlace 90-backlight.rules --replace /bin ${coreutils}/bin
+  '';
+
+  buildInputs = [ pyenv udev ];
+
+  makeFlags = [ "DESTDIR=$(out) prefix=" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://gitlab.com/wavexx/acpilight";
+    description = "ACPI backlight control";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ "smakarov" ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22151,6 +22151,8 @@ in
 
   ### MISC
 
+  acpilight = callPackage ../misc/acpilight { };
+
   android-file-transfer = libsForQt5.callPackage ../tools/filesystems/android-file-transfer { };
 
   antimicro = libsForQt5.callPackage ../tools/misc/antimicro { };


### PR DESCRIPTION
###### Motivation for this change
This adds acpilight, a backward-compatible replacement for xbacklight, that uses ACPI interface instead of XRandR

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

