### PR TITLE
python37Packages.cryptography: 2.5 -> 2.6.1

### DIFF
--- a/pkgs/development/python-modules/cryptography/default.nix
+++ b/pkgs/development/python-modules/cryptography/default.nix
@@ -20,9 +20,8 @@
 }:
 
 buildPythonPackage rec {
-  # also bump cryptography_vectors
   pname = "cryptography";
-  version = "2.5";
+  version = "2.5"; # Also update the hash in vectors.nix
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/cryptography/default.nix
+++ b/pkgs/development/python-modules/cryptography/default.nix
@@ -21,11 +21,11 @@
 
 buildPythonPackage rec {
   pname = "cryptography";
-  version = "2.5"; # Also update the hash in vectors.nix
+  version = "2.6.1"; # Also update the hash in vectors.nix
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "00c4d7gvsymlaw0r13zrm32dcnarmpayjyrh65yymlmr6mrbcij9";
+    sha256 = "19iwz5avym5zl6jrrrkym1rdaa9h61j20ph4cswsqgv8xg5j3j16";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/python-modules/cryptography/default.nix
+++ b/pkgs/development/python-modules/cryptography/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
 
   outputs = [ "out" "dev" ];
 
-  buildInputs = [ openssl cryptography_vectors ]
+  buildInputs = [ openssl ]
              ++ stdenv.lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Security;
   propagatedBuildInputs = [
     asn1crypto
@@ -41,11 +41,12 @@ buildPythonPackage rec {
   ++ stdenv.lib.optional (!isPyPy) cffi;
 
   checkInputs = [
-    pytest
-    pretend
-    iso8601
-    pytz
+    cryptography_vectors
     hypothesis
+    iso8601
+    pretend
+    pytest
+    pytz
   ];
 
   checkPhase = ''

--- a/pkgs/development/python-modules/cryptography/vectors.nix
+++ b/pkgs/development/python-modules/cryptography/vectors.nix
@@ -1,9 +1,9 @@
-{ buildPythonPackage, fetchPypi, lib }:
+{ buildPythonPackage, fetchPypi, lib, cryptography }:
 
 buildPythonPackage rec {
-  # also bump cryptography
   pname = "cryptography_vectors";
-  version = "2.5";
+  # The test vectors must have the same version as the cryptography package:
+  version = cryptography.version;
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/cryptography/vectors.nix
+++ b/pkgs/development/python-modules/cryptography/vectors.nix
@@ -7,7 +7,7 @@ buildPythonPackage rec {
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "15qfl3pnw2f11r0z0zhwl56f6pb60ysav8fxmpnz5p80cfwljdik";
+    sha256 = "1bsqcv3h49dzqnyn29ijq8r7k1ra8ikl1y9qcpcns9nbvhaq3wq3";
   };
 
   # No tests included

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1481,7 +1481,7 @@ in {
 
   cryptography = callPackage ../development/python-modules/cryptography { };
 
-  cryptography_vectors = callPackage ../development/python-modules/cryptography_vectors { };
+  cryptography_vectors = callPackage ../development/python-modules/cryptography/vectors.nix { };
 
   curtsies = callPackage ../development/python-modules/curtsies { };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

