### PR TITLE
aide: 0.16 -> 0.16.1

### DIFF
--- a/pkgs/tools/security/aide/default.nix
+++ b/pkgs/tools/security/aide/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "aide-${version}";
-  version = "0.16";
+  version = "0.16.1";
 
   src = fetchurl {
-    url = "mirror://sourceforge/aide/${version}/aide-${version}.tar.gz";
-    sha256 = "0ibkv4z2gk14fn014kq13rp2ysiq6nn2cflv2q5i7zf466hm6758";
+    url = "https://github.com/aide/aide/releases/download/v${version}/${name}.tar.gz";
+    sha256 = "1dqhc0c24wa4zid06pfy61k357yvzh28ij86bk9jf6hcqzn7qaqg";
   };
 
   buildInputs = [ flex bison libmhash zlib acl attr libselinux pcre ];


### PR DESCRIPTION
###### Motivation for this change

* Fixes compatibility problems with attr-2.4.48 (see #53716).
* Project moved to github.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

