### PR TITLE
xournalpp: init at 1.0.8

### DIFF
--- a/pkgs/applications/graphics/xournalpp/default.nix
+++ b/pkgs/applications/graphics/xournalpp/default.nix
@@ -1,0 +1,74 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, fetchpatch
+
+, cmake
+, gettext
+, wrapGAppsHook
+, pkgconfig
+
+, glib
+, gsettings-desktop-schemas
+, gtk3
+, hicolor-icon-theme
+, libsndfile
+, libxml2
+, pcre
+, poppler
+, portaudio
+, zlib
+
+# Plugins don't appear to be working in this version, so disable them by not
+# building with Lua support by default. In a future version, try switching this
+# to 'true' and seeing if the top-level Plugin menu appears.
+, withLua ? false, lua
+}:
+
+stdenv.mkDerivation rec {
+  name = "xournalpp-${version}";
+  version = "1.0.8";
+
+  src = fetchFromGitHub {
+    owner = "xournalpp";
+    repo = "xournalpp";
+    rev = version;
+    sha256 = "01q84xjp9z1krna10gjj562km6i3wdq8cg7paxax1k6bh52ryvf6";
+  };
+
+  patches = [
+    # This patch removes the unused 'xopp-recording.sh' file which breaks the
+    # cmake build; this patch isn't in a release yet, and should be removed at
+    # or after 1.0.9 is released.
+    (fetchpatch {
+      name = "remove-xopp-recording.sh.patch";
+      url = "https://github.com/xournalpp/xournalpp/commit/a17a3f2c80c607a22d0fdeb66d38358bea7e4d85.patch";
+      sha256 = "10pcpvklm6kr0lv2xrsbpg2037ni9j6dmxgjf56p466l3gz60iwy";
+    })
+  ];
+
+  nativeBuildInputs = [ cmake gettext pkgconfig wrapGAppsHook ];
+  buildInputs =
+    [ glib
+      gsettings-desktop-schemas
+      gtk3
+      hicolor-icon-theme
+      libsndfile
+      libxml2
+      pcre
+      poppler
+      portaudio
+      zlib
+    ]
+    ++ lib.optional withLua lua;
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "Xournal++ is a handwriting Notetaking software with PDF annotation support";
+    homepage    = https://github.com/xournalpp/xournalpp;
+    license     = licenses.gpl2;
+    maintainers = with maintainers; [ andrew-d ];
+    platforms   = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20297,6 +20297,8 @@ in
     inherit (gnome2) libgnomeprint libgnomeprintui libgnomecanvas;
   };
 
+  xournalpp = callPackage ../applications/graphics/xournalpp { };
+
   apvlv = callPackage ../applications/misc/apvlv { };
 
   xpdf = libsForQt5.callPackage ../applications/misc/xpdf { };


### PR DESCRIPTION
###### Motivation for this change
Closes #56470

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] ~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~
- [x] ~Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`~
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] ~Determined the impact on package closure size (by running `nix path-info -S` before and after)~
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @luzpaz @dotlambda 