### PR TITLE
shairplay: 2016-01-01 -> 2018-08-24 and add avahi-compat convenience derivation

### DIFF
--- a/pkgs/development/libraries/avahi/default.nix
+++ b/pkgs/development/libraries/avahi/default.nix
@@ -8,7 +8,7 @@
 assert qt4Support -> qt4 != null;
 
 stdenv.mkDerivation rec {
-  name = "avahi-${version}";
+  name = "avahi${stdenv.lib.optionalString withLibdnssdCompat "-compat"}-${version}";
   version = "0.7";
 
   src = fetchurl {

--- a/pkgs/servers/shairplay/default.nix
+++ b/pkgs/servers/shairplay/default.nix
@@ -2,14 +2,14 @@
 , avahi, libao }:
 
 stdenv.mkDerivation rec {
-  name = "shairplay-${version}";
-  version = "2016-01-01";
+  name = "shairplay-unstable-${version}";
+  version = "2018-08-24";
 
   src = fetchFromGitHub {
     owner  = "juhovh";
     repo   = "shairplay";
-    rev    = "ce80e005908f41d0e6fde1c4a21e9cb8ee54007b";
-    sha256 = "10b4bmqgf4rf1wszvj066mc42p90968vqrmyqyrdal4k6f8by1r6";
+    rev    = "096b61ad14c90169f438e690d096e3fcf87e504e";
+    sha256 = "02xkd9al79pbqh8rhzz5w99vv43jg5vqkqg7kxsw8c8sz9di9wsa";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     inherit (src.meta) homepage;
-    description = "Apple airplay and raop protocol server";
+    description = "Apple AirPlay and RAOP protocol server";
     license     = licenses.mit;
     maintainers = with maintainers; [ peterhoeg ];
     platforms   = platforms.unix;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14048,7 +14048,7 @@ in
 
   sambaFull = samba4Full;
 
-  shairplay = callPackage ../servers/shairplay { };
+  shairplay = callPackage ../servers/shairplay { avahi = avahi-compat; };
 
   shairport-sync = callPackage ../servers/shairport-sync { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -847,6 +847,10 @@ in
 
   avahi = callPackage ../development/libraries/avahi (config.avahi or {});
 
+  avahi-compat = callPackage ../development/libraries/avahi ((config.avahi or {}) // {
+    withLibdnssdCompat = true;
+  });
+
   avro-c = callPackage ../development/libraries/avro-c { };
 
   avro-cpp = callPackage ../development/libraries/avro-c++ { boost = boost160; };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18382,9 +18382,7 @@ in
   multimon-ng = callPackage ../applications/radio/multimon-ng { };
 
   inherit (callPackages ../applications/networking/mumble {
-      avahi = avahi.override {
-        withLibdnssdCompat = true;
-      };
+      avahi = avahi-compat;
       jackSupport = config.mumble.jackSupport or false;
       speechdSupport = config.mumble.speechdSupport or false;
       pulseSupport = config.pulseaudio or false;
@@ -18392,9 +18390,7 @@ in
     }) mumble mumble_git murmur;
 
   inherit (callPackages ../applications/networking/mumble {
-      avahi = avahi.override {
-        withLibdnssdCompat = true;
-      };
+      avahi = avahi-compat;
       jackSupport = config.mumble.jackSupport or false;
       speechdSupport = config.mumble.speechdSupport or false;
       pulseSupport = config.pulseaudio or false;


### PR DESCRIPTION
###### Motivation for this change

Normal update.

Additionally, a few places were overriding ```avahi``` to get the compatibility options compiled in, so let's separate that out to its own derivation for convenience (used by shairplay as well).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

