### PR TITLE
kitty: support macOS

### DIFF
--- a/pkgs/applications/misc/kitty/default.nix
+++ b/pkgs/applications/misc/kitty/default.nix
@@ -2,7 +2,20 @@
   harfbuzz, fontconfig, pkgconfig, ncurses, imagemagick, xsel,
   libstartup_notification, libX11, libXrandr, libXinerama, libXcursor,
   libxkbcommon, libXi, libXext, wayland-protocols, wayland,
-  which, dbus
+  which, dbus,
+  Cocoa,
+  CoreGraphics,
+  Foundation,
+  IOKit,
+  Kernel,
+  OpenGL,
+  cf-private,
+  libicns,
+  libpng,
+  librsvg,
+  optipng,
+  python3,
+  zlib,
 }:
 
 with python3Packages;
@@ -19,12 +32,32 @@ buildPythonApplication rec {
   };
 
   buildInputs = [
-    fontconfig glfw ncurses libunistring harfbuzz libX11
+    ncurses harfbuzz
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [
+    Cocoa
+    CoreGraphics
+    Foundation
+    IOKit
+    Kernel
+    OpenGL
+    cf-private
+    libpng
+    python3
+    zlib
+  ] ++ stdenv.lib.optionals stdenv.isLinux [
+    fontconfig glfw libunistring libX11
     libXrandr libXinerama libXcursor libxkbcommon libXi libXext
     wayland-protocols wayland dbus
   ];
 
-  nativeBuildInputs = [ pkgconfig which sphinx ncurses ];
+  nativeBuildInputs = [
+    pkgconfig which sphinx ncurses
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [
+    imagemagick
+    libicns  # For the png2icns tool.
+    librsvg
+    optipng
+  ];
 
   outputs = [ "out" "terminfo" ];
 
@@ -33,16 +66,30 @@ buildPythonApplication rec {
       src = ./fix-paths.patch;
       libstartup_notification = "${libstartup_notification}/lib/libstartup-notification-1.so";
     })
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [
+    ./macos-10.11.patch
+    ./no-lto.patch
+    ./no-werror.patch
+    ./png2icns.patch
   ];
 
-  buildPhase = ''
+  buildPhase = if stdenv.isDarwin then ''
+    make app
+  '' else ''
     ${python.interpreter} setup.py linux-package
   '';
 
   installPhase = ''
     runHook preInstall
     mkdir -p $out
+    ${if stdenv.isDarwin then ''
+    mkdir "$out/bin"
+    ln -s ../Applications/kitty.app/Contents/MacOS/kitty "$out/bin/kitty"
+    mkdir "$out/Applications"
+    cp -r kitty.app "$out/Applications/kitty.app"
+    '' else ''
     cp -r linux-package/{bin,share,lib} $out
+    ''}
     wrapProgram "$out/bin/kitty" --prefix PATH : "$out/bin:${stdenv.lib.makeBinPath [ imagemagick xsel ]}"
     runHook postInstall
 
@@ -54,8 +101,13 @@ buildPythonApplication rec {
   '';
 
   postInstall = ''
+    terminfo_src=${if stdenv.isDarwin then
+      ''"$out/Applications/kitty.app/Contents/Resources/terminfo"''
+      else
+      "$out/share/terminfo"}
+
     mkdir -p $terminfo/share
-    mv $out/share/terminfo $terminfo/share/terminfo
+    mv "$terminfo_src" $terminfo/share/terminfo
 
     mkdir -p $out/nix-support
     echo "$terminfo" >> $out/nix-support/propagated-user-env-packages
@@ -65,7 +117,7 @@ buildPythonApplication rec {
     homepage = https://github.com/kovidgoyal/kitty;
     description = "A modern, hackable, featureful, OpenGL based terminal emulator";
     license = licenses.gpl3;
-    platforms = platforms.linux;
+    platforms = platforms.darwin ++ platforms.linux;
     maintainers = with maintainers; [ tex rvolosatovs ];
   };
 }

--- a/pkgs/applications/misc/kitty/macos-10.11.patch
+++ b/pkgs/applications/misc/kitty/macos-10.11.patch
@@ -1,0 +1,116 @@
+commit 749772b8b8179eb3b71e542fd9ed5621feb578f5
+Author: Matthew Glazar <strager.nds@gmail.com>
+Date:   Thu Feb 28 22:01:32 2019 -0800
+
+    Support macOS 10.11
+
+    Allow Kitty to run on macOS 10.11 El Capitan.
+
+diff --git a/glfw/cocoa_init.m b/glfw/cocoa_init.m
+index 1e719d2e..05a680e4 100644
+--- a/glfw/cocoa_init.m
++++ b/glfw/cocoa_init.m
+@@ -30,6 +30,10 @@
+   #define NSEventMaskKeyUp NSKeyUpMask
+   #define NSEventMaskKeyDown NSKeyDownMask
+   #define NSEventModifierFlagCommand NSCommandKeyMask
++  #define NSEventModifierFlagControl NSControlKeyMask
++  #define NSEventModifierFlagDeviceIndependentFlagsMask NSDeviceIndependentModifierFlagsMask
++  #define NSEventModifierFlagShift NSShiftKeyMask
++  #define NSEventTypeApplicationDefined NSApplicationDefined
+ #endif
+
+ // Change to our application bundle's resources directory, if present
+diff --git a/glfw/cocoa_window.m b/glfw/cocoa_window.m
+index 1ce79b56..fd2255fc 100644
+--- a/glfw/cocoa_window.m
++++ b/glfw/cocoa_window.m
+@@ -41,6 +41,7 @@
+  #define NSWindowStyleMaskTitled NSTitledWindowMask
+  #define NSEventModifierFlagCommand NSCommandKeyMask
+  #define NSEventModifierFlagControl NSControlKeyMask
++ #define NSEventModifierFlagNumericPad NSNumericPadKeyMask
+  #define NSEventModifierFlagOption NSAlternateKeyMask
+  #define NSEventModifierFlagShift NSShiftKeyMask
+  #define NSEventModifierFlagCapsLock NSAlphaShiftKeyMask
+diff --git a/kitty/cocoa_window.m b/kitty/cocoa_window.m
+index 5e9252ba..99eb3352 100644
+--- a/kitty/cocoa_window.m
++++ b/kitty/cocoa_window.m
+@@ -15,6 +15,9 @@
+ #include <objc/runtime.h>
+
+ #if (MAC_OS_X_VERSION_MAX_ALLOWED < 101200)
++typedef NSUInteger NSWindowStyleMask;
++#define NSWindowStyleMaskBorderless NSBorderlessWindowMask
++#define NSWindowStyleMaskFullScreen NSFullScreenWindowMask
+ #define NSWindowStyleMaskResizable NSResizableWindowMask
+ #define NSEventModifierFlagOption NSAlternateKeyMask
+ #define NSEventModifierFlagCommand NSCommandKeyMask
+diff --git a/kitty/logging.c b/kitty/logging.c
+index 45c88174..1ec9f1b0 100644
+--- a/kitty/logging.c
++++ b/kitty/logging.c
+@@ -5,12 +5,21 @@
+  * Distributed under terms of the GPL3 license.
+  */
+
++#ifdef __APPLE__
++#include <AvailabilityMacros.h>
++#endif
++#if defined(__APPLE__) && defined(MAC_OS_X_VERSION_10_12) && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_12
++#define USE_APPLE_OS_LOG 1
++#else
++#define USE_APPLE_OS_LOG 0
++#endif
++
+ #include "data-types.h"
+ #include <stdlib.h>
+ #include <stdarg.h>
+ #include <time.h>
+ #include <sys/time.h>
+-#ifdef __APPLE__
++#if USE_APPLE_OS_LOG
+ #include <os/log.h>
+ #endif
+
+@@ -21,7 +30,7 @@ void
+ log_error(const char *fmt, ...) {
+     va_list ar;
+     struct timeval tv;
+-#ifdef __APPLE__
++#if USE_APPLE_OS_LOG
+     // Apple does not provide a varargs style os_logv
+     char logbuf[16 * 1024] = {0};
+ #else
+@@ -44,7 +53,7 @@ log_error(const char *fmt, ...) {
+     if (use_os_log) { bufprint(vsnprintf, fmt, ar); }
+     else vfprintf(stderr, fmt, ar);
+     va_end(ar);
+-#ifdef __APPLE__
++#if USE_APPLE_OS_LOG
+     if (use_os_log) os_log(OS_LOG_DEFAULT, "%{public}s", logbuf);
+ #endif
+     if (!use_os_log) fprintf(stderr, "\n");
+@@ -66,7 +75,7 @@ static PyMethodDef module_methods[] = {
+ bool
+ init_logging(PyObject *module) {
+     if (PyModule_AddFunctions(module, module_methods) != 0) return false;
+-#ifdef __APPLE__
++#if USE_APPLE_OS_LOG
+     if (getenv("KITTY_LAUNCHED_BY_LAUNCH_SERVICES") != NULL) use_os_log = true;
+ #endif
+     return true;
+diff --git a/setup.py b/setup.py
+index f8643fce..55a96e73 100755
+--- a/setup.py
++++ b/setup.py
+@@ -711,7 +711,7 @@ Categories=System;TerminalEmulator;
+             CFBundlePackageType='APPL',
+             CFBundleSignature='????',
+             CFBundleExecutable=appname,
+-            LSMinimumSystemVersion='10.12.0',
++            LSMinimumSystemVersion='10.11.0',
+             LSRequiresNativeExecution=True,
+             NSAppleScriptEnabled=False,
+             # Needed for dark mode in Mojave when linking against older SDKs

--- a/pkgs/applications/misc/kitty/no-lto.patch
+++ b/pkgs/applications/misc/kitty/no-lto.patch
@@ -1,0 +1,12 @@
+--- a/setup.py
++++ b/setup.py
+@@ -223,9 +223,6 @@ def init_env(
+     cppflags += shlex.split(os.environ.get('CPPFLAGS', ''))
+     cflags += shlex.split(os.environ.get('CFLAGS', ''))
+     ldflags += shlex.split(os.environ.get('LDFLAGS', ''))
+-    if not debug and not sanitize:
+-        # See https://github.com/google/sanitizers/issues/647
+-        cflags.append('-flto'), ldflags.append('-flto')
+
+     if profile:
+         cppflags.append('-DWITH_PROFILER')

--- a/pkgs/applications/misc/kitty/no-werror.patch
+++ b/pkgs/applications/misc/kitty/no-werror.patch
@@ -1,0 +1,11 @@
+--- a/setup.py
++++ b/setup.py
+@@ -202,7 +202,7 @@ def init_env(
+     cflags = os.environ.get(
+         'OVERRIDE_CFLAGS', (
+             '-Wextra -Wno-missing-field-initializers -Wall -std=c11'
+-            ' -pedantic-errors -Werror {} {} -fwrapv {} {} -pipe {} -fvisibility=hidden'
++            ' {} {} -fwrapv {} {} -pipe {} -fvisibility=hidden'
+         ).format(
+             optimize,
+             ' '.join(sanitize_args),

--- a/pkgs/applications/misc/kitty/png2icns.patch
+++ b/pkgs/applications/misc/kitty/png2icns.patch
@@ -1,0 +1,19 @@
+--- a/setup.py
++++ b/setup.py
+@@ -744,9 +744,15 @@ Categories=System;TerminalEmulator;
+         if not os.path.exists(logo_dir):
+             raise SystemExit('The kitty logo has not been generated, you need to run logo/make.py')
+         subprocess.check_call([
+-            'iconutil', '-c', 'icns', logo_dir, '-o',
++            'png2icns',
+             os.path.join('Resources', os.path.basename(logo_dir).partition('.')[0] + '.icns')
+-        ])
++        ] + [os.path.join(logo_dir, logo) for logo in (
++            'icon_128x128.png',
++            'icon_16x16.png',
++            'icon_256x256.png',
++            'icon_32x32.png',
++            'icon_512x512.png',
++        )])
+     # }}}
+ # }}}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17970,7 +17970,13 @@ in
 
   kipi-plugins = libsForQt5.callPackage ../applications/graphics/kipi-plugins { };
 
-  kitty = callPackage ../applications/misc/kitty { };
+  kitty = callPackage ../applications/misc/kitty {
+    harfbuzz = if stdenv.isDarwin then harfbuzz.override {
+      withCoreText = true;
+    } else harfbuzz;
+    inherit (darwin) cf-private;
+    inherit (darwin.apple_sdk.frameworks) Cocoa CoreGraphics Foundation IOKit Kernel OpenGL;
+  };
 
   kiwix = callPackage ../applications/misc/kiwix { };
 


### PR DESCRIPTION
###### Motivation for this change

Enable people to easily install and run [kitty][kitty] from source on macOS 10.12 and newer. This includes using kitty as a command-line utility (`kitty) and as a macOS application (`kitty.app`).

[kitty]: https://sw.kovidgoyal.net/kitty/index.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Additional information

* Prefer libicns (png2icns) over Apple's non-free iconutil.
* Work around warnings from Apple headers by disabling -pedantic-errors and -Werror.
* Work around ld not support LLVM-LTO by disabling LTO.
* Make Kitty and glfw compile for macOS 10.11 (and macOS 10.10).
* Make an alias for libicns called png2icns to reduce confusion.