### PR TITLE
Gnome 3.32

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/gnome3.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome3.nix
@@ -160,7 +160,11 @@ in {
     # If gnome3 is installed, build vim for gtk3 too.
     nixpkgs.config.vim.gui = "gtk3";
 
-    fonts.fonts = [ pkgs.dejavu_fonts pkgs.cantarell-fonts ];
+    fonts.fonts = [
+      pkgs.dejavu_fonts pkgs.cantarell-fonts
+      pkgs.source-sans-pro
+      pkgs.source-code-pro # Default monospace font in 3.32
+    ];
 
     services.xserver.displayManager.extraSessionFilePackages = [ pkgs.gnome3.gnome-session ]
       ++ map

--- a/pkgs/applications/audio/rhythmbox/default.nix
+++ b/pkgs/applications/audio/rhythmbox/default.nix
@@ -17,23 +17,14 @@
 }:
 let
   pname = "rhythmbox";
-  version = "3.4.2";
+  version = "3.4.3";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0hzcns8gf5yb0rm4ss8jd8qzarcaplp5cylk6plwilsqfvxj4xn2";
+    sha256 = "1yx3n7p9vmv23jsv98fxwq95n78awdxqm8idhyhxx2d6vk4w1hgx";
   };
-
-  patches = [
-    # build with GStreamer 1.14 https://bugzilla.gnome.org/show_bug.cgi?id=788706
-    (fetchurl {
-      name = "fmradio-Fix-build-with-GStreamer-master.patch";
-      url = https://bugzilla.gnome.org/attachment.cgi?id=361178;
-      sha256 = "1h09mimlglj9hcmc3pfp0d6c277mqh2khwv9fryk43pkv3904d2w";
-    })
-  ];
 
   nativeBuildInputs = [
     pkgconfig

--- a/pkgs/applications/editors/gnome-latex/default.nix
+++ b/pkgs/applications/editors/gnome-latex/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchurl, wrapGAppsHook, gsettings-desktop-schemas, gspell, gtksourceview4, libgee
 , tepl, amtk, gnome3, glib, pkgconfig, intltool, itstool, libxml2 }:
 let
-  version = "3.30.2";
+  version = "3.32.0";
   pname = "gnome-latex";
 in stdenv.mkDerivation {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0fn3vy6w714wy0bz3y11zpdprpwxbv5xfiyyxjwp2nix9mbvv2sm";
+    sha256 = "1jdca9yhm7mm1aijd1a5amphgn15142kngky3id2am379ixrq1hg";
   };
 
   NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/gio-unix-2.0";

--- a/pkgs/applications/graphics/shotwell/default.nix
+++ b/pkgs/applications/graphics/shotwell/default.nix
@@ -1,31 +1,89 @@
-{ fetchurl, stdenv, meson, ninja, gtk3, libexif, libgphoto2, libsoup, libxml2, vala, sqlite
-, webkitgtk, pkgconfig, gnome3, gst_all_1, libgudev, libraw, glib, json-glib, gcr
-, gettext, desktop-file-utils, gdk_pixbuf, librsvg, wrapGAppsHook
-, gobject-introspection, itstool, libgdata, python3 }:
+{ stdenv
+, fetchurl
+, fetchpatch
+, meson
+, ninja
+, gtk3
+, libexif
+, libgphoto2
+, libwebp
+, libsoup
+, libxml2
+, vala
+, sqlite
+, webkitgtk
+, pkgconfig
+, gnome3
+, gst_all_1
+, libgudev
+, libraw
+, glib
+, json-glib
+, gcr
+, libgee
+, gexiv2
+, librest
+, gettext
+, desktop-file-utils
+, gdk_pixbuf
+, librsvg
+, wrapGAppsHook
+, gobject-introspection
+, itstool
+, libgdata
+, libchamplain
+, python3
+}:
 
 # for dependencies see https://wiki.gnome.org/Apps/Shotwell/BuildingAndInstalling
 
-let
+stdenv.mkDerivation rec {
   pname = "shotwell";
-  version = "0.30.2";
-in stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
+  version = "0.31.0";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0pam0si110vkc65kh59lrmgkv91f9zxmf1gpfm99ixjgw25rfi8r";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "1pwq953wl7h9cvw7rvlr6pcbq9w28kkr7ddb8x2si81ngp0imwyx";
   };
 
   nativeBuildInputs = [
-    meson ninja vala pkgconfig itstool gettext desktop-file-utils python3 wrapGAppsHook gobject-introspection
+    meson
+    ninja
+    vala
+    pkgconfig
+    itstool
+    gettext
+    desktop-file-utils
+    python3
+    wrapGAppsHook
+    gobject-introspection
   ];
 
   buildInputs = [
-    gtk3 libexif libgphoto2 libsoup libxml2 sqlite webkitgtk
-    gst_all_1.gstreamer gst_all_1.gst-plugins-base gnome3.libgee
-    libgudev gnome3.gexiv2 gnome3.gsettings-desktop-schemas
-    libraw json-glib glib gdk_pixbuf librsvg gnome3.rest
-    gcr gnome3.adwaita-icon-theme libgdata
+    gtk3
+    libexif
+    libgphoto2
+    libwebp
+    libsoup
+    libxml2
+    sqlite
+    webkitgtk
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    libgee
+    libgudev
+    gexiv2
+    gnome3.gsettings-desktop-schemas
+    libraw
+    json-glib
+    glib
+    gdk_pixbuf
+    librsvg
+    librest
+    gcr
+    gnome3.adwaita-icon-theme
+    libgdata
+    libchamplain
   ];
 
   postPatch = ''

--- a/pkgs/applications/misc/gnome-usage/default.nix
+++ b/pkgs/applications/misc/gnome-usage/default.nix
@@ -1,21 +1,47 @@
-{ stdenv, fetchurl, meson, ninja, pkgconfig, vala, gettext
-, libxml2, desktop-file-utils, wrapGAppsHook
-, glib, gtk3, libgtop, gnome3 }:
+{ stdenv
+, fetchurl
+, meson
+, ninja
+, pkgconfig
+, vala
+, gettext
+, libxml2
+, desktop-file-utils
+, wrapGAppsHook
+, glib
+, gtk3
+, libgtop
+, libdazzle
+, gnome3
+}:
 
-let
+stdenv.mkDerivation rec {
   pname = "gnome-usage";
-  version = "3.30.0";
-in stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
+  version = "3.32.0";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0f1vccw916az8hzsqmx6f57jvl68s3sbd3qk4rpwn42ks1v7nmsh";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "0bgszckddfpd3czyb9fddx4pgv5yv44sxc45dfk2kgqyy169gjih";
   };
 
-  nativeBuildInputs = [ meson ninja pkgconfig vala gettext libxml2 desktop-file-utils wrapGAppsHook ];
+  nativeBuildInputs = [
+    desktop-file-utils
+    gettext
+    libxml2
+    meson
+    ninja
+    pkgconfig
+    vala
+    wrapGAppsHook
+  ];
 
-  buildInputs = [ glib gtk3 libgtop gnome3.adwaita-icon-theme ];
+  buildInputs = [
+    glib
+    gnome3.adwaita-icon-theme
+    gtk3
+    libdazzle
+    libgtop
+  ];
 
   postPatch = ''
     chmod +x build-aux/meson/postinstall.sh
@@ -29,7 +55,7 @@ in stdenv.mkDerivation rec {
   };
 
   meta = with stdenv.lib; {
-    description = "";
+    description = "A nice way to view information about use of system resources, like memory and disk space";
     license = licenses.gpl3;
     platforms = platforms.linux;
     maintainers = gnome3.maintainers;

--- a/pkgs/applications/misc/orca/default.nix
+++ b/pkgs/applications/misc/orca/default.nix
@@ -9,13 +9,13 @@
 
 buildPythonApplication rec {
   pname = "orca";
-  version = "3.30.2";
+  version = "3.32.0";
 
   format = "other";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "17asibc46i5gr2fw04jvvdi85zzmxwlnhyq7r6cr3m5prrdr8a53";
+    sha256 = "05jqzlg0f1x53hyl0l9282ynmw37159g6dsbrid12b7sjs12cc1i";
   };
 
   patches = [

--- a/pkgs/applications/networking/instant-messengers/mikutter/default.nix
+++ b/pkgs/applications/networking/instant-messengers/mikutter/default.nix
@@ -54,6 +54,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
+    broken = true;
     description = "An extensible Twitter client";
     homepage = https://mikutter.hachune.net;
     platforms = ruby.meta.platforms;

--- a/pkgs/applications/version-management/meld/default.nix
+++ b/pkgs/applications/version-management/meld/default.nix
@@ -1,22 +1,22 @@
 { stdenv, fetchurl, itstool, python3, intltool, wrapGAppsHook
 , libxml2, gobject-introspection, gtk3, gtksourceview, gnome3
-, dbus, xvfb_run
+, gsettings-desktop-schemas, dbus, xvfb_run
 }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "meld";
-  version = "3.20.0";
+  version = "3.20.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "11khi1sg02k3b9qdag3r939cwi27cql4kjim7jhxf9ckfhpzwh6b";
+    sha256 = "0jdj7kd6vj1mdc16gvrj1kar88b2j5875ajq18fx7cbc9ny46j55";
   };
 
   nativeBuildInputs = [
     intltool itstool libxml2 gobject-introspection wrapGAppsHook
   ];
   buildInputs = [
-    gtk3 gtksourceview gnome3.gsettings-desktop-schemas gnome3.adwaita-icon-theme
+    gtk3 gtksourceview gsettings-desktop-schemas gnome3.adwaita-icon-theme
     gobject-introspection # fixes https://github.com/NixOS/nixpkgs/issues/56943 for now
   ];
   propagatedBuildInputs = with python3.pkgs; [ pygobject3 pycairo ];

--- a/pkgs/applications/video/handbrake/default.nix
+++ b/pkgs/applications/video/handbrake/default.nix
@@ -11,7 +11,7 @@
   # Codecs, audio
   libopus, lame, libvorbis, a52dec, speex, libsamplerate,
   # Text processing
-  libiconv, fribidi, fontconfig, freetype, libass, jansson, libxml2,
+  libiconv, fribidi, fontconfig, freetype, libass, jansson, libxml2, harfbuzz,
   # Optical media
   libdvdread, libdvdnav, libdvdcss, libbluray,
   useGtk ? true, wrapGAppsHook ? null,
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     ffmpeg-full libogg libtheora x264 x265 libvpx
     libopus lame libvorbis a52dec speex libsamplerate
-    libiconv fribidi fontconfig freetype libass jansson libxml2
+    libiconv fribidi fontconfig freetype libass jansson libxml2 harfbuzz
     libdvdread libdvdnav libdvdcss libbluray
   ] ++ lib.optionals useGtk [
     glib gtk3 libappindicator-gtk3 libnotify

--- a/pkgs/data/misc/shared-mime-info/default.nix
+++ b/pkgs/data/misc/shared-mime-info/default.nix
@@ -1,13 +1,13 @@
 {stdenv, fetchurl, pkgconfig, gettext, perlPackages, intltool
 , libxml2, glib}:
 
-let version = "1.10"; in
+let version = "1.12"; in
 stdenv.mkDerivation rec {
   name = "shared-mime-info-${version}";
 
   src = fetchurl {
-    url = "http://freedesktop.org/~hadess/${name}.tar.xz";
-    sha256 = "1gxyvwym3xgpmp262gfn8jg5sla6k5hy6m6dmy6grgiq90xsh9f6";
+    url = "https://gitlab.freedesktop.org/xdg/shared-mime-info/uploads/80c7f1afbcad2769f38aeb9ba6317a51/shared-mime-info-1.12.tar.xz";
+    sha256 = "0gj0pp36qpsr9w6v4nywnjpcisadwkndapqsjn0ny3gd0zzg1chq";
   };
 
   nativeBuildInputs = [ pkgconfig gettext intltool ] ++ (with perlPackages; [ perl XMLParser ]);

--- a/pkgs/desktops/gnome-3/apps/accerciser/default.nix
+++ b/pkgs/desktops/gnome-3/apps/accerciser/default.nix
@@ -1,18 +1,18 @@
 { stdenv, fetchurl, pkgconfig, gnome3, gtk3, wrapGAppsHook, gobject-introspection
 , itstool, libxml2, python3Packages, at-spi2-core
-, dbus, intltool, libwnck3 }:
+, dbus, gettext, libwnck3 }:
 
 stdenv.mkDerivation rec {
   name = "accerciser-${version}";
-  version = "3.22.0";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/accerciser/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "883306274442c7ecc076b24afca5190c835c40871ded1b9790da69347e9ca3c5";
+    sha256 = "1j7wlks6j77kfjrw6lx1g0apsy2wwca63jsm5994av5l6xs8xd5m";
   };
 
   nativeBuildInputs = [
-    pkgconfig wrapGAppsHook itstool intltool
+    pkgconfig wrapGAppsHook itstool gettext
     gobject-introspection # For setup hook
   ];
   buildInputs = [

--- a/pkgs/desktops/gnome-3/apps/cheese/default.nix
+++ b/pkgs/desktops/gnome-3/apps/cheese/default.nix
@@ -6,11 +6,11 @@
 
 stdenv.mkDerivation rec {
   name = "cheese-${version}";
-  version = "3.30.0";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/cheese/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0zz2bgjaf2lsmfs3zn24925vbjb0rycr39i288brlbzixrpcyljr";
+    sha256 = "0ahkfs6v9qraz607k2sr4qw9a59lg2m8kiw5nxhc65qql110sjsl";
   };
 
   passthru = {

--- a/pkgs/desktops/gnome-3/apps/evolution/default.nix
+++ b/pkgs/desktops/gnome-3/apps/evolution/default.nix
@@ -7,13 +7,13 @@
 , libcanberra-gtk3, bogofilter, gst_all_1, procps, p11-kit, openldap }:
 
 let
-  version = "3.30.5";
+  version = "3.32.0";
 in stdenv.mkDerivation rec {
   name = "evolution-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/evolution/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1hhxj3rh921pp3l3c5k33bdypcas1p66krzs65k1qn82c5fpgl2h";
+    sha256 = "1skwhg3fbyg3acivknnpm7hs5xy0zwlvnyf5cxs59kxh1l41xmnc";
   };
 
   propagatedUserEnvPkgs = [ evolution-data-server ];

--- a/pkgs/desktops/gnome-3/apps/file-roller/default.nix
+++ b/pkgs/desktops/gnome-3/apps/file-roller/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "file-roller-${version}";
-  version = "3.30.1";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/file-roller/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0kiragsqyixyx15747b71qc4nw8y4jx9d55wgg612xb0hp5l9pj1";
+    sha256 = "1id7f6qbgdxfixxyqjypgwy04mf1w1rbczklqmgpqx5ry4kk0a03";
   };
 
   LANG = "en_US.UTF-8"; # postinstall.py

--- a/pkgs/desktops/gnome-3/apps/gedit/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gedit/default.nix
@@ -1,28 +1,43 @@
-{ stdenv, intltool, fetchurl
+{ stdenv, meson, fetchurl, python3
 , pkgconfig, gtk3, glib, adwaita-icon-theme
-, libpeas, gtksourceview, gsettings-desktop-schemas
-, wrapGAppsHook, itstool, libsoup, libxml2
-, gnome3, gspell }:
+, libpeas, gtksourceview4, gsettings-desktop-schemas
+, wrapGAppsHook, ninja, libsoup, libxml2
+, gnome3, gspell, perl, itstool, desktop-file-utils }:
 
 stdenv.mkDerivation rec {
   name = "gedit-${version}";
-  version = "3.30.2";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gedit/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0qwig35hzvjaqic9x92jcpmycnvcybsbnbiw6rppryx0arwb3wza";
+    sha256 = "1lray9vvbcrnhjv5cr5fc4bqfd68km2x79cj50byyqn9cnlf5qn9";
   };
 
-  nativeBuildInputs = [ pkgconfig wrapGAppsHook intltool itstool libxml2 ];
+  nativeBuildInputs = [
+    pkgconfig wrapGAppsHook meson ninja libxml2
+    python3 perl itstool desktop-file-utils
+  ];
 
   buildInputs = [
     gtk3 glib
     adwaita-icon-theme libsoup
-    libpeas gtksourceview
+    libpeas gtksourceview4
     gsettings-desktop-schemas gspell
   ];
 
-  enableParallelBuilding = true;
+  postPatch = ''
+    chmod +x build-aux/meson/post_install.py
+    chmod +x plugins/externaltools/scripts/gedit-tool-merge.pl
+    patchShebangs build-aux/meson/post_install.py
+    patchShebangs plugins/externaltools/scripts/gedit-tool-merge.pl
+  '';
+
+  mesonFlags = [
+    "--buildtype=plain" # don't require git
+  ];
+
+  # Reliably fails to generate gedit-file-browser-enum-types.h in time
+  enableParallelBuilding = false;
 
   passthru = {
     updateScript = gnome3.updateScript {

--- a/pkgs/desktops/gnome-3/apps/gnome-books/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-books/default.nix
@@ -1,0 +1,52 @@
+{ stdenv, meson, ninja, gettext, fetchurl, evince, gjs
+, pkgconfig, gtk3, glib, tracker, tracker-miners, libxslt
+, webkitgtk, gnome-desktop, libgepub, gnome3, gdk_pixbuf
+, gsettings-desktop-schemas, adwaita-icon-theme, docbook_xsl
+, docbook_xml_dtd_42, desktop-file-utils, python3
+, gobject-introspection, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  pname = "gnome-books";
+  version = "3.32.0";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "1wkcywcwwszj9mldr0lngczqdz7hys08rr1nd2k6rs8ykzs2z7m4";
+  };
+
+  mesonFlags = [
+    "--buildtype=plain"
+  ];
+
+  nativeBuildInputs = [
+    meson ninja pkgconfig gettext libxslt desktop-file-utils
+    docbook_xsl docbook_xml_dtd_42 wrapGAppsHook python3
+  ];
+
+  buildInputs = [
+    gtk3 glib gsettings-desktop-schemas
+    gdk_pixbuf adwaita-icon-theme evince
+    webkitgtk gjs gobject-introspection tracker
+    tracker-miners gnome-desktop libgepub
+  ];
+
+  postPatch = ''
+    chmod +x meson_post_install.py # patchShebangs requires executable file
+    patchShebangs meson_post_install.py
+  '';
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = "gnome-books";
+      attrPath = "gnome3.gnome-books";
+    };
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://wiki.gnome.org/Apps/Books;
+    description = "An e-book manager application for GNOME";
+    maintainers = gnome3.maintainers;
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/desktops/gnome-3/apps/gnome-boxes/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-boxes/default.nix
@@ -3,19 +3,19 @@
 , spice-protocol, libsoup, libosinfo, systemd, tracker, tracker-miners, vala
 , libcap, yajl, gmp, gdbm, cyrus_sasl, gnome3, librsvg, desktop-file-utils
 , mtools, cdrkit, libcdio, libusb, libarchive, acl, libgudev, qemu, libsecret
-, libcap_ng, numactl, xen, libapparmor, json-glib, webkitgtk
+, libcap_ng, numactl, xen, libapparmor, json-glib, webkitgtk, vte
 }:
 
 # TODO: ovirt (optional)
 
 let
-  version = "3.30.3";
+  version = "3.32.0.2";
 in stdenv.mkDerivation rec {
   name = "gnome-boxes-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-boxes/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0a9ljwhkanszzyzl0bhad8vmzk7v4wafl9b1zn09pf57znyymf3s";
+    sha256 = "1239x1bbkn0gxxq82zpvjjr7srla2d5ghi5rqwxnhsab0c2ypswk";
   };
 
   doCheck = true;
@@ -32,7 +32,7 @@ in stdenv.mkDerivation rec {
     libvirt spice-gtk spice-protocol libsoup json-glib webkitgtk libosinfo systemd
     tracker tracker-miners libcap yajl gmp gdbm cyrus_sasl libusb libarchive
     gnome3.adwaita-icon-theme librsvg acl libgudev libsecret
-    libcap_ng numactl xen libapparmor
+    libcap_ng numactl xen libapparmor vte
   ];
 
   preFixup = ''

--- a/pkgs/desktops/gnome-3/apps/gnome-calendar/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-calendar/default.nix
@@ -4,13 +4,13 @@
 
 let
   pname = "gnome-calendar";
-  version = "3.30.1";
+  version = "3.32.0";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1avi7a29y8d8kzwslp51nwy6s692alms7917454j0xpfc6hnw62s";
+    sha256 = "0fyy1slcvc32nz37clps7lz3w40i30fj93fc5m0rqk664w682ys4";
   };
 
   passthru = {

--- a/pkgs/desktops/gnome-3/apps/gnome-characters/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-characters/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-characters-${version}";
-  version = "3.30.0";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-characters/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "08cwz39iwgsyyb2wqhb8vfbmh1cwfkgfiy7adp08w7rwqi99x3dp";
+    sha256 = "1cwazk9x9fs4lf89jqxdian15dk8zfsnpypgl1kknnw8r9mv0bzd";
   };
 
   postPatch = ''

--- a/pkgs/desktops/gnome-3/apps/gnome-clocks/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-clocks/default.nix
@@ -6,11 +6,11 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-clocks-${version}";
-  version = "3.31.2";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-clocks/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0f0ak4b4vxh3b2c4wkg76c210ivffw2j8pcg78zkhm9i7l5aiv09";
+    sha256 = "1w6lgjdak3x76c9gyhd1lqrdmjfh8q77sjnrkcimylsg0jq913bc";
   };
 
   passthru = {

--- a/pkgs/desktops/gnome-3/apps/gnome-clocks/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-clocks/default.nix
@@ -6,11 +6,11 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-clocks-${version}";
-  version = "3.30.1";
+  version = "3.31.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-clocks/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "009fr6zwv37wryi0c0syi4i7pxpdbn3gliws68l99cjsbn2qd6pc";
+    sha256 = "0f0ak4b4vxh3b2c4wkg76c210ivffw2j8pcg78zkhm9i7l5aiv09";
   };
 
   passthru = {

--- a/pkgs/desktops/gnome-3/apps/gnome-documents/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-documents/default.nix
@@ -8,16 +8,19 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-documents-${version}";
-  version = "3.30.0";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-documents/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0zchkjpc9algmxrpj0f9i2lc4h1yp8z0h76vn32xa9jr46x4lsh6";
+    sha256 = "1gqddzbr4d8s0asmrhy0sfmwggzhbmpm61mqf8rxpdjk7s26086c";
   };
 
   doCheck = true;
 
-  mesonFlags = [ "-Dgetting-started=true" ];
+  mesonFlags = [
+    "-Dgetting-started=true"
+    "--buildtype=plain"
+  ];
 
   nativeBuildInputs = [
     meson ninja pkgconfig gettext itstool libxslt desktop-file-utils docbook_xsl docbook_xml_dtd_42 wrapGAppsHook python3
@@ -29,14 +32,6 @@ stdenv.mkDerivation rec {
     libsoup webkitgtk gjs gobject-introspection
     tracker tracker-miners libgdata
     gnome-desktop libzapojit libgepub
-  ];
-
-  patches = [
-    # fix RPATH to libgd
-    (fetchpatch {
-      url = "https://gitlab.gnome.org/GNOME/gnome-documents/commit/d18a92e0a940073ac766f609937539e4fc6cdbb7.patch";
-      sha256 = "0s3mk8vrl1gzk93yvgqbnz44i27qw1d9yvvmnck3fv23phrxkzk9";
-    })
   ];
 
   postPatch = ''

--- a/pkgs/desktops/gnome-3/apps/gnome-getting-started-docs/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-getting-started-docs/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-getting-started-docs-${version}";
-  version = "3.30.0";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-getting-started-docs/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "10vihv6n8703rapf915waz1vzr7axk43bjlhmm3hb7kwm32rc61k";
+    sha256 = "1nzba7l33dgijwvfs777kcyy29xp7bmyrjk9nrwvm5zww4l35gai";
   };
 
   passthru = {

--- a/pkgs/desktops/gnome-3/apps/gnome-logs/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-logs/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-logs-${version}";
-  version = "3.30.0";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-logs/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1rsk2whps7rwl01mmjmhwwww4iv09fsszils9zmgqd79y7l3fmyh";
+    sha256 = "1cn0ms24y9sg1kvhmk4mj7v9fi0n6ylyf11jjh4k81wfjsaah7w4";
   };
 
   mesonFlags = [

--- a/pkgs/desktops/gnome-3/apps/gnome-maps/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-maps/default.nix
@@ -5,13 +5,13 @@
 
 let
   pname = "gnome-maps";
-  version = "3.30.3";
+  version = "3.32.1";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0s1k6v1yzchbv6big09fdhmm0rzyjdh2y7qg6fsp7d0x4qnch9nq";
+    sha256 = "1q15qsp0ca67y4l0x31518cfakrj85x9g0cbcm0wysnbddi1aik0";
   };
 
   doCheck = true;

--- a/pkgs/desktops/gnome-3/apps/gnome-music/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-music/default.nix
@@ -6,13 +6,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "gnome-music";
-  version = "3.30.2";
+  version = "3.32.0";
 
   format = "other";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1d9gd9rqy71hibfrz4zglimvgv6yn1pw22cnrn7pbdz6k4yq209d";
+    sha256 = "075q8y4i66nh6wjga6vwdcivsm1dfbwv54hfvk4q8mbws7zfzky7";
   };
 
   nativeBuildInputs = [ meson ninja gettext itstool pkgconfig libxml2 wrapGAppsHook desktop-file-utils appstream-glib gobject-introspection ];

--- a/pkgs/desktops/gnome-3/apps/gnome-notes/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-notes/default.nix
@@ -5,13 +5,13 @@
 , gnome3, libxml2 }:
 
 let
-  version = "3.30.3";
+  version = "3.32.0";
 in stdenv.mkDerivation rec {
   name = "gnome-notes-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/bijiben/${stdenv.lib.versions.majorMinor version}/bijiben-${version}.tar.xz";
-    sha256 = "1mkpi2i9nqpip5l15ihjcscyiri113s0705sjgh6b89164ahyn5k";
+    sha256 = "09l98yvgrfjw427wn271ap5v6hbwdf9liyrkp34bl0k3hv2d6dv3";
   };
 
   doCheck = true;

--- a/pkgs/desktops/gnome-3/apps/gnome-photos/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-photos/default.nix
@@ -4,22 +4,25 @@
 , grilo, gnome-online-accounts
 , desktop-file-utils, wrapGAppsHook
 , gnome3, gdk_pixbuf, gexiv2, geocode-glib
-, dleyna-renderer }:
+, dleyna-renderer, dbus, meson, ninja, python3 }:
 
 let
   pname = "gnome-photos";
-  version = "3.30.1";
+  version = "3.32.0";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1mf1887x0pk46h6l51rfkpn29fwp3yvmqkk99kr1iwpz0lakyx6f";
+    sha256 = "160vqmcqvyzby27wd2lzwzgbfl6jxxk7phhnqh9498r3clr73haj";
   };
 
   # doCheck = true;
 
