### PR TITLE
paulstretch: init at version 2.2-2

### DIFF
--- a/pkgs/applications/audio/paulstretch/default.nix
+++ b/pkgs/applications/audio/paulstretch/default.nix
@@ -12,7 +12,6 @@
 , portaudio
 , libsamplerate
 }:
-with (import <nixpkgs> {});
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
@@ -20,7 +19,7 @@ stdenv.mkDerivation rec {
   version = "2.2-2";
 
   meta = with stdenv.lib;
-    { description = "Produces high quality extreme sound stretching.";
+    { description = "Produces high quality extreme sound stretching";
       longDescription = ''
         This is a program for stretching the audio. It is suitable only for
         extreme sound stretching of the audio (like 50x) and for applying
@@ -39,6 +38,8 @@ stdenv.mkDerivation rec {
     sha256 = "06dy03dbz1yznhsn0xvsnkpc5drzwrgxbxdx0hfpsjn2xcg0jrnc";
   };
 
+  nativeBuildInputs = [ pkgconfig ];
+
   buildInputs = [
     audiofile
     libvorbis
@@ -46,7 +47,6 @@ stdenv.mkDerivation rec {
     fftw
     fftwFloat
     minixml
-    pkgconfig
     libmad
     libjack2
     portaudio
@@ -58,7 +58,6 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    mkdir $out
-    cp paulstretch $out
+    install -Dm555 ./paulstretch $out/bin/paulstretch
   '';
 }

--- a/pkgs/applications/audio/paulstretch/default.nix
+++ b/pkgs/applications/audio/paulstretch/default.nix
@@ -1,0 +1,64 @@
+{ stdenv
+, fetchFromGitHub
+, audiofile
+, libvorbis
+, fltk
+, fftw
+, fftwFloat
+, minixml
+, pkgconfig
+, libmad
+, libjack2
+, portaudio
+, libsamplerate
+}:
+with (import <nixpkgs> {});
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "paulstretch";
+  version = "2.2-2";
+
+  meta = with stdenv.lib;
+    { description = "Produces high quality extreme sound stretching.";
+      longDescription = ''
+        This is a program for stretching the audio. It is suitable only for
+        extreme sound stretching of the audio (like 50x) and for applying
+        special effects by "spectral smoothing" the sounds.
+        It can transform any sound/music to a texture.
+      '';
+      homepage = http://hypermammut.sourceforge.net/paulstretch/;
+      platforms = platforms.linux;
+      license = lib.licenses.gpl2;
+    };
+
+  src = fetchFromGitHub {
+    owner = "paulnasca";
+    repo = "paulstretch_cpp";
+    rev = "7f5c3993abe420661ea0b808304b0e2b4b0048c5";
+    sha256 = "06dy03dbz1yznhsn0xvsnkpc5drzwrgxbxdx0hfpsjn2xcg0jrnc";
+  };
+
+  buildInputs = [
+    audiofile
+    libvorbis
+    fltk
+    fftw
+    fftwFloat
+    minixml
+    pkgconfig
+    libmad
+    libjack2
+    portaudio
+    libsamplerate
+  ];
+
+  buildPhase = ''
+    bash compile_linux_fftw_jack.sh
+  '';
+
+  installPhase = ''
+    mkdir $out
+    cp paulstretch $out
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4542,6 +4542,8 @@ with pkgs;
 
   parted = callPackage ../tools/misc/parted { };
 
+  paulstretch = callPackage ../applications/audio/paulstretch { };
+
   pell = callPackage ../applications/misc/pell { };
 
   pepper = callPackage ../tools/admin/salt/pepper { };


### PR DESCRIPTION
###### Motivation for this change
This awesome little program is not in nixpkgs yet.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---