### PR TITLE
unifont_upper: 10.0.06 -> 11.0.03

### DIFF
--- a/pkgs/data/fonts/unifont_upper/default.nix
+++ b/pkgs/data/fonts/unifont_upper/default.nix
@@ -1,15 +1,15 @@
 { stdenv, fetchzip }:
 
 let
-  version = "10.0.06";
+  version = "11.0.03";
 in fetchzip rec {
   name = "unifont_upper-${version}";
 
-  url = "http://unifoundry.com/pub/unifont-${version}/font-builds/${name}.ttf";
+  url = "mirror://gnu/unifont/unifont-${version}/${name}.ttf";
 
   postFetch = "install -Dm644 $downloadedFile $out/share/fonts/truetype/unifont_upper.ttf";
 
-  sha256 = "13x5z8iyh9xz5fllcy89yinnz1iy16a2pjf3vip66nz10sq8crlr";
+  sha256 = "1gfjv3n9pxwzla4pil518a80ihn5wz0c7d4mhfw0dj2n5fwgpdmr";
 
   meta = with stdenv.lib; {
     description = "Unicode font for glyphs above the Unicode Basic Multilingual Plane";


### PR DESCRIPTION
###### Motivation for this change

Match version used for `unifont`.
Also move to GNU mirror for the file, as we do for unifont.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---