### PR TITLE
strongswan: Make it build on macOS

### DIFF
--- a/pkgs/tools/networking/strongswan/default.nix
+++ b/pkgs/tools/networking/strongswan/default.nix
@@ -8,6 +8,7 @@
 , enableTNC            ? false, trousers, sqlite, libxml2
 , enableNetworkManager ? false, networkmanager
 , libpcap
+, darwin
 }:
 
 # Note on curl support: If curl is built with gnutls as its backend, the
@@ -29,9 +30,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig autoreconfHook ];
   buildInputs =
-    [ curl gmp python iptables ldns unbound openssl pcsclite ]
+    [ curl gmp python ldns unbound openssl pcsclite ]
     ++ optionals enableTNC [ trousers sqlite libxml2 ]
-    ++ optionals stdenv.isLinux [ systemd.dev pam ]
+    ++ optionals stdenv.isLinux [ systemd.dev pam iptables ]
+    ++ optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ SystemConfiguration ])
     ++ optionals enableNetworkManager [ networkmanager ]
     # ad-hoc fix for https://github.com/NixOS/nixpkgs/pull/51787
     # Remove when the above PR lands in master
@@ -41,23 +43,24 @@ stdenv.mkDerivation rec {
     ./ext_auth-path.patch
     ./firewall_defaults.patch
     ./updown-path.patch
-    (substituteAll {
+    (optional stdenv.isLinux (substituteAll {
       src = ./modprobe-path.patch;
       inherit kmod;
-    })
+    }))
   ];
 
   postPatch = ''
-    substituteInPlace src/libcharon/plugins/resolve/resolve_handler.c --replace "/sbin/resolvconf" "${openresolv}/sbin/resolvconf"
-
     # swanctl can be configured by files in SWANCTLDIR which defaults to
     # $out/etc/swanctl. Since that directory is in the nix store users can't
     # modify it. Ideally swanctl accepts a command line option for specifying
     # the configuration files. In the absence of that we patch swanctl to look
     # for configuration files in /etc/swanctl.
     substituteInPlace src/swanctl/swanctl.h --replace "SWANCTLDIR" "\"/etc/swanctl\""
+    '' + optionalString stdenv.isLinux ''
     # glibc-2.26 reorganized internal includes
     sed '1i#include <stdint.h>' -i src/libstrongswan/utils/utils/memory.h
+
+    substituteInPlace src/libcharon/plugins/resolve/resolve_handler.c --replace "/sbin/resolvconf" "${openresolv}/sbin/resolvconf"
     '';
 
   preConfigure = ''
@@ -65,17 +68,24 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags =
-    [ "--enable-swanctl" "--enable-cmd" "--enable-systemd"
-      "--enable-farp" "--enable-dhcp"
+    [ "--enable-swanctl"
+      "--enable-cmd"
       "--enable-openssl"
       "--enable-eap-sim" "--enable-eap-sim-file" "--enable-eap-simaka-pseudonym"
       "--enable-eap-simaka-reauth" "--enable-eap-identity" "--enable-eap-md5"
       "--enable-eap-gtc" "--enable-eap-aka" "--enable-eap-aka-3gpp2"
       "--enable-eap-mschapv2" "--enable-eap-radius" "--enable-xauth-eap" "--enable-ext-auth"
-      "--enable-forecast" "--enable-connmark" "--enable-acert"
+      "--enable-acert"
       "--enable-pkcs11" "--enable-eap-sim-pcsc" "--enable-dnscert" "--enable-unbound"
-      "--enable-af-alg" "--enable-xauth-pam" "--enable-chapoly"
+      "--enable-chapoly"
       "--enable-curl" ]
+    ++ optionals stdenv.isLinux [
+      "--enable-farp" "--enable-dhcp"
+      "--enable-systemd"
+      "--enable-xauth-pam"
+      "--enable-forecast"
+      "--enable-connmark"
+      "--enable-af-alg" ]
     ++ optionals stdenv.isx86_64 [ "--enable-aesni" "--enable-rdrand" ]
     ++ optional (stdenv.hostPlatform.system == "i686-linux") "--enable-padlock"
     ++ optionals enableTNC [
@@ -89,7 +99,17 @@ stdenv.mkDerivation rec {
          "--enable-sqlite" ]
     ++ optionals enableNetworkManager [
          "--enable-nm"
-         "--with-nm-ca-dir=/etc/ssl/certs"
+         "--with-nm-ca-dir=/etc/ssl/certs" ]
+    # Taken from: https://wiki.strongswan.org/projects/strongswan/wiki/MacOSX
+    ++ optionals stdenv.isDarwin [
+      "--disable-systemd"
+      "--disable-xauth-pam"
+      "--disable-kernel-netlink"
+      "--enable-kernel-pfkey"
+      "--enable-kernel-pfroute"
+      "--enable-kernel-libipsec"
+      "--enable-osx-attr"
+      "--disable-scripts"
     ];
 
   postInstall = ''
@@ -97,7 +117,7 @@ stdenv.mkDerivation rec {
     echo "include /etc/ipsec.secrets" >> $out/etc/ipsec.secrets
   '';
 
-  NIX_LDFLAGS = "-lgcc_s" ;
+  NIX_LDFLAGS = optionalString stdenv.cc.isGNU "-lgcc_s" ;
 
   meta = {
     description = "OpenSource IPsec-based VPN Solution";


### PR DESCRIPTION
###### Motivation for this change

Original expression could not be built on macOS due to using dependencies to
Linux only packages. This change fixes that by grouping the dependencies based
on the suitable system. In addition, it uses `configure` flags recommended by
the project for building on macOS, as well the ones used by Homebrew.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

