### PR TITLE
ffado: port to qt5

### DIFF
--- a/pkgs/development/python-modules/dbus/default.nix
+++ b/pkgs/development/python-modules/dbus/default.nix
@@ -6,12 +6,16 @@ if isPyPy then throw "dbus-python not supported for interpreter ${python.executa
   version = "1.2.4";
   format = "other";
 
+  outputs = [ "out" "dev" "doc" ];
+
   src = fetchurl {
     url = "http://dbus.freedesktop.org/releases/dbus-python/${pname}-${version}.tar.gz";
     sha256 = "1k7rnaqrk7mdkg0k6n2jn3d1mxsl7s3i07g5a8va5yvl3y3xdwg2";
   };
 
-  postPatch = "patchShebangs .";
+  patches = [
+    ./fix-includedir.patch
+  ];
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ dbus dbus-glib ]

--- a/pkgs/development/python-modules/dbus/fix-includedir.patch
+++ b/pkgs/development/python-modules/dbus/fix-includedir.patch
@@ -1,0 +1,8 @@
+--- a/dbus-python.pc.in
++++ b/dbus-python.pc.in
+@@ -9,4 +9,4 @@
+ Description: Python bindings for D-Bus
+ Requires: dbus-1 >= 1.0
+ Version: @VERSION@
+-Cflags: -I${includedir}
++Cflags: -I${includedir}/dbus-1.0

--- a/pkgs/development/python-modules/pyqt/5.x.nix
+++ b/pkgs/development/python-modules/pyqt/5.x.nix
@@ -27,24 +27,26 @@ in buildPythonPackage rec {
 
   buildInputs = [ dbus sip ];
 
-  propagatedBuildInputs = [ qtbase qtsvg qtwebengine ]
+  propagatedBuildInputs = [ qtbase qtsvg qtwebengine dbus-python ]
     ++ lib.optional (!isPy3k) enum34
     ++ lib.optional withConnectivity qtconnectivity
     ++ lib.optional withWebKit qtwebkit
     ++ lib.optional withWebSockets qtwebsockets;
 
+  patches = [
+    # Fix some wrong assumptions by ./configure.py
+    # TODO: figure out how to send this upstream
+    ./pyqt5-fix-dbus-mainloop-support.patch
+  ];
+
   configurePhase = ''
     runHook preConfigure
-
-    mkdir -p $out
-    lndir ${dbus-python} $out
-    rm -rf "$out/nix-support"
 
     export PYTHONPATH=$PYTHONPATH:$out/${python.sitePackages}
 
     ${python.executable} configure.py  -w \
       --confirm-license \
-      --dbus=${dbus.dev}/include/dbus-1.0 \
+      --dbus-moduledir=$out/${python.sitePackages}/dbus/mainloop \
       --no-qml-plugin \
       --bindir=$out/bin \
       --destdir=$out/${python.sitePackages} \

--- a/pkgs/development/python-modules/pyqt/pyqt5-fix-dbus-mainloop-support.patch
+++ b/pkgs/development/python-modules/pyqt/pyqt5-fix-dbus-mainloop-support.patch
@@ -1,0 +1,70 @@
+From 944d5467e1655aac20a14325631df6daccaf5804 Mon Sep 17 00:00:00 2001
+From: Jan Tojnar <jtojnar@gmail.com>
+Date: Sun, 3 Mar 2019 01:13:46 +0100
+Subject: [PATCH] Fix building on Nix
+
+./configure.py tries to find dbus-python header in dbus-1 includedir
+obtained from pkg-config or from --dbus flag. Unfortunately, when supplied,
+it also uses the flag for locating dbus-1 headers. This fails on Nix,
+since every package is installed into its own immutable tree so we cannot
+use a single directory for both dbus-python and dbus-1. We can fix this by
+using pkg-config for finding dbus-python headers too.
+
+Additionally, the build system also tries to install the dbus support module
+to dbus-python tree. Often, it is possible to handle this in pkgconfig as well [1]
+but unfortunately, dbus-python does not export the moduledir in its pc file
+so I have decided to solve this with an extra configure flag.
+
+[1]: https://www.bassi.io/articles/2018/03/15/pkg-config-and-paths/
+---
+ configure.py | 13 +++++++++++--
+ 1 file changed, 11 insertions(+), 2 deletions(-)
+
+diff --git a/configure.py b/configure.py
+index a3450ca3..440d90a2 100644
+--- a/configure.py
++++ b/configure.py
+@@ -905,6 +905,9 @@ class TargetConfiguration:
+         if opts.pydbusincdir is not None:
+             self.pydbus_inc_dir = opts.pydbusincdir
+ 
++        if opts.pydbusmoduledir is not None:
++            self.pydbus_module_dir = opts.pydbusmoduledir
++
+         if opts.pyuicinterpreter is not None:
+             self.pyuic_interpreter = opts.pyuicinterpreter
+ 
+@@ -1184,6 +1187,11 @@ def create_optparser(target_config):
+             metavar="DIR",
+             help="the directory containing the dbus/dbus-python.h header is "
+             "DIR [default: supplied by pkg-config]")
++    g.add_option("--dbus-moduledir", dest='pydbusmoduledir', type='string',
++            default=None, action='callback', callback=store_abspath,
++            metavar="DIR",
++            help="the directory where dbus support module will be installed to"
++            "DIR [default: obtained from dbus.mainloop python module]")
+     p.add_option_group(g)
+ 
+     # Installation.
+@@ -2149,7 +2157,7 @@ def check_dbus(target_config, verbose):
+ 
+     inform("Checking to see if the dbus support module should be built...")
+ 
+-    cmd = 'pkg-config --cflags-only-I --libs dbus-1'
++    cmd = 'pkg-config --cflags-only-I --libs dbus-1 dbus-python'
+ 
+     if verbose:
+         sys.stdout.write(cmd + "\n")
+@@ -2178,7 +2186,8 @@ def check_dbus(target_config, verbose):
+         inform("The Python dbus module doesn't seem to be installed.")
+         return
+ 
+-    target_config.pydbus_module_dir = dbus.mainloop.__path__[0]
++    if target_config.pydbus_module_dir == '':
++        target_config.pydbus_module_dir = dbus.mainloop.__path__[0]
+ 
+     # Try and find dbus-python.h.  We don't use pkg-config because it is broken
+     # for dbus-python (at least for versions up to and including v0.81.0).
+-- 
+2.18.0
+

