### PR TITLE
[WIP] filezilla: 3.31.0 -> 3.40.0, libfilezilla: 0.13.0 -> 0.15.1

### DIFF
--- a/pkgs/applications/networking/ftp/filezilla/default.nix
+++ b/pkgs/applications/networking/ftp/filezilla/default.nix
@@ -1,28 +1,26 @@
-{ stdenv, fetchsvn, autoconf, automake, libtool
-,  dbus, gnutls, wxGTK30, libidn, tinyxml, gettext
-, pkgconfig, xdg_utils, gtk2, sqlite, pugixml, libfilezilla, nettle }:
+{ stdenv, fetchurl, dbus, gnutls, wxGTK30, libidn, tinyxml, gettext
+, pkgconfig, xdg_utils, sqlite, pugixml, libfilezilla }:
 
 stdenv.mkDerivation rec {
   name = "filezilla-${version}";
   version = "3.40.0";
 
-  src = fetchsvn {
-    url = "https://svn.filezilla-project.org/svn/FileZilla3/tags/${version}";
-    sha256 = "0sxik1kjyjbpjkf74yzp9lmi6sxmrqqd3a2y3nz7ampyr1ayv5dz";
+  src = fetchurl {
+    url = "https://download.filezilla-project.org/client/FileZilla_${version}_src.tar.bz2";
+    sha256 = "11b0410fcwrahq5dd7ph10bc09m62sxra4bjp0kj5gph822s0v63";
   };
 
   configureFlags = [
     "--disable-manualupdatecheck"
+    "--disable-autoupdatecheck"
   ];
 
-  nativeBuildInputs = [ autoconf automake libtool pkgconfig ];
+  nativeBuildInputs = [ pkgconfig gettext ];
   buildInputs = [
-    dbus gnutls wxGTK30 libidn tinyxml gettext xdg_utils gtk2 sqlite
-    pugixml libfilezilla nettle ];
+    dbus gnutls wxGTK30 libidn tinyxml xdg_utils wxGTK30.gtk sqlite
+    pugixml libfilezilla ];
 
-  preConfigure = ''
-    autoreconf -i
-    '';
+  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     homepage = https://filezilla-project.org/;

--- a/pkgs/applications/networking/ftp/filezilla/default.nix
+++ b/pkgs/applications/networking/ftp/filezilla/default.nix
@@ -1,23 +1,28 @@
-{ stdenv, fetchurl, dbus, gnutls, wxGTK30, libidn, tinyxml, gettext
+{ stdenv, fetchsvn, autoconf, automake, libtool
+,  dbus, gnutls, wxGTK30, libidn, tinyxml, gettext
 , pkgconfig, xdg_utils, gtk2, sqlite, pugixml, libfilezilla, nettle }:
 
-let version = "3.31.0"; in
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "filezilla-${version}";
+  version = "3.40.0";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/project/filezilla/FileZilla_Client/${version}/FileZilla_${version}_src.tar.bz2";
-    sha256 = "1rfysb8dil35a7bzj2kw0mzzkys39d7yn6ipsbk8l6rkwfvnii8l";
+  src = fetchsvn {
+    url = "https://svn.filezilla-project.org/svn/FileZilla3/tags/${version}";
+    sha256 = "0sxik1kjyjbpjkf74yzp9lmi6sxmrqqd3a2y3nz7ampyr1ayv5dz";
   };
 
   configureFlags = [
     "--disable-manualupdatecheck"
   ];
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ autoconf automake libtool pkgconfig ];
   buildInputs = [
     dbus gnutls wxGTK30 libidn tinyxml gettext xdg_utils gtk2 sqlite
     pugixml libfilezilla nettle ];
+
+  preConfigure = ''
+    autoreconf -i
+    '';
 
   meta = with stdenv.lib; {
     homepage = https://filezilla-project.org/;

--- a/pkgs/development/libraries/libfilezilla/default.nix
+++ b/pkgs/development/libraries/libfilezilla/default.nix
@@ -1,13 +1,19 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchsvn, autoconf, automake, libtool, nettle, pkgconfig }:
 
 stdenv.mkDerivation rec {
   name = "libfilezilla-${version}";
-  version = "0.13.0";
+  version = "0.15.1";
 
-  src = fetchurl {
-    url = "http://download.filezilla-project.org/libfilezilla/${name}.tar.bz2";
-    sha256 = "0sk8kz2zrvf7kp9jrp3l4rpipv4xh0hg8d4h734xyag7vd03rjpz";
+  src = fetchsvn {
+    url = "https://svn.filezilla-project.org/svn/libfilezilla/tags/${version}";
+    sha256 = "0nhi75rr0hzql7533i78bkvnrjgh0dv5g5vfwfidjkli2xk9i867";
   };
+
+  buildInputs = [ autoconf automake libtool nettle pkgconfig ];
+
+  preConfigure = ''
+    autoreconf -i
+    '';
 
   meta = with stdenv.lib; {
     homepage = https://lib.filezilla-project.org/;

--- a/pkgs/development/libraries/libfilezilla/default.nix
+++ b/pkgs/development/libraries/libfilezilla/default.nix
@@ -1,19 +1,16 @@
-{ stdenv, fetchsvn, autoconf, automake, libtool, nettle, pkgconfig }:
+{ stdenv, fetchurl, pkgconfig, nettle }:
 
 stdenv.mkDerivation rec {
   name = "libfilezilla-${version}";
   version = "0.15.1";
 
-  src = fetchsvn {
-    url = "https://svn.filezilla-project.org/svn/libfilezilla/tags/${version}";
-    sha256 = "0nhi75rr0hzql7533i78bkvnrjgh0dv5g5vfwfidjkli2xk9i867";
+  src = fetchurl {
+    url = "https://download.filezilla-project.org/libfilezilla/${name}.tar.bz2";
+    sha256 = "17zlhw5b1a7jzh50cbpy2is3sps5lnzch5yf9qm7mwrviw9c8j10";
   };
 
-  buildInputs = [ autoconf automake libtool nettle pkgconfig ];
-
-  preConfigure = ''
-    autoreconf -i
-    '';
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ nettle ];
 
   meta = with stdenv.lib; {
     homepage = https://lib.filezilla-project.org/;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The filezilla project has migrated their source away from sourceforge, so the source is now pulled from their subversion repo. This also required some additional preparation with the auto*-tools.
The download link to their current source code uses some changing hash and timestamp, so it's probably unreliable.

Important: I've only verified these changes against release-18.09 and it's working for me.
Building against master and the new release-19.03 branch results in SIGSEGV when starting filezilla, which I believe is due to some incompatible mixing of the building and running gtk libraries, with similar output as observed in #56832