### PR TITLE
uefitool: init at A55 and 0.27.0

### DIFF
--- a/pkgs/tools/system/uefitool/common.nix
+++ b/pkgs/tools/system/uefitool/common.nix
@@ -1,0 +1,39 @@
+{ version, sha256, installFiles }:
+{ lib, mkDerivation, fetchFromGitHub, qtbase, qmake, cmake, zip }:
+
+mkDerivation rec {
+  passthru = {
+    inherit version;
+    inherit sha256;
+    inherit installFiles;
+  };
+  pname = "uefitool";
+  inherit version;
+
+  src = fetchFromGitHub {
+    inherit sha256;
+    owner = "LongSoft";
+    repo = pname;
+    rev = version;
+  };
+
+  buildInputs = [ qtbase ];
+  nativeBuildInputs = [ qmake cmake zip ];
+
+  configurePhase = ":";
+  buildPhase = "bash unixbuild.sh";
+
+  installPhase = ''
+    mkdir -p "$out"/bin
+    cp ${lib.concatStringsSep " " installFiles} "$out"/bin
+  '';
+
+  meta = with lib; {
+    description = "UEFI firmware image viewer and editor";
+    homepage = "https://github.com/LongSoft/uefitool";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ ajs124 ];
+    # uefitool supposedly works on other platforms, but their build script only works on linux in nixpkgs
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/system/uefitool/variants.nix
+++ b/pkgs/tools/system/uefitool/variants.nix
@@ -1,0 +1,15 @@
+{ libsForQt5 }:
+let
+  common = opts: libsForQt5.callPackage (import ./common.nix opts) {};
+in rec {
+  new-engine = common rec {
+    version = "A56";
+    sha256 = "0sxmjkrwcchxg2qmcjsw2vr42s7cdcg2fxkwb8axq2r2z23465gp";
+    installFiles = [ "UEFITool/UEFITool" "UEFIFind/UEFIFind" "UEFIExtract/UEFIExtract" ];
+  };
+  old-engine = common rec {
+    version = "0.27.0";
+    sha256 = "1i1p823qld927p4f1wcphqcnivb9mq7fi5xmzibxc3g9zzgnyc2h";
+    installFiles = [ "UEFITool" "UEFIReplace/UEFIReplace" "UEFIPatch/UEFIPatch" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21704,6 +21704,9 @@ in
 
   udocker = pythonPackages.callPackage ../tools/virtualization/udocker { };
 
+  uefitoolPackages = recurseIntoAttrs (callPackage ../tools/system/uefitool/variants.nix {});
+  uefitool = uefitoolPackages.new-engine;
+
   unigine-valley = callPackage ../applications/graphics/unigine-valley { };
 
   inherit (ocaml-ng.ocamlPackages_4_05) unison;


### PR DESCRIPTION
default to new-engine

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

