### PR TITLE
awscli: 1.16.106 -> 1.16.116

### DIFF
--- a/pkgs/development/python-modules/boto3/default.nix
+++ b/pkgs/development/python-modules/boto3/default.nix
@@ -13,11 +13,11 @@
 
 buildPythonPackage rec {
   pname =  "boto3";
-  version = "1.9.101"; # N.B: if you change this, change botocore too
+  version = "1.9.106"; # N.B: if you change this, change botocore too
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "bc25b83405cede6025fd7de0240fa8ade910f445da46f267c1dd13409d19ad64";
+    sha256 = "30badbe5dab638e764e23125479e848c446a9669ef0612b8d8d305738bc442d3";
   };
 
   propagatedBuildInputs = [ botocore jmespath s3transfer ] ++ lib.optionals (!isPy3k) [ futures ];

--- a/pkgs/development/python-modules/botocore/default.nix
+++ b/pkgs/development/python-modules/botocore/default.nix
@@ -12,11 +12,11 @@
 
 buildPythonPackage rec {
   pname = "botocore";
-  version = "1.12.101"; # N.B: if you change this, change boto3 and awscli to a matching version
+  version = "1.12.106"; # N.B: if you change this, change boto3 and awscli to a matching version
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "46e4daaa7c8cb29237802b63699c16a116f96f301ad2fcfef800574333b58b98";
+    sha256 = "bff336cccf1ed2b7cab54bb802e135a063cb7614271c6dacd2f49ecbc26df7da";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/tools/admin/awscli/default.nix
+++ b/pkgs/tools/admin/awscli/default.nix
@@ -26,11 +26,11 @@ let
 
 in py.pkgs.buildPythonApplication rec {
   pname = "awscli";
-  version = "1.16.106"; # N.B: if you change this, change botocore to a matching version too
+  version = "1.16.116"; # N.B: if you change this, change botocore to a matching version too
 
   src = py.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "169810cb895ac8608747e81480aebd2712f654ad2e49e1f1315f34d6052d5e2d";
+    sha256 = "0a0180dbbc58a804438c2d58ef141e9d80cb182f3101d619ad386ab76bbeff6a";
   };
 
   # No tests included


### PR DESCRIPTION
Fix #56613 broken build by rolling forward and ensuring the versions are
according to the botocore/boto3 dependencies in the awscli setup.py

###### Motivation for this change
Currently awscli build is broken on master.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

