### PR TITLE
catimg: init at 2.5.0

### DIFF
--- a/pkgs/tools/misc/catimg/default.nix
+++ b/pkgs/tools/misc/catimg/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, cmake } :
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  pname = "catimg";
+  version = "2.5.0";
+
+  src = fetchFromGitHub {
+    owner = "posva";
+    repo = pname;
+    rev = version;
+    sha256 = "0n74iczzgxrcq3zpa7ndycb9rinm829yvf81c747q4ngv5q6pzcm";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    license = licenses.mit;
+    homepage = "https://github.com/posva/catimg";
+    description = "Insanely fast image printing in your terminal";
+    maintainers = with maintainers; [ ryantm ];
+    platforms = platforms.unix;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16387,6 +16387,8 @@ in
 
   catfish = callPackage ../applications/search/catfish { };
 
+  catimg = callPackage ../tools/misc/catimg { };
+
   cava = callPackage ../applications/audio/cava { };
 
   cb2bib = libsForQt5.callPackage ../applications/office/cb2bib { };


### PR DESCRIPTION
###### Motivation for this change

program not packaged; it is useful to preview images on the console.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

