### PR TITLE
glib: 2.58.2 -> 2.58.3

### DIFF
--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -46,7 +46,7 @@ let
   '';
 
   binPrograms = optional (!stdenv.isDarwin) "gapplication" ++ [ "gdbus" "gio" "gsettings" ];
-  version = "2.58.2";
+  version = "2.58.3";
 in
 
 stdenv.mkDerivation rec {
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/glib/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0jrxfm4gn1qz3y1450z709v74ys2bkjr8yffkgy106kgagb4xcn7";
+    sha256 = "10blprf5djbwxq8dqmjvcsdc9vqz63rl0ammfbd2b2p8cwbw6hwg";
   };
 
   patches = optional stdenv.isDarwin ./darwin-compilation.patch
@@ -66,26 +66,6 @@ stdenv.mkDerivation rec {
       ./schema-override-variable.patch
       # Require substituteInPlace in postPatch
       ./fix-gio-launch-desktop-path.patch
-      # https://gitlab.gnome.org/GNOME/glib/issues/1626
-      # https://gitlab.gnome.org/GNOME/glib/merge_requests/557
-      (fetchpatch {
-        url = https://gitlab.gnome.org/GNOME/glib/commit/85c4031696add9797e2334ced20678edcd96c869.patch;
-        sha256 = "1hmyvhx89wip2a26gk1rvd87k0pjfia51s0ysybjyzf5f1pzw877";
-      })
-      # https://gitlab.gnome.org/GNOME/glib/issues/1645
-      (fetchpatch {
-        url = https://gitlab.gnome.org/GNOME/glib/commit/e695ca9f310c393d8f39694f77471dbcb06daa9e.diff;
-        sha256 = "1jkb2bdnni0xdyn86xrx9z0fdwxrm7y08lagz8x5x01wglkwa26w";
-      })
-      # https://gitlab.gnome.org/GNOME/glib/issues/1643
-      (fetchpatch {
-        url = https://gitlab.gnome.org/GNOME/glib/commit/c792e5adaa8ae3a45e6ff3ff71168ad8d040a0d4.patch;
-        sha256 = "022x70qfn5wlv5gz3nlg0bwiwjxcd7l11j3qvbms2y8d1ffh5rfd";
-      })
-      (fetchpatch {
-        url = https://gitlab.gnome.org/GNOME/glib/commit/30ccbc386026cecac6ef3a77d8fa4f3c24ac68d7.patch;
-        sha256 = "04y3pxgzlx92cppwibx4rlsyvwxb37aq52x2lr6ajfgykv2nzpr3";
-      })
     ];
 
   outputs = [ "bin" "out" "dev" "devdoc" ];


### PR DESCRIPTION
###### Motivation for this change

closes https://github.com/NixOS/nixpkgs/issues/55999

~Just targeting master to get reliable builds on all the platforms, will change to staging afterwards (so don't merge before that).~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platforms:
   - [x] x86_64-linux
   - [x] x86_64-darwin
   - [x] aarch64-linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

