### PR TITLE
lightdm_gtk_greeter: fix configureFlags to not be one long string

### DIFF
--- a/pkgs/applications/display-managers/lightdm/gtk-greeter.nix
+++ b/pkgs/applications/display-managers/lightdm/gtk-greeter.nix
@@ -23,18 +23,21 @@ stdenv.mkDerivation rec {
   buildInputs = [ lightdm exo intltool makeWrapper hicolor-icon-theme ]
     ++ (if useGTK2 then [ gtk2 ] else [ gtk3 ]);
 
-  configureFlagsArray = [
+  configureFlags = [
     "--localstatedir=/var"
     "--sysconfdir=/etc"
     "--disable-indicator-services-command"
-    "--enable-at-spi-command=${at-spi2-core}/libexec/at-spi-bus-launcher  --launch-immediately"
   ] ++ stdenv.lib.optional useGTK2 "--with-gtk2";
+
+  preConfigure = ''
+    configureFlagsArray+=( --enable-at-spi-command="${at-spi2-core}/libexec/at-spi-bus-launcher --launch-immediately" )
+  '';
 
   NIX_CFLAGS_COMPILE = [ "-Wno-error=deprecated-declarations" ];
 
   installFlags = [
     "localstatedir=\${TMPDIR}"
-    "sysconfdir=\${out}/etc"
+    "sysconfdir=${placeholder "out"}/etc"
   ];
 
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change

For whatever reason, setting `configureFlagsArray` causes
the configure invocation to escape spaces between parameters:

configure flags: --disable-static --disable-dependency-tracking --prefix=/nix/store/4bn8dsr743dp0g5j020jf8why5hkld3p-lightdm-gtk-greeter-2.0.6 --localstatedir=/var\ --sysconfdir=/etc\ --disable-indicator-services-command\ --enable-at-spi-command=/nix/store/li9bsxl8qja8qw0pa70xd572gw5hqsdm-at-spi2-core-2.30.1/libexec/at-spi-bus-launcher\ \ --launch-immediately

This actually doesn't break the build (!) but it does break
lightdm pretty badly for me and it's not hard to imagine why :).

Instead, use configureFlags as normal but just append the command
in `preConfigure` directly, so we can preserve the space.

cc @worldofpeace

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---