### PR TITLE
solaar: 2018-02-02 -> 2019-01-30 + udev rules inclusion

### DIFF
--- a/pkgs/applications/misc/solaar/default.nix
+++ b/pkgs/applications/misc/solaar/default.nix
@@ -1,8 +1,8 @@
 {fetchFromGitHub, stdenv, gtk3, pythonPackages, gobject-introspection}:
 pythonPackages.buildPythonApplication rec {
-  name = "solaar-unstable-${version}";
+  pname = "solaar-unstable";
   version = "2019-01-30";
-  namePrefix = "";
+
   src = fetchFromGitHub {
     owner = "pwr";
     repo = "Solaar";

--- a/pkgs/applications/misc/solaar/default.nix
+++ b/pkgs/applications/misc/solaar/default.nix
@@ -18,6 +18,9 @@ pythonPackages.buildPythonApplication rec {
     wrapProgram "$out/bin/solaar-cli" \
       --prefix PYTHONPATH : "$PYTHONPATH" \
       --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH"
+
+    mkdir -p $out/lib/udev/rules.d
+    cp rules.d/*.rules $out/lib/udev/rules.d/
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/applications/misc/solaar/default.nix
+++ b/pkgs/applications/misc/solaar/default.nix
@@ -1,13 +1,13 @@
 {fetchFromGitHub, stdenv, gtk3, pythonPackages, gobject-introspection}:
 pythonPackages.buildPythonApplication rec {
   name = "solaar-unstable-${version}";
-  version = "2018-02-02";
+  version = "2019-01-30";
   namePrefix = "";
   src = fetchFromGitHub {
     owner = "pwr";
     repo = "Solaar";
-    rev = "59b7285fdfc875119f0c92cfd5f5909e8a8e578c";
-    sha256 = "0zy5vmjzdybnjf0mpp8rny11sc43gmm8172svsm9s51h7x0v83y3";
+    rev = "c07c115ee379e82db84283aaa29dc53df033a8c8";
+    sha256 = "0xg181xcwzzs8pdqvjrkjyaaga7ir93hzjvd17j9g3ns8xfj2mvr";
   };
 
   propagatedBuildInputs = [pythonPackages.pygobject3 pythonPackages.pyudev gobject-introspection gtk3];


### PR DESCRIPTION
###### Motivation for this change

Includes the udev rules in the solaar package. This allows the following to work.

```nix
{ pkgs, ... }:
{
  services.udev.packages = [ pkgs.solaar ];
}
```

In addition, update to the latest commit.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ☑ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ☑ NixOS
- ☑ Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- ☑ Tested execution of all binary files (usually in `./result/bin/`)
- ☑ Assured whether relevant documentation is up to date
- ☑ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

