### PR TITLE
wireguard-go: 0.0.20181001 -> 0.0.20181222

### DIFF
--- a/pkgs/tools/networking/wireguard-go/default.nix
+++ b/pkgs/tools/networking/wireguard-go/default.nix
@@ -2,13 +2,13 @@
 
 buildGoPackage rec {
   name = "wireguard-go-${version}";
-  version = "0.0.20181001";
+  version = "0.0.20181222";
 
   goPackagePath = "git.zx2c4.com/wireguard-go";
 
   src = fetchzip {
     url = "https://git.zx2c4.com/wireguard-go/snapshot/wireguard-go-${version}.tar.xz";
-    sha256 = "0yh9f58xn8kcq3wgx2s8j19k2h1vbmg70fn5gvw9k98f5mzynls3";
+    sha256 = "00m1r97qrr4l21s5jk5m3xfpiybqbzgxp9failsy1nmx27wrdiky";
   };
 
   goDeps = ./deps.nix;
@@ -17,7 +17,7 @@ buildGoPackage rec {
     description = "Userspace Go implementation of WireGuard";
     homepage = https://git.zx2c4.com/wireguard-go/about/;
     license = licenses.gpl2;
-    maintainers = with maintainers; [ kirelagin yegortimoshenko zx2c4 ];
+    maintainers = with maintainers; [ elseym kirelagin yegortimoshenko zx2c4 ];
     platforms = platforms.darwin;
   };
 }

--- a/pkgs/tools/networking/wireguard-go/deps.nix
+++ b/pkgs/tools/networking/wireguard-go/deps.nix
@@ -1,30 +1,30 @@
-# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
+# file generated from go.mod using vgo2nix (https://github.com/adisbladis/vgo2nix)
 [
   {
-    goPackagePath  = "golang.org/x/crypto";
+    goPackagePath = "golang.org/x/crypto";
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/crypto";
-      rev =  "8ac0e0d97ce45cd83d1d7243c060cb8461dda5e9";
-      sha256 = "0vg0dfpv1wgj5imlakpma763yfd67aqbiy0fcklq3cw46qmfbzf1";
+      rev = "505ab145d0a9";
+      sha256 = "1vbsvcvmjz6c00p5vf8ls533p52fx2y3gy6v4k5qrdlzl4wf0i5s";
     };
   }
   {
-    goPackagePath  = "golang.org/x/net";
+    goPackagePath = "golang.org/x/net";
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/net";
-      rev =  "1e491301e022f8f977054da4c2d852decd59571f";
-      sha256 = "1wc18flnz99bip2j1gpnvr3qdp1y7wgyvawlvvc8rmd6ggf5f2yq";
+      rev = "610586996380";
+      sha256 = "1sqwmvf70rq1j65lv5jzyiy7gd53l37dxlnjf2xj6p2i4fcwkk4z";
     };
   }
   {
-    goPackagePath  = "golang.org/x/sys";
+    goPackagePath = "golang.org/x/sys";
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/sys";
-      rev =  "9527bec2660bd847c050fda93a0f0c6dee0800bb";
-      sha256 = "02kd2lnw7dnyqs0vvcpzwkv5brpgkwagqly2xs7dwmsi1vvf400p";
+      rev = "2a47403f2ae5";
+      sha256 = "0ww1iz1zcw995957h32289yascl37pkvfj3qcvyghvnzf7xg9v6z";
     };
   }
 ]


### PR DESCRIPTION
###### Motivation for this change

update wireguard-go

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

