### PR TITLE
fwupd: 1.2.3 -> 1.2.8

### DIFF
--- a/pkgs/os-specific/linux/firmware/fwupd/add-option-for-installation-sysconfdir.patch
+++ b/pkgs/os-specific/linux/firmware/fwupd/add-option-for-installation-sysconfdir.patch
@@ -1,36 +1,8 @@
-From 44887227f7f617cbf84713ec45685cb4999039ff Mon Sep 17 00:00:00 2001
-From: Jan Tojnar <jtojnar@gmail.com>
-Date: Tue, 30 Oct 2018 22:26:30 +0100
-Subject: [PATCH] build: Add option for installation sysconfdir
-
-On NixOS, sysconfdir is read-only by default, and packages are not supposed to
-install files there. Instead, NixOS has a concept of modules that declaratively
-describe the system configuration.
-
-We still want to install the config files and certificates to fwupd prefix,
-so that the modules can use them as they see fit, but at the same time, we
-cannot set sysconfdir=${prefix}/etc because the daemon needs to read the
-configuration from the directory created by the module.
-
-With autotools, we could easily solve this by passing a the sysconfdir inside
-prefix only to `make install`, but Meson does not support anything like that.
-Until we manage to convince Meson to support install flags, we need to create
-our own install flag.
----
- data/meson.build                 | 4 ++--
- data/pki/meson.build             | 8 ++++----
- data/remotes.d/meson.build       | 6 +++---
- meson.build                      | 6 ++++++
- meson_options.txt                | 1 +
- plugins/redfish/meson.build      | 2 +-
- plugins/uefi/meson.build         | 2 +-
- 7 files changed, 18 insertions(+), 11 deletions(-)
-
 diff --git a/data/meson.build b/data/meson.build
-index 8dd2ac9a..d4ad1cbc 100644
+index 61664cd6..f10abbba 100644
 --- a/data/meson.build
 +++ b/data/meson.build
