### PR TITLE
sublime3: fix icon

### DIFF
--- a/pkgs/applications/editors/sublime/3/common.nix
+++ b/pkgs/applications/editors/sublime/3/common.nix
@@ -122,9 +122,9 @@ in stdenv.mkDerivation (rec {
 
     ln $out/bin/subl $out/bin/sublime
     ln $out/bin/subl $out/bin/sublime3
-    mkdir -p $out/share/applications
+    mkdir -p $out/share/applications $out/share/icons/hicolor/256x256
     ln -s $sublime/sublime_text.desktop $out/share/applications/sublime_text.desktop
-    ln -s $sublime/Icon/256x256/ $out/share/icons
+    ln -s $sublime/Icon/256x256/ $out/share/icons/hicolor/256x256/apps
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
GNOME Shell no longer showed icon of Sublime Text for me,
`nixos-rebuild switch` with this followed by `touch`ing `~/.local/share/icons`
fixed it.

Perhaps the icon cache introduced in https://github.com/NixOS/nixpkgs/pull/48116 excludes `/share/icons`?

cc @hedning @romildo 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

