### PR TITLE
PyPy: 7.0.0

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -81,7 +81,7 @@ let
       intersperse concatStringsSep concatMapStringsSep
       concatImapStringsSep makeSearchPath makeSearchPathOutput
       makeLibraryPath makeBinPath optionalString
-      hasPrefix hasSuffix stringToCharacters stringAsChars escape
+      hasInfix hasPrefix hasSuffix stringToCharacters stringAsChars escape
       escapeShellArg escapeShellArgs replaceChars lowerChars
       upperChars toLower toUpper addContextFrom splitString
       removePrefix removeSuffix versionOlder versionAtLeast getVersion

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -30,7 +30,7 @@ with pkgs;
         isPy2 = lib.strings.substring 0 1 pythonVersion == "2";
         isPy3 = lib.strings.substring 0 1 pythonVersion == "3";
         isPy3k = isPy3;
-        isPyPy = interpreter == "pypy";
+        isPyPy = lib.hasInfix "pypy" interpreter;
 
         buildEnv = callPackage ./wrapper.nix { python = self; inherit (pythonPackages) requiredPythonModules; };
         withPackages = import ./with-packages.nix { inherit buildEnv pythonPackages;};

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -100,11 +100,11 @@ in {
   pypy27 = callPackage ./pypy {
     self = pypy27;
     sourceVersion = {
-      major = "6";
+      major = "7";
       minor = "0";
       patch = "0";
     };
-    sha256 = "1qjwpc8n68sxxlfg36s5vn1h2gdfvvd6lxvr4lzbvfwhzrgqahsw";
+    sha256 = "1m6ja79sbkl38p1hs7c0n4kq5xzn01wp7wl5456hsw9q6cwg6894";
     pythonVersion = "2.7";
     db = db.override { dbmSupport = true; };
     python = python27;
@@ -114,11 +114,11 @@ in {
   pypy35 = callPackage ./pypy {
     self = pypy35;
     sourceVersion = {
-      major = "6";
+      major = "7";
       minor = "0";
       patch = "0";
     };
-    sha256 = "0lwq8nn0r5yj01bwmkk5p7xvvrp4s550l8184mkmn74d3gphrlwg";
+    sha256 = "0hbv9ziv8n9lqnr6cndrw70p6g40c00w1ds7lmzgrr153myxkp7w";
     pythonVersion = "3.5";
     db = db.override { dbmSupport = true; };
     python = python27;

--- a/pkgs/development/interpreters/python/pypy/default.nix
+++ b/pkgs/development/interpreters/python/pypy/default.nix
@@ -108,6 +108,9 @@ in with passthru; stdenv.mkDerivation rec {
       "test_pathlib"
       # disable tarfile because it assumes gid 0 exists
       "test_tarfile"
+      # disable __all__ because of spurious imp/importlib warning and
+      # warning-to-error test policy
+      "test___all__"
     ];
   in ''
     export TERMINFO="${ncurses.out}/share/terminfo/";


### PR DESCRIPTION
###### Motivation for this change

We should have a robust PyPy story in place so that we can smoothly deprecate CPython 2 in concert with PSF.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

