### PR TITLE
initial ghidra-9.0

### DIFF
--- a/pkgs/tools/security/ghidra/default.nix
+++ b/pkgs/tools/security/ghidra/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, lib, makeWrapper, patchelf
+{ stdenv, fetchurl, unzip, lib, makeWrapper, autoPatchelfHook
 , openjdk11, pam
 }: let
 
@@ -15,22 +15,16 @@ in stdenv.mkDerivation {
 
   nativeBuildInputs = [
     makeWrapper
-    patchelf
+    autoPatchelfHook
     unzip
   ];
 
+  buildInputs = [
+    stdenv.cc.cc.lib
+    pam
+  ];
+
   dontStrip = true;
-
-  postPatch = ''
-    for f in Ghidra/Features/Decompiler/os/linux64/* GPL/DemanglerGnu/os/linux64/*; do
-      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-        --set-rpath "${stdenv.cc.libc}/lib:${stdenv.cc.cc.lib}/lib" "$f"
-    done
-
-    for f in Ghidra/Features/GhidraServer/os/linux64/*; do
-      patchelf --set-rpath "${stdenv.cc.libc}/lib:${pam}/lib" "$f"
-    done
-  '';
 
   installPhase = ''
     mkdir -p "${pkg_path}"

--- a/pkgs/tools/security/ghidra/default.nix
+++ b/pkgs/tools/security/ghidra/default.nix
@@ -1,0 +1,54 @@
+{ stdenv, fetchurl, unzip, lib, makeWrapper, patchelf
+, openjdk11, pam
+}: let
+
+  pkg_path = "$out/lib/ghidra";
+
+in stdenv.mkDerivation {
+
+  name = "ghidra-9.0";
+
+  src = fetchurl {
+    url = https://ghidra-sre.org/ghidra_9.0_PUBLIC_20190228.zip;
+    sha256 = "3b65d29024b9decdbb1148b12fe87bcb7f3a6a56ff38475f5dc9dd1cfc7fd6b2";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    patchelf
+    unzip
+  ];
+
+  dontStrip = true;
+
+  postPatch = ''
+    for f in Ghidra/Features/Decompiler/os/linux64/* GPL/DemanglerGnu/os/linux64/*; do
+      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+        --set-rpath "${stdenv.cc.libc}/lib:${stdenv.cc.cc.lib}/lib" "$f"
+    done
+
+    for f in Ghidra/Features/GhidraServer/os/linux64/*; do
+      patchelf --set-rpath "${stdenv.cc.libc}/lib:${pam}/lib" "$f"
+    done
+  '';
+
+  installPhase = ''
+    mkdir -p "${pkg_path}"
+    cp -a * "${pkg_path}"
+  '';
+
+  postFixup = ''
+    mkdir -p "$out/bin"
+    makeWrapper "${pkg_path}/ghidraRun" "$out/bin/ghidra" \
+      --prefix PATH : ${lib.makeBinPath [ openjdk11 ]}
+  '';
+
+  meta = with lib; {
+    description = "A software reverse engineering (SRE) suite of tools developed by NSA's Research Directorate in support of the Cybersecurity mission";
+    homepage = "https://ghidra-sre.org/";
+    platforms = [ "x86_64-linux" ];
+    license = licenses.asl20;
+    maintainers = [ maintainers.ck3d ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1447,6 +1447,8 @@ in
 
   gh-ost = callPackage ../tools/misc/gh-ost { };
 
+  ghidra-bin = callPackage ../tools/security/ghidra { };
+
   gif-for-cli = callPackage ../tools/misc/gif-for-cli { };
 
   gist = callPackage ../tools/text/gist { };


### PR DESCRIPTION
I tested basic usage of tool CodeBrowser.
The tool VersionTracking raises an error.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

