### PR TITLE
libu2f-host: 1.1.7 -> 1.1.9

### DIFF
--- a/pkgs/development/libraries/libu2f-host/default.nix
+++ b/pkgs/development/libraries/libu2f-host/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchurl, pkgconfig, json_c, hidapi }:
 
 stdenv.mkDerivation rec {
-  name = "libu2f-host-1.1.7";
+  pname = "libu2f-host";
+  version = "1.1.9";
 
   src = fetchurl {
-    url = "https://developers.yubico.com/libu2f-host/Releases/${name}.tar.xz";
-    sha256 = "1zyws91b1fsbfwn3f23ry9a9zr0i1a1hqmhk3v1qnlvp56gjayli";
+    url = "https://developers.yubico.com/${pname}/Releases/${pname}-${version}.tar.xz";
+    sha256 = "1hnh3f4scx07v9jfkr1nnxasmydk1cmivn0nijcp2p75bc1fznip";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

https://github.com/Yubico/libu2f-host/blob/master/NEWS

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---