### PR TITLE
wireless-tools: 30.pre2 -> 30.pre9

### DIFF
--- a/pkgs/os-specific/linux/wireless-tools/default.nix
+++ b/pkgs/os-specific/linux/wireless-tools/default.nix
@@ -1,17 +1,21 @@
 {stdenv, fetchurl}:
 
 stdenv.mkDerivation rec {
-  name = "wireless-tools-${version}";
-  version = "30.pre2";
+  pname = "wireless-tools";
+  version = "30.pre9";
 
   src = fetchurl {
     url = "http://www.hpl.hp.com/personal/Jean_Tourrilhes/Linux/wireless_tools.${version}.tar.gz";
-    sha256 = "01lgf592nk8fnk7l5afqvar4szkngwpgcv4xh58qsg9wkkjlhnls";
+    sha256 = "0qscyd44jmhs4k32ggp107hlym1pcyjzihiai48xs7xzib4wbndb";
   };
 
-  preBuild = "
-    makeFlagsArray=(PREFIX=$out CC=$CC LDCONFIG=: AR=$AR RANLIB=$RANLIB)
-  ";
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+    "CC:=$(CC)"
+    "AR:=$(AR)"
+    "RANLIB:=$(RANLIB)"
+    "LDCONFIG=:"
+  ];
 
   meta = {
     platforms = stdenv.lib.platforms.linux;


### PR DESCRIPTION
###### Motivation for this change


* 30.pre2 source is no longer available, apparently

Since changelog seems to be only inside the sources,
here's the diff from pre2 to pre9's CHANGELOG.h:

    ---
    o When using takeover, redo probing in case eth0 was in use [ifrename]
    o Update Hotplug documentation, add uDev bits [HOTPLUG-UDEV.txt]
    o Add ESSID bug patches and documentation [ESSID-BUG.txt]
    o Make wireless.21.h LGPL as promised a long time ago [wireless.21.h]
    ---
    	(Bug reported by Shaddy Baddah)
    o Fix unaligned access on SPARC in the 64->32 bit workaround [iwlib.c]
    ---
    	(From Maxime Charpenne <maxime.charpenne@free.fr>)
    o Mise à jour de la traduction en francais des pages manuel [fr/*]
    ---
    o Use wireless.22.h, make it LGPL [iwlib.h/wireless.22.h]
    o Show Scanning Capabilities in "iwlist event" [iwlist]
    	(Bug reported by Nikita Zhernosenko)
    o Fix parsing of retry/power when modifier is used [iwconfig]
    	(Bug reported by Alexis Phoenix)
    o Remove trailing '/' in INSTALL_* that fooled checkinstall [Makefile]
    	(From Dan Williams <dcbw@redhat.com>)
    o Scan capabilities in struct iw_range [wireless.h]
    	(From Guus Sliepen <guus@debian.org>)
    o Install localised man page [Makefile]
    ---
    o Fix #define that broke 32->64 bit workaround [wireless.22.h]
    o Workaround kernel bug when getting ESSID [iwlib/iwconfig/iwgetid]
    	(From Gerald Pfeifer  <gerald@pfeifer.com>)
    o Fix gramar in man page, add about hidden networks [iwlist.8]
    ---
    	(From Reinette Chatre <reinette.chatre@intel.com>)
    o Enable scan buffer to grow up to 65535 instead of 32768 [iwlist]
    o Return a proper error if scan result exceed buffer max [iwlist]
    	(From Jean Tourrilhes)
    o Do above two fixes for the simple scan API [iwlib]
    	(From Claudio Ferronato <claiudio@libero.it>)
    o Spelling and typos in [iwconfig.8]
    ---
    o Create iwlib-private.h to minimise namespace pollution [iwlib]
    o More fix to the 64->32bit band-aid for encode [iwlib]
    o Update udev rule to remove a warning [19-udev-ifrename.rules]
    	(from Ritesh Raj Sarraf <rrs@researchut.com> and Guus Sliepen)
    o Propagate error codes out of main for get [iwconfig/iwlist/iwspy]
    	(From Guus Sliepen <guus@debian.org>)
    o Remove spurious commands from Czech iwconfig manpage.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---