### PR TITLE
hopper: init at 4.5.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2673,6 +2673,11 @@
     github = "listx";
     name = "Linus Arver";
   };
+  luis = {
+      email = "luis.nixos@gmail.com";
+      github = "Luis-Hebendanz";
+      name = "Luis Hebendanz";
+  };
   lionello = {
     email = "lio@lunesu.com";
     github = "lionello";

--- a/pkgs/development/tools/analysis/hopper/default.nix
+++ b/pkgs/development/tools/analysis/hopper/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, fetchurl, pkgs, makeWrapper }:
+{ stdenv, fetchurl, pkgs, makeWrapper, lib }:
 
 stdenv.mkDerivation rec {
   pname    = "hopper";
   version = "4.5.7";
-  rev = "v{lib.versions.major version}";
+  rev = "v${lib.versions.major version}";
 
   src = fetchurl {
     url = "https://d2ap6ypl1xbe4k.cloudfront.net/Hopper-${rev}-${version}-Linux.pkg.tar.xz";

--- a/pkgs/development/tools/analysis/hopper/default.nix
+++ b/pkgs/development/tools/analysis/hopper/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation rec {
   name    = "hopper-${version}";
   version = "4.5.7";
-  rev = "v4";
+  rev = "v{lib.versions.major version}";
 
   src = fetchurl {
     url = "https://d2ap6ypl1xbe4k.cloudfront.net/Hopper-${rev}-${version}-Linux.pkg.tar.xz";

--- a/pkgs/development/tools/analysis/hopper/default.nix
+++ b/pkgs/development/tools/analysis/hopper/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, fetchurl, pkgs, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  name    = "hopper-${version}";
+  version = "4.5.7";
+  rev = "v4";
+
+  src = fetchurl {
+    url = "https://d2ap6ypl1xbe4k.cloudfront.net/Hopper-${rev}-${version}-Linux.pkg.tar.xz";
+    sha256 = "1ce7a0f13126a940398aa8da4a74e250dff0401074f30446a8840ac3dbb902c0";
+  };
+
+  sourceRoot = ".";
+
+  ldLibraryPath = with pkgs; stdenv.lib.makeLibraryPath  [
+libbsd.out libffi.out gmpxx.out python27Full.out python27Packages.libxml2 qt5.qtbase zlib  xlibs.libX11.out xorg_sys_opengl.out xlibs.libXrender.out gcc-unwrapped.lib
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+     mkdir -p $out/bin
+     mkdir -p $out/lib
+     mkdir -p $out/share
+     cp $sourceRoot/opt/hopper-${rev}/bin/Hopper $out/bin
+     cp -r $sourceRoot/opt/hopper-${rev}/lib $out
+     cp -r $sourceRoot/usr/share $out/share
+    patchelf \
+    --set-interpreter ${stdenv.glibc}/lib/ld-linux-x86-64.so.2 \
+    $out/bin/Hopper
+    # Details: https://nixos.wiki/wiki/Qt
+     wrapProgram $out/bin/Hopper \
+    --suffix LD_LIBRARY_PATH : ${ldLibraryPath} \
+    --suffix QT_PLUGIN_PATH : ${pkgs.qt5.qtbase}/lib/qt-${pkgs.qt5.qtbase.qtCompatVersion}/plugins
+  '';
+
+  meta = {
+    homepage = "https://www.hopperapp.com/index.html";
+    description = "A macOS and Linux Disassembler";
+    license = stdenv.lib.licenses.unfree;
+    maintainers = [ stdenv.lib.maintainers.luis ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/development/tools/analysis/hopper/default.nix
+++ b/pkgs/development/tools/analysis/hopper/default.nix
@@ -22,14 +22,14 @@ libbsd.out libffi.out gmpxx.out python27Full.out python27Packages.libxml2 qt5.qt
      mkdir -p $out/bin
      mkdir -p $out/lib
      mkdir -p $out/share
-     cp $sourceRoot/opt/hopper-${rev}/bin/Hopper $out/bin
+     cp $sourceRoot/opt/hopper-${rev}/bin/Hopper $out/bin/hopper
      cp -r $sourceRoot/opt/hopper-${rev}/lib $out
      cp -r $sourceRoot/usr/share $out/share
     patchelf \
     --set-interpreter ${stdenv.glibc}/lib/ld-linux-x86-64.so.2 \
-    $out/bin/Hopper
+    $out/bin/hopper
     # Details: https://nixos.wiki/wiki/Qt
-     wrapProgram $out/bin/Hopper \
+     wrapProgram $out/bin/hopper \
     --suffix LD_LIBRARY_PATH : ${ldLibraryPath} \
     --suffix QT_PLUGIN_PATH : ${pkgs.qt5.qtbase}/lib/qt-${pkgs.qt5.qtbase.qtCompatVersion}/plugins
   '';

--- a/pkgs/development/tools/analysis/hopper/default.nix
+++ b/pkgs/development/tools/analysis/hopper/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, pkgs, makeWrapper }:
 
 stdenv.mkDerivation rec {
-  name    = "hopper-${version}";
+  pname    = "hopper";
   version = "4.5.7";
   rev = "v{lib.versions.major version}";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1515,6 +1515,8 @@ in
 
   hostsblock = callPackage ../tools/misc/hostsblock { };
 
+  hopper = callPackage ../development/tools/analysis/hopper {};
+
   hr = callPackage ../applications/misc/hr { };
 
   hyx = callPackage ../tools/text/hyx { };


### PR DESCRIPTION
###### Motivation for this change
I wanted to have the Hopper dissasembler available in NixOS
https://www.hopperapp.com/

###### Things done

- [x ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ x] Assured whether relevant documentation is up to date
- [ x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

