### PR TITLE
junkie: init at 2.8.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3971,6 +3971,11 @@
     github = "rittelle";
     name = "Lennart Rittel";
   };
+  rixed = {
+    email = "rixed-github@happyleptic.org";
+    github = "rixed";
+    name = "Cedric Cellier";
+  };
   rkoe = {
     email = "rk@simple-is-better.org";
     github = "rkoe";

--- a/pkgs/tools/networking/junkie/default.nix
+++ b/pkgs/tools/networking/junkie/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, pkgconfig, libpcap, guile, openssl }:
+
+stdenv.mkDerivation rec {
+  pname = "junkie";
+  version = "2.8.0";
+
+  src = fetchFromGitHub {
+    owner = "rixed";
+    repo = "junkie";
+    rev = "v${version}";
+    sha256 = "c9b57bd6e06d4f90e6a88b775f33fa00f66313ba0f663df70198eddf1d4be298";
+  };
+  buildInputs = [ libpcap guile openssl ];
+  nativeBuildInputs = [ pkgconfig ];
+  configureFlags = [
+    "GUILELIBDIR=\${out}/share/guile/site"
+    "GUILECACHEDIR=\${out}/lib/guile/ccache"
+  ];
+
+  meta = {
+    description = "Deep packet inspection swiss-army knife";
+    homepage = "https://github.com/rixed/junkie";
+    license = stdenv.lib.licenses.agpl3Plus;
+    maintainers = [ stdenv.lib.maintainers.rixed ];
+    platforms = stdenv.lib.platforms.unix;
+    longDescription = ''
+      Junkie is a network sniffer like Tcpdump or Wireshark, but designed to
+      be easy to program and extend.
+
+      It comes with several command line tools to demonstrate this:
+      - a packet dumper;
+      - a nettop tool;
+      - a tool listing TLS certificates...
+    '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3610,6 +3610,8 @@ in
 
   jnettop = callPackage ../tools/networking/jnettop { };
 
+  junkie = callPackage ../tools/networking/junkie { };
+
   go-jira = callPackage ../applications/misc/go-jira { };
 
   john = callPackage ../tools/security/john { };


### PR DESCRIPTION
###### Motivation for this change

Addition of a new networking tool: a programmable sniffer/DPI

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

