### PR TITLE
bazelisk: init at 0.0.3

### DIFF
--- a/pkgs/development/tools/bazelisk/default.nix
+++ b/pkgs/development/tools/bazelisk/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "bazelisk";
+  version = "0.0.3";
+
+  src = fetchFromGitHub {
+    owner = "philwo";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1rkpw9izpav3ysb9fpbdf0m1wqrs3vl87s9zjjmfsjm5dfhxss72";
+  };
+
+  modSha256 = "1f73j6ryidzi3kfy3rhsqx047vzwvzaqcsl7ykhg87rn2l2s7fdl";
+
+  meta = with stdenv.lib; {
+    description = "A user-friendly launcher for Bazel";
+    homepage = https://github.com/philwo/bazelisk;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ elasticdog ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8493,6 +8493,8 @@ in
 
   bazel-watcher = callPackage ../development/tools/bazel-watcher { };
 
+  bazelisk = callPackage ../development/tools/bazelisk { };
+
   buildBazelPackage = callPackage ../build-support/build-bazel-package { };
 
   bear = callPackage ../development/tools/build-managers/bear { };


### PR DESCRIPTION
###### Motivation for this change

The `bazelisk` wrapper has become a [recommended means](https://blog.bazel.build/2019/02/26/bazel-0.23.html) of managing consistent Bazel versions and testing forward compatibility within the upstream community. I'd love to be able to install it via Nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [x]  ~~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~~ **N/A**
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

