### PR TITLE
apache-httpd: formating the config file

### DIFF
--- a/nixos/modules/services/web-servers/apache-httpd/default.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/default.nix
@@ -256,7 +256,7 @@ let
   ;
 
 
-  confFile = pkgs.writeText "httpd.conf" ''
+  confFile = pkgs.writers.writeHttpdConfig "httpd.conf" ''
 
     ServerRoot ${pkg}
     ServerName ${config.networking.hostName}

--- a/pkgs/build-support/writers/default.nix
+++ b/pkgs/build-support/writers/default.nix
@@ -184,6 +184,21 @@ rec {
   writeJSBin = name:
     writeJS "/bin/${name}";
 
+  awkFormatHttpd = builtins.toFile "awkFormat-httpd.awk" ''
+    awk -f
+    {sub(/^[ \t]+/,"");idx=0}
+    /<[^\/]/{ctx++;idx=1}
+    /<\//{ctx--}
+    {id="";for(i=idx;i<ctx;i++)id=sprintf("%s%s", id, "\t");printf "%s%s\n", id, $0}
+  '';
+
+  writeHttpdConfig = name: text: pkgs.runCommand name {
+    inherit text;
+    passAsFile = [ "text" ];
+  } /* sh */ ''
+    ${pkgs.gawk}/bin/awk -f ${awkFormatHttpd} "$textPath" | ${pkgs.gnused}/bin/sed '/^\s*$/d' > $out
+  '';
+
   awkFormatNginx = builtins.toFile "awkFormat-nginx.awk" ''
     awk -f
     {sub(/^[ \t]+/,"");idx=0}


### PR DESCRIPTION
###### Motivation for this change
Formating the config file with awk to readable format.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

