### PR TITLE
Adding railcar container module

### DIFF
--- a/doc/functions.xml
+++ b/doc/functions.xml
@@ -20,4 +20,5 @@
  <xi:include href="functions/appimagetools.xml" />
  <xi:include href="functions/prefer-remote-fetch.xml" />
  <xi:include href="functions/nix-gitignore.xml" />
+ <xi:include href="functions/ocitools.xml" />
 </chapter>

--- a/doc/functions/ocitools.xml
+++ b/doc/functions/ocitools.xml
@@ -1,0 +1,76 @@
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xml:id="sec-pkgs-ociTools">
+ <title>pkgs.ociTools</title>
+
+ <para>
+  <varname>pkgs.ociTools</varname> is a set of functions for creating
+  containers according to the
+  <link xlink:href="https://github.com/opencontainers/runtime-spec">OCI
+  container specification v1.0.0</link>. Beyond that it makes no assumptions
+  about the container runner you choose to use to run the created container.
+ </para>
+
+ <section xml:id="ssec-pkgs-ociTools-buildContainer">
+  <title>buildContainer</title>
+
+  <para>
+   This function creates a simple OCI container that runs a single command
+   inside of it. An OCI container consists of a <varname>config.json</varname>
+   and a rootfs directory.The nix store of the container will contain all
+   referenced dependencies of the given command.
+  </para>
+
+  <para>
+   The parameters of <varname>buildContainer</varname> with an example value
+   are described below:
+  </para>
+
+  <example xml:id='ex-ociTools-buildContainer'>
+   <title>Build Container</title>
+<programlisting>
+buildContainer {
+  cmd = with pkgs; writeScript "run.sh" ''
+    #!${bash}/bin/bash
+    ${coreutils}/bin/exec ${bash}/bin/bash
+  ''; <co xml:id='ex-ociTools-buildContainer-1' />
+
+  mounts = {
+    "/data" = {
+      type = "none";
+      source = "/var/lib/mydata";
+      options = [ "bind" ];
+    };
+  };<co xml:id='ex-ociTools-buildContainer-2' />
+
+  readonly = false; <co xml:id='ex-ociTools-buildContainer-3' />
+}
+
+    </programlisting>
+   <calloutlist>
+    <callout arearefs='ex-ociTools-buildContainer-1'>
+     <para>
+      <varname>cmd</varname> specifies the program to run inside the container.
+      This is the only required argument for <varname>buildContainer</varname>.
+      All referenced packages inside the derivation will be made available
+      inside the container
+     </para>
+    </callout>
+    <callout arearefs='ex-ociTools-buildContainer-2'>
+     <para>
+      <varname>mounts</varname> specifies additional mount points chosen by the
+      user. By default only a minimal set of necessary filesystems are mounted
+      into the container (e.g procfs, cgroupfs)
+     </para>
+    </callout>
+    <callout arearefs='ex-ociTools-buildContainer-3'>
+     <para>
+       <varname>readonly</varname> makes the container's rootfs read-only if it is set to true.
+       The default value is false <literal>false</literal>.
+     </para>
+    </callout>
+   </calloutlist>
+  </example>
+ </section>
+</section>

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -944,6 +944,7 @@
   ./virtualisation/openvswitch.nix
   ./virtualisation/parallels-guest.nix
   ./virtualisation/qemu-guest-agent.nix
+  ./virtualisation/railcar.nix
   ./virtualisation/rkt.nix
   ./virtualisation/virtualbox-guest.nix
   ./virtualisation/virtualbox-host.nix

--- a/nixos/modules/virtualisation/railcar.nix
+++ b/nixos/modules/virtualisation/railcar.nix
@@ -22,36 +22,37 @@ let
             Type = containerConfig.runType;
           };
       };
