### PR TITLE
Minidlna: Allow more configuration options

### DIFF
--- a/nixos/modules/services/networking/minidlna.nix
+++ b/nixos/modules/services/networking/minidlna.nix
@@ -36,6 +36,37 @@ in
         '';
     };
 
+    services.minidlna.friendlyName = mkOption {
+      type = types.str;
+      default = "${config.networking.hostName} MiniDLNA";
+      defaultText = "$HOSTNAME MiniDLNA";
+      example = "rpi3";
+      description =
+        ''
+          Name that the DLNA server presents to clients.
+        '';
+    };
+
+    services.minidlna.rootContainer = mkOption {
+      type = types.str;
+      default = ".";
+      example = "B";
+      description =
+        ''
+          Use a different container as the root of the directory tree presented
+          to clients. The possible values are:
+          - "." - standard container
+          - "B" - "Browse Directory"
+          - "M" - "Music"
+          - "P" - "Pictures"
+          - "V" - "Video"
+          - Or, you can specify the ObjectID of your desired root container
+            (eg. 1$F for Music/Playlists)
+          If you specify "B" and the client device is audio-only then
+          "Music/Folders" will be used as root.
+         '';
+    };
+
     services.minidlna.loglevel = mkOption {
       type = types.str;
       default = "warn";
@@ -66,7 +97,37 @@ in
 
     services.minidlna.config = mkOption {
       type = types.lines;
-      description = "The contents of MiniDLNA's configuration file.";
+      description =
+      ''
+        The contents of MiniDLNA's configuration file.
+        When the service is activated, a basic template is generated
+        from the current options opened here.
+      '';
+    };
+
+    services.minidlna.extraConfig = mkOption {
+      type = types.lines;
+      default = "";
+      example = ''
+        # Not exhaustive example
+        # Support for streaming .jpg and .mp3 files to a TiVo supporting HMO.
+        enable_tivo=no
+        # SSDP notify interval, in seconds.
+        notify_interval=10
+        # maximum number of simultaneous connections
+        # note: many clients open several simultaneous connections while
+        # streaming
+        max_connections=50
+        # set this to yes to allow symlinks that point outside user-defined
+        # media_dirs.
+        wide_links=yes
+      '';
+      description =
+      ''
+        Extra minidlna options not yet opened for configuration here
+        (strict_dlna, model_number, model_name, etc...).  This is appended
+        to the current service already provided.
+      '';
     };
   };
 
@@ -75,13 +136,15 @@ in
     services.minidlna.config =
       ''
         port=${toString port}
-        friendly_name=${config.networking.hostName} MiniDLNA
+        friendly_name=${cfg.friendlyName}
         db_dir=/var/cache/minidlna
         log_level=${cfg.loglevel}
         inotify=yes
+        root_container=${cfg.rootContainer}
         ${concatMapStrings (dir: ''
           media_dir=${dir}
         '') cfg.mediaDirs}
+        ${cfg.extraConfig}
       '';
 
     users.users.minidlna = {

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -133,6 +133,7 @@ in
   memcached = handleTest ./memcached.nix {};
   mesos = handleTest ./mesos.nix {};
   minio = handleTest ./minio.nix {};
+  minidlna = handleTest ./minidlna.nix {};
   misc = handleTest ./misc.nix {};
   mongodb = handleTest ./mongodb.nix {};
   morty = handleTest ./morty.nix {};

--- a/nixos/tests/minidlna.nix
+++ b/nixos/tests/minidlna.nix
@@ -1,0 +1,39 @@
+import ./make-test.nix ({ pkgs, ... }: {
+  name = "minidlna";
+
+  nodes = {
+    server =
+      { ... }:
+      {
+        imports = [ ../modules/profiles/minimal.nix ];
+        networking.firewall.allowedTCPPorts = [ 8200 ];
+        services.minidlna = {
+          enable = true;
+          loglevel = "error";
+          mediaDirs = [
+           "PV,/tmp/stuff"
+          ];
+          friendlyName = "rpi3";
+          rootContainer = "B";
+          extraConfig =
+          ''
+            album_art_names=Cover.jpg/cover.jpg/AlbumArtSmall.jpg/albumartsmall.jpg
+            album_art_names=AlbumArt.jpg/albumart.jpg/Album.jpg/album.jpg
+            album_art_names=Folder.jpg/folder.jpg/Thumb.jpg/thumb.jpg
+            notify_interval=60
+          '';
+        };
+      };
+      client = { ... }: { };
+  };
+
+  testScript =
+  ''
+    startAll;
+    $server->succeed("mkdir -p /tmp/stuff && chown minidlna: /tmp/stuff");
+    $server->waitForUnit("minidlna");
+    $server->waitForOpenPort("8200");
+    $server->succeed("curl --fail http://localhost:8200/");
+    $client->succeed("curl --fail http://server:8200/");
+  '';
+})


### PR DESCRIPTION
###### Motivation for this change

"As a minidlna user", i'd like to have more setup option choices.

----

At the moment, we have the choice between:
- having a subset of options
- override completely the full configuration ("losing" the existing minimal subset)

This PR allows to:
- configure some other options
- configure the ones not yet disclosed in nix (extending the
  existing minimal subset). This matches what is done for example in the sshd service.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions (debian with nix)

- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))

