### PR TITLE
strongswan: 5.7.1 -> 5.7.2

### DIFF
--- a/nixos/modules/services/networking/strongswan-swanctl/module.nix
+++ b/nixos/modules/services/networking/strongswan-swanctl/module.nix
@@ -65,9 +65,12 @@ in  {
       after    = [ "network-online.target" "keys.target" ];
       wants    = [ "keys.target" ];
       path = with pkgs; [ kmod iproute iptables utillinux ];
-      environment.STRONGSWAN_CONF = pkgs.writeTextFile {
-        name = "strongswan.conf";
-        text = cfg.strongswan.extraConfig;
+      environment = {
+        STRONGSWAN_CONF = pkgs.writeTextFile {
+          name = "strongswan.conf";
+          text = cfg.strongswan.extraConfig;
+        };
+        SWANCTL_DIR = "/etc/swanctl";
       };
       restartTriggers = [ config.environment.etc."swanctl/swanctl.conf".source ];
       serviceConfig = {

--- a/pkgs/tools/networking/strongswan/default.nix
+++ b/pkgs/tools/networking/strongswan/default.nix
@@ -19,11 +19,11 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "strongswan-${version}";
-  version = "5.7.1";
+  version = "5.7.2";
 
   src = fetchurl {
     url = "https://download.strongswan.org/${name}.tar.bz2";
-    sha256 = "1v2b8lnqrkbc9hx3p2rw36xvphdy5ayy3dblm3kz98p24s8rqvq0";
+    sha256 = "0w6cks42lvvyj5ivyhqyqxya48x93yzfpz281q3xmqicdskkp3ih";
   };
 
   dontPatchELF = true;
@@ -49,14 +49,7 @@ stdenv.mkDerivation rec {
     }))
   ];
 
-  postPatch = ''
-    # swanctl can be configured by files in SWANCTLDIR which defaults to
-    # $out/etc/swanctl. Since that directory is in the nix store users can't
-    # modify it. Ideally swanctl accepts a command line option for specifying
-    # the configuration files. In the absence of that we patch swanctl to look
-    # for configuration files in /etc/swanctl.
-    substituteInPlace src/swanctl/swanctl.h --replace "SWANCTLDIR" "\"/etc/swanctl\""
-    '' + optionalString stdenv.isLinux ''
+  postPatch = optionalString stdenv.isLinux ''
     # glibc-2.26 reorganized internal includes
     sed '1i#include <stdint.h>' -i src/libstrongswan/utils/utils/memory.h
 


### PR DESCRIPTION
###### Motivation for this change

The new update is out since December 2018, and it brings in many nice changes and improvements.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

