### PR TITLE
ipxe: 20180220 -> 20190310

### DIFF
--- a/pkgs/tools/misc/ipxe/default.nix
+++ b/pkgs/tools/misc/ipxe/default.nix
@@ -3,8 +3,8 @@
 }:
 
 let
-  date = "20180220";
-  rev = "47849be3a900c546cf92066849be0806f4e611d9";
+  date = "20190310";
+  rev = "b6ffe28a21c53a0946d95751c905d9e0b6c3b630";
 in
 
 stdenv.mkDerivation {
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
 
   src = fetchgit {
     url = git://git.ipxe.org/ipxe.git;
-    sha256 = "1f4pi1dp2zqnrbfnggnzycfvrxv0bqgw73dxbyy3hfy4mhdj6z45";
+    sha256 = "1s8sy75lpx8zq60wc0i35d8c1wwm1rq3scxpkq31623d097mch59";
     inherit rev;
   };
 


### PR DESCRIPTION
###### Motivation for this change

This fixes #57581 by updating iPXE to a newer version, which incorporates the patch from https://bugzilla.opensuse.org/show_bug.cgi?id=1105510, which has been upstreamed.

Please cherry-pick to 19.03

###### Things done

Tested by making a server boot over the network with ipxe

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

