### PR TITLE
candle: init at 1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2865,6 +2865,11 @@
     github = "matthiasbeyer";
     name = "Matthias Beyer";
   };
+  matti-kariluoma = {
+    email = "matti@kariluo.ma";
+    github = "matti-kariluoma";
+    name = "Matti Kariluoma";
+  };
   maurer = {
     email = "matthew.r.maurer+nix@gmail.com";
     github = "maurer";

--- a/pkgs/applications/misc/candle/default.nix
+++ b/pkgs/applications/misc/candle/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, qtbase, qtserialport, qmake }:
+
+stdenv.mkDerivation rec {
+  name = "candle-${version}";
+  version = "1.1";
+
+  src = fetchFromGitHub {
+    owner  = "Denvi";
+    repo   = "Candle";
+    rev    = "v${version}";
+    sha256 = "1gpx08gdz8awbsj6lsczwgffp19z3q0r2fvm72a73qd9az29pmm0";
+  };
+
+  nativeBuildInputs = [ qmake ];
+  
+  sourceRoot = "source/src";
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 Candle $out/bin/candle
+    runHook postInstall
+  '';
+
+  buildInputs = [ qtbase qtserialport ];
+
+  meta = with stdenv.lib; {
+    description = "GRBL controller application with G-Code visualizer written in Qt";
+    homepage = https://github.com/Denvi/Candle;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ matti-kariluoma ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1107,6 +1107,8 @@ in
     boost = pkgs.boost.override { python = python3; };
   };
 
+  candle = libsForQt5.callPackage ../applications/misc/candle { };
+
   capstone = callPackage ../development/libraries/capstone { };
   unicorn-emu = callPackage ../development/libraries/unicorn-emu { };
 


### PR DESCRIPTION
###### Motivation for this change

I've added an application for controlling GRBL machines, its source can be found at https://github.com/Denvi/Candle

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS **v18.09**
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

