### PR TITLE
emacs26: adds parameter siteStart: don't hard-code ./site-start.el

### DIFF
--- a/pkgs/applications/editors/emacs/default.nix
+++ b/pkgs/applications/editors/emacs/default.nix
@@ -10,6 +10,7 @@
 , withXwidgets ? false, webkitgtk ? null, wrapGAppsHook ? null, glib-networking ? null
 , withCsrc ? true
 , srcRepo ? false, autoconf ? null, automake ? null, texinfo ? null
+, siteStart ? ./site-start.el
 }:
 
 assert (libXft != null) -> libpng != null;      # probably a bug
@@ -100,7 +101,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     mkdir -p $out/share/emacs/site-lisp
-    cp ${./site-start.el} $out/share/emacs/site-lisp/site-start.el
+    cp ${siteStart} $out/share/emacs/site-lisp/site-start.el
     $out/bin/emacs --batch -f batch-byte-compile $out/share/emacs/site-lisp/site-start.el
 
     rm -rf $out/var


### PR DESCRIPTION
This adds a parameter to allow specifying what site-start.el to use with emacs.
cc @jwiegley ?