### PR TITLE
appeditor: init at 1.1.0

### DIFF
--- a/pkgs/applications/misc/appeditor/default.nix
+++ b/pkgs/applications/misc/appeditor/default.nix
@@ -1,0 +1,56 @@
+{ stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, pkgconfig
+, pantheon
+, python3
+, gettext
+, glib
+, gtk3
+, hicolor-icon-theme
+, libgee
+, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  pname = "appeditor";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "donadigo";
+    repo = "appeditor";
+    rev = version;
+    sha256 = "04x2f4x4dp5ca2y3qllqjgirbyl6383pfl4bi9bkcqlg8b5081rg";
+  };
+
+  nativeBuildInputs = [
+    gettext
+    meson
+    ninja
+    pantheon.vala
+    pkgconfig
+    python3
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    hicolor-icon-theme
+    pantheon.granite
+    libgee
+  ];
+
+  postPatch = ''
+    chmod +x meson/post_install.py
+    patchShebangs meson/post_install.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Edit the Pantheon desktop application menu";
+    homepage = https://github.com/donadigo/appeditor;
+    maintainers = with maintainers; [ kjuvi ] ++ pantheon.maintainers;
+    platforms = platforms.linux;
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16152,6 +16152,8 @@ in
 
   apache-directory-studio = callPackage ../applications/networking/apache-directory-studio {};
 
+  appeditor = callPackage ../applications/misc/appeditor { };
+
   aqemu = libsForQt5.callPackage ../applications/virtualization/aqemu { };
 
   ardour = callPackage ../applications/audio/ardour {


### PR DESCRIPTION
###### Motivation for this change

Edit the Pantheon application menu

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

