### PR TITLE
clprover: init at 1.0.3

### DIFF
--- a/pkgs/applications/science/logic/clprover/clprover.nix
+++ b/pkgs/applications/science/logic/clprover/clprover.nix
@@ -1,0 +1,26 @@
+{ stdenv, pkgs, fetchzip }:
+
+stdenv.mkDerivation rec {
+  name = "clprover-${version}";
+  version = "1.0.3";
+
+  src = fetchzip {
+    url = "http://cgi.csc.liv.ac.uk/~ullrich/CLProver++/CLProver++-v1.0.3-18-04-2015.zip";
+    sha256 = "10kmlg4m572qwfzi6hkyb0ypb643xw8sfb55xx7866lyh37w1q3s";
+    stripRoot = false;
+  };
+
+  installPhase = ''
+    mkdir $out
+    cp -r bin $out/bin
+    mkdir -p $out/share/clprover
+    cp -r examples $out/share/clprover/examples
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Resolution-based theorem prover for Coalition Logic implemented in C++.";
+    homepage = http://cgi.csc.liv.ac.uk/~ullrich/CLProver++/;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ mgttlinger ];
+  };
+}

--- a/pkgs/applications/science/logic/clprover/clprover.nix
+++ b/pkgs/applications/science/logic/clprover/clprover.nix
@@ -22,5 +22,6 @@ stdenv.mkDerivation rec {
     homepage = http://cgi.csc.liv.ac.uk/~ullrich/CLProver++/;
     license = licenses.gpl3; # Note that while the website states that it is GPLv2 but the file in the zip as well as the comments in the source state it is GPLv3
     maintainers = with maintainers; [ mgttlinger ];
+    platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/applications/science/logic/clprover/clprover.nix
+++ b/pkgs/applications/science/logic/clprover/clprover.nix
@@ -18,9 +18,9 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = "Resolution-based theorem prover for Coalition Logic implemented in C++.";
+    description = "Resolution-based theorem prover for Coalition Logic implemented in C++";
     homepage = http://cgi.csc.liv.ac.uk/~ullrich/CLProver++/;
-    license = licenses.gpl3;
+    license = licenses.gpl3; # Note that while the website states that it is GPLv2 but the file in the zip as well as the comments in the source state it is GPLv3
     maintainers = with maintainers; [ mgttlinger ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1181,6 +1181,8 @@ in
 
   clingo = callPackage ../applications/science/logic/potassco/clingo.nix { };
 
+  clprover = callPackage ../applications/science/logic/clprover/clprover.nix { };
+
   colord-kde = libsForQt5.callPackage ../tools/misc/colord-kde {};
 
   colpack = callPackage ../applications/science/math/colpack { };


### PR DESCRIPTION
###### Motivation for this change

There was no derivation for clprover.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

