### PR TITLE
gem-config: add native taglib dependency to taglib-ruby gem

### DIFF
--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -23,7 +23,7 @@
 , cmake, libssh2, openssl, mysql, darwin, git, perl, pcre, gecode_3, curl
 , msgpack, qt59, libsodium, snappy, libossp_uuid, lxc, libpcap, xorg, gtk2, buildRubyGem
 , cairo, re2, rake, gobject-introspection, gdk_pixbuf, zeromq, czmq, graphicsmagick, libcxx
-, file, libvirt, glib, vips
+, file, libvirt, glib, vips, taglib
 , libselinux ? null, libsepol ? null
 }@args:
 
@@ -421,6 +421,10 @@ in
       substituteInPlace lib/rbreadline.rb \
         --replace 'infocmp' '${ncurses.dev}/bin/infocmp'
     '';
+  };
+
+  taglib-ruby = attrs: {
+    buildInputs = [ taglib ];
   };
 
   timfel-krb5-auth = attrs: {


### PR DESCRIPTION
###### Motivation for this change

There is a ruby gem called [taglib-ruby](https://robinst.github.io/taglib-ruby/) which requires `taglib` as a native build-time dependency. Declaring it here allows one to package other ruby stuff that depends on `taglib-ruby` .

###### Things done

I've tested sandbox-building a ruby package that depends on `taglib-ruby` and it succeeded.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