-@@ -9,7 +9,7 @@ if get_option('tests') and get_option('daemon')
+@@ -11,7 +11,7 @@ if get_option('daemon')
  endif
  
  install_data(['daemon.conf'],
@@ -39,7 +11,7 @@ index 8dd2ac9a..d4ad1cbc 100644
  )
  
  install_data(['org.freedesktop.fwupd.metainfo.xml'],
-@@ -17,7 +17,7 @@ install_data(['org.freedesktop.fwupd.metainfo.xml'],
+@@ -23,7 +23,7 @@ install_data(['org.freedesktop.fwupd.svg'],
  )
  
  install_data(['org.freedesktop.fwupd.conf'],
@@ -47,7 +19,7 @@ index 8dd2ac9a..d4ad1cbc 100644
 +  install_dir : join_paths(sysconfdir_install, 'dbus-1', 'system.d')
  )
  
- install_data(['metadata.xml'],
+ if get_option('daemon')
 diff --git a/data/pki/meson.build b/data/pki/meson.build
 index eefcc914..dc801fa1 100644
 --- a/data/pki/meson.build
@@ -85,7 +57,7 @@ index eefcc914..dc801fa1 100644
  endif
  
 diff --git a/data/remotes.d/meson.build b/data/remotes.d/meson.build
-index 824291fc..d0599a00 100644
+index a27c31ef..374e09b6 100644
 --- a/data/remotes.d/meson.build
 +++ b/data/remotes.d/meson.build
 @@ -3,7 +3,7 @@ if get_option('daemon') and get_option('lvfs')
@@ -98,22 +70,22 @@ index 824291fc..d0599a00 100644
    i18n.merge_file(
      input: 'lvfs.metainfo.xml',
 @@ -37,12 +37,12 @@ configure_file(
-   output : 'fwupd.conf',
-   configuration : con2,
-   install: true,
--  install_dir: join_paths(sysconfdir, 'fwupd', 'remotes.d'),
-+  install_dir: join_paths(sysconfdir_install, 'fwupd', 'remotes.d'),
- )
- configure_file(
-   input : 'vendor.conf',
    output : 'vendor.conf',
    configuration : con2,
    install: true,
 -  install_dir: join_paths(sysconfdir, 'fwupd', 'remotes.d'),
 +  install_dir: join_paths(sysconfdir_install, 'fwupd', 'remotes.d'),
  )
+ configure_file(
+   input : 'vendor-directory.conf',
+   output : 'vendor-directory.conf',
+   configuration : con2,
+   install: true,
+-  install_dir: join_paths(sysconfdir, 'fwupd', 'remotes.d'),
++  install_dir: join_paths(sysconfdir_install, 'fwupd', 'remotes.d'),
+ )
 diff --git a/meson.build b/meson.build
-index b6df98b3..d672ee37 100644
+index a89f9b3f..736896eb 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -145,6 +145,12 @@ localstatedir = join_paths(prefix, get_option('localstatedir'))
@@ -130,22 +102,33 @@ index b6df98b3..d672ee37 100644
  if gio.version().version_compare ('>= 2.55.0')
    conf.set('HAVE_GIO_2_55_0', '1')
 diff --git a/meson_options.txt b/meson_options.txt
-index 23ef8cdb..db8f93b6 100644
+index 5d4163e8..db81fd1f 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -17,6 +17,7 @@ option('plugin_uefi', type : 'boolean', value : true, description : 'enable UEFI
- option('plugin_nvme', type : 'boolean', value : true, description : 'enable NVMe support')
+@@ -21,6 +21,7 @@ option('plugin_modem_manager', type : 'boolean', value : false, description : 'e
  option('systemd', type : 'boolean', value : true, description : 'enable systemd support')
  option('systemdunitdir', type: 'string', value: '', description: 'Directory for systemd units')
+ option('elogind', type : 'boolean', value : false, description : 'enable elogind support')
 +option('sysconfdir_install', type: 'string', value: '', description: 'sysconfdir to use during installation')
  option('tests', type : 'boolean', value : true, description : 'enable tests')
  option('udevdir', type: 'string', value: '', description: 'Directory for udev rules')
  option('efi-cc', type : 'string', value : 'gcc', description : 'the compiler to use for EFI modules')
+diff --git a/plugins/dell-esrt/meson.build b/plugins/dell-esrt/meson.build
+index cb9f4555..b972d7fb 100644
+--- a/plugins/dell-esrt/meson.build
++++ b/plugins/dell-esrt/meson.build
+@@ -36,5 +36,5 @@ configure_file(
+   output : 'dell-esrt.conf',
+   configuration : con2,
+   install: true,
+-  install_dir: join_paths(sysconfdir, 'fwupd', 'remotes.d'),
++  install_dir: join_paths(sysconfdir_install, 'fwupd', 'remotes.d'),
+ )
 diff --git a/plugins/redfish/meson.build b/plugins/redfish/meson.build
-index ef07bd81..d2c7e259 100644
+index 5c88504e..7706da71 100644
 --- a/plugins/redfish/meson.build
 +++ b/plugins/redfish/meson.build
-@@ -25,7 +25,7 @@ shared_module('fu_plugin_redfish',
+@@ -26,7 +26,7 @@ shared_module('fu_plugin_redfish',
  )
  
  install_data(['redfish.conf'],
@@ -155,10 +138,10 @@ index ef07bd81..d2c7e259 100644
  
  if get_option('tests')
 diff --git a/plugins/uefi/meson.build b/plugins/uefi/meson.build
-index 09ebdf82..02fc0661 100644
+index ac9f5dd8..1ab51b5e 100644
 --- a/plugins/uefi/meson.build
 +++ b/plugins/uefi/meson.build
-@@ -73,7 +73,7 @@ executable(
+@@ -79,7 +79,7 @@ executable(
  )
  
  install_data(['uefi.conf'],
@@ -167,5 +150,3 @@ index 09ebdf82..02fc0661 100644
  )
  
  if get_option('tests')
--- 
-2.19.1

--- a/pkgs/os-specific/linux/firmware/fwupd/default.nix
+++ b/pkgs/os-specific/linux/firmware/fwupd/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, substituteAll, gtk-doc, pkgconfig, gobject-introspection, intltool
 , libgudev, polkit, libxmlb, gusb, sqlite, libarchive, glib-networking
-, libsoup, help2man, gpgme, libxslt, elfutils, libsmbios, efivar, glibcLocales
-, gnu-efi, libyaml, valgrind, meson, libuuid, colord, docbook_xml_dtd_43, docbook_xsl
+, libsoup, help2man, gpgme, libxslt, elfutils, libsmbios, efivar, gnu-efi
+, libyaml, valgrind, meson, libuuid, colord, docbook_xml_dtd_43, docbook_xsl
 , ninja, gcab, gnutls, python3, wrapGAppsHook, json-glib, bash-completion
 , shared-mime-info, umockdev, vala, makeFontsConf, freefont_ttf
 , cairo, freetype, fontconfig, pango
@@ -18,17 +18,17 @@ let
   };
 in stdenv.mkDerivation rec {
   pname = "fwupd";
-  version = "1.2.3";
+  version = "1.2.8";
 
   src = fetchurl {
     url = "https://people.freedesktop.org/~hughsient/releases/fwupd-${version}.tar.xz";
-    sha256 = "11qpgincndahq96rbm2kgcy9kw5n9cmbbilsrqcqcyk7mvv464sl";
+    sha256 = "0qbvq52c0scn1h99i1rf2la6rrhckin6gb02k7l0v3g07mxs20wc";
   };
 
   outputs = [ "out" "lib" "dev" "devdoc" "man" "installedTests" ];
 
   nativeBuildInputs = [
-    meson ninja gtk-doc pkgconfig gobject-introspection intltool glibcLocales shared-mime-info
+    meson ninja gtk-doc pkgconfig gobject-introspection intltool shared-mime-info
     valgrind gcab docbook_xml_dtd_43 docbook_xsl help2man libxslt python wrapGAppsHook vala
   ];
   buildInputs = [
@@ -36,8 +36,6 @@ in stdenv.mkDerivation rec {
     libgudev colord gpgme libuuid gnutls glib-networking efivar json-glib umockdev
     bash-completion cairo freetype fontconfig pango
   ];
-
-  LC_ALL = "en_US.UTF-8"; # For po/make-images
 
   patches = [
     ./fix-paths.patch
@@ -114,10 +112,11 @@ in stdenv.mkDerivation rec {
   # /etc/fwupd/uefi.conf is created by the services.hardware.fwupd NixOS module
   passthru = {
     filesInstalledToEtc = [
-      "fwupd/remotes.d/fwupd.conf"
+      "fwupd/remotes.d/dell-esrt.conf"
       "fwupd/remotes.d/lvfs-testing.conf"
       "fwupd/remotes.d/lvfs.conf"
       "fwupd/remotes.d/vendor.conf"
+      "fwupd/remotes.d/vendor-directory.conf"
       "pki/fwupd/GPG-KEY-Hughski-Limited"
       "pki/fwupd/GPG-KEY-Linux-Foundation-Firmware"
       "pki/fwupd/GPG-KEY-Linux-Vendor-Firmware-Service"

--- a/pkgs/os-specific/linux/firmware/fwupd/fix-paths.patch
+++ b/pkgs/os-specific/linux/firmware/fwupd/fix-paths.patch
@@ -1,15 +1,71 @@
+diff --git a/data/builder/meson.build b/data/builder/meson.build
+index c7a430c0..e69de29b 100644
 --- a/data/builder/meson.build
 +++ b/data/builder/meson.build
 @@ -1,3 +0,0 @@
 -install_data('README.md',
 -  install_dir : join_paths(localstatedir, 'lib', 'fwupd', 'builder')
 -)
+diff --git a/meson_post_install.sh b/meson_post_install.sh
+index 0cbb6f41..d757a81a 100755
 --- a/meson_post_install.sh
 +++ b/meson_post_install.sh
-@@ -11,6 +11,4 @@
+@@ -11,6 +11,4 @@ LOCALSTATEDIR=$2
      echo 'Updating systemd deps'
      mkdir -p ${DESTDIR}${SYSTEMDUNITDIR}/system-update.target.wants
      ln -sf ../fwupd-offline-update.service ${DESTDIR}${SYSTEMDUNITDIR}/system-update.target.wants/fwupd-offline-update.service
 -    echo 'Creating stateful directory'
 -    mkdir -p ${DESTDIR}${LOCALSTATEDIR}/lib/fwupd
  #fi
+diff --git a/plugins/flashrom/fu-plugin-flashrom.c b/plugins/flashrom/fu-plugin-flashrom.c
+index 598e0c42..a0a2c4a7 100644
+--- a/plugins/flashrom/fu-plugin-flashrom.c
++++ b/plugins/flashrom/fu-plugin-flashrom.c
+@@ -52,7 +52,7 @@ fu_plugin_startup (FuPlugin *plugin, GError **error)
+ 	g_autoptr(GError) error_local = NULL;
+
+ 	/* we need flashrom from the host system */
+-	data->flashrom_fn = fu_common_find_program_in_path ("flashrom", &error_local);
++	data->flashrom_fn = fu_common_find_program_in_path ("@flashrom@/bin/flashrom", &error_local);
+
+ 	/* search for devices */
+ 	hwids = fu_plugin_get_hwids (plugin);
+diff --git a/plugins/uefi/fu-plugin-uefi.c b/plugins/uefi/fu-plugin-uefi.c
+index 9293715c..e2e77c58 100644
+--- a/plugins/uefi/fu-plugin-uefi.c
++++ b/plugins/uefi/fu-plugin-uefi.c
+@@ -416,7 +416,7 @@ fu_plugin_update (FuPlugin *plugin,
+ 	fu_plugin_add_report_metadata (plugin, "MissingCapsuleHeader", str);
+
+ 	/* record boot information to system log for future debugging */
+-	efibootmgr_path = fu_common_find_program_in_path ("efibootmgr", NULL);
++	efibootmgr_path = fu_common_find_program_in_path ("@efibootmgr@/bin/efibootmgr", NULL);
+ 	if (efibootmgr_path != NULL) {
+ 		if (!g_spawn_command_line_sync ("efibootmgr -v",
+ 						&boot_variables, NULL, NULL, error))
+diff --git a/plugins/uefi/fu-uefi-pcrs.c b/plugins/uefi/fu-uefi-pcrs.c
+index 5c7e5239..01acbf7f 100644
+--- a/plugins/uefi/fu-uefi-pcrs.c
++++ b/plugins/uefi/fu-uefi-pcrs.c
+@@ -147,7 +147,7 @@ fu_uefi_pcrs_setup (FuUefiPcrs *self, GError **error)
+ 		/* old name, then new name */
+ 		argv0 = fu_common_find_program_in_path ("tpm2_listpcrs", NULL);
+ 		if (argv0 == NULL)
+-			argv0 = fu_common_find_program_in_path ("tpm2_pcrlist", error);
++			argv0 = fu_common_find_program_in_path ("@tpm2_tools@/bin/tpm2_pcrlist", error);
+ 		if (argv0 == NULL)
+ 			return FALSE;
+ 		if (!fu_uefi_pcrs_setup_tpm20 (self, argv0, error))
+diff --git a/src/fu-common.c b/src/fu-common.c
+index bd6faeef..45ba2a60 100644
+--- a/src/fu-common.c
++++ b/src/fu-common.c
+@@ -436,7 +436,7 @@ fu_common_firmware_builder (GBytes *bytes,
+ 	g_return_val_if_fail (error == NULL || *error == NULL, NULL);
+
+ 	/* find bwrap in the path */
+-	bwrap_fn = fu_common_find_program_in_path ("bwrap", error);
++	bwrap_fn = fu_common_find_program_in_path ("@bubblewrap@/bin/bwrap", error);
+ 	if (bwrap_fn == NULL)
+ 		return NULL;
+


### PR DESCRIPTION
* use C.UTF-8 instead of en_US
* refresh sysconfdir_install patch
  * extend to vendor-directory.conf


###### Motivation for this change

Not sure how to link release notes reasonably,
they're in the tarballs IIRC.

Release tags:

https://github.com/hughsie/fwupd/releases/tag/1.2.5
https://github.com/hughsie/fwupd/releases/tag/1.2.4

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---