### PR TITLE
terraform-providers: introduce mkTerraformProvider

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -6,25 +6,26 @@
 let
   list = import ./data.nix;
 
-  toDrv = data:
-    buildGoPackage rec {
-      inherit (data) owner repo version sha256;
-      name = "${repo}-${version}";
-      goPackagePath = "github.com/${owner}/${repo}";
-      subPackages = [ "." ];
-      src = fetchFromGitHub {
-        inherit owner repo sha256;
-        rev = "v${version}";
-      };
-      
+  # a generic plugin builder
+  mkTerraformProvider = callPackage ./generic.nix {};
 
-      # Terraform allow checking the provider versions, but this breaks
-      # if the versions are not provided via file paths.
-      postBuild = "mv go/bin/${repo}{,_v${version}}";
-    };
+  toDrv = data:
+    let
+      inherit (data) owner repo version sha256;
+    in
+      mkTerraformProvider {
+        pname = repo;
+        version = version;
+        goPackagePath = "github.com/${owner}/${repo}";
+        src = fetchFromGitHub {
+          inherit owner repo sha256;
+          rev = "v${version}";
+        };
+      };
 in
   {
-    gandi = callPackage ./gandi {};
-    ibm = callPackage ./ibm {};
-    libvirt = callPackage ./libvirt {};
+    inherit mkTerraformProvider;
+    gandi = callPackage ./gandi { inherit mkTerraformProvider; };
+    ibm = callPackage ./ibm { inherit mkTerraformProvider; };
+    libvirt = callPackage ./libvirt { inherit mkTerraformProvider; };
   } // lib.mapAttrs (n: v: toDrv v) list

--- a/pkgs/applications/networking/cluster/terraform-providers/gandi/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/gandi/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, buildGoPackage }:
-buildGoPackage rec {
-  name = "terraform-provider-gandi-${version}";
+{ stdenv, fetchFromGitHub, mkTerraformProvider }:
+mkTerraformProvider rec {
+  pname = "terraform-provider-gandi";
   version = "1.0.0";
 
   goPackagePath = "github.com/tiramiseb/terraform-provider-gandi";
@@ -12,10 +12,6 @@ buildGoPackage rec {
     rev = "v${version}";
     sha256 = "0byydpqsimvnk11bh9iz8zlxbsmsk65w55pvkp18vjzqrhf4kyfv";
   };
-
-  # Terraform allow checking the provider versions, but this breaks
-  # if the versions are not provided via file paths.
-  postBuild = "mv go/bin/terraform-provider-gandi{,_v${version}}";
 
   meta = with stdenv.lib; {
     description = "Terraform provider for the Gandi LiveDNS service.";

--- a/pkgs/applications/networking/cluster/terraform-providers/generic.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/generic.nix
@@ -1,0 +1,13 @@
+{ buildGoPackage, src }:
+# A specialized buildGoPackage for the terraform provider plugins
+{ pname, version, ... }@attrs:
+buildGoPackage ({
+  name = "${pname}-${version}";
+
+  # Only build the provider
+  subPackages = [ "." ];
+
+  # Terraform allow checking the provider versions, but this breaks
+  # if the versions are not provided via file paths.
+  postBuild = "mv go/bin/${pname}{,_v${version}}";
+} // attrs)

--- a/pkgs/applications/networking/cluster/terraform-providers/ibm/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/ibm/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildGoPackage, fetchFromGitHub }:
+{ stdenv, mkTerraformProvider, fetchFromGitHub }:
 
 #
 # USAGE:
@@ -10,12 +10,11 @@
 # https://github.com/IBM-Cloud/terraform-provider-ibm/tree/master/examples
 #
 
-buildGoPackage rec {
-  name = "terraform-provider-ibm-${version}";
+mkTerraformProvider rec {
+  pname = "terraform-provider-ibm";
   version = "0.11.1";
 
   goPackagePath = "github.com/terraform-providers/terraform-provider-ibm";
-  subPackages = [ "./" ];
 
   src = fetchFromGitHub {
     owner = "IBM-Cloud";
@@ -23,10 +22,6 @@ buildGoPackage rec {
     sha256 = "1vp1kzadfkacn6c4illxjra8yki1fx7h77b38fixkcvc79mzasmv";
     rev = "v${version}";
   };
-
-  # Terraform allow checking the provider versions, but this breaks
-  # if the versions are not provided via file paths.
-  postBuild = "mv go/bin/terraform-provider-ibm{,_v${version}}";
 
   meta = with stdenv.lib; {
     homepage = https://github.com/IBM-Cloud/terraform-provider-ibm;

--- a/pkgs/applications/networking/cluster/terraform-providers/libvirt/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/libvirt/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildGoPackage, fetchFromGitHub, libvirt, pkgconfig, makeWrapper, cdrtools }:
+{ stdenv, mkTerraformProvider, fetchFromGitHub, libvirt, pkgconfig, makeWrapper, cdrtools }:
 
 # USAGE:
 # install the following package globally or in nix-shell:
@@ -17,8 +17,8 @@
 # pick an example from (i.e ubuntu):
 # https://github.com/dmacvicar/terraform-provider-libvirt/tree/master/examples
 
-buildGoPackage rec {
-  name = "terraform-provider-libvirt-${version}";
+mkTerraformProvider rec {
+  pname = "terraform-provider-libvirt";
   version = "0.5.1";
 
   goPackagePath = "github.com/dmacvicar/terraform-provider-libvirt";
@@ -35,10 +35,6 @@ buildGoPackage rec {
   # mkisofs needed to create ISOs holding cloud-init data,
   # and wrapped to terraform via deecb4c1aab780047d79978c636eeb879dd68630
   propagatedBuildInputs = [ cdrtools ];
-
-  # Terraform allow checking the provider versions, but this breaks
-  # if the versions are not provided via file paths.
-  postBuild = "mv go/bin/terraform-provider-libvirt{,_v${version}}";
 
   meta = with stdenv.lib; {
     homepage = https://github.com/dmacvicar/terraform-provider-libvirt;


### PR DESCRIPTION
###### Motivation for this change

keep the code DRY, use the same defaults when building providers outside
of the nixpkgs tree.

/cc @stephengroat

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

