### PR TITLE
solc: 0.5.3 -> 0.5.4

### DIFF
--- a/pkgs/development/compilers/solc/default.nix
+++ b/pkgs/development/compilers/solc/default.nix
@@ -3,11 +3,12 @@
 }:
 
 assert z3Support -> z3 != null;
+assert z3Support -> stdenv.lib.versionAtLeast z3.version "4.6.0";
 
 let
-  version = "0.5.3";
-  rev = "10d17f245839f208ec5085309022a32cd2502f55";
-  sha256 = "1jq41pd3nj534cricy1nq6wgk4wlwg239387n785aswpwd705jbb";
+  version = "0.5.4";
+  rev = "9549d8fff7343908228c3e8bedc309d1b83fc204";
+  sha256 = "1r6wklp3ab2s1lrm70zv6p7blv9917ph1arjsb250j7b7bpjg5pq";
   jsoncppURL = https://github.com/open-source-parsers/jsoncpp/archive/1.8.4.tar.gz;
   jsoncpp = fetchzip {
     url = jsoncppURL;


### PR DESCRIPTION
###### Motivation for this change

[Changelog](https://github.com/ethereum/solidity/releases/tag/v0.5.4).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

