### PR TITLE
Luarocks update

### DIFF
--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -1,3 +1,4 @@
+# nix name, luarocks name, server, version/additionnal args
 ansicolors,
 argparse,
 basexx,
@@ -17,15 +18,15 @@ lua-term,
 luabitop,
 luaevent,
 luacheck
-luaffi,http://luarocks.org/dev,
+luaffi,,http://luarocks.org/dev,
 luuid,
 penlight,
 say,
 luv,
 luasystem,
-mediator_lua,http://luarocks.org/manifests/teto
-mpack,http://luarocks.org/manifests/teto
-nvim-client,http://luarocks.org/manifests/teto
-busted,http://luarocks.org/manifests/teto
-luassert,http://luarocks.org/manifests/teto
-coxpcall,https://luarocks.org/manifests/hisham,1.17.0-1
+mediator_lua,,http://luarocks.org/manifests/teto
+mpack,,http://luarocks.org/manifests/teto
+nvim-client,,http://luarocks.org/manifests/teto
+busted,,http://luarocks.org/manifests/teto
+luassert,,http://luarocks.org/manifests/teto
+coxpcall,,https://luarocks.org/manifests/hisham,1.17.0-1

--- a/maintainers/scripts/update-luarocks-packages
+++ b/maintainers/scripts/update-luarocks-packages
@@ -74,17 +74,18 @@ FOOTER="
 
 
 function convert_pkg () {
-    pkg="$1"
+    nix_pkg_name="$1"
+    lua_pkg_name="$2"
 	server=""
-	if [ ! -z "$2" ]; then
-		server=" --server=$2"
+	if [ ! -z "$3" ]; then
+		server=" --server=$3"
 	fi
 
     version="${3:-}"
 
-    echo "looking at $pkg (version $version) from server [$server]" >&2
-    cmd="luarocks nix $server $pkg $version"
-    drv="$($cmd)"
+    echo "looking at $lua_pkg_name (version $version) from server [$server]" >&2
+    cmd="luarocks nix $server $lua_pkg_name $version"
+    drv="$nix_pkg_name = $($cmd)"
     if [ $? -ne 0 ]; then
         echo "Failed to convert $pkg" >&2
         echo "$drv" >&2
@@ -98,12 +99,17 @@ echo "$HEADER" | tee "$TMP_FILE"
 
 # list of packages with format
 # name,server,version
-while IFS=, read -r pkg_name server version
+while IFS=, read -r nix_pkg_name lua_pkg_name server version
 do
-	if [ -z "$pkg_name" ]; then
-		echo "Skipping empty package name" >&2
+	if [ "${nix_pkg_name:0:1}" == "#" ]; then
+		echo "Skipping comment ${nix_pkg_name}" >&2
+		continue
 	fi
-	convert_pkg "$pkg_name" "$server" "$version"
+	if [ -z "$lua_pkg_name" ]; then
+		echo "Using nix_name as lua_pkg_name" >&2
+		lua_pkg_name="$nix_pkg_name"
+	fi
+	convert_pkg "$nix_pkg_name" "$lua_pkg_name" "$server" "$version"
 done < "$CSV_FILE"
 
 # close the set

--- a/pkgs/development/tools/misc/luarocks/darwin.patch
+++ b/pkgs/development/tools/misc/luarocks/darwin.patch
@@ -1,27 +1,27 @@
-diff --git a/src/luarocks/cfg.lua b/src/luarocks/cfg.lua
-index 55cd4c9..060a6f1 100644
---- a/src/luarocks/cfg.lua
-+++ b/src/luarocks/cfg.lua
-@@ -587,9 +587,9 @@ if cfg.platforms.macosx then
-    defaults.external_lib_extension = "dylib"
-    defaults.arch = "macosx-"..cfg.target_cpu
-    defaults.variables.LIBFLAG = "-bundle -undefined dynamic_lookup -all_load"
--   defaults.variables.STAT = "/usr/bin/stat"
-+   defaults.variables.STAT = "stat"
-    defaults.variables.STATFLAG = "-f '%A'"
--   local version = io.popen("sw_vers -productVersion"):read("*l")
-+   local version = "10.10"
-    version = tonumber(version and version:match("^[^.]+%.([^.]+)")) or 3
-    if version >= 10 then
-       version = 8
-@@ -598,8 +598,8 @@ if cfg.platforms.macosx then
-    else
-       defaults.gcc_rpath = false
+diff --git a/src/luarocks/core/cfg.lua b/src/luarocks/core/cfg.lua
+index f93e67a..2eb2db9 100644
+--- a/src/luarocks/core/cfg.lua
++++ b/src/luarocks/core/cfg.lua
+@@ -425,9 +425,9 @@ local function make_defaults(lua_version, target_cpu, platforms, home)
+       defaults.external_lib_extension = "dylib"
+       defaults.arch = "macosx-"..target_cpu
+       defaults.variables.LIBFLAG = "-bundle -undefined dynamic_lookup -all_load"
+-      defaults.variables.STAT = "/usr/bin/stat"
++      defaults.variables.STAT = "stat"
+       defaults.variables.STATFLAG = "-f '%A'"
+-      local version = util.popen_read("sw_vers -productVersion")
++      local version = "10.10"
+       version = tonumber(version and version:match("^[^.]+%.([^.]+)")) or 3
+       if version >= 10 then
+          version = 8
+@@ -436,8 +436,8 @@ local function make_defaults(lua_version, target_cpu, platforms, home)
+       else
+          defaults.gcc_rpath = false
+       end
+-      defaults.variables.CC = "env MACOSX_DEPLOYMENT_TARGET=10."..version.." gcc"
+-      defaults.variables.LD = "env MACOSX_DEPLOYMENT_TARGET=10."..version.." gcc"
++      defaults.variables.CC = "env MACOSX_DEPLOYMENT_TARGET=10."..version.." clang"
++      defaults.variables.LD = "env MACOSX_DEPLOYMENT_TARGET=10."..version.." clang"
+       defaults.web_browser = "open"
     end
--   defaults.variables.CC = "env MACOSX_DEPLOYMENT_TARGET=10."..version.." gcc"
--   defaults.variables.LD = "env MACOSX_DEPLOYMENT_TARGET=10."..version.." gcc"
-+   defaults.variables.CC = "env MACOSX_DEPLOYMENT_TARGET=10."..version.." clang"
-+   defaults.variables.LD = "env MACOSX_DEPLOYMENT_TARGET=10."..version.." clang"
-    defaults.web_browser = "open"
- end
  

--- a/pkgs/development/tools/misc/luarocks/default.nix
+++ b/pkgs/development/tools/misc/luarocks/default.nix
@@ -7,16 +7,13 @@
 , cmake
 }:
 
