### PR TITLE
filet: 0.1.2 -> 0.1.3

### DIFF
--- a/pkgs/applications/misc/filet/default.nix
+++ b/pkgs/applications/misc/filet/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "filet";
-  version = "0.1.2";
+  version = "0.1.3";
 
   src = fetchFromGitHub {
     owner = "buffet";
     repo = "filet";
     rev = version;
-    sha256 = "0fk616rsninl97x4g1f4blidw6drh5dvjy6s41yf6zgragrr2xh5";
+    sha256 = "0hm7589ih30axafqxhhs4fg1pvfhlqzyzzmfi2ilx8haq5111fsf";
   };
 
   makeFlags = [ "PREFIX=$(out)" ];
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     description = "A fucking fucking fast file fucker (afffff)";
     homepage = https://github.com/buffet/filet;
     license = licenses.mpl20;
-    platforms = platforms.linux;
+    platforms = platforms.all;
     maintainers = with maintainers; [ buffet ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Compiles on MacOS now

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

