### PR TITLE
python: tensorflow: 1.11 -> 1.13

### DIFF
--- a/pkgs/development/python-modules/tensorflow/bin.nix
+++ b/pkgs/development/python-modules/tensorflow/bin.nix
@@ -41,7 +41,7 @@ let
 
 in buildPythonPackage rec {
   pname = "tensorflow";
-  version = "1.11.0";
+  version = "1.13.1";
   format = "wheel";
 
   src = let
@@ -50,7 +50,7 @@ in buildPythonPackage rec {
     platform = if stdenv.isDarwin then "mac" else "linux";
     unit = if cudaSupport then "gpu" else "cpu";
     key = "${platform}_py_${pyver}_${unit}";
-    dls = import ./tf1.11.0-hashes.nix;
+    dls = import ./tf1.13.1-hashes.nix;
   in fetchurl dls.${key};
 
   propagatedBuildInputs = [  protobuf numpy termcolor grpcio six astor absl-py gast tensorflow-tensorboard keras-applications keras-preprocessing ]

--- a/pkgs/development/python-modules/tensorflow/prefetcher.sh
+++ b/pkgs/development/python-modules/tensorflow/prefetcher.sh
@@ -1,10 +1,10 @@
-version=1.11.0
+version=1.13.1
 hashfile=tf${version}-hashes.nix
 rm -f $hashfile
 echo "{" >> $hashfile
 for sys in "linux" "mac"; do
     for tfpref in "cpu/tensorflow" "gpu/tensorflow_gpu"; do
-        for pykind in "py2-none-any" "py3-none-any" "cp27-none-linux_x86_64" "cp35-cp35m-linux_x86_64" "cp36-cp36m-linux_x86_64"; do
+        for pykind in "py2-none-any" "py3-none-any" "cp27-none-linux_x86_64" "cp35-cp35m-linux_x86_64" "cp36-cp36m-linux_x86_64" "cp37-cp37m-linux_x86_64"; do
             if [ $sys == "mac" ]; then
                [[ $pykind =~ py.* ]] && [[ $tfpref =~ cpu.* ]]
                result=$?

--- a/pkgs/development/python-modules/tensorflow/tf1.13.1-hashes.nix
+++ b/pkgs/development/python-modules/tensorflow/tf1.13.1-hashes.nix
@@ -1,0 +1,42 @@
+{
+linux_py_27_cpu = {
+  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.13.1-cp27-none-linux_x86_64.whl";
+  sha256 = "0y1vd3y5fxcjj5d35qbk8482b0s642nyp0c2sm068vx5wd4sjpcg";
+};
+linux_py_35_cpu = {
+  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.13.1-cp35-cp35m-linux_x86_64.whl";
+  sha256 = "0b27swk4c2vaimwzbzl4c7xnccr9cfak5a3848lfqlcavcmbp94j";
+};
+linux_py_36_cpu = {
+  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.13.1-cp36-cp36m-linux_x86_64.whl";
+  sha256 = "087jwjby3bym09z55cjhc587aasf01y6l009p1q2vcpfq7s7ljmk";
+};
+linux_py_37_cpu = {
+  url = "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.13.1-cp37-cp37m-linux_x86_64.whl";
+  sha256 = "0as68dp87lh7ffcccb149km6vws15ap04604irxwz35fq9h7grxg";
+};
+linux_py_27_gpu = {
+  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.13.1-cp27-none-linux_x86_64.whl";
+  sha256 = "0bf239f2bnsbqs3qh4xdql9pgbsm0zk7j8q1hg0wn0wrq440n0ds";
+};
+linux_py_35_gpu = {
+  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.13.1-cp35-cp35m-linux_x86_64.whl";
+  sha256 = "1cqav22a8yz6fzk46z6kv1ha2i28h5wccbd7k66drrfxibmb93j0";
+};
+linux_py_36_gpu = {
+  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.13.1-cp36-cp36m-linux_x86_64.whl";
+  sha256 = "1xnbiz36z7nicqrv0cmymfnwb8mdz2hifcv71gh6gnyi1962f2d7";
+};
+linux_py_37_gpu = {
+  url = "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.13.1-cp37-cp37m-linux_x86_64.whl";
+  sha256 = "10gcrmd9y5a89wpi4rpp9scc9l2krijv8yjp7iphlykmn54ps74k";
+};
+mac_py_2_cpu = {
+  url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-1.13.1-py2-none-any.whl";
+  sha256 = "1a6y5xj2wqkd8qmabn2xjg3q7x2jfixwrz351dgcxlhy8qy5yc0g";
+};
+mac_py_3_cpu = {
+  url = "https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-1.13.1-py3-none-any.whl";
+  sha256 = "1klsv18k0isfd61z1wirfz1lnqmx8k73ga8g9s18yand65iycads";
+};
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5010,15 +5010,15 @@ in {
 
   tensorflow-tensorboard = callPackage ../development/python-modules/tensorflow-tensorboard { };
 
-  tensorflow = disabledIf isPy37 (
+  tensorflow =
     if stdenv.isDarwin
     then callPackage ../development/python-modules/tensorflow/bin.nix { }
     else callPackage ../development/python-modules/tensorflow/bin.nix rec {
       cudaSupport = pkgs.config.cudaSupport or false;
       inherit (pkgs.linuxPackages) nvidia_x11;
-      cudatoolkit = pkgs.cudatoolkit_9_0;
-      cudnn = pkgs.cudnn_cudatoolkit_9_0;
-    });
+      cudatoolkit = pkgs.cudatoolkit_10_0;
+      cudnn = pkgs.cudnn_cudatoolkit_10_0;
+    };
 
   tensorflowWithoutCuda = self.tensorflow.override {
     cudaSupport = false;


### PR DESCRIPTION
###### Motivation for this change
Best thing here is the dropped python3.7 restriction. Not sure about all the old-version cruft, it's not in use, but maybe it's being left in for easier overrides?
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

