### PR TITLE
lightdm_gtk_greeter: cleanup

### DIFF
--- a/pkgs/applications/display-managers/lightdm/gtk-greeter.nix
+++ b/pkgs/applications/display-managers/lightdm/gtk-greeter.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation rec {
   configureFlagsArray = [
     "--localstatedir=/var"
     "--sysconfdir=/etc"
+    "--disable-indicator-services-command"
     "--enable-at-spi-command=${at-spi2-core}/libexec/at-spi-bus-launcher  --launch-immediately"
   ] ++ stdenv.lib.optional useGTK2 "--with-gtk2";
 

--- a/pkgs/applications/display-managers/lightdm/gtk-greeter.nix
+++ b/pkgs/applications/display-managers/lightdm/gtk-greeter.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, lightdm, pkgconfig, intltool
 , hicolor-icon-theme, makeWrapper
 , useGTK2 ? false, gtk2, gtk3 # gtk3 seems better supported
-, exo
+, exo, at-spi2-core
 }:
 
 #ToDo: bad icons with gtk2;
@@ -23,9 +23,10 @@ stdenv.mkDerivation rec {
   buildInputs = [ lightdm exo intltool makeWrapper hicolor-icon-theme ]
     ++ (if useGTK2 then [ gtk2 ] else [ gtk3 ]);
 
-  configureFlags = [
+  configureFlagsArray = [
     "--localstatedir=/var"
     "--sysconfdir=/etc"
+    "--enable-at-spi-command=${at-spi2-core}/libexec/at-spi-bus-launcher  --launch-immediately"
   ] ++ stdenv.lib.optional useGTK2 "--with-gtk2";
 
   NIX_CFLAGS_COMPILE = [ "-Wno-error=deprecated-declarations" ];


### PR DESCRIPTION
###### Motivation for this change
Noticed
```
** (lightdm-gtk-greeter:2775): WARNING **: 14:11:32.333: [PIDs] Failed to execute command: /usr/lib/at-spi2-core/at-spi-bus-launcher

** (lightdm-gtk-greeter:2775): WARNING **: 14:11:32.334: [PIDs] Failed to execute command: upstart
```
in the `/var/log/lightdm/seat0-greeter.log` when using this greeter.

This may fix accessibility features in that particular greeter.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

