### PR TITLE
Fix sc2-headless map hash

### DIFF
--- a/pkgs/applications/science/machine-learning/sc2-headless/maps.nix
+++ b/pkgs/applications/science/machine-learning/sc2-headless/maps.nix
@@ -12,7 +12,7 @@ in
   
   melee = fetchzip' {
     url = "http://blzdistsc2-a.akamaihd.net/MapPacks/Melee.zip";
-    sha256 = "0w050yah5rybx3m5zvpr09jv01r0xsazpyrc76338b2sd8pdxv3y";
+    sha256 = "0z44pgy10jklsvgpr0kcn4c2mz3hw7nlcmvsy6a6lzpi3dvzf33i";
     stripRoot = false;
   };
   ladder2017season1 = fetchzip' {


### PR DESCRIPTION
###### Motivation for this change
So it seems, if you change the UNZIP parameter for fetchzip, it doesn't check for a new hash if it's already downloaded. So it worked on my testing image, because it already had it prefetched :(

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

