### PR TITLE
solc: 0.5.4 -> 0.5.7

### DIFF
--- a/pkgs/development/compilers/solc/default.nix
+++ b/pkgs/development/compilers/solc/default.nix
@@ -6,9 +6,9 @@ assert z3Support -> z3 != null;
 assert z3Support -> stdenv.lib.versionAtLeast z3.version "4.6.0";
 
 let
-  version = "0.5.6";
-  rev = "b259423eb8326dae5340e3e43e34f912cfb1c645";
-  sha256 = "0mlmqc5547m9jqgalsdafi2yj64x8ibwsyzc0za7g71li9shhm5r";
+  version = "0.5.7";
+  rev = "6da8b019e4a155d1f70abe7a3acc0f9765480a9e";
+  sha256 = "0ii868r0ra6brjnn453kxqvw76p4bwjbvdyqfcn6v1bl2h4s60ir";
   jsoncppURL = https://github.com/open-source-parsers/jsoncpp/archive/1.8.4.tar.gz;
   jsoncpp = fetchzip {
     url = jsoncppURL;

--- a/pkgs/development/compilers/solc/default.nix
+++ b/pkgs/development/compilers/solc/default.nix
@@ -6,9 +6,9 @@ assert z3Support -> z3 != null;
 assert z3Support -> stdenv.lib.versionAtLeast z3.version "4.6.0";
 
 let
-  version = "0.5.4";
-  rev = "9549d8fff7343908228c3e8bedc309d1b83fc204";
-  sha256 = "1r6wklp3ab2s1lrm70zv6p7blv9917ph1arjsb250j7b7bpjg5pq";
+  version = "0.5.5";
+  rev = "47a71e8f1c884368ad340d61ed36ea7fe270805d";
+  sha256 = "0aibj342pzzmmmwcdwk5hgr2jn3s9sjcgc6rflq09r33vw1q5qln";
   jsoncppURL = https://github.com/open-source-parsers/jsoncpp/archive/1.8.4.tar.gz;
   jsoncpp = fetchzip {
     url = jsoncppURL;
@@ -43,8 +43,8 @@ stdenv.mkDerivation {
   ];
 
   doCheck = stdenv.hostPlatform.isLinux && stdenv.hostPlatform == stdenv.buildPlatform;
-  checkPhase = "LD_LIBRARY_PATH=./libsolc:./libsolidity:./libevmasm:./libdevcore:./libyul:./liblangutil:$LD_LIBRARY_PATH " +
-               "./test/soltest -p -- --no-ipc --no-smt --testpath ../test";
+  checkPhase = "LD_LIBRARY_PATH=./libsolc:./libsolidity:./libevmasm:./libdevcore:./libyul:./liblangutil:./test/tools/yulInterpreter:$LD_LIBRARY_PATH " +
+               "./test/soltest -p true -- --no-ipc --no-smt --testpath ../test";
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ boost ]

--- a/pkgs/development/compilers/solc/default.nix
+++ b/pkgs/development/compilers/solc/default.nix
@@ -6,9 +6,9 @@ assert z3Support -> z3 != null;
 assert z3Support -> stdenv.lib.versionAtLeast z3.version "4.6.0";
 
 let
-  version = "0.5.5";
-  rev = "47a71e8f1c884368ad340d61ed36ea7fe270805d";
-  sha256 = "0aibj342pzzmmmwcdwk5hgr2jn3s9sjcgc6rflq09r33vw1q5qln";
+  version = "0.5.6";
+  rev = "b259423eb8326dae5340e3e43e34f912cfb1c645";
+  sha256 = "0mlmqc5547m9jqgalsdafi2yj64x8ibwsyzc0za7g71li9shhm5r";
   jsoncppURL = https://github.com/open-source-parsers/jsoncpp/archive/1.8.4.tar.gz;
   jsoncpp = fetchzip {
     url = jsoncppURL;


### PR DESCRIPTION
###### Motivation for this change
[Changelog](https://github.com/ethereum/solidity/releases/tag/v0.5.7).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

