### PR TITLE
nixos/manual: document auto-login

### DIFF
--- a/nixos/doc/manual/configuration/x-windows.xml
+++ b/nixos/doc/manual/configuration/x-windows.xml
@@ -73,7 +73,7 @@
   <para>
   To enable auto-login, you need to define your default window manager and
   desktop environment. If you wanted no desktop environment and i3 as your your
-  windowzmanager, you'd define:
+  window manager, you'd define:
 <programlisting>
 <xref linkend="opt-services.xserver.desktopManager.default"/> = "none";
 <xref linkend="opt-services.xserver.windowManager.default"/> = "i3";

--- a/nixos/doc/manual/configuration/x-windows.xml
+++ b/nixos/doc/manual/configuration/x-windows.xml
@@ -59,6 +59,32 @@
 <screen>
 # systemctl start display-manager.service
 </screen>
+  <simplesect xml:id="sec-x11-auto-login">
+  <title>Auto-login</title>
+  <para>
+  The x11 login screen can be skipped entirely, automatically logging you into
+  your window manager and desktop environment when you boot your computer.
+  </para>
+  <para>
+  This is especially helpful if you have disk encryption enabled. Since you
+  already have to provide a password to decrypt your disk, entering a second
+  password to login can be redundant.
+  </para>
+  <para>
+  To enable auto-login, you need to define your default window manager and
+  desktop environment. If you wanted no desktop environment and i3 as your your
+  windowzmanager, you'd define:
+<programlisting>
+<xref linkend="opt-services.xserver.desktopManager.default"/> = "none";
+<xref linkend="opt-services.xserver.windowManager.default"/> = "i3";
+</programlisting>
+  And, finally, to enable auto-login for a user <literal>johndoe</literal>:
+<programlisting>
+<xref linkend="opt-services.xserver.displayManager.auto.enable"/> = true;
+<xref linkend="opt-services.xserver.displayManager.auto.user"/> = "johndoe";
+</programlisting>
+  </para>
+ </simplesect>
  </para>
  <simplesect xml:id="sec-x11-graphics-cards-nvidia">
   <title>NVIDIA Graphics Cards</title>


### PR DESCRIPTION
#29526: document x11 auto-login

###### Motivation for this change
fix #29526

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

