### PR TITLE
Fix locally created database

### DIFF
--- a/nixos/modules/services/misc/zoneminder.nix
+++ b/nixos/modules/services/misc/zoneminder.nix
@@ -49,7 +49,7 @@ let
     # Database
     ZM_DB_TYPE=mysql
     ZM_DB_HOST=${cfg.database.host}
-    ZM_DB_NAME=${cfg.database.name}
+    ZM_DB_NAME=${if cfg.database.createLocally user else cfg.database.name}
     ZM_DB_USER=${cfg.database.username}
     ZM_DB_PASS=${cfg.database.password}
 

--- a/nixos/modules/services/misc/zoneminder.nix
+++ b/nixos/modules/services/misc/zoneminder.nix
@@ -205,12 +205,12 @@ in {
 
       mysql = lib.mkIf cfg.database.createLocally {
         ensureDatabases = [ cfg.database.name ];
+        initialDatabases = [{
+          inherit (cfg.database) name; schema = "${pkg}/share/zoneminder/db/zm_create.sql";
+        }];
         ensureUsers = [{
           name = cfg.database.username;
           ensurePermissions = { "${cfg.database.name}.*" = "ALL PRIVILEGES"; };
-          initialDatabases = [
-            { inherit (cfg.database) name; schema = "${pkg}/share/zoneminder/db/zm_create.sql"; }
-          ];
         }];
       };
 

--- a/nixos/modules/services/misc/zoneminder.nix
+++ b/nixos/modules/services/misc/zoneminder.nix
@@ -49,7 +49,7 @@ let
     # Database
     ZM_DB_TYPE=mysql
     ZM_DB_HOST=${cfg.database.host}
-    ZM_DB_NAME=${if cfg.database.createLocally user else cfg.database.name}
+    ZM_DB_NAME=${if cfg.database.createLocally then user else cfg.database.username}
     ZM_DB_USER=${cfg.database.username}
     ZM_DB_PASS=${cfg.database.password}
 


### PR DESCRIPTION
###### Motivation for this change
In its current form the database.createLocally flag is broken. Those patches try to fix it.

###### Things done
 - mysql user auth: ensure that the mysql and the unix user running zonminder share the same name in order to allow unix socket mysql connection as enforced by the 'ensureUsers' directive
 - move the initial db creation and population to the right scope
Ping @peterhoeg 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

