### PR TITLE
pythonPackages.gcovr: Fix build

### DIFF
--- a/pkgs/development/python-modules/gcovr/default.nix
+++ b/pkgs/development/python-modules/gcovr/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   meta = with stdenv.lib; {
     description = "A Python script for summarizing gcov data";
     license = licenses.bsd0;
-    homepage = http://gcovr.com/;
+    homepage = https://www.gcovr.com/;
   };
 
 }

--- a/pkgs/development/python-modules/gcovr/default.nix
+++ b/pkgs/development/python-modules/gcovr/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, jinja2
 }:
 
 buildPythonPackage rec {
@@ -11,6 +12,15 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "ca94c337f2d9a70db177ec4330534fad7b2b772beda625c1ec071fbcf1361e22";
   };
+
+  propagatedBuildInputs = [
+    jinja2
+  ];
+
+  # There are no unit tests in the pypi tarball. Most of the unit tests on the
+  # github repository currently only work with gcc5, so we just disable them.
+  # See also: https://github.com/gcovr/gcovr/issues/206
+  doCheck = false;
 
   meta = with stdenv.lib; {
     description = "A Python script for summarizing gcov data";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10383,6 +10383,8 @@ in
 
   gcab = callPackage ../development/libraries/gcab { };
 
+  gcovr = with python3Packages; toPythonApplication gcovr;
+
   gcr = callPackage ../development/libraries/gcr { };
 
   gdl = callPackage ../development/libraries/gdl { };


### PR DESCRIPTION
###### Motivation for this change
This fixes pythonPackages.gcovr. Please backport to 19.03.
ZHF-19.03: #56826



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

