### PR TITLE
pythonPackages.block-io: fix incorrect dependency version

### DIFF
--- a/pkgs/development/python-modules/block-io/default.nix
+++ b/pkgs/development/python-modules/block-io/default.nix
@@ -9,6 +9,13 @@ buildPythonPackage rec {
     sha256 = "4909d58b32ab7f93d3cd83fa4bbe4edef42ab7566f016bdb6a405a0d8b1907c9";
   };
 
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/BlockIo/block_io-python/commit/8ec0a0cd1afcfcb439d6dc306d8497dd9e4a0993.patch";
+      sha256 = "1i6c153wvkr5ncm3cpn34faxvavz534x5kndwn4adlaxlzq30snn";
+    })
+  ];
+
   propagatedBuildInputs = [
     base58
     ecdsa


### PR DESCRIPTION
###### Motivation for this change

This should also be backported to 19.03 to fix the build

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

