### PR TITLE
go_1_12: init at go 1.12

### DIFF
--- a/pkgs/applications/networking/cluster/cni/plugins.nix
+++ b/pkgs/applications/networking/cluster/cni/plugins.nix
@@ -13,10 +13,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ removeReferencesTo go ];
 
-  GOCACHE = "off";
-
   buildPhase = ''
     patchShebangs build.sh
+    export "GOCACHE=$TMPDIR/go-cache"
     ./build.sh
   '';
 

--- a/pkgs/applications/version-management/gitlab/gitlab-shell/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-shell/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ruby bundler go ];
 
+  GOCACHE="$TMPDIR/go-cache";
+
   patches = [ ./remove-hardcoded-locations.patch ];
 
   installPhase = ''

--- a/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ git go ];
 
-  makeFlags = [ "PREFIX=$(out)" "VERSION=${version}" ];
+  makeFlags = [ "PREFIX=$(out)" "VERSION=${version}" "GOCACHE=$(TMPDIR)/go-cache" ];
 
   meta = with stdenv.lib; {
     homepage = http://www.gitlab.com/;

--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -100,6 +100,7 @@ rec {
       export AUTO_GOPATH=1
       export DOCKER_GITCOMMIT="${rev}"
       export VERSION="${version}"
+      export GOCACHE="$TMPDIR/go-cache"
       ./hack/make.sh dynbinary
       cd -
     '') + ''

--- a/pkgs/applications/virtualization/rkt/default.nix
+++ b/pkgs/applications/virtualization/rkt/default.nix
@@ -48,6 +48,7 @@ in stdenv.mkDerivation rec {
 
   preBuild = ''
     export BUILDDIR
+    export GOCACHE="$TMPDIR/go-cache"
   '';
 
   installPhase = ''

--- a/pkgs/desktops/deepin/dde-api/default.nix
+++ b/pkgs/desktops/deepin/dde-api/default.nix
@@ -44,6 +44,7 @@ buildGoPackage rec {
   '';
 
   buildPhase = ''
+    export GOCACHE="$TMPDIR/go-cache";
     make -C go/src/${goPackagePath}
   '';
 

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -1,13 +1,19 @@
-{ pkgs, makeScope, libsForQt5 }:
+{ pkgs, makeScope, libsForQt5, go_1_11 }:
 
 let
   packages = self: with self; {
     updateScript = callPackage ./update.nix { };
 
     dbus-factory = callPackage ./dbus-factory { };
-    dde-api = callPackage ./dde-api { };
+    dde-api = callPackage ./dde-api {
+      # XXX: the build is finding references to Go when compiled with go v1.12
+      go = go_1_11;
+    };
     dde-calendar = callPackage ./dde-calendar { };
-    dde-daemon = callPackage ./dde-daemon { };
+    dde-daemon = callPackage ./dde-daemon {
+      # XXX: the build is finding references to Go when compiled with go v1.12
+      go = go_1_11;
+    };
     dde-qt-dbus-factory = callPackage ./dde-qt-dbus-factory { };
     dde-session-ui = callPackage ./dde-session-ui { };
     deepin-desktop-base = callPackage ./deepin-desktop-base { };

--- a/pkgs/desktops/deepin/go-dbus-generator/default.nix
+++ b/pkgs/desktops/deepin/go-dbus-generator/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   makeFlags = [
     "PREFIX=$(out)"
-    "GOCACHE=off"
+    "GOCACHE=$TMPDIR/go-cache"
   ];
 
   passthru.updateScript = deepin.updateScript { inherit name; };

--- a/pkgs/desktops/deepin/go-gir-generator/default.nix
+++ b/pkgs/desktops/deepin/go-gir-generator/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
 
   makeFlags = [
     "PREFIX=$(out)"
-    "GOCACHE=off"
+    "GOCACHE=$TMPDIR/go-cache"
   ];
 
   passthru.updateScript = deepin.updateScript { inherit name; };

--- a/pkgs/development/compilers/go/1.12.nix
+++ b/pkgs/development/compilers/go/1.12.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, tzdata, iana-etc, go_bootstrap, runCommand, writeScriptBin
+{ stdenv, fetchurl, tzdata, iana-etc, go_bootstrap, runCommand, writeScriptBin
 , perl, which, pkgconfig, patch, procps, pcre, cacert, llvm, Security, Foundation
 , mailcap, runtimeShell
 , buildPackages, targetPackages }:
@@ -31,11 +31,9 @@ stdenv.mkDerivation rec {
   name = "go-${version}";
   version = "1.12";
 
-  src = fetchFromGitHub {
-    owner = "golang";
-    repo = "go";
-    rev = "go${version}";
-    sha256 = "08j7ghcy5cs5p4sw5rqi57lzg52lrix8xbxn87y7y9sv6s3wx44n";
+  src = fetchurl {
+    url = "https://dl.google.com/go/go${version}.src.tar.gz";
+    sha256 = "1wl8kq21fbzmv4plnaza5acz8dhbaaq6smjzk3r6cf3l6qrkvi09";
   };
 
   # perl is used for testing go vet

--- a/pkgs/development/compilers/go/1.12.nix
+++ b/pkgs/development/compilers/go/1.12.nix
@@ -1,0 +1,246 @@
+{ stdenv, fetchFromGitHub, tzdata, iana-etc, go_bootstrap, runCommand, writeScriptBin
+, perl, which, pkgconfig, patch, procps, pcre, cacert, llvm, Security, Foundation
+, mailcap, runtimeShell
+, buildPackages, targetPackages }:
+
+let
+
+  inherit (stdenv.lib) optionals optionalString;
+
+  goBootstrap = runCommand "go-bootstrap" {} ''
+    mkdir $out
+    cp -rf ${buildPackages.go_bootstrap}/* $out/
+    chmod -R u+w $out
+    find $out -name "*.c" -delete
+    cp -rf $out/bin/* $out/share/go/bin/
+  '';
+
+  goarch = platform: {
+    "i686" = "386";
+    "x86_64" = "amd64";
+    "aarch64" = "arm64";
+    "arm" = "arm";
+    "armv5tel" = "arm";
+    "armv6l" = "arm";
+    "armv7l" = "arm";
+  }.${platform.parsed.cpu.name} or (throw "Unsupported system");
+
+in
+
+stdenv.mkDerivation rec {
+  name = "go-${version}";
+  version = "1.12";
+
+  src = fetchFromGitHub {
+    owner = "golang";
+    repo = "go";
+    rev = "go${version}";
+    sha256 = "08j7ghcy5cs5p4sw5rqi57lzg52lrix8xbxn87y7y9sv6s3wx44n";
+  };
+
+  # perl is used for testing go vet
+  nativeBuildInputs = [ perl which pkgconfig patch procps ];
+  buildInputs = [ cacert pcre ]
+    ++ optionals stdenv.isLinux [ stdenv.cc.libc.out ]
+    ++ optionals (stdenv.hostPlatform.libc == "glibc") [ stdenv.cc.libc.static ];
+
+
+  propagatedBuildInputs = optionals stdenv.isDarwin [ Security Foundation ];
+
+  hardeningDisable = [ "all" ];
+
+  prePatch = ''
+    patchShebangs ./ # replace /bin/bash
+
+    # This source produces shell script at run time,
+    # and thus it is not corrected by patchShebangs.
+    substituteInPlace misc/cgo/testcarchive/carchive_test.go \
+      --replace '#!/usr/bin/env bash' '#!${runtimeShell}'
+
+    # Patch the mimetype database location which is missing on NixOS.
+    substituteInPlace src/mime/type_unix.go \
+      --replace '/etc/mime.types' '${mailcap}/etc/mime.types'
+
+    # Disabling the 'os/http/net' tests (they want files not available in
+    # chroot builds)
+    rm src/net/{listen,parse}_test.go
+    rm src/syscall/exec_linux_test.go
+
+    # !!! substituteInPlace does not seems to be effective.
+    # The os test wants to read files in an existing path. Just don't let it be /usr/bin.
+    sed -i 's,/usr/bin,'"`pwd`", src/os/os_test.go
+    sed -i 's,/bin/pwd,'"`type -P pwd`", src/os/os_test.go
+    # Disable the unix socket test
+    sed -i '/TestShutdownUnix/areturn' src/net/net_test.go
+    # Disable the hostname test
+    sed -i '/TestHostname/areturn' src/os/os_test.go
+    # ParseInLocation fails the test
+    sed -i '/TestParseInSydney/areturn' src/time/format_test.go
+    # Remove the api check as it never worked
+    sed -i '/src\/cmd\/api\/run.go/ireturn nil' src/cmd/dist/test.go
+    # Remove the coverage test as we have removed this utility
+    sed -i '/TestCoverageWithCgo/areturn' src/cmd/go/go_test.go
+    # Remove the timezone naming test
+    sed -i '/TestLoadFixed/areturn' src/time/time_test.go
+    # Remove disable setgid test
+    sed -i '/TestRespectSetgidDir/areturn' src/cmd/go/internal/work/build_test.go
+    # Remove cert tests that conflict with NixOS's cert resolution
+    sed -i '/TestEnvVars/areturn' src/crypto/x509/root_unix_test.go
+    # TestWritevError hangs sometimes
+    sed -i '/TestWritevError/areturn' src/net/writev_test.go
+    # TestVariousDeadlines fails sometimes
+    sed -i '/TestVariousDeadlines/areturn' src/net/timeout_test.go
+
+    sed -i 's,/etc/protocols,${iana-etc}/etc/protocols,' src/net/lookup_unix.go
+    sed -i 's,/etc/services,${iana-etc}/etc/services,' src/net/port_unix.go
+
+    # Disable cgo lookup tests not works, they depend on resolver
+    rm src/net/cgo_unix_test.go
+
+  '' + optionalString stdenv.isLinux ''
+    sed -i 's,/usr/share/zoneinfo/,${tzdata}/share/zoneinfo/,' src/time/zoneinfo_unix.go
+  '' + optionalString stdenv.isAarch32 ''
+    echo '#!${runtimeShell}' > misc/cgo/testplugin/test.bash
+  '' + optionalString stdenv.isDarwin ''
+    substituteInPlace src/race.bash --replace \
+      "sysctl machdep.cpu.extfeatures | grep -qv EM64T" true
+    sed -i 's,strings.Contains(.*sysctl.*,true {,' src/cmd/dist/util.go
+    sed -i 's,"/etc","'"$TMPDIR"'",' src/os/os_test.go
+    sed -i 's,/_go_os_test,'"$TMPDIR"'/_go_os_test,' src/os/path_test.go
+
+    sed -i '/TestChdirAndGetwd/areturn' src/os/os_test.go
+    sed -i '/TestCredentialNoSetGroups/areturn' src/os/exec/exec_posix_test.go
+    sed -i '/TestRead0/areturn' src/os/os_test.go
+    sed -i '/TestSystemRoots/areturn' src/crypto/x509/root_darwin_test.go
+
+    sed -i '/TestGoInstallRebuildsStalePackagesInOtherGOPATH/areturn' src/cmd/go/go_test.go
+    sed -i '/TestBuildDashIInstallsDependencies/areturn' src/cmd/go/go_test.go
+
+    sed -i '/TestDisasmExtld/areturn' src/cmd/objdump/objdump_test.go
+
+    sed -i 's/unrecognized/unknown/' src/cmd/link/internal/ld/lib.go
+
+    # TestCurrent fails because Current is not implemented on Darwin
+    sed -i 's/TestCurrent/testCurrent/g' src/os/user/user_test.go
+    sed -i 's/TestLookup/testLookup/g' src/os/user/user_test.go
+
+    touch $TMPDIR/group $TMPDIR/hosts $TMPDIR/passwd
+  '';
+
+  patches = [
+    ./remove-tools-1.11.patch
+    ./remove-test-pie.patch
+    ./creds-test.patch
+    ./go-1.9-skip-flaky-19608.patch
+    ./go-1.9-skip-flaky-20072.patch
+    ./skip-external-network-tests.patch
+    ./skip-nohup-tests.patch
+    # breaks under load: https://github.com/golang/go/issues/25628
+    ./skip-test-extra-files-on-386.patch
+  ];
+
+  postPatch = ''
+    find . -name '*.orig' -exec rm {} ';'
+  '' + optionalString stdenv.isDarwin ''
+    echo "substitute hardcoded dsymutil with ${llvm}/bin/llvm-dsymutil"
+    substituteInPlace "src/cmd/link/internal/ld/lib.go" --replace dsymutil ${llvm}/bin/llvm-dsymutil
+  '';
+
+  GOOS = stdenv.targetPlatform.parsed.kernel.name;
+  GOARCH = goarch stdenv.targetPlatform;
+  # GOHOSTOS/GOHOSTARCH must match the building system, not the host system.
+  # Go will nevertheless build a for host system that we will copy over in
+  # the install phase.
+  GOHOSTOS = stdenv.buildPlatform.parsed.kernel.name;
+  GOHOSTARCH = goarch stdenv.buildPlatform;
+
+  # {CC,CXX}_FOR_TARGET must be only set for cross compilation case as go expect those
+  # to be different from CC/CXX
+  CC_FOR_TARGET = if (stdenv.hostPlatform != stdenv.targetPlatform) then
+      "${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}cc"
+    else if (stdenv.buildPlatform != stdenv.targetPlatform) then
+      "${stdenv.cc.targetPrefix}cc"
+    else
+      null;
+  CXX_FOR_TARGET = if (stdenv.hostPlatform != stdenv.targetPlatform) then
+      "${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}c++"
+    else if (stdenv.buildPlatform != stdenv.targetPlatform) then
+      "${stdenv.cc.targetPrefix}c++"
+    else
+      null;
+
+  GOARM = toString (stdenv.lib.intersectLists [(stdenv.hostPlatform.parsed.cpu.version or "")] ["5" "6" "7"]);
+  GO386 = 387; # from Arch: don't assume sse2 on i686
+  CGO_ENABLED = 1;
+  # Hopefully avoids test timeouts on Hydra
+  GO_TEST_TIMEOUT_SCALE = 3;
+
+  # Indicate that we are running on build infrastructure
+  # Some tests assume things like home directories and users exists
+  GO_BUILDER_NAME = "nix";
+
+  GOROOT_BOOTSTRAP="${goBootstrap}/share/go";
+
+  postConfigure = ''
+    export GOCACHE=$TMPDIR/go-cache
+    # this is compiled into the binary
+    export GOROOT_FINAL=$out/share/go
+
+    export PATH=$(pwd)/bin:$PATH
+
+    # Independent from host/target, CC should produce code for the building system.
+    export CC=${buildPackages.stdenv.cc}/bin/cc
+    ulimit -a
+  '';
+
+  postBuild = ''
+    (cd src && ./make.bash)
+  '';
+
+  doCheck = stdenv.hostPlatform == stdenv.targetPlatform;
+
+  checkPhase = ''
+    runHook preCheck
+    (cd src && HOME=$TMPDIR GOCACHE=$TMPDIR/go-cache ./run.bash --no-rebuild)
+    runHook postCheck
+  '';
+
+  preInstall = ''
+    rm -r pkg/{bootstrap,obj}
+    # Contains the wrong perl shebang when cross compiling,
+    # since it is not used for anything we can deleted as well.
+    rm src/regexp/syntax/make_perl_groups.pl
+  '' + (if (stdenv.buildPlatform != stdenv.hostPlatform) then ''
+    mv bin/*_*/* bin
+    rmdir bin/*_*
+    ${optionalString (!(GOHOSTARCH == GOARCH && GOOS == GOHOSTOS)) ''
+      rm -rf pkg/${GOHOSTOS}_${GOHOSTARCH} pkg/tool/${GOHOSTOS}_${GOHOSTARCH}
+    ''}
+  '' else if (stdenv.hostPlatform != stdenv.targetPlatform) then ''
+    rm -rf bin/*_*
+    ${optionalString (!(GOHOSTARCH == GOARCH && GOOS == GOHOSTOS)) ''
+      rm -rf pkg/${GOOS}_${GOARCH} pkg/tool/${GOOS}_${GOARCH}
+    ''}
+  '' else "");
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $GOROOT_FINAL
+    cp -a bin pkg src lib misc api doc $GOROOT_FINAL
+    ln -s $GOROOT_FINAL/bin $out/bin
+    runHook postInstall
+  '';
+
+  setupHook = ./setup-hook.sh;
+
+  disallowedReferences = [ goBootstrap ];
+
+  meta = with stdenv.lib; {
+    branch = "1.11";
+    homepage = http://golang.org/;
+    description = "The Go Programming language";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ cstrahan orivej velovix mic92 ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/development/libraries/boringssl/default.nix
+++ b/pkgs/development/libraries/boringssl/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
   NIX_CFLAGS_COMPILE = "-Wno-error";
 
+  GOCACHE="$TMPDIR/go-cache";
+
   installPhase = ''
     mkdir -p $out/bin $out/include $out/lib
 

--- a/pkgs/servers/monitoring/cadvisor/default.nix
+++ b/pkgs/servers/monitoring/cadvisor/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ go ];
 
+  GOCACHE="$TMPDIR/go-cache";
+
   buildPhase = ''
     mkdir -p Godeps/_workspace/src/github.com/google/
     ln -s $(pwd) Godeps/_workspace/src/github.com/google/cadvisor

--- a/pkgs/tools/security/vault/default.nix
+++ b/pkgs/tools/security/vault/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ go gox removeReferencesTo ];
 
+  GOCACHE="$TMPDIR/go-cache";
+
   preBuild = ''
     patchShebangs ./
     substituteInPlace scripts/build.sh --replace 'git rev-parse HEAD' 'echo ${src.rev}'

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7139,7 +7139,11 @@ in
     inherit (darwin.apple_sdk.frameworks) Security Foundation;
   };
 
-  go = go_1_11;
+  go_1_12 = callPackage ../development/compilers/go/1.12.nix {
+    inherit (darwin.apple_sdk.frameworks) Security Foundation;
+  };
+
+  go = go_1_12;
 
   go-repo-root = callPackage ../development/tools/go-repo-root { };
 
@@ -17666,7 +17670,10 @@ in
 
   slack-term = callPackage ../applications/networking/instant-messengers/slack-term { };
 
-  singularity = callPackage ../applications/virtualization/singularity { };
+  singularity = callPackage ../applications/virtualization/singularity {
+    # XXX: the build is finding references to Go when compiled with go v1.12
+    go = go_1_11;
+  };
 
   spectmorph = callPackage ../applications/audio/spectmorph { };
 
@@ -21295,7 +21302,7 @@ in
   clearlooks-phenix = callPackage ../misc/themes/clearlooks-phenix { };
 
   deepin = recurseIntoAttrs (import ../desktops/deepin {
-    inherit pkgs libsForQt5;
+    inherit pkgs libsForQt5 go_1_11;
     inherit (lib) makeScope;
   });
 


### PR DESCRIPTION
###### Motivation for this change

The [build cache](https://golang.org/cmd/go/#hdr-Build_and_test_caching) is now required as a step toward eliminating $GOPATH/pkg. Setting the environment variable GOCACHE=off will cause go commands that write to the cache to fail. I've updated all the packages that I could find and are using go without using `buildGoPackage`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS (sandbox off)
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Tested with

```console
λ nix run -f '<nixpkgs>' nur.repos.kalbasit.nix-verify -c nix-verify -I nixpkgs=`pwd` \
        -A bazel-watcher \
        -A boringssl \
        -A cadvisor \
        -A cide \
        -A cni-plugins \
        -A deepin.dbus-factory \
        -A deepin.dde-api \
        -A deepin.dde-daemon \
        -A deepin.deepin-desktop-base \
        -A deepin.deepin-desktop-schemas \
        -A deepin.deepin-metacity \
        -A deepin.deepin-wallpapers \
        -A deepin.deepin-wm \
        -A deepin.go-dbus-generator \
        -A deepin.go-gir-generator \
        -A docker \
        -A docker-gc \
        -A gitlab-shell \
        -A gitlab-workhorse \
        -A go \
        -A go_1_11 \
        -A gometalinter \
        -A kubectl \
        -A kubectx \
        -A kubernetes \
        -A pipework \
        -A prometheus \
        -A prometheus-alertmanager \
        -A prometheus-pushgateway \
        -A prometheus_2 \
        -A python37Packages.jupyter-repo2docker \
        -A rkt \
        -A singularity \
        -A tmsu \
        -A vault \
        -A vgo2nix \
        -A vimPlugins.vim-go
```