-  nativeBuildInputs = [ pkgconfig gettext itstool libxml2 desktop-file-utils wrapGAppsHook ];
+  nativeBuildInputs = [
+    pkgconfig gettext itstool meson ninja libxml2
+    desktop-file-utils wrapGAppsHook python3
+  ];
   buildInputs = [
     gtk3 glib gegl babl libgdata libdazzle
     gnome3.gsettings-desktop-schemas
@@ -28,8 +31,17 @@ in stdenv.mkDerivation rec {
     gnome-online-accounts tracker
     gexiv2 geocode-glib dleyna-renderer
     tracker-miners # For 'org.freedesktop.Tracker.Miner.Files' GSettings schema
+    dbus
   ];
 
+  mesonFlags = [
+    "--buildtype=plain" # don't do any git commands
+  ];
+
+  postPatch = ''
+    chmod +x meson_post_install.py
+    patchShebangs meson_post_install.py
+  '';
 
   passthru = {
     updateScript = gnome3.updateScript {

--- a/pkgs/desktops/gnome-3/apps/gnome-power-manager/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-power-manager/default.nix
@@ -14,13 +14,13 @@
 
 let
   pname = "gnome-power-manager";
-  version = "3.30.0";
+  version = "3.32.0";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0m15x6i279wrfimz9ma2gfjv7jlkca2qbl2wcnxgx1pb3hzrwggm";
+    sha256 = "0drfn3wcc8l4n07qwv6p0rw2dwcd00hwzda282q62l6sasks2b2g";
   };
 
   passthru = {

--- a/pkgs/desktops/gnome-3/apps/gnome-sound-recorder/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-sound-recorder/default.nix
@@ -1,24 +1,25 @@
-{ stdenv, fetchurl, fetchpatch, pkgconfig, intltool, gobject-introspection, wrapGAppsHook, gjs, glib, gtk3, gdk_pixbuf, gst_all_1, gnome3 }:
+{ stdenv, fetchurl, fetchpatch, pkgconfig, gettext, gobject-introspection, wrapGAppsHook, gjs, glib, gtk3, gdk_pixbuf, gst_all_1, gnome3
+, meson, ninja, python3, hicolor-icon-theme, desktop-file-utils }:
 
 stdenv.mkDerivation rec {
   pname = "gnome-sound-recorder";
-  version = "3.28.2";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1k63xr3d16qbzi88md913ndaf2mzwmhmi6hipj0123sm7nsz1p94";
+    sha256 = "0rchzap5mg9ach3jcf4sci5v2h5pgpdjafjfllfd09w9yg3brspp";
   };
 
-  patches = [
-    # Fix crash when trying to play recordings
-    (fetchpatch {
-      url = https://gitlab.gnome.org/GNOME/gnome-sound-recorder/commit/2b311ef67909bc20d0e87f334fe37bf5c4e9f29f.patch;
-      sha256 = "0hqmk846bxma0p66cqp94zd02zc1if836ywjq3sv5dsfwnz7jv3f";
-    })
+  nativeBuildInputs = [
+    pkgconfig gettext meson ninja gobject-introspection
+    wrapGAppsHook python3 hicolor-icon-theme desktop-file-utils
   ];
-
-  nativeBuildInputs = [ pkgconfig intltool gobject-introspection wrapGAppsHook ];
   buildInputs = [ gjs glib gtk3 gdk_pixbuf ] ++ (with gst_all_1; [ gstreamer.dev gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad ]);
+
+  postPatch = ''
+    chmod +x build-aux/meson_post_install.py
+    patchShebangs build-aux/meson_post_install.py
+  '';
 
   # TODO: fix this in gstreamer
   # TODO: make stdenv.lib.getBin respect outputBin

--- a/pkgs/desktops/gnome-3/apps/gnome-todo/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-todo/default.nix
@@ -1,28 +1,67 @@
-{ stdenv, fetchurl, meson, ninja, pkgconfig, python3, wrapGAppsHook
-, gettext, gnome3, glib, gtk3, libpeas
-, gnome-online-accounts, gsettings-desktop-schemas
-, evolution-data-server, libxml2, libsoup, libical, librest, json-glib }:
+{ stdenv
+, fetchurl
+, fetchpatch
+, meson
+, ninja
+, pkgconfig
+, python3
+, wrapGAppsHook
+, gettext
+, gnome3
+, glib
+, gtk3
+, libpeas
+, gnome-online-accounts
+, gsettings-desktop-schemas
+, adwaita-icon-theme
+, evolution-data-server
+, libxml2
+, libsoup
+, libical
+, librest
+, json-glib
+}:
 
-let
+stdenv.mkDerivation rec {
   pname = "gnome-todo";
   version = "3.28.1";
-in stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "08ygqbib72jlf9y0a16k54zz51sncpq2wa18wp81v46q8301ymy7";
   };
 
-  nativeBuildInputs = [
-    meson ninja pkgconfig gettext python3 wrapGAppsHook
+  patches = [
+    # fix build with e-d-s 3.32
+    (fetchpatch {
+      url = https://gitlab.gnome.org/GNOME/gnome-todo/commit/6cdabc4dd0c6c804a093b94c269461ce376fed4f.patch;
+      sha256 = "08ldgyxv9216dgr8y9asqd7j2y82y9yqnqhkqaxc9i8a67yz1gzy";
+    })
   ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkgconfig
+    gettext
+    python3
+    wrapGAppsHook
+  ];
+
   buildInputs = [
-    glib gtk3 libpeas gnome-online-accounts
-    gsettings-desktop-schemas gnome3.adwaita-icon-theme
+    glib
+    gtk3
+    libpeas
+    gnome-online-accounts
+    gsettings-desktop-schemas
+    gnome3.adwaita-icon-theme
     # Plug-ins
-    evolution-data-server libxml2 libsoup libical
-    librest json-glib
+    evolution-data-server
+    libxml2
+    libsoup
+    libical
+    librest
+    json-glib
   ];
 
   postPatch = ''

--- a/pkgs/desktops/gnome-3/apps/gnome-weather/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-weather/default.nix
@@ -1,29 +1,32 @@
 { stdenv, fetchurl, pkgconfig, gnome3, gtk3, wrapGAppsHook, gjs, gobject-introspection
-, libgweather, intltool, itstool, geoclue2, gnome-desktop }:
+, libgweather, meson, ninja, geoclue2, gnome-desktop, python3 }:
 
 stdenv.mkDerivation rec {
   name = "gnome-weather-${version}";
-  version = "3.26.0";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-weather/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "965cc0d1b4d4e53c06d494db96f0b124d232af5c0e731ca900edd10f77a74c78";
+    sha256 = "0b7cqd3wfrgm0hps0cb8vhjz0bpjw955hbc4r82l626g8l3hf86w";
   };
 
-  nativeBuildInputs = [ pkgconfig intltool itstool wrapGAppsHook ];
+  nativeBuildInputs = [ pkgconfig meson ninja wrapGAppsHook python3 ];
   buildInputs = [
     gtk3 gjs gobject-introspection gnome-desktop
     libgweather gnome3.adwaita-icon-theme geoclue2 gnome3.gsettings-desktop-schemas
   ];
 
-  # The .service file isn't wrapped with the correct environment
-  # so misses GIR files when started. By re-pointing from the gjs
-  # entry point to the wrapped binary we get back to a wrapped
-  # binary.
-  preConfigure = ''
-    substituteInPlace "data/org.gnome.Weather.Application.service.in" \
-        --replace "Exec=@pkgdatadir@/@PACKAGE_NAME@.Application" \
+  postPatch = ''
+    # The .service file is not wrapped with the correct environment
+    # so misses GIR files when started. By re-pointing from the gjs
+    # entry point to the wrapped binary we get back to a wrapped
+    # binary.
+    substituteInPlace "data/org.gnome.Weather.service.in" \
+        --replace "Exec=@DATA_DIR@/@APP_ID@" \
                   "Exec=$out/bin/gnome-weather"
+
+    chmod +x meson_post_install.py
+    patchShebangs meson_post_install.py
   '';
 
   passthru = {

--- a/pkgs/desktops/gnome-3/apps/polari/default.nix
+++ b/pkgs/desktops/gnome-3/apps/polari/default.nix
@@ -5,13 +5,13 @@
 
 let
   pname = "polari";
-  version = "3.30.2";
+  version = "3.32.0";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "02wxkdq5s5ami9wj9vpqhs6n8qxr299bpmvpvd89mn49x73lq2w2";
+    sha256 = "1jq1xvk9a05x37g9w349f5q069cvg5lfbhxj88gpbnf4fyndnr70";
   };
 
   propagatedUserEnvPkgs = [ telepathy-idle telepathy-logger ];

--- a/pkgs/desktops/gnome-3/apps/seahorse/default.nix
+++ b/pkgs/desktops/gnome-3/apps/seahorse/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, vala, meson, ninja
+{ stdenv, fetchurl, vala, meson, ninja, libpwquality
 , pkgconfig, gtk3, glib, gobject-introspection
 , wrapGAppsHook, itstool, gnupg, libsoup
 , gnome3, gpgme, python3, openldap, gcr
@@ -6,11 +6,11 @@
 
 stdenv.mkDerivation rec {
   pname = "seahorse";
-  version = "3.30.1.1";
+  version = "3.32";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "12x7xmwh62yl0ax90v8nkx3jqzviaz9hz2g56yml78wzww20gawy";
+    sha256 = "1wxcxq6ahlwab8dr83gqml67y95mnk56hsgw19d4h0xjvyz2ym52";
   };
 
   doCheck = true;
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     gnome3.gsettings-desktop-schemas gnupg
     gnome3.adwaita-icon-theme gpgme
     libsecret avahi libsoup p11-kit
-    openssh openldap
+    openssh openldap libpwquality
   ];
 
   postPatch = ''

--- a/pkgs/desktops/gnome-3/core/adwaita-icon-theme/default.nix
+++ b/pkgs/desktops/gnome-3/core/adwaita-icon-theme/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "adwaita-icon-theme-${version}";
-  version = "3.30.1";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/adwaita-icon-theme/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1kp1lis3dr16jmlgycz1b29jsr6ir8wmqj6laqwlhs663cmjlxbd";
+    sha256 = "11ij35na8nisvxx3qh527iz33h6z2q1a7iinqyp7p65v0zjbd3b9";
   };
 
   # For convenience, we can specify adwaita-icon-theme only in packages

--- a/pkgs/desktops/gnome-3/core/baobab/default.nix
+++ b/pkgs/desktops/gnome-3/core/baobab/default.nix
@@ -4,13 +4,13 @@
 
 let
   pname = "baobab";
-  version = "3.30.0";
+  version = "3.32.0";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0kx721s1hhw1g0nvbqhb93g8iq6f852imyhfhl02zcqy4ipx0kay";
+    sha256 = "0b33s9bhpiffv5wl76cq2bbnqhvx3qs2vxyxmil5gcs583llqh9r";
   };
 
   nativeBuildInputs = [ meson ninja pkgconfig vala gettext itstool libxml2 desktop-file-utils wrapGAppsHook ];

--- a/pkgs/desktops/gnome-3/core/dconf-editor/default.nix
+++ b/pkgs/desktops/gnome-3/core/dconf-editor/default.nix
@@ -3,13 +3,13 @@
 
 let
   pname = "dconf-editor";
-  version = "3.30.2";
+  version = "3.32.0";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "06f736spn20s7qjsz00xw44v8r8bjhyrz1v3bix6v416jc5jp6ia";
+    sha256 = "1fmsmlh16njjm948grz20mzrsvb4wjj7pl1fvkrkxqi7mhr177gi";
   };
 
   nativeBuildInputs = [ meson ninja vala libxslt pkgconfig wrapGAppsHook gettext docbook_xsl libxml2 gobject-introspection python3 ];

--- a/pkgs/desktops/gnome-3/core/dconf-editor/default.nix
+++ b/pkgs/desktops/gnome-3/core/dconf-editor/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, meson, ninja, vala, libxslt, pkgconfig, glib, gtk3, gnome3, python3
-, libxml2, gettext, docbook_xsl, wrapGAppsHook, gobject-introspection }:
+, libxml2, gettext, docbook_xsl, hicolor-icon-theme, wrapGAppsHook, gobject-introspection }:
 
 let
   pname = "dconf-editor";
@@ -12,7 +12,11 @@ in stdenv.mkDerivation rec {
     sha256 = "1fmsmlh16njjm948grz20mzrsvb4wjj7pl1fvkrkxqi7mhr177gi";
   };
 
-  nativeBuildInputs = [ meson ninja vala libxslt pkgconfig wrapGAppsHook gettext docbook_xsl libxml2 gobject-introspection python3 ];
+  nativeBuildInputs = [
+    meson ninja vala libxslt pkgconfig wrapGAppsHook
+    gettext docbook_xsl libxml2 gobject-introspection python3
+    hicolor-icon-theme # for setup-hook
+  ];
 
   buildInputs = [ glib gtk3 gnome3.dconf ];
 

--- a/pkgs/desktops/gnome-3/core/dconf/default.nix
+++ b/pkgs/desktops/gnome-3/core/dconf/default.nix
@@ -6,11 +6,11 @@ let
 in
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
-  version = "0.30.1";
+  version = "0.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1dq2dn7qmxr4fxzx9wnag89ck24gxq17p2n4gl81h4w8qdy3m6jl";
+    sha256 = "1azz4hb9z76yxn34yrrsiib3iqz5z4vpwn5q7cncp55w365ygg38";
   };
 
   patches = [
@@ -23,8 +23,9 @@ stdenv.mkDerivation rec {
   ];
 
   postPatch = ''
-    chmod +x meson_post_install.py
+    chmod +x meson_post_install.py tests/test-dconf.py
     patchShebangs meson_post_install.py
+    patchShebangs tests/test-dconf.py
   '';
 
   outputs = [ "out" "lib" "dev" "devdoc" ];

--- a/pkgs/desktops/gnome-3/core/dconf/default.nix
+++ b/pkgs/desktops/gnome-3/core/dconf/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     "-Dgtk_doc=true"
   ];
 
-  doCheck = true;
+  doCheck = !stdenv.isAarch64;
 
   passthru = {
     updateScript = gnome3.updateScript {

--- a/pkgs/desktops/gnome-3/core/eog/default.nix
+++ b/pkgs/desktops/gnome-3/core/eog/default.nix
@@ -4,13 +4,13 @@
 
 let
   pname = "eog";
-  version = "3.28.4";
+  version = "3.32.0";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1wrq3l3z0x6q0hnc1vqr2hnyb1b14qw6aqvc5dldfgbs0yys6p55";
+    sha256 = "005cjq0i4281yw9wa6dyp5ymbx1yiprx1k5lgvfdd37qpbkk017z";
   };
 
   nativeBuildInputs = [ meson ninja pkgconfig gettext itstool wrapGAppsHook libxml2 gobject-introspection python3 ];

--- a/pkgs/desktops/gnome-3/core/epiphany/default.nix
+++ b/pkgs/desktops/gnome-3/core/epiphany/default.nix
@@ -2,19 +2,19 @@
 , wrapGAppsHook, gnome3, libxml2, libxslt, itstool
 , webkitgtk, libsoup, glib-networking, libsecret, gnome-desktop, libnotify, p11-kit
 , sqlite, gcr, isocodes, desktop-file-utils, python3
-, gdk_pixbuf, gst_all_1, json-glib, libdazzle }:
+, gdk_pixbuf, gst_all_1, json-glib, libdazzle, libhandy }:
 
 stdenv.mkDerivation rec {
   name = "epiphany-${version}";
-  version = "3.30.3";
+  version = "3.32.1.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/epiphany/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "05qdzx18ld1m3xiajpz6y6snfj56bgyjsgm7f4rqrnpjdbdvikbn";
+    sha256 = "1gi6g519i0dldwa8bmp047j9mdf8k0asr3ja2m593dy8pfwlya58";
   };
 
   # Tests need an X display
-  mesonFlags = [ "-Dunit_tests=false" ];
+  mesonFlags = [ "-Dunit_tests=disabled" ];
 
   nativeBuildInputs = [
     meson ninja libxslt pkgconfig itstool gettext wrapGAppsHook desktop-file-utils python3
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     gtk3 glib webkitgtk libsoup libxml2 libsecret gnome-desktop libnotify
-    sqlite isocodes p11-kit icu
+    sqlite isocodes p11-kit icu libhandy
     gdk_pixbuf gnome3.adwaita-icon-theme gcr
     glib-networking gst_all_1.gstreamer gst_all_1.gst-plugins-base
     gst_all_1.gst-plugins-good gst_all_1.gst-plugins-bad gst_all_1.gst-plugins-ugly

--- a/pkgs/desktops/gnome-3/core/evince/default.nix
+++ b/pkgs/desktops/gnome-3/core/evince/default.nix
@@ -1,35 +1,72 @@
-{ fetchurl, stdenv, pkgconfig, intltool, libxml2
-, glib, gtk3, pango, atk, gdk_pixbuf, shared-mime-info, itstool, gnome3
-, poppler, ghostscriptX, djvulibre, libspectre, libarchive, libsecret, wrapGAppsHook
-, librsvg, gobject-introspection, yelp-tools, gspell, adwaita-icon-theme, gsettings-desktop-schemas
+{ fetchurl
+, stdenv
+, autoreconfHook
+, pkgconfig
+, gettext
+, libxml2
+, appstream
+, glib
+, gtk3
+, pango
+, atk
+, gdk_pixbuf
+, shared-mime-info
+, itstool
+, gnome3
+, poppler
+, ghostscriptX
+, djvulibre
+, libspectre
+, libarchive
+, libsecret
+, wrapGAppsHook
+, librsvg
+, gobject-introspection
+, yelp-tools
+, gspell
+, adwaita-icon-theme
+, gsettings-desktop-schemas
 , libgxps
-, recentListSize ? null # 5 is not enough, allow passing a different number
-, supportXPS ? false    # Open XML Paper Specification via libgxps
-, autoreconfHook, pruneLibtoolFiles
+, supportXPS ? false # Open XML Paper Specification via libgxps
 }:
 
 stdenv.mkDerivation rec {
-  name = "evince-${version}";
-  version = "3.30.2";
+  pname = "evince";
+  version = "3.32.0";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/evince/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0k7jln6dpg4bpv61niicjzkzyq6fhb3yfld7pc8ck71c8pmvsnx9";
-  };
-
-  passthru = {
-    updateScript = gnome3.updateScript { packageName = "evince"; };
+    url = "mirror://gnome/sources/evince/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "0h2c6b2h6g3zy0gnycrjk1y7rp0kf7ppci76dmd2zvb6chhpgngh";
   };
 
   nativeBuildInputs = [
-    pkgconfig gobject-introspection intltool itstool wrapGAppsHook yelp-tools autoreconfHook pruneLibtoolFiles
+    autoreconfHook
+    pkgconfig
+    gobject-introspection
+    gettext
+    itstool
+    yelp-tools
+    appstream
+    wrapGAppsHook
   ];
 
   buildInputs = [
-    glib gtk3 pango atk gdk_pixbuf libxml2
+    glib
+    gtk3
+    pango
+    atk
+    gdk_pixbuf
+    libxml2
     gsettings-desktop-schemas
-    poppler ghostscriptX djvulibre libspectre libarchive
-    libsecret librsvg adwaita-icon-theme gspell
+    poppler
+    ghostscriptX
+    djvulibre
+    libspectre
+    libarchive
+    libsecret
+    librsvg
+    adwaita-icon-theme
+    gspell
   ] ++ stdenv.lib.optional supportXPS libgxps;
 
   configureFlags = [
@@ -41,16 +78,15 @@ stdenv.mkDerivation rec {
 
   NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/gio-unix-2.0";
 
-  preConfigure = stdenv.lib.optionalString (recentListSize != null) ''
-    sed -i 's/\(gtk_recent_chooser_set_limit .*\)5)/\1${builtins.toString recentListSize})/' shell/ev-open-recent-action.c
-    sed -i 's/\(if (++n_items == \)5\(.*\)/\1${builtins.toString recentListSize}\2/' shell/ev-window.c
-  '';
-
   preFixup = ''
     gappsWrapperArgs+=(--prefix XDG_DATA_DIRS : "${shared-mime-info}/share")
   '';
 
-  enableParallelBuilding = true;
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+    };
+  };
 
   meta = with stdenv.lib; {
     homepage = https://wiki.gnome.org/Apps/Evince;

--- a/pkgs/desktops/gnome-3/core/evolution-data-server/default.nix
+++ b/pkgs/desktops/gnome-3/core/evolution-data-server/default.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   name = "evolution-data-server-${version}";
-  version = "3.30.5";
+  version = "3.32.0";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/evolution-data-server/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1s952wyhgcbmq9nfgk75v15zdy1h3wy5p5rmkqibaavmc0pk3mli";
+    sha256 = "1pnxf0jcbmh86ahkjgn3l2521yvgypgmfz590wp350z4fi4vh44f";
   };
 
   patches = [

--- a/pkgs/desktops/gnome-3/core/gdm/default.nix
+++ b/pkgs/desktops/gnome-3/core/gdm/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   name = "gdm-${version}";
-  version = "3.30.3";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gdm/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "15f7lz7z75krgbq8vb800afj96h8mw2fpy1s28za2911x5vgq0ak";
+    sha256 = "12ypdz9i24hwbl1d1wnnxb8zlvfa4f49n9ac5cl9d6h8qp4b0gb4";
   };
 
   # Only needed to make it build

--- a/pkgs/desktops/gnome-3/core/gjs/default.nix
+++ b/pkgs/desktops/gnome-3/core/gjs/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "gjs-${version}";
-  version = "1.54.3";
+  version = "1.56.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gjs/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1cd65d4nq5xxlyjz1b83hm5zklyry6lillzf782nr0z97k60vcvn";
+    sha256 = "06pcfpscpdv9nir0hrcfglbkq0whlv7sncmlmdgi1c5daiasv9v4";
   };
 
   passthru = {

--- a/pkgs/desktops/gnome-3/core/gnome-backgrounds/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-backgrounds/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-backgrounds-${version}";
-  version = "3.30.0";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-backgrounds/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1179jrl16bp9gqabqhw7nnfp8qzf5y1vf9fi45bni6rfmwm3mrpc";
+    sha256 = "1s5krdmd3md44p1fgr2lqm5ifxb8s1vzx6hm11sb4cgzr4dw6lrz";
   };
 
   passthru = {

--- a/pkgs/desktops/gnome-3/core/gnome-bluetooth/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-bluetooth/default.nix
@@ -6,14 +6,14 @@ let
   pname = "gnome-bluetooth";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
-  version = "3.28.2";
+  version = "3.32.1";
 
   # TODO: split out "lib"
   outputs = [ "out" "dev" "devdoc" "man" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0ch7lll5n8v7m26y6y485gnrik19ml42rsh1drgcxydm6fn62j8z";
+    sha256 = "1am1gf0nzwg6x1s8ly13j0xnjzgrfj06j0dp52x4zy9s67ywlhb4";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/core/gnome-calculator/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-calculator/default.nix
@@ -1,14 +1,14 @@
 { stdenv, meson, ninja, vala, gettext, itstool, fetchurl, pkgconfig, libxml2
-, gtk3, glib, gtksourceview3, wrapGAppsHook, gobject-introspection, python3
+, gtk3, glib, gtksourceview4, wrapGAppsHook, gobject-introspection, python3
 , gnome3, mpfr, gmp, libsoup, libmpc }:
 
 stdenv.mkDerivation rec {
   name = "gnome-calculator-${version}";
-  version = "3.30.1";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-calculator/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0qkzcmj51cjmljxl1nc84h6jgq1a51xj4g6jwh3ymgm19m3sqypc";
+    sha256 = "0m4g7ml6ch9cc4wdchlyspakz3a9ak1rka26j08nvhhvllkdkqlw";
   };
 
   nativeBuildInputs = [
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    gtk3 glib libxml2 gtksourceview3 mpfr gmp
+    gtk3 glib libxml2 gtksourceview4 mpfr gmp
     gnome3.adwaita-icon-theme
     gnome3.gsettings-desktop-schemas libsoup libmpc
   ];

--- a/pkgs/desktops/gnome-3/core/gnome-color-manager/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-color-manager/default.nix
@@ -2,13 +2,13 @@
 
 let
   pname = "gnome-color-manager";
-  version = "3.30.0";
+  version = "3.32.0";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "105bqqq3yvdn5lx94mkl0d450f0l8lmwfjjcwyls1pycmj0vifwh";
+    sha256 = "1vpxa2zjz3lkq9ldjg0fl65db9s6b4kcs8nyaqfz3jygma7ifg3w";
   };
 
   nativeBuildInputs = [ meson ninja pkgconfig gettext itstool desktop-file-utils ];

--- a/pkgs/desktops/gnome-3/core/gnome-contacts/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-contacts/default.nix
@@ -2,16 +2,16 @@
 , pkgconfig, libxslt, docbook_xsl, docbook_xml_dtd_42, python3, gtk3, glib, cheese
 , libchamplain, clutter-gtk, geocode-glib, gnome-desktop, gnome-online-accounts
 , wrapGAppsHook, folks, libxml2, gnome3, telepathy-glib
-, vala, meson, ninja }:
+, vala, meson, ninja, libhandy }:
 
 let
-  version = "3.30.2";
+  version = "3.32";
 in stdenv.mkDerivation rec {
   name = "gnome-contacts-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-contacts/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1b0pkdwz9yqcv82zzdf76rs2w3wa5zli8pka09wnahikx1ykk43h";
+    sha256 = "12vr75d5akhs0fzmjg6j21jrrlr8njdrf9dwhw94k8p73y1gjjgw";
   };
 
   propagatedUserEnvPkgs = [ evolution-data-server ];
@@ -22,14 +22,18 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [
     gtk3 glib evolution-data-server gnome3.gsettings-desktop-schemas
-    folks gnome-desktop telepathy-glib
+    folks gnome-desktop telepathy-glib libhandy
     libxml2 gnome-online-accounts cheese
     gnome3.adwaita-icon-theme libchamplain clutter-gtk geocode-glib
   ];
 
+  mesonFlags = [
+    "-Dtelepathy=true"
+  ];
+
   postPatch = ''
-    chmod +x meson_post_install.py
-    patchShebangs meson_post_install.py
+    chmod +x build-aux/meson_post_install.py
+    patchShebangs build-aux/meson_post_install.py
   '';
 
   # In file included from src/gnome-contacts@exe/contacts-avatar-selector.c:30:0:

