### PR TITLE
stepmania: 5.0.12 -> 5.1.0-b2

### DIFF
--- a/pkgs/games/stepmania/default.nix
+++ b/pkgs/games/stepmania/default.nix
@@ -5,13 +5,13 @@
 
 stdenv.mkDerivation rec {
   name = "stepmania-${version}";
-  version = "5.0.12";
+  version = "5.1.0-b2";
 
   src = fetchFromGitHub {
     owner = "stepmania";
     repo  = "stepmania";
     rev   = "v${version}";
-    sha256 = "0ig5pnw78j45b35kfr76phaqbac9b2f6wg3c63l6mf0nrq17wslz";
+    sha256 = "0a7y9l7xm510vgnpmj1is7p9m6d6yd0fcaxrjcickz295k5w3rdn";
   };
 
   nativeBuildInputs = [ cmake nasm ];
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     mkdir -p $out/bin
-    ln -s $out/stepmania-5.0/stepmania $out/bin/stepmania
+    ln -s $out/stepmania-5.1/stepmania $out/bin/stepmania
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/games/stepmania/default.nix
+++ b/pkgs/games/stepmania/default.nix
@@ -1,9 +1,9 @@
-{ clangStdenv, lib, fetchFromGitHub, cmake, nasm
+{ stdenv, lib, fetchFromGitHub, cmake, nasm
 , gtk2, glib, ffmpeg, alsaLib, libmad, libogg, libvorbis
 , glew, libpulseaudio, udev
 }:
 
-clangStdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   name = "stepmania-${version}";
   version = "5.0.12";
 


### PR DESCRIPTION
###### Motivation for this change
The build on 5.0.12 fails to start with message "Fatal: crash from within the crash signal handler". This was solved on the 5.1 branch as said on stepmania's github, so we update.

###### Things done

Update the version field, hash and output directory to 5.1.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

