### PR TITLE
azure waagent: 2.0 -> 2.2.36

### DIFF
--- a/nixos/modules/virtualisation/azure-agent-entropy.patch
+++ b/nixos/modules/virtualisation/azure-agent-entropy.patch
@@ -1,6 +1,8 @@
---- a/waagent	2016-03-12 09:58:15.728088851 +0200
-+++ a/waagent	2016-03-12 09:58:43.572680025 +0200
-@@ -6173,10 +6173,10 @@
+diff --git a/bin/waagent2.0 b/bin/waagent2.0
+index 25aa0ce..b561ba7 100644
+--- a/bin/waagent2.0
++++ b/bin/waagent2.0
+@@ -5678,10 +5678,10 @@ class Agent(Util):
              Log("MAC  address: " + ":".join(["%02X" % Ord(a) for a in mac]))
          
          # Consume Entropy in ACPI table provided by Hyper-V

--- a/nixos/modules/virtualisation/azure-agent.nix
+++ b/nixos/modules/virtualisation/azure-agent.nix
@@ -7,12 +7,13 @@ let
   cfg = config.virtualisation.azure.agent;
 
   waagent = with pkgs; stdenv.mkDerivation rec {
-    name = "waagent-2.0";
+    name = "waagent-2.2";
+    version = "2.2.36";
     src = pkgs.fetchFromGitHub {
       owner = "Azure";
       repo = "WALinuxAgent";
-      rev = "1b3a8407a95344d9d12a2a377f64140975f1e8e4";
-      sha256 = "10byzvmpgrmr4d5mdn2kq04aapqb3sgr1admk13wjmy5cd6bwd2x";
+      rev = "v${version}";
+      sha256 = "09rv28rmvi26lf6gnk44bcgi3kij363p01x916c3asbawrmxxipd";
     };
 
     patches = [ ./azure-agent-entropy.patch ];
@@ -23,7 +24,7 @@ let
                     procps # for pidof
                     shadow # for useradd, usermod
                     utillinux # for (u)mount, fdisk, sfdisk, mkswap
-                    parted
+                    parted bash
                   ];
     pythonPath = [ pythonPackages.pyasn1 ];
 
@@ -31,13 +32,15 @@ let
     buildPhase = false;
 
     installPhase = ''
+      substituteInPlace config/66-azure-storage.rules \
+          --replace /bin/sh "${bash}/bin/sh"
       substituteInPlace config/99-azure-product-uuid.rules \
           --replace /bin/chmod "${coreutils}/bin/chmod"
       mkdir -p $out/lib/udev/rules.d
       cp config/*.rules $out/lib/udev/rules.d
 
       mkdir -p $out/bin
-      cp waagent $out/bin/
+      cp bin/waagent2.0 $out/bin/waagent
       chmod +x $out/bin/waagent
 
       wrapProgram "$out/bin/waagent" \

--- a/nixos/modules/virtualisation/azure-agent.nix
+++ b/nixos/modules/virtualisation/azure-agent.nix
@@ -7,7 +7,7 @@ let
   cfg = config.virtualisation.azure.agent;
 
   waagent = with pkgs; stdenv.mkDerivation rec {
-    name = "waagent-2.2";
+    pname = "waagent";
     version = "2.2.36";
     src = pkgs.fetchFromGitHub {
       owner = "Azure";


### PR DESCRIPTION
###### Motivation for this change

update the old Windows Azure Agent which is not anymore supported.

This is a WIP, I would appreciate any guidance how I could test locally that it is working as expected without having to go through the long process of creating the image.vhd, create a custom image and finally, boot and pray.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

