### PR TITLE
go-outline: unstable-2017-08-04 -> unstable-2018-11-22

### DIFF
--- a/pkgs/development/tools/go-outline/default.nix
+++ b/pkgs/development/tools/go-outline/default.nix
@@ -2,8 +2,8 @@
 
 buildGoPackage rec {
   name = "go-outline-${version}";
-  version = "unstable-2017-08-04";
-  rev = "9e9d089bb61a5ce4f8e0c8d8dc5b4e41b0e02a48";
+  version = "unstable-2018-11-22";
+  rev = "7182a932836a71948db4a81991a494751eccfe77";
 
   goPackagePath = "github.com/ramya-rao-a/go-outline";
   goDeps = ./deps.nix;
@@ -12,7 +12,7 @@ buildGoPackage rec {
     inherit rev;
     owner = "ramya-rao-a";
     repo = "go-outline";
-    sha256 = "0kbkv4d6q9w0d41m00sqdm10l0sg56mv8y6rmidqs152mm2w13x0";
+    sha256 = "0p381yvwvff0i4i7mf5v1k2q1lb0rs2xkjgv67n1cw2573c613r1";
   };
 
   meta = {


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vincent@sbr.pm>

###### Motivation for this change

Bump to a more recent version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

