### PR TITLE
kdeFrameworks: 5.55 -> 5.56

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/fetch.sh
+++ b/pkgs/development/libraries/kde-frameworks/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/frameworks/5.55/ -A '*.tar.xz' )
+WGET_ARGS=( https://download.kde.org/stable/frameworks/5.56/ -A '*.tar.xz' )

--- a/pkgs/development/libraries/kde-frameworks/kfilemetadata/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kfilemetadata/default.nix
@@ -1,7 +1,7 @@
 {
   mkDerivation, lib, copyPathsToStore,
   extra-cmake-modules,
-  attr, ebook_tools, exiv2, ffmpeg, karchive, ki18n, poppler, qtbase, qtmultimedia, taglib
+  attr, ebook_tools, exiv2, ffmpeg, karchive, kcoreaddons, ki18n, poppler, qtbase, qtmultimedia, taglib
 }:
 
 mkDerivation {
@@ -9,7 +9,7 @@ mkDerivation {
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [
-    attr ebook_tools exiv2 ffmpeg karchive ki18n poppler qtbase qtmultimedia
+    attr ebook_tools exiv2 ffmpeg karchive kcoreaddons ki18n poppler qtbase qtmultimedia
     taglib
   ];
   patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);

--- a/pkgs/development/libraries/kde-frameworks/srcs.nix
+++ b/pkgs/development/libraries/kde-frameworks/srcs.nix
@@ -323,11 +323,11 @@
     };
   };
   kirigami2 = {
-    version = "5.56.0";
+    version = "5.56.1";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kirigami2-5.56.0.tar.xz";
-      sha256 = "0pbyr50anbzrqmw1rzf46dck9gsrfs7zxw5jlcax98bpsajix87y";
-      name = "kirigami2-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kirigami2-5.56.1.tar.xz";
+      sha256 = "0npq65kslwkdsylmv5hgcqsa5i9386dmnx8ig79rlf3409awn2f8";
+      name = "kirigami2-5.56.1.tar.xz";
     };
   };
   kitemmodels = {
@@ -563,11 +563,11 @@
     };
   };
   plasma-framework = {
-    version = "5.56.0";
+    version = "5.56.1";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/plasma-framework-5.56.0.tar.xz";
-      sha256 = "0hw90975c00v5v4xhs18w5gnklwhnygk6jls3n132xflilgc5k0a";
-      name = "plasma-framework-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/plasma-framework-5.56.1.tar.xz";
+      sha256 = "0wn7q2cfrgzcprzgqj1d4calc0mmrrn615698fish7x9s1n7ag6w";
+      name = "plasma-framework-5.56.1.tar.xz";
     };
   };
   prison = {

--- a/pkgs/development/libraries/kde-frameworks/srcs.nix
+++ b/pkgs/development/libraries/kde-frameworks/srcs.nix
@@ -3,635 +3,635 @@
 
 {
   attica = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/attica-5.55.0.tar.xz";
-      sha256 = "0bsn9mi3nj23k2r3mfgjm9i1mp8qnwf08xn9x757wk3xas0cx98v";
-      name = "attica-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/attica-5.56.0.tar.xz";
+      sha256 = "1ib68yg7dgfyh2kq72abw5bh8h0m85z3hcada3b3axq2xkcfxfmb";
+      name = "attica-5.56.0.tar.xz";
     };
   };
   baloo = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/baloo-5.55.0.tar.xz";
-      sha256 = "068ms071639pskhjz37cszylvfzzqhp7x1rmwdfn5nlvzrv6lrxh";
-      name = "baloo-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/baloo-5.56.0.tar.xz";
+      sha256 = "04hjlhlgw26l2pl4b5jk76xfs7366my71zp1xgiws5aq620bmmcy";
+      name = "baloo-5.56.0.tar.xz";
     };
   };
   bluez-qt = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/bluez-qt-5.55.0.tar.xz";
-      sha256 = "1ixad1ya3c339c675w8nwmbga8ydq16db9fk2az3gjm68z3dch8a";
-      name = "bluez-qt-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/bluez-qt-5.56.0.tar.xz";
+      sha256 = "1phph0rjms8n2qpkh9bk1n1n1cd75znsqj9r8njs1siasm6vi4nm";
+      name = "bluez-qt-5.56.0.tar.xz";
     };
   };
   breeze-icons = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/breeze-icons-5.55.0.tar.xz";
-      sha256 = "03mb7x8mc2h6cjb4mrifrbkbpj3lv9c0mg4m619rqiydg0p1yf49";
-      name = "breeze-icons-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/breeze-icons-5.56.0.tar.xz";
+      sha256 = "0n6gizmzay98q1vi9ac60p0xq9hpaj9q0gcf8vbmvk4m0yzdd63x";
+      name = "breeze-icons-5.56.0.tar.xz";
     };
   };
   extra-cmake-modules = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/extra-cmake-modules-5.55.0.tar.xz";
-      sha256 = "1x868hs9jiqzkqx7gld4mdm5dzfxc5kann22y15a4f7g5a957534";
-      name = "extra-cmake-modules-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/extra-cmake-modules-5.56.0.tar.xz";
+      sha256 = "0a5mxk805rlmpgbxwa9qkn515jqpcifsrk8ydxc3anjcsq6ffg4i";
+      name = "extra-cmake-modules-5.56.0.tar.xz";
     };
   };
   frameworkintegration = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/frameworkintegration-5.55.0.tar.xz";
