### PR TITLE
WIP: vscode: patch .desktop file to use absolute files.

### DIFF
--- a/pkgs/applications/editors/vscode/default.nix
+++ b/pkgs/applications/editors/vscode/default.nix
@@ -44,7 +44,7 @@ in
       desktopName = longName;
       comment = "Code Editing. Redefined.";
       genericName = "Text Editor";
-      exec = executableName;
+      exec = "@out@/bin/${executableName}";
       icon = "@out@/share/pixmaps/code.png";
       startupNotify = "true";
       categories = "Utility;TextEditor;Development;IDE;";
@@ -56,7 +56,7 @@ in
 
         [Desktop Action new-empty-window]
         Name=New Empty Window
-        Exec=${executableName} --new-window %F
+        Exec=@out@/bin/${executableName} --new-window %F
         Icon=@out@/share/pixmaps/code.png
       '';
     };


### PR DESCRIPTION
###### Motivation for this change

fix to work with Crostini

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions (Crostini)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

