### PR TITLE
vim_customizable: Include manpages in the output

### DIFF
--- a/pkgs/misc/vim-plugins/vim-utils.nix
+++ b/pkgs/misc/vim-plugins/vim-utils.nix
@@ -359,19 +359,39 @@ rec {
   inherit vimrcFile;
 
   # shell script with custom name passing [-u vimrc] [-U gvimrc] to vim
-  vimWithRC = {vimExecutable, name ? null, vimrcFile ? null, gvimrcFile ? null}:
-    let rcOption = o: file: stdenv.lib.optionalString (file != null) "-${o} ${file}";
-    in writeScriptBin (if name == null then "vim" else name) ''
-      #!${stdenv.shell}
-      exec ${vimExecutable} ${rcOption "u" vimrcFile} ${rcOption "U" gvimrcFile} "$@"
+  vimWithRC = {vimExecutable, gvimExecutable, vimManPages, wrapManual, wrapGui, name ? null, vimrcFile ? null, gvimrcFile ? null}:
+    let
+      rcOption = o: file: stdenv.lib.optionalString (file != null) "-${o} ${file}";
+      vimWrapperScript = writeScriptBin (if name == null then "vim" else name) ''
+        #!${stdenv.shell}
+        exec ${vimExecutable} ${rcOption "u" vimrcFile} ${rcOption "U" gvimrcFile} "$@"
       '';
+      gvimWrapperScript = writeScriptBin (if name == null then "gvim" else (lib.concatStrings [ "g" name ])) ''
+        #!${stdenv.shell}
+        exec ${gvimExecutable} ${rcOption "u" vimrcFile} ${rcOption "U" gvimrcFile} "$@"
+      '';
+    in
+      buildEnv {
+        name = vimWrapperScript.name;
+        paths = [
+          vimWrapperScript
+        ] ++ lib.optional wrapGui gvimWrapperScript
+          ++ lib.optional wrapManual vimManPages
+        ;
+      };
 
   # add a customize option to a vim derivation
   makeCustomizable = vim: vim // {
-    customize = { name, vimrcConfig }: vimWithRC {
+    customize = { name, vimrcConfig, wrapManual ? true, wrapGui ? false }: vimWithRC {
       vimExecutable = "${vim}/bin/vim";
-      inherit name;
+      gvimExecutable = "${vim}/bin/gvim";
+      inherit name wrapManual wrapGui;
       vimrcFile = vimrcFile vimrcConfig;
+      vimManPages = buildEnv {
+        name = "${name}-doc";
+        paths = [ vim ];
+        pathsToLink = [ "/share/man" ];
+      };
     };
 
     override = f: makeCustomizable (vim.override f);


### PR DESCRIPTION
###### Motivation for this change
Fixes #24691.
Rebased fix from #26111, resolved conflicts, addressed review comments from that pull request.

###### Things done
Tested the following configurations:
1. `vim_configurable.customize { name = "vimx"; }`
2. `vim_configurable.customize { wrapGui = true; wrapManual = false; name = "vim"; vimExecutableName = "vimb"; gvimExecutableName = "gvimc"; }`

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

