### PR TITLE
stepmania: switch to clangStdenv

### DIFF
--- a/pkgs/games/stepmania/default.nix
+++ b/pkgs/games/stepmania/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, lib, fetchFromGitHub, cmake, nasm
+{ clangStdenv, lib, fetchFromGitHub, cmake, nasm
 , gtk2, glib, ffmpeg, alsaLib, libmad, libogg, libvorbis
 , glew, libpulseaudio, udev
 }:
 
-stdenv.mkDerivation rec {
+clangStdenv.mkDerivation rec {
   name = "stepmania-${version}";
   version = "5.0.12";
 


### PR DESCRIPTION
Fixes #54227

###### Motivation for this change

Stepmania crashes on every NixOS computer I have tried without this patch, after this patch it works fine.

Like I said in #54227, I don't know if this is a mis-compilation or UB in stepmania that I can't find, and if it is mis-compilation I don't know what specific gcc bug it is.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

