### PR TITLE
xsecurelock: Added missing X11 buildInputs

### DIFF
--- a/pkgs/tools/X11/xsecurelock/default.nix
+++ b/pkgs/tools/X11/xsecurelock/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchFromGitHub, autoreconfHook, pkgconfig
-, libX11, libXcomposite, libXft, libXmu, pam, apacheHttpd, imagemagick
-, pamtester, xscreensaver, xset }:
+, libX11, libXcomposite, libXft, libXmu, libXrandr, libXext, libXScrnSaver
+, pam, apacheHttpd, imagemagick, pamtester, xscreensaver, xset }:
 
 stdenv.mkDerivation rec {
   name = "xsecurelock-${version}";
@@ -17,8 +17,8 @@ stdenv.mkDerivation rec {
     autoreconfHook pkgconfig
   ];
   buildInputs = [
-    libX11 libXcomposite libXft libXmu pam
-    apacheHttpd imagemagick pamtester
+    libX11 libXcomposite libXft libXmu libXrandr libXext libXScrnSaver
+    pam apacheHttpd imagemagick pamtester
   ];
 
   configureFlags = [


### PR DESCRIPTION
###### Motivation for this change

According to [xsecurelock's](https://github.com/google/xsecurelock) `configure.ac` file, each of the add dependencies are used to:

- libXrandr: XRandR provides information about monitor layouts and is strongly recommended on systems which can use more than one monitor (which includes most laptops).
- libXext: The X Synchronization extension is used to get per-device idle times. Used by `until_nonidle` only.
- libXScrnSaver: The X11 Screen Saver extension is used to turn off the screen saver when X11 handles screen blanking (e.g. via timeout) anyway. Saves CPU power.

Adding libXrandr fixes an issue where locking a screen in a multi monitor setup results in the prompt information to not be in the middle of the screen. The other dependencies are not tested if they fixed something, however since upstream recommends then I think it is fair to include them also.

###### nix path-info

```shell
$ nix path-info -S /nix/store/0il0hlym3yax67xc0rm7ma0v3z5pirq8-xsecurelock-1.2/bin/xsecurelock # Before
/nix/store/0il0hlym3yax67xc0rm7ma0v3z5pirq8-xsecurelock-1.2       435328896
$ nix path-info -S /nix/store/l7i95dh3cplfzn0g0gay3590xip7b376-xsecurelock-1.2/bin/xsecurelock # After
/nix/store/l7i95dh3cplfzn0g0gay3590xip7b376-xsecurelock-1.2       466815872
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

