### PR TITLE
Fixes to a few Go packages

### DIFF
--- a/pkgs/applications/version-management/gitlab/gitlab-shell/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-shell/default.nix
@@ -13,11 +13,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ruby bundler go ];
 
-  GOCACHE="$TMPDIR/go-cache";
-
   patches = [ ./remove-hardcoded-locations.patch ];
 
   installPhase = ''
+    export GOCACHE="$TMPDIR/go-cache"
+
     ruby bin/compile
     mkdir -p $out/
     cp -R . $out/

--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -94,13 +94,14 @@ rec {
 
     dontStrip = true;
 
-    buildPhase = (optionalString (stdenv.isLinux) ''
+    buildPhase = ''
+      export GOCACHE="$TMPDIR/go-cache"
+    '' + (optionalString (stdenv.isLinux) ''
       # build engine
       cd ./components/engine
       export AUTO_GOPATH=1
       export DOCKER_GITCOMMIT="${rev}"
       export VERSION="${version}"
-      export GOCACHE="$TMPDIR/go-cache"
       ./hack/make.sh dynbinary
       cd -
     '') + ''

--- a/pkgs/desktops/deepin/go-dbus-generator/default.nix
+++ b/pkgs/desktops/deepin/go-dbus-generator/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   makeFlags = [
     "PREFIX=$(out)"
-    "GOCACHE=$TMPDIR/go-cache"
+    "GOCACHE=$(TMPDIR)/go-cache"
   ];
 
   passthru.updateScript = deepin.updateScript { inherit name; };

--- a/pkgs/desktops/deepin/go-gir-generator/default.nix
+++ b/pkgs/desktops/deepin/go-gir-generator/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
 
   makeFlags = [
     "PREFIX=$(out)"
-    "GOCACHE=$TMPDIR/go-cache"
+    "GOCACHE=$(TMPDIR)/go-cache"
   ];
 
   passthru.updateScript = deepin.updateScript { inherit name; };

--- a/pkgs/development/libraries/boringssl/default.nix
+++ b/pkgs/development/libraries/boringssl/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
   NIX_CFLAGS_COMPILE = "-Wno-error";
 
-  GOCACHE="$TMPDIR/go-cache";
+  makeFlags = [ "GOCACHE=$(TMPDIR)/go-cache" ];
 
   installPhase = ''
     mkdir -p $out/bin $out/include $out/lib

--- a/pkgs/servers/monitoring/cadvisor/default.nix
+++ b/pkgs/servers/monitoring/cadvisor/default.nix
@@ -13,9 +13,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ go ];
 
-  GOCACHE="$TMPDIR/go-cache";
-
   buildPhase = ''
+    export GOCACHE="$TMPDIR/go-cache"
     mkdir -p Godeps/_workspace/src/github.com/google/
     ln -s $(pwd) Godeps/_workspace/src/github.com/google/cadvisor
     GOPATH=$(pwd)/Godeps/_workspace go build -v -o cadvisor github.com/google/cadvisor

--- a/pkgs/tools/security/vault/default.nix
+++ b/pkgs/tools/security/vault/default.nix
@@ -13,8 +13,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ go gox removeReferencesTo ];
 
-  GOCACHE="$TMPDIR/go-cache";
-
   preBuild = ''
     patchShebangs ./
     substituteInPlace scripts/build.sh --replace 'git rev-parse HEAD' 'echo ${src.rev}'
@@ -24,6 +22,7 @@ stdenv.mkDerivation rec {
     ln -s $(pwd) src/github.com/hashicorp/vault
 
     export GOPATH=$(pwd)
+    export GOCACHE="$TMPDIR/go-cache"
   '';
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

In 6ef04cabd4913ebeb9339dda50760b0979eff145, the fix was missed for Darwin, and some other packages had the wrong GOCACHE value, working but wrong.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

