### PR TITLE
oxidized: 0.25.0 -> 0.26.2

### DIFF
--- a/pkgs/tools/admin/oxidized/Gemfile
+++ b/pkgs/tools/admin/oxidized/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'oxidized', '0.25.0'
-gem 'oxidized-web', '0.12.0'
+gem 'oxidized', '0.26.2'
+gem 'oxidized-web', '0.13.1'
 gem 'oxidized-script', '0.6.0'

--- a/pkgs/tools/admin/oxidized/Gemfile.lock
+++ b/pkgs/tools/admin/oxidized/Gemfile.lock
@@ -2,35 +2,35 @@ GEM
   remote: https://rubygems.org/
   specs:
     asetus (0.3.0)
-    backports (3.11.4)
+    backports (3.12.0)
     charlock_holmes (0.7.6)
     emk-sinatra-url-for (0.2.1)
       sinatra (>= 0.9.1.1)
-    ffi (1.9.25)
+    ffi (1.10.0)
     haml (5.0.4)
       temple (>= 0.8.0)
       tilt
     htmlentities (4.3.4)
-    json (2.1.0)
+    json (2.2.0)
     multi_json (1.13.1)
-    net-ssh (4.1.0)
+    net-ssh (5.1.0)
     net-telnet (0.1.1)
-    oxidized (0.25.0)
+    oxidized (0.26.2)
       asetus (~> 0.1)
-      net-ssh (~> 4.1.0)
+      net-ssh (~> 5)
       net-telnet (~> 0.1.1)
       rugged (~> 0.21, >= 0.21.4)
       slop (~> 3.5)
     oxidized-script (0.6.0)
       oxidized (~> 0.25)
       slop (~> 3.5)
-    oxidized-web (0.12.0)
+    oxidized-web (0.13.1)
       charlock_holmes (~> 0.7.5)
       emk-sinatra-url-for (~> 0.2)
       haml (~> 5.0)
       htmlentities (~> 4.3)
       json (>= 1.7.0)
-      oxidized (~> 0.25)
+      oxidized (~> 0.26)
       puma (~> 3.11.4)
       rack-test (~> 0.7.0)
       sass (~> 3.3)
@@ -45,8 +45,8 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
-    rugged (0.27.7)
-    sass (3.7.2)
+    rugged (0.28.0)
+    sass (3.7.3)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -63,16 +63,16 @@ GEM
       sinatra (~> 1.4.0)
       tilt (>= 1.3, < 3)
     slop (3.6.0)
-    temple (0.8.0)
+    temple (0.8.1)
     tilt (2.0.9)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  oxidized (= 0.25.0)
+  oxidized (= 0.26.2)
   oxidized-script (= 0.6.0)
-  oxidized-web (= 0.12.0)
+  oxidized-web (= 0.13.1)
 
 BUNDLED WITH
-   1.17.1
+   1.17.2

--- a/pkgs/tools/admin/oxidized/gemset.nix
+++ b/pkgs/tools/admin/oxidized/gemset.nix
@@ -14,10 +14,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1hshjxww2h7s0dk57njrygq4zpp0nlqrjfya7zwm27iq3rhc3y8g";
+      sha256 = "0ba6n9l4kki56s2cszarps14zp2wlhw7nfawb8qwsxy3a57v4mw4";
       type = "gem";
     };
-    version = "3.11.4";
+    version = "3.12.0";
   };
   charlock_holmes = {
     groups = ["default"];
@@ -45,10 +45,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0jpm2dis1j7zvvy3lg7axz9jml316zrn7s0j59vyq3qr127z0m7q";
+      sha256 = "0j8pzj8raxbir5w5k6s7a042sb5k02pg0f8s4na1r5lan901j00p";
       type = "gem";
     };
-    version = "1.9.25";
+    version = "1.10.0";
   };
   haml = {
     dependencies = ["temple" "tilt"];
@@ -76,10 +76,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "01v6jjpvh3gnq6sgllpfqahlgxzj50ailwhj9b3cd20hi2dx0vxp";
+      sha256 = "0sx97bm9by389rbzv8r1f43h06xcz8vwi3h5jv074gvparql7lcx";
       type = "gem";
     };
-    version = "2.1.0";
+    version = "2.2.0";
   };
   multi_json = {
     groups = ["default"];
@@ -96,10 +96,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "013p5jb4wy0cq7x7036piw2a3s1i9p752ki1srx2m289mpz4ml3q";
+      sha256 = "0jglf8rxvlw6is5019r6kwsdhw38zm3z39jbghdbj449r6h7h77n";
       type = "gem";
     };
-    version = "4.1.0";
+    version = "5.1.0";
   };
   net-telnet = {
     groups = ["default"];
@@ -117,10 +117,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0i8lbzjay60jpk6g86rpk59j4r0kyd1nnm79qdh64qvx6hy02ylq";
+      sha256 = "130h99wijfvv443wgdllxvlq880m0m31rxvrszq5wdii7ad977s5";
       type = "gem";
     };
-    version = "0.25.0";
+    version = "0.26.2";
   };
   oxidized-script = {
     dependencies = ["oxidized" "slop"];
@@ -139,10 +139,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "12ib7380sh9ca7qirw1yhs8di2vv38l09imqaamibdzgmk0rvs1r";
+      sha256 = "07qmal83h1h5dqapgirq5yrnclbm3xhcjqkj80lla3dq18jmjhqs";
       type = "gem";
     };
-    version = "0.12.0";
+    version = "0.13.1";
   };
   puma = {
     groups = ["default"];
@@ -212,10 +212,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0znb9n1grdsqf22jqzwin58kyq7x7ml57h6pf48j219f8by21sj6";
+      sha256 = "0crasx5dmbr9ws89137n53l8nap7rdncp8yg5alw1jb99lqslhmi";
       type = "gem";
     };
-    version = "0.27.7";
+    version = "0.28.0";
   };
   sass = {
     dependencies = ["sass-listen"];
@@ -223,10 +223,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1phs6hnd8b95m7n5wbh5bsclmwaajd1sqlgw9fmj72bfqldbmcqa";
+      sha256 = "0vll3bm1dllhqjxxj639nj3afsp12hlppgpysxrgcg24jb2xl2qn";
       type = "gem";
     };
-    version = "3.7.2";
+    version = "3.7.3";
   };
   sass-listen = {
     dependencies = ["rb-fsevent" "rb-inotify"];
@@ -276,10 +276,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "00nxf610nzi4n1i2lkby43nrnarvl89fcl6lg19406msr0k3ycmq";
+      sha256 = "158d7ygbwcifqnvrph219p7m78yjdjazhykv5darbkms7bxm5y09";
       type = "gem";
     };
-    version = "0.8.0";
+    version = "0.8.1";
   };
   tilt = {
     groups = ["default"];


### PR DESCRIPTION
###### Motivation for this change
[Latest release](https://github.com/ytti/oxidized/releases/tag/0.26.2) with bugfixes, some new features and new supported models.
([Changelog](https://github.com/ytti/oxidized/blob/0.26.2/CHANGELOG.md))

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