-      sha256 = "0pfpk268x06pjwciv4jr5v259kjck0sf4xzsgn29ifkmsk74wwmi";
-      name = "frameworkintegration-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/frameworkintegration-5.56.0.tar.xz";
+      sha256 = "1xc0vdvpjzhb6y1pz27c7x36qjjhcf4bll0fm3yljpm956v4d3gf";
+      name = "frameworkintegration-5.56.0.tar.xz";
     };
   };
   kactivities = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kactivities-5.55.0.tar.xz";
-      sha256 = "0dp9vx2nl9fnawzcz04fqa731s3bk2izxrqbvn71aqyrs7fymabg";
-      name = "kactivities-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kactivities-5.56.0.tar.xz";
+      sha256 = "0l0p966b5rs6xjc61mpzmrkj7qqjvlzi6fwc7lky4z3fr924ssp7";
+      name = "kactivities-5.56.0.tar.xz";
     };
   };
   kactivities-stats = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kactivities-stats-5.55.0.tar.xz";
-      sha256 = "12n178244ysfak0x9qm9a2k814qi56w8xpkg03na7hlsz2l4y9v6";
-      name = "kactivities-stats-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kactivities-stats-5.56.0.tar.xz";
+      sha256 = "1v3pf9drb22qv7039grx4k7q3a1jxd2a7sf818mxpqyys4fzkl3f";
+      name = "kactivities-stats-5.56.0.tar.xz";
     };
   };
   kapidox = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kapidox-5.55.0.tar.xz";
-      sha256 = "0x41adp3rnvr6njc57ffdyh6d5i5aw13xcjdr4p6kacw9pk63ajf";
-      name = "kapidox-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kapidox-5.56.0.tar.xz";
+      sha256 = "0rhqqsv4zf13idk426x84jykw6lc74bz7pk606llbmyw4775c7wp";
+      name = "kapidox-5.56.0.tar.xz";
     };
   };
   karchive = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/karchive-5.55.0.tar.xz";
-      sha256 = "1llznxc5wjjnmbjx8iwi3a93gc2z0z344viknsgls1fwdjjfyxc4";
-      name = "karchive-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/karchive-5.56.0.tar.xz";
+      sha256 = "1mnavc5baa4qw90baw5b95760lk61m2rx0vfa3w5d7fid3m6q6i8";
+      name = "karchive-5.56.0.tar.xz";
     };
   };
   kauth = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kauth-5.55.0.tar.xz";
-      sha256 = "1w6bp2kbp1sn4cl76fgl2pqrg660ix99qq4h65g090kc934np3zc";
-      name = "kauth-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kauth-5.56.0.tar.xz";
+      sha256 = "0gb1yh2na2kfphln7arscv5n7llagkkv2y0zdprdy4michqa3k6b";
+      name = "kauth-5.56.0.tar.xz";
     };
   };
   kbookmarks = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kbookmarks-5.55.0.tar.xz";
-      sha256 = "0vsn98znzdbiy8clbl9p3kiag3zvxgc9701gwg2ig8mpv3ci9lkg";
-      name = "kbookmarks-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kbookmarks-5.56.0.tar.xz";
+      sha256 = "0fwmq70ajyjqcva1n2vnf522gwl44aqsi6s9vf8zxsar14vil082";
+      name = "kbookmarks-5.56.0.tar.xz";
     };
   };
   kcmutils = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kcmutils-5.55.0.tar.xz";
-      sha256 = "1f49864xpxrbj77n7l474wkn3rw4zy8vkl3psdya7ccdk7ac2s0k";
-      name = "kcmutils-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kcmutils-5.56.0.tar.xz";
+      sha256 = "1f1sccwyk6fzqd9ywnhkrsyaklmxi0w0w5jqhp1m4n3l30caixkw";
+      name = "kcmutils-5.56.0.tar.xz";
     };
   };
   kcodecs = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kcodecs-5.55.0.tar.xz";
-      sha256 = "0491j6l28jwfpgaqs2816qpyggnra2df33iw3fgvb0wd4r4gvmjb";
-      name = "kcodecs-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kcodecs-5.56.0.tar.xz";
+      sha256 = "10lw85im4rd3nfdnw2p48cjwq0d47pa2s9v6vmhzmm3hxbflq8z7";
+      name = "kcodecs-5.56.0.tar.xz";
     };
   };
   kcompletion = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kcompletion-5.55.0.tar.xz";
-      sha256 = "08ym79fqk7vshsf3jk37d6jvg7ys63kwflcn5dff5ci18jan2ir2";
-      name = "kcompletion-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kcompletion-5.56.0.tar.xz";
+      sha256 = "1yxsrl0f24ps8xsilh2iqnl88yvw39iw2ch0yk7lwwk47jkgvns9";
+      name = "kcompletion-5.56.0.tar.xz";
     };
   };
   kconfig = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kconfig-5.55.0.tar.xz";
