### PR TITLE
doc/cross-compilation: fix typo

### DIFF
--- a/doc/cross-compilation.xml
+++ b/doc/cross-compilation.xml
@@ -96,7 +96,7 @@
        compiler resulting from a single build can itself only produce binaries
        for a single platform. The task of specifying this single "target
        platform" is thus pushed to build time of the compiler. The root cause of
-       this that the compiler (which will be run on the host) and the standard
+       this is that the compiler (which will be run on the host) and the standard
        library/runtime (which will be run on the target) are built by a single
        build process.
       </para>


### PR DESCRIPTION
###### Motivation for this change

Add missing verb.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

