### PR TITLE
unity3d: 2017.4.10f1 -> 2018.3.0f2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5461,4 +5461,9 @@
     github = "freezeboy";
     name = "freezeboy";
   };
+  tesq0 = {
+  	email = "mikolaj.galkowski@gmail.com";
+    github = "tesq0";
+    name = "Mikolaj Galkowski";
+	};
 }

--- a/pkgs/development/tools/unity3d/default.nix
+++ b/pkgs/development/tools/unity3d/default.nix
@@ -132,6 +132,6 @@ in stdenv.mkDerivation rec {
     '';
     license = licenses.unfree;
     platforms = [ "x86_64-linux" ];
-    maintainers = with maintainers; [ jb55 ];
+    maintainers = with maintainers; [ jb55 tesq0 ];
   };
 }

--- a/pkgs/development/tools/unity3d/default.nix
+++ b/pkgs/development/tools/unity3d/default.nix
@@ -1,9 +1,10 @@
 { stdenv, lib, fetchurl, makeWrapper, file, getopt
-, gtk2, gdk_pixbuf, glib, libGL, libGLU, nss, nspr, udev, tbb
+, gtk2, gtk3, gdk_pixbuf, glib, libGL, libGLU, nss, nspr, udev, tbb
 , alsaLib, GConf, cups, libcap, fontconfig, freetype, pango
 , cairo, dbus, expat, zlib, libpng12, nodejs, gnutar, gcc, gcc_32bit
 , libX11, libXcursor, libXdamage, libXfixes, libXrender, libXi
 , libXcomposite, libXext, libXrandr, libXtst, libSM, libICE, libxcb, chromium
+, libpqxx
 }:
 
 let
@@ -13,20 +14,21 @@ let
     cairo dbus expat zlib libpng12 udev tbb
     libX11 libXcursor libXdamage libXfixes libXrender libXi
     libXcomposite libXext libXrandr libXtst libSM libICE libxcb
+    libpqxx gtk3 
   ];
   libPath32 = lib.makeLibraryPath [ gcc_32bit.cc ];
   binPath = lib.makeBinPath [ nodejs gnutar ];
 
-  ver = "2017.4.10";
-  build = "f1";
+  ver = "2018.3.0";
+  build = "f2";
 
 in stdenv.mkDerivation rec {
   name = "unity-editor-${version}";
   version = "${ver}x${build}";
 
   src = fetchurl {
-    url = "https://beta.unity3d.com/download/14396d76537e/LinuxEditorInstaller/Unity.tar.xz";
-    sha256 = "e1b4fe41c0ff793f7a9146c49a8eca8c71d30abdfa3e81922bd69699810b3f67";
+  	url = "https://beta.unity3d.com/download/6e9a27477296/LinuxEditorInstaller/Unity.tar.xz";
+    sha1 = "083imikkrgha5w9sihjvv1m74naxm5yv";
   };
 
   nosuidLib = ./unity-nosuid.c;
@@ -79,7 +81,8 @@ in stdenv.mkDerivation rec {
       fi
     }
 
-    upm_linux=$unitydir/Data/Resources/Upm/upm-linux
+    upm_linux=$unitydir/Data/Resources/PackageManager/Server/UnityPackageManager
+    
 
     orig_size=$(stat --printf=%s $upm_linux)
 


### PR DESCRIPTION
###### Motivation for this change
Allow people to use a newer version of unity on nixos

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ x] Assured whether relevant documentation is up to date
- [ x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

