### PR TITLE
kicad: fix #49089 by adding libraries files

### DIFF
--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -5,7 +5,7 @@
 , oceSupport ? true, opencascade
 , ngspiceSupport ? true, libngspice
 , swig, python, pythonPackages
-, lndir, with3DPackages ? false
+, lndir
 }:
 
 assert ngspiceSupport -> libngspice != null;
@@ -93,9 +93,7 @@ in stdenv.mkDerivation rec {
     };
   };
 
-  modules = with passthru;
-    [ i18n symbols footprints templates ]
-    ++ optional with3DPackages packages3d;
+  modules = with passthru; [ i18n symbols footprints templates ];
 
   postInstall = ''
     mkdir -p $out/share

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22031,7 +22031,7 @@ in
     wxGTK = wxGTK30;
     boost = boost160;
   };
-  kicad-with-3dpackages = kicad.override { with3DPackages = true; };
+  kicad-with-packages3d = kicad.override { with3DPackages = true; };
 
   kicad-unstable = python.pkgs.callPackage ../applications/science/electronics/kicad/unstable.nix {
     wxGTK = wxGTK30;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22031,6 +22031,7 @@ in
     wxGTK = wxGTK30;
     boost = boost160;
   };
+  kicad-with-3dpackages = kicad.override { with3DPackages = true; };
 
   kicad-unstable = python.pkgs.callPackage ../applications/science/electronics/kicad/unstable.nix {
     wxGTK = wxGTK30;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22031,7 +22031,7 @@ in
     wxGTK = wxGTK30;
     boost = boost160;
   };
-  kicad-with-packages3d = kicad.override { with3DPackages = true; };
+  kicad-with-packages3d = kicad.overrideAttrs (old: { modules = old.modules ++ [ old.passthru.packages3d ]; });
 
   kicad-unstable = python.pkgs.callPackage ../applications/science/electronics/kicad/unstable.nix {
     wxGTK = wxGTK30;


### PR DESCRIPTION
This splits the KiCad package in several derivations:
- original package
- internationalization package
- templates
- schematic symbols libraries
- PCB footprints libraries
- 3D models libraries

From these derivations, 3 packages are proposed in top level:
- kicad (original package + internationalization)
- kicadWithLibraries (kicad + all libraries except 3D models) because 3D
  models can be heavy (currently 5.1GiB) and potentially unused
- kicadWithLibraries3D (kicad + all libraries)

###### Motivation for this change

KiCad's i18n files and libraries where missing. We needed to download the libraires manually and configure paths in the software. This PR adds them in the package output.

###### Things done

The different top level packages are combined with `symlinkJoin`, which joins two outputs by creating symbolic links.
The advantage is that only one compilation of the main package is needed, as other packages are symlinked to the main one.
The drawback is that, by default, kicad looks for libraries in the `/share` directory of its binary.
Thus I added a wrapper that sets `KICAD_SYMBOL_DIR` and other environment variables to correctly point the libraries. This prevent user to use its own library (but this is still possible by using)

The internationalization works. The menu used to exist, but did not have effect.

I would like to have comments on:
- Is `symlinkJoin` the best approach?
- Is wrapping other binaries than kicad is needed? (e.g if we launch directly eeschema, environment variables will not be set)
- Where should we put the `meta` attribute?
- Is the `top-level.nix` approach correct?

CC @berce (maintener) and @crawford (opened #49089)

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


