### PR TITLE
musly: init at 0.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1765,6 +1765,11 @@
     github = "Gerschtli";
     name = "Tobias Happ";
   };
+  ggpeti = {
+    email = "ggpeti@gmail.com";
+    github = "ggpeti";
+    name = "Peter Ferenczy";
+  };
   gilligan = {
     email = "tobias.pflug@gmail.com";
     github = "gilligan";

--- a/pkgs/applications/audio/musly/default.nix
+++ b/pkgs/applications/audio/musly/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, cmake, eigen, libav_all }:
+stdenv.mkDerivation rec {
+  name = "musly-${version}";
+  version = "0.2";
+  src = fetchFromGitHub {
+    owner = "dominikschnitzer";
+    repo = "musly";
+    rev = "f911eacbbe0b39ebe87cb37d0caef09632fa40d6";
+    sha256 = "1q42wvdwy2pac7bhfraqqj2czw7w2m33ms3ifjl8phm7d87i8825";
+  };
+  buildInputs = [ cmake eigen (libav_all.override { vaapiSupport = stdenv.isLinux; }).libav_11 ];
+  preBuild = ''
+    mkdir build
+    cd build
+    cmake -DCMAKE_INSTALL_PREFIX=$out $src
+  '';
+  fixupPhase = if stdenv.isDarwin then ''
+    install_name_tool -change libmusly.dylib $out/lib/libmusly.dylib $out/bin/musly
+    install_name_tool -change libmusly_resample.dylib $out/lib/libmusly_resample.dylib $out/bin/musly
+    install_name_tool -change libmusly_resample.dylib $out/lib/libmusly_resample.dylib $out/lib/libmusly.dylib
+  '' else "";
+
+  meta = with stdenv.lib; {
+    homepage = http://www.musly.org;
+    description = "A fast and high-quality audio music similarity library written in C/C++";
+    longDescription = ''
+      Musly analyzes the the audio signal of music pieces to estimate their similarity.
+      No meta-data about the music piece is included in the similarity estimation.
+      To use Musly in your application, have a look at the library documentation
+      or try the command line application included in the package and start generating
+      some automatic music playlists right away.
+    '';
+    license = licenses.mit;
+    maintainers = with maintainers; [ ggpeti ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22532,6 +22532,8 @@ in
 
   muse = callPackage ../applications/audio/muse { };
 
+  musly = callPackage ../applications/audio/musly { };
+
   mynewt-newt = callPackage ../tools/package-management/mynewt-newt { };
 
   inherit (callPackage ../tools/package-management/nix {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

