### PR TITLE
mkfontscale: 1.1.3 -> 1.2.0

### DIFF
--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -1249,11 +1249,11 @@ lib.makeScope newScope (self: with self; {
   }) {};
 
   mkfontscale = callPackage ({ stdenv, pkgconfig, fetchurl, libfontenc, freetype, xorgproto, zlib }: stdenv.mkDerivation {
-    name = "mkfontscale-1.1.3";
+    name = "mkfontscale-1.2.0";
     builder = ./builder.sh;
     src = fetchurl {
-      url = mirror://xorg/individual/app/mkfontscale-1.1.3.tar.bz2;
-      sha256 = "0siag28jpm8hj62bgjvw81sjfgrc7vcy2h7127bl4iazxrlxz60y";
+      url = mirror://xorg/individual/app/mkfontscale-1.2.0.tar.bz2;
+      sha256 = "1gn423m0v1w98df7ni74zrj2rkhsapnqfzr8139l638kkyz7far8";
     };
     hardeningDisable = [ "bindnow" "relro" ];
     nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -18,7 +18,7 @@ mirror://xorg/individual/app/iceauth-1.0.8.tar.bz2
 mirror://xorg/individual/app/ico-1.0.5.tar.bz2
 mirror://xorg/individual/app/listres-1.0.4.tar.bz2
 mirror://xorg/individual/app/mkfontdir-1.0.7.tar.bz2
-mirror://xorg/individual/app/mkfontscale-1.1.3.tar.bz2
+mirror://xorg/individual/app/mkfontscale-1.2.0.tar.bz2
 mirror://xorg/individual/app/oclock-1.0.4.tar.bz2
 mirror://xorg/individual/app/sessreg-1.1.1.tar.bz2
 mirror://xorg/individual/app/setxkbmap-1.3.1.tar.bz2


### PR DESCRIPTION
###### Motivation for this change

https://lists.x.org/archives/xorg-announce/2019-March/002960.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---