### PR TITLE
vim-plugins: Added more vim plugins

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4762,11 +4762,6 @@
     github = "snyh";
     name = "Xia Bin";
   };
-  softinio = {
-    email = "code@softinio.com";
-    github = "softinio";
-    name = "Salar Rahmanian";
-  };
   solson = {
     email = "scott@solson.me";
     github = "solson";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4762,6 +4762,11 @@
     github = "snyh";
     name = "Xia Bin";
   };
+  softinio = {
+    email = "code@softinio.com";
+    github = "softinio";
+    name = "Salar Rahmanian";
+  };
   solson = {
     email = "scott@solson.me";
     github = "solson";

--- a/pkgs/development/tools/tabnine/default.nix
+++ b/pkgs/development/tools/tabnine/default.nix
@@ -1,36 +1,38 @@
 { stdenv, fetchurl }:
 
 let
-  hashes = {
-    x86_64-linux   = "caa86a00d0ede8485bf855276ac1b2e411a5e99de612696b137ea3519a8e4967";
-    x86_64-darwin  = "eb5ceb534629dcf5d57640bf672ea0d94ac02e264209ab3a29e6bda8a44d3b8f";
-  };
+  platformSpecific = {
+    x86_64-linux = {
+      sha256 = "caa86a00d0ede8485bf855276ac1b2e411a5e99de612696b137ea3519a8e4967";
+      string = "x86_64-unknown-linux-gnu";
+    };
+    x86_64-darwin = {
+      sha256 = "eb5ceb534629dcf5d57640bf672ea0d94ac02e264209ab3a29e6bda8a44d3b8f";
+      string = "x86_64-apple-darwin";
+    };
+  }.${stdenv.hostPlatform.system} or (throw "Unsupported platform");
 in
 stdenv.mkDerivation rec {
-  name = "tabnine-${version}";
+  pname = "tabnine";
   version = "1.0.12";
 
-  platformString =
-    if stdenv.isDarwin then "x86_64-apple-darwin"
-    else if stdenv.isLinux then "x86_64-unknown-linux-gnu"
-    else throw "unsupported platform";
-
   src = fetchurl {
-    url = "https://update.tabnine.com/${version}/${platformString}/TabNine";
-    sha256 = hashes.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+    inherit (platformSpecific) sha256;
+    url = "https://update.tabnine.com/${version}/${platformSpecific.string}/TabNine";
   };
 
-  phases = "installPhase";
+  unpackPhase = "true";
 
   installPhase = ''
     mkdir -p $out/bin
-    cp ${src} $out/bin/TabNine
+    cp $src $out/bin/TabNine
     chmod +x $out/bin/TabNine
   '';
 
   meta = with stdenv.lib; {
     description = "TabNine is the all-language autocompleter. It uses machine learning to provide responsive, reliable, and relevant suggestions.";
     homepage = https://tabnine.com/;
+    # Exchanged emails with author to include in nix. Quote from tabnine author: "Thanks for adding TabNine to NixOS"
     license = stdenv.lib.licenses.unfreeRedistributable;
     maintainers = with maintainers; [ softinio ];
     platforms = [ "x86_64-linux" "x86_64-darwin" ];

--- a/pkgs/development/tools/tabnine/default.nix
+++ b/pkgs/development/tools/tabnine/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchurl }:
+
+let
+  hashes = {
+    x86_64-linux   = "caa86a00d0ede8485bf855276ac1b2e411a5e99de612696b137ea3519a8e4967";
+    x86_64-darwin  = "eb5ceb534629dcf5d57640bf672ea0d94ac02e264209ab3a29e6bda8a44d3b8f";
+  };
+in
+stdenv.mkDerivation rec {
+  name = "tabnine-${version}";
+  version = "1.0.12";
+
+  platformString =
+    if stdenv.isDarwin then "x86_64-apple-darwin"
+    else if stdenv.isLinux then "x86_64-unknown-linux-gnu"
+    else throw "unsupported platform";
+
+  src = fetchurl {
+    url = "https://update.tabnine.com/${version}/${platformString}/TabNine";
+    sha256 = hashes.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+  };
+
+  phases = "installPhase";
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ${src} $out/bin/TabNine
+    chmod +x $out/bin/TabNine
+  '';
+
+  meta = with stdenv.lib; {
+    description = "TabNine is the all-language autocompleter. It uses machine learning to provide responsive, reliable, and relevant suggestions.";
+    homepage = https://tabnine.com/;
+    license = stdenv.lib.licenses.unfreeRedistributable;
+    maintainers = with maintainers; [ softinio ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+  };
+}

--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -527,12 +527,12 @@ let
 
   deoplete-tabnine = buildVimPluginFrom2Nix {
     pname = "deoplete-tabnine";
-    version = "2019-01-14";
+    version = "2019-04-08";
     src = fetchFromGitHub {
       owner = "tbodt";
       repo = "deoplete-tabnine";
-      rev = "09d2e024ea125aba7ce3aaee373a12a46f02ed1f";
-      sha256 = "0jfj0qh2d5h72jrz8nxjz38a9hyl55p5ddbll8zpw5kk0z9dh3fv";
+      rev = "050a3bfd4f5ff065b1fe864748557b2d7e439b48";
+      sha256 = "0gk6d33v2j3cydvq4678brz0885pd91vj19ivbr7i24ymyhfg9ky";
     };
   };
 
@@ -750,12 +750,12 @@ let
 
   ghcid = buildVimPluginFrom2Nix {
     pname = "ghcid";
-    version = "2019-01-10";
+    version = "2019-04-09";
     src = fetchFromGitHub {
       owner = "ndmitchell";
       repo = "ghcid";
-      rev = "f8c1da12541cef9a1872d316517e78d160b9a84b";
-      sha256 = "0bwcd4k4sl5nhyyk2660p4dd2gr7in1jrzx8z556idzd1pfv96h2";
+      rev = "2f366b31775dbda38ba1d3e9d14c1320459e52ec";
+      sha256 = "11whzv6yxvswwh2s3qiy9y2yab26ic3rs7yxlmkrvbvckfphfyra";
     };
   };
 
@@ -2984,12 +2984,12 @@ let
 
   vim-hug-neovim-rpc = buildVimPluginFrom2Nix {
     pname = "vim-hug-neovim-rpc";
-    version = "2019-02-21";
+    version = "2019-04-08";
     src = fetchFromGitHub {
       owner = "roxma";
       repo = "vim-hug-neovim-rpc";
-      rev = "411b3f293cb41614e1bec154b8440226e0759ca6";
-      sha256 = "0b91qmlcrapxchsp1xjafpiwm08n54pp40bgjm9kni5vxylikls3";
+      rev = "55db7affbc9527464a88fb2d5f133f4994415f10";
+      sha256 = "1zlr761q12ds9z7xazrjfzqzrxd3z1dcxfq0p0vghwngrx8yqgyx";
     };
   };
 
@@ -3645,12 +3645,12 @@ let
 
   vim-rooter = buildVimPluginFrom2Nix {
     pname = "vim-rooter";
-    version = "2018-09-28";
+    version = "2019-02-25";
     src = fetchFromGitHub {
       owner = "airblade";
       repo = "vim-rooter";
-      rev = "d5bb76e31c030e6b9197491ff521eca49332564b";
-      sha256 = "1g1x7pkhalg354i41ch0wf2hmyjd33jsrc14lc8m732wxh65i0wa";
+      rev = "7db12da2d63b6da5cdb968b29788de5e2beec14d";
+      sha256 = "1dw9d69hvgnsjbj5qksbwb70kpnlba5nnygwq0baclnk7k5x1mbp";
     };
   };
 
@@ -3755,12 +3755,12 @@ let
 
   vim-slash = buildVimPluginFrom2Nix {
     pname = "vim-slash";
-    version = "2017-10-26";
+    version = "2019-04-03";
     src = fetchFromGitHub {
       owner = "junegunn";
       repo = "vim-slash";
-      rev = "abfd99fad599af932cb6b97e995bcb59784a9a3b";
-      sha256 = "04khan891kc4ry1x4qp9rc8vyrrgymr8rczjigsr44j039pqik9j";
+      rev = "3bbd704ebc6c423de60729d6af1cb39f9c4220b1";
+      sha256 = "1mfgwq8blj170nvah26c1fa0lvnhrfpcxka3mph6dwyzq08h1j9h";
     };
   };
 

--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -257,6 +257,17 @@ let
     };
   };
 
+  colorizer = buildVimPluginFrom2Nix {
+    pname = "colorizer";
+    version = "2018-06-16";
+    src = fetchFromGitHub {
+      owner = "lilydjwg";
+      repo = "colorizer";
+      rev = "afc1491e5b9c36305ce710bdad2b48f069141183";
+      sha256 = "1dpiv9z8h6196acncyjhzd1qa56y17468fpxbfzrx5q2266sajc7";
+    };
+  };
+
   Colour-Sampler-Pack = buildVimPluginFrom2Nix {
     pname = "Colour-Sampler-Pack";
     version = "2012-11-30";
@@ -514,6 +525,17 @@ let
     };
   };
 
