### PR TITLE
spl/zfs: 0.7.12 -> 0.7.13

### DIFF
--- a/pkgs/os-specific/linux/spl/default.nix
+++ b/pkgs/os-specific/linux/spl/default.nix
@@ -10,13 +10,13 @@ assert kernel != null;
 
 stdenv.mkDerivation rec {
   name = "spl-${version}-${kernel.version}";
-  version = "0.7.12";
+  version = "0.7.13";
 
   src = fetchFromGitHub {
     owner = "zfsonlinux";
     repo = "spl";
     rev = "spl-${version}";
-    sha256 = "13zqh1g132g63zv54l3bsg5kras9mllkx9wvlnfs13chfr7vpp4p";
+    sha256 = "1rzqgiszy8ad2gx20577azp1y5jgad0907slfzl5y2zb05jgaipa";
   };
 
   patches = [ ./install_prefix.patch ];

--- a/pkgs/os-specific/linux/spl/install_prefix.patch
+++ b/pkgs/os-specific/linux/spl/install_prefix.patch
@@ -136,14 +136,12 @@ index 7faab0a..8148b3d 100644
 +kerneldir = @prefix@/libexec/spl/include/vm
  kernel_HEADERS = $(KERNEL_H)
  endif
-diff --git a/module/Makefile.in b/module/Makefile.in
-index d4e62e1..73fa01c 100644
 --- a/module/Makefile.in
 +++ b/module/Makefile.in
-@@ -21,15 +21,15 @@ clean:
+@@ -21,22 +21,22 @@
  modules_install:
  	@# Install the kernel modules
- 	$(MAKE) -C @LINUX_OBJ@ SUBDIRS=`pwd` $@ \
+ 	$(MAKE) -C @LINUX_OBJ@ M=`pwd` $@ \
 -		INSTALL_MOD_PATH=$(DESTDIR)$(INSTALL_MOD_PATH) \
 +		INSTALL_MOD_PATH=@prefix@/$(INSTALL_MOD_PATH) \
  		INSTALL_MOD_DIR=$(INSTALL_MOD_DIR) \
@@ -160,3 +158,11 @@ index d4e62e1..73fa01c 100644
  	if [ -f $$sysmap ]; then \
  		depmod -ae -F $$sysmap @LINUX_VERSION@; \
  	fi
+ 
+ modules_uninstall:
+ 	@# Uninstall the kernel modules
+-	kmoddir=$(DESTDIR)$(INSTALL_MOD_PATH)/lib/modules/@LINUX_VERSION@
++	kmoddir=@prefix@/$(INSTALL_MOD_PATH)/lib/modules/@LINUX_VERSION@
+ 	list='$(subdir-m)'; for subdir in $$list; do \
+ 		$(RM) -R $$kmoddir/$(INSTALL_MOD_DIR)/$$subdir; \
+ 	done

--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -159,19 +159,14 @@ in {
   # to be adapted
   zfsStable = common {
     # comment/uncomment if breaking kernel versions are known
-    incompatibleKernelVersion = "4.20";
+    # incompatibleKernelVersion = "";
 
     # this package should point to the latest release.
-    version = "0.7.12";
+    version = "0.7.13";
 
-    sha256 = "1j432nb3a86isghdysir9xi6l5djmb5fbc5s9zr0rwg4ziisskbh";
+    sha256 = "1l77bq7pvc54vl15pnrjd0njgpf00qjzy0x85dpfh5jxng84x1fb";
 
-    extraPatches = [
-      (fetchpatch {
-        url = "https://github.com/Mic92/zfs/compare/zfs-0.7.0-rc3...nixos-zfs-0.7.0-rc3.patch";
-        sha256 = "1vlw98v8xvi8qapzl1jwm69qmfslwnbg3ry1lmacndaxnyckkvhh";
-      })
-    ];
+    extraPatches = [ ./install_prefix.patch ];
 
     inherit spl;
   };

--- a/pkgs/os-specific/linux/zfs/install_prefix.patch
+++ b/pkgs/os-specific/linux/zfs/install_prefix.patch
@@ -1,0 +1,106 @@
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -11,10 +11,10 @@
+ if CONFIG_KERNEL
+ SUBDIRS += module
+ 
+-extradir = @prefix@/src/zfs-$(VERSION)
++extradir = @prefix@/libexec/zfs-$(VERSION)
+ extra_HEADERS = zfs.release.in zfs_config.h.in
+ 
+-kerneldir = @prefix@/src/zfs-$(VERSION)/$(LINUX_VERSION)
++kerneldir = @prefix@/zfs-$(VERSION)/$(LINUX_VERSION)
+ nodist_kernel_HEADERS = zfs.release zfs_config.h module/$(LINUX_SYMBOLS)
+ endif
+ 
+--- a/include/Makefile.am
++++ b/include/Makefile.am
+@@ -29,6 +29,6 @@
+ endif
+ 
+ if CONFIG_KERNEL
+-kerneldir = @prefix@/src/zfs-$(VERSION)/include
++kerneldir = @prefix@/include
+ kernel_HEADERS = $(COMMON_H) $(KERNEL_H)
+ endif
+--- a/include/linux/Makefile.am
++++ b/include/linux/Makefile.am
+@@ -21,6 +21,6 @@
+ endif
+ 
+ if CONFIG_KERNEL
+-kerneldir = @prefix@/src/zfs-$(VERSION)/include/linux
++kerneldir = @prefix@/include/linux
+ kernel_HEADERS = $(COMMON_H) $(KERNEL_H)
+ endif
+--- a/include/sys/Makefile.am
++++ b/include/sys/Makefile.am
+@@ -129,6 +129,6 @@
+ endif
+ 
+ if CONFIG_KERNEL
+-kerneldir = @prefix@/src/zfs-$(VERSION)/include/sys
++kerneldir = @prefix@/include/sys
+ kernel_HEADERS = $(COMMON_H) $(KERNEL_H)
+ endif
+--- a/include/sys/fm/Makefile.am
++++ b/include/sys/fm/Makefile.am
+@@ -16,6 +16,6 @@
+ endif
+ 
+ if CONFIG_KERNEL
+-kerneldir = @prefix@/src/zfs-$(VERSION)/include/sys/fm
++kerneldir = @prefix@/include/sys/fm
+ kernel_HEADERS = $(COMMON_H) $(KERNEL_H)
+ endif
+--- a/include/sys/fm/fs/Makefile.am
++++ b/include/sys/fm/fs/Makefile.am
+@@ -13,6 +13,6 @@
+ endif
+ 
+ if CONFIG_KERNEL
+-kerneldir = @prefix@/src/zfs-$(VERSION)/include/sys/fm/fs
++kerneldir = @prefix@/include/sys/fm/fs
+ kernel_HEADERS = $(COMMON_H) $(KERNEL_H)
+ endif
+--- a/include/sys/fs/Makefile.am
++++ b/include/sys/fs/Makefile.am
+@@ -13,6 +13,6 @@
+ endif
+ 
+ if CONFIG_KERNEL
+-kerneldir = @prefix@/src/zfs-$(VERSION)/include/sys/fs
++kerneldir = @prefix@/include/sys/fs
+ kernel_HEADERS = $(COMMON_H) $(KERNEL_H)
+ endif
+--- a/module/Makefile.in
++++ b/module/Makefile.in
+@@ -35,6 +35,8 @@
+ 	fi
+ 	list='$(SUBDIR_TARGETS)'; for targetdir in $$list; do \
+ 		$(MAKE) -C $$targetdir; \
+ 	done
++	@# when copying a file out of the nix store, we need to make it writable again.
++	chmod +w @SPL_SYMBOLS@
+ 	$(MAKE) -C @LINUX_OBJ@ M=`pwd` @KERNELMAKE_PARAMS@ CONFIG_ZFS=m $@
+ 
+@@ -50,15 +52,15 @@
+ modules_install:
+ 	@# Install the kernel modules
+ 	$(MAKE) -C @LINUX_OBJ@ M=`pwd` $@ \
+-		INSTALL_MOD_PATH=$(DESTDIR)$(INSTALL_MOD_PATH) \
++		INSTALL_MOD_PATH=@prefix@/$(INSTALL_MOD_PATH) \
+ 		INSTALL_MOD_DIR=$(INSTALL_MOD_DIR) \
+ 		KERNELRELEASE=@LINUX_VERSION@
+ 	@# Remove extraneous build products when packaging
+-	kmoddir=$(DESTDIR)$(INSTALL_MOD_PATH)/lib/modules/@LINUX_VERSION@; \
+-	if [ -n "$(DESTDIR)" ]; then \
++	kmoddir=@prefix@/$(INSTALL_MOD_PATH)/lib/modules/@LINUX_VERSION@; \
++	if [ -n "@prefix@" ]; then \
+ 		find $$kmoddir -name 'modules.*' | xargs $(RM); \
+ 	fi
+-	sysmap=$(DESTDIR)$(INSTALL_MOD_PATH)/boot/System.map-@LINUX_VERSION@; \
++	sysmap=@prefix@/$(INSTALL_MOD_PATH)/boot/System.map-@LINUX_VERSION@; \
+ 	if [ -f $$sysmap ]; then \
+ 		depmod -ae -F $$sysmap @LINUX_VERSION@; \
+ 	fi


### PR DESCRIPTION
###### Motivation for this change
Upstream release, and 5.0 compatibility

###### Things done
Cherry-picked into nixos-18.09 and booted into with linux-5.0.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

