### PR TITLE
slurp: 1.0.1 -> 1.1.0

### DIFF
--- a/pkgs/tools/misc/slurp/default.nix
+++ b/pkgs/tools/misc/slurp/default.nix
@@ -1,27 +1,32 @@
-{ stdenv, fetchFromGitHub, cairo, meson, ninja, wayland, pkgconfig, wayland-protocols }:
+{ stdenv, fetchFromGitHub, meson, ninja, pkgconfig
+, cairo, wayland, wayland-protocols
+, buildDocs ? true, scdoc
+}:
 
 stdenv.mkDerivation rec {
-  name = "slurp-${version}";
-  version = "1.0.1";
+  pname = "slurp";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "emersion";
     repo = "slurp";
     rev = "v${version}";
-    sha256 = "072lkwhpvr753wfqzmd994bnhbrgfavxcgqcyml7abab28sdhs1y";
+    sha256 = "15fqspg3cjl830l95ibibprxf9p13mc2rpyf9bdwsdx2f4qrkq62";
   };
 
   nativeBuildInputs = [
     meson
     ninja
     pkgconfig
-  ];
+  ] ++ stdenv.lib.optional buildDocs scdoc;
 
   buildInputs = [
     cairo
     wayland
     wayland-protocols
   ];
+
+  mesonFlags = stdenv.lib.optional buildDocs "-Dman-pages=enabled";
 
   meta = with stdenv.lib; {
     description = "Select a region in a Wayland compositor";


### PR DESCRIPTION
```
Jan Beich (1):
      Add man-pages option like swaywm/sway@ba16f16e4d5a

Ridan Vandenbergh (2):
      Display alpha in usage
      Add user-defined output formatting (#33)

Yorick (2):
      Abort on escape (#25)
      Support selection across multiple outputs (#27)

emersion (1):
      Bump to v1.1.0
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @buffet 