### PR TITLE
geoclue2: 2.5.1 -> 2.5.2

### DIFF
--- a/pkgs/development/libraries/geoclue/add-option-for-installation-sysconfdir.patch
+++ b/pkgs/development/libraries/geoclue/add-option-for-installation-sysconfdir.patch
@@ -1,52 +1,69 @@
+diff --git a/data/meson.build b/data/meson.build
+index f826864..8b8a25e 100644
 --- a/data/meson.build
 +++ b/data/meson.build
-@@ -7,7 +7,7 @@
+@@ -7,7 +7,7 @@ if get_option('enable-backend')
          conf.set('demo_agent', '')
      endif
  
--    conf_dir = join_paths(get_option('sysconfdir'), 'geoclue')
+-    conf_dir = join_paths(sysconfdir, 'geoclue')
 +    conf_dir = join_paths(sysconfdir_install, 'geoclue')
      configure_file(output: 'geoclue.conf',
                     input: 'geoclue.conf.in',
                     configuration: conf,
-@@ -26,7 +26,7 @@
+@@ -26,7 +26,7 @@ if get_option('enable-backend')
      # DBus Service policy file
      dbus_service_dir = get_option('dbus-sys-dir')
-     if dbus_service_dir  == ''
--        dbus_service_dir = join_paths(get_option('sysconfdir'), 'dbus-1', 'system.d')
+     if dbus_service_dir == ''
+-        dbus_service_dir = join_paths(sysconfdir, 'dbus-1', 'system.d')
 +        dbus_service_dir = join_paths(sysconfdir_install, 'dbus-1', 'system.d')
      endif
      configure_file(output: 'org.freedesktop.GeoClue2.conf',
                     input: 'org.freedesktop.GeoClue2.conf.in',
+diff --git a/demo/meson.build b/demo/meson.build
+index 99c094f..a29ca96 100644
 --- a/demo/meson.build
 +++ b/demo/meson.build
-@@ -56,8 +56,7 @@
+@@ -56,7 +56,7 @@ if get_option('demo-agent')
                                     install_dir: desktop_dir)
  
      # Also install in the autostart directory.
--    autostart_dir = join_paths(get_option('prefix'),
--                               get_option('sysconfdir'),
-+    autostart_dir = join_paths(sysconfdir_install,
-                                'xdg', 'autostart')
+-    autostart_dir = join_paths(sysconfdir, 'xdg', 'autostart')
++    autostart_dir = join_paths(sysconfdir_install, 'xdg', 'autostart')
      meson.add_install_script('install-file.py',
                               desktop_file.full_path(),
+                              autostart_dir)
+diff --git a/meson.build b/meson.build
+index d738ef6..c794a1d 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -22,6 +22,11 @@
+@@ -12,7 +12,11 @@ gclue_api_version='2.0'
  datadir = join_paths(get_option('prefix'), get_option('datadir'))
- conf.set_quoted('LOCALEDIR', datadir + '/locale')
- conf.set_quoted('SYSCONFDIR', get_option('sysconfdir'))
+ includedir = join_paths(get_option('prefix'), get_option('includedir'))
+ libexecdir = join_paths(get_option('prefix'), get_option('libexecdir'))
+-sysconfdir = join_paths(get_option('prefix'), get_option('sysconfdir'))
 +if get_option('sysconfdir_install') != ''
 +  sysconfdir_install = join_paths(get_option('prefix'), get_option('sysconfdir_install'))
 +else
 +  sysconfdir_install = get_option('sysconfdir')
 +endif
+ localedir = join_paths(datadir, 'locale')
  
- configure_file(output: 'config.h', configuration : conf)
- configinc = include_directories('.')
+ header_dir = 'libgeoclue-' + gclue_api_version
+@@ -29,7 +33,7 @@ conf.set_quoted('PACKAGE_URL', 'http://www.freedesktop.org/wiki/Software/GeoClue
+ conf.set_quoted('PACKAGE_BUGREPORT', 'http://bugs.freedesktop.org/enter_bug.cgi?product=GeoClue')
+ conf.set_quoted('TEST_SRCDIR', meson.source_root() + '/data/')
+ conf.set_quoted('LOCALEDIR', localedir)
+-conf.set_quoted('SYSCONFDIR', sysconfdir)
++conf.set_quoted('SYSCONFDIR', get_option('sysconfdir'))
+ conf.set10('GCLUE_USE_3G_SOURCE', get_option('3g-source'))
+ conf.set10('GCLUE_USE_CDMA_SOURCE', get_option('cdma-source'))
+ conf.set10('GCLUE_USE_MODEM_GPS_SOURCE', get_option('modem-gps-source'))
+diff --git a/meson_options.txt b/meson_options.txt
+index 83bc60e..b726329 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -34,3 +34,6 @@
+@@ -34,3 +34,6 @@ option('systemd-system-unit-dir',
  option('dbus-srv-user',
         type: 'string', value: 'root',
         description: 'The user (existing) as which the service will run')

--- a/pkgs/development/libraries/geoclue/default.nix
+++ b/pkgs/development/libraries/geoclue/default.nix
@@ -6,15 +6,15 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  name = "geoclue-${version}";
-  version = "2.5.1";
+  pname = "geoclue";
+  version = "2.5.2";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
-    owner = "geoclue";
-    repo = "geoclue";
+    owner = pname;
+    repo = pname;
     rev = version;
-    sha256 = "0vww6irijw5ss7vawkdi5z5wdpcgw4iqljn5vs3vbd4y3d0lzrbs";
+    sha256 = "1zk6n28q030a9v03whad928b9zwq16d30ch369qv2c0994axdr5p";
   };
 
   patches = [

--- a/pkgs/development/libraries/xdg-desktop-portal/default.nix
+++ b/pkgs/development/libraries/xdg-desktop-portal/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, substituteAll, autoreconfHook, pkgconfig, libxml2, glib, pipewire, fontconfig, flatpak, gsettings-desktop-schemas, acl, dbus, fuse, wrapGAppsHook }:
+{ stdenv, fetchFromGitHub, substituteAll, autoreconfHook, pkgconfig, libxml2, glib, pipewire, fontconfig, flatpak, gsettings-desktop-schemas, acl, dbus, fuse, geoclue2, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "xdg-desktop-portal";
@@ -22,13 +22,12 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [ autoreconfHook pkgconfig libxml2 wrapGAppsHook ];
-  buildInputs = [ glib pipewire fontconfig flatpak acl dbus fuse gsettings-desktop-schemas ];
+  buildInputs = [ glib pipewire fontconfig flatpak acl dbus geoclue2 fuse gsettings-desktop-schemas ];
 
   doCheck = true; # XXX: investigate!
 
   configureFlags = [
     "--enable-installed-tests"
-    "--disable-geoclue" # Requires 2.5.2, not released yet
   ];
 
   makeFlags = [


### PR DESCRIPTION
###### Motivation for this change
https://gitlab.freedesktop.org/geoclue/geoclue/blob/2.5.2/NEWS

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

