### PR TITLE
scribus: 1.4.7 -> 1.4.8, dep fixups

### DIFF
--- a/pkgs/applications/office/scribus/default.nix
+++ b/pkgs/applications/office/scribus/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, pkgconfig, freetype, lcms, libtiff, libxml2
 , libart_lgpl, qt4, python2, cups, fontconfig, libjpeg
-, zlib, libpng, xorg, cairo, podofo, aspell, boost, cmake, imagemagick }:
+, zlib, libpng, xorg, cairo, podofo, hunspell, boost, cmake, imagemagick, ghostscript }:
 
 let
   icon = fetchurl {
@@ -8,26 +8,34 @@ let
     sha256 = "0hq3i7c2l50445an9glhhg47kj26y16svfajc6naqn307ph9vzc3";
   };
 
-  pythonEnv = python2.withPackages(ps: [ps.tkinter]);
+  pythonEnv = python2.withPackages(ps: [ps.tkinter ps.pillow]);
 in stdenv.mkDerivation rec {
-  name = "scribus-1.4.7";
+  pname = "scribus";
+  version = "1.4.8";
 
   src = fetchurl {
-    url = "mirror://sourceforge/scribus/scribus/${name}.tar.xz";
-    sha256 = "1v2ziq3k0yjz35nk5plcbc1jpi53p9v1cq1z3spch9lwlns3bls2";
+    url = "mirror://sourceforge/${pname}/${pname}/${pname}-${version}.tar.xz";
+    sha256 = "0bq433myw6h1siqlsakxv6ghb002rp3mfz5k12bg68s0k6skn992";
   };
 
   enableParallelBuilding = true;
 
+  nativeBuildInputs = [ pkgconfig cmake ];
   buildInputs = with xorg;
-    [ pkgconfig cmake freetype lcms libtiff libxml2 libart_lgpl qt4
+    [ freetype lcms libtiff libxml2 libart_lgpl qt4
       pythonEnv cups fontconfig
-      libjpeg zlib libpng podofo aspell cairo
+      libjpeg zlib libpng podofo hunspell cairo
       boost # for internal 2geom library
       libXaw libXext libX11 libXtst libXi libXinerama
       libpthreadstubs libXau libXdmcp
       imagemagick # To build the icon
     ];
+
+  postPatch = ''
+    substituteInPlace scribus/util_ghostscript.cpp \
+      --replace 'QString gsName("gs");' \
+                'QString gsName("${ghostscript}/bin/gs");'
+  '';
 
   postInstall = ''
     for i in 16 24 48 64 96 128 256 512; do


### PR DESCRIPTION
###### Motivation for this change

* Needs hunspell not aspell, not sure when
* bake in gs path to avoid warning on launch
* python-pillow for print preview, per README

https://www.scribus.net/scribus-1-4-8-released/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---