### PR TITLE
[WIP] Allow custom nssdb in Chromium

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -132,6 +132,7 @@ let
     patches = optional enableWideVine ./patches/widevine.patch ++ [
       ./patches/nix_plugin_paths_68.patch
       ./patches/remove-webp-include-69.patch
+      ./patches/custom_nssdb.patch
 
       # Unfortunately, chromium regularly breaks on major updates and
       # then needs various patches backported in order to be compiled with GCC.

--- a/pkgs/applications/networking/browsers/chromium/patches/custom_nssdb.patch
+++ b/pkgs/applications/networking/browsers/chromium/patches/custom_nssdb.patch
@@ -1,0 +1,51 @@
+diff --git a/base/base_paths.cc b/base/base_paths.cc
+index e3f322e72a97..45f396ba7d42 100644
+--- a/base/base_paths.cc
++++ b/base/base_paths.cc
+@@ -14,6 +14,14 @@ bool PathProvider(int key, FilePath* result) {
+   // NOTE: DIR_CURRENT is a special case in PathService::Get
+ 
+   switch (key) {
++    case DIR_NSS: {
++      const char* nss_dir = getenv("CHROMIUM_NSS");
++      if (nss_dir && nss_dir[0]) {
++        *result = FilePath(nss_dir);
++        return true;
++      }
++      return false;
++    }
+     case DIR_EXE:
+       if (!PathService::Get(FILE_EXE, result))
+         return false;
+diff --git a/base/base_paths.h b/base/base_paths.h
+index 2a163f48d43e..19f2b7b9e061 100644
+--- a/base/base_paths.h
++++ b/base/base_paths.h
+@@ -47,7 +47,8 @@ enum BasePathKey {
+ 
+   DIR_TEST_DATA,  // Used only for testing.
+ 
+-  PATH_END
++  PATH_END,
++  DIR_NSS
+ };
+ 
+ }  // namespace base
+diff --git a/crypto/nss_util.cc b/crypto/nss_util.cc
+index 97d6648f3a22..d2657260f002 100644
+--- a/crypto/nss_util.cc
++++ b/crypto/nss_util.cc
+@@ -100,7 +100,12 @@ base::FilePath GetInitialConfigDirectory() {
+     database_dir.clear();
+   return database_dir;
+ #else
+-  return GetDefaultConfigDirectory();
++  base::FilePath nssDir;
++  base::PathService::Get(base::DIR_NSS, &nssDir);
++  if (!base::PathExists(nssDir))
++    return nssDir;
++  else
++    return GetDefaultConfigDirectory();
+ #endif  // defined(OS_CHROMEOS)
+ }
+ 


### PR DESCRIPTION
###### Motivation for this change
#27800

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

