### PR TITLE
vulnix: 1.7.1 -> 1.8.0

### DIFF
--- a/pkgs/tools/security/vulnix/default.nix
+++ b/pkgs/tools/security/vulnix/default.nix
@@ -2,13 +2,14 @@
 
 pythonPackages.buildPythonApplication rec {
   pname = "vulnix";
-  version = "1.7.1";
+  version = "1.8.0";
 
   src = pythonPackages.fetchPypi {
     inherit pname version;
-    sha256 = "15c32976sgb5clixngi6z1fk5h02v1kn1a89h8rkbkvyhfnjgg8m";
+    sha256 = "15j8zz7qmf6c6vhim08yn1knn0qhwypmc7bxw608zg5nf50vghyb";
   };
 
+  outputs = [ "out" "doc" "man" ];
   nativeBuildInputs = [ ronn ];
 
   checkInputs = with pythonPackages; [
@@ -30,17 +31,15 @@ pythonPackages.buildPythonApplication rec {
     zodb
   ]);
 
-  outputs = [ "out" "doc" ];
-
   postBuild = "make -C doc";
 
   checkPhase = "py.test src/vulnix";
 
   postInstall = ''
-    install -D -t $out/share/man/man1 doc/vulnix.1
-    install -D -t $out/share/man/man5 doc/vulnix-whitelist.5
     install -D -t $doc/share/doc/vulnix README.rst CHANGES.rst
     gzip $doc/share/doc/vulnix/*.rst
+    install -D -t $man/share/man/man1 doc/vulnix.1
+    install -D -t $man/share/man/man5 doc/vulnix-whitelist.5
   '';
 
   dontStrip = true;


### PR DESCRIPTION
###### Motivation for this change

Update to newly released version which contains a few bugfixes and fixes build on master.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions (Ubuntu)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after): 169755408 -> 165938976
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

