### PR TITLE
set phpOptions per phpfpm pool, instead of applying to every phpfpm pool

### DIFF
--- a/nixos/modules/services/misc/zoneminder.nix
+++ b/nixos/modules/services/misc/zoneminder.nix
@@ -275,14 +275,14 @@ in {
       };
 
       phpfpm = lib.mkIf useNginx {
-        phpOptions = ''
-          date.timezone = "${config.time.timeZone}"
-
-          ${lib.concatStringsSep "\n" (map (e:
-          "extension=${e.pkg}/lib/php/extensions/${e.name}.so") phpExtensions)}
-        '';
         pools.zoneminder = {
           listen = socket;
+          phpOptions = ''
+            date.timezone = "${config.time.timeZone}"
+
+            ${lib.concatStringsSep "\n" (map (e:
+            "extension=${e.pkg}/lib/php/extensions/${e.name}.so") phpExtensions)}
+          '';
           extraConfig = ''
             user = ${user}
             group = ${group}

--- a/nixos/modules/services/web-apps/icingaweb2/icingaweb2.nix
+++ b/nixos/modules/services/web-apps/icingaweb2/icingaweb2.nix
@@ -546,25 +546,25 @@ in {
 
   config = mkIf cfg.enable {
     services.phpfpm.poolConfigs = mkIf (cfg.pool == "${poolName}") {
-      "${poolName}" = ''
-        listen = "${phpfpmSocketName}"
-        listen.owner = nginx
-        listen.group = nginx
-        listen.mode = 0600
-        user = icingaweb2
-        pm = dynamic
-        pm.max_children = 75
-        pm.start_servers = 2
-        pm.min_spare_servers = 2
-        pm.max_spare_servers = 10
-      '';
+      "${poolName}" = {
+        listen = phpfpmSocketName;
+        phpOptions = ''
+          extension = ${pkgs.phpPackages.imagick}/lib/php/extensions/imagick.so
+          date.timezone = "${cfg.timezone}"
+        '';
+        extraConfig = ''
+          listen.owner = nginx
+          listen.group = nginx
+          listen.mode = 0600
+          user = icingaweb2
+          pm = dynamic
+          pm.max_children = 75
+          pm.start_servers = 2
+          pm.min_spare_servers = 2
+          pm.max_spare_servers = 10
+        '';
+      };
     };
-
-    services.phpfpm.phpOptions = mkIf (cfg.pool == "${poolName}")
-      ''
-        extension = ${pkgs.phpPackages.imagick}/lib/php/extensions/imagick.so
-        date.timezone = "${cfg.timezone}"
-      '';
 
     systemd.services."phpfpm-${poolName}".serviceConfig.ReadWritePaths = [ "/etc/icingaweb2" ];
 

--- a/nixos/modules/services/web-apps/restya-board.nix
+++ b/nixos/modules/services/web-apps/restya-board.nix
@@ -179,33 +179,34 @@ in
   config = mkIf cfg.enable {
 
     services.phpfpm.poolConfigs = {
-      "${poolName}" = ''
-        listen = "${phpfpmSocketName}";
-        listen.owner = nginx
-        listen.group = nginx
-        listen.mode = 0600
-        user = ${cfg.user}
-        group = ${cfg.group}
-        pm = dynamic
-        pm.max_children = 75
-        pm.start_servers = 10
-        pm.min_spare_servers = 5
-        pm.max_spare_servers = 20
-        pm.max_requests = 500
-        catch_workers_output = 1
-      '';
+      "${poolName}" = {
+        listen = phpfpmSocketName;
+        phpOptions = ''
+          date.timezone = "CET"
+
+          ${optionalString (!isNull cfg.email.server) ''
+            SMTP = ${cfg.email.server}
+            smtp_port = ${toString cfg.email.port}
+            auth_username = ${cfg.email.login}
+            auth_password = ${cfg.email.password}
+          ''}
+        '';
+        extraConfig = ''
+          listen.owner = nginx
+          listen.group = nginx
+          listen.mode = 0600
+          user = ${cfg.user}
+          group = ${cfg.group}
+          pm = dynamic
+          pm.max_children = 75
+          pm.start_servers = 10
+          pm.min_spare_servers = 5
+          pm.max_spare_servers = 20
+          pm.max_requests = 500
+          catch_workers_output = 1
+        '';
+      };
     };
-
-    services.phpfpm.phpOptions = ''
-      date.timezone = "CET"
-
-      ${optionalString (!isNull cfg.email.server) ''
-        SMTP = ${cfg.email.server}
-        smtp_port = ${toString cfg.email.port}
-        auth_username = ${cfg.email.login}
-        auth_password = ${cfg.email.password}
-      ''}
-    '';
 
     services.nginx.enable = true;
     services.nginx.virtualHosts."${cfg.virtualHost.serverName}" = {


### PR DESCRIPTION
###### Motivation for this change
A follow up to https://github.com/NixOS/nixpkgs/pull/55742 which better sandboxes phpfpm pools, allowing for more reproducible systems.

- [ ] @peterhoeg I've never used zoneminder and there isn't a nixos test - can you test and/or do you approve?
- [ ] @dasJ I've never used icingaweb2 and there isn't a nixos test - can you test and/or do you approve?
- [ ] @ts468 I've never used restya-board and there isn't a nixos test - can you test and/or do you approve?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

