### PR TITLE
python2Packages.moinmoin: 1.9.9 -> 1.9.10

### DIFF
--- a/pkgs/development/python-modules/moinmoin/default.nix
+++ b/pkgs/development/python-modules/moinmoin/default.nix
@@ -4,24 +4,24 @@
 
 buildPythonPackage rec {
   pname = "moinmoin";
-  version = "1.9.9";
+  version = "1.9.10";
 
   # SyntaxError in setup.py
   disabled = isPy3k;
 
   src = fetchurl {
     url = "http://static.moinmo.in/files/moin-${version}.tar.gz";
-    sha256 = "197ga41qghykmir80ik17f9hjpmixslv3zjgj7bj9qvs1dvdg5s3";
+    sha256 = "0g05lnl1s8v61phi3z1g3b6lfj4g98grj9kw8nyjl246x0c489ja";
   };
 
   patches = [
     # Recommended to install on their download page.
-    (fetchpatch {
-      url = "https://bitbucket.org/thomaswaldmann/moin-1.9/commits/561b7a9c2bd91b61d26cd8a5f39aa36bf5c6159e/raw";
-      sha256 = "1nscnl9nspnrwyf3n95ig0ihzndryinq9kkghliph6h55cncfc65";
-    })
     ./fix_tests.patch
   ];
+
+  prePatch = ''
+    sed -i "s/\xfc/ü/" setup.cfg
+  '';
 
   checkInputs = [ pytest werkzeug pygments ];
 


### PR DESCRIPTION
###### Motivation for this change

Changes:

https://github.com/moinwiki/moin-1.9/blob/1.9.10/docs/CHANGES#L13

This commit also replaces a ISO-8859-1 character in setup.cfg to fix the
build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

