### PR TITLE
ipget: 0.2.5 -> 0.3.2

### DIFF
--- a/pkgs/applications/networking/ipget/default.nix
+++ b/pkgs/applications/networking/ipget/default.nix
@@ -2,25 +2,25 @@
 
 buildGoPackage rec {
   name = "ipget-${version}";
-  version = "0.2.5";
+  version = "0.3.2";
   rev = "v${version}";
 
   goPackagePath = "github.com/ipfs/ipget";
-  
+
   extraSrcPaths = [
     (fetchgx {
       inherit name src;
-      sha256 = "1d4w8zl5mcppn3d4bl7qdkiqlf8gi3z2a62nygx17bqpa3da8cf3";
+      sha256 = "07l9hpkhk5phr95zp1l5wd3ii38bw91hy4dlw2rsfbzcsc8bq4s8";
     })
   ];
- 
+
   goDeps = ../../../tools/package-management/gx/deps.nix;
 
   src = fetchFromGitHub {
     owner = "ipfs";
     repo = "ipget";
     inherit rev;
-    sha256 = "0a8yxqhl469ipiznrgkp3yi1xz3xzcbpx60wabqppq8hccrdiybk";
+    sha256 = "1ljf5ddvc1p5swmgn4m1ivfj74fykk56myk2r9c4grdjzksf4a15";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Unbreak the build by updating to a newer version.


cc @veprbl

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

