### PR TITLE
Sage python upgrade fixes

### DIFF
--- a/pkgs/applications/science/math/sage/patches/ignore-pip-deprecation.patch
+++ b/pkgs/applications/science/math/sage/patches/ignore-pip-deprecation.patch
@@ -1,0 +1,22 @@
+diff --git a/src/sage/misc/package.py b/src/sage/misc/package.py
+index 689e5a23b9..4e16fe3a8d 100644
+--- a/src/sage/misc/package.py
++++ b/src/sage/misc/package.py
+@@ -142,9 +142,14 @@ def pip_installed_packages():
+         sage: d['beautifulsoup']   # optional - beautifulsoup
+         u'...'
+     """
+-    proc = subprocess.Popen(["pip", "list", "--no-index", "--format", "json"], stdout=subprocess.PIPE)
+-    stdout = proc.communicate()[0].decode()
+-    return {package['name'].lower():package['version'] for package in json.loads(stdout)}
++    with open(os.devnull, 'w')  as devnull:
++        proc = subprocess.Popen(
++            ["pip", "list", "--no-index", "--format", "json"],
++            stdout=subprocess.PIPE,
++            stderr=devnull,
++        )
++        stdout = proc.communicate()[0].decode()
++        return {package['name'].lower():package['version'] for package in json.loads(stdout)}
+ 
+ def list_packages(*pkg_types, **opts):
+     r"""

--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -112,6 +112,9 @@ stdenv.mkDerivation rec {
       url = "https://git.sagemath.org/sage.git/patch?id=a05b6b038e1571ab15464e98f76d1927c0c3fd12";
       sha256 = "05yq97pq84xi60wb1p9skrad5h5x770gq98ll4frr7hvvmlwsf58";
     })
+
+    # https://trac.sagemath.org/ticket/27405
+    ./patches/ignore-pip-deprecation.patch
   ];
 
   patches = nixPatches ++ packageUpgradePatches;

--- a/pkgs/applications/science/math/sage/sagelib.nix
+++ b/pkgs/applications/science/math/sage/sagelib.nix
@@ -65,11 +65,13 @@ buildPythonPackage rec {
     perl
     jupyter_core
     pkg-config
+    pip # needed to query installed packages
   ];
 
   buildInputs = [
     gd
     readline
+    iml
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/rpy2/default.nix
+++ b/pkgs/development/python-modules/rpy2/default.nix
@@ -58,6 +58,10 @@ buildPythonPackage rec {
       tidyr
     ]) ++ extraRPackages ++ rWrapper.recommendedPackages;
 
+    nativeBuildInputs = [
+      R # needed at setup time to detect R_HOME (alternatively set R_HOME explicitly)
+    ];
+
     patches = [
       # R_LIBS_SITE is used by the nix r package to point to the installed R libraries.
       # This patch sets R_LIBS_SITE when rpy2 is imported.


### PR DESCRIPTION
###### Motivation for this change

Fixes the sage build after it was broken by the pip upgrade & `strictDeps` in https://github.com/NixOS/nixpkgs/pull/55757.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

