### PR TITLE
cachix: compose overrides

### DIFF
--- a/pkgs/development/tools/cachix/default.nix
+++ b/pkgs/development/tools/cachix/default.nix
@@ -1,8 +1,6 @@
-{ lib, haskellPackages, haskell }:
+{ haskellPackages, haskell }:
 
-(haskellPackages.override (old: {
-  overrides = lib.composeExtensions (old.overrides or (_: _: {})) (self: super: {
-    cachix = haskell.lib.justStaticExecutables (super.callPackage ./cachix.nix {});
-    cachix-api = super.callPackage ./cachix-api.nix {};
-  });
+(haskellPackages.extend (self: super: {
+  cachix = haskell.lib.justStaticExecutables (super.callPackage ./cachix.nix {});
+  cachix-api = super.callPackage ./cachix-api.nix {};
 })).cachix

--- a/pkgs/development/tools/cachix/default.nix
+++ b/pkgs/development/tools/cachix/default.nix
@@ -1,8 +1,8 @@
-{ haskellPackages, haskell }:
+{ lib, haskellPackages, haskell }:
 
-(haskellPackages.override {
-  overrides = self: super: {
+(haskellPackages.override (old: {
+  overrides = lib.composeExtensions (old.overrides or (_: _: {})) (self: super: {
     cachix = haskell.lib.justStaticExecutables (super.callPackage ./cachix.nix {});
     cachix-api = super.callPackage ./cachix-api.nix {};
-  };
-}).cachix
+  });
+})).cachix


### PR DESCRIPTION
###### Motivation for this change

Fixes https://github.com/NixOS/nixpkgs/issues/57529

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

