### PR TITLE
imgurbash2: 2.1 -> 3.1

### DIFF
--- a/pkgs/tools/graphics/imgurbash2/default.nix
+++ b/pkgs/tools/graphics/imgurbash2/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, bash, curl, xsel }:
 
 stdenv.mkDerivation rec {
-  name = "imgurbash2-${version}";
-  version = "2.1";
+  pname = "imgurbash2";
+  version = "3.1";
 
   src = fetchFromGitHub {
     owner = "ram-on";
     repo = "imgurbash2";
     rev = version;
-    sha256 = "1vdkyy0gvjqwc2g7a1lqx6cbynfxbd4f66m8sg1xjvd0kdpgi9wk";
+    sha256 = "1hqghlk8c6svfszhmp02bhkc791lqhqffgiypf05giqmr5d8b9a9";
   };
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Version 2.1 currently in nixpkgs plain doesn't work due to imgur API changes:

```
[nix-shell:~]$ imgurbash2 /tmp/test.png 
Upload failed for /tmp/test.png:  Invalid client_id
```

Bump to 3.1 which fixes this issue. Might be worth backporting to 19.03.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

