### PR TITLE
cc-wrapper: give -march=... flag less priority

### DIFF
--- a/pkgs/build-support/cc-wrapper/cc-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/cc-wrapper.sh
@@ -158,6 +158,23 @@ if [ "$dontLink" != 1 ]; then
     export NIX_@infixSalt@_LDFLAGS_SET=1
 fi
 
+# Remove -march= from extraAfter if -march= is among params
+# (likely compiling a single file with code optimized for a particular arch,
+# e.g. openblas files with AVX512 code,
+# while extraAfter is set for a the whole derivation (via $NIX_CFLAGS_COMPILE)
+# or even for the whole closure (via platform.gcc.arch))
+for p in ${params+"${params[@]}"}; do
+    if [[ "$p" = -march=* ]]; then
+        filteredExtraAfter=()
+        for q in ${extraAfter+"${extraAfter[@]}"}; do
+            if [[ "$q" != -march=* ]]; then
+                filteredExtraAfter+=("$q")
+            fi
+        done
+        extraAfter=(${filteredExtraAfter+"${filteredExtraAfter[@]}"})
+    fi
+done
+
 # As a very special hack, if the arguments are just `-v', then don't
 # add anything.  This is to prevent `gcc -v' (which normally prints
 # out the version number and returns exit code 0) from printing out


### PR DESCRIPTION
###### Motivation for this change

Do not override -march= with the value from $NIX_CFLAGS_COMPILE which is set for whole closure or even for the whole closure (via platform.gcc.arch), while per-file -march= is used by many packages (xen, openblas, qt512.qtwebengine, ...) to compile snippets of code optimized for a particual architecture.

It allows to set ```pureUsePlatformOptimizations``` (https://github.com/NixOS/nixpkgs/pull/56649) adapter globally:
```
self: super: {
  stdenv = self.stdenvAdapters.pureUsePlatformOptimizations super.stdenv;
  stdenvNoCC = self.stdenvAdapters.pureUsePlatformOptimizations super.stdenvNoCC;
}
```
resulting in Gentoo-style compilation of the whole system for a particual architecture (with the exception of those snippets above, which might target a higher (Xeon Phi) or an incompatible (AMD-specific) architecture and require custom -march= which must not be shadowed by a derivation-wide or system-wide -march.
