### PR TITLE
ili2c: init at 5.0.0

### DIFF
--- a/pkgs/tools/misc/ili2c/default.nix
+++ b/pkgs/tools/misc/ili2c/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchFromGitHub, jdk, ant, makeWrapper, jre }:
+
+stdenv.mkDerivation rec {
+  pname = "ili2c";
+  version = "5.0.0";
+
+  nativeBuildInputs = [ ant jdk makeWrapper ];
+
+  src = fetchFromGitHub {
+    owner = "claeis";
+    repo = pname;
+    rev = "${pname}-${version}";
+    sha256 = "0xps2343d5gdr2aj8j3l4cjq4k9zbxxlhnp8sjlhxh1wdczxlwx6";
+  };
+
+  buildPhase = "ant jar";
+
+  installPhase =
+    ''
+      mkdir -p $out/share/${pname}
+      cp $build/build/source/build/jar/ili2c.jar $out/share/${pname}
+
+      mkdir -p $out/bin
+      makeWrapper ${jre}/bin/java $out/bin/ili2c \
+        --add-flags "-jar $out/share/${pname}/ili2c.jar"
+    '';
+
+  meta = with stdenv.lib; {
+    description = "The INTERLIS Compiler";
+    longDescription = ''
+      Checks the syntactical correctness of an INTERLIS data model.
+    '';
+    homepage = "https://www.interlis.ch/downloads/ili2c";
+    license = licenses.lgpl21Plus;
+    maintainers = [ maintainers.das-g ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -816,6 +816,8 @@ in
 
   httperf = callPackage ../tools/networking/httperf { };
 
+  ili2c = callPackage ../tools/misc/ili2c { };
+
   imgpatchtools = callPackage ../development/mobile/imgpatchtools { };
 
   ipgrep = callPackage ../tools/networking/ipgrep { };


### PR DESCRIPTION
###### Motivation for this change

Make the [INTERLIS "compiler"](https://www.interlis.ch/downloads/ili2c) available on NixOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

##### Notes and questions:

###### Does this belong in "misc"?

"misc." categories always have the tendency to grow uncontrollably. Maybe it's time for a GIS subfolder in the pkgs tree?