### PR TITLE
pythonPackages.resampy: Fix build

### DIFF
--- a/pkgs/development/python-modules/resampy/default.nix
+++ b/pkgs/development/python-modules/resampy/default.nix
@@ -6,6 +6,7 @@
 , numpy
 , scipy
 , cython
+, numba
 , six
 }:
 
@@ -19,7 +20,7 @@ buildPythonPackage rec {
   };
 
   checkInputs = [ pytest pytestcov ];
-  propagatedBuildInputs = [ numpy scipy cython six ];
+  propagatedBuildInputs = [ numpy scipy cython numba six ];
 
   # No tests included
   doCheck = false;

--- a/pkgs/development/python-modules/resampy/default.nix
+++ b/pkgs/development/python-modules/resampy/default.nix
@@ -1,6 +1,6 @@
 { stdenv
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , pytest
 , pytestcov
 , numpy
@@ -14,16 +14,20 @@ buildPythonPackage rec {
   pname = "resampy";
   version = "0.2.1";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "7f6912ca2b746eb9bcdc05c52fcef088f0b7ba1ca6ee0b2d0a359d18fc57f8f8";
+  # No tests in PyPi Archive
+  src = fetchFromGitHub {
+    owner = "bmcfee";
+    repo = pname;
+    rev = version;
+    sha256 = "0a2bxj042y62dimm2i4vglbhpwbybam07mcl67cb6pmfsw9fbqhj";
   };
 
   checkInputs = [ pytest pytestcov ];
   propagatedBuildInputs = [ numpy scipy cython numba six ];
 
-  # No tests included
-  doCheck = false;
+  checkPhase = ''
+    pytest tests
+  '';
 
   meta = with stdenv.lib; {
     homepage = https://github.com/bmcfee/resampy;


### PR DESCRIPTION
###### Motivation for this change
This fixes resampy. Please backport to 19.03.
ZHF-19.03: #56826



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

