### PR TITLE
nixos/gnunet: fix typo in `PrivateTmp` parameter

### DIFF
--- a/nixos/modules/services/networking/gnunet.nix
+++ b/nixos/modules/services/networking/gnunet.nix
@@ -130,7 +130,7 @@ in
       group = "gnunet";
       description = "GNUnet User";
       home = homeDir;
-      createHome = true; 
+      createHome = true;
       uid = config.ids.uids.gnunet;
     };
 
@@ -146,7 +146,7 @@ in
       wantedBy = [ "multi-user.target" ];
       path = [ cfg.package pkgs.miniupnpc ];
       environment.TMPDIR = "/tmp";
-      serviceConfig.PrivateTemp = true;
+      serviceConfig.PrivateTmp = true;
       serviceConfig.ExecStart = "${cfg.package}/lib/gnunet/libexec/gnunet-service-arm -c ${configFile}";
       serviceConfig.User = "gnunet";
       serviceConfig.UMask = "0007";


### PR DESCRIPTION
###### Motivation for this change

Systemd expects `PrivateTmp` and not `PrivateTemp` in the service
configuration.

I found this by chance while grepping through nixpkgs…


###### Things done

Haven't tested GNUnet after this change since there was also no test to easily get into it.

---

