### PR TITLE
almanah: init at 0.11.1

### DIFF
--- a/pkgs/applications/misc/almanah/default.nix
+++ b/pkgs/applications/misc/almanah/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchurl, pkgconfig, intltool
+, libxml2, desktop-file-utils, wrapGAppsHook, evolution-data-server, gtkspell3, gpgme, libcryptui
+, glib, gtk3, gtksourceview3, sqlite, cairo, atk, gcr, gnome3 }:
+
+stdenv.mkDerivation rec {
+  pname = "almanah";
+  version = "0.11.1";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "1g0fyykq8bs3x1xqc0l0bk9zazcrxja784m68myymv1zfqqnp9h0";
+  };
+
+  nativeBuildInputs = [ pkgconfig intltool libxml2 desktop-file-utils wrapGAppsHook ];
+
+  buildInputs = [ glib gtk3 gtksourceview3 sqlite cairo atk gcr gtkspell3 evolution-data-server gnome3.evolution gpgme libcryptui ];
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+      versionPolicy = "none"; # it is quite odd
+    };
+  };
+
+  meta = with stdenv.lib; {
+    description = "Small GTK application to allow to keep a diary of your life";
+    homepage = https://wiki.gnome.org/Apps/Almanah_Diary;
+    license = licenses.gpl3Plus;
+    platforms = platforms.unix;
+    maintainers = gnome3.maintainers;
+  };
+}

--- a/pkgs/development/libraries/libcryptui/default.nix
+++ b/pkgs/development/libraries/libcryptui/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchurl, pkgconfig, intltool, glib, gnome3, gtk3, gnupg20, gpgme, dbus-glib, libgnome-keyring }:
+
+stdenv.mkDerivation rec {
+  pname = "libcryptui";
+  version = "3.12.2";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "0rh8wa5k2iwbwppyvij2jdxmnlfjbna7kbh2a5n7zw4nnjkx3ski";
+  };
+
+  nativeBuildInputs = [ pkgconfig intltool ];
+  buildInputs = [ glib gtk3 gnupg20 gpgme dbus-glib libgnome-keyring ];
+  propagatedBuildInputs = [ dbus-glib ];
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+    };
+  };
+
+  meta = with stdenv.lib; {
+    description = "Interface components for OpenPGP";
+    homepage = https://gitlab.gnome.org/GNOME/libcryptui;
+    license = licenses.lgpl21Plus;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3738,6 +3738,8 @@ in
 
   libcroco = callPackage ../development/libraries/libcroco { };
 
+  libcryptui = callPackage ../development/libraries/libcryptui { };
+
   libsmi = callPackage ../development/libraries/libsmi { };
 
   lesspipe = callPackage ../tools/misc/lesspipe { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -503,6 +503,8 @@ in
 
   aldo = callPackage ../applications/radio/aldo { };
 
+  almanah = callPackage ../applications/misc/almanah { };
+
   amazon-ecs-cli = callPackage ../tools/virtualization/amazon-ecs-cli { };
 
   amazon-glacier-cmd-interface = callPackage ../tools/backup/amazon-glacier-cmd-interface { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

