### PR TITLE
ping: init 0.6.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2454,6 +2454,11 @@
     github = "kisonecat";
     name = "Jim Fowler";
   };
+  kjuvi = {
+    email = "quentin.vaucher@pm.me";
+    github = "kjuvi";
+    name = "Quentin Vaucher";
+  };
   kkallio = {
     email = "tierpluspluslists@gmail.com";
     name = "Karn Kallio";

--- a/pkgs/applications/networking/ping/default.nix
+++ b/pkgs/applications/networking/ping/default.nix
@@ -5,8 +5,10 @@
 , pkgconfig
 , pantheon
 , python3
+, glib
 , gtk3
 , gtksourceview
+, hicolor-icon-theme
 , json-glib
 , libsoup
 , libgee

--- a/pkgs/development/web/ping/default.nix
+++ b/pkgs/development/web/ping/default.nix
@@ -1,0 +1,58 @@
+{ stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, pkgconfig
+, pantheon
+, python3
+, gtk3
+, gtksourceview
+, json-glib
+, libsoup
+, libgee
+, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  pname = "ping";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "jeremyvaartjes";
+    repo = "ping";
+    rev = version;
+    sha256 = "1h9cdy2jxa2ffykjg89j21hazls32z9yyv3g0x07x3vizzl5xcij";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pantheon.vala
+    pkgconfig
+    python3
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    gtksourceview
+    hicolor-icon-theme
+    json-glib
+    libgee
+    libsoup
+    pantheon.granite
+  ];
+
+  postPatch = ''
+    chmod +x meson/post_install.py
+    patchShebangs meson/post_install.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A helpful tool that lets you debug what part of your API is causing you issues";
+    homepage = https://github.com/jeremyvaartjes/ping;
+    maintainers = with maintainers; [ kjuvi ] ++ pantheon.maintainers;
+    platforms = platforms.linux;
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9016,6 +9016,8 @@ in
 
   phantomjs2 = libsForQt5.callPackage ../development/tools/phantomjs2 { };
 
+  ping = callPackages ../development/web/ping { };
+
   pmccabe = callPackage ../development/tools/misc/pmccabe { };
 
   pkgconf = callPackage ../development/tools/misc/pkgconf {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9016,8 +9016,6 @@ in
 
   phantomjs2 = libsForQt5.callPackage ../development/tools/phantomjs2 { };
 
-  ping = callPackages ../development/web/ping { };
-
   pmccabe = callPackage ../development/tools/misc/pmccabe { };
 
   pkgconf = callPackage ../development/tools/misc/pkgconf {};
@@ -18509,6 +18507,8 @@ in
   pig = callPackage ../applications/networking/cluster/pig { };
 
   pijul = callPackage ../applications/version-management/pijul {};
+
+  ping = callPackage ../applications/networking/ping { };
 
   piper = callPackage ../os-specific/linux/piper { };
 


### PR DESCRIPTION
###### Motivation for this change

Since Pantheon desktop has recently been added to Master, adding some "curated" apps from Elementary AppCenter seems to be a good idea to complete it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

