### PR TITLE
it87: init at 2018-08-14

### DIFF
--- a/pkgs/os-specific/linux/it87/default.nix
+++ b/pkgs/os-specific/linux/it87/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, kernel }:
+
+stdenv.mkDerivation rec {
+  name = "it87-${version}-${kernel.version}";
+  version = "2018-08-14";
+
+  # The original was deleted from github, but this seems to be an active fork
+  src = fetchFromGitHub {
+    owner = "hannesha";
+    repo = "it87";
+    rev = "5515f5b78838cb6be551943ffef5d1792012724c";
+    sha256 = "1ygi4mwds4q7byhg8gqnh3syamdj5rpjy3jj012k7vl54gdgrmgm";
+  };
+
+  hardeningDisable = [ "pic" ];
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  preConfigure = ''
+    sed -i 's|depmod|#depmod|' Makefile
+  '';
+
+  makeFlags = [
+    "TARGET=${kernel.modDirVersion}"
+    "KERNEL_MODULES=${kernel.dev}/lib/modules/${kernel.modDirVersion}"
+    "MODDESTDIR=$(out)/lib/modules/${kernel.modDirVersion}/kernel/drivers/hwmon"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Patched module for IT87xx superio chip sensors support";
+    homepage = https://github.com/hannesha/it87;
+    license = licenses.gpl2;
+    platforms = [ "x86_64-linux" "i686-linux" ];
+    maintainers = with maintainers; [ yorickvp ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14760,6 +14760,8 @@ in
 
     ixgbevf = callPackage ../os-specific/linux/ixgbevf {};
 
+    it87 = callPackage ../os-specific/linux/it87 {};
+
     ena = callPackage ../os-specific/linux/ena {};
 
     v4l2loopback = callPackage ../os-specific/linux/v4l2loopback { };


### PR DESCRIPTION
###### Motivation for this change

The upstream (kernel) it87 driver is missing support for several modern chips. One of which being the IT8665e, which one of our machines has.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

