### PR TITLE
factorio: experimental 0.17.6 → 0.17.12

### DIFF
--- a/pkgs/games/factorio/default.nix
+++ b/pkgs/games/factorio/default.nix
@@ -53,11 +53,11 @@ let
     x86_64-linux = let bdist = bdistForArch { inUrl = "linux64"; inTar = "x64"; }; in {
       alpha = {
         stable        = bdist { sha256 = "0b4hbpdcrh5hgip9q5dkmw22p66lcdhnr0kmb0w5dw6yi7fnxxh0"; version = "0.16.51"; withAuth = true; };
-        experimental  = bdist { sha256 = "1a3h24y2s9h8j4vcwzsgzgsgp6xaa522qzrmckfslbjxwqka2sqx"; version = "0.17.6"; withAuth = true; };
+        experimental  = bdist { sha256 = "0qdh1rkjgl0w0rg2gm4l7w78b0qq4py39fcixvcbj8dwavlghxs7"; version = "0.17.11"; withAuth = true; };
       };
       headless = {
         stable        = bdist { sha256 = "0zrnpg2js0ysvx9y50h3gajldk16mv02dvrwnkazh5kzr1d9zc3c"; version = "0.16.51"; };
-        experimental  = bdist { sha256 = "0bw12njp2smy2x99s7mrlbafvd8jnmw3a1zm6lkpiy20kn4mmqbc"; version = "0.17.6"; };
+        experimental  = bdist { sha256 = "0mbfm8b7ns6rkpp4w1grs09qkf5310gsh2hw0fij25aschpfjln2"; version = "0.17.11"; };
       };
       demo = {
         stable        = bdist { sha256 = "0zf61z8937yd8pyrjrqdjgd0rjl7snwrm3xw86vv7s7p835san6a"; version = "0.16.51"; };

--- a/pkgs/games/factorio/default.nix
+++ b/pkgs/games/factorio/default.nix
@@ -53,11 +53,11 @@ let
     x86_64-linux = let bdist = bdistForArch { inUrl = "linux64"; inTar = "x64"; }; in {
       alpha = {
         stable        = bdist { sha256 = "0b4hbpdcrh5hgip9q5dkmw22p66lcdhnr0kmb0w5dw6yi7fnxxh0"; version = "0.16.51"; withAuth = true; };
-        experimental  = bdist { sha256 = "0qdh1rkjgl0w0rg2gm4l7w78b0qq4py39fcixvcbj8dwavlghxs7"; version = "0.17.11"; withAuth = true; };
+        experimental  = bdist { sha256 = "0f8scld3447jwcn98zks634bv594zz24fy1xr41nf1k1llmgnmnc"; version = "0.17.12"; withAuth = true; };
       };
       headless = {
         stable        = bdist { sha256 = "0zrnpg2js0ysvx9y50h3gajldk16mv02dvrwnkazh5kzr1d9zc3c"; version = "0.16.51"; };
-        experimental  = bdist { sha256 = "0mbfm8b7ns6rkpp4w1grs09qkf5310gsh2hw0fij25aschpfjln2"; version = "0.17.11"; };
+        experimental  = bdist { sha256 = "1hfi8pngml3phdr3h30fym5qmi575fx0cv4zxn6prh2prz7h1z7d"; version = "0.17.12"; };
       };
       demo = {
         stable        = bdist { sha256 = "0zf61z8937yd8pyrjrqdjgd0rjl7snwrm3xw86vv7s7p835san6a"; version = "0.16.51"; };


### PR DESCRIPTION
###### Motivation for this change
Factorio is releasing a ridiculous number of bugfixes. I've finally had time to update the factorio package, so here it is.

###### Things done
Update the version and hashes.

I'm working on an autoupdater, but it's a little weird since the format is different than other packages.

I might want to request commit access to this repository so I can get my minor patches in before Wube releases too many more versions of factorio.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

