### PR TITLE
zathura-core: 0.4.1 -> 0.4.3, zathura-cb: init at 0.1.8 and refactoring

### DIFF
--- a/pkgs/applications/misc/zathura/cb/default.nix
+++ b/pkgs/applications/misc/zathura/cb/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, lib, fetchurl, meson, ninja, pkgconfig, zathura_core, girara, libarchive, gettext }:
+
+stdenv.mkDerivation rec {
+  name = "zathura-cb-0.1.8";
+
+  src = fetchurl {
+    url = "https://pwmt.org/projects/zathura/plugins/download/${name}.tar.xz";
+    sha256 = "1i6cf0vks501cggwvfsl6qb7mdaf3sszdymphimfvnspw810faj5";
+  };
+
+  nativeBuildInputs = [ meson ninja pkgconfig gettext ];
+  buildInputs = [ libarchive zathura_core girara ];
+
+  PKG_CONFIG_ZATHURA_PLUGINDIR = "lib/zathura";
+
+  meta = with lib; {
+    homepage = https://pwmt.org/projects/zathura-cb/;
+    description = "A zathura CB plugin";
+    longDescription = ''
+      The zathura-cb plugin adds comic book support to zathura.
+      '';
+    license = licenses.zlib;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ geistesk ];
+  };
+}
+

--- a/pkgs/applications/misc/zathura/core/default.nix
+++ b/pkgs/applications/misc/zathura/core/default.nix
@@ -11,14 +11,16 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "zathura-core-${version}";
-  version = "0.4.1";
+  version = "0.4.3";
 
   src = fetchurl {
     url = "https://pwmt.org/projects/zathura/download/zathura-${version}.tar.xz";
-    sha256 = "1znr3psqda06xklzj8mn452w908llapcg1rj468jwpg0wzv6pxfn";
+    sha256 = "0hgx5x09i6d0z45llzdmh4l348fxh1y102sb1w76f2fp4r21j4ky";
   };
 
   outputs = [ "bin" "man" "dev" "out" ];
+
+  mesonFlags = [ "-Dmanpages=enabled" ];
 
   nativeBuildInputs = [
     meson ninja pkgconfig appstream-glib desktop-file-utils python3.pkgs.sphinx

--- a/pkgs/applications/misc/zathura/default.nix
+++ b/pkgs/applications/misc/zathura/default.nix
@@ -12,16 +12,19 @@ let
       inherit synctexSupport;
     };
 
-    zathura_pdf_poppler = callPackage ./pdf-poppler { };
+    zathura_cb = callPackage ./cb { };
+
+    zathura_djvu = callPackage ./djvu { };
 
     zathura_pdf_mupdf = callPackage ./pdf-mupdf { };
 
-    zathura_djvu = callPackage ./djvu { };
+    zathura_pdf_poppler = callPackage ./pdf-poppler { };
 
     zathura_ps = callPackage ./ps { };
 
     zathuraWrapper = callPackage ./wrapper.nix {
       plugins = [
+        zathura_cb
         zathura_djvu
         zathura_ps
         (if useMupdf then zathura_pdf_mupdf else zathura_pdf_poppler)

--- a/pkgs/applications/misc/zathura/pdf-mupdf/default.nix
+++ b/pkgs/applications/misc/zathura/pdf-mupdf/default.nix
@@ -5,16 +5,9 @@ stdenv.mkDerivation rec {
   version = "0.3.4";
   name = "zathura-pdf-mupdf-${version}";
 
-  # pwmt.org server was down at the time of last update
-  # src = fetchurl {
-  #   url = "https://pwmt.org/projects/zathura-pdf-mupdf/download/${name}.tar.xz";
-  #   sha256 = "1zbaqimav4wfgimpy3nfzl10qj7vyv23rdy2z5z7z93jwbp2rc2j";
-  # };
-  src = fetchFromGitHub {
-    owner = "pwmt";
-    repo = "zathura-pdf-mupdf";
-    rev = version;
-    sha256 = "1m4w4jrybpjmx6pi33a5saxzmfd8rrym2k13jpd1fv543s17d9dy";
+  src = fetchurl {
+    url = "https://pwmt.org/projects/zathura-pdf-mupdf/download/${name}.tar.xz";
+    sha256 = "166d5nz47ixzwj4pixsd5fd9qvjf5v34cdqi3p72vr23pswk2hyn";
   };
 
   nativeBuildInputs = [ meson ninja pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change
This PR introduces some changes regarding the `zathura` document viewer.

- `zathura-core` was updated to 0.4.3
- `zathura-cb` was added at version 0.1.8 to add comic book support
- `zathura-pdf-mupdf`'s `src` was changed back to `zathura`'s official URL

Each change is in its own commit.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

