### PR TITLE
pull-request-template: Add the link on tests documentation?

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,7 +20,7 @@ Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/do
    - [ ] NixOS
    - [ ] macOS
    - [ ] other Linux distributions
-- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
+- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change ([cf. manual documentation on how to run/write/debug tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests))
 - [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
 - [ ] Tested execution of all binary files (usually in `./result/bin/`)
 - [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)


### PR DESCRIPTION
###### Motivation for this change

When i recently opened a PR [1], i realized i missed test thanks to this guide.

But reading the arborescence tests tree link from this guide overwhelmed me.
I was able somehow to replicate a test but did not know how to run it.
That's clearly well explained in the doc (which somehow i did not find myself...T.T) [2]

So why not link it from the guide for people willing to dig in?

[1] https://github.com/NixOS/nixpkgs/pull/57036

[2] thanks gchristensen and clever for the help on #nixos

Cheers,