### PR TITLE
nixos/kubernetes: stabilize cluster deployment/startup across machines

### DIFF
--- a/nixos/modules/services/cluster/kubernetes/addon-manager.nix
+++ b/nixos/modules/services/cluster/kubernetes/addon-manager.nix
@@ -72,7 +72,7 @@ in
     systemd.services.kube-addon-manager = {
       description = "Kubernetes addon manager";
       wantedBy = [ "kubernetes.target" ];
-      after = [ "kube-apiserver.service" ];
+      after = [ "kube-apiserver-online.target" "node-online.target" ];
       environment.ADDON_PATH = "/etc/kubernetes/addons/";
       path = [ pkgs.gawk ];
       serviceConfig = {

--- a/nixos/modules/services/cluster/kubernetes/addon-manager.nix
+++ b/nixos/modules/services/cluster/kubernetes/addon-manager.nix
@@ -71,8 +71,8 @@ in
 
     systemd.services.kube-addon-manager = {
       description = "Kubernetes addon manager";
-      wantedBy = [ "kubernetes.target" ];
-      after = [ "kube-apiserver-online.target" "node-online.target" ];
+      wantedBy = [ "kube-control-plane-online.target" ];
+      before = [ "kube-control-plane-online.target" ];
       environment.ADDON_PATH = "/etc/kubernetes/addons/";
       path = [ pkgs.gawk ];
       serviceConfig = {

--- a/nixos/modules/services/cluster/kubernetes/addon-manager.nix
+++ b/nixos/modules/services/cluster/kubernetes/addon-manager.nix
@@ -63,24 +63,48 @@ in
     };
 
     enable = mkEnableOption "Whether to enable Kubernetes addon manager.";
+
+    kubeconfig = top.lib.mkKubeConfigOptions "Kubernetes addon manager";
+    bootstrapAddonsKubeconfig = top.lib.mkKubeConfigOptions "Kubernetes addon manager bootstrap";
   };
 
   ###### implementation
-  config = mkIf cfg.enable {
+  config = let
+
+    addonManagerPaths = filter (a: a != null) [
+      cfg.kubeconfig.caFile
+      cfg.kubeconfig.certFile
+      cfg.kubeconfig.keyFile
+    ];
+    bootstrapAddonsPaths = filter (a: a != null) [
+      cfg.bootstrapAddonsKubeconfig.caFile
+      cfg.bootstrapAddonsKubeconfig.certFile
+      cfg.bootstrapAddonsKubeconfig.keyFile
+    ];
+
+  in mkIf cfg.enable {
     environment.etc."kubernetes/addons".source = "${addons}/";
 
+    #TODO: Get rid of kube-addon-manager in the future for the following reasons
+    # - it is basically just a shell script wrapped around kubectl
+    # - it assumes that it is clusterAdmin or can gain clusterAdmin rights through serviceAccount
+    # - it is designed to be used with k8s system components only
+    # - it would be better with a more Nix-oriented way of managing addons
     systemd.services.kube-addon-manager = {
       description = "Kubernetes addon manager";
-      wantedBy = [ "kube-control-plane-online.target" ];
-      after = [ "kube-addon-manager-bootstrap.service" ];
-      before = [ "kube-control-plane-online.target" ];
-      environment.ADDON_PATH = "/etc/kubernetes/addons/";
-      path = [ pkgs.gawk ];
+      wantedBy = [ "kubernetes.target" ];
+      after = [ "kube-node-online.target" ];
+      before = [ "kubernetes.target" ];
+      environment = {
+        ADDON_PATH = "/etc/kubernetes/addons/";
+        KUBECONFIG = top.lib.mkKubeConfig "kube-addon-manager" cfg.kubeconfig;
+      };
+      path = with pkgs; [ gawk kubectl ];
       preStart = ''
-        ${top.lib.mkWaitCurl ( with config.systemd.services.kube-addon-manager; {
-          path = "/api/v1/namespaces/kube-system/serviceaccounts/default";
-          cacert = top.caFile;
-        } // optionalAttrs (environment ? cert) { inherit (environment) cert key; })}
+        until kubectl -n kube-system get serviceaccounts/default 2>/dev/null; do
+          echo kubectl -n kube-system get serviceaccounts/default: exit status $?
+          sleep 2
+        done
       '';
       serviceConfig = {
         Slice = "kubernetes.slice";
@@ -91,26 +115,51 @@ in
         Restart = "on-failure";
         RestartSec = 10;
       };
+      unitConfig.ConditionPathExists = addonManagerPaths;
     };
+
+    systemd.paths.kube-addon-manager = {
+      wantedBy = [ "kube-addon-manager.service" ];
+      pathConfig = {
+        PathExists = addonManagerPaths;
+        PathChanged = addonManagerPaths;
+      };
+    };
+
+    services.kubernetes.addonManager.kubeconfig.server = mkDefault top.apiserverAddress;
 
     systemd.services.kube-addon-manager-bootstrap = mkIf (top.apiserver.enable && top.addonManager.bootstrapAddons != {}) {
       wantedBy = [ "kube-control-plane-online.target" ];
       after = [ "kube-apiserver.service" ];
       before = [ "kube-control-plane-online.target" ];
       path = [ pkgs.kubectl ];
+      environment = {
+        KUBECONFIG = top.lib.mkKubeConfig "kube-addon-manager-bootstrap" cfg.bootstrapAddonsKubeconfig;
+      };
       preStart = with pkgs; let
         files = mapAttrsToList (n: v: writeText "${n}.json" (builtins.toJSON v))
           cfg.bootstrapAddons;
       in ''
-        ${top.lib.mkWaitCurl ( with config.systemd.services.kube-addon-manager-bootstrap; {
-          path = "/api";
-          cacert = top.caFile;
-        } // optionalAttrs (environment ? cert) { inherit (environment) cert key; })}
+        until kubectl auth can-i '*' '*' -q 2>/dev/null; do
+          echo kubectl auth can-i '*' '*': exit status $?
+          sleep 2
+        done
 
         kubectl apply -f ${concatStringsSep " \\\n -f " files}
       '';
       script = "echo Ok";
+      unitConfig.ConditionPathExists = bootstrapAddonsPaths;
     };
+
+    systemd.paths.kube-addon-manager-bootstrap = {
+      wantedBy = [ "kube-addon-manager-bootstrap.service" ];
+      pathConfig = {
+        PathExists = bootstrapAddonsPaths;
+        PathChanged = bootstrapAddonsPaths;
+      };
+    };
+
+    services.kubernetes.addonManager.bootstrapAddonsKubeconfig.server = mkDefault top.apiserverAddress;
 
     services.kubernetes.addonManager.bootstrapAddons = mkIf isRBACEnabled
     (let

--- a/nixos/modules/services/cluster/kubernetes/addons/dashboard.nix
+++ b/nixos/modules/services/cluster/kubernetes/addons/dashboard.nix
@@ -169,6 +169,23 @@ in {
         };
       };
 
+      kubernetes-dashboard-cm = {
+        apiVersion = "v1";
+        kind = "ConfigMap";
+        metadata = {
+          labels = {
+            k8s-app = "kubernetes-dashboard";
+            # Allows editing resource and makes sure it is created first.
+            "addonmanager.kubernetes.io/mode" = "EnsureExists";
+          };
+          name = "kubernetes-dashboard-settings";
+          namespace = "kube-system";
+        };
+      };
+    };
+
+    services.kubernetes.addonManager.bootstrapAddons = mkMerge [{
+
       kubernetes-dashboard-sa = {
         apiVersion = "v1";
         kind = "ServiceAccount";
@@ -210,20 +227,9 @@ in {
         };
         type = "Opaque";
       };
-      kubernetes-dashboard-cm = {
-        apiVersion = "v1";
-        kind = "ConfigMap";
-        metadata = {
-          labels = {
-            k8s-app = "kubernetes-dashboard";
-            # Allows editing resource and makes sure it is created first.
-            "addonmanager.kubernetes.io/mode" = "EnsureExists";
-          };
-          name = "kubernetes-dashboard-settings";
-          namespace = "kube-system";
-        };
-      };
-    } // (optionalAttrs cfg.rbac.enable
+    }
+
+    (optionalAttrs cfg.rbac.enable
       (let
         subjects = [{
           kind = "ServiceAccount";
@@ -323,6 +329,6 @@ in {
             inherit subjects;
           };
         })
-    ));
+    ))];
   };
 }

--- a/nixos/modules/services/cluster/kubernetes/apiserver.nix
+++ b/nixos/modules/services/cluster/kubernetes/apiserver.nix
@@ -480,6 +480,9 @@ in
           })}
         '';
         script = "echo apiserver control plane is online";
