### PR TITLE
iso-image: make reproducible by not relying on mcopy's readdir

### DIFF
--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -336,8 +336,10 @@ let
 
   efiImg = pkgs.runCommand "efi-image_eltorito" { buildInputs = [ pkgs.mtools pkgs.libfaketime ]; }
     # Be careful about determinism: du --apparent-size,
-    #   dates (cp -p, touch, mcopy -m, faketime for label), IDs (mkfs.vfat -i)
+    #   dates (cp -p, touch, mcopy -m, faketime for label), IDs (mkfs.vfat -i),
+    #   mcopy's write order (-s uses `readdir` order)
     ''
+      # Prepare the ./EFI and ./boot directories
       mkdir ./contents && cd ./contents
       cp -rp "${efiDir}"/EFI .
       mkdir ./boot
@@ -345,6 +347,7 @@ let
         "${config.system.build.initialRamdisk}/${config.system.boot.loader.initrdFile}" ./boot/
       touch --date=@0 ./EFI ./boot
 
+      # Prepare the image file
       usage_size=$(du -sb --apparent-size . | tr -cd '[:digit:]')
       # Make the image 110% as big as the files need to make up for FAT overhead
       image_size=$(( ($usage_size * 110) / 100 ))
@@ -354,8 +357,16 @@ let
       echo "Usage size: $usage_size"
       echo "Image size: $image_size"
       truncate --size=$image_size "$out"
+
+      # Make the filesystem
       ${pkgs.libfaketime}/bin/faketime "2000-01-01 00:00:00" ${pkgs.dosfstools}/sbin/mkfs.vfat -i 12345678 -n EFIBOOT "$out"
-      mcopy -psvm -i "$out" ./EFI ./boot ::
+
+      # Copy the files
+      # Note: we can't use mcopy's recursive copying as it uses `readdir` order.
+      # So just copy file-after-file
+      find ./EFI ./boot -type f -print0 | sort -z | \
+        xargs -0I '{}' mcopy -pvm -i "$out" '{}' ::
+
       # Verify the FAT partition.
       ${pkgs.dosfstools}/sbin/fsck.vfat -vn "$out"
     ''; # */


### PR DESCRIPTION
###### Motivation for this change

https://r13y.com/diff/a367e8e30543e46b5ba60b938d64758ec869a804cdfc4b741baa49a6787115bb-5e7bb023000e2db7a008918f0f7bb59a6f66d17fe4974a54ee7945e9cf9675d8.html

My investigation ended up in `mcopy`'s copying implementation relying on `readdir` order (file `unixdir.c`).

I'm not sure of the fix yet, as diffoscope raises a much bigger than expected diff. If someone knows the attribute path to one of our tests that exercises this code, I'll be happy to trigger an ofborg run.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

