### PR TITLE
wireguard-tools: 0.0.20190123 -> 0.0.20190227

### DIFF
--- a/pkgs/os-specific/linux/wireguard/default.nix
+++ b/pkgs/os-specific/linux/wireguard/default.nix
@@ -21,7 +21,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ perl ] ++ kernel.moduleBuildDependencies;
 
-  buildPhase = "make module";
+  buildFlags = [ "module" ];
+  installTargets = [ "module-install" ];
 
   meta = with stdenv.lib; {
     inherit (wireguard-tools.meta) homepage license maintainers;

--- a/pkgs/tools/networking/wireguard-tools/default.nix
+++ b/pkgs/tools/networking/wireguard-tools/default.nix
@@ -4,11 +4,11 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "wireguard-tools-${version}";
-  version = "0.0.20190123";
+  version = "0.0.20190227";
 
   src = fetchzip {
     url = "https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${version}.tar.xz";
-    sha256 = "1lyl3nmsgp9jk9js3vz032vdx7cg9ynkwzdr19wrr26pkxhpcnxr";
+    sha256 = "1kaq0mjcdr4hxr3rx8z11rvlh4ycjsn5654fjw1gh1fdbjgczax5";
   };
 
   sourceRoot = "source/src/tools";
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     downloadPage = https://git.zx2c4.com/WireGuard/refs/;
     homepage = https://www.wireguard.com/;
     license = licenses.gpl2;
-    maintainers = with maintainers; [ ericsagnes mic92 zx2c4 ];
+    maintainers = with maintainers; [ elseym ericsagnes mic92 zx2c4 ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

update wireguard-tools

/cc @kirelagin

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

