### PR TITLE
pyqt4: fix nativeBuildInputs

### DIFF
--- a/pkgs/development/python-modules/pyqt/4.x.nix
+++ b/pkgs/development/python-modules/pyqt/4.x.nix
@@ -16,6 +16,12 @@ in buildPythonPackage {
     sha256 = "1nw8r88a5g2d550yvklawlvns8gd5slw53yy688kxnsa65aln79w";
   };
 
+  nativeBuildInputs = [ pkgconfig lndir qt4 ];
+
+  buildInputs = [ makeWrapper dbus ];
+
+  propagatedBuildInputs = [ sip ];
+
   configurePhase = ''
     mkdir -p $out
     lndir ${dbus-python} $out
@@ -40,11 +46,6 @@ in buildPythonPackage {
 
     ${python.executable} configure.py $configureFlags "''${configureFlagsArray[@]}"
   '';
-
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ makeWrapper qt4 lndir dbus ];
-
-  propagatedBuildInputs = [ sip ];
 
   postInstall = ''
     for i in $out/bin/*; do


### PR DESCRIPTION
###### Motivation for this change

fixes the broken build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

