### PR TITLE
messer-slim: init at 3.2.1

### DIFF
--- a/pkgs/applications/science/biology/messer-slim/default.nix
+++ b/pkgs/applications/science/biology/messer-slim/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchurl, cmake, gcc, gcc-unwrapped }:
+
+stdenv.mkDerivation rec {
+  version = "3.2.1"; 
+  name = "messer-slim-${version}";
+
+  src = fetchurl {
+    url = "https://github.com/MesserLab/SLiM/archive/v${version}.tar.gz";
+    sha256 = "1j3ssjvxpsc21mmzj59kwimglz8pdazi5w6wplmx11x744k77wa1";
+  };
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ cmake gcc gcc-unwrapped ];
+
+  cmakeFlags = [ "-DCMAKE_AR=${gcc-unwrapped}/bin/gcc-ar" 
+                 "-DCMAKE_RANLIB=${gcc-unwrapped}/bin/gcc-ranlib" ];
+
+  meta = {
+     description = "An evolutionary simulation framework";
+     homepage = https://messerlab.org/slim/;
+     license = with stdenv.lib.licenses; [ gpl3 ];
+     maintainers = with stdenv.lib.maintainers; [ bzizou ];
+     platforms = stdenv.lib.platforms.all;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21545,6 +21545,8 @@ in
 
   mrbayes = callPackage ../applications/science/biology/mrbayes { };
 
+  messer-slim = callPackage ../applications/science/biology/messer-slim { };
+
   minc_tools = callPackage ../applications/science/biology/minc-tools { };
 
   minc_widgets = callPackage ../applications/science/biology/minc-widgets { };


### PR DESCRIPTION
###### Motivation for this change
Tool needed into our supercomputing center

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

