### PR TITLE
[WiP] gtk-doc: patch the on-line DocBook XSL paths to the local

### DIFF
--- a/pkgs/development/tools/documentation/gtk-doc/default.nix
+++ b/pkgs/development/tools/documentation/gtk-doc/default.nix
@@ -1,6 +1,5 @@
 { stdenv, fetchurl, autoreconfHook, pkgconfig, perl, python3, libxml2Python, libxslt, which
 , docbook_xml_dtd_43, docbook_xsl, gnome-doc-utils, gettext, itstool
-, withDblatex ? false, dblatex
 }:
 
 stdenv.mkDerivation rec {
@@ -16,15 +15,23 @@ stdenv.mkDerivation rec {
     passthru.respect_xml_catalog_files_var_patch
   ];
 
+  postPatch = ''
+    substituteInPlace ./gtk-doc.xsl --replace \
+      "http://docbook.sourceforge.net/release/xsl/current/html/chunk.xsl" \
+      "${docbook_xsl}/share/xml/docbook-xsl/html/chunk.xsl" \
+      --replace "xsl:import" "xsl:include"
+    substituteInPlace ./gtk-doc-fo.xsl --replace \
+      "http://docbook.sourceforge.net/release/xsl/current/fo/docbook.xsl" \
+      "${docbook_xsl}/share/xml/docbook-xsl/fo/docbook.xsl" \
+      --replace "xsl:import" "xsl:include"
+  '';  # see also https://gitlab.gnome.org/GNOME/gtk-doc/issues/74
+
   outputDevdoc = "out";
 
   nativeBuildInputs = [ autoreconfHook ];
-  buildInputs =
-    [ pkgconfig perl python3 libxml2Python libxslt docbook_xml_dtd_43 docbook_xsl
-      gnome-doc-utils gettext which itstool
-    ] ++ stdenv.lib.optional withDblatex dblatex;
-
-  configureFlags = [ "--disable-scrollkeeper" ];
+  buildInputs = [ pkgconfig perl python3 libxml2Python libxslt
+                  docbook_xml_dtd_43 docbook_xsl gnome-doc-utils
+                  gettext which itstool ];
 
   # Make six available for binaries, python.withPackages creates a wrapper
   # but scripts are not allowed in shebangs so we link it into sys.path.
@@ -32,8 +39,7 @@ stdenv.mkDerivation rec {
     ln -s ${python3.pkgs.six}/${python3.sitePackages}/* $out/share/gtk-doc/python/
   '';
 
-  doCheck = false; # requires a lot of stuff
-  doInstallCheck = false; # fails
+  doInstallCheck = false;  # `gtkdoc-mkhtml2 --version` fails
 
   passthru = {
     # Consumers are expected to copy the m4 files to their source tree, let them reuse the patch
@@ -44,6 +50,6 @@ stdenv.mkDerivation rec {
     homepage = https://www.gtk.org/gtk-doc;
     description = "Tools to extract documentation embedded in GTK+ and GNOME source code";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ pSub ];
+    maintainers = with maintainers; [ amiloradovsky pSub ];
   };
 }


### PR DESCRIPTION
This is what's done in Guix, so `gtkdoc-mkhtml` would in no case even try to reach for the Internet.
Also removed `dblatex`, because it was never enabled and causes circular dependencies if it is.
The `--disable-scrollkeeper` configure flag isn't recognized by now.
And `doCheck` should be left alone, as long as the tests pass.

###### Motivation for this change

Cleaning up, robustness.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The [WiP] tag is because I couldn't test the impact on the other packages due to the limits of my hardware and Internet connection, and also because much of those packages fail for the deprecation warnings, not sure what that means.