### PR TITLE
linuxPackages.bcc: 0.8.0 -> 0.9.0

### DIFF
--- a/pkgs/os-specific/linux/bcc/default.nix
+++ b/pkgs/os-specific/linux/bcc/default.nix
@@ -19,7 +19,7 @@ python.pkgs.buildPythonApplication rec {
   buildInputs = [
     llvmPackages.llvm llvmPackages.clang-unwrapped kernel
     elfutils luajit netperf iperf
-    systemtap.stapBuild
+    systemtap.stapBuild flex
   ];
 
   patches = [

--- a/pkgs/os-specific/linux/bcc/default.nix
+++ b/pkgs/os-specific/linux/bcc/default.nix
@@ -4,14 +4,14 @@
 }:
 
 python.pkgs.buildPythonApplication rec {
-  version = "0.8.0";
+  version = "0.9.0";
   name = "bcc-${version}";
 
   src = fetchFromGitHub {
     owner  = "iovisor";
     repo   = "bcc";
     rev    = "v${version}";
-    sha256 = "15vvybllmh9hdj801v3psd671c0qq2a1xdv73kabb9r4fzgaknxk";
+    sha256 = "0gi12bsjaw1d77rx11wkdg4szcydwy55z6mkx558nfvdym0qj7yw";
   };
 
   format = "other";

--- a/pkgs/os-specific/linux/bcc/fix-deadlock-detector-import.patch
+++ b/pkgs/os-specific/linux/bcc/fix-deadlock-detector-import.patch
@@ -1,5 +1,5 @@
---- source.org/tools/deadlock_detector.py	1980-01-02 00:00:00.000000000 +0000
-+++ source/tools/deadlock_detector.py	2018-05-29 13:57:11.807126673 +0100
+--- source.org/tools/deadlock.py	1980-01-02 00:00:00.000000000 +0000
++++ source/tools/deadlock.py	2018-05-29 13:57:11.807126673 +0100
 @@ -44,9 +44,8 @@
  #
  # 01-Feb-2017   Kenny Yu   Created this.


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---