### PR TITLE
coursier: update to 1.1.0-M13

### DIFF
--- a/pkgs/development/tools/coursier/default.nix
+++ b/pkgs/development/tools/coursier/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://github.com/coursier/coursier/releases/download/v${version}/coursier";
-    sha256 = "sha256-ujskTE4HNqRkEL/I30ogQQJ7MslRBZCO+Tv2naTzX4w=";
+    sha256 = "0szqgxf22nmqflpmj0inpcjyqmffpd4vrmgv186b85g15i7504mm";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/development/tools/coursier/default.nix
+++ b/pkgs/development/tools/coursier/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "coursier-${version}";
-  version = "1.1.0-M10";
+  version = "1.1.0-M13";
 
   src = fetchurl {
-    url = "https://github.com/coursier/coursier/raw/v${version}/coursier";
-    sha256 = "14iq0717vdm0mj0196idc724vmxp1y0f3gfn41sbqahfhvcx05y8";
+    url = "https://github.com/coursier/coursier/releases/download/v${version}/coursier";
+    sha256 = "sha256-ujskTE4HNqRkEL/I30ogQQJ7MslRBZCO+Tv2naTzX4w=";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
The download url changed because, according to
https://get-coursier.io/docs/cli-overview.html#curl:

> For versions 1.1.0-M9 and later, the launcher is available as an
> asset on the GitHub release page, e.g.
> https://github.com/coursier/coursier/releases/download/v1.1.0-M9/coursier

(The old committed in-repo version has not been updated since M9)

The hash was generated by doing

$ curl -LO https://github.com/coursier/coursier/releases/download/v1.1.0-M13/coursier
$ nix hash-file coursier

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

