### PR TITLE
anki: 2.1.8 -> 2.1.9

### DIFF
--- a/pkgs/games/anki/default.nix
+++ b/pkgs/games/anki/default.nix
@@ -33,10 +33,10 @@ let
     # when updating, also update rev-manual to a recent version of
     # https://github.com/dae/ankidocs
     # The manual is distributed independently of the software.
-    version = "2.1.8";
-    sha256-pkg = "08wb9hwpmbq7636h7sinim33qygdwwlh3frqqh2gfgm49f46di2p";
-    rev-manual = "3a3d32dd9bfee6f5a7f5bdad2d70938874c881fa";
-    sha256-manual = "1kz9ywbb6f42krxg8c5cwpjsnzm863vnkkn07szb3m1j85c10gjy";
+    version = "2.1.9";
+    sha256-pkg = "0p4admjxs0gwc54hby9kc1isg99ghxd5kpy08w9hrk3mcyq74z3i";
+    rev-manual = "c2c443bf991089534b0193029f6ee34908124e80";
+    sha256-manual = "1jwm5zrydc6qis7zslfqj56d083kpbzbl51n0x4czhskm9pjh7qd";
 
     manual = stdenv.mkDerivation {
       name = "anki-manual-${version}";


### PR DESCRIPTION
###### Motivation for this change

newest stable from https://apps.ankiweb.net/index.html#download and latest manual

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using ~`nix-shell -p nox --run "nox-review wip"`~ `nix run nixpkgs.nox -c nox-review wip --against master`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

