### PR TITLE
termtosvg: fetch source from pypi

### DIFF
--- a/pkgs/tools/misc/termtosvg/default.nix
+++ b/pkgs/tools/misc/termtosvg/default.nix
@@ -1,18 +1,15 @@
-{ lib, python3, fetchFromGitHub }:
+{ lib, python3Packages }:
 
-python3.pkgs.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "termtosvg";
   version = "0.8.0";
 
-  # tests are not available when fetching from pypi
-  src = fetchFromGitHub {
-    owner = "nbedos";
-    repo = pname;
-    rev = version;
-    sha256 = "0si5l8cdbzapcibr4yavhld2vhfrpk7qj4cy7m4ws7js8g9iwzd4";
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "e3a0a7bd511028c96d242525df807a23e6f22e55b111a7ee861f294a86224b0c";
   };
 
-  propagatedBuildInputs = with python3.pkgs; [ lxml pyte ];
+  propagatedBuildInputs = with python3Packages; [ lxml pyte ];
 
   meta = with lib; {
     homepage = https://nbedos.github.io/termtosvg/;


### PR DESCRIPTION
###### Motivation for this change
Fixes https://github.com/NixOS/nixpkgs/issues/57433

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

