### PR TITLE
sewer: Fix build

### DIFF
--- a/pkgs/tools/admin/sewer/default.nix
+++ b/pkgs/tools/admin/sewer/default.nix
@@ -11,11 +11,6 @@ python3Packages.buildPythonApplication rec {
 
   propagatedBuildInputs = with python3Packages; [ pyopenssl requests tldextract ];
 
-  postPatch = ''
-    # The README has non-ascii characters which makes setup.py crash.
-    sed -i 's/[\d128-\d255]//g' README.md
-  '';
-
   meta = with stdenv.lib; {
     homepage = https://github.com/komuw/sewer;
     description = "ACME client";

--- a/pkgs/tools/admin/sewer/default.nix
+++ b/pkgs/tools/admin/sewer/default.nix
@@ -2,11 +2,11 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "sewer";
-  version = "0.6.0";
+  version = "0.7.0";
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "180slmc2zk4mvjqp25ks0j8kd63ai4y77ds5icm7qd7av865rryp";
+    sha256 = "16j4npqj3fdj3g2z7nqb0cvvxd85xk20g9c43f3q8a1k5psf1fmq";
   };
 
   propagatedBuildInputs = with python3Packages; [ pyopenssl requests tldextract ];


### PR DESCRIPTION
###### Motivation for this change
This fixes sewer. Please backport to 19.03.
ZHF-19.03: #56826



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

