### PR TITLE
pythonPackages.wrf-python: Fix build

### DIFF
--- a/pkgs/development/python-modules/wrf-python/default.nix
+++ b/pkgs/development/python-modules/wrf-python/default.nix
@@ -16,13 +16,14 @@ buildPythonPackage rec {
     numpy
     xarray
   ];
-  buildInputs = [
+
+  nativeBuildInputs = [
     gfortran
-  ] ++ lib.optional (pythonOlder "3.3") mock;
-  
+  ];
+
   checkInputs = [
     netcdf4
-  ];
+  ] ++ lib.optional (pythonOlder "3.3") mock;
 
   doCheck = true;
   checkPhase = ''


### PR DESCRIPTION
###### Motivation for this change

The latest changes to support better cross-compilation compatibility
have introduced a stricter handling of dependency specification in
python. Since b4acd977, gfortran should be put into nativeBuildInputs,
as it's a build-time only dependency for wrf-python. Similarly, mock is
only required when testing, so it should go to checkInputs.
Please backport to 19.03.
ZHF-19.03: #56826


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

