### PR TITLE
pythonPackages.cbor2: init at 4.1.2

### DIFF
--- a/pkgs/development/python-modules/cbor2/default.nix
+++ b/pkgs/development/python-modules/cbor2/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildPythonPackage, fetchPypi, pytest, pytestcov, setuptools_scm }:
+
+buildPythonPackage rec {
+  pname = "cbor2";
+  version = "4.1.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1bp9l3wdj0wm15xlmlcwbgv6hc6vcfx39nssikj8fkwnd7d1bdhp";
+  };
+
+  nativeBuildInputs = [ setuptools_scm ];
+  checkInputs = [ pytest pytestcov ];
+
+  checkPhase = "pytest";
+
+  meta = with lib; {
+    description = "Pure Python CBOR (de)serializer with extensive tag support";
+    homepage = https://github.com/agronholm/cbor2;
+    license = licenses.mit;
+    maintainers = with maintainers; [ taneb ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1330,6 +1330,8 @@ in {
 
   cbor = callPackage ../development/python-modules/cbor {};
 
+  cbor2 = callPackage ../development/python-modules/cbor2 {};
+
   cassandra-driver = callPackage ../development/python-modules/cassandra-driver { };
 
   cccolutils = callPackage ../development/python-modules/cccolutils {};


### PR DESCRIPTION
###### Motivation for this change
I've been asked at work to package this. It's apparently a better-documented, better-tested pure-Python alternative to `pythonPackages.cbor`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

