### PR TITLE
pythonPackages.XlsxWriter: enable tests and pythonPackages.can: 3.0.0 -> 3.1.0

### DIFF
--- a/pkgs/development/python-modules/XlsxWriter/default.nix
+++ b/pkgs/development/python-modules/XlsxWriter/default.nix
@@ -1,12 +1,17 @@
-{lib, buildPythonPackage, fetchPypi}:
+{lib, buildPythonPackage, fetchFromGitHub}:
 
 buildPythonPackage rec {
+
   pname = "XlsxWriter";
   version = "1.1.5";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "de9ef46088489915eaaee00c7088cff93cf613e9990b46b933c98eb46f21b47f";
+  # PyPI release tarball doesn't contain tests so let's use GitHub. See:
+  # https://github.com/jmcnamara/XlsxWriter/issues/327
+  src = fetchFromGitHub{
+    owner = "jmcnamara";
+    repo = pname;
+    rev = "RELEASE_${version}";
+    sha256 = "13250y53mr0pki93sqscy2bx01fxh6b6wvvj6m95ky0wqrrbmg39";
   };
 
   meta = {
@@ -15,4 +20,5 @@ buildPythonPackage rec {
     maintainers = with lib.maintainers; [ jluttine ];
     license = lib.licenses.bsd2;
   };
+
 }


### PR DESCRIPTION
###### Motivation for this change

Update XlsxWriter and also fix+upgrade python-can because otherwise nox-review failed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

