### PR TITLE
ogre: 1.10.11 -> 1.11.5

### DIFF
--- a/pkgs/development/libraries/ogre/1.10.x.nix
+++ b/pkgs/development/libraries/ogre/1.10.x.nix
@@ -4,18 +4,16 @@
 , libXaw, freeglut, libXt, libpng, boost, ois
 , libX11, libXmu, libSM, pkgconfig
 , libXxf86vm, libICE
-, unzip
 , libXrender
 , withNvidiaCg ? false, nvidia_cg_toolkit
 , withSamples ? false }:
 
-stdenv.mkDerivation rec {
-  name = "ogre-${version}";
-  version = "1.11.5";
+stdenv.mkDerivation {
+  name = "ogre-1.10.11";
 
   src = fetchurl {
-     url = "https://github.com/OGRECave/ogre/archive/v${version}.zip";
-     sha256 = "0hs7b81nr7i4wgsb603kkqw33m6cafjrj2zw4yhibwn8k7zzwddp";
+     url = "https://bitbucket.org/sinbad/ogre/get/v1-10-11.tar.gz";
+     sha256 = "1zwvlx5dz9nwjazhnrhzb0w8ilpa84r0hrxrmmy69pgr1p1yif5a";
   };
 
   cmakeFlags = [ "-DOGRE_BUILD_SAMPLES=${toString withSamples}" ]
@@ -33,8 +31,6 @@ stdenv.mkDerivation rec {
      libXxf86vm libICE
      libXrender
    ] ++ lib.optional withNvidiaCg nvidia_cg_toolkit;
-
-  nativeBuildInputs = [ unzip ];
 
   meta = {
     description = "A 3D engine";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9511,7 +9511,9 @@ in
   celt_0_7 = callPackage ../development/libraries/celt/0.7.nix {};
   celt_0_5_1 = callPackage ../development/libraries/celt/0.5.1.nix {};
 
-  cegui = callPackage ../development/libraries/cegui {};
+  cegui = callPackage ../development/libraries/cegui {
+    ogre = ogre1_10;
+  };
 
   certbot = callPackage ../tools/admin/certbot { };
 
@@ -11841,6 +11843,7 @@ in
 
   ogre = callPackage ../development/libraries/ogre {};
   ogre1_9 = callPackage ../development/libraries/ogre/1.9.x.nix {};
+  ogre1_10 = callPackage ../development/libraries/ogre/1.10.x.nix {};
 
   ogrepaged = callPackage ../development/libraries/ogrepaged { };
 


### PR DESCRIPTION
1.10.x retained for dependencies

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

