### PR TITLE
pythonPackages.pyext: 0.6 -> 0.8

### DIFF
--- a/pkgs/development/python-modules/pyext/default.nix
+++ b/pkgs/development/python-modules/pyext/default.nix
@@ -1,17 +1,22 @@
-{ stdenv, buildPythonPackage, fetchPypi }:
+{ stdenv, buildPythonPackage, fetchFromGitHub }:
 
 buildPythonPackage rec {
-    name = pname + "-" + version;
     pname = "pyext";
-    version = "0.6";
+    version = "0.8";
 
-    src = fetchPypi {
-      inherit pname version;
-      sha256 = "6c406cf71b991e1fc5a7f963d3a289525bce5e7ad1c43b697d9f5223185fcaef";
+    # Latest release not on Pypi or tagged since 2015
+    src = fetchFromGitHub {
+      owner = "kirbyfan64";
+      repo = "PyExt";
+      rev = "1e018b12752ceb279f11aee123ed773d63dcec7e";
+      sha256 = "16km897ng6lgjs39hv83xragdxh0mhyw6ds0qkm21cyci1k5m1vm";
     };
 
+    # Has no test suite
+    doCheck = false;
+
     meta = with stdenv.lib; {
-      description = "Simple Python extensions.";
+      description = "Simple Python extensions";
       homepage = https://github.com/kirbyfan64/PyExt;
       license = licenses.mit;
       maintainers = with maintainers; [ edwtjo ];


### PR DESCRIPTION
###### Motivation for this change

Updates pyext to the latest version.

###### Things done

- [x] Tested using sandboxing
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---