### PR TITLE
virtualbox: add warning for ineffective nixpkgs config

### DIFF
--- a/nixos/modules/virtualisation/virtualbox-host.nix
+++ b/nixos/modules/virtualisation/virtualbox-host.nix
@@ -83,6 +83,8 @@ in
   };
 
   config = mkIf cfg.enable (mkMerge [{
+    warnings = mkIf (config.nixpkgs.config.virtualbox.enableExtensionPack or false)
+      "'nixpkgs.virtualbox.enableExtensionPack' has no effect, please use 'virtualisation.virtualbox.host.enableExtensionPack'";
     boot.kernelModules = [ "vboxdrv" "vboxnetadp" "vboxnetflt" ];
     boot.extraModulePackages = [ kernelModules ];
     environment.systemPackages = [ virtualbox ];


### PR DESCRIPTION
nixpkgs.config.virtualbox.enableExtensionPack doesn't do anything, but
used to. Add a warning for the unsuspecting.

###### Motivation for this change

When testing a [virtualbox update](https://github.com/NixOS/nixpkgs/pull/53120), I complained about a non-working expansion-pack, while running afoul of having it misconfigured myself (sorry for that, @ptrhlm)

###### Things done

Tested positive and negative.

I wonder, whether we should re-introduce the config option, though. I don't like needing os-level configuration for using the expansion pack.

