### PR TITLE
kodiPlugins.osmc-skin: 17.0.4 -> 18.0.0

### DIFF
--- a/pkgs/applications/video/kodi/plugins.nix
+++ b/pkgs/applications/video/kodi/plugins.nix
@@ -432,13 +432,13 @@ let self = rec {
 
     plugin = "osmc-skin";
     namespace = "skin.osmc";
-    version = "17.0.4";
+    version = "18.0.0";
 
     src = fetchFromGitHub {
       owner = "osmc";
       repo = namespace;
-      rev = "a9268937f49286bab9fb49de430b8aafd7a60a9e";
-      sha256 = "1b3fm02annsq58pcfc985glrmh21rmqksdj3q8wn6gyza06jdf3v";
+      rev = "40a6c318641e2cbeac58fb0e7dde9c2beac737a0";
+      sha256 = "1l7hyfj5zvjxjdm94y325bmy1naak455b9l8952sb0gllzrcwj6s";
     };
 
     meta = {


### PR DESCRIPTION
###### Motivation for this change

With the recent v18 update merged, the nixpkgs' version of the OSMC skin plugin is no longer compatible. Since the "skin.osmc" repo doesn't do versioning, I just updated it to master's latest commit.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

