### PR TITLE
sshd: fix startWhenNeeded and listenAddresses combination for ipv6

### DIFF
--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -401,7 +401,11 @@ in
           { description = "SSH Socket";
             wantedBy = [ "sockets.target" ];
             socketConfig.ListenStream = if cfg.listenAddresses != [] then
-              map (l: "${l.addr}:${toString (if l.port != null then l.port else 22)}") cfg.listenAddresses
+            map (l:
+              (if (builtins.match ".*:.*" l.addr) != null then
+                "[${l.addr}]" else
+                l.addr) + ":" + toString (if l.port != null then l.port else 22)
+            ) cfg.listenAddresses
             else
               cfg.ports;
             socketConfig.Accept = true;

--- a/nixos/tests/openssh.nix
+++ b/nixos/tests/openssh.nix
@@ -39,7 +39,11 @@ in {
 
       {
         services.openssh = {
-          enable = true; listenAddresses = [ { addr = "127.0.0.1"; port = 22; } ];
+          enable = true;
+          listenAddresses = [
+            { addr = "127.0.0.1"; port = 22; }
+            { addr = "::1"; port = 22; }
+          ];
         };
       };
 
@@ -48,7 +52,12 @@ in {
 
       {
         services.openssh = {
-          enable = true; startWhenNeeded = true; listenAddresses = [ { addr = "127.0.0.1"; port = 22; } ];
+          enable = true;
+          startWhenNeeded = true;
+          listenAddresses = [
+            { addr = "127.0.0.1"; port = 22; }
+            { addr = "::1"; port = 22; }
+          ];
         };
       };
 
@@ -98,7 +107,9 @@ in {
 
     subtest "localhost-only", sub {
       $server_localhost_only->succeed("ss -nlt | grep '127.0.0.1:22'");
+      $server_localhost_only->succeed("ss -nlt | grep '[::1]:22'");
       $server_localhost_only_lazy->succeed("ss -nlt | grep '127.0.0.1:22'");
+      $server_localhost_only_lazy->succeed("ss -nlt | grep '[::1]:22'");
     }
   '';
 })


### PR DESCRIPTION
###### Motivation for this change
This is a continuation of #56326, @vcunat made a good comment regarding ipv6 support: https://github.com/NixOS/nixpkgs/pull/56326#discussion_r259708650

systemd.socket ListenSteam option requires ipv6 address to be enclosed
in brackets, see https://www.freedesktop.org/software/systemd/man/systemd.socket.html#ListenStream=.

In this implementation, I just check for colon in IP address string, which is not perfect but I'm not sure we need a full [ipv6 regex](https://stackoverflow.com/questions/53497/regular-expression-that-matches-valid-ipv6-addresses#17871737) for this purpose either.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

