### PR TITLE
zoneminder: Fix database name and username

### DIFF
--- a/nixos/modules/services/misc/zoneminder.nix
+++ b/nixos/modules/services/misc/zoneminder.nix
@@ -49,8 +49,8 @@ let
     # Database
     ZM_DB_TYPE=mysql
     ZM_DB_HOST=${cfg.database.host}
-    ZM_DB_NAME=${if cfg.database.createLocally then user else cfg.database.username}
-    ZM_DB_USER=${cfg.database.username}
+    ZM_DB_NAME=${cfg.database.name}
+    ZM_DB_USER=${if cfg.database.createLocally then user else cfg.database.username}
     ZM_DB_PASS=${cfg.database.password}
 
     # Web


### PR DESCRIPTION
###### Motivation for this change
PR #56889 messed up db and use naming while fixing the scope of the initialDatabases property.
This patch fixes the issue.


###### Things done
Invert the values of ZM_DB_NAME and ZM_DB_USERNAME that were previously messed up.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

