### PR TITLE
pythonPackages.sphinxcontrib-tikz: init at 0.4.6

### DIFF
--- a/pkgs/development/python-modules/sphinxcontrib-tikz/binary-paths.patch
+++ b/pkgs/development/python-modules/sphinxcontrib-tikz/binary-paths.patch
@@ -1,0 +1,22 @@
+diff --git a/sphinxcontrib/tikz.py b/sphinxcontrib/tikz.py
+index ee21113..a4f4589 100644
+--- a/sphinxcontrib/tikz.py
++++ b/sphinxcontrib/tikz.py
+@@ -242,7 +242,7 @@ def render_tikz(self, node, libs='', stringsubst=False):
+         tf.write(latex)
+         tf.close()
+ 
+-        system([self.builder.config.latex_engine, '--interaction=nonstopmode',
++        system(['@texLive@/bin/pdflatex', '--interaction=nonstopmode',
+                 'tikz-%s.tex' % shasum],
+                self.builder)
+ 
+@@ -281,7 +281,7 @@ def render_tikz(self, node, libs='', stringsubst=False):
+                     '-sOutputFile=%s' % outfn, '-r' + resolution + 'x' + resolution,
+                     '-f', 'tikz-%s.pdf' % shasum], self.builder)
+         elif self.builder.config.tikz_proc_suite == "pdf2svg":
+-            system(['pdf2svg', 'tikz-%s.pdf' % shasum, outfn], self.builder)
++            system(['@pdf2svg@/bin/pdf2svg', 'tikz-%s.pdf' % shasum, outfn], self.builder)
+         else:
+             self.builder._tikz_warned = True
+             raise TikzExtError('Error (tikz extension): Invalid configuration '

--- a/pkgs/development/python-modules/sphinxcontrib-tikz/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-tikz/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, substituteAll
+, buildPythonPackage
+, fetchPypi
+, sphinx
+, pdf2svg
+, texLive
+}:
+
+buildPythonPackage rec {
+  pname = "sphinxcontrib-tikz";
+  version = "0.4.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "4f362b11e3c2bd17d5f0f07fec03917c16fc5bbcda6fe31ee137c547ed6b03a3";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./binary-paths.patch;
+      inherit texLive pdf2svg;
+    })
+  ];
+
+  propagatedBuildInputs = [ sphinx ];
+
+  # no tests in package
+  doCheck = false;
+
+  meta = with lib; {
+    description = "TikZ extension for Sphinx";
+    homepage = https://bitbucket.org/philexander/tikz;
+    maintainers = with maintainers; [ costrouc ];
+    license = licenses.bsd3;
+  };
+
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4556,6 +4556,10 @@ in {
 
   sphinxcontrib-spelling = callPackage ../development/python-modules/sphinxcontrib-spelling { };
 
+  sphinxcontrib-tikz = callPackage ../development/python-modules/sphinxcontrib-tikz {
+    texLive = pkgs.texlive.combine { inherit (pkgs.texlive) scheme-small standalone pgfplots; };
+  };
+
   sphinx_pypi_upload = callPackage ../development/python-modules/sphinx_pypi_upload { };
 
   Pweave = callPackage ../development/python-modules/pweave { };


### PR DESCRIPTION
Limited texlive package to minimal packages schema-small + standalone + pgfplots

###### Motivation for this change

I want tikz for my documentation (nothing beats tikz in editable graphics :) )

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

