### PR TITLE
pythonPackage.Nikola: 8.0.1 -> 8.0.2

### DIFF
--- a/pkgs/development/python-modules/Nikola/default.nix
+++ b/pkgs/development/python-modules/Nikola/default.nix
@@ -31,11 +31,12 @@
 , pyyaml
 , toml
 , notebook
+, ruamel_yaml
 }:
 
 buildPythonPackage rec {
   pname = "Nikola";
-  version = "8.0.1";
+  version = "8.0.2";
 
   # Nix contains only Python 3 supported version of doit, which is a dependency
   # of Nikola. Python 2 support would require older doit 0.29.0 (which on the
@@ -47,17 +48,12 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     pygments pillow dateutil docutils Mako unidecode lxml Yapsy PyRSS2Gen
     Logbook blinker setuptools natsort requests piexif markdown phpserialize
-    jinja2 doit Babel pyyaml toml notebook
+    jinja2 doit Babel pyyaml toml notebook ruamel_yaml
   ];
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "18bq68f9v7xk9ahjl6x4k77yysq5g6g07ng2ndbg35kcsdnw4nk6";
-  };
-
-  patches = fetchpatch {
-    url = https://github.com/getnikola/nikola/commit/d40be74a86af71b5206dc22beb82fcd0d08ea2f6.patch;
-    sha256 = "0disr8bxbfjymwlbm82mxkal3ynnv8zfiqsgfh9fkqhb35bn4l8j";
+    sha256 = "1a5y1qriy76hl4yxvbf365b1ggsxybm06mi1pwb5jkgbkwk2gkrf";
   };
 
   checkPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Upgrade Nikola.

I'm not sure which should be the base branch. I now used staging-next as I was advised in another pull request that I can use that as the base branch in order to avoid merge conflicts with that branch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

