### PR TITLE
renpy: 7.1.3 -> 7.2.0

### DIFF
--- a/pkgs/development/interpreters/renpy/default.nix
+++ b/pkgs/development/interpreters/renpy/default.nix
@@ -7,7 +7,7 @@ with pythonPackages;
 
 stdenv.mkDerivation rec {
   name = "renpy-${version}";
-  version = "7.1.3";
+  version = "7.2.0";
 
   meta = with stdenv.lib; {
     description = "Ren'Py Visual Novel Engine";
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://www.renpy.org/dl/${version}/renpy-${version}-source.tar.bz2";
-    sha256 = "0z6s1vzjb5jh0i79pv5kgynfrzqj1a1f3afrpmp2aaqbrljkidbn";
+    sha256 = "1pnzxmh37zzldvlyklk2wgc8xbh3hm3wwmbl70zdphybjrxvc7i5";
   };
 
   patches = [

--- a/pkgs/development/python-modules/pygame_sdl2/default.nix
+++ b/pkgs/development/python-modules/pygame_sdl2/default.nix
@@ -4,12 +4,12 @@
 buildPythonPackage rec {
   pname = "pygame_sdl2";
   version = "2.1.0";
-  renpy_version = "6.99.14";
+  renpy_version = "7.2.0";
   name = "${pname}-${version}-${renpy_version}";
 
   src = fetchurl {
     url = "https://www.renpy.org/dl/${renpy_version}/pygame_sdl2-${version}-for-renpy-${renpy_version}.tar.gz";
-    sha256 = "1zsnb2bivbwysgxmfg9iv12arhpf3gqkmqinhciz955hlqv016b9";
+    sha256 = "1amgsb6mm8ssf7vdcs5dr8rlxrgyhh29m4i573z1cw61ynd7vgcw";
   };
 
   # force rebuild of headers needed for install
@@ -17,17 +17,13 @@ buildPythonPackage rec {
     rm -rf gen gen3
   '';
 
-  patches = [
-    # fix for recent sdl2
-    (fetchpatch {
-      url = "https://github.com/apoleon/pygame_sdl2/commit/ced6051f4a4559a725804cc58c079e1efea0a573.patch";
-      sha256 = "08rqjzvdlmmdf8kyd8ws5lzjy1mrwnds4fdy38inkyw7saydcxyr";
-    })
+  nativeBuildInputs = [
+    SDL2.dev cython
   ];
 
   buildInputs = [
     SDL2 SDL2_image SDL2_ttf SDL2_mixer
-    cython libjpeg libpng
+    libjpeg libpng
   ];
 
 


### PR DESCRIPTION
###### Motivation for this change

Version bump, builds and runs locally.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