--- a/pkgs/desktops/gnome-3/core/gnome-control-center/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-control-center/default.nix
@@ -1,28 +1,27 @@
 { fetchurl, stdenv, substituteAll, meson, ninja, pkgconfig, gnome3, ibus, gettext, upower, wrapGAppsHook
 , libcanberra-gtk3, accountsservice, libpwquality, libpulseaudio
-, gdk_pixbuf, librsvg, libnotify, libgudev, libsecret, gnome-color-manager
+, gdk_pixbuf, librsvg, libgudev, libsecret, gnome-color-manager
 , libxml2, polkit, libxslt, libgtop, libsoup, colord, colord-gtk
-, cracklib, libkrb5, networkmanagerapplet, networkmanager, glibc
-, libwacom, samba, shared-mime-info, tzdata, libtool, libgnomekbd
+, libkrb5, networkmanagerapplet, networkmanager, glibc
+, libwacom, samba, shared-mime-info, tzdata, libgnomekbd
 , docbook_xsl, modemmanager, clutter, clutter-gtk, cheese, gnome-session
 , fontconfig, sound-theme-freedesktop, grilo, python3
 , gtk3, glib, glib-networking, gsettings-desktop-schemas
 , gnome-desktop, gnome-settings-daemon, gnome-online-accounts
-, vino, gnome-bluetooth, tracker, adwaita-icon-theme }:
+, vino, gnome-bluetooth, tracker, adwaita-icon-theme
+, udisks2, gsound, libhandy, cups }:
 
-let
+stdenv.mkDerivation rec {
   pname = "gnome-control-center";
-  version = "3.30.3";
-in stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
+  version = "3.32.1";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0gih1cmqbv803kp30704sllghb0impa0mmv3j8pndfg4zr2mnq9r";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "0xpcmwgnn29syi2kfxc8233a5f3j8cij5wcn76xmsmwxvxz5r85l";
   };
 
   nativeBuildInputs = [
-    meson ninja pkgconfig gettext wrapGAppsHook libtool libxslt docbook_xsl
+    meson ninja pkgconfig gettext wrapGAppsHook libxslt docbook_xsl
     shared-mime-info python3
   ];
 
@@ -30,10 +29,11 @@ in stdenv.mkDerivation rec {
     ibus gtk3 glib glib-networking upower gsettings-desktop-schemas
     libxml2 gnome-desktop gnome-settings-daemon polkit libgtop
     gnome-online-accounts libsoup colord libpulseaudio fontconfig colord-gtk
-    accountsservice libkrb5 networkmanagerapplet libwacom samba libnotify
-    grilo libpwquality cracklib vino libcanberra-gtk3 libgudev libsecret
+    accountsservice libkrb5 networkmanagerapplet libwacom samba
+    grilo libpwquality vino libcanberra-gtk3 libgudev libsecret
     gdk_pixbuf adwaita-icon-theme librsvg clutter clutter-gtk cheese
     networkmanager modemmanager gnome-bluetooth tracker
+    udisks2 gsound libhandy
   ];
 
   patches = [
@@ -41,6 +41,7 @@ in stdenv.mkDerivation rec {
       src = ./paths.patch;
       gcm = gnome-color-manager;
       inherit glibc libgnomekbd tzdata;
+      inherit cups networkmanagerapplet;
     })
   ];
 

--- a/pkgs/desktops/gnome-3/core/gnome-control-center/paths.patch
+++ b/pkgs/desktops/gnome-3/core/gnome-control-center/paths.patch
@@ -1,6 +1,8 @@
+diff --git a/panels/color/cc-color-panel.c b/panels/color/cc-color-panel.c
+index 49ca35220..adefb87b9 100644
 --- a/panels/color/cc-color-panel.c
 +++ b/panels/color/cc-color-panel.c
-@@ -599,7 +599,7 @@
+@@ -599,7 +599,7 @@ gcm_prefs_calibrate_cb (GtkWidget *widget, CcColorPanel *prefs)
  
    /* run with modal set */
    argv = g_ptr_array_new_with_free_func (g_free);
@@ -9,7 +11,7 @@
    g_ptr_array_add (argv, g_strdup ("--device"));
    g_ptr_array_add (argv, g_strdup (cd_device_get_id (prefs->current_device)));
    g_ptr_array_add (argv, g_strdup ("--parent-window"));
-@@ -1038,7 +1038,7 @@
+@@ -1038,7 +1038,7 @@ gcm_prefs_profile_view (CcColorPanel *prefs, CdProfile *profile)
  
    /* open up gcm-viewer as a info pane */
    argv = g_ptr_array_new_with_free_func (g_free);
@@ -18,7 +20,7 @@
    g_ptr_array_add (argv, g_strdup ("--profile"));
    g_ptr_array_add (argv, g_strdup (cd_profile_get_id (profile)));
    g_ptr_array_add (argv, g_strdup ("--parent-window"));
