### PR TITLE
Thonny: 3.0.5 -> 3.1.2

### DIFF
--- a/pkgs/applications/editors/thonny/default.nix
+++ b/pkgs/applications/editors/thonny/default.nix
@@ -1,16 +1,16 @@
-{ stdenv, fetchFromBitbucket, python3 }:
+{ stdenv, fetchFromGitHub, python3 }:
 
 with python3.pkgs;
 
 buildPythonApplication rec {
   pname = "thonny";
-  version = "3.0.5";
+  version = "3.1.2";
 
-  src = fetchFromBitbucket {
-    owner = "plas";
+  src = fetchFromGitHub {
+    owner = pname;
     repo = pname;
-    rev = "e5a1ad4ae9d24066a769489b1e168b4bd6e00b03";
-    sha256 = "1lrl5pj9dpw9i5ij863hd47gfd15nmvglqkl2ldwgfn7kgpsdkz5";
+    rev = "v${version}";
+    sha256 = "1simqqxm72k5zhavhllkinsyw8ggy6fjs5ppj82g3l5g3919pfna";
   };
 
   propagatedBuildInputs = with python3.pkgs; [
@@ -21,6 +21,7 @@ buildPythonApplication rec {
     pylint
     mypy
     pyperclip
+    asttokens
   ];
 
   preInstall = ''

--- a/pkgs/development/python-modules/asttokens/default.nix
+++ b/pkgs/development/python-modules/asttokens/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchPypi, buildPythonPackage, astroid, six, coverage
+, lazy-object-proxy, nose, wrapt
+}:
+
+buildPythonPackage rec {
+  pname = "asttokens";
+  version = "1.1.13";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1vd4djlxmgznz84gzakkv45avnrcpgl1kir92l1pxyp0z5c0dh2m";
+  };
+
+  propagatedBuildInputs = [ lazy-object-proxy six wrapt astroid ];
+
+  checkInputs = [ coverage nose ];
+
+  meta = with lib; {
+    homepage = https://github.com/gristlabs/asttokens;
+    description = "Annotate Python AST trees with source text and token information";
+    license = licenses.asl20;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ leenaars ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -194,6 +194,8 @@ in {
 
   astroquery = callPackage ../development/python-modules/astroquery { };
 
+  asttokens = callPackage ../development/python-modules/asttokens { };
+
   atom = callPackage ../development/python-modules/atom { };
 
   augeas = callPackage ../development/python-modules/augeas {


### PR DESCRIPTION
###### Motivation for this change

Version bump as per repology of this Python 3 IDE. Upstream project has moved to Github.
Packaged a new dependency (asttokens).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

