### PR TITLE
lxqt: 0.14.0 -> 0.14.1

### DIFF
--- a/pkgs/desktops/lxqt/compton-conf/default.nix
+++ b/pkgs/desktops/lxqt/compton-conf/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "compton-conf";
-  version = "0.14.0";
+  version = "0.14.1";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "1vxbh0vr7wknr7rbmdbmy5md1fdkw3zwlgpbv16cwdplbv9m97xi";
+    sha256 = "0bx21r83ahmsqf7bm1h17pi4y9js1iqsv7nwnlq58rc0ddkkhcdb";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/libfm-qt/default.nix
+++ b/pkgs/desktops/lxqt/libfm-qt/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libfm-qt";
-  version = "0.14.0";
+  version = "0.14.1";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "1siqqn4waglymfi7c7lrmlxkylddw8qz0qfwqxr1hnmx3dsj9c36";
+    sha256 = "00rn5i16h659zyp1dx213nc3jz7rx9phiw71zf6nspxzxsb8w2sc";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/liblxqt/default.nix
+++ b/pkgs/desktops/lxqt/liblxqt/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "liblxqt";
-  version = "0.14.0";
+  version = "0.14.1";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "1cpl6sd2fifpflahm8fvrrscrv03sinfm03m7yc1k59y6nsbwi36";
+    sha256 = "0g2502lcws5j74p82qhfryz9n51cvi85hb50r5s227xhkv91q65k";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/libqtxdg/default.nix
+++ b/pkgs/desktops/lxqt/libqtxdg/default.nix
@@ -1,25 +1,25 @@
-{ stdenv, fetchFromGitHub, cmake, qtbase, qtsvg }:
+{ stdenv, fetchFromGitHub, cmake, qtbase, qtsvg, lxqt-build-tools }:
 
 stdenv.mkDerivation rec {
   pname = "libqtxdg";
-  version = "3.3.0";
+  version = "3.3.1";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "0qgqqgy15h0d1fwk4mnbv2hirz8njjjlng64bv33rc6wwrsaa50b";
+    sha256 = "0y3s0hva64m64j9lqgnja1li8zhlywqzv8xwjg8pyd2nr9h918db";
   };
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake lxqt-build-tools ];
 
   buildInputs = [ qtbase qtsvg ];
 
   preConfigure = ''
     cmakeFlagsArray+=(
-    "-DQTXDGX_ICONENGINEPLUGIN_INSTALL_PATH=$out/$qtPluginPrefix"
-    "-DCMAKE_INSTALL_INCLUDEDIR=include"
-    "-DCMAKE_INSTALL_LIBDIR=lib"
+      "-DQTXDGX_ICONENGINEPLUGIN_INSTALL_PATH=$out/$qtPluginPrefix"
+      "-DCMAKE_INSTALL_INCLUDEDIR=include"
+      "-DCMAKE_INSTALL_LIBDIR=lib"
     )
   '';
 

