### PR TITLE
nixos/kubernetes: minor module fixes

### DIFF
--- a/nixos/modules/services/cluster/kubernetes/apiserver.nix
+++ b/nixos/modules/services/cluster/kubernetes/apiserver.nix
@@ -350,7 +350,7 @@ in
           listenPeerUrls = mkDefault ["https://0.0.0.0:2380"];
           advertiseClientUrls = mkDefault ["https://${top.masterAddress}:2379"];
           initialCluster = mkDefault ["${top.masterAddress}=https://${top.masterAddress}:2380"];
-          name = top.masterAddress;
+          name = mkDefault top.masterAddress;
           initialAdvertisePeerUrls = mkDefault ["https://${top.masterAddress}:2380"];
         };
 

--- a/nixos/modules/services/cluster/kubernetes/controller-manager.nix
+++ b/nixos/modules/services/cluster/kubernetes/controller-manager.nix
@@ -131,7 +131,7 @@ in
           ${optionalString (cfg.tlsCertFile!=null)
             "--tls-cert-file=${cfg.tlsCertFile}"} \
           ${optionalString (cfg.tlsKeyFile!=null)
-            "--tls-key-file=${cfg.tlsKeyFile}"} \
+            "--tls-private-key-file=${cfg.tlsKeyFile}"} \
           ${optionalString (elem "RBAC" top.apiserver.authorizationMode)
             "--use-service-account-credentials"} \
           ${optionalString (cfg.verbosity != null) "--v=${toString cfg.verbosity}"} \

--- a/nixos/modules/services/cluster/kubernetes/default.nix
+++ b/nixos/modules/services/cluster/kubernetes/default.nix
@@ -10,7 +10,7 @@ let
     kind = "Config";
     clusters = [{
       name = "local";
-      cluster.certificate-authority = cfg.caFile;
+      cluster.certificate-authority = conf.caFile or cfg.caFile;
       cluster.server = conf.server;
     }];
     users = [{


### PR DESCRIPTION
###### Motivation for this change

While testing the revamped kubernetes module on our existing staging cluster with `easyCerts` disabled, I discovered some minor flaws in the module:

1. The name of the etcd instance must be `mkDefault`'ed, because otherwise we risk overriding existing etcd cluster names, and that *could* potentially lead to cluster re-initiation on existing setups.

2. It's currently not possible to use the `kubernetes.lib.mkKubeConfig` function to generate a kubeconfig with a custom ca. It will always use the toplevel ca cert. This is fine for current easyCerts setup, where we don't have multiple CA's, but in existing setups this might cause problems. We

3. Turns out adding TLS-server certs to the controller manager was never done as part of the revamp and therefore we never discovered that the `--tls-key-file` flag on kube-controller-manager was named incorrectly. Similar flag names differ across various k8s components, but in this case it must be `--tls-private-key-file`. We should add TLS-serving certs to the controller-manager in another PR.

cc @fpletz for review
**please backport to 19.03** :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

