### PR TITLE
wireshark: 2.6.6 -> 3.0.1 [RDY]

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -64,10 +64,10 @@ in stdenv.mkDerivation {
     mkdir -p $out/Applications
     mv $out/bin/Wireshark.app $out/Applications/Wireshark.app
 
-    for so in $out/Applications/Wireshark.app/Contents/PlugIns/wireshark/*.so; do
-        install_name_tool $so -change libwireshark.10.dylib $out/lib/libwireshark.10.dylib
-        install_name_tool $so -change libwiretap.7.dylib $out/lib/libwiretap.7.dylib
-        install_name_tool $so -change libwsutil.8.dylib $out/lib/libwsutil.8.dylib
+    for f in $(find $out/Applications/Wireshark.app/Contents/PlugIns -name "*.so"); do
+        for dylib in $(otool -L $f | awk '/^\t*lib/ {print $1}'); do
+            install_name_tool -change "$dylib" "$out/lib/$dylib" "$f"
+        done
     done
 
     wrapProgram $out/Applications/Wireshark.app/Contents/MacOS/Wireshark \

--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -1,19 +1,17 @@
 { stdenv, fetchurl, pkgconfig, pcre, perl, flex, bison, gettext, libpcap, libnl, c-ares
-, gnutls, libgcrypt, libgpgerror, geoip, openssl, lua5, python, libcap, glib
+, gnutls, libgcrypt, libgpgerror, geoip, openssl, lua5, python3, libcap, glib
 , libssh, zlib, cmake, extra-cmake-modules, fetchpatch, makeWrapper
-, withGtk ? false, gtk3 ? null, librsvg ? null, gsettings-desktop-schemas ? null, wrapGAppsHook ? null
 , withQt ? true, qt5 ? null
 , ApplicationServices, SystemConfiguration, gmp
 }:
 
-assert withGtk -> !withQt  && gtk3 != null;
-assert withQt  -> !withGtk && qt5  != null;
+assert withQt  -> qt5  != null;
 
 with stdenv.lib;
 
 let
-  version = "2.6.6";
-  variant = if withGtk then "gtk" else if withQt then "qt" else "cli";
+  version = "3.0.1";
+  variant = if withQt then "qt" else "cli";
 
 in stdenv.mkDerivation {
   name = "wireshark-${variant}-${version}";
@@ -21,11 +19,10 @@ in stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://www.wireshark.org/download/src/all-versions/wireshark-${version}.tar.xz";
-    sha256 = "0qz8a1ays63712pq1v7nnw7c57zlqkcifq7himfv5nsv0zm36ya8";
+    sha256 = "13605bpnnbqsdr8ybqnscbz9g422zmyymn4q5aci28vc1wylr1l6";
   };
 
   cmakeFlags = [
-    "-DBUILD_wireshark_gtk=${if withGtk then "ON" else "OFF"}"
     "-DBUILD_wireshark=${if withQt then "ON" else "OFF"}"
     "-DENABLE_QT5=${if withQt then "ON" else "OFF"}"
     "-DENABLE_APPLICATION_BUNDLE=${if withQt && stdenv.isDarwin then "ON" else "OFF"}"
@@ -33,13 +30,12 @@ in stdenv.mkDerivation {
 
   nativeBuildInputs = [
     bison cmake extra-cmake-modules flex pkgconfig
-  ] ++ optional withGtk wrapGAppsHook;
+  ];
 
   buildInputs = [
     gettext pcre perl libpcap lua5 libssh openssl libgcrypt
-    libgpgerror gnutls geoip c-ares python glib zlib makeWrapper
+    libgpgerror gnutls geoip c-ares python3 glib zlib makeWrapper
   ] ++ optionals withQt  (with qt5; [ qtbase qtmultimedia qtsvg qttools ])
-    ++ optionals withGtk [ gtk3 librsvg gsettings-desktop-schemas ]
     ++ optionals stdenv.isLinux  [ libcap libnl ]
     ++ optionals stdenv.isDarwin [ SystemConfiguration ApplicationServices gmp ]
     ++ optionals (withQt && stdenv.isDarwin) (with qt5; [ qtmacextras ]);
@@ -60,8 +56,7 @@ in stdenv.mkDerivation {
     export LD_LIBRARY_PATH="$PWD/run"
   '';
 
-  postInstall = if stdenv.isDarwin then ''
-    ${optionalString withQt ''
+  postInstall = if (stdenv.isDarwin && withQt) then ''
       mkdir -p $out/Applications
       mv $out/bin/Wireshark.app $out/Applications/Wireshark.app
 
@@ -73,16 +68,10 @@ in stdenv.mkDerivation {
 
       wrapProgram $out/Applications/Wireshark.app/Contents/MacOS/Wireshark \
         --set QT_PLUGIN_PATH ${qt5.qtbase.bin}/${qt5.qtbase.qtPluginPrefix}
-    ''}
-  '' else optionalString (withQt || withGtk) ''
-    ${optionalString withGtk ''
-      install -Dm644 -t $out/share/applications ../wireshark-gtk.desktop
-    ''}
-    ${optionalString withQt ''
+  '' else optionalString withQt ''
       install -Dm644 -t $out/share/applications ../wireshark.desktop
       wrapProgram $out/bin/wireshark \
         --set QT_PLUGIN_PATH ${qt5.qtbase.bin}/${qt5.qtbase.qtPluginPrefix}
-    ''}
 
     substituteInPlace $out/share/applications/*.desktop \
       --replace "Exec=wireshark" "Exec=$out/bin/wireshark"
@@ -98,7 +87,12 @@ in stdenv.mkDerivation {
     cp ../epan/dfilter/*.h $dev/include/epan/dfilter/
     cp ../wsutil/*.h $dev/include/wsutil/
     cp ../wiretap/*.h $dev/include/wiretap
-  '';
+
+  '' + ''
+      # to remove "cycle detected in the references"
+      mkdir -p $dev/lib/wireshark
+      mv $out/lib/wireshark/cmake $dev/lib/wireshark
+    '';
 
   enableParallelBuilding = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17467,14 +17467,13 @@ in
   welle-io = libsForQt5.callPackage ../applications/radio/welle-io { };
 
   wireshark = callPackage ../applications/networking/sniffers/wireshark {
-    qt5 = qt59;
     inherit (darwin.apple_sdk.frameworks) ApplicationServices SystemConfiguration;
   };
   wireshark-qt = wireshark;
 
   # The GTK UI is deprecated by upstream. You probably want the QT version.
-  wireshark-gtk = wireshark.override { withGtk = true; withQt = false; };
-  wireshark-cli = wireshark.override { withGtk = false; withQt = false; };
+  wireshark-gtk = throw "Not supported anymore. Use wireshark-qt or wireshark-cli instead.";
+  wireshark-cli = wireshark.override { withQt = false; };
 
   fbida = callPackage ../applications/graphics/fbida { };
 


### PR DESCRIPTION
###### Motivation for this change
full changelog 
https://code.wireshark.org/review/gitweb?p=wireshark.git;a=blob;f=ChangeLog;h=132c0093ac247b015dee713aee9bbdceafff9ac3;hb=937e33de60bcfcd6f68e7250e5e6914ae1d1e1e4

higher level changes: 
https://code.wireshark.org/review/gitweb?p=wireshark.git;a=blob;f=NEWS;h=e8da4fb667fde0ff6107c2c861f4cb7f33f3bfda;hb=937e33de60bcfcd6f68e7250e5e6914ae1d1e1e4

###### Things done
Removed gtk support


~~I end up with "cycle detected in the references of" mentioned in https://github.com/NixOS/nix/issues/1741 . I noticed the generated pkgconfig file $dev/wireshark.pc has a wrong libdir while its includedir is fine https://paste.ubuntu.com/p/tkM277HCdv/~~
Problem fixed, cmake files were referring to $dev. I moved them to $dev.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

