### PR TITLE
compcert: 3.4 -> 3.5

### DIFF
--- a/pkgs/development/compilers/compcert/default.nix
+++ b/pkgs/development/compilers/compcert/default.nix
@@ -12,11 +12,11 @@ let
 in
 stdenv.mkDerivation rec {
   name    = "compcert-${version}";
-  version = "3.4";
+  version = "3.5";
 
   src = fetchurl {
     url    = "http://compcert.inria.fr/release/${name}.tgz";
-    sha256 = "12gchwvkzhd2bhrnwzfb4a06wc4hgv98z987k06vj7ga31ii763h";
+    sha256 = "127s8nwsmpl7ng7h4yy8cci8p6ncsw8i8jq3z0pyhx2siryddq0v";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   patchPhase = ''
+    substituteInPlace ./VERSION --replace 3.4 3.5
     substituteInPlace ./configure \
       --replace '{toolprefix}gcc' '{toolprefix}cc'
   '';


### PR DESCRIPTION
###### Motivation for this change

Compatibility with Coq 8.9

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

