### PR TITLE
gucharmap: 11.0.3 -> 12.0.1, unicode 12

### DIFF
--- a/pkgs/desktops/gnome-3/core/gucharmap/default.nix
+++ b/pkgs/desktops/gnome-3/core/gucharmap/default.nix
@@ -7,17 +7,17 @@
 let
   unicode-data = callPackage ./unicode-data.nix {};
 in stdenv.mkDerivation rec {
-  name = "gucharmap-${version}";
-  version = "11.0.3";
+  pname = "gucharmap";
+  version = "12.0.1";
 
   outputs = [ "out" "lib" "dev" "devdoc" ];
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "GNOME";
-    repo = "gucharmap";
+    repo = pname;
     rev = version;
-    sha256 = "1a590nxy8jdf6zxh6jdsyvhxyaz94ixx3aa1pj7gicf1aqp26vnh";
+    sha256 = "0si3ymyfzc5v7ly0dmcs3qgw2wp8cyasycq5hmcr8frl09lr6gkw";
   };
 
   nativeBuildInputs = [
@@ -45,7 +45,7 @@ in stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = gnome3.updateScript {
-      packageName = "gucharmap";
+      packageName = pname;
     };
   };
 

--- a/pkgs/desktops/gnome-3/core/gucharmap/unicode-data.nix
+++ b/pkgs/desktops/gnome-3/core/gucharmap/unicode-data.nix
@@ -1,31 +1,31 @@
 { fetchurl, stdenv, gnome3 }:
 stdenv.mkDerivation rec {
   name = "unicode-data-${version}";
-  version = "11.0.0";
+  version = "12.0.0";
   srcs = [
     (fetchurl {
       url = "http://www.unicode.org/Public/${version}/ucd/Blocks.txt";
-      sha256 = "0lnh9iazikpr548bd7nkaq9r3vfljfvz0rg2462prac8qxk7ni8b";
+      sha256 = "041sk54v6rjzb23b9x7yjdwzdp2wc7gvfz7ybavgg4gbh51wm8x1";
     })
     (fetchurl {
       url = "http://www.unicode.org/Public/${version}/ucd/DerivedAge.txt";
-      sha256 = "0rlqqd0b1sqbzvrj29dwdizx8lyvrbfirsnn8za9lb53x5fml4gb";
+      sha256 = "04j92xp07v273z3pxkbfmi1svmw9kmnjl9nvz9fv0g5ybk9zk7r6";
     })
     (fetchurl {
       url = "http://www.unicode.org/Public/${version}/ucd/NamesList.txt";
-      sha256 = "0yr2h0nfqhirfi3bxl33z6cc94qqshlpgi06c25xh9754irqsgv8";
+      sha256 = "0vsq8gx7hws8mvxy3nlglpwxw7ky57q0fs09d7w9xgb2ylk7fz61";
     })
     (fetchurl {
       url = "http://www.unicode.org/Public/${version}/ucd/Scripts.txt";
-      sha256 = "1mbnvf97nwa3pvyzx9nd2wa94f8s0npg9740kic2p2ag7jmc1wz9";
+      sha256 = "18c63hx4y5yg408a8d0wx72d2hfnlz4l560y1fsf9lpzifxpqcmx";
     })
     (fetchurl {
       url = "http://www.unicode.org/Public/${version}/ucd/UnicodeData.txt";
-      sha256 = "16b0jzvvzarnlxdvs2izd5ia0ipbd87md143dc6lv6xpdqcs75s9";
+      sha256 = "07d1kq190kgl92ispfx6zmdkvwvhjga0ishxsngzlw8j3kdkz4ap";
     })
     (fetchurl {
       url = "http://www.unicode.org/Public/${version}/ucd/Unihan.zip";
-      sha256 = "0cy8gxb17ksi5h4ysypk4c09z61am1svjrvg97hm5m5ccjfrs1vj";
+      sha256 = "1kfdhgg2gm52x3s07bijb5cxjy0jxwhd097k5lqhvzpznprm6ibf";
     })
   ];
   phases = "installPhase";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---