### PR TITLE
 qgis: 2.18.28 -> 3.4.5 

### DIFF
--- a/pkgs/applications/gis/qgis/default.nix
+++ b/pkgs/applications/gis/qgis/default.nix
@@ -1,94 +1,27 @@
-{ stdenv, fetchurl, fetchpatch, gdal, cmake, qt4, flex, bison, proj, geos, xlibsWrapper, sqlite, gsl
-, qwt, fcgi, python2Packages, libspatialindex, libspatialite, qscintilla, postgresql, makeWrapper
-, qjson, qca2, txt2tags, openssl, darwin, pkgconfig
-, withGrass ? true, grass, saga, IOKit, ApplicationServices
+{ stdenv, lib, makeWrapper, symlinkJoin
+, qgis-unwrapped, extraPythonPackages ? (ps: [ ])
 }:
+with lib;
+symlinkJoin rec {
+  inherit (qgis-unwrapped) version;
+  name = "qgis-${version}";
 
-stdenv.mkDerivation rec {
-  name = "qgis-2.18.28";
+  paths = [ qgis-unwrapped ];
 
-  buildInputs = [ gdal qt4 flex openssl bison proj geos xlibsWrapper sqlite gsl qwt qscintilla
-    fcgi libspatialindex libspatialite postgresql qjson qca2 txt2tags pkgconfig
-    saga ]
-  ++
-    (stdenv.lib.optionals stdenv.isDarwin [IOKit ApplicationServices])
-  ++
-    (stdenv.lib.optional withGrass grass) ++
-    (stdenv.lib.optional (stdenv.isDarwin && withGrass) darwin.apple_sdk.libs.utmp) ++
-    (with python2Packages; [ jinja2 numpy psycopg2 pygments requests python2Packages.qscintilla sip ]);
+  nativeBuildInputs = [ makeWrapper qgis-unwrapped.python3Packages.wrapPython ];
 
-  nativeBuildInputs = [ cmake makeWrapper pkgconfig ];
+  # extend to add to the python environment of QGIS without rebuilding QGIS application.
+  pythonInputs = qgis-unwrapped.pythonBuildInputs ++ (extraPythonPackages qgis-unwrapped.python3Packages);
 
-  # `make -f src/providers/wms/CMakeFiles/wmsprovider_a.dir/build.make src/providers/wms/CMakeFiles/wmsprovider_a.dir/qgswmssourceselect.cpp.o`:
-  # fatal error: ui_qgsdelimitedtextsourceselectbase.h: No such file or directory
-  enableParallelBuilding = false;
+  postBuild = ''
+    # unpackPhase
 
-  preConfigure = ''
-    NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE $(pkg-config --cflags libspatialindex)"
+    buildPythonPath "$pythonInputs"
+
+    wrapProgram $out/bin/qgis \
+      --prefix PATH : $program_PATH \
+      --set PYTHONPATH $program_PYTHONPATH
   '';
 
-  # To handle the lack of 'local' RPATH; required, as they call one of
-  # their built binaries requiring their libs, in the build process.
-  preBuild = ''
-    export LD_LIBRARY_PATH=`pwd`/output/lib:${stdenv.lib.makeLibraryPath [ openssl ]}:$LD_LIBRARY_PATH
-  '';
-
-  src = fetchurl {
-    url = "https://qgis.org/downloads/${name}.tar.bz2";
-    sha256 = "18pijqls1isd2bpg0mkrw07jqvdfaiwwb9mvz7p2xrgqcjx7dxsq";
-  };
-
-  patches = [
-    # already merged upstream in QGIS-3.*, but needs to be backported to QGIS-2
-    (fetchpatch {
-      url = "https://patch-diff.githubusercontent.com/raw/qgis/QGIS/pull/7263.patch";
-      name = "Ensure_qgis.db_is_writable_when_copied_from_RO_source";
-      sha256 = "19wr2kz0x8x6p2n0ylzd4lqrdmbkxyxr0zpwf2vl9hdp92rdjxbv";
-    })
-  ];
-
-  # CMAKE_FIND_FRAMEWORK=never stops the installer choosing system
-  # installed frameworks
-  # QGIS_MACAPP_BUNDLE=0 stops the installer copying the Qt binaries into the
-  # installation which causes havoc
-  # Building RelWithDebInfo allows QGIS_DEBUG to print debugging information
-  cmakeFlags = stdenv.lib.optional withGrass "-DGRASS_PREFIX7=${grass}/${grass.name}"
-               ++ stdenv.lib.optional stdenv.isDarwin
-                    (["-DCMAKE_FIND_FRAMEWORK=never"]
-                      ++ ["-DQGIS_MACAPP_BUNDLE=0"]);
-#                     ++ ["-DCMAKE_BUILD_TYPE=RelWithDebInfo"];
-
-
-
-  postInstall =
-    (stdenv.lib.optionalString stdenv.isLinux ''
-          wrapProgram $out/bin/qgis \
-            --set PYTHONPATH $PYTHONPATH \
-            --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [ openssl ]}
-          '') +
-    (stdenv.lib.optionalString stdenv.isDarwin ''
-      # Necessary for QGIS to find the correct default GRASS path
-      # Plugins look for gdal tools like deminfo on the PATH
-      ${stdenv.lib.optionalString withGrass "ln -sf ${grass} $out/QGIS.app/Contents/MacOS/grass"}
-      # Necessary for QGIS to find the right SAGA installation
-      ln -sf ${saga}/bin/saga_cmd $out/QGIS.app/Contents/MacOS/bin/saga_cmd
-      for file in $(find $out -type f -name "QGIS"); do
-        wrapProgram "$file" \
-          --prefix DYLD_LIBRARY_PATH : "${qwt}/lib" \
-          --prefix DYLD_LIBRARY_PATH : "${qscintilla}/lib" \
-          --prefix PATH : "${gdal}/bin" \
-          ${stdenv.lib.optionalString withGrass "--prefix PATH : ${grass}/bin"} \
-          --set PYTHONPATH $PYTHONPATH
-      done
-      mkdir -p $out/bin
-      ln -s $out/QGIS.app/Contents/MacOS/QGIS $out/bin/qgis
-      '');
-
-  meta = {
-    description = "User friendly Open Source Geographic Information System";
-    homepage = http://www.qgis.org;
-    license = stdenv.lib.licenses.gpl2Plus;
-    platforms = with stdenv.lib.platforms; unix;
-    maintainers = with stdenv.lib.maintainers; [mpickering];
-  };
+  meta = qgis-unwrapped.meta;
 }

--- a/pkgs/applications/gis/qgis/unwrapped.nix
+++ b/pkgs/applications/gis/qgis/unwrapped.nix
@@ -1,0 +1,54 @@
+{ stdenv, lib, fetchurl, cmake, ninja, flex, bison, proj, geos, xlibsWrapper, sqlite, gsl
+, qwt, fcgi, python3Packages, libspatialindex, libspatialite, postgresql
+, txt2tags, openssl, libzip, hdf5, netcdf
+, qtbase, qtwebkit, qtsensors, qca-qt5, qtkeychain, qscintilla, qtserialport, qtxmlpatterns
+, withGrass ? true, grass
+}:
+with lib;
+let
+  pythonBuildInputs = with python3Packages;
+    [ qscintilla-qt5 gdal jinja2 numpy psycopg2
+      chardet dateutil pyyaml pytz requests urllib3 pygments pyqt5 sip owslib six ];
+in stdenv.mkDerivation rec {
+  version = "3.4.5";
+  name = "qgis-unwrapped-${version}";
+
+  src = fetchurl {
+    url = "http://qgis.org/downloads/qgis-${version}.tar.bz2";
+    sha256 = "0myw1jgz8v8wncmrjsszn9ixylx84hafn0281c4hqhz623n3lxgx";
+  };
+
+  passthru = {
+    inherit pythonBuildInputs;
+    inherit python3Packages;
+  };
+
+  buildInputs = [ openssl proj geos xlibsWrapper sqlite gsl qwt
+    fcgi libspatialindex libspatialite postgresql txt2tags libzip hdf5 netcdf
+    qtbase qtwebkit qtsensors qca-qt5 qtkeychain qscintilla qtserialport qtxmlpatterns] ++
+    (stdenv.lib.optional withGrass grass) ++ pythonBuildInputs;
+
+  nativeBuildInputs = [ cmake flex bison ninja ];
+
+  # Force this pyqt_sip_dir variable to point to the sip dir in PyQt5
+  #
+  # TODO: Correct PyQt5 to provide the expected directory and fix
+  # build to use PYQT5_SIP_DIR consistently.
+  postPatch = ''
+     substituteInPlace cmake/FindPyQt5.py \
+       --replace 'pyqtcfg.pyqt_sip_dir' '"${python3Packages.pyqt5}/share/sip/PyQt5"'
+   '';
+
+  cmakeFlags = [ "-DCMAKE_SKIP_BUILD_RPATH=OFF"
+                 "-DPYQT5_SIP_DIR=${python3Packages.pyqt5}/share/sip/PyQt5"
+                 "-DQSCI_SIP_DIR=${python3Packages.qscintilla-qt5}/share/sip/PyQt5" ] ++
+                 stdenv.lib.optional withGrass "-DGRASS_PREFIX7=${grass}/${grass.name}";
+
+  meta = {
+    description = "A Free and Open Source Geographic Information System";
+    homepage = http://www.qgis.org;
+    license = stdenv.lib.licenses.gpl2Plus;
+    platforms = with stdenv.lib.platforms; linux;
+    maintainers = with stdenv.lib.maintainers; [ lsix ];
+  };
+}

--- a/pkgs/development/python-modules/qscintilla-qt5/default.nix
+++ b/pkgs/development/python-modules/qscintilla-qt5/default.nix
@@ -1,19 +1,18 @@
 { lib
-, buildPythonPackage
-, qscintillaCpp
+, pythonPackages
+, qscintilla
 , lndir
-, sip
-, python
-, pyqt5 }:
-
+, qtbase
+}:
+with pythonPackages;
 buildPythonPackage rec {
   pname = "qscintilla";
-  version = qscintillaCpp.version;
-  src = qscintillaCpp.src;
+  version = qscintilla.version;
+  src = qscintilla.src;
   format = "other";
 
-  nativeBuildInputs = [ lndir sip ];
-  buildInputs = [ qscintillaCpp ];
+  nativeBuildInputs = [ lndir sip qtbase ];
+  buildInputs = [ qscintilla ];
   propagatedBuildInputs = [ pyqt5 ];
 
   preConfigure = ''
@@ -23,13 +22,14 @@ buildPythonPackage rec {
     cd Python
     ${python.executable} ./configure.py \
       --pyqt=PyQt5 \
-      --destdir=$out/lib/${python.sitePackages}/PyQt5 \
-      --stubsdir=$out/lib/${python.sitePackages}/PyQt5 \
+      --destdir=$out/${python.sitePackages}/PyQt5 \
+      --stubsdir=$out/${python.sitePackages}/PyQt5 \
       --apidir=$out/api/${python.libPrefix} \
-      --qsci-incdir=${qscintillaCpp}/include \
-      --qsci-libdir=${qscintillaCpp}/lib \
+      --qsci-incdir=${qscintilla}/include \
+      --qsci-libdir=${qscintilla}/lib \
       --pyqt-sipdir=${pyqt5}/share/sip/PyQt5 \
-      --qsci-sipdir=$out/share/sip/PyQt5
+      --qsci-sipdir=$out/share/sip/PyQt5 \
+      --sip-incdir=${sip}/include
   '';
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18997,10 +18997,11 @@ in
     inherit (darwin.stubs) rez setfile;
   };
 
-  qgis = callPackage ../applications/gis/qgis {
-    inherit (darwin.apple_sdk.frameworks) IOKit ApplicationServices;
-    saga = saga_2_3_2;
+  qgis-unwrapped = libsForQt5.callPackage ../applications/gis/qgis/unwrapped.nix {
+      withGrass = false;
   };
+
+  qgis = callPackage ../applications/gis/qgis { };
 
   qgroundcontrol = libsForQt5.callPackage ../applications/science/robotics/qgroundcontrol { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3990,8 +3990,8 @@ in {
 
   qscintilla-qt4 = callPackage ../development/python-modules/qscintilla { };
 
-  qscintilla-qt5 = callPackage ../development/python-modules/qscintilla-qt5 {
-    qscintillaCpp = pkgs.libsForQt5.qscintilla;
+  qscintilla-qt5 = pkgs.libsForQt5.callPackage ../development/python-modules/qscintilla-qt5 {
+    pythonPackages = self;
     lndir = pkgs.xorg.lndir;
   };
 


### PR DESCRIPTION
###### Motivation for this change
QGis-3.4.5 is the new LTR version.

We should use this instead of the now obselete 2.18 one for the upcoming 19.03 release. I am really sorry this comes this close to the branch off deadline.

See #35669
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

