### PR TITLE
gipc,gdrivefs: update

### DIFF
--- a/pkgs/development/python-modules/gdrivefs/default.nix
+++ b/pkgs/development/python-modules/gdrivefs/default.nix
@@ -12,13 +12,13 @@
 }:
 
 buildPythonPackage rec {
-  version = "0.14.9";
+  version = "0.14.12";
   pname = "gdrivefs";
   disabled = isPy3k;
 
   src = fetchurl {
     url = "https://github.com/dsoprea/GDriveFS/archive/${version}.tar.gz";
-    sha256 = "1mc2r35nf5k8vzwdcdhi0l9rb97amqd5xb53lhydj8v8f4rndk7a";
+    sha256 = "0m45z77idy0bs5fqlz0y534fy28ikamrd321hmqsc3q7d39kqzv0";
   };
 
   buildInputs = [ gipc greenlet httplib2 six ];

--- a/pkgs/development/python-modules/gipc/default.nix
+++ b/pkgs/development/python-modules/gipc/default.nix
@@ -7,13 +7,11 @@
 
 buildPythonPackage rec {
   pname = "gipc";
-  version = "0.6.0";
-  disabled = isPy3k;
+  version = "1.0.1";
 
   src = fetchPypi {
     inherit pname version;
-    extension = "zip";
-    sha256 = "0pd9by719qh882hqs6xpby61sn1x5h98hms5p2p8yqnycrf1s0h2";
+    sha256 = "1zg5bm30lqqd8x0jqbvr4yi8i4rzzk2hdnh280qnj2bwm5nqpghi";
   };
 
   propagatedBuildInputs = [ gevent ];


### PR DESCRIPTION
###### Motivation for this change

Was working for moving to py3 for gdrivefs,
but that's only in latest git not a tagged release.

Even so, updates!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---