### PR TITLE
boost: fix misspelled version numbers in 1.66.0, 1.67.0, 1.68.0, and 1.69.0

### DIFF
--- a/pkgs/development/libraries/boost/1.66.nix
+++ b/pkgs/development/libraries/boost/1.66.nix
@@ -1,7 +1,7 @@
 { stdenv, callPackage, fetchurl, ... } @ args:
 
 callPackage ./generic.nix (args // rec {
-  version = "1.66_0";
+  version = "1.66.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/boost/boost_1_66_0.tar.bz2";

--- a/pkgs/development/libraries/boost/1.67.nix
+++ b/pkgs/development/libraries/boost/1.67.nix
@@ -1,7 +1,7 @@
 { stdenv, callPackage, fetchurl, fetchpatch, ... } @ args:
 
 callPackage ./generic.nix (args // rec {
-  version = "1.67_0";
+  version = "1.67.0";
 
   patches = [ (fetchpatch {
     url = "https://github.com/boostorg/lockfree/commit/12726cda009a855073b9bedbdce57b6ce7763da2.patch";

--- a/pkgs/development/libraries/boost/1.68.nix
+++ b/pkgs/development/libraries/boost/1.68.nix
@@ -1,7 +1,7 @@
 { stdenv, callPackage, fetchurl, fetchpatch, ... } @ args:
 
 callPackage ./generic.nix (args // rec {
-  version = "1.68_0";
+  version = "1.68.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/boost/boost_1_68_0.tar.bz2";

--- a/pkgs/development/libraries/boost/1.69.nix
+++ b/pkgs/development/libraries/boost/1.69.nix
@@ -1,7 +1,7 @@
 { stdenv, callPackage, fetchurl, fetchpatch, ... } @ args:
 
 callPackage ./generic.nix (args // rec {
-  version = "1.69_0";
+  version = "1.69.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/boost/boost_1_69_0.tar.bz2";


### PR DESCRIPTION
The version numbers were spelled 1.x_y rather than 1.x.y.