### PR TITLE
gnuradio-limesdr: fix build

### DIFF
--- a/pkgs/applications/radio/gnuradio/limesdr.nix
+++ b/pkgs/applications/radio/gnuradio/limesdr.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, boost, gnuradio
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, boost, gnuradio
 , pythonSupport ? true, python, swig, limesuite
 } :
 
@@ -19,6 +19,7 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
+    pkgconfig
   ] ++ stdenv.lib.optionals pythonSupport [ swig ];
 
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change
A cmake update (?) broke the build (https://hydra.nixos.org/build/89859086).
`pkconfig` is now required to find the limesuite include.

Needs backport to 19.03

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

