### PR TITLE
 pari: fix off-by-one error

### DIFF
--- a/pkgs/applications/science/math/pari/default.nix
+++ b/pkgs/applications/science/math/pari/default.nix
@@ -1,17 +1,21 @@
-{ stdenv, fetchurl
-, gmp, readline, libX11, tex, perl
+{ stdenv
+, fetchurl
+, gmp
+, readline
+, libX11
+, tex
+, perl
 , withThread ? true, libpthreadstubs
 }:
 
 assert withThread -> libpthreadstubs != null;
 
 stdenv.mkDerivation rec {
-
-  name = "pari-${version}";
+  pname = "pari";
   version = "2.11.1";
 
   src = fetchurl {
-    url = "https://pari.math.u-bordeaux.fr/pub/pari/unix/${name}.tar.gz";
+    url = "https://pari.math.u-bordeaux.fr/pub/pari/unix/${pname}-${version}.tar.gz";
     sha256 = "1jfax92jpydjd02fwl30r6b8kfzqqd6sm4yx94gidyz9lqjb7a94";
   };
 

--- a/pkgs/applications/science/math/pari/default.nix
+++ b/pkgs/applications/science/math/pari/default.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation rec {
     homepage    = http://pari.math.u-bordeaux.fr;
     downloadPage = http://pari.math.u-bordeaux.fr/download.html;
     license     = licenses.gpl2Plus;
-    maintainers = with maintainers; [ ertes raskin AndersonTorres ];
+    maintainers = with maintainers; [ ertes raskin AndersonTorres timokau ];
     platforms   = platforms.linux ++ platforms.darwin;
     updateWalker = true;
   };

--- a/pkgs/applications/science/math/pari/default.nix
+++ b/pkgs/applications/science/math/pari/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , fetchurl
+, fetchpatch
 , gmp
 , readline
 , libX11
@@ -18,6 +19,18 @@ stdenv.mkDerivation rec {
     url = "https://pari.math.u-bordeaux.fr/pub/pari/unix/${pname}-${version}.tar.gz";
     sha256 = "1jfax92jpydjd02fwl30r6b8kfzqqd6sm4yx94gidyz9lqjb7a94";
   };
+
+  patches = [
+    # Fix a off-by-one bug that can potentially lead to segfaults (accepted upstream)
+    # https://pari.math.u-bordeaux.fr/cgi-bin/bugreport.cgi?bug=2117
+    # https://trac.sagemath.org/ticket/27335
+    (fetchpatch {
+      name = "fix-off-by-one-error.patch";
+      # only relevant parts of https://pari.math.u-bordeaux.fr/cgi-bin/gitweb.cgi?p=pari.git;a=patch;h=aa1ee6e0898d177e6bcf49237d82c804bc410985
+      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/pari/patches/red_montgomery.patch?id=bbea55c96e1f05302b3c7f593cf64492497047c5";
+      sha256 = "0vqkmhgv9splsdswp6zjnkj50z76rc1m6k9iy3cf9dxwqw3h3nr6";
+    })
+  ];
 
   buildInputs = [
     gmp


### PR DESCRIPTION
###### Motivation for this change

Fixes an upstream bug, brought to my attention by sage. May cause a segfault (or even have security implications, though unlikely). While I'm at it I've also done a slight refactoring and added myself as a maintainer (so that I'll be notified on changes which may break sage).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

