### PR TITLE
pureUsePlatformOptimizations: add stdenv adapter

### DIFF
--- a/pkgs/development/compilers/gcc/common/platform-flags.nix
+++ b/pkgs/development/compilers/gcc/common/platform-flags.nix
@@ -4,7 +4,7 @@ let
   p =  targetPlatform.platform.gcc or {}
     // targetPlatform.parsed.abi;
 in lib.concatLists [
-  (lib.optional (p ? arch) "--with-arch=${p.arch}")
+  (lib.optional (!targetPlatform.isx86_64 && p ? arch) "--with-arch=${p.arch}") # --with-arch= is unknown flag on x86_64
   (lib.optional (p ? cpu) "--with-cpu=${p.cpu}")
   (lib.optional (p ? abi) "--with-abi=${p.abi}")
   (lib.optional (p ? fpu) "--with-fpu=${p.fpu}")

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -195,4 +195,13 @@ rec {
         allowSubstitutes = false;
       });
     };
+
+  /* Modify a stdenv so that it builds binaries optimized specifically
+     for the platform architecture ("westmere", "sandybridge", "skylake-avx512", ...) */
+  pureUsePlatformOptimizations = stdenv: stdenv //
+    { mkDerivation = args: stdenv.mkDerivation (args // {
+        NIX_CFLAGS_COMPILE = toString (args.NIX_CFLAGS_COMPILE or "") +
+          stdenv.lib.optionalString (stdenv.hostPlatform.platform?gcc.arch) " -march=${stdenv.hostPlatform.platform.gcc.arch}";
+      });
+    };
 }

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -204,7 +204,7 @@ rec {
         mkDerivation = args: stdenv.mkDerivation (args
           // {
             requiredSystemFeatures = args.requiredSystemFeatures or [] ++ [ "gccarch-${stdenv.hostPlatform.platform.gcc.arch}" ];
-          } # too old compilers, for example bootstrap's GCC5 does not understand -march=skylake
+          } # too old compilers, for example bootstrap's GCC5 do not understand -march=skylake
           // stdenv.lib.optionalAttrs (stdenv.cc != null &&
                                         ( stdenv.cc.isGNU   && stdenv.lib.versionAtLeast (builtins.parseDrvName stdenv.cc.name).version "6.0"
                                        || stdenv.cc.isClang && true

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -199,11 +199,14 @@ rec {
   /* Modify a stdenv so that it builds binaries optimized specifically
      for the platform architecture ("westmere", "sandybridge", "skylake-avx512", ...) */
    pureUsePlatformOptimizations = stdenv:
-     # exclude stdenvNoCC and bootstrap's GCC5 which does not understand -march=skylake
-     if stdenv.hostPlatform.platform?gcc.arch && stdenv.cc!=null && !(stdenv.cc.isGNU && stdenv.lib.versionOlder (builtins.parseDrvName stdenv.cc.name).version "7.0") then
+     if stdenv.hostPlatform.platform ? gcc.arch &&
+        stdenv.cc != null &&                       # exclude stdenvNoCC and bootstrap's GCC5 which does not understand -march=skylake
+        !(stdenv.cc.isGNU && stdenv.lib.versionOlder (builtins.parseDrvName stdenv.cc.name).version "7.0") then
        stdenv // {
          mkDerivation = args: stdenv.mkDerivation (args // {
-           NIX_CFLAGS_COMPILE = toString (args.NIX_CFLAGS_COMPILE or "") + " -march=${stdenv.hostPlatform.platform.gcc.arch}";
+           NIX_CFLAGS_COMPILE = stdenv.lib.concatStringsSep " " ([ (toString (args.NIX_CFLAGS_COMPILE or ""))          
+                                                                    "-march=${stdenv.hostPlatform.platform.gcc.arch}"   
+                                                                 ] ++ stdenv.hostPlatform.platform.gcc.extraFlags or []);                                                     
          });
        }
      else

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -204,6 +204,7 @@ rec {
         !(stdenv.cc.isGNU && stdenv.lib.versionOlder (builtins.parseDrvName stdenv.cc.name).version "7.0") then
        stdenv // {
          mkDerivation = args: stdenv.mkDerivation (args // {
+           requiredSystemFeatures = args.requiredSystemFeatures or [] ++ [ "gccarch-${stdenv.hostPlatform.platform.gcc.arch}" ];         
            NIX_CFLAGS_COMPILE = stdenv.lib.concatStringsSep " " ([ (toString (args.NIX_CFLAGS_COMPILE or ""))          
                                                                     "-march=${stdenv.hostPlatform.platform.gcc.arch}"   
                                                                  ] ++ stdenv.hostPlatform.platform.gcc.extraFlags or []);                                                     


### PR DESCRIPTION
###### Motivation for this change

This allows one to force a compiler to use optimizations for a particular architecture (for example "sandybridge" or "skylake-avx512").
The resulting binaries won't work on the older or incomparible architecture (likely will crash with "Invalid instruction").

Contrary to ```impureUseNativeOptimizations``` of https://github.com/NixOS/nixpkgs/pull/37600,
this adapter does not break purity and allows to prepare a NixOps deployment specifying exact CPU architecture of each node,
so it might become the default one day.
