### PR TITLE
minio: 2019-01-31 -> 2019-02-26

### DIFF
--- a/pkgs/servers/minio/default.nix
+++ b/pkgs/servers/minio/default.nix
@@ -2,13 +2,13 @@
 
 buildGoPackage rec {
   name = "minio-${version}";
-  version = "2019-01-31T00-31-19Z";
+  version = "2019-02-26T19-51-46Z";
 
   src = fetchFromGitHub {
     owner = "minio";
     repo = "minio";
     rev = "RELEASE.${version}";
-    sha256 = "0rvvjgnbk9khi443bahrg6iqa5lhmv8gydg96vgkrby13r1yy84k";
+    sha256 = "1f2c7wzcb47msb0iqrcc0idz39wdm9fz61q835ks1nx4qs6hi2db";
   };
 
   goPackagePath = "github.com/minio/minio";


### PR DESCRIPTION
https://github.com/minio/minio/releases/tag/RELEASE.2019-02-26T19-51-46Z
https://github.com/minio/minio/releases/tag/RELEASE.2019-02-20T22-44-29Z (security)
https://github.com/minio/minio/releases/tag/RELEASE.2019-02-14T00-21-45Z
https://github.com/minio/minio/releases/tag/RELEASE.2019-02-12T21-58-47Z (critical)
https://github.com/minio/minio/releases/tag/RELEASE.2019-02-06T21-16-36Z


###### Motivation for this change

Critical and security updates, see list of release notes above.

Should check at least NixOS minio test.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---