### PR TITLE
[wip] Statically built Nix

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -78,10 +78,9 @@ rec {
         else if final.isx86 then "i386"
         else {
           "powerpc" = "ppc";
+          "powerpcle" = "ppc";
           "powerpc64" = "ppc64";
-          "powerpc64le" = "ppc64";
-          "mips64" = "mips";
-          "mipsel64" = "mipsel";
+          "powerpc64le" = "ppc64le";
         }.${final.parsed.cpu.name} or final.parsed.cpu.name;
 
       emulator = pkgs: let

--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -102,7 +102,7 @@ rec {
       in
         if final.parsed.kernel.name == pkgs.stdenv.hostPlatform.parsed.kernel.name &&
            pkgs.stdenv.hostPlatform.isCompatible final
-        then "${pkgs.runtimeShell} -c"
+        then "${pkgs.runtimeShell} -c '$@' --"
         else if final.isWindows
         then "${wine}/bin/${wine-name}"
         else if final.isLinux && pkgs.stdenv.hostPlatform.isLinux

--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -102,7 +102,7 @@ rec {
       in
         if final.parsed.kernel.name == pkgs.stdenv.hostPlatform.parsed.kernel.name &&
            pkgs.stdenv.hostPlatform.isCompatible final
-        then "${pkgs.runtimeShell} -c '$@' --"
+        then "${pkgs.runtimeShell} -c '\"$@\"' --"
         else if final.isWindows
         then "${wine}/bin/${wine-name}"
         else if final.isLinux && pkgs.stdenv.hostPlatform.isLinux

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -295,6 +295,10 @@ stdenv.mkDerivation {
       hardening_unsupported_flags+=" stackprotector fortify"
     ''
 
+    + optionalString targetPlatform.isx86_32 ''
+      hardening_unsupported_flags+=" stackprotector"
+    ''
+
     + optionalString (targetPlatform.libc == "newlib") ''
       hardening_unsupported_flags+=" stackprotector fortify pie pic"
     ''

--- a/pkgs/development/libraries/boehm-gc/default.nix
+++ b/pkgs/development/libraries/boehm-gc/default.nix
@@ -24,14 +24,17 @@ stdenv.mkDerivation rec {
     export NIX_CFLAGS_COMPILE+=" -D_GNU_SOURCE -DUSE_MMAP -DHAVE_DL_ITERATE_PHDR"
   '';
 
-  patches =
+  patches = [ (fetchpatch {
+    name = "boehm-gc-7.6.0-sys_select.patch";
+    url = "https://gitweb.gentoo.org/proj/musl.git/plain/dev-libs/boehm-gc/files/boehm-gc-7.6.0-sys_select.patch?id=85b6a600996bdd71162b357e9ba93d8559342432";
+    sha256 = "1gydwlklvci30f5dpp5ccw2p2qpph5y41r55wx9idamjlq66fbb3";
+  }) ] ++
     # https://github.com/ivmai/bdwgc/pull/208
     lib.optional stdenv.hostPlatform.isRiscV ./riscv.patch;
 
   configureFlags =
     [ "--enable-cplusplus" ]
     ++ lib.optional enableLargeConfig "--enable-large-config"
-    ++ lib.optional (stdenv.hostPlatform.libc == "musl") "--disable-static"
     # Configure script can't detect whether C11 atomic intrinsics are available
     # when cross-compiling, so it links to libatomic_ops, which has to be
     # propagated to all dependencies. To avoid this, assume that the intrinsics

--- a/pkgs/development/libraries/kerberos/krb5.nix
+++ b/pkgs/development/libraries/kerberos/krb5.nix
@@ -3,9 +3,6 @@
 
 # Extra Arguments
 , type ? ""
-# This is called "staticOnly" because krb5 does not support
-# builting both static and shared, see below.
-, staticOnly ? false
 }:
 
 let
@@ -25,9 +22,6 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" ];
 
   configureFlags = [ "--with-tcl=no" "--localstatedir=/var/lib"]
-    # krb5's ./configure does not allow passing --enable-shared and --enable-static at the same time.
-    # See https://bbs.archlinux.org/viewtopic.php?pid=1576737#p1576737
-    ++ optional staticOnly [ "--enable-static" "--disable-shared" ]
     ++ optional stdenv.isFreeBSD ''WARN_CFLAGS=""''
     ++ optionals (stdenv.buildPlatform != stdenv.hostPlatform)
        [ "krb5_cv_attr_constructor_destructor=yes,yes"

--- a/pkgs/os-specific/linux/busybox/default.nix
+++ b/pkgs/os-specific/linux/busybox/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, buildPackages, fetchurl
 , enableStatic ? false
 , enableMinimal ? false
-, useMusl ? stdenv.hostPlatform.libc == "musl", musl
+, useMusl ? stdenv.hostPlatform.libc == "musl"
 , extraConfig ? ""
 }:
 
@@ -86,10 +86,6 @@ stdenv.mkDerivation rec {
     make oldconfig
 
     runHook postConfigure
-  '';
-
-  postConfigure = lib.optionalString useMusl ''
-    makeFlagsArray+=("CC=${stdenv.cc.targetPrefix}cc -isystem ${musl.dev}/include -B${musl}/lib -L${musl}/lib")
   '';
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -44,6 +44,7 @@ rec {
       then throw "Cannot build fully static binaries on Darwin/macOS"
       else stdenv'.mkDerivation (args // {
         NIX_CFLAGS_LINK = toString (args.NIX_CFLAGS_LINK or "") + " -static";
+        separateDebugInfo = false;
         configureFlags = (args.configureFlags or []) ++ [
             "--disable-shared" # brrr...
           ];

--- a/pkgs/tools/compression/brotli/default.nix
+++ b/pkgs/tools/compression/brotli/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake }:
+{ stdenv, fetchFromGitHub, cmake, fetchpatch, staticOnly ? false }:
 
 # ?TODO: there's also python lib in there
 
@@ -15,7 +15,13 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  cmakeFlags = [];
+  patches = stdenv.lib.optional staticOnly (fetchpatch {
+    url = "https://github.com/google/brotli/pull/655/commits/7289e5a378ba13801996a84d89d8fe95c3fc4c11.patch";
+    sha256 = "1bghbdvj24jrvb0sqfdif9vwg7wx6pn8dvl6flkrcjkhpj0gi0jg";
+  });
+
+  cmakeFlags = []
+    ++ stdenv.lib.optional staticOnly "-DBUILD_SHARED_LIBS=OFF";
 
   outputs = [ "out" "dev" "lib" ];
 

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, fetchFromGitHub, callPackage
+{ lib, fetchurl, fetchFromGitHub, fetchpatch, callPackage
 , storeDir ? "/nix/store"
 , stateDir ? "/nix/var"
 , confDir ? "/etc"
@@ -9,7 +9,7 @@ let
 
 common =
   { lib, stdenv, fetchurl, fetchpatch, perl, curl, bzip2, sqlite, openssl ? null, xz
-  , pkgconfig, boehmgc, perlPackages, libsodium, brotli, boost, editline
+  , pkgconfig, boehmgc, perlPackages, libsodium, brotli, boost, editline, libatomic_ops
   , autoreconfHook, autoconf-archive, bison, flex, libxml2, libxslt, docbook5, docbook_xsl_ns
   , busybox-sandbox-shell
   , storeDir
@@ -31,14 +31,16 @@ common =
 
       VERSION_SUFFIX = lib.optionalString fromGit suffix;
 
+      patches = [ ./static.patch ];
+
       outputs = [ "out" "dev" "man" "doc" ];
 
       nativeBuildInputs =
         [ pkgconfig ]
         ++ lib.optionals (!is20) [ curl perl ]
-        ++ lib.optionals fromGit [ autoreconfHook autoconf-archive bison flex libxml2 libxslt docbook5 docbook_xsl_ns ];
+        ++ [ autoreconfHook autoconf-archive bison flex libxml2 libxslt docbook5 docbook_xsl_ns ];
 
-      buildInputs = [ curl openssl sqlite xz bzip2 ]
+      buildInputs = [ curl openssl sqlite xz bzip2 libatomic_ops ]
         ++ lib.optional (stdenv.isLinux || stdenv.isDarwin) libsodium
         ++ lib.optionals is20 [ brotli boost editline ]
         ++ lib.optional withLibseccomp libseccomp

--- a/pkgs/tools/package-management/nix/static.patch
+++ b/pkgs/tools/package-management/nix/static.patch
@@ -1,0 +1,55 @@
+diff --git a/Makefile.config.in b/Makefile.config.in
+index b01a4afb..59730b64 100644
+--- a/Makefile.config.in
++++ b/Makefile.config.in
+@@ -1,4 +1,6 @@
++AR = @AR@
+ BDW_GC_LIBS = @BDW_GC_LIBS@
++BUILD_SHARED_LIBS = @BUILD_SHARED_LIBS@
+ CC = @CC@
+ CFLAGS = @CFLAGS@
+ CXX = @CXX@
+diff --git a/configure.ac b/configure.ac
+index 5a252667..410b2097 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -64,6 +64,7 @@ AC_PROG_CXX
+ AC_PROG_CPP
+ AX_CXX_COMPILE_STDCXX_14
+ 
++AC_CHECK_TOOL([AR], [ar])
+ 
+ # Use 64-bit file system calls so that we can support files > 2 GiB.
+ AC_SYS_LARGEFILE
+@@ -267,6 +268,15 @@ AC_ARG_WITH(sandbox-shell, AC_HELP_STRING([--with-sandbox-shell=PATH],
+   sandbox_shell=$withval)
+ AC_SUBST(sandbox_shell)
+ 
++AC_ARG_ENABLE(shared, AC_HELP_STRING([--enable-shared],
++  [Build shared libraries for Nix [default=yes]]),
++  shared=$enableval, shared=yes)
++if test "$shared" = yes; then
++  AC_SUBST(BUILD_SHARED_LIBS, 1, [Whether to build shared libraries.])
++else
++  AC_SUBST(BUILD_SHARED_LIBS, 0, [Whether to build shared libraries.])
++fi
++
+ 
+ # Expand all variables in config.status.
+ test "$prefix" = NONE && prefix=$ac_default_prefix
+diff --git a/mk/libraries.mk b/mk/libraries.mk
+index 14c95fa9..28173629 100644
+--- a/mk/libraries.mk
++++ b/mk/libraries.mk
+@@ -125,9 +125,9 @@ define build-library
+     $(1)_PATH := $$(_d)/$$($(1)_NAME).a
+ 
+     $$($(1)_PATH): $$($(1)_OBJS) | $$(_d)/
+-	$(trace-ar) ar crs $$@ $$?
++	$(trace-ar) $(AR) crs $$@ $$?
+ 
+-    $(1)_LDFLAGS_USE += $$($(1)_PATH) $$($(1)_LDFLAGS)
++    $(1)_LDFLAGS_USE += -Wl,--whole-archive $$($(1)_PATH) -Wl,--no-whole-archive $$($(1)_LDFLAGS)
+ 
+     $(1)_INSTALL_PATH := $$(libdir)/$$($(1)_NAME).a
+ 

--- a/pkgs/top-level/impure.nix
+++ b/pkgs/top-level/impure.nix
@@ -72,6 +72,8 @@ in
         else overlays homeOverlaysDir
       else []
 
+, crossOverlays ? []
+
 , ...
 } @ args:
 
@@ -80,7 +82,7 @@ in
 assert args ? localSystem -> !(args ? system || args ? platform);
 
 import ./. (builtins.removeAttrs args [ "system" "platform" ] // {
-  inherit config overlays crossSystem;
+  inherit config overlays crossSystem crossOverlays;
   # Fallback: Assume we are building packages on the current (build, in GNU
   # Autotools parlance) system.
   localSystem = (if args ? localSystem then {}

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -153,7 +153,7 @@ in {
   };
 
   brotli = super.brotli.override {
-    stdenv = super.stdenv;
+    staticOnly = true;
   };
 
   curl = super.curl.override {

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -160,4 +160,7 @@ in {
     gssSupport = false;
   };
 
+  nix = (super.nix.override { withAWS = false; }).overrideAttrs (o: {
+    NIX_LDFLAGS = "-lssl -lbrotlicommon -lssh2 -lz -lnghttp2 -lcrypto -latomic";
+  });
 }

--- a/pkgs/top-level/static.nix
+++ b/pkgs/top-level/static.nix
@@ -114,6 +114,10 @@ in {
   boost = super.boost.override {
     enableStatic = true;
     enableShared = false;
+
+    # Don’t use new stdenv for boost because it doesn’t like the
+    # --disable-shared flag
+    stdenv = super.stdenv;
   };
   gmp = super.gmp.override {
     withStatic = true;
@@ -146,6 +150,14 @@ in {
       enableShared = false;
       enableStatic = true;
     };
+  };
+
+  brotli = super.brotli.override {
+    stdenv = super.stdenv;
+  };
+
+  curl = super.curl.override {
+    gssSupport = false;
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change

This makes it possible to build Nix statically through pkgsStatic.nix. Needs a couple of patches to nix but otherwise works smoothly.

If you'd like to try it, you can just check out this branch and run:

```
nix-build -A pkgsStatic.nix
```

and wait a little bit. More targets are available here:

https://github.com/matthewbauer/static-nix

Alternatively, you can use my prebuilt binary at https://matthewbauer.us/nix. It is built for x86_64-linux and can be used on any system like this:

```
$ curl https://matthewbauer.us/nix | sh -s ...
```

For instance, on a linux system without nix installed, you can do this:

```
$ curl https://matthewbauer.us/nix | sh -s run --store $HOME/.cache/nix/store -f channel:nixpkgs-unstable hello -c hello
Hello World!
```

There are many uses cases where nix is unavailable and the above command can be extremely useful. It's a little slow still, but can be sped up by reusing the same ```--store``` value (such as $HOME/.cache/nix/store). Here is the time:

```
$ time (curl https://matthewbauer.us/nix | sh -s run --store $HOME/.cache/nix/store -f channel:nixpkgs-unstable hello -c hello)
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 5596k  100 5596k    0     0  2807k      0  0:00:01  0:00:01 --:--:-- 2807k
[2 copied (24.0 MiB), 35.5 MiB DL]
Hello, world!
( curl https://matthewbauer.us/nix | sh -s run --store $(mktemp -d) -f  hello)  3.39s user 3.52s system 70% cpu 9.757 total
```