### PR TITLE
davix: 0.6.4 -> 0.7.2

### DIFF
--- a/pkgs/tools/networking/davix/default.nix
+++ b/pkgs/tools/networking/davix/default.nix
@@ -1,22 +1,24 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, openssl, libxml2, boost }:
+{ stdenv, fetchurl, cmake, pkgconfig, openssl, libxml2, boost, python3, libuuid }:
 
 stdenv.mkDerivation rec {
-  name = "davix-0.6.4";
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ stdenv cmake openssl libxml2 boost ];
+  version = "0.7.2";
+  name = "davix-${version}";
+  nativeBuildInputs = [ cmake pkgconfig python3 ];
+  buildInputs = [ openssl libxml2 boost libuuid ];
 
-  src = fetchFromGitHub {
-    owner = "cern-it-sdc-id";
-    repo = "davix";
-    rev = "R_0_6_4";
-    sha256 = "10hg7rs6aams96d4ghldgkrrnikskdpmn8vy6hj5j0s17a2yms6q";
+  # using the url below since the 0.7.2 release did carry a broken CMake file,
+  # supposedly fixed in the next release
+  # https://github.com/cern-fts/davix/issues/40
+  src = fetchurl {
+    url = "http://grid-deployment.web.cern.ch/grid-deployment/dms/lcgutil/tar/davix/${version}/davix-${version}.tar.gz";
+    sha256 = "1w1q7r6r5j5f23ra4qhx3x29w9z9xal23c2azazpfmcz88hkkmhz";
   };
 
 
   meta = with stdenv.lib; {
     description = "Toolkit for Http-based file management";
 
-    longDescription = "Davix is a toolkit designed for file 
+    longDescription = "Davix is a toolkit designed for file
     operations with Http based protocols (WebDav, Amazon S3, ...).
     Davix provides an API and a set of command line tools";
 
@@ -24,6 +26,6 @@ stdenv.mkDerivation rec {
     homepage    = http://dmc.web.cern.ch/projects/davix/home;
     maintainers = [ maintainers.adev ];
     platforms   = platforms.all;
-  };  
+  };
 }
 


### PR DESCRIPTION
###### Motivation for this change
Bump version to be compatible with OpenSSL 1.1.

cc #22357 

maintainer @adevress 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

