### PR TITLE
errbot: fix broken dependencies

### DIFF
--- a/pkgs/development/python-modules/irc/default.nix
+++ b/pkgs/development/python-modules/irc/default.nix
@@ -1,6 +1,7 @@
 { buildPythonPackage, fetchPypi, isPy3k
 , six, jaraco_logging, jaraco_text, jaraco_stream, pytz, jaraco_itertools
-, setuptools_scm }:
+, setuptools_scm, jaraco_collections
+}:
 
 buildPythonPackage rec {
   pname = "irc";
@@ -23,5 +24,6 @@ buildPythonPackage rec {
     jaraco_stream
     pytz
     jaraco_itertools
+    jaraco_collections
   ];
 }

--- a/pkgs/development/python-modules/jaraco_collections/default.nix
+++ b/pkgs/development/python-modules/jaraco_collections/default.nix
@@ -1,5 +1,6 @@
 { buildPythonPackage, fetchPypi, setuptools_scm
-, six, jaraco_classes }:
+, six, jaraco_classes, jaraco_text
+}:
 
 buildPythonPackage rec {
   pname = "jaraco.collections";
@@ -11,7 +12,7 @@ buildPythonPackage rec {
 
   doCheck = false;
   buildInputs = [ setuptools_scm ];
-  propagatedBuildInputs = [ six jaraco_classes ];
+  propagatedBuildInputs = [ six jaraco_classes jaraco_text ];
 
   # break dependency cycle
   patchPhase = ''

--- a/pkgs/development/python-modules/jaraco_itertools/0001-Don-t-run-flake8-checks-during-the-build.patch
+++ b/pkgs/development/python-modules/jaraco_itertools/0001-Don-t-run-flake8-checks-during-the-build.patch
@@ -1,0 +1,38 @@
+From fcffcc61e432e5250e7fbfb1ecbe0f1cac3006cf Mon Sep 17 00:00:00 2001
+From: Maximilian Bosch <maximilian@mbosch.me>
+Date: Sun, 10 Mar 2019 13:10:18 +0100
+Subject: [PATCH] Don't run flake8 checks during the build
+
+If the code simply violates their code style, the Nix package shouldn't fail.
+---
+ pytest.ini | 2 +-
+ setup.cfg  | 1 -
+ 2 files changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/pytest.ini b/pytest.ini
+index d165e5e..d8e4694 100644
+--- a/pytest.ini
++++ b/pytest.ini
+@@ -1,6 +1,6 @@
+ [pytest]
+ norecursedirs=dist build .tox .eggs
+-addopts=--doctest-modules --flake8
++addopts=--doctest-modules
+ doctest_optionflags=ALLOW_UNICODE ELLIPSIS ALLOW_BYTES
+ filterwarnings=
+ 	ignore:Possible nested set::pycodestyle:113
+diff --git a/setup.cfg b/setup.cfg
+index 9f3517f..c9033ec 100644
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -30,7 +30,6 @@ setup_requires = setuptools_scm >= 1.15.0
+ testing = 
+ 	pytest >= 3.5, !=3.7.3
+ 	pytest-checkdocs
+-	pytest-flake8
+ docs = 
+ 	sphinx
+ 	jaraco.packaging >= 3.2
+-- 
+2.18.1
+

--- a/pkgs/development/python-modules/jaraco_itertools/default.nix
+++ b/pkgs/development/python-modules/jaraco_itertools/default.nix
@@ -1,5 +1,6 @@
 { lib, buildPythonPackage, fetchPypi, setuptools_scm
-, inflect, more-itertools, six, pytest, pytest-flake8 }:
+, inflect, more-itertools, six, pytest
+}:
 
 buildPythonPackage rec {
   pname = "jaraco.itertools";
@@ -10,9 +11,11 @@ buildPythonPackage rec {
     sha256 = "d1380ed961c9a4724f0bcca85d2bffebaa2507adfde535d5ee717441c9105fae";
   };
 
+  patches = [ ./0001-Don-t-run-flake8-checks-during-the-build.patch ];
+
   buildInputs = [ setuptools_scm ];
   propagatedBuildInputs = [ inflect more-itertools six ];
-  checkInputs = [ pytest pytest-flake8 ];
+  checkInputs = [ pytest ];
 
   checkPhase = ''
     pytest

--- a/pkgs/development/python-modules/jaraco_logging/0001-Don-t-run-flake8-checks-during-the-build.patch
+++ b/pkgs/development/python-modules/jaraco_logging/0001-Don-t-run-flake8-checks-during-the-build.patch
@@ -1,0 +1,38 @@
+From 4b9801d9bbe535fd6719933b96278915573e3595 Mon Sep 17 00:00:00 2001
+From: Maximilian Bosch <maximilian@mbosch.me>
+Date: Sun, 10 Mar 2019 16:42:21 +0100
+Subject: [PATCH] Don't run flake8 checks during the build
+
+If the code simply violates their code style, the Nix package shouldn't fail.
+---
+ pytest.ini | 2 +-
+ setup.cfg  | 1 -
+ 2 files changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/pytest.ini b/pytest.ini
+index 9b3c1ec..a5189c1 100644
+--- a/pytest.ini
++++ b/pytest.ini
+@@ -1,6 +1,6 @@
+ [pytest]
+ norecursedirs=dist build .tox .eggs
+-addopts=--doctest-modules --flake8
++addopts=--doctest-modules
+ doctest_optionflags=ALLOW_UNICODE ELLIPSIS
+ filterwarnings=
+ 	ignore:Possible nested set::pycodestyle:113
+diff --git a/setup.cfg b/setup.cfg
+index 3e7bbed..5cac7a2 100644
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -29,7 +29,6 @@ setup_requires = setuptools_scm >= 1.15.0
+ testing = 
+ 	pytest >= 3.5, !=3.7.3
+ 	pytest-checkdocs
+-	pytest-flake8
+ docs = 
+ 	sphinx
+ 	jaraco.packaging >= 3.2
+-- 
+2.18.1
+

--- a/pkgs/development/python-modules/jaraco_logging/default.nix
+++ b/pkgs/development/python-modules/jaraco_logging/default.nix
@@ -1,5 +1,6 @@
 { lib, buildPythonPackage, fetchPypi, setuptools_scm
-, tempora, six, pytest, pytest-flake8 }:
+, tempora, six, pytest
+}:
 
 buildPythonPackage rec {
   pname = "jaraco.logging";
@@ -10,9 +11,11 @@ buildPythonPackage rec {
     sha256 = "1lb846j7qs1hgqwkyifv51nhl3f8jimbc4lk8yn9nkaynw0vyzcg";
   };
 
+  patches = [ ./0001-Don-t-run-flake8-checks-during-the-build.patch ];
+
   buildInputs = [ setuptools_scm ];
   propagatedBuildInputs = [ tempora six ];
-  checkInputs = [ pytest pytest-flake8 ];
+  checkInputs = [ pytest ];
 
   checkPhase = ''
     PYTHONPATH=".:$PYTHONPATH" pytest

--- a/pkgs/development/python-modules/jaraco_text/default.nix
+++ b/pkgs/development/python-modules/jaraco_text/default.nix
@@ -1,14 +1,15 @@
 { buildPythonPackage, fetchPypi, setuptools_scm
-, jaraco_functools, jaraco_collections }:
+, jaraco_functools
+}:
 
 buildPythonPackage rec {
   pname = "jaraco.text";
-  version = "2.0";
+  version = "3.0";
   src = fetchPypi {
     inherit pname version;
-    sha256 = "3660678d395073626e72a455b24bacf07c064138a4cc6c1dae63e616f22478aa";
+    sha256 = "1l5hq2jvz9xj05aayc42f85v8wx8rpi16lxph8blw51wgnvymsyx";
   };
   doCheck = false;
   buildInputs =[ setuptools_scm ];
-  propagatedBuildInputs = [ jaraco_functools jaraco_collections ];
+  propagatedBuildInputs = [ jaraco_functools ];
 }


### PR DESCRIPTION
###### Motivation for this change

This PR aims to fix several dependencies of errbot that were broken recently.
Each commit fixes a broken dependencies, further details are in the commit message's body.

Addresses #56826 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

