### PR TITLE
pythonPackages.pvlib: enable tests

### DIFF
--- a/pkgs/development/python-modules/pvlib/default.nix
+++ b/pkgs/development/python-modules/pvlib/default.nix
@@ -1,20 +1,30 @@
-{ stdenv, buildPythonPackage, fetchPypi, numpy, pandas, pytz, six, pytest }:
+{ stdenv, buildPythonPackage, fetchFromGitHub, numpy, pandas, pytz, six
+, pytest, mock, pytest-mock }:
 
 buildPythonPackage rec {
   pname = "pvlib";
   version = "0.6.1";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "56e70747add2e50846dd8bbef9a4735e82c1224ce630d1db7590b96bd59dd3f7";
+  # Use GitHub because PyPI release tarball doesn't contain the tests. See:
+  # https://github.com/pvlib/pvlib-python/issues/473
+  src = fetchFromGitHub{
+    owner = "pvlib";
+    repo = "pvlib-python";
+    rev = "v${version}";
+    sha256 = "17h7vz9s829qxnl4byr8458gzgiismrbrn5gl0klhfhwvc5kkdfh";
   };
 
-  checkInputs = [ pytest ];
+  checkInputs = [ pytest mock pytest-mock ];
   propagatedBuildInputs = [ numpy pandas pytz six ];
 
-  # Currently, the PyPI tarball doesn't contain the tests. When that has been
-  # fixed, enable testing. See: https://github.com/pvlib/pvlib-python/issues/473
-  doCheck = false;
+  # Skip a few tests that try to access some URLs
+  checkPhase = ''
+    runHook preCheck
+    pushd pvlib/test
+    pytest . -k "not test_read_srml_dt_index and not test_read_srml_month_from_solardata"
+    popd
+    runHook postCheck
+  '';
 
   meta = with stdenv.lib; {
     homepage = http://pvlib-python.readthedocs.io;


### PR DESCRIPTION
###### Motivation for this change

Upgrade pvlib and also enable unit tests.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

