### PR TITLE
openssl: 1.0.2q -> 1.0.2r, 1.1.1a -> 1.1.1b

### DIFF
--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -132,8 +132,8 @@ in {
   };
 
   openssl_1_1 = common {
-    version = "1.1.1a";
-    sha256 = "0hcz7znzznbibpy3iyyhvlqrq44y88plxwdj32wjzgbwic7i687w";
+    version = "1.1.1b";
+    sha256 = "0jza8cmznnyiia43056dij1jdmz62dx17wsn0zxksh9h6817nmaw";
     patches = [
       ./1.1/nix-ssl-cert-file.patch
 

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -120,8 +120,8 @@ let
 in {
 
   openssl_1_0_2 = common {
-    version = "1.0.2q";
-    sha256 = "115nisqy7kazbg6br2wrcra9nphyph1l4dgp563b9cf2rv5wyi2p";
+    version = "1.0.2r";
+    sha256 = "1mnh27zf6r1bhm5d9fxqq9slv2gz0d9z2ij9i679b0wapa5x0ldf";
     patches = [
       ./1.0.2/nix-ssl-cert-file.patch
 


### PR DESCRIPTION
###### Motivation for this change

- [CVE-2019-1559](https://www.openssl.org/news/secadv/20190226.txt)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---