### PR TITLE
mitmproxy: wsproto and pytest fixes

### DIFF
--- a/pkgs/tools/networking/mitmproxy/default.nix
+++ b/pkgs/tools/networking/mitmproxy/default.nix
@@ -22,6 +22,16 @@ buildPythonPackage rec {
       url = "https://github.com/mitmproxy/mitmproxy/commit/1b6a8d6acd3d70f9b9627ad4ae9def08103f8250.patch";
       sha256 = "03y79c25yir7d8xj79czdc81y3irqq1i3ks9ca0mv1az8b7xsvfv";
     })
+    (fetchpatch {
+      # 0.13 <= wsproto < 0.14 patch
+      # https://github.com/mitmproxy/mitmproxy/issues/3459
+      # TODO: remove on next update
+      name = "wsproto-0.13.patch";
+      url = https://github.com/mitmproxy/mitmproxy/commit/70777a1b6ed64af9cafcdef223a8a260ecc96864.patch;
+      sha256 = "1ddxdr7js510kzyq3gyks4k5k1n8zb1i9amxw7wzmi1dcg8kqw9a";
+      # We strip these bounds anyway
+      excludes = [ "setup.py" ];
+    })
   ];
 
   postPatch = ''

--- a/pkgs/tools/networking/mitmproxy/default.nix
+++ b/pkgs/tools/networking/mitmproxy/default.nix
@@ -32,6 +32,16 @@ buildPythonPackage rec {
       # We strip these bounds anyway
       excludes = [ "setup.py" ];
     })
+    (fetchpatch {
+      # Fix for newer pytest disallowing calling fixtures
+      # https://github.com/mitmproxy/mitmproxy/issues/3403
+      # TODO: remove on next update
+      name = "dont-call-fixtures.patch";
+      url = https://github.com/mitmproxy/mitmproxy/commit/ce28721458c8cc71de86513a5110676e9763041b.patch;
+      sha256 = "05pljr28lx7l1xgswqr9sz8dnhvc7npzh8xg2p9hignf159kd54d";
+      # Irrelevant in nixpkgs
+      excludes = [ "setup.py" "setup.cfg" "release/docker/*" ];
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change
Pull in a few more patches to bring mitmproxy in line with nixpkgs proper until a new release is in.

Needs backport to 19.03

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

