### PR TITLE
solarc-gtk-theme: init at 1.0.2

### DIFF
--- a/pkgs/misc/themes/solarc/default.nix
+++ b/pkgs/misc/themes/solarc/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, autoconf, automake, pkgconfig,
+  gtk-engine-murrine, gtk3
+}:
+
+stdenv.mkDerivation rec {
+  name = "solarc-gtk-theme-${version}";
+  version = "1.0.2";
+
+  src = fetchFromGitHub {
+    owner = "schemar";
+    repo = "solarc-theme";
+    rev = "d1eb117325b8e5085ecaf78df2eb2413423fc643";
+    sha256 = "005b66whyxba3403yzykpnlkz0q4m154pxpb4jzcny3fggy9r70s";
+  };
+
+  nativeBuildInputs = [ autoconf automake pkgconfig gtk3 ];
+
+  propagatedUserEnvPkgs = [ gtk-engine-murrine gtk3 ];
+
+  buildPhase = ''
+    ./autogen.sh --prefix=$out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Solarized version of the Arc theme";
+    homepage = https://github.com/schemar/solarc-theme;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.bricewge ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21391,6 +21391,8 @@ in
     gtk = gtk2;
   };
 
+  solarc-gtk-theme = callPackage ../misc/themes/solarc { };
+
   xfce = xfce4-12;
   xfceUnstable = xfce4-13;
 


### PR DESCRIPTION
###### Motivation for this change
Add SolArc theme.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

