### PR TITLE
[wip] vimPlugins.vim-markdown-composer: init at 2018-11-05

### DIFF
--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -39,6 +39,30 @@ self: super: {
     src = skim.vim;
   };
 
+  vim-markdown-composer = let
+    vim-markdown-composer-bin = rustPlatform.buildRustPackage {
+      name = "vim-markdown-composer-vim";
+      src = super.vim-markdown-composer.src;
+
+      cargoSha256 = "0pjghdk6bfc32v6z6p7nyqmsk8vqzzk3xld6gk8j7m8i19wc0032";
+      buildInputs = stdenv.lib.optionals stdenv.isDarwin [ CoreServices ];
+
+      # FIXME: Use impure version of CoreFoundation because of missing symbols.
+      #   Undefined symbols for architecture x86_64: "_CFURLResourceIsReachable"
+      preConfigure = stdenv.lib.optionalString stdenv.isDarwin ''
+        export NIX_LDFLAGS="-F${CoreFoundation}/Library/Frameworks -framework CoreFoundation $NIX_LDFLAGS"
+      '';
+    };
+  in super.vim-markdown-composer.overrideAttrs(oa: {
+
+    propagatedBuildsInputs = (oa.propagatedBuildsInputs or []) ++ [ vim-markdown-composer-bin ];
+
+    postInstall = ''
+      mkdir -p $out/share/vim-plugins/vim-markdown-composer/target/release/markdown-composer
+      ln -s ${vim-markdown-composer-bin}/bin/markdown-composer $out/share/vim-plugins/vim-markdown-composer/target/release/markdown-composer
+      '';
+  });
+
   LanguageClient-neovim = let
     LanguageClient-neovim-src = fetchurl {
       url = "https://github.com/autozimu/LanguageClient-neovim/archive/0.1.140.tar.gz";

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -64,6 +64,7 @@ enomsg/vim-haskellConcealPlus
 ensime/ensime-vim
 ervandew/supertab
 esneider/YUNOcommit.vim
+euclio/vim-markdown-composer
 farmergreg/vim-lastplace
 fatih/vim-go
 FelikZ/ctrlp-py-matcher


### PR DESCRIPTION
###### Motivation for this change
adds a markdown viewer, for some reason displays a blank page for now :/ .

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

