### PR TITLE
nfdump: 1.6.16 -> 1.6.17

### DIFF
--- a/pkgs/tools/networking/nfdump/default.nix
+++ b/pkgs/tools/networking/nfdump/default.nix
@@ -1,19 +1,33 @@
-{ stdenv, fetchFromGitHub, bzip2, yacc, flex }:
+{ stdenv, fetchFromGitHub
+, autoconf, automake, libtool, pkg-config
+, bzip2, libpcap, flex, yacc }:
 
-let version = "1.6.16"; in
+let version = "1.6.17"; in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   name = "nfdump-${version}";
 
   src = fetchFromGitHub {
     owner = "phaag";
     repo = "nfdump";
     rev = "v${version}";
-    sha256 = "0dgrzf9m4rg5ygibjw21gjdm9am3570wys7wdh5k16nsnyai1gqm";
+    sha256 = "1z8zpvd9jfi2raafcbkykw55y0hd4mp74jvna19h3k0g86mqkxya";
   };
 
-  nativeBuildInputs = [yacc flex];
-  buildInputs = [bzip2];
+  nativeBuildInputs = [ autoconf automake flex libtool pkg-config yacc ];
+  buildInputs = [ bzip2 libpcap ];
+
+  preConfigure = ''
+    patchShebangs autogen.sh
+    LIBTOOLIZE=libtoolize ./autogen.sh
+  '';
+
+  configureFlags = [
+    "--enable-nsel"
+    "--enable-sflow"
+    "--enable-readpcap"
+    "--enable-nfpcapd"
+  ];
 
   meta = with stdenv.lib; {
     description = "Tools for working with netflow data";

--- a/pkgs/tools/networking/nfdump/default.nix
+++ b/pkgs/tools/networking/nfdump/default.nix
@@ -18,7 +18,8 @@ stdenv.mkDerivation {
   buildInputs = [ bzip2 libpcap ];
 
   preConfigure = ''
-    patchShebangs autogen.sh
+    # The script defaults to glibtoolize on darwin, so we pass the correct
+    # name explicitly.
     LIBTOOLIZE=libtoolize ./autogen.sh
   '';
 


### PR DESCRIPTION


###### Motivation for this change


###### Things done
Also enabled the build of a few additional tools.
Closure size increases from 33.8M to 35.0M.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

