### PR TITLE
creep: init at 0.31

### DIFF
--- a/pkgs/data/fonts/creep/default.nix
+++ b/pkgs/data/fonts/creep/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, fontforge }:
+
+stdenv.mkDerivation rec {
+  pname = "creep";
+  version = "0.31";
+
+  src = fetchFromGitHub {
+    owner = "romeovs";
+    repo = pname;
+    rev = version;
+    sha256 = "0zs21kznh1q883jfdgz74bb63i4lxlv98hj3ipp0wvsi6zw0vs8n";
+  };
+
+  nativeBuildInputs = [ fontforge ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    install -D -m644 creep.bdf "$out/usr/share/fonts/misc/creep.bdf"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A pretty sweet 4px wide pixel font";
+    homepage = https://github.com/romeovs/creep;
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ buffet ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15487,6 +15487,8 @@ in
 
   cm_unicode = callPackage ../data/fonts/cm-unicode {};
 
+  creep = callPackage ../data/fonts/creep { };
+
   crimson = callPackage ../data/fonts/crimson {};
 
   dejavu_fonts = lowPrio (callPackage ../data/fonts/dejavu-fonts {});


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

