### PR TITLE
cdk: 5.0-20171209 -> 5.0-20190224

### DIFF
--- a/pkgs/development/libraries/cdk/default.nix
+++ b/pkgs/development/libraries/cdk/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   name = "cdk-${version}";
-  version ="5.0-20171209";
+  version ="5.0-20190224";
 
   buildInputs = [
     ncurses
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
       "ftp://ftp.invisible-island.net/cdk/cdk-${version}.tgz"
       "https://invisible-mirror.net/archives/cdk/cdk-${version}.tgz"
     ];
-    sha256 = "0jq0dx7gm7gl6lv5mhlfkxhw5362g9dxqdlpjlrag069nns8xdc8";
+    sha256 = "0767xqwm377ak909c589vqm0v83slsnkm2ycq7bg545xx5nycncs";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

bump to 2019 :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Only in-tree user is gtdialog which looks good AFAICT :)