### PR TITLE
demoit: init at unstable-2019-03-29

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5441,4 +5441,9 @@
     github = "shazow";
     name = "Andrey Petrov";
   };
+  freezeboy = {
+    email = "freezeboy@users.noreply.github.com";
+    github = "freezeboy";
+    name = "freezeboy";
+  };
 }

--- a/pkgs/servers/demoit/default.nix
+++ b/pkgs/servers/demoit/default.nix
@@ -1,0 +1,24 @@
+{ stdenv
+, buildGoPackage
+, fetchFromGitHub
+}:
+
+buildGoPackage rec {
+  pname = "demoit";
+  version = "unstable-2019-03-29";
+  goPackagePath = "github.com/dgageot/demoit";
+
+  src = fetchFromGitHub {
+    owner = "dgageot";
+    repo = "demoit";
+    rev = "ec70fbdf5a5e92fa1c06d8f039f7d388e0237ba2";
+    sha256 = "01584cxlnrc928sw7ldmi0sm7gixmwnawy3c5hd79rqkw8r0gbk0";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Live coding demos without Context Switching";
+    homepage = https://github.com/dgageot/demoit;
+    license = licenses.asl20;
+    maintainers = [ maintainers.freezeboy ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -157,6 +157,8 @@ in
 
   deadcode = callPackage ../development/tools/deadcode { };
 
+  demoit = callPackage ../servers/demoit { };
+
   diffPlugins = (callPackage ../build-support/plugins.nix {}).diffPlugins;
 
   dieHook = makeSetupHook {} ../build-support/setup-hooks/die.sh;


### PR DESCRIPTION
###### Motivation for this change

Add `demoit` application from dgageot
It lets include a shell in web pages (used in html5 slides (bespoke, reveal.js, ...))

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

