### PR TITLE
findnewest: init at 0.3

### DIFF
--- a/pkgs/development/tools/misc/findnewest/default.nix
+++ b/pkgs/development/tools/misc/findnewest/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "0-wiz-0";
-    repo = "findnewest";
+    repo = pname;
     rev = name;
     sha256 = "1x1cbn2b27h5r0ah5xc06fkalfdci2ngrgd4wibxjw0h88h0nvgq";
   };

--- a/pkgs/development/tools/misc/findnewest/default.nix
+++ b/pkgs/development/tools/misc/findnewest/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "1x1cbn2b27h5r0ah5xc06fkalfdci2ngrgd4wibxjw0h88h0nvgq";
   };
 
-  buildInputs = [ autoreconfHook ];
+  nativeBuildInputs = [ autoreconfHook ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/0-wiz-0/findnewest;

--- a/pkgs/development/tools/misc/findnewest/default.nix
+++ b/pkgs/development/tools/misc/findnewest/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchFromGitHub, autoreconfHook }:
+
+stdenv.mkDerivation rec {
+  name = "findnewest-${version}";
+  version = "0.3";
+
+  src = fetchFromGitHub {
+    owner = "0-wiz-0";
+    repo = "findnewest";
+    rev = name;
+    sha256 = "1x1cbn2b27h5r0ah5xc06fkalfdci2ngrgd4wibxjw0h88h0nvgq";
+  };
+
+  buildInputs = [ autoreconfHook ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/0-wiz-0/findnewest;
+    description = "Recursively find newest file in a hierarchy and print its timestamp";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ bhipple ];
+  };
+}

--- a/pkgs/development/tools/misc/findnewest/default.nix
+++ b/pkgs/development/tools/misc/findnewest/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, autoreconfHook }:
 
 stdenv.mkDerivation rec {
-  name = "findnewest-${version}";
+  pname = "findnewest";
   version = "0.3";
 
   src = fetchFromGitHub {

--- a/pkgs/development/tools/misc/findnewest/default.nix
+++ b/pkgs/development/tools/misc/findnewest/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "0-wiz-0";
     repo = pname;
-    rev = name;
+    rev = "${pname}-${version}";
     sha256 = "1x1cbn2b27h5r0ah5xc06fkalfdci2ngrgd4wibxjw0h88h0nvgq";
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8720,6 +8720,8 @@ in
 
   findbugs = callPackage ../development/tools/analysis/findbugs { };
 
+  findnewest = callPackage ../development/tools/misc/findnewest { };
+
   flootty = callPackage ../development/tools/flootty { };
 
   flow = callPackage ../development/tools/analysis/flow {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

