### PR TITLE
pinentry: Use lib.string.{enable,with}Feature to avoid duplication

### DIFF
--- a/pkgs/tools/security/pinentry/default.nix
+++ b/pkgs/tools/security/pinentry/default.nix
@@ -1,13 +1,8 @@
 { fetchurl, fetchpatch, stdenv, lib, pkgconfig
-, libgpgerror, libassuan, libcap ? null, libsecret ? null, ncurses ? null,  gtk2 ? null, gcr ? null, qt ? null
+, libgpgerror, libassuan, libcap ? null, libsecret ? null, ncurses ? null, gtk2 ? null, gcr ? null, qt ? null
 , enableEmacs ? false
 }:
 
-let
-  mkFlag = pfxTrue: pfxFalse: cond: name: "--${if cond then pfxTrue else pfxFalse}-${name}";
-  mkEnable = mkFlag "enable" "disable";
-  mkWith = mkFlag "with" "without";
-in
 stdenv.mkDerivation rec {
   name = "pinentry-1.1.0";
 
@@ -30,14 +25,14 @@ stdenv.mkDerivation rec {
   ];
 
   configureFlags = [
-    (mkWith   (libcap != null)    "libcap")
-    (mkEnable (libsecret != null) "libsecret")
-    (mkEnable (ncurses != null)   "pinentry-curses")
-    (mkEnable true                "pinentry-tty")
-    (mkEnable enableEmacs         "pinentry-emacs")
-    (mkEnable (gtk2 != null)      "pinentry-gtk2")
-    (mkEnable (gcr != null)       "pinentry-gnome3")
-    (mkEnable (qt != null)        "pinentry-qt")
+    (stdenv.lib.withFeature   (libcap != null)    "libcap")
+    (stdenv.lib.enableFeature (libsecret != null) "libsecret")
+    (stdenv.lib.enableFeature (ncurses != null)   "pinentry-curses")
+    (stdenv.lib.enableFeature true                "pinentry-tty")
+    (stdenv.lib.enableFeature enableEmacs         "pinentry-emacs")
+    (stdenv.lib.enableFeature (gtk2 != null)      "pinentry-gtk2")
+    (stdenv.lib.enableFeature (gcr != null)       "pinentry-gnome3")
+    (stdenv.lib.enableFeature (qt != null)        "pinentry-qt")
   ];
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

