### PR TITLE
jl: Patch to work with MonadFail GHC 8.6 change

### DIFF
--- a/pkgs/development/tools/jl/default.nix
+++ b/pkgs/development/tools/jl/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, fetchFromGitHub
+{ mkDerivation, fetchFromGitHub, fetchpatch
 , aeson, aeson-pretty, attoparsec, base, bytestring, conduit, conduit-extra
 , containers, exceptions, mtl, optparse-simple, parsec, scientific, stdenv
 , text, unordered-containers, vector
@@ -12,6 +12,14 @@ mkDerivation rec {
     rev = "v${version}";
     sha256 = "1hlnwsl4cj0l4x8dxwda2fcnk789cwlphl9gv9cfrivl43mgkgar";
   };
+  patches = [
+    # MonadFail compatibility patch. Should be removed with the next release
+    (fetchpatch {
+      url = https://github.com/chrisdone/jl/commit/6d40308811cbc22a96b47ebe69ec308b4e9fd356.patch;
+      sha256 = "1pg92ffkg8kim5r8rz8js6fjqyjisg1266sf7p9jyxjgsskwpa4g";
+    })
+  ];
+
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [


### PR DESCRIPTION
###### Motivation for this change
Patch needed until next jl is released properly.

Needs backport to 19.03

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

