### PR TITLE
Revert "nixos/redmine: replace imagemagickBig with imagemagick" (#57078)

### DIFF
--- a/nixos/modules/services/misc/redmine.nix
+++ b/nixos/modules/services/misc/redmine.nix
@@ -266,7 +266,7 @@ in
       environment.REDMINE_LANG = "en";
       environment.SCHEMA = "${cfg.stateDir}/cache/schema.db";
       path = with pkgs; [
-        imagemagick
+        imagemagickBig
         bazaar
         cvs
         darcs


### PR DESCRIPTION
imagemagickBig has been fixed in https://github.com/NixOS/nixpkgs/pull/57313 and can be used again.

cc @Mic92 