### PR TITLE
sage: downgrade maxima to 5.41

### DIFF
--- a/pkgs/applications/science/math/maxima/5.41.nix
+++ b/pkgs/applications/science/math/maxima/5.41.nix
@@ -1,0 +1,102 @@
+{ stdenv, fetchurl, fetchpatch, sbcl, texinfo, perl, python, makeWrapper, rlwrap ? null
+, tk ? null, gnuplot ? null, ecl ? null, ecl-fasl ? false
+}:
+
+let
+  name    = "maxima";
+  # old version temporarily kept for sage, see discussion at
+  # https://github.com/NixOS/nixpkgs/commit/82254747af35f3e0e0d6f78023ded3a81e25331b
+  version = "5.41.0";
+
+  searchPath =
+    stdenv.lib.makeBinPath
+      (stdenv.lib.filter (x: x != null) [ sbcl ecl rlwrap tk gnuplot ]);
+in
+stdenv.mkDerivation ({
+  inherit version;
+  name = "${name}-${version}";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/${name}/${name}-${version}.tar.gz";
+    sha256 = "0x0n81z0s4pl8nwpf7ivlsbvsdphm9w42250g7qdkizl0132by6s";
+  };
+
+  buildInputs = stdenv.lib.filter (x: x != null) [
+    sbcl ecl texinfo perl python makeWrapper
+  ];
+
+  postInstall = ''
+    # Make sure that maxima can find its runtime dependencies.
+    for prog in "$out/bin/"*; do
+      wrapProgram "$prog" --prefix PATH ":" "$out/bin:${searchPath}"
+    done
+    # Move emacs modules and documentation into the right place.
+    mkdir -p $out/share/emacs $out/share/doc
+    ln -s ../maxima/${version}/emacs $out/share/emacs/site-lisp
+    ln -s ../maxima/${version}/doc $out/share/doc/maxima
+  ''
+   + (stdenv.lib.optionalString ecl-fasl ''
+     cp src/binary-ecl/maxima.fas* "$out/lib/maxima/${version}/binary-ecl/"
+   '')
+  ;
+
+  patches = [
+    # fix path to info dir (see https://trac.sagemath.org/ticket/11348)
+    (fetchpatch {
+      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/maxima/patches/infodir.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
+      sha256 = "09v64n60f7i6frzryrj0zd056lvdpms3ajky4f9p6kankhbiv21x";
+    })
+
+    # fix https://sourceforge.net/p/maxima/bugs/2596/
+    (fetchpatch {
+      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/maxima/patches/matrixexp.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
+      sha256 = "06961hn66rhjijfvyym21h39wk98sfxhp051da6gz0n9byhwc6zg";
+    })
+
+    # undo https://sourceforge.net/p/maxima/code/ci/f5e9b0f7eb122c4e48ea9df144dd57221e5ea0ca, see see https://trac.sagemath.org/ticket/13364#comment:93
+    (fetchpatch {
+      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/maxima/patches/undoing_true_false_printing_patch.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
+      sha256 = "0fvi3rcjv6743sqsbgdzazy9jb6r1p1yq63zyj9fx42wd1hgf7yx";
+    })
+
+    # upstream bug https://sourceforge.net/p/maxima/bugs/2520/ (not fixed)
+    # introduced in https://trac.sagemath.org/ticket/13364
+    (fetchpatch {
+      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/maxima/patches/0001-taylor2-Avoid-blowing-the-stack-when-diff-expand-isn.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
+      sha256 = "0xa0b6cr458zp7lc7qi0flv5ar0r3ivsqhjl0c3clv86di2y522d";
+    })
+  ] ++ stdenv.lib.optionals ecl-fasl [
+    # build fasl, needed for ECL support
+    (fetchpatch {
+      url = "https://git.sagemath.org/sage.git/plain/build/pkgs/maxima/patches/maxima.system.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
+      sha256 = "18zafig8vflhkr80jq2ivk46k92dkszqlyq8cfmj0b2vcfjwwbar";
+    })
+    # There are some transient test failures. I hope this disables all those tests.
+    # If those test failures ever happen in the non-ecl version, that should be
+    # reportetd upstream.
+    ./known-ecl-failures.patch
+  ];
+
+  # Failures in the regression test suite won't abort the build process. We run
+  # the suite only so that potential errors show up in the build log. See also:
+  # https://sourceforge.net/tracker/?func=detail&aid=3365831&group_id=4933&atid=104933.
+  doCheck = true;
+
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "Computer algebra system";
+    homepage = http://maxima.sourceforge.net;
+    license = stdenv.lib.licenses.gpl2;
+
+    longDescription = ''
+      Maxima is a fairly complete computer algebra system written in
+      lisp with an emphasis on symbolic computation. It is based on
+      DOE-MACSYMA and licensed under the GPL. Its abilities include
+      symbolic integration, 3D plotting, and an ODE solver.
+    '';
+
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.peti ];
+  };
+})

