### PR TITLE
protonmail-bridge: 1.1.1-1 -> 1.1.3-1

### DIFF
--- a/pkgs/applications/networking/protonmail-bridge/default.nix
+++ b/pkgs/applications/networking/protonmail-bridge/default.nix
@@ -2,7 +2,7 @@
   libsecret, libGL, libpulseaudio, glib, makeWrapper, makeDesktopItem }:
 
 let
-  version = "1.1.1-1";
+  version = "1.1.3-1";
 
   description = ''
     An application that runs on your computer in the background and seamlessly encrypts
@@ -25,7 +25,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://protonmail.com/download/protonmail-bridge_${version}_amd64.deb";
-    sha256 = "148syyz92yqxp2fw18fhflhmdrakxz7cc30va7h0pwysz97gni2p";
+    sha256 = "15kyhyx1v4bb2sqzwq7bqrxxw7g733p5jnsgjqka2ygzg6dl2c5n";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -40,7 +40,7 @@ in stdenv.mkDerivation rec {
     mkdir -p $out/{bin,lib,share/applications}
     mkdir -p $out/share/{applications,icons/hicolor/scalable/apps}
 
-    cp -r usr/lib/protonmail/bridge/protonmail-bridge{,.sh} $out/lib
+    cp -r usr/lib/protonmail/bridge/protonmail-bridge $out/lib
     cp usr/share/icons/protonmail/ProtonMail_Bridge.svg $out/share/icons/hicolor/scalable/apps/protonmail-bridge.svg
     cp ${desktopItem}/share/applications/* $out/share/applications
 


### PR DESCRIPTION
###### Motivation for this change
Fixes MIME for sending messages. I don't know how to see the changelog again after closing the dialog, but I know the bugfixes included MIME.

With this change, I can now send emails from the Geary email client.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

