### PR TITLE
nixos/guix: init at 1.0.0

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -293,6 +293,7 @@
   ./services/desktops/tumbler.nix
   ./services/desktops/zeitgeist.nix
   ./services/development/bloop.nix
+  ./services/development/guix.nix
   ./services/development/hoogle.nix
   ./services/development/jupyter/default.nix
   ./services/editors/emacs.nix

--- a/nixos/modules/services/development/guix.nix
+++ b/nixos/modules/services/development/guix.nix
@@ -1,0 +1,95 @@
+{config, pkgs, lib, ...}:
+
+with lib;
+
+let
+
+  cfg = config.services.guix;
+
+  buildGuixUser = i:
+    {
+      "guixbuilder${builtins.toString i}" = {
+        group = "guixbuild";
+        extraGroups = ["guixbuild"];
+        home = "/var/empty";
+        shell = pkgs.nologin;
+        description = "Guix build user ${builtins.toString i}";
+        isSystemUser = true;
+      };
+    };
+
+in {
+
+  options.services.guix = {
+    enable = mkEnableOption "GNU Guix package manager";
+    package = mkOption {
+      type = types.package;
+      default = pkgs.guix;
+      defaultText = "pkgs.guix";
+      description = "Package that contains the guix binary and initial store.";
+    };
+  };
+
+  config = mkIf (cfg.enable) {
+
+    users = {
+      extraUsers = lib.fold (a: b: a // b) {} (builtins.map buildGuixUser (lib.range 1 10));
+      extraGroups.guixbuild = {name = "guixbuild";};
+    };
+
+    systemd.services.guix-daemon = {
+      enable = true;
+      description = "Build daemon for GNU Guix";
+      serviceConfig = {
+        ExecStart="/var/guix/profiles/per-user/root/current-guix/bin/guix-daemon --build-users-group=guixbuild";
+        Environment="GUIX_LOCPATH=/var/guix/profiles/per-user/root/guix-profile/lib/locale";
+        RemainAfterExit="yes";
+
+        # See <https://lists.gnu.org/archive/html/guix-devel/2016-04/msg00608.html>.
+        # Some package builds (for example, go@1.8.1) may require even more than
+        # 1024 tasks.
+        TasksMax="8192";
+      };
+      wantedBy = [ "multi-user.target" ];
+    };
+
+    system.activationScripts.guix = ''
+
+      # copy initial /gnu/store
+      if [ ! -d /gnu/store ]
+      then
+        mkdir -p /gnu
+        cp -ra ${cfg.package.store}/gnu/store /gnu/
+      fi
+
+      # copy initial /var/guix content
+      if [ ! -d /var/guix ]
+      then
+        mkdir -p /var
+        cp -ra ${cfg.package.var}/var/guix /var/
+      fi
+
+      # root profile
+      if [ ! -d ~root/.config/guix ]
+      then
+        mkdir -p ~root/.config/guix
+        ln -sf /var/guix/profiles/per-user/root/current-guix \
+          ~root/.config/guix/current
+      fi
+
+      # authorize substitutes
+      GUIX_PROFILE="`echo ~root`/.config/guix/current"; source $GUIX_PROFILE/etc/profile
+      guix archive --authorize < ~root/.config/guix/current/share/guix/ci.guix.info.pub
+    '';
+
+    environment.shellInit = ''
+      # Make the Guix command available to users
+      export PATH="/var/guix/profiles/per-user/root/current-guix/bin:$PATH"
+
+      export GUIX_LOCPATH="$HOME/.guix-profile/lib/locale"
+      export PATH="$HOME/.guix-profile/bin:$PATH"
+      export INFOPATH="$HOME/.guix-profile/share/info:$INFOPATH"
+    '';
+  };
+
+}

--- a/pkgs/development/guix/guix.nix
+++ b/pkgs/development/guix/guix.nix
@@ -1,0 +1,42 @@
+{stdenv, fetchurl}:
+stdenv.mkDerivation rec
+  { name = "guix-${version}";
+    version = "1.0.0";
+
+    src = fetchurl {
+      url = "https://ftp.gnu.org/gnu/guix/guix-binary-${version}.${stdenv.targetPlatform.system}.tar.xz";
+      sha256 = {
+        "x86_64-linux" = "11y9nnicd3ah8dhi51mfrjmi8ahxgvx1mhpjvsvdzaz07iq56333";
+        "i686-linux" = "14qkz12nsw0cm673jqx0q6ls4m2bsig022iqr0rblpfrgzx20f0i";
+        "aarch64-linux" = "0qzlpvdkiwz4w08xvwlqdhz35mjfmf1v3q8mv7fy09bk0y3cwzqs";
+        }."${stdenv.targetPlatform.system}";
+    };
+    sourceRoot = ".";
+
+    outputs = [ "out" "store" "var" ];
+    phases = [ "unpackPhase" "installPhase" ];
+
+    installPhase = ''
+      # copy the /gnu/store content
+      mkdir -p $store
+      cp -r gnu $store
+
+      # copy /var content
+      mkdir -p $var
+      cp -r var $var
+
+      # link guix binaries
+      mkdir -p $out/bin
+      ln -s /var/guix/profiles/per-user/root/current-guix/bin/guix $out/bin/guix
+      ln -s /var/guix/profiles/per-user/root/current-guix/bin/guix-daemon $out/bin/guix-daemon
+    '';
+
+    meta = with stdenv.lib; {
+      description = "The GNU Guix package manager";
+      homepage = https://www.gnu.org/software/guix/;
+      license = licenses.gpl3Plus;
+      maintainers = [ maintainers.johnazoidberg ];
+      platforms = [ "aarch64-linux" "i686-linux" "x86_64-linux" ];
+    };
+
+  }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -234,6 +234,8 @@ in
 
   graph-easy = callPackage ../tools/graphics/graph-easy { };
 
+  guix = callPackage ../development/guix/guix.nix { };
+
   packer = callPackage ../development/tools/packer { };
 
   pet = callPackage ../development/tools/pet { };


### PR DESCRIPTION
Add [GNU Guix package manager](https://www.gnu.org/software/guix/) as a NixOS module that can be enabled with the configuration `services.guix.enable = true`.

- Guix was previously available in nixpkgs (https://github.com/NixOS/nixpkgs/commit/b9960211abaaaac044d9bfa0a8395fde46847d05) but was removed (https://github.com/NixOS/nixpkgs/commit/5dab370d7779b0e372da00dcd262c64c2d8b58eb) as the package was not maintained or used.
- A more recent pull request to include Guix (only as package - without daemon, etc.): https://github.com/NixOS/nixpkgs/pull/43221
- Uses the Guix binary tarball and installation as described [here](https://www.gnu.org/software/guix/manual/en/html_node/Binary-Installation.html#Binary-Installation).
- Based on previous work: https://euandre.org/2018/07/17/running-guix-on-nixos.html

## Todo

I would like to ask for input and assistance in how to tackle these issues.

- [x] Activation script causes a warning that should be prevented.

```
guile: warning: failed to install locale
hint: Consider installing the `glibc-utf8-locales' or `glibc-locales' package and defining `GUIX_LOCPATH', along these lines:

     guix package -i glibc-utf8-locales
     export GUIX_LOCPATH="$HOME/.guix-profile/lib/locale"

See the "Application Setup" section in the manual, for more info.
```

Hint on how to prevent the warning is already given. But how to do this nicely

- [ ] Currently some setup is done using `environment.shellInit`. I have mixed feelings about messing with users `PATH`. This could be forgone and users could be required to do manual setup of their environment to use Guix (see [Application Setup](https://www.gnu.org/software/guix/manual/en/html_node/Application-Setup.html#Application-Setup)).

- [x] Related to point above: Directory in Guix profile containing info files needs to be added to `INFOPATH` environment variable. This is currently attempted in `environment.shellInit` but does not seem to work.

- [ ] Support more platforms than just `x86_64`.

## Futher Improvements

### Bootstrap Guix

Instead of using the Guix binary tarball it would be much cooler to [bootstrap Guix](https://www.gnu.org/software/guix/manual/en/html_node/Bootstrapping.html#Bootstrapping) from a smaller bootstrap binaries.

### Automated test

A NixOS test that checks functioning of Guix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