-      sha256 = "06gscipc3914gwiswhp1xx4sy74bpy645ykq2i6r1sb6sm16hmja";
-      name = "kconfig-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kconfig-5.56.0.tar.xz";
+      sha256 = "0wii6pn5dq899s1r7p4q5vmm01jk11zwg2ky6760xf8nv8rhg5ra";
+      name = "kconfig-5.56.0.tar.xz";
     };
   };
   kconfigwidgets = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kconfigwidgets-5.55.0.tar.xz";
-      sha256 = "0npfp6z5lc2h8y6slmz3sbymyyv9k2w73rpsjzl5zswqhzlvrb5k";
-      name = "kconfigwidgets-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kconfigwidgets-5.56.0.tar.xz";
+      sha256 = "00x5cxgxqza81znzm5rzxzr6scv3s5wbwbhsq61ksmjnlf5wvky5";
+      name = "kconfigwidgets-5.56.0.tar.xz";
     };
   };
   kcoreaddons = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kcoreaddons-5.55.0.tar.xz";
-      sha256 = "1j7bc5fhak8db3vdfslbjdffbdclakhfwsni2a855d08yfrl1n1w";
-      name = "kcoreaddons-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kcoreaddons-5.56.0.tar.xz";
+      sha256 = "17kvndaab9l6r79rh0pyjgw4yqh99xfyksc4yxzhhlyl3fgh6hcz";
+      name = "kcoreaddons-5.56.0.tar.xz";
     };
   };
   kcrash = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kcrash-5.55.0.tar.xz";
-      sha256 = "08a8c5mbj6ll0d1ivhcjx5ga1jfbnwxsk618wcfpwwi6mkxrc3f9";
-      name = "kcrash-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kcrash-5.56.0.tar.xz";
+      sha256 = "1q5iyqi1qgk5ngc9fdilrc5mjxy2mb0xbdnlx234hn1a44aq47jq";
+      name = "kcrash-5.56.0.tar.xz";
     };
   };
   kdbusaddons = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kdbusaddons-5.55.0.tar.xz";
-      sha256 = "1sj3cycgci3ih65bkh7bsvbzyp7r654ppcryj4azpcsxqhy5gc7l";
-      name = "kdbusaddons-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kdbusaddons-5.56.0.tar.xz";
+      sha256 = "0wmrcz92k27j0s2iyzd9ldynv4p52x70sxzby2m807ffrs692c5r";
+      name = "kdbusaddons-5.56.0.tar.xz";
     };
   };
   kdeclarative = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kdeclarative-5.55.0.tar.xz";
-      sha256 = "043jl7rn9yawh04fwgaxb8iwksn3z8qb4yfc4s6v1znwcs7ajlda";
-      name = "kdeclarative-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kdeclarative-5.56.0.tar.xz";
+      sha256 = "0slhxqzbrj23vw7f017cx3brpqkw3933jj7z8kc2bgfzjypj373r";
+      name = "kdeclarative-5.56.0.tar.xz";
     };
   };
   kded = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kded-5.55.0.tar.xz";
-      sha256 = "0kn9kzzji257mppd12jzwiibha8127ajxvng2ls765lylv9nad7q";
-      name = "kded-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kded-5.56.0.tar.xz";
+      sha256 = "0fdzpsrigjqssqw25gxz5d1i0j8g3hc8xpv4v74mp0pcv9g10apz";
+      name = "kded-5.56.0.tar.xz";
     };
   };
   kdelibs4support = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/portingAids/kdelibs4support-5.55.0.tar.xz";
-      sha256 = "1l1gjv06yp9jdiapiypwscbb6y0rfgrnw9rdsl7kkxh9ps8b8j39";
-      name = "kdelibs4support-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/portingAids/kdelibs4support-5.56.0.tar.xz";
+      sha256 = "1yhfnvzgwmnivm99gkq67gnx0ar02j043mq3fg2lgwlrarqi9k7d";
+      name = "kdelibs4support-5.56.0.tar.xz";
     };
   };
   kdesignerplugin = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kdesignerplugin-5.55.0.tar.xz";
-      sha256 = "114035wil0p5z6h0li8wjzivsdxhqbih54kn4nvhn43b71xnzs3y";
-      name = "kdesignerplugin-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kdesignerplugin-5.56.0.tar.xz";
+      sha256 = "05nqayzafn2zz74lx8zj7hi7knclcip7zbqmpk1g3nriysc39x4v";
+      name = "kdesignerplugin-5.56.0.tar.xz";
     };
   };
   kdesu = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kdesu-5.55.0.tar.xz";
-      sha256 = "1x2gjnmgpcaxvfav2pm92zfgxbn60awpvmn9ycs68rq47p6h9x0f";
-      name = "kdesu-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kdesu-5.56.0.tar.xz";
+      sha256 = "0fc77rbkd1m7rv4rq56g0fg4vg0siamdm5g788816ig9gn1j76ll";
+      name = "kdesu-5.56.0.tar.xz";
     };
   };
   kdewebkit = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kdewebkit-5.55.0.tar.xz";
-      sha256 = "1mnbdsiih94hlwwff9fs9gnzl3y7ayf1pskmz1rajgjmqd6rm7mm";
-      name = "kdewebkit-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kdewebkit-5.56.0.tar.xz";
+      sha256 = "1c1mxs30182ilxybp0xwaljrjg5y9j1ri79169hn8664xs3wcbc2";
+      name = "kdewebkit-5.56.0.tar.xz";
     };
   };
   kdnssd = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kdnssd-5.55.0.tar.xz";
