### PR TITLE
cytoscape: bump 3.6.1 -> 3.7.1

### DIFF
--- a/pkgs/applications/science/misc/cytoscape/default.nix
+++ b/pkgs/applications/science/misc/cytoscape/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "cytoscape-${version}";
-  version = "3.6.1";
+  version = "3.7.1";
 
   src = fetchurl {
-    url = "http://chianti.ucsd.edu/${name}/${name}.tar.gz";
-    sha256 = "1pkdilv1nw6vvdxk71bwjngr8yafrsqwaqvlakhp8yb342r1jd4s";
+    url = "https://github.com/cytoscape/cytoscape/releases/download/${version}/${name}.tar.gz";
+    sha256 = "1mhsngbwbgdwl70wj7850zg94534lasihwv2ryifardm35mkh48k";
   };
 
   buildInputs = [jre makeWrapper];


### PR DESCRIPTION
Needed to update URL, because `wget "http://chianti.ucsd.edu/cytoscape-3.7.1/cytoscape-3.7.1.tar.gz"` returns `404`.

###### Motivation for this change

Update to latest version, bumping from 3.6.1 -> 3.7.1.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

