### PR TITLE
ima-evm-utils: apply upstream fix for attr-2.4.48 compatibility (19.03)

### DIFF
--- a/pkgs/os-specific/linux/ima-evm-utils/default.nix
+++ b/pkgs/os-specific/linux/ima-evm-utils/default.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
   buildInputs = [ openssl attr keyutils asciidoc libxslt ];
 
+  patches = [ ./xattr.patch ];
+
   buildPhase = "make prefix=$out MANPAGE_DOCBOOK_XSL=${docbook_xsl}/xml/xsl/docbook/manpages/docbook.xsl";
 
   meta = {

--- a/pkgs/os-specific/linux/ima-evm-utils/xattr.patch
+++ b/pkgs/os-specific/linux/ima-evm-utils/xattr.patch
@@ -1,0 +1,73 @@
+commit 6aea54d2ad2287b3e8894c262ee895f3d4a60516
+Author: André Draszik <git@andred.net>
+Date:   Mon Oct 17 12:45:32 2016 +0100
+
+    evmctl: use correct include for xattr.h
+    
+    The xattr API/ABI is provided by both the c-library, as well as by the
+    libattr package. The c-library's header file is sys/xattr.h, whereas
+    libattr's header file can be found in attr/xattr.h.
+    
+    Given none of the code here *links* against the libattr.so shared library, it
+    is wrong to *compile* against libattr's API (header file).
+    
+    Doing so avoids confusion as to which xattr.h is used as the least problem,
+    and potential ABI differences as the worst problem due the mismatching header
+    file used.
+    
+    So make sure we compile and link against the same thing, the c-library in
+    both cases.
+    
+    Signed-off-by: André Draszik <git@andred.net>
+    Signed-off-by: Mimi Zohar <zohar@linux.vnet.ibm.com>
+
+diff --git a/configure.ac b/configure.ac
+index 0497eb7..a5b4288 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -30,7 +30,7 @@ AC_SUBST(OPENSSL_LIBS)
+ AC_CHECK_HEADER(unistd.h)
+ AC_CHECK_HEADERS(openssl/conf.h)
+ 
+-AC_CHECK_HEADERS(attr/xattr.h, , [AC_MSG_ERROR([attr/xattr.h header not found. You need the libattr development package.])])
++AC_CHECK_HEADERS(sys/xattr.h, , [AC_MSG_ERROR([sys/xattr.h header not found. You need the c-library development package.])])
+ AC_CHECK_HEADERS(keyutils.h, , [AC_MSG_ERROR([keyutils.h header not found. You need the libkeyutils development package.])])
+ 
+ #debug support - yes for a while
+diff --git a/packaging/ima-evm-utils.spec b/packaging/ima-evm-utils.spec
+index a11a27a..63388d2 100644
+--- a/packaging/ima-evm-utils.spec
++++ b/packaging/ima-evm-utils.spec
+@@ -11,7 +11,6 @@ BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root
+ BuildRequires:    autoconf
+ BuildRequires:    automake
+ BuildRequires:    openssl-devel
+-BuildRequires:    libattr-devel
+ BuildRequires:    keyutils-libs-devel
+ 
+ %description
+diff --git a/packaging/ima-evm-utils.spec.in b/packaging/ima-evm-utils.spec.in
+index 7ca6c6f..65c32f9 100644
+--- a/packaging/ima-evm-utils.spec.in
++++ b/packaging/ima-evm-utils.spec.in
+@@ -11,7 +11,6 @@ BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root
+ BuildRequires:    autoconf
+ BuildRequires:    automake
+ BuildRequires:    openssl-devel
+-BuildRequires:    libattr-devel
+ BuildRequires:    keyutils-libs-devel
+ 
+ %description
+diff --git a/src/evmctl.c b/src/evmctl.c
+index 2ffee78..3fbcd33 100644
+--- a/src/evmctl.c
++++ b/src/evmctl.c
+@@ -49,7 +49,7 @@
+ #include <stdint.h>
+ #include <string.h>
+ #include <dirent.h>
+-#include <attr/xattr.h>
++#include <sys/xattr.h>
+ #include <linux/xattr.h>
+ #include <getopt.h>
+ #include <keyutils.h>


### PR DESCRIPTION
###### Motivation for this change

Fix build for release 19.03 by applying upstream patch. (In context of https://github.com/NixOS/nixpkgs/issues/53716)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

