### PR TITLE
knot-dns: 2.7.6 -> 2.8.0

### DIFF
--- a/pkgs/servers/dns/knot-dns/default.nix
+++ b/pkgs/servers/dns/knot-dns/default.nix
@@ -7,11 +7,11 @@ let inherit (stdenv.lib) optional optionals; in
 # Note: ATM only the libraries have been tested in nixpkgs.
 stdenv.mkDerivation rec {
   name = "knot-dns-${version}";
-  version = "2.7.6";
+  version = "2.8.0";
 
   src = fetchurl {
     url = "https://secure.nic.cz/files/knot-dns/knot-${version}.tar.xz";
-    sha256 = "a1cb1877f04f7c2549c977c2658cfafd07c7e0e924f8e8aa8d4ae4b707f697a2";
+    sha256 = "494ad926705018bd754d96711dc2129f3173f326a0b57d33978090ba4eef87ef";
   };
 
   outputs = [ "bin" "out" "dev" ];

--- a/pkgs/servers/dns/knot-resolver/default.nix
+++ b/pkgs/servers/dns/knot-resolver/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, runCommand, pkgconfig, hexdump, which
+{ stdenv, fetchurl, fetchpatch, runCommand, pkgconfig, hexdump, which
 , knot-dns, luajit, libuv, lmdb, gnutls, nettle
 , cmocka, systemd, dns-root-data, makeWrapper
 , extraFeatures ? false /* catch-all if defaults aren't enough */
@@ -18,6 +18,14 @@ unwrapped = stdenv.mkDerivation rec {
     url = "https://secure.nic.cz/files/knot-resolver/${name}.tar.xz";
     sha256 = "d1396888ec3a63f19dccdf2b7dbcb0d16a5d8642766824b47f4c21be90ce362b";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "support-libzscanner-2.8.diff";
+      url = "https://gitlab.labs.nic.cz/knot/knot-resolver/commit/186f263.diff";
+      sha256 = "19zqigvc7m2a4j6bk9whx7gj0v009568rz5qwk052z7pzfikr8mk";
+    })
+  ];
 
   # Short-lived cross fix, as upstream is migrating to meson anyway.
   postPatch = ''


### PR DESCRIPTION
https://gitlab.labs.nic.cz/knot/knot-dns/tags/v2.8.0
Some explanation for the patching is in this ML thread:
https://lists.nic.cz/pipermail/knot-dns-users/2019-March/001616.html

###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/56922#issuecomment-470176678

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] N/A Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of **some** binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after): +69k
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

