### PR TITLE
Fix trash-cli and meld's checkPhase after #53440

### DIFF
--- a/pkgs/applications/version-management/meld/default.nix
+++ b/pkgs/applications/version-management/meld/default.nix
@@ -19,7 +19,7 @@ python3.pkgs.buildPythonApplication rec {
     gtk3 gtksourceview gnome3.gsettings-desktop-schemas gnome3.adwaita-icon-theme
   ];
   propagatedBuildInputs = with python3.pkgs; [ pygobject3 pycairo ];
-  checkInputs = [ xvfb_run python3.pkgs.pytest dbus ];
+  checkInputs = [ xvfb_run python3.pkgs.pytest dbus gtksourceview gtk3 ];
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/tools/misc/trash-cli/default.nix
+++ b/pkgs/tools/misc/trash-cli/default.nix
@@ -28,7 +28,7 @@ python3Packages.buildPythonApplication rec {
     })
   ];
 
-  buildInputs = with python3Packages; [ nose mock ];
+  checkInputs = with python3Packages; [ nose mock ];
 
   checkPhase = "nosetests";
 


### PR DESCRIPTION
###### Motivation for this change

Fix `trash-cli` and `meld` after https://github.com/NixOS/nixpkgs/pull/53440

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

