### PR TITLE
ocamlPackages.stdlib-shims: init at 0.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/stdlib-shims/default.nix
+++ b/pkgs/development/ocaml-modules/stdlib-shims/default.nix
@@ -1,0 +1,18 @@
+{ buildDunePackage, lib, fetchurl, ocaml }:
+
+buildDunePackage rec {
+  pname = "stdlib-shims";
+  version = "0.1.0";
+  src = fetchurl {
+    url = "https://github.com/ocaml/${pname}/releases/download/${version}/${pname}-${version}.tbz";
+    sha256 = "1jv6yb47f66239m7hsz7zzw3i48mjpbvfgpszws48apqx63wjwsk";
+  };
+  minimumOCamlVersion = "4.02";
+  doCheck = true;
+  meta = {
+    description = "Shims for forward-compatibility between versions of the OCaml standard library";
+    homepage = "https://github.com/ocaml/stdlib-shims";
+    inherit (ocaml.meta) license;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -709,6 +709,8 @@ let
 
     ssl = callPackage ../development/ocaml-modules/ssl { };
 
+    stdlib-shims = callPackage ../development/ocaml-modules/stdlib-shims { };
+
     stog = callPackage ../applications/misc/stog { };
 
     stringext = callPackage ../development/ocaml-modules/stringext { };


### PR DESCRIPTION
###### Motivation for this change

Use the new stdlib with old OCaml versions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

