### PR TITLE
SDL2_image: support WebP images

### DIFF
--- a/pkgs/development/libraries/SDL2_image/default.nix
+++ b/pkgs/development/libraries/SDL2_image/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, SDL2, libpng, libjpeg, libtiff, libungif, libXpm, zlib, Foundation }:
+{ stdenv, fetchurl, SDL2, libpng, libjpeg, libtiff, libungif, libwebp, libXpm, zlib, Foundation }:
 
 stdenv.mkDerivation rec {
   name = "SDL2_image-${version}";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "1b6f7002bm007y3zpyxb5r6ag0lml51jyvx1pwpj9sq24jfc8kp7";
   };
 
-  buildInputs = [ SDL2 libpng libjpeg libtiff libungif libXpm zlib ]
+  buildInputs = [ SDL2 libpng libjpeg libtiff libungif libwebp libXpm zlib ]
     ++ stdenv.lib.optional stdenv.isDarwin Foundation;
 
 


### PR DESCRIPTION
###### Motivation for this change

SDL2 supports the [WebP](https://developers.google.com/speed/webp/) image format, but only if `libwebp` is available in `buildInputs`.

This builds and works fine on my end.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

