### PR TITLE
 drawpile: 2.0.11 -> 2.1.2 

### DIFF
--- a/pkgs/applications/graphics/drawpile/default.nix
+++ b/pkgs/applications/graphics/drawpile/default.nix
@@ -11,15 +11,20 @@
 , libmicrohttpd
 , giflib
 , miniupnpc
+, extra-cmake-modules
+, libvpx
 }:
 
 stdenv.mkDerivation rec {
   name = "drawpile-${version}";
-  version = "2.0.11";
+  version = "2.1.2";
   src = fetchurl {
     url = "https://drawpile.net/files/src/drawpile-${version}.tar.gz";
-    sha256 = "0h018rxhc0lwpqwmlihalz634nd0xaafk4p2b782djjd87irnjpk";
+    sha256 = "02kkn317w9xhdqq2b4fq2bvipsnbp9945b6vghx3q2p6mckr9mhi";
   };
+  nativeBuildInputs = [
+    extra-cmake-modules
+  ];
   buildInputs = [
     cmake
     qtbase qtsvg qtmultimedia qttools
@@ -30,6 +35,7 @@ stdenv.mkDerivation rec {
     giflib # gif animation export support
     miniupnpc # automatic port forwarding
     kdnssd # local server discovery with Zeroconf
+    libvpx # WebM video export
   ];
   configurePhase = "cmake -DCMAKE_INSTALL_PREFIX=$out .";
 

--- a/pkgs/applications/graphics/drawpile/default.nix
+++ b/pkgs/applications/graphics/drawpile/default.nix
@@ -26,12 +26,15 @@ stdenv.mkDerivation rec {
     extra-cmake-modules
   ];
   buildInputs = [
+    # common deps:
     cmake
     qtbase qtsvg qtmultimedia qttools
     karchive
     # optional deps:
+    #   server-specific:
     libsodium # ext-auth support
     libmicrohttpd # HTTP admin api
+    #   client-specific:
     giflib # gif animation export support
     miniupnpc # automatic port forwarding
     kdnssd # local server discovery with Zeroconf


### PR DESCRIPTION
###### Motivation for this change

Major release \o/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

