### PR TITLE
linux: Makes the -dev output reproducible

### DIFF
--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -195,6 +195,10 @@ let
         cp $buildRoot/{.config,Module.symvers} $dev/lib/modules/${modDirVersion}/build
         make modules_prepare $makeFlags "''${makeFlagsArray[@]}" O=$dev/lib/modules/${modDirVersion}/build
 
+        # For reproducibility, removes accidental leftovers from a `cc1` call
+        # from a `try-run` call from the Makefile
+        rm -f $dev/lib/modules/${modDirVersion}/build/.[0-9]*.d
+
         # Keep some extra files on some arches (powerpc, aarch64)
         for f in arch/powerpc/lib/crtsavres.o arch/arm64/kernel/ftrace-mod.o; do
           if [ -f "$buildRoot/$f" ]; then


### PR DESCRIPTION
###### Motivation for this change

Makes the `-dev` output of the kernel reproducible.

The (temporary) file has been spotted by r13y.com

![image](https://user-images.githubusercontent.com/132835/54063294-806f5780-41d9-11e9-8d1c-9eda66afcdc6.png)

* https://r13y.com/diff/d335b303b5576b1d624d791ccffa32496386fd4ae97f99a5f34f86e32db03154-c30bc77f137f50e5e23504d0affb93e25b979507be08de2f21d2658743ff3283.html

This file is, in turn, generated by a poor cleanup under `try-run` from the Makefiles. The particular one is this one:

 * https://github.com/torvalds/linux/blob/3601fe43e8164f67a8de3de8e988bfcb3a94af46/arch/x86/purgatory/Makefile#L24
 * https://github.com/torvalds/linux/blob/3601fe43e8164f67a8de3de8e988bfcb3a94af46/scripts/Kbuild.include#L107-L121
 * https://github.com/torvalds/linux/blob/3601fe43e8164f67a8de3de8e988bfcb3a94af46/scripts/Kbuild.include#L82-L93

It was found via using `strace` (and a good guess). The underlying `cc` call will call `cc1` which will use `-MD` with the filename modified to be `*.d`, meaning `try-run` will not clean it up.

The file name is different each run, and cannot be derived. Thus the patterned `rm`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ☑  Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ☑  NixOS
- ☑  Assured whether relevant documentation is up to date
- ☑  Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @grahamc 