### PR TITLE
e2fsprogs: 1.44.5 -> 1.45.0

### DIFF
--- a/pkgs/tools/filesystems/e2fsprogs/default.nix
+++ b/pkgs/tools/filesystems/e2fsprogs/default.nix
@@ -1,11 +1,12 @@
 { stdenv, buildPackages, fetchurl, fetchpatch, pkgconfig, libuuid, gettext, texinfo, perl }:
 
 stdenv.mkDerivation rec {
-  name = "e2fsprogs-1.44.5";
+  pname = "e2fsprogs";
+  version = "1.45.0";
 
   src = fetchurl {
-    url = "mirror://sourceforge/e2fsprogs/${name}.tar.gz";
-    sha256 = "1k6iwv2bz2a8mcd1gg9kb5jpry7pil5v2h2f9apxax7g4yp1y89f";
+    url = "mirror://sourceforge/${pname}/${pname}-${version}.tar.gz";
+    sha256 = "1sgcjarfksa8bkx81q5cd6rzqvhzgs28a0ljwyr4ggqpfx7d18vk";
   };
 
   outputs = [ "bin" "dev" "out" "man" "info" ];
@@ -36,10 +37,9 @@ stdenv.mkDerivation rec {
   checkInputs = [ perl ];
   doCheck = false; # fails
 
-  # hacky way to make it install *.pc
   postInstall = ''
-    make install-libs
-    rm "$out"/lib/*.a
+    # avoid cycle between outputs
+    mv $out/lib/${pname}/e2scrub_all_cron $bin/bin/
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/tools/filesystems/e2fsprogs/default.nix
+++ b/pkgs/tools/filesystems/e2fsprogs/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     ];
 
   checkInputs = [ perl ];
-  doCheck = false; # fails
+  doCheck = true;
 
   postInstall = ''
     # avoid cycle between outputs


### PR DESCRIPTION
###### Motivation for this change

Changes:
* https://git.kernel.org/pub/scm/fs/ext2/e2fsprogs.git/tree/doc/RelNotes/v1.44.6.txt?h=v1.44.6
* https://git.kernel.org/pub/scm/fs/ext2/e2fsprogs.git/tree/doc/RelNotes/v1.45.0.txt?h=v1.45.0

Also:
* remove 'hack' for installing pc files
* fixup location of `e2scrub_all_cron` to avoid reference cycle in
  outputs, promote to $bin/bin for now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---