### PR TITLE
pythonPackages.rabbitpy: Fix build

### DIFF
--- a/pkgs/development/python-modules/rabbitpy/default.nix
+++ b/pkgs/development/python-modules/rabbitpy/default.nix
@@ -1,6 +1,6 @@
 { stdenv
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , mock
 , nose
 , pamqp
@@ -10,13 +10,30 @@ buildPythonPackage rec {
   version = "1.0.0";
   pname = "rabbitpy";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "54d33746d0c6a686417cd354346803945df0740b39fb92842d259387100db126";
+  # No tests in the pypi tarball, so we directly fetch from git
+  src = fetchFromGitHub {
+    owner = "gmr";
+    repo = pname;
+    rev = "${version}";
+    sha256 = "0fd80zlr4p2sh77rxyyfi9l0h2zqi2csgadr0rhnpgpqsy10qck6";
   };
 
-  buildInputs = [ mock nose ];
   propagatedBuildInputs = [ pamqp ];
+  doCheck = true;
+  checkInputs = [ mock nose ];
+
+  checkPhase = ''
+    runHook preCheck
+    rm tests/integration_tests.py # Impure tests requiring network
+    nosetests tests
+    runHook postCheck
+  '';
+
+  postPatch = ''
+    # See: https://github.com/gmr/rabbitpy/issues/118
+    substituteInPlace setup.py \
+      --replace 'pamqp>=1.6.1,<2.0' 'pamqp'
+  '';
 
   meta = with stdenv.lib; {
     description = "A pure python, thread-safe, minimalistic and pythonic RabbitMQ client library";


### PR DESCRIPTION
###### Motivation for this change
This fixes pythonPackages.rabbitpy. Please backport to 19.03.
ZHF-19.03: #56826



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

