### PR TITLE
qtbase: let build use gold linker if it wants, maybe works now

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -301,7 +301,6 @@ stdenv.mkDerivation {
       then
         [
           "-platform macx-clang"
-          "-no-use-gold-linker"
           "-no-fontconfig"
           "-qt-freetype"
           "-qt-libpng"
@@ -329,9 +328,6 @@ stdenv.mkDerivation {
           "-glib"
           "-system-libjpeg"
           "-system-libpng"
-          # gold linker of binutils 2.28 generates duplicate symbols
-          # TODO: remove for newer version of binutils
-          "-no-use-gold-linker"
         ]
         ++ lib.optional withGtk3 "-gtk"
         ++ lib.optional (compareVersion "5.9.0" >= 0) "-inotify"


### PR DESCRIPTION
###### Motivation for this change

Remove configure flags forcing qtbase to not use gold linker,
inspired by comment above the flag indicating this is likely specific
to binutils 2.28 (we're currently on 2.31).

Builds for me as does the package set for my day-to-day NixOS system,
so if there's a problem it's not causing complete breakage.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---