### PR TITLE
gromit-mpx: 1.2 -> 1.3

### DIFF
--- a/pkgs/tools/graphics/gromit-mpx/default.nix
+++ b/pkgs/tools/graphics/gromit-mpx/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, autoconf, automake, pkgconfig
+{ stdenv, fetchFromGitHub, cmake, pkgconfig
 , gtk, glib, pcre, libappindicator, libpthreadstubs, libXdmcp
 , libxkbcommon, epoxy, at-spi2-core, dbus, libdbusmenu
 }:
 
 stdenv.mkDerivation rec {
   name = "gromit-mpx-${version}";
-  version = "1.2";
+  version = "1.3";
 
   src = fetchFromGitHub {
     owner = "bk138";
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
-    autoconf automake autoreconfHook
+    cmake
     gtk glib pcre libappindicator libpthreadstubs
     libXdmcp libxkbcommon epoxy at-spi2-core
     dbus libdbusmenu


### PR DESCRIPTION
###### Motivation for this change

Upgrade package `gromit-mpx` from version 1.2 to 1.3.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

###### Additional Notes

On `nixpkgs/master` there is a problem with GDK which causes gromit-mpx to exit with a segmentation fault.  This problem *does not* exist on the `channels/18.09` branch:

```
Program received signal SIGSEGV, Segmentation fault.
0x00007fffee4bf390 in pixbuf_create_from_xpm ()
   from /nix/store/dap6ngds92w3d2x7gg3fl8i4pp123dd3-gdk-pixbuf-2.36.12/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-xpm.so
(gdb) bt
#0  0x00007fffee4bf390 in pixbuf_create_from_xpm ()
   from /nix/store/dap6ngds92w3d2x7gg3fl8i4pp123dd3-gdk-pixbuf-2.36.12/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-xpm.so
#1  0x00007fffee4bf701 in gdk_pixbuf.xpm_image_load_xpm_data ()
   from /nix/store/dap6ngds92w3d2x7gg3fl8i4pp123dd3-gdk-pixbuf-2.36.12/lib/gdk-pixbuf-2.0/2.10.0/loaders/libpixbufloader-xpm.so
#2  0x00007ffff75b4d71 in gdk_pixbuf_new_from_xpm_data ()
   from /nix/store/vyibwikjzxwr2l19xhz3b5zmrj73d8sw-gdk-pixbuf-2.38.0/lib/libgdk_pixbuf-2.0.so.0
#3  0x00000000004090ec in setup_main_app (data=data@entry=0x4ad050, activate=0)
    at /build/source/src/gromit-mpx.c:681
#4  0x0000000000405d1c in main (argc=<optimized out>, argv=<optimized out>)
    at /build/source/src/gromit-mpx.c:1264
```

NOTE: The existing package for gromit-mpx (version 1.2) also seg faults in the same place on `nixpkgs/master`.