### PR TITLE
[18.09] backport pythonPackages: trezor: 0.10.2 -> 0.11.1

### DIFF
--- a/pkgs/development/python-modules/trezor/default.nix
+++ b/pkgs/development/python-modules/trezor/default.nix
@@ -1,27 +1,48 @@
-{ lib, fetchPypi, buildPythonPackage,
-  protobuf, hidapi, ecdsa, mnemonic, requests, pyblake2, click, libusb1, rlp, isPy3k
+{ lib, fetchPypi, buildPythonPackage, isPy3k, python, pytest
+, typing-extensions
+, protobuf
+, hidapi
+, ecdsa
+, mnemonic
+, requests
+, pyblake2
+, click
+, construct
+, libusb1
+, rlp
 }:
 
 buildPythonPackage rec {
   pname = "trezor";
-  version = "0.10.2";
+  version = "0.11.1";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "4dba4d5c53d3ca22884d79fb4aa68905fb8353a5da5f96c734645d8cf537138d";
+    sha256 = "6043f321d856e1b45b9df0c37810264f08d065bb56cd999f61a05fe2906e9e18";
   };
 
-  propagatedBuildInputs = [ protobuf hidapi ecdsa mnemonic requests pyblake2 click libusb1 rlp ];
+  propagatedBuildInputs = [ typing-extensions protobuf hidapi ecdsa mnemonic requests pyblake2 click construct libusb1 rlp ];
 
-  # There are no actual tests: "ImportError: No module named tests"
-  doCheck = false;
+  # build requires UTF-8 locale
+  LANG = "en_US.UTF-8";
+
+  checkInputs = [
+    pytest
+  ];
+
+  # disable test_tx_api.py as it requires being online
+  checkPhase = ''
+    runHook preCheck
+    ${python.interpreter} -m pytest --pyarg trezorlib.tests.unit_tests --ignore trezorlib/tests/unit_tests/test_tx_api.py
+    runHook postCheck
+  '';
 
   meta = {
     description = "Python library for communicating with TREZOR Bitcoin Hardware Wallet";
     homepage = https://github.com/trezor/python-trezor;
     license = lib.licenses.gpl3;
-    maintainers = with lib.maintainers; [ np ];
+    maintainers = with lib.maintainers; [ np prusnak ];
   };
 }


### PR DESCRIPTION
(cherry picked from commit bdb81a8d29334416d74e0f60940ea58917047c64)

###### Motivation for this change
Backport for 18.09 as stated in the original [PR](https://github.com/NixOS/nixpkgs/pull/52741)

> 1. we add a lot of features into Trezor and these are not accessible if a user has an older version of python-trezor leading to frustration
> 
> 2. I assume NixPkgs Electrum maintainers don't backport security patches individually, but rather the whole package is being updated to the newest stable release. This release might already be depending on the new python-trezor package, using the new API, etc. so it makes sense to upgrade the whole package for python-trezor too.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

