### PR TITLE
pythonPackages.pysideTools: Use fetchFromGitHub and update meta

### DIFF
--- a/pkgs/development/python-modules/pyside/tools.nix
+++ b/pkgs/development/python-modules/pyside/tools.nix
@@ -1,17 +1,16 @@
-{ lib, fetchurl, cmake, pyside, qt4, pysideShiboken, buildPythonPackage }:
+{ lib, buildPythonPackage, fetchFromGitHub, cmake, qt4, pyside, pysideShiboken }:
 
-# This derivation provides a Python module and should therefore be called via `python-packages.nix`.
 buildPythonPackage rec {
   pname = "pyside-tools";
   version = "0.2.15";
   format = "other";
 
-  src = fetchurl {
-    url = "https://github.com/PySide/Tools/archive/0.2.15.tar.gz";
-    sha256 = "0x4z3aq7jgar74gxzwznl3agla9i1dcskw5gh11jnnwwn63ffzwa";
+  src = fetchFromGitHub {
+    owner = "PySide";
+    repo = "Tools";
+    rev = version;
+    sha256 = "017i2yxgjrisaifxqnl3ym8ijl63l2yl6a3474dsqhlyqz2nx2ll";
   };
-
-  enableParallelBuilding = true;
 
   nativeBuildInputs = [ cmake ];
 
@@ -19,11 +18,11 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ pyside pysideShiboken ];
 
-  meta = {
-    description = "Tools for pyside, the LGPL-licensed Python bindings for the Qt cross-platform application and UI framework";
-    license = lib.licenses.gpl2;
-    homepage = http://www.pyside.org;
+  meta = with lib; {
+    description = "Development tools (pyside-uic/rcc/lupdate) for PySide, the LGPL-licensed Python bindings for the Qt framework";
+    license = licenses.gpl2;
+    homepage = https://wiki.qt.io/PySide;
     maintainers = [ ];
-    platforms = lib.platforms.all;
+    platforms = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Fixes build of the pysideTools python package. Without this patch, cmake will not be added to the path and the cmake hooks will fail to find and run cmake.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

