### PR TITLE
init pythonPackages.firetv for home-assistant

### DIFF
--- a/pkgs/development/python-modules/adb-homeassistant/default.nix
+++ b/pkgs/development/python-modules/adb-homeassistant/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, libusb1
+, rsa
+, pycryptodome
+, pytest
+, mock
+}:
+buildPythonPackage rec {
+  pname = "adb-homeassistant";
+  version = "1.3.1";
+
+  # pypi does not contain tests, using github sources instead
+  src = fetchFromGitHub {
+    owner = "JeffLIrion";
+    repo = "python-adb";
+    rev = "5949bf432307cbba7128e84d7bc6add7f054a078";
+    sha256 = "0s3fazvbzchn1fsvjrd1jl8w9y4dvvgq6q8m8p5lr2gri0npr581";
+
+  };
+
+  propagatedBuildInputs = [
+    libusb1
+    rsa
+    pycryptodome
+  ];
+
+  checkInputs = [ pytest mock ];
+  checkPhase = ''
+    py.test test
+  '';
+
+  meta = with lib; {
+    description = "A pure python implementation of the Android ADB and Fastboot protocols";
+    homepage = https://github.com/JeffLIrion/python-adb/tree/adb-homeassistant;
+    license = licenses.asl20;
+    maintainers = [ maintainers.makefu ];
+  };
+}

--- a/pkgs/development/python-modules/firetv/default.nix
+++ b/pkgs/development/python-modules/firetv/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, adb-homeassistant
+, flask
+, pure-python-adb-homeassistant
+, pycryptodome
+, pyyaml
+, rsa
+}:
+buildPythonPackage rec {
+  pname = "firetv";
+  version = "1.0.9";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "602de77411c2caffb322e4ff63fa6cc4eeb9a50c5f4b14e13930ed7cd87cf513";
+  };
+
+  propagatedBuildInputs = [
+    adb-homeassistant
+    flask
+    pure-python-adb-homeassistant
+    pycryptodome
+    pyyaml
+    rsa
+  ];
+
+  # No Tests
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Communicate with an Amazon Fire TV device via ADB over a network";
+    homepage = https://github.com/happyleavesaoc/python-firetv/;
+    license = licenses.mit;
+    maintainers = [ maintainers.makefu ];
+  };
+}

--- a/pkgs/development/python-modules/pure-python-adb-homeassistant/default.nix
+++ b/pkgs/development/python-modules/pure-python-adb-homeassistant/default.nix
@@ -1,0 +1,24 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+buildPythonPackage rec {
+  pname = "pure-python-adb-homeassistant";
+  version = "0.1.6.dev0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "fe6d90220a6880649f6d6df4e707ce5034676710ee6146145ef995f7b769a482";
+  };
+
+  # Disable tests as they require docker, docker-compose and a dedicated
+  # android emulator
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Pure python implementation of the adb client";
+    homepage = https://github.com/JeffLIrion/pure-python-adb;
+    license = licenses.mit;
+    maintainers = [ maintainers.makefu ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -699,7 +699,7 @@
     "media_player.dunehd" = ps: with ps; [  ];
     "media_player.emby" = ps: with ps; [  ];
     "media_player.epson" = ps: with ps; [  ];
-    "media_player.firetv" = ps: with ps; [  ];
+    "media_player.firetv" = ps: with ps; [ firetv ];
     "media_player.frontier_silicon" = ps: with ps; [  ];
     "media_player.gpmdp" = ps: with ps; [ websocket_client ];
     "media_player.gstreamer" = ps: with ps; [  ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -384,6 +384,8 @@ in {
 
   fire = callPackage ../development/python-modules/fire { };
 
+  firetv = callPackage ../development/python-modules/firetv { };
+
   fdint = callPackage ../development/python-modules/fdint { };
 
   fuse = callPackage ../development/python-modules/fuse-python {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -146,6 +146,8 @@ in {
 
   absl-py = callPackage ../development/python-modules/absl-py { };
 
+  adb-homeassistant = callPackage ../development/python-modules/adb-homeassistant { };
+
   aenum = callPackage ../development/python-modules/aenum { };
 
   affinity = callPackage ../development/python-modules/affinity { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -550,6 +550,8 @@ in {
 
   progress = callPackage ../development/python-modules/progress { };
 
+  pure-python-adb-homeassistant = callPackage ../development/python-modules/pure-python-adb-homeassistant { };
+
   pymysql = callPackage ../development/python-modules/pymysql { };
 
   Pmw = callPackage ../development/python-modules/Pmw { };


### PR DESCRIPTION
###### Motivation for this change

add firetv support to home-assistant

###### Things done


- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

