### PR TITLE
datadog-agent: 6.9.0 -> 6.10.0

### DIFF
--- a/nixos/modules/services/monitoring/datadog-agent.nix
+++ b/nixos/modules/services/monitoring/datadog-agent.nix
@@ -202,7 +202,7 @@ in {
     };
   };
   config = mkIf cfg.enable {
-    environment.systemPackages = [ datadogPkg pkgs.sysstat pkgs.procps ];
+    environment.systemPackages = [ datadogPkg pkgs.sysstat pkgs.procps pkgs.iproute ];
 
     users.extraUsers.datadog = {
       description = "Datadog Agent User";
@@ -216,7 +216,7 @@ in {
 
     systemd.services = let
       makeService = attrs: recursiveUpdate {
-        path = [ datadogPkg pkgs.python pkgs.sysstat pkgs.procps ];
+        path = [ datadogPkg pkgs.python pkgs.sysstat pkgs.procps pkgs.iproute ];
         wantedBy = [ "multi-user.target" ];
         serviceConfig = {
           User = "datadog";

--- a/pkgs/tools/networking/dd-agent/6.nix
+++ b/pkgs/tools/networking/dd-agent/6.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, buildGoPackage, makeWrapper, pythonPackages, pkgconfig, systemd }:
+{ lib, stdenv, fetchFromGitHub, buildGoPackage, makeWrapper, pythonPackages, pkgconfig, systemd, hostname }:
 
 let
   # keep this in sync with github.com/DataDog/agent-payload dependency
@@ -51,6 +51,8 @@ in buildGoPackage rec {
     sed -e "s|PyChecksPath =.*|PyChecksPath = \"$bin/${python.sitePackages}\"|" \
         -e "s|distPath =.*|distPath = \"$bin/share/datadog-agent\"|" \
         -i cmd/agent/common/common_nix.go
+    sed -e "s|/bin/hostname|${lib.getBin hostname}/bin/hostname|" \
+        -i pkg/util/hostname_nix.go
   '';
 
   # Install the config files and python modules from the "dist" dir

--- a/pkgs/tools/networking/dd-agent/6.nix
+++ b/pkgs/tools/networking/dd-agent/6.nix
@@ -6,14 +6,14 @@ let
 
 in buildGoPackage rec {
   name = "datadog-agent-${version}";
-  version = "6.9.0";
+  version = "6.10.0";
   owner   = "DataDog";
   repo    = "datadog-agent";
 
   src = fetchFromGitHub {
     inherit owner repo;
     rev    = "${version}";
-    sha256 = "1ddzml9ip5nm5z6cmnsrqxlmcr8411qlyr05hky7yn1dacin9ifw";
+    sha256 = "076ww3swlqi7gfmqmnllhif8f6skv0jwc2gq3mi855p4mm6qyiia";
   };
 
   subPackages = [

--- a/pkgs/tools/networking/dd-agent/deps.nix
+++ b/pkgs/tools/networking/dd-agent/deps.nix
@@ -892,12 +892,12 @@
     };
   }
   {
-    goPackagePath  = "github.com/spf13/viper";
+    goPackagePath  = "github.com/DataDog/viper";
     fetch = {
       type = "git";
-      url = "https://github.com/spf13/viper";
-      rev =  "b5e8006cbee93ec955a89ab31e0e3ce3204f3736";
-      sha256 = "0y3r6ysi5vn0yq5c7pbl62yg2i64fkv54xgj2jf1hn3v6zzyimis";
+      url = "https://github.com/DataDog/viper";
+      rev =  "23ced3bc6b3751855704445e48da2c53075ade86";
+      sha256 = "1zzf4mqpmk47p3395k2v8q6wi7lnqxr0l55vv4zk9gpqqyifbm9m";
     };
   }
   {


### PR DESCRIPTION
###### Motivation for this change
Update package datadog-agent to v6.10.0
Datadog-agent v6.10.0 need go Package https://github.com/DataDog/viper
Fix working instance collect_connection_state
Fix check fqdn hostname

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

