### PR TITLE
capitaine-cursors: 2.1 -> 3

### DIFF
--- a/pkgs/data/icons/capitaine-cursors/default.nix
+++ b/pkgs/data/icons/capitaine-cursors/default.nix
@@ -2,12 +2,12 @@
 , inkscape, xcursorgen }:
 
 stdenv.mkDerivation rec {
-  name = "capitaine-cursors-${version}";
+  pname = "capitaine-cursors";
   version = "3";
 
   src = fetchFromGitHub {
     owner = "keeferrourke";
-    repo = "capitaine-cursors";
+    repo = pname;
     rev = "r${version}";
     sha256 = "0pnfbmrn9nv8pryv6cbjcq5hl9366hzvz1kd8vsdkgb2nlfv5gdv";
   };

--- a/pkgs/data/icons/capitaine-cursors/default.nix
+++ b/pkgs/data/icons/capitaine-cursors/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "capitaine-cursors-${version}";
-  version = "2.1";
+  version = "3";
 
   src = fetchFromGitHub {
     owner = "keeferrourke";
     repo = "capitaine-cursors";
     rev = "r${version}";
-    sha256 = "0ljvq1dqscp5gyf23qszn2ax80bxkqw2vx5zh3qln9vnzfascirb";
+    sha256 = "0pnfbmrn9nv8pryv6cbjcq5hl9366hzvz1kd8vsdkgb2nlfv5gdv";
   };
 
   postPatch = ''
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     install -dm 0755 $out/share/icons
     cp -pr dist $out/share/icons/capitaine-cursors
+    cp -pr dist-white $out/share/icons/capitaine-cursors-white
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Adds white variant!

And compared to 2.1, more sizes and better crosshair!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---