### PR TITLE
zram: revert "change default algorithm to zstd" (19.03)

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -563,7 +563,7 @@
        but is still possible by setting <literal>zramSwap.swapDevices</literal> explicitly.
      </para>
      <para>
-      Default algorithm for ZRAM swap was changed to <literal>zstd</literal>.
+      ZRAM algorithm can be changed now.
      </para>
      <para>
       Changes to ZRAM algorithm are applied during <literal>nixos-rebuild switch</literal>,

--- a/nixos/modules/config/zram.nix
+++ b/nixos/modules/config/zram.nix
@@ -91,13 +91,13 @@ in
       };
 
       algorithm = mkOption {
-        default = "zstd";
-        example = "lzo";
+        default = "lzo";
+        example = "lz4";
         type = with types; either (enum [ "lzo" "lz4" "zstd" ]) str;
         description = ''
           Compression algorithm. <literal>lzo</literal> has good compression,
           but is slow. <literal>lz4</literal> has bad compression, but is fast.
-          <literal>zstd</literal> is both good compression and fast.
+          <literal>zstd</literal> is both good compression and fast, but requires newer kernel.
           You can check what other algorithms are supported by your zram device with
           <programlisting>cat /sys/class/block/zram*/comp_algorithm</programlisting>
         '';


### PR DESCRIPTION
19.03 default kernel is still 4.14, which doesn't support zstd. So,
zramSwap in current fasion fails on default kernel.

Kernel was revert after my zram-zstd patch landed https://github.com/NixOS/nixpkgs/pull/55092