### PR TITLE
xteddy: init at 2.2

### DIFF
--- a/pkgs/applications/misc/xteddy/default.nix
+++ b/pkgs/applications/misc/xteddy/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchzip, pkg-config, xorg, imlib2, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name = "xteddy-${version}";
+  version = "2.2";
+  src = fetchzip {
+    url = "https://deb.debian.org/debian/pool/main/x/xteddy/xteddy_${version}.orig.tar.gz";
+    sha256 = "0sap4fqvs0888ymf5ga10p3n7n5kr35j38kfsfd7nj0xm4hmcma3";
+  };
+  nativeBuildInputs = [ pkg-config makeWrapper ];
+  buildInputs = [ imlib2 xorg.libX11 xorg.libXext ];
+
+  makeFlags = [ "LIBS=-lXext" ];
+
+  postPatch = ''
+    sed -i 's/man 1 xteddy/man 6 xteddy/' xteddy.c
+    sed -i "s:/usr/games/xteddy:$out/bin/xteddy:" xtoys
+    sed -i "s:/usr/share/xteddy:$out/share/xteddy:" xtoys
+  '';
+
+  postInstall = ''
+    cp -R images $out/share/images
+    # remove broken test script
+    rm $out/bin/xteddy_test
+  '';
+
+  postFixup = ''
+    # this is needed, because xteddy expects images to reside
+    # in the current working directory
+    wrapProgram $out/bin/xteddy --run "cd $out/share/images/"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Cuddly teddy bear for your X desktop";
+    homepage = https://weber.itn.liu.se/~stegu/xteddy/;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.xaverdh ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23124,6 +23124,8 @@ in
    SDL = SDL_sixel;
   };
 
+  xteddy = callPackage ../applications/misc/xteddy { };
+
   xwiimote = callPackage ../misc/drivers/xwiimote {
     bluez = pkgs.bluez5.override {
       enableWiimote = true;


### PR DESCRIPTION
###### Motivation for this change

This adds the version of xteddy as packaged by debian.

Im not sure which meta.homepage to set. There are several sane choices:
* http://weber.itn.liu.se/~stegu/xteddy/
* https://people.debian.org/~tille/upstream/xteddy/
* https://packages.debian.org/sid/xteddy

Also I had to drop two trivial scripts from the upstream tarball, that reference paths in /usr and such.
They are not essential for the program, so I decided to just remove them.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

