### PR TITLE
Proposal to changes in contribution guidelines for custom nixpkgs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -49,6 +49,29 @@ In addition to writing properly formatted commit messages, it's important to inc
 
 For package version upgrades and such a one-line commit message is usually sufficient.
 
+## Configuration instructions
+
+Installing and configuring packages from Nix (or in NixOS) is slightly different than other package managers or distros, where you often need to enable services, or specify settings for a package or service differently than the original package requires.
+
+It is even more relevant when your package builds/generates a configuration file expected by the binary or service. Think of udev rules, services (web servers, database engines) or networking (proxies, etc) configurations. Sometimes the user is expected to simply *enable* the package in their configuration.nix or config.nix for it to actually start working:
+
+```
+services.openssh.enable = true
+# or
+services.udev.extraRules = ''
+  SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="0925", ATTR{idProduct}=="3881", MODE="0666"
+''
+# or
+services.mosquitto = {
+    enable = true;
+    host = "0.0.0.0";
+    allowAnonymous = true;
+    users = {};
+  };
+```
+
+A README.md file along your *my_package*.nix will make your Nix friends very happy and productive, and will greatly reduce the uncertainty and/or confusion of installing and testing the software you have so kindly made available through Nix.
+
 ## Reviewing contributions
 
 See the nixpkgs manual for more details on how to [Review contributions](https://nixos.org/nixpkgs/manual/#sec-reviewing-contributions).

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ For pull requests, please rebase onto nixpkgs `master`.
 * [Continuous package builds for 18.09 release](https://hydra.nixos.org/jobset/nixos/release-18.09)
 * [Tests for unstable/master](https://hydra.nixos.org/job/nixos/trunk-combined/tested#tabs-constituents)
 * [Tests for 18.09 release](https://hydra.nixos.org/job/nixos/release-18.09/tested#tabs-constituents)
+* [Contributing](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md)
 
 Communication:
 


### PR DESCRIPTION
###### Motivation for this change

I would like to encourage devs contributing to Nixpkgs repositories to add a README.md for any package that requires configuration. I learnt a great deal about Nix and NixOS in the past 2 weeks, since I dove head-first, thanks to the great design of the package manager and the OS, and the discussions and contributions, but in many cases it would be a better user experience, for noobs in Nix or linux, to have a proper documentation page appended to the nix package/derivation in Github.

This definitely applies to packages that require a config file or one that add a systemd service or udev rules.
Now, the nix derivations are not impossible to read, but for a non-Haskell or a new user, it's a bit tough to figure out where (local .nixpkgs/config.nix or /etc/nixos/configuration.nix) and how to structure/setup the configuration. I have seen a few packages have some #configuration block at the bottom of the nix file but it wouldn't take much effort to have a nicely formatted and simple documentation.

I also think this will greatly reduce the learning curve and teach new comers the proper and (hopefully) standardize way to install and setup packages in Nix or NixOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

