### PR TITLE
cuetools: symlink cuetag to cuetag.sh

### DIFF
--- a/pkgs/tools/cd-dvd/cuetools/default.nix
+++ b/pkgs/tools/cd-dvd/cuetools/default.nix
@@ -15,6 +15,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ bison flac flex id3v2 vorbis-tools ];
 
+  postInstall = ''
+    # add link for compatibility with Debian-based distros, which package `cuetag.sh` as `cuetag`
+    ln -s $out/bin/cuetag.sh $out/bin/cuetag
+  '';
+
   meta = with stdenv.lib; {
     description = "A set of utilities for working with cue files and toc files";
     homepage = https://github.com/svend/cuetools;

--- a/pkgs/tools/cd-dvd/cuetools/default.nix
+++ b/pkgs/tools/cd-dvd/cuetools/default.nix
@@ -1,14 +1,16 @@
-{ stdenv, fetchurl, autoreconfHook
+{ stdenv, fetchFromGitHub, autoreconfHook
 , bison, flac, flex, id3v2, vorbis-tools
 }:
 
 stdenv.mkDerivation rec {
-  name = "cuetools-${version}";
+  pname = "cuetools";
   version = "1.4.1";
 
-  src = fetchurl {
-    url = "https://github.com/svend/cuetools/archive/${version}.tar.gz";
-    sha256 = "01xi3rvdmil9nawsha04iagjylqr1l9v9vlzk99scs8c207l58i4";
+  src = fetchFromGitHub {
+    owner = "svend";
+    repo = pname;
+    rev = version;
+    sha256 = "02ksv1ahf1v4cr2xbclsfv5x17m9ivzbssb5r8xjm97yh8a7spa3";
   };
 
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
Debian-based distros call `cuetag.sh` "cuetag" (see https://packages.debian.org/buster/amd64/cuetools/filelist).
This adds a symlink for compatibility with those distros.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