-  mount = {
+  mount = with types; (submodule {
     options = {
       type = mkOption {
-        type = types.string;
+        type = string;
         default = "none";
         description = ''
-        The type of the filesystem to be mounted.
-        Linux: filesystem types supported by the kernel as listed in 
-        `/proc/filesystems` (e.g., "minix", "ext2", "ext3", "jfs", "xfs", 
-        "reiserfs", "msdos", "proc", "nfs", "iso9660"). For bind mounts 
-        (when options include either bind or rbind), the type is a dummy,
-        often "none" (not listed in /proc/filesystems).
-      '';
+          The type of the filesystem to be mounted.
+          Linux: filesystem types supported by the kernel as listed in 
+          `/proc/filesystems` (e.g., "minix", "ext2", "ext3", "jfs", "xfs", 
+          "reiserfs", "msdos", "proc", "nfs", "iso9660"). For bind mounts 
+          (when options include either bind or rbind), the type is a dummy,
+          often "none" (not listed in /proc/filesystems).
+        '';
       };
       source = mkOption {
-        type = types.string;
+        type = string;
         description = "Source for the in-container mount";
       };
       options = mkOption {
-        type = with types; loaOf (string);
+        type = loaOf (string);
         default = [ "bind" ];
         description = ''
-        Mount options of the filesystem to be used.
+          Mount options of the filesystem to be used.
         
-        Support optoions are listed in the mount(8) man page. Note that both
-        filesystem-independent and filesystem-specific options are listed.
-      '';
+          Support optoions are listed in the mount(8) man page. Note that 
+          both filesystem-independent and filesystem-specific options 
+          are listed.
+        '';
       };
     };
-  };
+  });
 in
 {
   options.services.railcar = {
@@ -68,7 +69,7 @@ in
           };
 
           mounts = mkOption {
-            type = with types; attrsOf (submodule (mount));
+            type = with types; attrsOf mount;
             default = {};
             description = ''
               A set of mounts inside the container.

--- a/nixos/modules/virtualisation/railcar.nix
+++ b/nixos/modules/virtualisation/railcar.nix
@@ -1,0 +1,124 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.railcar;
+  generateUnit = name: containerConfig:
+    let
+      container = pkgs.ociTools.buildContainer {
+        args = [
+          (pkgs.writeShellScript "run.sh" containerConfig.cmd).outPath
+        ];
+      };
+    in
+      nameValuePair "railcar-${name}" {
+        enable = true;
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+            ExecStart = ''
+              ${cfg.package}/bin/railcar -r ${cfg.stateDir} run ${name} -b ${container}
+            '';
+            Type = containerConfig.runType;
+          };
+      };
+  mount = {
+    options = {
+      type = mkOption {
+        type = types.string;
+        default = "none";
+        description = ''
+        The type of the filesystem to be mounted.
+        Linux: filesystem types supported by the kernel as listed in 
+        `/proc/filesystems` (e.g., "minix", "ext2", "ext3", "jfs", "xfs", 
+        "reiserfs", "msdos", "proc", "nfs", "iso9660"). For bind mounts 
+        (when options include either bind or rbind), the type is a dummy,
+        often "none" (not listed in /proc/filesystems).
+      '';
+      };
+      source = mkOption {
+        type = types.string;
+        description = "Source for the in-container mount";
+      };
+      options = mkOption {
+        type = with types; loaOf (string);
+        default = [ "bind" ];
+        description = ''
+        Mount options of the filesystem to be used.
+        
+        Support optoions are listed in the mount(8) man page. Note that both
+        filesystem-independent and filesystem-specific options are listed.
+      '';
+      };
+    };
+  };
+in
+{
+  options.services.railcar = {
+    enable = mkEnableOption "railcar";
+
+    containers = mkOption {
+      default = {};
+      description = "Declarative container configuration";
+      type = with types; loaOf (submodule ({ name, config, ... }: {
+        options = {
+          cmd = mkOption {
+            type = types.string;
+            description = "Command or script to run inside the container";
+          };
+
+          mounts = mkOption {
+            type = with types; attrsOf (submodule (mount));
+            default = {};
+            description = ''
+              A set of mounts inside the container.
+
+              The defaults have been chosen for simple bindmounts, meaning
+              that you only need to provide the "source" parameter.
+            '';
+            example = ''
+              { "/data" = { source = "/var/lib/data"; }; }
+            '';
+          };
+
+          runType = mkOption {
+            type = types.string;
+            default = "oneshot";
+            description = "The systemd service run type";
+          };
+
+          os = mkOption {
+            type = types.string;
+            default = "linux";
+            description = "OS type of the container";
+          };
+
+          arch = mkOption {
+            type = types.string;
+            default = "x86_64";
+            description = "Computer architecture type of the container";
+          };
+        };
+      }));
+    };
+
+    stateDir = mkOption {
+      type = types.path;
+      default = ''/var/railcar'';
+      description = "Railcar persistent state directory";
+    };
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.railcar;
+      description = "Railcar package to use";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services = flip mapAttrs' cfg.containers (name: containerConfig:
+      generateUnit name containerConfig
+    );
+  };
+}
+