+  deoplete-tabnine = buildVimPluginFrom2Nix {
+    pname = "deoplete-tabnine";
+    version = "2019-01-14";
+    src = fetchFromGitHub {
+      owner = "tbodt";
+      repo = "deoplete-tabnine";
+      rev = "09d2e024ea125aba7ce3aaee373a12a46f02ed1f";
+      sha256 = "0jfj0qh2d5h72jrz8nxjz38a9hyl55p5ddbll8zpw5kk0z9dh3fv";
+    };
+  };
+
   deoplete-ternjs = buildVimPluginFrom2Nix {
     pname = "deoplete-ternjs";
     version = "2019-01-03";
@@ -726,6 +748,17 @@ let
     };
   };
 
+  ghcid = buildVimPluginFrom2Nix {
+    pname = "ghcid";
+    version = "2019-01-10";
+    src = fetchFromGitHub {
+      owner = "ndmitchell";
+      repo = "ghcid";
+      rev = "f8c1da12541cef9a1872d316517e78d160b9a84b";
+      sha256 = "0bwcd4k4sl5nhyyk2660p4dd2gr7in1jrzx8z556idzd1pfv96h2";
+    };
+  };
+
   ghcmod-vim = buildVimPluginFrom2Nix {
     pname = "ghcmod-vim";
     version = "2016-06-19";
@@ -789,6 +822,17 @@ let
       repo = "gundo.vim";
       rev = "46c443ee9d5854320eb965a1fdee781ba83a070e";
       sha256 = "0adk7agzmbfv342zw6lc8jad6yjs1wap4c0ca98s0qm2bs0r1hl2";
+    };
+  };
+
+  gv-vim = buildVimPluginFrom2Nix {
+    pname = "gv-vim";
+    version = "2018-10-22";
+    src = fetchFromGitHub {
+      owner = "junegunn";
+      repo = "gv.vim";
+      rev = "3296bbf58d2ca38f12595cbfefd4816dd19f3fb5";
+      sha256 = "09avxzyw8cdch5z97127b0a1v8zviap9mfvdyaqbpznh759z8z52";
     };
   };
 
