### PR TITLE
dlib: improve AVX configuration

### DIFF
--- a/doc/package-notes.xml
+++ b/doc/package-notes.xml
@@ -886,4 +886,31 @@ citrix_receiver.override {
    </para>
   </section>
  </section>
+ <section xml:id="dlib">
+  <title>DLib</title>
+
+  <para>
+    <link xlink:href="http://dlib.net/">DLib</link> is a modern, C++-based toolkit which
+    provides several machine learning algorithms.
+  </para>
+
+  <section xml:id="compiling-without-avx-support">
+   <title>Compiling without AVX support</title>
+
+   <para>
+     Especially older CPUs don't support
+     <link xlink:href="https://en.wikipedia.org/wiki/Advanced_Vector_Extensions">AVX</link>
+     (<abbrev>Advanced Vector Extensions</abbrev>) instructions that are used by DLib to
+     optimize their algorithms.
+   </para>
+
+   <para>
+    On the affected hardware errors like <literal>Illegal instruction</literal> will occur.
+    In those cases AVX support needs to be disabled:
+<programlisting>self: super: {
+  dlib = super.dlib.override { avxSupport = false; };
+}</programlisting>
+   </para>
+  </section>
+ </section>
 </chapter>

--- a/pkgs/development/libraries/dlib/default.nix
+++ b/pkgs/development/libraries/dlib/default.nix
@@ -1,5 +1,8 @@
 { stdenv, lib, fetchFromGitHub, cmake, pkgconfig, libpng, libjpeg
 , guiSupport ? false, libX11
+
+  # see http://dlib.net/compile.html
+, avxSupport ? true
 }:
 
 stdenv.mkDerivation rec {
@@ -16,6 +19,8 @@ stdenv.mkDerivation rec {
   postPatch = ''
     rm -rf dlib/external
   '';
+
+  cmakeFlags = [ "-DUSE_AVX_INSTRUCTIONS=${if avxSupport then "yes" else "no"}" ];
 
   enableParallelBuilding = true;
   nativeBuildInputs = [ cmake pkgconfig ];

--- a/pkgs/development/python-modules/dlib/default.nix
+++ b/pkgs/development/python-modules/dlib/default.nix
@@ -1,11 +1,16 @@
-{ buildPythonPackage, dlib, python, pytest }:
+{ buildPythonPackage, dlib, python, pytest, avxSupport ? true }:
 
 buildPythonPackage {
   inherit (dlib) name src nativeBuildInputs buildInputs meta;
 
+  # although AVX can be enabled, we never test with it. Some Hydra machines
+  # fail because of this, however their build results are probably used on hardware
+  # with AVX support.
   checkPhase = ''
     ${python.interpreter} nix_run_setup test --no USE_AVX_INSTRUCTIONS
   '';
+
+  setupPyBuildFlags = [ "--${if avxSupport then "yes" else "no"} USE_AVX_INSTRUCTIONS" ];
 
   patches = [ ./build-cores.patch ];
 

--- a/pkgs/development/python-modules/face_recognition/default.nix
+++ b/pkgs/development/python-modules/face_recognition/default.nix
@@ -4,13 +4,13 @@
 
 buildPythonPackage rec {
   pname = "face_recognition";
-  version = "1.2.2";
+  version = "1.2.3";
 
   src = fetchFromGitHub {
     repo = pname;
     owner = "ageitgey";
-    rev = "v${version}";
-    sha256 = "17jnyr80j1p74gyvh1jabvwd3zsxvip2y7cjhh2g6gsjv2dpvrjv";
+    rev = "634db2e4309a365cee2503cb65d6f2e88f519d1e";
+    sha256 = "06zw5hq417d5yp17zynhxhb73074lx2qy64fqfzf711rw5vrn2mx";
   };
 
   postPatch = ''
@@ -19,6 +19,15 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ pillow click dlib numpy face_recognition_models ];
 
+  # Our dlib is compiled with AVX instructions by default which breaks
+  # with "Illegal instruction" on some builders due to missing hardware features.
+  #
+  # As this makes the build fairly unreliable, it's better to skip the test and to ensure that
+  # the build is working and after each change to the package, manual testing should be done.
+  doCheck = false;
+
+  # Although tests are disabled by default, checkPhase still exists, so
+  # maintainers can check the package's functionality locally before modifying it.
   checkInputs = [ flake8 pytest glibcLocales ];
   checkPhase = ''
     LC_ALL="en_US.UTF-8" py.test


### PR DESCRIPTION
###### Motivation for this change

This change aims to improve the overall situation of how AVX is used to compile DLib and its Python bindings. This PR consists of the following commits:

* `9732c44`: Adds `avxSupport` (true by default) to the `dlib` builds. If older hardware is used, DLib can be compiled without AVX.

* `6fec5aa`: Bump face_recognition to 1.2.3 and disable the check phase for now to avoid breakage on Hydra builders without AVX support. After changes, maintainers should run `checkPhase` locally in a `nix-shell`.

Please have a look at the full commit messages for more information.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

