### PR TITLE
brig: init at 0.3.0

### DIFF
--- a/pkgs/applications/networking/brig/default.nix
+++ b/pkgs/applications/networking/brig/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildGoPackage, fetchFromGitHub, fetchgx }:
+
+buildGoPackage rec {
+  name = "brig-${version}";
+  version = "0.3.0";
+  rev = "v${version}";
+
+  goPackagePath = "github.com/sahib/brig";
+  subPackages = ["."];
+
+  src = fetchFromGitHub {
+    owner = "sahib";
+    repo = "brig";
+    inherit rev;
+    sha256 = "01hpb6cvq8cw21ka74jllggkv5pavc0sbl1207x32gzxslw3gsvy";
+  };
+
+  meta = with stdenv.lib; {
+    description = "File synchronization on top of ipfs with git like interface and FUSE filesystem";
+    homepage = https://github.com/sahib/brig;
+    license = licenses.agpl3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ offline ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16351,6 +16351,8 @@ in
 
   notmuch-bower = callPackage ../applications/networking/mailreaders/notmuch-bower { };
 
+  brig = callPackages ../applications/networking/brig { };
+
   bristol = callPackage ../applications/audio/bristol { };
 
   bs1770gain = callPackage ../applications/audio/bs1770gain { };


### PR DESCRIPTION
###### Motivation for this change

Package brig tool

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

