### PR TITLE
gnome3.gnome-desktop: fix thumbnailing with missing fontconfig cache

### DIFF
--- a/pkgs/desktops/gnome-3/core/gnome-desktop/bubblewrap-paths.patch
+++ b/pkgs/desktops/gnome-3/core/gnome-desktop/bubblewrap-paths.patch
@@ -8,7 +8,7 @@
 -	    "--ro-bind", "/usr", "/usr",
 -	    "--ro-bind", "/etc/ld.so.cache", "/etc/ld.so.cache",
 +	    "@bubblewrap_bin@",
-+	    "--ro-bind", "/nix/store", "/nix/store",
++	    "--ro-bind", "@storeDir@", "@storeDir@",
 +	    "--ro-bind", "/run/current-system", "/run/current-system",
  	    NULL);
  

--- a/pkgs/desktops/gnome-3/core/gnome-desktop/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-desktop/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, substituteAll, pkgconfig, libxslt, which, libX11, gnome3, gtk3, glib
-, gettext, libxml2, xkeyboard_config, isocodes, itstool, wayland
+, gettext, libxml2, xkeyboard_config, isocodes, itstool, wayland, fetchpatch
 , libseccomp, bubblewrap, gobject-introspection, gtk-doc, docbook_xsl }:
 
 stdenv.mkDerivation rec {
@@ -30,6 +30,12 @@ stdenv.mkDerivation rec {
     (substituteAll {
       src = ./bubblewrap-paths.patch;
       bubblewrap_bin = "${bubblewrap}/bin/bwrap";
+      inherit (builtins) storeDir;
+    })
+    (fetchpatch {
+      name = "fix-missing-font-cache";
+      url = https://gitlab.gnome.org/GNOME/gnome-desktop/commit/b87de7495160dbf48f01aa1ddb361fc2556ffd0c.patch;
+      sha256 = "1aw7lw93kcflmqmbx25cwja25441i8xzvgjm1pfsxvw3vr8j6scb";
     })
   ];
 


### PR DESCRIPTION

###### Motivation for this change

#56174 updated `gnome-desktop` which broke thumbnailing due to the sandbox trying to mount a non-existing directory (`/var/cache/fontconfig`). We patch the script so it won't try mounting the directory when it doesn't exist.

###### Things done

Tested thumbnailing in `eog` and `gnome-desktop`.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

