### PR TITLE
torrential: init at 1.1.0

### DIFF
--- a/pkgs/applications/networking/p2p/torrential/default.nix
+++ b/pkgs/applications/networking/p2p/torrential/default.nix
@@ -1,0 +1,60 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, pkgconfig
+, pantheon
+, curl
+, glib
+, gtk3
+, hicolor-icon-theme
+, libb64
+, libevent
+, libgee
+, libnatpmp
+, libunity
+, miniupnpc
+, openssl
+, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  pname = "torrential";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "davidmhewitt";
+    repo = "torrential";
+    rev = version;
+    fetchSubmodules = true;
+    sha256 = "17aby0c17ybyzyzyc1cg1j6q1a186801fy84avlaxahqp7vdammx";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pantheon.vala
+    pkgconfig
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    curl
+    glib
+    gtk3
+    hicolor-icon-theme
+    libb64
+    libevent
+    libgee
+    libnatpmp
+    libunity
+    miniupnpc
+    openssl
+    pantheon.granite
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Download torrents in style with this speedy, minimalist torrent client for elementary OS";
+    homepage = https://github.com/davidmhewitt/torrential;
+    maintainers = with maintainers; [ kjuvi ] ++ pantheon.maintainers;
+    platforms = platforms.linux;
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19707,6 +19707,8 @@ in
     inherit (pythonPackages) wrapPython wxPython;
   };
 
+  torrential = callPackage ../applications/networking/p2p/torrential { };
+
   tortoisehg = callPackage ../applications/version-management/tortoisehg { };
 
   toot = callPackage ../applications/misc/toot { };


### PR DESCRIPTION
###### Motivation for this change

Add a torrent client which is well integrated with the Pantheon Desktop.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

