### PR TITLE
python.pkgs.bpython: correct Exec in bpython.desktop

### DIFF
--- a/pkgs/development/python-modules/bpython/default.nix
+++ b/pkgs/development/python-modules/bpython/default.nix
@@ -11,6 +11,11 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ curtsies greenlet pygments requests urwid ];
 
+  postInstall = ''
+    substituteInPlace "$out/share/applications/bpython.desktop" \
+      --replace "Exec=/usr/bin/bpython" "Exec=$out/bin/bpython"
+  '';
+
   checkInputs = [ mock ];
 
   # tests fail: https://github.com/bpython/bpython/issues/712


### PR DESCRIPTION
###### Motivation for this change
fixes https://github.com/NixOS/nixpkgs/issues/56831

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @Soft