### PR TITLE
thunderbird: 60.5.2 -> 60.5.3

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,585 +1,585 @@
 {
-  version = "60.5.2";
+  version = "60.5.3";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/ar/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/ar/thunderbird-60.5.3.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "ebb79e23a3f67c6d365c95d4570d5d278731231839cf4ba8ae2231aa68eb28ef08165bf025798d5311f5fd28a66dc90a1fe52ec52e4e1eb21084c1d613c3c3e5";
+      sha512 = "50f0fcc51835e75cf58cad5d94225dccd490e2278cbb43944b99b732d4995e0776f921c3004e3ec74702c54b89a67d779c2abaf1568af993921d7bdb2ab7263a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/ast/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/ast/thunderbird-60.5.3.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "d3eb72f40f5fedc2e3c6f3b3472a8d90d74e1c6599e6dded49f20c1b3e99efcdd724c09645354d0ee531b2bb9f5750742c6c97f5323b23803b59a0f93f2fe98c";
+      sha512 = "a1d7cc1d63a9c0bf3a750d5f27a94800b71169c1c46d714741d14dbd0fd7e5dd1647ed93bc5485442bb9c7ab5ca4a8152158234f527b9d30d2c25a09727cb6c1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/be/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/be/thunderbird-60.5.3.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "b895b42343a9abc291b0cbaca4d1a190d7472f9206b3161cfa93d97489846682be44c923e92b27fb7e84e3dcda9d727ff8130eea731bdfd28273a691a38b3f00";
+      sha512 = "4da51c8345d418c38ca2993a8c2d80196298bca19c6f15e1cf7903b66aa6901ce7e99676bc7f2853974f989be046a9a7312c7ff8b5dff6b867fa25f2cd39f8fc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/bg/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/bg/thunderbird-60.5.3.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "ba2b1c0666466d89ff01dba6fae809b7515d026b3d34de4f27c0bc6230f722739822da1d65f4a9c1ada66ecdff8b50f8aa6164c4ff0bb3d8a1c11c355e441cbe";
+      sha512 = "19883dde8fcf9258840ecb33a105b42fcc61f5335944c834b5f481fe0a697800964751a0ae1cf3d97b615d506cc991bc4428d940f8a9e234cd03126f385e6aa1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/br/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/br/thunderbird-60.5.3.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "79937d514822bcf5f2882c4f71e277d6450adce04cd490001bf2535850689ff8691a715030132c805b85406d3aac0d4bbdc78c7f77398db43e1fedeaea2ebd81";
+      sha512 = "2faca5febfefe2a60d49907a727cd8d5b3cf90e0da9a54eb2468fe4406401bba711ff3b26c4840080b463393dd68d15079758cd8f9a126e193330e23d05391a7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/ca/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/ca/thunderbird-60.5.3.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "f1948d481fff6cad4ab0ba48c40c3e317c3cd9a68972d7c94fd4d92fabcc0becc8bebaf4e5517016af26125334695fc6b7be17ccf26fd291cd5a679e95b632b7";
+      sha512 = "62faf2eec4eed0cac9acc3fc66603e385c21cb09672c15444c23bd2d01da0e3f3efa9b0c7c4a6943ccb6e7293c14b4d9ba2a309ee2eca4944ceb9f092df64c03";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/cs/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/cs/thunderbird-60.5.3.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "9210fda93564133c67db5f6a10783a65e34fe0a2e8dbdb7f30fda60b4b839525530081376dc88482bbe5aff37580f0d837010e21d076994520e36a7c6ea27721";
+      sha512 = "b8b7ea47bcdf4ccfb31f0777c3aff9f183737b8a39911b41dfa5b97f105c7e9c941c8bd1145eccd636f402d17d0b6b2a97c07bd60b12bb7d40da6c26667ca8d5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/cy/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/cy/thunderbird-60.5.3.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "29c35ffd5e33627ee4f3c9574b1dbe4e8addac509afbd4186f5e47284071711dc0bf74e550aa0896f39fb4fbefc72a8475b665685121fddbbbd870d020e5913d";
+      sha512 = "93c2d071c439001f67a010908bcd36b2551384a7036e1f2f3258b0f0595f8b06de0e1685742ec7b983754f9869735b29de93f73a0b8f6ada45e4f187369e2583";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/da/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/da/thunderbird-60.5.3.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "e64c03f083325750020f5502ae4bdbd3b6e20a0fb9cd1163c87c2b7baabbd576dffb06b24d79c76a81d40744e6dc4064dff6d316d8e2a216a4a4e9e546f11aed";
+      sha512 = "2af9c68e39ba9b767f348751c7ecbaa32db7a7f8c46a7fcbb7958a48e5cc742725bdfa1363be6509b3ceed38448cbb0b97b90e967cb1cb4e727597b5bee6e71d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/de/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/de/thunderbird-60.5.3.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "d2727f56906e742c77365655422f0e53ca822702c13b496181889dc778502f922900c76178259797300dd3a440128103e7e6f48be1316a85f41edccb7a9c291f";
+      sha512 = "cc32b86dc9b5dd1561e030f55f2dde3e7c85fdb638c212b4f5a115fc580c1c133b79ba5d7d9fbe6ddc5820b9699be4892b175630c22af2e87641fc9e0c1c342e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/dsb/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/dsb/thunderbird-60.5.3.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "19eb975d0c97168e0106baec96ca8a645bf42f7f5993e11f0e4e2c6bd797808a98b70cc643872e3f03c8f8fa644cfb46210bbcd96d91a5f5f8bb4443f49befdf";
+      sha512 = "809a0fdd22137e4c5653ddf855ab68945594547aea5243b5afd6b4338d068fae5a514ce57f743cbc16682424dcce22493fedc01fdc5e09198d92cbbd9ac2885f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/el/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/el/thunderbird-60.5.3.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "10cdb6888830d88bde779d402140dcfcc68c5d6d1fe77a8a0014bd230314af28b5a04a93f36a15e32d6cedbc6c06f9cedd447d1ef120bf0e332b71e8bd67930b";
+      sha512 = "3f5b0012951e930a2fbc3cfca1041fe39311f5ec2e24dea58857c9edfc7eb0ea769657d5f92b3f49c75a77dd2822edd6397573968ad6d7eb179d932de01dc50f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/en-GB/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/en-GB/thunderbird-60.5.3.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "09c8fb67e8d8c914be78d7af15e9cfc292fba45d87a8e95c83c38ee271c9004155a8d2826aaa880716e997ef4e6edeeab32b447b673c1ec6684d796d53e872f4";
+      sha512 = "174a8f72a55f8ec6c6cdbbdffa3f7bfb136c73bf5a343a7919716df257d02ec3242f93a4eed5335269f28400c41ceac9bf57fe842f85c5212265bd0bba5ef5e7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/en-US/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/en-US/thunderbird-60.5.3.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "89efb313ef9246590e38bec044682c0a472741be3dcb7addb982ae09072d0f63652e4bda632d76f0340417b7a4bbed4631e009300d896c0e06af7626ef2fe526";
+      sha512 = "1cdc4db705ca0e0ff75c26ee1098e2a27294b0ee2079844bf31569dee5dbeb52fa6105e2b50f19215bb4c6a0c94973e92a914836e90fa3b8b96381552c708603";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/es-AR/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/es-AR/thunderbird-60.5.3.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "df915675422bd60d59f1e427c8a7fd68c20b3feb70e7a15a3d280ef3c98a40edae7663a266e5df3fb1045f63c480584a862dbe9c20bb4a208bc2baec2ab9255d";
+      sha512 = "ee8a3908745ef4c9520bd41a448f1b8b44239e151df70e020d00a10af9d7b006296b5c03199f144b8cbeaebc92ae19ea82a50df23afe3c1b27403bc6fbafdd97";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/es-ES/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/es-ES/thunderbird-60.5.3.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "449e0e5d02bbad21569a45b61d16f5a8ccee853b1e6716b24e66744f1e6688bdd9adf240e06b2e40b71306759795bda150d8fff201c2b91466df06a66f55e484";
+      sha512 = "d968c04a9650f5276d7f8c1f47282bfcc2ea6a42863e6f81c4086e8c582106c6ccbef3b364e2e806d797146827e635485ae2af057b0908ff4b5e59bcf42150f4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/et/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/et/thunderbird-60.5.3.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "09f0e6dcbc99e9d39f253225db3d6f370414c3120b5ef0fcb3258ea3779117f4f41c6481aedda00ec7006993c3b05e14b0aaaf7b9a805046717ba29054803a70";
+      sha512 = "fda1b0c0d7f8337ade62c60cc9b77ed8a445d0fd4fcb9a196bcd10f49935dd17bb98222a8b4a692406b478ce8c7de5c5e94134f34ff52ccffa5a4c14ec1162b5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/eu/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/eu/thunderbird-60.5.3.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "fd2097d6fbee4ccaa85744af1676b7ab8097315d9f52dbe0b60d2e620d1bcd052f9eabb9eff5791654a5b87a8d4e6b170318ef8dd68d666d4861c5bede1fc879";
+      sha512 = "1a9214831d01e9d8b516991a35ef9c788cb485962071994e3f6ea7fd6e00e5d77264cf96259c9d4b09609013cd8a90bc9afcca25968db5c3e4f1cc4421edbccc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/fi/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/fi/thunderbird-60.5.3.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "2c7ac9136d7d44f8870f5b5555f21405ddf6f243cbd346c985f71ca12bebc05c81a25ccc7050919704d9101643accc50c3fa8a5c6f93a6f97c96e91adcc07833";
+      sha512 = "b1f4a79e22ad3e4219f9249cc0e20106c11e73556b264322ae52d8ce7d0bc467c9441d24f4b6dabd8f0e2e56812d69f0e6759d9e16229249c9b840444ba9eb51";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/fr/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/fr/thunderbird-60.5.3.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "303dc437b230d5991c4ca33afdec531c2c5b2b67d02b4f9ee923c2b4ec434d0765a8fd670cc2978226eb7a25982ddb4a14f91c0829aa97d822f7927421313170";
+      sha512 = "5f2bbaf7180771185001432e94ef1a691a0b3bd63a4fb9e7823c333e88c4d05e3048bfd3cd6dd3c9f5ba2ef3b8da10f5deb3c3cc980f181e559418db87378d0d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/fy-NL/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/fy-NL/thunderbird-60.5.3.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "040d1112d135ff81aaf86964eafd235f6d9cb793049e5cbb68d9d183555eb2b08af257046de373a1bdc76e0113e372369cc1c0ba26381204cc089f2a7c752977";
+      sha512 = "ce6b1a68d96b5a68c409b1b63446de565e56e4676bd98068f9a5425ec72b59ad513c626ea5849afb42a9b7ebb19fd330ec87e087ab938b5821bfffe48140fa7e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/ga-IE/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/ga-IE/thunderbird-60.5.3.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "aa9eaaabbae45d554a31a5ec9940f7dad5c1ad46d34438f6cbdce5573a12d019c014bb4e9013e3efd73b68ffc699b5bda8721901b78af83dc370c71d588ca1db";
+      sha512 = "df34217f28583d165c05b30e6159841af8e37aa6ea124f06d47f9841ba820451a7c6f7c758dbd4538e854e8c3864e1922619cd67b669ee57bc22e7c51371b79c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/gd/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/gd/thunderbird-60.5.3.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "479601e5d4b346d9c69daf2673b12a8e74e5f4ee924b0deaea7a6ff56c92ff5aa3ada825ebd75bbcf6e115455e032e50d1e7cfefe51f9bd059d499a023b514eb";
+      sha512 = "03794b7c5f626af31c97fc20b1d604c7dfb8032151e1cb9aa5679620b6d85f724bf8db180b288c5d79bc3c452539a55ba11f058934d0bc9b09dd58bbb0278173";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/gl/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/gl/thunderbird-60.5.3.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "fc6b5c061bf402f46c255befe2ce6a752d2ede4af5ba303e1e88ce935553ff4bc3defa5a4b54a10a8b6a3888044300f9472e0390ce71e43b256be0e549a61f60";
+      sha512 = "ef6dd2cee975f9878660a58de6fffeff87937257140daa094b9afb3085d5789b01b1679037387b9288677d35467ea2d68a17a5b749d9684e74829fd7a6261bbb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/he/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/he/thunderbird-60.5.3.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "f942b69831af29e4024c3b5250e6eee3cd5cc19863f960bc477f90e75e55bce7098fba1155452d67dc2f5a957c1fdcef049a0b4e0cd8867b540d34b6c17ac6c0";
+      sha512 = "ae9a5c7d9b91be761883fa532d21cfadd0e933414879008711b5328c0e3ce6b60e6facce0443c9cebf9aa089d357bb299f7372ddbc8cd5cdc2310e84d8f21fc7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/hr/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/hr/thunderbird-60.5.3.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "dd0cd07f20e8b28581ce34c3481a8aebad31099392151b5cfb5503b3cfbb6b69a595a4c58702a4f359d860f325cf1feb73ac13456f743410e63b2471587e45c0";
+      sha512 = "b8a8f5998f9f8e7c94ee1ca66d04c420eb49580e9eee44d819a8f911cde0ada79550587ea6e168e1b58d6414ff1b320ddb75584a2d28a06e4c511f39ed53d577";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/hsb/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/hsb/thunderbird-60.5.3.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "7a18f221a0d41fc52a4efa63ad85bc41e3d7789f8e5d82ff60f2163ec4e9a0da420f795a2be4e4d05c35589cf26460b01f660d03b83039cd46684fde3f980668";
+      sha512 = "8bc0522e6407013780b198c7d7140654ad2dc5b9e4d07489f3194a3da51b2996b94e62594e5d135a7a17e1e41cb777c0dabc86af87d990532095bb4161ab7acc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/hu/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/hu/thunderbird-60.5.3.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "9a8206e613c8989f1288936853070b0e719294aabbd2454ceff0ea8f2fca36ead7aa51a0b7b1134b4d75854d77f64cc809d4a12e6e2216e30f7d67ff41c8db6e";
+      sha512 = "ce1c971cffba79c74b16ee4a68f97905b71ea325a2dcb97823d3957007c7fce76c708d8ef8ec2b5838290367007535e048a06abaa98204060d5b8d01762cb379";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/hy-AM/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/hy-AM/thunderbird-60.5.3.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "1166b2380d09ae62dbe73713e9ae978f613997326cfac04b7c30abe94e51637a5ac4ac23be75d2cbdcdc60e1997b58bd8c07c35e13987be89b439cae4edc04ef";
+      sha512 = "1b1f5c0a44931836713a70b5300855e498ca27504b8af7618dae7471dc4df194abb830ebf4818f00abf28818ad34517c03f2d3e3f7a7eb23e08d56e948b5513b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/id/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/id/thunderbird-60.5.3.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "34006d900389d1cb5f29ef379e5aee0177df74f22e43a42f99520821c04fe5c33cda7ab8b77665091403b889ea54537561eea14532290fd096efb4f7f8ca3615";
+      sha512 = "14ad818ad9aac3308df8eca28c650803519885b0d318222a0e0d320cf9e6cf81da17b7e11c198715478085749389bf9d6a56fc25d7f47e874436d582e15c6269";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/is/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/is/thunderbird-60.5.3.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "e8b96762eae43a50b73b7faec2647d13612dfacc4c58687461ce2ac08e14c54bcce138c82378ec7a71660dde3bb9d96a29f78f304f51ede8751d97f32b9a4151";
+      sha512 = "de83b7a3b78185175a170a435f5c43c755c867bc9e8be9fbce46bb4eb8cb6b771676071c76acc9e9072c0dd69b6cc62373b7a8eb3510b64bd892ca968bb4539c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/it/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/it/thunderbird-60.5.3.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "42182a88f948f57a9c8efb347b6178bc14c6d5bc13b3814cd9f187c84c47aa897d904495443d1d8800837d66e8c3bc4a266df4a08ff1a31ac136f0860a563423";
+      sha512 = "072c225ba9959c7a26324fa05ebd7fc193a878cc35591a08da437f99daa32b68ec5a2975e873ef229126432e0e701b10ca8497404f9225183622759b7c74282e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/ja/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/ja/thunderbird-60.5.3.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "dbc4ccf655ded43805192ae65c67467002645fc527c935c4e15871173c7bf975681df66ba1e21ff823cefddc551e3680d50dcda9fd2a072234977c83dcbe31c9";
+      sha512 = "6b84dc14361b275e3470819a8d7d3deca4d6ce9fdda2c8d028bcd90f928044960c9059e0166200aa671a8ed9fe88e4697022b8c79d3e40fa8ba2e2bd16da41ca";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/kab/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/kab/thunderbird-60.5.3.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "cf4fc5243334b8ad84e007606cf836c12d0c51aaffb02d97eff8a248fcbd5644a82767b8e129d1643e0efc03525db65b6ed7cefe8a53e0680c9984fe2a13f472";
+      sha512 = "eb5022f5f8b213dfee8a371f6f7f3de320e97ff184d16f5f3d4de9574acf13f9c5dc1452f488ee596a260b601efb0a4ef7820a4c262499d5a797b382958bcf58";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/kk/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/kk/thunderbird-60.5.3.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "a2be7803b84d9bc9ad5be834226e314a980c60d5079339beba9de6e296c9b26c02ab0fb6e06398061588df005b9dec4e19a6eb55a1f7f51ad7ecc61fe17a9b50";
+      sha512 = "d84f4dcd4e897d7f87d13904463900c0defbfd8de8a8485f072837a47607a9e2759e686a107dc7337234e8d14abb78e56dcf3a89d1536b3bf4b7f9b0fe0f531c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/ko/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/ko/thunderbird-60.5.3.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "a0b0a2a4818c61b838c22f55c8950a826be819c22e17e38548e18b189e5bf9743eb3832eba176087c291ff12349415d12c3c83416b24d38d148973e2219f6daf";
+      sha512 = "ff7cf503372390aa6c7e82a743d5c2fd8a3c88415ec711f41a3e02d397349939b15f5ffe3a3f8027c3647860db642b6603f55da5e1086416f15d7f4956393a09";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/lt/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/lt/thunderbird-60.5.3.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "0b2635edecfa8517a967fb298f91e77861e8af2a6dead50a451ce23e36c26ba8b0aa4c9339828008178d5b3c3f36fb2a13d91f48446a507eeed8824fb162c578";
+      sha512 = "0aeedd104d1a44c6e235fc5956d58b9359d7639aa64f1f87f407b93f555018e51e466b08118adb82682f77c1163b72eb19eccf46aa8c584ebfd7f2d7c8ca3b03";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/ms/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/ms/thunderbird-60.5.3.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "3671774abf19d63fb5141c28f4d3a35608db59eb75530e6f78337122a42a78a467fbd0a0cd33402286cb3ebd43ce777b202ca704ddbf0ea7a4ed52981ea1c01b";
+      sha512 = "ec48c4e4107303a194e3bc74494743949fdc95464a10cd7474262c65f0538f9d430fcc9089e3b4c96ba3fdef2aa53903182ff9423437413314f030b45ec42f30";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/nb-NO/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/nb-NO/thunderbird-60.5.3.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "cf1052a4c0a48d2f2c2b2a63a36266b7f33c572f5bc8d5fa0c6be94c5f4e5a71dfb19fb8971282bbccdc2c5366255bc46e0c549acfdb98b5b769af0b392496c7";
+      sha512 = "c4e3f5b66107e424d201f15b4cef49d6efecc2d1bdce02670168d374d53701f1c724a0b9d967ea948d3b5660d2565df664dbfb35710db4691e69eeb63c82353f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/nl/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/nl/thunderbird-60.5.3.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "8448a26d8e80d042f59d4bf617a60915b656d2477ca0e214b954104ff7a2d1a7751881c09f262d32046f9e9f3bece7e591dba689bf6b09b21b318e76de9cbffd";
+      sha512 = "312be31424561fec5a7dbf24de44de3d367e070409a2367850ab46bd4baf653e3696803eeed1af7faec8de2d6e1300173ca3e1539224422cf06d6d2ca9b4a7d5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/nn-NO/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/nn-NO/thunderbird-60.5.3.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "c6a2c15d4e2470c9c0cbd984f8928b4eef88f356bdd16a24e4698bca7005a381001667e6ed357c22047c748a7fe0a6647402763c9c90c026306c23bd8b2dc3f2";
+      sha512 = "85cd0a74d7a33e9ba7669f9832a412a424a97668246216748a6fffbf03d89eb3e2e091bdfc2d199976986a21f4bc29daff360b57b3daaed41a3891060625238b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/pl/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/pl/thunderbird-60.5.3.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "d8a5e014e95074e68678c2fa2f4ecf0151495891d496dbb9c89fbfb9a2fd9e168af8751c214d612789dbf179817ffed4e0fbe27b8d8b15a1fe5a5bfa1710ca50";
+      sha512 = "1a422c51684c0fa68cfd3b39507899438948a26161ef167d16dcffeb7164dcb3f2e15f8c8521acee1d171e9ebb7b592cd6f38b6607d7621ea976fdfd4fb7d1b5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/pt-BR/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/pt-BR/thunderbird-60.5.3.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "913c164af6d714b9a99c8c28b52eac4fae702fd0626bb3c232d556c6047c809834c390946b4c9cfc52894bc8da7d0fbe794055642f3570f8bf7bab5b1de00977";
+      sha512 = "93c9bc275b605ca977e4c2a93f7d1c103d3948c0f797fc87b6d8df9be4e64616e7fb0b957ddc4efb4f43a245fd9245eda5ea8ddf8e224574c0593141c70c453b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/pt-PT/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/pt-PT/thunderbird-60.5.3.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "ed84b2dc5bc16bc79d9ad14ddf22d03c0b23c78a42e3cf447c4e456bb643ce23ef890399114bf47229f0a496d56617ba65ee71282bce5bb5f085eebda0e3b5ee";
+      sha512 = "f3f9682f927bfbf1ebe90c23ed12de1e8e3e6cd5ec799da48a21d3d11737dca6075746ee4173f4376a8d62146d31a5842dc772108f9c0d45b78fc7e5b7dd7608";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/rm/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/rm/thunderbird-60.5.3.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "b41c15cc2758f3a90c8e96ee20abfbd20f747bce5e40eb0301faec23e512e2a39c4d69b18356fbe72c6b8de3a83e79dc18be20a20c77f33d03bfaf7584cb86d6";
+      sha512 = "55ec95509dc78e522123172e250934f2f2c26b620a66af9a08b38965a85962924cf3443ae936c39413ea608bad522447b2849fe6359a988e61b876eced93ee57";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/ro/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/ro/thunderbird-60.5.3.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "b100178b0ddf33e5568180f7d3f64755a2722ed8693bfb92391bfa9a8c0a2f3b88534bd0bdecd3eb823cf25c5b17ea0d80a9a3f007b805d512a6f4b29321ae17";
+      sha512 = "65f550dd961c81f350724155b603f407ff6ce030983134e10d1cfd6577444576c44be4e6d3e9b980a340e67cc271f9fe6bd65147122fd45d829d812770dd86e7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/ru/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/ru/thunderbird-60.5.3.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "486b51a55c5dcac73ffc92a763dabdb4a428f7b23c7f4d3fd3e44ef814f26d4987f4cb794431d372d07453a9e3beaf3b985e22fce0d2d45cad7f75f0b32c5875";
+      sha512 = "f001aafb98e6847d97984ae1f1db8e74c4bfcffaecf6ef8a69b66559cb99b7424f8200cf270e41b9ab0691b6c833ee8ab446a80dd00aa3a5f6d6cc5879224f36";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/si/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/si/thunderbird-60.5.3.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "edc25ee0903b52f6f5bde6bd81519e0cd76597fa5b93880312a1e251dae03ceff5166dfa137478805619b4776d4c00f9be6144c72dda2b4301794d38c1fe7c10";
+      sha512 = "7bee83930edc463761ba67de3983a77a02392d8e6c320dddadc158e28e13d58829f3ac617e713419a150e520abf437ff1f9daaa708baf9dac4ffdf84deb7f09d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/sk/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/sk/thunderbird-60.5.3.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "fe383eda44cac66ffee31ac2dcd0afd1e5d864ca32f14114bd3be4ed9d59ce45b4cffda40aa15f5276b682110205c71f28ccc5a29222194782f0ec9ce4262f65";
+      sha512 = "284a7fd983807e8be81caaa8cafb17d96ba28e782f1b5cc4bc63f949bc0f80b617cfb16a60d15bcd47e969fa4c851288f678c4681d1105031c0a8d3d78a40a67";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/sl/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/sl/thunderbird-60.5.3.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "be543501922ef4b0e6205f25846a5ff07009566f018a880b38ca5525d601d107a1b0589fba4502711e4bf187f2e47445ece5c2f2b3b4523f887e865edef8816a";
+      sha512 = "50eaacd7faf00e35054044fd28df9a96c9f01722e7651f20b2615d6d07f77cb79aee048a638ec11c98f5b9cf35e7af555ae6b89ea411bebc13379120398460d1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/sq/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/sq/thunderbird-60.5.3.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "1a26c71d2466ff93aa8814f0138e597f9b05e6c80ef712c6d91d17dd793529274b30dca8c9a864cfe5d5e959594cc5905e6aa6ec9503264b3e25e6dc240cda50";
+      sha512 = "e2709c818b4e805a1abec4409a54c7a734b198e3030c7c32109ae69193797d61b35fe36411db56923d360f06c32c3732246532b8730dea1737fe635fe03ec908";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/sr/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/sr/thunderbird-60.5.3.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "6e61edd11aee58cde3e50f94d0053140289927239627e53b79a68d81d8ae4eb3adddf6fbaa92c71584a8cdb9b352f32ea64b1d118abee64be9ec5bd5ade6ab03";
+      sha512 = "1cc7bd55c5e4f24ff294e432b7d38abdeb75c5184c8289df22bc25589b86342f2e1d09e831757449b43e3ff6ae1342417f1bec09e3867189cc506c1f3a659c2e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/sv-SE/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/sv-SE/thunderbird-60.5.3.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "c85b14d0d69675290734896c2fa188fa2ebd291aefbc006c88f6a8b0929c3a0fdc88728af8f7a584155988e44ac18cc18468d05b38c0a3be45d0d9225a3ae8f8";
+      sha512 = "12c702b4698b6a8489e0ce7434c213f098dee704ff7f51cc9494d001ea9e67b2eeac3eb9a472792d988e0196428e5246100bd0a906aec7e5f8d9bdca032b17dd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/tr/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/tr/thunderbird-60.5.3.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "03440acea9928ebab312dd9411aa01f4928bb379acd377b2999c9c11b0a39aa5045cbb396b4a76bbfe0c0161b1e1bb75bbbacca1b370dcc84a12a22925189642";
+      sha512 = "548fe14a41b46b6a527854ac9bc7f44a15e7359a9e1e6e03d45c6697e4e22bd251cdaa6f130f5772eb3252f9df94642feb1426cf54b2a7cacf8e170e332f8c87";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/uk/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/uk/thunderbird-60.5.3.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "7f55c44695a62c9b889b2867dcf8c8b42e057afb9b94bd44912ad3da617c18f4064f41a05e2582b24acd982cb3c667d081dee4f012cfbe096f06d795dabe456e";
+      sha512 = "dfac15a954c43ae87ff6b3d60ea89a014ec8329c733cbcede58a9a202fa62cb8dad72d1b096c1e3bdcc30dcecde80f357c9f51242771480da28c2d508edecd4c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/vi/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/vi/thunderbird-60.5.3.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "316cc05da31325eab8299496660d0c3785ee4bee9939ef4c4ee4cb19688fea79131d1b47ffde3fe1154a9b90048bdd584ef584a0044c66d104eae6aae98f5913";
+      sha512 = "4695d333661a11b944148ce7833249c26fb534323de5163a2dc0d0bbeb5d1e87a7008a5c570378d2bc66537f60c10b7d44c4a01e7036234767aa209845152b7c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/zh-CN/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/zh-CN/thunderbird-60.5.3.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "99d7524b51e9d43b129903e9c4339d9db7e18541973e5813b491b4866e94ae51373a8b3e23aca41681bf097905e93dc888590cc208d40bacc907546b0f6f5106";
+      sha512 = "1c5af3fe5b0f392e4fcce2e713d8e03e9be94821d942612799dda022d2062edad7d99749bd64f947dbce00f0f7d45eb50fc45f6fc6b847fad5ac31b33be6afcc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-x86_64/zh-TW/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-x86_64/zh-TW/thunderbird-60.5.3.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "235cd4de682d65ceae05aa2ed9f7971cc85aa01cb60e6bcd85de7da24d878d5d98a4e2f5386a9ee30263eb51da7cd50e9bfdd44136bddbcb7b001af0a79da34a";
+      sha512 = "a49e7d64cf2ccf1fd795df867b331c4aade35143ef6e031b3d491e50a59f3098b9c0f795822b6b24d88a8a1db72332fd0c5c5d3df2da9a132e083a1f7b8291aa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/ar/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/ar/thunderbird-60.5.3.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "a9356c983c9ecacc5f381c51709c41a529cb792eb2cfbe62bd55fa190ba6f53a417c5e7f1ee13ca57b71cb781cc7d1485d794cb1486a2f74d06e17dd3a59ccb5";
+      sha512 = "61e99d4d40ac2e976a7ec2724fe6c6490353e0c4b59ee2e83979a41e0c8c93c31221c86e4859bb992a3a85d678280229c9362f80a981b92189d39c64e530558b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/ast/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/ast/thunderbird-60.5.3.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "627cbc249e56351c527b33571a43f5b28c7c2267ce83466d74a66c231349a6677f423eb817a86fed84b3e214a274c87af5284164d39fdc74f04610bc289771c3";
+      sha512 = "22aed2850e0eaf1b49d7fd2b2e102d7be8949cf071597134ee936d1467f0e4cd6c0101db2d16d80b445172d27f8f087c47b91f2edc696489879e6655d19f7cfb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/be/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/be/thunderbird-60.5.3.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "a3d96e1ac59aa7144cdc50d7064ece222e401f8d6e6a2d7b60b2731510f934b8eb3c686ac53f6ff96915e14ff3b3cec38d7b01b4c549490d314aaa6a40bba365";
+      sha512 = "cdc7a7ab80d3c72e3d7a582688e9b2de5c13a4d93fe3ac6ef5242061d3864f3dac1c4c23046656c227acdd72bef0aff32d68829195469cffe264ca9bc3e575b5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/bg/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/bg/thunderbird-60.5.3.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "c39fd5d4dab48ce85bb4d524f210b17e1bf16d7b576639055d4f949e7ee549db3c681fb3579cc3722882753c401ce0a0dc97182767dbce57785a474105521345";
+      sha512 = "35a9654f188666e4eb153ca8a256d0fea1e1b9404a38ef5a8a1e0dd40c450ab4cdc313b13c6d000c3c753e473e8033ac29da9fec214fc77104489f112b831590";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/br/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/br/thunderbird-60.5.3.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "b5e1a4c7fb6c12ea41d5e5c1cc7a6214e822012fe318e2777ebcd89b2502018c5af0758b704dc3cb1b0487a759222393a4cc4f57a491f5d9ee1f71522a8d242b";
+      sha512 = "0aa47703a64dda34df1ac9496bb8e522aed0f7b4c1ee026f2f14d00363a8f480142fe5dc928480cfe58e9bb848f05a7ebdbd3bd1fd9f84477b9e89a15e9f61e4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/ca/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/ca/thunderbird-60.5.3.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "0004d9792dcd2d0ae211083d6dc87019e362a6e10390a29dd8d9ef567a0282b0fcedfd95c4e91c857c25361673e2f3c429b3afd19f35714925a7252e15fc4231";
+      sha512 = "e1e65fb6a0b90dfa8618f4fb8d66f4fa9b802a7ea0cff038eac05849cc505e59aa9622c67c75ceb0bc322a1edc5129ff0bb684569cb7639f44e65b21ef169a1b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/cs/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/cs/thunderbird-60.5.3.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "c7428593007a117f44e9891e2cab7d352a64f9f53487478671bb062d7dfc623b65f15749b994c298afebd4776afae4619f36da513866607cdc1160896748918d";
+      sha512 = "2eb0235e397c1e368b703df7f0e2192eb13bee414d16fd0687d047dc95c2a1e4da052ab385fb1bdb8f6920e1668b04bb19491cc0661cf6c0a9812ef7b25b1a5a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/cy/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/cy/thunderbird-60.5.3.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "6c768a2e5ff27988f7e52c9f38f543b40f3111c6e944e573e8dda4791253cb9f4f25d2dafd8d0c63d2120e7bd331315cc3ebcdf6381cbae0d4700564d7a54d11";
+      sha512 = "610b46a48856b53a3acf79dc66d44364846aa29e269eb1072281b1bc9c1d146d090660c564ad4a9bfd083591656fb1ac15e8f8cc28cdda5b58d059e2f8345f92";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/da/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/da/thunderbird-60.5.3.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "e4bdab9dbdd1c4d2db731dad1e42c3e9839e6d2c8b9f92ae88ae76d6b838ff5d328f43c73c03a2a2e3998bf7f667d59f02016f676d3d23f1ca2d2fec105ed0db";
+      sha512 = "90f1ac386761901b39e027132f14ed1cc6a3ca32200e9f98f95abdfafb181b2205c73e907076abce538138678b9a91a36db0b5bbcf33247fa5df2acfd52a73cf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/de/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/de/thunderbird-60.5.3.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "df0dc702eee0a658e2756fee0f3d26a43a8c2e5defca1e1a7a4cb34909af0e6a88f73f880fd06d0fb336b740b2d25174386d615434b1e4dd85c91416d08c2e2b";
+      sha512 = "d49af63bfa947c2abf58299c10e22b386df10958d6cde72453a454518277bba76d7ca0713c7897f07e4bfbb500747c0c74741f79f9316b6c0743e002640706a6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/dsb/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/dsb/thunderbird-60.5.3.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "0ba2bb386d9408b86041a87414e1c84ebae07f9ca357ad9aeb76aab195b16b90ba8313bcfa3b386b232a10ab295e183d4c1eda37ec4448b02abc1566ffc29b74";
+      sha512 = "7515a1ab604ca2d1341c62c798d4d0ec0dff19da3589ed571b256744958e10b15df1d78cb542ac703a5adcf1e621578330061a846db65d29563fce69877fbe9c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/el/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/el/thunderbird-60.5.3.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "66b8ccf62e7e8bc3964ad18a21437acce9980b1378b05bc943fc579f8c3f201972ac7dfb3ce25dcfdfeda88008b6c273fa4a748e3b73d8500ace905ebc3cc816";
+      sha512 = "18ae068a28e0f8d601695c7514eb159e6d1891b1198cb8225717ebddc7670dd9e85f33ce19dc43087723336d08ba99e5f198c2449b559f4dbb0c33dda55ca1c4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/en-GB/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/en-GB/thunderbird-60.5.3.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "ce8cccda4e620f712a78b477a37815404acd55580a977a7bb71cd349e64e28747935231cd5dec048e9d31fc1cf198a4579308f9a320220c282427913f323ecfd";
+      sha512 = "8c5a0cb152f3a1eb39840197efc0935b278cc8ba8efac3e980ad2cd003029bb43c76c5584cf6c0d3c26cc907b5f2712f8ccf5e1c1d96007392ac95fbcd06ade0";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/en-US/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/en-US/thunderbird-60.5.3.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "50b50e2df00fc2a71c555105806b2134ba9f7e09601e9194334ac2e89e53fb940065e604b56c22a8aeb97ec6f30fa8cda6881347a53acd22270b38767c3b00ae";
+      sha512 = "8e08fd1eaaab33a18b07df167474b99ec096535cf6d90dcd54eba93b471dd80822732a84a0f10ff54c204e9f76b6fc600edae7be500b82a444a58ea3104ca982";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/es-AR/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/es-AR/thunderbird-60.5.3.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "e3d0708a89548a36712fddaeec6e7e2a15a255b29fb63e05efeb279e1748dd41034f9d568013ddae50484300b536ddcc08cb37d013b1d4beb52e7ca0fa47a924";
+      sha512 = "33c2632399469c1e9d33d86cc49f507c99e85007a872a3ab7f6be32408d9c2a229ef95f88e0733a191e36d9e4b40ddb2e0240f840299296b690278d7bf45ff5c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/es-ES/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/es-ES/thunderbird-60.5.3.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "b34202bff1054718cc068f21c2d4cad9cf1cfdaedd5802a1c1a9f897e75e7cba1b2b63d4bfc9e3849468f69728308c2c1ebb716b19468de054149c8c5e614c7b";
+      sha512 = "3ac84892701fd88d3d793f05b1b780f1ae44f2385720448f43eb869d8b5e40877ac940e8e5912fd9aa4a5fc1edfaa38fc70082a61c031d6bca2a274a93b5ed4e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/et/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/et/thunderbird-60.5.3.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "023343885b09835dc7a924407724aafbc6e833d668d4066aee0971abe93ecc53deab16b0d3a0e0527d159f62c1fcb1243615736cd68404537587b57173c52573";
+      sha512 = "7dd74db4f8ad6459d674b06f2bf847b8de6f8ea46f89debd619b6963e9d810a0f0b248f4c7c7203cb6d4ea4baa59f67445d87609dc7e95bc4c107166dd81297c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/eu/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/eu/thunderbird-60.5.3.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "b5db0e61be652f851cb4e729abaec04cd2295f5b769cbae82da9a13521b145e3af7bcdec0d595e82200840eb0e9e8d3b321c9e2bca7e504ecc45b4a438494e7d";
+      sha512 = "ebed49917e329a0505f4f457dc56488210984e55c0f46d0678b4c69ddb2e2eef99a543cdcb79a628e1245adc73ca6e44ced6d304b545727c679a38ca1ab6b68e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/fi/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/fi/thunderbird-60.5.3.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "cfcd1cfc0b49b94acf2c4b65064badf4f48d85f6833b4ba6bb3b9da21a41815ca9c544899ca5282a96b3e498ff948037fd6e97755b9bd4f994e67341ddb46aa0";
+      sha512 = "b62b8810205bc37eb3672ef1776527de0d2e0fbafe8ace1a2a53b8c3c81b24cc406762b86e76ca5a4ac13ddd77be3f313e164119c4e3e90cf329d8463499b114";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/fr/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/fr/thunderbird-60.5.3.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "853d0b8d8cee1d036adc8784ffb750acebf4499adc41c770436e1499622e3a6dd4c79c64a088c2e80e7ae33b158f696c5d7b055e920379f0c39e574ef04b208e";
+      sha512 = "a1256ef2e078e99432ca1ba9b73ce6621b7652a41347051dc5b402b25f6ebebd71ba55d9ce2b54efb1043958d4e3074bf6eeef0ef731ff2265cf9557580e9205";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/fy-NL/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/fy-NL/thunderbird-60.5.3.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "5556f9faa896595e1e3bf6b57fbd9e15cf66240b1483ffe0d4af2b58481892dbd2ba542e143b322a00cb8c3a25a54c5c6d35ab2a3eee0e20acfcb805706b9ed5";
+      sha512 = "f6b110e2033c6d63860cf9c674044125f63ab80d131a4f5de47a5fd72afcf225018b76ead6462c0b1a31deb883aeeb55d8608c8944fe42b3ea08f8829dad1f99";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/ga-IE/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/ga-IE/thunderbird-60.5.3.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "db7df726276180585e203b375f19adeec45bc7241f2f9804626cb4ded86714234c16ee39ca96e29b23caa9400100adbcc34d7610323b5c5c96b301fe80746f20";
+      sha512 = "ffd4cc1e4704313fddb145ddf8109d47082aba4a878d1eedd29e3b07527bc74a5fa60cf95916e911d9e486cac4e961505fa3c4ad186c93ccc2ee4056a239026d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/gd/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/gd/thunderbird-60.5.3.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "5a5a2b058ce97d7860601a5e41edae6d4c61f4b533c3822aaf20a31a996fadb4da73c505cc83d42f53f4544c5dd95f03ca175950a8354ffafdbf8910c436a43d";
+      sha512 = "1d18fef3eee8b7cfb18795aef0e143b1fbb9451496185d1c9ef1f9390184245bbab10e811c41485cfd5719343e8506f7d57ab1525b448d3f4ff521bf9b411117";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/gl/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/gl/thunderbird-60.5.3.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "6d757d6634bed978f71031fee24299015b1d9b1cba5166a29cb6a57dbddd93a2ce1ac002766cd4f705ebd3448b9f1e1360e88658d1e90225e04dd9533cc7fc41";
+      sha512 = "0c4b0bec3d4662ee8ce39cb0c6c6c90785ade12399754e24289bada345985d3011c44831c8a4122ea8f47d7e1b18d96d11a35fe513a6068108fad9c2c3dc934d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/he/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/he/thunderbird-60.5.3.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "790b99eab94e6bf70fe935c4794413ff6fe1020a1baa73a66cb9b27dd630dd712266104b94eef23b17161fde4484037264b114cb367bd7db2c3fd213b6b0655a";
+      sha512 = "0df51119e30cf245aaee0c597eaa203485dfa46406fb9a78efccca44b28c369528e925c3ecc71a208dee278a076cf1288cb3350aff2ab1da66db31efa288e86d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/hr/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/hr/thunderbird-60.5.3.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "b6e7649321d2f8976f71bb685cd6f29ad47a890139ea4d9ab509677e462a43cb27410c8516d7d1fa65e7273a2c006ae44ccc4e9cb93275970926661502bbba90";
+      sha512 = "2633931bc0182d38422e5d9bf65759646e9189eaccd9ddaf66e9ec17f12173e43500e7d48f01ab72480c7a2aed848d2bb449660c522afb9048cd8356ca34cf17";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/hsb/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/hsb/thunderbird-60.5.3.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "6c957a26ee1b17ed8a9087187fabb228028c2b6d472cb7d5e28c66724a8b34a7e6c74bbdb625041db9f4ddcf754c574b9d6b803cdb6b0445bb82077b93de35ce";
+      sha512 = "cda3a0096dc4870af1f5b8c2f550848c0a0a21fe463bfa5dc325849b8ab43f8727f440c846e333cf2218239d57c2a180f53a7e23a05c6940d0802a78b0d1017b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/hu/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/hu/thunderbird-60.5.3.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "a8f920c0b3691b36586d9a756d68a2e61d54e0195cf602dff5803cf79a0c13aef90db60a608b9d0defefde4e2e8778b316dc2fe38647fdb9406f74b6c316fb9c";
+      sha512 = "df739a73f813f7b424d443b16d877d35c0ad68d22c508d12fbd1c471c6fcacfe6d9686062ff358dc151496ef2d5db334779dc738117a038edebc893397fc0d02";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/hy-AM/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/hy-AM/thunderbird-60.5.3.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "bd24605ba4a7eaa399e56cf244aab6a6f3c1158a7733bb99a4f57c3028acb648562adba1b7b4885b89a4142d023bd5be5d483fa4ba47378b8de300893e1e9ef6";
+      sha512 = "360617a9ec53faef08d4308cb92b63b9a09ce7ebb9924c468c7358875530bf7055f0818bdfb81f82c847476b9ecbb98d0a3be1e4610ad01cfeb302c895e0853d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/id/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/id/thunderbird-60.5.3.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "0c66a067811907292ec54f1673c912b5bb4564e5493108121c628b277f91410b0fd6b579e073d8937588606be34ca2c9c317d4f46bdf5aaf0f839ce9704a9d20";
+      sha512 = "53a3debc6363734cf99c60862620ad5a2cf661d11e418aac164f5d5a56e7be441799d19542849172671df8801f067394cbfd655dce0c8ce40cd494847570338b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/is/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/is/thunderbird-60.5.3.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "9b9e85ac15437a3b7871f0842996e5c85386e9594fb4399ecfd3f599318155abd24929ec8be1ed0034ad24539415aa26d74cb1a1edc06368b71464cab28ed8b0";
+      sha512 = "96768d36bcbaebd23d78f3d983c0c0492b3d62c1312d3ec35b74a744438a3cbc78c6fcce9f6ef43db77418fa786fbe75b18bb5eb5ae8ebf1eb97936e7d43a357";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/it/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/it/thunderbird-60.5.3.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "07c6fa4027816e1e6d58799d746543890f5eda26fc92179daa2d7b5c7762f5a5b3bb4e6aad784097ec4e013c5012e975289651a77fd78af711dc7c0516344297";
+      sha512 = "c5f3d3145b878959b39ae05eba8e7b56fdf4b4bd60799d1ed76cb8fa09a9b964153a20dfcfb9bb13dd990cfef9e5be66e05dc1ad6a10f41e4c432602c62e56b6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/ja/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/ja/thunderbird-60.5.3.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "c64e1719914fc50b110a800395e404b0aa356cf8b7deaede6315da122b8cec01a69c530ffce232e3ef130068b6df94a1210b9655403e167ffe6e42d59b2456f5";
+      sha512 = "93437b4e1891bdba9a720ad25a55435066bf4cf410d2fcfaf073068518182d66e2dc9d92b0fe1f7e671cd015bf76e7d12ca06de4bb8f33b136d3089f9b0f0983";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/kab/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/kab/thunderbird-60.5.3.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "b0067c1d698a5a032122609fc9df96966c33c78b71611fba43762b9f14944c9b1be52e7d16d71cdf323330e3a473f0822a75b8d5ccb4756ce86e3c6cf5d47c3f";
+      sha512 = "f7307a74de347f77aef712ff37fd5373edb6e00a5d519e381f3d032d917b6bc883967b9a8ba87206a68acc5dcc831d4c6a0e81926ac39f8f0c437f68a3e3f833";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/kk/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/kk/thunderbird-60.5.3.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "7e0e9a5f7bdb609687c4e8a87c581a9c33b242c80f71fecfce0a0737a8cf70b4d864e6e8bc8ddf0d6bfe5212b4a5f44a7c11cc586348bf2c1325a177f04bc62d";
+      sha512 = "92afa198dfb788035f7abfedaf9aeba955c7bae5382d707d0773113d9fed58342d956d987b92cc6a5313d430a77cb0f2e0df459208a22fc4efad55f27d378414";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/ko/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/ko/thunderbird-60.5.3.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "45ecc21470e10df9d6b6eb9eb91729384c4aab20f4bdb3ab9659d30e0447441c26b9daa86b670d458ff90c8a7120333a5398caccafd4000a88fb219244bd5bca";
+      sha512 = "eeac05365594ff3b9152cd6ab335060cb93475cbd57e918d230e3fd71cd3806a326fa135c23ce6b4be96e28c2c5a2cbdf43521e4890b580ee153a6c7c491dcc1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/lt/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/lt/thunderbird-60.5.3.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "6b47400b6260b172d9e40ac0c3f8cf94b02f31273acc18b9befa1c602188f6d8e0c46fefcb9b4faaa2513bd5c586559bf9fd6f5c03c1d4ff895c78e14c5a593a";
+      sha512 = "cc3a19e17126f23b5c61a62b297383bcc55fe3a9ecbffc22d3d24e2eaa2f34eaf62ea4b610b9e2ce446850d237d1f9e18ba7c4668a8b735119235f9c2e2ca2a5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/ms/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/ms/thunderbird-60.5.3.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "037c6d52bca81ddc54389546dcbf9422e3dc5872477f49e4a681a2dd75b6b7456ff2477b0b6e2e88d8b9e899ca9569751809a4ab5cfae8f8d8e7a5c13cd10bbb";
+      sha512 = "23f8641f2861fe0b73f3b7c27421ae0e29dddb54c5ed0e8a49695deeb0719e80298d51f26cfd29769bba0f69a80a49fdca3905d598a8b011e86916b0ee91f1cd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/nb-NO/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/nb-NO/thunderbird-60.5.3.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "ebdb9cd19d874cee39a27f2f44e23d877c304cc44b3cbb9849237d08077a5e8890d444671efddb4ba0633f89ff6348a7195e96f8041025f39fd4773ad8a04a56";
+      sha512 = "4c7eaa905cd3c57810fc093c2fe49684c999454db15279fd59ac04e1e0b8de1e11d7e63c9a9667ea82dff85693436ddee047936419b098bcf059b31b991f29e1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/nl/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/nl/thunderbird-60.5.3.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "251ccf641a7e6f724cbdee55eec09f6ef0a2b77b3c12c483e1b159840f039df0820c583ecc0ff5831d48582df7716f9c29678f1be81b6cdc39480dc2fc870d65";
+      sha512 = "e43aaf80295ced8dd39809a5433b42bcbfdb1998e60564e87e4536c98ccac085e29b122f84deb06ff6ebda3e27e7d40b0424e45c8684dc86e2045a9dca413880";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/nn-NO/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/nn-NO/thunderbird-60.5.3.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "e4b12c33bb86fef90f699a2c8aa3bf66d140f77e3bcae5012fa005f47cecf978ca5b5051c7826b56f65cd8501413e649bbd73c01cddfadf97e3635a19a0f3406";
+      sha512 = "c97f1f7ae213eefdc8e0f3c8d7e761eb6056c59b19db177acc6aecfc95e02de23682655c14a0b59ac9ae58f7c438ae81618719c2bb96f5ca44bccab57c9e77a2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/pl/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/pl/thunderbird-60.5.3.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "c9d8fcf4a468fae3849fdd4c02e054bde1407f3007743744defc09a0d56de5796b46e8ea27247bad3e9ec8f3d588f8871390ef3568c2b27a4fc12d795474b739";
+      sha512 = "d99413a37e7059ed1de8654a0c29b3a9d5ad672eb945040e31ac12b872e9669e7e9787df45d180546977ec3b7b825d61647f7c5b32c32ebe0d5a31fc0a520cee";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/pt-BR/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/pt-BR/thunderbird-60.5.3.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "0cdaf41470e28eb15d66da46ba2d3841f62fa11235b91b3b054e3ee7906e1952feb8f447ffef4195a6b49f7224af316731607945646d1157f6674b50d8c7e7fe";
+      sha512 = "261a03ed8f6187f4556539cd53d349f25527ad2568a5b7aa2957139cc97fa317821ec1e1cde7b64cfab7c7d5c1df7b8a071b22e30783915f697a07e1056a85b2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/pt-PT/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/pt-PT/thunderbird-60.5.3.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "bdf0af0eca14e74518d43246f515aa3e5ead284502a27d4b6dbf9e69a2657e55484793859682b807f0b9f2e7ae6d2c084a239f276524829b923ed6eaa4d63457";
+      sha512 = "7b2859217bd5ea3bcc620fab7574646117b08db4f7d7588f7ac80af5856c145152300c49237dbbff225708ffbc24e380eae0ef6e698c32d798182c19baca618d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/rm/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/rm/thunderbird-60.5.3.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "4db1bcf38a6525e5507f02c07ee1bb877f81b4643df25eddf0c6b85a6fca5a4e892affb397caa0b5fbebdc5a044bc1eecf5d8755420e8e032906e81a1fcb68c0";
+      sha512 = "0fbec28f5bf593d10afcff47e67b5a3940df36f7a6204de3a5c10c6bbf673fabf4c0a5d446a922366d9e26f6514ea7220818d79bb180e288383ae46b9ebcc7a2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/ro/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/ro/thunderbird-60.5.3.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "21a2dcf1a70657afaa49e3825fc6c544bd123c50c753ab2af52474daf80f7c01dafdff95a6c84a48f3f4b09d019acf6cf84958ef81fd12b5616fe4f7c44517c5";
+      sha512 = "5de39b2859e623d5691f303348c5cfdb11ce6b0e56a88770887a0774f473caa5a352abf1a546dd78dba7618b2f01501bc3eded3e149960fbf9e3b9c7a5629c9d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/ru/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/ru/thunderbird-60.5.3.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "427b84004ea0a93c1eb55fdf3c46d4fc1560cd5b9284294b91ffc1f48581acfca4931fb90b2ec67f8f41763e47505be9e677e30ff009f1607b910272bd2aa481";
+      sha512 = "c93291f1134ce459f7ca29af87697b76234d9419d9f6cf38385c2d03194c9e3a833ffbfa8e6e75ba3b8ef12193bafb6114a870a07fbabb0d8c16733161e44d4b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/si/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/si/thunderbird-60.5.3.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "adb6bb5a5ea5aa26cd8edce2eccfce86c1f05bfedd784dd8b6438d5f9bc9b21b6fd1e9d544f0d72ca4c09b502843426b1db3a9faa51c795d1da7342263a68acf";
+      sha512 = "bbdfdce165df9724cce18615f71380eb356679e79640246314092cdf8d44fd94c92d29ec054e4c4b332558f27634c265e5850635ce725082b558cd6e73144ecd";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/sk/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/sk/thunderbird-60.5.3.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "8e5774e339f29d4db96541227f0cbac8aa43940f8db803b1c3d0037e870ebabe0e35e931866206c45ceca60df940342e837f5a341fe297d1d77094a68ff087c0";
+      sha512 = "673cace9cb6b4fe7cde43bc7ec84088df8e9487b9bf6179796758d9d7c658a9dd1bab4c57c7d773159ea6c51b59b78f555b2737fae71954711994ada0126ab18";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/sl/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/sl/thunderbird-60.5.3.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "5bc6c3afe167b81e67236e2ce405c784ea6b3eccefbe64169df9c5846ac352b786e7cbb5a130134bc00bf711577425dcc228e44028b907517c870110392de9c9";
+      sha512 = "6373fb7ec3240420fd4f0bbfb8cb89671b68dcc7d586f8586e4bd7ea4b0a178c4c74f509ee44d2ae0c783b3ba994d2f4f840311db31b80f225d823adee5259ba";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/sq/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/sq/thunderbird-60.5.3.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "056cb05dbd7a8eaf482fe70cd48182d821724d531f482fa39f220b74da4ac3ffdd01ca25b3a31589081254b8be2868bb0bbe24d28fd02f817d64521136e9b652";
+      sha512 = "1c1224cbf920062c401f398ad50a1904326a445e72bc35c518a859d7b3528ec0301cab6f31a47ad6a5eac63b65ceac65d43609e1f8f6ec28ef76a65cb3a88541";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/sr/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/sr/thunderbird-60.5.3.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "76a3b4c6d620a3d2309d1075d9a85e3603ab60bb9bfdfe6b538662b5281a4e2458d6e6ecbc977dadd7f7a2c9c78691277d5ca336c54beb2cb3f653ff4fe4e6c2";
+      sha512 = "21d03385dbba09ecfca27e640ba736cef61515729922fe3fb8743fc92c173aa1c55ece5e57ebf1081828f278adf394a58aec19e82fa8186f24ac97f8f7cfc3a8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/sv-SE/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/sv-SE/thunderbird-60.5.3.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "3519106ffd79c84ed2609675104889010ea3dad76ca2b3db5cb2729c99927ffa9d457e714e73862b01d0c88c52ccdd986ab15844e9bb3b8de2de0eb6f0e29b96";
+      sha512 = "70979cfb05ec2c438a4bef72e06c7048f5bd5ba0711419b014c3d660de086d2b9a34e9d8f6a22bbc938f6d4a6006396e7761ff1840042aa5187fe4360ad30471";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/tr/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/tr/thunderbird-60.5.3.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "782825d4bb3f0073a2e417ec86e7ad27f7d84e482e6fd0435941cd2ecad4f930329362a1b1be32a99379e98d2dd4f43bc7bc4a80b0c38692c9f1e5436c6e3131";
+      sha512 = "efdb6bc9b4e871e8d066b9952eb779f3b1ae78baaf2d257d8095e64f8353393b3d79d23e8ce162a2dccca78bdd9e0d1f57b1277532cb263e1528d00ce02300e9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/uk/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/uk/thunderbird-60.5.3.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "9246e616b9c87383064697f8f9b17304768a85ef6e1f8bcf83d07cbf0990dac3c20b5add194f85f3a58021fc2f707004e8b348ca41a3052cad27f7ba117539d7";
+      sha512 = "13319b531644c3aa4de30eb7aae02d6f61820f3f37691b81adda8f1faf967af51a51bd01217f643e5235b46a5673a0e9b99b36a828017c9bf8d0d20792e6b11b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/vi/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/vi/thunderbird-60.5.3.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "2601517a8a04bfc8068f03295c357f3980228fcb53e54d90a3aca190f94546ba8a4712e763c93faeffab036ad623e1e3cda4bf16d22774a3f95ed2869a4f00b8";
+      sha512 = "8ad568dc9d2700be611989d61d1cae580e060b89ac81c5361dd50119d01e4ceb867e6a1d3580502df72c786cbeb69b6c6407035e88e68ec3479bc2734068121f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/zh-CN/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/zh-CN/thunderbird-60.5.3.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "8ca48799b44edaec1d35bc690433c5a6790daa907cc64f67c1e350ce24bb4422ac04657f68898c6e3f40737b32a74b139e715c2e4dc33d4b179eac2d7e04c7de";
+      sha512 = "2096982633e2ffe2a548b903b1d54771c27f1b3e37eb591f775ac04b798572581abd8ba705e06efdaec34f785ac6a34168e7a6b3fd526e400a47e2a79cb12373";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.2/linux-i686/zh-TW/thunderbird-60.5.2.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.5.3/linux-i686/zh-TW/thunderbird-60.5.3.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "716c6392918f8fc6e6c1046b7454acc84484bc39a723dc659cc1e3919f04fcce628783685f63110370b38f64d60771e40425eeef1ecbb4b83ad999e29d8bede4";
+      sha512 = "1773905bf41c809869c3d40dac69b58e61c19304229a140330cbc9e6b21fc09ee3d203ed562b0c13644dfa836b414b5272d915d228145d8ce2bd983ef80ef1cb";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -24,11 +24,11 @@ let
   gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
 in stdenv.mkDerivation rec {
   name = "thunderbird-${version}";
-  version = "60.5.2";
+  version = "60.5.3";
 
   src = fetchurl {
     url = "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
-    sha512 = "3q7h9jbxz7p7dh2dskmcqikpgd8czbmxknij063w02bh9lyffv6rasszl8pwz21mcylb9zzqjn29xl99g51sjx81555bdr38l8mjg55";
+    sha512 = "34nbmczidyr7cpi0dzw2az4xma5kgniizqanq2i9ydkc8y6xg4n6likn7aphrfilhb1krliadkqm280ja40slkc7c8rmghiwy47jr0b";
   };
 
   # from firefox, but without sound libraries


### PR DESCRIPTION
###### Motivation for this change

- Bug fix for Windows platform.

https://www.thunderbird.net/en-US/thunderbird/60.5.3/releasenotes/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

