### PR TITLE
pythonPackages.pyhocon: init at 0.3.51

### DIFF
--- a/pkgs/development/python-modules/pyhocon/default.nix
+++ b/pkgs/development/python-modules/pyhocon/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+# Runtime inputs:
+, pyparsing
+# Check inputs:
+, setuptools
+, pytest
+, mock
+}:
+
+buildPythonPackage rec{
+  pname = "pyhocon";
+  version = "0.3.51";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "10l014br012fa583rnj3wqf6g9gmljamcwpw4snqwwg15i0dmkll";
+  };
+
+  propagatedBuildInputs = [ pyparsing ];
+
+  checkInputs = [ setuptools pytest mock ];
+
+  # Tests fail because necessary data files aren't packaged for PyPi yet.
+  # See https://github.com/chimpler/pyhocon/pull/203
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = https://github.com/chimpler/pyhocon/;
+    description = "HOCON parser for Python";
+    # Long description copied from <GitHub>/setup.py on 2019-03-06.
+    longDescription = ''
+      A HOCON parser for Python. It additionally provides a tool
+      (pyhocon) to convert any HOCON content into json, yaml and properties
+      format
+    '';
+    license = licenses.asl20;
+    maintainers = [ maintainers.chreekat ];
+  };
+}

--- a/pkgs/development/python-modules/pyhocon/default.nix
+++ b/pkgs/development/python-modules/pyhocon/default.nix
@@ -4,7 +4,6 @@
 # Runtime inputs:
 , pyparsing
 # Check inputs:
-, setuptools
 , pytest
 , mock
 }:
@@ -20,7 +19,7 @@ buildPythonPackage rec{
 
   propagatedBuildInputs = [ pyparsing ];
 
-  checkInputs = [ setuptools pytest mock ];
+  checkInputs = [ pytest mock ];
 
   # Tests fail because necessary data files aren't packaged for PyPi yet.
   # See https://github.com/chimpler/pyhocon/pull/203

--- a/pkgs/development/python-modules/pyhocon/default.nix
+++ b/pkgs/development/python-modules/pyhocon/default.nix
@@ -8,7 +8,7 @@
 , mock
 }:
 
-buildPythonPackage rec{
+buildPythonPackage rec {
   pname = "pyhocon";
   version = "0.3.51";
 

--- a/pkgs/development/python-modules/pyhocon/default.nix
+++ b/pkgs/development/python-modules/pyhocon/default.nix
@@ -28,7 +28,9 @@ buildPythonPackage rec {
   meta = with lib; {
     homepage = https://github.com/chimpler/pyhocon/;
     description = "HOCON parser for Python";
-    # Long description copied from <GitHub>/setup.py on 2019-03-06.
+    # Long description copied from
+    # https://github.com/chimpler/pyhocon/blob/55a9ea3ebeeac5764bdebebfbeacbf099f64db26/setup.py
+    # (the tip of master as of 2019-03-24).
     longDescription = ''
       A HOCON parser for Python. It additionally provides a tool
       (pyhocon) to convert any HOCON content into json, yaml and properties

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3894,6 +3894,8 @@ in {
 
   purepng = callPackage ../development/python-modules/purepng { };
 
+  pyhocon = callPackage ../development/python-modules/pyhocon { };
+
   pymaging = callPackage ../development/python-modules/pymaging { };
 
   pymaging_png = callPackage ../development/python-modules/pymaging_png { };


### PR DESCRIPTION
###### Motivation for this change

Add pyhocon package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

