### PR TITLE
vscode: patch vscode wrapper to use predetermined path

### DIFF
--- a/pkgs/applications/editors/vscode/Absolute_VSCODE_PATH.patch
+++ b/pkgs/applications/editors/vscode/Absolute_VSCODE_PATH.patch
@@ -1,0 +1,24 @@
+diff --git a/resources/linux/bin/code.sh b/resources/linux/bin/code.sh
+index 55f50b6f1c..3552f0c4fa 100755
+--- a/bin/code
++++ b/bin/code
+@@ -17,18 +17,7 @@ if [ "$(id -u)" = "0" ]; then
+ 	fi
+ fi
+ 
+-if [ ! -L $0 ]; then
+-	# if path is not a symlink, find relatively
+-	VSCODE_PATH="$(dirname $0)/.."
+-else
+-	if which readlink >/dev/null; then
+-		# if readlink exists, follow the symlink and find relatively
+-		VSCODE_PATH="$(dirname $(readlink -f $0))/.."
+-	else
+-		# else use the standard install location
+-		VSCODE_PATH="/usr/share/code"
+-	fi
+-fi
++VSCODE_PATH="@out@/lib/vscode/"
+ 
+ ELECTRON="$VSCODE_PATH/@@NAME@@"
+ CLI="$VSCODE_PATH/resources/app/out/cli.js"

--- a/pkgs/applications/editors/vscode/default.nix
+++ b/pkgs/applications/editors/vscode/default.nix
@@ -87,6 +87,11 @@ in
     dontBuild = true;
     dontConfigure = true;
 
+    patchPhase = ''
+      substituteAll ${./Absolute_VSCODE_PATH.patch} ../Absolute_VSCODE_PATH.patch
+      patch -p1 ../Absolute_VSCODE_PATH.patch
+    '';
+
     installPhase =
       if system == "x86_64-darwin" then ''
         mkdir -p $out/lib/vscode $out/bin


### PR DESCRIPTION
###### Motivation for this change

Currently, vscode fails to start with:

```
/nix/store/b835qr7gcvf86vmb54dchwcnsckalv6s-vscode-1.31.1/bin/.code-wrapped: line 35: /nix/store/b835qr7gcvf86vmb54dchwcnsckalv6s-vscode-1.31.1/lib/vscode/bin/../code: No such file or directory
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

