### PR TITLE
Fixed fatal error with libX11 and libGL while building playonlinux

### DIFF
--- a/pkgs/applications/misc/playonlinux/default.nix
+++ b/pkgs/applications/misc/playonlinux/default.nix
@@ -52,7 +52,7 @@ let
     else if stdenv.hostPlatform.system == "i686-linux" then "${stdenv.cc}/nix-support/dynamic-linker"
     else throw "Unsupported platform for PlayOnLinux: ${stdenv.hostPlatform.system}";
   ld64 = "${stdenv.cc}/nix-support/dynamic-linker";
-  libs = pkgs: stdenv.lib.makeLibraryPath [ xorg.libX11 xorg.libX11.dev libGL ];
+  libs = pkgs: stdenv.lib.makeLibraryPath [ xorg.libX11 libGL ];
 
 in stdenv.mkDerivation {
   name = "playonlinux-${version}";
@@ -68,7 +68,7 @@ in stdenv.mkDerivation {
     [ python2Packages.python
       python2Packages.wxPython
       python2Packages.setuptools
-      xorg.libX11.dev
+      xorg.libX11
       libGL
     ];
 

--- a/pkgs/applications/misc/playonlinux/default.nix
+++ b/pkgs/applications/misc/playonlinux/default.nix
@@ -20,6 +20,8 @@
 , which
 , curl
 , jq
+, xorg
+, libGL
 }:
 
 let
@@ -50,7 +52,7 @@ let
     else if stdenv.hostPlatform.system == "i686-linux" then "${stdenv.cc}/nix-support/dynamic-linker"
     else throw "Unsupported platform for PlayOnLinux: ${stdenv.hostPlatform.system}";
   ld64 = "${stdenv.cc}/nix-support/dynamic-linker";
-  libs = pkgs: stdenv.lib.makeLibraryPath [ pkgs.xorg.libX11 ];
+  libs = pkgs: stdenv.lib.makeLibraryPath [ xorg.libX11 xorg.libX11.dev libGL ];
 
 in stdenv.mkDerivation {
   name = "playonlinux-${version}";
@@ -66,6 +68,8 @@ in stdenv.mkDerivation {
     [ python2Packages.python
       python2Packages.wxPython
       python2Packages.setuptools
+      xorg.libX11.dev
+      libGL
     ];
 
   patchPhase = ''
@@ -102,6 +106,5 @@ in stdenv.mkDerivation {
     license = licenses.gpl3;
     maintainers = [ maintainers.a1russell ];
     platforms = [ "x86_64-linux" "i686-linux" ];
-    broken = true;
   };
 }


### PR DESCRIPTION
This is my first attempt on fixing a package on NixOS, any advice is extremely welcome. 

###### Motivation for this change

I was experiencing the following errors while building playonlinux 4.3.4 on unstable [19.09pre171786.34aa254f9eb (Loris)]

```
fatal error: X11/Xlib.h: No such file or directory
fatal error: GL/gl.h: No such file or directory
```

###### Things done

I've changed some `buildInputs` and `makeLibraryPath` until `nix-build -A playonlinux` finally compiled.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

