### PR TITLE
pythonPackages.rfc3986: fix pytest dependency

### DIFF
--- a/pkgs/development/python-modules/rfc3986/default.nix
+++ b/pkgs/development/python-modules/rfc3986/default.nix
@@ -10,7 +10,7 @@ buildPythonPackage rec {
     sha256 = "1qf4dyxvjs7mxrxc0gr7gzyn4iflb2wgq01r5pzrxac8rnvy8fmw";
   };
 
-  buildInputs = [ pytest ];
+  checkInputs = [ pytest ];
   checkPhase = ''
     py.test
   '';

--- a/pkgs/development/python-modules/rfc3986/default.nix
+++ b/pkgs/development/python-modules/rfc3986/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
 
   checkInputs = [ pytest ];
   checkPhase = ''
-    py.test
+    pytest
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
Build fails with
```
/nix/store/63karsgdg7fm3q0if4zfd7apbd8ac1ci-stdenv-linux/setup: line 1311: py.test: command not found
```

https://hydra.nixos.org/build/89616980/nixlog/1/tail

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

