### PR TITLE
pythonPackages.protobuf: propagate native pkgs.protobuf input

### DIFF
--- a/pkgs/development/python-modules/protobuf/default.nix
+++ b/pkgs/development/python-modules/protobuf/default.nix
@@ -14,7 +14,8 @@ buildPythonPackage rec {
     ++ optional (versionOlder protobuf.version "2.7.0") "-std=c++98";
 
   propagatedBuildInputs = [ google_apputils ];
-  nativeBuildInputs = [ google_apputils pyext protobuf ];
+  propagatedNativeBuildInputs = [ protobuf ];  # For protoc.
+  nativeBuildInputs = [ google_apputils pyext ];
   buildInputs = [ protobuf ];
 
   patches = optional isPy37


### PR DESCRIPTION
###### Motivation for this change

Python packages depending on the protobuf library often use the "protoc" tool from pkgs.protobuf to codegen at build time. It thus makes sense to propagate that native dependency automatically from the Python lib.

Fixes python3Packages.trezor not building in master nixpkgs.

@FRidh since you changed this last, any thoughts?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

