### PR TITLE
areca: fix build

### DIFF
--- a/pkgs/applications/backup/areca/default.nix
+++ b/pkgs/applications/backup/areca/default.nix
@@ -21,6 +21,10 @@ stdenv.mkDerivation rec {
     substituteInPlace bin/areca_run.sh --replace "/usr/java" "${jre}/lib/openjdk"
     substituteInPlace bin/areca_run.sh --replace "/usr/lib/java/swt.jar" "${swt}/jars/swt.jar"
 
+    # Fix for NixOS/nixpkgs/issues/53716
+    sed -i -e 's;^;#include <attr/attributes.h>;' jni/com_myJava_file_metadata_posix_jni_wrapper_FileAccessWrapper.c
+    substituteInPlace jni/com_myJava_file_metadata_posix_jni_wrapper_FileAccessWrapper.c --replace attr/xattr.h sys/xattr.h
+
     sed -i "s#^PROGRAM_DIR.*#PROGRAM_DIR=$out#g" bin/areca_run.sh
     sed -i "s#^LIBRARY_PATH.*#LIBRARY_PATH=$out/lib:${stdenv.lib.makeLibraryPath [ swt acl ]}#g" bin/areca_run.sh
 


### PR DESCRIPTION
###### Motivation for this change

The update to attr-2.4.48 broke the areca build (see #53716). This PR fixes the build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

