### PR TITLE
arpack: 3.6.3 -> 3.7.0

### DIFF
--- a/pkgs/development/libraries/science/math/arpack/default.nix
+++ b/pkgs/development/libraries/science/math/arpack/default.nix
@@ -28,8 +28,11 @@ stdenv.mkDerivation {
     "-DINTERFACE64=${optionalString openblas.blas64 "1"}"
   ];
 
-  preCheck = ''
+  preCheck = if stdenv.isDarwin then ''
+    export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:`pwd`/lib
+  '' else ''
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/lib
+  '' + ''
     # Prevent tests from using all cores
     export OMP_NUM_THREADS=2
   '';

--- a/pkgs/development/libraries/science/math/arpack/default.nix
+++ b/pkgs/development/libraries/science/math/arpack/default.nix
@@ -1,31 +1,44 @@
-{ stdenv, fetchurl, autoconf, automake, gettext, libtool
-, gfortran, openblas }:
+{ stdenv, fetchFromGitHub, cmake
+, gfortran, openblas, eigen }:
 
 with stdenv.lib;
 
 let
-  version = "3.6.3";
+  version = "3.7.0";
 in
 stdenv.mkDerivation {
   name = "arpack-${version}";
 
-  src = fetchurl {
-    url = "https://github.com/opencollab/arpack-ng/archive/${version}.tar.gz";
-    sha256 = "0lzlcsrjsi36pv5bnipwjnyg2fx3nrv31bw2klwrg11gb8g5bwv4";
+  src = fetchFromGitHub {
+    owner = "opencollab";
+    repo = "arpack-ng";
+    rev = version;
+    sha256 = "1x7a1dj3dg43nlpvjlh8jzzbadjyr3mbias6f0256qkmgdyk4izr";
   };
 
-  nativeBuildInputs = [ autoconf automake gettext libtool ];
-  buildInputs = [ gfortran openblas ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ gfortran openblas eigen ];
 
   doCheck = true;
 
   BLAS_LIBS = "-L${openblas}/lib -lopenblas";
 
-  INTERFACE64 = optional openblas.blas64 "1";
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=ON"
+    "-DINTERFACE64=${optionalString openblas.blas64 "1"}"
+  ];
 
-  preConfigure = ''
-    ./bootstrap
+  preCheck = ''
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:`pwd`/lib
+    # Prevent tests from using all cores
+    export OMP_NUM_THREADS=2
   '';
+
+  postInstall = ''
+    mkdir -p $out/lib/pkgconfig
+    cp arpack.pc $out/lib/pkgconfig/
+  '';
+
 
   meta = {
     homepage = https://github.com/opencollab/arpack-ng;


### PR DESCRIPTION
###### Motivation for this change
Regular update. Did require some manual work.

Changelog: https://github.com/opencollab/arpack-ng/blob/master/CHANGES

CC @ttuegel 

###### Things done
* switch to FetchFromGitHub
* switch from autotools to cmake
* add eigen to input (is now required)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

