### PR TITLE
chromium (72): Add hardware video decoding using VAAPI

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -29,6 +29,7 @@
 , proprietaryCodecs ? true
 , cupsSupport ? true
 , pulseSupport ? false, libpulseaudio ? null
+, VAAPISupport ? false, libva ? null
 
 , upstream-info
 }:
@@ -127,6 +128,7 @@ let
       ++ optionals gnomeSupport [ gnome.GConf libgcrypt ]
       ++ optionals cupsSupport [ libgcrypt cups ]
       ++ optional pulseSupport libpulseaudio
+      ++ optional (VAAPISupport && (versionAtLeast version "72")) libva
       ++ optional (versionAtLeast version "72") jdk.jre;
 
     patches = optional enableWideVine ./patches/widevine.patch ++ [
@@ -143,6 +145,11 @@ let
       # ++ optional (versionRange "68" "72") ( githubPatch "<patch>" "0000000000000000000000000000000000000000000000000000000000000000" )
     ] ++ optionals (!stdenv.cc.isClang && (versionRange "71" "72")) [
       ( githubPatch "65be571f6ac2f7942b4df9e50b24da517f829eec" "1sqv0aba0mpdi4x4f21zdkxz2cf8ji55ffgbfcr88c5gcg0qn2jh" )
+    ] ++ optionals (VAAPISupport && (versionRange "72" "73")) [
+      ./patches/enable-vaapi-72.patch
+      ./patches/vaapi-relax-the-version-check-for-VA-API-72.patch
+      ./patches/enable-mojo-video-decoders-by-default-72.patch
+      ./patches/vaapi-fix-the-VA_CHECK_VERSION-72.patch
     ] ++ optional stdenv.isAarch64
            (if (versionOlder version "71") then
               fetchpatch {
@@ -261,6 +268,8 @@ let
     } // optionalAttrs pulseSupport {
       use_pulseaudio = true;
       link_pulseaudio = true;
+    } // optionalAttrs (VAAPISupport && (versionRange "72" "73")) {
+      use_vaapi = true;
     } // (extraAttrs.gnFlags or {}));
 
     configurePhase = ''

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -128,7 +128,7 @@ let
       ++ optionals gnomeSupport [ gnome.GConf libgcrypt ]
       ++ optionals cupsSupport [ libgcrypt cups ]
       ++ optional pulseSupport libpulseaudio
