### PR TITLE
zsh-git-prompt: switch to a new fork.

### DIFF
--- a/pkgs/shells/zsh/zsh-git-prompt/default.nix
+++ b/pkgs/shells/zsh/zsh-git-prompt/default.nix
@@ -38,9 +38,9 @@ haskellPackages.callPackage
      pname = "zsh-git-prompt";
      version = "0.5";
      src = fetchgit {
-       url = "https://github.com/olivierverdier/zsh-git-prompt.git";
-       rev = "0a6c8b610e799040b612db8888945f502a2ddd9d";
-       sha256 = "19x1gf1r6l7r6i7vhhsgzcbdlnr648jx8j84nk2zv1b8igh205hw";
+       url = "https://github.com/starcraftman/zsh-git-prompt.git";
+       rev = "11b83ba3b85d14c66cf2ab79faefab6d838da28e";
+       sha256 = "04aylsjfb03ckw219plkzpyiq4j9g66bjxa5pa56h1p7df6pjssb";
      };
      prePatch = ''
         substituteInPlace zshrc.sh                       \

--- a/pkgs/shells/zsh/zsh-git-prompt/default.nix
+++ b/pkgs/shells/zsh/zsh-git-prompt/default.nix
@@ -24,7 +24,7 @@
 # More details are in share/doc/zsh-git-prompt/README.md, once
 # installed.
 #
-{ fetchgit
+{ fetchFromGitHub
 , haskell
 , python
 , git
@@ -36,9 +36,10 @@ haskellPackages.callPackage
   ({ mkDerivation, base, HUnit, parsec, process, QuickCheck, stdenv }:
    mkDerivation rec {
      pname = "zsh-git-prompt";
-     version = "0.5";
-     src = fetchgit {
-       url = "https://github.com/starcraftman/zsh-git-prompt.git";
+     version = "0.4z";  # While we await a real 0.5 release.
+     src = fetchFromGitHub {
+       owner = "starcraftman";
+       repo = "zsh-git-prompt";
        rev = "11b83ba3b85d14c66cf2ab79faefab6d838da28e";
        sha256 = "04aylsjfb03ckw219plkzpyiq4j9g66bjxa5pa56h1p7df6pjssb";
      };


### PR DESCRIPTION
###### Motivation for this change
The [git repo](https://github.com/olivierverdier/zsh-git-prompt) this package is based on has been left unmaintained for some years. Based on [a thread](https://github.com/olivierverdier/zsh-git-prompt/issues/123) in that repo, [a new(-ish) fork](https://github.com/starcraftman/zsh-git-prompt) seems to have emerged with fixes and ongoing maintainership. I found this while looking for solutions to issues I was seeing with the existing package, and this solved them all for me.

I propose we switch our package to point to this fork instead. I have been using this change for the last week or so and found it generally works well. Wider testing is probably needed(!)



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

