### PR TITLE
_0x0: init at 2018-06-24

### DIFF
--- a/pkgs/tools/misc/0x0/default.nix
+++ b/pkgs/tools/misc/0x0/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, pkgs, xsel, curl, fetchFromGitLab, makeWrapper}:
+
+stdenv.mkDerivation rec {
+  name = "0x0-${version}";
+  version = "2018-06-24";
+
+  src = fetchFromGitLab {
+    owner = "somasis";
+    repo = "scripts";
+    rev  = "70422c83b2ac5856559b0ddaf6e2dc3dbef40dee";
+    sha256 = "1qpylyxrisy3p2lyirfarfj5yzrdjgsgxwf8gqwljpcjn207hr72";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    install -Dm755 0x0 $out/bin/0x0
+
+    patchShebangs $out/bin/0x0
+    wrapProgram $out/bin/0x0 \
+      --prefix PATH : '${stdenv.lib.makeBinPath [ curl xsel ]}'
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A client for 0x0.st";
+    homepage = "https://gitlab.com/somasis/scripts/";
+    maintainers = [ maintainers.ar1a ];
+    license = licenses.unlicense;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -410,6 +410,8 @@ in
 
   ### TOOLS
 
+  _0x0 = callPackage ../tools/misc/0x0 { };
+
   _1password = callPackage ../applications/misc/1password { };
 
   _9pfs = callPackage ../tools/filesystems/9pfs { };


### PR DESCRIPTION
###### Motivation for this change
With my recent contribution pb_cli out of the way, unfortunately ptpb.pw shut down last night. 0x0 is another pastebin service, and this script is a simple bash script that uploads from stdin.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

