### PR TITLE
ephemeral: init at 4.2.0

### DIFF
--- a/pkgs/applications/networking/browsers/ephemeral/default.nix
+++ b/pkgs/applications/networking/browsers/ephemeral/default.nix
@@ -1,0 +1,60 @@
+{ stdenv
+, fetchFromGitHub
+, desktop-file-utils
+, gettext
+, glib
+, gtk3
+, hicolor-icon-theme
+, libgee
+, meson
+, ninja
+, pantheon
+, pkgconfig
+, python3
+, webkitgtk
+, wrapGAppsHook }:
+
+stdenv.mkDerivation rec {
+  pname = "ephemeral";
+  version = "4.2.0";
+
+  src = fetchFromGitHub {
+    owner = "cassidyjames";
+    repo = "ephemeral";
+    rev = version;
+    sha256 = "1bdqi1k1x2aywi2jm610qil2k5xn2kbs2nni55c5pgilq0sd7xnp";
+  };
+
+  nativeBuildInputs = [
+    desktop-file-utils
+    gettext
+    meson
+    ninja
+    pantheon.vala
+    pkgconfig
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    hicolor-icon-theme
+    libgee
+    pantheon.granite
+    python3
+    webkitgtk
+  ];
+
+  postPatch = ''
+    chmod +x meson/post_install.py
+    patchShebangs meson/post_install.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = "The always-incognito web browser";
+    homepage = https://github.com/cassidyjames/ephemeral;
+    maintainers = with maintainers; [ kjuvi ] ++ pantheon.maintainers;
+    platforms = platforms.linux;
+    license = licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17000,6 +17000,8 @@ in
 
   inherit (gnome3) epiphany;
 
+  ephemeral = callPackage ../applications/networking/browsers/ephemeral { };
+
   epic5 = callPackage ../applications/networking/irc/epic5 { };
 
   eq10q = callPackage ../applications/audio/eq10q { };


### PR DESCRIPTION
###### Motivation for this change

Browse the web more privately with the pantheon desktop.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