-      sha256 = "0lljj7mxmqm60kfzr37zb7z58mfyfh7zgykf7a5is1k0lxpgk6zc";
-      name = "kdnssd-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kdnssd-5.56.0.tar.xz";
+      sha256 = "1gskwc8sbj6cicblmrxh7qnh1gap0qivs8k5zf5qs94p1xc864vy";
+      name = "kdnssd-5.56.0.tar.xz";
     };
   };
   kdoctools = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kdoctools-5.55.0.tar.xz";
-      sha256 = "0dlal0vkxf5yh1hbfhrcrxqqi1w43q7bvv8ws8pb18jjgimzr46l";
-      name = "kdoctools-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kdoctools-5.56.0.tar.xz";
+      sha256 = "01y06rf1nhw2p8s0j60anr2qvssrqfimddvp2mqqkvx9xkx3py74";
+      name = "kdoctools-5.56.0.tar.xz";
     };
   };
   kemoticons = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kemoticons-5.55.0.tar.xz";
-      sha256 = "03vx22f9mjd10qm61f6ihr283w2sarrhg0rssxp7g7wahvshcvmh";
-      name = "kemoticons-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kemoticons-5.56.0.tar.xz";
+      sha256 = "00hbd09gnwyfszdwa9yf5m8wpbbapc4kwhs3qxhbvvmll0jv9vl2";
+      name = "kemoticons-5.56.0.tar.xz";
     };
   };
   kfilemetadata = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kfilemetadata-5.55.0.tar.xz";
-      sha256 = "0fqj266f9f66rfjzg0rl35fac5rn5n3npyfb4gsla3mdc8fjz9mi";
-      name = "kfilemetadata-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kfilemetadata-5.56.0.tar.xz";
+      sha256 = "04pmd2f77zxi14l3rhw4dyrh9dafchxqw1xjyv60j97gmm1b9796";
+      name = "kfilemetadata-5.56.0.tar.xz";
     };
   };
   kglobalaccel = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kglobalaccel-5.55.0.tar.xz";
-      sha256 = "1c6dxp6jvbw8l74n1mv0v62yr34b9447szhvd61y4sxmmfjimhz4";
-      name = "kglobalaccel-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kglobalaccel-5.56.0.tar.xz";
+      sha256 = "0pmgvizc2dwrwr7m49125ybcpsc95r9riwxnihf37napyaacd9y3";
+      name = "kglobalaccel-5.56.0.tar.xz";
     };
   };
   kguiaddons = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kguiaddons-5.55.0.tar.xz";
-      sha256 = "190jwhvq2fi8g03saszlaslzxmcbqrbwli9f9vm6h5j9nnc0z6h3";
-      name = "kguiaddons-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kguiaddons-5.56.0.tar.xz";
+      sha256 = "0gp2i29y1vws8i3q8s1bhyxksa42l6q55m459yczddcvcw0vd45i";
+      name = "kguiaddons-5.56.0.tar.xz";
     };
   };
   kholidays = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kholidays-5.55.0.tar.xz";
-      sha256 = "0y44alimywggd4xvis9lz49j0fhgwkggzwpp7bnmcxjnbj9z0vd9";
-      name = "kholidays-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kholidays-5.56.0.tar.xz";
+      sha256 = "0lm2ls3a15qbsfhamh2ldzvr62wi9nrhxd83rhyk3ifsgac4mg18";
+      name = "kholidays-5.56.0.tar.xz";
     };
   };
   khtml = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/portingAids/khtml-5.55.0.tar.xz";
-      sha256 = "0wh9z5xm0gaf1c2s7cq7763jfyv83d58x80nwsvb0ayd6y8id1bq";
-      name = "khtml-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/portingAids/khtml-5.56.0.tar.xz";
+      sha256 = "1wmcqc4546mqagqpgb97h3yd7nxaq4si2484li5hnw8mglm1qf3x";
+      name = "khtml-5.56.0.tar.xz";
     };
   };
   ki18n = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/ki18n-5.55.0.tar.xz";
-      sha256 = "0kvwjzqibby9fawyfb8bd81abjhsjlyi8xy9mcapnih5x2gx3z92";
-      name = "ki18n-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/ki18n-5.56.0.tar.xz";
+      sha256 = "0hdfad9vmyzfni9ln0dc9p26gpjksk754z28v35hww6z9kgbr1dq";
+      name = "ki18n-5.56.0.tar.xz";
     };
   };
   kiconthemes = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kiconthemes-5.55.0.tar.xz";
-      sha256 = "1rgbfklb7xxg7z2zyrsmaxf883ixgfbkqilps3npwk3xac2f66rw";
-      name = "kiconthemes-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kiconthemes-5.56.0.tar.xz";
+      sha256 = "0rdpvbqsb2wqi3glmggilm1mhpy6nc80am5hl4c34269mxd55q8a";
+      name = "kiconthemes-5.56.0.tar.xz";
     };
   };
   kidletime = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kidletime-5.55.0.tar.xz";
-      sha256 = "1kq6zh6cjhzffjhxnc7l1pw6g38swxyspp8xl8c860zdhc9xfd1g";
-      name = "kidletime-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kidletime-5.56.0.tar.xz";
+      sha256 = "09184bi8fvq34hwkldyibji7r79wd2wvhxk1i4kzkjg177dnaa95";
+      name = "kidletime-5.56.0.tar.xz";
     };
   };
   kimageformats = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kimageformats-5.55.0.tar.xz";