Added test on that service.
I followed the doc about tests [1] though which i think is a better link
https://nixos.org/nixos/manual/index.html#sec-nixos-tests

- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`

I'm still not sure what that does but it seems to have worked:
```
$ git reset --soft origin/master  # now there is wip
$ nix-shell -p nox --run "nox-review wip"
...
Result in /run/user/1000/nox-review-1xmyktwu
total 0
lrwxrwxrwx 1 tony tony 67 Mar  8 18:36 result -> /nix/store/l7lzfp2i0yizm7grylcrmkikm96hmx82-nixos-system-nixos-test
```

- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)

Not sure i did this correctly:
```
$ git checkout master
$ nix-build -A minidlna
$ nix path-info -S ./result
/nix/store/1283pa3i7yyjpz7aana2rncq41qjwkxd-minidlna-1.2.1        141423736
$ git checkout minidlna-update-configuration
$ nix-build -A minidlna
$ nix path-info -S ./result
/nix/store/1283pa3i7yyjpz7aana2rncq41qjwkxd-minidlna-1.2.1        141423736

```
- [x] Assured whether relevant documentation is up to date
~> every new option opened has the docstring updated as well

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
as far as i could tell ;)

- [x] Tested execution of all binary files (usually in `./result/bin/`)

It's a service, i don't know how to test that without actually
installing it...  Any pointer on that is very welcome, thanks.  (I
searched quite some time at nixpkgs, nixos, and nix manuals without
quite the answer i hoped for)

So, i settled on testing it with my rpi3 (aarch64), so:
- [x] disabled the mainstream service
- [x] import this patched version
- [x] define what i wanted as setup

Excerpt:
```
  ...
  disabledModules = [ "services/networking/minidlna.nix" ];
  imports = [
    ./override-minidlna.nix  # <- the pr's patch
  ];
  services.minidlna = {
    enable = true;
    mediaDirs = [
      "PV,${path}/family"
      "V,${path}/judo"
      "V,${path}/courses"
    ];
    friendlyName = "rpi3";
    rootContainer = "B";
    extraConfig = ''
      album_art_names=Cover.jpg/cover.jpg/AlbumArtSmall.jpg/albumartsmall.jpg
      album_art_names=AlbumArt.jpg/albumart.jpg/Album.jpg/album.jpg
      album_art_names=Folder.jpg/folder.jpg/Thumb.jpg/thumb.jpg
      notify_interval=60
    '';
  };

```
- [x] built
- [x] installed
- [x] runs fine with the new configuration \m/

```
tony@kids> cat $(systemctl status minidlna.service  | grep minidlna.conf | awk '{print $7}')                                                                                                 ~
port=8200
friendly_name=rpi3
db_dir=/var/cache/minidlna
log_level=warn
inotify=yes
root_container=B
media_dir=PV,/family
media_dir=V,/judo
media_dir=V,/courses

album_art_names=Cover.jpg/cover.jpg/AlbumArtSmall.jpg/albumartsmall.jpg
album_art_names=AlbumArt.jpg/albumart.jpg/Album.jpg/album.jpg
album_art_names=Folder.jpg/folder.jpg/Thumb.jpg/thumb.jpg
notify_interval=60
```

Cheers,