### PR TITLE
nixos/mysql: specify option types, add tests

### DIFF
--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -103,6 +103,24 @@ in
       };
 
       initialDatabases = mkOption {
+        type = types.listOf (types.submodule {
+          options = {
+            name = mkOption {
+              type = types.str;
+              description = ''
+                The name of the database to create.
+              '';
+            };
+            schema = mkOption {
+              type = types.nullOr types.path;
+              default = null;
+              description = ''
+                The initial schema of the database; if null (the default),
+                an empty database is created.
+              '';
+            };
+          };
+        });
         default = [];
         description = ''
           List of database names and their initial schemas that should be used to create databases on the first startup
@@ -115,11 +133,13 @@ in
       };
 
       initialScript = mkOption {
+        type = types.nullOr types.lines;
         default = null;
         description = "A file containing SQL statements to be executed on the first startup. Can be used for granting certain permissions on the database";
       };
 
       ensureDatabases = mkOption {
+        type = types.listOf types.str;
         default = [];
         description = ''
           Ensures that the specified databases exist.
@@ -134,6 +154,38 @@ in
       };
 
       ensureUsers = mkOption {
+        type = types.listOf (types.submodule {
+          options = {
+            name = mkOption {
+              type = types.str;
+              description = ''
+                Name of the user to ensure.
+              '';
+            };
+            ensurePermissions = mkOption {
+              type = types.attrsOf types.str;
+              default = {};
+              description = ''
+                Permissions to ensure for the user, specified as attribute set.
+                The attribute names specify the database and tables to grant the permissions for,
+                separated by a dot. You may use wildcards here.
+                The attribute values specfiy the permissions to grant.
+                You may specify one or multiple comma-separated SQL privileges here.
+
+                For more information on how to specify the target
+                and on which privileges exist, see the
+                <link xlink:href="https://mariadb.com/kb/en/library/grant/">GRANT syntax</link>.
+                The attributes are used as <code>GRANT ''${attrName} ON ''${attrValue}</code>.
+              '';
+              example = literalExample ''
+                {
+                  "database.*" = "ALL PRIVILEGES";
+                  "*.*" = "SELECT, LOCK TABLES";
+                }
+              '';
+            };
+          };
+        });
         default = [];
         description = ''
           Ensures that the specified users exist and have at least the ensured permissions.
@@ -143,20 +195,22 @@ in
           option is changed. This means that users created and permissions assigned once through this option or
           otherwise have to be removed manually.
         '';
-        example = literalExample ''[
-          {
-            name = "nextcloud";
-            ensurePermissions = {
-              "nextcloud.*" = "ALL PRIVILEGES";
-            };
-          }
-          {
-            name = "backup";
-            ensurePermissions = {
-              "*.*" = "SELECT, LOCK TABLES";
-            };
-          }
-        ]'';
+        example = literalExample ''
+          [
+            {
+              name = "nextcloud";
+              ensurePermissions = {
+                "nextcloud.*" = "ALL PRIVILEGES";
+              };
+            }
+            {
+              name = "backup";
+              ensurePermissions = {
+                "*.*" = "SELECT, LOCK TABLES";
+              };
+            }
+          ]
+        '';
       };
 
       # FIXME: remove this option; it's a really bad idea.

--- a/nixos/tests/mysql.nix
+++ b/nixos/tests/mysql.nix
@@ -5,7 +5,7 @@ import ./make-test.nix ({ pkgs, ...} : {
   };
 
   nodes = {
-    master =
+    mysql =
       { pkgs, ... }:
 
       {
@@ -13,12 +13,34 @@ import ./make-test.nix ({ pkgs, ...} : {
         services.mysql.initialDatabases = [ { name = "testdb"; schema = ./testdb.sql; } ];
         services.mysql.package = pkgs.mysql;
       };
+
+    mariadb =
+      { pkgs, ... }:
+
+      {
+        users.users.testuser = { };
+        services.mysql.enable = true;
+        services.mysql.ensureDatabases = [ "testdb" ];
+        services.mysql.ensureUsers = [{
+          name = "testuser";
+          ensurePermissions = {
+            "testdb.*" = "ALL PRIVILEGES";
+          };
+        }];
+        services.mysql.package = pkgs.mariadb;
+      };
+
   };
 
   testScript = ''
     startAll;
 
-    $master->waitForUnit("mysql");
-    $master->succeed("echo 'use testdb; select * from tests' | mysql -u root -N | grep 4");
+    $mysql->waitForUnit("mysql");
+    $mysql->succeed("echo 'use testdb; select * from tests' | mysql -u root -N | grep 4");
+
+    $mariadb->waitForUnit("mysql");
+    $mariadb->succeed("echo 'use testdb; create table tests (test_id INT, PRIMARY KEY (test_id));' | sudo -u testuser mysql -u testuser");
+    $mariadb->succeed("echo 'use testdb; insert into tests values (42);' | sudo -u testuser mysql -u testuser");
+    $mariadb->succeed("echo 'use testdb; select test_id from tests' | sudo -u testuser mysql -u testuser -N | grep 42");
   '';
 })


### PR DESCRIPTION
###### Motivation for this change
Prevent bugs, as mentioned in
https://github.com/NixOS/nixpkgs/pull/56720#issuecomment-471194925

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

