### PR TITLE
 opam: put the whole /nix in OPAM_USER_PATH_RO 

### DIFF
--- a/pkgs/development/tools/ocaml/opam/default.nix
+++ b/pkgs/development/tools/ocaml/opam/default.nix
@@ -104,7 +104,7 @@ in stdenv.mkDerivation rec {
     makeWrapper $out/bin/.opam-wrapped $out/bin/opam \
       --argv0 "opam" \
       --suffix PATH : ${aspcud}/bin:${unzip}/bin:${curl}/bin:${lib.optionalString stdenv.isLinux "${bubblewrap}/bin:"}${getconf}/bin \
-      --set OPAM_USER_PATH_RO /run/current-system/sw/bin:/nix/store
+      --set OPAM_USER_PATH_RO /run/current-system/sw/bin:/nix/
     $out/bin/opam-installer --prefix=$installer opam-installer.install
   '';
 

--- a/pkgs/development/tools/ocaml/opam/opam.nix.pl
+++ b/pkgs/development/tools/ocaml/opam/opam.nix.pl
@@ -114,7 +114,7 @@ print <<'EOF';
     makeWrapper $out/bin/.opam-wrapped $out/bin/opam \
       --argv0 "opam" \
       --suffix PATH : ${aspcud}/bin:${unzip}/bin:${curl}/bin:${lib.optionalString stdenv.isLinux "${bubblewrap}/bin:"}${getconf}/bin \
-      --set OPAM_USER_PATH_RO /run/current-system/sw/bin:/nix/store
+      --set OPAM_USER_PATH_RO /run/current-system/sw/bin:/nix/
     $out/bin/opam-installer --prefix=$installer opam-installer.install
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Opam uses bubblewrap to limit access to certain parts of the system. Currently, read-only access is given to `\nix/store`. User installed software is found under the `/home/user/.nix-profile/bin` component of the path, however `/home/user/.nix-profile` itself is a symlink to `/nix/var/nix/profiles/per-user/user`. This results in user-installed software not being found by opam. Granting access to `/nix/var` by registering the whole `/nix` directory with bubblewrap solves this.  

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

