### PR TITLE
udocker: Fix build

### DIFF
--- a/pkgs/tools/virtualization/udocker/default.nix
+++ b/pkgs/tools/virtualization/udocker/default.nix
@@ -12,7 +12,7 @@ buildPythonApplication rec {
     sha256 = "134xk7rfj0xki9znryk5qf1nsfa318ahrrsi1k6ia7kipp7i3hb4";
   };
 
-  buildInputs = [ proot patchelf fakechroot runc simplejson pycurl coreutils nose mock ];
+  buildInputs = [ proot patchelf fakechroot runc simplejson pycurl coreutils ];
 
   postPatch = ''
       substituteInPlace udocker.py --replace /usr/sbin:/sbin:/usr/bin:/bin $PATH
@@ -21,6 +21,11 @@ buildPythonApplication rec {
       substituteInPlace tests/unit_tests.py --replace /bin/rm ${coreutils}/bin/rm
       substituteInPlace udocker.py --replace "autoinstall = True" "autoinstall = False"
   '';
+
+  checkInputs = [
+    nose
+    mock
+  ];
 
   checkPhase = ''
     NOSE_EXCLUDE=test_03_create_repo,test_04_is_repo,test_02__get_group_from_host nosetests -v tests/unit_tests.py


### PR DESCRIPTION
###### Motivation for this change

The latest changes to support better cross-compilation compatibility
have introduced a stricter handling of dependency specifications in
python. Since b4acd97, mock and nosetest should be checkInputs, since
they are used for testing.

Fixes: #56972

Please backport to 19.03.
ZHF-19.03: #56826



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

