### PR TITLE
pythonPackages.rbtools: fix tests

### DIFF
--- a/pkgs/development/python-modules/rbtools/default.nix
+++ b/pkgs/development/python-modules/rbtools/default.nix
@@ -16,10 +16,10 @@ buildPythonPackage rec {
     sha256 = "1ng8l8cx81cz23ls7fq9wz4ijs0zbbaqh4kj0mj6plzcqcf8na4i";
   };
 
-  buildInputs = [ nose ];
+  checkInputs = [ nose ];
   propagatedBuildInputs = [ six ];
 
-  checkPhase = "nosetests";
+  checkPhase = "LC_ALL=C nosetests";
 
   meta = with stdenv.lib; {
     homepage = https://www.reviewboard.org/docs/rbtools/dev/;


### PR DESCRIPTION
###### Motivation for this change

rbtools was broken, in the checkPhase it could not find the `nosetests` executable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

