### PR TITLE
pgmetrics: 1.5.0 -> 1.6.1

### DIFF
--- a/pkgs/tools/misc/pgmetrics/default.nix
+++ b/pkgs/tools/misc/pgmetrics/default.nix
@@ -1,8 +1,8 @@
 { stdenv, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
-  name = "pgmetrics-${version}";
-  version = "1.5.0";
+  pname = "pgmetrics";
+  version = "1.6.1";
 
   goPackagePath = "github.com/rapidloop/pgmetrics";
 
@@ -10,7 +10,7 @@ buildGoPackage rec {
     owner  = "rapidloop";
     repo   = "pgmetrics";
     rev    = "refs/tags/v${version}";
-    sha256 = "1l3vd1lvp4a6irx0zpjb5bkskkb9krx9j7pwii8jy9dcjy4gj24f";
+    sha256 = "0dj4b4gghzzwnzb0fdix1ps97scfr24f6dfa7d0vwak95ds5vz3s";
   };
 
   goDeps = ./deps.nix;

--- a/pkgs/tools/misc/pgmetrics/deps.nix
+++ b/pkgs/tools/misc/pgmetrics/deps.nix
@@ -1,83 +1,83 @@
-# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
+# file generated from go.mod using vgo2nix (https://github.com/adisbladis/vgo2nix)
 [
   {
-    goPackagePath  = "github.com/dustin/go-humanize";
+    goPackagePath = "github.com/dustin/go-humanize";
     fetch = {
       type = "git";
       url = "https://github.com/dustin/go-humanize";
-      rev =  "bb3d318650d48840a39aa21a027c6630e198e626";
+      rev = "bb3d318650d4";
       sha256 = "1lqd8ix3cb164j5iazjby2jpa6bdsflhy0h9mi4yldvvcvrc194c";
     };
   }
   {
-    goPackagePath  = "github.com/howeyc/gopass";
+    goPackagePath = "github.com/howeyc/gopass";
     fetch = {
       type = "git";
       url = "https://github.com/howeyc/gopass";
-      rev =  "bf9dde6d0d2c004a008c27aaee91170c786f6db8";
+      rev = "bf9dde6d0d2c";
       sha256 = "1jxzyfnqi0h1fzlsvlkn10bncic803bfhslyijcxk55mgh297g45";
     };
   }
   {
-    goPackagePath  = "github.com/lib/pq";
-    fetch = {
-      type = "git";
-      url = "https://github.com/lib/pq";
-      rev =  "88edab0803230a3898347e77b474f8c1820a1f20";
-      sha256 = "02y7c8xy33x5q4167x2drzrys41nfi7wxxp9hy4vpazfws88al9p";
-    };
-  }
-  {
-    goPackagePath  = "github.com/pborman/getopt";
+    goPackagePath = "github.com/pborman/getopt";
     fetch = {
       type = "git";
       url = "https://github.com/pborman/getopt";
-      rev =  "7148bc3a4c3008adfcab60cbebfd0576018f330b";
+      rev = "7148bc3a4c30";
       sha256 = "0zhvvmv671r1fbdd5hbv3flx8k2rb60giqx115w0553c56qkqfpj";
     };
   }
   {
-    goPackagePath  = "github.com/rapidloop/pq";
+    goPackagePath = "github.com/rapidloop/pq";
     fetch = {
       type = "git";
       url = "https://github.com/rapidloop/pq";
-      rev =  "f379fd34d14f11337c3945aa665f7718c0213317";
-      sha256 = "0svhissh6v1qdj9zypvj6jpjrx9g56gq8sf1pila41mczglmni05";
+      rev = "66681b501d6d";
+      sha256 = "1pa3h40b52g3vdwgh6ny0hw66qmxf64jqapxyy1zkjhhwab1h71y";
     };
   }
   {
-    goPackagePath  = "github.com/xdg-go/stringprep";
+    goPackagePath = "github.com/xdg-go/stringprep";
     fetch = {
       type = "git";
       url = "https://github.com/xdg-go/stringprep";
-      rev =  "bd625b8dc1e3b0f57412280ccbcc317f0c69d8db";
+      rev = "v1.0.0";
       sha256 = "03nard51zgzbaq64p6gsvrz8fps3yazl3ydd115y0bppkdx2i4ji";
     };
   }
   {
-    goPackagePath  = "golang.org/x/crypto";
+    goPackagePath = "github.com/xdg/stringprep";
+    fetch = {
+      type = "git";
+      url = "https://github.com/xdg/stringprep";
+      rev = "v1.0.0";
+      sha256 = "03nard51zgzbaq64p6gsvrz8fps3yazl3ydd115y0bppkdx2i4ji";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/crypto";
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/crypto";
-      rev =  "432090b8f568c018896cd8a0fb0345872bbac6ce";
+      rev = "432090b8f568";
       sha256 = "1i8616qqwih6g5nx8c1hfqhp0kb110ml3xkgsn6qvc36q04amjmq";
     };
   }
   {
-    goPackagePath  = "golang.org/x/sys";
+    goPackagePath = "golang.org/x/sys";
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/sys";
-      rev =  "37707fdb30a5b38865cfb95e5aab41707daec7fd";
+      rev = "37707fdb30a5";
       sha256 = "1abrr2507a737hdqv4q7pw7hv6ls9pdiq9crhdi52r3gcz6hvizg";
     };
   }
   {
-    goPackagePath  = "golang.org/x/text";
+    goPackagePath = "golang.org/x/text";
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/text";
-      rev =  "f21a4dfb5e38f5895301dc265a8def02365cc3d0";
+      rev = "v0.3.0";
       sha256 = "0r6x6zjzhr8ksqlpiwm5gdd7s209kwk5p4lw54xjvz10cs3qlq19";
     };
   }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

