### PR TITLE
datovka, libisds: init at 4.12.0 and 0.10.8; added maintainer cptMikky

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1006,7 +1006,12 @@
     github = "cpages";
     name = "Carles Pagès";
   };
-  cransom = {
+  cptMikky = {
+    email = "kuba@ufiseru.cz";
+    github = "cptMikky";
+    name = "Jakub Fišer";
+  };
+   cransom = {
     email = "cransom@hubns.net";
     github = "cransom";
     name = "Casey Ransom";

--- a/pkgs/applications/networking/datovka/default.nix
+++ b/pkgs/applications/networking/datovka/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, libxml2, libisds, qmake, qtbase, qtsvg}:
+{ stdenv, fetchurl, libxml2, libisds, qmake, qtbase, qtsvg }:
 
 stdenv.mkDerivation rec {
   name = "datovka-${version}";
@@ -11,8 +11,8 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [ libxml2 ];
-  buildInputs = [ libisds qmake qtbase qtsvg ];
+  buildInputs = [ libisds qmake qtbase qtsvg libxml2 ];
+  NIX_CFLAGS_COMPILE = [ "-I${libxml2.dev}/include/libxml2/" ];
 
   meta = with stdenv.lib; {
     description = "Client application for operating Czech government-provided Databox infomation system";

--- a/pkgs/applications/networking/datovka/default.nix
+++ b/pkgs/applications/networking/datovka/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchurl, libxml2, libisds, qmake, qtbase, qtsvg}:
+
+stdenv.mkDerivation rec {
+  name = "datovka-${version}";
+  version = "4.12.0";
+
+  src = fetchurl {
+    url = "https://secure.nic.cz/files/datove_schranky/${version}/${name}.tar.xz";
+    sha256 = "1dcs6yk7dflk1dxxbn5hjgc008bpgiqfcgy0cj0fxnpdn0i7za57";
+  };
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ libxml2 ];
+  buildInputs = [ libisds qmake qtbase qtsvg ];
+
+  meta = with stdenv.lib; {
+    description = "Client application for operating Czech government-provided Databox infomation system";
+    homepage = "https://www.datovka.cz";
+    license = licenses.lgpl3;
+    maintainers = [ maintainers.cptMikky ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/libisds/default.nix
+++ b/pkgs/development/libraries/libisds/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl, expat, gpgme, libgcrypt, libxml2 }:
+
+stdenv.mkDerivation rec {
+  name = "libisds-${version}";
+  version = "0.10.8";
+
+
+
+  src = fetchurl {
+    url = "http://xpisar.wz.cz/libisds/dist/${name}.tar.xz";
+    sha256 = "1av6i7acqrsl054mm6hbz20qcnbmxmzbax942c31576f00vwcqbq";
+  };
+
+  enableParallelBuilding = true;
+
+  buildInputs = [ expat gpgme libgcrypt ];
+  propagatedBuildInputs = [ libxml2 ];
+
+  meta = with stdenv.lib; {
+    description = "Client library for accessing SOAP services of Czech government-provided Databox infomation system";
+    homepage = "https://xpisar.wz.cz/libisds";
+    license = licenses.lgpl3;
+    maintainers = [ maintainers.cptMikky ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -683,6 +683,8 @@ in
 
   cozy = callPackage ../applications/audio/cozy-audiobooks { };
 
+  datovka = libsForQt5.callPackage ../applications/networking/datovka { };
+
   deskew = callPackage ../applications/graphics/deskew { };
 
   detect-secrets = python3Packages.callPackage ../development/tools/detect-secrets { };
@@ -3983,6 +3985,8 @@ in
   libipfix = callPackage ../development/libraries/libipfix { };
 
   libircclient = callPackage ../development/libraries/libircclient { };
+
+  libisds = callPackage ../development/libraries/libisds { };
 
   libite = callPackage ../development/libraries/libite { };
 


### PR DESCRIPTION
###### Motivation for this change

Add new package `Datovka` (https://www.datovka.cz) useful to anyone who has to communicate with Czech government via Databoxes.

Add new pacakge `libisds` (http://xpisar.wz.cz/libisds/) which `Datovka` depends on.

Add new maintainer, @cptMikky .
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

