### PR TITLE
sshuttle: 0.78.4 -> 0.78.5

### DIFF
--- a/pkgs/tools/security/sshuttle/default.nix
+++ b/pkgs/tools/security/sshuttle/default.nix
@@ -1,23 +1,23 @@
-{ stdenv, python3Packages, fetchurl, makeWrapper, pandoc
+{ stdenv, python3Packages, fetchurl, makeWrapper
 , coreutils, iptables, nettools, openssh, procps, fetchpatch }:
 
 python3Packages.buildPythonApplication rec {
   name = "sshuttle-${version}";
-  version = "0.78.4";
+  version = "0.78.5";
 
   src = fetchurl {
-    sha256 = "0pqk43kd7crqhg6qgnl8kapncwgw1xgaf02zarzypcw64kvdih9h";
+    sha256 = "0vp13xwrhx4m6zgsyzvai84lkq9mzkaw47j58dk0ll95kaymk2x8";
     url = "mirror://pypi/s/sshuttle/${name}.tar.gz";
   };
 
   patches = [ ./sudo.patch ];
 
-  nativeBuildInputs = [ makeWrapper python3Packages.setuptools_scm ] ++ stdenv.lib.optional (stdenv.hostPlatform.system != "i686-linux") pandoc;
+  nativeBuildInputs = [ makeWrapper python3Packages.setuptools_scm ];
   buildInputs =
     [ coreutils openssh procps nettools ]
     ++ stdenv.lib.optionals stdenv.isLinux [ iptables ];
 
-  checkInputs = with python3Packages; [ mock pytest pytestrunner ];
+  checkInputs = with python3Packages; [ mock pytest pytestcov pytestrunner flake8 ];
 
   postInstall = let
     mapPath = f: x: stdenv.lib.concatStringsSep ":" (map f x);
@@ -31,11 +31,11 @@ python3Packages.buildPythonApplication rec {
     description = "Transparent proxy server that works as a poor man's VPN";
     longDescription = ''
       Forward connections over SSH, without requiring administrator access to the
-      target network (though it does require Python 2 at both ends).
+      target network (though it does require Python 2.7, Python 3.5 or later at both ends).
       Works with Linux and Mac OS and supports DNS tunneling.
     '';
     license = licenses.gpl2;
-    maintainers = with maintainers; [ domenkozar ];
+    maintainers = with maintainers; [ domenkozar carlosdagos ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/security/sshuttle/sudo.patch
+++ b/pkgs/tools/security/sshuttle/sudo.patch
@@ -1,9 +1,9 @@
 diff --git a/sshuttle/client.py b/sshuttle/client.py
-index 7a7b6d7..8dde615 100644
+index cab5b1c..e89f8a6 100644
 --- a/sshuttle/client.py
 +++ b/sshuttle/client.py
-@@ -158,7 +158,7 @@ class FirewallClient:
-     def __init__(self, method_name):
+@@ -192,7 +192,7 @@ class FirewallClient:
+ 
          self.auto_nets = []
          python_path = os.path.dirname(os.path.dirname(__file__))
 -        argvbase = ([sys.executable, sys.argv[0]] +


### PR DESCRIPTION
###### Motivation for this change

Newer version.

Remove the pandoc dependency which is no longer required.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