@@ -1662,6 +1706,17 @@ let
     };
   };
 
+  seoul256-vim = buildVimPluginFrom2Nix {
+    pname = "seoul256-vim";
+    version = "2017-09-05";
+    src = fetchFromGitHub {
+      owner = "junegunn";
+      repo = "seoul256.vim";
+      rev = "1475b7610663c68aa90b6e565997c8792ce0d222";
+      sha256 = "03gqw14f5cirivcg1p06g500ns066yv5rd0z3zikvn4ql7n278dk";
+    };
+  };
+
   shabadou-vim = buildVimPluginFrom2Nix {
     pname = "shabadou-vim";
     version = "2016-07-19";
@@ -1670,6 +1725,17 @@ let
       repo = "shabadou.vim";
       rev = "7d4bfed1ea8985ae125df3d1403cc19e252443e1";
       sha256 = "1kvik1yf7yjg9jdmdw38yhkksxg0n3nry02banwik7wgjnpvg870";
+    };
+  };
+
+  smartpairs-vim = buildVimPluginFrom2Nix {
+    pname = "smartpairs-vim";
+    version = "2018-01-01";
+    src = fetchFromGitHub {
+      owner = "gorkunov";
+      repo = "smartpairs.vim";
+      rev = "dc754c29509b1a942552b3cfa348e4aae209322c";
+      sha256 = "1pyynwz7wfbgccdxsyggzl0301qjj3wgyymah5spx8b3s42a6slj";
     };
   };
 
