### PR TITLE
nsis: init at 3.04

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3727,6 +3727,11 @@
     github = "polyrod";
     name = "Maurizio Di Pietro";
   };
+  pombeirp = {
+    email = "nix@endgr.33mail.com";
+    github = "PombeirP";
+    name = "Pedro Pombeiro";
+  };
   pradeepchhetri = {
     email = "pradeep.chhetri89@gmail.com";
     github = "pradeepchhetri";

--- a/pkgs/development/tools/nsis/default.nix
+++ b/pkgs/development/tools/nsis/default.nix
@@ -35,7 +35,6 @@ in stdenv.mkDerivation rec {
     "APPEND_CPPPATH=${ZLIB_HOME}/include"
     "APPEND_LIBPATH=${ZLIB_HOME}/lib"
     "NSIS_CONFIG_CONST_DATA=no"
-    "STRIP=no"
   ];
 
   preBuild = ''
@@ -44,8 +43,6 @@ in stdenv.mkDerivation rec {
 
   prefixKey = "PREFIX=";
   installTargets = "install-compiler";
-
-  dontStrip = true;
 
   meta = with stdenv.lib; {
     description = "NSIS is a free scriptable win32 installer/uninstaller system that doesn't suck and isn't huge";

--- a/pkgs/development/tools/nsis/default.nix
+++ b/pkgs/development/tools/nsis/default.nix
@@ -6,12 +6,12 @@ stdenv.mkDerivation rec {
 
   src =
     fetchurl {
-      url = "https://vorboss.dl.sourceforge.net/project/nsis/NSIS%203/${version}/nsis-${version}-src.tar.bz2";
+      url = "mirror://sourceforge/project/nsis/NSIS%203/${version}/nsis-${version}-src.tar.bz2";
       sha256 = "1xgllk2mk36ll2509hd31mfq6blgncmdzmwxj3ymrwshdh23d5b0";
     };
   srcWinDistributable =
     fetchzip {
-      url = "https://vorboss.dl.sourceforge.net/project/nsis/NSIS%203/${version}/nsis-${version}.zip";
+      url = "mirror://sourceforge/project/nsis/NSIS%203/${version}/nsis-${version}.zip";
       sha256 = "1g31vz73x4d3cmsw2wfk43qa06bpqp5815fb5qq9vmwms6hym6y2";
     };
 

--- a/pkgs/development/tools/nsis/default.nix
+++ b/pkgs/development/tools/nsis/default.nix
@@ -18,30 +18,34 @@ in stdenv.mkDerivation rec {
       sha256 = "1g31vz73x4d3cmsw2wfk43qa06bpqp5815fb5qq9vmwms6hym6y2";
     };
 
+  postUnpack = ''
+    mkdir -p $out/share/nsis
+    cp -avr ${srcWinDistributable}/{Contrib,Include,Plugins,Stubs} \
+      $out/share/nsis
+  '';
+
   nativeBuildInputs = [ scons ];
   buildInputs = [ zlib ];
 
-  phases = [ "unpackPhase" "installPhase" ];
+  sconsFlags = [
+    "SKIPSTUBS=all"
+    "SKIPPLUGINS=all"
+    "SKIPUTILS=all"
+    "SKIPMISC=all"
+    "APPEND_CPPPATH=${ZLIB_HOME}/include"
+    "APPEND_LIBPATH=${ZLIB_HOME}/lib"
+    "NSIS_CONFIG_CONST_DATA=no"
+    "STRIP=no"
+  ];
+
+  preBuild = ''
+    sconsFlagsArray+=("PATH=$PATH")
+  '';
+
+  prefixKey = "PREFIX=";
+  installTargets = "install-compiler";
 
   dontStrip = true;
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/share/nsis/Contrib $out/share/nsis/Include $out/share/nsis/Plugins $out/share/nsis/Stubs
-    cp -avr ${srcWinDistributable}/Contrib ${srcWinDistributable}/Include ${srcWinDistributable}/Plugins ${srcWinDistributable}/Stubs \
-      $out/share/nsis
-
-    scons \
-      SKIPSTUBS=all SKIPPLUGINS=all SKIPUTILS=all SKIPMISC=all \
-      PATH="$PATH" \
-      APPEND_CPPPATH="${ZLIB_HOME}/include" \
-      APPEND_LIBPATH="${ZLIB_HOME}/lib" \
-      NSIS_CONFIG_CONST_DATA=no \
-      STRIP=no \
-      PREFIX=$out install-compiler
-
-    runHook postInstall
-  '';
 
   meta = with stdenv.lib; {
     description = "NSIS is a free scriptable win32 installer/uninstaller system that doesn't suck and isn't huge";

--- a/pkgs/development/tools/nsis/default.nix
+++ b/pkgs/development/tools/nsis/default.nix
@@ -1,9 +1,6 @@
-{ stdenv, symlinkJoin, fetchurl, fetchzip, scons, zlib }:
+{ stdenv, fetchurl, fetchzip, scons, zlib }:
 
-let
-  ZLIB_HOME = symlinkJoin { name="zlib-wrap"; paths = [ zlib zlib.dev ]; };
-
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   name = "nsis-${version}";
   version = "3.04";
 
@@ -32,8 +29,8 @@ in stdenv.mkDerivation rec {
     "SKIPPLUGINS=all"
     "SKIPUTILS=all"
     "SKIPMISC=all"
-    "APPEND_CPPPATH=${ZLIB_HOME}/include"
-    "APPEND_LIBPATH=${ZLIB_HOME}/lib"
+    "APPEND_CPPPATH=${zlib.dev}/include"
+    "APPEND_LIBPATH=${zlib}/lib"
     "NSIS_CONFIG_CONST_DATA=no"
   ];
 

--- a/pkgs/development/tools/nsis/default.nix
+++ b/pkgs/development/tools/nsis/default.nix
@@ -1,0 +1,53 @@
+{ stdenv, symlinkJoin, fetchurl, fetchzip, scons, zlib }:
+
+let
+  ZLIB_HOME = symlinkJoin { name="zlib-wrap"; paths = [ zlib zlib.dev ]; };
+
+in stdenv.mkDerivation rec {
+  name = "nsis-${version}";
+  version = "3.04";
+
+  src =
+    fetchurl {
+      url = "https://vorboss.dl.sourceforge.net/project/nsis/NSIS%203/${version}/nsis-${version}-src.tar.bz2";
+      sha256 = "1xgllk2mk36ll2509hd31mfq6blgncmdzmwxj3ymrwshdh23d5b0";
+    };
+  srcWinDistributable =
+    fetchzip {
+      url = "https://vorboss.dl.sourceforge.net/project/nsis/NSIS%203/${version}/nsis-${version}.zip";
+      sha256 = "1g31vz73x4d3cmsw2wfk43qa06bpqp5815fb5qq9vmwms6hym6y2";
+    };
+
+  nativeBuildInputs = [ scons ];
+  buildInputs = [ zlib ];
+
+  phases = [ "unpackPhase" "installPhase" ];
+
+  dontStrip = true;
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/nsis/Contrib $out/share/nsis/Include $out/share/nsis/Plugins $out/share/nsis/Stubs
+    cp -avr ${srcWinDistributable}/Contrib ${srcWinDistributable}/Include ${srcWinDistributable}/Plugins ${srcWinDistributable}/Stubs \
+      $out/share/nsis
+
+    scons \
+      SKIPSTUBS=all SKIPPLUGINS=all SKIPUTILS=all SKIPMISC=all \
+      PATH="$PATH" \
+      APPEND_CPPPATH="${ZLIB_HOME}/include" \
+      APPEND_LIBPATH="${ZLIB_HOME}/lib" \
+      NSIS_CONFIG_CONST_DATA=no \
+      STRIP=no \
+      PREFIX=$out install-compiler
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "NSIS is a free scriptable win32 installer/uninstaller system that doesn't suck and isn't huge";
+    homepage = https://nsis.sourceforge.io/;
+    license = licenses.zlib;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ pombeirp ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9343,6 +9343,8 @@ in
 
   mypy = with python3Packages; toPythonApplication mypy;
 
+  nsis = callPackage ../development/tools/nsis { };
+
   ### DEVELOPMENT / LIBRARIES
 
   a52dec = callPackage ../development/libraries/a52dec { };


### PR DESCRIPTION
###### Motivation for this change

Add support for [NSIS](https://nsis.sourceforge.io) (Nullsoft Scriptable Install System) in Nix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

