### PR TITLE
nginx: add http subs filter module

### DIFF
--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -243,6 +243,15 @@
     };
   };
 
+  subsFilter = {
+    src = fetchFromGitHub {
+      owner = "yaoweibin";
+      repo = "ngx_http_substitutions_filter_module";
+      rev = "v0.6.4";
+      sha256 = "0q86cv0mfffh43id5xanywyhpd7b0jijrmk8y311c13l9ajrd2rx";
+    };
+  };
+
   sysguard = {
     src = fetchFromGitHub {
       owner = "vozlt";


### PR DESCRIPTION
###### Motivation for this change

We use this module: https://github.com/yaoweibin/ngx_http_substitutions_filter_module/tree/v0.6.4
In production on our nginx proxy layer. We are currently switching to NixOS and so I thought it would be helpful to others as well if we included it in the nginxModules package set.

###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

