### PR TITLE
libqb,corosync: update; kronosnet: init at 1.7

### DIFF
--- a/pkgs/development/libraries/kronosnet/default.nix
+++ b/pkgs/development/libraries/kronosnet/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub
+, autoreconfHook, pkgconfig
+, libqb, libxml2, libnl, lksctp-tools
+, nss, openssl, bzip2, lzo, lz4, xz, zlib
+, doxygen
+}:
+
+stdenv.mkDerivation rec {
+  pname = "kronosnet";
+  version = "1.7";
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1vfwwv8i1n2yvlyx14sgyr2q5igf68qlsdhb1yisnw4bjs1g1s4x";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig doxygen ];
+
+  buildInputs = [
+    libqb libxml2 libnl lksctp-tools
+    nss openssl
+    bzip2 lzo lz4 xz zlib
+  ];
+
+  meta = with stdenv.lib; {
+    description = "VPN on steroids";
+    homepage = https://kronosnet.org/;
+    license = [ licenses.lgpl21Plus licenses.gpl2Plus ];
+  };
+}

--- a/pkgs/development/libraries/libqb/default.nix
+++ b/pkgs/development/libraries/libqb/default.nix
@@ -1,14 +1,30 @@
-{ stdenv, fetchurl, pkgconfig }:
+{ stdenv, fetchurl, fetchpatch, pkgconfig, autoreconfHook, doxygen }:
 
 stdenv.mkDerivation rec{
-  name = "libqb-0.17.2";
+  pname = "libqb";
+  version = "1.0.3";
 
   src = fetchurl {
-    url = "https://fedorahosted.org/releases/q/u/quarterback/${name}.tar.xz";
-    sha256 = "1zpl45p3n6dn1jgbsrrmccrmv2mvp8aqmnl0qxfjf7ymkrj9qhcs";
+    url = "https://github.com/ClusterLabs/libqb/releases/download/v${version}/${pname}-${version}.tar.xz";
+    sha256 = "1xzlx9agx7fir151ni3lwsjp6aicjpqd80xw1fhykgx49dbahax0";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig doxygen ];
+
+  outputs = [ "out" "dev" "doc" "man" ];
+
+  patches = [
+    (fetchurl {
+      url = "https://github.com/ClusterLabs/libqb/commit/6d62b64752c2a94acc3974be4b2528f4d05363cf.patch";
+      sha256 = "178ygfq6v4qla1b39i5q44083d6jbiihcr6b29dir78kysv426bz";
+    })
+  ];
+
+  # Purity fix
+  preFixup = ''
+    grep -q "$TMPDIR" "$out"/lib/libqb.la
+    sed -i "s,\(inherited_linker_flags='\).*,\1'," "$out"/lib/libqb.la
+  '';
 
   meta = with stdenv.lib; {
     homepage = https://github.com/clusterlabs/libqb;

--- a/pkgs/development/libraries/libqb/default.nix
+++ b/pkgs/development/libraries/libqb/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec{
   ];
 
   # Purity fix
-  preFixup = ''
+  preFixup = stdenv.lib.optionalString stdenv.isLinux ''
     grep -q "$TMPDIR" "$out"/lib/libqb.la
     sed -i "s,\(inherited_linker_flags='\).*,\1'," "$out"/lib/libqb.la
   '';

--- a/pkgs/servers/corosync/default.nix
+++ b/pkgs/servers/corosync/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, pkgconfig, nss, nspr, libqb
+{ stdenv, fetchurl, makeWrapper, pkgconfig, kronosnet, nss, nspr, libqb
 , dbus, rdma-core, libstatgrab, net_snmp
 , enableDbus ? false
 , enableInfiniBandRdma ? false
@@ -9,17 +9,18 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  name = "corosync-2.4.3";
+  pname = "corosync";
+  version = "3.0.1";
 
   src = fetchurl {
-    url = "http://build.clusterlabs.org/corosync/releases/${name}.tar.gz";
-    sha256 = "15y5la04qn2lh1gabyifygzpa4dx3ndk5yhmaf7azxyjx0if9rxi";
+    url = "http://build.clusterlabs.org/corosync/releases/${pname}-${version}.tar.gz";
+    sha256 = "0zk75yknvhc691y0j4lkh1bx55mryzdgw60mrcr5j6fid1xbfnqy";
   };
 
   nativeBuildInputs = [ makeWrapper pkgconfig ];
 
   buildInputs = [
-    nss nspr libqb
+    kronosnet nss nspr libqb
   ] ++ optional enableDbus dbus
     ++ optional enableInfiniBandRdma rdma-core
     ++ optional enableMonitoring libstatgrab

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10551,6 +10551,8 @@ in
   libkrb5 = krb5.override { type = "lib"; };
   kerberos = libkrb5; # TODO: move to aliases.nix
 
+  kronosnet = callPackage ../development/libraries/kronosnet { };
+
   languageMachines = recurseIntoAttrs (import ../development/libraries/languagemachines/packages.nix { inherit callPackage; });
 
   lasem = callPackage ../development/libraries/lasem { };


### PR DESCRIPTION
###### Motivation for this change

:sparkles:

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---