### PR TITLE
pytorch: fix CUDA support

### DIFF
--- a/pkgs/development/python-modules/pytorch/default.nix
+++ b/pkgs/development/python-modules/pytorch/default.nix
@@ -79,20 +79,19 @@ in buildPythonPackage rec {
 
   nativeBuildInputs = [
      cmake
+     numpy.blas
      utillinux
      which
-  ];
-
-  buildInputs = [
-     numpy.blas
   ] ++ lib.optionals cudaSupport [ cudatoolkit_joined cudnn ]
     ++ lib.optionals stdenv.isLinux [ numactl ];
 
   propagatedBuildInputs = [
     cffi
+    numpy.blas
     numpy
     pyyaml
-  ] ++ lib.optional (pythonOlder "3.5") typing;
+  ] ++ lib.optional (pythonOlder "3.5") typing
+    ++ lib.optionals cudaSupport [ cudatoolkit_joined cudnn ];
 
   checkInputs = [ hypothesis ];
   checkPhase = ''


### PR DESCRIPTION
This commit fixes CUDA support when building with `allowUnfree = true` and `cudaSupport = true`. The previous change to pytorch.nix
built, but at runtime cuda support didn't work.

This is a work in progress, the test-suite still doesn't find CUDA, so no CUDA-tests are made of the compiled package.
Also the list of packages in `nativeBuildInputs` and `propagatedBuildInputs` are probably wrong, due to a lack of understanding from my side.

###### Motivation for this change

CUDA support didn't work in the previous version.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

