### PR TITLE
cargo-raze: init at 0.2.8

### DIFF
--- a/pkgs/development/tools/rust/cargo-raze/default.nix
+++ b/pkgs/development/tools/rust/cargo-raze/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, rustPlatform
+, pkgconfig, curl, libgit2, openssl, Security }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-raze";
+  version = "0.2.8";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0d87azip59bmkk38par23f5yvb9w8ikvdg6grn689zpgc3di2phx";
+  };
+  sourceRoot = "source/impl";
+
+  cargoSha256 = "06rl7v0f1lgj9ii07fcnaxmhn28ckr03cpf5b93q8ripm5qh7my9";
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ curl libgit2 openssl ]
+    ++ stdenv.lib.optional stdenv.isDarwin Security;
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "Generate Bazel BUILD files from Cargo dependencies";
+    homepage = https://github.com/google/cargo-raze;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ elasticdog ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1944,9 +1944,9 @@ in
     enableExtraPlugins = true;
   });
 
-  asciidoctor = callPackage ../tools/typesetting/asciidoctor { 
+  asciidoctor = callPackage ../tools/typesetting/asciidoctor {
     # kindlegen is unfree, don't enable by default
-    kindlegen = null; 
+    kindlegen = null;
     # epubcheck pulls in Java, which is problematic on some platforms
     epubcheck = null;
   };
@@ -8098,6 +8098,9 @@ in
   cargo-fuzz = callPackage ../development/tools/rust/cargo-fuzz { };
   cargo-inspect = callPackage ../development/tools/rust/cargo-inspect { };
   cargo-make = callPackage ../development/tools/rust/cargo-make {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
+  cargo-raze = callPackage ../development/tools/rust/cargo-raze {
     inherit (darwin.apple_sdk.frameworks) Security;
   };
   cargo-sweep = callPackage ../development/tools/rust/cargo-sweep { };


### PR DESCRIPTION
###### Motivation for this change

I'm working on packaging common tools used to manage multi-language monorepos with Bazel, and this is the current defacto means of generating BUILD files for Rust dependencies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [x] ~~Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~~ **N/A**
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