@@ -2916,6 +2982,17 @@ let
     };
   };
 
+  vim-hug-neovim-rpc = buildVimPluginFrom2Nix {
+    pname = "vim-hug-neovim-rpc";
+    version = "2019-02-21";
+    src = fetchFromGitHub {
+      owner = "roxma";
+      repo = "vim-hug-neovim-rpc";
+      rev = "411b3f293cb41614e1bec154b8440226e0759ca6";
+      sha256 = "0b91qmlcrapxchsp1xjafpiwm08n54pp40bgjm9kni5vxylikls3";
+    };
+  };
+
   vim-husk = buildVimPluginFrom2Nix {
     pname = "vim-husk";
     version = "2015-11-29";
@@ -3566,6 +3643,17 @@ let
     };
   };
 
+  vim-rooter = buildVimPluginFrom2Nix {
+    pname = "vim-rooter";
+    version = "2018-09-28";
+    src = fetchFromGitHub {
+      owner = "airblade";
+      repo = "vim-rooter";
+      rev = "d5bb76e31c030e6b9197491ff521eca49332564b";
+      sha256 = "1g1x7pkhalg354i41ch0wf2hmyjd33jsrc14lc8m732wxh65i0wa";
+    };
+  };
+
   vim-rsi = buildVimPluginFrom2Nix {
     pname = "vim-rsi";
     version = "2019-03-15";
@@ -3662,6 +3750,17 @@ let
       repo = "vim-signify";
       rev = "ac23bd95d5fe0c7a7bf4a331e9d37eb72697c46e";
       sha256 = "18vwj2avxpvgk7pl82i6sxvv6cr80g0gvfsljpag1ncg278yap97";
+    };
+  };
+
+  vim-slash = buildVimPluginFrom2Nix {
+    pname = "vim-slash";
+    version = "2017-10-26";
+    src = fetchFromGitHub {
+      owner = "junegunn";
+      repo = "vim-slash";
+      rev = "abfd99fad599af932cb6b97e995bcb59784a9a3b";
+      sha256 = "04khan891kc4ry1x4qp9rc8vyrrgymr8rczjigsr44j039pqik9j";
     };
   };
 

--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -4,12 +4,13 @@
 , llvmPackages, rustPlatform
 , xkb-switch, fzf, skim, stylish-haskell
 , python3, boost, icu, ncurses
-, ycmd, rake, curl
+, ycmd, rake
 , gobject-introspection, glib, wrapGAppsHook
 , substituteAll
 , languagetool
 , Cocoa, CoreFoundation, CoreServices
 , buildVimPluginFrom2Nix
+, tabnine
 
 # vim-go denpencies
 , asmfmt, delve, errcheck, godef, golint
