### PR TITLE
Typed `nixpkgs.config` with Gentoo-like use-flags

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -394,12 +394,12 @@ rec {
      to refer to the full configuration without creating an infinite
      recursion.
   */
-  pushDownProperties = cfg:
-    if cfg._type or "" == "merge" then
+  pushDownProperties = cfg: let type = cfg._type or ""; in
+    if type == "merge" then
       concatMap pushDownProperties cfg.contents
-    else if cfg._type or "" == "if" then
+    else if type == "if" then
       map (mapAttrs (n: v: mkIf cfg.condition v)) (pushDownProperties cfg.content)
-    else if cfg._type or "" == "override" then
+    else if type == "override" then
       map (mapAttrs (n: v: mkOverride cfg.priority v)) (pushDownProperties cfg.content)
     else # FIXME: handle mkOrder?
       [ cfg ];

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -35,9 +35,9 @@ rec {
       # attribute.  These options are fragile, as they are used by the
       # module system to change the interpretation of modules.
       internalModule = rec {
-        _file = ./modules.nix;
+        file = ./modules.nix;
 
-        key = _file;
+        key = file;
 
         options = {
           _module.args = mkOption {
@@ -121,11 +121,11 @@ rec {
       else {};
     in
     if m ? config || m ? options then
-      let badAttrs = removeAttrs m ["_file" "key" "disabledModules" "imports" "options" "config" "meta"]; in
+      let badAttrs = removeAttrs m ["file" "key" "disabledModules" "imports" "options" "config" "meta"]; in
       if badAttrs != {} then
         throw "Module `${key}' has an unsupported attribute `${head (attrNames badAttrs)}'. This is caused by assignments to the top-level attributes `config' or `options'."
       else
-        { file = m._file or file;
+        { file = m.file or file;
           key = toString m.key or key;
           disabledModules = m.disabledModules or [];
           imports = m.imports or [];
@@ -133,12 +133,12 @@ rec {
           config = mkMerge [ (m.config or {}) metaSet ];
         }
     else
-      { file = m._file or file;
+      { file = m.file or file;
         key = toString m.key or key;
         disabledModules = m.disabledModules or [];
         imports = m.require or [] ++ m.imports or [];
         options = {};
-        config = mkMerge [ (removeAttrs m ["_file" "key" "disabledModules" "require" "imports"]) metaSet ];
+        config = mkMerge [ (removeAttrs m ["file" "key" "disabledModules" "require" "imports"]) metaSet ];
       };
 
   applyIfFunction = key: f: args@{ config, options, lib, ... }: if isFunction f then
@@ -176,7 +176,7 @@ rec {
      of the submodule. (see applyIfFunction) */
   unpackSubmodule = unpack: m: args:
     if isType "submodule" m then
-      { _file = m.file; } // (unpack m.submodule args)
+      { inherit (m) file; } // (unpack m.submodule args)
     else unpack m args;
 
   packSubmodule = file: m:

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -116,9 +116,9 @@ rec {
   /* Massage a module into canonical form, that is, a set consisting
      of ‘options’, ‘config’ and ‘imports’ attributes. */
   unifyModuleSyntax = file: key: m:
-    let metaSet = if m ? meta
-      then { meta = m.meta; }
-      else {};
+    let addMetaSet = arg: if m ? meta
+      then mkMerge [ arg { meta = m.meta; } ]
+      else arg;
     in
     if m ? config || m ? options then
       let badAttrs = removeAttrs m ["file" "key" "disabledModules" "imports" "options" "config" "meta"]; in
@@ -130,7 +130,7 @@ rec {
           disabledModules = m.disabledModules or [];
           imports = m.imports or [];
           options = m.options or {};
-          config = mkMerge [ (m.config or {}) metaSet ];
+          config = addMetaSet (m.config or {});
         }
     else
       { file = m.file or file;
@@ -138,7 +138,7 @@ rec {
         disabledModules = m.disabledModules or [];
         imports = m.require or [] ++ m.imports or [];
         options = {};
-        config = mkMerge [ (removeAttrs m ["file" "key" "disabledModules" "require" "imports"]) metaSet ];
+        config = addMetaSet (removeAttrs m ["file" "key" "disabledModules" "require" "imports"]);
       };
 
   applyIfFunction = key: f: args@{ config, options, lib, ... }: if isFunction f then

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -382,7 +382,7 @@ rec {
         merge = loc: defs:
           let
             coerce = def: if isFunction def then def else { config = def; };
-            modules = opts' ++ map (def: { _file = def.file; imports = [(coerce def.value)]; }) defs;
+            modules = opts' ++ map (def: { inherit (def) file; imports = [(coerce def.value)]; }) defs;
           in (evalModules {
             inherit modules;
             args.name = last loc;

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -94,7 +94,7 @@ rec {
 
 
   # When adding new types don't forget to document them in
-  # nixos/doc/manual/development/option-types.xml!
+  # ../nixos/doc/manual/development/option-types.xml!
   types = rec {
     unspecified = mkOptionType {
       name = "unspecified";
@@ -368,6 +368,16 @@ rec {
       getSubOptions = elemType.getSubOptions;
       getSubModules = elemType.getSubModules;
       substSubModules = m: functionTo (elemType.substSubModules m);
+    };
+
+    # An opaque value. The result of evaluation of an option of this
+    # type is a list of { file, value } pairs describing all the
+    # values assigned to this option (with corresponding files where
+    # these values were applied).
+    opaque = mkOptionType {
+      name = "opaque";
+      description = "opaque value";
+      merge = loc: args: args;
     };
 
     # A submodule (like typed attribute set). See NixOS manual.

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -356,6 +356,20 @@ rec {
       functor = (defaultFunctor name) // { wrapped = elemType; };
     };
 
+    # A function to something mergeable (i.e., to a monoid). You
+    # should use something else. This type is a last resort and should
+    # only be used when there is absolutely nothing else you can do.
+    # Most uses of this type imply bad design.
+    functionTo = elemType: mkOptionType {
+      name = "function that evaluates to a(n) ${elemType.name}";
+      check = isFunction;
+      merge = loc: defs:
+        fnArgs: elemType.merge loc (map (fn: { inherit (fn) file; value = fn.value fnArgs; }) defs);
+      getSubOptions = elemType.getSubOptions;
+      getSubModules = elemType.getSubModules;
+      substSubModules = m: functionTo (elemType.substSubModules m);
+    };
+
     # A submodule (like typed attribute set). See NixOS manual.
     submodule = opts:
       let

--- a/nixos/doc/manual/development/option-types.xml
+++ b/nixos/doc/manual/development/option-types.xml
@@ -364,6 +364,20 @@
   </variablelist>
  </section>
 
+ <section xml:id='section-option-types-opaque>
+  <title>Opaque</title>
+
+  <para>
+   <literal>opaque</literal> is a type that simply collects assignments to itself into
+   a list of <literal>{ file, value }</literal> pairs.
+  </para>
+
+  <para>
+   This is useful when you want to merge these values outside of
+   <literal>evalModules</literal> done by NixOS.
+  </para>
+ </section>
+
  <section xml:id='section-option-types-submodule'>
   <title>Submodule</title>
 

--- a/nixos/lib/eval-config.nix
+++ b/nixos/lib/eval-config.nix
@@ -33,8 +33,8 @@ in
 
 let
   pkgsModule = rec {
-    _file = ./eval-config.nix;
-    key = _file;
+    file = ./eval-config.nix;
+    key = file;
     config = {
       # Explicit `nixpkgs.system` or `nixpkgs.localSystem` should override
       # this.  Since the latter defaults to the former, the former should

--- a/nixos/modules/misc/nixpkgs.nix
+++ b/nixos/modules/misc/nixpkgs.nix
@@ -6,42 +6,6 @@ let
   cfg = config.nixpkgs;
   opt = options.nixpkgs;
 
-  isConfig = x:
-    builtins.isAttrs x || lib.isFunction x;
-
-  optCall = f: x:
-    if lib.isFunction f
-    then f x
-    else f;
-
-  mergeConfig = lhs_: rhs_:
-    let
-      lhs = optCall lhs_ { inherit pkgs; };
-      rhs = optCall rhs_ { inherit pkgs; };
-    in
-    lhs // rhs //
-    optionalAttrs (lhs ? packageOverrides) {
-      packageOverrides = pkgs:
-        optCall lhs.packageOverrides pkgs //
-        optCall (attrByPath ["packageOverrides"] ({}) rhs) pkgs;
-    } //
-    optionalAttrs (lhs ? perlPackageOverrides) {
-      perlPackageOverrides = pkgs:
-        optCall lhs.perlPackageOverrides pkgs //
-        optCall (attrByPath ["perlPackageOverrides"] ({}) rhs) pkgs;
-    };
-
-  configType = mkOptionType {
-    name = "nixpkgs-config";
-    description = "nixpkgs config";
-    check = x:
-      let traceXIfNot = c:
-            if c x then true
-            else lib.traceSeqN 1 x false;
-      in traceXIfNot isConfig;
-    merge = args: fold (def: mergeConfig def.value) {};
-  };
-
   overlayType = mkOptionType {
     name = "nixpkgs-overlay";
     description = "nixpkgs overlay";
@@ -56,7 +20,8 @@ let
   };
 
   defaultPkgs = import ../../.. {
-    inherit (cfg) config overlays localSystem crossSystem;
+    configs = cfg.config;
+    inherit (cfg) overlays localSystem crossSystem;
   };
 
   finalPkgs = if opt.pkgs.isDefined then cfg.pkgs.appendOverlays cfg.overlays else defaultPkgs;
@@ -113,7 +78,7 @@ in
         ''
           { allowBroken = true; allowUnfree = true; }
         '';
-      type = configType;
+      type = types.opaque;
       description = ''
         The configuration of the Nix Packages collection.  (For
         details, see the Nixpkgs documentation.)  It allows you to set

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -4,20 +4,6 @@
 { lib, config, hostPlatform, meta }:
 
 let
-  # If we're in hydra, we can dispense with the more verbose error
-  # messages and make problems easier to spot.
-  inHydra = config.inHydra or false;
-
-  # See discussion at https://github.com/NixOS/nixpkgs/pull/25304#issuecomment-298385426
-  # for why this defaults to false, but I (@copumpkin) want to default it to true soon.
-  shouldCheckMeta = config.checkMeta or false;
-
-  allowUnfree = config.allowUnfree or false
-    || builtins.getEnv "NIXPKGS_ALLOW_UNFREE" == "1";
-
-  whitelist = config.whitelistedLicenses or [];
-  blacklist = config.blacklistedLicenses or [];
-
   onlyLicenses = list:
     lib.lists.all (license:
       let l = lib.licenses.${license.shortName or "BROKEN"} or false; in
@@ -26,8 +12,8 @@ let
     ) list;
 
   areLicenseListsValid =
-    if lib.mutuallyExclusive whitelist blacklist then
-      assert onlyLicenses whitelist; assert onlyLicenses blacklist; true
+    if lib.mutuallyExclusive config.whitelistedLicenses config.blacklistedLicenses then
+      assert onlyLicenses config.whitelistedLicenses; assert onlyLicenses config.blacklistedLicenses; true
     else
       throw "whitelistedLicenses and blacklistedLicenses are not mutually exclusive.";
 
@@ -35,99 +21,89 @@ let
     attrs ? meta.license;
 
   hasWhitelistedLicense = assert areLicenseListsValid; attrs:
-    hasLicense attrs && builtins.elem attrs.meta.license whitelist;
+    hasLicense attrs && builtins.elem attrs.meta.license config.whitelistedLicenses;
 
   hasBlacklistedLicense = assert areLicenseListsValid; attrs:
-    hasLicense attrs && builtins.elem attrs.meta.license blacklist;
-
-  allowBroken = config.allowBroken or false
-    || builtins.getEnv "NIXPKGS_ALLOW_BROKEN" == "1";
-
-  allowUnsupportedSystem = config.allowUnsupportedSystem or false
-    || builtins.getEnv "NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM" == "1";
+    hasLicense attrs && builtins.elem attrs.meta.license config.blacklistedLicenses;
 
   isUnfree = licenses: lib.lists.any (l: !l.free or true) licenses;
-
-  # Alow granular checks to allow only some unfree packages
-  # Example:
-  # {pkgs, ...}:
-  # {
-  #   allowUnfree = false;
-  #   allowUnfreePredicate = (x: pkgs.lib.hasPrefix "flashplayer-" x.name);
-  # }
-  allowUnfreePredicate = config.allowUnfreePredicate or (x: false);
 
   # Check whether unfree packages are allowed and if not, whether the
   # package has an unfree license and is not explicitely allowed by the
   # `allowUnfreePredicate` function.
   hasDeniedUnfreeLicense = attrs:
-    !allowUnfree &&
+    !config.allowUnfree &&
     hasLicense attrs &&
     isUnfree (lib.lists.toList attrs.meta.license) &&
-    !allowUnfreePredicate attrs;
-
-  allowInsecureDefaultPredicate = x: builtins.elem x.name (config.permittedInsecurePackages or []);
-  allowInsecurePredicate = x: (config.allowInsecurePredicate or allowInsecureDefaultPredicate) x;
+    !(config.allowUnfreePredicate attrs);
 
   hasAllowedInsecure = attrs:
     (attrs.meta.knownVulnerabilities or []) == [] ||
-    allowInsecurePredicate attrs ||
-    builtins.getEnv "NIXPKGS_ALLOW_INSECURE" == "1";
+    config.allowInsecure ||
+    config.allowInsecurePredicate attrs;
 
   showLicense = license: license.shortName or "unknown";
 
   pos_str = meta.position or "«unknown-file»";
 
   remediation = {
-    unfree = remediate_whitelist "Unfree";
-    broken = remediate_whitelist "Broken";
-    unsupported = remediate_whitelist "UnsupportedSystem";
+    broken = remediate_whitelist "Broken" false;
+    unsupported = remediate_whitelist "UnsupportedSystem" false;
     blacklisted = x: "";
+    unfree = remediate_unfree;
     insecure = remediate_insecure;
     broken-outputs = remediateOutputsToInstall;
     unknown-meta = x: "";
   };
-  remediate_whitelist = allow_attr: attrs:
-    ''
+
+  remediate_whitelist = allow_attr: permitted: attrs: let
+    name = attrs.name or "«name-missing»";
+  in ''
       a) For `nixos-rebuild` you can set
-        { nixpkgs.config.allow${allow_attr} = true; }
+    '' + (lib.optionalString permitted ''
+
+         {
+           nixpkgs.config.permitted${allow_attr}Packages = [
+             "${name}"
+           ];
+         }
+      or
+    '') + ''
+         { nixpkgs.config.allow${allow_attr} = true; }
+
       in configuration.nix to override this.
 
+    '' + ''
       b) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
+    '' + (lib.optionalString permitted ''
+
+         {
+           permitted${allow_attr}Packages = [
+             "${name}"
+           ];
+         }
+      or
+    '') + ''
         { allow${allow_attr} = true; }
+
       to ~/.config/nixpkgs/config.nix.
     '';
 
+  remediate_unfree = attrs:
+    ''
+      This package is unfree, but you can install it anyway by using one of the following methods:
+
+    '' + (remediate_whitelist "Unfree" true attrs);
+
   remediate_insecure = attrs:
     ''
-
       Known issues:
+
     '' + (lib.concatStrings (map (issue: " - ${issue}\n") attrs.meta.knownVulnerabilities)) + ''
 
-        You can install it anyway by whitelisting this package, using the
-        following methods:
+      You can install it anyway by using one of the following methods:
 
-        a) for `nixos-rebuild` you can add ‘${attrs.name or "«name-missing»"}’ to
-           `nixpkgs.config.permittedInsecurePackages` in the configuration.nix,
-           like so:
-
-             {
-               nixpkgs.config.permittedInsecurePackages = [
-                 "${attrs.name or "«name-missing»"}"
-               ];
-             }
-
-        b) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
-        ‘${attrs.name or "«name-missing»"}’ to `permittedInsecurePackages` in
-        ~/.config/nixpkgs/config.nix, like so:
-
-             {
-               permittedInsecurePackages = [
-                 "${attrs.name or "«name-missing»"}"
-               ];
-             }
-
-      '';
+    '' + (remediate_whitelist "Insecure" true attrs);
 
   remediateOutputsToInstall = attrs: let
       expectedOutputs = attrs.meta.outputsToInstall or [];
@@ -145,7 +121,7 @@ let
 
   handleEvalIssue = attrs: { reason , errormsg ? "" }:
     let
-      msg = if inHydra
+      msg = if config.inHydra
         then "Failed to evaluate ${attrs.name or "«name-missing»"}: «${reason}»: ${errormsg}"
         else ''
           Package ‘${attrs.name or "«name-missing»"}’ in ${pos_str} ${errormsg}, refusing to evaluate.
@@ -207,7 +183,8 @@ let
     if metaTypes?${k} then
       if metaTypes.${k}.check v then null else "key '${k}' has a value ${toString v} of an invalid type ${builtins.typeOf v}; expected ${metaTypes.${k}.description}"
     else "key '${k}' is unrecognized; expected one of: \n\t      [${lib.concatMapStringsSep ", " (x: "'${x}'") (lib.attrNames metaTypes)}]";
-  checkMeta = meta: if shouldCheckMeta then lib.remove null (lib.mapAttrsToList checkMetaAttr meta) else [];
+
+  checkMeta = meta: if config.checkMeta then lib.remove null (lib.mapAttrsToList checkMetaAttr meta) else [];
 
   checkPlatform = attrs: let
       anyMatch = lib.any (lib.meta.platformMatch hostPlatform);
@@ -218,7 +195,7 @@ let
       expectedOutputs = attrs.meta.outputsToInstall or [];
       actualOutputs = attrs.outputs or [ "out" ];
       missingOutputs = builtins.filter (output: ! builtins.elem output actualOutputs) expectedOutputs;
-    in if shouldCheckMeta
+    in if config.checkMeta
        then builtins.length missingOutputs > 0
        else false;
 
@@ -233,9 +210,9 @@ let
       { valid = false; reason = "unfree"; errormsg = "has an unfree license (‘${showLicense attrs.meta.license}’)"; }
     else if hasBlacklistedLicense attrs then
       { valid = false; reason = "blacklisted"; errormsg = "has a blacklisted license (‘${showLicense attrs.meta.license}’)"; }
-    else if !allowBroken && attrs.meta.broken or false then
+    else if !config.allowBroken && attrs.meta.broken or false then
       { valid = false; reason = "broken"; errormsg = "is marked as broken"; }
-    else if !allowUnsupportedSystem && !(checkPlatform attrs) then
+    else if !config.allowUnsupportedSystem && !(checkPlatform attrs) then
       { valid = false; reason = "unsupported"; errormsg = "is not supported on ‘${hostPlatform.config}’"; }
     else if !(hasAllowedInsecure attrs) then
       { valid = false; reason = "insecure"; errormsg = "is marked as insecure"; }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13384,12 +13384,12 @@ in
   # the latest Maint version
   perl528Packages = recurseIntoAttrs (callPackage ./perl-packages.nix {
     perl = perl528;
-    overrides = (config.perlPackageOverrides or (p: {})) pkgs;
+    overrides = config.perlPackageOverrides pkgs;
   });
   # the latest Devel version
   perldevelPackages = recurseIntoAttrs (callPackage ./perl-packages.nix {
     perl = perldevel;
-    overrides = (config.perlPackageOverrides or (p: {})) pkgs;
+    overrides = config.perlPackageOverrides pkgs;
   });
 
   perlPackages = perl528Packages;
@@ -13437,7 +13437,7 @@ in
   };
 
   rPackages = dontRecurseIntoAttrs (callPackage ../development/r-modules {
-    overrides = (config.rPackageOverrides or (p: {})) pkgs;
+    overrides = config.rPackageOverrides pkgs;
   });
 
   ### SERVERS

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -149,6 +149,47 @@ let
       feature = "run <literal>checkPhase</literal> by default";
     };
 
+    /* callPackage scope */
+
+    extraScope = mkOption {
+      type = types.attrs;
+      default = {};
+      example = literalExample ''
+        {
+          openssl = libressl;
+          libpulseaudio = libcardiacarrest;
+        }
+      '';
+      description = ''
+        Extra scope to supply to all <literal>callPackages</literal> calls.
+
+        This mechanism is a cheap and simple alternative to overlays for when
+        you don't want to touch the global scope of <literal>pkgs</literal> but
+        you want to override scopes of all packages produced by
+        <literal>callPackage</literal>.
+
+        For instance:
+        <itemizedlist>
+          <listitem><para>
+            you want to make all packages to depend on <literal>libressl</literal>
+            instead of <literal>openssl</literal>, but you want to keep the
+            vanilla <literal>openssl</literal> available as
+            <literal>pkgs.openssl</literal>;
+          </para></listitem>
+          <listitem><para>
+            you want to set the default value for some option like
+            <literal>x11Support</literal> for all packages all at
+            once.
+          </para></listitem>
+        </itemizedlist>
+
+        Changing this to a non-default value will void your warranty! That is,
+        at the very least, you will not be able to benefit from Hydra binary
+        cache. It is also entirely possible (likely, even) that your system will
+        not even build.
+      '';
+    };
+
   };
 
 in {

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -26,6 +26,11 @@ let
     '';
   });
 
+  mkOverrides = args: mkMassRebuild ({
+    type = types.functionTo (types.attrsOf (types.uniq types.unspecified));
+    default = super: {};
+  } // args);
+
   options = {
 
     /* Internal stuff */
@@ -106,7 +111,27 @@ let
       description = "A list of blacklisted licenses.";
     };
 
-    # TODO: packageOverrides, needs functionTo removed in 4ff1ab5a56f1280d2de319ad4eb4b2796e07ed35
+    /* Overlays */
+
+    # It feels to me like if overlays really belong here.
+
+    packageOverrides = mkOverrides {
+      description = "Poor man's global overlay.";
+    };
+
+    haskellPackageOverrides = mkMassRebuild {
+      type = types.uniq types.unspecified;
+      default = self: super: {};
+      description = "Haskell's overlay.";
+    };
+
+    perlPackageOverrides = mkOverrides {
+      description = "Poor man's perl overlay.";
+    };
+
+    rPackageOverrides = mkOverrides {
+      description = "Poor man's R overlay.";
+    };
 
     # See discussion at https://github.com/NixOS/nixpkgs/pull/25304#issuecomment-298385426
     # for why this defaults to false, but I (@copumpkin) want to default it to true soon.

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -38,6 +38,82 @@ let
 
     /* Config options */
 
+    inHydra = mkMeta {
+      internal = true;
+      description = ''
+        If we're in hydra, we can dispense with the more verbose error
+        messages and make problems easier to spot.
+      '';
+    };
+
+    allowBroken = mkMeta {
+      default = builtins.getEnv "NIXPKGS_ALLOW_BROKEN" == "1";
+      defaultText = ''builtins.getEnv "NIXPKGS_ALLOW_BROKEN" == "1"'';
+      feature = "permit evaluation of broken packages";
+    };
+
+    allowUnsupportedSystem = mkMeta {
+      default = builtins.getEnv "NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM" == "1";
+      defaultText = ''builtins.getEnv "NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM" == "1"'';
+      feature = "permit evaluation of packages not available for the current system";
+    };
+
+    allowUnfree = mkMeta {
+      default = builtins.getEnv "NIXPKGS_ALLOW_UNFREE" == "1";
+      defaultText = ''builtins.getEnv "NIXPKGS_ALLOW_UNFREE" == "1"'';
+      feature = "permit evaluation of unfree packages";
+    };
+
+    permittedUnfreePackages = mkMeta {
+      type = types.listOf types.str;
+      default = [];
+      description = "A list of permitted unfree packages.";
+    };
+
+    allowUnfreePredicate = mkMeta {
+      type = types.unspecified;
+      default = x: builtins.elem x.name config.permittedUnfreePackages;
+      description = "A predicate permitting evaluation for some unfree packages.";
+    };
+
+    allowInsecure = mkMeta {
+      default = builtins.getEnv "NIXPKGS_ALLOW_INSECURE" == "1";
+      defaultText = ''builtins.getEnv "NIXPKGS_ALLOW_INSECURE" == "1"'';
+      feature = "permit evaluation of packages marked as insecure";
+    };
+
+    permittedInsecurePackages = mkMeta {
+      type = types.listOf types.str;
+      default = [];
+      description = "A list of permitted insecure packages.";
+    };
+
+    allowInsecurePredicate = mkMeta {
+      type = types.unspecified;
+      default = x: builtins.elem x.name config.permittedInsecurePackages;
+      description = "A predicate for permitting evaluation for some insecure packages.";
+    };
+
+    whitelistedLicenses = mkMeta {
+      type = types.listOf types.unspecified;
+      default = [];
+      description = "A list of whitelisted licenses.";
+    };
+
+    blacklistedLicenses = mkMeta {
+      type = types.listOf types.unspecified;
+      default = [];
+      description = "A list of blacklisted licenses.";
+    };
+
+    # TODO: packageOverrides, needs functionTo removed in 4ff1ab5a56f1280d2de319ad4eb4b2796e07ed35
+
+    # See discussion at https://github.com/NixOS/nixpkgs/pull/25304#issuecomment-298385426
+    # for why this defaults to false, but I (@copumpkin) want to default it to true soon.
+    checkMeta = mkMeta {
+      feature = "check <literal>meta</literal> attributes of all the packages";
+    };
+
     doCheckByDefault = mkMassRebuild {
       feature = "run <literal>checkPhase</literal> by default";
     };

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -41,6 +41,12 @@ let
       internal = true;
     };
 
+    unknowns = mkOption {
+      type = types.attrsOf (types.uniq types.unspecified);
+      default = {};
+      internal = true;
+    };
+
     /* Config options */
 
     inHydra = mkMeta {

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -126,6 +126,7 @@ in let
   # sets. Only apply arguments which no stdenv would want to override.
   allPackages = newArgs: import ./stage.nix ({
     inherit lib nixpkgsFun;
+    inherit (config) extraScope;
   } // newArgs);
 
   boot = import ../stdenv/booter.nix { inherit lib allPackages; };

--- a/pkgs/top-level/impure.nix
+++ b/pkgs/top-level/impure.nix
@@ -5,10 +5,53 @@ with builtins;
 
 let
 
-  homeDir = builtins.getEnv "HOME";
+  homeDir = getEnv "HOME";
 
   # Return ‘x’ if it evaluates, or ‘def’ if it throws an exception.
   try = x: def: let res = tryEval x; in if res.success then res.value else def;
+
+  configFile = getEnv "NIXPKGS_CONFIG";
+  configFile2 = homeDir + "/.config/nixpkgs/config.nix";
+  configFile3 = homeDir + "/.nixpkgs/config.nix"; # obsolete
+
+  config_ =
+    if configFile != "" && pathExists configFile then import configFile
+    else if homeDir != "" && pathExists configFile2 then import configFile2
+    else if homeDir != "" && pathExists configFile3 then import configFile3
+    else {};
+
+  isDir = path: pathExists (path + "/.");
+  pathOverlays = try (toString <nixpkgs-overlays>) "";
+  homeOverlaysFile = homeDir + "/.config/nixpkgs/overlays.nix";
+  homeOverlaysDir = homeDir + "/.config/nixpkgs/overlays";
+  importOverlays = path:
+    # check if the path is a directory or a file
+    if isDir path then
+      # it's a directory, so the set of overlays from the directory, ordered lexicographically
+      let content = readDir path; in
+      map (n: import (path + ("/" + n)))
+        (filter (n: match ".*\\.nix" n != null || pathExists (path + ("/" + n + "/default.nix")))
+          (attrNames content))
+    else
+      # it's a file, so the result is the contents of the file itself
+      import path;
+
+  overlays_ =
+    if pathOverlays != "" && pathExists pathOverlays then importOverlays pathOverlays
+    else if pathExists homeOverlaysFile && pathExists homeOverlaysDir then
+      throw ''
+        Nixpkgs overlays can be specified with ${homeOverlaysFile} or ${homeOverlaysDir}, but not both.
+        Please remove one of them and try again.
+      ''
+    else if pathExists homeOverlaysFile then
+      if isDir homeOverlaysFile then
+        throw (homeOverlaysFile + " should be a file")
+      else importOverlays homeOverlaysFile
+    else if pathExists homeOverlaysDir then
+      if !(isDir homeOverlaysDir) then
+        throw (homeOverlaysDir + " should be a directory")
+      else importOverlays homeOverlaysDir
+    else [];
 
 in
 
@@ -16,7 +59,7 @@ in
   # `localSystem` was not passed. Strictly speaking, this is pure desugar, but
   # it is most convient to do so before the impure `localSystem.system` default,
   # so we do it now.
-  localSystem ? builtins.intersectAttrs { system = null; platform = null; } args
+  localSystem ? intersectAttrs { system = null; platform = null; } args
 
 , # These are needed only because nix's `--arg` command-line logic doesn't work
   # with unnamed parameters allowed by ...
@@ -26,51 +69,12 @@ in
 
 , # Fallback: The contents of the configuration file found at $NIXPKGS_CONFIG or
   # $HOME/.config/nixpkgs/config.nix.
-  config ? let
-      configFile = getEnv "NIXPKGS_CONFIG";
-      configFile2 = homeDir + "/.config/nixpkgs/config.nix";
-      configFile3 = homeDir + "/.nixpkgs/config.nix"; # obsolete
-    in
-      if configFile != "" && pathExists configFile then import configFile
-      else if homeDir != "" && pathExists configFile2 then import configFile2
-      else if homeDir != "" && pathExists configFile3 then import configFile3
-      else {}
+  config ? config_
 
 , # Overlays are used to extend Nixpkgs collection with additional
   # collections of packages.  These collection of packages are part of the
   # fix-point made by Nixpkgs.
-  overlays ? let
-      isDir = path: pathExists (path + "/.");
-      pathOverlays = try (toString <nixpkgs-overlays>) "";
-      homeOverlaysFile = homeDir + "/.config/nixpkgs/overlays.nix";
-      homeOverlaysDir = homeDir + "/.config/nixpkgs/overlays";
-      overlays = path:
-        # check if the path is a directory or a file
-        if isDir path then
-          # it's a directory, so the set of overlays from the directory, ordered lexicographically
-          let content = readDir path; in
-          map (n: import (path + ("/" + n)))
-            (builtins.filter (n: builtins.match ".*\\.nix" n != null || pathExists (path + ("/" + n + "/default.nix")))
-              (attrNames content))
-        else
-          # it's a file, so the result is the contents of the file itself
-          import path;
-    in
-      if pathOverlays != "" && pathExists pathOverlays then overlays pathOverlays
-      else if pathExists homeOverlaysFile && pathExists homeOverlaysDir then
-        throw ''
-          Nixpkgs overlays can be specified with ${homeOverlaysFile} or ${homeOverlaysDir}, but not both.
-          Please remove one of them and try again.
-        ''
-      else if pathExists homeOverlaysFile then
-        if isDir homeOverlaysFile then
-          throw (homeOverlaysFile + " should be a file")
-        else overlays homeOverlaysFile
-      else if pathExists homeOverlaysDir then
-        if !(isDir homeOverlaysDir) then
-          throw (homeOverlaysDir + " should be a directory")
-        else overlays homeOverlaysDir
-      else []
+  overlays ? overlays_
 
 , ...
 } @ args:
@@ -79,7 +83,7 @@ in
 # not be passed.
 assert args ? localSystem -> !(args ? system || args ? platform);
 
-import ./. (builtins.removeAttrs args [ "system" "platform" ] // {
+import ./. (removeAttrs args [ "system" "platform" ] // {
   inherit config overlays crossSystem;
   # Fallback: Assume we are building packages on the current (build, in GNU
   # Autotools parlance) system.

--- a/pkgs/top-level/splice.nix
+++ b/pkgs/top-level/splice.nix
@@ -21,7 +21,7 @@
 # For performance reasons, rather than uniformally splice in all cases, we only
 # do so when `pkgs` and `buildPackages` are distinct. The `actuallySplice`
 # parameter there the boolean value of that equality check.
-lib: pkgs: actuallySplice:
+{ lib, pkgs, actuallySplice, extraScope }:
 
 let
 
@@ -126,9 +126,9 @@ in
   # `newScope' for sets of packages in `pkgs' (see e.g. `gnome' below).
   callPackage = pkgs.newScope {};
 
-  callPackages = lib.callPackagesWith splicedPackagesWithXorg;
+  callPackages = lib.callPackagesWith (splicedPackagesWithXorg // extraScope);
 
-  newScope = extra: lib.callPackageWith (splicedPackagesWithXorg // extra);
+  newScope = extra: lib.callPackageWith (splicedPackagesWithXorg // extraScope // extra);
 
   # Haskell package sets need this because they reimplement their own
   # `newScope`.

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -111,8 +111,7 @@ let
   # attributes to refer to the original attributes (e.g. "foo =
   # ... pkgs.foo ...").
   configOverrides = self: super:
-    lib.optionalAttrs allowCustomOverrides
-      ((config.packageOverrides or (super: {})) super);
+    lib.optionalAttrs allowCustomOverrides (config.packageOverrides super);
 
   # Convenience attributes for instantitating package sets. Each of
   # these will instantiate a new version of allPackages. Currently the

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -56,6 +56,9 @@
 , # A list of overlays (Additional `self: super: { .. }` customization
   # functions) to be fixed together in the produced package set
   overlays
+
+, # Extra scope for newScope, callPackage, and similar
+  extraScope
 } @args:
 
 let
@@ -87,7 +90,11 @@ let
     inherit (hostPlatform) system;
   };
 
-  splice = self: super: import ./splice.nix lib self (buildPackages != null);
+  splice = self: super: import ./splice.nix {
+    inherit lib extraScope;
+    pkgs = self;
+    actuallySplice = buildPackages != null;
+  };
 
   allPackages = self: super:
     let res = import ./all-packages.nix


### PR DESCRIPTION
# What?

This patchset does two things:

- firstly, it checks types and produces defaults for `config` attribute (aka `nixpkgs.config`),

- secondly, it introduces Gentoo-like use-flags of #12877 for the cheap on top of that.

The first part is inspired by and is similar to #43672 by @matthewbauer (but it is simpler than #43672 module-mechanics-wise and less comprehensive option-wise, that latter part and removal of `or false` from `config\..* or false` and similar is left for future work if this gets merged).

The second part is inspired by #56109 by me and https://github.com/NixOS/nixpkgs/pull/56110#issuecomment-465906622 by @danbst, and is similar in function to #39580 by @matthewbauer (but it doesn't use overlays, which makes this very cheap (this patchset is unnoticeable in metrics, the impact of ~0.02% on allocations and something unmeasurable on eval time), and without `pkgs` scope pollution with any new attributes).

# Why?

See commit messages below, #43672, #12877, #39580.

# `git log`

- pkgs/top-level/stage.nix: don't override `overlays` and `config` in `nixpkgsFun`

  `nixpkgsFun` already sets them. The next patch will also make
  `nixpkgsFun` use the original `config` while `stage.nix` will get the
  processed one. Mixing them up can cause unexpected errors.

- pkgs/top-level: check types of nixpkgs.config

  This patch simply introduces a plain simple NixOS module and passes
  `nixpkgs.config` through it via `evalModules` (with some temporary hackery to
  passthru undefined options).

- lib: add `extra` property to `mkOption`

- top-level: introduce Gentoo-like global USE flags

  This uses the above `nixpkgs.config` infra to make `nixpkgs.config.use` option
  set that influences the default scope of `callPackage` and etc, thus
  implementing Gentoo-like use flags.

  Note that the whole point of use-flags is that they cover use cases not covered
  by overlays and overrides. For instance, it is very hard to maintain a working
  overlay of headless packages (as `minimal.nix` profile of NixOS dutifully
  demonstrates, see #29135 for more discussion), but it is almost trivial to make
  such a thing using use-flags.

  Moreover, influencing the default scope of `callPackage` and etc allows one to
  override all packages in `pkgs` all at once while keeping `pkgs` scope as-is.
  For instance, by setting `x11Support = false` in `callPackage` scope one
  will (in the ideal world, Nixpkgs' reality is much more cruel, see the actual
  patch) disable X11 support in all the packages while keeping, e.g. `xlib`
  available. The combination of these two properties
  (influencing all the packages while keeping the `pkgs` scope) is impossible to
  achieve with overlays without manually overriding almost every single package in
  scope.

# `nix-instantiate` environment

- Host OS: Linux 4.9, SLNOS 19.03
- Nix: nix-env (Nix) 2.1.3
- Multi-user: yes
- Sandbox: yes
- NIXPKGS_CONFIG:

```nix
{
  checkMeta = true;
  doCheckByDefault = true;
}
```

# `nix-env -qaP` diffs

- On x86_64-linux: noop
- On aarch64-linux: noop
- On x86_64-darwin:
  - New (9):
    - darkice
    - libretro.mame
    - mathematica
    - openmsx
    - pmidi
    - rtaudio
    - rtmidi
    - shairport-sync
    - traverso

# Notes

Note that the above diff shows that this _adds_ some packages on Darwin. "WTF?" you may rightfully ask after reading the changes.

What happens there is the above infra has `config.use.alsa` disabled on Darwin by default, which "overrides" all packages with corresponding scope changes on Darwin, thus removing `alsaLib` dependencies from the above packages, thus allowing above packages to be evaluated on Darwin. If stuff like this isn't cool, then I don't know what is.

I also wanted to disable PulseAudio on Darwin, because AFAIK nobody runs it on Darwin anyway, but that changes a lot of packages, so I decided against it for now.

# What's next?

- If this gets merged:

  - Most of #43672 should be ported on top of this to simplify `config` handling in the rest of nixpkgs.

  - Old `config` options, including those defined by packages, need to be added, a lot of them can then be depricated using normal NixOS module mechanisms like `mkRenamedOptionModule` and etc.

  - Ideally, package options need to be cleaned up.

- If not:

  - Unlike #56110 this is not a "demo". Clearly, this patchset can be managed outside of Nixpkgs tree without any cooperation from Nixpkgs. I.e. unless/until there's a clearly superior implementation of this I will maintain this as the first public branch of SLNOS.
