### PR TITLE
kustomize: 2.0.1 -> 2.0.3

### DIFF
--- a/pkgs/development/tools/kustomize/default.nix
+++ b/pkgs/development/tools/kustomize/default.nix
@@ -2,9 +2,9 @@
 
 buildGoPackage rec {
   name = "kustomize-${version}";
-  version = "2.0.1";
-  # rev is the 2.0.1 commit, mainly for kustomize version command output
-  rev = "ce7e5ee2c30cc5856fea01fe423cf167f2a2d0c3";
+  version = "2.0.3";
+  # rev is the 2.0.3 commit, mainly for kustomize version command output
+  rev = "a6f65144121d1955266b0cd836ce954c04122dc8";
 
   goPackagePath = "sigs.k8s.io/kustomize";
 
@@ -16,7 +16,7 @@ buildGoPackage rec {
   '';
 
   src = fetchFromGitHub {
-    sha256 = "1ljllx2gd329lnq6mdsgh8zzr517ji80b0j21pgr23y0xmd43ijf";
+    sha256 = "1dfkpx9rllj1bzm5f52bx404kdds3zx1h38yqri9ha3p3pcb1bbb";
     rev = "v${version}";
     repo = "kustomize";
     owner = "kubernetes-sigs";


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vincent@sbr.pm>

###### Motivation for this change

Bump to latest release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

