### PR TITLE
pgcli: Patch tests

### DIFF
--- a/pkgs/development/tools/database/pgcli/default.nix
+++ b/pkgs/development/tools/database/pgcli/default.nix
@@ -1,4 +1,4 @@
-{ lib, python3Packages, fetchFromGitHub }:
+{ lib, python3Packages, fetchFromGitHub, fetchpatch }:
 
 python3Packages.buildPythonApplication rec {
   pname = "pgcli";
@@ -12,6 +12,16 @@ python3Packages.buildPythonApplication rec {
     inherit pname version;
     sha256 = "1p4j2dbcfxd3kz86qi519jkqjx1mg5wdgn1gxdjx3lk1vpsd7x04";
   };
+
+  patches = [
+    (fetchpatch {
+      # TODO: Remove with next pgcli release. Fixes TypeError in tests
+      # https://github.com/dbcli/pgcli/pull/1006
+      url = https://github.com/dbcli/pgcli/commit/351135b61ef9ad3184c49a406544708daf589fe3.patch;
+      sha256 = "08131y0lv1v760i0ypcx2hljx066ks93kp96xkv3bycxnavvcl53";
+      excludes = [ "changelog.rst" ];
+    })
+  ];
 
   propagatedBuildInputs = with python3Packages; [
     cli-helpers click configobj humanize prompt_toolkit psycopg2


### PR DESCRIPTION
###### Motivation for this change
Patches the tests until the next pgcli release fixes them

Should be backported to 19.03

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

