### PR TITLE
odyssey: init at 2019-03-12

### DIFF
--- a/pkgs/tools/misc/odyssey/default.nix
+++ b/pkgs/tools/misc/odyssey/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, cmake, openssl }:
+
+stdenv.mkDerivation rec {
+  pname = "odyssey";
+  version = "unstable-2019-03-12";
+
+  src = fetchFromGitHub {
+    owner = "yandex";
+    repo = pname;
+    rev = "af015839b03f30260c75d8f565521910c0694ed6";
+    sha256 = "1cnnypvk78wp1qmqfriky40ls0grkp4v46mypyaq5kl8ppknvnvs";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ openssl ];
+
+  installPhase = ''
+    install -Dm755 -t $out/bin sources/odyssey
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Scalable PostgreSQL connection pooler";
+    homepage = https://github.com/yandex/odyssey;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.marsam ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4628,6 +4628,8 @@ in
 
   odt2txt = callPackage ../tools/text/odt2txt { };
 
+  odyssey = callPackage ../tools/misc/odyssey { };
+
   offlineimap = callPackage ../tools/networking/offlineimap { };
 
   oh-my-zsh = callPackage ../shells/zsh/oh-my-zsh { };


### PR DESCRIPTION
###### Motivation for this change
Add https://github.com/yandex/odyssey

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

