### PR TITLE
zfs: 0.7.12 -> 0.7.13

### DIFF
--- a/pkgs/os-specific/linux/spl/default.nix
+++ b/pkgs/os-specific/linux/spl/default.nix
@@ -1,5 +1,5 @@
 { fetchFromGitHub, stdenv, autoreconfHook, coreutils, gawk
-
+, fetchpatch
 # Kernel dependencies
 , kernel
 }:
@@ -10,13 +10,13 @@ assert kernel != null;
 
 stdenv.mkDerivation rec {
   name = "spl-${version}-${kernel.version}";
-  version = "0.7.12";
+  version = "0.7.13";
 
   src = fetchFromGitHub {
     owner = "zfsonlinux";
     repo = "spl";
     rev = "spl-${version}";
-    sha256 = "13zqh1g132g63zv54l3bsg5kras9mllkx9wvlnfs13chfr7vpp4p";
+    sha256 = "1rzqgiszy8ad2gx20577azp1y5jgad0907slfzl5y2zb05jgaipa";
   };
 
   patches = [ ./install_prefix.patch ];

--- a/pkgs/os-specific/linux/spl/install_prefix.patch
+++ b/pkgs/os-specific/linux/spl/install_prefix.patch
@@ -136,14 +136,12 @@ index 7faab0a..8148b3d 100644
 +kerneldir = @prefix@/libexec/spl/include/vm
  kernel_HEADERS = $(KERNEL_H)
  endif
-diff --git a/module/Makefile.in b/module/Makefile.in
-index d4e62e1..73fa01c 100644
 --- a/module/Makefile.in
 +++ b/module/Makefile.in
-@@ -21,15 +21,15 @@ clean:
+@@ -21,22 +21,22 @@
  modules_install:
  	@# Install the kernel modules
- 	$(MAKE) -C @LINUX_OBJ@ SUBDIRS=`pwd` $@ \
+ 	$(MAKE) -C @LINUX_OBJ@ M=`pwd` $@ \
 -		INSTALL_MOD_PATH=$(DESTDIR)$(INSTALL_MOD_PATH) \
 +		INSTALL_MOD_PATH=@prefix@/$(INSTALL_MOD_PATH) \
  		INSTALL_MOD_DIR=$(INSTALL_MOD_DIR) \
@@ -160,3 +158,11 @@ index d4e62e1..73fa01c 100644
  	if [ -f $$sysmap ]; then \
  		depmod -ae -F $$sysmap @LINUX_VERSION@; \
  	fi
+ 
+ modules_uninstall:
+ 	@# Uninstall the kernel modules
+-	kmoddir=$(DESTDIR)$(INSTALL_MOD_PATH)/lib/modules/@LINUX_VERSION@
++	kmoddir=@prefix@/$(INSTALL_MOD_PATH)/lib/modules/@LINUX_VERSION@
+ 	list='$(subdir-m)'; for subdir in $$list; do \
+ 		$(RM) -R $$kmoddir/$(INSTALL_MOD_DIR)/$$subdir; \
+ 	done

--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -159,17 +159,18 @@ in {
   # to be adapted
   zfsStable = common {
     # comment/uncomment if breaking kernel versions are known
-    incompatibleKernelVersion = "4.20";
+    # incompatibleKernelVersion = "4.20";
 
     # this package should point to the latest release.
-    version = "0.7.12";
+    version = "0.7.13";
 
-    sha256 = "1j432nb3a86isghdysir9xi6l5djmb5fbc5s9zr0rwg4ziisskbh";
+    sha256 = "1l77bq7pvc54vl15pnrjd0njgpf00qjzy0x85dpfh5jxng84x1fb";
 
     extraPatches = [
+      # in case this gets out of date, just send Mic92 a pull request!
       (fetchpatch {
-        url = "https://github.com/Mic92/zfs/compare/zfs-0.7.0-rc3...nixos-zfs-0.7.0-rc3.patch";
-        sha256 = "1vlw98v8xvi8qapzl1jwm69qmfslwnbg3ry1lmacndaxnyckkvhh";
+        url = "https://github.com/Mic92/zfs/commit/cf23c1d38bfc698a8a729fc0c5f9ca41591f4d95.patch";
+        sha256 = "14v3x9ipvg2qd1vyf70nv909jd5zdxlsw5y8k60pfyvwm7g80wr5";
       })
     ];
 
@@ -187,6 +188,7 @@ in {
     isUnstable = true;
 
     extraPatches = [
+      # in case this gets out of date, just send Mic92 a pull request!
       (fetchpatch {
         url = "https://github.com/Mic92/zfs/commit/bc29b5783da0af2c80c85126a1831ce1d52bfb69.patch";
         sha256 = "1sdcr1w2jp3djpwlf1f91hrxxmc34q0jl388smdkxh5n5bpw5gzw";


### PR DESCRIPTION
(cherry picked from commit b57080d34136fd8dcc49632696ceb5ed1ff73326)

###### Motivation for this change

cc @clefru regarding your question, personally I found rebasing a patch with
git easier then having a patch file in nixpkgs itself.
However we could also move the zfs fork to a more official place, what do you think?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

