### PR TITLE
pythonPackages.pdfminer: 20170720 -> 20181108

### DIFF
--- a/pkgs/development/python-modules/pdfminer_six/default.nix
+++ b/pkgs/development/python-modules/pdfminer_six/default.nix
@@ -1,18 +1,18 @@
-{ stdenv, buildPythonPackage, python, fetchFromGitHub, six, pycryptodome, chardet, nose, pytest }:
+{ stdenv, buildPythonPackage, python, fetchFromGitHub, six, pycryptodome, chardet, nose, pytest, sortedcontainers }:
 
 buildPythonPackage rec {
   pname = "pdfminer_six";
-  version = "20170720";
+  version = "20181108";
 
   src = fetchFromGitHub {
     owner = "pdfminer";
     repo = "pdfminer.six";
     rev = "${version}";
-    sha256 = "0vax5k0a8qn8x86ybpzqydk7x3hajsk8b6xf3y610j19mgag6wvs";
+    sha256 = "1v8pcx43fgidv1g54s92k85anvcss08blkhm4yi1hn1ybl0mmw6c";
   };
 
-  propagatedBuildInputs = [ six pycryptodome chardet ];
-  
+  propagatedBuildInputs = [ six pycryptodome chardet sortedcontainers ];
+
   checkInputs = [ nose pytest ];
   checkPhase = ''
     ${python.interpreter} -m pytest


### PR DESCRIPTION
###### Motivation for this change
In the course of adding a new package I found that it needed a newer version of pdfminer_six than we had so I updated to the latest version

###### Things done
i did a nox-review wip and other than the packages that didn't work anyway (see #57555) everything seems fine. Also successfully executed everything in bin

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

