### PR TITLE
davmail: 4.8.6 -> 5.2.0

### DIFF
--- a/pkgs/applications/networking/davmail/default.nix
+++ b/pkgs/applications/networking/davmail/default.nix
@@ -1,10 +1,11 @@
 { fetchurl, stdenv, jre, glib, libXtst, gtk2, makeWrapper, unzip }:
 
 stdenv.mkDerivation rec {
-  name = "davmail-4.8.6";
+  pname = "davmail";
+  version = "5.2.0";
   src = fetchurl {
-    url = "mirror://sourceforge/davmail/4.8.6/davmail-4.8.6-2600.zip";
-    sha256 = "1wk4jxb46qlyipxj57flqadgm4mih243rhqq9sp9m5pifjqrw9dp";
+    url = "mirror://sourceforge/${pname}/${version}/${pname}-${version}-2961.zip";
+    sha256 = "0jw6sjg7k7zg8ab0srz6cjjj5hnw5ppxx1w35sw055dlg54fh2m5";
   };
 
   sourceRoot = ".";
@@ -14,7 +15,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/share/davmail
     cp -vR ./* $out/share/davmail
-    makeWrapper $out/share/davmail/davmail.sh $out/bin/davmail \
+    makeWrapper $out/share/davmail/davmail $out/bin/davmail \
       --prefix PATH : ${jre}/bin \
       --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [ glib gtk2 libXtst ]}
   '';


### PR DESCRIPTION
###### Motivation for this change

5.2.0 announcement:

https://sourceforge.net/p/davmail/news/2019/02/davmail-520-released/


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The UI appears when running `davmail`, but I haven't tried pointing at a
proper server or otherwise actually seeing it in action.