### PR TITLE
pythonPackages.isort: 4.3.4 -> 4.3.15

### DIFF
--- a/pkgs/development/python-modules/cssselect2/default.nix
+++ b/pkgs/development/python-modules/cssselect2/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, tinycss2, pytest, pytestrunner, pytestcov, pytest-flake8, pytest-isort, glibcLocales }:
+{ lib, buildPythonPackage, fetchPypi, tinycss2, pytest, pytestrunner }:
 
 buildPythonPackage rec {
   pname = "cssselect2";
@@ -9,11 +9,21 @@ buildPythonPackage rec {
     sha256 = "505d2ce3d3a1d390ddb52f7d0864b7efeb115a5b852a91861b498b92424503ab";
   };
 
+  # We're not interested in code quality tests
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "pytest-cov" "" \
+      --replace "pytest-flake8" "" \
+      --replace "pytest-isort" ""
+    substituteInPlace setup.cfg \
+      --replace "--cov=cssselect2" "" \
+      --replace "--flake8" "" \
+      --replace "--isort" ""
+  '';
+
   propagatedBuildInputs = [ tinycss2 ];
 
-  checkInputs = [ pytest pytestrunner pytestcov pytest-flake8 pytest-isort glibcLocales ];
-
-  LC_ALL = "en_US.UTF-8";
+  checkInputs = [ pytest pytestrunner ];
 
   meta = with lib; {
     description = "CSS selectors for Python ElementTree";

--- a/pkgs/development/python-modules/isort/default.nix
+++ b/pkgs/development/python-modules/isort/default.nix
@@ -1,22 +1,24 @@
-{ lib, buildPythonPackage, fetchPypi, isPy27, futures, mock, pytest }:
+{ lib, buildPythonPackage, fetchPypi, isPy27, futures, backports_functools_lru_cache, mock, pytest }:
 
-buildPythonPackage rec {
+let
+  skipTests = lib.optional isPy27 "test_standard_library_deprecates_user_issue_778";
+  testOpts = lib.concatMapStringsSep " " (t: "--deselect test_isort.py::${t}") skipTests;
+in buildPythonPackage rec {
   pname = "isort";
-  version = "4.3.4";
+  version = "4.3.16"; # Note 4.x is the last version that supports Python2
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1y0yfv56cqyh9wyg7kxxv9y5wmfgcq18n7a49mp7xmzka2bhxi5r";
+    sha256 = "1v6lapqhc33rxr9698lqjyb49fis27i42p3ymngrw95py3qf7y08";
   };
 
-  propagatedBuildInputs = lib.optional isPy27 futures;
+  propagatedBuildInputs = lib.optionals isPy27 [ futures backports_functools_lru_cache ];
 
   checkInputs = [ mock pytest ];
 
+  # isort excludes paths that contain /build/, so test fixtures don't work with TMPDIR=/build/
   checkPhase = ''
-    py.test test_isort.py -k "not test_long_line_comments \
-                          and not test_import_case_produces_inconsistent_results_issue_472 \
-                          and not test_no_extra_lines_issue_557"
+    PATH=$out/bin:$PATH TMPDIR=/tmp/ pytest ${testOpts}
   '';
 
   meta = with lib; {


### PR DESCRIPTION
We set $TMPDIR, because isort refuses to run in paths containing
'build' (since that is part of Python's typical build infrastructure).

###### Motivation for this change

Version bump.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

