### PR TITLE
tds_fdw: init a 1.0.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4464,6 +4464,11 @@
     github = "stesie";
     name = "Stefan Siegl";
   };
+  steve-chavez = {
+    email = "stevechavezast@gmail.com";
+    github = "steve-chavez";
+    name = "Steve Chávez";
+  };
   steveej = {
     email = "mail@stefanjunker.de";
     github = "steveej";

--- a/pkgs/servers/sql/postgresql/ext/tds_fdw.nix
+++ b/pkgs/servers/sql/postgresql/ext/tds_fdw.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, postgresql, freetds }:
 
 stdenv.mkDerivation rec {
-  name = "tds_fdw-${version}";
+  pname = "tds_fdw";
   version = "1.0.8";
 
   buildInputs = [ postgresql freetds ];
 
   src = fetchFromGitHub {
     owner  = "tds-fdw";
-    repo   = "tds_fdw";
+    repo   =  pname;
     rev    = "refs/tags/v${version}";
     sha256 = "0dlv1imiy773yplqqpl26xka65bc566k2x81wkrbvwqagnwvcai2";
   };

--- a/pkgs/servers/sql/postgresql/ext/tds_fdw.nix
+++ b/pkgs/servers/sql/postgresql/ext/tds_fdw.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, postgresql, freetds }:
+
+stdenv.mkDerivation rec {
+  name = "tds_fdw-${version}";
+  version = "1.0.8";
+
+  buildInputs = [ postgresql freetds ];
+
+  src = fetchFromGitHub {
+    owner  = "tds-fdw";
+    repo   = "tds_fdw";
+    rev    = "refs/tags/v${version}";
+    sha256 = "0dlv1imiy773yplqqpl26xka65bc566k2x81wkrbvwqagnwvcai2";
+  };
+
+  installPhase = ''
+    install -D tds_fdw.so                  -t $out/lib
+    install -D sql/tds_fdw--${version}.sql -t $out/share/extension
+    install -D tds_fdw.control             -t $out/share/extension
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A PostgreSQL foreign data wrapper to connect to TDS databases (Sybase and Microsoft SQL Server)";
+    homepage    = https://github.com/tds-fdw/tds_fdw;
+    maintainers = [ maintainers.steve-chavez ];
+    platforms   = platforms.linux;
+    license     = licenses.postgresql;
+  };
+}

--- a/pkgs/servers/sql/postgresql/packages.nix
+++ b/pkgs/servers/sql/postgresql/packages.nix
@@ -34,4 +34,6 @@ self: super: {
     timescaledb = super.callPackage ./ext/timescaledb.nix { };
 
     tsearch_extras = super.callPackage ./ext/tsearch_extras.nix { };
+
+    tds_fdw = super.callPackage ./ext/tds_fdw.nix { };
 }


### PR DESCRIPTION
###### Motivation for this change

Need to access Sql Server using PostgreSQL foreign data wrappers. This is possible thanks to https://github.com/tds-fdw/tds_fdw/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

