### PR TITLE
 python.pkgs.pplpy: init at 0.8.4

### DIFF
--- a/pkgs/development/python-modules/cysignals/default.nix
+++ b/pkgs/development/python-modules/cysignals/default.nix
@@ -31,12 +31,13 @@ buildPythonPackage rec {
     export PATH="$out/bin:$PATH"
   '';
 
-  buildInputs = lib.optionals pariSupport [
-    pari
-  ];
-
   propagatedBuildInputs = [
     cython
+  ] ++ lib.optionals pariSupport [
+    # When cysignals is built with pari, including cysignals into the
+    # buildInputs of another python package will cause cython to link against
+    # pari.
+    pari
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/development/python-modules/pplpy/default.nix
+++ b/pkgs/development/python-modules/pplpy/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, gmp
+, mpfr
+, libmpc
+, ppl
+, pari
+, cython
+, cysignals
+, gmpy2_2_1
+}:
+
+buildPythonPackage rec {
+  pname = "pplpy";
+  version = "0.8.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0dk8l5r3f2jbkkasddvxwvhlq35pjsiirh801lrapv8lb16r2qmr";
+  };
+
+  buildInputs = [
+    gmp
+    mpfr
+    libmpc
+    ppl
+  ];
+
+  propagatedBuildInputs = [
+    cython
+    cysignals
+    gmpy2_2_1
+  ];
+
+  meta = with lib; {
+    description = "A Python wrapper for ppl";
+    homepage = https://gitlab.com/videlec/pplpy;
+    maintainers = with maintainers; [ timokau ];
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -570,6 +570,8 @@ in {
 
   poetry = callPackage ../development/python-modules/poetry { };
 
+  pplpy = callPackage ../development/python-modules/pplpy { };
+
   pprintpp = callPackage ../development/python-modules/pprintpp { };
 
   progress = callPackage ../development/python-modules/progress { };
@@ -1876,6 +1878,18 @@ in {
   gmpy = callPackage ../development/python-modules/gmpy { };
 
   gmpy2 = callPackage ../development/python-modules/gmpy2 { };
+
+  # alpha release, big refactor, adds cython support
+  # see https://github.com/aleaxit/gmpy/issues/146, https://github.com/aleaxit/gmpy/issues/199
+  gmpy2_2_1 = (callPackage ../development/python-modules/gmpy2 {}).overridePythonAttrs (oldAttrs: rec {
+      version = "2.1a4";
+      src = pkgs.fetchFromGitHub {
+        owner = "aleaxit";
+        repo = "gmpy";
+        rev = "gmpy2-${version}";
+        sha256 = "1wg4w4q2l7n26ksrdh4rwqmifgfm32n7x29cgdvmmbv5lmilb5hz";
+      };
+    });
 
   gmusicapi = callPackage ../development/python-modules/gmusicapi { };
 


### PR DESCRIPTION
###### Motivation for this change

This package depends on a newer version (alpha) of `gmpy2`, which has significant changes (including a cython interface).
I've copied the way `shpinx` adds multiple versions in `python-packages.nix`. I'm not sure if that is the right way to do it. @FRidh @domenkozar?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

