### PR TITLE
cheat: 2.3.1 -> 2.5.1

### DIFF
--- a/pkgs/applications/misc/cheat/default.nix
+++ b/pkgs/applications/misc/cheat/default.nix
@@ -4,15 +4,15 @@ with python3Packages;
 buildPythonApplication rec {
   name = "${pname}-${version}";
   pname = "cheat";
-  version = "2.3.1";
+  version = "2.5.1";
 
-  propagatedBuildInputs = [ docopt pygments ];
+  propagatedBuildInputs = [ docopt pygments termcolor ];
 
   src = fetchFromGitHub {
     owner = "chrisallenlane";
     repo = "cheat";
     rev = version;
-    sha256 = "1dcpjvbv648r8325qjf30m8b4cyrrjbzc2kvh40zy2mbjsa755zr";
+    sha256 = "1i543hvg1yizamfd83bawflfcb500hvc72i59ikck8j1hjk50hsl";
   };
   # no tests available
   doCheck = false;


### PR DESCRIPTION
###### Motivation for this change

I personally wanted the new version because of the new configurable options they have added. Tested on my system and it works like a charm.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

