### PR TITLE
network-scripting: do not run resolvconf if /etc/resolv.conf is managed manually

### DIFF
--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -103,16 +103,18 @@ let
 
             script =
               ''
-                # Set the static DNS configuration, if given.
-                ${pkgs.openresolv}/sbin/resolvconf -m 1 -a static <<EOF
-                ${optionalString (cfg.nameservers != [] && cfg.domain != null) ''
-                  domain ${cfg.domain}
+                ${optionalString (!config.environment.etc?"resolv.conf") ''
+                  # Set the static DNS configuration, if given.
+                  ${pkgs.openresolv}/sbin/resolvconf -m 1 -a static <<EOF
+                  ${optionalString (cfg.nameservers != [] && cfg.domain != null) ''
+                    domain ${cfg.domain}
+                  ''}
+                  ${optionalString (cfg.search != []) ("search " + concatStringsSep " " cfg.search)}
+                  ${flip concatMapStrings cfg.nameservers (ns: ''
+                    nameserver ${ns}
+                  '')}
+                  EOF
                 ''}
-                ${optionalString (cfg.search != []) ("search " + concatStringsSep " " cfg.search)}
-                ${flip concatMapStrings cfg.nameservers (ns: ''
-                  nameserver ${ns}
-                '')}
-                EOF
 
                 # Set the default gateway.
                 ${optionalString (cfg.defaultGateway != null && cfg.defaultGateway.address != "") ''


### PR DESCRIPTION
###### Motivation for this change

It is the second invocation of ```resolvconf```, missed in https://github.com/NixOS/nixpkgs/pull/32308

The fix was a part of https://github.com/NixOS/nixpkgs/pull/44986 which got stalled because other changes were controversial

Partially fixes https://github.com/NixOS/nixpkgs/issues/56681 (on systems which do not use ```resolvconf``` but still suffer from its failures)

cc @orivej @danbst 


Only ```${optionalString (!config.environment.etc?"resolv.conf")``` is added, the patch looks bigger because of the indentation change.