### PR TITLE
virtualenv: Update patch for 16.2.0

### DIFF
--- a/pkgs/development/python-modules/virtualenv/virtualenv-change-prefix.patch
+++ b/pkgs/development/python-modules/virtualenv/virtualenv-change-prefix.patch
@@ -52,7 +52,7 @@ index bcf3225..3530997 100755
      site_filename_dst = change_prefix(site_filename, home_dir)
      site_dir = os.path.dirname(site_filename_dst)
      writefile(site_filename_dst, SITE_PY)
-+    wrapper_path = join(prefix, "lib", py_version, "site-packages")
++    wrapper_path = join(prefix, "lib", PY_VERSION, "site-packages")
 +    writefile(
 +        join(site_dir, 'sitecustomize.py',),
 +        "import sys; sys.path.append('%s')" % wrapper_path


### PR DESCRIPTION
###### Motivation for this change

This just updates the patch to try to address https://github.com/NixOS/nixpkgs/issues/57008. The names of global constants in virtualenv changed to be all caps in https://github.com/pypa/virtualenv/pull/1262. 

I didn't take the time to understand the deeper context of the patch nor did I try to regenerate the patch from virtualenv master. However, I was able to use this to build a virtualenv inside a nix-shell.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

