### PR TITLE
tikzit: 2.1 -> 2.1.4

### DIFF
--- a/pkgs/tools/typesetting/tikzit/default.nix
+++ b/pkgs/tools/typesetting/tikzit/default.nix
@@ -2,18 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "tikzit-${version}";
-  version = "2.1";
+  version = "2.1.4";
 
   src = fetchFromGitHub {
     owner = "tikzit";
     repo = "tikzit";
-    # We don't reference the revision by the appropriate tag (v2.1) here,
-    # as the version of that tag still has the old version number in the
-    # relevant header file. This would cause a bad user experience, as
-    # "Help > About" would still display the old version number even though
-    # we indeed ship the new version 2.1.
-    rev = "97c2a2a7ecae12bf376558997805c24c3b6e3e07";
-    sha256 = "0sbgijbln18gac9989x484r62jlxyagkq0ap0fvzislrkac4z3y9";
+    rev = "v2.1.4";
+    sha256 = "121pgl2cdkksw48mjg6hzk7324ax6iw6fq7q3v1kdgwm8rwxm1fl";
   };
 
   nativeBuildInputs = [ qmake qttools flex bison ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

