### PR TITLE
nixos-rebuild: elevate privileges when necessary

### DIFF
--- a/nixos/modules/installer/tools/nixos-rebuild.sh
+++ b/nixos/modules/installer/tools/nixos-rebuild.sh
@@ -97,6 +97,20 @@ while [ "$#" -gt 0 ]; do
 done
 
 
+# if necessary, request elevated privileges early on
+if [ "$action" = switch -o "$action" = boot -o "$action" = test -o "$upgrade" = 1 ]; then
+    if [ $EUID != 0 ]; then
+    	if [ -x "$(which sudo 2>/dev/null)" ]; then
+            sudo "$0" "$origArgs"
+            exit $?
+        else
+        	su root -c "$0 $origArgs"
+        	exit $?
+        fi
+    fi
+fi
+
+
 if [ -z "$buildHost" -a -n "$targetHost" ]; then
     buildHost="$targetHost"
 fi


### PR DESCRIPTION
###### Motivation for this change
Currently, if nixos-rebuild is not run as root, it fails when nearly complete.

This is both not an efficient use of the user's time [1] and confusing to new users [2].

[1] since users don't know there is a problem until the very end
[2] since the paths in the error message may be really long, "Permission denied" can be hard to find

This is a typical error message printed when nixos-rebuild is run as non-root:
```
error: creating symlink from '/nix/var/nix/profiles/.0_system' to 'system-58-link': Permission denied
```

###### Things done


Following the style of the current error message, my pull request makes nixos-rebuild echo the following to stderr when run as non-root:
```
error: Permission denied. Try running nixos-rebuild as root.
```

I made `error` bold red because that's how error messages are printed by the original code.

The inclusion of "permission denied" in the error message should cater to advanced linux users skimming for the phrase, while the latter portion of the error message explains how to resolve the issue.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I don't know how to build the script using Nix, but I have tested the script manually using both bash and sh.
