### PR TITLE
qtbase: Fix paths returned by qmake -query

### DIFF
--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -175,7 +175,7 @@ stdenv.mkDerivation {
     NIX_OUTPUT_BIN = $bin
     NIX_OUTPUT_DEV = $dev
     NIX_OUTPUT_OUT = $out
-    NIX_OUTPUT_DOC = $dev/$qtDocPrefix
+    NIX_OUTPUT_DOC = $out/$qtDocPrefix
     NIX_OUTPUT_QML = $bin/$qtQmlPrefix
     NIX_OUTPUT_PLUGIN = $bin/$qtPluginPrefix
     EOF
@@ -374,6 +374,18 @@ stdenv.mkDerivation {
     + ''
       moveQtDevTools
       moveToOutput bin "$dev"
+    ''
+
+    # Fix paths returned by qmake -query
+    + ''
+      cat > $dev/bin/qt.conf <<EOF
+        [Paths]
+        Prefix = $out
+        Headers = $dev/include
+        Plugins = $bin/$qtPluginPrefix
+        Documentation = $out/$qtDocPrefix
+        HostBinaries = $dev/bin
+      EOF
     ''
 
     + (


### PR DESCRIPTION
###### Motivation for this change

Some project rely on the output of qmake's property mode (```qmake -query```) to find their dependencies, which currently returns the incorrect paths for any Qt files not installed into the main output path of qtbase, because they are installed in into a secondary output (namely Headers and Plugins), do not follow Qt path standard (Docs and Plugins) or are part of a different module (e.g qtmultimedia, etc.). 

qmake computes these paths using the [```QLibrarySettings```](https://github.com/qt/qtbase/blob/5.12.2/src/corelib/global/qlibraryinfo.cpp) class compiled with ```QT_BUILD_QMAKE``` defined. The class uses ```QT_CONFIGURE_PREFIX_PATH``` as the default prefix, and appends certain default suffixes as definded in ```qtConfEntries``` inside the ```QLibrarySettings``` implementation. These can however be overwritten using a ```qt.conf``` INI file, which is what this patch does to override the path of Headers, Plugins and Documentation. The Prefix also needs to be supplied as it would default to the current working directory else. This fix of course only works for qtbase, as any other moduel (e.g. qtmultimedia) would need their own ```qt.conf``` and symlink to qmake, which would introduce other PATH related issues itself and therefore is not in the scope of this patch

Fixes #56357.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

