### PR TITLE
Avoid problematic test case of llvm6 on Android

### DIFF
--- a/pkgs/development/compilers/llvm/6/llvm.nix
+++ b/pkgs/development/compilers/llvm/6/llvm.nix
@@ -79,6 +79,9 @@ in stdenv.mkDerivation (rec {
     substituteInPlace unittests/Support/CMakeLists.txt \
       --replace "add_subdirectory(DynamicLibrary)" ""
     rm unittests/Support/DynamicLibrary/DynamicLibraryTest.cpp
+  '' + optionalString stdenv.targetPlatform.isAndroid ''
+    echo "Deleting test case that fails when host platform contains \"and\""
+    rm ./test/CodeGen/AMDGPU/llvm.amdgcn.mbcnt.ll
   '';
 
   # hacky fix: created binaries need to be run before installation


### PR DESCRIPTION
a test case in llvm, introduced by upstream in
https://github.com/llvm-mirror/llvm/commit/12d09b0dedd50fdbdc1c5316373a014519420d10
checks the generated code for the string `and`. When building with Android as
the target platform, this string shows up there, and the tail fails
(erroneously). So we disable this single unit test in this case (by deleting it).

Fixes #56156