### PR TITLE
Fix the upstream project URL

### DIFF
--- a/pkgs/applications/science/misc/simgrid/default.nix
+++ b/pkgs/applications/science/misc/simgrid/default.nix
@@ -104,7 +104,7 @@ stdenv.mkDerivation rec {
       scheduling on distributed computing platforms ranging from simple
       network of workstations to Computational Grids.
     '';
-    homepage = http://simgrid.gforge.inria.fr/;
+    homepage = https://simgrid.org/;
     license = licenses.lgpl2Plus;
     maintainers = with maintainers; [ mickours ];
     platforms = ["x86_64-linux"];


### PR DESCRIPTION
As a upstream developer, I just wanted to tell you that our URL changed recently.
This change seems trivial enough to not mandate the full check-list of your usual contributing guidelines. 

Kudos for this process, and for the rest.
Mt


