### PR TITLE
emscripten: 1.37.36 -> 1.38.28

### DIFF
--- a/pkgs/development/compilers/binaryen/default.nix
+++ b/pkgs/development/compilers/binaryen/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, cmake, fetchFromGitHub, emscriptenRev ? null }:
+{ stdenv, cmake, python, fetchFromGitHub, emscriptenRev ? null }:
 
 let
   defaultVersion = "45";
@@ -6,7 +6,7 @@ let
   # Map from git revs to SHA256 hashes
   sha256s = {
     "version_45" = "1wgzfzjjzkiaz0rf2lnwrcvlcsjvjhyvbyh58jxhqq43vi34zyjc";
-    "1.37.36" = "1wgzfzjjzkiaz0rf2lnwrcvlcsjvjhyvbyh58jxhqq43vi34zyjc";
+    "1.38.28" = "172s7y5f38736ic8ri3mnbdqcrkadd40a26cxcfwbscc53phl11v";
   };
 in
 
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     inherit rev;
   };
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake python ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/WebAssembly/binaryen;

--- a/pkgs/development/compilers/emscripten/default.nix
+++ b/pkgs/development/compilers/emscripten/default.nix
@@ -12,9 +12,9 @@ stdenv.mkDerivation {
   name = "emscripten-${rev}";
 
   src = fetchFromGitHub {
-    owner = "kripken";
+    owner = "emscripten-core";
     repo = "emscripten";
-    sha256 = "02p0cp86vd1mydlpq544xbydggpnrq9dhbxx7h08j235frjm5cdc";
+    sha256 = "1j3f0hpy05qskaiyv75l7wv4n0nzxhrh9b296zchx3f6f9h2rghq";
     inherit rev;
   };
 
@@ -61,7 +61,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with stdenv.lib; {
-    homepage = https://github.com/kripken/emscripten;
+    homepage = https://github.com/emscripten-core/emscripten;
     description = "An LLVM-to-JavaScript Compiler";
     platforms = platforms.all;
     maintainers = with maintainers; [ qknight matthewbauer ];

--- a/pkgs/development/compilers/emscripten/fastcomp/emscripten-fastcomp.nix
+++ b/pkgs/development/compilers/emscripten/fastcomp/emscripten-fastcomp.nix
@@ -8,16 +8,16 @@ stdenv.mkDerivation rec {
   name = "emscripten-fastcomp-${rev}";
 
   src = fetchFromGitHub {
-    owner = "kripken";
+    owner = "emscripten-core";
     repo = "emscripten-fastcomp";
-    sha256 = "04j698gmp686b5lricjakm5hyh2z2kh28m1ffkghmkyz4zkzmx98";
+    sha256 = "0bd0l5k2fa4k0nax2cpxi003pqffqivx4z4m2j5xdha1a12sid8i";
     inherit rev;
   };
 
   srcFL = fetchFromGitHub {
-    owner = "kripken";
+    owner = "emscripten-core";
     repo = "emscripten-fastcomp-clang";
-    sha256 = "1ici51mmpgg80xk3y8f376nbbfak6rz27qdy98l8lxkrymklp5g5";
+    sha256 = "1iw2qplhp489qzw0rma73sab7asnm27g4m95sr36c6kq9cq6agri";
     inherit rev;
   };
 
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with stdenv.lib; {
-    homepage = https://github.com/kripken/emscripten-fastcomp;
+    homepage = https://github.com/emscripten-core/emscripten-fastcomp;
     description = "Emscripten LLVM";
     platforms = platforms.all;
     maintainers = with maintainers; [ qknight matthewbauer ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2460,7 +2460,7 @@ in
 
   cholmod-extra = callPackage ../development/libraries/science/math/cholmod-extra { };
 
-  emscriptenVersion = "1.37.36";
+  emscriptenVersion = "1.38.28";
 
   emscripten = callPackage ../development/compilers/emscripten { };
 


### PR DESCRIPTION
###### Motivation for this change
The `1.37.36` version is almost a year old.

###### Issues
When running `nox-review wip` the only package that fails is `meguca`. Maybe just updating this package could help. @Chiiruno

###### Things done
Tested with a personal project.
Build everything in `emscriptenPackages`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

