### PR TITLE
skawarePackages.execline: wrap execlineb with tools

### DIFF
--- a/pkgs/build-support/skaware/build-skaware-package.nix
+++ b/pkgs/build-support/skaware/build-skaware-package.nix
@@ -19,6 +19,10 @@ in {
   # mostly for moving and deleting files from the build directory
   # : lines
 , postInstall
+  # packages with setup hooks that should be run
+  # (see definition of `makeSetupHook`)
+  # : list drv
+, setupHooks ? []
   # : list Maintainer
 , maintainers ? []
 
@@ -81,6 +85,8 @@ in stdenv.mkDerivation {
 
   dontDisableStatic = true;
   enableParallelBuilding = true;
+
+  nativeBuildInputs = setupHooks;
 
   configureFlags = configureFlags ++ [
     "--enable-absolute-paths"

--- a/pkgs/tools/misc/execline/default.nix
+++ b/pkgs/tools/misc/execline/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, skawarePackages }:
+{ stdenv, skawarePackages, makeWrapper }:
 
 with skawarePackages;
 
@@ -10,6 +10,8 @@ buildPackage {
   description = "A small scripting language, to be used in place of a shell in non-interactive scripts";
 
   outputs = [ "bin" "lib" "dev" "doc" "out" ];
+
+  setupHooks = [ makeWrapper ];
 
   # TODO: nsss support
   configureFlags = [
@@ -30,6 +32,11 @@ buildPackage {
 
     mv doc $doc/share/doc/execline/html
     mv examples $doc/share/doc/execline/examples
+
+    # finally, add all tools to PATH so they are available
+    # from within execlineb scripts by default
+    wrapProgram $bin/bin/execlineb \
+      --suffix PATH : $bin/bin
   '';
 
 }


### PR DESCRIPTION
The execlineb program is the launcher (and lexer) of execline scripts.
So it makes a lot of sense to have all the small tools in scope by
default.
We append to the end of PATH so that they can be easily overwritten by
the user.

@GrahamcOfBorg build skawarePackages

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

