### PR TITLE
pdfgrep: relax platform from linux to unix

### DIFF
--- a/pkgs/tools/typesetting/pdfgrep/default.nix
+++ b/pkgs/tools/typesetting/pdfgrep/default.nix
@@ -23,6 +23,6 @@ stdenv.mkDerivation rec {
     homepage = https://pdfgrep.org/;
     license = stdenv.lib.licenses.gpl2Plus;
     maintainers = with stdenv.lib.maintainers; [ qknight fpletz ];
-    platforms = with stdenv.lib.platforms; linux;
+    platforms = with stdenv.lib.platforms; unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Enable building pdfgrep on additional platforms. I couldn't find a clear statement on platform support, but it did build fine on macos with `allowUnsupportedSystem = true` and saw no issues after a fair amount of use. Close #56541.

###### Things done

Not in a position to clone nixpkgs to a system for further testing at the moment; I'm just making this change via github's online interface.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
