### PR TITLE
libsepol: 2.7 -> 2.8

### DIFF
--- a/pkgs/os-specific/linux/libsepol/default.nix
+++ b/pkgs/os-specific/linux/libsepol/default.nix
@@ -2,15 +2,15 @@
 
 stdenv.mkDerivation rec {
   name = "libsepol-${version}";
-  version = "2.7";
-  se_release = "20170804";
+  version = "2.8";
+  se_release = "20180524";
   se_url = "https://raw.githubusercontent.com/wiki/SELinuxProject/selinux/files/releases";
 
   outputs = [ "bin" "out" "dev" "man" ];
 
   src = fetchurl {
     url = "${se_url}/${se_release}/libsepol-${version}.tar.gz";
-    sha256 = "1rzr90d3f1g5wy1b8sh6fgnqb9migys2zgpjmpakn6lhxkc3p7fn";
+    sha256 = "1mi4kpx7b94wjphv8k2fz5b8rd7mllvq1k4ssjxg1gjjhdm93mis";
   };
 
   nativeBuildInputs = [ flex ];
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     description = "SELinux binary policy manipulation library";
     homepage = http://userspace.selinuxproject.org;
     platforms = platforms.linux;
-    maintainers = [ maintainers.phreedom ];
+    maintainers = with maintainers; [ phreedom e-user ];
     license = stdenv.lib.licenses.gpl2;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update libsepol to 2.8, required to fix NixOS/nix#2374.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