-      ++ optional (VAAPISupport && (versionAtLeast version "72")) libva
+      ++ optional VAAPISupport libva
       ++ optional (versionAtLeast version "72") jdk.jre;
 
     patches = optional enableWideVine ./patches/widevine.patch ++ [
@@ -145,11 +145,9 @@ let
       # ++ optional (versionRange "68" "72") ( githubPatch "<patch>" "0000000000000000000000000000000000000000000000000000000000000000" )
     ] ++ optionals (!stdenv.cc.isClang && (versionRange "71" "72")) [
       ( githubPatch "65be571f6ac2f7942b4df9e50b24da517f829eec" "1sqv0aba0mpdi4x4f21zdkxz2cf8ji55ffgbfcr88c5gcg0qn2jh" )
-    ] ++ optionals (VAAPISupport && (versionRange "72" "73")) [
+    ] ++ optionals VAAPISupport [
       ./patches/enable-vaapi-72.patch
-      ./patches/vaapi-relax-the-version-check-for-VA-API-72.patch
       ./patches/enable-mojo-video-decoders-by-default-72.patch
-      ./patches/vaapi-fix-the-VA_CHECK_VERSION-72.patch
     ] ++ optional stdenv.isAarch64
            (if (versionOlder version "71") then
               fetchpatch {
@@ -268,7 +266,7 @@ let
     } // optionalAttrs pulseSupport {
       use_pulseaudio = true;
       link_pulseaudio = true;
-    } // optionalAttrs (VAAPISupport && (versionRange "72" "73")) {
+    } // optionalAttrs VAAPISupport {
       use_vaapi = true;
     } // (extraAttrs.gnFlags or {}));
 

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -90,13 +90,13 @@ in stdenv.mkDerivation {
 
   outputs = ["out" "sandbox"];
 
-  buildCommand = let
+  buildCommand = with stdenv.lib; let
     browserBinary = "${chromium.browser}/libexec/chromium/chromium";
     getWrapperFlags = plugin: "$(< \"${plugin}/nix-support/wrapper-flags\")";
-    libPath = stdenv.lib.makeLibraryPath (
-      versionAtLeast version "72" && stdenv.lib.optional VAAPISupport libva
+    libPath = makeLibraryPath (
+      optional (versionAtLeast version "72" && VAAPISupport) libva
     );
-  in with stdenv.lib; ''
+  in ''
     mkdir -p "$out/bin"
 
     eval makeWrapper "${browserBinary}" "$out/bin/chromium" \

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -16,6 +16,8 @@
 , VAAPISupport ? false, libva ? null
 }:
 
+assert VAAPISupport -> libva != null;
+
 let
   stdenv_ = if stdenv.isAarch64 then gcc8Stdenv else llvmPackages_7.stdenv;
   llvmPackages_ = if stdenv.isAarch64 then llvmPackages else llvmPackages_7;
@@ -74,7 +76,10 @@ in let
 
   version = chromium.browser.version;
 
-in stdenv.mkDerivation {
+
+in
+  assert VAAPISupport -> stdenv.lib.versionAtLeast version "72";
+  stdenv.mkDerivation {
   name = "chromium${suffix}-${version}";
   inherit version;
 
@@ -94,7 +99,7 @@ in stdenv.mkDerivation {
     browserBinary = "${chromium.browser}/libexec/chromium/chromium";
     getWrapperFlags = plugin: "$(< \"${plugin}/nix-support/wrapper-flags\")";
     libPath = makeLibraryPath (
-      optional (versionAtLeast version "72" && VAAPISupport) libva
+      optional VAAPISupport libva
     );
   in ''
     mkdir -p "$out/bin"

--- a/pkgs/applications/networking/browsers/chromium/patches/enable-mojo-video-decoders-by-default-72.patch
+++ b/pkgs/applications/networking/browsers/chromium/patches/enable-mojo-video-decoders-by-default-72.patch
@@ -1,0 +1,104 @@
+From 31225b9c5f3f685d65f742dc129241c30c32157c Mon Sep 17 00:00:00 2001
+From: Julien Isorce <julien.isorce@chromium.org>
+Date: Sat, 15 Dec 2018 01:02:18 +0000
+Subject: [PATCH] Enable mojo video decoders by default on Linux desktop if
+ use_vaapi is true
+
+Already the case for ChromeOS, Mac and Win. And run the service
+in the GPU process too. Except that here the gn arg use_vaapi
+has to be true as well.
+
+Note that this CL does not change the following:
+  - the gn arg 'use_vaapi' is still false by default on Linux,
+    see media/gpu/args.gni
+  - 'accelerated_video_decode' is still black listed on Linux,
+    see entry 48 in gpu/config/software_rendering_list.json
+  - it is still not possible to enable hw video decode from
+    about:flags, see chrome/browser/about_flags.cc
+
+Also note that with this CL the ffmpeg and libvpx video decoders
+are still selected thanks to media::DecoderSelector::SelectDecoder
+in case vaapi fails to initialize.
+
+Also see https://chromium-review.googlesource.com/c/chromium/src/+/1225275/
+which was very similar but for ChromeOS.
+
+Tested on Linux desktop with gn args:
+  - use_vaapi = true (default is false)
+  ./out/release/chrome --ignore-gpu-blacklist --use-gl=desktop url_to_vp9_video
+  ./out/release/chrome --ignore-gpu-blacklist --use-gl=egl url_to_vp9_video
+   -> MojoVideoDecoder was in use and VaapiVideoDecodeAccelerator runing in the
+      GPU process, through MojoVideoDecoderService
+
+
+Bug: 522298
+Change-Id: Ia19f9f3edc0af488a477a16001b7de4f4818b3b2
+Reviewed-on: https://chromium-review.googlesource.com/c/1370717
+Reviewed-by: Dan Sanders <sandersd@chromium.org>
+Commit-Queue: Julien Isorce <julien.isorce@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#616901}
+---
+ media/media_options.gni                      | 9 ++++++---
+ media/mojo/services/gpu_mojo_media_client.cc | 5 +++--
+ 2 files changed, 9 insertions(+), 5 deletions(-)
+
+diff --git a/media/media_options.gni b/media/media_options.gni
+index 46eaa58181..6e338f651b 100644
+--- a/media/media_options.gni
++++ b/media/media_options.gni
+@@ -5,6 +5,7 @@
+ import("//build/config/chrome_build.gni")
+ import("//build/config/chromecast_build.gni")
+ import("//build/config/features.gni")
++import("//media/gpu/args.gni")
+ import("//testing/libfuzzer/fuzzer_test.gni")
+ 
+ # Do not expand this list without double-checking with OWNERS, this is a list of
+@@ -129,8 +130,9 @@ declare_args() {
+   # |mojo_media_services|). When enabled, selected mojo paths will be enabled in
+   # the media pipeline and corresponding services will hosted in the selected
+   # remote process (e.g. "utility" process, see |mojo_media_host|).
+-  enable_mojo_media = is_android || is_chromecast || is_chromeos || is_mac ||
+-                      is_win || enable_library_cdms
++  enable_mojo_media =
++      is_android || is_chromecast || is_chromeos || is_mac || is_win ||
++      enable_library_cdms || (is_desktop_linux && use_vaapi)
+ 
+   # Enable the TestMojoMediaClient to be used in mojo MediaService. This is for
+   # testing only and will override the default platform MojoMediaClient, if any.
+@@ -200,7 +202,8 @@ if (enable_mojo_media) {
+       ]
+       _default_mojo_media_host = "gpu"
+     }
+-  } else if (is_chromeos || is_mac || is_win) {
++  } else if (is_chromeos || is_mac || is_win ||
++             (is_desktop_linux && use_vaapi)) {
+     _default_mojo_media_services = [ "video_decoder" ]
+     _default_mojo_media_host = "gpu"
+   }
+diff --git a/media/mojo/services/gpu_mojo_media_client.cc b/media/mojo/services/gpu_mojo_media_client.cc
+index 75f5e611c7..f056e1b315 100644
+--- a/media/mojo/services/gpu_mojo_media_client.cc
++++ b/media/mojo/services/gpu_mojo_media_client.cc
+@@ -54,7 +54,7 @@ namespace media {
+ namespace {
+ 
+ #if defined(OS_ANDROID) || defined(OS_CHROMEOS) || defined(OS_MACOSX) || \
+-    defined(OS_WIN)
++    defined(OS_WIN) || defined(OS_LINUX)
+ gpu::CommandBufferStub* GetCommandBufferStub(
+     base::WeakPtr<MediaGpuChannelManager> media_gpu_channel_manager,
+     base::UnguessableToken channel_token,
+@@ -148,7 +148,8 @@ std::unique_ptr<VideoDecoder> GpuMojoMediaClient::CreateVideoDecoder(
+       android_overlay_factory_cb_, std::move(request_overlay_info_cb),
+       std::make_unique<VideoFrameFactoryImpl>(gpu_task_runner_,
+                                               std::move(get_stub_cb)));
+-#elif defined(OS_CHROMEOS) || defined(OS_MACOSX) || defined(OS_WIN)
++#elif defined(OS_CHROMEOS) || defined(OS_MACOSX) || defined(OS_WIN) || \
++    defined(OS_LINUX)
+   std::unique_ptr<VideoDecoder> vda_video_decoder = VdaVideoDecoder::Create(
+       task_runner, gpu_task_runner_, media_log->Clone(), target_color_space,
+       gpu_preferences_, gpu_workarounds_,
+-- 
+2.20.1
+

--- a/pkgs/applications/networking/browsers/chromium/patches/enable-vaapi-72.patch
+++ b/pkgs/applications/networking/browsers/chromium/patches/enable-vaapi-72.patch
@@ -1,0 +1,116 @@
+From abc7295ca1653c85472916909f0eb76e28e79a58 Mon Sep 17 00:00:00 2001
+From: Akarshan Biswas <akarshan.biswas@gmail.com>
+Date: Thu, 24 Jan 2019 12:45:29 +0530
+Subject: [PATCH] Enable mojo with VDA2 on Linux
+
+---
+ chrome/browser/about_flags.cc                |  8 ++++----
+ chrome/browser/flag_descriptions.cc          |  9 +++++++--
+ chrome/browser/flag_descriptions.h           | 10 ++++++++--
+ gpu/config/software_rendering_list.json      |  3 ++-
+ media/media_options.gni                      |  9 ++++++---
+ media/mojo/services/gpu_mojo_media_client.cc |  4 ++--
+ 6 files changed, 29 insertions(+), 14 deletions(-)
+
+diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
+index 0a84c6ac1..be2aa1d8b 100644
+--- a/chrome/browser/about_flags.cc
++++ b/chrome/browser/about_flags.cc
+@@ -1714,7 +1714,7 @@ const FeatureEntry kFeatureEntries[] = {
+         "disable-accelerated-video-decode",
+         flag_descriptions::kAcceleratedVideoDecodeName,
+         flag_descriptions::kAcceleratedVideoDecodeDescription,
+-        kOsMac | kOsWin | kOsCrOS | kOsAndroid,
++        kOsMac | kOsWin | kOsCrOS | kOsAndroid | kOsLinux,
+         SINGLE_DISABLE_VALUE_TYPE(switches::kDisableAcceleratedVideoDecode),
+     },
+ #if defined(OS_WIN)
+@@ -2345,12 +2345,12 @@ const FeatureEntry kFeatureEntries[] = {
+      FEATURE_VALUE_TYPE(service_manager::features::kXRSandbox)},
+ #endif  // ENABLE_ISOLATED_XR_SERVICE
+ #endif  // ENABLE_VR
+-#if defined(OS_CHROMEOS)
++#if defined(OS_CHROMEOS) || defined(OS_LINUX)
+     {"disable-accelerated-mjpeg-decode",
+      flag_descriptions::kAcceleratedMjpegDecodeName,
+-     flag_descriptions::kAcceleratedMjpegDecodeDescription, kOsCrOS,
++     flag_descriptions::kAcceleratedMjpegDecodeDescription, kOsCrOS | kOsLinux,
+      SINGLE_DISABLE_VALUE_TYPE(switches::kDisableAcceleratedMjpegDecode)},
+-#endif  // OS_CHROMEOS
++#endif  // OS_CHROMEOS // OS_LINUX
+     {"v8-cache-options", flag_descriptions::kV8CacheOptionsName,
+      flag_descriptions::kV8CacheOptionsDescription, kOsAll,
+      MULTI_VALUE_TYPE(kV8CacheOptionsChoices)},
+diff --git a/chrome/browser/flag_descriptions.cc b/chrome/browser/flag_descriptions.cc
+index 62637e092..86f89fc6e 100644
+--- a/chrome/browser/flag_descriptions.cc
++++ b/chrome/browser/flag_descriptions.cc
+@@ -3085,15 +3085,20 @@ const char kTextSuggestionsTouchBarDescription[] =
+ 
+ #endif
+ 
+-// Chrome OS -------------------------------------------------------------------
++// Chrome OS Linux-------------------------------------------------------------------
+ 
+-#if defined(OS_CHROMEOS)
++#if defined(OS_CHROMEOS) || (defined(OS_LINUX) && !defined(OS_ANDROID))
+ 
+ const char kAcceleratedMjpegDecodeName[] =
+     "Hardware-accelerated mjpeg decode for captured frame";
+ const char kAcceleratedMjpegDecodeDescription[] =
+     "Enable hardware-accelerated mjpeg decode for captured frame where "
+     "available.";
++#endif
++
++// Chrome OS --------------------------------------------------
++
++#if defined(OS_CHROMEOS)
+ 
+ const char kAllowTouchpadThreeFingerClickName[] = "Touchpad three-finger-click";
+ const char kAllowTouchpadThreeFingerClickDescription[] =
+diff --git a/chrome/browser/flag_descriptions.h b/chrome/browser/flag_descriptions.h
+index 5dac660bb..6cc4115da 100644
+--- a/chrome/browser/flag_descriptions.h
++++ b/chrome/browser/flag_descriptions.h
+@@ -1846,13 +1846,19 @@ extern const char kPermissionPromptPersistenceToggleDescription[];
+ 
+ #endif  // defined(OS_MACOSX)
+ 
+-// Chrome OS ------------------------------------------------------------------
++// Chrome OS and Linux ------------------------------------------------------------------
+ 
+-#if defined(OS_CHROMEOS)
++#if defined(OS_CHROMEOS) || (defined(OS_LINUX) && !defined(OS_ANDROID))
+ 
+ extern const char kAcceleratedMjpegDecodeName[];
+ extern const char kAcceleratedMjpegDecodeDescription[];
+ 
++#endif // defined(OS_CHROMEOS) || (defined(OS_LINUX) && !defined(OS_ANDROID))
++
++// Chrome OS ------------------------------------------------------------------------
++
++#if defined(OS_CHROMEOS)
++
+ extern const char kAllowTouchpadThreeFingerClickName[];
+ extern const char kAllowTouchpadThreeFingerClickDescription[];
+ 
+diff --git a/gpu/config/software_rendering_list.json b/gpu/config/software_rendering_list.json
+index 65f37b3f1..ae8a1718f 100644
+--- a/gpu/config/software_rendering_list.json
++++ b/gpu/config/software_rendering_list.json
+@@ -371,11 +371,12 @@
+     },
+     {
+       "id": 48,
+-      "description": "Accelerated video decode is unavailable on Linux",
++      "description": "Accelerated VA-API video decode is not supported on NVIDIA platforms",
+       "cr_bugs": [137247],
+       "os": {
+         "type": "linux"
+       },
++      "vendor_id": "0x10de",
+       "features": [
+         "accelerated_video_decode"
+       ]
+-- 
+2.20.1

--- a/pkgs/applications/networking/browsers/chromium/patches/vaapi-fix-the-VA_CHECK_VERSION-72.patch
+++ b/pkgs/applications/networking/browsers/chromium/patches/vaapi-fix-the-VA_CHECK_VERSION-72.patch
@@ -1,0 +1,74 @@
+From 674fb0486a1b525cb850530c4cdc79506338bd37 Mon Sep 17 00:00:00 2001
+From: Azhar Shaikh <azhar.shaikh@intel.com>
+Date: Fri, 11 Jan 2019 07:44:38 +0000
+Subject: [PATCH] media/gpu/vaapi: Fix the VA_CHECK_VERSION
+
+commit 6f1309ef8fe109 ("media/gpu/vaapi: Relax the version
+check for VA-API") added the VA_CHECK_VERSION to relax the
+VA-API version check. But it still does the same thing as
+the previous check. VA_CHECK_VERSION will return 'true', only
+when the VA-API version is greater than or equal to the
+parameters passed to it. So in this case when the major and
+minor version were passed from vaInitialize() output, it did
+the same strict check as earlier. When trying to update libva
+to a newer version, there will still be a mismatch, since
+vaInitialize() would return the updated/newer libva version
+installed on the system, but the chromium would still be built
+with older version (libva-2.1.0 as of now).
+To fix this and actually relax the check, make sure the system
+version of libva is greater than the libva version with which
+the browser is built, since libva is backward compatible. This
+will allow any future libva updates without breaking existing code.
+
+Fixes: 6f1309ef8fe109 ("media/gpu/vaapi: Relax the version check for VA-API")
+
+Bug: 905814
+TEST=Below scenarios were tested and h/w acceleration is working successfully.
+TEST=Build chromium with libva-2.3.0 and system version 2.3.0
+TEST=Build chromium with libva-2.1.0 and system version 2.3.0
+TEST=Build chromium with libva 2.1.0 and system version 2.1.0
+
+Signed-off-by: Azhar Shaikh <azhar.shaikh@intel.com>
+Change-Id: I1ec14aabed21b7d6b6fc55080bbac17233c40ec0
+Reviewed-on: https://chromium-review.googlesource.com/c/1376716
+Commit-Queue: Alexandre Courbot <acourbot@chromium.org>
+Reviewed-by: Alexandre Courbot <acourbot@chromium.org>
+Reviewed-by: Miguel Casas <mcasas@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#621940}
+---
+ media/gpu/vaapi/vaapi_wrapper.cc | 19 ++++++++++---------
+ 1 file changed, 10 insertions(+), 9 deletions(-)
+
+diff --git a/media/gpu/vaapi/vaapi_wrapper.cc b/media/gpu/vaapi/vaapi_wrapper.cc
+index 4921aabf64..93d7c98b80 100644
+--- a/media/gpu/vaapi/vaapi_wrapper.cc
++++ b/media/gpu/vaapi/vaapi_wrapper.cc
+@@ -337,15 +337,16 @@ bool VADisplayState::InitializeOnce() {
+            << va_vendor_string_;
+ 
+   // The VAAPI version is determined from what is loaded on the system by
+-  // calling vaInitialize(). We want a runtime evaluation of libva version,
+-  // of what is loaded on the system, with, what browser is compiled with.
+-  // Also since the libva is now ABI-compatible, relax the version check
+-  // which helps in upgrading the libva, without breaking any existing
+-  // functionality.
+-  if (!VA_CHECK_VERSION(major_version, minor_version, 0)) {
+-    LOG(ERROR) << "This build of Chromium requires VA-API version "
+-               << VA_MAJOR_VERSION << "." << VA_MINOR_VERSION
+-               << ", system version: " << major_version << "." << minor_version;
++  // calling vaInitialize(). Since the libva is now ABI-compatible, relax the
++  // version check which helps in upgrading the libva, without breaking any
++  // existing functionality. Make sure the system version is not older than
++  // the version with which the chromium is built since libva is only
++  // guaranteed to be backward (and not forward) compatible.
++  if (VA_MAJOR_VERSION > major_version ||
++     (VA_MAJOR_VERSION == major_version && VA_MINOR_VERSION > minor_version)) {
++    LOG(ERROR) << "The system version " << major_version << "." << minor_version
++               << " should be greater than or equal to "
++               << VA_MAJOR_VERSION << "." << VA_MINOR_VERSION;
+     return false;
+   }
+   return true;
+-- 
+2.20.1
+

--- a/pkgs/applications/networking/browsers/chromium/patches/vaapi-relax-the-version-check-for-VA-API-72.patch
+++ b/pkgs/applications/networking/browsers/chromium/patches/vaapi-relax-the-version-check-for-VA-API-72.patch
@@ -1,0 +1,62 @@
+From 6f1309ef8fe10965e4d0018b4f1b80ac6deccdaa Mon Sep 17 00:00:00 2001
+From: Azhar Shaikh <azhar.shaikh@intel.com>
+Date: Fri, 30 Nov 2018 23:11:57 +0000
+Subject: [PATCH] media/gpu/vaapi: Relax the version check for VA-API
+
+Since the newer versions of VA-API are ABI compatible, relax the
+version checks for VA-API, by using VA_CHECK_VERSION().
+This will help in updating the libva to the latest releases,
+while still supporting the old versions, till the new version of
+libva is merged and picked by the builds. Thus ensuring that
+hardware accleration is not broken while updating the libva.
+
+Bug: 905814
+TEST=libva-2.3.0 and libva-2.1.0 are able to do hardware acceleration.
+
+Suggested-by: Alexandre Courbot <acourbot@chromium.org>
+Signed-off-by: Azhar Shaikh <azhar.shaikh@intel.com>
+Change-Id: I510549f72290d20676927eeeeb89a87199c062af
+Reviewed-on: https://chromium-review.googlesource.com/c/1352519
+Reviewed-by: Alexandre Courbot <acourbot@chromium.org>
+Reviewed-by: Hirokazu Honda <hiroh@chromium.org>
+Commit-Queue: Miguel Casas <mcasas@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#612832}
+---
+ AUTHORS                          | 1 +
+ media/gpu/vaapi/vaapi_wrapper.cc | 8 +++++++-
+ 2 files changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/AUTHORS b/AUTHORS
+index 567fe15a60..ff42fc5df0 100644
+--- a/AUTHORS
++++ b/AUTHORS
+@@ -103,6 +103,7 @@ Asish Singh <asish.singh@samsung.com>
+ Attila Dusnoki <dati91@gmail.com>
+ Avinaash Doreswamy <avi.nitk@samsung.com>
+ Ayush Khandelwal <k.ayush@samsung.com>
++Azhar Shaikh <azhar.shaikh@intel.com>
+ Balazs Kelemen <b.kelemen@samsung.com>
+ Baul Eun <baul.eun@samsung.com>
+ Behara Mani Shyam Patro <behara.ms@samsung.com>
+diff --git a/media/gpu/vaapi/vaapi_wrapper.cc b/media/gpu/vaapi/vaapi_wrapper.cc
+index b4156423f7..053384d378 100644
+--- a/media/gpu/vaapi/vaapi_wrapper.cc
++++ b/media/gpu/vaapi/vaapi_wrapper.cc
+@@ -333,7 +333,13 @@ bool VADisplayState::InitializeOnce() {
+   DVLOG(1) << "VAAPI version: " << major_version << "." << minor_version << " "
+            << va_vendor_string_;
+ 
+-  if (major_version != VA_MAJOR_VERSION || minor_version != VA_MINOR_VERSION) {
++  // The VAAPI version is determined from what is loaded on the system by
++  // calling vaInitialize(). We want a runtime evaluation of libva version,
++  // of what is loaded on the system, with, what browser is compiled with.
++  // Also since the libva is now ABI-compatible, relax the version check
++  // which helps in upgrading the libva, without breaking any existing
++  // functionality.
++  if (!VA_CHECK_VERSION(major_version, minor_version, 0)) {
+     LOG(ERROR) << "This build of Chromium requires VA-API version "
+                << VA_MAJOR_VERSION << "." << VA_MINOR_VERSION
+                << ", system version: " << major_version << "." << minor_version;
+-- 
+2.20.1
+


### PR DESCRIPTION
###### Motivation for this change
Using HW video decoding should improve performances and "smoothness" while reducing battery consumption.
Seems to be an often requested feature per issue #21481

###### Things done
- Introduces a VAAPISupport parameter to the expression (default to false)
- Import patches from the Arch package
- Enable use_vaapi gn parameter
- Put libva.so in dlopen seach path by tweaking LD_LIBRARY_PATH env var in the launcher script.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

