### PR TITLE
chromium: fix sha256 for 72.0.3626.121

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/upstream-info.nix
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.nix
@@ -11,7 +11,7 @@
     version = "74.0.3717.0";
   };
   stable = {
-    sha256 = "0ylig933xzn6c0018nxq95xhl0wkxcm95fdiy2c7s4a4h3hkr5dk";
+    sha256 = "07xwmlvmzfga61nrimqmzl7s29jb4kc94nkzwwlb7sh6nr55a7jc";
     sha256bin64 = "1jdj2jp4jvzi5a24dm56ls5kx6xpiiv98yx4si9z19lm5srrji8j";
     version = "72.0.3626.121";
   };


### PR DESCRIPTION
###### Motivation for this change

The sha256 [was previously unchanged](https://github.com/NixOS/nixpkgs/issues/56998#issuecomment-470315370) from 72.0.3626.119.

Fixes #56998.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

72.0.3626.121 (for real now) is running fine here.