### PR TITLE
Revert "Merge pull request #54980 from danbst/etc-relative"

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -568,20 +568,6 @@
    </listitem>
    <listitem>
     <para>
-     Symlinks in <filename>/etc</filename> (except <filename>/etc/static</filename>)
-     are now relative instead of absolute. This makes possible to examine
-     NixOS container's <filename>/etc</filename> directory from host system
-     (previously it pointed to host <filename>/etc</filename> when viewed from host,
-     and to container <filename>/etc</filename> when viewed from container chroot).
-    </para>
-    <para>
-     This also makes <filename>/etc/os-release</filename> adhere to
-     <link xlink:href="https://www.freedesktop.org/software/systemd/man/os-release.html">the standard</link>
-     for NixOS containers.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
       Flat volumes are now disabled by default in <literal>hardware.pulseaudio</literal>.
       This has been done to prevent applications, which are unaware of this feature, setting
       their volumes to 100% on startup causing harm to your audio hardware and potentially your ears.

--- a/nixos/modules/system/etc/make-etc.sh
+++ b/nixos/modules/system/etc/make-etc.sh
@@ -10,11 +10,6 @@ users_=($users)
 groups_=($groups)
 set +f
 
-# Create relative symlinks, so that the links can be followed if
-# the NixOS installation is not mounted as filesystem root.
-# Absolute symlinks violate the os-release format
-# at https://www.freedesktop.org/software/systemd/man/os-release.html
-# and break e.g. systemd-nspawn and os-prober.
 for ((i = 0; i < ${#targets_[@]}; i++)); do
     source="${sources_[$i]}"
     target="${targets_[$i]}"
@@ -24,14 +19,14 @@ for ((i = 0; i < ${#targets_[@]}; i++)); do
         # If the source name contains '*', perform globbing.
         mkdir -p $out/etc/$target
         for fn in $source; do
-            ln -s --relative "$fn" $out/etc/$target/
+            ln -s "$fn" $out/etc/$target/
         done
 
     else
-
+        
         mkdir -p $out/etc/$(dirname $target)
         if ! [ -e $out/etc/$target ]; then
-            ln -s --relative $source $out/etc/$target
+            ln -s $source $out/etc/$target
         else
             echo "duplicate entry $target -> $source"
             if test "$(readlink $out/etc/$target)" != "$source"; then
@@ -39,13 +34,13 @@ for ((i = 0; i < ${#targets_[@]}; i++)); do
                 exit 1
             fi
         fi
-
+        
         if test "${modes_[$i]}" != symlink; then
             echo "${modes_[$i]}"  > $out/etc/$target.mode
             echo "${users_[$i]}"  > $out/etc/$target.uid
             echo "${groups_[$i]}" > $out/etc/$target.gid
         fi
-
+        
     fi
 done
 

--- a/nixos/modules/system/etc/setup-etc.pl
+++ b/nixos/modules/system/etc/setup-etc.pl
@@ -4,7 +4,6 @@ use File::Copy;
 use File::Path;
 use File::Basename;
 use File::Slurp;
-use File::Spec;
 
 my $etc = $ARGV[0] or die;
 my $static = "/etc/static";
@@ -18,20 +17,6 @@ sub atomicSymlink {
     return 1;
 }
 
-# Create relative symlinks, so that the links can be followed if
-# the NixOS installation is not mounted as filesystem root.
-# Absolute symlinks violate the os-release format
-# at https://www.freedesktop.org/software/systemd/man/os-release.html
-# and break e.g. systemd-nspawn and os-prober.
-sub atomicRelativeSymlink {
-    my ($source, $target) = @_;
-    my $tmp = "$target.tmp";
-    unlink $tmp;
-    my $rel = File::Spec->abs2rel($source, dirname $target);
-    symlink $rel, $tmp or return 0;
-    rename $tmp, $target or return 0;
-    return 1;
-}
 
 # Atomically update /etc/static to point at the etc files of the
 # current configuration.
@@ -118,7 +103,7 @@ sub link {
     if (-e "$_.mode") {
         my $mode = read_file("$_.mode"); chomp $mode;
         if ($mode eq "direct-symlink") {
-            atomicRelativeSymlink readlink("$static/$fn"), $target or warn;
+            atomicSymlink readlink("$static/$fn"), $target or warn;
         } else {
             my $uid = read_file("$_.uid"); chomp $uid;
             my $gid = read_file("$_.gid"); chomp $gid;
@@ -132,7 +117,7 @@ sub link {
         push @copied, $fn;
         print CLEAN "$fn\n";
     } elsif (-l "$_") {
-        atomicRelativeSymlink "$static/$fn", $target or warn;
+        atomicSymlink "$static/$fn", $target or warn;
     }
 }
 


### PR DESCRIPTION
This reverts commit 0b91fa43e40c121ff4682256aa46a425c984da6c, reversing
changes made to 183919a0c072061b98ebe9fca2e899ade871ff1c.

###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/56278
https://github.com/NixOS/nixpkgs/pull/54980#issuecomment-466224732
https://github.com/NixOS/nixpkgs/pull/54980#issuecomment-466504857
https://discourse.nixos.org/t/nixos-rebuild-switch-upgrade-error-directory-contains-user-files-symlinking-may-fail/2266

The `isStatic` check now doesn't work, which leads to warnings