### PR TITLE
pythonPackages.joblib: 0.12.4 -> 0.13.2

### DIFF
--- a/pkgs/development/python-modules/joblib/default.nix
+++ b/pkgs/development/python-modules/joblib/default.nix
@@ -1,5 +1,6 @@
 { lib
 , buildPythonPackage
+, fetchpatch
 , fetchFromGitHub
 , sphinx
 , numpydoc
@@ -10,21 +11,31 @@
 
 buildPythonPackage rec {
   pname = "joblib";
-  version = "0.12.4";
+  version = "0.13.2";
 
   # get full repository inorder to run tests
   src = fetchFromGitHub {
     owner = "joblib";
     repo = pname;
     rev = version;
-    sha256 = "06zszgp7wpa4jr554wkk6kkigp4k9n5ad5h08i6w9qih963rlimb";
+    sha256 = "11bspmm2is8akcld2kh6bgp0in1ggdy91qsk5zqybzgapc8b4zdf";
   };
+
+  patches = [
+    # python-lz4 compatibility
+    (fetchpatch {
+      url = "https://github.com/joblib/joblib/pull/847.patch";
+      sha256 = "0b381d1jzbn6ymj9r859ijk4yk9sd00giv51nqwzbbcmpv17kdas";
+    })
+  ];
 
   checkInputs = [ sphinx numpydoc pytest ];
   propagatedBuildInputs = [ python-lz4 ];
 
+  # test_disk_used is broken
+  # https://github.com/joblib/joblib/issues/57
   checkPhase = ''
-    py.test joblib
+    py.test joblib -k "not test_disk_used"
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Updates joblib as well as fixing flaky tests.

Big thanks to @sveitser for supplying the patch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

