### PR TITLE
pythonPackages.pykeepass: fix build

### DIFF
--- a/pkgs/development/python-modules/argon2_cffi/default.nix
+++ b/pkgs/development/python-modules/argon2_cffi/default.nix
@@ -1,30 +1,33 @@
 { cffi
 , six
+, enum34
 , hypothesis
 , pytest
 , wheel
 , buildPythonPackage
 , fetchPypi
+, isPy3k
+, lib
 }:
 
 buildPythonPackage rec {
   pname = "argon2_cffi";
   version = "19.1.0";
-  name    = "${pname}-${version}";
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "81548a27b919861040cb928a350733f4f9455dd67c7d1ba92eb5960a1d7f8b26";
   };
 
-  propagatedBuildInputs = [ cffi six ];
+  propagatedBuildInputs = [ cffi six ] ++ lib.optional (!isPy3k) enum34;
   checkInputs = [ hypothesis pytest wheel ];
   checkPhase = ''
     pytest tests
   '';
 
-  meta = {
+  meta = with lib; {
     description = "Secure Password Hashes for Python";
     homepage    = https://argon2-cffi.readthedocs.io/;
+    license     = licenses.mit;
   };
 }

--- a/pkgs/development/python-modules/pykeepass/default.nix
+++ b/pkgs/development/python-modules/pykeepass/default.nix
@@ -1,6 +1,6 @@
 { lib, fetchPypi, buildPythonPackage
 , lxml, pycryptodome, construct
-, argon2_cffi, dateutil, enum34
+, argon2_cffi, dateutil, future
 }:
 
 buildPythonPackage rec {
@@ -14,8 +14,11 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     lxml pycryptodome construct
-    argon2_cffi dateutil enum34
+    argon2_cffi dateutil future
   ];
+
+  # no tests in PyPI tarball
+  doCheck = false;
 
   meta = {
     homepage = https://github.com/pschmitt/pykeepass;


### PR DESCRIPTION
Add missing dependency future

It turns out a dependency was added in the latest patch version.
https://github.com/pschmitt/pykeepass/compare/3.0.2...3.0.3

###### Motivation for this change
This package build is currently broken on master. Fixes #56612

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

