### PR TITLE
firefox: Fixes build with rust 1.33

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -11,7 +11,7 @@
 , hunspell, libevent, libstartup_notification, libvpx
 , icu, libpng, jemalloc, glib
 , autoconf213, which, gnused, cargo, rustc, llvmPackages
-, rust-cbindgen, nodejs
+, rust-cbindgen, nodejs, fetchpatch
 , debugBuild ? false
 
 ### optionals

--- a/pkgs/applications/networking/browsers/firefox/fix-build-with-rust-1.33.patch
+++ b/pkgs/applications/networking/browsers/firefox/fix-build-with-rust-1.33.patch
@@ -1,0 +1,21 @@
+--- a/servo/components/style/gecko/regen_atoms.py
++++ b/servo/components/style/gecko/regen_atoms.py
+@@ -171,6 +171,7 @@
+ '''[1:]
+ 
+ MACRO_TEMPLATE = '''
++/// Returns a static atom by passing the literal string it represents.
+ #[macro_export]
+ macro_rules! atom {{
+ {body}\
+--- a/servo/components/style/gecko_string_cache/namespace.rs
++++ b/servo/components/style/gecko_string_cache/namespace.rs
+@@ -11,6 +11,8 @@
+ use std::fmt;
+ use std::ops::Deref;
+ 
++/// In Gecko namespaces are just regular atoms, so this is a simple macro to
++/// forward one macro to the other.
+ #[macro_export]
+ macro_rules! ns {
+     () => {

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -18,6 +18,16 @@ rec {
 
     patches = [
       ./no-buildconfig-ffx65.patch
+      (fetchpatch {
+        url = "https://hg.mozilla.org/mozilla-central/raw-rev/f63ebd7e9e28";
+        sha256 = "0xmms4f3qxp6wfr76bqp8ymk14ksf86mmiwm2ka540zwqzhrc24b";
+      })
+      (fetchpatch {
+        url = "https://hg.mozilla.org/mozilla-central/raw-rev/4f2e84dc490d";
+        sha256 = "18ba9riwplchii60664j2shydb19s2gyd3jldr1225bqj3wky521";
+      })
+      # Modified version of: https://hg.mozilla.org/mozilla-central/rev/1a1d8b9f1a3a 
+      ./fix-build-with-rust-1.33.patch
     ];
 
     extraNativeBuildInputs = [ python3 ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

