### PR TITLE
plex: rewrite to use FHS userenv

### DIFF
--- a/pkgs/servers/plex/raw.nix
+++ b/pkgs/servers/plex/raw.nix
@@ -1,0 +1,70 @@
+{ stdenv
+, fetchurl
+, rpmextract
+}:
+
+# The raw package that fetches and extracts the Plex RPM. Override the source
+# and version of this derivation if you want to use a Plex Pass version of the
+# server, and the FHS userenv and corresponding NixOS module should
+# automatically pick up the changes.
+stdenv.mkDerivation rec {
+  version = "1.15.3.876-ad6e39743";
+  pname = "plexmediaserver";
+  name = "${pname}-${version}";
+
+  # Fetch the source
+  src = fetchurl {
+    url = "https://downloads.plex.tv/plex-media-server-new/${version}/redhat/plexmediaserver-${version}.x86_64.rpm";
+    sha256 = "01g7wccm01kg3nhf3qrmwcn20nkpv0bqz6zqv2gq5v03ps58h6g5";
+  };
+
+  outputs = [ "out" "basedb" ];
+
+  nativeBuildInputs = [ rpmextract ];
+
+  phases = [ "unpackPhase" "installPhase" "fixupPhase" "distPhase" ];
+
+  unpackPhase = ''
+    rpmextract $src
+  '';
+
+  installPhase = ''
+    mkdir -p "$out/lib"
+    cp -dr --no-preserve='ownership' usr/lib/plexmediaserver $out/lib/
+
+    # Location of the initial Plex plugins database
+    f=$out/lib/plexmediaserver/Resources/com.plexapp.plugins.library.db
+
+    # Store the base database in the 'basedb' output
+    cat $f > $basedb
+
+    # Overwrite the base database in the Plex package with an absolute symlink
+    # to the '/db' file; we create this path in the FHS userenv (see the "plex"
+    # package).
+    ln -fs /db $f
+  '';
+
+  # We're running in a FHS userenv; don't patch anything
+  dontPatchShebangs = true;
+  dontStrip = true;
+  dontPatchELF = true;
+  dontAutoPatchelf = true;
+
+  meta = with stdenv.lib; {
+    homepage = https://plex.tv/;
+    license = licenses.unfree;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [
+      colemickens
+      forkk
+      lnl7
+      pjones
+      thoughtpolice
+    ];
+    description = "Media library streaming server";
+    longDescription = ''
+      Plex is a media server which allows you to store your media and play it
+      back across many different devices.
+    '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5103,6 +5103,7 @@ in
   playbar2 = libsForQt5.callPackage ../applications/audio/playbar2 { };
 
   plex = callPackage ../servers/plex { };
+  plexRaw = callPackage ../servers/plex/raw.nix { };
 
   tautulli = callPackage ../servers/tautulli { python = python2; };
 


### PR DESCRIPTION
###### Motivation for this change
This PR attempts to rewrite the Plex derivation and NixOS module to use `buildFHSUserEnv`. Plex downloads binary codecs from the internet and runs them, and this prevents errors when that happens. This PR is an alternative to #48506 that maintains compatibility with the previous Plex `dataDir` option.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

###### Remaining questions
- We now default to a `dataDir` in `$HOME` if none is given to the FHS userenv, since that feels less likely to break without running as elevated permisisons (though the NixOS module keeps the previous default). Does this make sense?
- Is there a nicer way to do the `plex` / `plexRaw` split that still allows overriding `plexRaw.src` for Plex Pass users?
- Does this sound sensible?

cc @yegortimoshenko @colemickens @dywedir @Forkk @LnL7 @pjones @thoughtpolice 