### PR TITLE
lua-modules/generated-packages.nix: fix 'lua' to propagate

### DIFF
--- a/maintainers/scripts/update-luarocks-packages
+++ b/maintainers/scripts/update-luarocks-packages
@@ -61,7 +61,7 @@ nixpkgs$ ${0} ${GENERATED_NIXFILE}
 
 These packages are manually refined in lua-overrides.nix
 */
-{ self, lua, stdenv, fetchurl, fetchgit, pkgs, ... } @ args:
+{ self, stdenv, fetchurl, fetchgit, pkgs, ... } @ args:
 self: super:
 with self;
 {

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -5,7 +5,7 @@ nixpkgs$ maintainers/scripts/update-luarocks-packages pkgs/development/lua-modul
 
 These packages are manually refined in lua-overrides.nix
 */
-{ self, lua, stdenv, fetchurl, fetchgit, pkgs, ... } @ args:
+{ self, stdenv, fetchurl, fetchgit, pkgs, ... } @ args:
 self: super:
 with self;
 {


### PR DESCRIPTION
Otherwise 'lua' is from the argument populated by callPackage
which means it's whatever the default is.

(instead of the lua we're generating packages for!)


###### Motivation for this change

Without this, I was finding lua53Packages managed to pull lua 5.2 along
with which caused confusion/mismatches.

This can be observed by specifying `luaPackages = lua53Packages;`
in top-level/all-packages.nix for the `awesome` package,
and inspect the build log (or try `awesome --version`) to see
what version of lua it detects.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---