### PR TITLE
 protobuf: 3.6 -> 3.7 

### DIFF
--- a/pkgs/development/libraries/protobuf/3.6.nix
+++ b/pkgs/development/libraries/protobuf/3.6.nix
@@ -1,6 +1,6 @@
 { callPackage, ... }:
 
 callPackage ./generic-v3.nix {
-  version = "3.6.1";
-  sha256 = "1bg40miylzpy2wgbd7l7zjgmk43l12q38fq0zkn0vzy1lsj457sq";
+  version = "3.6.1.3";
+  sha256 = "1spj0d4flx6h3phxx3sg9r00yv734hina3365avkcz9brnm089c1";
 }

--- a/pkgs/development/libraries/protobuf/3.7.nix
+++ b/pkgs/development/libraries/protobuf/3.7.nix
@@ -1,0 +1,6 @@
+{ callPackage, ... }:
+
+callPackage ./generic-v3.nix {
+  version = "3.7.0";
+  sha256 = "0nlxif4cajqllsj2vdh7zp14ag48fb8lsa64zmq8625q9m2lcmdh";
+}

--- a/pkgs/development/python-modules/protobuf/default.nix
+++ b/pkgs/development/python-modules/protobuf/default.nix
@@ -18,8 +18,8 @@ buildPythonPackage rec {
   nativeBuildInputs = [ google_apputils pyext ];
   buildInputs = [ protobuf ];
 
-  patches = optional isPy37
-    # Python 3.7 compatibility (remove when protobuf 3.7 is released)
+  patches = optional (isPy37 && (versionOlder protobuf.version "3.6.1.2"))
+    # Python 3.7 compatibility (not needed for protobuf >= 3.6.1.2)
     (fetchpatch {
       url = "https://github.com/protocolbuffers/protobuf/commit/0a59054c30e4f0ba10f10acfc1d7f3814c63e1a7.patch";
       sha256 = "09hw22y3423v8bbmc9xm07znwdxfbya6rp78d4zqw6fisdvjkqf1";

--- a/pkgs/development/python-modules/protobuf/default.nix
+++ b/pkgs/development/python-modules/protobuf/default.nix
@@ -41,9 +41,9 @@ buildPythonPackage rec {
 
   preBuild = ''
     # Workaround for https://github.com/google/protobuf/issues/2895
-    ${python}/bin/${python.executable} setup.py build
+    ${python.interpreter} setup.py build
   '' + optionalString (versionAtLeast protobuf.version "2.6.0") ''
-    ${python}/bin/${python.executable} setup.py build_ext --cpp_implementation
+    ${python.interpreter} setup.py build_ext --cpp_implementation
   '';
 
   installFlags = optional (versionAtLeast protobuf.version "2.6.0")

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12085,8 +12085,9 @@ in
     buildPythonApplication click future six;
   };
 
-  protobuf = protobuf3_6;
+  protobuf = protobuf3_7;
 
+  protobuf3_7 = callPackage ../development/libraries/protobuf/3.7.nix { };
   protobuf3_6 = callPackage ../development/libraries/protobuf/3.6.nix { };
   protobuf3_5 = callPackage ../development/libraries/protobuf/3.5.nix { };
   protobuf3_4 = callPackage ../development/libraries/protobuf/3.4.nix { };


### PR DESCRIPTION
###### Motivation for this change

Adds and switches to protobuf version 3.7.

Also updates protobuf 3.6.1 to 3.6.1.3.

A few of the derivates in nox-review fail because of issues not related to this update.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