-      sha256 = "0hhxv8m5993vlpi5yf7w3fadzckficn16flshdkby7bwq8agrbz1";
-      name = "kimageformats-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kimageformats-5.56.0.tar.xz";
+      sha256 = "1cgh32jkg0ybfp8z6qwn7y6yr9mb0fiqly4pb0qc1lcm6awdx3d5";
+      name = "kimageformats-5.56.0.tar.xz";
     };
   };
   kinit = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kinit-5.55.0.tar.xz";
-      sha256 = "11xwiny5sfqbdls249vnq6ssp5pzw1w9wg4ql9nkwwygl4ml8b9y";
-      name = "kinit-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kinit-5.56.0.tar.xz";
+      sha256 = "1ihrannyaj33wsir20qy363vdjafhlsmj45qzl3xkl4rbyl6ngs7";
+      name = "kinit-5.56.0.tar.xz";
     };
   };
   kio = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kio-5.55.0.tar.xz";
-      sha256 = "1k3cn7hvp5z9nirss29v164hahrlvlqivxlk64c8w9ynjx699ira";
-      name = "kio-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kio-5.56.0.tar.xz";
+      sha256 = "1m2c3a5isj966snmzs97i9kyhwnbzlwf61lqw5yxck25x7d0pyyn";
+      name = "kio-5.56.0.tar.xz";
     };
   };
   kirigami2 = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kirigami2-5.55.0.tar.xz";
-      sha256 = "11djxli5cq7pn19lmjz2y7z39mhlr98jskasfzyax546j47v973k";
-      name = "kirigami2-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kirigami2-5.56.0.tar.xz";
+      sha256 = "0pbyr50anbzrqmw1rzf46dck9gsrfs7zxw5jlcax98bpsajix87y";
+      name = "kirigami2-5.56.0.tar.xz";
     };
   };
   kitemmodels = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kitemmodels-5.55.0.tar.xz";
-      sha256 = "13609avkqrfi79zyr737662nr8bwcfdya9dxc6gzyqx5i0l2nbw6";
-      name = "kitemmodels-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kitemmodels-5.56.0.tar.xz";
+      sha256 = "13m1bvhljyc1jb9hdlz5v009kmkz7q0qf06l5zkck5k0fq41rkrg";
+      name = "kitemmodels-5.56.0.tar.xz";
     };
   };
   kitemviews = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kitemviews-5.55.0.tar.xz";
-      sha256 = "1mgh7z5xcbhc7a2qq8mqfp7j4amk93hypkpy2zc3rdhc60ps94ad";
-      name = "kitemviews-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kitemviews-5.56.0.tar.xz";
+      sha256 = "1ar492jpyprxvzcgnq0gnbyxlndb3rd0z32drk7xsx19vpk3ch58";
+      name = "kitemviews-5.56.0.tar.xz";
     };
   };
   kjobwidgets = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kjobwidgets-5.55.0.tar.xz";
-      sha256 = "1pbx974jpn8n2080gblmbh8q0yb5wxb9xblpm100rbhpg20sc2by";
-      name = "kjobwidgets-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kjobwidgets-5.56.0.tar.xz";
+      sha256 = "1dh4ilry575k6z0glqb60ldjfkwpnkvijdzfyrc22bn84hbh19iy";
+      name = "kjobwidgets-5.56.0.tar.xz";
     };
   };
   kjs = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/portingAids/kjs-5.55.0.tar.xz";
-      sha256 = "0c1wyxsgn70jvw7zcjjpw12w9sg9xxvyslgnqlnnyh8sx7rrp70c";
-      name = "kjs-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/portingAids/kjs-5.56.0.tar.xz";
+      sha256 = "1b3l76ipf0fr8bvp3f4njimmg5yw9ciwzzgvb34ds65aycplagln";
+      name = "kjs-5.56.0.tar.xz";
     };
   };
   kjsembed = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/portingAids/kjsembed-5.55.0.tar.xz";
-      sha256 = "0dh9012y9bqj48jp50lrsmd28bbvf4jd93l34vfzmza252yvyw3l";
-      name = "kjsembed-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/portingAids/kjsembed-5.56.0.tar.xz";
+      sha256 = "0lkfq7099yiwvlycrix3s0dbk860rqfnix5fiw5vmi855is7mpkv";
+      name = "kjsembed-5.56.0.tar.xz";
     };
   };
   kmediaplayer = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/portingAids/kmediaplayer-5.55.0.tar.xz";
-      sha256 = "0gpfrhgk2l63lyz0bz93cg7mc5g7mjvrkfvpyndmi1v7vhndp5zq";
-      name = "kmediaplayer-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/portingAids/kmediaplayer-5.56.0.tar.xz";
+      sha256 = "0blqbi40l1pk8qf9054ha4a8r7cb4pddbqydsqlsscl4gm8530jh";
+      name = "kmediaplayer-5.56.0.tar.xz";
     };
   };
   knewstuff = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/knewstuff-5.55.0.tar.xz";
