### PR TITLE
 omnisharp-roslyn: init at 1.32.8

### DIFF
--- a/pkgs/development/tools/omnisharp-roslyn/default.nix
+++ b/pkgs/development/tools/omnisharp-roslyn/default.nix
@@ -1,0 +1,41 @@
+{ stdenv
+, fetchurl
+, mono5
+, makeWrapper
+}:
+
+stdenv.mkDerivation rec {
+
+  name = "omnisharp-roslyn-${version}";
+  version = "1.32.8";
+  
+  src = fetchurl {
+    url = "https://github.com/OmniSharp/omnisharp-roslyn/releases/download/v${version}/omnisharp-mono.tar.gz";
+    sha256 = "0k2a4awmzb7ppll2skyzaa94n3hxqm35ffibl0sygldk3symzwgp";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  preUnpack = ''
+    mkdir src
+    cd src
+    sourceRoot=.
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cd ..
+		cp -r src $out/
+    ls -al $out/src
+    makeWrapper ${mono5}/bin/mono $out/bin/omnisharp \
+    --add-flags "$out/src/OmniSharp.exe"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "OmniSharp based on roslyn workspaces";
+    platforms = platforms.linux;
+    license = licenses.mit;
+    maintainers = with maintainers; [ tesq0 ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23684,6 +23684,8 @@ in
   newlib = callPackage ../development/misc/newlib { };
   newlibCross = callPackage ../development/misc/newlib {
     stdenv = crossLibcStdenv;
-  };
-
+    };
+    
+	omnisharp-roslyn = callPackage ../development/tools/omnisharp-roslyn { };
+  
 }


### PR DESCRIPTION
###### Motivation for this change
Intellisense for c# 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

