### PR TITLE
cadre: init at 1.0.4

### DIFF
--- a/pkgs/development/tools/cadre/Gemfile
+++ b/pkgs/development/tools/cadre/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'cadre', '=1.0.4'

--- a/pkgs/development/tools/cadre/Gemfile.lock
+++ b/pkgs/development/tools/cadre/Gemfile.lock
@@ -1,0 +1,19 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    cadre (1.0.4)
+      thor (>= 0.14, < 1.0)
+      tilt (> 1.0)
+      valise (~> 1.2)
+    thor (0.20.3)
+    tilt (2.0.9)
+    valise (1.2.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  cadre (= 1.0.4)
+
+BUNDLED WITH
+   1.16.3

--- a/pkgs/development/tools/cadre/default.nix
+++ b/pkgs/development/tools/cadre/default.nix
@@ -1,0 +1,15 @@
+{ lib, bundlerApp }:
+
+bundlerApp {
+  pname = "cadre";
+  gemdir = ./.;
+  exes = [ "cadre" ];
+
+  meta = with lib; {
+    description = "Toolkit to add Ruby development - in-editor coverage, libnotify of test runs";
+    homepage    = https://github.com/nyarly/cadre;
+    license     = licenses.mit;
+    maintainers = [ maintainers.nyarly ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/development/tools/cadre/gemset.nix
+++ b/pkgs/development/tools/cadre/gemset.nix
@@ -1,0 +1,35 @@
+{
+  cadre = {
+    dependencies = ["thor" "tilt" "valise"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "07q60s1bm2xar46g00ls5fjkn6dm2kfxhsz9ayblc31x5kr8d83a";
+      type = "gem";
+    };
+    version = "1.0.4";
+  };
+  thor = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1yhrnp9x8qcy5vc7g438amd5j9sw83ih7c30dr6g6slgw9zj3g29";
+      type = "gem";
+    };
+    version = "0.20.3";
+  };
+  tilt = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0ca4k0clwf0rkvy7726x4nxpjxkpv67w043i39saxgldxd97zmwz";
+      type = "gem";
+    };
+    version = "2.0.9";
+  };
+  valise = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1arsbmk2gifrhv244qrld7s3202xrnxy6vlc5gqklg70dpsinbn5";
+      type = "gem";
+    };
+    version = "1.2.1";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8446,6 +8446,8 @@ in
 
   byacc = callPackage ../development/tools/parsing/byacc { };
 
+  cadre = callPackage ../development/tools/cadre { };
+
   casperjs = callPackage ../development/tools/casperjs {
     inherit (texFunctions) fontsConf;
   };


### PR DESCRIPTION
###### Motivation for this change

Adding `cadre` because I want to use it for Ruby development under NixOS

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

