### PR TITLE
ctrtool: init at 0.15

### DIFF
--- a/pkgs/tools/archivers/ctrtool/default.nix
+++ b/pkgs/tools/archivers/ctrtool/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "ctrtool";
+  version = "0.15";
+
+  src = fetchFromGitHub {
+    owner  = "profi200";
+    repo   = "Project_CTR";
+    rev    = version;
+    sha256 = "1l6z05x18s1crvb283yvynlwsrpa1pdx1nbijp99plw06p88h4va";
+  };
+
+  sourceRoot = "source/ctrtool";
+
+  enableParallelBuilding = true;
+
+  installPhase = "
+    mkdir $out/bin -p
+    cp ctrtool $out/bin/ctrtool
+  ";
+
+  meta = with stdenv.lib; {
+    license = licenses.mit;
+    description = "A tool to extract data from a 3ds rom";
+    platforms = platforms.linux;
+    maintainers = [ maintainers.marius851000 ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -712,6 +712,8 @@ in
 
   cozy = callPackage ../applications/audio/cozy-audiobooks { };
 
+  ctrtool = callPackage ../tools/archivers/ctrtool { };
+
   crumbs = callPackage ../applications/misc/crumbs { };
 
   deskew = callPackage ../applications/graphics/deskew { };


### PR DESCRIPTION
###### Motivation for this change
A tool I use for 3ds modding

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

