### PR TITLE
picotts: init at 2018-10-19

### DIFF
--- a/pkgs/tools/audio/picotts/default.nix
+++ b/pkgs/tools/audio/picotts/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, autoconf, automake, libtool, popt }:
+
+stdenv.mkDerivation {
+  name = "picotts-unstable-2018-10-19";
+  src = fetchFromGitHub {
+    repo = "picotts";
+    owner = "naggety";
+    rev = "2f86050dc5da9ab68fc61510b594d8e6975c4d2d";
+    sha256 = "1k2mdv9llkh77jr4qr68yf0zgjqk87np35fgfmnc3rpdp538sccl";
+  };
+  nativeBuildInputs = [ autoconf automake ];
+  buildInputs = [ libtool popt ];
+  sourceRoot = "source/pico";
+  preConfigure = "./autogen.sh";
+  meta = {
+    description = "Text to speech voice sinthesizer from SVox.";
+    homepage = https://github.com/naggety/picotts;
+    license = stdenv.lib.licenses.asl20;
+    maintainers = [ stdenv.lib.maintainers.canndrew ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}
+
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2298,6 +2298,8 @@ in
     inherit (pythonPackages) mutagen python wrapPython;
   };
 
+  picotts = callPackage ../tools/audio/picotts { };
+
   wgetpaste = callPackage ../tools/text/wgetpaste { };
 
   dirmngr = callPackage ../tools/security/dirmngr { };


### PR DESCRIPTION
###### Motivation for this change

I wanted to be able to use this program: https://github.com/naggety/picotts

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