+        serviceConfig = {
+          TimeoutSec = "500";
+        };
       };
     }
   ];

--- a/nixos/modules/services/cluster/kubernetes/apiserver.nix
+++ b/nixos/modules/services/cluster/kubernetes/apiserver.nix
@@ -293,9 +293,9 @@ in
     in {
         systemd.services.kube-apiserver = {
           description = "Kubernetes APIServer Service";
-          wantedBy = [ "kube-apiserver-online.target" ];
+          wantedBy = [ "kube-control-plane-online.target" ];
           after = [ "certmgr.service" ];
-          before = [ "kube-apiserver-online.target" ];
+          before = [ "kube-control-plane-online.target" ];
           serviceConfig = {
             Slice = "kubernetes.slice";
             ExecStart = ''${top.package}/bin/kube-apiserver \
@@ -461,16 +461,16 @@ in
 
     }))
     {
-      systemd.targets.kube-apiserver-online = {
+      systemd.targets.kube-control-plane-online = {
         wantedBy = [ "kubernetes.target" ];
         before = [ "kubernetes.target" ];
       };
 
-      systemd.services.kube-apiserver-online = mkIf top.flannel.enable {
-        description = "apiserver control plane is online";
-        wantedBy = [ "kube-apiserver-online.target" ];
+      systemd.services.kube-control-plane-online = rec {
+        description = "Kubernetes control plane is online";
+        wantedBy = [ "kube-control-plane-online.target" ];
         after = [ "kube-scheduler.service" "kube-controller-manager.service" ];
-        before = [ "kube-apiserver-online.target" ];
+        before = [ "kube-control-plane-online.target" ];
         preStart = ''
           ${top.lib.mkWaitCurl (with top.pki.certs.flannelClient; {
             sleep = 3;
@@ -479,7 +479,7 @@ in
             inherit cert key;
           })}
         '';
-        script = "echo apiserver control plane is online";
+        script = "echo Ok";
         serviceConfig = {
           TimeoutSec = "500";
         };

--- a/nixos/modules/services/cluster/kubernetes/apiserver.nix
+++ b/nixos/modules/services/cluster/kubernetes/apiserver.nix
@@ -272,25 +272,7 @@ in
   ###### implementation
   config = mkMerge [
 
-    (mkIf cfg.enable (let
-      apiserverPaths = [
-        cfg.clientCaFile
-        cfg.etcd.caFile
-        cfg.etcd.certFile
-        cfg.etcd.keyFile
-        cfg.kubeletClientCaFile
-        cfg.kubeletClientCertFile
-        cfg.kubeletClientKeyFile
-        cfg.serviceAccountKeyFile
-        cfg.tlsCertFile
-        cfg.tlsKeyFile
-      ];
-      etcdPaths = [
-        config.services.etcd.certFile
-        config.services.etcd.keyFile
-        config.services.etcd.trustedCaFile
-      ];
-    in {
+    (mkIf cfg.enable {
         systemd.services.kube-apiserver = {
           description = "Kubernetes APIServer Service";
           wantedBy = [ "kube-control-plane-online.target" ];
@@ -359,25 +341,6 @@ in
             AmbientCapabilities = "cap_net_bind_service";
             Restart = "on-failure";
             RestartSec = 5;
-          };
-          unitConfig.ConditionPathExists = apiserverPaths;
-        };
-
-        systemd.paths.kube-apiserver = {
-          wantedBy = [ "kube-apiserver.service" ];
-          pathConfig = {
-            PathExists = apiserverPaths;
-            PathChanged = apiserverPaths;
-          };
-        };
-
-        systemd.services.etcd.unitConfig.ConditionPathExists = etcdPaths;
-
-        systemd.paths.etcd = {
-          wantedBy = [ "etcd.service" ];
-          pathConfig = {
-            PathExists = etcdPaths;
-            PathChanged = etcdPaths;
           };
         };
 
@@ -459,7 +422,7 @@ in
         };
       };
 
-    }))
+    })
     {
       systemd.targets.kube-control-plane-online = {
         wantedBy = [ "kubernetes.target" ];

--- a/nixos/modules/services/cluster/kubernetes/apiserver.nix
+++ b/nixos/modules/services/cluster/kubernetes/apiserver.nix
@@ -472,12 +472,11 @@ in
         after = [ "kube-scheduler.service" "kube-controller-manager.service" ];
         before = [ "kube-control-plane-online.target" ];
         preStart = ''
-          ${top.lib.mkWaitCurl (with top.pki.certs.flannelClient; {
+          ${top.lib.mkWaitCurl ( with config.systemd.services.kube-control-plane-online; {
             sleep = 3;
             path = "/healthz";
             cacert = top.caFile;
-            inherit cert key;
-          })}
+          } // optionalAttrs (environment ? cert) { inherit (environment) cert key; })}
         '';
         script = "echo Ok";
         serviceConfig = {

--- a/nixos/modules/services/cluster/kubernetes/apiserver.nix
+++ b/nixos/modules/services/cluster/kubernetes/apiserver.nix
@@ -423,30 +423,7 @@ in
       };
 
     })
-    {
-      systemd.targets.kube-control-plane-online = {
-        wantedBy = [ "kubernetes.target" ];
-        before = [ "kubernetes.target" ];
-      };
 
-      systemd.services.kube-control-plane-online = rec {
-        description = "Kubernetes control plane is online";
-        wantedBy = [ "kube-control-plane-online.target" ];
-        after = [ "kube-scheduler.service" "kube-controller-manager.service" ];
-        before = [ "kube-control-plane-online.target" ];
-        preStart = ''
-          ${top.lib.mkWaitCurl ( with config.systemd.services.kube-control-plane-online; {
-            sleep = 3;
-            path = "/healthz";
-            cacert = top.caFile;
-          } // optionalAttrs (environment ? cert) { inherit (environment) cert key; })}
-        '';
-        script = "echo Ok";
-        serviceConfig = {
-          TimeoutSec = "500";
-        };
-      };
-    }
   ];
 
 }

--- a/nixos/modules/services/cluster/kubernetes/controller-manager.nix
+++ b/nixos/modules/services/cluster/kubernetes/controller-manager.nix
@@ -111,12 +111,11 @@ in
       after = [ "kube-apiserver.service" ];
       before = [ "kube-control-plane-online.target" ];
       preStart = ''
-        ${top.lib.mkWaitCurl (with top.pki.certs.controllerManagerClient; {
+        ${top.lib.mkWaitCurl ( with config.systemd.services.kube-controller-manager; {
           sleep = 1;
           path = "/api";
           cacert = top.caFile;
-          inherit cert key;
-        })}
+        } // optionalAttrs (environment ? cert) { inherit (environment) cert key; })}
       '';
       serviceConfig = {
         RestartSec = "30s";

--- a/nixos/modules/services/cluster/kubernetes/controller-manager.nix
+++ b/nixos/modules/services/cluster/kubernetes/controller-manager.nix
@@ -116,9 +116,9 @@ in
 
     systemd.services.kube-controller-manager = {
       description = "Kubernetes Controller Manager Service";
-      wantedBy = [ "kube-apiserver-online.target" ];
+      wantedBy = [ "kube-control-plane-online.target" ];
       after = [ "kube-apiserver.service" ];
-      before = [ "kube-apiserver-online.target" ];
+      before = [ "kube-control-plane-online.target" ];
       preStart = ''
         ${top.lib.mkWaitCurl (with top.pki.certs.controllerManagerClient; {
           sleep = 1;

--- a/nixos/modules/services/cluster/kubernetes/controller-manager.nix
+++ b/nixos/modules/services/cluster/kubernetes/controller-manager.nix
@@ -116,8 +116,17 @@ in
 
     systemd.services.kube-controller-manager = {
       description = "Kubernetes Controller Manager Service";
-      wantedBy = [ "kubernetes.target" ];
+      wantedBy = [ "kube-apiserver-online.target" ];
       after = [ "kube-apiserver.service" ];
+      before = [ "kube-apiserver-online.target" ];
+      preStart = ''
+        ${top.lib.mkWaitCurl (with top.pki.certs.controllerManagerClient; {
+          sleep = 1;
+          path = "/api";
+          cacert = top.caFile;
+          inherit cert key;
+        })}
+      '';
       serviceConfig = {
         RestartSec = "30s";
         Restart = "on-failure";

--- a/nixos/modules/services/cluster/kubernetes/controller-manager.nix
+++ b/nixos/modules/services/cluster/kubernetes/controller-manager.nix
@@ -104,16 +104,7 @@ in
   };
 
   ###### implementation
-  config = mkIf cfg.enable (let
-    controllerManagerPaths = [
-      cfg.rootCaFile
-      cfg.tlsCertFile
-      cfg.tlsKeyFile
-      top.pki.certs.controllerManagerClient.cert
-      top.pki.certs.controllerManagerClient.key
-    ];
-  in {
-
+  config = mkIf cfg.enable {
     systemd.services.kube-controller-manager = {
       description = "Kubernetes Controller Manager Service";
       wantedBy = [ "kube-control-plane-online.target" ];
@@ -160,15 +151,6 @@ in
         Group = "kubernetes";
       };
       path = top.path;
-      unitConfig.ConditionPathExists = controllerManagerPaths;
-    };
-
-    systemd.paths.kube-controller-manager = {
-      wantedBy = [ "kube-controller-manager.service" ];
-      pathConfig = {
-        PathExists = controllerManagerPaths;
-        PathChanged = controllerManagerPaths;
-      };
     };
 
     services.kubernetes.pki.certs = with top.lib; {
@@ -185,5 +167,5 @@ in
     };
 
     services.kubernetes.controllerManager.kubeconfig.server = mkDefault top.apiserverAddress;
-  });
+  };
 }

--- a/nixos/modules/services/cluster/kubernetes/controller-manager.nix
+++ b/nixos/modules/services/cluster/kubernetes/controller-manager.nix
@@ -104,18 +104,30 @@ in
   };
 
   ###### implementation
-  config = mkIf cfg.enable {
-    systemd.services.kube-controller-manager = {
+  config = let
+
+    controllerManagerPaths = filter (a: a != null) [
+      cfg.kubeconfig.caFile
+      cfg.kubeconfig.certFile
+      cfg.kubeconfig.keyFile
+      cfg.rootCaFile
+      cfg.serviceAccountKeyFile
+      cfg.tlsCertFile
+      cfg.tlsKeyFile
+    ];
+
+  in mkIf cfg.enable {
+    systemd.services.kube-controller-manager = rec {
       description = "Kubernetes Controller Manager Service";
       wantedBy = [ "kube-control-plane-online.target" ];
       after = [ "kube-apiserver.service" ];
       before = [ "kube-control-plane-online.target" ];
+      environment.KUBECONFIG = top.lib.mkKubeConfig "kube-controller-manager" cfg.kubeconfig;
       preStart = ''
-        ${top.lib.mkWaitCurl ( with config.systemd.services.kube-controller-manager; {
-          sleep = 1;
-          path = "/api";
-          cacert = top.caFile;
-        } // optionalAttrs (environment ? cert) { inherit (environment) cert key; })}
+        until kubectl auth can-i get /api -q 2>/dev/null; do
+          echo kubectl auth can-i get /api: exit status $?
+          sleep 2
+        done
       '';
       serviceConfig = {
         RestartSec = "30s";
@@ -128,7 +140,7 @@ in
             "--cluster-cidr=${cfg.clusterCidr}"} \
           ${optionalString (cfg.featureGates != [])
             "--feature-gates=${concatMapStringsSep "," (feature: "${feature}=true") cfg.featureGates}"} \
-          --kubeconfig=${top.lib.mkKubeConfig "kube-controller-manager" cfg.kubeconfig} \
+          --kubeconfig=${environment.KUBECONFIG} \
           --leader-elect=${boolToString cfg.leaderElect} \
           ${optionalString (cfg.rootCaFile!=null)
             "--root-ca-file=${cfg.rootCaFile}"} \
@@ -149,7 +161,16 @@ in
         User = "kubernetes";
         Group = "kubernetes";
       };
-      path = top.path;
+      path = top.path ++ [ pkgs.kubectl ];
+      unitConfig.ConditionPathExists = controllerManagerPaths;
+    };
+
+    systemd.paths.kube-controller-manager = {
+      wantedBy = [ "kube-controller-manager.service" ];
+      pathConfig = {
+        PathExists = controllerManagerPaths;
+        PathChanged = controllerManagerPaths;
+      };
     };
 
     services.kubernetes.pki.certs = with top.lib; {

--- a/nixos/modules/services/cluster/kubernetes/default.nix
+++ b/nixos/modules/services/cluster/kubernetes/default.nix
@@ -73,6 +73,18 @@ let
     };
   };
 
+  mkWaitCurl = { address ? cfg.apiserverAddress, sleep ? 2, path ? "", args ? "-o /dev/null",
+                 cacert ? null, cert ? null, key ? null, }: ''
+    while ! ${pkgs.curl}/bin/curl --fail-early -fs \
+      ${if cacert != null then "--cacert ${cacert}" else ""} \
+      ${if cert != null then "--cert ${cert}" else ""} \
+      ${if key != null then "--key ${key}" else ""} \
+      ${address}${path} ${args} ; do
+        sleep ${toString sleep}
+        echo Waiting to be able to reach ${address}${path}
+    done
+  '';
+
   kubeConfigDefaults = {
     server = mkDefault cfg.kubeconfig.server;
     caFile = mkDefault cfg.kubeconfig.caFile;
@@ -162,6 +174,7 @@ in {
         inherit mkCert;
         inherit mkKubeConfig;
         inherit mkKubeConfigOptions;
+        inherit mkWaitCurl;
       };
       type = types.attrs;
     };

--- a/nixos/modules/services/cluster/kubernetes/default.nix
+++ b/nixos/modules/services/cluster/kubernetes/default.nix
@@ -73,18 +73,6 @@ let
     };
   };
 
-  mkWaitCurl = { address ? cfg.apiserverAddress, sleep ? 2, path ? "", args ? "-o /dev/null",
-                 cacert ? null, cert ? null, key ? null, }: ''
-    while ! ${pkgs.curl}/bin/curl --fail-early -fs \
-      ${if cacert != null then "--cacert ${cacert}" else ""} \
-      ${if cert != null then "--cert ${cert}" else ""} \
-      ${if key != null then "--key ${key}" else ""} \
-      ${address}${path} ${args} ; do
-        sleep ${toString sleep}
-        echo Waiting to be able to reach ${address}${path}
-    done
-  '';
-
   kubeConfigDefaults = {
     server = mkDefault cfg.kubeconfig.server;
     caFile = mkDefault cfg.kubeconfig.caFile;
@@ -174,7 +162,6 @@ in {
         inherit mkCert;
         inherit mkKubeConfig;
         inherit mkKubeConfigOptions;
-        inherit mkWaitCurl;
       };
       type = types.attrs;
     };

--- a/nixos/modules/services/cluster/kubernetes/flannel.nix
+++ b/nixos/modules/services/cluster/kubernetes/flannel.nix
@@ -71,8 +71,8 @@ in
     };
 
     systemd.targets.flannel = {
-      wantedBy = [ "node-online.target" ];
-      before = [ "node-online.target" ];
+      wantedBy = [ "kube-node-online.target" ];
+      before = [ "kube-node-online.target" ];
     };
 
     systemd.services.flannel = {

--- a/nixos/modules/services/cluster/kubernetes/flannel.nix
+++ b/nixos/modules/services/cluster/kubernetes/flannel.nix
@@ -55,13 +55,15 @@ in
         ${mkDockerOpts}/mk-docker-opts -d /run/flannel/docker
         systemctl restart docker
       '';
+      unitConfig.ConditionPathExists = [ "/run/flannel/subnet.env" ];
       serviceConfig.Type = "oneshot";
     };
 
-    systemd.paths."flannel-subnet-env" = {
-      wantedBy = [ "flannel.service" ];
+    systemd.paths.flannel-subnet-env = {
+      wantedBy = [ "mk-docker-opts.service" ];
       pathConfig = {
-        PathModified = "/run/flannel/subnet.env";
+        PathExists = [ "/run/flannel/subnet.env" ];
+        PathChanged = [ "/run/flannel/subnet.env" ];
         Unit = "mk-docker-opts.service";
       };
     };

--- a/nixos/modules/services/cluster/kubernetes/flannel.nix
+++ b/nixos/modules/services/cluster/kubernetes/flannel.nix
@@ -80,6 +80,13 @@ in
       after = [ "kubelet.target" ];
       before = [ "flannel.target" ];
       path = [ pkgs.iptables ];
+      preStart = ''
+        ${top.lib.mkWaitCurl ( with config.systemd.services.flannel; {
+          path = "/api/v1/nodes";
+          cacert = top.caFile;
+          args = "-o - | grep podCIDR >/dev/null";
+        } // optionalAttrs (environment ? cert) { inherit (environment) cert key; })}
+      '';
     };
 
     systemd.services.docker = {

--- a/nixos/modules/services/cluster/kubernetes/flannel.nix
+++ b/nixos/modules/services/cluster/kubernetes/flannel.nix
@@ -84,6 +84,7 @@ in
       wantedBy = [ "flannel.target" ];
       after = [ "kubelet.target" ];
       before = [ "flannel.target" ];
+      path = [ pkgs.iptables ];
     };
 
     systemd.services.docker = {

--- a/nixos/modules/services/cluster/kubernetes/kubelet.nix
+++ b/nixos/modules/services/cluster/kubernetes/kubelet.nix
@@ -340,9 +340,9 @@ in
       };
 
       systemd.services.kubelet-online = {
-        wantedBy = [ "node-online.target" ];
+        wantedBy = [ "kube-node-online.target" ];
         after = [ "flannel.target" "kubelet.target" ];
-        before = [ "node-online.target" ];
+        before = [ "kube-node-online.target" ];
         # it is complicated. flannel needs kubelet to run the pause container before
         # it discusses the node CIDR with apiserver and afterwards configures and restarts
         # dockerd. Until then prevent creating any pods because they have to be recreated anyway
@@ -407,11 +407,11 @@ in
 
     {
       systemd.targets.kubelet = {
-        wantedBy = [ "node-online.target" ];
-        before = [ "node-online.target" ];
+        wantedBy = [ "kube-node-online.target" ];
+        before = [ "kube-node-online.target" ];
       };
 
-      systemd.targets.node-online = {
+      systemd.targets.kube-node-online = {
         wantedBy = [ "kubernetes.target" ];
         before = [ "kubernetes.target" ];
       };

--- a/nixos/modules/services/cluster/kubernetes/kubelet.nix
+++ b/nixos/modules/services/cluster/kubernetes/kubelet.nix
@@ -253,7 +253,7 @@ in
       systemd.services.kubelet = {
         description = "Kubernetes Kubelet Service";
         wantedBy = [ "kubelet.target" ];
-        after = [ "kube-apiserver-online.target" ];
+        after = [ "kube-control-plane-online.target" ];
         before = [ "kubelet.target" ];
         path = with pkgs; [ gitMinimal openssh docker utillinux iproute ethtool thin-provisioning-tools iptables socat ] ++ top.path;
         preStart = ''
@@ -339,7 +339,7 @@ in
         serviceConfig.Slice = "kubernetes.slice";
       };
 
-      systemd.services.node-online = {
+      systemd.services.kubelet-online = {
         wantedBy = [ "node-online.target" ];
         after = [ "flannel.target" "kubelet.target" ];
         before = [ "node-online.target" ];

--- a/nixos/modules/services/cluster/kubernetes/kubelet.nix
+++ b/nixos/modules/services/cluster/kubernetes/kubelet.nix
@@ -241,13 +241,7 @@ in
 
   ###### implementation
   config = mkMerge [
-    (mkIf cfg.enable (let
-      kubeletPaths = [
-        cfg.clientCaFile
-        cfg.tlsCertFile
-        cfg.tlsKeyFile
-      ];
-    in {
+    (mkIf cfg.enable {
       services.kubernetes.kubelet.seedDockerImages = [infraContainer];
 
       systemd.services.kubelet = {
@@ -309,15 +303,6 @@ in
             ${cfg.extraOpts}
           '';
           WorkingDirectory = top.dataDir;
-        };
-        unitConfig.ConditionPathExists = kubeletPaths;
-      };
-
-      systemd.paths.kubelet = {
-        wantedBy =  [ "kubelet.service" ];
-        pathConfig = {
-          PathExists = kubeletPaths;
-          PathChanged = kubeletPaths;
         };
       };
 
@@ -387,7 +372,7 @@ in
       };
 
       services.kubernetes.kubelet.kubeconfig.server = mkDefault top.apiserverAddress;
-    }))
+    })
 
     (mkIf (cfg.enable && cfg.manifests != {}) {
       environment.etc = mapAttrs' (name: manifest:

--- a/nixos/modules/services/cluster/kubernetes/pki.nix
+++ b/nixos/modules/services/cluster/kubernetes/pki.nix
@@ -143,6 +143,13 @@ in
       cfg.certs.schedulerClient.cert
       cfg.certs.schedulerClient.key
     ];
+    controllerManagerPaths = [
+      top.controllerManager.rootCaFile
+      top.controllerManager.tlsCertFile
+      top.controllerManager.tlsKeyFile
+      cfg.certs.controllerManagerClient.cert
+      cfg.certs.controllerManagerClient.key
+    ];
   in
   {
 
@@ -333,6 +340,18 @@ in
         pathConfig = {
           PathExists = addonManagerPaths;
           PathChanged = addonManagerPaths;
+        };
+      };
+
+      systemd.services.kube-controller-manager = mkIf top.controllerManager.enable {
+        unitConfig.ConditionPathExists = controllerManagerPaths;
+      };
+
+      systemd.paths.kube-controller-manager = mkIf top.controllerManager.enable {
+        wantedBy = [ "kube-controller-manager.service" ];
+        pathConfig = {
+          PathExists = controllerManagerPaths;
+          PathChanged = controllerManagerPaths;
         };
       };
 

--- a/nixos/modules/services/cluster/kubernetes/pki.nix
+++ b/nixos/modules/services/cluster/kubernetes/pki.nix
@@ -246,7 +246,7 @@ in
       '')
       ];
       serviceConfig = {
-        TimeoutSec = "300";
+        TimeoutSec = "500";
         RestartSec = "1s";
         Restart = "on-failure";
       };

--- a/nixos/modules/services/cluster/kubernetes/pki.nix
+++ b/nixos/modules/services/cluster/kubernetes/pki.nix
@@ -375,33 +375,17 @@ in
           exit 1
         fi
 
+        do_restart=$(test -s ${certmgrAPITokenPath} && echo -n y || echo -n n)
+
         echo $token > ${certmgrAPITokenPath}
         chmod 600 ${certmgrAPITokenPath}
 
-        echo "Restarting certmgr..." >&1
-        systemctl restart certmgr
+        if [ y = $do_restart ]; then
+          echo "Restarting certmgr..." >&1
+          systemctl restart certmgr
+        fi
 
-        echo "Waiting for certs to appear..." >&1
-
-        ${optionalString top.kubelet.enable ''
-          while [ ! -f ${cfg.certs.kubelet.cert} ]; do sleep 1; done
-          echo "Restarting kubelet..." >&1
-          systemctl restart kubelet
-        ''}
-
-        ${optionalString top.proxy.enable ''
-          while [ ! -f ${cfg.certs.kubeProxyClient.cert} ]; do sleep 1; done
-          echo "Restarting kube-proxy..." >&1
-          systemctl restart kube-proxy
-        ''}
-
-        ${optionalString top.flannel.enable ''
-          while [ ! -f ${cfg.certs.flannelClient.cert} ]; do sleep 1; done
-          echo "Restarting flannel..." >&1
-          systemctl restart flannel
-        ''}
-
-        echo "Node joined succesfully"
+        echo "Node joined succesfully" >&1
       '')];
 
       # isolate etcd on loopback at the master node

--- a/nixos/modules/services/cluster/kubernetes/pki.nix
+++ b/nixos/modules/services/cluster/kubernetes/pki.nix
@@ -254,8 +254,6 @@ in
       ];
       serviceConfig = {
         TimeoutSec = "500";
-        RestartSec = "1s";
-        Restart = "on-failure";
       };
     };
 

--- a/nixos/modules/services/cluster/kubernetes/pki.nix
+++ b/nixos/modules/services/cluster/kubernetes/pki.nix
@@ -124,10 +124,6 @@ in
       top.caFile
       certmgrAPITokenPath
     ];
-    schedulerPaths = mkIf top.scheduler.enable [
-      cfg.certs.schedulerClient.cert
-      cfg.certs.schedulerClient.key
-    ];
   in
   {
 
@@ -284,19 +280,6 @@ in
         pathConfig = {
           PathExists = certmgrPaths;
           PathChanged = certmgrPaths;
-        };
-      };
-
-      systemd.services.kube-scheduler = mkIf top.scheduler.enable {
-        environment = { inherit (top.pki.certs.schedulerClient) cert key; };
-        unitConfig.ConditionPathExists = schedulerPaths;
-      };
-
-      systemd.paths.kube-scheduler = mkIf top.scheduler.enable {
-        wantedBy = [ "kube-scheduler.service" ];
-        pathConfig = {
-          PathExists = schedulerPaths;
-          PathChanged = schedulerPaths;
         };
       };
 

--- a/nixos/modules/services/cluster/kubernetes/pki.nix
+++ b/nixos/modules/services/cluster/kubernetes/pki.nix
@@ -132,11 +132,6 @@ in
       cfg.certs.schedulerClient.cert
       cfg.certs.schedulerClient.key
     ];
-    kubeletPaths = [
-      top.kubelet.clientCaFile
-      top.kubelet.tlsCertFile
-      top.kubelet.tlsKeyFile
-    ];
   in
   {
 
@@ -374,18 +369,6 @@ in
       systemd.services.kube-proxy = mkIf top.proxy.enable {
         environment = { inherit (top.pki.certs.kubeProxyClient) cert key; };
         unitConfig.ConditionPathExists = proxyPaths;
-      };
-
-      systemd.services.kubelet = mkIf top.kubelet.enable {
-        unitConfig.ConditionPathExists = kubeletPaths;
-      };
-
-      systemd.paths.kubelet = mkIf top.kubelet.enable {
-        wantedBy =  [ "kubelet.service" ];
-        pathConfig = {
-          PathExists = kubeletPaths;
-          PathChanged = kubeletPaths;
-        };
       };
 
       systemd.paths.kube-proxy = mkIf top.proxy.enable {

--- a/nixos/modules/services/cluster/kubernetes/pki.nix
+++ b/nixos/modules/services/cluster/kubernetes/pki.nix
@@ -124,23 +124,6 @@ in
       top.caFile
       certmgrAPITokenPath
     ];
-    apiserverPaths = [
-      top.apiserver.clientCaFile
-      top.apiserver.etcd.caFile
-      top.apiserver.etcd.certFile
-      top.apiserver.etcd.keyFile
-      top.apiserver.kubeletClientCaFile
-      top.apiserver.kubeletClientCertFile
-      top.apiserver.kubeletClientKeyFile
-      top.apiserver.serviceAccountKeyFile
-      top.apiserver.tlsCertFile
-      top.apiserver.tlsKeyFile
-    ];
-    etcdPaths = [
-      config.services.etcd.certFile
-      config.services.etcd.keyFile
-      config.services.etcd.trustedCaFile
-    ];
     flannelPaths = [
       cfg.certs.flannelClient.cert
       cfg.certs.flannelClient.key
@@ -411,30 +394,6 @@ in
       networking.extraHosts = mkIf (config.services.etcd.enable) ''
         127.0.0.1 etcd.${top.addons.dns.clusterDomain} etcd.local
       '';
-
-      systemd.services.kube-apiserver = mkIf top.apiserver.enable {
-        unitConfig.ConditionPathExists = apiserverPaths;
-      };
-
-      systemd.paths.kube-apiserver = mkIf top.apiserver.enable {
-        wantedBy = [ "kube-apiserver.service" ];
-        pathConfig = {
-          PathExists = apiserverPaths;
-          PathChanged = apiserverPaths;
-        };
-      };
-
-      systemd.services.etcd = mkIf top.apiserver.enable {
-        unitConfig.ConditionPathExists = etcdPaths;
-      };
-
-      systemd.paths.etcd = mkIf top.apiserver.enable {
-        wantedBy = [ "etcd.service" ];
-        pathConfig = {
-          PathExists = etcdPaths;
-          PathChanged = etcdPaths;
-        };
-      };
 
       services.flannel = with cfg.certs.flannelClient; {
         kubeconfig = top.lib.mkKubeConfig "flannel" {

--- a/nixos/modules/services/cluster/kubernetes/pki.nix
+++ b/nixos/modules/services/cluster/kubernetes/pki.nix
@@ -124,10 +124,6 @@ in
       top.caFile
       certmgrAPITokenPath
     ];
-    proxyPaths = mkIf top.proxy.enable [
-      cfg.certs.kubeProxyClient.cert
-      cfg.certs.kubeProxyClient.key
-    ];
     schedulerPaths = mkIf top.scheduler.enable [
       cfg.certs.schedulerClient.cert
       cfg.certs.schedulerClient.key
@@ -365,19 +361,6 @@ in
       networking.extraHosts = mkIf (config.services.etcd.enable) ''
         127.0.0.1 etcd.${top.addons.dns.clusterDomain} etcd.local
       '';
-
-      systemd.services.kube-proxy = mkIf top.proxy.enable {
-        environment = { inherit (top.pki.certs.kubeProxyClient) cert key; };
-        unitConfig.ConditionPathExists = proxyPaths;
-      };
-
-      systemd.paths.kube-proxy = mkIf top.proxy.enable {
-        wantedBy = [ "kube-proxy.service" ];
-        pathConfig = {
-          PathExists = proxyPaths;
-          PathChanged = proxyPaths;
-        };
-      };
 
       services.kubernetes = {
 

--- a/nixos/modules/services/cluster/kubernetes/pki.nix
+++ b/nixos/modules/services/cluster/kubernetes/pki.nix
@@ -136,13 +136,6 @@ in
       cfg.certs.schedulerClient.cert
       cfg.certs.schedulerClient.key
     ];
-    controllerManagerPaths = [
-      top.controllerManager.rootCaFile
-      top.controllerManager.tlsCertFile
-      top.controllerManager.tlsKeyFile
-      cfg.certs.controllerManagerClient.cert
-      cfg.certs.controllerManagerClient.key
-    ];
     kubeletPaths = [
       top.kubelet.clientCaFile
       top.kubelet.tlsCertFile
@@ -304,19 +297,6 @@ in
         pathConfig = {
           PathExists = certmgrPaths;
           PathChanged = certmgrPaths;
-        };
-      };
-
-      systemd.services.kube-controller-manager = mkIf top.controllerManager.enable {
-        environment = { inherit (cfg.certs.controllerManagerClient) cert key; };
-        unitConfig.ConditionPathExists = controllerManagerPaths;
-      };
-
-      systemd.paths.kube-controller-manager = mkIf top.controllerManager.enable {
-        wantedBy = [ "kube-controller-manager.service" ];
-        pathConfig = {
-          PathExists = controllerManagerPaths;
-          PathChanged = controllerManagerPaths;
         };
       };
 

--- a/nixos/modules/services/cluster/kubernetes/pki.nix
+++ b/nixos/modules/services/cluster/kubernetes/pki.nix
@@ -283,12 +283,6 @@ in
         };
       };
 
-      systemd.services.kube-control-plane-online.environment = let
-        client = with cfg.certs; if top.apiserver.enable then clusterAdmin else kubelet;
-      in {
-        inherit (client) cert key;
-      };
-
       environment.etc.${cfg.etcClusterAdminKubeconfig}.source = mkIf (!isNull cfg.etcClusterAdminKubeconfig)
         (top.lib.mkKubeConfig "cluster-admin" clusterAdminKubeconfig);
 

--- a/nixos/modules/services/cluster/kubernetes/proxy.nix
+++ b/nixos/modules/services/cluster/kubernetes/proxy.nix
@@ -48,9 +48,9 @@ in
   config = mkIf cfg.enable {
     systemd.services.kube-proxy = {
       description = "Kubernetes Proxy Service";
-      wantedBy = [ "node-online.target" ];
+      wantedBy = [ "kube-node-online.target" ];
       after = [ "kubelet-online.service" ];
-      before = [ "node-online.target" ];
+      before = [ "kube-node-online.target" ];
       path = with pkgs; [ iptables conntrack_tools ];
       preStart = ''
         ${top.lib.mkWaitCurl ( with config.systemd.services.kube-proxy; {

--- a/nixos/modules/services/cluster/kubernetes/proxy.nix
+++ b/nixos/modules/services/cluster/kubernetes/proxy.nix
@@ -48,9 +48,9 @@ in
   config = mkIf cfg.enable {
     systemd.services.kube-proxy = {
       description = "Kubernetes Proxy Service";
-      wantedBy = [ "kubernetes.target" ];
-      after = [ "node-online.target" ];
-      before = [ "kubernetes.target" ];
+      wantedBy = [ "node-online.target" ];
+      after = [ "kubelet-online.service" ];
+      before = [ "node-online.target" ];
       path = with pkgs; [ iptables conntrack_tools ];
       preStart = ''
         ${top.lib.mkWaitCurl (with top.pki.certs.kubeProxyClient; {

--- a/nixos/modules/services/cluster/kubernetes/proxy.nix
+++ b/nixos/modules/services/cluster/kubernetes/proxy.nix
@@ -53,11 +53,10 @@ in
       before = [ "node-online.target" ];
       path = with pkgs; [ iptables conntrack_tools ];
       preStart = ''
-        ${top.lib.mkWaitCurl (with top.pki.certs.kubeProxyClient; {
+        ${top.lib.mkWaitCurl ( with config.systemd.services.kube-proxy; {
           path = "/api/v1/nodes/${top.kubelet.hostname}";
           cacert = top.caFile;
-          inherit cert key;
-        })}
+        } // optionalAttrs (environment ? cert) { inherit (environment) cert key; })}
       '';
       serviceConfig = {
         Slice = "kubernetes.slice";

--- a/nixos/modules/services/cluster/kubernetes/proxy.nix
+++ b/nixos/modules/services/cluster/kubernetes/proxy.nix
@@ -45,18 +45,27 @@ in
   };
 
   ###### implementation
-  config = mkIf cfg.enable {
-    systemd.services.kube-proxy = {
+  config = let
+
+    proxyPaths = filter (a: a != null) [
+      cfg.kubeconfig.caFile
+      cfg.kubeconfig.certFile
+      cfg.kubeconfig.keyFile
+    ];
+
+  in mkIf cfg.enable {
+    systemd.services.kube-proxy = rec {
       description = "Kubernetes Proxy Service";
       wantedBy = [ "kube-node-online.target" ];
       after = [ "kubelet-online.service" ];
       before = [ "kube-node-online.target" ];
-      path = with pkgs; [ iptables conntrack_tools ];
+      environment.KUBECONFIG = top.lib.mkKubeConfig "kube-proxy" cfg.kubeconfig;
+      path = with pkgs; [ iptables conntrack_tools kubectl ];
       preStart = ''
-        ${top.lib.mkWaitCurl ( with config.systemd.services.kube-proxy; {
-          path = "/api/v1/nodes/${top.kubelet.hostname}";
-          cacert = top.caFile;
-        } // optionalAttrs (environment ? cert) { inherit (environment) cert key; })}
+        until kubectl auth can-i get nodes/${top.kubelet.hostname} -q 2>/dev/null; do
+          echo kubectl auth can-i get nodes/${top.kubelet.hostname}: exit status $?
+          sleep 2
+        done
       '';
       serviceConfig = {
         Slice = "kubernetes.slice";
@@ -66,13 +75,22 @@ in
             "--cluster-cidr=${top.clusterCidr}"} \
           ${optionalString (cfg.featureGates != [])
             "--feature-gates=${concatMapStringsSep "," (feature: "${feature}=true") cfg.featureGates}"} \
-          --kubeconfig=${top.lib.mkKubeConfig "kube-proxy" cfg.kubeconfig} \
+          --kubeconfig=${environment.KUBECONFIG} \
           ${optionalString (cfg.verbosity != null) "--v=${toString cfg.verbosity}"} \
           ${cfg.extraOpts}
         '';
         WorkingDirectory = top.dataDir;
         Restart = "on-failure";
         RestartSec = 5;
+      };
+      unitConfig.ConditionPathExists = proxyPaths;
+    };
+
+    systemd.paths.kube-proxy = {
+      wantedBy = [ "kube-proxy.service" ];
+      pathConfig = {
+        PathExists = proxyPaths;
+        PathChanged = proxyPaths;
       };
     };
 

--- a/nixos/modules/services/cluster/kubernetes/scheduler.nix
+++ b/nixos/modules/services/cluster/kubernetes/scheduler.nix
@@ -63,12 +63,11 @@ in
       after = [ "kube-apiserver.service" ];
       before = [ "kube-control-plane-online.target" ];
       preStart = ''
-        ${top.lib.mkWaitCurl (with top.pki.certs.schedulerClient; {
+        ${top.lib.mkWaitCurl ( with config.systemd.services.kube-scheduler; {
           sleep = 1;
           path = "/api";
           cacert = top.caFile;
-          inherit cert key;
-        })}
+        } // optionalAttrs (environment ? cert) { inherit (environment) cert key; })}
       '';
       serviceConfig = {
         Slice = "kubernetes.slice";

--- a/nixos/modules/services/cluster/kubernetes/scheduler.nix
+++ b/nixos/modules/services/cluster/kubernetes/scheduler.nix
@@ -59,9 +59,9 @@ in
   config = mkIf cfg.enable {
     systemd.services.kube-scheduler = {
       description = "Kubernetes Scheduler Service";
-      wantedBy = [ "kube-apiserver-online.target" ];
+      wantedBy = [ "kube-control-plane-online.target" ];
       after = [ "kube-apiserver.service" ];
-      before = [ "kube-apiserver-online.target" ];
+      before = [ "kube-control-plane-online.target" ];
       preStart = ''
         ${top.lib.mkWaitCurl (with top.pki.certs.schedulerClient; {
           sleep = 1;

--- a/nixos/tests/kubernetes/base.nix
+++ b/nixos/tests/kubernetes/base.nix
@@ -30,7 +30,10 @@ let
         { config, pkgs, lib, nodes, ... }:
           mkMerge [
             {
-              boot.postBootCommands = "rm -fr /var/lib/kubernetes/secrets /tmp/shared/*";
+              boot = {
+                postBootCommands = "rm -fr /var/lib/kubernetes/secrets /tmp/shared/*";
+                kernel.sysctl = { "fs.inotify.max_user_instances" = 256; };
+              };
               virtualisation.memorySize = mkDefault 1536;
               virtualisation.diskSize = mkDefault 4096;
               networking = {

--- a/nixos/tests/kubernetes/dns.nix
+++ b/nixos/tests/kubernetes/dns.nix
@@ -77,6 +77,7 @@ let
   singleNodeTest = {
     test = ''
       # prepare machine1 for test
+      $machine1->waitForUnit("kubernetes.target");
       $machine1->waitUntilSucceeds("kubectl get node machine1.${domain} | grep -w Ready");
       $machine1->waitUntilSucceeds("docker load < ${redisImage}");
       $machine1->waitUntilSucceeds("kubectl create -f ${redisPod}");
@@ -102,6 +103,8 @@ let
       # Node token exchange
       $machine1->waitUntilSucceeds("cp -f /var/lib/cfssl/apitoken.secret /tmp/shared/apitoken.secret");
       $machine2->waitUntilSucceeds("cat /tmp/shared/apitoken.secret | nixos-kubernetes-node-join");
+      $machine1->waitForUnit("kubernetes.target");
+      $machine2->waitForUnit("kubernetes.target");
 
       # prepare machines for test
       $machine1->waitUntilSucceeds("kubectl get node machine2.${domain} | grep -w Ready");

--- a/nixos/tests/kubernetes/rbac.nix
+++ b/nixos/tests/kubernetes/rbac.nix
@@ -94,6 +94,8 @@ let
 
   singlenode = base // {
     test = ''
+      $machine1->waitForUnit("kubernetes.target");
+
       $machine1->waitUntilSucceeds("kubectl get node machine1.my.zyx | grep -w Ready");
 
       $machine1->waitUntilSucceeds("docker load < ${kubectlImage}");
@@ -116,6 +118,8 @@ let
       # Node token exchange
       $machine1->waitUntilSucceeds("cp -f /var/lib/cfssl/apitoken.secret /tmp/shared/apitoken.secret");
       $machine2->waitUntilSucceeds("cat /tmp/shared/apitoken.secret | nixos-kubernetes-node-join");
+      $machine1->waitForUnit("kubernetes.target");
+      $machine2->waitForUnit("kubernetes.target");
 
       $machine1->waitUntilSucceeds("kubectl get node machine2.my.zyx | grep -w Ready");
 


### PR DESCRIPTION
###### Motivation for this change
I had a tough time getting to know the kubernetes with all the errors in the logs caused by services dying because of missing required certificates (because they were not generated yet) or simply because services depend on other services which were not started yet.

This PR makes all the services related to kubernetes start in order, even across machines and ensures the requirements for the services are met in advance of starting. The kubernetes tests had 28K lines of log before ran about 4m 20s and are now down to 13K and 3m 40s. All service start clean on the first boot.

Please see the commit messages for further information about the changes.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

