### PR TITLE
pius: fix dependencies

### DIFF
--- a/pkgs/tools/security/pius/default.nix
+++ b/pkgs/tools/security/pius/default.nix
@@ -18,7 +18,8 @@ pythonPackages.buildPythonApplication {
     done
   '';
 
-  buildInputs = [ perl ];
+  nativeBuildInputs = [ perl ];
+  propagatedBuildInputs = with pythonPackages; [ six ];
 
   meta = {
     homepage = https://www.phildev.net/pius/;


### PR DESCRIPTION
`perl` needs to be a native build input to ensure that it is
present in `PATH` during the build, allowing `patchShebangs` to
correctly fix the shebang in `pius-party-worksheet`. Previously,
the shebang was left as `/usr/bin/perl` because `perl` could not
be found by `patchShebangs`.

`six` is a required dependency of `pius` and likely should have
been included in the derivation a long time ago, since the `pius`,
`pius-report` and `pius-keyring-mgr` commands are broken without it.
Annoyingly, `pius` still uses `distutils` rather than `setuptools`
which seems to happily install the package without checking that
its dependencies have been installed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - Before 344407416, after 398863960, difference +54456544
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

