### PR TITLE
ocaml: 4.08.0+beta1 -> 4.08.0+beta2

### DIFF
--- a/pkgs/development/compilers/ocaml/4.08.nix
+++ b/pkgs/development/compilers/ocaml/4.08.nix
@@ -1,8 +1,8 @@
 import ./generic.nix {
   major_version = "4";
   minor_version = "08";
-  patch_version = "0+beta1";
-  sha256 = "1jgvp4pyhrg27wqpsx88kacw3ymjiz44nms9lzbh5s8pp05z5f5f";
+  patch_version = "0+beta2";
+  sha256 = "1ngsrw74f3hahzsglxkrdxzv86bkmpsiaaynnzjwfwyzvy8sqrac";
 
   # If the executable is stripped it does not work
   dontStrip = true;


### PR DESCRIPTION
###### Motivation for this change

Announcement: https://inbox.ocaml.org/caml-list/50013A0A-B5B3-47B7-BADF-32A9A94D9C15@inria.fr/T/#u

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

