### PR TITLE
cmake: fix darwin bootstrapping

### DIFF
--- a/pkgs/development/tools/build-managers/cmake/application-services.patch
+++ b/pkgs/development/tools/build-managers/cmake/application-services.patch
@@ -1,6 +1,24 @@
-diff -ur cmake-3.12.1/Source/cmGlobalXCodeGenerator.cxx cmake-3.12.1-patched/Source/cmGlobalXCodeGenerator.cxx
---- cmake-3.12.1/Source/cmGlobalXCodeGenerator.cxx	2018-08-09 21:14:08.000000000 +0900
-+++ cmake-3.12.1-patched/Source/cmGlobalXCodeGenerator.cxx	2018-08-12 02:47:28.719691934 +0900
+diff --git a/Source/CMakeLists.txt b/Source/CMakeLists.txt
+index 8aff8f6..af1852d 100644
+--- a/Source/CMakeLists.txt
++++ b/Source/CMakeLists.txt
+@@ -791,12 +791,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR MATCHES "sparc"
+   endif()
+ endif()
+ 
+-# On Apple we need CoreFoundation and CoreServices
+-if(APPLE)
+-  target_link_libraries(CMakeLib "-framework CoreFoundation")
+-  target_link_libraries(CMakeLib "-framework CoreServices")
+-endif()
+-
+ if(WIN32 AND NOT UNIX)
+   # We need the rpcrt4 library on Windows.
+   # We need the crypt32 library on Windows for crypto/cert APIs.
+diff --git a/Source/cmGlobalXCodeGenerator.cxx b/Source/cmGlobalXCodeGenerator.cxx
+index e353a37..b06f842 100644
+--- a/Source/cmGlobalXCodeGenerator.cxx
++++ b/Source/cmGlobalXCodeGenerator.cxx
 @@ -35,11 +35,6 @@
  
  struct cmLinkImplementation;
@@ -13,3 +31,19 @@ diff -ur cmake-3.12.1/Source/cmGlobalXCodeGenerator.cxx cmake-3.12.1-patched/Sou
  #if defined(CMAKE_BUILD_WITH_CMAKE)
  #  include "cmXMLParser.h"
  
+diff --git a/Utilities/cmlibarchive/CMakeLists.txt b/Utilities/cmlibarchive/CMakeLists.txt
+index d7af6e2..d4808fc 100644
+--- a/Utilities/cmlibarchive/CMakeLists.txt
++++ b/Utilities/cmlibarchive/CMakeLists.txt
+@@ -1662,11 +1662,6 @@ IF(MSVC)
+   ADD_DEFINITIONS(-D_CRT_SECURE_NO_DEPRECATE)
+ ENDIF(MSVC)
+ 
+-# We need CoreServices on Mac OS.
+-IF(APPLE)
+-  LIST(APPEND ADDITIONAL_LIBS "-framework CoreServices")
+-ENDIF(APPLE)
+-
+ add_subdirectory(libarchive)
+ 
+ install(FILES COPYING DESTINATION ${CMAKE_DOC_DIR}/cmlibarchive)

--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -2,7 +2,7 @@
 , bzip2, curl, expat, libarchive, xz, zlib, libuv, rhash
 , buildPackages
 # darwin attributes
-, ps
+, cf-private, ps
 , isBootstrap ? false
 , useSharedLibraries ? (!isBootstrap && !stdenv.isCygwin)
 , useNcurses ? false, ncurses
@@ -52,6 +52,7 @@ stdenv.mkDerivation rec {
 
   buildInputs =
     [ setupHook pkgconfig ]
+    ++ optional stdenv.isDarwin cf-private  # needed for CFBundleCopyExecutableURL
     ++ optionals useSharedLibraries [ bzip2 curl expat libarchive xz zlib libuv rhash ]
     ++ optional useNcurses ncurses
     ++ optional useQt4 qt4

--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -34,11 +34,6 @@ stdenv.mkDerivation rec {
     inherit sha256;
   };
 
-  prePatch = optionalString (!useSharedLibraries) ''
-    substituteInPlace Utilities/cmlibarchive/CMakeLists.txt \
-      --replace '"-framework CoreServices"' '""'
-  '';
-
   patches = [
     # Don't search in non-Nix locations such as /usr, but do search in our libc.
     ./search-path.patch

--- a/pkgs/tools/compression/xar/default.nix
+++ b/pkgs/tools/compression/xar/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, libxml2, openssl, zlib, bzip2, fts }:
+{ stdenv, fetchurl, libxml2, lzma, openssl, zlib, bzip2, fts }:
 
 stdenv.mkDerivation rec {
   version = "1.6.1";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0ghmsbs6xwg1092v7pjcibmk5wkyifwxw6ygp08gfz25d2chhipf";
   };
 
-  buildInputs = [ libxml2 openssl zlib bzip2 fts ];
+  buildInputs = [ libxml2 lzma openssl zlib bzip2 fts ];
 
   meta = {
     homepage    = https://mackyle.github.io/xar/;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8496,7 +8496,9 @@ in
 
   cmake_2_8 = callPackage ../development/tools/build-managers/cmake/2.8.nix { };
 
-  cmake = libsForQt5.callPackage ../development/tools/build-managers/cmake { };
+  cmake = libsForQt5.callPackage ../development/tools/build-managers/cmake {
+    inherit (darwin) cf-private;
+  };
 
   cmakeCurses = cmake.override { useNcurses = true; };
 


### PR DESCRIPTION
###### Motivation for this change

**NOTE** I only tested the bootstrap cmake at this point, but this might unblock staging-next.

Fixes #56244

/cc @FRidh @vcunat

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
