### PR TITLE
cypress: init at 3.1.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -98,6 +98,11 @@
     github = "acowley";
     name = "Anthony Cowley";
   };
+  acyuta108 = {
+    email = "acyuta108@gmail.com";
+    github = "acyuta108";
+    name = "Acyuta C";
+  };
   adamt = {
     email = "mail@adamtulinius.dk";
     github = "adamtulinius";

--- a/pkgs/development/web/cypress/default.nix
+++ b/pkgs/development/web/cypress/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, pkgs, fetchurl, atomEnv, gtk2-x11, unzip }:
+
+let
+  dynamic-linker = stdenv.cc.bintools.dynamicLinker;
+
+in stdenv.mkDerivation rec {
+  name = "cypress";
+  src = fetchurl {
+    url = "https://cdn.cypress.io/desktop/3.1.5/linux64/cypress.zip";
+    sha256 = "19ilnb0ww8zvzxv0pq0qsjy6zp789c26rw6559j8q2s3f59jqv05";
+  };
+
+  buildInputs = [ unzip ];
+
+  phases = "unpackPhase fixupPhase";
+
+  targetPath = "$out/Cypress/3.1.5";
+
+  unpackPhase = ''
+    mkdir -p ${targetPath}
+    unzip $src -d ${targetPath}
+  '';
+
+  rpath = with pkgs; lib.makeLibraryPath [
+    atomEnv.libPath
+    gtk2-x11
+  ];
+
+  fixupPhase = ''
+    patchelf \
+      --set-interpreter "${dynamic-linker}" \
+      --set-rpath "${rpath}:${targetPath}/Cypress" \
+      ${targetPath}/Cypress/Cypress
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Fast, easy and reliable testing for anything that runs in a browser";
+    homepage = https://www.cypress.io/;
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.acyuta108 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -154,6 +154,8 @@ in
 
   corgi = callPackage ../development/tools/corgi { };
 
+  cypress = callPackage ../development/web/cypress { };
+
   dhallToNix = callPackage ../build-support/dhall-to-nix.nix {
     inherit dhall-nix;
   };


### PR DESCRIPTION
###### Motivation for this change
Missing package.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

