### PR TITLE
pytjon.pkgs.wptserve: correctly fix build

### DIFF
--- a/pkgs/development/python-modules/wptserve/default.nix
+++ b/pkgs/development/python-modules/wptserve/default.nix
@@ -16,6 +16,10 @@ buildPythonPackage rec {
     sha256 = "9d0c6adc279748abea81ac12b7a2cac97ebbdd87826dc11f6dbd85b781e9442a";
   };
 
+  postPatch = ''
+    substituteInPlace setup.py --replace "h2==" "h2>="
+  '';
+
   propagatedBuildInputs = [ six h2 ];
 
   meta = {

--- a/pkgs/development/python-modules/wptserve/default.nix
+++ b/pkgs/development/python-modules/wptserve/default.nix
@@ -5,19 +5,6 @@
 , isPy3k
 }:
 
-let
-  _h2 = h2;
-in let
-  h2 = _h2.overrideAttrs (x: {
-    version = "3.0.1";
-    src = fetchPypi {
-      pname = "h2";
-      version = "3.0.1";
-      sha256 = "0r3f43r0v7sqgdjjg5ngw0dndk2v6cyd0jncpwya54m37y42z5mj";
-    };
-  });
-in
-
 buildPythonPackage rec {
   pname = "wptserve";
   version = "2.0";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

