### PR TITLE
nixos/types: cast `path` type to string, when it is "path"

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -241,9 +241,16 @@ rec {
 
     path = mkOptionType {
       name = "path";
-      # Hacky: there is no ‘isPath’ primop.
       check = x: builtins.substring 0 1 (toString x) == "/";
-      merge = mergeOneOption;
+      merge = loc: defs: let
+          merged = mergeOneOption loc defs;
+        in if builtins.typeOf merged == "path"
+            then toString merged
+            else merged;
+      # FIXME: in many places types.package should be used instead of types.path
+      # after making types correct everywhere, replace `check` and `merge` with
+      #  check = x: builtins.isString x || builtins.typeOf x == "path";
+      #  merge = loc: defs: toString (mergeOneOption loc defs);
     };
 
     # drop this in the future:

--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -203,7 +203,7 @@ let
       };
 
       passwordFile = mkOption {
-        type = with types; uniq (nullOr string);
+        type = with types; nullOr path;
         default = null;
         description = ''
           The full path to a file that contains the user's password. The password


### PR DESCRIPTION
###### Motivation for this change

This handles a specific case, when "path" type was supplied to `types.path`
option. Previously it was converted into store path, because it was used
in other derivations:

```
nix-repl> builtins.toJSON /etc/nixos/configuration.nix
"\"/nix/store/wd12lm99vp1syi3ywala46w4zhnvk83z-configuration.nix\""
```

So making `users.users.alice.home = /home/alice;` would convert `/home/alice`
directory into store path.

I can't think of situation when this is what is expected. State dirs and
password files could have been converted into store paths as well.
Having state dir on ro mount would probably result into error, but
password files were simple enough, so could easily be copied into
`/nix/store` and nobody noticed.

On other hand, we can't cast `types.path` to string always, because
in many places package is provided instead of path. It worked because of
silent casts... I'll leave a TODO for future contributors.

Reported in https://discourse.nixos.org/t/re-use-existing-home-migrating-from-ubuntu/2353

PS. I don't know how to write automated test for this, because it involves "paths", which are awkward to work with in a reproducible manner. I've tested locally with a local "path".

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
