### PR TITLE
git: 2.19.2 -> 2.21.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git/default.nix
@@ -20,7 +20,7 @@ assert sendEmailSupport -> perlSupport;
 assert svnSupport -> perlSupport;
 
 let
-  version = "2.19.2";
+  version = "2.21.0";
   svn = subversionClient.override { perlBindings = perlSupport; };
 in
 
@@ -29,7 +29,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://www.kernel.org/pub/software/scm/git/git-${version}.tar.xz";
-    sha256 = "1scbggzghkzzfqg4ky3qh7h9w87c3zya4ls5disz7dbx56is7sgw";
+    sha256 = "0a0d0b07rmvs985zpndxxy0vzr0vq53kq5kyd68iv6gf8gkirjwc";
   };
 
   outputs = [ "out" ] ++ stdenv.lib.optional perlSupport "gitweb";

--- a/pkgs/applications/version-management/git-and-tools/git/docbook2texi.patch
+++ b/pkgs/applications/version-management/git-and-tools/git/docbook2texi.patch
@@ -3,9 +3,10 @@ and (2) make sure `gitman.info' isn't produced since it's broken (duplicate
 node names).
 
 diff --git a/Documentation/Makefile b/Documentation/Makefile
+index 26a2342bea..ceccd67ebb 100644
 --- a/Documentation/Makefile
 +++ b/Documentation/Makefile
-@@ -122,7 +122,7 @@
+@@ -132,7 +132,7 @@ HTML_REPO = ../../git-htmldocs
  
  MAKEINFO = makeinfo
  INSTALL_INFO = install-info
@@ -14,7 +15,7 @@ diff --git a/Documentation/Makefile b/Documentation/Makefile
  DBLATEX = dblatex
  ASCIIDOC_DBLATEX_DIR = /etc/asciidoc/dblatex
  DBLATEX_COMMON = -p $(ASCIIDOC_DBLATEX_DIR)/asciidoc-dblatex.xsl -s $(ASCIIDOC_DBLATEX_DIR)/asciidoc-dblatex.sty
-@@ -240,7 +240,7 @@
+@@ -250,7 +250,7 @@ man1: $(DOC_MAN1)
  man5: $(DOC_MAN5)
  man7: $(DOC_MAN7)
  
@@ -23,7 +24,7 @@ diff --git a/Documentation/Makefile b/Documentation/Makefile
  
  pdf: user-manual.pdf
  
-@@ -256,10 +256,9 @@
+@@ -266,10 +266,9 @@ install-man: man
  
  install-info: info
  	$(INSTALL) -d -m 755 $(DESTDIR)$(infodir)

--- a/pkgs/applications/version-management/git-and-tools/git/git-send-email-honor-PATH.patch
+++ b/pkgs/applications/version-management/git-and-tools/git/git-send-email-honor-PATH.patch
@@ -1,7 +1,8 @@
 diff --git a/Documentation/git-send-email.txt b/Documentation/git-send-email.txt
+index 1afe9fc858..05dd7c3a90 100644
 --- a/Documentation/git-send-email.txt
 +++ b/Documentation/git-send-email.txt
-@@ -208,8 +208,7 @@ a password is obtained using 'git-credential'.
+@@ -215,8 +215,7 @@ a password is obtained using 'git-credential'.
  	specify a full pathname of a sendmail-like program instead;
  	the program must support the `-i` option.  Default value can
  	be specified by the `sendemail.smtpServer` configuration
@@ -9,14 +10,15 @@ diff --git a/Documentation/git-send-email.txt b/Documentation/git-send-email.txt
 -	`/usr/sbin`, `/usr/lib` and $PATH if such program is
 +	option; the built-in default is to search in $PATH if such program is
  	available, falling back to `localhost` otherwise.
-
+ 
  --smtp-server-port=<port>::
 diff --git a/git-send-email.perl b/git-send-email.perl
+index 8eb63b5a2f..74a61d8213 100755
 --- a/git-send-email.perl
 +++ b/git-send-email.perl
-@@ -944,8 +944,7 @@ if (defined $reply_to) {
+@@ -956,8 +956,7 @@ sub expand_one_alias {
  }
-
+ 
  if (!defined $smtp_server) {
 -	my @sendmail_paths = qw( /usr/sbin/sendmail /usr/lib/sendmail );
 -	push @sendmail_paths, map {"$_/sendmail"} split /:/, $ENV{PATH};

--- a/pkgs/applications/version-management/git-and-tools/git/git-sh-i18n.patch
+++ b/pkgs/applications/version-management/git-and-tools/git/git-sh-i18n.patch
@@ -1,94 +1,23 @@
+diff --git a/git-sh-i18n.sh b/git-sh-i18n.sh
+index e1d917fd27..e90f8e1414 100644
 --- a/git-sh-i18n.sh
 +++ b/git-sh-i18n.sh
-@@ -15,87 +15,11 @@
- fi
- export TEXTDOMAINDIR
-
--# First decide what scheme to use...
--GIT_INTERNAL_GETTEXT_SH_SCHEME=fallthrough
--if test -n "$GIT_GETTEXT_POISON"
--then
--	GIT_INTERNAL_GETTEXT_SH_SCHEME=poison
--elif test -n "@@USE_GETTEXT_SCHEME@@"
--then
--	GIT_INTERNAL_GETTEXT_SH_SCHEME="@@USE_GETTEXT_SCHEME@@"
--elif test -n "$GIT_INTERNAL_GETTEXT_TEST_FALLBACKS"
--then
--	: no probing necessary
+@@ -26,7 +26,7 @@ then
+ elif test -n "$GIT_INTERNAL_GETTEXT_TEST_FALLBACKS"
+ then
+ 	: no probing necessary
 -elif type gettext.sh >/dev/null 2>&1
--then
--	# GNU libintl's gettext.sh
--	GIT_INTERNAL_GETTEXT_SH_SCHEME=gnu
--elif test "$(gettext -h 2>&1)" = "-h"
--then
--	# gettext binary exists but no gettext.sh. likely to be a gettext
--	# binary on a Solaris or something that is not GNU libintl and
--	# lack eval_gettext.
--	GIT_INTERNAL_GETTEXT_SH_SCHEME=gettext_without_eval_gettext
--fi
--export GIT_INTERNAL_GETTEXT_SH_SCHEME
--
--# ... and then follow that decision.
--case "$GIT_INTERNAL_GETTEXT_SH_SCHEME" in
--gnu)
--	# Use libintl's gettext.sh, or fall back to English if we can't.
++elif type @gettext@/bin/gettext.sh >/dev/null 2>&1
+ then
+ 	# GNU libintl's gettext.sh
+ 	GIT_INTERNAL_GETTEXT_SH_SCHEME=gnu
+@@ -43,7 +43,8 @@ export GIT_INTERNAL_GETTEXT_SH_SCHEME
+ case "$GIT_INTERNAL_GETTEXT_SH_SCHEME" in
+ gnu)
+ 	# Use libintl's gettext.sh, or fall back to English if we can't.
 -	. gettext.sh
--	;;
--gettext_without_eval_gettext)
--	# Solaris has a gettext(1) but no eval_gettext(1)
--	eval_gettext () {
--		gettext "$1" | (
--			export PATH $(git sh-i18n--envsubst --variables "$1");
--			git sh-i18n--envsubst "$1"
--		)
--	}
--
--	eval_ngettext () {
--		ngettext "$1" "$2" "$3" | (
--			export PATH $(git sh-i18n--envsubst --variables "$2");
--			git sh-i18n--envsubst "$2"
--		)
--	}
--	;;
--poison)
--	# Emit garbage so that tests that incorrectly rely on translatable
--	# strings will fail.
--	gettext () {
--		printf "%s" "# GETTEXT POISON #"
--	}
--
--	eval_gettext () {
--		printf "%s" "# GETTEXT POISON #"
--	}
--
--	eval_ngettext () {
--		printf "%s" "# GETTEXT POISON #"
--	}
--	;;
--*)
--	gettext () {
--		printf "%s" "$1"
--	}
--
--	eval_gettext () {
--		printf "%s" "$1" | (
--			export PATH $(git sh-i18n--envsubst --variables "$1");
--			git sh-i18n--envsubst "$1"
--		)
--	}
-+# GNU gettext
-+export GIT_INTERNAL_GETTEXT_SH_SCHEME=gnu
-+export PATH=@gettext@/bin:$PATH
-
--	eval_ngettext () {
--		(test "$3" = 1 && printf "%s" "$1" || printf "%s" "$2") | (
--			export PATH $(git sh-i18n--envsubst --variables "$2");
--			git sh-i18n--envsubst "$2"
--		)
--	}
--	;;
--esac
-+. @gettext@/bin/gettext.sh
-
- # Git-specific wrapper functions
- gettextln () {
++	. @gettext@/bin/gettext.sh
++	export PATH=@gettext@/bin:$PATH
+ 	;;
+ gettext_without_eval_gettext)
+ 	# Solaris has a gettext(1) but no eval_gettext(1)

--- a/pkgs/applications/version-management/git-and-tools/git/installCheck-path.patch
+++ b/pkgs/applications/version-management/git-and-tools/git/installCheck-path.patch
@@ -1,12 +1,13 @@
 diff --git a/t/test-lib.sh b/t/test-lib.sh
+index 8665b0a9b6..8bb892b1af 100644
 --- a/t/test-lib.sh
 +++ b/t/test-lib.sh
-@@ -923,7 +923,7 @@
+@@ -1227,7 +1227,7 @@ elif test -n "$GIT_TEST_INSTALLED"
  then
  	GIT_EXEC_PATH=$($GIT_TEST_INSTALLED/git --exec-path)  ||
  	error "Cannot run git from $GIT_TEST_INSTALLED."
--	PATH=$GIT_TEST_INSTALLED:$GIT_BUILD_DIR:$PATH
+-	PATH=$GIT_TEST_INSTALLED:$GIT_BUILD_DIR/t/helper:$PATH
 +	PATH=$GIT_TEST_INSTALLED:$GIT_BUILD_DIR/t/helper:$GIT_BUILD_DIR:$PATH
  	GIT_EXEC_PATH=${GIT_TEST_EXEC_PATH:-$GIT_EXEC_PATH}
  else # normal case, use ../bin-wrappers only unless $with_dashes:
- 	git_bin_dir="$GIT_BUILD_DIR/bin-wrappers"
+ 	if test -n "$no_bin_wrappers"

--- a/pkgs/applications/version-management/git-and-tools/git/ssh-path.patch
+++ b/pkgs/applications/version-management/git-and-tools/git/ssh-path.patch
@@ -1,18 +1,18 @@
 diff --git a/connect.c b/connect.c
-index c3a014c5b..fbca3262b 100644
+index 4813f005ab..b3f12f3268 100644
 --- a/connect.c
 +++ b/connect.c
-@@ -1010,7 +1010,7 @@ static void fill_ssh_args(struct child_process *conn, const char *ssh_host,
-
+@@ -1183,7 +1183,7 @@ static void fill_ssh_args(struct child_process *conn, const char *ssh_host,
+ 
  		ssh = getenv("GIT_SSH");
  		if (!ssh)
 -			ssh = "ssh";
 +			ssh = "@ssh@";
  		variant = determine_ssh_variant(ssh, 0);
  	}
-
+ 
 diff --git a/git-gui/lib/remote_add.tcl b/git-gui/lib/remote_add.tcl
-index 480a6b30d..781720424 100644
+index 480a6b30d0..7817204241 100644
 --- a/git-gui/lib/remote_add.tcl
 +++ b/git-gui/lib/remote_add.tcl
 @@ -139,7 +139,7 @@ method _add {} {


### PR DESCRIPTION
###### Motivation for this change
Git 2.19.2 is out of date

###### Things done
I modified default.nix, then rebased all patches onto git 2.21.0. I had to make significant modifications to git-sh-i18n.patch to allow it to pass tests.  All tests pass for gitFull and git-annex, which relies on gitBase. I have nowhere near the computing power to test all reliant packages, however. This commit was made using this updated git.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

