### PR TITLE
nspr: patch out timestamp-based impurities

### DIFF
--- a/pkgs/development/libraries/nspr/default.nix
+++ b/pkgs/development/libraries/nspr/default.nix
@@ -22,6 +22,10 @@ stdenv.mkDerivation {
     substituteInPlace configure.in --replace '@executable_path/' "$out/lib/"
   '';
 
+  # Avoid timestamp-based impurity
+  # Patch proposed upstream on 2019-03-15 to dev-tech-nspr@lists.mozilla.org
+  patches = [ ./source_date_epoch.patch ];
+
   HOST_CC = "cc";
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   configureFlags = [

--- a/pkgs/development/libraries/nspr/source_date_epoch.patch
+++ b/pkgs/development/libraries/nspr/source_date_epoch.patch
@@ -1,0 +1,57 @@
+diff --git a/nspr/lib/ds/Makefile.in b/nspr/lib/ds/Makefile.in
+--- a/nspr/lib/ds/Makefile.in
++++ b/nspr/lib/ds/Makefile.in
+@@ -101,8 +101,8 @@
+ TINC = $(OBJDIR)/_pl_bld.h
+ PROD = $(notdir $(SHARED_LIBRARY))
+ NOW = $(MOD_DEPTH)/config/$(OBJDIR)/now
+-SH_DATE = $(shell date "+%Y-%m-%d %T")
+-SH_NOW = $(shell $(NOW))
++SH_DATE = $(shell date $${SOURCE_DATE_EPOCH:+-d "@$$SOURCE_DATE_EPOCH"} "+%Y-%m-%d %T")
++SH_NOW = $(shell echo $${SOURCE_DATE_EPOCH:-$(shell $(NOW))})
+ 
+ ifeq ($(NS_USE_GCC)_$(OS_ARCH),_WINNT)
+ 	SUF = i64
+diff --git a/nspr/lib/libc/src/Makefile.in b/nspr/lib/libc/src/Makefile.in
+--- a/nspr/lib/libc/src/Makefile.in
++++ b/nspr/lib/libc/src/Makefile.in
+@@ -103,8 +103,8 @@
+ TINC = $(OBJDIR)/_pl_bld.h
+ PROD = $(notdir $(SHARED_LIBRARY))
+ NOW = $(MOD_DEPTH)/config/$(OBJDIR)/now
+-SH_DATE = $(shell date "+%Y-%m-%d %T")
+-SH_NOW = $(shell $(NOW))
++SH_DATE = $(shell date $${SOURCE_DATE_EPOCH:+-d "@$$SOURCE_DATE_EPOCH"} "+%Y-%m-%d %T")
++SH_NOW = $(shell echo $${SOURCE_DATE_EPOCH:-$(shell $(NOW))})
+ 
+ ifeq ($(NS_USE_GCC)_$(OS_ARCH),_WINNT)
+ 	SUF = i64
+diff --git a/nspr/lib/prstreams/Makefile.in b/nspr/lib/prstreams/Makefile.in
+--- a/nspr/lib/prstreams/Makefile.in
++++ b/nspr/lib/prstreams/Makefile.in
+@@ -105,8 +105,8 @@
+ TINC = $(OBJDIR)/_pl_bld.h
+ PROD = $(notdir $(SHARED_LIBRARY))
+ NOW = $(MOD_DEPTH)/config/$(OBJDIR)/now
+-SH_DATE = $(shell date "+%Y-%m-%d %T")
+-SH_NOW = $(shell $(NOW))
++SH_DATE = $(shell date $${SOURCE_DATE_EPOCH:+-d "@$$SOURCE_DATE_EPOCH"} "+%Y-%m-%d %T")
++SH_NOW = $(shell echo $${SOURCE_DATE_EPOCH:-$(shell $(NOW))})
+ 
+ ifeq ($(OS_ARCH), WINNT)
+ 	SUF = i64
+diff --git a/nspr/pr/src/Makefile.in b/nspr/pr/src/Makefile.in
+--- a/nspr/pr/src/Makefile.in
++++ b/nspr/pr/src/Makefile.in
+@@ -311,8 +311,8 @@
+ endif
+ 
+ NOW = $(MOD_DEPTH)/config/$(OBJDIR)/now
+-SH_DATE = $(shell date "+%Y-%m-%d %T")
+-SH_NOW = $(shell $(NOW))
++SH_DATE = $(shell date $${SOURCE_DATE_EPOCH:+-d "@$$SOURCE_DATE_EPOCH"} "+%Y-%m-%d %T")
++SH_NOW = $(shell echo $${SOURCE_DATE_EPOCH:-$(shell $(NOW))})
+ 
+ ifeq ($(NS_USE_GCC)_$(OS_ARCH),_WINNT)
+ 	SUF = i64
+


### PR DESCRIPTION
###### Motivation for this change

https://r13y.com/diff/9c582ff3a3e9892dc2ae5d017110cfbac0f7d83d8614e4e9ff436a5467d46013-54f2851d51fb8de80f54619cd6249fc00f93119d092b34dab5d7a48d2ccfce4c.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@GrahamcOfBorg build nspr 

cc @grahamc for the reproducibility project, as this package appears to have no maintainer nor regular committer