### PR TITLE
lib/attrsets: add mapAttrsToString and mapAttrsToStringSep

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -4,7 +4,7 @@
 let
   inherit (builtins) head tail length;
   inherit (lib.trivial) and;
-  inherit (lib.strings) concatStringsSep;
+  inherit (lib.strings) concatStrings concatStringsSep;
   inherit (lib.lists) fold concatMap concatLists;
 in
 
@@ -232,6 +232,30 @@ rec {
   */
   mapAttrsToList = f: attrs:
     map (name: f name attrs.${name}) (attrNames attrs);
+
+
+  /* Call a function for each attribute in the given set and
+     concatenate the returned strings.
+
+     Example:
+       mapAttrsToString (name: value: name + value)
+          { x = "a"; y = "b"; }
+       => "xayb"
+  */
+  mapAttrsToString = f: attrs:
+    concatStrings (mapAttrsToList f attrs);
+
+
+  /* Call a function for each attribute in the given set and
+     concatenate the returned strings with a separator between each element.
+
+     Example:
+       mapAttrsToStringSep "," (name: value: name + value)
+          { x = "a"; y = "b"; }
+       => "xa,yb"
+  */
+  mapAttrsToStringSep = sep: f: attrs:
+    concatStringsSep sep (mapAttrsToList f attrs);
 
 
   /* Like `mapAttrs', except that it recursively applies itself to

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -66,7 +66,8 @@ let
     inherit (attrsets) attrByPath hasAttrByPath setAttrByPath
       getAttrFromPath attrVals attrValues getAttrs catAttrs filterAttrs
       filterAttrsRecursive foldAttrs collect nameValuePair mapAttrs
-      mapAttrs' mapAttrsToList mapAttrsRecursive mapAttrsRecursiveCond
+      mapAttrs' mapAttrsToList mapAttrsToString mapAttrsToStringSep
+      mapAttrsRecursive mapAttrsRecursiveCond
       genAttrs isDerivation toDerivation optionalAttrs
       zipAttrsWithNames zipAttrsWith zipAttrs recursiveUpdateUntil
       recursiveUpdate matchAttrs overrideExisting getOutput getBin


### PR DESCRIPTION
###### Motivation for this change

The combination of `mapAttrsToList` followed by a `concatStrings`/`concatStringsSep` has been used a lot.
```shell
> rg 'concatStrings.*mapAttrsToList' ./pkgs | wc -l
11
> rg 'concatStrings.*mapAttrsToList' ./nixos | wc -l
96
```

This pull request adds `mapAttrsToString` and `mapAttrsToStringSep`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

