### PR TITLE
Bonnie 1.98

### DIFF
--- a/pkgs/tools/filesystems/bonnie/default.nix
+++ b/pkgs/tools/filesystems/bonnie/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, perl }:
 
 stdenv.mkDerivation rec {
   name = "bonnie++-1.98";
@@ -8,6 +8,8 @@ stdenv.mkDerivation rec {
   };
 
   enableParallelBuilding = true;
+
+  buildInputs = [ perl ];
 
   meta = {
     homepage = http://www.coker.com.au/bonnie++/;

--- a/pkgs/tools/filesystems/bonnie/default.nix
+++ b/pkgs/tools/filesystems/bonnie/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "bonnie++-1.97.3";
+  name = "bonnie++-1.98";
   src = fetchurl {
-    url = "https://fossies.org/linux/privat/${name}.tgz";
-    sha256 = "0vkl42rsrsy95fc1ykc6g8rsdbnpxayvdaihnnkly1fww1m3hyz2";
+    url = "https://www.coker.com.au/bonnie++/${name}.tgz";
+    sha256 = "010bmlmi0nrlp3aq7p624sfaj5a65lswnyyxk3cnz1bqig0cn2vf";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change

Update to latest version:
https://metadata.ftp-master.debian.org/changelogs//main/b/bonnie++/bonnie++_1.98_changelog

Make the `bon_csv2txt` untility work. It is a perl script and thus requires the correct perl interpreter.
Closure size increased from 34'006'536 bytes to  90'289'456 due to perl.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

