### PR TITLE
qt5.qtwebengine: fix on darwin (again)

### DIFF
--- a/pkgs/development/libraries/qt-5/5.11/default.nix
+++ b/pkgs/development/libraries/qt-5/5.11/default.nix
@@ -64,7 +64,10 @@ let
     qttools = [ ./qttools.patch ];
     qtwebengine = [ ./qtwebengine-no-build-skip.patch ]
       ++ optional stdenv.cc.isClang ./qtwebengine-clang-fix.patch
-      ++ optional stdenv.isDarwin ./qtwebengine-darwin-sdk-10.10.patch;
+      ++ optionals stdenv.isDarwin [
+        ./qtwebengine-darwin-no-platform-check.patch
+        ./qtwebengine-darwin-sdk-10.10.patch
+      ];
     qtwebkit = [ ./qtwebkit.patch ]
       ++ optionals stdenv.isDarwin [
         ./qtwebkit-darwin-no-readline.patch

--- a/pkgs/development/libraries/qt-5/5.11/default.nix
+++ b/pkgs/development/libraries/qt-5/5.11/default.nix
@@ -67,6 +67,7 @@ let
       ++ optionals stdenv.isDarwin [
         ./qtwebengine-darwin-no-platform-check.patch
         ./qtwebengine-darwin-sdk-10.10.patch
+        ./qtwebengine-darwin-old-sdk.patch
       ];
     qtwebkit = [ ./qtwebkit.patch ]
       ++ optionals stdenv.isDarwin [

--- a/pkgs/development/libraries/qt-5/5.11/qtwebengine-darwin-no-platform-check.patch
+++ b/pkgs/development/libraries/qt-5/5.11/qtwebengine-darwin-no-platform-check.patch
@@ -1,0 +1,37 @@
+diff --git a/mkspecs/features/platform.prf b/mkspecs/features/platform.prf
+--- a/mkspecs/features/platform.prf
++++ b/mkspecs/features/platform.prf
+@@ -38,10 +38,6 @@ defineTest(isPlatformSupported) {
+          return(false)
+     }
+   } else:osx {
+-    !isMinXcodeVersion(7, 3) {
+-      skipBuild("Using Xcode version $$QMAKE_XCODE_VERSION, but at least version 7.3 is required to build Qt WebEngine.")
+-      return(false)
+-    }
+     !clang|intel_icc {
+         skipBuild("Qt WebEngine on macOS requires Clang.")
+         return(false)
+@@ -52,10 +48,6 @@ defineTest(isPlatformSupported) {
+       skipBuild("Building Qt WebEngine requires macOS version 10.11 or newer.")
+       return(false)
+     }
+-    !isMinOSXSDKVersion(10, 10): {
+-      skipBuild("Building Qt WebEngine requires a macOS SDK version of 10.11 or newer. Current version is $${WEBENGINE_OSX_SDK_PRODUCT_VERSION}.")
+-      return(false)
+-    }
+   } else {
+     skipBuild("Unknown platform. Qt WebEngine only supports Linux, Windows, and macOS.")
+     return(false)
+diff --git a/src/core/config/mac_osx.pri b/src/core/config/mac_osx.pri
+--- a/src/core/config/mac_osx.pri
++++ b/src/core/config/mac_osx.pri
+@@ -5,8 +5,6 @@ load(functions)
+ # otherwise query for it.
+ QMAKE_MAC_SDK_VERSION = $$eval(QMAKE_MAC_SDK.$${QMAKE_MAC_SDK}.SDKVersion)
+ isEmpty(QMAKE_MAC_SDK_VERSION) {
+-     QMAKE_MAC_SDK_VERSION = $$system("/usr/bin/xcodebuild -sdk $${QMAKE_MAC_SDK} -version SDKVersion 2>/dev/null")
+-     isEmpty(QMAKE_MAC_SDK_VERSION): error("Could not resolve SDK version for \'$${QMAKE_MAC_SDK}\'")
+ }
+ 
+ QMAKE_CLANG_DIR = "/usr"

--- a/pkgs/development/libraries/qt-5/5.11/qtwebengine-darwin-old-sdk.patch
+++ b/pkgs/development/libraries/qt-5/5.11/qtwebengine-darwin-old-sdk.patch
@@ -1,0 +1,21 @@
+diff --git a/src/3rdparty/chromium/third_party/webrtc/sdk/objc/Framework/Classes/Common/RTCFieldTrials.mm b/src/3rdparty/chromium/third_party/webrtc/sdk/objc/Framework/Classes/Common/RTCFieldTrials.mm
+--- a/src/3rdparty/chromium/third_party/webrtc/sdk/objc/Framework/Classes/Common/RTCFieldTrials.mm
++++ b/src/3rdparty/chromium/third_party/webrtc/sdk/objc/Framework/Classes/Common/RTCFieldTrials.mm
+@@ -45,7 +45,7 @@ NSString *RTCFieldTrialTrendlineFilterValue(
+   return [NSString stringWithFormat:format, windowSize, smoothingCoeff, thresholdGain];
+ }
+ 
+-void RTCInitFieldTrialDictionary(NSDictionary<NSString *, NSString *> *fieldTrials) {
++void RTCInitFieldTrialDictionary(NSDictionary *fieldTrials) {
+   if (!fieldTrials) {
+     RTCLogWarning(@"No fieldTrials provided.");
+     return;
+diff --git a/src/3rdparty/chromium/third_party/webrtc/sdk/objc/Framework/Headers/WebRTC/RTCFieldTrials.h b/src/3rdparty/chromium/third_party/webrtc/sdk/objc/Framework/Headers/WebRTC/RTCFieldTrials.h
+--- a/src/3rdparty/chromium/third_party/webrtc/sdk/objc/Framework/Headers/WebRTC/RTCFieldTrials.h
++++ b/src/3rdparty/chromium/third_party/webrtc/sdk/objc/Framework/Headers/WebRTC/RTCFieldTrials.h
+@@ -40,4 +40,4 @@ RTC_EXTERN NSString *RTCFieldTrialTrendlineFilterValue(
+  *  Must be called before any other call into WebRTC. See:
+  *  webrtc/system_wrappers/include/field_trial_default.h
+  */
+-RTC_EXTERN void RTCInitFieldTrialDictionary(NSDictionary<NSString *, NSString *> *fieldTrials);
++RTC_EXTERN void RTCInitFieldTrialDictionary(NSDictionary *fieldTrials);

--- a/pkgs/development/libraries/qt-5/5.12/default.nix
+++ b/pkgs/development/libraries/qt-5/5.12/default.nix
@@ -63,7 +63,8 @@ let
     qtwebengine = [
       ./qtwebengine-no-build-skip.patch
       ./qtwebengine-CVE-2019-5786.patch
-    ];
+    ]
+      ++ optional stdenv.isDarwin ./qtwebengine-darwin-no-platform-check.patch;
     qtwebkit = [ ./qtwebkit.patch ]
       ++ optionals stdenv.isDarwin [
         ./qtwebkit-darwin-no-readline.patch

--- a/pkgs/development/libraries/qt-5/5.12/qtwebengine-darwin-no-platform-check.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtwebengine-darwin-no-platform-check.patch
@@ -1,0 +1,21 @@
+diff --git a/mkspecs/features/platform.prf b/mkspecs/features/platform.prf
+--- a/mkspecs/features/platform.prf
++++ b/mkspecs/features/platform.prf
+@@ -40,8 +40,6 @@ defineTest(isPlatformSupported) {
+   } else:osx {
+     # FIXME: Try to get it back down to 8.2 for building on OS X 10.11
+     !isMinXcodeVersion(8, 3, 3) {
+-      skipBuild("Using Xcode version $$QMAKE_XCODE_VERSION, but at least version 8.3.3 is required to build Qt WebEngine.")
+-      return(false)
+     }
+     !clang|intel_icc {
+         skipBuild("Qt WebEngine on macOS requires Clang.")
+@@ -54,8 +52,6 @@ defineTest(isPlatformSupported) {
+       return(false)
+     }
+     !isMinOSXSDKVersion(10, 12): {
+-      skipBuild("Building Qt WebEngine requires a macOS SDK version of 10.12 or newer. Current version is $${WEBENGINE_OSX_SDK_PRODUCT_VERSION}.")
+-      return(false)
+     }
+   } else {
+     skipBuild("Unknown platform. Qt WebEngine only supports Linux, Windows, and macOS.")

--- a/pkgs/development/libraries/qt-5/5.9/default.nix
+++ b/pkgs/development/libraries/qt-5/5.9/default.nix
@@ -43,7 +43,8 @@ let
     qtscript = [ ./qtscript.patch ];
     qtserialport = [ ./qtserialport.patch ];
     qttools = [ ./qttools.patch ];
-    qtwebengine = [ ./qtwebengine-no-build-skip.patch ];
+    qtwebengine = [ ./qtwebengine-no-build-skip.patch ]
+      ++ optional stdenv.isDarwin ./qtwebengine-darwin-no-platform-check.patch;
     qtwebkit = [ ./qtwebkit.patch ];
     qtvirtualkeyboard = [
       (fetchpatch {

--- a/pkgs/development/libraries/qt-5/5.9/default.nix
+++ b/pkgs/development/libraries/qt-5/5.9/default.nix
@@ -44,6 +44,7 @@ let
     qtserialport = [ ./qtserialport.patch ];
     qttools = [ ./qttools.patch ];
     qtwebengine = [ ./qtwebengine-no-build-skip.patch ]
+      ++ optional stdenv.cc.isClang ./qtwebengine-clang-fix.patch
       ++ optional stdenv.isDarwin ./qtwebengine-darwin-no-platform-check.patch;
     qtwebkit = [ ./qtwebkit.patch ];
     qtvirtualkeyboard = [

--- a/pkgs/development/libraries/qt-5/5.9/qtwebengine-clang-fix.patch
+++ b/pkgs/development/libraries/qt-5/5.9/qtwebengine-clang-fix.patch
@@ -1,0 +1,38 @@
+Fix a following build error:
+
+In file included from ../../3rdparty/chromium/device/bluetooth/bluetooth_remote_gatt_characteristic_mac.mm:7:
+In file included from ../../3rdparty/chromium/base/bind.h:8:
+../../3rdparty/chromium/base/bind_internal.h:214:31: error: cannot initialize a parameter of type 'NSError *' with an lvalue of type 'const long'
+    return (receiver.*method)(std::forward<RunArgs>(args)...);
+                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~
+../../3rdparty/chromium/base/bind_internal.h:285:20: note: in instantiation of function template specialization 'base::internal::FunctorTraits<void (device::BluetoothRemoteGat
+tCharacteristicMac::*)(NSError *), void>::Invoke<device::BluetoothRemoteGattCharacteristicMac *, const long &>' requested here
+    return Traits::Invoke(std::forward<Functor>(functor),
+                   ^
+../../3rdparty/chromium/base/bind_internal.h:361:43: note: in instantiation of function template specialization 'base::internal::InvokeHelper<false, void>::MakeItSo<void (devi
+ce::BluetoothRemoteGattCharacteristicMac::*const &)(NSError *), device::BluetoothRemoteGattCharacteristicMac *, const long &>' requested here
+    return InvokeHelper<is_weak_call, R>::MakeItSo(
+                                          ^
+../../3rdparty/chromium/base/bind_internal.h:339:12: note: in instantiation of function template specialization 'base::internal::Invoker<base::internal::BindState<void (device::BluetoothRemoteGattCharacteristicMac::*)(NSError *), base::internal::UnretainedWrapper<device::BluetoothRemoteGattCharacteristicMac>, long>, void ()>::RunImpl<void (device::BluetoothRemoteGattCharacteristicMac::*const &)(NSError *), const std::__1::tuple<base::internal::UnretainedWrapper<device::BluetoothRemoteGattCharacteristicMac>, long> &, 0, 1>' requested here
+    return RunImpl(storage->functor_,
+           ^
+../../3rdparty/chromium/base/bind.h:62:45: note: in instantiation of member function 'base::internal::Invoker<base::internal::BindState<void (device::BluetoothRemoteGattCharacteristicMac::*)(NSError *), base::internal::UnretainedWrapper<device::BluetoothRemoteGattCharacteristicMac>, long>, void ()>::Run' requested here
+  PolymorphicInvoke invoke_func = &Invoker::Run;
+                                            ^
+../../3rdparty/chromium/base/bind.h:77:10: note: in instantiation of function template specialization 'base::BindRepeating<void (device::BluetoothRemoteGattCharacteristicMac::*)(NSError *), base::internal::UnretainedWrapper<device::BluetoothRemoteGattCharacteristicMac>, long>' requested here
+  return BindRepeating(std::forward<Functor>(functor),
+         ^
+../../3rdparty/chromium/device/bluetooth/bluetooth_remote_gatt_characteristic_mac.mm:241:15: note: in instantiation of function template specialization 'base::Bind<void (device::BluetoothRemoteGattCharacteristicMac::*)(NSError *), base::internal::UnretainedWrapper<device::BluetoothRemoteGattCharacteristicMac>, long>' requested here
+        base::Bind(&BluetoothRemoteGattCharacteristicMac::DidWriteValue,
+
+--- a/src/3rdparty/chromium/device/bluetooth/bluetooth_remote_gatt_characteristic_mac.mm
++++ b/src/3rdparty/chromium/device/bluetooth/bluetooth_remote_gatt_characteristic_mac.mm
+@@ -239,7 +239,7 @@ void BluetoothRemoteGattCharacteristicMac::WriteRemoteCharacteristic(
+     base::ThreadTaskRunnerHandle::Get()->PostTask(
+         FROM_HERE,
+         base::Bind(&BluetoothRemoteGattCharacteristicMac::DidWriteValue,
+-                   base::Unretained(this), nil));
++                   base::Unretained(this), nullptr));
+   }
+ }
+ 

--- a/pkgs/development/libraries/qt-5/5.9/qtwebengine-darwin-no-platform-check.patch
+++ b/pkgs/development/libraries/qt-5/5.9/qtwebengine-darwin-no-platform-check.patch
@@ -1,0 +1,50 @@
+diff --git a/mkspecs/features/configure.prf b/mkspecs/features/configure.prf
+--- a/mkspecs/features/configure.prf
++++ b/mkspecs/features/configure.prf
+@@ -194,9 +194,6 @@ defineTest(runConfigure) {
+         } else {
+             log("Native Spellchecker .............. Not enabled         (Default, enable with WEBENGINE_CONFIG+=use_native_spellchecker)$${EOL}")
+         }
+-        !isMinOSXSDKVersion(10, 10, 3) {
+-            log("  Force Touch API usage .............. Not enabled         (Because the OS X SDK version to be used \"$${WEBENGINE_OSX_SDK_PRODUCT_VERSION}\" is lower than the required \"10.10.3\")$${EOL}")
+-        }
+     }
+ }
+ 
+diff --git a/mkspecs/features/functions.prf b/mkspecs/features/functions.prf
+--- a/mkspecs/features/functions.prf
++++ b/mkspecs/features/functions.prf
+@@ -38,10 +38,6 @@ defineTest(isPlatformSupported) {
+       return(false)
+     }
+   } else:osx {
+-    !isMinXcodeVersion(5, 1) {
+-      skipBuild("Using XCode version $$QMAKE_XCODE_VERSION, but at least version 5.1 is required to build Qt WebEngine.")
+-      return(false)
+-    }
+     !clang|intel_icc {
+         skipBuild("Qt WebEngine on macOS requires Clang.")
+         return(false)
+@@ -52,10 +48,6 @@ defineTest(isPlatformSupported) {
+       skipBuild("Qt WebEngine requires OS X version 10.10 or newer.")
+       return(false)
+     }
+-    !isMinOSXSDKVersion(10, 10): {
+-      skipBuild("Qt WebEngine requires an OS X SDK version of 10.10 or newer. Current version is $${WEBENGINE_OSX_SDK_PRODUCT_VERSION}.")
+-      return(false)
+-    }
+   } else {
+     skipBuild("Unknown platform. Qt WebEngine only supports Linux, Windows, and OS X.")
+     return(false)
+diff --git a/src/core/config/mac_osx.pri b/src/core/config/mac_osx.pri
+--- a/src/core/config/mac_osx.pri
++++ b/src/core/config/mac_osx.pri
+@@ -5,8 +5,6 @@ load(functions)
+ # otherwise query for it.
+ QMAKE_MAC_SDK_VERSION = $$eval(QMAKE_MAC_SDK.$${QMAKE_MAC_SDK}.SDKVersion)
+ isEmpty(QMAKE_MAC_SDK_VERSION) {
+-     QMAKE_MAC_SDK_VERSION = $$system("/usr/bin/xcodebuild -sdk $${QMAKE_MAC_SDK} -version SDKVersion 2>/dev/null")
+-     isEmpty(QMAKE_MAC_SDK_VERSION): error("Could not resolve SDK version for \'$${QMAKE_MAC_SDK}\'")
+ }
+ 
+ QMAKE_CLANG_DIR = "/usr"

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -70,6 +70,10 @@ qtModule {
       substituteInPlace src/core/config/mac_osx.pri \
         --replace /usr ${stdenv.cc}
     ''
+    + (optionalString (lib.versionAtLeast qtCompatVersion "5.11") ''
+      substituteInPlace src/3rdparty/chromium/third_party/crashpad/crashpad/util/BUILD.gn \
+        --replace '$sysroot/usr' "${darwin.xnu}"
+    '')
     + ''
 
     cat <<EOF > src/3rdparty/chromium/build/mac/find_sdk.py
@@ -89,9 +93,6 @@ print('sdk_version="10.10"')
 print('sdk_platform_path=""')
 print('sdk_build="17B41"')
 EOF
-
-    substituteInPlace src/3rdparty/chromium/third_party/crashpad/crashpad/util/BUILD.gn \
-      --replace '$sysroot/usr' "${darwin.xnu}"
 
     # Apple has some secret stuff they don't share with OpenBSM
     substituteInPlace src/3rdparty/chromium/base/mac/mach_port_broker.mm \

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -67,18 +67,8 @@ qtModule {
         src/3rdparty/chromium/gpu/config/gpu_info_collector_linux.cc
     ''
     + optionalString stdenv.isDarwin (''
-      # Remove annoying xcode check
-      substituteInPlace mkspecs/features/platform.prf \
-        --replace "lessThan(QMAKE_XCODE_VERSION, 7.3)" false \
-        --replace "/usr/bin/xcodebuild" "xcodebuild"
-
-      substituteInPlace src/3rdparty/chromium/build/mac_toolchain.py \
-        --replace "/usr/bin/xcode-select" "xcode-select"
-
       substituteInPlace src/core/config/mac_osx.pri \
-        --replace /usr ${stdenv.cc} \
-        --replace "isEmpty(QMAKE_MAC_SDK_VERSION)" false
-
+        --replace /usr ${stdenv.cc}
     ''
     # TODO remove when new Apple SDK is in
     + (if lib.versionOlder qtCompatVersion "5.11" then ''

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -70,20 +70,6 @@ qtModule {
       substituteInPlace src/core/config/mac_osx.pri \
         --replace /usr ${stdenv.cc}
     ''
-    # TODO remove when new Apple SDK is in
-    + (if lib.versionOlder qtCompatVersion "5.11" then ''
-    substituteInPlace src/3rdparty/chromium/base/mac/foundation_util.mm \
-      --replace "NSArray<NSString*>*" "NSArray*"
-    substituteInPlace src/3rdparty/chromium/base/mac/sdk_forward_declarations.h \
-      --replace "NSDictionary<VNImageOption, id>*" "NSDictionary*" \
-      --replace "NSArray<VNRequest*>*" "NSArray*" \
-      --replace "typedef NSString* VNImageOption NS_STRING_ENUM" "typedef NSString* VNImageOption"
-    '' else ''
-    substituteInPlace src/3rdparty/chromium/third_party/webrtc/sdk/objc/Framework/Classes/Common/RTCFieldTrials.mm \
-      --replace "NSDictionary<NSString *, NSString *> *" "NSDictionary*"
-    substituteInPlace src/3rdparty/chromium/third_party/webrtc/sdk/objc/Framework/Headers/WebRTC/RTCFieldTrials.h \
-      --replace "NSDictionary<NSString *, NSString *> *" "NSDictionary*"
-    '')
     + ''
 
     cat <<EOF > src/3rdparty/chromium/build/mac/find_sdk.py


### PR DESCRIPTION
This is a continuation of #53848 that fixes some of the breakage coming after #54986 and also fixes qt59.qtwebengine.

I'm trying to switch away from `substituteInPlace` to using patches to improve maintainability.

#### Things done

* [x] qt59.qtwebengine builds
* [x] qt511.qtwebengine builds
* [x] Test with qutebrowser