### PR TITLE
pythonPackages.odfpy: fix build

### DIFF
--- a/pkgs/development/python-modules/odfpy/default.nix
+++ b/pkgs/development/python-modules/odfpy/default.nix
@@ -3,6 +3,7 @@
 , fetchPypi
 , python
 , isPy27
+, defusedxml
 }:
 
 buildPythonPackage rec {
@@ -13,6 +14,8 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "596021f0519623ca8717331951c95e3b8d7b21e86edc7efe8cb650a0d0f59a2b";
   };
+
+  propagatedBuildInputs = [ defusedxml ];
 
   # Python 2.7 uses a different ordering for xml namespaces.
   # The testAttributeForeign test expects "ns44", but fails since it gets "ns43"


### PR DESCRIPTION
###### Motivation for this change

As of 1.4.0, `odfpy` requires `defusedxml`. Details in the [version
bump] and [pull request].

[version bump]: https://github.com/eea/odfpy/commit/85d8f403816c08e58fb43e2d9c9b26e624048b89
[pull request]: https://github.com/eea/odfpy/pull/81

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

