### PR TITLE
arangodb: 3.3.19 -> 3.2.18, 3.3.23.1, 3.4.7, 3.5.0-rc.7

### DIFF
--- a/pkgs/servers/nosql/arangodb/default.nix
+++ b/pkgs/servers/nosql/arangodb/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchFromGitHub, openssl, zlib, cmake, python2, perl, snappy, lzo, which }:
 
 let
-  common = { version, sha256, platforms }: stdenv.mkDerivation {
+  common = { version, sha256 }: stdenv.mkDerivation {
     pname = "arangodb";
     inherit version;
 
@@ -29,20 +29,18 @@ let
     '';
 
     cmakeFlags = [
-      # do not set GCC's -march=xxx based on builder's /proc/cpuifo
-      # `stdenv.hostPlatform.platform.gcc.arch` goes to -march= the usual way
+      # do not set GCC's -march=xxx based on builder's /proc/cpuinfo
       "-DUSE_OPTIMIZE_FOR_ARCHITECTURE=OFF"
       # also avoid using builder's /proc/cpuinfo
-      "-DHAVE_SSE42=${ { "westmere"       = "ON";
-                         "sandybridge"    = "ON";
-                         "ivybridge"      = "ON";
-                         "haswell"        = "ON";
-                         "broadwell"      = "ON";
-                         "skylake"        = "ON";
-                         "skylake-avx512" = "ON";
-                       }.${stdenv.hostPlatform.platform.gcc.arch or ""} or "OFF"
-                     }"
-    ];
+    ] ++
+    { "westmere"       = [ "-DHAVE_SSE42=ON" "-DASM_OPTIMIZATIONS=ON" ];
+      "sandybridge"    = [ "-DHAVE_SSE42=ON" "-DASM_OPTIMIZATIONS=ON" ];
+      "ivybridge"      = [ "-DHAVE_SSE42=ON" "-DASM_OPTIMIZATIONS=ON" ];
+      "haswell"        = [ "-DHAVE_SSE42=ON" "-DASM_OPTIMIZATIONS=ON" ];
+      "broadwell"      = [ "-DHAVE_SSE42=ON" "-DASM_OPTIMIZATIONS=ON" ];
+      "skylake"        = [ "-DHAVE_SSE42=ON" "-DASM_OPTIMIZATIONS=ON" ];
+      "skylake-avx512" = [ "-DHAVE_SSE42=ON" "-DASM_OPTIMIZATIONS=ON" ];
+    }.${stdenv.hostPlatform.platform.gcc.arch or ""} or [ "-DHAVE_SSE42=OFF" "-DASM_OPTIMIZATIONS=OFF" ];
 
     enableParallelBuilding = true;
 
@@ -50,13 +48,13 @@ let
       homepage = https://www.arangodb.com;
       description = "A native multi-model database with flexible data models for documents, graphs, and key-values";
       license = licenses.asl20;
-      inherit platforms;
+      platforms = platforms.linux;
       maintainers = [ maintainers.flosse ];
     };
   };
 in {
-  arangodb_3_2 = common { version = "3.2.18";     sha256 = "05mfrx1g6dh1bzzqs23nvk0rg3v8y2dhdam4lym55pzlhqa7lf0x"; platforms = lib.platforms.linux; };
-  arangodb_3_3 = common { version = "3.3.23.1";   sha256 = "0bnbiispids7jcgrgcmanf9jqgvk0vaflrvgalz587jwr2zf21k8"; platforms = lib.platforms.linux; };
-  arangodb_3_4 = common { version = "3.4.7";      sha256 = "1wr2xvi5lnl6f2ryyxdwn4wnfiaz0rrf58ja1k19m7b6w3264iim"; platforms = lib.platforms.linux; };
-  arangodb_3_5 = common { version = "3.5.0-rc.7"; sha256 = "1sdmbmyml9d3ia3706bv5901qqmh4sxk7js5b9hyfjqpcib10d1k"; platforms = [ "x86_64-linux" ];  }; # "aarch64-linux" fails with "fatal error: x86intrin.h: No such file or directory"
+  arangodb_3_2 = common { version = "3.2.18";     sha256 = "05mfrx1g6dh1bzzqs23nvk0rg3v8y2dhdam4lym55pzlhqa7lf0x"; };
+  arangodb_3_3 = common { version = "3.3.23.1";   sha256 = "0bnbiispids7jcgrgcmanf9jqgvk0vaflrvgalz587jwr2zf21k8"; };
+  arangodb_3_4 = common { version = "3.4.7";      sha256 = "1wr2xvi5lnl6f2ryyxdwn4wnfiaz0rrf58ja1k19m7b6w3264iim"; };
+  arangodb_3_5 = common { version = "3.5.0-rc.7"; sha256 = "1sdmbmyml9d3ia3706bv5901qqmh4sxk7js5b9hyfjqpcib10d1k"; };
 }

--- a/pkgs/servers/nosql/arangodb/default.nix
+++ b/pkgs/servers/nosql/arangodb/default.nix
@@ -1,39 +1,62 @@
-{ stdenv, fetchFromGitHub
-, openssl, zlib, readline, cmake, python }:
+{ stdenv, lib, fetchFromGitHub, openssl, zlib, cmake, python2, perl, snappy, lzo, which }:
 
 let
