### PR TITLE
pacman: 5.1.2 -> 5.1.3

### DIFF
--- a/pkgs/tools/package-management/pacman/default.nix
+++ b/pkgs/tools/package-management/pacman/default.nix
@@ -3,11 +3,11 @@ zlib, bzip2, lzma }:
 
 stdenv.mkDerivation rec {
   name = "pacman-${version}";
-  version = "5.1.2";
+  version = "5.1.3";
 
   src = fetchurl {
     url = "https://git.archlinux.org/pacman.git/snapshot/pacman-${version}.tar.gz";
-    sha256 = "19fr60h0ffxzjxmlmhrfcq8447l0bkxnh64fwjagqn133d3dgd5x";
+    sha256 = "108xp6dhvp02jnzskhgzjmp9jvrxhhkffvmpvs3rrif7vj47xd76";
   };
 
   configureFlags = [


### PR DESCRIPTION
###### Motivation for this change

Not listed on official website[1],
but present in release directory[2]...
and seems legit[3][4]

Fixes CVE, looks like:

https://lwn.net/Articles/782828/

[1] https://www.archlinux.org/pacman/#_releases
[2] https://sources.archlinux.org/other/pacman/
[3] https://git.archlinux.org/svntogit/packages.git/commit/trunk?h=packages/pacman&id=f48884ebff6788406fe1911f179a363bd2aeb9b1
[4] https://lists.archlinux.org/pipermail/pacman-dev/2019-March/023208.html


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

build-tested, works well enough for `pacman -V` :innocent:.