### PR TITLE
rubber: fix build

### DIFF
--- a/pkgs/tools/typesetting/rubber/default.nix
+++ b/pkgs/tools/typesetting/rubber/default.nix
@@ -9,7 +9,7 @@ python3Packages.buildPythonApplication rec {
     sha256 = "178dmrp0mza5gqjiqgk6dqs0c10s0c517pk6k9pjbam86vf47a1p";
   };
 
-  propagatedBuildInputs = [ texinfo ];
+  nativeBuildInputs = [ texinfo ];
 
   # I couldn't figure out how to pass the proper parameter to disable pdf generation, so we
   # use sed to change the default


### PR DESCRIPTION
###### Motivation for this change

propagatedBuildInputs -> nativeBuildInputs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

