### PR TITLE
plasma: handle kbuildsycoca5 better

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -226,7 +226,29 @@ in
       security.pam.services.slim.enableKwallet = true;
 
       # Update the start menu for each user that is currently logged in
-      system.userActivationScripts.plasmaSetup = "${pkgs.libsForQt5.kservice}/bin/kbuildsycoca5";
+      system.userActivationScripts.plasmaSetup = ''
+        # The KDE icon cache is supposed to update itself
+        # automatically, but it uses the timestamp on the icon
+        # theme directory as a trigger.  Since in Nix the
+        # timestamp is always the same, this doesn't work.  So as
+        # a workaround, nuke the icon cache on login.  This isn't
+        # perfect, since it may require logging out after
+        # installing new applications to update the cache.
+        # See http://lists-archives.org/kde-devel/26175-what-when-will-icon-cache-refresh.html
+        rm -fv $HOME/.cache/icon-cache.kcache
+
+        # xdg-desktop-settings generates this empty file but
+        # it makes kbuildsyscoca5 fail silently. To fix this
+        # remove that menu if it exists.
+        rm -fv $HOME/.config/menus/applications-merged/xdg-desktop-menu-dummy.menu
+
+        # Remove the kbuildsyscoca5 cache. It will be regenerated
+        # immediately after. This is necessary for kbuildsyscoca5 to
+        recognize that software that has been removed.
+        rm -fv $HOME/.cache/ksycoca*
+
+        ${pkgs.libsForQt5.kservice}/bin/kbuildsycoca5
+      '';
     })
   ];
 

--- a/pkgs/desktops/plasma-5/plasma-workspace/plasma-workspace.patch
+++ b/pkgs/desktops/plasma-5/plasma-workspace/plasma-workspace.patch
@@ -81,7 +81,7 @@ index 714a9bf1..9733c612 100644
  fi
  
  # Boot sequence:
-@@ -33,61 +42,133 @@ fi
+@@ -33,61 +42,142 @@ fi
  #
  # * Then ksmserver is started which takes control of the rest of the startup sequence
  
@@ -101,6 +101,15 @@ index 714a9bf1..9733c612 100644
 +# installing new applications to update the cache.
 +# See http://lists-archives.org/kde-devel/26175-what-when-will-icon-cache-refresh.html
 +rm -fv $HOME/.cache/icon-cache.kcache
++
++# xdg-desktop-settings generates this empty file but
++# it makes kbuildsyscoca5 fail silently. To fix this
++# remove that menu if it exists.
++rm -fv $HOME/.config/menus/applications-merged/xdg-desktop-menu-dummy.menu
++
++# Remove the kbuildsyscoca5 cache. It will be regenerated immediately after.
++# This is necessary for kbuildsyscoca5 to recognize that software that has been removed.
++rm -fv $HOME/.cache/ksycoca*
 +
 +# Qt writes a weird ‘libraryPath’ line to
 +# ~/.config/Trolltech.conf that causes the KDE plugin
@@ -721,7 +730,7 @@ diff --git a/startkde/startplasmacompositor.cmake b/startkde/startplasmacomposit
 index dd9e304d..12132f9e 100644
 --- a/startkde/startplasmacompositor.cmake
 +++ b/startkde/startplasmacompositor.cmake
-@@ -1,118 +1,165 @@
+@@ -1,118 +1,174 @@
  #!/bin/sh
  #
 -#  DEFAULT Plasma STARTUP SCRIPT ( @PROJECT_VERSION@ )
@@ -748,6 +757,15 @@ index dd9e304d..12132f9e 100644
 +# installing new applications to update the cache.
 +# See http://lists-archives.org/kde-devel/26175-what-when-will-icon-cache-refresh.html
 +rm -fv $HOME/.cache/icon-cache.kcache
++
++# xdg-desktop-settings generates this empty file but
++# it makes kbuildsyscoca5 fail silently. To fix this
++# remove that menu if it exists.
++rm -fv $HOME/.config/menus/applications-merged/xdg-desktop-menu-dummy.menu
++
++# Remove the kbuildsyscoca5 cache. It will be regenerated immediately after.
++# This is necessary for kbuildsyscoca5 to recognize that software that has been removed.
++rm -fv $HOME/.cache/ksycoca*
 +
 +# Qt writes a weird ‘libraryPath’ line to
 +# ~/.config/Trolltech.conf that causes the KDE plugin


### PR DESCRIPTION
The xdg-desktop-menu-dummy.menu file breaks kbuildsycoca5. Not sure why but it is a pretty
big failure if it exists. See issue #56176.

xdg-settings-desktop creates this file for some reason. I have no idea
why this is created though. But, it is used by Chromium and some other
software to set stuff up.

Also remove the ksycoca5 cache. Otherwise removed software hangs around in the cache forever.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

