### PR TITLE
gnome-keysign: init at 1.0.1

### DIFF
--- a/pkgs/tools/security/gnome-keysign/default.nix
+++ b/pkgs/tools/security/gnome-keysign/default.nix
@@ -1,0 +1,73 @@
+{ stdenv
+, fetchFromGitLab
+, python3
+, wrapGAppsHook
+, gobject-introspection
+, gtk3
+, glib
+, gnome3
+, gst_all_1
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "gnome-keysign";
+  version = "1.0.1";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "GNOME";
+    repo = pname;
+    rev = version;
+    sha256 = "0iy70dskd7wly37lpb2ypd9phhyml5j3c7rzajii4f2s7zgb3abg";
+  };
+
+  nativeBuildInputs = [
+    wrapGAppsHook
+    gobject-introspection
+  ] ++ (with python3.pkgs; [
+    Babel
+    lxml
+  ]);
+
+  buildInputs = [
+    # TODO: add avahi support
+    gtk3
+    glib
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    (gst_all_1.gst-plugins-good.override { gtkSupport = true; })
+    gst_all_1.gst-plugins-bad # for zbar plug-in
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    dbus-python
+    future
+    gpgme
+    magic-wormhole
+    pygobject3
+    pybluez
+    qrcode
+    requests
+    twisted
+  ];
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+    };
+  };
+
+  # https://github.com/NixOS/nixpkgs/issues/56943
+  strictDeps = false;
+
+  # bunch of linting
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "GTK/GNOME application to use GnuPG for signing other peoples’ keys";
+    homepage = https://wiki.gnome.org/Apps/Keysign;
+    license = licenses.gpl3Plus;
+    maintainers = gnome3.maintainers;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3434,6 +3434,8 @@ in
 
   gnome-builder = callPackage ../applications/editors/gnome-builder { };
 
+  gnome-keysign = callPackage ../tools/security/gnome-keysign { };
+
   gnome-podcasts = callPackage ../applications/audio/gnome-podcasts { };
 
   gnome-photos = callPackage ../applications/graphics/gnome-photos {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

