### PR TITLE
module system: revert "remove types.optionSet", just deprecate

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -48,6 +48,8 @@ rec {
     visible ? null,
     # Whether the option can be set only once
     readOnly ? null,
+    # Deprecated, used by types.optionSet.
+    options ? null
     } @ attrs:
     attrs // { _type = "option"; };
 

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -469,8 +469,10 @@ rec {
     # Obsolete alternative to configOf.  It takes its option
     # declarations from the ‘options’ attribute of containing option
     # declaration.
-    optionSet = builtins.throw "types.optionSet is deprecated; use types.submodule instead" "optionSet";
-
+    optionSet = mkOptionType {
+      name = builtins.trace "types.optionSet is deprecated; use types.submodule instead" "optionSet";
+      description = "option set";
+    };
     # Augment the given type with an additional type check function.
     addCheck = elemType: check: elemType // { check = x: elemType.check x && check x; };
 

--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -456,8 +456,8 @@
   </listitem>
   <listitem>
    <para>
-    Support for NixOS module system type <literal>types.optionSet</literal> and
-    <literal>lib.mkOption</literal> argument <literal>options</literal> is removed.
+    NixOS module system type <literal>types.optionSet</literal> and
+    <literal>lib.mkOption</literal> argument <literal>options</literal> are deprecated.
     Use <literal>types.submodule</literal> instead.
     (<link xlink:href="https://github.com/NixOS/nixpkgs/pull/54637">#54637</link>)
    </para>


### PR DESCRIPTION
The explicit remove helped to uncover some hidden uses of `optionSet`
in NixOps. However it makes life harder for end-users of NixOps - it will
be impossible to deploy 19.03 systems with old NixOps, but there is no
new release of NixOps with `optionSet` fixes.

https://github.com/NixOS/nixops/pull/1088

Also, "deprecation" process isn't well defined. Even that `optionSet` was
declared "deprecated" for many years, it was never announced. Hence, I
leave "deprecation" announce. Then, 3 releases after announce,
we can announce removal of this feature.

This type has to be removed, not `throw`-ed in runtime, because it makes
some perfectly fine code to fail. For example:
```
$ nix-instantiate --eval -E '(import <nixpkgs/lib>).types' --strict
trace: `types.list` is deprecated; use `types.listOf` instead
error: types.optionSet is deprecated; use types.submodule instead
(use '--show-trace' to show detailed location information)
```

cc @samueldr @lheckemann @delroth (shoutout to @delroth for fixing issues in NixOps!)

This has to be backported to 19.03