### PR TITLE
[19.03] Mark Riak and Riak-cs as insecure

### DIFF
--- a/pkgs/servers/nosql/riak-cs/2.1.1.nix
+++ b/pkgs/servers/nosql/riak-cs/2.1.1.nix
@@ -65,5 +65,6 @@ stdenv.mkDerivation rec {
     platforms   = [ "x86_64-linux" "x86_64-darwin" ];
     license     = licenses.asl20;
     maintainers = with maintainers; [ mdaiter ];
+    knownVulnerabilities = [ "CVE-2017-3163 - see https://github.com/NixOS/nixpkgs/issues/33876" ];
   };
 }

--- a/pkgs/servers/nosql/riak/2.2.0.nix
+++ b/pkgs/servers/nosql/riak/2.2.0.nix
@@ -93,5 +93,6 @@ stdenv.mkDerivation rec {
     description = "Dynamo inspired NoSQL DB by Basho";
     platforms   = [ "x86_64-linux" ];
     license     = licenses.asl20;
+    knownVulnerabilities = [ "CVE-2017-3163 - see https://github.com/NixOS/nixpkgs/issues/33876" ];
   };
 }


### PR DESCRIPTION
Port of #56480 to 19.03.


/cc release managers @samueldr @lheckemann 