--- a/pkgs/build-support/oci-tools/default.nix
+++ b/pkgs/build-support/oci-tools/default.nix
@@ -1,0 +1,78 @@
+{ lib, writeText, runCommand, writeReferencesToFile }:
+
+{
+  buildContainer =
+    { args
+    , mounts ? {}
+    , os ? "linux"
+    , arch ? "x86_64"
+    , readonly ? false
+    }:
+  let
+    sysMounts = {
+      "/proc" = {
+        type = "proc";
+        source = "proc";
+      };
+      "/dev" = {
+        type = "tmpfs";
+        source = "tmpfs";
+        options = [ "nosuid" "strictatime" "mode=755" "size=65536k" ];
+      };
+      "/dev/pts" = {
+        type = "devpts";
+        source = "devpts";
+        options = [ "nosuid" "noexec" "newinstance" "ptmxmode=0666" "mode=755" "gid=5" ];
+      };
+      "/dev/shm" = {
+        type = "tmpfs";
+        source = "shm";
+        options = [ "nosuid" "noexec" "nodev" "mode=1777" "size=65536k" ];
+      };
+      "/dev/mqueue" = {
+        type = "mqueue";
+        source = "mqueue";
+        options = [ "nosuid" "noexec" "nodev" ];
+      };
+      "/sys" = {
+        type = "sysfs";
+        source = "sysfs";
+        options = [ "nosuid" "noexec" "nodev" "ro" ];
+      };
+      "/sys/fs/cgroup" = {
+        type = "cgroup";
+        source = "cgroup";
+        options = [ "nosuid" "noexec" "nodev" "realatime" "ro" ];
+      };
+    };
+    config = writeText "config.json" (builtins.toJSON {
+      ociVersion = "1.0.0";
+      platform = {
+        inherit os arch;
+      };
+
+      linux = {
+        namespaces = map (type: { inherit type; }) [ "pid" "network" "mount" "ipc" "uts" ];
+      };
+
+      root = { path = "rootfs"; inherit readonly; };
+
+      process = {
+        inherit args;
+        user = { uid = 0; gid = 0; };
+        cwd = "/";
+      };
+
+      mounts = lib.mapAttrsToList (destination: { type, source, options ? null }: {
+        inherit destination type source options;
+      }) sysMounts;
+    });
+  in
+    runCommand "join" {} ''
+      set -o pipefail
+      mkdir -p $out/rootfs/{dev,proc,sys}
+      cp ${config} $out/config.json
+      xargs tar c < ${writeReferencesToFile args} | tar -xC $out/rootfs/
+    '';
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -381,6 +381,8 @@ in
 
   nix-gitignore = callPackage ../build-support/nix-gitignore { };
 
+  ociTools = callPackage ../build-support/oci-tools { };
+
   pathsFromGraph = ../build-support/kernel/paths-from-graph.pl;
 
   pruneLibtoolFiles = makeSetupHook { name = "prune-libtool-files"; }


### PR DESCRIPTION
###### Motivation for this change
The OCI container spec describes a simple way of creating a container with a `config.json` and a `rootfs`. These containers can be run by a container runner (such as `runc` or `railcar`) without having to rely on a daemon to manage containers outside of a NixOS config.

This PR adds two things

- A simple builder function that can create an OCI spec container in the nix-store
- A module to configure one particular container runner (railcar)

I also added documentation to the manual to explain how to use the underlying container-building function, so that other container runner modules can be added down the line.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

