### PR TITLE
minishift: 1.31.0 -> 1.32.0

### DIFF
--- a/pkgs/applications/networking/cluster/minishift/default.nix
+++ b/pkgs/applications/networking/cluster/minishift/default.nix
@@ -4,10 +4,10 @@
 }:
 
 let
-  version = "1.31.0";
+  version = "1.32.0";
 
   # Update these on version bumps according to Makefile
-  centOsIsoVersion = "v1.14.0";
+  centOsIsoVersion = "v1.15.0";
   openshiftVersion = "v3.11.0";
 
 in buildGoPackage rec {
@@ -18,7 +18,7 @@ in buildGoPackage rec {
     owner = "minishift";
     repo = "minishift";
     rev = "v${version}";
-    sha256 = "0v5hngfz393yi3x4c328g5bjazw02jr59ljqh6ws0j6wzxzm8jxf";
+    sha256 = "06qhcycnr06fw5dmmzwizmknm0j34j43894nl3kxa5mxh8x542pa";
   };
 
   nativeBuildInputs = [ pkgconfig go-bindata makeWrapper ];


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vincent@sbr.pm>

###### Motivation for this change

Bump to latest release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