--- a/pkgs/desktops/lxqt/lximage-qt/default.nix
+++ b/pkgs/desktops/lxqt/lximage-qt/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lximage-qt";
-  version = "0.14.0";
+  version = "0.14.1";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "0zx9903ym5a9zk4m9khr22fj5sy57mg2v8wnk177wjm11lhic5v8";
+    sha256 = "175l2w5w6iag01v05jq90pxx0al24wpw3mgsbcgqhl4z6h860r32";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/lxqt-about/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-about/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lxqt-about";
-  version = "0.14.0";
+  version = "0.14.1";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "14b13v1r5ncz4ycg25ac9ppafiifc37qws8kcw078if72rp9n121";
+    sha256 = "0dj2rhbhnkzmv1iqqyq0bcp03imwnvxdr7rnpqnrs9kkjacm8zvr";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/lxqt-admin/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-admin/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lxqt-admin";
-  version = "0.14.0";
+  version = "0.14.1";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "0sdb514hgha5yvmbzi6nm1yx1rmbkh5fam09ybidjwpdwl2l4pxx";
+    sha256 = "121qj46app2bqdr24g5sz2mdjfd9w86wpgkwap46s0zgxm4li44i";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/lxqt-config/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-config/default.nix
@@ -4,13 +4,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lxqt-config";
-  version = "0.14.0";
+  version = "0.14.1";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "1pp2pw43zh8kwi2cxk909wn6bw7kba95b6bv96l2gmzhdqpfw2a7";
+    sha256 = "0x1k08587i2pakxlrj2n0l82r179sfywnzn2cphxiy89r5zpn7vi";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/lxqt-globalkeys/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-globalkeys/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lxqt-globalkeys";
-  version = "0.14.0";
+  version = "0.14.1";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "14bfkh54mn3jyq8g9ipy3xmc3n9lmlqpvm26kpqig7567hbncv7n";
+    sha256 = "0q7hfbs4dhsgyzch2msq2hsfzzfgbc611ki9x1x132n7zqk76pmp";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/lxqt-notificationd/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-notificationd/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lxqt-notificationd";
-  version = "0.14.0";
+  version = "0.14.1";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "1nawcxy2qnrngcxvwjwmmh4fn7mhnfgy1g77rn90243jvy29wv5f";
+    sha256 = "1ihaf2i361j2snyy6kg8ccpfnc8hppvacmxjqzb1lpyaf1ajd139";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/lxqt-openssh-askpass/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-openssh-askpass/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lxqt-openssh-askpass";
-  version = "0.14.0";
+  version = "0.14.1";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "19xcc6i7jg35780r4dfg4vwfp9x4pz5sqzagxnpzspz61jaj5ibv";
+    sha256 = "04jmvhhlhhspwzj4hfq7fnaa3h7h02z3rlq8p55hzlzkvshqqh1q";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/lxqt-panel/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-panel/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lxqt-panel";
-  version = "0.14.0";
+  version = "0.14.1";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "0jr7ylf6d35m0ckn884arjk4armknnw8iyph00gcphn5bqycbn8l";
+    sha256 = "1py3i7qgm6h2iwjwqfjml1rp06s7ls1d7z5i9iizsmfshdzkaq86";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/lxqt-policykit/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-policykit/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lxqt-policykit";
-  version = "0.14.0";
+  version = "0.14.1";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "05k39819nsdyg2pp1vk6g2hdpxqp78h6bhb0hp5rclf9ap5fpvvc";
+    sha256 = "0mh9jw09r0mk8xmgvmzk3yyfix0pzqya28rcx71fqjpbdv1sc44l";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/lxqt-powermanagement/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-powermanagement/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lxqt-powermanagement";
-  version = "0.14.0";
+  version = "0.14.1";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "08xdnb54lji09izzzfip8fw0gp17qkx66jm6i04zby4whx4mqniv";
+    sha256 = "1nhp4a28bpczhwz8b8da355zsxr1qwmkrm3bwllwp39liw947clx";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/lxqt-runner/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-runner/default.nix
@@ -3,13 +3,13 @@ menu-cache, muparser, pcre }:
 
 stdenv.mkDerivation rec {
   pname = "lxqt-runner";
-  version = "0.14.0";
+  version = "0.14.1";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "1qyacig9ksnjrhws8cpk6arlaxn7kl0z39l3c62ql3m89mibsm88";
+    sha256 = "01a8ycpkzcbh85y4025pd3nbpnzxh98ll1xwz4ykz13yvm0l2n1w";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/lxqt-session/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-session/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lxqt-session";
-  version = "0.14.0";
+  version = "0.14.1";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "0nla1ki23p1bwzw5hbmh9l8yg3b0f55kflgnvyfakmvpivjbz3k6";
+    sha256 = "0s6b0lblb795zz1p7sy677c1iznhmdzc4vw3jkc2agmsrhm7if7s";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/lxqt-sudo/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-sudo/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "lxqt-sudo";
-  version = "0.14.0";
+  version = "0.14.1";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "0l8fq06kfsrmvg2fr8lqdsxr6fwxmxsa9zwaa3fs9inzaylm0jkh";
+    sha256 = "1my0wpic20493rdlabp9ghag1g3nhwafk2yklkgczlajmarakgpc";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/obconf-qt/default.nix
+++ b/pkgs/desktops/lxqt/obconf-qt/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "obconf-qt";
-  version = "0.14.0";
+  version = "0.14.1";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "00v5w8qr3vs0k91flij9lz7y1cpp2g8ivgnmmm43ymjfiz5j6l27";
+    sha256 = "15dizs072ylmld1lxwgqkvybqy8ms8zki5586xm305jnlmrkb4lq";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/pavucontrol-qt/default.nix
+++ b/pkgs/desktops/lxqt/pavucontrol-qt/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "pavucontrol-qt";
-  version = "0.14.0";
+  version = "0.14.1";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "1vyjm6phgbxglk65c889bd73b0p2ffb5bsc89dmb07qzllyrjb4h";
+    sha256 = "124dk41v8l5pv7afi1h7fgbhm8zj605yfd8b769sn7id2bqj7bis";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/pcmanfm-qt/default.nix
+++ b/pkgs/desktops/lxqt/pcmanfm-qt/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "pcmanfm-qt";
-  version = "0.14.0";
+  version = "0.14.1";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "0hf4qyn12mpr6rrla9mf6ka5gb4y36amk7d14ayr7yka1r16p8lz";
+    sha256 = "1zchxlbyiifing94mqwh45pp7z3ihldknqiaz0kanq1cnma1jj6k";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/qps/default.nix
+++ b/pkgs/desktops/lxqt/qps/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "qps";
-  version = "1.10.19";
+  version = "1.10.20";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "1vyi1vw4z5j2sp9yhhv91wl2sbg4fh0djqslg1ssc7fww2ka6dx3";
+    sha256 = "1g8j4cjy5x33jzjkx6vwyl5qbf9i2z2w01ipgk7nrik5drf9crbf";
   };
 
   nativeBuildInputs = [ cmake lxqt-build-tools ];

