### PR TITLE
buildLuarocksPackage: adjust the manifest path

### DIFF
--- a/pkgs/development/interpreters/lua-5/build-lua-package.nix
+++ b/pkgs/development/interpreters/lua-5/build-lua-package.nix
@@ -165,7 +165,7 @@ builtins.removeAttrs attrs ["disabled" "checkInputs"] // {
     # to prevent collisions when creating environments
     # also added -f as it doesn't always exist
     # don't remove the whole directory as
-    rm -rf $out/lib/luarocks/rocks/manifest
+    rm -rf $out/lib/luarocks/rocks-${lua.luaversion}/manifest
 
     runHook postInstall
   '';


### PR DESCRIPTION
the new luarocks 3.0.4 uses different paths for the manifests, hence creating new collisions.

###### Motivation for this change
fixes https://github.com/NixOS/nixpkgs/issues/57043

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

