### PR TITLE
coreutils: 8.30 -> 8.31, touchups

### DIFF
--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -16,37 +16,41 @@ assert selinuxSupport -> libselinux != null && libsepol != null;
 with lib;
 
 stdenv.mkDerivation rec {
-  name = "coreutils-8.30";
+  pname = "coreutils";
+  version = "8.31";
 
   src = fetchurl {
-    url = "mirror://gnu/coreutils/${name}.tar.xz";
-    sha256 = "0mxhw43d4wpqmvg0l4znk1vm10fy92biyh90lzdnqjcic2lb6cg8";
+    url = "mirror://gnu/${pname}/${pname}-${version}.tar.xz";
+    sha256 = "1zg9m79x1i2nifj4kb0waf9x3i5h6ydkypkjnbsb9rnwis8rqypz";
   };
 
   patches = optional stdenv.hostPlatform.isCygwin ./coreutils-8.23-4.cygwin.patch;
 
   postPatch = ''
     # The test tends to fail on btrfs,f2fs and maybe other unusual filesystems.
-    sed '2i echo Skipping dd sparse test && exit 0' -i ./tests/dd/sparse.sh
-    sed '2i echo Skipping du threshold test && exit 0' -i ./tests/du/threshold.sh
-    sed '2i echo Skipping cp sparse test && exit 0' -i ./tests/cp/sparse.sh
-    sed '2i echo Skipping rm deep-2 test && exit 0' -i ./tests/rm/deep-2.sh
-    sed '2i echo Skipping du long-from-unreadable test && exit 0' -i ./tests/du/long-from-unreadable.sh
+    sed '2i echo Skipping dd sparse test && exit 77' -i ./tests/dd/sparse.sh
+    sed '2i echo Skipping du threshold test && exit 77' -i ./tests/du/threshold.sh
+    sed '2i echo Skipping cp sparse test && exit 77' -i ./tests/cp/sparse.sh
+    sed '2i echo Skipping rm deep-2 test && exit 77' -i ./tests/rm/deep-2.sh
+    sed '2i echo Skipping du long-from-unreadable test && exit 77' -i ./tests/du/long-from-unreadable.sh
 
     # sandbox does not allow setgid
-    sed '2i echo Skipping chmod setgid test && exit 0' -i ./tests/chmod/setgid.sh
+    sed '2i echo Skipping chmod setgid test && exit 77' -i ./tests/chmod/setgid.sh
     substituteInPlace ./tests/install/install-C.sh \
       --replace 'mode3=2755' 'mode3=1755'
 
-    sed '2i print "Skipping env -S test";  exit 0;' -i ./tests/misc/env-S.pl
+    sed '2i print "Skipping env -S test";  exit 77;' -i ./tests/misc/env-S.pl
 
     # these tests fail in the unprivileged nix sandbox (without nix-daemon) as we break posix assumptions
     for f in ./tests/chgrp/{basic.sh,recurse.sh,default-no-deref.sh,no-x.sh,posix-H.sh}; do
-      sed '2i echo Skipping chgrp && exit 0' -i "$f"
+      sed '2i echo Skipping chgrp && exit 77' -i "$f"
     done
     for f in gnulib-tests/{test-chown.c,test-fchownat.c,test-lchown.c}; do
-      echo "int main() { return 0; }" > "$f"
+      echo "int main() { return 77; }" > "$f"
     done
+  '' + optionalString (stdenv.hostPlatform.libc == "musl") ''
+    echo "int main() { return 77; }" > gnulib-tests/test-parse-datetime.c
+    echo "int main() { return 77; }" > gnulib-tests/test-getlogin.c
   '';
 
   outputs = [ "out" "info" ];
@@ -80,7 +84,7 @@ stdenv.mkDerivation rec {
   # and {Open,Free}BSD.
   # With non-standard storeDir: https://github.com/NixOS/nix/issues/512
   doCheck = stdenv.hostPlatform == stdenv.buildPlatform
-    && stdenv.hostPlatform.libc == "glibc"
+    && (stdenv.hostPlatform.libc == "glibc" || stdenv.hostPlatform.isMusl)
     && builtins.storeDir == "/nix/store";
 
   # Prevents attempts of running 'help2man' on cross-built binaries.


### PR DESCRIPTION
###### Motivation for this change

Release notes:

https://savannah.gnu.org/forum/forum.php?forum_id=9394

Touchups:
* enable tests w/musl (disable 2 gnulib tests)
* improve tests we modify: use exit code 77 to
  indicate test skipped (causing it to be reportd as SKIP)

Note: Not yet on mirrors, but can be (manually) fetched from primary

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---