### PR TITLE
nixos: introduce `nixpkgs.pkgsFun`, deprecate `nixpkgs.pkgs`

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22575,15 +22575,9 @@ in
   nixos = configuration:
     (import (pkgs.path + "/nixos/lib/eval-config.nix") {
       inherit (pkgs.stdenv.hostPlatform) system;
-      modules = [(
-                  { lib, ... }: {
-                    config.nixpkgs.pkgs = lib.mkDefault pkgs;
-                  }
-                )] ++ (
-                  if builtins.isList configuration
-                  then configuration
-                  else [configuration]
-                );
+      modules = if builtins.isList configuration
+                then configuration
+                else [configuration];
     }).config.system.build;
 
 
@@ -22623,11 +22617,6 @@ in
         (import ../../nixos/lib/testing.nix {
           inherit (pkgs.stdenv.hostPlatform) system;
           inherit pkgs;
-          extraConfigurations = [(
-            { lib, ... }: {
-              config.nixpkgs.pkgs = lib.mkDefault pkgs;
-            }
-          )];
         });
     in
       test:


### PR DESCRIPTION
# `git log`

- nixos: introduce `nixpkgs.pkgsFun`, deprecate `nixpkgs.pkgs`

  Despite what the description of `nixpkgs.pkgs` option said, the
  use of `nixpkgs.pkgs` actually produced 2x evaluation slowdown
  after a54a799d59f2a4fba2e119e0c42dbe96c2c74a68 because NixOS had
  to reevaluate `nixpkgs` to reapply overlays the second time.

  The use of `nixpkgs.pkgs` also complicates many things, e.g. why
  are `overlays` reapplied, but `configuration` is not? It also
  prevents proper `config` type checking via #56227.

  `nixpkgs.pkgsFun` approach is much simpler and doesn't have
  any of those problems, half of the code in that module can also be
  dropped after `nixpkgs.pkgs` option is completely removed.

  If such an option is really needed for optimizion purposes of
  `nixosTests` or whatever (which I doubt, note that e.g.
  NixOps users actually lose on average by using it for above
  reasons), it should be made `internal` and hidden from users.

# `nix-instantiate` environment

- Host OS: Linux 4.9, SLNOS 19.09
- Nix: nix-env (Nix) 2.2
- Multi-user: yes
- Sandbox: yes
- NIXPKGS_CONFIG:

```nix
{
  checkMeta = true;
  doCheckByDefault = true;
}
```

# `nix-env -qaP` diffs

- On x86_64-linux:
  - Updated (2):
    - tests.nixos-functions.nixos-test
    - tests.nixos-functions.nixosTest-test
- On aarch64-linux: ditto
- On x86_64-darwin: noop

/cc @roberth @Ericson2314 @matthewbauer from git-blame, @7c6f434c
