### PR TITLE
azure-mgmt-*: re-init older versions for use with nixops

### DIFF
--- a/pkgs/tools/package-management/nixops/azure-mgmt-compute/default.nix
+++ b/pkgs/tools/package-management/nixops/azure-mgmt-compute/default.nix
@@ -1,0 +1,37 @@
+{ pkgs
+, buildPythonPackage
+, fetchPypi
+, python
+, azure-mgmt-common
+}:
+
+buildPythonPackage rec {
+  version = "0.20.1";
+  pname = "azure-mgmt-compute";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "97298fc7f133f1d50a974ed6299151eda494a574b0f7fdf8192a388015c2215a";
+  };
+
+  preConfigure = ''
+    # Patch to make this package work on requests >= 2.11.x
+    # CAN BE REMOVED ON NEXT PACKAGE UPDATE
+    sed -i 's|len(request_content)|str(len(request_content))|' azure/mgmt/compute/computemanagement.py
+  '';
+
+  postInstall = ''
+    echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/__init__.py
+    echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/mgmt/__init__.py
+  '';
+
+  propagatedBuildInputs = [ azure-mgmt-common ];
+
+  meta = with pkgs.lib; {
+    description = "Microsoft Azure SDK for Python";
+    homepage = "https://azure.microsoft.com/en-us/develop/python/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ olcai ];
+  };
+}

--- a/pkgs/tools/package-management/nixops/azure-mgmt-network/default.nix
+++ b/pkgs/tools/package-management/nixops/azure-mgmt-network/default.nix
@@ -1,0 +1,37 @@
+{ pkgs
+, buildPythonPackage
+, fetchPypi
+, azure-mgmt-common
+, python
+}:
+
+buildPythonPackage rec {
+  version = "0.20.1";
+  pname = "azure-mgmt-network";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "10vj22h6nxpw0qpvib5x2g6qs5j8z31142icvh4qk8k40fcrs9hx";
+  };
+
+  preConfigure = ''
+    # Patch to make this package work on requests >= 2.11.x
+    # CAN BE REMOVED ON NEXT PACKAGE UPDATE
+    sed -i 's|len(request_content)|str(len(request_content))|' azure/mgmt/network/networkresourceprovider.py
+  '';
+
+  postInstall = ''
+    echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/__init__.py
+    echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/mgmt/__init__.py
+  '';
+
+  propagatedBuildInputs = [ azure-mgmt-common ];
+
+  meta = with pkgs.lib; {
+    description = "Microsoft Azure SDK for Python";
+    homepage = "https://azure.microsoft.com/en-us/develop/python/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ olcai ];
+  };
+}

--- a/pkgs/tools/package-management/nixops/azure-mgmt-nspkg/default.nix
+++ b/pkgs/tools/package-management/nixops/azure-mgmt-nspkg/default.nix
@@ -1,0 +1,25 @@
+{ pkgs
+, buildPythonPackage
+, fetchPypi
+, azure-nspkg
+}:
+
+buildPythonPackage rec {
+  version = "1.0.0";
+  pname = "azure-mgmt-nspkg";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "1rq92fj3kvnqkk18596dybw0kvhgscvc6cd8hp1dhy3wrkqnhwmq";
+  };
+
+  propagatedBuildInputs = [ azure-nspkg ];
+
+  meta = with pkgs.lib; {
+    description = "Microsoft Azure SDK for Python";
+    homepage = "https://azure.microsoft.com/en-us/develop/python/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ olcai ];
+  };
+}

