### PR TITLE
drawpile: add build options and split into multiple top-level attrs

### DIFF
--- a/pkgs/applications/graphics/drawpile/default.nix
+++ b/pkgs/applications/graphics/drawpile/default.nix
@@ -1,21 +1,63 @@
 { stdenv
 , fetchurl
 , cmake
-, qtbase
-, qtsvg
-, qtmultimedia
-, qttools
-, kdnssd
-, karchive
-, libsodium
-, libmicrohttpd
-, giflib
-, miniupnpc
 , extra-cmake-modules
+
+# common deps
+, karchive
+
+# client deps
+, qtbase
+, qtmultimedia
+, qtsvg
+, qttools
+
+# optional client deps
+, giflib
+, kdnssd
 , libvpx
+, miniupnpc
+, qtx11extras # kis
+
+# optional server deps
+, libmicrohttpd
+, libsodium
+
+# options
+, buildClient ? true
+, buildServer ? true
+, buildServerGui ? true # if false builds a headless server
+, buildExtraTools ? false
+, enableKisTablet ? false # enable improved graphics tablet support
 }:
 
-stdenv.mkDerivation rec {
+with stdenv.lib;
+
+let
+  commonDeps = [
+    karchive
+  ];
+  clientDeps = [
+    qtbase
+    qtmultimedia
+    qtsvg
+    qttools
+    # optional:
+    giflib # gif animation export support
+    kdnssd # local server discovery with Zeroconf
+    libvpx # WebM video export
+    miniupnpc # automatic port forwarding
+  ];
+  serverDeps = [
+    # optional:
+    libmicrohttpd # HTTP admin api
+    libsodium # ext-auth support
+  ];
+  kisDeps = [
+    qtx11extras
+  ];
+
+in stdenv.mkDerivation rec {
   name = "drawpile-${version}";
   version = "2.1.6";
   src = fetchurl {
@@ -23,26 +65,25 @@ stdenv.mkDerivation rec {
     sha256 = "0vwsdvphigrq1daiazi411qflahlvgx8x8ssp581bng2lbq1vrbd";
   };
   nativeBuildInputs = [
+    cmake
     extra-cmake-modules
   ];
-  buildInputs = [
-    # common deps:
-    cmake
-    qtbase qtsvg qtmultimedia qttools
-    karchive
-    # optional deps:
-    #   server-specific:
-    libsodium # ext-auth support
-    libmicrohttpd # HTTP admin api
-    #   client-specific:
-    giflib # gif animation export support
-    miniupnpc # automatic port forwarding
-    kdnssd # local server discovery with Zeroconf
-    libvpx # WebM video export
-  ];
-  configurePhase = "cmake -DCMAKE_INSTALL_PREFIX=$out .";
+  buildInputs =
+    commonDeps ++
+    optionals buildClient      clientDeps ++
+    optionals buildServer      serverDeps ++
+    optionals enableKisTablet  kisDeps    ;
+  configurePhase = ''
+    cmake . \
+      ${optionalString (!buildClient    )  "-DCLIENT=off"   } \
+      ${optionalString (!buildServer    )  "-DSERVER=off"   } \
+      ${optionalString (!buildServerGui )  "-DSERVERGUI=off"} \
+      ${optionalString ( buildExtraTools)  "-DTOOLS=on"     } \
+      ${optionalString ( enableKisTablet)  "-DKIS_TABLET=on"} \
+      -DCMAKE_INSTALL_PREFIX=$out
+  '';
 
-  meta = with stdenv.lib; {
+  meta = {
     description = "A collaborative drawing program that allows multiple users to sketch on the same canvas simultaneously";
     homepage = https://drawpile.net/;
     downloadPage = https://drawpile.net/download/;

--- a/pkgs/applications/graphics/drawpile/default.nix
+++ b/pkgs/applications/graphics/drawpile/default.nix
@@ -60,10 +60,12 @@ let
 in stdenv.mkDerivation rec {
   name = "drawpile-${version}";
   version = "2.1.6";
+
   src = fetchurl {
     url = "https://drawpile.net/files/src/drawpile-${version}.tar.gz";
     sha256 = "0vwsdvphigrq1daiazi411qflahlvgx8x8ssp581bng2lbq1vrbd";
   };
+
   nativeBuildInputs = [
     cmake
     extra-cmake-modules
@@ -73,15 +75,13 @@ in stdenv.mkDerivation rec {
     optionals buildClient      clientDeps ++
     optionals buildServer      serverDeps ++
     optionals enableKisTablet  kisDeps    ;
-  configurePhase = ''
-    cmake . \
-      ${optionalString (!buildClient    )  "-DCLIENT=off"   } \
-      ${optionalString (!buildServer    )  "-DSERVER=off"   } \
-      ${optionalString (!buildServerGui )  "-DSERVERGUI=off"} \
-      ${optionalString ( buildExtraTools)  "-DTOOLS=on"     } \
-      ${optionalString ( enableKisTablet)  "-DKIS_TABLET=on"} \
-      -DCMAKE_INSTALL_PREFIX=$out
-  '';
+
+  cmakeFlags =
+    optional (!buildClient    )  "-DCLIENT=off" ++
+    optional (!buildServer    )  "-DSERVER=off" ++
+    optional (!buildServerGui )  "-DSERVERGUI=off" ++
+    optional ( buildExtraTools)  "-DTOOLS=on" ++
+    optional ( enableKisTablet)  "-DKIS_TABLET=on";
 
   meta = {
     description = "A collaborative drawing program that allows multiple users to sketch on the same canvas simultaneously";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16956,6 +16956,10 @@ in
   dragonfly-reverb = callPackage ../applications/audio/dragonfly-reverb { };
 
   drawpile = libsForQt5.callPackage ../applications/graphics/drawpile { };
+  drawpile-server-headless = libsForQt5.callPackage ../applications/graphics/drawpile {
+    buildClient = false;
+    buildServerGui = false;
+  };
 
   droopy = callPackage ../applications/networking/droopy {
     inherit (python3Packages) wrapPython;


### PR DESCRIPTION
###### Motivation for this change

Right now the `drawpile` derivation builds a full package, but someone may want only the server or client. This pr makes it possible and adds some drawpile variants to `all-packages.nix`.

Is the way I did it ok? Am I unnecessarily polluting the global namespace?

Depends on #57568.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

