### PR TITLE
crystal: init at 0.27.2

### DIFF
--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -2,30 +2,32 @@
 , gmp, openssl, readline, tzdata, libxml2, libyaml
 , boehmgc, libatomic_ops, pcre, libevent, libiconv, llvm, clang, which, zlib }:
 
-let
-  binaryVersion = "0.26.0";
-  releaseDate = "2018-08-29";
+# We need multiple binaries as a given binary isn't always able to build
+# (even slightly) older or newer version.
+# - 0.26.1 can build 0.25.x and 0.26.x but not 0.27.x
+# - 0.27.2 can build 0.27.x but not 0.25.x and 0.26.x
+#
+# We need to keep around at least the latest version released with a stable
+# NixOS
 
-  arch = {
+let
+  archs = {
     "x86_64-linux"  = "linux-x86_64";
     "i686-linux"    = "linux-i686";
     "x86_64-darwin" = "darwin-x86_64";
-  }."${stdenv.system}" or (throw "system ${stdenv.system} not supported");
+  };
+
+  arch = archs."${stdenv.system}" or (throw "system ${stdenv.system} not supported");
 
   checkInputs = [ gmp openssl readline libxml2 libyaml tzdata ];
 
-  # we could turn this into a function instead in case we cannot use the same
-  # binary to build multiple versions
-  binary = stdenv.mkDerivation rec {
-    name = "crystal-binary-${binaryVersion}";
+  genericBinary = { version, sha256s, rel ? 1 }:
+  stdenv.mkDerivation rec {
+    name = "crystal-binary-${version}";
 
     src = fetchurl {
-      url = "https://github.com/crystal-lang/crystal/releases/download/${binaryVersion}/crystal-${binaryVersion}-1-${arch}.tar.gz";
-      sha256 = {
-        "x86_64-linux"  = "1xban102yiiwmlklxvn3xp3q546bp8hlxxpakayajkhhnpl6yv45";
-        "i686-linux"    = "1igspf1lrv7wpmz0pfrkbx8m1ykvnv4zhic53cav4nicppm2v0ic";
-        "x86_64-darwin" = "0hzc65ccajr0yhmvi5vbdgbzbp1gbjy56da24ds3zwwkam1ddk0k";
-      }."${stdenv.system}";
+      url = "https://github.com/crystal-lang/crystal/releases/download/${version}/crystal-${version}-${toString rel}-${arch}.tar.gz";
+      sha256 = sha256s."${stdenv.system}";
     };
 
     buildCommand = ''
@@ -34,7 +36,7 @@ let
     '';
   };
 
-  generic = { version, sha256, doCheck ? true }:
+  generic = { version, sha256, binary, doCheck ? true }:
   stdenv.mkDerivation rec {
     inherit doCheck;
     name = "crystal-${version}";
@@ -46,13 +48,10 @@ let
       inherit sha256;
     };
 
-    # the first bit can go when https://github.com/crystal-lang/crystal/pull/6788 is merged
     postPatch = ''
-      substituteInPlace src/compiler/crystal/config.cr \
-        --replace '{{ `date "+%Y-%m-%d"`.stringify.chomp }}' '"${releaseDate}"'
       ln -s spec/compiler spec/std
       substituteInPlace spec/std/process_spec.cr \
-        --replace /bin/ /run/current-system/sw/bin
+        --replace /bin/ /run/current-system/sw/bin/
     '';
 
     buildInputs = [
@@ -64,9 +63,7 @@ let
 
     nativeBuildInputs = [ binary makeWrapper which ];
 
-
     makeFlags = [
-      "CRYSTAL_CONFIG_BUILD_DATE=${releaseDate}"
       "CRYSTAL_CONFIG_VERSION=${version}"
     ];
 
@@ -121,22 +118,49 @@ let
       homepage = https://crystal-lang.org/;
       license = licenses.asl20;
       maintainers = with maintainers; [ manveru david50407 peterhoeg ];
-      platforms = [ "x86_64-linux" "i686-linux" "x86_64-darwin" ];
+      platforms = builtins.attrNames archs;
     };
   };
 
 in rec {
+  binaryCrystal_0_26 = genericBinary {
+    version = "0.26.1";
+    sha256s = {
+      "x86_64-linux"  = "1xban102yiiwmlklxvn3xp3q546bp8hlxxpakayajkhhnpl6yv45";
+      "i686-linux"    = "1igspf1lrv7wpmz0pfrkbx8m1ykvnv4zhic53cav4nicppm2v0ic";
+      "x86_64-darwin" = "0hzc65ccajr0yhmvi5vbdgbzbp1gbjy56da24ds3zwwkam1ddk0k";
+    };
+  };
+
+  binaryCrystal_0_27 = genericBinary {
+    version = "0.27.2";
+    sha256s = {
+      "x86_64-linux"  = "05l5x7kx2acgnv42fj3rr17z73ix06zvi05h7d7vf3kw0izxrasm";
+      "i686-linux"    = "1iwizkvn6pglc0azkyfhlmk9ap793krdgcnbihd1kvrvs4cz0mm9";
+      "x86_64-darwin" = "14c69ac2dmfwmb5q56ps3xyxxb0mrbc91ahk9h07c8fiqfii3k9g";
+    };
+  };
+
   crystal_0_25 = generic {
     version = "0.25.1";
     sha256  = "15xmbkalsdk9qpc6wfpkly3sifgw6a4ai5jzlv78dh3jp7glmgyl";
     doCheck = false;
+    binary = binaryCrystal_0_26;
   };
 
   crystal_0_26 = generic {
     version = "0.26.1";
     sha256  = "0jwxrqm99zcjj82gyl6bzvnfj79nwzqf8sa1q3f66q9p50v44f84";
     doCheck = false; # about 20 tests out of more than 14000 are failing
+    binary = binaryCrystal_0_26;
   };
 
-  crystal = crystal_0_26;
+  crystal_0_27 = generic {
+    version = "0.27.2";
+    sha256  = "0vxqnpqi85yh0167nrkbksxsni476iwbh6y3znbvbjbbfhsi3nsj";
+    doCheck = false; # about 20 tests out of more than 15000 are failing
+    binary = binaryCrystal_0_27;
+  };
+
+  crystal = crystal_0_27;
 }


### PR DESCRIPTION
###### Motivation for this change

New crystal - we need multiple binary builders as well to be able to do 0.26.x and 0.27.x

Cc: @manveru @david50407

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

