### PR TITLE
mkchromecast: init at 0.3.8.1

### DIFF
--- a/pkgs/applications/networking/mkchromecast/default.nix
+++ b/pkgs/applications/networking/mkchromecast/default.nix
@@ -1,0 +1,84 @@
+{ stdenv
+, fetchFromGitHub
+, python3Packages
+, sox
+, flac
+, lame
+, wrapQtAppsHook
+, ffmpeg
+, vorbis-tools
+, pulseaudio
+, nodejs
+, youtube-dl
+, opusTools
+, gst_all_1
+}:
+let packages = [
+  vorbis-tools
+  sox
+  flac
+  lame
+  opusTools
+  gst_all_1.gstreamer
+  nodejs
+  ffmpeg
+  youtube-dl
+] ++ stdenv.lib.optionals stdenv.isLinux [ pulseaudio ];
+
+in
+python3Packages.buildPythonApplication rec {
+  pname = "mkchromecast-unstable";
+  version = "2020-10-17";
+
+  src = fetchFromGitHub rec {
+    owner = "muammar";
+    repo = "mkchromecast";
+    rev = "eb9da74d887acd70ed179e6e4c0cbed4ff83de04";
+    sha256 = "1l565n3rmyghc4vzh80gazvdks1i97j1h94x33pkmxxlf9a9rncj";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    PyChromecast
+    psutil
+    mutagen
+    flask
+    netifaces
+    requests
+    pyqt5
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace 'platform.system() == "Darwin"' 'False' \
+      --replace 'platform.system() == "Linux"' 'True'
+  '';
+
+  nativeBuildInputs = [ wrapQtAppsHook ];
+
+  # Relies on an old version (0.7.7) of PyChromecast unavailable in Nixpkgs.
+  # Is also I/O bound and impure, testing an actual device, so we disable.
+  doCheck = false;
+
+  dontWrapQtApps = true;
+
+  makeWrapperArgs = [
+    "\${qtWrapperArgs[@]}"
+    "--prefix PATH : ${stdenv.lib.makeBinPath packages}"
+  ];
+
+  postInstall = ''
+    substituteInPlace $out/lib/${python3Packages.python.libPrefix}/site-packages/mkchromecast/video.py \
+      --replace '/usr/share/mkchromecast/nodejs/' '${placeholder "out"}/share/mkchromecast/nodejs/'
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+    install -Dm 755 -t $out/bin bin/audiodevice
+    substituteInPlace $out/lib/${python3Packages.python.libPrefix}/site-packages/mkchromecast/audio_devices.py \
+      --replace './bin/audiodevice' '${placeholder "out"}/bin/audiodevice'
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://mkchromecast.com/";
+    description = "Cast macOS and Linux Audio/Video to your Google Cast and Sonos Devices";
+    license = licenses.mit;
+    maintainers = with maintainers; [ shou ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16637,6 +16637,8 @@ in
 
   minio = callPackage ../servers/minio { };
 
+  mkchromecast = libsForQt5.callPackage ../applications/networking/mkchromecast { };
+
   # Backwards compatibility.
   mod_dnssd = pkgs.apacheHttpdPackages.mod_dnssd;
   mod_fastcgi = pkgs.apacheHttpdPackages.mod_fastcgi;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

