### PR TITLE
appimage-run improvements

### DIFF
--- a/pkgs/build-support/appimage/default.nix
+++ b/pkgs/build-support/appimage/default.nix
@@ -75,6 +75,8 @@ rec {
       krb5
     ];
 
+    # list of libraries expected in an appimage environment:
+    # https://github.com/AppImage/pkg2appimage/blob/master/excludelist
     multiPkgs = pkgs: with pkgs; [
       desktop-file-utils
       xorg.libXcomposite
@@ -171,6 +173,13 @@ rec {
       xorg.libXft
       libvdpau
       alsaLib
+
+      harfbuzz
+      e2fsprogs
+      libgpgerror
+      keyutils.lib
+      libjack2
+      fribidi
     ];
   };
 }

--- a/pkgs/build-support/appimage/default.nix
+++ b/pkgs/build-support/appimage/default.nix
@@ -180,6 +180,10 @@ rec {
       keyutils.lib
       libjack2
       fribidi
+
+      # libraries not on the upstream include list, but nevertheless expected
+      # by at least one appimage
+      libtool.lib # for Synfigstudio
     ];
   };
 }

--- a/pkgs/tools/package-management/appimage-run/default.nix
+++ b/pkgs/tools/package-management/appimage-run/default.nix
@@ -13,10 +13,12 @@ in buildFHSUserEnv (fhsArgs // {
     if [ $# -eq 0 ]; then 
       echo "Usage: $0 FILE [OPTION...]"
       echo
+      echo 'Options are passed on to the appimage.'
       echo "If you want to execute a custom command in the appimage's environment, set the APPIMAGE_DEBUG_EXEC environment variable."
       exit 1
     fi
     APPIMAGE="$(realpath "$1")"
+    shift
 
     if [ ! -x "$APPIMAGE" ]; then
       echo "fatal: $APPIMAGE is not executable"
@@ -49,6 +51,6 @@ in buildFHSUserEnv (fhsArgs // {
       exec "$APPIMAGE_DEBUG_EXEC"
     fi
 
-    exec ./AppRun
+    exec ./AppRun "$@"
   '';
 })

--- a/pkgs/tools/package-management/appimage-run/default.nix
+++ b/pkgs/tools/package-management/appimage-run/default.nix
@@ -10,6 +10,12 @@ in buildFHSUserEnv (fhsArgs // {
 
   runScript = writeScript "appimage-exec" ''
     #!${runtimeShell}
+    if [ $# -eq 0 ]; then 
+      echo "Usage: $0 FILE [OPTION...]"
+      echo
+      echo "If you want to execute a custom command in the appimage's environment, set the APPIMAGE_DEBUG_EXEC environment variable."
+      exit 1
+    fi
     APPIMAGE="$(realpath "$1")"
 
     if [ ! -x "$APPIMAGE" ]; then


### PR DESCRIPTION
###### Motivation for this change

Fixes https://github.com/NixOS/nixpkgs/issues/57127. CC @tilpner.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

