### PR TITLE
mesa: extract stubs

### DIFF
--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -68,8 +68,9 @@ let
   branch  = head (splitString "." version);
 in
 
-let self = stdenv.mkDerivation {
-  name = "mesa-${version}";
+stdenv.mkDerivation rec {
+  pname = "mesa";
+  inherit version;
 
   src =  fetchurl {
     urls = [
@@ -228,80 +229,8 @@ let self = stdenv.mkDerivation {
   '';
 
   passthru = {
-    inherit libdrm version;
+    inherit libdrm;
     inherit (libglvnd) driverLink;
-
-    # Use stub libraries from libglvnd and headers from Mesa.
-    stubs = stdenv.mkDerivation {
-      name = "libGL-${libglvnd.version}";
-      outputs = [ "out" "dev" ];
-
-      # On macOS, libglvnd is not supported, so we just use what mesa
-      # build. We need to also include OpenGL.framework, and some
-      # extra tricks to go along with. We add mesa’s libGLX to support
-      # the X extensions to OpenGL.
-      buildCommand = if stdenv.hostPlatform.isDarwin then ''
-        mkdir -p $out/nix-support $dev
-        echo ${OpenGL} >> $out/nix-support/propagated-build-inputs
-        ln -s ${self.out}/lib $out/lib
-
-        mkdir -p $dev/lib/pkgconfig $dev/nix-support
-        echo "$out" > $dev/nix-support/propagated-build-inputs
-        ln -s ${self.dev}/include $dev/include
-
-        cat <<EOF >$dev/lib/pkgconfig/gl.pc
-      Name: gl
-      Description: gl library
-      Version: ${self.version}
-      Libs: -L${self.out}/lib -lGL
-      Cflags: -I${self.dev}/include
-      EOF
-
-        cat <<EOF >$dev/lib/pkgconfig/glesv1_cm.pc
-      Name: glesv1_cm
-      Description: glesv1_cm library
-      Version: ${self.version}
-      Libs: -L${self.out}/lib -lGLESv1_CM
-      Cflags: -I${self.dev}/include
-      EOF
-
-        cat <<EOF >$dev/lib/pkgconfig/glesv2.pc
-      Name: glesv2
-      Description: glesv2 library
-      Version: ${self.version}
-      Libs: -L${self.out}/lib -lGLESv2
-      Cflags: -I${self.dev}/include
-      EOF
-      ''
-
-      # Otherwise, setup gl stubs to use libglvnd.
-      else ''
-        mkdir -p $out/nix-support
-        ln -s ${libglvnd.out}/lib $out/lib
-
-        mkdir -p $dev/{,lib/pkgconfig,nix-support}
-        echo "$out" > $dev/nix-support/propagated-build-inputs
-        ln -s ${self.dev}/include $dev/include
-
-        genPkgConfig() {
-          local name="$1"
-          local lib="$2"
-
-          cat <<EOF >$dev/lib/pkgconfig/$name.pc
-        Name: $name
-        Description: $lib library
-        Version: ${self.version}
-        Libs: -L${libglvnd.out}/lib -l$lib
-        Cflags: -I${self.dev}/include
-        EOF
-        }
-
-        genPkgConfig gl GL
-        genPkgConfig egl EGL
-        genPkgConfig glesv1_cm GLESv1_CM
-        genPkgConfig glesv2 GLESv2
-      '';
-    };
   };
 
   meta = with stdenv.lib; {
@@ -311,5 +240,5 @@ let self = stdenv.mkDerivation {
     platforms = platforms.mesaPlatforms;
     maintainers = with maintainers; [ vcunat ];
   };
-};
-in self
+}
+

--- a/pkgs/development/libraries/mesa/stubs.nix
+++ b/pkgs/development/libraries/mesa/stubs.nix
@@ -1,0 +1,75 @@
+{ stdenv
+, libglvnd, mesa
+, OpenGL }:
+
+stdenv.mkDerivation {
+  inherit (libglvnd) version;
+  pname = "libGL";
+  outputs = [ "out" "dev" ];
+
+  # On macOS, libglvnd is not supported, so we just use what mesa
+  # build. We need to also include OpenGL.framework, and some
+  # extra tricks to go along with. We add mesa’s libGLX to support
+  # the X extensions to OpenGL.
+  buildCommand = if stdenv.hostPlatform.isDarwin then ''
+    mkdir -p $out/nix-support $dev
+    echo ${OpenGL} >> $out/nix-support/propagated-build-inputs
+    ln -s ${mesa.out}/lib $out/lib
+
+    mkdir -p $dev/lib/pkgconfig $dev/nix-support
+    echo "$out" > $dev/nix-support/propagated-build-inputs
+    ln -s ${mesa.dev}/include $dev/include
+
+    cat <<EOF >$dev/lib/pkgconfig/gl.pc
+  Name: gl
+  Description: gl library
+  Version: ${mesa.version}
+  Libs: -L${mesa.out}/lib -lGL
+  Cflags: -I${mesa.dev}/include
+  EOF
+
+    cat <<EOF >$dev/lib/pkgconfig/glesv1_cm.pc
+  Name: glesv1_cm
+  Description: glesv1_cm library
+  Version: ${mesa.version}
+  Libs: -L${mesa.out}/lib -lGLESv1_CM
+  Cflags: -I${mesa.dev}/include
+  EOF
+
+    cat <<EOF >$dev/lib/pkgconfig/glesv2.pc
+  Name: glesv2
+  Description: glesv2 library
+  Version: ${mesa.version}
+  Libs: -L${mesa.out}/lib -lGLESv2
+  Cflags: -I${mesa.dev}/include
+  EOF
+  ''
+
+  # Otherwise, setup gl stubs to use libglvnd.
+  else ''
+    mkdir -p $out/nix-support
+    ln -s ${libglvnd.out}/lib $out/lib
+
+    mkdir -p $dev/{,lib/pkgconfig,nix-support}
+    echo "$out" > $dev/nix-support/propagated-build-inputs
+    ln -s ${mesa.dev}/include $dev/include
+
+    genPkgConfig() {
+      local name="$1"
+      local lib="$2"
+
+      cat <<EOF >$dev/lib/pkgconfig/$name.pc
+    Name: $name
+    Description: $lib library
+    Version: ${mesa.version}
+    Libs: -L${libglvnd.out}/lib -l$lib
+    Cflags: -I${mesa.dev}/include
+    EOF
+    }
+
+    genPkgConfig gl GL
+    genPkgConfig egl EGL
+    genPkgConfig glesv1_cm GLESv1_CM
+    genPkgConfig glesv2 GLESv2
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12230,7 +12230,9 @@ in
   # libGL.so/libEGL.so/... to link agains them. Android NDK provides
   # an OpenGL implementation, we can just use that.
   libGL = if stdenv.hostPlatform.useAndroidPrebuilt then stdenv
-          else mesa.stubs;
+          else callPackage ../development/libraries/mesa/stubs.nix {
+            inherit (darwin.apple_sdk.frameworks) OpenGL;
+          };
 
   # Default libGLU
   libGLU = mesa_glu;


### PR DESCRIPTION
###### Motivation for this change
So that I can properly (if I'm doing it properly) override `mesa_noglu`. 

Indirectly tested as part of #56199.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

