### PR TITLE
matrix-synapse: restore service wrapper script

### DIFF
--- a/nixos/modules/services/misc/matrix-synapse.nix
+++ b/nixos/modules/services/misc/matrix-synapse.nix
@@ -651,16 +651,12 @@ in {
 
     services.postgresql.enable = mkIf usePostgresql (mkDefault true);
 
-    systemd.services.matrix-synapse =
-    let
-      python = (pkgs.python3.withPackages (ps: with ps; [ (ps.toPythonModule cfg.package) ]));
-    in
-    {
+    systemd.services.matrix-synapse = {
       description = "Synapse Matrix homeserver";
       after = [ "network.target" "postgresql.service" ];
       wantedBy = [ "multi-user.target" ];
       preStart = ''
-        ${python.interpreter} -m synapse.app.homeserver \
+        ${cfg.package}/bin/homeserver \
           --config-path ${configFile} \
           --keys-directory ${cfg.dataDir} \
           --generate-keys
@@ -691,7 +687,7 @@ in {
         WorkingDirectory = cfg.dataDir;
         PermissionsStartOnly = true;
         ExecStart = ''
-          ${python.interpreter} -m synapse.app.homeserver \
+          ${cfg.package}/bin/homeserver \
             ${ concatMapStringsSep "\n  " (x: "--config-path ${x} \\") ([ configFile ] ++ cfg.extraConfigFiles) }
             --keys-directory ${cfg.dataDir}
         '';

--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -77,6 +77,6 @@ in buildPythonApplication rec {
     homepage = https://matrix.org;
     description = "Matrix reference homeserver";
     license = licenses.asl20;
-    maintainers = with maintainers; [ ralith roblabla ekleog ];
+    maintainers = with maintainers; [ ralith roblabla ekleog pacien ];
   };
 }

--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -30,6 +30,11 @@ in buildPythonApplication rec {
     sha256 = "1ych13x3c2cam7af4q2ariwvzwvr65g3j2x8ajjn33ydwxxbqbg6";
   };
 
+  patches = [
+    # adds an entry point for the service
+    ./homeserver-script.patch
+  ];
+
   propagatedBuildInputs = [
     bcrypt
     bleach

--- a/pkgs/servers/matrix-synapse/homeserver-script.patch
+++ b/pkgs/servers/matrix-synapse/homeserver-script.patch
@@ -1,0 +1,21 @@
+diff --git a/homeserver b/homeserver
+new file mode 120000
+index 0000000..2f1d413
+--- /dev/null
++++ b/homeserver
+@@ -0,0 +1,1 @@
++synapse/app/homeserver.py
+\ No newline at end of file
+diff --git a/setup.py b/setup.py
+index b00c2af..c7f6e0a 100755
+--- a/setup.py
++++ b/setup.py
+@@ -92,6 +92,6 @@ setup(
+     include_package_data=True,
+     zip_safe=False,
+     long_description=long_description,
+-    scripts=["synctl"] + glob.glob("scripts/*"),
++    scripts=["synctl", "homeserver"] + glob.glob("scripts/*"),
+     cmdclass={'test': TestCommand},
+ )
+


### PR DESCRIPTION
###### Motivation for this change

This restores the service wrapper script removed in #55320, preventing external interpreter version conflict (see https://github.com/NixOS/nixpkgs/pull/55320#issuecomment-462023379).

It's simpler than exposing the Python interpreter of this package (https://github.com/NixOS/nixpkgs/pull/55320#issuecomment-462025678).

This PR also registers myself as a maintainer for this package.

It has been successfully tested on NixOS 18.09.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC package maintainers: @ralith @roblabla @ekleog
