### PR TITLE
cheat: 2.3.1 -> 2.5.1

### DIFF
--- a/pkgs/applications/misc/cheat/default.nix
+++ b/pkgs/applications/misc/cheat/default.nix
@@ -1,30 +1,37 @@
-{ stdenv, python3Packages, fetchFromGitHub }:
+{ stdenv, python3, fetchFromGitHub }:
 
-with python3Packages;
+with python3.pkgs;
 buildPythonApplication rec {
   name = "${pname}-${version}";
   pname = "cheat";
-  version = "2.3.1";
+  version = "2.5.1";
 
-  propagatedBuildInputs = [ docopt pygments ];
+  propagatedBuildInputs = [ docopt pygments termcolor ];
 
   src = fetchFromGitHub {
     owner = "chrisallenlane";
     repo = "cheat";
     rev = version;
-    sha256 = "1dcpjvbv648r8325qjf30m8b4cyrrjbzc2kvh40zy2mbjsa755zr";
+    sha256 = "1i543hvg1yizamfd83bawflfcb500hvc72i59ikck8j1hjk50hsl";
   };
   # no tests available
   doCheck = false;
 
   postInstall = ''
     install -D man1/cheat.1.gz $out/share/man/man1/cheat.1.gz
+    mv $out/${python3.sitePackages}/etc $out/
+    mv $out/${python3.sitePackages}/usr/share/* $out/share/
+    rm -r $out/${python3.sitePackages}/usr
   '';
+
+  makeWrapperArgs = [
+    "--suffix" "CHEAT_PATH" ":" "$out/share/cheat"
+  ];
 
   meta = with stdenv.lib; {
     description = "cheat allows you to create and view interactive cheatsheets on the command-line";
     maintainers = with maintainers; [ mic92 ];
-    license = with licenses; [gpl3 mit];
+    license = with licenses; [ gpl3 mit ];
     homepage = https://github.com/chrisallenlane/cheat;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

The other upgrade broke cheat as no internal cheatsheats where found.
Now it works again.
cc @BadDecisionsAlex 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

