### PR TITLE
nixos/manual: fix build

### DIFF
--- a/nixos/doc/manual/man-nixos-rebuild.xml
+++ b/nixos/doc/manual/man-nixos-rebuild.xml
@@ -201,6 +201,7 @@ $ nix-build /path/to/nixpkgs/nixos -A system
         Opens <filename>configuration.nix</filename> in the default editor.
       </para>
      </listitem>
+    </varlistentry>
     <varlistentry>
      <term>
       <option>build-vm</option>


### PR DESCRIPTION
###### Motivation for this change

NixOS manual and man pages don't build at the moment.

/cc @srhb @LnL7 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] `nix-build nixos/release-combined.nix -A nixos.manpages.x86_64-linux`
- [x] `nix-build nixos/release-combined.nix -A nixos.manual.x86_64-linux`
---
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

