### PR TITLE
stack-hook: deduplicate better

### DIFF
--- a/pkgs/development/haskell-modules/stack-hook.sh
+++ b/pkgs/development/haskell-modules/stack-hook.sh
@@ -1,11 +1,11 @@
 addStackArgs () {
-  if [ -d "$1/lib" ] && [[ "$STACK_IN_NIX_EXTRA_ARGS" != *"--extra-lib-dirs=$1/lib"* ]]; then
+  if [ -n "$(echo $1/lib/lib*)" ]; then
     STACK_IN_NIX_EXTRA_ARGS+=" --extra-lib-dirs=$1/lib"
   fi
 
-  if [ -d "$1/include" ] && [[ "$STACK_IN_NIX_EXTRA_ARGS" != *"--extra-include-dirs=$1/include"* ]]; then
+  if [ -d "$1/include" ]; then
     STACK_IN_NIX_EXTRA_ARGS+=" --extra-include-dirs=$1/include"
   fi
 }
 
-addEnvHooks "$hostOffset" addStackArgs
+addEnvHooks "$targetOffset" addStackArgs


### PR DESCRIPTION
No need to check for duplicates as it is now handled by setup.sh
deduplication. Also should use targetOffset here instead of hostOffset
because we are using stack-hook natively.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

