### PR TITLE
python3Packages.aiounifi: init at 4 + a few other minor updates to satisfy HA

### DIFF
--- a/pkgs/development/python-modules/aiounifi/default.nix
+++ b/pkgs/development/python-modules/aiounifi/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildPythonPackage, fetchPypi, isPy3k
+, aiohttp }:
+
+buildPythonPackage rec {
+  pname = "aiounifi";
+  version = "4";
+
+  disabled = ! isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0594nb8mpfhnnk9jadbdnbn9v7p4sh3430kcgfyhsh7ayw2mpb9m";
+  };
+
+  propagatedBuildInputs = [ aiohttp ];
+
+  # upstream has no tests
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "An asynchronous Python library for communicating with Unifi Controller API";
+    homepage    = https://pypi.python.org/pypi/aiounifi/;
+    license     = licenses.mit;
+    maintainers = with maintainers; [ peterhoeg ];
+  };
+}

--- a/pkgs/development/python-modules/ha-ffmpeg/default.nix
+++ b/pkgs/development/python-modules/ha-ffmpeg/default.nix
@@ -3,13 +3,13 @@
 
 buildPythonPackage rec {
   pname = "ha-ffmpeg";
-  version = "1.9";
+  version = "1.11";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0644j5fqw8p6li6nrnm1rw7nhvsixq1c7gik3f1yx50776yg05i8";
+    sha256 = "1hqwpxhndxw0xj6q15c1pvwl2kz6v15m477cmy5isd1sxjxwav1q";
   };
 
   buildInputs = [ ffmpeg ];

--- a/pkgs/development/python-modules/pyunifi/default.nix
+++ b/pkgs/development/python-modules/pyunifi/default.nix
@@ -3,11 +3,11 @@
 
 buildPythonPackage rec {
   pname = "pyunifi";
-  version = "2.15";
+  version = "2.16";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "cf2f9f538722447bded6b319a35c26ea088c51ccdbd3dec887210946c7992ebf";
+    sha256 = "10vwa3gz1y6gc3bij14sv1gqxhx28svajnrz0jqhwfzy0j1fqa0x";
   };
 
   propagatedBuildInputs = [ requests ];

--- a/pkgs/development/python-modules/pyupdate/default.nix
+++ b/pkgs/development/python-modules/pyupdate/default.nix
@@ -3,11 +3,11 @@
 
 buildPythonPackage rec {
   pname = "pyupdate";
-  version = "0.2.16";
+  version = "1.3.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1p4zpjvwy6h9kr0dp80z5k04s14r9f75jg9481gpx8ygxj0l29bi";
+    sha256 = "1qxbakhsgmdc5aakhkadr26dlhi0lma7170b245sragn170fqjxf";
   };
 
   propagatedBuildInputs = [ requests ];

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -1351,7 +1351,7 @@
     "switch.tradfri" = ps: with ps; [  ];
     "switch.transmission" = ps: with ps; [ transmissionrpc ];
     "switch.tuya" = ps: with ps; [  ];
-    "switch.unifi" = ps: with ps; [  ];
+    "switch.unifi" = ps: with ps; [ aiounifi ];
     "switch.upcloud" = ps: with ps; [  ];
     "switch.velbus" = ps: with ps; [  ];
     "switch.vera" = ps: with ps; [  ];
@@ -1402,7 +1402,7 @@
     "tts.yandextts" = ps: with ps; [  ];
     "tuya" = ps: with ps; [  ];
     "twilio" = ps: with ps; [ aiohttp-cors twilio ];
-    "unifi" = ps: with ps; [  ];
+    "unifi" = ps: with ps; [ aiounifi ];
     "unifi.const" = ps: with ps; [  ];
     "unifi.controller" = ps: with ps; [  ];
     "unifi.errors" = ps: with ps; [  ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -850,7 +850,11 @@ in {
 
   tomlkit = callPackage ../development/python-modules/tomlkit { };
 
+  aiounifi = callPackage ../development/python-modules/aiounifi { };
+
   unifi = callPackage ../development/python-modules/unifi { };
+
+  pyunifi = callPackage ../development/python-modules/pyunifi { };
 
   vidstab = callPackage ../development/python-modules/vidstab { };
 
@@ -1430,8 +1434,6 @@ in {
   jsonrpc-websocket = callPackage ../development/python-modules/jsonrpc-websocket { };
 
   onkyo-eiscp = callPackage ../development/python-modules/onkyo-eiscp { };
-
-  pyunifi = callPackage ../development/python-modules/pyunifi { };
 
   tablib = callPackage ../development/python-modules/tablib { };
 


### PR DESCRIPTION
###### Motivation for this change

ffmpeg and unifi components broke with HA 0.87.1

Cc: @dotlambda 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

