### PR TITLE
Initialize python pyviz stack and intake

### DIFF
--- a/pkgs/development/python-modules/holoviews/default.nix
+++ b/pkgs/development/python-modules/holoviews/default.nix
@@ -1,0 +1,47 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+, param
+, numpy
+, pyviz-comms
+, ipython
+, notebook
+, pandas
+, matplotlib
+, bokeh
+, scipy
+, panel
+}:
+
+buildPythonPackage rec {
+  pname = "holoviews";
+  version = "1.11.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0902wzzz73ikkdy0jfhg1lx97y1gk7v1nr3d3jqqdfzaa7bmhqwj";
+  };
+
+  propagatedBuildInputs = [
+    param
+    numpy
+    pyviz-comms
+    ipython
+    notebook
+    pandas
+    matplotlib
+    bokeh
+    scipy
+    panel
+  ];
+
+  # tests not fully included with pypi release
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Python data analysis and visualization seamless and simple";
+    homepage = http://www.holoviews.org/;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/hvplot/default.nix
+++ b/pkgs/development/python-modules/hvplot/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, bokeh
+, holoviews
+, pandas
+, pytest
+, parameterized
+, nbsmoke
+, flake8
+, coveralls
+, xarray
+, networkx
+, streamz
+}:
+
+buildPythonPackage rec {
+  pname = "hvplot";
+  version = "0.4.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "bce169cf2d1b3ff9ce607d1787f608758e72a498434eaa2bece31eea1f51963a";
+  };
+
+  checkInputs = [ pytest parameterized nbsmoke flake8 coveralls xarray networkx streamz ];
+  propagatedBuildInputs = [
+    bokeh
+    holoviews
+    pandas
+  ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  # many tests require a network connection
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A high-level plotting API for the PyData ecosystem built on HoloViews";
+    homepage = https://hvplot.pyviz.org;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/intake/default.nix
+++ b/pkgs/development/python-modules/intake/default.nix
@@ -1,0 +1,60 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, appdirs
+, dask
+, holoviews
+, jinja2
+, msgpack-numpy
+, msgpack-python
+, numpy
+, pandas
+, python-snappy
+, requests
+, ruamel_yaml
+, six
+, tornado
+, pytest
+, pythonOlder
+, isPy27
+}:
+
+buildPythonPackage rec {
+  pname = "intake";
+  version = "0.4.1";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "f47e53aa764eeadf6adcc667b9817b1ad32496477476da0b982d4fc0744b40ef";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [
+    appdirs
+    dask
+    holoviews
+    jinja2
+    msgpack-numpy
+    msgpack-python
+    numpy
+    pandas
+    python-snappy
+    requests
+    ruamel_yaml
+    six
+    tornado
+  ];
+
+  checkPhase = ''
+    # single test assumes python for executable name
+    PATH=$out/bin:$PATH HOME=$(mktemp -d) pytest --ignore=intake/catalog/tests/test_default.py
+  '';
+
+  meta = with lib; {
+    description = "Data load and catalog system";
+    homepage = https://github.com/ContinuumIO/intake;
+    license = licenses.bsd2;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/nbsmoke/default.nix
+++ b/pkgs/development/python-modules/nbsmoke/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytest
+, jupyter_client
+, ipykernel
+, nbformat
+, nbconvert
+, pyflakes
+, requests
+, beautifulsoup4
+}:
+
+buildPythonPackage rec {
+  pname = "nbsmoke";
+  version = "0.2.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "40891e556dc9e252da2a649028cacb949fc8efb81062ada7d9a87a01b08bb454";
+  };
+
+  propagatedBuildInputs = [
+    pytest
+    jupyter_client
+    ipykernel
+    nbformat
+    nbconvert
+    pyflakes
+    requests
+    beautifulsoup4
+  ];
+
+  # tests not included with pypi release
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Basic notebook checks and linting";
+    homepage = https://github.com/pyviz/nbsmoke;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/panel/default.nix
+++ b/pkgs/development/python-modules/panel/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, bokeh
+, param
+, pyviz-comms
+, markdown
+, pyct
+, testpath
+, pytest
+, scipy
+, plotly
+, altair
+, vega_datasets
+, hvplot
+}:
+
+buildPythonPackage rec {
+  pname = "panel";
+  version = "0.4.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "21fc6729909dba4ba8c9a84b7fadd293322cc2594d15ac73b0f66a5ceffd1f98";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "testpath<0.4" "testpath"
+  '';
+
+  propagatedBuildInputs = [
+    bokeh
+    param
+    pyviz-comms
+    markdown
+    pyct
+    testpath
+  ];
+
+  # infinite recursion in test dependencies (hvplot)
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A high level dashboarding library for python visualization libraries";
+    homepage = http://pyviz.org;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/param/default.nix
+++ b/pkgs/development/python-modules/param/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, flake8
+, nose
+}:
+
+buildPythonPackage rec {
+  pname = "param";
+  version = "1.8.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "49927979d4f6c994bcd8f6f7f2b34e3a0a7f0d62404dca6bcae5acde0192bb01";
+  };
+
+  checkInputs = [ flake8 nose ];
+
+  # tests not included with pypi release
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Declarative Python programming using Parameters";
+    homepage = https://github.com/pyviz/param;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/pyct/default.nix
+++ b/pkgs/development/python-modules/pyct/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, param
+, pyyaml
+, requests
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "pyct";
+  version = "0.4.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "df7b2d29f874cabdbc22e4f8cba2ceb895c48aa33da4e0fe679e89873e0a4c6e";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [
+    param
+    pyyaml
+    requests
+  ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with lib; {
+    description = "Cli for python common tasks for users";
+    homepage = https://github.com/pyviz/pyct;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/python-snappy/default.nix
+++ b/pkgs/development/python-modules/python-snappy/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, isPyPy
+, python
+, snappy
+, cffi
+, nose
+}:
+
+buildPythonPackage rec {
+  pname = "python-snappy";
+  version = "0.5.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "8a7f803f06083d4106d55387d2daa32c12b5e376c3616b0e2da8b8a87a27d74a";
+  };
+
+  buildInputs = [ snappy ];
+
+  propagatedBuildInputs = lib.optional isPyPy cffi;
+
+  checkInputs = [ nose ];
+
+  checkPhase = ''
+    rm -r snappy # prevent local snappy from being picked up
+    nosetests test_snappy.py
+  '' + lib.optionalString isPyPy ''
+    nosetests test_snappy_cffi.py
+  '';
+
+  meta = with lib; {
+    description = "Python library for the snappy compression library from Google";
+    homepage = http://github.com/andrix/python-snappy;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/pyviz-comms/default.nix
+++ b/pkgs/development/python-modules/pyviz-comms/default.nix
@@ -1,0 +1,27 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+, param
+}:
+
+buildPythonPackage rec {
+  pname = "pyviz_comms";
+  version = "0.7.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "7ad4ff0c2166f0296ee070049ce21341f868f907003714eb6eaf1630ea8e241a";
+  };
+
+  propagatedBuildInputs = [ param ];
+
+  # there are not tests with the package
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Launch jobs, organize the output, and dissect the results";
+    homepage = http://pyviz.org/;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/streamz/default.nix
+++ b/pkgs/development/python-modules/streamz/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, tornado
+, toolz
+, zict
+, six
+, pytest
+, networkx
+, distributed
+, confluent-kafka
+, graphviz
+}:
+
+buildPythonPackage rec {
+  pname = "streamz";
+  version = "0.5.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "cfdd42aa62df299f550768de5002ec83112136a34b44441db9d633b2df802fb4";
+  };
+
+  checkInputs = [ pytest networkx distributed confluent-kafka graphviz ];
+  propagatedBuildInputs = [
+    tornado
+    toolz
+    zict
+    six
+  ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with lib; {
+    description = "Pipelines to manage continuous streams of data";
+    homepage = http://github.com/mrocklin/streamz/;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3462,6 +3462,8 @@ in {
 
   pandas = callPackage ../development/python-modules/pandas { };
 
+  panel = callPackage ../development/python-modules/panel { };
+
   xlrd = callPackage ../development/python-modules/xlrd { };
 
   bottleneck = callPackage ../development/python-modules/bottleneck { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3679,6 +3679,8 @@ in {
 
   pycryptopp = callPackage ../development/python-modules/pycryptopp { };
 
+  pyct = callPackage ../development/python-modules/pyct { };
+
   pycups = callPackage ../development/python-modules/pycups { };
 
   pycurl = callPackage ../development/python-modules/pycurl { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4168,6 +4168,8 @@ in {
 
   statsmodels = callPackage ../development/python-modules/statsmodels { };
 
+  streamz = callPackage ../development/python-modules/streamz { };
+
   structlog = callPackage ../development/python-modules/structlog { };
 
   sybil = callPackage ../development/python-modules/sybil { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4164,6 +4164,8 @@ in {
 
   hieroglyph = callPackage ../development/python-modules/hieroglyph { };
 
+  hvplot = callPackage ../development/python-modules/hvplot { };
+
   guzzle_sphinx_theme = callPackage ../development/python-modules/guzzle_sphinx_theme { };
 
   sphinx-testing = callPackage ../development/python-modules/sphinx-testing { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3568,6 +3568,8 @@ in {
 
   pystringtemplate = callPackage ../development/python-modules/stringtemplate { };
 
+  pyviz-comms = callPackage ../development/python-modules/pyviz-comms { };
+
   pillow = callPackage ../development/python-modules/pillow {
     inherit (pkgs) freetype libjpeg zlib libtiff libwebp tcl lcms2 tk;
     inherit (pkgs.xorg) libX11;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -452,6 +452,8 @@ in {
 
   imutils = callPackage ../development/python-modules/imutils { };
 
+  intake = callPackage ../development/python-modules/intake { };
+
   intelhex = callPackage ../development/python-modules/intelhex { };
 
   jira = callPackage ../development/python-modules/jira { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -438,6 +438,8 @@ in {
 
   hdmedians = callPackage ../development/python-modules/hdmedians { };
 
+  holoviews = callPackage ../development/python-modules/holoviews { };
+
   hoomd-blue = toPythonModule (callPackage ../development/python-modules/hoomd-blue {
     inherit python;
   });

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -498,6 +498,8 @@ in {
 
   nanomsg-python = callPackage ../development/python-modules/nanomsg-python { inherit (pkgs) nanomsg; };
 
+  nbsmoke = callPackage ../development/python-modules/nbsmoke { };
+
   nbsphinx = callPackage ../development/python-modules/nbsphinx { };
 
   nbval = callPackage ../development/python-modules/nbval { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3474,6 +3474,8 @@ in {
 
   parsedatetime = callPackage ../development/python-modules/parsedatetime { };
 
+  param = callPackage ../development/python-modules/param { };
+
   paramiko = callPackage ../development/python-modules/paramiko { };
 
   parameterized = callPackage ../development/python-modules/parameterized { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -754,6 +754,10 @@ in {
 
   python-sql = callPackage ../development/python-modules/python-sql { };
 
+  python-snappy = callPackage ../development/python-modules/python-snappy {
+    inherit (pkgs) snappy;
+  };
+
   python-stdnum = callPackage ../development/python-modules/python-stdnum { };
 
   python-socketio = callPackage ../development/python-modules/python-socketio { };


### PR DESCRIPTION
###### Motivation for this change

Initially this PR was meant to include [intake](https://github.com/intake/intake) but their description of "Intake is a lightweight package for finding, investigating, loading and disseminating data". Turns out that it has a lot of dependencies... which I ended up adding holoviews, panel, and hvplot which will be great additions to the jupyter notebook workflow.

~~This PR additionally fixes https://github.com/NixOS/nixpkgs/issues/56276.~~ This is already fixed in staging-next.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

