### PR TITLE
buildRustCrate: Make CARGO_MANIFEST_DIR absolute

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
@@ -81,7 +81,7 @@ in ''
   export CARGO_CFG_TARGET_POINTER_WIDTH=${toString stdenv.hostPlatform.parsed.cpu.bits}
   export CARGO_CFG_TARGET_VENDOR=${stdenv.hostPlatform.parsed.vendor.name}
 
-  export CARGO_MANIFEST_DIR="."
+  export CARGO_MANIFEST_DIR=$(pwd)
   export DEBUG="${toString (!release)}"
   export OPT_LEVEL="${toString optLevel}"
   export TARGET="${stdenv.hostPlatform.config}"


### PR DESCRIPTION
###### Motivation for this change

While it is not obvious from the source, cargo sets CARGO_MANIFEST_DIR to an absolute directory. This let to a build problem with the popular "tera" crate using the "pest" crate.

See #56808 for details.

###### Cargo details

The variable is set here:

https://github.com/rust-lang/cargo/blob/f7c91ba6220e1b96aa14e5964e7074452f9551fb/src/cargo/core/compiler/compilation.rs#L229

and computed from the `manifest_path`:

https://github.com/rust-lang/cargo/blob/f7c91ba6220e1b96aa14e5964e7074452f9551fb/src/cargo/core/package.rs#L163

The manifest path is also exported via `cargo metadata` where you can see that it is absolute.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [? ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip --against origin/master"` (still running)
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

