### PR TITLE
luakit: 2017.08.10 → 2.1

### DIFF
--- a/pkgs/applications/networking/browsers/luakit/default.nix
+++ b/pkgs/applications/networking/browsers/luakit/default.nix
@@ -1,6 +1,7 @@
-{stdenv, fetchFromGitHub, pkgconfig, wrapGAppsHook, makeWrapper
-,help2man, lua5, luafilesystem, luajit, sqlite
-,webkitgtk, gtk3, gst_all_1, glib-networking}:
+{ stdenv, fetchFromGitHub, pkgconfig, wrapGAppsHook
+, help2man, lua5, luafilesystem, luajit, sqlite
+, webkitgtk, gtk3, gst_all_1, glib-networking
+}:
 
 let
   lualibs = [luafilesystem];
@@ -11,51 +12,56 @@ let
   luaCPath      = stdenv.lib.concatStringsSep ";" (map getLuaCPath lualibs);
 
 in stdenv.mkDerivation rec {
-
-  name = "luakit-${version}";
+  pname = "luakit";
   version = "2017.08.10";
+
   src = fetchFromGitHub {
     owner = "luakit";
     repo = "luakit";
-    rev = "${version}";
+    rev = version;
     sha256 = "09z88b50vf2y64vj79cymknyzk3py6azv4r50jng4cw9jx2ray7r";
   };
 
-  nativeBuildInputs = [pkgconfig help2man wrapGAppsHook makeWrapper];
+  nativeBuildInputs = [
+    pkgconfig help2man wrapGAppsHook
+  ];
 
-  buildInputs = [webkitgtk lua5 luafilesystem luajit sqlite gtk3
+  buildInputs = [
+    webkitgtk lua5 luafilesystem luajit sqlite gtk3
     gst_all_1.gstreamer gst_all_1.gst-plugins-base
     gst_all_1.gst-plugins-good gst_all_1.gst-plugins-bad gst_all_1.gst-plugins-ugly
     gst_all_1.gst-libav
     glib-networking # TLS support
   ];
 
-  postPatch =
-    #Kind of ugly seds here. There must be a better solution.
-  ''
-    patchShebangs ./build-utils
-    sed -i "2 s|require \"lib.lousy.util\"|dofile(\"./lib/lousy/util.lua\")|" ./build-utils/docgen/gen.lua;
-    sed -i "3 s|require \"lib.markdown\"|dofile(\"./lib/markdown.lua\")|" ./build-utils/docgen/gen.lua;
-    sed -i "1,2 s|require(\"lib.lousy.util\")|dofile(\"./lib/lousy/util.lua\")|" ./build-utils/find_files.lua;
+  preBuild = ''
+    # build-utils/docgen/gen.lua:2: module 'lib.lousy.util' not found
+    # TODO: why is not this the default?
+    LUA_PATH=?.lua
   '';
 
-  buildPhase = ''
-    make DEVELOPMENT_PATHS=0 USE_LUAJIT=1 INSTALLDIR=$out PREFIX=$out USE_GTK3=1
-  '';
+  makeFlags = [
+    "DEVELOPMENT_PATHS=0"
+    "USE_LUAJIT=1"
+    "INSTALLDIR=${placeholder "out"}"
+    "PREFIX=${placeholder "out"}"
+    "USE_GTK3=1"
+    "XDGPREFIX=${placeholder "out"}/etc/xdg"
+  ];
 
-  installPhase = let
+  preFixup = let
     luaKitPath = "$out/share/luakit/lib/?/init.lua;$out/share/luakit/lib/?.lua";
   in ''
-    make DEVELOPMENT_PATHS=0 INSTALLDIR=$out PREFIX=$out XDGPREFIX=$out/etc/xdg USE_GTK3=1 install
-    wrapProgram $out/bin/luakit                                         \
-      --prefix XDG_CONFIG_DIRS : "$out/etc/xdg"                         \
-      --set LUA_PATH '${luaKitPath};${luaPath};'                      \
+    gappsWrapperArgs+=(
+      --prefix XDG_CONFIG_DIRS : "$out/etc/xdg"
+      --set LUA_PATH '${luaKitPath};${luaPath};'
       --set LUA_CPATH '${luaCPath};'
+    )
   '';
 
   meta = with stdenv.lib; {
     description = "Fast, small, webkit based browser framework extensible in Lua";
-    homepage    = "http://luakit.org";
+    homepage    = http://luakit.org;
     license     = licenses.gpl3;
     platforms   = platforms.linux; # Only tested linux
   };

--- a/pkgs/applications/networking/browsers/luakit/default.nix
+++ b/pkgs/applications/networking/browsers/luakit/default.nix
@@ -13,13 +13,13 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "luakit";
-  version = "2017.08.10";
+  version = "2.1";
 
   src = fetchFromGitHub {
     owner = "luakit";
     repo = "luakit";
     rev = version;
-    sha256 = "09z88b50vf2y64vj79cymknyzk3py6azv4r50jng4cw9jx2ray7r";
+    sha256 = "05mm76g72fs48410pbij4mw0s3nqji3r7f3mnr2fvhv02xqj05aa";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
Cleaned up the expression a bit.

As for the docgen requires, [lua docs](https://www.lua.org/pil/8.1.html) state:

> To determine its path, require first checks the global variable LUA_PATH. If the value of LUA_PATH is a string, that string is the path. Otherwise, require checks the environment variable LUA_PATH. **Finally, if both checks fail, require uses a fixed path (typically "?;?.lua", although it is easy to change that when you compile Lua).** 

Not sure why it does not work.

cc @lprndn @emmanuelrosa
cc @teto (https://github.com/NixOS/nixpkgs/pull/55747)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

