### PR TITLE
appimagekit: add some fixes

### DIFF
--- a/pkgs/tools/package-management/appimagekit/default.nix
+++ b/pkgs/tools/package-management/appimagekit/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub
-, pkgconfig, cmake, autoconf, automake, libtool
+, pkgconfig, cmake, autoconf, automake, libtool, makeWrapper
 , wget, xxd, desktop-file-utils, file
-, glib, zlib, cairo, openssl, fuse, xz, squashfuse, inotify-tools, libarchive
+, gnupg, glib, zlib, cairo, openssl, fuse, xz, squashfuse, inotify-tools, libarchive
 , squashfsTools
 , gtest
 }:
@@ -72,8 +72,12 @@ in stdenv.mkDerivation rec {
   buildInputs = [
     glib zlib cairo openssl fuse
     xz inotify-tools libarchive
-    squashfsTools
+    squashfsTools makeWrapper
   ];
+
+  postPatch = ''
+    substituteInPlace src/appimagetool.c --replace "/usr/bin/file" "${file}/bin/file"
+  '';
 
   preConfigure = ''
     export HOME=$(pwd)
@@ -89,6 +93,14 @@ in stdenv.mkDerivation rec {
     "-DUSE_SYSTEM_MKSQUASHFS=ON"
     "-DBUILD_TESTING=${if doCheck then "ON" else "OFF"}"
   ];
+
+  postInstall = ''
+    cp "${squashfsTools}/bin/mksquashfs" "$out/lib/appimagekit/"
+    cp "${desktop-file-utils}/bin/desktop-file-validate" "$out/bin"
+
+    wrapProgram "$out/bin/appimagetool" \
+      --prefix PATH : "${stdenv.lib.makeBinPath [ file gnupg ]}"
+  '';
 
   checkInputs = [ gtest ];
   doCheck = false; # fails 1 out of 4 tests, I'm too lazy to debug why

--- a/pkgs/tools/package-management/appimagekit/default.nix
+++ b/pkgs/tools/package-management/appimagekit/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub
 , pkgconfig, cmake, autoconf, automake, libtool
-, wget, xxd, desktop-file-utils
+, wget, xxd, desktop-file-utils, file
 , glib, zlib, cairo, openssl, fuse, xz, squashfuse, inotify-tools, libarchive
 , squashfsTools
 , gtest

--- a/pkgs/tools/package-management/appimagekit/nix.patch
+++ b/pkgs/tools/package-management/appimagekit/nix.patch
@@ -172,3 +172,16 @@ index cf5fd5c..4f48dbc 100644
  #include "shared.h"
  
  #if HAVE_LIBARCHIVE3 == 1 // CentOS
+diff --git a/src/appimagetool.c b/src/appimagetool.c
+index 69beaa1..b797ae6 100644
+--- a/src/appimagetool.c
++++ b/src/appimagetool.c
+@@ -348,7 +345,7 @@ void extract_arch_from_text(gchar *archname, const gchar* sourcename, bool* arch
+ void guess_arch_of_file(const gchar *archfile, bool* archs) {
+     char line[PATH_MAX];
+     char command[PATH_MAX];
+-    sprintf(command, "/usr/bin/file -L -N -b %s", archfile);
++    sprintf(command, "file -L -N -b %s", archfile);
+     FILE* fp = popen(command, "r");
+     if (fp == NULL)
+         die("Failed to run file command");

--- a/pkgs/tools/package-management/appimagekit/nix.patch
+++ b/pkgs/tools/package-management/appimagekit/nix.patch
@@ -172,16 +172,3 @@ index cf5fd5c..4f48dbc 100644
  #include "shared.h"
  
  #if HAVE_LIBARCHIVE3 == 1 // CentOS
-diff --git a/src/appimagetool.c b/src/appimagetool.c
-index 69beaa1..b797ae6 100644
---- a/src/appimagetool.c
-+++ b/src/appimagetool.c
-@@ -348,7 +345,7 @@ void extract_arch_from_text(gchar *archname, const gchar* sourcename, bool* arch
- void guess_arch_of_file(const gchar *archfile, bool* archs) {
-     char line[PATH_MAX];
-     char command[PATH_MAX];
--    sprintf(command, "/usr/bin/file -L -N -b %s", archfile);
-+    sprintf(command, "file -L -N -b %s", archfile);
-     FILE* fp = popen(command, "r");
-     if (fp == NULL)
-         die("Failed to run file command");


### PR DESCRIPTION
###### Motivation for this change

appimagetool fails on NixOS because it relies on the hardcoded path `/usr/bin/file`. This PR adds the `file` Nix expression to `appimagekit` and patches the sources so they use the Nix file command. It also adds [missing binaries](https://github.com/AppImage/AppImageKit/blob/master/build-appdir.sh#L25) from the output.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

