### PR TITLE
mosquitto: 1.5.4 -> 1.5.8

### DIFF
--- a/pkgs/servers/mqtt/mosquitto/default.nix
+++ b/pkgs/servers/mqtt/mosquitto/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "mosquitto-${version}";
-  version = "1.5.4";
+  version = "1.5.5";
 
   src = fetchFromGitHub {
     owner  = "eclipse";
     repo   = "mosquitto";
     rev    = "v${version}";
-    sha256 = "0pb38y6m682xqrkzhp41mj54x5ic43761xzschgnw055mzksbgk2";
+    sha256 = "1sfwmvrglfy5gqfk004kvbjldqr36dqz6xmppbgfhr47j5zs66xc";
   };
 
   postPatch = ''

--- a/pkgs/servers/mqtt/mosquitto/default.nix
+++ b/pkgs/servers/mqtt/mosquitto/default.nix
@@ -1,20 +1,27 @@
-{ stdenv, fetchFromGitHub, fetchpatch, cmake, docbook_xsl, libxslt
-, openssl, libuuid, libwebsockets, c-ares, libuv }:
+{ stdenv, lib, fetchFromGitHub, fetchpatch, cmake, docbook_xsl, libxslt
+, openssl, libuuid, libwebsockets, c-ares, libuv
+, systemd ? null }:
 
 stdenv.mkDerivation rec {
   name = "mosquitto-${version}";
-  version = "1.5.5";
+  version = "1.5.8";
 
   src = fetchFromGitHub {
     owner  = "eclipse";
     repo   = "mosquitto";
     rev    = "v${version}";
-    sha256 = "1sfwmvrglfy5gqfk004kvbjldqr36dqz6xmppbgfhr47j5zs66xc";
+    sha256 = "1rf8g6fq7g1mhwsajsgvvlynasybgc51v0qg5j6ynsxfh8yi7s6r";
   };
 
   postPatch = ''
-    substituteInPlace man/manpage.xsl \
-      --replace /usr/share/xml/docbook/stylesheet/ ${docbook_xsl}/share/xml/
+    for f in html manpage ; do
+      substituteInPlace man/$f.xsl \
+        --replace http://docbook.sourceforge.net/release/xsl/current ${docbook_xsl}/share/xml/docbook-xsl
+    done
+
+    for f in {lib,lib/cpp,src}/CMakeLists.txt ; do
+      substituteInPlace $f --replace /sbin/ldconfig true
+    done
 
     # the manpages are not generated when using cmake
     pushd man
@@ -22,7 +29,9 @@ stdenv.mkDerivation rec {
     popd
   '';
 
-  buildInputs = [ openssl libuuid libwebsockets c-ares libuv ];
+  buildInputs = [
+    openssl libuuid libwebsockets c-ares libuv
+  ];
 
   nativeBuildInputs = [ cmake docbook_xsl libxslt ];
 
@@ -30,6 +39,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DWITH_THREADING=ON"
+    "-DWITH_WEBSOCKETS=ON"
   ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

A few nasty CVEs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

