### PR TITLE
.github/CODEOWNERS: remove @ryantm from haskell

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -58,11 +58,11 @@
 /doc/languages-frameworks/python.section.md     @FRidh
 
 # Haskell
-/pkgs/development/compilers/ghc                       @peti @ryantm @basvandijk
-/pkgs/development/haskell-modules                     @peti @ryantm @basvandijk
-/pkgs/development/haskell-modules/default.nix         @peti @ryantm @basvandijk
-/pkgs/development/haskell-modules/generic-builder.nix @peti @ryantm @basvandijk
-/pkgs/development/haskell-modules/hoogle.nix          @peti @ryantm @basvandijk
+/pkgs/development/compilers/ghc                       @peti @basvandijk
+/pkgs/development/haskell-modules                     @peti @basvandijk
+/pkgs/development/haskell-modules/default.nix         @peti @basvandijk
+/pkgs/development/haskell-modules/generic-builder.nix @peti @basvandijk
+/pkgs/development/haskell-modules/hoogle.nix          @peti @basvandijk
 
 # Perl
 /pkgs/development/interpreters/perl @volth


### PR DESCRIPTION
I'm happy to keep helping out with Haskell infrastructure where I can,
but I don't have a good system for handling the accidental codeowner
pings caused by target branch switches.

cc @peti @basvandijk 