### PR TITLE
libselinux 2.7 -> 2.8

### DIFF
--- a/pkgs/os-specific/linux/libselinux/default.nix
+++ b/pkgs/os-specific/linux/libselinux/default.nix
@@ -9,14 +9,14 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "libselinux-${version}";
-  version = "2.7";
+  version = "2.8";
   inherit (libsepol) se_release se_url;
 
   outputs = [ "bin" "out" "dev" "man" "py" ];
 
   src = fetchurl {
     url = "${se_url}/${se_release}/libselinux-${version}.tar.gz";
-    sha256 = "0mwcq78v6ngbq06xmb9dvilpg0jnl2vs9fgrpakhmmiskdvc1znh";
+    sha256 = "1qc7c6lzvhs9sdgqalg1rxni3a88d989hgrw5f8i1kj3fvn9dnri";
   };
 
   nativeBuildInputs = [ pkgconfig ] ++ optionals enablePython [ swig python ];
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     "MAN3DIR=$(man)/share/man/man3"
     "MAN5DIR=$(man)/share/man/man5"
     "MAN8DIR=$(man)/share/man/man8"
-    "PYSITEDIR=$(py)/${python.sitePackages}"
+    "PYTHONLIBDIR=$(py)/${python.sitePackages}"
     "SBINDIR=$(bin)/sbin"
     "SHLIBDIR=$(out)/lib"
 

--- a/pkgs/os-specific/linux/libsepol/default.nix
+++ b/pkgs/os-specific/linux/libsepol/default.nix
@@ -2,15 +2,15 @@
 
 stdenv.mkDerivation rec {
   name = "libsepol-${version}";
-  version = "2.7";
-  se_release = "20170804";
+  version = "2.8";
+  se_release = "20180524";
   se_url = "https://raw.githubusercontent.com/wiki/SELinuxProject/selinux/files/releases";
 
   outputs = [ "bin" "out" "dev" "man" ];
 
   src = fetchurl {
     url = "${se_url}/${se_release}/libsepol-${version}.tar.gz";
-    sha256 = "1rzr90d3f1g5wy1b8sh6fgnqb9migys2zgpjmpakn6lhxkc3p7fn";
+    sha256 = "1mi4kpx7b94wjphv8k2fz5b8rd7mllvq1k4ssjxg1gjjhdm93mis";
   };
 
   nativeBuildInputs = [ flex ];
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     description = "SELinux binary policy manipulation library";
     homepage = http://userspace.selinuxproject.org;
     platforms = platforms.linux;
-    maintainers = [ maintainers.phreedom ];
+    maintainers = with maintainers; [ phreedom e-user ];
     license = stdenv.lib.licenses.gpl2;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update libselinux to 2.8, required to fix NixOS/nix#2374.
Depends on #56960.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

