### PR TITLE
pythonPackages.distlib: init at 0.2.8

### DIFF
--- a/pkgs/development/python-modules/distlib/default.nix
+++ b/pkgs/development/python-modules/distlib/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "distlib";
+  version = "0.2.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "068zqb3w7nyqiv2hpy0zcpz2xd6xwhq5chigqrp9h9zav7bpr5sp";
+    extension = "zip";
+  };
+
+  # Tests use pypi.org.
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Low-level components of distutils2/packaging";
+    homepage = https://distlib.readthedocs.io;
+    license = licenses.psfl;
+    maintainers = with maintainers; [ lnl7 ];
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -368,6 +368,8 @@ in {
 
   distorm3 = callPackage ../development/python-modules/distorm3 { };
 
+  distlib = callPackage ../development/python-modules/distlib { };
+
   distributed = callPackage ../development/python-modules/distributed { };
 
   docutils = callPackage ../development/python-modules/docutils { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

