### PR TITLE
git-ignore: init at v0.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4347,6 +4347,15 @@
     github = "solson";
     name = "Scott Olson";
   };
+  sondr3 = {
+    email = "nilsen.sondre@gmail.com";
+    github = "sondr3";
+    name = "Sondre Nilsen";
+    keys = [{
+      longkeyid = "ed25519/0x25676BCBFFAD76B1";
+      fingerprint = "0EC3 FA89 EFBA B421 F82E  40B0 2567 6BCB FFAD 76B1";
+    }];
+  };
   sorki = {
     email = "srk@48.io";
     github = "sorki";

--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -82,6 +82,8 @@ let
 
   git-hub = callPackage ./git-hub { };
 
+  git-ignore = callPackage ./git-ignore { };
+
   git-imerge = callPackage ./git-imerge { };
 
   git-octopus = callPackage ./git-octopus { };

--- a/pkgs/applications/version-management/git-and-tools/git-ignore/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-ignore/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, rustPlatform, pkgconfig, openssl, darwin }:
+
+with rustPlatform;
+
+buildRustPackage rec {
+  name = "git-ignore-${version}";
+  version = "0.2.0";
+
+  cargoSha256 = "1fqfy8lnvpn5sd3l73x2p359zq4303vsrdgw3aphvy6580yjb84d";
+
+  src = fetchFromGitHub {
+    owner = "sondr3";
+    repo = "git-ignore";
+    rev = "v${version}";
+    sha256 = "1nihh5inh46r8jg9z7d6g9gqfyhrznmkn15nmzpbnzf0653dl629";
+  };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ openssl ]
+  ++ stdenv.lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.Security
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Quickly and easily fetch .gitignore templates from gitignore.io";
+    homepage = https://github.com/sondr3/git-ignore;
+    license = licenses.gpl3Plus;
+    platforms = platforms.all;
+    maintainers = [ maintainers.sondr3 ];
+  };
+}


### PR DESCRIPTION
A small program to quickly and easily fetch .gitignore templates from
www.gitignore.io

###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

