### PR TITLE
llvmPackages_8: rc2 -> rc5

### DIFF
--- a/pkgs/development/compilers/llvm/8/clang/default.nix
+++ b/pkgs/development/compilers/llvm/8/clang/default.nix
@@ -9,7 +9,7 @@ let
     name = "clang-${version}";
 
     unpackPhase = ''
-      unpackFile ${fetch "cfe" "0z5si83w0i3l445c7624204mxsv82naps96icnv7v20s6njbsbsi"}
+      unpackFile ${fetch "cfe" "0i4ak817issrainsrxkb57i2mqscmrjkmlf9lqr6kcy2x4glrv10"}
       mv cfe-${version}* clang
       sourceRoot=$PWD/clang
       unpackFile ${clang-tools-extra_src}

--- a/pkgs/development/compilers/llvm/8/clang/default.nix
+++ b/pkgs/development/compilers/llvm/8/clang/default.nix
@@ -9,7 +9,7 @@ let
     name = "clang-${version}";
 
     unpackPhase = ''
-      unpackFile ${fetch "cfe" "0i4ak817issrainsrxkb57i2mqscmrjkmlf9lqr6kcy2x4glrv10"}
+      unpackFile ${fetch "cfe" "07k6vcxnf9n8x21mala3rfvf450iqy24wcsqw4yc8b8lp1fwii6p"}
       mv cfe-${version}* clang
       sourceRoot=$PWD/clang
       unpackFile ${clang-tools-extra_src}