-@@ -1288,15 +1288,12 @@
+@@ -1288,15 +1288,12 @@ gcm_prefs_device_clicked (CcColorPanel *prefs, CdDevice *device)
  static void
  gcm_prefs_profile_clicked (CcColorPanel *prefs, CdProfile *profile, CdDevice *device)
  {
@@ -35,6 +37,8 @@
      gtk_widget_set_sensitive (prefs->toolbutton_profile_view, TRUE);
    else
      gtk_widget_set_sensitive (prefs->toolbutton_profile_view, FALSE);
+diff --git a/panels/datetime/tz.h b/panels/datetime/tz.h
+index 96b25140c..1ad704d4a 100644
 --- a/panels/datetime/tz.h
 +++ b/panels/datetime/tz.h
 @@ -27,11 +27,7 @@
@@ -50,24 +54,96 @@
  
  typedef struct _TzDB TzDB;
  typedef struct _TzLocation TzLocation;
---- a/panels/region/cc-region-panel.c
-+++ b/panels/region/cc-region-panel.c
-@@ -1265,10 +1265,10 @@
+diff --git a/panels/network/connection-editor/net-connection-editor.c b/panels/network/connection-editor/net-connection-editor.c
+index 9390a3308..d30b4a68e 100644
+--- a/panels/network/connection-editor/net-connection-editor.c
++++ b/panels/network/connection-editor/net-connection-editor.c
+@@ -247,9 +247,9 @@ net_connection_editor_do_fallback (NetConnectionEditor *editor, const gchar *typ
+         GError *error = NULL;
+ 
+         if (editor->is_new_connection) {
+-                cmdline = g_strdup_printf ("nm-connection-editor --type='%s' --create", type);
++                cmdline = g_strdup_printf ("@networkmanagerapplet@/bin/nm-connection-editor --type='%s' --create", type);
+         } else {
+-                cmdline = g_strdup_printf ("nm-connection-editor --edit='%s'",
++                cmdline = g_strdup_printf ("@networkmanagerapplet@/bin/nm-connection-editor --edit='%s'",
+                                            nm_connection_get_uuid (editor->connection));
          }
  
-         if (variant && variant[0])
+diff --git a/panels/network/net-device-wifi.c b/panels/network/net-device-wifi.c
+index 360fbfc72..870157a11 100644
+--- a/panels/network/net-device-wifi.c
++++ b/panels/network/net-device-wifi.c
+@@ -1385,7 +1385,7 @@ device_wifi_edit (NetObject *object)
+                 return;
+         }
+         uuid = nm_connection_get_uuid (NM_CONNECTION (connection));
+-        cmdline = g_strdup_printf ("nm-connection-editor --edit %s", uuid);
++        cmdline = g_strdup_printf ("@networkmanagerapplet@/bin/nm-connection-editor --edit %s", uuid);
+         g_debug ("Launching '%s'\n", cmdline);
+         if (!g_spawn_command_line_async (cmdline, &error)) {
+                 g_warning ("Failed to launch nm-connection-editor: %s", error->message);
+diff --git a/panels/network/net-device.c b/panels/network/net-device.c
+index d73b537b9..e2ee54294 100644
+--- a/panels/network/net-device.c
++++ b/panels/network/net-device.c
+@@ -197,7 +197,7 @@ net_device_edit (NetObject *object)
+ 
+         connection = net_device_get_find_connection (device);
+         uuid = nm_connection_get_uuid (connection);
+-        cmdline = g_strdup_printf ("nm-connection-editor --edit %s", uuid);
++        cmdline = g_strdup_printf ("@networkmanagerapplet@/bin/nm-connection-editor --edit %s", uuid);
+         g_debug ("Launching '%s'\n", cmdline);
+         if (!g_spawn_command_line_async (cmdline, &error)) {
+                 g_warning ("Failed to launch nm-connection-editor: %s", error->message);
+diff --git a/panels/printers/pp-host.c b/panels/printers/pp-host.c
+index f53ba217e..d24bcaeb9 100644
+--- a/panels/printers/pp-host.c
++++ b/panels/printers/pp-host.c
+@@ -256,7 +256,7 @@ _pp_host_get_snmp_devices_thread (GTask        *task,
+   devices = g_new0 (PpDevicesList, 1);
+ 
+   argv = g_new0 (gchar *, 3);
+-  argv[0] = g_strdup ("/usr/lib/cups/backend/snmp");
++  argv[0] = g_strdup ("@cups@/lib/cups/backend/snmp");
+   argv[1] = g_strdup (priv->hostname);
+ 
+   /* Use SNMP to get printer's informations */
+diff --git a/panels/region/cc-region-panel.c b/panels/region/cc-region-panel.c
+index 35859526d..21486c917 100644
+--- a/panels/region/cc-region-panel.c
++++ b/panels/region/cc-region-panel.c
+@@ -755,10 +755,10 @@ row_layout_cb (CcRegionPanel *self,
+         layout_variant = cc_input_source_get_layout_variant (source);
+ 
+         if (layout_variant && layout_variant[0])
 -                commandline = g_strdup_printf ("gkbd-keyboard-display -l \"%s\t%s\"",
 +                commandline = g_strdup_printf ("@libgnomekbd@/bin/gkbd-keyboard-display -l \"%s\t%s\"",
-                                                layout, variant);
+                                                layout, layout_variant);
          else
 -                commandline = g_strdup_printf ("gkbd-keyboard-display -l %s",
 +                commandline = g_strdup_printf ("@libgnomekbd@/bin/gkbd-keyboard-display -l %s",
                                                 layout);
  
          g_spawn_command_line_async (commandline, NULL);
+diff --git a/panels/user-accounts/run-passwd.c b/panels/user-accounts/run-passwd.c
+index 00239ce0f..617c98870 100644
+--- a/panels/user-accounts/run-passwd.c
++++ b/panels/user-accounts/run-passwd.c
+@@ -150,7 +150,7 @@ spawn_passwd (PasswdHandler *passwd_handler, GError **error)
+         gchar  **envp;
+         gint    my_stdin, my_stdout, my_stderr;
+ 
+-        argv[0] = "/usr/bin/passwd";    /* Is it safe to rely on a hard-coded path? */
++        argv[0] = "/run/wrappers/bin/passwd";    /* Is it safe to rely on a hard-coded path? */
+         argv[1] = NULL;
+ 
+         envp = g_get_environ ();
+diff --git a/tests/datetime/test-endianess.c b/tests/datetime/test-endianess.c
+index 9cb92007a..84d2f0fa3 100644
 --- a/tests/datetime/test-endianess.c
 +++ b/tests/datetime/test-endianess.c
-@@ -26,7 +26,7 @@
+@@ -26,7 +26,7 @@ test_endianess (void)
  	g_autoptr(GDir) dir = NULL;
  	const char *name;
  

--- a/pkgs/desktops/gnome-3/core/gnome-desktop/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-desktop/default.nix
@@ -1,22 +1,22 @@
-{ stdenv, fetchurl, substituteAll, pkgconfig, libxslt, which, libX11, gnome3, gtk3, glib
-, gettext, libxml2, xkeyboard_config, isocodes, itstool, wayland, fetchpatch
+{ stdenv, fetchurl, substituteAll, pkgconfig, libxslt, ninja, libX11, gnome3, gtk3, glib
+, gettext, libxml2, xkeyboard_config, isocodes, meson, wayland, fetchpatch
 , libseccomp, bubblewrap, gobject-introspection, gtk-doc, docbook_xsl }:
 
 stdenv.mkDerivation rec {
   name = "gnome-desktop-${version}";
-  version = "3.30.2.1";
+  version = "3.32.0";
 
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-desktop/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "07s95fpfl3kjq51yxbrx6q87w812pq6bl0xdn0zzyi6qvg33m00v";
+    sha256 = "0m3vs3rhhykr4xnwzi18h4bb1l05l8ykpiw4mi90dz19zk2ksfd6";
   };
 
   enableParallelBuilding = true;
 
   nativeBuildInputs = [
-    pkgconfig which itstool gettext libxslt libxml2 gobject-introspection
+    pkgconfig meson ninja gettext libxslt libxml2 gobject-introspection
     gtk-doc docbook_xsl
   ];
   buildInputs = [
@@ -32,15 +32,11 @@ stdenv.mkDerivation rec {
       bubblewrap_bin = "${bubblewrap}/bin/bwrap";
       inherit (builtins) storeDir;
     })
-    (fetchpatch {
-      name = "fix-missing-font-cache";
-      url = https://gitlab.gnome.org/GNOME/gnome-desktop/commit/b87de7495160dbf48f01aa1ddb361fc2556ffd0c.patch;
-      sha256 = "1aw7lw93kcflmqmbx25cwja25441i8xzvgjm1pfsxvw3vr8j6scb";
-    })
   ];
 
-  configureFlags = [
-    "--enable-gtk-doc"
+  mesonFlags = [
+    "-Dgtk_doc=true"
+    "-Ddesktop_docs=false"
   ];
 
   passthru = {

--- a/pkgs/desktops/gnome-3/core/gnome-disk-utility/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-disk-utility/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-disk-utility-${version}";
-  version = "3.30.2";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-disk-utility/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1365fabz3q7n3bl775z82m1nzg18birxxyd7l2ssbbkqrx3h7wgi";
+    sha256 = "1prnmfxll1hskqqbhd8lyz2zafbrj2dv04fn817rn3266dr94kpq";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/core/gnome-font-viewer/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-font-viewer/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-font-viewer-${version}";
-  version = "3.30.0";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-font-viewer/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1wwnx2zrlbd2d6np7m9s78alx6j6ranrnh1g2z6zrv9qcj8rpzz5";
+    sha256 = "10b150sa3971i5lfnk0jkkzlril97lz09sshwsbkabc8b7kv1qa3";
   };
 
   doCheck = true;

--- a/pkgs/desktops/gnome-3/core/gnome-font-viewer/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-font-viewer/default.nix
@@ -1,6 +1,6 @@
 { stdenv, meson, ninja, gettext, fetchurl
 , pkgconfig, gtk3, glib, libxml2, gnome-desktop, adwaita-icon-theme
-, wrapGAppsHook, gnome3 }:
+, wrapGAppsHook, gnome3, harfbuzz }:
 
 stdenv.mkDerivation rec {
   name = "gnome-font-viewer-${version}";
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   nativeBuildInputs = [ meson ninja pkgconfig gettext wrapGAppsHook libxml2 ];
-  buildInputs = [ gtk3 glib gnome-desktop adwaita-icon-theme ];
+  buildInputs = [ gtk3 glib gnome-desktop adwaita-icon-theme harfbuzz ];
 
   # Do not run meson-postinstall.sh
   preConfigure = "sed -i '2,$ d'  meson-postinstall.sh";

--- a/pkgs/desktops/gnome-3/core/gnome-keyring/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-keyring/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-keyring-${version}";
-  version = "3.28.2";
+  version = "3.31.91";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-keyring/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0sk4las4ji8wv9nx8mldzqccmpmkvvr9pdwv9imj26r10xyin5w1";
+    sha256 = "1fjylqw4xp0rqsylq4gbxzw1sql2sy55h1mnz1pprrxb9py0mnd4";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/desktops/gnome-3/core/gnome-online-accounts/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-online-accounts/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, vala, glib, libxslt, gtk3, wrapGAppsHook
 , webkitgtk, json-glib, librest, libsecret, gtk-doc, gobject-introspection
-, gettext, icu, glib-networking
+, gettext, icu, glib-networking, hicolor-icon-theme
 , libsoup, docbook_xsl, docbook_xml_dtd_412, gnome3, gcr, kerberos
 }:
 
@@ -31,6 +31,7 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkgconfig gobject-introspection vala gettext wrapGAppsHook
     libxslt docbook_xsl docbook_xml_dtd_412 gtk-doc
+    hicolor-icon-theme # for setup-hook
   ];
   buildInputs = [
     glib gtk3 webkitgtk json-glib librest libsecret glib-networking icu libsoup

--- a/pkgs/desktops/gnome-3/core/gnome-online-accounts/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-online-accounts/default.nix
@@ -6,13 +6,13 @@
 
 let
   pname = "gnome-online-accounts";
-  version = "3.30.2";
+  version = "3.32.0";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1p1gdgryziklrgngn6m13xnvfx4gb01h723nndfi9944r24fbiq5";
+    sha256 = "1anlx0rb2hafg9929pgfms25mdz23sd0vdva06h6zlf8f5byc68w";
   };
 
   outputs = [ "out" "man" "dev" "devdoc" ];

--- a/pkgs/desktops/gnome-3/core/gnome-screenshot/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-screenshot/default.nix
@@ -4,13 +4,13 @@
 
 let
   pname = "gnome-screenshot";
-  version = "3.30.0";
+  version = "3.32.0";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "06dx3svxq6sar4913mrz5lzb7hmc66wck138vmyxj8x8iv1iw0w8";
+    sha256 = "09ha7dizjm5ymqpjyrqd10ijfb3xlqc1mwg9ajkrbfry11q9yq4b";
   };
 
   doCheck = true;

--- a/pkgs/desktops/gnome-3/core/gnome-session/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-session/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-session-${version}";
-  version = "3.30.1";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-session/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0fbpq103md4g9gi67rxnwvha21629nxx7qazddy6q6494sbqbzpa";
+    sha256 = "0zrzkpd406i159mla7bfs5npa32fgqh66aip1rfq02rgsgmc9m5v";
   };
 
   patches = [

--- a/pkgs/desktops/gnome-3/core/gnome-settings-daemon/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-settings-daemon/default.nix
@@ -1,15 +1,48 @@
-{ fetchurl, substituteAll, stdenv, meson, ninja, pkgconfig, gnome3, perl, gettext, gtk3, glib, libnotify, lcms2, libXtst
-, libxkbfile, libpulseaudio, alsaLib, libcanberra-gtk3, upower, colord, libgweather, polkit, gsettings-desktop-schemas
-, geoclue2, librsvg, xf86_input_wacom, udev, libgudev, libwacom, libxslt, libxml2, networkmanager
-, gnome-desktop, geocode-glib, docbook_xsl, wrapGAppsHook, python3, ibus, xkeyboard_config, tzdata, nss }:
+{ stdenv
+, substituteAll
+, fetchurl
+, meson
+, ninja
+, pkgconfig
+, gnome3
+, perl
+, gettext
+, gtk3
+, glib
+, libnotify
+, libgnomekbd
+, lcms2
+, libpulseaudio
+, alsaLib
+, libcanberra-gtk3
+, upower
+, colord
+, libgweather
+, polkit
+, gsettings-desktop-schemas
+, geoclue2
+, systemd
+, libgudev
+, libwacom
+, libxslt
+, libxml2
+, networkmanager
+, gnome-desktop
+, geocode-glib
+, docbook_xsl
+, wrapGAppsHook
+, python3
+, tzdata
+, nss
+}:
 
 stdenv.mkDerivation rec {
-  name = "gnome-settings-daemon-${version}";
-  version = "3.30.2";
+  pname = "gnome-settings-daemon";
+  version = "3.32.0";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gnome-settings-daemon/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0c663csa3gnsr6wm0xfll6aani45snkdj7zjwjfzcwfh8w4a3z12";
+    url = "mirror://gnome/sources/gnome-settings-daemon/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "15w3sn9qf1zqlmk8c93kgrh2a20s62m5yfizkp21m5ylrrd07f63";
   };
 
   patches = [
@@ -19,13 +52,41 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  nativeBuildInputs = [ meson ninja pkgconfig perl gettext libxml2 libxslt docbook_xsl wrapGAppsHook python3 ];
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkgconfig
+    perl
+    gettext
+    libxml2
+    libxslt
+    docbook_xsl
+    wrapGAppsHook
+    python3
+  ];
 
   buildInputs = [
-    ibus gtk3 glib gsettings-desktop-schemas networkmanager
-    libnotify gnome-desktop lcms2 libXtst libxkbfile libpulseaudio alsaLib
-    libcanberra-gtk3 upower colord libgweather xkeyboard_config nss
-    polkit geocode-glib geoclue2 librsvg xf86_input_wacom udev libgudev libwacom
+    gtk3
+    glib
+    gsettings-desktop-schemas
+    networkmanager
+    libnotify
+    libgnomekbd # for org.gnome.libgnomekbd.keyboard schema
+    gnome-desktop
+    lcms2
+    libpulseaudio
+    alsaLib
+    libcanberra-gtk3
+    upower
+    colord
+    libgweather
+    nss
+    polkit
+    geocode-glib
+    geoclue2
+    systemd
+    libgudev
+    libwacom
   ];
 
   mesonFlags = [
@@ -41,8 +102,8 @@ stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = gnome3.updateScript {
-      packageName = "gnome-settings-daemon";
-      attrPath = "gnome3.gnome-settings-daemon";
+      packageName = pname;
+      attrPath = "gnome3.${pname}";
     };
   };
 

--- a/pkgs/desktops/gnome-3/core/gnome-shell-extensions/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-shell-extensions/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-shell-extensions-${version}";
-  version = "3.30.1";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-shell-extensions/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1grxn4f5x754r172wmnf0h0xpy69afmj359zsj1rwgqlzw4i4c5p";
+    sha256 = "0wzrivhp6vs4754yldza38gkhkhah35rdncb3c3hxhhyv9fr3pl5";
   };
 
   passthru = {

--- a/pkgs/desktops/gnome-3/core/gnome-shell-extensions/fix_gmenu.patch
+++ b/pkgs/desktops/gnome-3/core/gnome-shell-extensions/fix_gmenu.patch
@@ -1,24 +1,11 @@
-From f72924a59d4a30daefccf84526bd854ebbe65ac8 Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?Tor=20Hedin=20Br=C3=B8nner?= <torhedinbronner@gmail.com>
-Date: Tue, 3 Apr 2018 14:13:12 +0200
-Subject: [PATCH] Fix gmenu typelib path
-
----
- extensions/apps-menu/extension.js | 2 ++
- 1 file changed, 2 insertions(+)
-
-diff --git a/extensions/apps-menu/extension.js b/extensions/apps-menu/extension.js
-index 5b38213..d706f64 100644
 --- a/extensions/apps-menu/extension.js
 +++ b/extensions/apps-menu/extension.js
-@@ -1,5 +1,7 @@
+@@ -1,6 +1,8 @@
  /* -*- mode: js2; js2-basic-offset: 4; indent-tabs-mode: nil -*- */
+ /* exported init enable disable */
  
 +imports.gi.GIRepository.Repository.prepend_search_path('@gmenu_path@');
 +
- const Atk = imports.gi.Atk;
- const DND = imports.ui.dnd;
- const GMenu = imports.gi.GMenu;
--- 
-2.16.2
-
+ const {
+     Atk, Clutter, Gio, GLib, GMenu, GObject, Gtk, Meta, Shell, St
+ } = imports.gi;

--- a/pkgs/desktops/gnome-3/core/gnome-shell/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-shell/default.nix
@@ -14,11 +14,11 @@ let
 
 in stdenv.mkDerivation rec {
   name = "gnome-shell-${version}";
-  version = "3.30.2";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-shell/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0kacd4w9lc5finsvs170i7827qkxwd1ddj0g2giizwffpjdjqqr2";
+    sha256 = "1djkswsv3fhb3lf2w77bbl6z2kvji29cfxbwh5gqvyykwwx87y92";
   };
 
   LANG = "en_US.UTF-8";

--- a/pkgs/desktops/gnome-3/core/gnome-shell/fix-paths.patch
+++ b/pkgs/desktops/gnome-3/core/gnome-shell/fix-paths.patch
@@ -11,12 +11,12 @@
                                            null);
 --- a/js/ui/status/keyboard.js
 +++ b/js/ui/status/keyboard.js
-@@ -1019,7 +1019,7 @@
+@@ -1059,7 +1059,7 @@ class InputSourceIndicator extends PanelMenu.Button {
+         let description = xkbLayout;
          if (xkbVariant.length > 0)
              description = description + '\t' + xkbVariant;
  
 -        Util.spawn(['gkbd-keyboard-display', '-l', description]);
 +        Util.spawn(['@libgnomekbd@/bin/gkbd-keyboard-display', '-l', description]);
-     },
- 
-     _containerGetPreferredWidth: function(container, for_height, alloc) {
+     }
+ });

--- a/pkgs/desktops/gnome-3/core/gnome-software/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-software/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, substituteAll, pkgconfig, meson, ninja, gettext, gnome3, wrapGAppsHook, packagekit, ostree
 , glib, appstream-glib, libsoup, polkit, isocodes, gspell, libxslt, gobject-introspection, flatpak, fwupd
-, gtk3, gsettings-desktop-schemas, gnome-desktop, libxmlb, gnome-online-accounts
+, gtk3, gsettings-desktop-schemas, gnome-desktop, libxmlb, gnome-online-accounts, hicolor-icon-theme
 , json-glib, libsecret, valgrind-light, docbook_xsl, docbook_xml_dtd_42, docbook_xml_dtd_43, gtk-doc, desktop-file-utils }:
 
 stdenv.mkDerivation rec {
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     meson ninja pkgconfig gettext wrapGAppsHook libxslt docbook_xml_dtd_42 docbook_xml_dtd_43
     valgrind-light docbook_xsl gtk-doc desktop-file-utils gobject-introspection
+    hicolor-icon-theme # for setup-hook
   ];
 
   buildInputs = [

--- a/pkgs/desktops/gnome-3/core/gnome-software/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-software/default.nix
@@ -1,15 +1,15 @@
 { stdenv, fetchurl, substituteAll, pkgconfig, meson, ninja, gettext, gnome3, wrapGAppsHook, packagekit, ostree
 , glib, appstream-glib, libsoup, polkit, isocodes, gspell, libxslt, gobject-introspection, flatpak, fwupd
-, gtk3, gsettings-desktop-schemas, gnome-desktop
+, gtk3, gsettings-desktop-schemas, gnome-desktop, libxmlb, gnome-online-accounts
 , json-glib, libsecret, valgrind-light, docbook_xsl, docbook_xml_dtd_42, docbook_xml_dtd_43, gtk-doc, desktop-file-utils }:
 
 stdenv.mkDerivation rec {
   name = "gnome-software-${version}";
-  version = "3.30.6";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-software/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "00lh1ifgcs888i0774qdz2pzd5vnzcc5kvx20lcmgk37vvf0qqsl";
+    sha256 = "19hrvkyavrfrhs19ii4ky5bpzsijiyq2vcxb5s4xk13xv8ys2151";
   };
 
   patches = [
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
     gsettings-desktop-schemas gnome-desktop
     gspell json-glib libsecret ostree
     polkit flatpak fwupd
+    libxmlb gnome-online-accounts
   ];
 
   mesonFlags = [

--- a/pkgs/desktops/gnome-3/core/gnome-system-monitor/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-system-monitor/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-system-monitor-${version}";
-  version = "3.30.0";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-system-monitor/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0g0y565bjs6bdszrnxsz1f7hcm1x59i3mfvplysirh7nz3hpz888";
+    sha256 = "1qvpibyhdcmscyja5a5i5nc206vmqw8xp3p8mgcignyi5njc805g";
   };
 
   doCheck = true;

--- a/pkgs/desktops/gnome-3/core/gnome-terminal/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-terminal/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-terminal-${version}";
-  version = "3.30.2";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-terminal/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0f2y76gs72sw5l5lkkkvxzsvvwm0sg83h7nl8lk5kz1v1rrc47vb";
+    sha256 = "1p4m2k63caprxmwf8d5ycpzkv3yj7146hhvnbjnr9dkl95bl41r4";
   };
 
   buildInputs = [

--- a/pkgs/desktops/gnome-3/core/gnome-user-docs/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-user-docs/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-user-docs-${version}";
-  version = "3.30.2";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-user-docs/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1pgsrvd79rqxa183wsmzh422y2zsg7fl5hskgc0s87jsc8b57fkg";
+    sha256 = "0lqbhhihxkflwckm3b8dgq62rjljkzdghcc4k4ym7n2hyc304vxy";
   };
 
   passthru = {

--- a/pkgs/desktops/gnome-3/core/gnome-user-share/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-user-share/default.nix
@@ -1,24 +1,29 @@
-{ stdenv, intltool, fetchurl, apacheHttpd, nautilus
-, pkgconfig, gtk3, glib, libxml2, systemd, adwaita-icon-theme
-, wrapGAppsHook, itstool, libnotify, libtool, mod_dnssd
-, gnome3, librsvg, gdk_pixbuf, file, libcanberra-gtk3 }:
+{ stdenv
+, gettext
+, fetchurl
+, apacheHttpd
+, nautilus
+, pkgconfig
+, gtk3
+, glib
+, libxml2
+, systemd
+, wrapGAppsHook
+, itstool
+, libnotify
+, mod_dnssd
+, gnome3
+, libcanberra-gtk3
+}:
 
 stdenv.mkDerivation rec {
-  name = "gnome-user-share-${version}";
-  version = "3.28.0";
+  pname = "gnome-user-share";
+  version = "3.32.0.1";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gnome-user-share/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "04wjnrcdlmyszj582nsda32sgi44nwgrw2ksy11xp17nb09d7m09";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "16w6n0cjyzp8vln3zspvab8jhjprpvs88xc9x7bvigg0wry74945";
   };
-
-  passthru = {
-    updateScript = gnome3.updateScript { packageName = "gnome-user-share"; attrPath = "gnome3.gnome-user-share"; };
-  };
-
-  doCheck = true;
-
-  NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/gio-unix-2.0";
 
   preConfigure = ''
     sed -e 's,^LoadModule dnssd_module.\+,LoadModule dnssd_module ${mod_dnssd}/modules/mod_dnssd.so,' \
@@ -29,22 +34,35 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--with-httpd=${apacheHttpd.out}/bin/httpd"
     "--with-modules-path=${apacheHttpd.dev}/modules"
-    "--with-systemduserunitdir=$(out)/etc/systemd/user"
-    "--with-nautilusdir=$(out)/lib/nautilus/extensions-3.0"
+    "--with-systemduserunitdir=${placeholder ''out''}/etc/systemd/user"
+    "--with-nautilusdir=${placeholder ''out''}/lib/nautilus/extensions-3.0"
   ];
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [
+    pkgconfig
+    gettext
+    itstool
+    libxml2
+    wrapGAppsHook
+  ];
+
   buildInputs = [
-    gtk3 glib intltool itstool libxml2 libtool
-    wrapGAppsHook file gdk_pixbuf adwaita-icon-theme librsvg
-    nautilus libnotify libcanberra-gtk3 systemd
+    gtk3
+    glib
+    nautilus
+    libnotify
+    libcanberra-gtk3
+    systemd
   ];
 
-  postInstall = ''
-    mkdir -p $out/share/gsettings-schemas/$name
-    mv $out/share/glib-2.0 $out/share/gsettings-schemas/$name
-    glib-compile-schemas "$out/share/gsettings-schemas/$name/glib-2.0/schemas"
-  '';
+  doCheck = true;
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+      attrPath = "gnome3.${pname}";
+    };
+  };
 
   meta = with stdenv.lib; {
     homepage = https://help.gnome.org/users/gnome-user-share/3.8;

--- a/pkgs/desktops/gnome-3/core/gsettings-desktop-schemas/default.nix
+++ b/pkgs/desktops/gnome-3/core/gsettings-desktop-schemas/default.nix
@@ -1,23 +1,29 @@
 { stdenv, fetchurl, pkgconfig, intltool, glib, gobject-introspection
+, meson
+, ninja
+, python3
   # just for passthru
 , gnome3 }:
 
 stdenv.mkDerivation rec {
   name = "gsettings-desktop-schemas-${version}";
-  version = "3.28.1";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gsettings-desktop-schemas/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0bshwm49cd01ighsxqlbqn10q0ch71ff99gcrx8pr2gyky2ad3pq";
+    sha256 = "0d8a6479vappgplq5crdr3ah0ykqcr3fw533wkx9v1a8lnrv8n9d";
   };
 
   passthru = {
     updateScript = gnome3.updateScript { packageName = "gsettings-desktop-schemas"; };
   };
 
+  # meson installs the schemas to share/glib-2.0/schemas
+  # We add the override file there too so it will be compiled and later moved by
+  # glib's setup hook.
   preInstall = ''
-    mkdir -p $out/share/gsettings-schemas/${name}/glib-2.0/schemas
-    cat - > $out/share/gsettings-schemas/${name}/glib-2.0/schemas/remove-backgrounds.gschema.override <<- EOF
+    mkdir -p $out/share/glib-2.0/schemas
+    cat - > $out/share/glib-2.0/schemas/remove-backgrounds.gschema.override <<- EOF
       [org.gnome.desktop.background]
       picture-uri='''
 
@@ -26,9 +32,14 @@ stdenv.mkDerivation rec {
     EOF
   '';
 
+  postPatch = ''
+    chmod +x build-aux/meson/post-install.py
+    patchShebangs build-aux/meson/post-install.py
+  '';
+
   buildInputs = [ glib gobject-introspection ];
 
-  nativeBuildInputs = [ pkgconfig intltool ];
+  nativeBuildInputs = [ pkgconfig python3 meson ninja ];
 
   meta = with stdenv.lib; {
     maintainers = gnome3.maintainers;

--- a/pkgs/desktops/gnome-3/core/gucharmap/default.nix
+++ b/pkgs/desktops/gnome-3/core/gucharmap/default.nix
@@ -7,17 +7,17 @@
 let
   unicode-data = callPackage ./unicode-data.nix {};
 in stdenv.mkDerivation rec {
-  name = "gucharmap-${version}";
-  version = "11.0.3";
+  pname = "gucharmap";
+  version = "12.0.1";
 
   outputs = [ "out" "lib" "dev" "devdoc" ];
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "GNOME";
-    repo = "gucharmap";
+    repo = pname;
     rev = version;
-    sha256 = "1a590nxy8jdf6zxh6jdsyvhxyaz94ixx3aa1pj7gicf1aqp26vnh";
+    sha256 = "0si3ymyfzc5v7ly0dmcs3qgw2wp8cyasycq5hmcr8frl09lr6gkw";
   };
 
   nativeBuildInputs = [
@@ -45,7 +45,7 @@ in stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = gnome3.updateScript {
-      packageName = "gucharmap";
+      packageName = pname;
     };
   };
 

--- a/pkgs/desktops/gnome-3/core/gucharmap/unicode-data.nix
+++ b/pkgs/desktops/gnome-3/core/gucharmap/unicode-data.nix
@@ -1,31 +1,31 @@
 { fetchurl, stdenv, gnome3 }:
 stdenv.mkDerivation rec {
   name = "unicode-data-${version}";
-  version = "11.0.0";
+  version = "12.0.0";
   srcs = [
     (fetchurl {
       url = "http://www.unicode.org/Public/${version}/ucd/Blocks.txt";
-      sha256 = "0lnh9iazikpr548bd7nkaq9r3vfljfvz0rg2462prac8qxk7ni8b";
+      sha256 = "041sk54v6rjzb23b9x7yjdwzdp2wc7gvfz7ybavgg4gbh51wm8x1";
     })
     (fetchurl {
       url = "http://www.unicode.org/Public/${version}/ucd/DerivedAge.txt";
-      sha256 = "0rlqqd0b1sqbzvrj29dwdizx8lyvrbfirsnn8za9lb53x5fml4gb";
+      sha256 = "04j92xp07v273z3pxkbfmi1svmw9kmnjl9nvz9fv0g5ybk9zk7r6";
     })
     (fetchurl {
       url = "http://www.unicode.org/Public/${version}/ucd/NamesList.txt";
-      sha256 = "0yr2h0nfqhirfi3bxl33z6cc94qqshlpgi06c25xh9754irqsgv8";
+      sha256 = "0vsq8gx7hws8mvxy3nlglpwxw7ky57q0fs09d7w9xgb2ylk7fz61";
     })
     (fetchurl {
       url = "http://www.unicode.org/Public/${version}/ucd/Scripts.txt";
-      sha256 = "1mbnvf97nwa3pvyzx9nd2wa94f8s0npg9740kic2p2ag7jmc1wz9";
+      sha256 = "18c63hx4y5yg408a8d0wx72d2hfnlz4l560y1fsf9lpzifxpqcmx";
     })
     (fetchurl {
       url = "http://www.unicode.org/Public/${version}/ucd/UnicodeData.txt";
-      sha256 = "16b0jzvvzarnlxdvs2izd5ia0ipbd87md143dc6lv6xpdqcs75s9";
+      sha256 = "07d1kq190kgl92ispfx6zmdkvwvhjga0ishxsngzlw8j3kdkz4ap";
     })
     (fetchurl {
       url = "http://www.unicode.org/Public/${version}/ucd/Unihan.zip";
-      sha256 = "0cy8gxb17ksi5h4ysypk4c09z61am1svjrvg97hm5m5ccjfrs1vj";
+      sha256 = "1kfdhgg2gm52x3s07bijb5cxjy0jxwhd097k5lqhvzpznprm6ibf";
     })
   ];
   phases = "installPhase";

--- a/pkgs/desktops/gnome-3/core/mutter/default.nix
+++ b/pkgs/desktops/gnome-3/core/mutter/default.nix
@@ -1,39 +1,25 @@
-{ fetchurl, fetchpatch, stdenv, pkgconfig, gnome3, intltool, gobject-introspection, upower, cairo
+{ fetchurl, fetchpatch, stdenv, pkgconfig, gnome3, gettext, gobject-introspection, upower, cairo
 , pango, cogl, clutter, libstartup_notification, zenity, libcanberra-gtk3
-, libtool, makeWrapper, xkeyboard_config, libxkbfile, libxkbcommon, libXtst, libinput
+, ninja, xkeyboard_config, libxkbfile, libxkbcommon, libXtst, libinput
 , gsettings-desktop-schemas, glib, gtk3, gnome-desktop
-, geocode-glib, pipewire, libgudev, libwacom, xwayland, autoreconfHook }:
+, geocode-glib, pipewire, libgudev, libwacom, xwayland, meson
+, gnome-settings-daemon
+, xorgserver
+, python3
+, wrapGAppsHook
+}:
 
 stdenv.mkDerivation rec {
   name = "mutter-${version}";
-  version = "3.30.2";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/mutter/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0qr3w480p31nbiad49213rj9rk6p9fl82a68pzznpz36p30dq96z";
+    sha256 = "068zir5c1awmzb31gx94zjykv6c3xb1p5pch7860y3xlihha4s3n";
   };
 
-  patches = [
-    # https://gitlab.gnome.org/GNOME/mutter/issues/270
-    # Fixes direction of the desktop switching animation when using workspace
-    # grid extension with desktops arranged horizontally.
-    (fetchpatch {
-      url = https://gitlab.gnome.org/GNOME/mutter/commit/92cccf53dfe9e077f1d61ac4f896fd391f8cb689.patch;
-      sha256 = "11vmypypjss50xg7hhdbqrxvgqlxx4lnwy59089qsfl3akg4kk2i";
-    })
-  ];
-
-  configureFlags = [
-    "--with-x"
-    "--disable-static"
-    "--enable-remote-desktop"
-    "--enable-shape"
-    "--enable-sm"
-    "--enable-startup-notification"
-    "--enable-xsync"
-    "--enable-verbose-mode"
-    "--with-libcanberra"
-    "--with-xwayland-path=${xwayland}/bin/Xwayland"
+  mesonFlags = [
+    "-Dxwayland-path=${xwayland}/bin/Xwayland"
   ];
 
   propagatedBuildInputs = [
@@ -41,19 +27,32 @@ stdenv.mkDerivation rec {
     libXtst
   ];
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig intltool libtool makeWrapper ];
+  nativeBuildInputs = [
+    meson
+    pkgconfig
+    gettext
+    ninja
+    python3
+    # for cvt command
+    xorgserver
+    wrapGAppsHook
+  ];
 
   buildInputs = [
     glib gobject-introspection gtk3 gsettings-desktop-schemas upower
     gnome-desktop cairo pango cogl clutter zenity libstartup_notification
     geocode-glib libinput libgudev libwacom
     libcanberra-gtk3 zenity xkeyboard_config libxkbfile
-    libxkbcommon pipewire
+    libxkbcommon pipewire xwayland
+    gnome-settings-daemon
   ];
 
-  preFixup = ''
-    wrapProgram "$out/bin/mutter" \
-      --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
+  postPatch = ''
+    patchShebangs src/backends/native/gen-default-modes.py
+  '';
+
+  postInstall = ''
+    ${glib.dev}/bin/glib-compile-schemas "$out/share/glib-2.0/schemas"
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/desktops/gnome-3/core/mutter/default.nix
+++ b/pkgs/desktops/gnome-3/core/mutter/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, fetchpatch, stdenv, pkgconfig, gnome3, gettext, gobject-introspection, upower, cairo
+{ fetchurl, substituteAll, stdenv, pkgconfig, gnome3, gettext, gobject-introspection, upower, cairo
 , pango, cogl, clutter, libstartup_notification, zenity, libcanberra-gtk3
 , ninja, xkeyboard_config, libxkbfile, libxkbcommon, libXtst, libinput
 , gsettings-desktop-schemas, glib, gtk3, gnome-desktop
@@ -45,6 +45,13 @@ stdenv.mkDerivation rec {
     libcanberra-gtk3 zenity xkeyboard_config libxkbfile
     libxkbcommon pipewire xwayland
     gnome-settings-daemon
+  ];
+
+  patches = [
+    (substituteAll {
+      src = ./fix-paths.patch;
+      inherit zenity;
+    })
   ];
 
   postPatch = ''

--- a/pkgs/desktops/gnome-3/core/mutter/fix-paths.patch
+++ b/pkgs/desktops/gnome-3/core/mutter/fix-paths.patch
@@ -1,0 +1,13 @@
+diff --git a/src/core/util.c b/src/core/util.c
+index 57b73747d..f424cc81c 100644
+--- a/src/core/util.c
++++ b/src/core/util.c
+@@ -636,7 +636,7 @@ meta_show_dialog (const char *type,
+ 
+   args = g_ptr_array_new ();
+ 
+-  append_argument (args, "zenity");
++  append_argument (args, "@zenity@/bin/zenity");
+   append_argument (args, type);
+ 
+   if (display)

--- a/pkgs/desktops/gnome-3/core/nautilus/bubblewrap-paths.patch
+++ b/pkgs/desktops/gnome-3/core/nautilus/bubblewrap-paths.patch
@@ -1,20 +1,15 @@
 ---   a/src/gnome-desktop/gnome-desktop-thumbnail-script.c
 +++   a/src/gnome-desktop/gnome-desktop-thumbnail-script.c
-@@ -514,14 +514,11 @@ add_bwrap (GPtrArray   *array,
+@@ -536,9 +536,9 @@ add_bwrap (GPtrArray   *array,
    g_return_val_if_fail (script->s_infile != NULL, FALSE);
  
    add_args (array,
 -	    "bwrap",
 -	    "--ro-bind", "/usr", "/usr",
--	    "--ro-bind", "/lib", "/lib",
--	    "--ro-bind", "/lib64", "/lib64",
+-	    "--ro-bind", "/etc/ld.so.cache", "/etc/ld.so.cache",
 +	    "@bubblewrap_bin@",
 +	    "--ro-bind", "@storeDir@", "@storeDir@",
 +	    "--ro-bind", "/run/current-system", "/run/current-system",
- 	    "--proc", "/proc",
- 	    "--dev", "/dev",
--	    "--symlink", "usr/bin", "/bin",
--	    "--symlink", "usr/sbin", "/sbin",
- 	    "--chdir", "/",
- 	    "--setenv", "GIO_USE_VFS", "local",
- 	    "--unshare-all",
+ 	    NULL);
+ 
+   /* These directories might be symlinks into /usr/... */

--- a/pkgs/desktops/gnome-3/core/nautilus/default.nix
+++ b/pkgs/desktops/gnome-3/core/nautilus/default.nix
@@ -2,18 +2,18 @@
 , desktop-file-utils, python3, wrapGAppsHook , gtk3, gnome3, gnome-autoar
 , glib-networking, shared-mime-info, libnotify, libexif, libseccomp , exempi
 , librsvg, tracker, tracker-miners, gexiv2, libselinux, gdk_pixbuf
-, substituteAll, bubblewrap
+, substituteAll, bubblewrap, gst_all_1
 }:
 
 let
   pname = "nautilus";
-  version = "3.30.5";
+  version = "3.32.0";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "144r4py9b8w9ycsg6fggjg05kwvymh003qsb3h6apgpch5y3zgnv";
+    sha256 = "1pnh32fal7dkwadga5savg1nv0zqnbakhk0hxr5726087i6y6ii2";
   };
 
   nativeBuildInputs = [
@@ -23,7 +23,7 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [
     glib-networking shared-mime-info libexif gtk3 exempi libnotify libselinux
-    tracker tracker-miners gexiv2 libseccomp bubblewrap
+    tracker tracker-miners gexiv2 libseccomp bubblewrap gst_all_1.gst-plugins-base
     gnome3.adwaita-icon-theme gnome3.gsettings-desktop-schemas
   ];
 

--- a/pkgs/desktops/gnome-3/core/simple-scan/default.nix
+++ b/pkgs/desktops/gnome-3/core/simple-scan/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "simple-scan-${version}";
-  version = "3.30.2";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/simple-scan/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0dknvdjlnxrp9nxd3yr8wyjc4kv94nwglss8pr6rfvl4hnlly53i";
+    sha256 = "1b1nspiwzgxan2b11n96ax0c2q93dz17m67z1krdsrzdkyhh4hnh";
   };
 
   buildInputs = [

--- a/pkgs/desktops/gnome-3/core/sushi/default.nix
+++ b/pkgs/desktops/gnome-3/core/sushi/default.nix
@@ -1,25 +1,25 @@
-{ stdenv, fetchurl, pkgconfig, file, intltool, gobject-introspection, glib
-, clutter-gtk, clutter-gst, gnome3, aspell, hspell, gtksourceview, gjs
+{ stdenv, fetchurl, pkgconfig, meson, gettext, gobject-introspection, glib
+, clutter-gtk, clutter-gst, gnome3, gtksourceview, gjs
 , webkitgtk, libmusicbrainz5, icu, wrapGAppsHook, gst_all_1
-, gdk_pixbuf, librsvg, gtk3, harfbuzz }:
+, gdk_pixbuf, librsvg, gtk3, harfbuzz, ninja }:
 
 stdenv.mkDerivation rec {
   name = "sushi-${version}";
-  version = "3.30.0";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/sushi/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0zpaiw5r734fky3zq95a6szwn7srbkpixajqg2xvdivhhx4mbnnj";
+    sha256 = "0f1i8qp39gq749h90f7nwgrj4q6y55jnyh62n1v8hxvlk0b2wqnx";
   };
 
-  nativeBuildInputs = [ pkgconfig file intltool gobject-introspection wrapGAppsHook ];
+  nativeBuildInputs = [
+    pkgconfig meson ninja gettext gobject-introspection wrapGAppsHook
+  ];
   buildInputs = [
     glib gtk3 gnome3.evince icu harfbuzz
     clutter-gtk clutter-gst gjs gtksourceview gdk_pixbuf
     librsvg libmusicbrainz5 webkitgtk
     gst_all_1.gstreamer gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good
-    # cannot find -laspell, -lhspell
-    aspell hspell
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/desktops/gnome-3/core/totem/default.nix
+++ b/pkgs/desktops/gnome-3/core/totem/default.nix
@@ -1,24 +1,22 @@
-{ stdenv, fetchurl, meson, ninja, intltool, gst_all_1
+{ stdenv, fetchurl, meson, ninja, gettext, gst_all_1
 , clutter-gtk, clutter-gst, python3Packages, shared-mime-info
 , pkgconfig, gtk3, glib, gobject-introspection, totem-pl-parser
 , wrapGAppsHook, itstool, libxml2, vala, gnome3, grilo, grilo-plugins
 , libpeas, adwaita-icon-theme, gnome-desktop, gsettings-desktop-schemas
-, gdk_pixbuf, tracker, nautilus }:
+, gdk_pixbuf, tracker, nautilus, xvfb_run }:
 
 stdenv.mkDerivation rec {
   name = "totem-${version}";
-  version = "3.30.0";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/totem/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0rahkybxbmxhlmrrgrzxny1xm7wycx7ib4blxp1i2l1q3i8s84b0";
+    sha256 = "12iykwslvnpgmrm4bcchx5rzn2g4rl5r9s86n2001djn58yw6m6r";
   };
 
   doCheck = true;
 
-  NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/gio-unix-2.0";
-
-  nativeBuildInputs = [ meson ninja vala pkgconfig intltool python3Packages.python itstool gobject-introspection wrapGAppsHook ];
+  nativeBuildInputs = [ meson ninja vala pkgconfig gettext python3Packages.python itstool gobject-introspection wrapGAppsHook ];
   buildInputs = [
     gtk3 glib grilo clutter-gtk clutter-gst totem-pl-parser grilo-plugins
     gst_all_1.gstreamer gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good gst_all_1.gst-plugins-bad
@@ -40,6 +38,13 @@ stdenv.mkDerivation rec {
     # https://github.com/mesonbuild/meson/issues/1994
     "-Denable-vala=no"
   ];
+
+  checkInputs = [ xvfb_run ];
+
+  checkPhase = ''
+    xvfb-run -s '-screen 0 800x600x24' \
+      ninja test
+  '';
 
   wrapPrefixVariables = [ "PYTHONPATH" ];
 

--- a/pkgs/desktops/gnome-3/core/tracker-miners/default.nix
+++ b/pkgs/desktops/gnome-3/core/tracker-miners/default.nix
@@ -64,6 +64,7 @@ in stdenv.mkDerivation rec {
     # TODO: tests do not like our sandbox
     "-Dfunctional_tests=false"
     "-Ddbus_services=${placeholder "out"}/share/dbus-1/services"
+    "-Dsystemd_user_services=${placeholder "out"}/lib/systemd/user"
   ];
 
   patches = [

--- a/pkgs/desktops/gnome-3/core/tracker-miners/default.nix
+++ b/pkgs/desktops/gnome-3/core/tracker-miners/default.nix
@@ -8,11 +8,11 @@ let
   pname = "tracker-miners";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
-  version = "2.1.5";
+  version = "2.2.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1kdq7fk9c80ngg65p31pjdk4za0fq7nfhblqsma9alvkam5kvzgm";
+    sha256 = "1xbjbd994jxhdan7227kzdnmiblfy0f1vnsws5l809ydgk58f0qr";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/core/tracker-miners/fix-paths.patch
+++ b/pkgs/desktops/gnome-3/core/tracker-miners/fix-paths.patch
@@ -1,25 +1,3 @@
---- a/meson.build
-+++ b/meson.build
-@@ -25,15 +25,15 @@
-   #
-   # This check acts as a guard to make sure we are being configured with the
-   # right prefix, among other things.
--  tracker_store = find_program(join_paths(get_option('prefix'), get_option('libexecdir'), 'tracker-store'))
-+  tracker_store = find_program(join_paths(tracker_miner.get_pkgconfig_variable('prefix'), 'libexec', 'tracker-store'))
-   tracker_store_path = tracker_store.path()
- 
-   # If we are building against an installed version of tracker core rather than
-   # having it as a subproject, these 'uninstalled' locations point to the actual
-   # installed locations.
--  tracker_uninstalled_domain_rule = join_paths(get_option('prefix'), get_option('datadir'), 'tracker', 'domain-ontologies', 'default.rule')
--  tracker_uninstalled_nepomuk_ontologies_dir = join_paths(get_option('prefix'), get_option('datadir'), 'tracker', 'ontologies', 'nepomuk')
--  tracker_uninstalled_stop_words_dir = join_paths(get_option('prefix'), get_option('datadir'), 'tracker', 'stop-words', 'default.rule')
-+  tracker_uninstalled_domain_rule = join_paths(tracker_miner.get_pkgconfig_variable('prefix'), 'share', 'tracker', 'domain-ontologies', 'default.rule')
-+  tracker_uninstalled_nepomuk_ontologies_dir = join_paths(tracker_miner.get_pkgconfig_variable('prefix'), 'share', 'tracker', 'ontologies', 'nepomuk')
-+  tracker_uninstalled_stop_words_dir = join_paths(tracker_miner.get_pkgconfig_variable('prefix'), 'share', 'tracker', 'stop-words', 'default.rule')
- else
-   tracker_subproject = subproject('tracker',
-     default_options: [
 --- a/src/libtracker-miners-common/tracker-domain-ontology.c
 +++ b/src/libtracker-miners-common/tracker-domain-ontology.c
 @@ -323,7 +323,7 @@

--- a/pkgs/desktops/gnome-3/core/tracker/default.nix
+++ b/pkgs/desktops/gnome-3/core/tracker/default.nix
@@ -1,11 +1,12 @@
-{ stdenv, fetchurl, fetchFromGitLab, intltool, meson, ninja, pkgconfig, gobject-introspection, python2
+{ stdenv, fetchurl, fetchFromGitLab, intltool, meson, ninja, pkgconfig, gobject-introspection, python3
 , gtk-doc, docbook_xsl, docbook_xml_dtd_412, docbook_xml_dtd_43, glibcLocales
 , libxml2, upower, glib, wrapGAppsHook, vala, sqlite, libxslt, libstemmer
-, gnome3, icu, libuuid, networkmanager, libsoup, json-glib }:
+, gnome3, icu, libuuid, networkmanager, libsoup, json-glib
+, substituteAll}:
 
 let
   pname = "tracker";
-  version = "2.1.6";
+  version = "2.2.1";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
@@ -13,13 +14,13 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "143zapq50lggj3mpqg2y4rh1hgnkbn9vgvzpqxr7waiawsmx0awq";
+    sha256 = "1zx2mlnsv6clgh0j50f0b94b7cf1al1j7bkcz8cr31a0fkkgkkhc";
   };
 
   nativeBuildInputs = [
     meson ninja vala pkgconfig intltool libxslt wrapGAppsHook gobject-introspection
     gtk-doc docbook_xsl docbook_xml_dtd_412 docbook_xml_dtd_43 glibcLocales
-    python2 # for data-generators
+    python3 # for data-generators
   ];
 
   buildInputs = [
@@ -33,27 +34,19 @@ in stdenv.mkDerivation rec {
     "-Dsystemd_user_services=lib/systemd/user"
     # TODO: figure out wrapping unit tests, some of them fail on missing gsettings-desktop-schemas
     "-Dfunctional_tests=false"
+    "-Ddocs=true"
   ];
 
   patches = [
-    # Always generate tracker-sparql.h in time
-    (fetchurl {
-      url = https://gitlab.gnome.org/GNOME/tracker/commit/3cbfaa5b374e615098e60eb4430f108b642ebe76.diff;
-      sha256 = "0smavzvsglpghggrcl8sjflki13nh7pr0jl2yv6ymbf5hr1c4dws";
+    (substituteAll {
+      src = ./fix-paths.patch;
+      glib_dev = glib.dev;
     })
   ];
 
   postPatch = ''
     patchShebangs utils/g-ir-merge/g-ir-merge
     patchShebangs utils/data-generators/cc/generate
-
-    # make .desktop Exec absolute
-    patch -p0 <<END_PATCH
-    +++ src/tracker-store/tracker-store.desktop.in.in
-    @@ -4 +4 @@
-    -Exec=gdbus call -e -d org.freedesktop.DBus -o /org/freedesktop/DBus -m org.freedesktop.DBus.StartServiceByName org.freedesktop.Tracker1 0
-    +Exec=${glib.dev}/bin/gdbus call -e -d org.freedesktop.DBus -o /org/freedesktop/DBus -m org.freedesktop.DBus.StartServiceByName org.freedesktop.Tracker1 0
-    END_PATCH
   '';
 
   postInstall = ''

--- a/pkgs/desktops/gnome-3/core/tracker/fix-paths.patch
+++ b/pkgs/desktops/gnome-3/core/tracker/fix-paths.patch
@@ -1,0 +1,12 @@
+--- a/src/tracker-store/tracker-store.desktop.in
++++ b/src/tracker-store/tracker-store.desktop.in
+@@ -1,8 +1,8 @@
+ [Desktop Entry]
+ Name=Tracker Store
+ Comment=Metadata database store and lookup manager
+-Exec=gdbus call -e -d org.freedesktop.DBus -o /org/freedesktop/DBus -m org.freedesktop.DBus.StartServiceByName org.freedesktop.Tracker1 0
++Exec=@glib_dev@/bin/gdbus call -e -d org.freedesktop.DBus -o /org/freedesktop/DBus -m org.freedesktop.DBus.StartServiceByName org.freedesktop.Tracker1 0
+ Terminal=false
+ Type=Application
+ Categories=Utility;
+ X-GNOME-Autostart-enabled=true

--- a/pkgs/desktops/gnome-3/core/yelp-tools/default.nix
+++ b/pkgs/desktops/gnome-3/core/yelp-tools/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "yelp-tools-${version}";
-  version = "3.28.0";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/yelp-tools/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1b61dmlb1sd50fgq6zgnkcpx2s1py33q0x9cx67fzpsr4gmgxnw2";
+    sha256 = "037fd6xpy3zab7j5p7c0vfc6c3nk6qs0prvz1hbilzc31p8l1pdz";
   };
 
   passthru = {

--- a/pkgs/desktops/gnome-3/core/yelp-xsl/default.nix
+++ b/pkgs/desktops/gnome-3/core/yelp-xsl/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "yelp-xsl-${version}";
-  version = "3.30.1";
+  version = "3.32.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/yelp-xsl/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0ffgp3ymcc11r9sdndliwwngljcy1mfqpfxsdfbm8rlcjg2k3vzw";
+    sha256 = "013z2ixx9kfrs6hq79qpil093xfbc12y1p0mvsh6lpala30iphya";
   };
 
   passthru = {

--- a/pkgs/desktops/gnome-3/core/yelp/default.nix
+++ b/pkgs/desktops/gnome-3/core/yelp/default.nix
@@ -1,18 +1,18 @@
-{ stdenv, intltool, fetchurl, webkitgtk, pkgconfig, gtk3, glib
+{ stdenv, gettext, fetchurl, webkitgtk, pkgconfig, gtk3, glib
 , gnome3, sqlite
 , itstool, libxml2, libxslt, gst_all_1
 , wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "yelp-${version}";
-  version = "3.30.0";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/yelp/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "060a902j15k76fyhk8xfl38ipvrrcc0qd7nm2mcck4ifb45b0zv4";
+    sha256 = "090klk2mhd87y5w228gd1ia1lvvxaj913lkvxzcb1apz8n0i8mm7";
   };
 
-  nativeBuildInputs = [ pkgconfig intltool itstool wrapGAppsHook ];
+  nativeBuildInputs = [ pkgconfig gettext itstool wrapGAppsHook ];
   buildInputs = [
     gtk3 glib webkitgtk sqlite
     libxml2 libxslt gnome3.yelp-xsl

--- a/pkgs/desktops/gnome-3/core/zenity/default.nix
+++ b/pkgs/desktops/gnome-3/core/zenity/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "zenity-${version}";
-  version = "3.30.0";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/zenity/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1wipnp46pd238z9ck5rsckbaw7yla6c936fswq5w94k4c6bgcplr";
+    sha256 = "15fdh8xfdhnwcynyh4byx3mrjxbyprqnwxzi7qn3g5wwaqryg1p7";
   };
 
   preBuild = ''

--- a/pkgs/desktops/gnome-3/default.nix
+++ b/pkgs/desktops/gnome-3/default.nix
@@ -229,6 +229,8 @@ lib.makeScope pkgs.newScope (self: with self; {
 
   glade = callPackage ./apps/glade { };
 
+  gnome-books = callPackage ./apps/gnome-books { };
+
   gnome-boxes = callPackage ./apps/gnome-boxes { };
 
   gnome-calendar = callPackage ./apps/gnome-calendar { };

--- a/pkgs/desktops/gnome-3/devtools/devhelp/default.nix
+++ b/pkgs/desktops/gnome-3/devtools/devhelp/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "devhelp-${version}";
-  version = "3.30.1";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/devhelp/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "036sddvhs0blqpc2ixmjdl9vxynvkn5jpgn0jxr1fxcm4rh3q07a";
+    sha256 = "06sa83zggk29wcg75fl3gqh0rmi7cd3gsbk09a2z23r7vpy7xanq";
   };
 
   nativeBuildInputs = [ meson ninja pkgconfig gettext itstool wrapGAppsHook appstream-glib gobject-introspection python3 ];

--- a/pkgs/desktops/gnome-3/devtools/gnome-devel-docs/default.nix
+++ b/pkgs/desktops/gnome-3/devtools/gnome-devel-docs/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-devel-docs-${version}";
-  version = "3.30.2";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-devel-docs/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1sssxagf0aaiyld8731247qq74bnrnq4arr7mpjrg0j6gwdfgxia";
+    sha256 = "0kxa74ijsahipvpm57cpkvgllyg1qqap3lkxxqn6rbys474c5371";
   };
 
   passthru = {

--- a/pkgs/desktops/gnome-3/extensions/appindicator/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/appindicator/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-shell-extension-appindicator-${version}";
-  version = "22";
+  version = "23.1";
 
   src = fetchFromGitHub {
     owner = "Ubuntu";
     repo = "gnome-shell-extension-appindicator";
     rev = "v${version}";
-    sha256 = "1gqw54d55hxjj2hh04p0dx2j40bhi4ck9hgwlz8f7j4v7r37z0qw";
+    sha256 = "1v10jdncb9d5f5i0yzir20km4zvsb6ql7p8mv8w9ihw318rzh3qv";
   };
 
   # This package has a Makefile, but it's used for building a zip for

--- a/pkgs/desktops/gnome-3/extensions/battery-status/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/battery-status/default.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Configurable lightweight battery charge indicator and autohider";
     license = licenses.gpl2;
+    broken = true; # not compatable with latest GNOME
     maintainers = with maintainers; [ jonafato ];
     homepage = https://github.com/milliburn/gnome-shell-extension-battery_status;
   };

--- a/pkgs/desktops/gnome-3/extensions/caffeine/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/caffeine/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-shell-extension-caffeine-${version}";
-  version = "unstable-2018-09-25";
+  version = "unstable-2019-04-02";
 
   src = fetchFromGitHub {
     owner = "eonpatapon";
     repo = "gnome-shell-extension-caffeine";
-    rev = "71b6392c53e063563602c3d919c0ec6a4c5c9733";
-    sha256 = "170zyxa41hvyi463as650nw3ygr297901inr3xslrhvjq1qacxri";
+    rev = "a6b37dee108cddf50a0f0a19f0101854a75bf173";
+    sha256 = "1j3q12j36v97551sjb0c8qc8zr7a7gmxibygczryfdfmwjzp6icl";
   };
 
   uuid = "caffeine@patapon.info";

--- a/pkgs/desktops/gnome-3/extensions/chrome-gnome-shell/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/chrome-gnome-shell/default.nix
@@ -1,7 +1,7 @@
 {stdenv, fetchurl, cmake, ninja, jq, python3, gnome3, wrapGAppsHook}:
 
 let
-  version = "10";
+  version = "10.1";
 
   inherit (python3.pkgs) python pygobject3 requests;
 in stdenv.mkDerivation rec {
@@ -9,7 +9,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/chrome-gnome-shell/${version}/${name}.tar.xz";
-    sha256 = "1wp6qvcp758yfj8xlj15sk1d3jsb1p8136y8xxwpi9wfdjpzjs8j";
+    sha256 = "0f54xyamm383ypbh0ndkza0pif6ljddg2f947p265fkqj3p4zban";
   };
 
   nativeBuildInputs = [ cmake ninja jq wrapGAppsHook ];

--- a/pkgs/desktops/gnome-3/extensions/dash-to-dock/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/dash-to-dock/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-shell-dash-to-dock-${version}";
-  version = "65";
+  version = "66";
 
   src = fetchFromGitHub {
     owner = "micheleg";
     repo = "dash-to-dock";
     rev = "extensions.gnome.org-v" + version;
-    sha256 = "0ln49l9s0yfl30pi77pz7xlmh63l9vjppi863kry5lay10dsvz47";
+    sha256 = "04krl6rxlp1qc97psraf2kwin7h0mx4c7pnfpi7vhplmvasrwkfh";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/extensions/dash-to-panel/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/dash-to-panel/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-shell-dash-to-panel-${version}";
-  version = "16";
+  version = "19";
 
   src = fetchFromGitHub {
-    owner = "jderose9";
+    owner = "home-sweet-gnome";
     repo = "dash-to-panel";
     rev = "v${version}";
-    sha256 = "1gi2qfinafihax0j0rbs1k5nf6msdv86gzl2vfkc8s6gfkncv9bp";
+    sha256 = "0r26ph6zq87kvglydv00rf24mshz7l4r38zf9niyp3mxyzz6rwys";
   };
 
   buildInputs = [

--- a/pkgs/desktops/gnome-3/extensions/gsconnect/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/gsconnect/default.nix
@@ -1,16 +1,16 @@
-{ stdenv, fetchFromGitHub, substituteAll, python3, openssl
+{ stdenv, fetchFromGitHub, substituteAll, python3, openssl, folks, gsound
 , meson, ninja, libxml2, pkgconfig, gobject-introspection, wrapGAppsHook
 , glib, gtk3, at-spi2-core, upower, openssh, gnome3 }:
 
 stdenv.mkDerivation rec {
   name = "gnome-shell-gsconnect-${version}";
-  version = "20";
+  version = "21";
 
   src = fetchFromGitHub {
     owner = "andyholmes";
     repo = "gnome-shell-extension-gsconnect";
     rev = "v${version}";
-    sha256 = "1x5lrb4hdw482hr5dh4ki0p1651w1s0ijs96vs65vrh15cd60h02";
+    sha256 = "0ikkb2rly3h4qglswn15vs8f2kl727gpri5c9x3jiy27ylag7yav";
   };
 
   patches = [
@@ -34,10 +34,10 @@ stdenv.mkDerivation rec {
     glib # libgobject
     gtk3
     at-spi2-core # atspi
-    gnome3.folks # libfolks
+    folks # libfolks
     gnome3.nautilus # TODO: this contaminates the package with nautilus and gnome-autoar typelibs but it is only needed for the extension
     gnome3.nautilus-python
-    gnome3.gsound
+    gsound
     upower
     gnome3.caribou
     gnome3.gjs # for running daemon
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
   preFixup = ''
     # TODO: figure out why folks GIR does not contain shared-library attribute
     # https://github.com/NixOS/nixpkgs/issues/47226
-    gappsWrapperArgs+=(--prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [ gnome3.folks ]}")
+    gappsWrapperArgs+=(--prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [ folks ]}")
   '';
 
   postFixup = ''

--- a/pkgs/desktops/gnome-3/extensions/icon-hider/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/icon-hider/default.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Icon Hider is a GNOME Shell extension for managing status area items";
     license = licenses.bsd3;
+    broken = true; # not compatable with latest GNOME
     maintainers = with maintainers; [ jonafato ];
     platforms = platforms.linux;
     homepage = https://github.com/ikalnytskyi/gnome-shell-extension-icon-hider;

--- a/pkgs/desktops/gnome-3/extensions/mediaplayer/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/mediaplayer/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-shell-extensions-mediaplayer-${version}";
-  version = "3.5";
+  version = "unstable-2019-03-21";
 
   src = fetchFromGitHub {
     owner = "JasonLG1979";
     repo = "gnome-shell-extensions-mediaplayer";
-    rev = version;
-    sha256 = "0b8smid9vdybgs0601q9chlbgfm1rzrj3vmd3i6p2a5d1n4fyvsc";
+    rev = "b382c98481fa421501684e2ff3eafc53971ef22b";
+    sha256 = "01z2dml8dvl5sljw62g7x19mz02dz1g4gkmyp0h5bx49djcw1nnh";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/extensions/no-title-bar/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/no-title-bar/default.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
     description = "Integrates maximized windows with the top panel";
     homepage = https://github.com/franglais125/no-title-bar;
     license = licenses.gpl2;
+    broken = true; # https://github.com/franglais125/no-title-bar/issues/114
     maintainers = with maintainers; [ jonafato svsdep ];
     platforms = platforms.linux;
   };

--- a/pkgs/desktops/gnome-3/extensions/nohotcorner/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/nohotcorner/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-shell-extension-nohotcorner-${version}";
-  version = "18.0";
+  version = "19.0";
 
   src = fetchFromGitHub {
     owner = "HROMANO";
     repo = "nohotcorner";
     rev = "v${version}";
-    sha256 = "0vajiys93gs7fs9v6brgf8fplkmh28j103in3wq04l34cx5sqkks";
+    sha256 = "059n4gyz7d686hknaifyjax8gygrda1xab5m15a09p98jdrdfdhi";
   };
 
   # Taken from the extension download link at

--- a/pkgs/desktops/gnome-3/extensions/remove-dropdown-arrows/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/remove-dropdown-arrows/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-shell-extension-remove-dropdown-arrows-${version}";
-  version = "9";
+  version = "11";
 
   src = fetchFromGitHub {
     owner = "mpdeimos";
     repo = "gnome-shell-remove-dropdown-arrows";
     rev = "version/${version}";
-    sha256 = "1z9icxr75rd3cas28xjlmsbbd3j3sm1qvj6mp95jhfaqj821q665";
+    sha256 = "1g99r9bpjdhab3xj74wkl40gdnaf2w51kswcr8mi6bq72n4wjxwh";
   };
 
   # This package has a Makefile, but it's used for publishing and linting, not

--- a/pkgs/desktops/gnome-3/extensions/sound-output-device-chooser/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/sound-output-device-chooser/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-shell-extension-sound-output-device-chooser";
-  version = "unstable-2018-12-30";
+  version = "unstable-2019-03-10";
 
   src = fetchFromGitHub {
     owner = "kgshank";
     repo = "gse-sound-output-device-chooser";
-    rev = "3ec8aded413034e7943eb36ee509405873ccc575";
-    sha256 = "1svc3d3pr2j7fr0660a0zj2n320vld8zkkddf5iphbdwivmkrh3n";
+    rev = "26c66da6795104802f3240bd9f5741f64367c8e7";
+    sha256 = "153cdd0pip4nbpc2a9y1v3y7qivafv3wk296zqdamcjrd0p94nqz";
   };
 
   dontBuild = true;

--- a/pkgs/desktops/gnome-3/extensions/system-monitor/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/system-monitor/default.nix
@@ -39,6 +39,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Display system informations in gnome shell status bar";
     license = licenses.gpl3Plus;
+    broken = true; # GNOME 3.32 support WIP: https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet/pull/510
     maintainers = with maintainers; [ aneeshusa tiramiseb ];
     homepage = https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet;
   };

--- a/pkgs/desktops/gnome-3/extensions/taskwhisperer/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/taskwhisperer/default.nix
@@ -1,36 +1,35 @@
-{ stdenv, substituteAll, fetchFromGitHub, taskwarrior }:
+{ stdenv, substituteAll, fetchFromGitHub, taskwarrior, gettext, runtimeShell }:
 
 stdenv.mkDerivation rec {
   name = "gnome-shell-extension-taskwhisperer-${version}";
-  version = "11";
+  version = "12";
 
   src = fetchFromGitHub {
     owner = "cinatic";
     repo = "taskwhisperer";
     rev = "v${version}";
-    sha256 = "1g1301rwnfg5jci78bjpmgxrn78ra80m1zp2inhfsm8jssr1i426";
+    sha256 = "187p6p498dd258avsfqqsm322g58y75pc2wbhb4jpmm9insqm1bj";
   };
 
-  buildInputs = [ taskwarrior ];
+  nativeBuildInputs = [
+    gettext
+  ];
+
+  buildInputs = [
+    taskwarrior
+  ];
 
   uuid = "taskwhisperer-extension@infinicode.de";
 
-  installPhase = ''
-    mkdir -p $out/share/gnome-shell/extensions/${uuid}
-    cp *.js $out/share/gnome-shell/extensions/${uuid}
-    cp -r extra $out/share/gnome-shell/extensions/${uuid}
-    cp -r icons $out/share/gnome-shell/extensions/${uuid}
-    cp -r locale $out/share/gnome-shell/extensions/${uuid}
-    cp -r schemas $out/share/gnome-shell/extensions/${uuid}
-    cp metadata.json $out/share/gnome-shell/extensions/${uuid}
-    cp settings.ui $out/share/gnome-shell/extensions/${uuid}
-    cp stylesheet.css $out/share/gnome-shell/extensions/${uuid}
-  '';
+  makeFlags = [
+    "INSTALLBASE=${placeholder ''out''}/share/gnome-shell/extensions"
+  ];
 
   patches = [
     (substituteAll {
       src = ./fix-paths.patch;
       task = "${taskwarrior}/bin/task";
+      shell = "${runtimeShell}";
     })
   ];
 

--- a/pkgs/desktops/gnome-3/extensions/taskwhisperer/fix-paths.patch
+++ b/pkgs/desktops/gnome-3/extensions/taskwhisperer/fix-paths.patch
@@ -1,22 +1,22 @@
-diff --git a/extra/create.sh b/extra/create.sh
+diff --git a/taskwhisperer-extension@infinicode.de/extra/create.sh b/taskwhisperer-extension@infinicode.de/extra/create.sh
 index a69e369..35d5ea1 100755
---- a/extra/create.sh
-+++ b/extra/create.sh
+--- a/taskwhisperer-extension@infinicode.de/extra/create.sh
++++ b/taskwhisperer-extension@infinicode.de/extra/create.sh
 @@ -1 +1 @@
 -bash -c "task add $1"
 +bash -c "@task@ add $1"
-diff --git a/extra/modify.sh b/extra/modify.sh
+diff --git a/taskwhisperer-extension@infinicode.de/extra/modify.sh b/taskwhisperer-extension@infinicode.de/extra/modify.sh
 index 7964a26..8edd21b 100755
---- a/extra/modify.sh
-+++ b/extra/modify.sh
+--- a/taskwhisperer-extension@infinicode.de/extra/modify.sh
++++ b/taskwhisperer-extension@infinicode.de/extra/modify.sh
 @@ -1 +1 @@
 -bash -c "task $1 modify $2"
 +bash -c "@task@ $1 modify $2"
-diff --git a/taskService.js b/taskService.js
-index dea40d8..ff35a80 100644
---- a/taskService.js
-+++ b/taskService.js
-@@ -186,7 +186,7 @@ const TaskService = new Lang.Class({
+diff --git a/taskwhisperer-extension@infinicode.de/taskService.js b/taskwhisperer-extension@infinicode.de/taskService.js
+index ead7a12..aa36db4 100644
+--- a/taskwhisperer-extension@infinicode.de/taskService.js
++++ b/taskwhisperer-extension@infinicode.de/taskService.js
+@@ -182,7 +182,7 @@ const TaskService = class TaskService {
  
          let project = projectName ? "project:" + projectName : "";
  
@@ -25,57 +25,75 @@ index dea40d8..ff35a80 100644
          let reader = new SpawnReader.SpawnReader();
  
          let buffer = "";
-@@ -227,7 +227,7 @@ const TaskService = new Lang.Class({
+@@ -220,7 +220,7 @@ const TaskService = class TaskService {
                  break;
          }
  
 -        let shellProc = Gio.Subprocess.new(['task', status, 'projects'], Gio.SubprocessFlags.STDOUT_PIPE);
 +        let shellProc = Gio.Subprocess.new(['@task@', status, 'projects'], Gio.SubprocessFlags.STDOUT_PIPE);
  
-         shellProc.wait_async(null, function(obj, result){
+         shellProc.wait_async(null, function (obj, result) {
              let shellProcExited = true;
-@@ -274,7 +274,7 @@ const TaskService = new Lang.Class({
+@@ -261,7 +261,7 @@ const TaskService = class TaskService {
              return;
          }
  
 -        let shellProc = Gio.Subprocess.new(['task', taskID.toString(), 'done'], Gio.SubprocessFlags.STDOUT_PIPE);
 +        let shellProc = Gio.Subprocess.new(['@task@', taskID.toString(), 'done'], Gio.SubprocessFlags.STDOUT_PIPE);
  
-         shellProc.wait_async(null, function(obj, result){
+         shellProc.wait_async(null, function (obj, result) {
              let shellProcExited = true;
-@@ -307,7 +307,7 @@ const TaskService = new Lang.Class({
+@@ -290,7 +290,7 @@ const TaskService = class TaskService {
              return;
          }
  
 -        let shellProc = Gio.Subprocess.new(['task', 'modify', taskID.toString(), 'status:pending'], Gio.SubprocessFlags.STDOUT_PIPE);
 +        let shellProc = Gio.Subprocess.new(['@task@', 'modify', taskID.toString(), 'status:pending'], Gio.SubprocessFlags.STDOUT_PIPE);
  
-         shellProc.wait_async(null, function(obj, result){
+         shellProc.wait_async(null, function (obj, result) {
              let shellProcExited = true;
-@@ -339,7 +339,7 @@ const TaskService = new Lang.Class({
-         {
+@@ -318,7 +318,7 @@ const TaskService = class TaskService {
+         if (!taskID) {
              return;
          }
 -        let shellProc = Gio.Subprocess.new(['task', taskID.toString(), 'start'], Gio.SubprocessFlags.STDOUT_PIPE);
 +        let shellProc = Gio.Subprocess.new(['@task@', taskID.toString(), 'start'], Gio.SubprocessFlags.STDOUT_PIPE);
-         shellProc.wait_async(null, function(obj, result){
+         shellProc.wait_async(null, function (obj, result) {
              let shellProcExited = true;
              shellProc.wait_finish(result);
-@@ -369,7 +369,7 @@ const TaskService = new Lang.Class({
-         {
+@@ -344,7 +344,7 @@ const TaskService = class TaskService {
+         if (!taskID) {
              return;
          }
 -        let shellProc = Gio.Subprocess.new(['task', taskID.toString(), 'stop'], Gio.SubprocessFlags.STDOUT_PIPE);
 +        let shellProc = Gio.Subprocess.new(['@task@', taskID.toString(), 'stop'], Gio.SubprocessFlags.STDOUT_PIPE);
-         shellProc.wait_async(null, function(obj, result){
+         shellProc.wait_async(null, function (obj, result) {
              let shellProcExited = true;
              shellProc.wait_finish(result);
-@@ -468,7 +468,7 @@ const TaskService = new Lang.Class({
+@@ -374,7 +374,7 @@ const TaskService = class TaskService {
+         // FIXME: Gio.Subprocess: due to only passing string vector is allowed, it's not possible to directly pass the
+         //        input of the user to subprocess (why & how, if you can answer then please send msg to fh@infinicode.de)
+         //        bypassing problem with own shell script
+-        let shellProc = Gio.Subprocess.new(['/bin/sh', EXTENSIONDIR + '/extra/modify.sh', taskID.toString(), params], Gio.SubprocessFlags.STDOUT_PIPE + Gio.SubprocessFlags.STDERR_MERGE);
++        let shellProc = Gio.Subprocess.new(['@shell@', EXTENSIONDIR + '/extra/modify.sh', taskID.toString(), params], Gio.SubprocessFlags.STDOUT_PIPE + Gio.SubprocessFlags.STDERR_MERGE);
  
-         try
-         {
+         shellProc.wait_async(null, function (obj, result) {
+             let shellProcExited = true;
+@@ -403,7 +403,7 @@ const TaskService = class TaskService {
+         // FIXME: Gio.Subprocess: due to only passing string vector is allowed, it's not possible to directly pass the
+         //        input of the user to subprocess (why & how, if you can answer then please send msg to fh@infinicode.de)
+         //        bypassing problem with own shell script
+-        let shellProc = Gio.Subprocess.new(['/bin/sh', EXTENSIONDIR + '/extra/create.sh', params], Gio.SubprocessFlags.STDOUT_PIPE + Gio.SubprocessFlags.STDERR_MERGE);
++        let shellProc = Gio.Subprocess.new(['@shell@', EXTENSIONDIR + '/extra/create.sh', params], Gio.SubprocessFlags.STDOUT_PIPE + Gio.SubprocessFlags.STDERR_MERGE);
+ 
+         shellProc.wait_async(null, function (obj, result) {
+             let shellProcExited = true;
+@@ -432,7 +432,7 @@ const TaskService = class TaskService {
+         let shellProc;
+ 
+         try {
 -            shellProc = Gio.Subprocess.new(['task', 'sync'], Gio.SubprocessFlags.STDOUT_PIPE);
 +            shellProc = Gio.Subprocess.new(['@task@', 'sync'], Gio.SubprocessFlags.STDOUT_PIPE);
-         }
-         catch(err)
-         {
+         } catch (err) {
+             onError(err);
+             return;

--- a/pkgs/desktops/gnome-3/extensions/timepp/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/timepp/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-shell-extension-timepp-${version}";
-  version = "2018.03.17";
+  version = "unstable-2019-03-30";
 
   src = fetchFromGitHub {
     owner = "zagortenay333";
     repo = "timepp__gnome";
-    rev = "440cf85dc68d9e6ba876793f13910ee6239622cf";
-    sha256 = "0idsqsii5rvynvj78w2j7xiiz9rrl3384m5mj6bf6rg8vprpfi8v";
+    rev = "f90fb5573b37ac89fb57bf62e07d6d3bdb6a2c63";
+    sha256 = "0p6rsbm6lf61vzly775qkwc2rcjjl38bkqdxnv4sccqmw2wwclnp";
   };
 
   uuid = "timepp@zagortenay333";
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    description = " A todo.txt manager, time tracker, timer, stopwatch, pomodoro, and alarms gnome-shell extension.";
+    description = "A todo.txt manager, time tracker, timer, stopwatch, pomodoro, and alarms gnome-shell extension.";
     homepage = https://github.com/zagortenay333/timepp__gnome;
     license = licenses.gpl3;
     maintainers = with maintainers; [ svsdep ];

--- a/pkgs/desktops/gnome-3/games/aisleriot/default.nix
+++ b/pkgs/desktops/gnome-3/games/aisleriot/default.nix
@@ -3,12 +3,12 @@
 , guile_2_0, libcanberra-gtk3 }:
 
 stdenv.mkDerivation rec {
-  name = "aisleriot-${version}";
-  version = "3.22.7";
+  pname = "aisleriot";
+  version = "3.22.8";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/aisleriot/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1ysljnrlvzssgbhxcgb28n9k3l0rybxi5lkrm8pg6a4nspaw5mc4";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "15pm39679ymxki07sb5nvhycz4z53zwbvascyp5wm4864bn98815";
   };
 
   configureFlags = [
@@ -21,8 +21,8 @@ stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = gnome3.updateScript {
-      packageName = "aisleriot";
-      attrPath = "gnome3.aisleriot";
+      packageName = pname;
+      attrPath = "gnome3.${pname}";
     };
   };
 

--- a/pkgs/desktops/gnome-3/games/atomix/default.nix
+++ b/pkgs/desktops/gnome-3/games/atomix/default.nix
@@ -3,13 +3,13 @@
 
 let
   pname = "atomix";
-  version = "3.30.0.1";
+  version = "3.32.0";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0hvr36m8ixa172zblv29fga1cn9yb84zqbisb21msfkwia2pabw3";
+    sha256 = "0qxmdrmqsxpfv6w0l557jsjbd7cpdf3jni5mdhnsr4h2n8knf7m0";
   };
 
   nativeBuildInputs = [ meson ninja pkgconfig gettext wrapGAppsHook python3 ];

--- a/pkgs/desktops/gnome-3/games/five-or-more/default.nix
+++ b/pkgs/desktops/gnome-3/games/five-or-more/default.nix
@@ -1,16 +1,19 @@
 { stdenv, fetchurl, meson, ninja, pkgconfig, gnome3, gtk3, wrapGAppsHook
-, librsvg, libgnome-games-support, gettext, itstool, libxml2, python3 }:
+, librsvg, libgnome-games-support, gettext, itstool, libxml2, python3, vala }:
 
 stdenv.mkDerivation rec {
   name = "five-or-more-${version}";
-  version = "3.30.0";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/five-or-more/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "00d729p251kh96624i7qg2370r5mxwafs016i6hy01vsr71jzb9x";
+    sha256 = "0v52i22ygv6y4zqs8nyb1qmacmj9whhqrw7qss6vn7by4nsikhrn";
   };
 
-  nativeBuildInputs = [ meson ninja pkgconfig gettext itstool libxml2 python3 wrapGAppsHook ];
+  nativeBuildInputs = [
+    meson ninja pkgconfig gettext itstool libxml2 python3 wrapGAppsHook
+    vala
+  ];
   buildInputs = [
     gtk3 librsvg libgnome-games-support gnome3.adwaita-icon-theme
   ];

--- a/pkgs/desktops/gnome-3/games/four-in-a-row/default.nix
+++ b/pkgs/desktops/gnome-3/games/four-in-a-row/default.nix
@@ -1,17 +1,26 @@
 { stdenv, fetchurl, pkgconfig, gnome3, gtk3, wrapGAppsHook
-, gettext, itstool, libcanberra-gtk3, librsvg, libxml2 }:
+, gettext, meson, libcanberra-gtk3, librsvg, itstool, vala
+, python3, ninja, desktop-file-utils }:
 
 stdenv.mkDerivation rec {
   name = "four-in-a-row-${version}";
-  version = "3.28.0";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/four-in-a-row/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1iszaay2r92swb0q67lmip6r1w3hw2dwmlgnz9v2h6blgdyncs4k";
+    sha256 = "0h4wmbkdp7x3gp9sbxmvla316m8n6iy4f5sq0ksldj0z7ghlx9zl";
   };
 
-  nativeBuildInputs = [ pkgconfig wrapGAppsHook gettext itstool libxml2 ];
+  nativeBuildInputs = [
+    pkgconfig wrapGAppsHook gettext meson itstool vala
+    ninja python3 desktop-file-utils
+  ];
   buildInputs = [ gtk3 libcanberra-gtk3 librsvg gnome3.adwaita-icon-theme ];
+
+  postPatch = ''
+    chmod +x build-aux/meson_post_install.py
+    patchShebangs build-aux/meson_post_install.py
+  '';
 
   passthru = {
     updateScript = gnome3.updateScript {

--- a/pkgs/desktops/gnome-3/games/gnome-chess/default.nix
+++ b/pkgs/desktops/gnome-3/games/gnome-chess/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-chess-${version}";
-  version = "3.30.1";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-chess/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1gzdm6z54kxx06lh616g33klrp4dby2a68wxvjpsavdll28kgwgl";
+    sha256 = "0hzb6s4wmfy1fysagc5hmn1ijvrwyd2cg7iz41mpn7gfdjyak639";
   };
 
   nativeBuildInputs = [ meson ninja vala pkgconfig gettext itstool libxml2 python3 wrapGAppsHook gobject-introspection ];

--- a/pkgs/desktops/gnome-3/games/gnome-klotski/default.nix
+++ b/pkgs/desktops/gnome-3/games/gnome-klotski/default.nix
@@ -1,19 +1,30 @@
 { stdenv, fetchurl, pkgconfig, vala, gnome3, gtk3, wrapGAppsHook, appstream-glib, desktop-file-utils
-, glib, librsvg, libxml2, intltool, itstool, libgee, libgnome-games-support }:
+, glib, librsvg, libxml2, gettext, itstool, libgee, libgnome-games-support
+, meson, ninja, python3
+}:
 
 let
   pname = "gnome-klotski";
-  version = "3.22.3";
+  version = "3.32.0";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0prc0s28pdflgzyvk1g0yfx982q2grivmz3858nwpqmbkha81r7f";
+    sha256 = "1p4s15gxj6gasix22z9vlx2yrx196fvcxr6v6qrl569idfgjbi72";
   };
 
-  nativeBuildInputs = [ pkgconfig vala wrapGAppsHook intltool itstool libxml2 appstream-glib desktop-file-utils ];
-  buildInputs = [ glib gtk3 librsvg libgee libgnome-games-support gnome3.adwaita-icon-theme ];
+  nativeBuildInputs = [
+    pkgconfig vala meson ninja python3 wrapGAppsHook
+    gettext itstool libxml2 appstream-glib desktop-file-utils
+    gnome3.adwaita-icon-theme
+  ];
+  buildInputs = [ glib gtk3 librsvg libgee libgnome-games-support ];
+
+  postPatch = ''
+    chmod +x build-aux/meson_post_install.py
+    patchShebangs build-aux/meson_post_install.py
+  '';
 
   passthru = {
     updateScript = gnome3.updateScript {

--- a/pkgs/desktops/gnome-3/games/gnome-mahjongg/default.nix
+++ b/pkgs/desktops/gnome-3/games/gnome-mahjongg/default.nix
@@ -1,24 +1,35 @@
 { stdenv, fetchurl, pkgconfig, gnome3, gtk3, wrapGAppsHook
-, librsvg, intltool, itstool, libxml2 }:
+, librsvg, gettext, itstool, libxml2
+, meson, ninja, python3, vala, desktop-file-utils
+}:
 
 stdenv.mkDerivation rec {
   name = "gnome-mahjongg-${version}";
-  version = "3.22.0";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-mahjongg/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "f5972a14fa4ad04153bd6e68475b85cd79c6b44f6cac1fe1edb64dbad4135218";
+    sha256 = "12kamxnxbh26k4iykhbs873mx25a2wrjnhr013lfkwbyl52kg12j";
   };
 
   passthru = {
     updateScript = gnome3.updateScript { packageName = "gnome-mahjongg"; attrPath = "gnome3.gnome-mahjongg"; };
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [
-    gtk3 wrapGAppsHook librsvg intltool itstool libxml2
-    gnome3.adwaita-icon-theme
+  nativeBuildInputs = [
+    meson ninja vala python3 desktop-file-utils
+    pkgconfig gnome3.adwaita-icon-theme
+    libxml2 itstool gettext wrapGAppsHook
   ];
+  buildInputs = [
+    gtk3 librsvg
+  ];
+
+  postPatch = ''
+    chmod +x data/meson_post_install.py
+    patchShebangs data/meson_post_install.py
+  '';
+
 
   meta = with stdenv.lib; {
     homepage = https://wiki.gnome.org/Apps/Mahjongg;

--- a/pkgs/desktops/gnome-3/games/gnome-mines/default.nix
+++ b/pkgs/desktops/gnome-3/games/gnome-mines/default.nix
@@ -1,22 +1,25 @@
 { stdenv, fetchurl, meson, ninja, vala, gobject-introspection, pkgconfig, gnome3, gtk3, wrapGAppsHook
-, librsvg, gettext, itstool, python3, libxml2, libgnome-games-support, libgee }:
+, librsvg, gettext, itstool, python3, libxml2, libgnome-games-support, libgee, desktop-file-utils }:
 
 stdenv.mkDerivation rec {
   name = "gnome-mines-${version}";
-  version = "3.30.1.1";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-mines/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "08ddk400sg1g3q26gnm5mgv81vdqyix0yl7pd47p50vkc1w6f33z";
+    sha256 = "13ia8a7bmdnp1281lwp8nvdqqkclvg1n3pw4bbr2dgsrsswfkscj";
   };
 
   # gobject-introspection for finding vapi files
-  nativeBuildInputs = [ meson ninja vala gobject-introspection pkgconfig gettext itstool python3 libxml2 wrapGAppsHook ];
+  nativeBuildInputs = [
+    meson ninja vala gobject-introspection pkgconfig gettext itstool python3
+    libxml2 wrapGAppsHook desktop-file-utils
+  ];
   buildInputs = [ gtk3 librsvg gnome3.adwaita-icon-theme libgnome-games-support libgee ];
 
   postPatch = ''
-    chmod +x data/meson_compile_gschema.py # patchShebangs requires executable file
-    patchShebangs data/meson_compile_gschema.py
+    chmod +x build-aux/meson_post_install.py
+    patchShebangs build-aux/meson_post_install.py
   '';
 
   passthru = {

--- a/pkgs/desktops/gnome-3/games/gnome-nibbles/default.nix
+++ b/pkgs/desktops/gnome-3/games/gnome-nibbles/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-nibbles-${version}";
-  version = "3.24.1";
+  version = "3.31.3";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-nibbles/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "19g44cnrb191v50bdvy2qkrfhvyfsahd0kx9hz95x9gkjfn2nn35";
+    sha256 = "0wg0l3aghkxcwp74liw115qjzy6w18hn80mhsz4lrjpnbpaivi18";
   };
 
   nativeBuildInputs = [ pkgconfig wrapGAppsHook intltool itstool libxml2 ];

--- a/pkgs/desktops/gnome-3/games/gnome-robots/default.nix
+++ b/pkgs/desktops/gnome-3/games/gnome-robots/default.nix
@@ -1,25 +1,33 @@
 { stdenv, fetchurl, pkgconfig, gnome3, gtk3, wrapGAppsHook
-, librsvg, libcanberra-gtk3, intltool, itstool, libxml2, libgnome-games-support
-, libgee}:
+, librsvg, libcanberra-gtk3, gettext, itstool, libxml2, libgnome-games-support
+, libgee, meson, ninja, python3, desktop-file-utils , hicolor-icon-theme, adwaita-icon-theme }:
 
 stdenv.mkDerivation rec {
   name = "gnome-robots-${version}";
-  version = "3.22.3";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-robots/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0dzcjd7rdmlzgr6rmljhrbccwif8wj0cr1xcrrj7malj33098wwk";
+    sha256 = "1xp1sijl5k7wmnbb0hdgh4ajxgp74k7fcnmd5c6rw6lf51wpinyh";
   };
 
   passthru = {
     updateScript = gnome3.updateScript { packageName = "gnome-robots"; attrPath = "gnome3.gnome-robots"; };
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [
-    gtk3 wrapGAppsHook intltool itstool librsvg libcanberra-gtk3
-    libxml2 gnome3.adwaita-icon-theme libgnome-games-support libgee
+  nativeBuildInputs = [
+    pkgconfig meson ninja python3
+    libxml2 wrapGAppsHook gettext itstool desktop-file-utils
+    hicolor-icon-theme # For setup-hook
   ];
+  buildInputs = [
+    gtk3 librsvg libcanberra-gtk3 libgnome-games-support libgee adwaita-icon-theme
+  ];
+
+  postPatch = ''
+    chmod +x build-aux/meson_post_install.py
+    patchShebangs build-aux/meson_post_install.py
+  '';
 
   meta = with stdenv.lib; {
     homepage = https://wiki.gnome.org/Apps/Robots;

--- a/pkgs/desktops/gnome-3/games/gnome-sudoku/default.nix
+++ b/pkgs/desktops/gnome-3/games/gnome-sudoku/default.nix
@@ -3,19 +3,19 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-sudoku-${version}";
-  version = "3.30.0";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-sudoku/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1xy986s51jnrcqwan2hy4bjdg6797yr9s7gxx2z2q4j4gkx3qa1f";
+    sha256 = "1wwdjflw1lbx3cv6gvqcgp5jnjkrq37ld6mjbjj03g3vr90qaf0l";
   };
 
   nativeBuildInputs = [ meson ninja vala pkgconfig gobject-introspection gettext itstool libxml2 python3 desktop-file-utils wrapGAppsHook ];
   buildInputs = [ gtk3 libgee json-glib qqwing ];
 
   postPatch = ''
-    chmod +x post_install.py # patchShebangs requires executable file
-    patchShebangs post_install.py
+    chmod +x build-aux/post_install.py
+    patchShebangs build-aux/post_install.py
   '';
 
   passthru = {

--- a/pkgs/desktops/gnome-3/games/gnome-taquin/default.nix
+++ b/pkgs/desktops/gnome-3/games/gnome-taquin/default.nix
@@ -1,23 +1,28 @@
 { stdenv, fetchurl, pkgconfig, gnome3, gtk3, wrapGAppsHook
-, librsvg, libcanberra-gtk3, intltool, itstool, libxml2 }:
+, librsvg, libcanberra-gtk3, gettext, itstool, libxml2
+, meson, ninja, vala, python3, desktop-file-utils
+}:
 
 stdenv.mkDerivation rec {
   name = "gnome-taquin-${version}";
-  version = "3.30.0";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-taquin/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0qijv7wyrjlj56m79la4k7m00712v2m1m994vfx43x3v4isxidgp";
+    sha256 = "1kyxh68gg7clxg22ls4sliisxb2sydwccbxqgfvxjg2fklr6r1lm";
   };
 
   passthru = {
     updateScript = gnome3.updateScript { packageName = "gnome-taquin"; attrPath = "gnome3.gnome-taquin"; };
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [
+    pkgconfig wrapGAppsHook meson ninja python3
+    gettext itstool libxml2 vala desktop-file-utils
+  ];
   buildInputs = [
-    gtk3 wrapGAppsHook librsvg libcanberra-gtk3
-    intltool itstool libxml2 gnome3.adwaita-icon-theme
+    gtk3 librsvg libcanberra-gtk3
+    gnome3.adwaita-icon-theme
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/desktops/gnome-3/games/gnome-tetravex/default.nix
+++ b/pkgs/desktops/gnome-3/games/gnome-tetravex/default.nix
@@ -1,23 +1,33 @@
 { stdenv, fetchurl, pkgconfig, gnome3, gtk3, wrapGAppsHook
-, libxml2, intltool, itstool }:
+, libxml2, gettext, itstool, meson, ninja, python3
+, vala, desktop-file-utils
+}:
 
 stdenv.mkDerivation rec {
   name = "gnome-tetravex-${version}";
-  version = "3.22.0";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-tetravex/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0a6d7ff5ffcd6c05454a919d46a2e389d6b5f87bc80e82c52c2f20d9d914e18d";
+    sha256 = "18drxp43j2jnywxl6qa7mn1iv33jxr0dpc1l9xza3lnrb0jp0kjl";
   };
 
   passthru = {
     updateScript = gnome3.updateScript { packageName = "gnome-tetravex"; attrPath = "gnome3.gnome-tetravex"; };
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [
-    gtk3 wrapGAppsHook intltool itstool libxml2 gnome3.adwaita-icon-theme
+  nativeBuildInputs = [
+    wrapGAppsHook itstool libxml2 gnome3.adwaita-icon-theme
+    pkgconfig gettext meson ninja python3 vala desktop-file-utils
   ];
+  buildInputs = [
+    gtk3
+  ];
+
+  postPatch = ''
+    chmod +x build-aux/meson_post_install.py
+    patchShebangs build-aux/meson_post_install.py
+  '';
 
   meta = with stdenv.lib; {
     homepage = https://wiki.gnome.org/Apps/Tetravex;

--- a/pkgs/desktops/gnome-3/games/hitori/default.nix
+++ b/pkgs/desktops/gnome-3/games/hitori/default.nix
@@ -1,24 +1,60 @@
-{ stdenv, fetchurl, pkgconfig, gnome3, gtk3, wrapGAppsHook
-, libxml2, intltool, itstool }:
+{ stdenv
+, fetchurl
+, meson
+, ninja
+, pkgconfig
+, gnome3
+, glib
+, gtk3
+, cairo
+, wrapGAppsHook
+, libxml2
+, python3
+, gettext
+, itstool
+, desktop-file-utils
+, adwaita-icon-theme
+}:
 
 stdenv.mkDerivation rec {
-  name = "hitori-${version}";
-  version = "3.22.4";
+  pname = "hitori";
+  version = "3.31.92";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/hitori/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "dcac6909b6007857ee425ac8c65fed179f2c71da138d5e5300cd62c8b9ea15d3";
+    url = "mirror://gnome/sources/hitori/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "0m2w3zz6v1bsd1fn78ab79d72ywd9vq60rziazsblxsi4qy9dva5";
   };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkgconfig
+    gettext
+    itstool
+    desktop-file-utils
+    libxml2
+    python3
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    cairo
+    adwaita-icon-theme
+  ];
+
+  postPatch = ''
+    chmod +x build-aux/meson_post_install.py
+    patchShebangs build-aux/meson_post_install.py
+  '';
 
   passthru = {
-    updateScript = gnome3.updateScript { packageName = "hitori"; attrPath = "gnome3.hitori"; };
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+      attrPath = "gnome3.${pname}";
+    };
   };
-
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [
-    gtk3 wrapGAppsHook intltool itstool libxml2
-    gnome3.adwaita-icon-theme
-  ];
 
   meta = with stdenv.lib; {
     homepage = https://wiki.gnome.org/Apps/Hitori;

--- a/pkgs/desktops/gnome-3/games/iagno/default.nix
+++ b/pkgs/desktops/gnome-3/games/iagno/default.nix
@@ -1,16 +1,21 @@
 { stdenv, fetchurl, pkgconfig, gtk3, gnome3, gdk_pixbuf, librsvg, wrapGAppsHook
-, intltool, itstool, libcanberra-gtk3, libxml2, dconf }:
+, intltool, itstool, libcanberra-gtk3, libxml2
+, meson, ninja, python3, vala, desktop-file-utils
+}:
 
 stdenv.mkDerivation rec {
   name = "iagno-${version}";
-  version = "3.30.0";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/iagno/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "15skh7186gp0k1lvzpv0l7dsr7mhb57njc3wjbgjwixym67h2d1z";
+    sha256 = "1rcqb4gpam16xw87n4q2akkrg94ksrn16ry21pr6bsd7qs7hw17d";
   };
 
-  nativeBuildInputs = [ pkgconfig wrapGAppsHook itstool libxml2 ];
+  nativeBuildInputs = [
+    meson ninja python3 vala desktop-file-utils
+    pkgconfig wrapGAppsHook itstool libxml2
+  ];
   buildInputs = [ gtk3 gnome3.adwaita-icon-theme gdk_pixbuf librsvg libcanberra-gtk3 ];
 
   enableParallelBuilding = true;

--- a/pkgs/desktops/gnome-3/games/lightsoff/default.nix
+++ b/pkgs/desktops/gnome-3/games/lightsoff/default.nix
@@ -4,24 +4,23 @@
 
 stdenv.mkDerivation rec {
   name = "lightsoff-${version}";
-  version = "3.30.0";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/lightsoff/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1cv5pkw0n8k5wb98ihx0z1z615w1wc09y884wk608wy40bgq46wp";
+    sha256 = "0vc3ibjs9ynnm0gxlhhin7jpnsx22vnn4ygaybxwmv9w2q49cs9f";
   };
-
-  postPatch = ''
-    chmod +x meson_post_install.py # patchShebangs requires executable file
-    patchShebangs meson_post_install.py
-    sed -i '/gtk-update-icon-cache/s/^/#/' meson_post_install.py
-  '';
 
   nativeBuildInputs = [
     vala pkgconfig wrapGAppsHook itstool gettext appstream-glib libxml2
     meson ninja python3
   ];
   buildInputs = [ gtk3 gnome3.adwaita-icon-theme gdk_pixbuf librsvg clutter clutter-gtk ];
+
+  postPatch = ''
+    chmod +x build-aux/meson_post_install.py
+    patchShebangs build-aux/meson_post_install.py
+  '';
 
   passthru = {
     updateScript = gnome3.updateScript {

--- a/pkgs/desktops/gnome-3/games/quadrapassel/default.nix
+++ b/pkgs/desktops/gnome-3/games/quadrapassel/default.nix
@@ -1,21 +1,27 @@
 { stdenv, fetchurl, pkgconfig, gtk3, gnome3, gdk_pixbuf
-, librsvg, libcanberra-gtk3
-, intltool, itstool, libxml2, clutter, clutter-gtk, wrapGAppsHook }:
+, librsvg, libcanberra-gtk3, libmanette
+, gettext, itstool, libxml2, clutter, clutter-gtk, wrapGAppsHook
+, meson, ninja, python3, vala, desktop-file-utils
+}:
 
 let
   pname = "quadrapassel";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
-  version = "3.22.0";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/quadrapassel/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0ed44ef73c8811cbdfc3b44c8fd80eb6e2998d102d59ac324e4748f5d9dddb55";
+    sha256 = "1zhi1957knz9dm98drn2dh95mr33sdch590yddh1f8r6bzsfjvpy";
   };
 
-  nativeBuildInputs = [ pkgconfig itstool intltool wrapGAppsHook ];
+  nativeBuildInputs = [
+    meson ninja python3 vala desktop-file-utils
+    pkgconfig gnome3.adwaita-icon-theme
+    libxml2 itstool gettext wrapGAppsHook
+  ];
   buildInputs = [
-    gtk3 gnome3.adwaita-icon-theme gdk_pixbuf librsvg
+    gtk3 gdk_pixbuf librsvg libmanette
     libcanberra-gtk3 clutter libxml2 clutter-gtk
   ];
 

--- a/pkgs/desktops/gnome-3/games/swell-foop/default.nix
+++ b/pkgs/desktops/gnome-3/games/swell-foop/default.nix
@@ -3,13 +3,13 @@
 
 let
   pname = "swell-foop";
-  version = "3.30.0";
+  version = "3.32.0";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "00h795clcyzch1sgcxflslv2q03vsz2j5xyy4ghbg6a6dgg8a0ax";
+    sha256 = "0jpci3c1wyzbvsq86j30rcl166skhi2wf12001amfgh0dmmwipci";
   };
 
   passthru = {

--- a/pkgs/desktops/gnome-3/games/tali/default.nix
+++ b/pkgs/desktops/gnome-3/games/tali/default.nix
@@ -1,24 +1,32 @@
 { stdenv, fetchurl, pkgconfig, gtk3, gnome3, gdk_pixbuf
-, librsvg, intltool, itstool, libxml2, wrapGAppsHook }:
+, librsvg, gettext, itstool, libxml2, wrapGAppsHook
+, meson, ninja, python3, desktop-file-utils
+}:
 
 stdenv.mkDerivation rec {
   name = "tali-${version}";
-  version = "3.22.0";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/tali/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "5ba17794d6fb06b794daaffa62a6aaa372b7de8886ce5ec596c37e62bb71728b";
+    sha256 = "0s5clkn0qm298mvphx1xdymg67w1p8vvgvypvs97k6lfjqijkx3v";
   };
 
   passthru = {
     updateScript = gnome3.updateScript { packageName = "tali"; attrPath = "gnome3.tali"; };
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ gtk3 gnome3.adwaita-icon-theme gdk_pixbuf librsvg
-                  libxml2 itstool intltool wrapGAppsHook ];
+  nativeBuildInputs = [
+    meson ninja python3 desktop-file-utils
+    pkgconfig gnome3.adwaita-icon-theme
+    libxml2 itstool gettext wrapGAppsHook
+  ];
+  buildInputs = [ gtk3 gdk_pixbuf librsvg ];
 
-  enableParallelBuilding = true;
+  postPatch = ''
+    chmod +x build-aux/meson_post_install.py
+    patchShebangs build-aux/meson_post_install.py
+  '';
 
   meta = with stdenv.lib; {
     homepage = https://wiki.gnome.org/Apps/Tali;

--- a/pkgs/desktops/gnome-3/misc/geary/default.nix
+++ b/pkgs/desktops/gnome-3/misc/geary/default.nix
@@ -1,26 +1,17 @@
-{ stdenv, fetchurl, fetchpatch, pkgconfig, gtk3, vala, enchant2, wrapGAppsHook, meson, ninja
+{ stdenv, fetchurl, pkgconfig, gtk3, vala, enchant2, wrapGAppsHook, meson, ninja
 , desktop-file-utils, gnome-online-accounts, gsettings-desktop-schemas, adwaita-icon-theme
 , libnotify, libcanberra-gtk3, libsecret, gmime, isocodes, libxml2, gettext
 , sqlite, gcr, json-glib, itstool, libgee, gnome3, webkitgtk, python3
-, xvfb_run, dbus, shared-mime-info, libunwind, glib-networking }:
+, xvfb_run, dbus, shared-mime-info, libunwind, folks, glib-networking }:
 
 stdenv.mkDerivation rec {
   pname = "geary";
-  version = "0.13.2";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1fp3zzgpkm1l4d0g5194wnriz2spxa9kgrgy98kvvffl7ac860kk";
+    sha256 = "1mxlzkmwzg1fyf4r1izwnskm5z681c6hiby48n606n89gjcq565j";
   };
-
-  patches = [
-    # gobject-introspection is not needed
-    # https://gitlab.gnome.org/GNOME/geary/merge_requests/138
-    (fetchpatch {
-      url = https://gitlab.gnome.org/GNOME/geary/commit/d2f1b1076aa942d140e83fdf03b66621c11229f5.patch;
-      sha256 = "1dsj4ybnibpi572w9hafm0w90jbjv7wzdl6j8d4c2qg5h7knlvfk";
-    })
-  ];
 
   nativeBuildInputs = [
     desktop-file-utils gettext itstool libxml2 meson ninja
@@ -31,7 +22,7 @@ stdenv.mkDerivation rec {
     adwaita-icon-theme enchant2 gcr gmime gnome-online-accounts
     gsettings-desktop-schemas gtk3 isocodes json-glib libcanberra-gtk3
     libgee libnotify libsecret sqlite webkitgtk glib-networking
-    libunwind
+    libunwind folks
   ];
 
   checkInputs = [ xvfb_run dbus ];
@@ -43,11 +34,8 @@ stdenv.mkDerivation rec {
   postPatch = ''
     chmod +x build-aux/post_install.py
     patchShebangs build-aux/post_install.py
-  '';
 
-  preFixup = ''
-    # Add geary to path for geary-attach
-    gappsWrapperArgs+=(--prefix PATH : "$out/bin")
+    chmod +x desktop/geary-attach
   '';
 
   doCheck = true;
@@ -58,6 +46,11 @@ stdenv.mkDerivation rec {
     xvfb-run -s '-screen 0 800x600x24' dbus-run-session \
       --config-file=${dbus.daemon}/share/dbus-1/session.conf \
       meson test -v --no-stdsplit
+  '';
+
+  preFixup = ''
+    # Add geary to path for geary-attach
+    gappsWrapperArgs+=(--prefix PATH : "$out/bin")
   '';
 
   passthru = {

--- a/pkgs/desktops/gnome-3/misc/gitg/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gitg/default.nix
@@ -31,7 +31,7 @@ in stdenv.mkDerivation rec {
     substituteInPlace tests/libgitg/test-commit.vala --replace "/bin/bash" "${bash}/bin/bash"
   '';
 
-  doCheck = true;
+  doCheck = false; # FAIL: tests-gitg gtk_style_context_add_provider_for_screen: assertion 'GDK_IS_SCREEN (screen)' failed
 
   enableParallelBuilding = true;
 

--- a/pkgs/desktops/gnome-3/misc/gnome-packagekit/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gnome-packagekit/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-packagekit-${version}";
-  version = "3.30.0";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-packagekit/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1i1hf6833psnq174xm0gjlz5rbrkl8i512y47w7nk8mrrrc31b35";
+    sha256 = "08rhsisdvx7pnx3rrg5v7c09jbw4grglkdj979gwl4a31j24zjsd";
   };
 
   nativeBuildInputs = [ pkgconfig meson ninja gettext wrapGAppsHook desktop-file-utils ];

--- a/pkgs/desktops/gnome-3/misc/gnome-packagekit/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gnome-packagekit/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, pkgconfig, meson, ninja, gettext, gnome3, packagekit, polkit
-, gtk3, systemd, wrapGAppsHook, desktop-file-utils }:
+, gtk3, systemd, wrapGAppsHook, desktop-file-utils, hicolor-icon-theme }:
 
 stdenv.mkDerivation rec {
   name = "gnome-packagekit-${version}";
@@ -10,7 +10,11 @@ stdenv.mkDerivation rec {
     sha256 = "08rhsisdvx7pnx3rrg5v7c09jbw4grglkdj979gwl4a31j24zjsd";
   };
 
-  nativeBuildInputs = [ pkgconfig meson ninja gettext wrapGAppsHook desktop-file-utils ];
+  nativeBuildInputs = [
+    pkgconfig meson ninja gettext wrapGAppsHook desktop-file-utils
+    hicolor-icon-theme # for setup-hook
+  ];
+
   buildInputs = [ gtk3 packagekit systemd polkit ];
 
   postPatch = ''

--- a/pkgs/desktops/gnome-3/misc/gnome-tweaks/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gnome-tweaks/default.nix
@@ -5,13 +5,13 @@
 
 let
   pname = "gnome-tweaks";
-  version = "3.30.2";
+  version = "3.32.0";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0j63siy1i5pl2g6di1r9vjn54m9ahh42wj20j6689pza2lamay1z";
+    sha256 = "037r35cw34ifcs676fq9n2v4mh1nkqx0qk474bznf18mr6r62h55";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/misc/gpaste/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gpaste/default.nix
@@ -2,20 +2,16 @@
 , pango, gtk3, gnome3, dbus, clutter, appstream-glib, wrapGAppsHook, systemd, gobject-introspection }:
 
 stdenv.mkDerivation rec {
-  version = "3.30.2";
+  version = "3.32.0";
   name = "gpaste-${version}";
 
   src = fetchurl {
     url = "https://github.com/Keruspe/GPaste/archive/v${version}.tar.gz";
-    sha256 = "0vlbvv6rjxq7h9cl3ilndjk7d51ac1x7agj8k6a7bwjx8h1fr62x";
+    sha256 = "1fvpl9vqmrr1w22hm0ybabn9pjfii5qj9ghnc2jzihgrn2h486v6";
   };
 
   patches = [
     ./fix-paths.patch
-    (fetchpatch {
-      url = https://github.com/Keruspe/GPaste/commit/eacd9ecbcf6db260a2bdc22275c7a855cad66424.patch;
-      sha256 = "1668xcmx90gpjlgv2iyp6yqbxq3r5sw5cxds0dmzlyvbqdmc3py2";
-    })
   ];
 
   # TODO: switch to substituteAll with placeholder

--- a/pkgs/desktops/gnome-3/misc/gpaste/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gpaste/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, autoreconfHook, pkgconfig, vala, glib, gjs, mutter
+{ stdenv, fetchurl, autoreconfHook, pkgconfig, vala, glib, gjs, mutter, fetchpatch
 , pango, gtk3, gnome3, dbus, clutter, appstream-glib, wrapGAppsHook, systemd, gobject-introspection }:
 
 stdenv.mkDerivation rec {
@@ -12,6 +12,10 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./fix-paths.patch
+    (fetchpatch {
+      url = https://github.com/Keruspe/GPaste/commit/eacd9ecbcf6db260a2bdc22275c7a855cad66424.patch;
+      sha256 = "1668xcmx90gpjlgv2iyp6yqbxq3r5sw5cxds0dmzlyvbqdmc3py2";
+    })
   ];
 
   # TODO: switch to substituteAll with placeholder

--- a/pkgs/desktops/gnome-3/misc/gpaste/fix-paths.patch
+++ b/pkgs/desktops/gnome-3/misc/gpaste/fix-paths.patch
@@ -1,6 +1,6 @@
 --- a/src/gnome-shell/extension.js
 +++ b/src/gnome-shell/extension.js
-@@ -7,6 +7,8 @@
+@@ -6,6 +6,8 @@
  
  const Config = imports.misc.config;
  
@@ -11,45 +11,27 @@
  imports.gi.versions.GPaste = '1.0';
 --- a/src/gnome-shell/prefs.js
 +++ b/src/gnome-shell/prefs.js
-@@ -7,6 +7,8 @@
+@@ -6,6 +6,8 @@
  
  const Gettext = imports.gettext;
  
 +imports.gi.GIRepository.Repository.prepend_search_path('@typelibPath@');
 +
- const GPaste = imports.gi.GPaste;
+ const { GPaste } = imports.gi;
  
  const ExtensionUtils = imports.misc.extensionUtils;
 --- a/src/libgpaste/settings/gpaste-settings.c
 +++ b/src/libgpaste/settings/gpaste-settings.c
-@@ -22,6 +22,8 @@
- 
- typedef struct
- {
-+    GSettingsSchemaSource *schema_source;
-+    GSettingsSchema *schema;
-     GSettings *settings;
-     GSettings *shell_settings;
- 
-@@ -919,6 +921,8 @@
-     {
-         g_signal_handler_disconnect (settings, priv->c_signals[C_CHANGED]);
-         g_clear_object (&priv->settings);
-+        g_settings_schema_unref (priv->schema);
-+        g_settings_schema_source_unref (priv->schema_source);
+@@ -1013,7 +1013,11 @@
      }
+     else
+     {
+-        return g_settings_new (G_PASTE_SETTINGS_NAME);
++        // library used by introspection requires schemas but we cannot set XDG_DATA_DIRS for the library
++        GSettingsSchemaSource *schema_source = g_settings_schema_source_new_from_directory ("@gschemasCompiled@", NULL, FALSE, NULL);
++        g_autoptr (GSettingsSchema) schema = g_settings_schema_source_lookup (schema_source, G_PASTE_SETTINGS_NAME, FALSE);
++        g_settings_schema_source_unref (schema_source);
++        return g_settings_new_full (schema, NULL, NULL);
+     }
+ }
  
-     if (shell_settings)
-@@ -1000,7 +1004,11 @@
- g_paste_settings_init (GPasteSettings *self)
- {
-     GPasteSettingsPrivate *priv = g_paste_settings_get_instance_private (self);
--    GSettings *settings = priv->settings = g_settings_new (G_PASTE_SETTINGS_NAME);
-+
-+    // library used by introspection requires schemas but we cannot set XDG_DATA_DIRS for the library
-+    GSettingsSchemaSource *schema_source = priv->schema_source = g_settings_schema_source_new_from_directory ("@gschemasCompiled@", NULL, FALSE, NULL);
-+    priv->schema = g_settings_schema_source_lookup (schema_source, G_PASTE_SETTINGS_NAME, FALSE);
-+    GSettings *settings = priv->settings = g_settings_new_full (priv->schema, NULL, NULL);
- 
-     priv->history_name = NULL;
-     priv->launch_ui = NULL;

--- a/pkgs/desktops/mate/libmatekbd/default.nix
+++ b/pkgs/desktops/mate/libmatekbd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, gtk3, mate, libxklavier }:
+{ stdenv, fetchurl, fetchpatch, pkgconfig, intltool, gtk3, mate, libxklavier }:
 
 stdenv.mkDerivation rec {
   name = "libmatekbd-${version}";
@@ -8,6 +8,14 @@ stdenv.mkDerivation rec {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
     sha256 = "1l1zbphs4snswf4bkrwkk6gsmb44bdhymcfgaaspzbrcmw3y7hr1";
   };
+
+  patches = [
+    # Fix build with glib 2.60 (TODO: remove after 1.22.0 update)
+    (fetchpatch {
+      url = https://github.com/mate-desktop/libmatekbd/commit/dc04e969dd61a2b1f82beae2d3c8ad105447812d.patch;
+      sha256 = "1ps6mbj6hrm9djn4riya049w2cb0dknghysny8pafmvpkaqvckrb";
+    })
+  ];
 
   nativeBuildInputs = [ pkgconfig intltool ];
 

--- a/pkgs/desktops/pantheon/apps/elementary-photos/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-photos/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, pantheon, meson, ninja, pkgconfig, vala, desktop-file-utils
-, gtk3, glib, libaccounts-glib, libexif, libgee, geocode-glib, gexiv2,libgphoto2
+, gtk3, glib, libaccounts-glib, libexif, libgee, geocode-glib, gexiv2,libgphoto2, fetchpatch
 , granite, gst_all_1, libgudev, json-glib, libraw, librest, libsoup, sqlite, python3
 , scour, webkitgtk, libwebp, appstream, libunity, wrapGAppsHook, gobject-introspection, elementary-icon-theme }:
 
@@ -64,6 +64,14 @@ stdenv.mkDerivation rec {
 
   mesonFlags = [
     "-Dplugins=false"
+  ];
+
+  patches = [
+    # Fix build against gexiv2 0.12
+    (fetchpatch {
+      url = "https://github.com/elementary/photos/commit/86df00ced674abb2ee430ea24422079cfabb314c.patch";
+      sha256 = "0836fzja93w36jf7ldqypsmnqn46mwsl93q41m104zn8qm0wrkmy";
+    })
   ];
 
   postPatch = ''

--- a/pkgs/desktops/pantheon/default.nix
+++ b/pkgs/desktops/pantheon/default.nix
@@ -133,9 +133,7 @@ lib.makeScope pkgs.newScope (self: with self; {
   # We're using ubuntu and elementary's patchset due to reasons
   # explained here -> https://github.com/elementary/greeter/issues/92#issuecomment-376215614
   # Take note of "I am holding off on "fixing" this bug for as long as possible."
-  elementary-settings-daemon = callPackage ./services/elementary-settings-daemon {
-    inherit (gnome3) libgweather;
-  };
+  elementary-settings-daemon = callPackage ./services/elementary-settings-daemon { };
 
   pantheon-agent-geoclue2 = callPackage ./services/pantheon-agent-geoclue2 { };
 

--- a/pkgs/desktops/pantheon/services/elementary-settings-daemon/default.nix
+++ b/pkgs/desktops/pantheon/services/elementary-settings-daemon/default.nix
@@ -1,23 +1,59 @@
-{ fetchurl, fetchgit, substituteAll, stdenv, meson, ninja, pkgconfig, gnome3, perl, gettext, glib, libnotify, lcms2, libXtst
-, libxkbfile, libpulseaudio, alsaLib, libcanberra-gtk3, upower, colord, libgweather, polkit
-, geocode-glib, gtk3
-, geoclue2, librsvg, xf86_input_wacom, udev, libgudev, libwacom, libxslt, libxml2, networkmanager
-, docbook_xsl, wrapGAppsHook, python3, ibus, xkeyboard_config, tzdata, nss, pantheon, accountsservice }:
+{ accountsservice
+, alsaLib
+, colord
+, docbook_xsl
+, fetchgit
+, fetchurl
+, geoclue2
+, geocode-glib
+, gettext
+, glib
+, gnome3
+, gsettings-desktop-schemas
+, gtk3
+, lcms2
+, libcanberra-gtk3
+, libgnomekbd
+, libgudev
+, libgweather
+, libnotify
+, libpulseaudio
+, libwacom
+, libxml2
+, libxslt
+, meson
+, networkmanager
+, ninja
+, nss
+, pantheon
+, perl
+, pkgconfig
+, polkit
+, python3
+, substituteAll
+, systemd
+, tzdata
+, upower
+, wrapGAppsHook
+, stdenv
+}:
 
 stdenv.mkDerivation rec {
   pname = "elementary-settings-daemon";
-  version = "3.30.2";
+  version = "3.32.0";
+
+  projectName = "gnome-settings-daemon";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gnome-settings-daemon/${stdenv.lib.versions.majorMinor version}/gnome-settings-daemon-${version}.tar.xz";
-    sha256 = "0c663csa3gnsr6wm0xfll6aani45snkdj7zjwjfzcwfh8w4a3z12";
+    url = "mirror://gnome/sources/${projectName}/${stdenv.lib.versions.majorMinor version}/${projectName}-${version}.tar.xz";
+    sha256 = "15w3sn9qf1zqlmk8c93kgrh2a20s62m5yfizkp21m5ylrrd07f63";
   };
 
   # Source for ubuntu's patchset
   src2 = fetchgit {
-    url = "https://git.launchpad.net/~ubuntu-desktop/ubuntu/+source/gnome-settings-daemon";
+    url = "https://git.launchpad.net/~ubuntu-desktop/ubuntu/+source/${projectName}";
     rev = "refs/tags/ubuntu/${version}-1ubuntu1";
-    sha256 = "02awkhw6jqm7yh812mw0nsdmsljfi8ksz8mvd2qpns5pcv002g2c";
+    sha256 = "0ayd50mr0pv2h4j1r1haf8y2hj8jv59vypa7lx8jis0llrm7s3yn";
   };
 
   # We've omitted the 53_sync_input_sources_to_accountsservice patch because it breaks the build.
@@ -33,7 +69,6 @@ stdenv.mkDerivation rec {
     "${patchPath}/64_restore_terminal_keyboard_shortcut_schema.patch"
     "${patchPath}/correct_logout_action.patch"
     "${patchPath}/ubuntu-lid-close-suspend.patch"
-    "${patchPath}/revert-wacom-migration.patch"
     "${patchPath}/revert-gsettings-removals.patch"
     "${patchPath}/revert-mediakeys-dbus-interface-drop.patch"
     "${patchPath}/ubuntu_ibus_configs.patch"
@@ -60,6 +95,7 @@ stdenv.mkDerivation rec {
     done
 
     # This breaks lightlocker https://github.com/elementary/session-settings/commit/b0e7a2867608c3a3916f9e4e21a68264a20e44f8
+    # TODO: shouldn't be neeed for the 5.1 greeter (awaiting release)
     rm $out/etc/xdg/autostart/org.gnome.SettingsDaemon.ScreensaverProxy-pantheon.desktop
   '';
 
@@ -84,31 +120,33 @@ stdenv.mkDerivation rec {
     geocode-glib
     glib
     gnome3.gnome-desktop
-    gnome3.gsettings-desktop-schemas
+    gsettings-desktop-schemas
     gtk3
-    ibus
     lcms2
-    libXtst
     libcanberra-gtk3
+    libgnomekbd # for org.gnome.libgnomekbd.keyboard schema
     libgudev
     libgweather
     libnotify
     libpulseaudio
-    librsvg
     libwacom
-    libxkbfile
     networkmanager
     nss
     polkit
-    udev
+    systemd
     upower
-    xf86_input_wacom
-    xkeyboard_config
   ];
 
   mesonFlags = [
     "-Dudev_dir=${placeholder "out"}/lib/udev"
   ];
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = projectName;
+      attrPath = "pantheon.${pname}";
+    };
+  };
 
   meta = with stdenv.lib; {
     license = licenses.gpl2Plus;

--- a/pkgs/development/libraries/at-spi2-atk/default.nix
+++ b/pkgs/development/libraries/at-spi2-atk/default.nix
@@ -18,11 +18,11 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "at-spi2-atk";
-  version = "2.30.1";
+  version = "2.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1rxqp9kgf8mcyg84b9pq2kpqr1ws81ijn9nfdis2w0ixy9cbjfyr";
+    sha256 = "0p54wx6f6q7s8w0b1j0sgw87pikllp79q5g3lfiwqazs779ycl8b";
   };
 
   nativeBuildInputs = [ meson ninja pkgconfig ]

--- a/pkgs/development/libraries/at-spi2-core/default.nix
+++ b/pkgs/development/libraries/at-spi2-core/default.nix
@@ -19,11 +19,11 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "at-spi2-core";
-  version = "2.30.1";
+  version = "2.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0j6aa071lnhpgv9h8l0pqimk8pc152gqpcbmq8djlj7h3f7iyvw5";
+    sha256 = "083j1v7kdjrpjsv1b9dl3d8xqj39jyp4cfn8i9gbbm7q2g93b923";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/folks/default.nix
+++ b/pkgs/development/libraries/folks/default.nix
@@ -14,17 +14,17 @@ stdenv.mkDerivation rec {
   };
 
   propagatedBuildInputs = [ glib libgee sqlite ];
-  # dbus_daemon needed for tests
+
   buildInputs = [
-    dbus-glib telepathy-glib evolution-data-server dbus
+    dbus-glib telepathy-glib evolution-data-server
     libsecret libxml2 libsoup nspr nss db
   ];
+
+  checkInputs = [ dbus ];
+
   nativeBuildInputs = [ pkgconfig intltool vala gobject-introspection ];
 
   configureFlags = [ "--disable-fatal-warnings" ];
-
-  NIX_CFLAGS_COMPILE = ["-I${nss.dev}/include/nss"
-                        "-I${dbus-glib.dev}/include/dbus-1.0" "-I${dbus.dev}/include/dbus-1.0"];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/geocode-glib/default.nix
+++ b/pkgs/development/libraries/geocode-glib/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "geocode-glib";
-  version = "3.26.0";
+  version = "3.26.1";
 
   outputs = [ "out" "dev" "devdoc" "installedTests" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/geocode-glib/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1vmydxs5xizcmaxpkfrq75xpj6pqrpdjizxyb30m00h54yqqch7a";
+    sha256 = "076ydfpyc4n5c9dbqmf26i4pilfi5jpw6cjcgrbgrjbndavnmajv";
   };
 
   nativeBuildInputs = [ meson ninja pkgconfig gettext gtk-doc docbook_xsl gobject-introspection ];

--- a/pkgs/development/libraries/gexiv2/default.nix
+++ b/pkgs/development/libraries/gexiv2/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gexiv2";
-  version = "0.10.10";
+  version = "0.12.0";
 
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1qbcwq89g4r67k1dj4laqj441pj4195c8hzhxn8vc6mmg8adg6kx";
+    sha256 = "0slj5yj8c90l9pp5i3z74x5r3r4da0xfmbzkfq5k0dkg72q3kxaq";
   };
 
   nativeBuildInputs = [ meson ninja pkgconfig gobject-introspection vala gtk-doc docbook_xsl docbook_xml_dtd_43 ];
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ exiv2 ];
 
   mesonFlags = [
-    "-Denable-gtk-doc=true" # TODO: change to gtk_doc in a next release
+    "-Dgtk_doc=true"
   ];
 
   doCheck = true;

--- a/pkgs/development/libraries/glib-networking/default.nix
+++ b/pkgs/development/libraries/glib-networking/default.nix
@@ -3,14 +3,14 @@
 
 let
   pname = "glib-networking";
-  version = "2.58.0";
+  version = "2.60.1";
 in
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0s006gs9nsq6mg31spqha1jffzmp6qjh10y27h0fxf1iw1ah5ymx";
+    sha256 = "14jx8ca7plgh196629ghj41gsaha0aza222g64093hjsm8pnn76p";
   };
 
   outputs = [ "out" "dev" ]; # to deal with propagatedBuildInputs
@@ -27,6 +27,11 @@ stdenv.mkDerivation rec {
     python3 # install_script
   ];
   propagatedBuildInputs = [ glib gnutls p11-kit libproxy gsettings-desktop-schemas ];
+
+  mesonFlags = [
+    # Default auto detection doesn't work
+    "-Dgnutls=enabled"
+  ];
 
   doCheck = false; # tests need to access the certificates (among other things)
 

--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -46,7 +46,7 @@ let
   '';
 
   binPrograms = optional (!stdenv.isDarwin) "gapplication" ++ [ "gdbus" "gio" "gsettings" ];
-  version = "2.58.3";
+  version = "2.60.0";
 in
 
 stdenv.mkDerivation rec {
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/glib/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "10blprf5djbwxq8dqmjvcsdc9vqz63rl0ammfbd2b2p8cwbw6hwg";
+    sha256 = "0ls3njqknb345ni5i8hn9nr1n70kn6s8bi0g6kcqj3c4js5mv1i0";
   };
 
   patches = optional stdenv.isDarwin ./darwin-compilation.patch
@@ -96,15 +96,15 @@ stdenv.mkDerivation rec {
     # Avoid the need for gobject introspection binaries in PATH in cross-compiling case.
     # Instead we just copy them over from the native output.
     "-Dgtk_doc=${if stdenv.hostPlatform == stdenv.buildPlatform then "true" else "false"}"
+    "-Dnls=enabled"
   ];
 
   LC_ALL = "en_US.UTF-8";
 
-  NIX_CFLAGS_COMPILE = optional stdenv.isSunOS "-DBSD_COMP";
+  NIX_CFLAGS_COMPILE = (optional stdenv.isSunOS "-DBSD_COMP")
+    ++ [ "-Wno-error=nonnull" ];
 
   postPatch = ''
-    substituteInPlace meson.build --replace "install_dir : 'bin'," "install_dir : glib_bindir,"
-
     # substitute fix-gio-launch-desktop-path.patch
     substituteInPlace gio/gdesktopappinfo.c --replace "@bindir@" "$out/bin"
 

--- a/pkgs/development/libraries/gnome-menus/default.nix
+++ b/pkgs/development/libraries/gnome-menus/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, fetchurl, pkgconfig, glib, gobject-introspection }:
+{ stdenv, fetchurl, pkgconfig, gettext, glib, gobject-introspection }:
 
 stdenv.mkDerivation rec {
   pname = "gnome-menus";
-  version = "3.31.4";
+  version = "3.32.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1iihxcibjg22jxsw3s1cxzcq0rhn1rdmx4xg7qjqij981afs8dr7";
+    sha256 = "0x2blzqrapmbsbfzxjcdcpa3vkw9hq5k96h9kvjmy9kl415wcl68";
   };
 
   makeFlags = [
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     "INTROSPECTION_TYPELIBDIR=${placeholder ''out''}/lib/girepository-1.0"
   ];
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig gettext ];
   buildInputs = [ glib gobject-introspection ];
 
   meta = {

--- a/pkgs/development/libraries/gobject-introspection/default.nix
+++ b/pkgs/development/libraries/gobject-introspection/default.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
       cairoLib = "${getLib cairo}/lib";
     });
 
-  doCheck = true;
+  doCheck = !stdenv.isAarch64;
 
   passthru = {
     updateScript = gnome3.updateScript {

--- a/pkgs/development/libraries/gobject-introspection/default.nix
+++ b/pkgs/development/libraries/gobject-introspection/default.nix
@@ -9,7 +9,7 @@
 
 let
   pname = "gobject-introspection";
-  version = "1.58.3";
+  version = "1.60.0";
 in
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1j63rll0s608s0v4kqxkjapkpf46l069mlahzh8wykclplmn6nq2";
+    sha256 = "0pgk9lcvz3i79m6g2ynlp00ghws7g0p0d5qyf0k72warrf841zly";
   };
 
   outputs = [ "out" "dev" "man" ];

--- a/pkgs/development/libraries/gtkmm/3.x.nix
+++ b/pkgs/development/libraries/gtkmm/3.x.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gtkmm";
-  version = "3.24.0";
+  version = "3.24.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0hxaq4x9jqj8vvnv3sb6nwapz83v8lclbm887qqci0g50llcjpyg";
+    sha256 = "1zfj89spr8ianib5y10wcw63ybdmyjy58a15vqs0m8jq4knl5znx";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/gtksourceview/3.x.nix
+++ b/pkgs/development/libraries/gtksourceview/3.x.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, atk, cairo, glib, gtk3, pango, vala_0_40
+{ stdenv, fetchurl, pkgconfig, atk, cairo, glib, gtk3, pango, vala
 , libxml2, perl, intltool, gettext, gnome3, gobject-introspection, dbus, xvfb_run, shared-mime-info }:
 
 stdenv.mkDerivation rec {
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ pkgconfig intltool perl gobject-introspection vala_0_40 ];
+  nativeBuildInputs = [ pkgconfig intltool perl gobject-introspection vala ];
 
   checkInputs = [ xvfb_run dbus ];
 

--- a/pkgs/development/libraries/gtksourceview/3.x.nix
+++ b/pkgs/development/libraries/gtksourceview/3.x.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  doCheck = stdenv.isLinux;
+  doCheck = false; # FAIL: test-language
   checkPhase = ''
     NO_AT_BRIDGE=1 \
     XDG_DATA_DIRS="$XDG_DATA_DIRS:${shared-mime-info}/share" \

--- a/pkgs/development/libraries/gtksourceview/4.x.nix
+++ b/pkgs/development/libraries/gtksourceview/4.x.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "gtksourceview-${version}";
-  version = "4.0.3";
+  version = "4.2.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gtksourceview/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0wwxgw43dmmaz07lzdzpladir26l2bly3lnf2ks6pna152wafm9x";
+    sha256 = "0xgnjj7jd56wbl99s76sa1vjq9bkz4mdsxwgwlcphg689liyncf4";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/libraries/gtksourceview/4.x.nix
+++ b/pkgs/development/libraries/gtksourceview/4.x.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, atk, cairo, glib, gtk3, pango, vala_0_40
+{ stdenv, fetchurl, pkgconfig, atk, cairo, glib, gtk3, pango, vala
 , libxml2, perl, gettext, gnome3, gobject-introspection, dbus, xvfb_run, shared-mime-info }:
 
 stdenv.mkDerivation rec {
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ pkgconfig gettext perl gobject-introspection vala_0_40 ];
+  nativeBuildInputs = [ pkgconfig gettext perl gobject-introspection vala ];
 
   checkInputs = [ xvfb_run dbus ];
 

--- a/pkgs/development/libraries/gvfs/default.nix
+++ b/pkgs/development/libraries/gvfs/default.nix
@@ -9,20 +9,19 @@
 
 let
   pname = "gvfs";
-  version = "1.38.1";
+  version = "1.40.0";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "18311pn5kp9b4kf5prvhcjs0cwf7fm3mqh6s6p42avcr5j26l4zd";
+    sha256 = "1wp266dx3v2nwrf46cb4vpmv5d4qaag5yb5gkw7rynn9g55xcf9p";
   };
 
   postPatch = ''
     # patchShebangs requires executable file
-    chmod +x codegen.py meson_post_install.py
+    chmod +x meson_post_install.py
     patchShebangs meson_post_install.py
-    patchShebangs codegen.py
     patchShebangs test test-driver
   '';
 

--- a/pkgs/development/libraries/jsonrpc-glib/default.nix
+++ b/pkgs/development/libraries/jsonrpc-glib/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, meson, ninja, glib, json-glib, pkgconfig, gobject-introspection, vala, gtk-doc, docbook_xsl, docbook_xml_dtd_43, gnome3 }:
 stdenv.mkDerivation rec {
   pname = "jsonrpc-glib";
-  version = "3.30.1";
+  version = "3.32.0";
 
   outputs = [ "out" "dev" "devdoc" ];
 
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1iqxfdymsspsn1xr5bv7xllw73yhqq6k9bfixsggrf2g85pwwxdn";
+    sha256 = "1sx6xvzzdm9k0vfmpgg07abz7a9kar20h1a9ml0wgjdxr0valq5w";
   };
 
   mesonFlags = [

--- a/pkgs/development/libraries/libdazzle/default.nix
+++ b/pkgs/development/libraries/libdazzle/default.nix
@@ -2,7 +2,7 @@
 , gtk-doc, docbook_xsl, docbook_xml_dtd_43, glibcLocales, dbus, xvfb_run, glib, gtk3, gnome3 }:
 
 let
-  version = "3.30.2";
+  version = "3.32.0";
   pname = "libdazzle";
 in
 stdenv.mkDerivation {
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "mirror://gnome/sources/libdazzle/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1m9n1gcxndly24rjkxzvmx02a2rkb6ad4cy7p6ncanm1kyp0wxvq";
+    sha256 = "1mi87c10wa8d9bz2c8lil7gs2m76i51hq7i8ixm839zqrq5xi7ll";
   };
 
   nativeBuildInputs = [ ninja meson pkgconfig vala gobject-introspection libxml2 gtk-doc docbook_xsl docbook_xml_dtd_43 glibcLocales dbus xvfb_run ];

--- a/pkgs/development/libraries/libgdata/default.nix
+++ b/pkgs/development/libraries/libgdata/default.nix
@@ -10,8 +10,6 @@ stdenv.mkDerivation rec {
     sha256 = "0fj54yqxdapdppisqm1xcyrpgcichdmipq0a0spzz6009ikzgi45";
   };
 
-  NIX_CFLAGS_COMPILE = "-I${gnome3.libsoup.dev}/include/libsoup-gnome-2.4/ -I${gcr}/include/gcr-3 -I${gcr}/include/gck-1";
-
   nativeBuildInputs = [ pkgconfig intltool gobject-introspection ];
 
   buildInputs = [ gnome3.libsoup libxml2 glib liboauth gcr gnome3.gnome-online-accounts p11-kit openssl uhttpmock ];

--- a/pkgs/development/libraries/libgtop/default.nix
+++ b/pkgs/development/libraries/libgtop/default.nix
@@ -1,30 +1,34 @@
-{ stdenv, fetchurl, fetchpatch, glib, pkgconfig, perl, gettext, gobject-introspection, libtool, gnome3, gtk-doc }:
-let
-  pname = "libgtop";
-  version = "2.38.0";
-in
+{ stdenv
+, fetchurl
+, glib
+, pkgconfig
+, perl
+, gettext
+, gobject-introspection
+, gnome3
+, gtk-doc
+}:
+
 stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
+  pname = "libgtop";
+  version = "2.40.0";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "04mnxgzyb26wqk6qij4iw8cxwl82r8pcsna5dg8vz2j3pdi0wv2g";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "1m6jbqk8maa52gxrf223442fr5bvvxgb7ham6v039i3r1i62gwvq";
   };
 
-  patches = [
-    # Fix darwin build
-    (fetchpatch {
-        url = https://gitlab.gnome.org/GNOME/libgtop/commit/42b049f338363f92c1e93b4549fc944098eae674.patch;
-        sha256 = "0kf9ihgb0wqji6dcvg36s6igkh7b79k6y1n7w7wzsxya84x3hhyn";
-      })
+  nativeBuildInputs = [
+    pkgconfig
+    gtk-doc
+    perl
+    gettext
+    gobject-introspection
   ];
 
-  propagatedBuildInputs = [ glib ];
-  nativeBuildInputs = [ pkgconfig gnome3.gnome-common libtool gtk-doc perl gettext gobject-introspection ];
-
-  preConfigure = ''
-    ./autogen.sh
-  '';
+  propagatedBuildInputs = [
+    glib
+  ];
 
   passthru = {
     updateScript = gnome3.updateScript {

--- a/pkgs/development/libraries/libgweather/default.nix
+++ b/pkgs/development/libraries/libgweather/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libgweather";
-  version = "3.28.2";
+  version = "3.32.0";
 
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0xfy5ghwvnz2g9074dy6512m4z2pv66pmja14vhi9imgacbfh708";
+    sha256 = "04qxm5jgj5fzjb06ghwqx3c2qsc502arrfw0xl9f09wb58wjp6ny";
   };
 
   nativeBuildInputs = [ meson ninja pkgconfig gettext vala gtk-doc docbook_xsl docbook_xml_dtd_43 gobject-introspection python3 ];

--- a/pkgs/development/libraries/libmanette/default.nix
+++ b/pkgs/development/libraries/libmanette/default.nix
@@ -2,7 +2,7 @@
 , glib, libgudev, libevdev, gnome3 }:
 
 let
-  version = "0.2.1";
+  version = "0.2.2";
   pname = "libmanette";
 in
 stdenv.mkDerivation {
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "14vqz30p4693yy3yxs0gj858x25sl2kawib1g9lj8g5frgl0hd82";
+    sha256 = "1lpprk2qz1lsqf9xj6kj2ciyc1zmjhj5lwd584qkh7jgz2x9y6wb";
   };
 
   nativeBuildInputs = [ meson ninja pkgconfig vala gobject-introspection ];

--- a/pkgs/development/libraries/librsvg/default.nix
+++ b/pkgs/development/libraries/librsvg/default.nix
@@ -5,14 +5,14 @@
 
 let
   pname = "librsvg";
-  version = "2.44.12";
+  version = "2.45.5";
 in
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1h3qnqhr0l7pd2bxg69ki6ckl4srdwgr471dpp4jq9i4784hp0v6";
+    sha256 = "001phhq3dd9i6mkbjnmw468vjlqvs1330nwdzldy1rcgc3f74230";
   };
 
   outputs = [ "out" "dev" "installedTests" ];

--- a/pkgs/development/libraries/libsoup/default.nix
+++ b/pkgs/development/libraries/libsoup/default.nix
@@ -5,11 +5,11 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "libsoup";
-  version = "2.64.2";
+  version = "2.66.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1il6lyrmfi0hfh3ysw8w1qzc1rdz0igkb7dv6d8g5mmilnac3pbm";
+    sha256 = "08c9kkdhzy504gv23pfdm4sq3dd3j20sikwz6gv0qrwcdjnw5bai";
   };
 
   postPatch = ''

--- a/pkgs/development/libraries/ntrack/default.nix
+++ b/pkgs/development/libraries/ntrack/default.nix
@@ -16,6 +16,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig python ];
 
+  # error: ISO C does not support '__FUNCTION__' predefined identifier [-Werror=pedantic]
+  NIX_CFLAGS_COMPILE = [ "-Wno-error" ];
+
   configureFlags = [ "--without-gobject" "CFLAGS=--std=gnu99" ];
 
   # Remove this patch after version 016

--- a/pkgs/development/libraries/pango/default.nix
+++ b/pkgs/development/libraries/pango/default.nix
@@ -17,7 +17,8 @@ in stdenv.mkDerivation rec {
     sha256 = "1lnxldmv1a12dq5h0dlq5jyzl4w75k76dp8cn360x2ijlm9w5h6j";
   };
 
-  outputs = [ "bin" "dev" "out" "devdoc" ];
+  # FIXME: docs fail on darwin
+  outputs = [ "bin" "dev" "out" ] ++ optional (!stdenv.isDarwin) "devdoc";
 
   nativeBuildInputs = [
     meson ninja
@@ -42,7 +43,7 @@ in stdenv.mkDerivation rec {
   ];
 
   mesonFlags = [
-    "-Denable_docs=true"
+    "-Denable_docs=${if stdenv.isDarwin then "false" else "true"}"
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/pango/default.nix
+++ b/pkgs/development/libraries/pango/default.nix
@@ -1,30 +1,49 @@
 { stdenv, fetchurl, pkgconfig, libXft, cairo, harfbuzz
 , libintl, gobject-introspection, darwin, fribidi, gnome3
 , gtk-doc, docbook_xsl, docbook_xml_dtd_43, makeFontsConf, freefont_ttf
+, meson, ninja, glib
 }:
 
 with stdenv.lib;
 
 let
   pname = "pango";
-  version = "1.42.4";
+  version = "1.43.0";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "17bwb7dgbncrfsmchlib03k9n3xaalirb39g3yb43gg8cg6p8aqx";
+    sha256 = "1lnxldmv1a12dq5h0dlq5jyzl4w75k76dp8cn360x2ijlm9w5h6j";
   };
 
   outputs = [ "bin" "dev" "out" "devdoc" ];
 
-  nativeBuildInputs = [ pkgconfig gobject-introspection gtk-doc docbook_xsl docbook_xml_dtd_43 ];
-  buildInputs = optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
+  nativeBuildInputs = [
+    meson ninja
+    pkgconfig gobject-introspection gtk-doc docbook_xsl docbook_xml_dtd_43
+  ];
+  buildInputs = [
+    harfbuzz fribidi
+  ] ++ optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
+    ApplicationServices
     Carbon
     CoreGraphics
     CoreText
   ]);
-  propagatedBuildInputs = [ cairo harfbuzz libXft libintl fribidi ];
+  propagatedBuildInputs = [ cairo glib libXft libintl ];
+
+  patches = [
+    (fetchurl {
+      # Add gobject-2 to .pc file
+      url = "https://gitlab.gnome.org/GNOME/pango/commit/546f4c242d6f4fe312de3b7c918a848e5172e18d.patch";
+      sha256 = "034na38cq98vk8gggn3yfr65jmv3jgig8d25zg89wydrandp14yr";
+    })
+  ];
+
+  mesonFlags = [
+    "-Denable_docs=true"
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/template-glib/default.nix
+++ b/pkgs/development/libraries/template-glib/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, meson, ninja, pkgconfig, glib, gobject-introspection, flex, bison, vala, gettext, gnome3, gtk-doc, docbook_xsl, docbook_xml_dtd_43 }:
 let
-  version = "3.30.0";
+  version = "3.32.0";
   pname = "template-glib";
 in
 stdenv.mkDerivation {
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0j9ndswl3fc0ymbqd6kk7yw3sniij3dgczc665p06wgw3cwhssfg";
+    sha256 = "1g0zx0sxpw8kqp7p3sgl9kngaqrg9xl6cir24nrahks0vgsk98rr";
   };
 
   buildInputs = [ meson ninja pkgconfig gettext flex bison vala glib gtk-doc docbook_xsl docbook_xml_dtd_43 ];

--- a/pkgs/development/libraries/vte/default.nix
+++ b/pkgs/development/libraries/vte/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   pname = "vte";
-  version = "0.54.3";
+  version = "0.56.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1zgb8jgi6sr4km58zfml8zkm24qipbngl2h7s5razhi5a0a84dk9";
+    sha256 = "1w5p26p7gadvh49g28m2yiihpmhhxlsc7ad1qvgvfnwxdgk51asz";
   };
 
   passthru = {

--- a/pkgs/development/python-modules/pyatspi/default.nix
+++ b/pkgs/development/python-modules/pyatspi/default.nix
@@ -2,12 +2,12 @@
 
 buildPythonPackage rec {
   pname = "pyatspi";
-  version = "2.30.0";
+  version = "2.32.0";
   format = "other";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "11g7dx21brfmi5vrq289cw983rydalx0cy91afv5gigyadsmyam2";
+    sha256 = "0jfmm5684sfb035ihvla75gxz4cls5d2vnf0s02y6dw7s12zbb8a";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/development/python-modules/pygobject/3.nix
+++ b/pkgs/development/python-modules/pygobject/3.nix
@@ -3,13 +3,13 @@ pycairo, cairo, which, ncurses, meson, ninja, isPy3k, gnome3 }:
 
 buildPythonPackage rec {
   pname = "pygobject";
-  version = "3.30.4";
+  version = "3.32.0";
 
   format = "other";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0hscyvr6hh8l90fyz97b9d03506g3r8s5hl1bgk5aadq8jja3h9d";
+    sha256 = "0agg8nxgqp96wyw4qnjjpiczf0j8aw454plwsfqccsyykzjxgx43";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -1,12 +1,12 @@
 { lib, python3Packages, stdenv, writeTextDir, substituteAll, targetPackages }:
 
 python3Packages.buildPythonApplication rec {
-  version = "0.49.1";
+  version = "0.49.2";
   pname = "meson";
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "05wr4kn88aqq2cbzqx59zj56410c9d42wracb4cjs70mvq0lp50s";
+    sha256 = "0ckkzq0kbnnk4rwv20lggm9a4fb5054jbv99i9pwjhid23qy7059";
   };
 
   postFixup = ''

--- a/pkgs/development/tools/profiling/sysprof/default.nix
+++ b/pkgs/development/tools/profiling/sysprof/default.nix
@@ -18,13 +18,13 @@
 
 stdenv.mkDerivation rec {
   pname = "sysprof";
-  version = "3.30.2";
+  version = "3.32.0";
 
   outputs = [ "out" "lib" "dev" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "02xsr3cxyws3cnbhvbxgcc9sn22mri3iv9d7f38pkg89lpjph279";
+    sha256 = "0kamsnnig56lzs4ziwcxm3b1xyis4z361s9nj3nca0c78sgac8pw";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/tools/valadoc/default.nix
+++ b/pkgs/development/tools/valadoc/default.nix
@@ -1,11 +1,11 @@
 {stdenv, fetchurl, gnome3, automake, autoconf, which, libtool, pkgconfig, graphviz, glib, gobject-introspection, expat}:
 stdenv.mkDerivation rec {
-  version = "0.36.1";
+  version = "0.36.2";
   name = "valadoc-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/valadoc/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "07501k2j9c016bd7rfr6xzaxdplq7j9sd18b5ixbqdbipvn6whnv";
+    sha256 = "0hfaskbm7y4z4jf6lxm8hg4c0b8621qn1gchxjxcngq0cpx79z9h";
   };
 
   nativeBuildInputs = [ automake autoconf which gnome3.vala libtool pkgconfig gobject-introspection ];

--- a/pkgs/misc/themes/arc/default.nix
+++ b/pkgs/misc/themes/arc/default.nix
@@ -31,6 +31,8 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     patchShebangs .
+    # TODO: remove this after update
+    ln -s 3.30 common/gnome-shell/3.32
   '';
 
   preBuild = ''

--- a/pkgs/tools/inputmethods/uim/default.nix
+++ b/pkgs/tools/inputmethods/uim/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub
+{ stdenv, fetchFromGitHub, shared-mime-info
 , autoconf, automake, intltool, libtool, pkgconfig, cmake
 , ruby, librsvg
 , ncurses, m17n_lib, m17n_db, expat
@@ -126,6 +126,12 @@ stdenv.mkDerivation rec {
   #--with-prime            Build a plugin for PRIME [default=yes]
   #--with-sj3              Use SJ3 [default=no]
   #--with-osx-dcs          Build with OS X Dictionary Services [default=no]
+
+  # TODO: fix this in librsvg/glib later
+  # https://github.com/NixOS/nixpkgs/pull/57027#issuecomment-475461733
+  preBuild = ''
+    export XDG_DATA_DIRS="${shared-mime-info}/share"
+  '';
 
   dontUseCmakeConfigure = true;
 

--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -9,11 +9,11 @@ let
   pname = "NetworkManager";
 in stdenv.mkDerivation rec {
   name = "network-manager-${version}";
-  version = "1.14.6";
+  version = "1.16.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0p9s6b1z9bdmzdjw2gnjsar1671vvcyy9inb0rxg1izf2nnwsfv9";
+    sha256 = "0b2x9hrg41cd17psqi0vacwj733v99hxczn53gdfs0yanqrji5lf";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/tools/networking/network-manager/fix-paths.patch
+++ b/pkgs/tools/networking/network-manager/fix-paths.patch
@@ -43,7 +43,7 @@
 +				ping_binary = "@inetutils@/bin/ping";
  				log_domain = LOGD_IP4;
  			}
- 		} else if (priv->ip_config_6 && priv->ip6_state == IP_DONE) {
+ 		} else if (priv->ip_config_6 && priv->ip_state_6 == NM_DEVICE_IP_STATE_DONE) {
  			gw = nm_ip6_config_best_default_route_get (priv->ip_config_6);
  			if (gw) {
  				nm_utils_inet6_ntop (&NMP_OBJECT_CAST_IP6_ROUTE (gw)->gateway, buf);
@@ -54,12 +54,13 @@
  		}
 --- a/src/nm-core-utils.c
 +++ b/src/nm-core-utils.c
-@@ -421,7 +421,7 @@
+@@ -421,8 +421,8 @@
  
  	/* construct the argument list */
  	argv = g_ptr_array_sized_new (4);
 -	g_ptr_array_add (argv, "/sbin/modprobe");
 +	g_ptr_array_add (argv, "@kmod@/bin/modprobe");
+ 	g_ptr_array_add (argv, "--use-blacklist");
  	g_ptr_array_add (argv, (char *) arg1);
  
  	va_start (ap, arg1);

--- a/pkgs/tools/networking/network-manager/fortisslvpn/default.nix
+++ b/pkgs/tools/networking/network-manager/fortisslvpn/default.nix
@@ -1,15 +1,15 @@
-{ stdenv, fetchurl, substituteAll, openfortivpn, intltool, pkgconfig, gtk3,
+{ stdenv, fetchurl, substituteAll, openfortivpn, intltool, pkgconfig, file, gtk3,
 networkmanager, ppp, libsecret, withGnome ? true, gnome3 }:
 
 let
   pname = "NetworkManager-fortisslvpn";
-  version = "1.2.8";
+  version = "1.2.10";
 in stdenv.mkDerivation rec {
   name = "${pname}${if withGnome then "-gnome" else ""}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "01gvdv9dknvzx05plq863jh1xz1v8vgj5w7v9fmw5v601ggybf4w";
+    sha256 = "1sw66cxgs4in4cjp1cm95c5ijsk8xbbmq4ykg2jwqwgz6cf2lr3s";
   };
 
   patches = [
@@ -22,7 +22,7 @@ in stdenv.mkDerivation rec {
   buildInputs = [ openfortivpn networkmanager ppp ]
     ++ stdenv.lib.optionals withGnome [ gtk3 libsecret gnome3.networkmanagerapplet ];
 
-  nativeBuildInputs = [ intltool pkgconfig ];
+  nativeBuildInputs = [ intltool pkgconfig file ];
 
   configureFlags = [
     "--without-libnm-glib"

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -6426,6 +6426,7 @@ let
       sha256 = "0d9ak0zknz81lv3cqkzr2mxdic6g5rrbb87skqc4jj48rz4f2k3v";
     };
     buildInputs = [ pkgs.glib ];
+    doCheck = false; # tests failing with glib 2.60 https://rt.cpan.org/Public/Bug/Display.html?id=128165
     meta = {
       homepage = http://gtk2-perl.sourceforge.net/;
       description = "Perl wrappers for the GLib utility and Object libraries";


### PR DESCRIPTION
The branch should be viable to use (I'm running it on my own system. Note that mutter is now build without checks which means extensions are more likely to crash the system :/

See https://hydra.nixos.org/eval/1509880?filter=x86_64-linux&compare=1509196&full=#tabs-now-fail for failures compared to appropriate trunk.

Closes: #56966

### darwin

- [x] [`pango`](https://hydra.nixos.org/build/90663191) the new meson build fails the custom install script for the docs.
- [ ] [`dconf`](https://hydra.nixos.org/build/90676822) fails tests

### general:

- [x] trying to set a password in users-accounts panel of gnome-control-center is impossible because
the path to the cracklib dictionary is non-existent (libpwquality -> cracklib) [(error)](https://gist.github.com/worldofpeace/0b391db8304c34eb2198e09752f8e474)
- [x] we should probably mark extensions that are known to be broken in 3.32 as broken. Mutter is now built without checks which makes it fairly easy for a wrong code path to crash the shell.
- [x] fix launching `gnome-gweather` from desktop file again as I broke it.
- [x] `arc-theme` fails to build, we should probably pick [this patch](https://github.com/NicoHood/arc-theme/commit/6815e946dcbf5ad93bf98c9f49c2f30a38ebcb1f)
- [x] [`mate.libmatekbd`](https://hydra.nixos.org/build/90661039) fails
- [x] [`papirus-icon-theme`](https://hydra.nixos.org/build/90694788) fails due to a bad hash, not our fault, most of the deepin stuff is due to this
- [ ] [`deepin.dd-api`](https://hydra.nixos.org/build/90676346) actually fails the build (this happened last upgrade too)
- [x] [`handbrake`](https://hydra.nixos.org/build/90673760) required harfbuzz (no longer propagated by pango) 
- [x] [`pantheon.elementary-photos`](https://hydra.nixos.org/build/90676656) fails, same problem as shotwell with the gexiv vapi ([upstream issue](https://github.com/elementary/photos/issues/484))
- [x] [`perl528Packages.Glib`](https://hydra.nixos.org/build/90720265) fails tests
- [x] [`mikutter`](https://hydra.nixos.org/build/90704042) fails due to pango gem, similar to last time with gio I believe
- [x] [`ntrack`](https://hydra.nixos.org/build/90675024) fails due to `-Werror=pedantic` 
- [x] [`notary`](https://hydra.nixos.org/build/90672930) transient error, also fails on master with `--check`
- [x] [`uim`](https://hydra.nixos.org/build/90715929) fails to do some svg stuff, probably due librsvg upgrade
- [x] [`vips`](https://hydra.nixos.org/build/90689218) fails to find po/Makefile.in.in, which seems pretty strange, doesn't occur on master.
- [x] `gnome-todo` fails ([upstream issue](https://gitlab.gnome.org/GNOME/gnome-todo/issues/239))
- [x] `shotwell` fails
- [x] [`gnome-builder` is missing llvm-config](https://hydra.nixos.org/build/90681602/nixlog/4)
- [x] ~`dconf` fails a new integration tests~ (thought patchShebangs could take several arguments)
- [ ] gtksourceview3 fails tests
- [x] haven't updated `gnomeExtensions` so most are probably broken
- [x] update dash-to-dock when they do a new release
- [x] I'm hitting this bug (telepathy-idle uses 100% cpu):  https://gitlab.gnome.org/GNOME/polari/issues/74
- [x] rygel require packaging `gupnp-1.2` and `gssdp-1.2` and patching `gupnp-igd` if we're to continue having support in `libnice` (not sure if that's important tbh). According to [release news](https://download.gnome.org/core/3.31/3.31.92/NEWS) rygel shouldn't be upgrade, so I'm assuming 0.37 is a dev branch not targeted for 3.32
- [x] see if any packages have libhandy suppert (eg. gnome-contacts ships its own, but we should probably use the system package).

- I encountered a weird problem with vala-38 getting stuck in a loop parsing gir files, switching to 42 fixed the problem (`libdbusmenu` and `packagekit`), see a72b22519824620110d2d2cc05345c37d5aab194. I wouldn't be surprised if we'll see it a few more times
- [x] Remove `libsoup` from `gnome-contacts` next rebase