### PR TITLE
vim-vint: Fix

### DIFF
--- a/pkgs/development/tools/vim-vint/default.nix
+++ b/pkgs/development/tools/vim-vint/default.nix
@@ -17,10 +17,10 @@ buildPythonApplication rec {
   disabled = ! pythonAtLeast "3.5";
 
   # Prevent setup.py from adding dependencies in run-time and insisting on specific package versions
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace setup.py --replace "return requires" "return []"
-    '';
-  buildInputs = [ coverage pytest pytestcov ];
+  '';
+  checkInputs = [ pytest ];
   propagatedBuildInputs = [ ansicolor chardet pyyaml ] ;
 
   # The acceptance tests check for stdout and location of binary files, which fails in nix-build.


### PR DESCRIPTION
###### Motivation for this change
#56826 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

