### PR TITLE
pythonPackages.mxnet: Fix build

### DIFF
--- a/pkgs/development/python-modules/mxnet/default.nix
+++ b/pkgs/development/python-modules/mxnet/default.nix
@@ -20,9 +20,9 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace python/setup.py \
-    --replace "graphviz<0.9.0" "graphviz<0.10.0" \
-    --replace "numpy<=1.15.0" "numpy<1.16.0" \
-    --replace "requests<2.19.0" "requests<2.20.0"
+      --replace "graphviz<0.9.0," "graphviz" \
+      --replace "numpy<=1.15.0," "numpy" \
+      --replace "requests<2.19.0," "requests"
   '';
 
   preConfigure = ''


### PR DESCRIPTION
###### Motivation for this change
This fixes pzthonPackages.mxnet. Please backport to 19.03.
ZHF-19.03: #56826



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