-      sha256 = "0a2d9wrhjsjl0klsrn501sp9681v7qmq6hmalw061arjv165dzw2";
-      name = "knewstuff-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/knewstuff-5.56.0.tar.xz";
+      sha256 = "0r0ia0521vfri7mc6wpg3ihryqj48s3krgmliwbh635rfd3lcj9j";
+      name = "knewstuff-5.56.0.tar.xz";
     };
   };
   knotifications = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/knotifications-5.55.0.tar.xz";
-      sha256 = "1dbrk9r3w8pmg15bhrb8qdk4fiqvc9qggb67zvk1n7ddlfkyarz6";
-      name = "knotifications-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/knotifications-5.56.0.tar.xz";
+      sha256 = "05nf2870fq9cwacgyy8iky5v37fq4jrsh4hl9xy9928d19qnmb24";
+      name = "knotifications-5.56.0.tar.xz";
     };
   };
   knotifyconfig = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/knotifyconfig-5.55.0.tar.xz";
-      sha256 = "01hxj6s2sq5k5j6j1y4c5gxyl1886j7ghh0hdc95b7n4gdjwwbci";
-      name = "knotifyconfig-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/knotifyconfig-5.56.0.tar.xz";
+      sha256 = "0zwq0p779482sxxjg62z1rkpiiyn6b3r47l450dm6hm56vkf7vxl";
+      name = "knotifyconfig-5.56.0.tar.xz";
     };
   };
   kpackage = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kpackage-5.55.0.tar.xz";
-      sha256 = "175b0lj4qybddjpc25b1p60lr8f9220i9ymk3wk3y3vf4893v833";
-      name = "kpackage-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kpackage-5.56.0.tar.xz";
+      sha256 = "037r0ldp70q0yafld1ddff1d4wipb5ras88r72qazjcfqfg9rzjr";
+      name = "kpackage-5.56.0.tar.xz";
     };
   };
   kparts = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kparts-5.55.0.tar.xz";
-      sha256 = "0gqkgnvkdai8hbg1n32jq4a3yzlkarmw8a7hxlfr0ykgysanjh65";
-      name = "kparts-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kparts-5.56.0.tar.xz";
+      sha256 = "1vj5ard5ff0wzpjqzrkd2kb31dkjly1cf4ww1ljrrwi7qgzxgw0z";
+      name = "kparts-5.56.0.tar.xz";
     };
   };
   kpeople = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kpeople-5.55.0.tar.xz";
-      sha256 = "0vbgi4l14g4f0klbxqbkjcag6yi0ghhpxn5nik5sssmcx8qyk885";
-      name = "kpeople-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kpeople-5.56.0.tar.xz";
+      sha256 = "0h456kjhx4ylbkiv3706g8ccdq55aamrhj5rgiql2gaw3d5dbrkr";
+      name = "kpeople-5.56.0.tar.xz";
     };
   };
   kplotting = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kplotting-5.55.0.tar.xz";
-      sha256 = "0nn2v1yvvpzpi1y1pm47zvmwsa942c7d9n8iqymqihnp0fqjr8y7";
-      name = "kplotting-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kplotting-5.56.0.tar.xz";
+      sha256 = "1hrk3iv77s46lcs6c5mfiyzr80vpg9261mlixc3qwps0mww43r1r";
+      name = "kplotting-5.56.0.tar.xz";
     };
   };
   kpty = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kpty-5.55.0.tar.xz";
-      sha256 = "0r5080xl7x13qmjnjssb0d1pk626anaa4xahb7fi869fndr4xhzn";
-      name = "kpty-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kpty-5.56.0.tar.xz";
+      sha256 = "1dzp4a6rz6hsp1y8m5l73i8v2a3bpwkv4rrypkd00051ajcch47k";
+      name = "kpty-5.56.0.tar.xz";
     };
   };
   kross = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/portingAids/kross-5.55.0.tar.xz";
-      sha256 = "0p3q36gka6m62nryc3l11d30mlhiqjpghvfcyq6wikiqlv2kqvjs";
-      name = "kross-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/portingAids/kross-5.56.0.tar.xz";
+      sha256 = "0ry6fpl0rb8z5r08bzh6kj14mp7l94calvdk3vrnc89cpm5gxymv";
+      name = "kross-5.56.0.tar.xz";
     };
   };
   krunner = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/krunner-5.55.0.tar.xz";
-      sha256 = "0yw2jh9dailhcwkkjl2qggg5k90bwbfsn88a3hzwyj2ng2haypis";
-      name = "krunner-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/krunner-5.56.0.tar.xz";
+      sha256 = "1gs0fr78zbhxl8c08zj4s98zshc42zxzwv7p9l7rmq8h21spc8ga";
+      name = "krunner-5.56.0.tar.xz";
     };
   };
   kservice = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kservice-5.55.0.tar.xz";
-      sha256 = "0k8xksmw2ai7m0js7l98rv5v6ykifmnqiyy2yc1xhgn40lf1r89j";
-      name = "kservice-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kservice-5.56.0.tar.xz";
+      sha256 = "1hsc8pagigwspyv9ipl3l2b9mf8amfksk8a2k3iic9nw1hmpxinv";
+      name = "kservice-5.56.0.tar.xz";
     };
   };
   ktexteditor = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/ktexteditor-5.55.0.tar.xz";
