### PR TITLE
citrix_receiver: remove old versions

### DIFF
--- a/pkgs/applications/networking/remote/citrix-receiver/default.nix
+++ b/pkgs/applications/networking/remote/citrix-receiver/default.nix
@@ -38,51 +38,30 @@ let
     };
   });
 
-  versionInfo = {
-    "13.8.0" = {
-      major     = "13";
-      minor     = "8";
-      patch     = "0";
-      x64hash   = "FDF5991CCD52B2B98289D7B2FB46D492D3E4032846D4AFA52CAA0F8AC0578931";
-      x86hash   = "E0CFB43312BF79F753514B11F7B8DE4529823AE4C92D1B01E8A2C34F26AC57E7";
-      x64suffix = "10299729";
-      x86suffix = "10299729";
-      homepage  = https://www.citrix.com/downloads/citrix-receiver/legacy-receiver-for-linux/receiver-for-linux-138.html;
+  versionInfo = let
+    supportedVersions = {
+      "13.10.0" = {
+        major     = "13";
+        minor     = "10";
+        patch     = "0";
+        x64hash   = "7025688C7891374CDA11C92FC0BA2FA8151AEB4C4D31589AD18747FAE943F6EA";
+        x86hash   = "2DCA3C8EDED11C5D824D579BC3A6B7D531EAEDDCBFB16E91B5702C72CAE9DEE4";
+        x64suffix = "20";
+        x86suffix = "20";
+        homepage  = https://www.citrix.com/downloads/citrix-receiver/linux/receiver-for-linux-latest.html;
+      };
     };
 
-    "13.9.0" = {
-      major     = "13";
-      minor     = "9";
-      patch     = "0";
-      x64hash   = "00l18s7i9yky3ddabwljwsf7fx4cjgjn9hfd74j0x1v4gl078nl9";
-      x86hash   = "117fwynpxfnrw98933y8z8v2q4g6ycs1sngvpbki2qj09bjkwmag";
-      x64suffix = "102";
-      x86suffix = "102";
-      homepage  = https://www.citrix.com/downloads/citrix-receiver/linux/receiver-for-linux-latest.html; # This version has disappeared from Citrix's website... *sigh*
-    };
-
-    "13.9.1" = {
-      major     = "13";
-      minor     = "9";
-      patch     = "1";
-      x64hash   = "A9A9157CE8C287E8AA11447A0E3C3AB7C227330E9D8882C6F7B938A4DD5925BC";
-      x86hash   = "A93E9770FD10FDD3586A2D47448559EA037265717A7000B9BD2B1DCCE7B0A483";
-      x64suffix = "6";
-      x86suffix = "6";
-      homepage  = https://www.citrix.com/downloads/citrix-receiver/legacy-receiver-for-linux/receiver-for-linux-1391.html;
-    };
-
-    "13.10.0" = {
-      major     = "13";
-      minor     = "10";
-      patch     = "0";
-      x64hash   = "7025688C7891374CDA11C92FC0BA2FA8151AEB4C4D31589AD18747FAE943F6EA";
-      x86hash   = "2DCA3C8EDED11C5D824D579BC3A6B7D531EAEDDCBFB16E91B5702C72CAE9DEE4";
-      x64suffix = "20";
-      x86suffix = "20";
-      homepage  = https://www.citrix.com/downloads/citrix-receiver/linux/receiver-for-linux-latest.html;
-    };
-  };
+    # break an evaluation for old Citrix versions rather than exiting with
+    # an "attribute name not found" error to avoid confusion.
+    deprecatedVersions = let
+      versions = [ "13.8.0" "13.9.0" "13.9.1" ];
+    in
+      lib.listToAttrs
+        (lib.flip map versions
+          (v: lib.nameValuePair v (throw "Unsupported citrix_receiver version: ${v}")));
+  in
+    deprecatedVersions // supportedVersions;
 
   citrixReceiverForVersion = { major, minor, patch, x86hash, x64hash, x86suffix, x64suffix, homepage }:
     stdenv.mkDerivation rec {


### PR DESCRIPTION
###### Motivation for this change

The versions 13.8.0 and 13.9.{0,1} will be EOLed before the end of 19.03
and should be dropped.
To provide an easy upgrade path, all unsupported versions will throw an
evaluation error. All versions that are about the be EOLed can be added
there as well.

For now, all of those deprecated versions are still referenced in
`all-packages.nix`, but should be removed before the next release.

See also https://www.citrix.co.uk/support/product-lifecycle/milestones/receiver.html

Unless the merger beats me, I'd backport this to 19.03 as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

