### PR TITLE
cryptsetup: 2.0.6 -> 2.1.0

### DIFF
--- a/pkgs/os-specific/linux/cryptsetup/default.nix
+++ b/pkgs/os-specific/linux/cryptsetup/default.nix
@@ -5,13 +5,13 @@
 assert enablePython -> python2 != null;
 
 stdenv.mkDerivation rec {
-  name = "cryptsetup-2.0.6";
+  name = "cryptsetup-2.1.0";
 
   outputs = [ "out" "dev" "man" ];
 
   src = fetchurl {
-    url = "mirror://kernel/linux/utils/cryptsetup/v2.0/${name}.tar.xz";
-    sha256 = "0c1x125s7p4ps13spsqrcsd9dclz01vsrchmypq9msp7y3hgllbw";
+    url = "mirror://kernel/linux/utils/cryptsetup/v2.1/${name}.tar.xz";
+    sha256 = "15y8n547garz0x5kqv09gscdsrz0c0y1y6c5cp8pccwg3xsb5vm3";
   };
 
   # Disable 4 test cases that fail in a sandbox


### PR DESCRIPTION
###### Motivation for this change

Bump to the latest stable version. Be aware that cryptsetup changed the
default LUKS header format with this version. When porting this to a
stable distribution you should supply the configure flag
`--with-default-luks-format=LUKS1` to preserve the user experience
there.

The full changelog can be seen at https://gitlab.com/cryptsetup/cryptsetup/blob/master/docs/v2.1.0-ReleaseNotes

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

