### PR TITLE
btpd: init at 0.16, add module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -857,6 +857,7 @@
   ./services/system/nscd.nix
   ./services/system/saslauthd.nix
   ./services/system/uptimed.nix
+  ./services/torrent/btpd.nix
   ./services/torrent/deluge.nix
   ./services/torrent/flexget.nix
   ./services/torrent/magnetico.nix

--- a/nixos/modules/services/torrent/btpd.nix
+++ b/nixos/modules/services/torrent/btpd.nix
@@ -1,0 +1,194 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.btpd;
+in {
+  options = {
+    services.btpd = {
+      enable = mkEnableOption "the BitTorrent protocol daemon";
+
+      dataDir = mkOption {
+        type = types.str;
+        default = "/var/lib/btpd";
+        description = ''
+          Base directory for btpd. State, logs, a socket, and torrent downloads are stored here.
+        '';
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "btpd";
+        description = ''
+          User which to run btpd as.
+        '';
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "btpd";
+        description = ''
+          Group which to run btpd as.
+        '';
+      };
+
+      address = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          IP address to send to trackers.
+
+          Null sends no address, so trackers will advertise the one they see btpd connect from.
+        '';
+      };
+
+      port = mkOption {
+        type = types.port;
+        default = 6681;
+        description = ''
+          Port for btpd to listen on.
+        '';
+      };
+
+      ipv4 = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Whether to enable IPv4 support for btpd.
+        '';
+      };
+
+      ipv6 = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to enable IPv6 support for btpd.
+
+          Note this section of
+          <citerefentry>
+            <refentrytitle>btpd</refentrytitle>
+            <manvolnum>1</manvolnum>
+          </citerefentry>:
+          <quote>Unfortunately enabling both IPv6 and IPv4 in btpd is less
+          useful than it should be. The problem is that some sites have
+          trackers for both versions and it's likely that the IPv6 one,
+          which probably has less peers, will be used in favour of the IPv4 one.</quote>
+        '';
+      };
+
+      bandwidthLimitIn = mkOption {
+        type = types.ints.unsigned;
+        default = 0;
+        description = ''
+          Limit incoming BitTorrent traffic to n kB/s. 0 is unlimited.
+        '';
+      };
+
+      bandwidthLimitOut = mkOption {
+        type = types.ints.unsigned;
+        default = 0;
+        description = ''
+          Limit outgoing BitTorrent traffic to n kB/s. 0 is unlimited.
+        '';
+      };
+
+      emptyStart = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Start btpd without any active torrents.
+        '';
+      };
+
+      ipcPermission = mkOption {
+        type = types.ints.unsigned;
+        default = 600;
+        example = 666;
+        description = ''
+          Permission mode of the btpd socket.
+        '';
+      };
+
+      maxPeers = mkOption {
+        type = types.ints.unsigned;
+        default = 0;
+        description = ''
+          Limit the amount of peers to n.
+        '';
+      };
+
+      maxUploads = mkOption {
+        type = types.int;
+        default = -2;
+        description = ''
+          Controls the number of simultaneous uploads.
+          The possible values are:
+          <itemizedlist>
+            <listitem><para>
+              <literal>n &lt; -1</literal>: Choose n >= 2 based on bandwidthLimitOut (default).
+            </para></listitem>
+            <listitem><para>
+              <literal>n = -1</literal>: Upload to every interested peer.
+            </para></listitem>
+            <listitem><para>
+              <literal>n = 0</literal>: Don't upload to anyone.
+            </para></listitem>
+            <listitem><para>
+              <literal>n &gt; 0</literal>: Upload to at most n peers simultaneously.
+            </para></listitem>
+          </itemizedlist>
+        '';
+      };
+
+      prealloc = mkOption {
+        type = types.ints.unsigned;
+        default = 2048;
+        description = ''
+          Preallocate disk space in chunks of n kB.
+          Note that n will be rounded up to the closest multiple of the
+          torrent piece size. If n is zero no preallocation will be done.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.btpd ];
+
+    users.users.btpd = mkIf (cfg.user == "btpd") { group = mkDefault cfg.group; };
+    users.groups.btpd = mkIf (cfg.group == "btpd") { };
+
+    systemd.tmpfiles.rules = [
+      "d ${cfg.dataDir} - ${cfg.user} ${cfg.group} - -"
+    ];
+
+    systemd.services.btpd = {
+      after = [ "network.target" ];
+      description = "BitTorrent Protocol Daemon";
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+        ExecStart = ''
+          ${pkgs.btpd}/bin/btpd \
+              --no-daemon \
+              -d ${escapeShellArg cfg.dataDir} \
+              ${optionalString cfg.ipv4 "-4"} \
+              ${optionalString cfg.ipv6 "-6"} \
+              ${optionalString (cfg.address != null) "--ip ${cfg.address}"} \
+              ${optionalString cfg.emptyStart "--empty-start"} \
+              --bw-in ${toString cfg.bandwidthLimitIn} \
+              --bw-out ${toString cfg.bandwidthLimitOut} \
+              --ipcprot ${toString cfg.ipcPermission} \
+              --max-peers ${toString cfg.maxPeers} \
+              --max-uploads ${toString cfg.maxUploads} \
+              --port ${toString cfg.port} \
+              --prealloc ${toString cfg.prealloc}
+        '';
+      };
+    };
+  };
+
+  meta.maintainers = with maintainers; [ tadeokondrak ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -43,6 +43,7 @@ in
   boot = handleTestOn ["x86_64-linux"] ./boot.nix {}; # syslinux is unsupported on aarch64
   boot-stage1 = handleTest ./boot-stage1.nix {};
   borgbackup = handleTest ./borgbackup.nix {};
+  btpd = handleTest ./btpd.nix {};
   buildbot = handleTest ./buildbot.nix {};
   buildkite-agents = handleTest ./buildkite-agents.nix {};
   caddy = handleTest ./caddy.nix {};

--- a/nixos/tests/btpd.nix
+++ b/nixos/tests/btpd.nix
@@ -1,0 +1,16 @@
+import ./make-test.nix ({ lib, ... }: {
+  name = "btpd";
+
+  meta.maintainers = with lib.maintainers; [ tadeokondrak ];
+
+  machine = { ... }: {
+    services.btpd.enable = true;
+  };
+
+  testScript = ''
+    $machine->start;
+    $machine->waitForUnit("btpd.service");
+    $machine->waitForOpenPort("6681");
+    $machine->succeed("btcli -d /var/lib/btpd stat");
+  '';
+})

--- a/nixos/tests/btpd.nix
+++ b/nixos/tests/btpd.nix
@@ -1,4 +1,4 @@
-import ./make-test.nix ({ lib, ... }: {
+import ./make-test-python.nix ({ lib, ... }: {
   name = "btpd";
 
   meta.maintainers = with lib.maintainers; [ tadeokondrak ];
@@ -8,9 +8,9 @@ import ./make-test.nix ({ lib, ... }: {
   };
 
   testScript = ''
-    $machine->start;
-    $machine->waitForUnit("btpd.service");
-    $machine->waitForOpenPort("6681");
-    $machine->succeed("btcli -d /var/lib/btpd stat");
+    machine.start()
+    machine.wait_for_unit("btpd.service")
+    machine.wait_for_open_port("6681")
+    machine.succeed("btcli -d /var/lib/btpd stat")
   '';
 })

--- a/pkgs/applications/networking/p2p/btpd/default.nix
+++ b/pkgs/applications/networking/p2p/btpd/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, openssl
+}:
+
+stdenv.mkDerivation rec {
+  pname = "btpd";
+  version = "0.16";
+
+  src = fetchFromGitHub {
+    owner = "btpd";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0r8jml306jjfr0cpmgjv78kjln0pq899vj1v3pgnys2j6i3wq9s0";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  meta = with lib; {
+    description = "BitTorrent Protocol Daemon";
+    longDescription = ''
+      btpd is a utility for sharing files over the BitTorrent network protocol.
+      It runs in daemon mode, thus needing no controlling terminal or GUI.
+      Instead, the daemon is controlled by btcli, its command line utility, or
+      other programs capable of sending commands and queries on the control socket.
+    '';
+    homepage = "https://github.com/btpd/btpd";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ tadeokondrak ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21286,6 +21286,8 @@ in
 
   breezy = with python3Packages; toPythonApplication breezy;
 
+  btpd = callPackage ../applications/networking/p2p/btpd { };
+
   notmuch-bower = callPackage ../applications/networking/mailreaders/notmuch-bower { };
 
   brig = callPackage ../applications/networking/brig { };


### PR DESCRIPTION
Fixes: #75636

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

First module I've written, I probably got a few things wrong.