### PR TITLE
tayga: init at 0.9.2

### DIFF
--- a/pkgs/tools/networking/tayga/default.nix
+++ b/pkgs/tools/networking/tayga/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  version = "0.9.2";
+  pname = "tayga";
+
+  src = fetchurl {
+    url= "http://www.litech.org/${pname}/${pname}-${version}.tar.bz2";
+    sha256 = "1700y121lhvpna49bjpssb7jq1abj9qw5wxgjn8gzp6jm4kpj7rb";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Userland stateless NAT64 daemon";
+    longDescription = ''
+      TAYGA is an out-of-kernel stateless NAT64 implementation
+      for Linux that uses the TUN driver to exchange IPv4 and
+      IPv6 packets with the kernel.
+      It is intended to provide production-quality NAT64 service
+      for networks where dedicated NAT64 hardware would be overkill.
+    '';
+    homepage = http://www.litech.org/tayga;
+    license = licenses.gpl2;
+    maintainers = [ maintainers."0x4A6F" ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5717,6 +5717,8 @@ in
 
   tarsnapper = callPackage ../tools/backup/tarsnapper { };
 
+  tayga = callPackage ../tools/networking/tayga { };
+
   tcpcrypt = callPackage ../tools/security/tcpcrypt { };
 
   tcptraceroute = callPackage ../tools/networking/tcptraceroute { };


### PR DESCRIPTION
###### Motivation for this change

[tayga](http://www.litech.org/tayga/)

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

