### PR TITLE
zathura: 0.4.1 -> 0.4.3, new features and plugin

### DIFF
--- a/pkgs/applications/misc/zathura/cb/default.nix
+++ b/pkgs/applications/misc/zathura/cb/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, lib, fetchurl, meson, ninja, pkgconfig, zathura_core
+, girara, gettext, libarchive }:
+
+stdenv.mkDerivation rec {
+  name = "zathura-cb-${version}";
+  version = "0.1.8";
+
+  src = fetchurl {
+    url = "https://pwmt.org/projects/zathura/plugins/download/${name}.tar.xz";
+    sha256 = "1i6cf0vks501cggwvfsl6qb7mdaf3sszdymphimfvnspw810faj5";
+  };
+
+  nativeBuildInputs = [ meson ninja pkgconfig gettext ];
+  buildInputs = [ libarchive zathura_core girara ];
+
+  PKG_CONFIG_ZATHURA_PLUGINDIR = "lib/zathura";
+
+  meta = with lib; {
+    homepage = https://pwmt.org/projects/zathura-cb/;
+    description = "A zathura CB plugin";
+    longDescription = ''
+      The zathura-cb plugin adds comic book support to zathura.
+      '';
+    license = licenses.zlib;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ jlesquembre ];
+  };
+}

--- a/pkgs/applications/misc/zathura/core/default.nix
+++ b/pkgs/applications/misc/zathura/core/default.nix
@@ -2,6 +2,7 @@
 , appstream-glib, desktop-file-utils, python3
 , gtk, girara, gettext, libxml2
 , sqlite, glib, texlive, libintl, libseccomp
+, file, librsvg
 , gtk-mac-integration, synctexSupport ? true
 }:
 
@@ -11,14 +12,24 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "zathura-core-${version}";
-  version = "0.4.1";
+  version = "0.4.3";
 
   src = fetchurl {
     url = "https://pwmt.org/projects/zathura/download/zathura-${version}.tar.xz";
-    sha256 = "1znr3psqda06xklzj8mn452w908llapcg1rj468jwpg0wzv6pxfn";
+    sha256 = "0hgx5x09i6d0z45llzdmh4l348fxh1y102sb1w76f2fp4r21j4ky";
   };
 
   outputs = [ "bin" "man" "dev" "out" ];
+
+  # Flag list:
+  # https://github.com/pwmt/zathura/blob/master/meson_options.txt
+  mesonFlags = [
+    "-Dsqlite=enabled"
+    "-Dmagic=enabled"
+    # "-Dseccomp=enabled"
+    "-Dmanpages=enabled"
+    "-Dconvert-icon=enabled"
+  ] ++ optional synctexSupport "-Dsynctex=enabled";
 
   nativeBuildInputs = [
     meson ninja pkgconfig appstream-glib desktop-file-utils python3.pkgs.sphinx
@@ -27,7 +38,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     gtk girara libintl libseccomp
-    sqlite glib
+    sqlite glib file librsvg
   ] ++ optional synctexSupport texlive.bin.core
     ++ optional stdenv.isDarwin [ gtk-mac-integration ];
 

--- a/pkgs/applications/misc/zathura/default.nix
+++ b/pkgs/applications/misc/zathura/default.nix
@@ -20,10 +20,13 @@ let
 
     zathura_ps = callPackage ./ps { };
 
+    zathura_cb = callPackage ./cb { };
+
     zathuraWrapper = callPackage ./wrapper.nix {
       plugins = [
         zathura_djvu
         zathura_ps
+        zathura_cb
         (if useMupdf then zathura_pdf_mupdf else zathura_pdf_poppler)
       ];
     };


### PR DESCRIPTION
Update to 0.4.3, compile it with more features and add CB plugin

###### Motivation for this change
Update to 0.4.3, add the [CB plugin](https://pwmt.org/projects/zathura-cb/) and compile it with more features. I think many of the features (e.g. sqlite and manpages) where before enabled by default, but in newer releases zathura is using meson and making the features more configurable.

I commented the seccomp feature because if enabled, zathura returns an error when you try to open a link (it uses xdg-open). Not sure how to fix it, nor what seccomp does.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

