### PR TITLE
Add the Janet programming language.

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -335,6 +335,11 @@
     github = "andrew-d";
     name = "Andrew Dunham";
   };
+  andrewchambers = {
+    email = "ac@acha.ninja";
+    github = "andrewchambers";
+    name = "Andrew Chambers";
+  };
   andrewrk = {
     email = "superjoe30@gmail.com";
     github = "andrewrk";

--- a/pkgs/development/interpreters/janet/default.nix
+++ b/pkgs/development/interpreters/janet/default.nix
@@ -1,8 +1,7 @@
 { stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  name = "janet-${version}";
-
+  pname = "janet";
   version = "0.4.0";
 
   src = fetchFromGitHub {

--- a/pkgs/development/interpreters/janet/default.nix
+++ b/pkgs/development/interpreters/janet/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub }:
+stdenv.mkDerivation rec {
+  name = "janet-${version}";
+
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "janet-lang";
+    repo = "janet";
+    rev = "v${version}";
+    sha256 = "1590f1fxb6qfhf1vp2xhbvdn2jfrgipn5572cckk1ma7f13jnkpy";
+  };
+
+  JANET_BUILD=''\"release\"'';
+
+  buildPhase = ''
+    PREFIX="$out" make
+  '';
+
+  installPhase = ''
+    mkdir "$out"
+    PREFIX="$out" make install
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Janet programming language";
+    homepage = https://janet-lang.org/;
+    license = stdenv.lib.licenses.mit;
+    platforms = platforms.all;
+    maintainers = with stdenv.lib.maintainers; [ andrewchambers ];
+  };
+}

--- a/pkgs/development/interpreters/janet/default.nix
+++ b/pkgs/development/interpreters/janet/default.nix
@@ -1,4 +1,5 @@
 { stdenv, fetchFromGitHub }:
+
 stdenv.mkDerivation rec {
   name = "janet-${version}";
 
@@ -12,15 +13,9 @@ stdenv.mkDerivation rec {
   };
 
   JANET_BUILD=''\"release\"'';
+  PREFIX = placeholder "out";
 
-  buildPhase = ''
-    PREFIX="$out" make
-  '';
-
-  installPhase = ''
-    mkdir "$out"
-    PREFIX="$out" make install
-  '';
+  doCheck = true;
 
   meta = with stdenv.lib; {
     description = "Janet programming language";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7809,6 +7809,8 @@ in
 
   j = callPackage ../development/interpreters/j {};
 
+  janet = callPackage ../development/interpreters/janet {};
+
   jimtcl = callPackage ../development/interpreters/jimtcl {};
 
   jmeter = callPackage ../applications/networking/jmeter {};


### PR DESCRIPTION

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

