### PR TITLE
pythonPackages.mnist: init at 0.2.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1780,6 +1780,12 @@
     githubId = 875324;
     name = "David Johnson";
   };
+  dmrauh = {
+    email = "dmrauh@posteo.de";
+    github = "dmrauh";
+    githubId = 37698547;
+    name = "Dominik Michael Rauh";
+  };
   dmvianna = {
     email = "dmlvianna@gmail.com";
     github = "dmvianna";

--- a/pkgs/development/python-modules/mnist/default.nix
+++ b/pkgs/development/python-modules/mnist/default.nix
@@ -1,0 +1,36 @@
+{ buildPythonPackage, fetchFromGitHub, isPy27, lib, mock, numpy, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "mnist";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "datapythonista";
+    repo = "mnist";
+    rev = "${pname}-${version}";
+    sha256 = "17r37pbxiv5dw857bmg990x836gq6sgww069w3q5jjg9m3xdm7dh";
+  };
+
+  propagatedBuildInputs = [ numpy ] ++ lib.optional isPy27 mock;
+
+  checkInputs = [ pytestCheckHook ];
+
+  dontUseSetuptoolsCheck = true;
+
+  # disable tests which fail due to socket related errors
+  disabledTests = [
+    "test_test_images_has_right_size"
+    "test_test_labels_has_right_size"
+    "test_train_images_has_right_size"
+    "test_train_labels_has_right_size"
+  ];
+
+  meta = with lib; {
+    description = "Python utilities to download and parse the MNIST dataset";
+    homepage = "https://github.com/datapythonista/mnist";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ dmrauh ];
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -770,6 +770,8 @@ in {
 
   mkl-service = callPackage ../development/python-modules/mkl-service { };
 
+  mnist = callPackage ../development/python-modules/mnist { };
+
   monkeyhex = callPackage ../development/python-modules/monkeyhex { };
 
   monty = callPackage ../development/python-modules/monty { };


### PR DESCRIPTION
###### Motivation for this change
Add python mnist utilities.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

