### PR TITLE
libosinfo: 1.2.0 -> 1.4.0

### DIFF
--- a/pkgs/data/misc/osinfo-db/default.nix
+++ b/pkgs/data/misc/osinfo-db/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchurl, osinfo-db-tools, intltool, libxml2 }:
 
 stdenv.mkDerivation rec {
-  name = "osinfo-db-20181214";
+  pname = "osinfo-db";
+  version = "20190301";
 
   src = fetchurl {
-    url = "https://releases.pagure.org/libosinfo/${name}.tar.xz";
-    sha256 = "18ym54wvhvjk66fqpsfvfd5b7d7743dvfqrcq91w1n71r20fkhcd";
+    url = "https://releases.pagure.org/libosinfo/${pname}-${version}.tar.xz";
+    sha256 = "1rjqizsglgdcjxi7kpbwm26krdkrlxacinjp9684sfzhqwdqi4as";
   };
 
   nativeBuildInputs = [ osinfo-db-tools intltool libxml2 ];

--- a/pkgs/development/libraries/libosinfo/default.nix
+++ b/pkgs/development/libraries/libosinfo/default.nix
@@ -3,11 +3,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "libosinfo-1.2.0";
+  name = "libosinfo-1.4.0";
 
   src = fetchurl {
     url = "https://releases.pagure.org/libosinfo/${name}.tar.gz";
-    sha256 = "0y2skfrcg38y212qqd26vs3sg566j3qnsgvvm23pfi4j7z7ly9gf";
+    sha256 = "0ra1p2rnnwkq0181ayn0l0rs1pvk4a0i8fa08nqjfmqs5fl637m2";
   };
 
   outputs = [ "out" "dev" "devdoc" ];
@@ -20,16 +20,6 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./osinfo-db-data-dir.patch
-    # Fix bug causing tests to fail (and presumably the real scenarios they're representative of)
-    # using upstream commits:
-    (fetchpatch {
-      url = "https://gitlab.com/libosinfo/libosinfo/commit/b9cb227842948b1b2289cdd3e9b8d925664c2ee7.patch";
-      sha256 = "0nj0wmibq52j8qbzmxfzj76fpkqjs18kssbb9lmfhz16s30darbw";
-    })
-    (fetchpatch {
-      url = "https://gitlab.com/libosinfo/libosinfo/commit/e6168463f4fc659b9827b5c8694dc1c6d7d5239a.patch";
-      sha256 = "135yfhjm2wxip5dnng3r9k9igfhdi1083ys4a4f3ipjxfskcs9rv";
-    })
   ];
 
   postPatch = ''

--- a/pkgs/tools/misc/osinfo-db-tools/default.nix
+++ b/pkgs/tools/misc/osinfo-db-tools/default.nix
@@ -1,17 +1,18 @@
 { stdenv, fetchurl, pkgconfig, intltool, glib, libxml2
-, libxslt, libarchive, bzip2, lzma
+, libxslt, libarchive, bzip2, lzma, json-glib
 }:
 
 stdenv.mkDerivation rec {
-  name = "osinfo-db-tools-1.2.0";
+  pname = "osinfo-db-tools";
+  version = "1.4.0";
 
   src = fetchurl {
-    url = "https://releases.pagure.org/libosinfo/${name}.tar.gz";
-    sha256 = "07zqbwsmdgnzqah2smm4zri04c0qm82z1jn8kzz1bnsqbfg84l1v";
+    url = "https://releases.pagure.org/libosinfo/${pname}-${version}.tar.gz";
+    sha256 = "08zpjq1g27n6wmmqwxws95w045warhg9bxcv1phvkdcrddf15q3y";
   };
 
   nativeBuildInputs = [ pkgconfig intltool ];
-  buildInputs = [ glib libxml2 libxslt libarchive bzip2 lzma ];
+  buildInputs = [ glib json-glib libxml2 libxslt libarchive bzip2 lzma ];
 
   meta = with stdenv.lib; {
     description = "Tools for managing the osinfo database";


### PR DESCRIPTION
###### Motivation for this change

Also update osinfo-db-tools and the osinfo-db data.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---