### PR TITLE
nixos: better support for logitech devices and update relevant packages

### DIFF
--- a/nixos/modules/hardware/logitech.nix
+++ b/nixos/modules/hardware/logitech.nix
@@ -1,0 +1,28 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.hardware.logitech;
+
+in {
+  options.hardware.logitech = {
+    enable = mkEnableOption "Logitech Devices";
+
+    enableGraphical = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Enable graphical support applications.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [
+      pkgs.ltunify
+    ] ++ lib.optional cfg.enableGraphical pkgs.solaar;
+
+    # ltunifi and solaar both provide udev rules but the most up-to-date have been split
+    # out into a dedicated derivation
+    services.udev.packages = with pkgs; [ logitech-udev-rules ];
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -45,6 +45,7 @@
   ./hardware/sensor/iio.nix
   ./hardware/ksm.nix
   ./hardware/ledger.nix
+  ./hardware/logitech.nix
   ./hardware/mcelog.nix
   ./hardware/network/b43.nix
   ./hardware/nitrokey.nix

--- a/pkgs/applications/misc/solaar/default.nix
+++ b/pkgs/applications/misc/solaar/default.nix
@@ -1,5 +1,9 @@
-{fetchFromGitHub, stdenv, gtk3, pythonPackages, gobject-introspection}:
-pythonPackages.buildPythonApplication rec {
+{ fetchFromGitHub, lib, gobject-introspection, gtk3, python3Packages }:
+
+# Although we copy in the udev rules here, you probably just want to use logitech-udev-rules instead of
+# adding this to services.udev.packages on NixOS
+
+python3Packages.buildPythonApplication rec {
   pname = "solaar-unstable";
   version = "2019-01-30";
 
@@ -10,7 +14,8 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "0xg181xcwzzs8pdqvjrkjyaaga7ir93hzjvd17j9g3ns8xfj2mvr";
   };
 
-  propagatedBuildInputs = [pythonPackages.pygobject3 pythonPackages.pyudev gobject-introspection gtk3];
+  propagatedBuildInputs = with python3Packages; [ gobject-introspection gtk3 pygobject3 pyudev ];
+
   postInstall = ''
     wrapProgram "$out/bin/solaar" \
       --prefix PYTHONPATH : "$PYTHONPATH" \
@@ -19,12 +24,12 @@ pythonPackages.buildPythonApplication rec {
       --prefix PYTHONPATH : "$PYTHONPATH" \
       --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH"
 
-    mkdir -p $out/lib/udev/rules.d
-    cp rules.d/*.rules $out/lib/udev/rules.d/
+    install -Dm644 -t $out/etc/udev/rules.d rules.d/*.rules
   '';
 
   enableParallelBuilding = true;
-  meta = with stdenv.lib; {
+
+  meta = with lib; {
     description = "Linux devices manager for the Logitech Unifying Receiver";
     longDescription = ''
       Solaar is a Linux device manager for Logitech’s Unifying Receiver
@@ -40,6 +45,6 @@ pythonPackages.buildPythonApplication rec {
     license = licenses.gpl2;
     homepage = https://pwr.github.io/Solaar/;
     platforms = platforms.linux;
-    maintainers = [maintainers.spinus maintainers.ysndr];
+    maintainers = with maintainers; [ spinus ysndr ];
   };
 }

--- a/pkgs/development/python-modules/xcffib/default.nix
+++ b/pkgs/development/python-modules/xcffib/default.nix
@@ -7,12 +7,12 @@
 }:
 
 buildPythonPackage rec {
-  version = "0.6.0";
+  version = "0.7.0";
   pname = "xcffib";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "36142cb72535933e8e1ed39ff2c45559fa7038823bd6be6961ef8ee5bb0f6912";
+    sha256 = "12yc2r8967hknk829q1lbsw6b9z7qa25y8dx8kz6c9qnlc215vb8";
   };
 
   patchPhase = ''

--- a/pkgs/os-specific/linux/logitech-udev-rules/default.nix
+++ b/pkgs/os-specific/linux/logitech-udev-rules/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, solaar }:
+
+# ltunifi and solaar both provide udev rules but solaar's rules are more
+# up-to-date so we simply use that instead of having to maintain our own rules
+
+stdenv.mkDerivation rec {
+  name = "logitech-udev-rules-${version}";
+  inherit (solaar) version;
+
+  buildCommand = ''
+    install -Dm644 -t $out/etc/udev/rules.d ${solaar.src}/rules.d/*.rules
+  '';
+
+  meta = with stdenv.lib; {
+    description = "udev rules for Logitech devices";
+    inherit (solaar.meta) homepage license platforms;
+    maintainers = with maintainers; [ peterhoeg ];
+  };
+}

--- a/pkgs/tools/misc/ltunify/default.nix
+++ b/pkgs/tools/misc/ltunify/default.nix
@@ -1,12 +1,17 @@
-{ stdenv, fetchgit }:
+{ stdenv, fetchFromGitHub }:
+
+# Although we copy in the udev rules here, you probably just want to use logitech-udev-rules instead of
+# adding this to services.udev.packages on NixOS
 
 stdenv.mkDerivation rec {
-  name = "ltunify-20140331";
+  name = "ltunify-${version}";
+  version = "unstable-20180330";
 
-  src = fetchgit {
-    url = "https://git.lekensteyn.nl/ltunify.git";
-    rev = "c3a263ff97bcd31e96abbfed33d066f8d2778f58";
-    sha256 = "04g7mmljkx8643k53yd9x4k2ndrr98w7fbq10qn8ll6didkph3v8";
+  src = fetchFromGitHub {
+    owner  = "Lekensteyn";
+    repo   = "ltunify";
+    rev    = "f664d1d41d5c4beeac5b81e485c3498f13109db7";
+    sha256 = "07sqhih9jmm7vgiwqsjzihd307cj7l096sxjl25p7nwr1q4180wv";
   };
 
   makeFlags = [ "DESTDIR=$(out)" "bindir=/bin" ];
@@ -15,7 +20,7 @@ stdenv.mkDerivation rec {
     description = "Tool for working with Logitech Unifying receivers and devices";
     homepage = https://lekensteyn.nl/logitech-unifying.html;
     license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ abbradar ];
     platforms = platforms.linux;
-    maintainers = [ maintainers.abbradar ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15777,6 +15777,8 @@ in
 
   lobster-two = callPackage ../data/fonts/lobster-two {};
 
+  logitech-udev-rules = callPackage ../os-specific/linux/logitech-udev-rules {};
+
   # lohit-fonts.assamese lohit-fonts.bengali lohit-fonts.devanagari lohit-fonts.gujarati lohit-fonts.gurmukhi
   # lohit-fonts.kannada lohit-fonts.malayalam lohit-fonts.marathi lohit-fonts.nepali lohit-fonts.odia
   # lohit-fonts.tamil-classical lohit-fonts.tamil lohit-fonts.telugu


### PR DESCRIPTION
###### Motivation for this change

I got a new mouse that solaar didn't detect properly so here are updates to ```ltunify``` and ```solaar``` as well as a super basic NixOS module that configures the udev rules.

Cc: @spinus @ysndr @abbradar 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