--- a/pkgs/development/compilers/llvm/8/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/8/compiler-rt.nix
@@ -2,7 +2,7 @@
 stdenv.mkDerivation rec {
   name = "compiler-rt-${version}";
   inherit version;
-  src = fetch "compiler-rt" "1rxa1rcn7r3yfn9cj0sx5gd90kslbd13q080rdyqb6jr9a9i1avb";
+  src = fetch "compiler-rt" "00gv3ldwaw7jw8mlzfx16l5jk248x2fz4k8c1lxqisvmfzacknii";
 
   nativeBuildInputs = [ cmake python llvm ];
   buildInputs = stdenv.lib.optional stdenv.hostPlatform.isDarwin libcxxabi;

--- a/pkgs/development/compilers/llvm/8/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/8/compiler-rt.nix
@@ -2,7 +2,7 @@
 stdenv.mkDerivation rec {
   name = "compiler-rt-${version}";
   inherit version;
-  src = fetch "compiler-rt" "00gv3ldwaw7jw8mlzfx16l5jk248x2fz4k8c1lxqisvmfzacknii";
+  src = fetch "compiler-rt" "16la7ksxwfs6wk3y7w8hh3c1svp095m7j4qfrdgv65lnfwp6rwf9";
 
   nativeBuildInputs = [ cmake python llvm ];
   buildInputs = stdenv.lib.optional stdenv.hostPlatform.isDarwin libcxxabi;

--- a/pkgs/development/compilers/llvm/8/default.nix
+++ b/pkgs/development/compilers/llvm/8/default.nix
@@ -6,14 +6,14 @@
 
 let
   release_version = "8.0.0";
-  version = release_version + "rc2"; # differentiating these is important for rc's
+  version = release_version + "rc3"; # differentiating these is important for rc's
 
   fetch = name: sha256: fetchurl {
-    url = "https://prereleases.llvm.org/${release_version}/rc2/${name}-${version}.src.tar.xz";
+    url = "https://prereleases.llvm.org/${release_version}/rc3/${name}-${version}.src.tar.xz";
     inherit sha256;
   };
 
-  clang-tools-extra_src = fetch "clang-tools-extra" "1ypzbk7lf9dzkqh4p37dlr1bggjdrixr5gwb71jk9gh98grr2m5g";
+  clang-tools-extra_src = fetch "clang-tools-extra" "070rxrqhc3flgx5vrnzzs4b39l42amnrh4xwf02rxbmvd9n6gva6";
 
   tools = stdenv.lib.makeExtensible (tools: let
     callPackage = newScope (tools // { inherit stdenv cmake libxml2 python isl release_version version fetch; });

--- a/pkgs/development/compilers/llvm/8/default.nix
+++ b/pkgs/development/compilers/llvm/8/default.nix
@@ -6,14 +6,14 @@
 
 let
   release_version = "8.0.0";
-  version = release_version + "rc3"; # differentiating these is important for rc's
+  version = release_version + "rc5"; # differentiating these is important for rc's
 
   fetch = name: sha256: fetchurl {
-    url = "https://prereleases.llvm.org/${release_version}/rc3/${name}-${version}.src.tar.xz";
+    url = "https://prereleases.llvm.org/${release_version}/rc5/${name}-${version}.src.tar.xz";
     inherit sha256;
   };
 
-  clang-tools-extra_src = fetch "clang-tools-extra" "070rxrqhc3flgx5vrnzzs4b39l42amnrh4xwf02rxbmvd9n6gva6";
+  clang-tools-extra_src = fetch "clang-tools-extra" "0705xl8ysjc9pdrggyc51zjq3kwcrckhz4cf4z8wbgi7x2li1djd";
 
   tools = stdenv.lib.makeExtensible (tools: let
     callPackage = newScope (tools // { inherit stdenv cmake libxml2 python isl release_version version fetch; });

--- a/pkgs/development/compilers/llvm/8/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/8/libc++/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation rec {
   name = "libc++-${version}";
 
-  src = fetch "libcxx" "1c8idvlqm4ik62q0llsndk9449yrgkj8hv5lz411hnbqjs09q9qq";
+  src = fetch "libcxx" "1i7i8cdd39h9wks1h43hih4iyjnq36n5m7gl4figc8dgqa95xwfs";
 
   postUnpack = ''
     unpackFile ${libcxxabi.src}

--- a/pkgs/development/compilers/llvm/8/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/8/libc++/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation rec {
   name = "libc++-${version}";
 
-  src = fetch "libcxx" "1i7i8cdd39h9wks1h43hih4iyjnq36n5m7gl4figc8dgqa95xwfs";
+  src = fetch "libcxx" "1hdhr4nnynwf1m1581sjl8pdh3gdxsz1rdzdryig7ll9v2lp0rkc";
 
   postUnpack = ''
     unpackFile ${libcxxabi.src}

--- a/pkgs/development/compilers/llvm/8/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/8/libc++abi.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation {
   name = "libc++abi-${version}";
 
-  src = fetch "libcxxabi" "0hdg7xw8vazw85i675qld7i6wqx502srny84cp0w6wi6pk44xiqr";
+  src = fetch "libcxxabi" "12pvxvxdy3qjkrlmdv4fcmfa24l7vjl9x81frn29phz00s7ldl6c";
 
   nativeBuildInputs = [ cmake ];
   buildInputs = stdenv.lib.optional (!stdenv.isDarwin && !stdenv.isFreeBSD) libunwind;

--- a/pkgs/development/compilers/llvm/8/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/8/libc++abi.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation {
   name = "libc++abi-${version}";
 
-  src = fetch "libcxxabi" "12pvxvxdy3qjkrlmdv4fcmfa24l7vjl9x81frn29phz00s7ldl6c";
+  src = fetch "libcxxabi" "1s65sb5vv5l532fmcwvxd3apxm1jjc64yb5qn30f0zzdx9g3rx69";
 
   nativeBuildInputs = [ cmake ];
   buildInputs = stdenv.lib.optional (!stdenv.isDarwin && !stdenv.isFreeBSD) libunwind;

--- a/pkgs/development/compilers/llvm/8/lld.nix
+++ b/pkgs/development/compilers/llvm/8/lld.nix
@@ -9,7 +9,7 @@
 stdenv.mkDerivation {
   name = "lld-${version}";
 
-  src = fetch "lld" "14nganpwr5y111zhwws95p6ikp8kfiybfdr2yfz5cmhb3zkcgk4h";
+  src = fetch "lld" "0vcspgi5yx46ld9j4x0hcl554m92a7x1zhngh1wqyxj7mbng1854";
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ llvm libxml2 ];

--- a/pkgs/development/compilers/llvm/8/lld.nix
+++ b/pkgs/development/compilers/llvm/8/lld.nix
@@ -9,7 +9,7 @@
 stdenv.mkDerivation {
   name = "lld-${version}";
 
-  src = fetch "lld" "0vcspgi5yx46ld9j4x0hcl554m92a7x1zhngh1wqyxj7mbng1854";
+  src = fetch "lld" "1w0f3s5rzv90yiv4k9wdvkpc89k3g9crbwf1sh8xbi5jsjnz4539";
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ llvm libxml2 ];

--- a/pkgs/development/compilers/llvm/8/lldb.nix
+++ b/pkgs/development/compilers/llvm/8/lldb.nix
@@ -17,7 +17,7 @@
 stdenv.mkDerivation {
   name = "lldb-${version}";
 
-  src = fetch "lldb" "0r364w49m0l0808wm06g777qd14gwxnz0z267dbnwqkw6zc361lc";
+  src = fetch "lldb" "1h0hix0sgybh11sq6a9ynnk55jv63zi83l5x5617jm7am09zv6zy";
 
   postPatch = ''
     # Fix up various paths that assume llvm and clang are installed in the same place

--- a/pkgs/development/compilers/llvm/8/lldb.nix
+++ b/pkgs/development/compilers/llvm/8/lldb.nix
@@ -17,7 +17,7 @@
 stdenv.mkDerivation {
   name = "lldb-${version}";
 
-  src = fetch "lldb" "1h0hix0sgybh11sq6a9ynnk55jv63zi83l5x5617jm7am09zv6zy";
+  src = fetch "lldb" "1i3hy37qmwqblxpac88ing7mg3jyp2hh08rfv3xhlxj9wddz7nyd";
 
   postPatch = ''
     # Fix up various paths that assume llvm and clang are installed in the same place

--- a/pkgs/development/compilers/llvm/8/llvm.nix
+++ b/pkgs/development/compilers/llvm/8/llvm.nix
@@ -22,8 +22,8 @@
 let
   inherit (stdenv.lib) optional optionals optionalString;
 
-  src = fetch "llvm" "1h9zqgf968si0nzdmsa9rz634zrmz6mprvz2ifw6ky0h7va5rcvq";
-  polly_src = fetch "polly" "1wwnn0cxnrmiqb6kg577myz6kb8sm18jwc020lf0b1k5as7aw2kq";
+  src = fetch "llvm" "193aiag8914sr3a6w9msaiwjjl0w9i5h0dd994by85j4abczaqw3";
+  polly_src = fetch "polly" "111p8f4nqawl9rrykd784dkjgjrkq92ska9l8n91jwr5jir6f86b";
 
   # Used when creating a version-suffixed symlink of libLLVM.dylib
   shortVersion = with stdenv.lib;

--- a/pkgs/development/compilers/llvm/8/llvm.nix
+++ b/pkgs/development/compilers/llvm/8/llvm.nix
@@ -22,8 +22,8 @@
 let
   inherit (stdenv.lib) optional optionals optionalString;
 
-  src = fetch "llvm" "193aiag8914sr3a6w9msaiwjjl0w9i5h0dd994by85j4abczaqw3";
-  polly_src = fetch "polly" "111p8f4nqawl9rrykd784dkjgjrkq92ska9l8n91jwr5jir6f86b";
+  src = fetch "llvm" "1hb5if7vmgkb52dpj9lyvn986mnk2jbpryng2r1rc5vy25wxw759";
+  polly_src = fetch "polly" "07l3y20j8124x24yqiq0qmz9rhkfh3c48q6vnpgldj2scr3vgyb2";
 
   # Used when creating a version-suffixed symlink of libLLVM.dylib
   shortVersion = with stdenv.lib;

--- a/pkgs/development/compilers/llvm/8/openmp.nix
+++ b/pkgs/development/compilers/llvm/8/openmp.nix
@@ -9,7 +9,7 @@
 stdenv.mkDerivation {
   name = "openmp-${version}";
 
-  src = fetch "openmp" "1xxxclzizcrfh0k870n4n3hh0khw14sv5i7s2kbdwl099k8b96cv";
+  src = fetch "openmp" "1ab4m3agbk9zx810bbvxbjg3103y337zff0ngajk77nvsmc6fl55";
 
   nativeBuildInputs = [ cmake perl ];
   buildInputs = [ llvm ];

--- a/pkgs/development/compilers/llvm/8/openmp.nix
+++ b/pkgs/development/compilers/llvm/8/openmp.nix
@@ -9,7 +9,7 @@
 stdenv.mkDerivation {
   name = "openmp-${version}";
 
-  src = fetch "openmp" "1ab4m3agbk9zx810bbvxbjg3103y337zff0ngajk77nvsmc6fl55";
+  src = fetch "openmp" "1nad9ihnaa4xpr77lp9y6zzqqi90d5p280zwv260z9mifkl4dlhm";
 
   nativeBuildInputs = [ cmake perl ];
   buildInputs = [ llvm ];


### PR DESCRIPTION
###### Motivation for this change

Latest rc...

Bug causing test failure w/musl
(and seemingly bug w/o musl but happens not to crash?)
but looks like will need to chase that upstream :).


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---