### PR TITLE
teamspeak_server: 3.5.1 -> 3.6.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/teamspeak/server.nix
+++ b/pkgs/applications/networking/instant-messengers/teamspeak/server.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, makeWrapper }:
 
 let
-  version = "3.5.1";
+  version = "3.6.1";
   arch = if stdenv.is64bit then "amd64" else "x86";
   libDir = if stdenv.is64bit then "lib64" else "lib";
 in
@@ -15,8 +15,8 @@ stdenv.mkDerivation {
       "http://teamspeak.gameserver.gamed.de/ts3/releases/${version}/teamspeak3-server_linux_${arch}-${version}.tar.bz2"
     ];
     sha256 = if stdenv.is64bit
-      then "0ygb867ff2fvi9n9hgs4hldpg4y012w4i1d9cx4f5mpli1xim6da"
-      else "0g1cixsldpdbfzg2vain7h3hr5j3xjdngjw66r0aqnzbx743gjzj";
+      then "0wgnb7fdy393anridymm1frlgr86j0awxnzvd498ar5fch06ij87"
+      else "0x6p1z4qvgy464n6gnkaqrm7dns1ysyadm68sr260d39a7028q1c";
   };
 
   buildInputs = [ makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change

Update teamspeak server to version 3.6.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

