### PR TITLE
nomachine-client: 6.4.6_1 -> 6.5.6

### DIFF
--- a/pkgs/tools/admin/nomachine-client/default.nix
+++ b/pkgs/tools/admin/nomachine-client/default.nix
@@ -1,23 +1,25 @@
 { stdenv, lib, file, fetchurl, makeWrapper,
   autoPatchelfHook, jsoncpp, libpulseaudio }:
 let
-  versionMajor = "6.4";
-  versionMinor = "6_1";
+  versionMajor = "6.5";
+  versionMinor = "6";
+  versionBuild_x86_64 = "9";
+  versionBuild_i686 = "8";
 in
   stdenv.mkDerivation rec {
-    name = "nomachine-client-${version}";
+    pname = "nomachine-client";
     version = "${versionMajor}.${versionMinor}";
   
     src =
       if stdenv.hostPlatform.system == "x86_64-linux" then
         fetchurl {
-          url = "https://download.nomachine.com/download/${versionMajor}/Linux/nomachine_${version}_x86_64.tar.gz";
-          sha256 = "141pv277kl5ij1pmc0iadc0hnslxri2qaqvsjkmmvls4432jh0yi";
+          url = "https://download.nomachine.com/download/${versionMajor}/Linux/nomachine_${version}_${versionBuild_x86_64}_x86_64.tar.gz";
+          sha256 = "07lg5yadxpl5qfvvh067b3kxd8hm3xv95ralm2pyjl4lw6aql46p";
         }
       else if stdenv.hostPlatform.system == "i686-linux" then
         fetchurl {
-          url = "https://download.nomachine.com/download/${versionMajor}/Linux/nomachine_${version}_i686.tar.gz";
-          sha256 = "0a2vi4ygw34yw8rcjhw17mqx5qbjnym4jkap8paik8lisb5mhnyj";
+          url = "https://download.nomachine.com/download/${versionMajor}/Linux/nomachine_${version}_${versionBuild_i686}_i686.tar.gz";
+          sha256 = "1a23isw09vicazkrypq0kxbb8qy2i4vxiarrgz5xmasjhiy5999a";
         }
       else
         throw "NoMachine client is not supported on ${stdenv.hostPlatform.system}";


### PR DESCRIPTION
###### Motivation for this change

Update package. Also, since the last digit differs between the 32- and
64-bit version, remove it from the version number and introduce two
separate variables - one for each architecture.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

