### PR TITLE
yubioath-desktop: prefix QML2_IMPORT_PATH

### DIFF
--- a/pkgs/applications/misc/yubioath-desktop/default.nix
+++ b/pkgs/applications/misc/yubioath-desktop/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   doCheck = false;
 
-  buildInputs = [ stdenv qtbase qtquickcontrols pyotherside python3 ];
+  buildInputs = [ stdenv qtbase qtquickcontrols python3 ];
 
   nativeBuildInputs = [ qmake makeWrapper python3.pkgs.wrapPython ];
 
@@ -33,6 +33,7 @@ stdenv.mkDerivation rec {
     buildPythonPath "$out $pythonPath"
     wrapProgram $out/bin/yubioath-desktop \
       --prefix PYTHONPATH : "$program_PYTHONPATH" \
+      --prefix QML2_IMPORT_PATH : "${pyotherside}/${qtbase.qtQmlPrefix}" \
       --prefix LD_PRELOAD : "${yubikey-personalization}/lib/libykpers-1.so" \
       --prefix LD_LIBRARY_PATH : "${stdenv.lib.getLib pcsclite}/lib:${yubikey-personalization}/lib"
 


### PR DESCRIPTION
Otherwise, yubioath-desktop can't find pyothersides qml files:

QQmlApplicationEngine failed to load component
qrc:/qml/main.qml:168 Type YubiKey unavailable
qrc:/qml/YubiKey.qml:2 module "io.thp.pyotherside" is not installed

[1]    17017 segmentation fault  result/bin/yubioath-desktop

###### Motivation for this change
I wasn't able to run yubioath-desktop.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

