### PR TITLE
nixos/hdaps: automatically enable the hdapsd kernel module

### DIFF
--- a/nixos/modules/services/monitoring/hdaps.nix
+++ b/nixos/modules/services/monitoring/hdaps.nix
@@ -16,6 +16,7 @@ in
   };
 
   config = mkIf cfg.enable {
+    boot.kernelModules = [ "hdapsd" ];
     services.udev.packages = hdapsd;
     systemd.packages = hdapsd;
   };


### PR DESCRIPTION
patch by hpoussin via
https://discourse.nixos.org/t/hdapsd-automatically-enable-the-hdapsd-kernel-module/2183

###### Motivation for this change
Motivation provided by hpoussin:

Without the patch (or with “hdaps” as you suggest), I get

```
dmesg | grep -i hdaps
[ 15.086633] hdaps: supported laptop not found!
[ 15.086635] hdaps: driver init failed (ret=-19)!
[ 24.204814] audit: type=1130 audit(1551030602.203:74): pid=1 uid=0 auid=4294967295 ses=4294967295 msg=‘unit=hdapsd@sda comm=“systemd” exe="/nix/store/kinpd6wss80pf2d04jnvvmw25lzkrlbq-systemd-239/lib/systemd/systemd" hostname=? addr=? terminal=? res=success’
```

With this patch, I get:
```
dmesg | grep -i hdaps
[ 16.093667] hdaps: LENOVO ThinkPad X220 detected, setting orientation 4
[ 16.093764] hdaps: initial mode latch is 0x05
[ 16.093907] hdaps: setting ec_rate=250, filter_order=2
[ 16.094130] hdaps: device successfully initialized.
[ 16.094192] input: ThinkPad HDAPS joystick emulation as /devices/virtual/input/input6
[ 16.094220] input: ThinkPad HDAPS accelerometer data as /devices/virtual/input/input7
[ 16.094221] hdaps: driver successfully loaded.
[ 24.919059] audit: type=1130 audit(1551029327.917:73): pid=1 uid=0 auid=4294967295 ses=4294967295 msg=‘unit=hdapsd@sda comm=“systemd” exe="/nix/store/kinpd6wss80pf2d04jnvvmw25lzkrlbq-systemd-239/lib/systemd/systemd" hostname=? addr=? terminal=? res=success’
```
Joystick and accelerometers are available, and hard disk protection is enabled.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

