### PR TITLE
jellyfin: init at 10.2.2

### DIFF
--- a/pkgs/servers/jellyfin/default.nix
+++ b/pkgs/servers/jellyfin/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchurl, unzip, sqlite, makeWrapper, dotnet-sdk, ffmpeg }:
+
+stdenv.mkDerivation rec {
+  pname = "jellyfin";
+  version = "10.2.2";
+
+  # Impossible to build anything offline with dotnet
+  src = fetchurl {
+    url = "https://github.com/jellyfin/jellyfin/releases/download/v${version}/jellyfin_${version}_portable.tar.gz";
+    sha256 = "1q5wwjhlvykcad6jcizbr4yx5fiyzs97zl4qnkf79236xgvdyx53";
+  };
+
+  buildInputs = [
+    unzip
+    makeWrapper
+  ];
+
+  propagatedBuildInputs = [
+    dotnet-sdk
+    sqlite
+  ];
+
+  preferLocalBuild = true;
+
+  installPhase = ''
+    install -dm 755 "$out/opt/jellyfin"
+    cp -r * "$out/opt/jellyfin"
+
+    makeWrapper "${dotnet-sdk}/bin/dotnet" $out/bin/jellyfin \
+      --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [
+        sqlite
+      ]}" \
+      --add-flags "$out/opt/jellyfin/jellyfin.dll -ffmpeg ${ffmpeg}/bin/ffmpeg -ffprobe ${ffmpeg}/bin/ffprobe"
+  '';
+
+  meta =  with stdenv.lib; {
+    description = "The Free Software Media System";
+    homepage = https://jellyfin.github.io/;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ nyanloutre ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1519,6 +1519,8 @@ in
 
   interlock = callPackage ../servers/interlock {};
 
+  jellyfin = callPackage ../servers/jellyfin { };
+
   kapacitor = callPackage ../servers/monitoring/kapacitor { };
 
   kisslicer = callPackage ../tools/misc/kisslicer { };


### PR DESCRIPTION
###### Motivation for this change

Mostly a copy paste from the emby package (it might be impossible to build any dotnet package from source in NixOS because of a "feature" https://github.com/NuGet/Home/issues/2623#issuecomment-212670967)
Did not test much. `jellyfin --help` is outputing something.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

