### PR TITLE
nixos/flannel: Add iptables package to service path

### DIFF
--- a/nixos/modules/services/networking/flannel.nix
+++ b/nixos/modules/services/networking/flannel.nix
@@ -161,6 +161,7 @@ in {
         FLANNELD_KUBECONFIG_FILE = cfg.kubeconfig;
         NODE_NAME = cfg.nodeName;
       };
+      path = [ pkgs.iptables ];
       preStart = ''
         mkdir -p /run/flannel
         touch /run/flannel/docker


### PR DESCRIPTION
###### Motivation for this change

Flannel requires the iptables command during runtime to set e.g. natting rules.
Otherwise the following warning will be shown in the flannel logs.

```
flannel[5290]: E0312 13:08:01.117430    5290 iptables.go:104] Failed to setup IPTables. iptables binary was not found: exec: "iptables": executable file not found in $PATH
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

