### PR TITLE
pkgs/applespi: add experimental Linux support for MacBook keyboards

### DIFF
--- a/pkgs/os-specific/linux/applespi/default.nix
+++ b/pkgs/os-specific/linux/applespi/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, fetchgit, pkgs }:
+let
+  version = "git";
+  kernel = pkgs.linux;
+in
+stdenv.mkDerivation {
+  name = "applespi-${version}-${kernel.version}";
+
+  src = fetchgit {
+    url = "https://github.com/cb22/macbook12-spi-driver.git";
+    rev = "aeb7ca96eaf7c82418eb967aba5d991a33006899";
+    sha256 = "04hcy8cfm2kdrqs1cyd9s37x4qh5az5vdy477y5lfw2f33rwid1l";
+  };
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  makeFlags = "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
+
+  installPhase = ''
+    install -D -m 755 -t $out/lib/modules/${kernel.version}/kernel/drivers/input/misc/ applespi.ko
+  '';
+
+  meta = {
+    description = "Experimental input driver for the SPI touchpad and keyboard found in some MacBooks";
+    longDescription = ''
+      To have the keyboard enabled during boot add the following to configuration.nix,
+ 
+        boot = {
+          initrd.availableKernelModules = [ "crc16" "spi_pxa2xx_platform" "spi_pxa2xx_pci" "intel_lpss_pci" ];
+          extraModulePackages = with pkgs; [ applespi ];
+          initrd.kernelModules = [ "applespi" ];
+        }
+    '';
+    homepage = https://github.com/cb22/macbook12-spi-driver;
+    license = pkgs.licenses.gpl2;
+    maintainers = [ pkgs.maintainers.krav ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1737,6 +1737,8 @@ in
 
   appleseed = callPackage ../tools/graphics/appleseed { };
 
+  applespi = callPackage ../os-specific/linux/applespi {};
+
   arping = callPackage ../tools/networking/arping { };
 
   arpoison = callPackage ../tools/networking/arpoison { };


### PR DESCRIPTION


###### Motivation for this change
According to https://github.com/Dunedan/mbp-2016-linux#keyboard--touchpad, this adds support for the keyboard and touchpad in MacBookPro1[3,4],[1-3]. Confirmed working on a MacBookPro14,1.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

