### PR TITLE
typora: 0.9.64 -> 0.9.65

### DIFF
--- a/pkgs/applications/editors/typora/default.nix
+++ b/pkgs/applications/editors/typora/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "typora";
-  version = "0.9.64";
+  version = "0.9.65";
 
   src = fetchurl {
     url = "https://www.typora.io/linux/typora_${version}_amd64.deb";
-    sha256 = "0dffydc11ys2i38gdy8080ph1xlbbzhcdcc06hyfv0dr0nf58a09";
+    sha256 = "1y2ydz1vcphcp8rzw9q1iray446xig3m48c8r50qs3bx6bfyf0g9";
   };
 
   nativeBuildInputs = [ dpkg makeWrapper wrapGAppsHook ];

--- a/pkgs/applications/editors/typora/default.nix
+++ b/pkgs/applications/editors/typora/default.nix
@@ -15,16 +15,12 @@ stdenv.mkDerivation rec {
 
   unpackPhase = "dpkg-deb -x $src .";
 
-  dontWrapGApps = true;
-
   installPhase = ''
-    mkdir -p $out/bin $out/share/typora
+    mkdir -p $out/bin $out/share
     {
       cd usr
-      mv share/typora/resources/app/* $out/share/typora
-      mv share/applications $out/share
-      mv share/icons $out/share
-      mv share/doc $out/share
+      mv share/typora/resources/app $out/share/typora
+      mv share/{applications,icons,doc} $out/share/
     }
 
     makeWrapper ${electron_3}/bin/electron $out/bin/typora \


### PR DESCRIPTION
###### Motivation for this change

new version, changelog
(may need to scroll to find this version in the future):

https://typora.io/windows/dev_release.html

(yes, "windows" in URL is what the Linux page links to)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---