### PR TITLE
nodejs: Remove the requirement for dir-prefix from includes

### DIFF
--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -125,8 +125,14 @@ in
         done
       ''}
 
+      # Strip directory prefix from include files, but include a symlink to
+      # support packages including just <node_version.h>
+      mv $out/include/node/* $out/include/
+      rmdir $out/include/node
+      ln -s $out/include $out/include/node
+
       # install the missing headers for node-gyp
-      cp -r ${concatStringsSep " " copyLibHeaders} $out/include/node
+      cp -r ${concatStringsSep " " copyLibHeaders} $out/include
     '' + optionalString (stdenv.isDarwin && enableNpm) ''
       sed -i 's/raise.*No Xcode or CLT version detected.*/version = "7.0.0"/' $out/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/xcode_emulation.py
     '';


### PR DESCRIPTION
###### Motivation for this change
"npm install scrypt" fails to compile with the compiler not being able to find "node_version.h" in the "nan" dependency. Looking at our installation, we find that we have /nix/store/.../nodejs.../include/node containing the node_version.h, so #include <node/node_version.h> would work but #include <node_version.h> doesn't. Strangely this step only fails with CXX step not with the CC. 

Searching github for what's the correct way seems to find that a lot of projects just do #include <node_version.h> hence I found it ok to make our nix installation strip the node path.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

