### PR TITLE
nginx: do not run anything as root

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2003.xml
+++ b/nixos/doc/manual/release-notes/rl-2003.xml
@@ -251,6 +251,18 @@
    </listitem>
    <listitem>
     <para>
+     The nginx web server previously started its master process as root
+     privileged, then ran worker processes as a less privileged identity user.
+     This was changed to start all of nginx as a less privileged user (defined by
+     <literal>services.nginx.user</literal> and
+     <literal>services.nginx.group</literal>). As a consequence, all files that
+     are needed for nginx to run (included configuration fragments, SSL
+     certificates and keys, etc.) must now be readable by this less privileged
+     user/group.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
      OpenSSH has been upgraded from 7.9 to 8.1, improving security and adding features
      but with potential incompatibilities.  Consult the
      <link xlink:href="https://www.openssh.com/txt/release-8.1">


### PR DESCRIPTION
###### Motivation for this change
Reopened and updated this PR https://github.com/NixOS/nixpkgs/pull/51551
Change location pidFile from /var/spool/nginx/log/nginx.pid to /run/nginx/nginx.pid

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

