### PR TITLE
pythonPackages.dnslib: init at 0.9.9

### DIFF
--- a/pkgs/development/python-modules/dnslib/default.nix
+++ b/pkgs/development/python-modules/dnslib/default.nix
@@ -1,0 +1,20 @@
+{ lib, python, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "dnslib";
+  version = "0.9.9";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0w8spp4fnw63xx9zj77zvgk1qabd97ifrj6gap2j36gydnarr42c";
+  };
+
+  checkPhase = "VERSIONS=${python.interpreter} ./run_tests.sh";
+
+  meta = with lib; {
+    description = "Simple library to encode/decode DNS wire-format packets";
+    license = licenses.bsd2;
+    homepage = https://bitbucket.org/paulc/dnslib/;
+    maintainers = with maintainers; [ delroth ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1749,6 +1749,8 @@ in {
 
   dmenu-python = callPackage ../development/python-modules/dmenu { };
 
+  dnslib = callPackage ../development/python-modules/dnslib { };
+
   dnspython = callPackage ../development/python-modules/dnspython { };
   dns = self.dnspython; # Alias for compatibility, 2017-12-10
 


### PR DESCRIPTION
###### Motivation for this change

New package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

