### PR TITLE
pavucontrol: 3.0 -> 4.0

### DIFF
--- a/pkgs/applications/audio/pavucontrol/default.nix
+++ b/pkgs/applications/audio/pavucontrol/default.nix
@@ -2,11 +2,12 @@
 , libcanberra-gtk3, makeWrapper, gnome3 }:
 
 stdenv.mkDerivation rec {
-  name = "pavucontrol-3.0";
+  pname = "pavucontrol";
+  version = "4.0";
 
   src = fetchurl {
-    url = "https://freedesktop.org/software/pulseaudio/pavucontrol/${name}.tar.xz";
-    sha256 = "14486c6lmmirkhscbfygz114f6yzf97h35n3h3pdr27w4mdfmlmk";
+    url = "https://freedesktop.org/software/pulseaudio/${pname}/${pname}-${version}.tar.xz";
+    sha256 = "1qhlkl3g8d7h72xjskii3g1l7la2cavwp69909pzmbi2jyn5pi4g";
   };
 
   preFixup = ''


### PR DESCRIPTION
###### Motivation for this change

Notes can be found here, currently:

https://freedesktop.org/software/pulseaudio/pavucontrol/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---