--- a/pkgs/tools/package-management/nixops/azure-mgmt-resource/default.nix
+++ b/pkgs/tools/package-management/nixops/azure-mgmt-resource/default.nix
@@ -1,0 +1,38 @@
+{ pkgs
+, buildPythonPackage
+, fetchPypi
+, python
+, azure-mgmt-common
+}:
+
+
+buildPythonPackage rec {
+  version = "0.20.1";
+  pname = "azure-mgmt-resource";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "0slh9qfm5nfacrdm3lid0sr8kwqzgxvrwf27laf9v38kylkfqvml";
+  };
+
+  preConfigure = ''
+    # Patch to make this package work on requests >= 2.11.x
+    # CAN BE REMOVED ON NEXT PACKAGE UPDATE
+    sed -i 's|len(request_content)|str(len(request_content))|' azure/mgmt/resource/resourcemanagement.py
+  '';
+
+  postInstall = ''
+    echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/__init__.py
+    echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/mgmt/__init__.py
+  '';
+
+  propagatedBuildInputs = [ azure-mgmt-common ];
+
+  meta = with pkgs.lib; {
+    description = "Microsoft Azure SDK for Python";
+    homepage = "https://azure.microsoft.com/en-us/develop/python/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ olcai ];
+  };
+}

--- a/pkgs/tools/package-management/nixops/azure-mgmt-storage/default.nix
+++ b/pkgs/tools/package-management/nixops/azure-mgmt-storage/default.nix
@@ -1,0 +1,37 @@
+{ pkgs
+, buildPythonPackage
+, fetchPypi
+, python
+, azure-mgmt-common
+}:
+
+buildPythonPackage rec {
+  version = "0.20.0";
+  pname = "azure-mgmt-storage";
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "16iw7hqhq97vlzfwixarfnirc60l5mz951p57brpcwyylphl3yim";
+  };
+
+  preConfigure = ''
+    # Patch to make this package work on requests >= 2.11.x
+    # CAN BE REMOVED ON NEXT PACKAGE UPDATE
+    sed -i 's|len(request_content)|str(len(request_content))|' azure/mgmt/storage/storagemanagement.py
+  '';
+
+  postInstall = ''
+    echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/__init__.py
+    echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/mgmt/__init__.py
+  '';
+
+  propagatedBuildInputs = [ azure-mgmt-common ];
+
+  meta = with pkgs.lib; {
+    description = "Microsoft Azure SDK for Python";
+    homepage = "https://azure.microsoft.com/en-us/develop/python/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ olcai ];
+  };
+}

--- a/pkgs/tools/package-management/nixops/default.nix
+++ b/pkgs/tools/package-management/nixops/default.nix
@@ -1,9 +1,24 @@
-{ callPackage, fetchurl }:
+{ callPackage, newScope, pkgs, fetchurl }:
 
 callPackage ./generic.nix (rec {
   version = "1.6.1";
   src = fetchurl {
     url = "http://nixos.org/releases/nixops/nixops-${version}/nixops-${version}.tar.bz2";
     sha256 = "0lfx5fhyg3z6725ydsk0ibg5qqzp5s0x9nbdww02k8s307axiah3";
+  };
+# nixops is incompatible with the most recent versions of listed
+# azure-mgmt-* packages, therefore we are pinning them to
+# package-private versions, so that they don't get trampled by
+# updates.
+# see
+# https://github.com/NixOS/nixops/issues/1065
+  python2Packages = pkgs.python2Packages.override {
+    overrides = (self: super: let callPackage = newScope self; in {
+      azure-mgmt-compute = callPackage ./azure-mgmt-compute { };
+      azure-mgmt-network = callPackage ./azure-mgmt-network { };
+      azure-mgmt-nspkg = callPackage ./azure-mgmt-nspkg { };
+      azure-mgmt-resource = callPackage ./azure-mgmt-resource { };
+      azure-mgmt-storage = callPackage ./azure-mgmt-storage { };
+    });
   };
 })


### PR DESCRIPTION
add pinned versions package-private

azure-mgmt-compute 0.20.1
azure-mgmt-network 0.20.1
azure-mgmt-nspkg 1.0.0
azure-mgmt-resource 0.20.1
azure-mgmt-storage 0.20.0

replacement for https://github.com/NixOS/nixpkgs/pull/52550

###### Motivation for this change

nixops is incompatible with the most recent versions of listed
azure-mgmt-* packages, therefore we should pin them to
package-private versions, so that they don't get trampled by
updates, while https://github.com/NixOS/nixops/issues/1065 is fixed.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

