### PR TITLE
ntp: 4.2.8p12 -> 4.2.8p13

### DIFF
--- a/pkgs/tools/networking/ntp/default.nix
+++ b/pkgs/tools/networking/ntp/default.nix
@@ -8,11 +8,11 @@ let
 in
 
 stdenv.mkDerivation rec {
-  name = "ntp-4.2.8p12";
+  name = "ntp-4.2.8p13";
 
   src = fetchurl {
     url = "https://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-4.2/${name}.tar.gz";
-    sha256 = "0m04ndn0674kcf9x0aggjya07a3hlig2nlzzpwk7vmqka0mj56vh";
+    sha256 = "0f1a4fya7v5s0426nim8ydvvlcashb8hicgs9xlm76ndrz7751r8";
   };
 
   # The hardcoded list of allowed system calls for seccomp is


### PR DESCRIPTION
###### Motivation for this change

From http://www.ntp.org/index.html:
> ntp-4.2.8p13 was released on 07 March 2019.
> It addresses 1 medium-severity security issue in ntpd, and provides 17
> other non-security fixes and 1 improvements over 4.2.8p12.

**backport candidate**

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---