### PR TITLE
pythonPackages.qscintilla: fix build

### DIFF
--- a/pkgs/development/python-modules/qscintilla/default.nix
+++ b/pkgs/development/python-modules/qscintilla/default.nix
@@ -17,7 +17,9 @@ disabledIf (isPy3k || isPyPy)
 
     src = pkgs.qscintilla.src;
 
-    buildInputs = [ pkgs.xorg.lndir pyqt4.qt pyqt4 ];
+    nativeBuildInputs = [ pkgs.xorg.lndir ];
+
+    buildInputs = [ pyqt4.qt pyqt4 ];
 
     preConfigure = ''
       mkdir -p $out


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

