### PR TITLE
qt512: patch qtwebengine against CVE-2019-5786

### DIFF
--- a/pkgs/development/libraries/qt-5/5.12/default.nix
+++ b/pkgs/development/libraries/qt-5/5.12/default.nix
@@ -60,7 +60,10 @@ let
     qtdeclarative = [ ./qtdeclarative.patch ];
     qtscript = [ ./qtscript.patch ];
     qtserialport = [ ./qtserialport.patch ];
-    qtwebengine = [ ./qtwebengine-no-build-skip.patch ];
+    qtwebengine = [
+      ./qtwebengine-no-build-skip.patch
+      ./qtwebengine-CVE-2019-5786.patch
+    ];
     qtwebkit = [ ./qtwebkit.patch ]
       ++ optionals stdenv.isDarwin [
         ./qtwebkit-darwin-no-readline.patch

--- a/pkgs/development/libraries/qt-5/5.12/qtwebengine-CVE-2019-5786.patch
+++ b/pkgs/development/libraries/qt-5/5.12/qtwebengine-CVE-2019-5786.patch
@@ -1,0 +1,26 @@
+--- a/src/3rdparty/chromium/third_party/blink/renderer/core/fileapi/file_reader_loader.cc
++++ b/src/3rdparty/chromium/third_party/blink/renderer/core/fileapi/file_reader_loader.cc
+@@ -135,14 +135,16 @@
+   if (!raw_data_ || error_code_)
+     return nullptr;
+ 
+-  DOMArrayBuffer* result = DOMArrayBuffer::Create(raw_data_->ToArrayBuffer());
+-  if (finished_loading_) {
+-    array_buffer_result_ = result;
+-    AdjustReportedMemoryUsageToV8(
+-        -1 * static_cast<int64_t>(raw_data_->ByteLength()));
+-    raw_data_.reset();
++  if (!finished_loading_) {
++    return DOMArrayBuffer::Create(
++        ArrayBuffer::Create(raw_data_->Data(), raw_data_->ByteLength()));
+   }
+-  return result;
++  array_buffer_result_ = DOMArrayBuffer::Create(raw_data_->ToArrayBuffer());
++  AdjustReportedMemoryUsageToV8(-1 *
++                                static_cast<int64_t>(raw_data_->ByteLength()));
++
++  raw_data_.reset();
++  return array_buffer_result_;
+ }
+ 
+ String FileReaderLoader::StringResult() {


### PR DESCRIPTION
###### Motivation for this change

qtwebengine is vulnerable to CVE-2019-5786

See: https://codereview.qt-project.org/#/c/255162/

###### Things done
Took the patch at http://code.qt.io/cgit/qt/qtwebengine-chromium.git/patch/?id=43316b15
and modified it so it would apply (only the paths needed to be changed).

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

