### PR TITLE
moosefs: init at 3.0.103

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2962,7 +2962,7 @@
   mfossen = {
     email = "msfossen@gmail.com";
     github = "mfossen";
-    name = "Mitchell Fossen"
+    name = "Mitchell Fossen";
   };
   mgdelacroix = {
     email = "mgdelacroix@gmail.com";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2960,7 +2960,7 @@
     name = "Celine Mercier";
   };
   mfossen = {
-    email = "mfossen@gmail.com";
+    email = "msfossen@gmail.com";
     github = "mfossen";
     name = "Mitchell Fossen"
   };

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2959,6 +2959,11 @@
     email = "softs@metabarcoding.org";
     name = "Celine Mercier";
   };
+  mfossen = {
+    email = "mfossen@gmail.com";
+    github = "mfossen";
+    name = "Mitchell Fossen"
+  };
   mgdelacroix = {
     email = "mgdelacroix@gmail.com";
     github = "mgdelacroix";

--- a/pkgs/tools/filesystems/moosefs/default.nix
+++ b/pkgs/tools/filesystems/moosefs/default.nix
@@ -11,12 +11,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "moosefs-${version}";
+  pname = "moosefs";
   version = "3.0.103";
 
   src = fetchFromGitHub {
-    owner = "moosefs";
-    repo = "moosefs";
+    owner = pname;
+    repo = pname;
     rev = "v${version}";
     sha256 = "0pqralv57ci4zwd75hz4pxmd4l9d4nib2mcsvrb6jndxqkaqcvns";
   };
@@ -24,8 +24,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig makeWrapper ];
 
   buildInputs =
-    [ fuse libpcap zlib   
-    ];
+    [ fuse libpcap zlib ];
 
   postInstall = ''
     wrapProgram $out/sbin/mfscgiserv \

--- a/pkgs/tools/filesystems/moosefs/default.nix
+++ b/pkgs/tools/filesystems/moosefs/default.nix
@@ -1,0 +1,42 @@
+{ stdenv
+, fetchzip
+, fetchFromGitHub
+, makeWrapper
+, python
+, fuse
+, pkgconfig
+, libpcap
+, file
+, zlib 
+}:
+
+stdenv.mkDerivation rec {
+  name = "moosefs-${version}";
+  version = "3.0.103";
+
+  src = fetchFromGitHub {
+    owner = "moosefs";
+    repo = "moosefs";
+    rev = "v${version}";
+    sha256 = "0pqralv57ci4zwd75hz4pxmd4l9d4nib2mcsvrb6jndxqkaqcvns";
+  };
+
+  nativeBuildInputs = [ pkgconfig makeWrapper ];
+
+  buildInputs =
+    [ fuse libpcap zlib   
+    ];
+
+  postInstall = ''
+    wrapProgram $out/sbin/mfscgiserv \
+        --prefix PATH ":" "${python}/bin"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://moosefs.com;
+    description = "Open Source, Petabyte, Fault-Tolerant, Highly Performing, Scalable Network Distributed File System";
+    platforms = platforms.linux;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.mfossen ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1713,6 +1713,8 @@ in
 
   mongodb-tools = callPackage ../tools/misc/mongodb-tools { };
 
+  moosefs = callPackage ../tools/filesystems/moosefs { };
+
   mozlz4a = callPackage ../tools/compression/mozlz4a { };
 
   msr-tools = callPackage ../os-specific/linux/msr-tools { };


### PR DESCRIPTION
###### Motivation for this change
Add the moosefs package as another option for distributed filesystems

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

