### PR TITLE
Teradici PCoIP Client: init at 3.9.0~dev11

### DIFF
--- a/pkgs/applications/networking/remote/teradici-pcoip-client/default.nix
+++ b/pkgs/applications/networking/remote/teradici-pcoip-client/default.nix
@@ -1,0 +1,88 @@
+{ stdenv, fetchurl, makeWrapper, file, boost165, protobuf3_0, openssl_1_1, icu58, glib, xorg, libGL, libpulseaudio, qt56 }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${builtins.replaceStrings ["~"] ["-"] version}";
+  pname = "teradici-pcoip-client";
+  version = "3.9.0~dev11";
+
+  src = fetchurl {
+    inherit name;
+    url = "https://downloads.teradici.com/ubuntu/pool/non-free/p/pcoip-client/pcoip-client_${version}-18.04_amd64.deb";
+    sha256 = "01yx8x7pk6s4nvkb5v62s7ixgqc3s44g5kqgzzr0xwzijgvhkw8j";
+  };
+
+  unpackPhase = ''
+    ar x $src
+    tar xf data.tar.*
+  '';
+
+  nativeBuildInputs = [ makeWrapper file ];
+
+  dontBuild = true;
+
+  libPath = stdenv.lib.makeLibraryPath [
+    boost165
+    glib
+    libGL
+    libpulseaudio
+    openssl_1_1
+    protobuf3_0
+    icu58
+    stdenv.cc.cc
+    xorg.libX11
+    qt56.qtbase
+    qt56.qtx11extras
+    # qt56.qtdeclarative
+    qt56.qtxmlpatterns
+    qt56.qtscript
+  ];
+
+  installPhase = ''
+    lib_dir=usr/lib/x86_64-linux-gnu/pcoip-client
+
+    # Get rid of vendored dependencies:
+    # =================================
+
+    # We get this one from icu58
+    rm -v $lib_dir/libicu*
+
+    # This one we keep because we don't know how to build it (see https://stackoverflow.com/questions/55071459/how-can-i-build-libqt5declarative-so):
+    mv $lib_dir/libQt5Declarative.so.* usr/lib
+
+    # The other QT ones we've got:
+    rm -rv $lib_dir/libQt5*
+
+    # The QT plugings we've got as well, thanks to the wrapper setting QT_PLUGIN_PATH below:
+    rm -rv $lib_dir/plugins
+
+    # The rest appears to be actual Teradici stuff:
+    mv -v $lib_dir/* usr/lib
+    rm -rv usr/lib/x86_64-linux-gnu
+
+    mv -v usr/libexec/pcoip-client/pcoip-client usr/bin/pcoip-client
+    mkdir -p $out
+    mv -v usr/bin usr/sbin usr/lib usr/share $out
+
+    patchelf \
+      --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+      $out/bin/pcoip-client
+
+    find $out -type f -exec file {} \; |
+      grep 'ELF.*shared object' |
+      cut -f 1 -d : |
+      xargs -d '\n' -n 1 -t -I {} patchelf \
+        --set-rpath "$out/lib:$libPath" {}
+
+    wrapProgram $out/bin/pcoip-client --set QT_PLUGIN_PATH ${qt56.qtbase}/lib/qt-5.6/plugins
+  '';
+
+  dontStrip = true;
+
+  meta = with stdenv.lib; {
+    homepage = http://www.teradici.com/web-help/pcoip_client/linux/3.8.1/installation/installing_the_client_overview/;
+    license = licenses.unfree;
+    description = "Teradici PCoIP Software Client (compatible with Amazon Workspaces)";
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ obadz ];
+  };
+}

--- a/pkgs/development/libraries/protobuf/3.0.nix
+++ b/pkgs/development/libraries/protobuf/3.0.nix
@@ -1,0 +1,6 @@
+{ callPackage, ... }:
+
+callPackage ./generic-v3.nix {
+  version = "3.0.2";
+  sha256 = "16wmr1fgdqpf84fkq90cxvccfsxx7h0q0wzqkbg8vdjmka412g09";
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7582,6 +7582,8 @@ in
 
   tbb = callPackage ../development/libraries/tbb { };
 
+  teradici_pcoip_client = callPackage ../applications/networking/remote/teradici-pcoip-client { };
+
   terra = callPackage ../development/compilers/terra {
     llvmPackages = llvmPackages_38 // {
       llvm = llvmPackages_38.llvm.override { enableSharedLibraries = false; };
@@ -12045,6 +12047,7 @@ in
   protobuf3_5 = callPackage ../development/libraries/protobuf/3.5.nix { };
   protobuf3_4 = callPackage ../development/libraries/protobuf/3.4.nix { };
   protobuf3_1 = callPackage ../development/libraries/protobuf/3.1.nix { };
+  protobuf3_0 = callPackage ../development/libraries/protobuf/3.0.nix { };
   protobuf2_5 = callPackage ../development/libraries/protobuf/2.5.nix { };
 
   protobufc = callPackage ../development/libraries/protobufc/1.3.nix { };


### PR DESCRIPTION
Two issues:
1. I could not "unvendor" `libQt5Declarative.so.5.6.3` as I can't find it in any Nix package (see https://stackoverflow.com/questions/55071459/how-can-i-build-libqt5declarative-so) cc: @ttuegel @acowley
2. I cannot actually connect to an Amazon Workspace as I get this error: "The message is missing some content" (see https://communities.teradici.com/questions/10133/error-message-on-ubuntu-1604.html?childToView=10746#answer-10746)

Other than that, it's ready to roll :-)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

