### PR TITLE
xpdf: added long description

### DIFF
--- a/pkgs/applications/misc/xpdf/default.nix
+++ b/pkgs/applications/misc/xpdf/default.nix
@@ -44,6 +44,19 @@ stdenv.mkDerivation {
   meta = with stdenv.lib; {
     homepage = https://www.xpdfreader.com;
     description = "Viewer for Portable Document Format (PDF) files";
+    longDescription = ''
+      XPDF includes multiple tools for viewing and processing PDF files.
+        xpdf:      PDF viewer (with Graphical Interface)
+        pdftotext: converts PDF to text
+        pdftops:   converts PDF to PostScript
+        pdftoppm:  converts PDF pages to netpbm (PPM/PGM/PBM) image files
+        pdftopng:  converts PDF pages to PNG image files
+        pdftohtml: converts PDF to HTML
+        pdfinfo:   extracts PDF metadata
+        pdfimages: extracts raw images from PDF files
+        pdffonts:  lists fonts used in PDF files
+        pdfdetach: extracts attached files from PDF files
+    '';
     license = with licenses; [ gpl2 gpl3 ];
     platforms = platforms.unix;
     maintainers = [ maintainers.peti ];


### PR DESCRIPTION
The added description will help folks who are looking for a specific tool to be directed here.
When looking for `texttopdf` it was a mild hassle to need to turn to google rather than nixpkgs to find the proper package.
When someone else had the same hassle just now in the IRC I thought I'd add this to help remedy others who are searching.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

