### PR TITLE
shelldap: init at 1.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4738,6 +4738,11 @@
     github = "tobimpub";
     name = "Tobias Mayer";
   };
+  tobiasBora = {
+    email = "tobias.bora.list@gmail.com";
+    github = "tobiasBora";
+    name = "Tobias Bora";
+  };
   tohl = {
     email = "tom@logand.com";
     github = "tohl";

--- a/pkgs/tools/misc/shelldap/default.nix
+++ b/pkgs/tools/misc/shelldap/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl, perlPackages }:
+perlPackages.buildPerlPackage rec {
+  name = "shelldap-${version}";
+  version = "1.4.0";
+  src = fetchurl {
+    url = "https://bitbucket.org/mahlon/shelldap/downloads/shelldap-${version}.tar.gz";
+    sha256 = "07gkvvxcgw3pgkfy8p9mmidakciaq1rsq5zhmdqd8zcwgqkrr24i";
+  };
+  buildInputs = with perlPackages; [ perl YAMLSyck NetLDAP AlgorithmDiff IOSocketSSL AuthenSASL TermReadLineGnu TermShell ];
+  prePatch = ''
+    touch Makefile.PL
+  '';
+  installPhase = ''
+    runHook preInstall
+    install -Dm555 -t $out/bin shelldap
+    runHook preInstall
+  '';
+  outputs = [ "out" ];
+  meta = with stdenv.lib; {
+    homepage = https://bitbucket.org/mahlon/shelldap/;
+    description = "A handy shell-like interface for browsing LDAP servers and editing their content";
+    license = with licenses; [ bsd3 ];
+    maintainers = with maintainers; [ tobiasBora ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5416,6 +5416,8 @@ in
 
   sharutils = callPackage ../tools/archivers/sharutils { };
 
+  shelldap = callPackage ../tools/misc/shelldap { };
+
   schema2ldif = callPackage ../tools/text/schema2ldif { };
 
   shocco = callPackage ../tools/text/shocco { };

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -14646,6 +14646,20 @@ let
     };
   };
 
+  TermShell = buildPerlModule rec {
+    name = "Term-Shell-0.10";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/${name}.tar.gz";
+      sha256 = "7d1f824c2db22769b60000b5b9ca2ad469c154939f9ec1cd3f0e06e9c967dda3";
+    };
+    propagatedBuildInputs = [ TermReadKey TextAutoformat ];
+    meta = with stdenv.lib; {
+      homepage = http://metacpan.org/release/Term-Shell;
+      description = "A simple command-line shell framework";
+      license = with licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   TermShellUI = buildPerlPackage rec {
     name = "Term-ShellUI-0.92";
     src = fetchurl {


### PR DESCRIPTION
###### Motivation for this change

Integrate the tool shelldap (that let you browse in shelldap like in a shell).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

