### PR TITLE
haskellPackages.xattr: fix build with attr-2.4.48 (see #53716)

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1240,4 +1240,7 @@ self: super: {
       };
   }) (with self; [base-compat generic-lens microlens optparse-applicative ShellCheck]));
 
+  # Fix build with attr-2.4.48 (see #53716)
+  xattr = appendPatch super.xattr ./patches/xattr-fix-build.patch;
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super

--- a/pkgs/development/haskell-modules/patches/xattr-fix-build.patch
+++ b/pkgs/development/haskell-modules/patches/xattr-fix-build.patch
@@ -1,0 +1,16 @@
+diff --git a/System/Xattr.hsc b/System/Xattr.hsc
+index adaf9cb..9b49996 100644
+--- a/System/Xattr.hsc
++++ b/System/Xattr.hsc
+@@ -45,11 +45,7 @@ module System.Xattr
+     where
+ 
+ #include <sys/types.h>
+-#ifdef __APPLE__
+ #include <sys/xattr.h>
+-#else
+-#include <attr/xattr.h>
+-#endif
+ 
+ import Data.Functor ((<$>))
+ import Foreign.C


### PR DESCRIPTION
###### Motivation for this change
Fixes the build with attr-2.4.48 (see #53716). I've submitted with patch (https://github.com/deian/libattr-hs/pull/3) to upstream as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

