### PR TITLE
python: make it possible to disable the python setup-hook

### DIFF
--- a/pkgs/development/interpreters/python/setup-hook.sh
+++ b/pkgs/development/interpreters/python/setup-hook.sh
@@ -12,7 +12,9 @@ toPythonPath() {
     echo $result
 }
 
-addEnvHooks "$hostOffset" addPythonPath
+if [ -z "${dontAddPythonPath:-}" ]; then
+    addEnvHooks "$hostOffset" addPythonPath
+fi
 
 # Determinism: The interpreter is patched to write null timestamps when compiling python files.
 # This way python doesn't try to update them when we freeze timestamps in nix store.


### PR DESCRIPTION
###### Motivation for this change

Without this it's impossible to use a python binary that depends on a
different python version then what's used during the current build.
I think it would be better to get rid of it in the future and only apply it for a specific set of inputs (eg `pythonDepends` or move it to mkPythonPackage.

/cc @FRidh

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