-      sha256 = "0b5zqhm5aw7jj7dj600xa674ik11gwyzamhyz5962xhvsg5pyjwx";
-      name = "ktexteditor-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/ktexteditor-5.56.0.tar.xz";
+      sha256 = "1a2r97v3xwh61q688jvwkk99bphfd0v0ldqms5d73q3m6w1x122c";
+      name = "ktexteditor-5.56.0.tar.xz";
     };
   };
   ktextwidgets = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/ktextwidgets-5.55.0.tar.xz";
-      sha256 = "1ymqmb5z4flzrns3wdjagxbzbpighbincwbhy29a0mqg4zcm82xk";
-      name = "ktextwidgets-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/ktextwidgets-5.56.0.tar.xz";
+      sha256 = "1km19z577y29di8zp6amlccqdavxk4f4sg1dblj6gp64zkw9dbqp";
+      name = "ktextwidgets-5.56.0.tar.xz";
     };
   };
   kunitconversion = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kunitconversion-5.55.0.tar.xz";
-      sha256 = "1v5cfxk5v76w1f1qvrpilrs111wvp8bn2p3bswhqp4lg0qxync0q";
-      name = "kunitconversion-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kunitconversion-5.56.0.tar.xz";
+      sha256 = "1kf5dc6p77mkx2i23ppfs0k3laybmx5vqq7aq1bxnkxj1ws75144";
+      name = "kunitconversion-5.56.0.tar.xz";
     };
   };
   kwallet = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kwallet-5.55.0.tar.xz";
-      sha256 = "1dp072h5r6yd81i69759pj8klfsikrg25za44sry2kh6fxvwmngm";
-      name = "kwallet-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kwallet-5.56.0.tar.xz";
+      sha256 = "02i6xkq9ki6sybjvcxkznf5v8b34pqxysg9pi5v4z6jkw2jpr5fj";
+      name = "kwallet-5.56.0.tar.xz";
     };
   };
   kwayland = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kwayland-5.55.0.tar.xz";
-      sha256 = "0m9q13qzgvp03jrsyc59l6pp7jf0dvhx768p21drs46qxw6wla7l";
-      name = "kwayland-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kwayland-5.56.0.tar.xz";
+      sha256 = "1779in51z63sv6607xd7y30wprs9vs8nnqa28fxg1q4nicwnvrxv";
+      name = "kwayland-5.56.0.tar.xz";
     };
   };
   kwidgetsaddons = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kwidgetsaddons-5.55.0.tar.xz";
-      sha256 = "0kpbvvmjrhxxjqc0cb63zlq06a3xspq43xv3wdingcn28zypynzc";
-      name = "kwidgetsaddons-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kwidgetsaddons-5.56.0.tar.xz";
+      sha256 = "0flmw1wfzs49dmmlbbimizjwj09wp4qwr9znxn3h5yfn0mxfc1lv";
+      name = "kwidgetsaddons-5.56.0.tar.xz";
     };
   };
   kwindowsystem = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kwindowsystem-5.55.0.tar.xz";
-      sha256 = "10zdxm08d758zbwlrbsn0ghxjpf39ids2s5pnca072gbrbrxv656";
-      name = "kwindowsystem-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kwindowsystem-5.56.0.tar.xz";
+      sha256 = "0dk9ymlpdpvra2zm1f2rcx2dwnn9qc49n2y7p6iw094fwk5rzczc";
+      name = "kwindowsystem-5.56.0.tar.xz";
     };
   };
   kxmlgui = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kxmlgui-5.55.0.tar.xz";
-      sha256 = "0ph67zarf1sccvp7882brrihv4dsmxq0nggan0rnk54qg0zdhgcn";
-      name = "kxmlgui-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kxmlgui-5.56.0.tar.xz";
+      sha256 = "1ipa0qnkh6gs3f6ygvb7cf0yv1m89m3cdl1z23br4fn14d5mxbrl";
+      name = "kxmlgui-5.56.0.tar.xz";
     };
   };
   kxmlrpcclient = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/kxmlrpcclient-5.55.0.tar.xz";
-      sha256 = "1573wnv2fbjjzgx3f1qm7y8wlj22bz45mny0rxci90i76nnh4538";
-      name = "kxmlrpcclient-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kxmlrpcclient-5.56.0.tar.xz";
+      sha256 = "1bjnpl4521gv35zghaanz6v5bap2b9n2kz7b0rif1bf6iak018ql";
+      name = "kxmlrpcclient-5.56.0.tar.xz";
     };
   };
   modemmanager-qt = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/modemmanager-qt-5.55.0.tar.xz";
-      sha256 = "10pkgm4dzsrfnjsf78pssd1wp0y27d1y834chd267hx9vgrv8axm";
-      name = "modemmanager-qt-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/modemmanager-qt-5.56.0.tar.xz";
+      sha256 = "1xwx6yybij8nlaqfpz76pindfxshcyg9p21nqm6ddpgyzh74klbc";
+      name = "modemmanager-qt-5.56.0.tar.xz";
     };
   };
   networkmanager-qt = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/networkmanager-qt-5.55.0.tar.xz";
