### PR TITLE
sqlite{,-analyzer}: 3.26.0 -> 3.27.1

### DIFF
--- a/pkgs/development/libraries/sqlite/analyzer.nix
+++ b/pkgs/development/libraries/sqlite/analyzer.nix
@@ -6,11 +6,11 @@ in
 
 stdenv.mkDerivation rec {
   name = "sqlite-analyzer-${version}";
-  version = "3.26.0";
+  version = "3.27.1";
 
   src = assert version == sqlite.version; fetchurl {
-    url = "https://sqlite.org/2018/sqlite-src-${archiveVersion version}.zip";
-    sha256 = "0ysgi2jrl348amdfifsl3cx90d04bijm4pn4xnvivmi3m1dq4hp0";
+    url = "https://sqlite.org/2019/sqlite-src-${archiveVersion version}.zip";
+    sha256 = "11jrr14ld9cs9l5pz3z83xds1mhsqwgg47vwdx8rq6p667dc9z7h";
   };
 
   nativeBuildInputs = [ unzip ];

--- a/pkgs/development/libraries/sqlite/default.nix
+++ b/pkgs/development/libraries/sqlite/default.nix
@@ -10,12 +10,12 @@ in
 
 stdenv.mkDerivation rec {
   name = "sqlite-${version}";
-  version = "3.26.0";
+  version = "3.27.1";
 
   # NB! Make sure to update analyzer.nix src (in the same directory).
   src = fetchurl {
-    url = "https://sqlite.org/2018/sqlite-autoconf-${archiveVersion version}.tar.gz";
-    sha256 = "0pdzszb4sp73hl36siiv3p300jvfvbcdxi2rrmkwgs6inwznmajx";
+    url = "https://sqlite.org/2019/sqlite-autoconf-${archiveVersion version}.tar.gz";
+    sha256 = "1y7l225jm18fz6z3vyffrkl9k6qi964w1c5ri4giixizyy7jpaal";
   };
 
   outputs = [ "bin" "dev" "out" ];


### PR DESCRIPTION
https://sqlite.org/releaselog/3_27_1.html
https://sqlite.org/releaselog/3_27_0.html


###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Packages to check that've cause problems when previously upgrading
sqlite:

* [x] `python3Packages.sqlalchemy`

Others, I'm sure.