### PR TITLE
cgui: 2.0.3 -> 2.1.0 (to fix build)

### DIFF
--- a/pkgs/development/libraries/cgui/default.nix
+++ b/pkgs/development/libraries/cgui/default.nix
@@ -1,15 +1,15 @@
-{ stdenv, fetchurl, texinfo, allegro, perl }:
+{ stdenv, fetchurl, texinfo, allegro, perl, libX11 }:
 
 stdenv.mkDerivation rec {
   name = "cgui-${version}";
-  version="2.0.3";
+  version="2.1.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/project/cgui/${version}/${name}.tar.gz";
-    sha256 = "00kk4xaw68m44awy8zq4g5plx372swwccvzshn68a0a8f3f2wi4x";
+    sha256 = "1pp1hvidpilq37skkmbgba4lvzi01rasy04y0cnas9ck0canv00s";
   };
 
-  buildInputs = [ texinfo allegro perl ];
+  buildInputs = [ texinfo allegro perl libX11 ];
 
   configurePhase = ''
     sh fix.sh unix


### PR DESCRIPTION
###### Motivation for this change
Hydra build was broken due to missing linking against the math library. Could have been fixed by adding `NIX_LDFLAGS=-lm`, but upgrading the package also solved it.
Please backport to 19.03.
ZHF-19.03: #56826



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

