### PR TITLE
scfbuild: bump to latest git (Jun 2017)

### DIFF
--- a/pkgs/tools/misc/scfbuild/default.nix
+++ b/pkgs/tools/misc/scfbuild/default.nix
@@ -7,8 +7,8 @@ buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "eosrei";
     repo = "scfbuild";
-    rev = "c179c8d279b7cc0a9a3536a713ac880ac6010318";
-    sha256 = "1bsi7k4kkj914pycp1g92050hjxscyvc9qflqb3cv5yz3c93cs46";
+    rev = "9acc7fc5fedbf48683d8932dd5bd7583bf922bae";
+    sha256 = "1zlqsxkpg7zvmhdjgbqwwc9qgac2b8amzq8c5kwyh5cv95zcp6qn";
   };
 
   phases = [ "unpackPhase" "installPhase" "fixupPhase" ];


### PR DESCRIPTION
No release tags on the repo, unclear how versioning works,
keeping version number reported in repo for now.

Users of this (such as twemoji-color-font) have build instructions
that always grab latest git revision so we should probably do so.


###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---