### PR TITLE
vgo2nix: 2019-02-01 -> 2019-02-06

### DIFF
--- a/pkgs/development/tools/vgo2nix/default.nix
+++ b/pkgs/development/tools/vgo2nix/default.nix
@@ -9,7 +9,7 @@
 
 buildGoPackage rec {
   name = "vgo2nix-${version}";
-  version = "unstable-2019-02-01";
+  version = "unstable-2019-02-06";
   goPackagePath = "github.com/adisbladis/vgo2nix";
 
   nativeBuildInputs = [ makeWrapper ];
@@ -17,8 +17,8 @@ buildGoPackage rec {
   src = fetchFromGitHub {
     owner = "adisbladis";
     repo = "vgo2nix";
-    rev = "8213e1ffe9e59b1f92df15a995eafd96b66da472";
-    sha256 = "1djwsw7zbprz4czaqsimpwccmmnk8wn38ksj7dis8xdvqrfy7h0g";
+    rev = "f2694cd352830f0561bc00bbcaa08cefb2e36439";
+    sha256 = "10cwi67cyhqjq1pwhry2n1v8z7wybl4cawzmjmfgs5mbsvqp0h78";
   };
 
   goDeps = ./deps.nix;


### PR DESCRIPTION
###### Motivation for this change
the latest vgo2nix contains a bugfix about how nix-prefetch-git is called https://github.com/adisbladis/vgo2nix/commit/c3cf0554e9c6b721097276c09d0b416b50ae5650
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

