### PR TITLE
slurm: 18.08.5.2 -> 18.08.6.2

### DIFF
--- a/nixos/tests/slurm.nix
+++ b/nixos/tests/slurm.nix
@@ -108,6 +108,8 @@ in {
   # cluster in the database before slurmctld is restarted
   subtest "add_account", sub {
     $control->succeed("sacctmgr -i add cluster default");
+    # check for cluster entry
+    $control->succeed("sacctmgr list cluster | awk '{ print \$1 }' | grep default");
   };
 
   subtest "can_start_slurmctld", sub {
@@ -133,6 +135,7 @@ in {
 
   subtest "check_slurm_dbd", sub {
     # find the srun job from above in the database
+    sleep 2;
     $submit->succeed("sacct | grep hostname");
   };
   '';

--- a/pkgs/servers/computing/slurm/default.nix
+++ b/pkgs/servers/computing/slurm/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   name = "slurm-${version}";
-  version = "18.08.5.2";
+  version = "18.08.6.2";
 
   # N.B. We use github release tags instead of https://www.schedmd.com/downloads.php
   # because the latter does not keep older releases.
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     repo = "slurm";
     # The release tags use - instead of .
     rev = "${builtins.replaceStrings ["."] ["-"] name}";
-    sha256 = "0x1pdq58sdf0m28cai0lcyzvhhjl7l85gq324pwh8fi3zy2h0n4k";
+    sha256 = "0py1795jrgip00k46gr9f9y49gpv5478kc3v68d90nl158fngixc";
   };
 
   outputs = [ "out" "dev" ];


### PR DESCRIPTION
###### Motivation for this change
bugfix release, should be backported to 19.03

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
nixos/tests/slurm.nix suceeds
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

