### PR TITLE
parlatype: init at version 1.6-beta

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2955,6 +2955,11 @@
     github = "meisternu";
     name = "Matt Miemiec";
   };
+  melchips = {
+    email = "truphemus.francois@gmail.com";
+    github = "melchips";
+    name = "Francois Truphemus";
+  };
   melsigl = {
     email = "melanie.bianca.sigl@gmail.com";
     github = "melsigl";

--- a/pkgs/applications/audio/parlatype/default.nix
+++ b/pkgs/applications/audio/parlatype/default.nix
@@ -1,0 +1,69 @@
+{ stdenv, fetchFromGitHub, pkgconfig, meson, gnome3, at-spi2-core, dbus, gst_all_1, sphinxbase, pocketsphinx, ninja, gettext, appstream-glib, python3, glib, gobject-introspection, gsettings-desktop-schemas, itstool, wrapGAppsHook, makeWrapper, hicolor-icon-theme }:
+
+stdenv.mkDerivation rec {
+  name = "parlatype-${version}";
+  version = "v1.6-beta";
+
+  src = fetchFromGitHub {
+    owner  = "gkarsay";
+    repo   = "parlatype";
+    rev    = "98fffe19b7a0b9bdc893309321f435338a58423f";
+    sha256 = "0bi0djic9kf178s7vl3y83v4rzhvynlvyf64n94fy80n2f100dj9";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    meson
+    ninja
+    gettext
+    appstream-glib
+    python3
+    gobject-introspection
+    itstool
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gnome3.gtk
+    at-spi2-core
+    dbus
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+    gst_all_1.gst-plugins-ugly
+    gst_all_1.gst-libav
+    sphinxbase
+    pocketsphinx
+    glib
+    gsettings-desktop-schemas
+    hicolor-icon-theme
+  ];
+
+  mesonFlags = [ "-Dlibreoffice=false" ];
+
+  postPatch = ''
+    chmod +x data/meson_post_install.py
+    patchShebangs data/meson_post_install.py
+  '';
+
+  doCheck = false;
+  enableParallelBuilding = true;
+
+  buildPhase = ''
+    export GST_PLUGIN_SYSTEM_PATH_1_0="$out/lib/gstreamer-1.0/:$GST_PLUGIN_SYSTEM_PATH_1_0"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "GNOME audio player for transcription";
+    longDescription = ''
+      Parlatype is a minimal audio player for manual speech transcription, written for the GNOME desktop environment.
+      It plays audio sources to transcribe them in your favourite text application.
+      It’s intended to be useful for journalists, students, scientists and whoever needs to transcribe audio files.
+    '';
+    homepage = https://gkarsay.github.io/parlatype/;
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.melchips ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/audio/parlatype/default.nix
+++ b/pkgs/applications/audio/parlatype/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, pkgconfig, meson, gnome3, at-spi2-core, dbus, gst_all_1, sphinxbase, pocketsphinx, ninja, gettext, appstream-glib, python3, glib, gobject-introspection, gsettings-desktop-schemas, itstool, wrapGAppsHook, makeWrapper, hicolor-icon-theme }:
 
 stdenv.mkDerivation rec {
-  name = "parlatype-${version}";
+  pname = "parlatype";
   version = "v1.6-beta";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/audio/parlatype/default.nix
+++ b/pkgs/applications/audio/parlatype/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "parlatype";
-  version = "v1.6-beta";
+  version = "1.6-beta";
 
   src = fetchFromGitHub {
     owner  = "gkarsay";

--- a/pkgs/applications/audio/parlatype/default.nix
+++ b/pkgs/applications/audio/parlatype/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner  = "gkarsay";
-    repo   = "parlatype";
+    repo   = pname;
     rev    = "98fffe19b7a0b9bdc893309321f435338a58423f";
     sha256 = "0bi0djic9kf178s7vl3y83v4rzhvynlvyf64n94fy80n2f100dj9";
   };

--- a/pkgs/applications/audio/parlatype/default.nix
+++ b/pkgs/applications/audio/parlatype/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner  = "gkarsay";
     repo   = pname;
-    rev    = "98fffe19b7a0b9bdc893309321f435338a58423f";
+    rev    = "v${version}";
     sha256 = "0bi0djic9kf178s7vl3y83v4rzhvynlvyf64n94fy80n2f100dj9";
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18817,6 +18817,8 @@ in
 
   paraview = libsForQt5.callPackage ../applications/graphics/paraview { };
 
+  parlatype = callPackage ../applications/audio/parlatype { };
+
   packet = callPackage ../development/tools/packet { };
 
   pb_cli = callPackage ../tools/misc/pb_cli {};


### PR DESCRIPTION
###### Motivation for this change
Added package parlatype, a minimal audio player for manual speech transcription, at version v1.6-beta.

###### Things done
Added package, and myself to maintainers list.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

