### PR TITLE
tamsyn: init at 1.11

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4036,6 +4036,11 @@
     github = "rprospero";
     name = "Adam Washington";
   };
+  rps = {
+    email = "robbpseaton@gmail.com";
+    github = "robertseaton";
+    name = "Robert P. Seaton";
+  };
   rszibele = {
     email = "richard@szibele.com";
     github = "rszibele";

--- a/pkgs/data/fonts/tamsyn/default.nix
+++ b/pkgs/data/fonts/tamsyn/default.nix
@@ -3,7 +3,8 @@
 let
   version = "1.11"; 
 in stdenv.mkDerivation {
-  name = "tamsyn-font-${version}";
+  pname = "tamsyn-font";
+  inherit version;
 
   src = fetchurl {
     url = "http://www.fial.com/~scott/tamsyn-font/download/tamsyn-font-${version}.tar.gz";

--- a/pkgs/data/fonts/tamsyn/default.nix
+++ b/pkgs/data/fonts/tamsyn/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchurl, mkfontdir, mkfontscale }:
+
+let
+  version = "1.11"; 
+in stdenv.mkDerivation rec {
+  name = "tamsyn-font-${version}";
+
+  src = fetchurl {
+    url = "http://www.fial.com/~scott/tamsyn-font/download/tamsyn-font-${version}.tar.gz";
+    sha256 = "0kpjzdj8sv5871b8827mjgj9dswk75h94jj5iia2bds18ih1pglp";
+   };
+
+  nativeBuildInputs = [ mkfontdir mkfontscale ];
+
+  unpackPhase = ''
+    tar -xzf $src --strip-components=1
+  '';
+
+  installPhase = ''
+    # install the pcf fonts (for xorg applications)
+    fontDir="$out/share/fonts/tamsyn"
+    mkdir -p "$fontDir"
+    mv *.pcf "$fontDir"
+    mv *.psf.gz "$fontDir" 
+
+    cd "$fontDir"
+    mkfontdir
+    mkfontscale
+  '';
+
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+  outputHash = "13l7ighfmn3kmqmchlksfg8ss22ndjk71rs0f9fn5p5zk7s4dn5x";
+
+  meta = with stdenv.lib; {
+    description = "A monospace bitmap font aimed at programmers";
+    longDescription = '' Tamsyn is a monospace bitmap font, primarily aimed at
+    programmers. It was derived from Gilles Boccon-Gibod's MonteCarlo. Tamsyn
+    font was further inspired by Gohufont, Terminus, Dina, Proggy, Fixedsys, and
+    Consolas. 
+    '';
+    homepage = http://www.fial.com/~scott/tamsyn-font/;
+    downloadPage = http://www.fial.com/~scott/tamsyn-font/download;
+    license = licenses.free;
+    maintainers = [ maintainers.rps ];
+    platforms = platforms.linux;
+  };
+}
+

--- a/pkgs/data/fonts/tamsyn/default.nix
+++ b/pkgs/data/fonts/tamsyn/default.nix
@@ -35,7 +35,7 @@ in stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "A monospace bitmap font aimed at programmers";
-    longDescription = '' Tamsyn is a monospace bitmap font, primarily aimed at
+    longDescription = ''Tamsyn is a monospace bitmap font, primarily aimed at
     programmers. It was derived from Gilles Boccon-Gibod's MonteCarlo. Tamsyn
     font was further inspired by Gohufont, Terminus, Dina, Proggy, Fixedsys, and
     Consolas. 

--- a/pkgs/data/fonts/tamsyn/default.nix
+++ b/pkgs/data/fonts/tamsyn/default.nix
@@ -2,7 +2,7 @@
 
 let
   version = "1.11"; 
-in stdenv.mkDerivation rec {
+in stdenv.mkDerivation {
   name = "tamsyn-font-${version}";
 
   src = fetchurl {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15990,6 +15990,8 @@ in
 
   inherit (callPackages ../data/fonts/tai-languages { }) tai-ahom;
 
+  tamsyn = callPackage ../data/fonts/tamsyn { };
+
   tango-icon-theme = callPackage ../data/icons/tango-icon-theme {
     gtk = res.gtk2;
   };


### PR DESCRIPTION
###### Motivation for this change

Wanting to look like a l33t hackerman at Starbucks, needing a suitable bitmap font. 

###### Things done

- Created build file `fonts/tamsyn/default.nix`
- Edited `all-packages.nix`to add package
- Edited `maintainer-list.nix` to add self as maintainer

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

