### PR TITLE
pythonPackages.weboob: fix build

### DIFF
--- a/pkgs/development/python-modules/weboob/default.nix
+++ b/pkgs/development/python-modules/weboob/default.nix
@@ -40,6 +40,13 @@ in buildPythonPackage rec {
     }; p' weboob/browser/browsers.py weboob/browser/pages.py
   '';
 
+  # Would fail with `Could not find executable: pyuic5`.
+  # That executable will be looked up from an environment variable
+  # in this format when available
+  #
+  # See: https://git.weboob.org/weboob/weboob/blob/1.3/setup.py#L32
+  PYUIC5_EXECUTABLE = "${pyqt5}/bin/pyuic5";
+
   setupPyBuildFlags = ["--qt" "--xdg"];
 
   checkInputs = [ nose ];


### PR DESCRIPTION
###### Motivation for this change
In the course of adding a package I had to update one of its dependencies (pdfminer) to a newer version, I found out that this weboob wouldn't build... (and that was unrelated to my changes)

###### Things done
I did the nox-review wip successfully
Voiced my frustrations on irc and simpson confirmed it wasn't only me and gave me a patch, which was nice as I had no idea how to fix it
I don't use this thing so I don't know what it is or how to use it but I ran some of the bins to see if they still worked (the few I checked didn't error)
Found out there's a new version of it anyway...

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

