### PR TITLE
buildRustPackage: Allow pname attribute

### DIFF
--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -1,6 +1,7 @@
 { stdenv, cacert, git, cargo, rustc, cargo-vendor, fetchcargo, python3 }:
 
-{ name, cargoSha256 ? "unset"
+{ name ? "${args.pname}-${args.version}"
+, cargoSha256 ? "unset"
 , src ? null
 , srcs ? null
 , cargoPatches ? []


### PR DESCRIPTION
###### Motivation for this change
Since https://github.com/NixOS/nixpkgs/pull/49398 most of the package build helpers accept `pname`, but `buildRustPackage` was missing this feature

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

