### PR TITLE
spice-up: 1.7.0 -> 1.8.0

### DIFF
--- a/pkgs/applications/office/spice-up/default.nix
+++ b/pkgs/applications/office/spice-up/default.nix
@@ -1,38 +1,35 @@
 { stdenv
 , fetchFromGitHub
-, gettext
-, libxml2
-, pkgconfig
-, gtk3
-, gnome3
-, gobject-introspection
-, json-glib
 , cmake
+, gdk_pixbuf
+, gtk3
+, gettext
 , ninja
+, pantheon
+, pkgconfig
+, json-glib
 , libgudev
 , libevdev
+, libgee
 , libsoup
-, pantheon
 , wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
-  name = "spice-up-${version}";
-  version = "1.7.0";
+  pname = "spice-up";
+  version = "1.8.0";
 
   src = fetchFromGitHub {
     owner = "Philip-Scott";
     repo = "Spice-up";
     rev = version;
-    sha256 = "1qb1hlw7g581dmgg5mh832ixjkcgqm3lqzj6xma2cz8wdncwwjaq";
+    sha256 = "0jbqgf936pqss8ha27fcyjbhvkn4ij96b3d87c6gcx90glmq33zb";
   };
 
-  USER = "nix-build-user";
+  USER = "pbuilder";
 
   nativeBuildInputs = [
     cmake
     gettext
-    gobject-introspection # For setup hook
-    libxml2
     ninja
     pkgconfig
     pantheon.vala
@@ -41,18 +38,19 @@ stdenv.mkDerivation rec {
   buildInputs = [
     pantheon.elementary-icon-theme
     pantheon.granite
-    gnome3.libgee
+    gdk_pixbuf
     gtk3
     json-glib
     libevdev
+    libgee
     libgudev
     libsoup
   ];
 
   meta = with stdenv.lib; {
-    description = "Create simple and beautiful presentations on the Linux desktop";
+    description = "Create simple and beautiful presentations";
     homepage = https://github.com/Philip-Scott/Spice-up;
-    maintainers = with maintainers; [ samdroid-apps ];
+    maintainers = with maintainers; [ samdroid-apps kjuvi ] ++ pantheon.maintainers;
     platforms = platforms.linux;
     # The COPYING file has GPLv3; some files have GPLv2+ and some have GPLv3+
     license = licenses.gpl3Plus;


### PR DESCRIPTION
###### Motivation for this change

Fix spice-up which didn't build on master and update to 1.8.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

