### PR TITLE
lib: introduce `foreach`, `combined` and `combined map` idioms

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -76,9 +76,9 @@ let
       optional optionals toList range partition zipListsWith zipLists
       reverseList listDfs toposort sort naturalSort compareLists take
       drop sublist last init crossLists unique intersectLists
-      subtractLists mutuallyExclusive groupBy groupBy';
+      subtractLists mutuallyExclusive groupBy groupBy' foreach;
     inherit (strings) concatStrings concatMapStrings concatImapStrings
-      intersperse concatStringsSep concatMapStringsSep
+      intersperse concatStringsSep concatMapStringsSep combined
       concatImapStringsSep makeSearchPath makeSearchPathOutput
       makeLibraryPath makeBinPath optionalString
       hasPrefix hasSuffix stringToCharacters stringAsChars escape

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -21,6 +21,28 @@ rec {
   */
   singleton = x: [x];
 
+  /*  Flipped map.
+
+      Type: foreach :: a -> [a]
+
+      Example:
+        foreach [ 1 2 ] (x:
+          toString x
+        )
+        => [ "1" "2" ]
+
+        foreach { a = 1; b = 2; } (n: v:
+          toString v
+        )
+        => { a = "1"; b = "2"; }
+  */
+  foreach = xs: f:
+    if builtins.isList xs
+      then map f xs
+    else if builtins.isAttrs xs
+      then lib.mapAttrs f xs
+    else throw "Wrong arguments supplied to 'foreach'. It supports only lists and attrsets. Make sure argument order is correct";
+
   /* “right fold” a binary function `op` between successive elements of
      `list` with `nul' as the starting value, i.e.,
      `foldr op nul [x_1 x_2 ... x_n] == op x_1 (op x_2 ... (op x_n nul))`.


### PR DESCRIPTION
This PR adds `foreach` and `combined` functions. They are repainted
versions of following standard lib functions:
- `foreach        == flip map`
- `foreach        == flip mapAttrs` when applied to attrset
- `combined       == concatStrings`
- `combined "sep" == concatStringsSep "sep"`
- `combined map   == flip concatMapStrings`
- `combined "sep" map == flip (concatMapStringsSep "sep")`

The idea behind this rename is to encourage flipped usage of functions
in templaters and other script generators.

Flipped version are often easier to read. They are also more consistent with
existing usage of `optional`, `optionalAttrs`, `mkIf` in sense that
*usually* first argument is shorter (syntatically) than second.

I rewrote two files in Nixos to show how these new functions should be used.
 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