-in stdenv.mkDerivation rec {
-  version = "3.3.19";
-  name    = "arangodb-${version}";
+  common = { version, sha256, platforms }: stdenv.mkDerivation {
+    pname = "arangodb";
+    inherit version;
 
-  src = fetchFromGitHub {
-    repo = "arangodb";
-    owner = "arangodb";
-    rev = "v${version}";
-    sha256 = "1qg4lqnn5x0xsmkq41mjj301mfh76r8ys1rkzhinxlq30jld3155";
+    src = fetchFromGitHub {
+      repo = "arangodb";
+      owner = "arangodb";
+      rev = "v${version}";
+      inherit sha256;
+    };
+
+    nativeBuildInputs = [ cmake python2 perl which ];
+    buildInputs = [ openssl zlib snappy lzo ];
+
+    # prevent failing with "cmake-3.13.4/nix-support/setup-hook: line 10: ./3rdParty/rocksdb/RocksDBConfig.cmake.in: No such file or directory"
+    dontFixCmake       =                     lib.versionAtLeast version "3.5";
+    NIX_CFLAGS_COMPILE = lib.optionals      (lib.versionAtLeast version "3.5") [ "-Wno-error" ];
+    preConfigure       = lib.optionalString (lib.versionAtLeast version "3.5") "patchShebangs utils";
+
+    postPatch = ''
+      sed -ie 's!/bin/echo!echo!' 3rdParty/V8/v*/gypfiles/*.gypi
+
+      # with nixpkgs, it has no sense to check for a version update
+      substituteInPlace js/client/client.js --replace "require('@arangodb').checkAvailableVersions();" ""
+      substituteInPlace js/server/server.js --replace "require('@arangodb').checkAvailableVersions();" ""
+    '';
+
+    cmakeFlags = [
+      # do not set GCC's -march=xxx based on builder's /proc/cpuifo
+      # `stdenv.hostPlatform.platform.gcc.arch` goes to -march= the usual way
+      "-DUSE_OPTIMIZE_FOR_ARCHITECTURE=OFF"
+      # also avoid using builder's /proc/cpuinfo
+      "-DHAVE_SSE42=${ { "westmere"       = "ON";
+                         "sandybridge"    = "ON";
+                         "ivybridge"      = "ON";
+                         "haswell"        = "ON";
+                         "broadwell"      = "ON";
+                         "skylake"        = "ON";
+                         "skylake-avx512" = "ON";
+                       }.${stdenv.hostPlatform.platform.gcc.arch or ""} or "OFF"
+                     }"
+    ];
+
+    enableParallelBuilding = true;
+
+    meta = with lib; {
+      homepage = https://www.arangodb.com;
+      description = "A native multi-model database with flexible data models for documents, graphs, and key-values";
+      license = licenses.asl20;
+      inherit platforms;
+      maintainers = [ maintainers.flosse ];
+    };
   };
-
-  buildInputs = [
-    openssl zlib readline python
-  ];
-
-  nativeBuildInputs = [ cmake ];
-
-  postPatch = ''
-    sed -ie 's!/bin/echo!echo!' 3rdParty/V8/v*/gypfiles/*.gypi
-  '';
-
-  configureFlagsArray = [ "--with-openssl-lib=${openssl.out}/lib" ];
-
-  NIX_CFLAGS_COMPILE = "-Wno-error=strict-overflow";
-
-  enableParallelBuilding = true;
-
-  meta = with stdenv.lib; {
-    homepage = https://github.com/arangodb/arangodb;
-    description = "A native multi-model database with flexible data models for documents, graphs, and key-values";
-    license = licenses.asl20;
-    platforms = platforms.linux;
-    maintainers = [ maintainers.flosse ];
-  };
+in {
+  arangodb_3_2 = common { version = "3.2.18";     sha256 = "05mfrx1g6dh1bzzqs23nvk0rg3v8y2dhdam4lym55pzlhqa7lf0x"; platforms = lib.platforms.linux; };
+  arangodb_3_3 = common { version = "3.3.23.1";   sha256 = "0bnbiispids7jcgrgcmanf9jqgvk0vaflrvgalz587jwr2zf21k8"; platforms = lib.platforms.linux; };
+  arangodb_3_4 = common { version = "3.4.7";      sha256 = "1wr2xvi5lnl6f2ryyxdwn4wnfiaz0rrf58ja1k19m7b6w3264iim"; platforms = lib.platforms.linux; };
+  arangodb_3_5 = common { version = "3.5.0-rc.7"; sha256 = "1sdmbmyml9d3ia3706bv5901qqmh4sxk7js5b9hyfjqpcib10d1k"; platforms = [ "x86_64-linux" ];  }; # "aarch64-linux" fails with "fatal error: x86intrin.h: No such file or directory"
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -573,7 +573,8 @@ in
 
   arandr = callPackage ../tools/X11/arandr { };
 
-  arangodb = callPackage ../servers/nosql/arangodb { };
+  inherit (callPackages ../servers/nosql/arangodb { }) arangodb_3_2 arangodb_3_3 arangodb_3_4 arangodb_3_5;
+  arangodb = arangodb_3_4;
 
   arcanist = callPackage ../development/tools/misc/arcanist {};
 


### PR DESCRIPTION
###### Motivation for this change

- [x] update version
- [x] follow all three branches (```3.2.x```, ```3.3.x``` and ```3.4.x```) currently supported by upstream (all the minor versions [are younger than 1 month](https://github.com/arangodb/arangodb/releases))

It depends on #59148 (it is used in a fork where #59148 is backported from)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc maintainer @flosse 