### PR TITLE
ocamlPackages.ocamlbuild: 0.12.0 -> 0.14.0

### DIFF
--- a/pkgs/development/tools/ocaml/ocamlbuild/default.nix
+++ b/pkgs/development/tools/ocaml/ocamlbuild/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, ocaml, findlib }:
 let
-  version = "0.12.0";
+  version = "0.14.0";
 in
 stdenv.mkDerivation {
   name = "ocamlbuild-${version}";
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
     owner = "ocaml";
     repo = "ocamlbuild";
     rev = version;
-    sha256 = "1shyim50ms0816fphc4mk0kldcx3pnba2i6m10q0cbm18m9d7chq";
+    sha256 = "1hb5mcdz4wv7sh1pj7dq9q4fgz5h3zg7frpiya6s8zd3ypwzq0kh";
   };
 
   createFindlibDestdir = true;


### PR DESCRIPTION
###### Motivation for this change

Compatibility with OCaml 4.08

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

