### PR TITLE
miniflux: add service

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -745,6 +745,7 @@
   ./services/web-apps/icingaweb2/icingaweb2.nix
   ./services/web-apps/icingaweb2/module-monitoring.nix
   ./services/web-apps/mattermost.nix
+  ./services/web-apps/miniflux.nix
   ./services/web-apps/nextcloud.nix
   ./services/web-apps/nexus.nix
   ./services/web-apps/pgpkeyserver-lite.nix

--- a/nixos/modules/services/web-apps/miniflux.nix
+++ b/nixos/modules/services/web-apps/miniflux.nix
@@ -1,0 +1,97 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.services.miniflux;
+
+  dbUser = "miniflux";
+  dbPassword = "miniflux";
+  dbHost = "localhost";
+  dbName = "miniflux";
+
+  defaultCredentials = pkgs.writeText "miniflux-admin-credentials" ''
+    ADMIN_USERNAME=admin
+    ADMIN_PASSWORD=password
+  '';
+
+  pgsu = "${pkgs.sudo}/bin/sudo -u ${config.services.postgresql.superUser}";
+  pgbin = "${config.services.postgresql.package}/bin";
+  preStart = pkgs.writeScript "miniflux-pre-start" ''
+    #!${pkgs.runtimeShell}
+    db_exists() {
+      [ "$(${pgsu} ${pgbin}/psql -Atc "select 1 from pg_database where datname='$1'")" == "1" ]
+    }
+    if ! db_exists "${dbName}"; then
+      ${pgsu} ${pgbin}/psql postgres -c "CREATE ROLE ${dbUser} WITH LOGIN NOCREATEDB NOCREATEROLE ENCRYPTED PASSWORD '${dbPassword}'"
+      ${pgsu} ${pgbin}/createdb --owner "${dbUser}" "${dbName}"
+      ${pgsu} ${pgbin}/psql "${dbName}" -c "CREATE EXTENSION IF NOT EXISTS hstore"
+    fi
+  '';
+in
+
+{
+  options = {
+    services.miniflux = {
+      enable = mkEnableOption "miniflux";
+
+      config = mkOption {
+        type = types.attrsOf types.str;
+        example = literalExample ''
+          {
+            CLEANUP_FREQUENCY = "48";
+            LISTEN_ADDR = "localhost:8080";
+          }
+        '';
+        description = ''
+          Configuration for Miniflux, refer to
+          <link xlink:href="http://docs.miniflux.app/en/latest/configuration.html"/>
+          for documentation on the supported values.
+        '';
+      };
+
+      adminCredentialsFile = mkOption  {
+        type = types.nullOr types.path;
+        default = null;
+        description = ''
+          File containing the ADMIN_USERNAME, default is "admin", and
+          ADMIN_PASSWORD (length >= 6), default is "password"; in the format of
+          an EnvironmentFile=, as described by systemd.exec(5).
+        '';
+        example = "/etc/nixos/miniflux-admin-credentials";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    services.miniflux.config =  {
+      LISTEN_ADDR = mkDefault "localhost:8080";
+      DATABASE_URL = "postgresql://${dbUser}:${dbPassword}@${dbHost}/${dbName}?sslmode=disable";
+      RUN_MIGRATIONS = "1";
+      CREATE_ADMIN = "1";
+    };
+
+    services.postgresql.enable = true;
+
+    systemd.services.miniflux = {
+      description = "Miniflux service";
+      wantedBy = [ "multi-user.target" ];
+      requires = [ "postgresql.service" ];
+      after = [ "network.target" "postgresql.service" ];
+
+      serviceConfig = {
+        ExecStart = "${pkgs.miniflux}/bin/miniflux";
+        ExecStartPre = "+${preStart}";
+        DynamicUser = true;
+        RuntimeDirectory = "miniflux";
+        RuntimeDirectoryMode = "0700";
+        EnvironmentFile = if isNull cfg.adminCredentialsFile
+        then defaultCredentials
+        else cfg.adminCredentialsFile;
+      };
+
+      environment = cfg.config;
+    };
+    environment.systemPackages = [ pkgs.miniflux ];
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -137,6 +137,7 @@ in
   matrix-synapse = handleTest ./matrix-synapse.nix {};
   memcached = handleTest ./memcached.nix {};
   mesos = handleTest ./mesos.nix {};
+  miniflux = handleTest ./miniflux.nix {};
   minio = handleTest ./minio.nix {};
   misc = handleTest ./misc.nix {};
   mongodb = handleTest ./mongodb.nix {};

--- a/nixos/tests/miniflux.nix
+++ b/nixos/tests/miniflux.nix
@@ -1,0 +1,52 @@
+import ./make-test.nix ({ pkgs, lib, ... }:
+
+let
+  port = 3142;
+  username = "alice";
+  password = "correcthorsebatterystaple";
+  defaultPort = 8080;
+  defaultUsername = "admin";
+  defaultPassword = "password";
+in
+with lib;
+{
+  name = "miniflux";
+  meta.maintainers = with pkgs.stdenv.lib.maintainers; [ bricewge ];
+
+  nodes = {
+    default =
+      { ... }:
+      {
+        services.miniflux.enable = true;
+      };
+
+    customized =
+      { ... }:
+      {
+        services.miniflux = {
+          enable = true;
+          config = {
+            CLEANUP_FREQUENCY = "48";
+            LISTEN_ADDR = "localhost:${toString port}";
+          };
+          adminCredentialsFile = pkgs.writeText "admin-credentials" ''
+            ADMIN_USERNAME=${username}
+            ADMIN_PASSWORD=${password}
+          '';
+        };
+      };
+  };
+  testScript = ''
+    startAll;
+
+    $default->waitForUnit('miniflux.service');
+    $default->waitForOpenPort(${toString defaultPort});
+    $default->succeed("curl --fail 'http://localhost:${toString defaultPort}/healthcheck' | grep -q OK");
+    $default->succeed("curl 'http://localhost:${toString defaultPort}/v1/me' -u '${defaultUsername}:${defaultPassword}' -H Content-Type:application/json | grep -q '\"is_admin\":true'");
+
+    $customized->waitForUnit('miniflux.service');
+    $customized->waitForOpenPort(${toString port});
+    $customized->succeed("curl --fail 'http://localhost:${toString port}/healthcheck' | grep -q OK");
+    $customized->succeed("curl 'http://localhost:${toString port}/v1/me' -u '${username}:${password}' -H Content-Type:application/json | grep -q '\"is_admin\":true'");
+  '';
+})


### PR DESCRIPTION
###### Motivation for this change
This is an update for the PR #52638 written by @nornagon to add a service for miniflux. It amend the initial PR with the remarks made by @Infinisil and two config options to specify the initial admin account.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

