### PR TITLE
treewide: fixup bcf54ce

### DIFF
--- a/pkgs/applications/version-management/smartgithg/default.nix
+++ b/pkgs/applications/version-management/smartgithg/default.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation rec {
     bin_path = "$out/bin";
     install_freedesktop_items = substituteAll {
       inherit (stdenv) shell;
+      isExecutable = true;
       src = ./install_freedesktop_items.sh;
     };
     runtime_paths = lib.makeBinPath [

--- a/pkgs/build-support/docker/store-path-to-layer.sh
+++ b/pkgs/build-support/docker/store-path-to-layer.sh
@@ -1,4 +1,4 @@
-#! @shell@
+#!@shell@
 
 set -eu
 

--- a/pkgs/development/compilers/ghc/8.2.2-binary.nix
+++ b/pkgs/development/compilers/ghc/8.2.2-binary.nix
@@ -123,6 +123,7 @@ stdenv.mkDerivation rec {
   let
     gcc-clang-wrapper = substituteAll {
       inherit (stdenv) shell;
+      isExecutable = true;
       src = ./gcc-clang-wrapper.sh;
     };
   in

--- a/pkgs/games/gargoyle/default.nix
+++ b/pkgs/games/gargoyle/default.nix
@@ -40,7 +40,11 @@ stdenv.mkDerivation {
 
   installPhase =
   if stdenv.isDarwin then
-    (substituteAll { inherit (stdenv) shell; src = ./darwin.sh; })
+  (substituteAll {
+    inherit (stdenv) shell;
+    isExecutable = true;
+    src = ./darwin.sh;
+  })
   else jamenv + ''
     jam -j$NIX_BUILD_CORES install
     mkdir -p "$out/bin"

--- a/pkgs/os-specific/linux/rfkill/udev.nix
+++ b/pkgs/os-specific/linux/rfkill/udev.nix
@@ -27,9 +27,10 @@
 let
   rfkillHook =
     substituteAll {
-    inherit (stdenv) shell;
-    src = ./rfkill-hook.sh;
-  };
+      inherit (stdenv) shell;
+      isExecutable = true;
+      src = ./rfkill-hook.sh;
+    };
 in stdenv.mkDerivation {
   name = "rfkill-udev";
 
@@ -44,7 +45,6 @@ in stdenv.mkDerivation {
 
     mkdir -p "$out/bin/";
     cp ${rfkillHook} "$out/bin/rfkill-hook.sh"
-    chmod +x "$out/bin/rfkill-hook.sh";
   '';
 
   meta = {

--- a/pkgs/os-specific/linux/service-wrapper/default.nix
+++ b/pkgs/os-specific/linux/service-wrapper/default.nix
@@ -7,6 +7,7 @@ in
 runCommand "${name}" {
   script = substituteAll {
     src = ./service-wrapper.sh;
+    isExecutable = true;
     inherit (stdenv) shell;
     inherit coreutils;
   };

--- a/pkgs/tools/archivers/rpmextract/default.nix
+++ b/pkgs/tools/archivers/rpmextract/default.nix
@@ -9,6 +9,7 @@ stdenv.mkDerivation rec {
     
   script = substituteAll {
     src = ./rpmextract.sh;
+    isExecutable = true;
     inherit rpm cpio;
     inherit (stdenv) shell;
   };

--- a/pkgs/tools/security/eid-mw/default.nix
+++ b/pkgs/tools/security/eid-mw/default.nix
@@ -37,6 +37,7 @@ stdenv.mkDerivation rec {
   let
     eid-nssdb-in = substituteAll {
       inherit (stdenv) shell;
+      isExecutable = true;
       src = ./eid-nssdb.in;
     };
   in

--- a/pkgs/tools/security/eid-mw/eid-nssdb.in
+++ b/pkgs/tools/security/eid-mw/eid-nssdb.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!@shell@
 
 rootdb="/etc/pki/nssdb"
 userdb="$HOME/.pki/nssdb"


### PR DESCRIPTION
fix the executable bit for scripts installed with substituteAll
and some remaining shebangs.

###### Motivation for this change
Fix for issues reported in #56878 #56151 caused by changes in bcf54ce.

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

