### PR TITLE
factorio: experimental 0.17.2 → 0.17.6

### DIFF
--- a/pkgs/games/factorio/default.nix
+++ b/pkgs/games/factorio/default.nix
@@ -53,11 +53,11 @@ let
     x86_64-linux = let bdist = bdistForArch { inUrl = "linux64"; inTar = "x64"; }; in {
       alpha = {
         stable        = bdist { sha256 = "0b4hbpdcrh5hgip9q5dkmw22p66lcdhnr0kmb0w5dw6yi7fnxxh0"; version = "0.16.51"; withAuth = true; };
-        experimental  = bdist { sha256 = "15k0kgayh5j3gd0cq8jc24ykwnay32jd2b5v0nij27jslj0hkdx6"; version = "0.17.5"; withAuth = true; };
+        experimental  = bdist { sha256 = "1a3h24y2s9h8j4vcwzsgzgsgp6xaa522qzrmckfslbjxwqka2sqx"; version = "0.17.6"; withAuth = true; };
       };
       headless = {
         stable        = bdist { sha256 = "0zrnpg2js0ysvx9y50h3gajldk16mv02dvrwnkazh5kzr1d9zc3c"; version = "0.16.51"; };
-        experimental  = bdist { sha256 = "1avwhwc323ga276hhagdy9piy9xlcqf99z8d63pwjmvbshznbl41"; version = "0.17.5"; };
+        experimental  = bdist { sha256 = "0bw12njp2smy2x99s7mrlbafvd8jnmw3a1zm6lkpiy20kn4mmqbc"; version = "0.17.6"; };
       };
       demo = {
         stable        = bdist { sha256 = "0zf61z8937yd8pyrjrqdjgd0rjl7snwrm3xw86vv7s7p835san6a"; version = "0.16.51"; };

--- a/pkgs/games/factorio/default.nix
+++ b/pkgs/games/factorio/default.nix
@@ -53,11 +53,11 @@ let
     x86_64-linux = let bdist = bdistForArch { inUrl = "linux64"; inTar = "x64"; }; in {
       alpha = {
         stable        = bdist { sha256 = "0b4hbpdcrh5hgip9q5dkmw22p66lcdhnr0kmb0w5dw6yi7fnxxh0"; version = "0.16.51"; withAuth = true; };
-        experimental  = bdist { sha256 = "0s8fhf790wwmckhi8wdbc036gg5vs1mrj3gd38ln4ynx9s3jb1z8"; version = "0.17.2"; withAuth = true; };
+        experimental  = bdist { sha256 = "15k0kgayh5j3gd0cq8jc24ykwnay32jd2b5v0nij27jslj0hkdx6"; version = "0.17.5"; withAuth = true; };
       };
       headless = {
         stable        = bdist { sha256 = "0zrnpg2js0ysvx9y50h3gajldk16mv02dvrwnkazh5kzr1d9zc3c"; version = "0.16.51"; };
-        experimental  = bdist { sha256 = "0gp3csf2dckvv0nf5k3cwylda4zpijlz3g18s10jgfxj03a6aly6"; version = "0.17.2"; };
+        experimental  = bdist { sha256 = "1avwhwc323ga276hhagdy9piy9xlcqf99z8d63pwjmvbshznbl41"; version = "0.17.5"; };
       };
       demo = {
         stable        = bdist { sha256 = "0zf61z8937yd8pyrjrqdjgd0rjl7snwrm3xw86vv7s7p835san6a"; version = "0.16.51"; };


### PR DESCRIPTION
###### Motivation for this change
Factorio has been releasing a lot of bugfixes. This is the latest version (as of the time of writing)

###### Things done

Change the version and hashes

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

