### PR TITLE
rust: 1.32.0 -> 1.33.0

### DIFF
--- a/pkgs/development/compilers/rust/bootstrap.nix
+++ b/pkgs/development/compilers/rust/bootstrap.nix
@@ -3,16 +3,16 @@
 let
   # Note: the version MUST be one version prior to the version we're
   # building
-  version = "1.31.1";
+  version = "1.32.0";
 
-  # fetch hashes by running `print-hashes.sh 1.31.1`
+  # fetch hashes by running `print-hashes.sh 1.32.0`
   hashes = {
-    i686-unknown-linux-gnu = "1e77e5e8c745320faad9ce6f319a77b4a2e75d972eb68a195acd081ad910ab6d";
-    x86_64-unknown-linux-gnu = "a64685535d0c457f49a8712a096a5c21564cd66fd2f7da739487f028192ebe3c";
-    armv7-unknown-linux-gnueabihf = "11c717b781a7af5bdc829894139f8f45d4c12a061f7f9e39481f21426a04eb21";
-    aarch64-unknown-linux-gnu = "29a7c6eb536fefd0ca459e48dfaea006aa8bff8a87aa82a9b7d483487033632a";
-    i686-apple-darwin = "46566dc25fcbd8badc9950b8c9f9b0faeca065b5a09cd96258e4f4b10d686aed";
-    x86_64-apple-darwin = "8398b1b303bdf0e7605d08b87070a514a4f588797c6fb3593718cb9cec233ad6";
+    i686-unknown-linux-gnu = "4ce3a6a656669fa86606074b43fadeac7465ef48394249407e21106ed714c8db";
+    x86_64-unknown-linux-gnu = "e024698320d76b74daf0e6e71be3681a1e7923122e3ebd03673fcac3ecc23810";
+    armv7-unknown-linux-gnueabihf = "d7b69f60689d2905d8d3c2829b0f1cd0f86265a255ff88ea0deb601aebac6428";
+    aarch64-unknown-linux-gnu = "60def40961728212da4b3a9767d5a2ddb748400e150a5f8a6d5aa0e1b8ba1cee";
+    i686-apple-darwin = "76cc1280f6b61bf7cf1fddd5202cc236db7573ee05f39fc8cd12ddda8f39a7c3";
+    x86_64-apple-darwin = "f0dfba507192f9b5c330b5984ba71d57d434475f3d62bd44a39201e36fa76304";
   };
 
   platform =

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -7,11 +7,11 @@
 
 let
   rustPlatform = recurseIntoAttrs (makeRustPlatform (callPackage ./bootstrap.nix {}));
