### PR TITLE
certmgr: 1.6.1 -> 1.6.4

### DIFF
--- a/pkgs/tools/security/certmgr/default.nix
+++ b/pkgs/tools/security/certmgr/default.nix
@@ -3,7 +3,7 @@
 let
   generic = { patches ? [] }:
     buildGoPackage rec {
-      version = "1.6.1";
+      version = "1.6.4";
       name = "certmgr-${version}";
 
       goPackagePath = "github.com/cloudflare/certmgr/";
@@ -12,7 +12,7 @@ let
         owner = "cloudflare";
         repo = "certmgr";
         rev = "v${version}";
-        sha256 = "1ky2pw1wxrb2fxfygg50h0mid5l023x6xz9zj5754a023d01qqr2";
+        sha256 = "0glvyp61ya21pdm2bsvq3vfhmmxc2998vxc6hiyc79ijsv9n6jqi";
       };
 
       inherit patches;


### PR DESCRIPTION
###### Motivation for this change
@GrahamcOfBorg build certmgr certmgr-selfsigned
@GrahamcOfBorg test certmgr

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
