### PR TITLE
nixos/gitlab fix tar.gz and tar.bz2 archive download 

### DIFF
--- a/nixos/modules/services/misc/gitlab.nix
+++ b/nixos/modules/services/misc/gitlab.nix
@@ -515,6 +515,8 @@ in {
         gitAndTools.git
         cfg.packages.gitaly.rubyEnv
         cfg.packages.gitaly.rubyEnv.wrappedRuby
+        gzip
+        bzip2
       ];
       serviceConfig = {
         Type = "simple";

--- a/nixos/tests/gitlab.nix
+++ b/nixos/tests/gitlab.nix
@@ -1,5 +1,8 @@
 # This test runs gitlab and checks if it works
 
+let
+  initialRootPassword = "notproduction";
+in
 import ./make-test.nix ({ pkgs, lib, ...} : with lib; {
   name = "gitlab";
   meta = with pkgs.stdenv.lib.maintainers; {
@@ -27,7 +30,7 @@ import ./make-test.nix ({ pkgs, lib, ...} : with lib; {
       services.gitlab = {
         enable = true;
         databasePassword = "dbPassword";
-        initialRootPassword = "notproduction";
+        inherit initialRootPassword;
         smtp.enable = true;
         secrets = {
           secret = "secret";
@@ -69,7 +72,27 @@ import ./make-test.nix ({ pkgs, lib, ...} : with lib; {
     };
   };
 
-  testScript = ''
+  testScript =
+  let
+    auth = pkgs.writeText "auth.json" (builtins.toJSON {
+      grant_type = "password";
+      username = "root";
+      password = initialRootPassword;
+    });
+
+    createProject = pkgs.writeText "create-project.json" (builtins.toJSON {
+      name = "test";
+    });
+
+    putFile = pkgs.writeText "put-file.json" (builtins.toJSON {
+      branch = "master";
+      author_email = "author@example.com";
+      author_name = "Firstname Lastname";
+      content = "some content";
+      commit_message = "create a new file";
+    });
+  in
+  ''
     $gitlab->start();
     $gitlab->waitForUnit("gitaly.service");
     $gitlab->waitForUnit("gitlab-workhorse.service");
@@ -78,6 +101,13 @@ import ./make-test.nix ({ pkgs, lib, ...} : with lib; {
     $gitlab->waitForFile("/var/gitlab/state/tmp/sockets/gitlab.socket");
     $gitlab->waitUntilSucceeds("curl -sSf http://gitlab/users/sign_in");
     $gitlab->succeed("curl -isSf http://gitlab  | grep -i location | grep -q http://gitlab/users/sign_in");
-    $gitlab->succeed("${pkgs.sudo}/bin/sudo -u gitlab -H gitlab-rake gitlab:check 1>&2")
+    $gitlab->succeed("${pkgs.sudo}/bin/sudo -u gitlab -H gitlab-rake gitlab:check 1>&2");
+    $gitlab->succeed("echo \"Authorization: Bearer \$(curl -X POST -H 'Content-Type: application/json' -d @${auth} http://gitlab/oauth/token | ${pkgs.jq}/bin/jq -r '.access_token')\" >/tmp/headers");
+    $gitlab->succeed("curl -X POST -H 'Content-Type: application/json' -H @/tmp/headers -d @${createProject} http://gitlab/api/v4/projects");
+    $gitlab->succeed("curl -X POST -H 'Content-Type: application/json' -H @/tmp/headers -d @${putFile} http://gitlab/api/v4/projects/1/repository/files/some-file.txt");
+    $gitlab->succeed("curl -H @/tmp/headers http://gitlab/api/v4/projects/1/repository/archive.tar.gz > /tmp/archive.tar.gz");
+    $gitlab->succeed("curl -H @/tmp/headers http://gitlab/api/v4/projects/1/repository/archive.tar.bz2 > /tmp/archive.tar.bz2");
+    $gitlab->succeed("test -s /tmp/archive.tar.gz");
+    $gitlab->succeed("test -s /tmp/archive.tar.bz2");
   '';
 })


### PR DESCRIPTION
###### Motivation for this change
Download of either tar.gz or tar.bz2 archives from any repository fails, because gitaly needs gzip and bzip2 on PATH.

00f7b11 extends the gitlab nixos test to verify downloads of tar.gz and tar.bz2 archives
9376f1d adds the two missing packages to gitaly path

@GrahamcOfBorg test gitlab
cc @globin for review.

Please cherry-pick this to 19.03.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
