### PR TITLE
mailcatcher: 0.6.5 -> 0.7.1

### DIFF
--- a/pkgs/development/web/mailcatcher/Gemfile.lock
+++ b/pkgs/development/web/mailcatcher/Gemfile.lock
@@ -1,11 +1,11 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    daemons (1.2.4)
+    daemons (1.3.1)
     eventmachine (1.0.9.1)
-    mail (2.6.6)
-      mime-types (>= 1.16, < 4)
-    mailcatcher (0.6.5)
+    mail (2.7.1)
+      mini_mime (>= 0.1.1)
+    mailcatcher (0.7.1)
       eventmachine (= 1.0.9.1)
       mail (~> 2.3)
       rack (~> 1.5)
@@ -13,11 +13,9 @@ GEM
       skinny (~> 0.2.3)
       sqlite3 (~> 1.3)
       thin (~> 1.5.0)
-    mime-types (3.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0521)
+    mini_mime (1.0.1)
     rack (1.6.11)
-    rack-protection (1.5.3)
+    rack-protection (1.5.5)
       rack
     sinatra (1.4.8)
       rack (~> 1.5)
@@ -26,12 +24,12 @@ GEM
     skinny (0.2.4)
       eventmachine (~> 1.0.0)
       thin (>= 1.5, < 1.7)
-    sqlite3 (1.3.13)
+    sqlite3 (1.4.0)
     thin (1.5.1)
       daemons (>= 1.0.9)
       eventmachine (>= 0.12.6)
       rack (>= 1.0.0)
-    tilt (2.0.7)
+    tilt (2.0.9)
 
 PLATFORMS
   ruby
@@ -40,4 +38,4 @@ DEPENDENCIES
   mailcatcher
 
 BUNDLED WITH
-   1.16.4
+   1.17.2

--- a/pkgs/development/web/mailcatcher/gemset.nix
+++ b/pkgs/development/web/mailcatcher/gemset.nix
@@ -1,13 +1,17 @@
 {
   daemons = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1bmb4qrd95b5gl3ym5j3q6mf090209f4vkczggn49n56w6s6zldz";
+      sha256 = "0l5gai3vd4g7aqff0k1mp41j9zcsvm2rbwmqn115a325k9r7pf4w";
       type = "gem";
     };
-    version = "1.2.4";
+    version = "1.3.1";
   };
   eventmachine = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "17jr1caa3ggg696dd02g2zqzdjqj9x9q2nl7va82l36f7c5v6k4z";
@@ -16,41 +20,40 @@
     version = "1.0.9.1";
   };
   mail = {
-    dependencies = ["mime-types"];
+    dependencies = ["mini_mime"];
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0d7lhj2dw52ycls6xigkfz6zvfhc6qggply9iycjmcyj9760yvz9";
+      sha256 = "00wwz6ys0502dpk8xprwcqfwyf3hmnx6lgxaiq6vj43mkx43sapc";
       type = "gem";
     };
-    version = "2.6.6";
+    version = "2.7.1";
   };
   mailcatcher = {
     dependencies = ["eventmachine" "mail" "rack" "sinatra" "skinny" "sqlite3" "thin"];
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0h6gk8n18i5f651f244al1hscjzl27fpma4vqw0qhszqqpd5p3bx";
+      sha256 = "02w1ycyfv7x0sh9799lz7xa65p5qvl5z4pa8a7prb68h2zwkfq0n";
       type = "gem";
     };
-    version = "0.6.5";
+    version = "0.7.1";
   };
-  mime-types = {
-    dependencies = ["mime-types-data"];
+  mini_mime = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0087z9kbnlqhci7fxh9f6il63hj1k02icq2rs0c6cppmqchr753m";
+      sha256 = "1q4pshq387lzv9m39jv32vwb8wrq3wc4jwgl4jk209r4l33v09d3";
       type = "gem";
     };
-    version = "3.1";
-  };
-  mime-types-data = {
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "04my3746hwa4yvbx1ranhfaqkgf6vavi1kyijjnw8w3dy37vqhkm";
-      type = "gem";
-    };
-    version = "3.2016.0521";
+    version = "1.0.1";
   };
   rack = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1g9926ln2lw12lfxm4ylq1h6nl0rafl10za3xvjzc87qvnqic87f";
@@ -60,15 +63,19 @@
   };
   rack-protection = {
     dependencies = ["rack"];
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0cvb21zz7p9wy23wdav63z5qzfn4nialik22yqp6gihkgfqqrh5r";
+      sha256 = "0my0wlw4a5l3hs79jkx2xzv7djhajgf8d28k8ai1ddlnxxb0v7ss";
       type = "gem";
     };
-    version = "1.5.3";
+    version = "1.5.5";
   };
   sinatra = {
     dependencies = ["rack" "rack-protection" "tilt"];
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0byxzl7rx3ki0xd7aiv1x8mbah7hzd8f81l65nq8857kmgzj1jqq";
@@ -78,6 +85,8 @@
   };
   skinny = {
     dependencies = ["eventmachine" "thin"];
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1y3yvx88ylgz4d2s1wskjk5rkmrcr15q3ibzp1q88qwzr5y493a9";
@@ -86,15 +95,19 @@
     version = "0.2.4";
   };
   sqlite3 = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "01ifzp8nwzqppda419c9wcvr8n82ysmisrs0hph9pdmv1lpa4f5i";
+      sha256 = "0pmgpqx2sg8pms54rk7kjjy8jwsw21g1f7mb02fggbdcqy8jk3fx";
       type = "gem";
     };
-    version = "1.3.13";
+    version = "1.4.0";
   };
   thin = {
     dependencies = ["daemons" "eventmachine" "rack"];
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0hrq9m3hb6pm8yrqshhg0gafkphdpvwcqmr7k722kgdisp3w91ga";
@@ -103,11 +116,13 @@
     version = "1.5.1";
   };
   tilt = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1is1ayw5049z8pd7slsk870bddyy5g2imp4z78lnvl8qsl8l0s7b";
+      sha256 = "0ca4k0clwf0rkvy7726x4nxpjxkpv67w043i39saxgldxd97zmwz";
       type = "gem";
     };
-    version = "2.0.7";
+    version = "2.0.9";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

The new release of mailcatcher finally has proper UTF-8 support

###### Things done



- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

