### PR TITLE
selinux: 2.7 -> 2.8

### DIFF
--- a/pkgs/os-specific/linux/checkpolicy/default.nix
+++ b/pkgs/os-specific/linux/checkpolicy/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "checkpolicy-${version}";
-  version = "2.7";
+  version = "2.8";
   inherit (libsepol) se_release se_url;
 
   src = fetchurl {
     url = "${se_url}/${se_release}/checkpolicy-${version}.tar.gz";
-    sha256 = "009j9jc0hi4l7k8f21hn8fm25n0mqgzdpd4nk30nds6d3nglf4sl";
+    sha256 = "1j4lh44nikxahkrbiz5265ar9fqxrzm6a4vlpz1mi3mq4hf83v4x";
   };
 
   nativeBuildInputs = [ bison flex ];

--- a/pkgs/os-specific/linux/libselinux/default.nix
+++ b/pkgs/os-specific/linux/libselinux/default.nix
@@ -9,14 +9,14 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "libselinux-${version}";
-  version = "2.7";
+  version = "2.8";
   inherit (libsepol) se_release se_url;
 
   outputs = [ "bin" "out" "dev" "man" "py" ];
 
   src = fetchurl {
     url = "${se_url}/${se_release}/libselinux-${version}.tar.gz";
-    sha256 = "0mwcq78v6ngbq06xmb9dvilpg0jnl2vs9fgrpakhmmiskdvc1znh";
+    sha256 = "1qc7c6lzvhs9sdgqalg1rxni3a88d989hgrw5f8i1kj3fvn9dnri";
   };
 
   nativeBuildInputs = [ pkgconfig ] ++ optionals enablePython [ swig python ];
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     "MAN3DIR=$(man)/share/man/man3"
     "MAN5DIR=$(man)/share/man/man5"
     "MAN8DIR=$(man)/share/man/man8"
-    "PYSITEDIR=$(py)/${python.sitePackages}"
+    "PYTHONLIBDIR=$(py)/${python.sitePackages}"
     "SBINDIR=$(bin)/sbin"
     "SHLIBDIR=$(out)/lib"
 

--- a/pkgs/os-specific/linux/libsemanage/default.nix
+++ b/pkgs/os-specific/linux/libsemanage/default.nix
@@ -6,12 +6,12 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "libsemanage-${version}";
-  version = "2.7";
+  version = "2.8";
   inherit (libsepol) se_release se_url;
 
   src = fetchurl {
     url = "${se_url}/${se_release}/libsemanage-${version}.tar.gz";
-    sha256 = "0xnlp1yg8b1aqc6kq3pss1i1nl06rfj4x4pyl5blasnf2ivlgs87";
+    sha256 = "1qm8pr67w08xrkqfky6qvy3r18w4bh873qr1dj960m0yqp9fh38w";
   };
 
   nativeBuildInputs = [ bison flex pkgconfig ];
@@ -19,11 +19,9 @@ stdenv.mkDerivation rec {
     ++ optionals enablePython [ swig python ];
 
   preBuild = ''
-    makeFlagsArray+=("PREFIX=$out")
+    makeFlagsArray+=("PREFIX=/")
     makeFlagsArray+=("DESTDIR=$out")
-    makeFlagsArray+=("MAN3DIR=$out/share/man/man3")
-    makeFlagsArray+=("MAN5DIR=$out/share/man/man5")
-    makeFlagsArray+=("PYSITEDIR=$out/lib/${python.libPrefix}/site-packages")
+    makeFlagsArray+=("PYTHONLIBDIR=lib/${python.libPrefix}/site-packages")
   '';
 
   installTargets = [ "install" ] ++ optionals enablePython [ "install-pywrap" ];

--- a/pkgs/os-specific/linux/libsepol/default.nix
+++ b/pkgs/os-specific/linux/libsepol/default.nix
@@ -2,15 +2,15 @@
 
 stdenv.mkDerivation rec {
   name = "libsepol-${version}";
-  version = "2.7";
-  se_release = "20170804";
+  version = "2.8";
+  se_release = "20180524";
   se_url = "https://raw.githubusercontent.com/wiki/SELinuxProject/selinux/files/releases";
 
   outputs = [ "bin" "out" "dev" "man" ];
 
   src = fetchurl {
     url = "${se_url}/${se_release}/libsepol-${version}.tar.gz";
-    sha256 = "1rzr90d3f1g5wy1b8sh6fgnqb9migys2zgpjmpakn6lhxkc3p7fn";
+    sha256 = "1mi4kpx7b94wjphv8k2fz5b8rd7mllvq1k4ssjxg1gjjhdm93mis";
   };
 
   nativeBuildInputs = [ flex ];
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     description = "SELinux binary policy manipulation library";
     homepage = http://userspace.selinuxproject.org;
     platforms = platforms.linux;
-    maintainers = [ maintainers.phreedom ];
+    maintainers = with maintainers; [ phreedom e-user ];
     license = stdenv.lib.licenses.gpl2;
   };
 }

--- a/pkgs/os-specific/linux/policycoreutils/default.nix
+++ b/pkgs/os-specific/linux/policycoreutils/default.nix
@@ -1,13 +1,13 @@
-{ stdenv, fetchurl, gettext, libsepol, libselinux, libsemanage }:
+{ stdenv, fetchurl, gettext, libsepol, libselinux, libsemanage, audit, pam }:
 
 stdenv.mkDerivation rec {
   name = "policycoreutils-${version}";
-  version = "2.7";
+  version = "2.8";
   inherit (libsepol) se_release se_url;
 
   src = fetchurl {
     url = "${se_url}/${se_release}/policycoreutils-${version}.tar.gz";
-    sha256 = "1x742c7lkw30namhkw87yg7z384qzqjz0pvmqs0lk19v6958l6qa";
+    sha256 = "168hph0y2paqn5hvc0ygw9lfxchylmgc7dy2sxxfwyzj6ni56rcq";
   };
 
   postPatch = ''
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ gettext ];
-  buildInputs = [ libsepol libselinux libsemanage ];
+  buildInputs = [ libsepol libselinux libsemanage audit pam ];
 
   preBuild = ''
     makeFlagsArray+=("PREFIX=$out")

--- a/pkgs/os-specific/linux/semodule-utils/default.nix
+++ b/pkgs/os-specific/linux/semodule-utils/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "semodule-utils-${version}";
-  version = "2.7";
+  version = "2.8";
 
   inherit (libsepol) se_release se_url;
 
   src = fetchurl {
     url = "${se_url}/${se_release}/${name}.tar.gz";
-    sha256 = "1fl60x4w8rn5bcwy68sy48aydwsn1a17d48slni4sfx4c8rqpjch";
+    sha256 = "1pya3i6ggpl9hzfjhy74n4c91yqyzr6spkj3n5078qqc0w9rrxa4";
   };
 
   buildInputs = [ libsepol ];
@@ -21,7 +21,6 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "SELinux policy core utilities (packaging additions)";
     license = licenses.gpl2;
-    inherit (libsepol.meta) homepage platforms;
-    maintainers = [ maintainers.e-user ];
+    inherit (libsepol.meta) homepage platforms maintainers;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update checkpolicy, policycoreutils, semodule-utils, libsemanage, libselinux and libsepol to 2.8, required to fix NixOS/nix#2374.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

