### PR TITLE
pythonPackages.pyopencl: Fix build

### DIFF
--- a/pkgs/development/libraries/pybind11/default.nix
+++ b/pkgs/development/libraries/pybind11/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
-  checkInputs = with python.pkgs; [ catch eigen pytest numpy scipy ];
+  checkInputs = with python.pkgs; [ catch eigen pytest_3 numpy scipy ];
 
   # Disable test_cmake_build test, as it fails in sandbox
   # https://github.com/pybind/pybind11/issues/1355

--- a/pkgs/development/python-modules/pyopencl/default.nix
+++ b/pkgs/development/python-modules/pyopencl/default.nix
@@ -1,4 +1,5 @@
 { stdenv
+, python
 , fetchPypi
 , buildPythonPackage
 , Mako
@@ -11,6 +12,7 @@
 , six
 , opencl-headers
 , ocl-icd
+, pybind11
 }:
 
 buildPythonPackage rec {
@@ -18,7 +20,7 @@ buildPythonPackage rec {
   version = "2018.2.3";
 
   checkInputs = [ pytest ];
-  buildInputs = [ opencl-headers ocl-icd ];
+  buildInputs = [ opencl-headers ocl-icd pybind11 ];
 
   propagatedBuildInputs = [ numpy cffi pytools decorator appdirs six Mako ];
 
@@ -27,10 +29,13 @@ buildPythonPackage rec {
     sha256 = "ebefe9505cad970dfb4c8024630ef5a546c68d22943dbb3e5677943a6d006ac6";
   };
 
-  # py.test is not needed during runtime, so remove it from `install_requires`
-  postPatch = ''
-    substituteInPlace setup.py --replace "pytest>=2" ""
+  preBuild = ''
+    export HOME=$(pwd)
   '';
+
+  NIX_CFLAGS_COMPILE = [
+    "-I${pybind11}/include/${python.libPrefix}/"
+  ];
 
   # gcc: error: pygpu_language_opencl.cpp: No such file or directory
   doCheck = false;


### PR DESCRIPTION
###### Motivation for this change
This fixes pyopencl. Please backport to 19.03.
ZHF-19.03: #56826



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