-  version = "1.32.0";
-  cargoVersion = "1.32.0";
+  version = "1.33.0";
+  cargoVersion = "1.33.0";
   src = fetchurl {
     url = "https://static.rust-lang.org/dist/rustc-${version}-src.tar.gz";
-    sha256 = "0ji2l9xv53y27xy72qagggvq47gayr5lcv2jwvmfirx029vlqnac";
+    sha256 = "152x91mg7bz4ygligwjb05fgm1blwy2i70s2j03zc9jiwvbsh0as";
   };
 in rec {
   rustc = callPackage ./rustc.nix {

--- a/pkgs/development/compilers/rust/patches/net-tcp-disable-tests.patch
+++ b/pkgs/development/compilers/rust/patches/net-tcp-disable-tests.patch
@@ -1,8 +1,8 @@
 diff --git a/src/libstd/net/tcp.rs b/src/libstd/net/tcp.rs
-index 0f60b5b3e..9b08415e7 100644
+index 86ecb10edf..626be0a52d 100644
 --- a/src/libstd/net/tcp.rs
 +++ b/src/libstd/net/tcp.rs
-@@ -962,6 +962,7 @@ mod tests {
+@@ -955,6 +955,7 @@ mod tests {
          }
      }
  
@@ -10,7 +10,7 @@ index 0f60b5b3e..9b08415e7 100644
      #[test]
      fn listen_localhost() {
          let socket_addr = next_test_ip4();
-@@ -1020,6 +1021,7 @@ mod tests {
+@@ -1013,6 +1014,7 @@ mod tests {
          })
      }
  
@@ -18,7 +18,7 @@ index 0f60b5b3e..9b08415e7 100644
      #[test]
      fn read_eof() {
          each_ip(&mut |addr| {
-@@ -1039,6 +1041,7 @@ mod tests {
+@@ -1032,6 +1034,7 @@ mod tests {
          })
      }
  
@@ -26,7 +26,7 @@ index 0f60b5b3e..9b08415e7 100644
      #[test]
      fn write_close() {
          each_ip(&mut |addr| {
-@@ -1065,6 +1068,7 @@ mod tests {
+@@ -1058,6 +1061,7 @@ mod tests {
          })
      }
  
@@ -34,7 +34,7 @@ index 0f60b5b3e..9b08415e7 100644
      #[test]
      fn multiple_connect_serial() {
          each_ip(&mut |addr| {
-@@ -1087,6 +1091,7 @@ mod tests {
+@@ -1080,6 +1084,7 @@ mod tests {
          })
      }
  
@@ -42,7 +42,7 @@ index 0f60b5b3e..9b08415e7 100644
      #[test]
      fn multiple_connect_interleaved_greedy_schedule() {
          const MAX: usize = 10;
-@@ -1123,6 +1128,7 @@ mod tests {
+@@ -1116,6 +1121,7 @@ mod tests {
      }
  
      #[test]
@@ -50,7 +50,7 @@ index 0f60b5b3e..9b08415e7 100644
      fn multiple_connect_interleaved_lazy_schedule() {
          const MAX: usize = 10;
          each_ip(&mut |addr| {
-@@ -1401,6 +1407,7 @@ mod tests {
+@@ -1394,6 +1400,7 @@ mod tests {
      }
  
      #[test]
@@ -58,7 +58,7 @@ index 0f60b5b3e..9b08415e7 100644
      fn clone_while_reading() {
          each_ip(&mut |addr| {
              let accept = t!(TcpListener::bind(&addr));
-@@ -1421,7 +1422,10 @@ mod tests {
+@@ -1504,7 +1511,10 @@ mod tests {
  
      // FIXME: re-enabled bitrig/openbsd tests once their socket timeout code
      //        no longer has rounding errors.
@@ -70,7 +70,7 @@ index 0f60b5b3e..9b08415e7 100644
      #[test]
      fn timeouts() {
          let addr = next_test_ip4();
-@@ -1596,6 +1603,7 @@ mod tests {
+@@ -1591,6 +1601,7 @@ mod tests {
          drop(listener);
      }
  
@@ -78,7 +78,7 @@ index 0f60b5b3e..9b08415e7 100644
      #[test]
      fn nodelay() {
          let addr = next_test_ip4();
-@@ -1610,6 +1618,7 @@ mod tests {
+@@ -1605,6 +1616,7 @@ mod tests {
          assert_eq!(false, t!(stream.nodelay()));
      }
  
@@ -86,7 +86,7 @@ index 0f60b5b3e..9b08415e7 100644
      #[test]
      fn ttl() {
          let ttl = 100;
-@@ -1647,6 +1656,7 @@ mod tests {
+@@ -1642,6 +1654,7 @@ mod tests {
          }
      }
  
@@ -94,11 +94,3 @@ index 0f60b5b3e..9b08415e7 100644
      #[test]
      fn peek() {
          each_ip(&mut |addr| {
-@@ -1679,6 +1689,7 @@ mod tests {
-     }
- 
-     #[test]
-+    #[cfg_attr(any(target_os = "linux", target_os = "macos"), ignore)]
-     fn connect_timeout_unroutable() {
-         // this IP is unroutable, so connections should always time out,
-         // provided the network is reachable to begin with.


### PR DESCRIPTION
###### Motivation for this change
Bump rust to 1.33.0

Tested on internal rust project and random crates in the tree.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

