### PR TITLE
python.pkgs.poetry: install shell completions

### DIFF
--- a/pkgs/development/python-modules/poetry/default.nix
+++ b/pkgs/development/python-modules/poetry/default.nix
@@ -60,6 +60,15 @@ in buildPythonPackage rec {
   ] ++ lib.optionals (isPy27 || isPy34) [ typing pathlib2 ]
     ++ lib.optionals isPy27 [ virtualenv functools32 ];
 
+  postInstall = ''
+    mkdir -p "$out/share/bash-completion/completions"
+    "$out/bin/poetry" completions bash > "$out/share/bash-completion/completions/poetry"
+    mkdir -p "$out/share/zsh/vendor-completions"
+    "$out/bin/poetry" completions zsh > "$out/share/zsh/vendor-completions/_poetry"
+    mkdir -p "$out/share/fish/vendor_completions.d"
+    "$out/bin/poetry" completions fish > "$out/share/fish/vendor_completions.d/poetry.fish"
+  '';
+
   # No tests in Pypi tarball
   doCheck = false;
   checkInputs = [ pytest ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @jbaum98 