### PR TITLE
udiskie: fix build

### DIFF
--- a/pkgs/applications/misc/udiskie/default.nix
+++ b/pkgs/applications/misc/udiskie/default.nix
@@ -1,14 +1,11 @@
 { stdenv, fetchFromGitHub, asciidoc-full, gettext
 , gobject-introspection, gtk3, hicolor-icon-theme, libappindicator-gtk3, libnotify, librsvg
 , udisks2, wrapGAppsHook
-, buildPythonApplication
-, docopt
-, pygobject3
-, pyyaml
+, python3Packages
 }:
 
-buildPythonApplication rec {
-  name = "udiskie-${version}";
+python3Packages.buildPythonApplication rec {
+  pname = "udiskie";
   version = "1.7.7";
 
   src = fetchFromGitHub {
@@ -18,16 +15,27 @@ buildPythonApplication rec {
     sha256 = "1j17z26vy44il2s9zgchvhq280vq8ag64ddi35f35b444wz2azlb";
   };
 
-  buildInputs = [
+  nativeBuildInputs = [
+    gettext
     asciidoc-full        # For building man page.
-    hicolor-icon-theme
+    gobject-introspection
     wrapGAppsHook
-    librsvg              # required for loading svg icons (udiskie uses svg icons)
   ];
 
-  propagatedBuildInputs = [
-    gettext gobject-introspection gtk3 libnotify docopt
-    pygobject3 pyyaml udisks2 libappindicator-gtk3
+  buildInputs = [
+    hicolor-icon-theme
+    librsvg              # required for loading svg icons (udiskie uses svg icons)
+    gobject-introspection
+    libnotify
+    gtk3
+    udisks2
+    libappindicator-gtk3
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    docopt
+    pygobject3
+    pyyaml
   ];
 
   postBuild = "make -C doc";

--- a/pkgs/applications/misc/udiskie/default.nix
+++ b/pkgs/applications/misc/udiskie/default.nix
@@ -45,8 +45,14 @@ python3Packages.buildPythonApplication rec {
     cp -v doc/udiskie.8 $out/share/man/man8/
   '';
 
-  # tests require dbusmock
-  doCheck = false;
+  checkInputs = with python3Packages; [
+    nose
+    keyutils
+  ];
+
+  checkPhase = ''
+    nosetests
+  '';
 
   meta = with stdenv.lib; {
     description = "Removable disk automounter for udisks";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19228,7 +19228,7 @@ in
 
   udevil = callPackage ../applications/misc/udevil {};
 
-  udiskie = python3Packages.callPackage ../applications/misc/udiskie { };
+  udiskie = callPackage ../applications/misc/udiskie { };
 
   sakura = callPackage ../applications/misc/sakura { };
 


### PR DESCRIPTION
###### Motivation for this change
It was broken by b4acd9772975d549f491d48debb679cf4ec78133.
Fixes #56771.

I'm not sure I know enough about GTK to determine which dependencies belong where. Feedback is welcome.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @teto 