### PR TITLE
ponyc: 0.26.0 -> 0.27.0, cleanup, use recent LLVM

### DIFF
--- a/pkgs/development/compilers/ponyc/default.nix
+++ b/pkgs/development/compilers/ponyc/default.nix
@@ -25,24 +25,14 @@ stdenv.mkDerivation ( rec {
     substituteInPlace packages/process/_test.pony \
         --replace '=/bin' "${coreutils}/bin"
 
-
-    # Fix llvm-ar check for darwin
-    substituteInPlace Makefile \
-        --replace "llvm-ar-3.8" "llvm-ar"
-
     # Remove impure system refs
     substituteInPlace src/libponyc/pkg/package.c \
-        --replace "/usr/local/lib" ""
-    substituteInPlace src/libponyc/pkg/package.c \
+        --replace "/usr/local/lib" "" \
         --replace "/opt/local/lib" ""
 
     for file in `grep -irl '/usr/local/opt/libressl/lib' ./*`; do
       substituteInPlace $file  --replace '/usr/local/opt/libressl/lib' "${stdenv.lib.getLib libressl}/lib"
     done
-
-    # Fix ponypath issue
-    substituteInPlace Makefile \
-        --replace "PONYPATH=." "PONYPATH=.:\$(PONYPATH)"
 
     export LLVM_CONFIG=${llvm}/bin/llvm-config
   '' + stdenv.lib.optionalString ((!stdenv.isDarwin) && (!cc.isClang) && lto) ''
@@ -73,9 +63,7 @@ stdenv.mkDerivation ( rec {
     wrapProgram $out/bin/ponyc \
       --prefix PATH ":" "${stdenv.cc}/bin" \
       --set-default CC "$CC" \
-      --prefix PONYPATH : "$out/lib" \
-      --prefix PONYPATH : "${stdenv.lib.getLib pcre2}/lib" \
-      --prefix PONYPATH : "${stdenv.lib.getLib libressl}/lib"
+      --prefix PONYPATH : "${stdenv.lib.makeLibraryPath [ pcre2 libressl (placeholder "out") ]}"
   '';
 
   # Stripping breaks linking for ponyc

--- a/pkgs/development/compilers/ponyc/default.nix
+++ b/pkgs/development/compilers/ponyc/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation ( rec {
   name = "ponyc-${version}";
-  version = "0.26.0";
+  version = "0.27.0";
 
   src = fetchFromGitHub {
     owner = "ponylang";
     repo = "ponyc";
     rev = version;
-    sha256 = "1k1ysqk7j8kpysndps2ic9hprvp0z0d32d6jvqlapjrfccghy7dh";
+    sha256 = "11vdfvv9xirfi92y7zza9pqimfx33w74vw7rg5n7l60qqc8y2cla";
   };
 
   buildInputs = [ llvm makeWrapper which ];

--- a/pkgs/development/compilers/ponyc/pony-stable.nix
+++ b/pkgs/development/compilers/ponyc/pony-stable.nix
@@ -2,20 +2,18 @@
 
 stdenv.mkDerivation rec {
   name = "pony-stable-${version}";
-  version = "0.1.6";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "ponylang";
     repo = "pony-stable";
     rev = version;
-    sha256 = "02lqba75psnxcxj2y8lm1fy1hmwa088nvxjghhpnlkqbwz7wa2sw";
+    sha256 = "0zzcq0vsl6kcrsxwqzd3s9mq7aq5sg8si5c83rxyi9n6a06gnbh7";
   };
 
   buildInputs = [ ponyc ];
 
-  installPhase = ''
-    make prefix=$out install
-  '';
+  installFlags = [ "prefix=${placeholder "out"}" "install" ];
 
   meta = {
     description = "A simple dependency manager for the Pony language.";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7502,7 +7502,7 @@ in
   };
 
   ponyc = callPackage ../development/compilers/ponyc {
-    llvm = llvm_39;
+    llvm = llvm_7;
   };
 
   pony-stable = callPackage ../development/compilers/ponyc/pony-stable.nix { };


### PR DESCRIPTION
Also bump pony-stable while visiting.


###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---