### PR TITLE
Use C++ 11 for MySQL 5.7 to fix build in mac

### DIFF
--- a/pkgs/servers/sql/mysql/5.7.x.nix
+++ b/pkgs/servers/sql/mysql/5.7.x.nix
@@ -57,7 +57,7 @@ self = stdenv.mkDerivation rec {
     "-DINSTALL_SHAREDIR=share/mysql"
   ];
 
-  CXXFLAGS = "-fpermissive";
+  CXXFLAGS = "-fpermissive -std=c++11";
   NIX_LDFLAGS = stdenv.lib.optionalString stdenv.isLinux "-lgcc_s";
 
   prePatch = ''


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/49174 shows us the error that we were experiencing.
The last successful build was https://hydra.nixos.org/build/81938220, with the first failing here: https://hydra.nixos.org/build/82083071

###### Description

https://github.com/NixOS/nixpkgs/issues/49174 shows us the error that we were experiencing.
The last successful build was https://hydra.nixos.org/build/81938220, with the first failing here: https://hydra.nixos.org/build/82083071

The difference between these 2 builds seems to be Protobuf 3.4 being updated to Protobuf 3.6.

This commit makes MySQL 5.7 use c++ 11 to fix these issues as Protobuf 3.6 uses newer C++ features

Fixes #49174

###### Things done

- Not entirely sure how to run all of this.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
    -> Can't do this one as it didn't work before. It's just a revert anyways, so it is the same as it once was.
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

