### PR TITLE
superTuxKart: fix broken build

### DIFF
--- a/pkgs/games/super-tux-kart/default.nix
+++ b/pkgs/games/super-tux-kart/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, fetchsvn, cmake, pkgconfig
+{ stdenv, fetchFromGitHub, fetchsvn, fetchpatch, cmake, pkgconfig
 , openal, freealut, libGLU_combined, libvorbis, libogg, gettext, curl, freetype
 , fribidi, libtool, bluez, libjpeg, libpng, zlib, libX11, libXrandr }:
 
@@ -32,6 +32,14 @@ in stdenv.mkDerivation rec {
     libX11 libXrandr
     openal freealut libGLU_combined libvorbis libogg zlib freetype
     curl fribidi bluez libjpeg libpng
+  ];
+
+  # https://github.com/supertuxkart/stk-code/issues/3557#issuecomment-440794379
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/supertuxkart/stk-code/commit/3a3953f38c3555e87f3608d0291dbfccf34e9775.patch";
+      sha256 = "13mr5pwf45g7frpxzlxiyiq39qi3z9spd7l6gi8i3dr3li9wrb1k";
+    })
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/56826

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

