### PR TITLE
emojione: 1.3 -> 1.4

### DIFF
--- a/pkgs/data/fonts/emojione/default.nix
+++ b/pkgs/data/fonts/emojione/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "emojione-${version}";
-  version = "1.3";
+  version = "1.4";
 
   src = fetchFromGitHub {
     owner = "eosrei";
     repo = "emojione-color-font";
     rev = "v${version}";
-    sha256 = "0hgs661g1j91lkafhrfx5ix7ymarh5bzcx34r2id6jl7dc3j41l3";
+    sha256 = "1781kxfbhnvylypbkwxc3mx6hi0gcjisfjr9cf0jdz4d1zkf09b3";
   };
 
   preBuild = ''


### PR DESCRIPTION
###### Motivation for this change

https://github.com/eosrei/emojione-color-font/releases/tag/v1.4

twemoji-color-font is suggested as replacement for unicode 11 and such,
but as long as we have this expression might as well use latest.

(Suggestion is in the release notes on the linked tag)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---