### PR TITLE
cracklib: 2.9.6 -> 2.9.7, generate dictionary from wordlists

### DIFF
--- a/pkgs/development/libraries/cracklib/default.nix
+++ b/pkgs/development/libraries/cracklib/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchurl, zlib, gettext }:
 
 stdenv.mkDerivation rec {
-  name = "cracklib-2.9.6";
+  pname = "cracklib";
+  version = "2.9.7";
 
   src = fetchurl {
-    url = "https://github.com/cracklib/cracklib/releases/download/${name}/${name}.tar.gz";
-    sha256 = "0hrkb0prf7n92w6rxgq0ilzkk6rkhpys2cfqkrbzswp27na7dkqp";
+    url = "https://github.com/${pname}/${pname}/releases/download/v${version}/${pname}-${version}.tar.bz2";
+    sha256 = "1rimpjsdnmw8f5b7k558cic41p2qy2n2yrlqp5vh7mp4162hk0py";
   };
 
   buildInputs = [ zlib gettext ];

--- a/pkgs/development/libraries/cracklib/default.nix
+++ b/pkgs/development/libraries/cracklib/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchurl, zlib, gettext }:
 
+# TODO: wordlist? https://github.com/cracklib/cracklib/releases/download/v2.9.7/cracklib-words-2.9.7.gz is a start!
 stdenv.mkDerivation rec {
   pname = "cracklib";
   version = "2.9.7";
@@ -10,6 +11,17 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ zlib gettext ];
+
+  postPatch = ''
+    chmod +x util/cracklib-format
+    patchShebangs util
+  '';
+
+  postInstall = ''
+    make dict
+  '';
+  doInstallCheck = true;
+  installCheckTarget = "test";
 
   meta = with stdenv.lib; {
     homepage    = https://github.com/cracklib/cracklib;

--- a/pkgs/development/libraries/cracklib/default.nix
+++ b/pkgs/development/libraries/cracklib/default.nix
@@ -1,9 +1,14 @@
-{ stdenv, fetchurl, zlib, gettext }:
+let version = "2.9.7"; in
+{ stdenv, fetchurl, zlib, gettext
+, wordlists ? [ (fetchurl {
+  url = "https://github.com/cracklib/cracklib/releases/download/v${version}/cracklib-words-${version}.gz";
+  sha256 = "12fk8w06q628v754l357cf8kfjna98wj09qybpqr892az3x4a33z";
+}) ]
+}:
 
-# TODO: wordlist? https://github.com/cracklib/cracklib/releases/download/v2.9.7/cracklib-words-2.9.7.gz is a start!
 stdenv.mkDerivation rec {
   pname = "cracklib";
-  version = "2.9.7";
+  inherit version;
 
   src = fetchurl {
     url = "https://github.com/${pname}/${pname}/releases/download/v${version}/${pname}-${version}.tar.bz2";
@@ -15,6 +20,8 @@ stdenv.mkDerivation rec {
   postPatch = ''
     chmod +x util/cracklib-format
     patchShebangs util
+
+    ln -vs ${toString wordlists} dicts/
   '';
 
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change

Fixes #56179.

Dictionary is generated from optionally-specified (override'able)
list of files to include.

This isn't entirely optimal
(dictionary changes will trigger rebuild, and many packages depending)
but provides better default behavior and can be improved in the future
should that be found to be warranted.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---