-let
-in
-
 stdenv.mkDerivation rec {
-  pname="luarocks";
-  version="2.4.4";
+  pname = "luarocks";
+  version = "3.0.4";
 
   src = fetchurl {
     url="http://luarocks.org/releases/luarocks-${version}.tar.gz";
-    sha256="0d7rl60dwh52qh5pfsphgx5ypp7k190h9ri6qpr2yx9kvqrxyf1r";
+    sha256="1pqfzwvjy8dzqg4fqjq2cgqcr00fgrdd7nwzxm7nqmawr83s6dhj";
   };
 
   patches = [ ./darwin.patch ];

--- a/pkgs/development/tools/misc/luarocks/luarocks-nix.nix
+++ b/pkgs/development/tools/misc/luarocks/luarocks-nix.nix
@@ -1,9 +1,10 @@
 { luarocks, fetchFromGitHub }:
 luarocks.overrideAttrs(old: {
+  pname = "luarocks-nix";
   src = fetchFromGitHub {
     owner = "teto";
     repo = "luarocks";
-    rev = "f9dc7892214bff6bce822d94aca3331048e61df0";
-    sha256 = "117qqbiv87p2qw0zwapl7b0p4wgnn9f8k0qpppkj3653a1bwli05";
+    rev = "8fb03a9bc8f4fa079d26c0f02804139bb2578848";
+    sha256 = "09iwjvs9sbk6vwhrh7sijmfpji6wvg5bbdraw7l5lpnr9jj5wy91";
   };
 })

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -12,7 +12,6 @@
 , fetchFromGitHub, libmpack, which, fetchpatch, writeText
 , pkgs
 , fetchgit
-, overrides ? (self: super: {})
 , lib
 }:
 
@@ -867,4 +866,4 @@ with self; {
   });
 
 });
-in (lib.extends overrides packages)
+in packages


### PR DESCRIPTION
###### Motivation for this change

Some lua packages have one rockspec per lua interpreter:
https://github.com/NixOS/nixpkgs/commit/c01fe375ca192395af8ae8c575ff8eaa79ed03d8#commitcomment-32572249

I've bumped luarocks that should help with nix integration (noew distinguishes test_dependencies, build_dependencies) as well as it can install rockspecs for a different lua version than its own interpreter. With the luarocks in nixpkgs, I would have to rerun the generator for every interpreter.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

