### PR TITLE
Zotero: Fix to use patchelf instead of FHS Env.

### DIFF
--- a/pkgs/applications/office/zotero/default.nix
+++ b/pkgs/applications/office/zotero/default.nix
@@ -1,67 +1,125 @@
-{ stdenv, fetchurl, buildFHSUserEnv, makeDesktopItem, runCommand, bash, wrapGAppsHook, gsettings-desktop-schemas, gtk3, gnome3 }:
+{ stdenv, fetchurl, wrapGAppsHook
+, atk
+, cairo
+, curl
+, cups
+, dbus-glib
+, dbus
+, fontconfig
+, freetype
+, gdk_pixbuf
+, glib
+, glibc
+, gtk3
+, libX11
+, libXScrnSaver
+, libxcb
+, libXcomposite
+, libXcursor
+, libXdamage
+, libXext
+, libXfixes
+, libXi
+, libXinerama
+, libXrender
+, libXt
+, libnotify
+, gnome3
+, libGLU_combined
+, nspr
+, nss
+, pango
+, coreutils
+, gnused
+, gsettings-desktop-schemas
+}:
 
-let
-version = "5.0.60";
-meta = with stdenv.lib; {
-  homepage = https://www.zotero.org;
-  description = "Collect, organize, cite, and share your research sources";
-  license = licenses.agpl3;
-  platforms = platforms.linux;
-};
-
-zoteroSrc = stdenv.mkDerivation rec {
-  inherit version;
-  name = "zotero-${version}-pkg";
-
+stdenv.mkDerivation rec {
+  name    = "zotero-${version}";
+  version = "5.0.60";
+  
   src = fetchurl {
     url = "https://download.zotero.org/client/release/${version}/Zotero-${version}_linux-x86_64.tar.bz2";
     sha256 = "0753xk95shhxma4dvdxrj2q6y81z8lianxg7jnab9m17fb67jy2d";
   };
-
+  
   buildInputs= [ wrapGAppsHook gsettings-desktop-schemas gtk3 gnome3.adwaita-icon-theme gnome3.dconf ];
-  phases = [ "unpackPhase" "installPhase" "fixupPhase"];
 
-  installPhase = ''
-    mkdir -p $out/data
-    cp -r * $out/data
-    mkdir $out/bin
-    ln -s $out/data/zotero $out/bin/zotero
+  phases = [ "unpackPhase" "patchPhase" "installPhase" "fixupPhase" ];
+
+  dontStrip = true;
+  dontPatchELF = true;
+
+  libPath = stdenv.lib.makeLibraryPath
+    [ stdenv.cc.cc
+      atk
+      cairo
+      curl
+      cups
+      dbus-glib
+      dbus
+      fontconfig
+      freetype
+      gdk_pixbuf
+      glib
+      glibc
+      gtk3
+      libX11
+      libXScrnSaver
+      libXcomposite
+      libXcursor
+      libxcb
+      libXdamage
+      libXext
+      libXfixes
+      libXi
+      libXinerama
+      libXrender
+      libXt
+      libnotify
+      libGLU_combined
+      nspr
+      nss
+      pango
+    ] + ":" + stdenv.lib.makeSearchPathOutput "lib" "lib64" [
+      stdenv.cc.cc
+    ];
+
+  patchPhase = ''
+    sed -i '/pref("app.update.enabled", true);/c\pref("app.update.enabled", false);' defaults/preferences/prefs.js
   '';
-};
 
-fhsEnv = buildFHSUserEnv {
-  name = "zotero-fhs-env";
-  targetPkgs = pkgs: with pkgs; with xorg; [
-    gtk3 dbus-glib glib
-    libXt nss
-    libX11
-  ];
-};
+  installPhase =
+  ''
+     mkdir -p "$prefix/usr/lib/zotero-bin-${version}"
+     cp -r * "$prefix/usr/lib/zotero-bin-${version}"
+     mkdir -p "$out/bin"
+     ln -s "$prefix/usr/lib/zotero-bin-${version}/zotero" "$out/bin/"
 
-desktopItem = makeDesktopItem rec {
-  name = "zotero-${version}";
-  exec = "zotero -url %U";
-  icon = "zotero";
-  type = "Application";
-  comment = meta.description;
-  desktopName = "Zotero";
-  genericName = "Reference Management";
-  categories = "Office;Database;";
-  startupNotify = "true";
-};
+     install -Dm444 zotero.desktop $out/share/applications/zotero.desktop
+     for size in 16 32 48 256; do
+       install -Dm444 chrome/icons/default/default$size.png \
+         $out/share/icons/hicolor/''${size}x''${size}/apps/zotero.png
+     done
 
-in runCommand "zotero-${version}" { inherit meta; } ''
-  mkdir -p $out/bin $out/share/applications
-  cat >$out/bin/zotero <<EOF
-#!${bash}/bin/bash
-${fhsEnv}/bin/zotero-fhs-env ${zoteroSrc}/bin/zotero
-EOF
-  chmod +x $out/bin/zotero
+     for executable in \
+       zotero-bin plugin-container \
+       updater minidump-analyzer
+     do
+       if [ -e "$out/usr/lib/zotero-bin-${version}/$executable" ]; then
+         patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+           "$out/usr/lib/zotero-bin-${version}/$executable"
+       fi
+     done
+     find . -executable -type f -exec \
+       patchelf --set-rpath "$libPath" \
+         "$out/usr/lib/zotero-bin-${version}/{}" \;
+  '';
 
-  cp ${desktopItem}/share/applications/* $out/share/applications/
-
-  for size in 16 32 48 256; do
-    install -Dm444 ${zoteroSrc}/data/chrome/icons/default/default$size.png \
-      $out/share/icons/hicolor/''${size}x''${size}/apps/zotero.png
-  done
-''
+  meta = with stdenv.lib; {
+    homepage = https://www.zotero.org;
+    description = "Collect, organize, cite, and share your research sources";
+    license = licenses.agpl3;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/office/zotero/default.nix
+++ b/pkgs/applications/office/zotero/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, wrapGAppsHook
+{ stdenv, fetchurl, wrapGAppsHook, makeDesktopItem
 , atk
 , cairo
 , curl
@@ -89,6 +89,19 @@ stdenv.mkDerivation rec {
     sed -i '/pref("app.update.enabled", true);/c\pref("app.update.enabled", false);' defaults/preferences/prefs.js
   '';
 
+  desktopItem = makeDesktopItem rec {
+    name = "zotero-${version}";
+    exec = "zotero -url %U";
+    icon = "zotero";
+    type = "Application";
+    comment = meta.description;
+    desktopName = "Zotero";
+    genericName = "Reference Management";
+    categories = "Office;Database;";
+    startupNotify = "true";
+    mimeType = "text/plain";
+  };
+
   installPhase =
   ''
      mkdir -p "$prefix/usr/lib/zotero-bin-${version}"
@@ -96,7 +109,9 @@ stdenv.mkDerivation rec {
      mkdir -p "$out/bin"
      ln -s "$prefix/usr/lib/zotero-bin-${version}/zotero" "$out/bin/"
 
-     install -Dm444 zotero.desktop $out/share/applications/zotero.desktop
+     # install desktop file and icons.
+     mkdir -p $out/share/applications
+     cp ${desktopItem}/share/applications/* $out/share/applications/
      for size in 16 32 48 256; do
        install -Dm444 chrome/icons/default/default$size.png \
          $out/share/icons/hicolor/''${size}x''${size}/apps/zotero.png


### PR DESCRIPTION
Don't use buildFHSUserEnv and use patchelf to fix up the binary and libs. This should fix issue #48814.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

