### PR TITLE
dsseries: init at 1.0.5-1

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -311,6 +311,7 @@
   ./services/hardware/ratbagd.nix
   ./services/hardware/sane.nix
   ./services/hardware/sane_extra_backends/brscan4.nix
+  ./services/hardware/sane_extra_backends/dsseries.nix
   ./services/hardware/tcsd.nix
   ./services/hardware/tlp.nix
   ./services/hardware/thinkfan.nix

--- a/nixos/modules/services/hardware/sane_extra_backends/dsseries.nix
+++ b/nixos/modules/services/hardware/sane_extra_backends/dsseries.nix
@@ -1,0 +1,26 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  options = {
+
+    hardware.sane.dsseries.enable =
+      mkEnableOption "Brother DSSeries scan backend" // {
+      description = ''
+        When enabled, will automatically register the "dsseries" SANE backend.
+
+        This supports the Brother DSmobile scanner series, including the
+        DS-620, DS-720D, DS-820W, and DS-920DW scanners.
+      '';
+    };
+  };
+
+  config = mkIf (config.hardware.sane.enable && config.hardware.sane.dsseries.enable) {
+
+    hardware.sane.extraBackends = [ pkgs.dsseries ];
+    services.udev.packages = [ pkgs.dsseries ];
+    boot.kernelModules = [ "sg" ];
+
+  };
+}

--- a/pkgs/applications/graphics/sane/backends/dsseries/default.nix
+++ b/pkgs/applications/graphics/sane/backends/dsseries/default.nix
@@ -1,0 +1,53 @@
+{ stdenv, fetchurl, rpmextract }:
+
+stdenv.mkDerivation rec {
+  name = "libsane-dsseries-${version}";
+  version = "1.0.5-1";
+
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf100974/${name}.x86_64.rpm";
+    sha256 = "1wfdbfbf51cc7njzikdg48kwpnpc0pg5s6p0s0y3z0q7y59x2wbq";
+  };
+
+  nativeBuildInputs = [ rpmextract ];
+
+  unpackCmd = ''
+    mkdir ${name} && pushd ${name}
+    rpmextract $curSrc
+    popd
+  '';
+
+  patchPhase = ''
+    substituteInPlace etc/udev/rules.d/50-Brother_DSScanner.rules \
+      --replace 'GROUP="users"' 'GROUP="scanner", ENV{libsane_matched}="yes"'
+
+    mkdir -p etc/sane.d/dll.d
+    echo "dsseries" > etc/sane.d/dll.d/dsseries.conf
+  '';
+
+  installPhase = ''
+    mkdir -p $out
+    cp -dr etc $out
+    cp -dr usr/lib64 $out/lib
+  '';
+
+  preFixup = ''
+    for f in `find $out/lib/sane/ -type f`; do
+      # Make it possible to find libstdc++.so.6
+      patchelf --set-rpath ${stdenv.cc.cc.lib}/lib:$out/lib/sane $f
+
+      # Horrible kludge: The driver hardcodes /usr/lib/sane/ as a dlopen path.
+      # We can directly modify the binary to force a relative lookup instead.
+      # The new path is NULL-padded to the same length as the original path.
+      sed -i "s|/usr/lib/sane/%s|%s\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00|g" $f
+    done
+  '';
+
+  meta = {
+    description = "Brother DSSeries SANE backend driver";
+    homepage = http://www.brother.com;
+    platforms = stdenv.lib.platforms.linux;
+    license = stdenv.lib.licenses.unfree;
+    maintainers = with stdenv.lib.maintainers; [ callahad ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22869,6 +22869,8 @@ in
 
   brscan4 = callPackage ../applications/graphics/sane/backends/brscan4 { };
 
+  dsseries = callPackage ../applications/graphics/sane/backends/dsseries { };
+
   mkSaneConfig = callPackage ../applications/graphics/sane/config.nix { };
 
   sane-frontends = callPackage ../applications/graphics/sane/frontends.nix { };


### PR DESCRIPTION
###### Motivation for this change

Picking up from the ashes of #6766, this PR adds support for the Brother DSmobile scanners, including the DS-620, DS-720D, DS-820W, and DS-920DW.

It works on my machine, but there are likely ways to improve this PR. Please suggest them!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

