### PR TITLE
proot: update, consolidate, python extension support

### DIFF
--- a/pkgs/tools/system/proot/default.nix
+++ b/pkgs/tools/system/proot/default.nix
@@ -49,8 +49,8 @@
     })
   ];
 } else {
-  version = "5.1.0.20181214";
-  sha256 = "07g1gfyjq7rypjdwxw495sk8k1y2i3y3nsm1rh9kgx3z47z28aah";
-  rev = "11972c0dab34e088c55c16a94d26c399ca7a26d8";
+  version = "5.1.0.20190305";
+  sha256 = "0qink34bjv0lshf3c8997w39r8yxgbhxpjbxw47l5xkvimlpc0dl";
+  rev = "ff61c86cb26f71c06af22574d9d4cc3a77292781";
   patches = [];
 })

--- a/pkgs/tools/system/proot/default.nix
+++ b/pkgs/tools/system/proot/default.nix
@@ -1,22 +1,26 @@
-{ stdenv, fetchFromGitHub, fetchpatch
-, talloc, docutils }:
+{ stdenv, fetchFromGitHub
+, talloc, docutils, swig, python, coreutils, enablePython ? true }:
 
-({ version, rev, sha256, patches }: stdenv.mkDerivation {
-  name = "proot-${version}";
-  inherit version;
+stdenv.mkDerivation rec {
+  pname = "proot";
+  version = "5.1.0.20190305";
 
   src = fetchFromGitHub {
-    inherit rev sha256;
     repo = "proot";
     owner = "proot-me";
+    rev = "ff61c86cb26f71c06af22574d9d4cc3a77292781";
+    sha256 = "0qink34bjv0lshf3c8997w39r8yxgbhxpjbxw47l5xkvimlpc0dl";
   };
 
-  buildInputs = [ talloc ];
-  nativeBuildInputs = [ docutils ];
+  postPatch = ''
+    substituteInPlace src/GNUmakefile \
+      --replace /bin/echo ${coreutils}/bin/echo
+  '';
+
+  buildInputs = [ talloc ] ++ stdenv.lib.optional enablePython python;
+  nativeBuildInputs = [ docutils ] ++ stdenv.lib.optional enablePython swig;
 
   enableParallelBuilding = true;
-
-  inherit patches;
 
   makeFlags = [ "-C src" ];
 
@@ -24,7 +28,7 @@
     make -C doc proot/man.1
   '';
 
-  installFlags = [ "PREFIX=$(out)" ];
+  installFlags = [ "PREFIX=${placeholder "out"}" ];
 
   postInstall = ''
     install -Dm644 doc/proot/man.1 $out/share/man/man1/proot.1
@@ -35,22 +39,6 @@
     description = "User-space implementation of chroot, mount --bind and binfmt_misc";
     platforms = platforms.linux;
     license = licenses.gpl2;
-    maintainers = with maintainers; [ ianwookim makefu veprbl ];
+    maintainers = with maintainers; [ ianwookim makefu veprbl dtzWill ];
   };
-})
-(if stdenv.isAarch64 then rec {
-  version = "5.1.0";
-  sha256 = "0azsqis99gxldmbcg43girch85ysg4hwzf0h1b44bmapnsm89fbz";
-  rev = "v${version}";
-  patches = [
-    (fetchpatch { # debian patch for aarch64 build
-      sha256 = "18milpzjkbfy5ab789ia3m4pyjyr9mfzbw6kbjhkj4vx9jc39svv";
-      url = "https://sources.debian.net/data/main/p/proot/5.1.0-1.2/debian/patches/arm64.patch";
-    })
-  ];
-} else {
-  version = "5.1.0.20190305";
-  sha256 = "0qink34bjv0lshf3c8997w39r8yxgbhxpjbxw47l5xkvimlpc0dl";
-  rev = "ff61c86cb26f71c06af22574d9d4cc3a77292781";
-  patches = [];
-})
+}


### PR DESCRIPTION
###### Motivation for this change

* Commits in update: https://github.com/proot-me/PRoot/compare/11972c0dab34e088c55c16a94d26c399ca7a26d8...ff61c86cb26f71c06af22574d9d4cc3a77292781
* Consolidate by using single version of proot regardless, aarch64 works now
  * Tested on aarch64 box
* minor cleanup

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---