-      sha256 = "0j8l4k13vsqh0a8mw8dw5bc78xvxhz2rh7bb870as04i32bvw772";
-      name = "networkmanager-qt-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/networkmanager-qt-5.56.0.tar.xz";
+      sha256 = "0p0b3rq7s1yzy6zspd6xnzjc0hza9d7fixm8pw369kn5k3pi5lk1";
+      name = "networkmanager-qt-5.56.0.tar.xz";
     };
   };
   oxygen-icons5 = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/oxygen-icons5-5.55.0.tar.xz";
-      sha256 = "0fvm9bq1573xkha4a577s1iik8nwzks8xhrli5mm6rbh53s12wp4";
-      name = "oxygen-icons5-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/oxygen-icons5-5.56.0.tar.xz";
+      sha256 = "17cjcfmc8vywh8n2ck0s3b0i88ilamdah0gipicn7vj65l4wc1qb";
+      name = "oxygen-icons5-5.56.0.tar.xz";
     };
   };
   plasma-framework = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/plasma-framework-5.55.0.tar.xz";
-      sha256 = "1pvxxw52s03i11p5byd2sh8sbvlk6h8q6briq9d4qvjy6c0pmbq4";
-      name = "plasma-framework-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/plasma-framework-5.56.0.tar.xz";
+      sha256 = "0hw90975c00v5v4xhs18w5gnklwhnygk6jls3n132xflilgc5k0a";
+      name = "plasma-framework-5.56.0.tar.xz";
     };
   };
   prison = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/prison-5.55.0.tar.xz";
-      sha256 = "1xadc2fq6csml78czg5p572cwvmqmn334a5dxjnd7k1pdx50gi07";
-      name = "prison-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/prison-5.56.0.tar.xz";
+      sha256 = "05hy6fz05snpgjz6bnm3qcr7smg65a0m6rdmyv7avrpbs4qpbghx";
+      name = "prison-5.56.0.tar.xz";
     };
   };
   purpose = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/purpose-5.55.0.tar.xz";
-      sha256 = "1krgjcfjrwvr7widz3rmcbbag4l0940gyzfpxni1p47c76kcb13b";
-      name = "purpose-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/purpose-5.56.0.tar.xz";
+      sha256 = "0rvywfkhqbmd39g950mpnn35i3kg7j63ylvdy2px2d71am6acal8";
+      name = "purpose-5.56.0.tar.xz";
     };
   };
   qqc2-desktop-style = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/qqc2-desktop-style-5.55.0.tar.xz";
-      sha256 = "0aj37ldc3ywqap3sz73j54kbzycn529imr15jgl252k04rqpjya5";
-      name = "qqc2-desktop-style-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/qqc2-desktop-style-5.56.0.tar.xz";
+      sha256 = "08afy1gsy0lvpzqmv5azzfiy5x9lvffsf6qvzxxab4v5ch8fn00b";
+      name = "qqc2-desktop-style-5.56.0.tar.xz";
     };
   };
   solid = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/solid-5.55.0.tar.xz";
-      sha256 = "18dw55g41q34m2qzvybvpsas1dnyryqxnlf2md0xc4r36ib9p2pn";
-      name = "solid-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/solid-5.56.0.tar.xz";
+      sha256 = "17kfwj0y41pkd0kxj2fj9m9qs7bq05vka9ngfr022lfwdhs907c4";
+      name = "solid-5.56.0.tar.xz";
     };
   };
   sonnet = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/sonnet-5.55.0.tar.xz";
-      sha256 = "13bb1s2f4kfaikcga297j2fqlyr4qxdcq4v1b3zs1gas4z1wpcg6";
-      name = "sonnet-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/sonnet-5.56.0.tar.xz";
+      sha256 = "0r8bsf7a9rjvv4jirycwf3xvkqa9iax23p93m301x82hdvmkjr9w";
+      name = "sonnet-5.56.0.tar.xz";
     };
   };
   syndication = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/syndication-5.55.0.tar.xz";
-      sha256 = "1p9xwbzlrw4bh5is5i6fq3yalmpsf099rzf6d2qc3a0sc21hxs63";
-      name = "syndication-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/syndication-5.56.0.tar.xz";
+      sha256 = "0wnrhfp5b4wgmigqh39c0f2qfblgmc3x6018b4wcayfs8gb4m1q9";
+      name = "syndication-5.56.0.tar.xz";
     };
   };
   syntax-highlighting = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/syntax-highlighting-5.55.0.tar.xz";
-      sha256 = "00w5nmz9l70znv8q7q1zw3f7gngwfgf41iwbs53zqcv1z7wmrz6m";
-      name = "syntax-highlighting-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/syntax-highlighting-5.56.0.tar.xz";
+      sha256 = "0gl0v1bscqd6xhl3644wix8ix04lax0h1zzr1v65704c4qp87h8l";
+      name = "syntax-highlighting-5.56.0.tar.xz";
     };
   };
   threadweaver = {
-    version = "5.55.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.55/threadweaver-5.55.0.tar.xz";
-      sha256 = "0r0ml5pz7h0vmydcg4gqqkl21lp6c5gqdwyfsnyad02dcjkh4hql";
-      name = "threadweaver-5.55.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/threadweaver-5.56.0.tar.xz";
+      sha256 = "1gyvj0v1zhfk8shi31pivvf5rwxkgv9bjmy2vippk2vxvkh0qc5x";
+      name = "threadweaver-5.56.0.tar.xz";
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change

https://kde.org/announcements/kde-frameworks-5.56.0.php

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---