### PR TITLE
forkstat, smemstat, stress-ng: bump various cking utils

### DIFF
--- a/pkgs/os-specific/linux/forkstat/default.nix
+++ b/pkgs/os-specific/linux/forkstat/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   name = "forkstat-${version}";
-  version = "0.02.03";
+  version = "0.02.09";
   src = fetchurl {
-    url = "http://kernel.ubuntu.com/~cking/tarballs/forkstat/forkstat-${version}.tar.gz";
-    sha256 = "1dl95ijs9bs9s9i629bi88qmvxjl25ym742gc063bysbp8drban1";
+    url = "http://kernel.ubuntu.com/~cking/tarballs/forkstat/forkstat-${version}.tar.xz";
+    sha256 = "1h5ha9w6rawh9kx39swjxs029202qxi0j9w38y7ilwq5pj447bxw";
   };
   installFlags = [ "DESTDIR=$(out)" ];
   postInstall = ''

--- a/pkgs/os-specific/linux/smemstat/default.nix
+++ b/pkgs/os-specific/linux/smemstat/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   name = "smemstat-${version}";
-  version = "0.02.00";
+  version = "0.02.03";
   src = fetchurl {
-    url = "http://kernel.ubuntu.com/~cking/tarballs/smemstat/smemstat-${version}.tar.gz";
-    sha256 = "16in8bzsrrcz7mc5qvyvjkxgpzz4bnq8zvkb7vsv6qfgyd3xr1dp";
+    url = "http://kernel.ubuntu.com/~cking/tarballs/smemstat/smemstat-${version}.tar.xz";
+    sha256 = "04q06wb37n4g1dlsjl8j2bwzd7qis4wanm0f4xg8y29br6skljx1";
   };
   buildInputs = [ ncurses ];
   installFlags = [ "DESTDIR=$(out)" ];

--- a/pkgs/tools/system/stress-ng/default.nix
+++ b/pkgs/tools/system/stress-ng/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "stress-ng-${version}";
-  version = "0.09.49";
+  version = "0.09.54";
 
   src = fetchurl {
     url = "https://kernel.ubuntu.com/~cking/tarballs/stress-ng/${name}.tar.xz";
-    sha256 = "1ll2i7vgnwpfhvq963m2aqwffkrmjggnscpmwn8qbdh0a82lmq2x";
+    sha256 = "0qbgabrxm8aj4a6bgf55mi7rv9sqcgl3kkm7j3qhkqjfn9rqzslb";
   };
 
   # All platforms inputs then Linux-only ones


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---