### PR TITLE
shapelib: 1.4.1 -> 1.5.0

### DIFF
--- a/pkgs/development/libraries/shapelib/default.nix
+++ b/pkgs/development/libraries/shapelib/default.nix
@@ -1,14 +1,12 @@
-{ stdenv, fetchurl, proj }:
+{ stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "shapelib-1.4.1";
+  name = "shapelib-1.5.0";
 
   src = fetchurl {
     url = "https://download.osgeo.org/shapelib/${name}.tar.gz";
-    sha256 = "1cr3b5jfglwisbyzj7fnxp9xysqad0fcmcqvqaja6qap6qblijd4";
+    sha256 = "1qfsgb8b3yiqwvr6h9m81g6k9fjhfys70c22p7kzkbick20a9h0z";
   };
-
-  buildInputs =  [ proj ];
 
   meta = with stdenv.lib; {
     description = "C Library for reading, writing and updating ESRI Shapefiles";


### PR DESCRIPTION
###### Motivation for this change

https://lists.osgeo.org/pipermail/shapelib/2019-February/000647.html

* s in 1.5.0 notes, no longer need 'proj' dep (so drop)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---