### PR TITLE
fragments: init at 1.3

### DIFF
--- a/pkgs/applications/networking/p2p/fragments/default.nix
+++ b/pkgs/applications/networking/p2p/fragments/default.nix
@@ -1,0 +1,56 @@
+{ stdenv, fetchgit, meson, ninja, cmake, desktop-file-utils, automake, autoconf, libtool, libevent, openssl, zlib, pkgconfig, libgee, curl, vala, glib, python3, gtk3, libhandy, hicolor-icon-theme, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  pname = "fragments";
+  version = "1.3";
+
+  src = fetchgit {
+    url = "https://gitlab.gnome.org/World/Fragments";
+    rev = version;
+    fetchSubmodules = true;
+    sha256 = "0wz70yvl5ndv93bn0993scq1ys18q15n03nnjmlplj5j8l8yammz";
+  };
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+    cmake
+    desktop-file-utils
+    libtool
+    meson
+    ninja
+    pkgconfig
+    python3
+    vala
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    curl
+    glib
+    gtk3
+    hicolor-icon-theme
+    libevent
+    libgee
+    libhandy
+    openssl
+    zlib
+  ];
+
+  patches = [ ./find_library.patch ];
+
+  postPatch = ''
+    chmod +x build-aux/*
+    patchShebangs build-aux
+  '';
+
+  dontUseCmakeConfigure = true;
+
+  meta = with stdenv.lib; {
+    description = "An easy to use BitTorrent client which follows the GNOME HIG and includes well thought-out features";
+    homepage = https://gitlab.gnome.org/World/Fragments;
+    maintainers = with maintainers; [ worldofpeace ];
+    platforms = platforms.linux;
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/applications/networking/p2p/fragments/find_library.patch
+++ b/pkgs/applications/networking/p2p/fragments/find_library.patch
@@ -1,0 +1,24 @@
+diff --git a/submodules/meson.build b/submodules/meson.build
+index 53e73a2..c2132b8 100644
+--- a/submodules/meson.build
++++ b/submodules/meson.build
+@@ -5,12 +5,12 @@ dht_lib = meson.get_compiler('c').find_library('dht', dirs: join_paths (meson.so
+ natpmp_lib = meson.get_compiler('c').find_library('natpmp', dirs: join_paths (meson.source_root (), 'submodules', 'libtransmission', 'third-party', 'natpmp', 'lib'))
+ event_lib = meson.get_compiler('c').find_library('event')
+ 
+-curl_lib = meson.get_compiler('c').find_library('libcurl')
+-crypto_lib = meson.get_compiler('c').find_library('libcrypto')
+-pthread_lib = meson.get_compiler('c').find_library('libpthread', dirs: join_paths (meson.source_root (), 'submodules', 'libtransmission', 'libtransmission'))
+-zlib_lib = meson.get_compiler('c').find_library('libz', dirs: join_paths (meson.source_root (), 'submodules', 'libtransmission', 'libtransmission'))
++curl_lib = meson.get_compiler('c').find_library('curl')
++crypto_lib = meson.get_compiler('c').find_library('crypto')
++pthread_lib = meson.get_compiler('c').find_library('pthread', dirs: join_paths (meson.source_root (), 'submodules', 'libtransmission', 'libtransmission'))
++zlib_lib = meson.get_compiler('c').find_library('z')
+ 
+ transmission_include = include_directories('transmission/')
+-transmission_lib = meson.get_compiler('c').find_library('libtransmission', dirs: join_paths (meson.source_root (), 'submodules', 'libtransmission', 'libtransmission'))
++transmission_lib = meson.get_compiler('c').find_library('transmission', dirs: join_paths (meson.source_root (), 'submodules', 'libtransmission', 'libtransmission'))
+ transmission_vapi = meson.get_compiler('vala').find_library('transmission', dirs: vapi_dir)
+-transmission_dep = declare_dependency(include_directories: [transmission_include], dependencies: [pthread_lib, b64_lib, utp_lib, miniupnpc_lib, dht_lib, natpmp_lib, curl_lib, crypto_lib, event_lib, zlib_lib, transmission_vapi, transmission_lib])
+\ No newline at end of file
++transmission_dep = declare_dependency(include_directories: [transmission_include], dependencies: [pthread_lib, b64_lib, utp_lib, miniupnpc_lib, dht_lib, natpmp_lib, curl_lib, crypto_lib, event_lib, zlib_lib, transmission_vapi, transmission_lib])

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2775,6 +2775,8 @@ in
 
   fprintd = callPackage ../tools/security/fprintd { };
 
+  fragments = callPackage ../applications/networking/p2p/fragments { };
+
   franz = callPackage ../applications/networking/instant-messengers/franz { };
 
   freedroidrpg = callPackage ../games/freedroidrpg { };


### PR DESCRIPTION
###### Motivation for this change
Got carried away when I saw #56784 :smile: 

The build system for Fragments Is kinda problematic in nix because of how it builds the latest [`transmission`](https://gitlab.gnome.org/World/Fragments/blob/master/build-aux/build_libtransmission.sh).

Also couldn't get `libz` to go in [`submodules/meson.build`](https://gitlab.gnome.org/World/Fragments/blob/master/submodules/meson.build).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