--- a/pkgs/applications/science/math/maxima/default.nix
+++ b/pkgs/applications/science/math/maxima/default.nix
@@ -70,10 +70,6 @@ stdenv.mkDerivation ({
       url = "https://git.sagemath.org/sage.git/plain/build/pkgs/maxima/patches/maxima.system.patch?id=07d6c37d18811e2b377a9689790a7c5e24da16ba";
       sha256 = "18zafig8vflhkr80jq2ivk46k92dkszqlyq8cfmj0b2vcfjwwbar";
     })
-    # There are some transient test failures. I hope this disables all those tests.
-    # If those test failures ever happen in the non-ecl version, that should be
-    # reportetd upstream.
-    ./known-ecl-failures.patch
   ];
 
   # The test suite is disabled since 5.42.2 because of the following issues:

--- a/pkgs/applications/science/math/sage/default.nix
+++ b/pkgs/applications/science/math/sage/default.nix
@@ -60,7 +60,7 @@ let
   # the files its looking fore are located. Also see `sage-env`.
   env-locations = callPackage ./env-locations.nix {
     inherit pari_data ecl;
-    inherit singular;
+    inherit singular maxima-ecl;
     cysignals = python.pkgs.cysignals;
     three = nodePackages.three;
     mathjax = nodePackages.mathjax;
@@ -71,21 +71,21 @@ let
   sage-env = callPackage ./sage-env.nix {
     sagelib = python.pkgs.sagelib;
     inherit env-locations;
-    inherit python ecl singular palp flint pynac pythonEnv;
+    inherit python ecl singular palp flint pynac pythonEnv maxima-ecl;
     pkg-config = pkgs.pkgconfig; # not to confuse with pythonPackages.pkgconfig
   };
 
   # The documentation for sage, building it takes a lot of ram.
   sagedoc = callPackage ./sagedoc.nix {
     inherit sage-with-env;
-    inherit python;
+    inherit python maxima-ecl;
   };
 
   # sagelib with added wrappers and a dependency on sage-tests to make sure thet tests were run.
   sage-with-env = callPackage ./sage-with-env.nix {
     inherit pythonEnv;
     inherit sage-env;
-    inherit pynac singular;
+    inherit pynac singular maxima-ecl;
     pkg-config = pkgs.pkgconfig; # not to confuse with pythonPackages.pkgconfig
     three = nodePackages.three;
   };
@@ -128,6 +128,9 @@ let
   arb = pkgs.arb.override { inherit flint; };
 
   singular = pkgs.singular.override { inherit flint; };
+
+  # https://trac.sagemath.org/ticket/26625
+  maxima-ecl = pkgs.maxima-ecl-5_41;
 
   # *not* to confuse with the python package "pynac"
   pynac = pkgs.pynac.override { inherit singular flint; };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22058,6 +22058,12 @@ in
     ecl-fasl = true;
     sbcl = null;
   };
+  # old version temporarily kept for sage
+  maxima-ecl-5_41 = callPackage ../applications/science/math/maxima/5.41.nix {
+    ecl = ecl_16_1_2;
+    ecl-fasl = true;
+    sbcl = null;
+  };
 
   mxnet = callPackage ../applications/science/math/mxnet {
     inherit (linuxPackages) nvidia_x11;


### PR DESCRIPTION
###### Motivation for this change

See discussion at https://github.com/NixOS/nixpkgs/commit/82254747af35f3e0e0d6f78023ded3a81e25331b.

CC @peti @7c6f434c 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

