### PR TITLE
sublime3: add updateScript

### DIFF
--- a/pkgs/applications/editors/sublime/3/packages.nix
+++ b/pkgs/applications/editors/sublime/3/packages.nix
@@ -6,6 +6,7 @@ in
   rec {
     sublime3-dev = common {
       buildVersion = "3184";
+      dev = true;
       x32sha256 = "1b6f1fid75g5z247dbnyyj276lrlv99scrdk1vvfcr6vyws77vzr";
       x64sha256 = "03127jhfjr17ai96p3axh5b5940fds8jcw6vkid8y6dmvd2dpylz";
     } {};

--- a/pkgs/applications/networking/browsers/firefox/update.nix
+++ b/pkgs/applications/networking/browsers/firefox/update.nix
@@ -32,5 +32,5 @@ writeScript "update-${attrPath}" ''
            sort --version-sort | \
            tail -n 1`
 
-  update-source-version ${attrPath} "$version" "" "" ${versionKey}
+  update-source-version ${attrPath} "$version" "" "" --version-key=${versionKey}
 ''

--- a/pkgs/common-updater/scripts.nix
+++ b/pkgs/common-updater/scripts.nix
@@ -1,4 +1,4 @@
-{ stdenv, makeWrapper, coreutils, gawk, gnused, diffutils, nix }:
+{ stdenv, makeWrapper, coreutils, gawk, gnused, gnugrep, diffutils, nix }:
 
 stdenv.mkDerivation {
   name = "common-updater-scripts";
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
     cp ${./scripts}/* $out/bin
 
     for f in $out/bin/*; do
-      wrapProgram $f --prefix PATH : ${stdenv.lib.makeBinPath [ coreutils gawk gnused nix diffutils ]}
+      wrapProgram $f --prefix PATH : ${stdenv.lib.makeBinPath [ coreutils gawk gnused gnugrep nix diffutils ]}
     done
   '';
 }

--- a/pkgs/common-updater/scripts/update-source-version
+++ b/pkgs/common-updater/scripts/update-source-version
@@ -1,29 +1,79 @@
 #!/usr/bin/env bash
 set -e
 
+scriptName=update-source-versions # do not use the .wrapped name
+
 die() {
-    echo "$0: error: $1" >&2
+    echo "$scriptName: error: $1" >&2
     exit 1
 }
 
-# Usage: update-source-hash <attr> <version> [<new-source-hash>] [<new-source-url>] [<version-key>]
-attr=$1
-newVersion=$2
-newHash=$3
-newUrl=$4
-versionKey=$5
+usage() {
+    echo "Usage: $scriptName <attr> <version> [<new-source-hash>] [<new-source-url>]"
+    echo "                              [--version-key=<version-key>] [--system=<system>] [--file=<file-to-update>]"
+}
+
+args=()
+
+for arg in "$@"; do
+    case $arg in
+        --system=*)
+            systemArg="--system ${arg#*=}"
+        ;;
+        --version-key=*)
+            versionKey="${arg#*=}"
+        ;;
+        --file=*)
+            nixFile="${arg#*=}"
+            if [ ! -f "$nixFile" ]; then
+                die "Could not find provided file $nixFile"
+            fi
+        ;;
+        --help)
+            usage
+            exit 0
+        ;;
+        --*)
+            echo "$scriptName: Unknown argument: " $arg
+            usage
+            exit 1
+        ;;
+        *)
+            args["${#args[*]}"]=$arg
+        ;;
+    esac
+done
+
+attr=${args[0]}
+newVersion=${args[1]}
+newHash=${args[2]}
+newUrl=${args[3]}
+
+if [ "${#args[*]}" -lt 2 ]; then
+    echo "$scriptName: Too few arguments"
+    usage
+    exit 1
+fi
+
+if [ "${#args[*]}" -gt 4 ]; then
+    echo "$scriptName: Too many arguments"
+    usage
+    exit 1
+fi
 
 if [ -z "$versionKey" ]; then
     versionKey=version
 fi
 
-nixFile=$(nix-instantiate --eval --strict -A "$attr.meta.position" | sed -re 's/^"(.*):[0-9]+"$/\1/')
-if [ ! -f "$nixFile" ]; then
-    die "Couldn't evaluate '$attr.meta.position' to locate the .nix file!"
+if [ -z "$nixFile" ]; then
+    nixFile=$(nix-instantiate $systemArg --eval --strict -A "$attr.meta.position" | sed -re 's/^"(.*):[0-9]+"$/\1/')
+    if [ ! -f "$nixFile" ]; then
+        die "Couldn't evaluate '$attr.meta.position' to locate the .nix file!"
+    fi
 fi
 
-oldHashAlgo=$(nix-instantiate --eval --strict -A "$attr.src.drvAttrs.outputHashAlgo" | tr -d '"')
-oldHash=$(nix-instantiate --eval --strict -A "$attr.src.drvAttrs.outputHash" | tr -d '"')
+oldHashAlgo=$(nix-instantiate $systemArg --eval --strict -A "$attr.src.drvAttrs.outputHashAlgo" | tr -d '"')
+oldHash=$(nix-instantiate $systemArg --eval --strict -A "$attr.src.drvAttrs.outputHash" | tr -d '"')
 
 if [ -z "$oldHashAlgo" -o -z "$oldHash" ]; then
     die "Couldn't evaluate old source hash from '$attr.src'!"
@@ -33,21 +83,21 @@ if [ $(grep -c "$oldHash" "$nixFile") != 1 ]; then
     die "Couldn't locate old source hash '$oldHash' (or it appeared more than once) in '$nixFile'!"
 fi
 
-oldUrl=$(nix-instantiate --eval -E "with import ./. {}; builtins.elemAt $attr.src.drvAttrs.urls 0" | tr -d '"')
+oldUrl=$(nix-instantiate $systemArg --eval -E "with import ./. {}; builtins.elemAt $attr.src.drvAttrs.urls 0" | tr -d '"')
 
 if [ -z "$oldUrl" ]; then
     die "Couldn't evaluate source url from '$attr.name'!"
 fi
 
-drvName=$(nix-instantiate --eval -E "with import ./. {}; (builtins.parseDrvName $attr.name).name" | tr -d '"')
-oldVersion=$(nix-instantiate --eval -E "with import ./. {}; $attr.version or (builtins.parseDrvName $attr.name).version" | tr -d '"')
+drvName=$(nix-instantiate $systemArg --eval -E "with import ./. {}; (builtins.parseDrvName $attr.name).name" | tr -d '"')
+oldVersion=$(nix-instantiate $systemArg --eval -E "with import ./. {}; $attr.version or (builtins.parseDrvName $attr.name).version" | tr -d '"')
 
 if [ -z "$drvName" -o -z "$oldVersion" ]; then
     die "Couldn't evaluate name and version from '$attr.name'!"
 fi
 
 if [ "$oldVersion" = "$newVersion" ]; then
-    echo "$0: New version same as old version, nothing to do." >&2
+    echo "$scriptName: New version same as old version, nothing to do." >&2
     exit 0
 fi
 
@@ -94,7 +144,7 @@ fi
 
 # If new hash not given on the command line, recalculate it ourselves.
 if [ -z "$newHash" ]; then
-    nix-build --no-out-link -A "$attr.src" 2>"$attr.fetchlog" >/dev/null || true
+    nix-build $systemArg --no-out-link -A "$attr.src" 2>"$attr.fetchlog" >/dev/null || true
     # FIXME: use nix-build --hash here once https://github.com/NixOS/nix/issues/1172 is fixed
     newHash=$(egrep -v "killing process|dependencies couldn't be built|wanted: " "$attr.fetchlog" | tail -n2 | sed "s~output path .* has .* hash ‘\(.*\)’ when .* was expected\|fixed-output derivation produced path '.*' with .* hash '\(.*\)' instead of the expected hash '.*'\|  got:    .*:\(.*\)~\1\2\3~" | head -n1)
 fi


### PR DESCRIPTION
###### Motivation for this change
I extended our `update-source-version` utility and now we can update Sublime with `update.nix`.

cc @wmertens @demin-dmitriy @zimbatm (Sublime)
cc @dezgeg (common-updater-scripts)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