--- a/pkgs/development/python-modules/python-efl/default.nix
+++ b/pkgs/development/python-modules/python-efl/default.nix
@@ -18,9 +18,9 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ python.pkgs.dbus-python ];
 
   preConfigure = ''
-    export NIX_CFLAGS_COMPILE="$(pkg-config --cflags efl) -I${python.pkgs.dbus-python}/include/dbus-1.0 $NIX_CFLAGS_COMPILE"
+    export NIX_CFLAGS_COMPILE="$(pkg-config --cflags efl) -I${stdenv.lib.getDev python.pkgs.dbus-python}/include/dbus-1.0 $NIX_CFLAGS_COMPILE"
   '';
-  
+
   preBuild = "${python.interpreter} setup.py build_ext";
 
   installPhase= "${python.interpreter} setup.py install --prefix=$out";

--- a/pkgs/os-specific/linux/ffado/default.nix
+++ b/pkgs/os-specific/linux/ffado/default.nix
@@ -1,61 +1,57 @@
-{ stdenv, fetchurl, scons, pkgconfig, which, makeWrapper, python
-, expat, libraw1394, libconfig, libavc1394, libiec61883, libxmlxx
+{ stdenv, fetchurl, scons, pkgconfig, which, makeWrapper, python3
+, libraw1394, libconfig, libavc1394, libiec61883, libxmlxx3
 , glibmm
 , alsaLib, dbus, dbus_cplusplus
-, pyqt4, dbus-python
 }:
 
-stdenv.mkDerivation rec {
-  name = "ffado-${version}";
-  version = "2.4.0";
+let
+  inherit (python3.pkgs) pyqt5 dbus-python;
+  python = python3.withPackages (pkgs: with pkgs; [ pyqt5 dbus-python ]);
+in stdenv.mkDerivation rec {
+  pname = "ffado";
+  version = "2.4.1";
 
   src = fetchurl {
     url = "http://www.ffado.org/files/libffado-${version}.tgz";
-    sha256 = "14rprlcd0gpvg9kljh0zzjzd2rc9hbqqpjidshxxjvvfh4r00f4f";
+    sha256 = "0byr3kv58d1ryy60vr69fd868zlfkvl2gq9hl94dqdn485l9pq9y";
   };
+
+  patches = [
+    # fix installing metainfo file
+    ./fix-build.patch
+  ];
 
   outputs = [ "out" "bin" "dev" ];
 
-  nativeBuildInputs = [ scons pkgconfig which makeWrapper python ];
+  nativeBuildInputs = [ scons pkgconfig which makeWrapper python pyqt5 ];
 
   prefixKey = "PREFIX=";
   sconsFlags = [
     "DEBUG=False"
     "ENABLE_ALL=True"
-    "SERIALIZE_USE_EXPAT=True"
     "BUILD_TESTS=False"
     "WILL_DEAL_WITH_XDG_MYSELF=True"
     "BUILD_MIXER=True"
+    "UDEVDIR=${placeholder "out"}/lib/udev/rules.d"
+    "PYPKGDIR=${placeholder "out"}/${python3.sitePackages}"
+    "BINDIR=${placeholder "bin"}/bin"
+    "INCLUDEDIR=${placeholder "dev"}/include"
+    "PYTHON_INTERPRETER=${python.interpreter}"
   ];
-
-  configurePhase = ''
-    mkdir -p $out/lib/udev/rules.d $bin/bin $dev/include \
-             $out/lib/${python.libPrefix}/site-packages
-    sconsFlagsArray+=(UDEVDIR=$out/lib/udev/rules.d)
-    sconsFlagsArray+=(PYPKGDIR=$out/lib/${python.libPrefix}/site-packages)
-    sconsFlagsArray+=(BINDIR=$bin/bin)
-    sconsFlagsArray+=(INCLUDEDIR=$dev/include)
-    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE $(pkg-config --cflags libxml++-2.6)"
-  '';
 
   buildInputs = [
-    expat libraw1394 libconfig libavc1394 libiec61883 dbus dbus_cplusplus
-    libxmlxx pyqt4 dbus-python glibmm
+    libraw1394
+    libconfig
+    libavc1394
+    libiec61883
+    dbus
+    dbus_cplusplus
+    libxmlxx3
+    python
+    glibmm
   ];
 
-  postPatch = ''
-    sed '1iimport sys' -i SConstruct
-  '';
-
-  postInstall = ''
-    for exe in $bin/bin/ffado-mixer $bin/bin/ffado-diag; do
-      wrapProgram $exe \
-        --prefix PYTHONPATH : $out/lib/${python.libPrefix}/site-packages \
-        --prefix PYTHONPATH : $out/share/libffado/python \
-        --prefix PYTHONPATH : ${pyqt4}/lib/${python.libPrefix}/site-packages \
-        --prefix PYTHONPATH : ${dbus-python}/lib/${python.libPrefix}/site-packages
-    done
-  '';
+  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     homepage = http://www.ffado.org;

--- a/pkgs/os-specific/linux/ffado/fix-build.patch
+++ b/pkgs/os-specific/linux/ffado/fix-build.patch
@@ -1,0 +1,26 @@
+From b0f2b20b23780dd2e67a01c15462070dd86c4ac1 Mon Sep 17 00:00:00 2001
+From: Jan Tojnar <jtojnar@gmail.com>
+Date: Sun, 3 Mar 2019 11:50:27 +0100
+Subject: [PATCH] Fix build on Nix
+
+We do not have global /usr.
+---
+ SConstruct | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/SConstruct b/SConstruct
+index 05755e4b..3fbdc1d8 100644
+--- a/SConstruct
++++ b/SConstruct
+@@ -537,7 +537,7 @@ env['mandir'] = Template( env.destdir + env['MANDIR'] ).safe_substitute( env )
+ env['pypkgdir'] = Template( env.destdir + env['PYPKGDIR'] ).safe_substitute( env )
+ env['udevdir'] = Template( env.destdir + env['UDEVDIR'] ).safe_substitute( env )
+ env['PYPKGDIR'] = Template( env['PYPKGDIR'] ).safe_substitute( env )
+-env['metainfodir'] = Template( env.destdir + "/usr/share/metainfo" ).safe_substitute( env )
++env['metainfodir'] = Template( env.destdir + env['SHAREDIR'] + "/metainfo" ).safe_substitute( env )
+ 
+ env.Command( target=env['sharedir'], source="", action=Mkdir( env['sharedir'] ) )
+ 
+-- 
+2.19.2
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14432,9 +14432,7 @@ in
 
   fatrace = callPackage ../os-specific/linux/fatrace { };
 
-  ffado = callPackage ../os-specific/linux/ffado {
-    inherit (python2Packages) python pyqt4 dbus-python;
-  };
+  ffado = callPackage ../os-specific/linux/ffado { };
   libffado = ffado;
 
   fbterm = callPackage ../os-specific/linux/fbterm { };


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/33248
Closes: https://github.com/NixOS/nixpkgs/issues/56712

cc @cillianderoiste 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

