### PR TITLE
pythonPackages.ppft: use custom checkPhase

### DIFF
--- a/pkgs/development/python-modules/ppft/default.nix
+++ b/pkgs/development/python-modules/ppft/default.nix
@@ -13,6 +13,10 @@ buildPythonPackage rec {
     sha256 = "5537b00afb7b247da0f59cc57ee5680178be61c8b2e21b5a0672b70a3d247791";
   };
 
+  checkPhase = ''
+    python -m ppft.tests
+  '';
+
   propagatedBuildInputs = [ six ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
Fixes #56908 

`doCheck = true;`  fails on python3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

