### PR TITLE
pugixml: Fix pkg-config file installation and use fetchFromGitHub

### DIFF
--- a/pkgs/development/libraries/pugixml/default.nix
+++ b/pkgs/development/libraries/pugixml/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, shared ? false }:
+{ stdenv, fetchFromGitHub, fetchpatch, cmake, shared ? false }:
 
 stdenv.mkDerivation rec {
   name = "pugixml-${version}";
@@ -11,9 +11,17 @@ stdenv.mkDerivation rec {
     sha256 = "0iraznwm78pyyzc9snvd3dyz8gddvmxsm1b3kpw7wixkvcawdviv";
   };
 
+  patches = [
+    # To be removed after a version newer than 1.9 is released
+    (fetchpatch {
+      url = "https://github.com/zeux/pugixml/pull/193.patch";
+      sha256 = "0s4anqlr2ppfibxyl29nrqbcprrg89k7il6303dm91s6620ydmka";
+    })
+  ];
+
   nativeBuildInputs = [ cmake ];
 
-  cmakeFlags = [ "-DBUILD_SHARED_LIBS=${if shared then "ON" else "OFF"} -DBUILD_PKGCONFIG=ON" ];
+  cmakeFlags = [ "-DBUILD_SHARED_LIBS=${if shared then "ON" else "OFF"}" ];
 
   preConfigure = ''
     # Enable long long support (required for filezilla)

--- a/pkgs/development/libraries/pugixml/default.nix
+++ b/pkgs/development/libraries/pugixml/default.nix
@@ -1,12 +1,14 @@
-{ stdenv, fetchurl, cmake, shared ? false }:
+{ stdenv, fetchFromGitHub, cmake, shared ? false }:
 
 stdenv.mkDerivation rec {
   name = "pugixml-${version}";
   version = "1.9";
 
-  src = fetchurl {
-    url = "https://github.com/zeux/pugixml/releases/download/v${version}/${name}.tar.gz";
-    sha256 = "19nv3zhik3djp4blc4vrjwrl8dfhzmal8b21sq7y907nhddx6mni";
+  src = fetchFromGitHub {
+    owner = "zeux";
+    repo = "pugixml";
+    rev = "v${version}";
+    sha256 = "0iraznwm78pyyzc9snvd3dyz8gddvmxsm1b3kpw7wixkvcawdviv";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
###### Motivation for this change

FileZilla was not building (#56505) and tracked it down to a pugixml change (#56351).

Tested this by building FileZilla.

cc @pSub 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