@@ -172,12 +173,11 @@ self: super: {
   });
 
   deoplete-tabnine = super.deoplete-tabnine.overrideAttrs(old: {
-    nativeBuildInputs = [ curl ];
-    buildPhase = ''
-      patchShebangs .
-      unset SSL_CERT_FILE
-      ./install.sh
+    postPatch = ''
+      substituteInPlace rplugin/python3/deoplete/sources/tabnine.py \
+        --replace "path = get_tabnine_path(binary_dir)" "path = ${lib.getBin tabnine}/bin/TabNine"
     '';
+    meta.maintainers = with stdenv.lib.maintainers; [ softinio ];
   });
 
   ensime-vim = super.ensime-vim.overrideAttrs(old: {

--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -4,7 +4,7 @@
 , llvmPackages, rustPlatform
 , xkb-switch, fzf, skim, stylish-haskell
 , python3, boost, icu, ncurses
-, ycmd, rake
+, ycmd, rake, curl
 , gobject-introspection, glib, wrapGAppsHook
 , substituteAll
 , languagetool
@@ -169,6 +169,15 @@ self: super: {
       popd
       find ./rplugin/ -name "ujson*.so" -exec mv -v {} ./rplugin/python3/ \;
    '';
+  });
+
+  deoplete-tabnine = super.deoplete-tabnine.overrideAttrs(old: {
+    nativeBuildInputs = [ curl ];
+    buildPhase = ''
+      patchShebangs .
+      unset SSL_CERT_FILE
+      ./install.sh
+    '';
   });
 
   ensime-vim = super.ensime-vim.overrideAttrs(old: {

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -1,5 +1,6 @@
 907th/vim-auto-save
 airblade/vim-gitgutter
+airblade/vim-rooter
 ajh17/Spacegray.vim
 albfan/nerdtree-git-plugin
 altercation/vim-colors-solarized
@@ -83,6 +84,7 @@ godlygeek/tabular
 google/vim-codefmt
 google/vim-jsonnet
 google/vim-maktaba
+gorkunov/smartpairs.vim
 gregsexton/gitv
 guns/xterm-color-table.vim
 hashivim/vim-terraform
@@ -126,10 +128,13 @@ JuliaEditorSupport/julia-vim
 junegunn/fzf.vim
 junegunn/goyo.vim
 junegunn/limelight.vim
+junegunn/seoul256.vim
 junegunn/vim-easy-align
 junegunn/vim-github-dashboard
+junegunn/gv.vim
 junegunn/vim-peekaboo
 junegunn/vim-plug
+junegunn/vim-slash
 justincampbell/vim-eighties
 justinmk/vim-dirvish
 justinmk/vim-sneak
@@ -155,6 +160,7 @@ ledger/vim-ledger
 lepture/vim-jinja
 lervag/vimtex
 lfilho/cosco.vim
+lilydjwg/colorizer
 LnL7/vim-nix
 ludovicchabant/vim-gutentags
 ludovicchabant/vim-lawrencium
@@ -216,6 +222,7 @@ ncm2/ncm2-jedi
 ncm2/ncm2-path
 ncm2/ncm2-tmux
 ncm2/ncm2-ultisnips
+ndmitchell/ghcid
 neoclide/coc.nvim
 neoclide/vim-easygit
 neomake/neomake
@@ -263,6 +270,7 @@ rodjek/vim-puppet
 roxma/nvim-cm-racer
 roxma/nvim-completion-manager
 roxma/nvim-yarp
+roxma/vim-hug-neovim-rpc
 rust-lang/rust.vim
 ryanoasis/vim-devicons
 Rykka/riv.vim
@@ -299,6 +307,7 @@ sonph/onehalf
 t9md/vim-choosewin
 t9md/vim-smalls
 takac/vim-hardtime
+tbodt/deoplete-tabnine
 ternjs/tern_for_vim
 terryma/vim-expand-region
 terryma/vim-multiple-cursors

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8114,6 +8114,8 @@ in
 
   swiProlog = callPackage ../development/compilers/swi-prolog { };
 
+  tabnine = callPackage ../development/tools/tabnine { };
+
   tbb = callPackage ../development/libraries/tbb { };
 
   terra = callPackage ../development/compilers/terra {


### PR DESCRIPTION
###### Motivation for this change
I recently moved to using Nix as my package manager of choice on macOs and noticed some of the vim/nvim plugins I use and need are missing from nixpkgs so thought of adding them so I can completely move my vim/neovim setup to using nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

