### PR TITLE
Added jq to playonlinux deps

### DIFF
--- a/pkgs/applications/misc/playonlinux/default.nix
+++ b/pkgs/applications/misc/playonlinux/default.nix
@@ -19,6 +19,7 @@
 , pkgsi686Linux
 , which
 , curl
+, jq
 }:
 
 let
@@ -41,6 +42,7 @@ let
       xterm
       which
       curl
+      jq
     ];
 
   ld32 =


### PR DESCRIPTION
###### Motivation for this change

Playonlinux is complaining about not finding `jq` the first time i've opened it. More info on the following [issue](https://github.com/NixOS/nixpkgs/issues/56381):

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