--- a/pkgs/desktops/lxqt/qterminal/default.nix
+++ b/pkgs/desktops/lxqt/qterminal/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "qterminal";
-  version = "0.14.0";
+  version = "0.14.1";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "071qz248j9gcqzchnrz8xamm07g4r2xyrmnb0a2vjkjd63pk2r8f";
+    sha256 = "0bq6lvns56caijdmjm05nsj9vg69v9x5vid24bfxasck6q8nw24w";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/qtermwidget/default.nix
+++ b/pkgs/desktops/lxqt/qtermwidget/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "qtermwidget";
-  version = "0.14.0";
+  version = "0.14.1";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "0wv8fssbc2w7kkpq9ngsa8wyjraggdhsbz36gyxyv8fy5m78jq0n";
+    sha256 = "1pz8dwb86jpga4vfyn5v9n2s6dx3zh74yfp1kjsmsmhf878zs6lv";
   };
 
   nativeBuildInputs = [ cmake lxqt-build-tools ];

--- a/pkgs/desktops/lxqt/screengrab/default.nix
+++ b/pkgs/desktops/lxqt/screengrab/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "screengrab";
-  version = "1.100";
+  version = "1.101";
 
   src = fetchFromGitHub {
     owner = "lxqt";
     repo = pname;
     rev = version;
-    sha256 = "1iqrmf581x9ab6zzjxm2509gg6fkn7hwril4v0aki7n7dgxw1c4g";
+    sha256 = "111gnkhp77qkch7xqr7k3h8zrg4871gapyd4vvlpaj0gjhirjg6h";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lxqt/update.sh
+++ b/pkgs/desktops/lxqt/update.sh
@@ -7,7 +7,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 root=../../..
 export NIXPKGS_ALLOW_UNFREE=1
 
-lxqt_version=0.14.0
+lxqt_version=0.14.1
 lxqtrepo=https://downloads.lxqt.org/${lxqt_version}.html
 
 version() {


### PR DESCRIPTION
###### Motivation for this change

Update LXQt to version 0.14.1.

[Release LXQt 0.14.1](https://lxqt.org/release/2019/02/26/lxqt-0141/)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).