### PR TITLE
pythonPackages.py3status: Added missing Python dependencies

### DIFF
--- a/pkgs/development/python-modules/py3status/default.nix
+++ b/pkgs/development/python-modules/py3status/default.nix
@@ -5,6 +5,10 @@
 , requests
 , pytz
 , tzlocal
+, i3ipc
+, pydbus
+, pygobject3
+, pyserial
 
 , file
 , acpi
@@ -20,14 +24,14 @@
 buildPythonPackage rec {
   pname = "py3status";
   version = "3.16";
-  
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "1xrfph277bgjln3jbpzpgkhxad04fjvj7s3xfil42q1sxi4s3q3g";
   };
 
   doCheck = false;
-  propagatedBuildInputs = [ pytz requests tzlocal ];
+  propagatedBuildInputs = [ pytz requests tzlocal i3ipc pydbus pygobject3 pyserial ];
   buildInputs = [ file ];
   prePatch = ''
     sed -i -e "s|'file|'${file}/bin/file|" py3status/parse_config.py


### PR DESCRIPTION
###### Motivation for this change
According to py3status' modules documentation [1]:

- i3ipc: Used by `scratchpad_async` and `window_title_async` modules.
- pydbus: Used by `kdeconnector`, `mpris`, `systemd`, `vpn_status` and `wwan`
modules.
- pyserial: Used by `wwan_status` module.

Tested with my current py3status configuration, some modules that depends on i3ipc or py3dbus works. Did not test pyserial because I don't have a wwan to test.

[1]: https://py3status.readthedocs.io/en/latest/modules.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

