### PR TITLE
xorg.editres: fix build

### DIFF
--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -42,6 +42,10 @@ self: super:
     buildInputs = attrs.buildInputs ++ [ self.mkfontscale ];
   });
 
+  editres = super.editres.overrideAttrs (attrs: {
+    hardeningDisable = [ "format" ];
+  });
+
   fontbhttf = super.fontbhttf.overrideAttrs (attrs: {
     meta = attrs.meta // { license = lib.licenses.unfreeRedistributable; };
   });


### PR DESCRIPTION
###### Motivation for this change
This fixes xorg.editres. Please backport to 19.03.
ZHF-19.03: #56826



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

