### PR TITLE
Revert "Merge #56170: Revert "file: 5.35 -> 5.36" (staging)"

### DIFF
--- a/pkgs/tools/misc/file/default.nix
+++ b/pkgs/tools/misc/file/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   name = "file-${version}";
-  version = "5.35";
+  version = "5.36";
 
   src = fetchurl {
     urls = [
       "ftp://ftp.astron.com/pub/file/${name}.tar.gz"
       "https://distfiles.macports.org/file/${name}.tar.gz"
     ];
-    sha256 = "0ijm1fabm68ykr1zbx0bxnka5jr3n42sj8y5mbkrnxs0fj0mxi1h";
+    sha256 = "0ya330cdkvfi2d28h8gvhghj4gnhysmifmryysl0a97xq2884q7v";
   };
 
   nativeBuildInputs = stdenv.lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) file;


### PR DESCRIPTION
###### Motivation for this change

Try this again, seems to work now.

Motivated by new version possibly fixing security issues
described here:

https://github.com/NixOS/nixpkgs/issues/56360

This reverts commit 7d47102bbccb28cb3417dc949ad9df24e9d59686, reversing
changes made to 2ed8187107c8efa3cf77311ef58cf3783e3dd749.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @vcunat