### PR TITLE
hackertyper: init at 1.1

### DIFF
--- a/pkgs/tools/misc/hackertyper/default.nix
+++ b/pkgs/tools/misc/hackertyper/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, ncurses }:
+
+stdenv.mkDerivation rec {
+  pname = "hackertyper";
+  version = "20190226";
+
+  src = fetchFromGitHub {
+    owner  = "Hurricane996";
+    repo   = "Hackertyper";
+    rev    = "dc017270777f12086271bb5a1162d0f3613903c4";
+    sha256 = "0szkkkxspmfq1z2n4nldj2c9jn6jgiqik085rx1wkks0zgcdcgy1";
+  };
+
+
+  makeFlags = [ "PREFIX=$(out)" ];
+  buildInputs = [ ncurses ];
+
+  preInstall = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/man/man1
+  '';
+
+
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/hackertyper -v
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A C rewrite of hackertyper.net";
+    homepage = "https://github.com/Hurricane996/Hackertyper";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.marius851000 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3428,6 +3428,8 @@ in
     stdenv = if stdenv.cc.isClang then llvmPackages_6.stdenv else stdenv;
   };
 
+  hackertyper = callPackage ../tools/misc/hackertyper { };
+
   haveged = callPackage ../tools/security/haveged { };
 
   habitat = callPackage ../applications/networking/cluster/habitat { };


### PR DESCRIPTION
###### Motivation for this change
Wanted to test this and train at package creation

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

