### PR TITLE
doc: Convert natural deduction to MathML

### DIFF
--- a/doc/dependencies-01.xml
+++ b/doc/dependencies-01.xml
@@ -1,0 +1,131 @@
+<math xmlns="http://www.w3.org/1998/Math/MathML">
+ <mrow>
+  <mfrac>
+   <mrow>
+    <mrow>
+     <mi>propagated-dep</mi>
+     <mo> &#x2061;<!--FUNCTION APPLICATION-->
+     </mo>
+     <mfenced>
+      <msub>
+       <mi>h</mi>
+       <mn>0</mn>
+      </msub>
+      <msub>
+       <mi>t</mi>
+       <mn>0</mn>
+      </msub>
+      <mi>A</mi>
+      <mi>B</mi>
+     </mfenced>
+    </mrow>
+    <mspace width="2em" />
+    <mrow>
+     <mi>propagated-dep</mi>
+     <mo> &#x2061;<!--FUNCTION APPLICATION-->
+     </mo>
+     <mfenced>
+      <msub>
+       <mi>h</mi>
+       <mn>1</mn>
+      </msub>
+      <msub>
+       <mi>t</mi>
+       <mn>1</mn>
+      </msub>
+      <mi>B</mi>
+      <mi>C</mi>
+     </mfenced>
+    </mrow>
+    <mspace width="2em" />
+    <mrow>
+     <mrow>
+      <msub>
+       <mi>h</mi>
+       <mn>0</mn>
+      </msub>
+      <mo>+</mo>
+      <msub>
+       <mi>h</mi>
+       <mn>1</mn>
+      </msub>
+     </mrow>
+     <mo>∈</mo>
+     <mfenced open="{" close="}">
+      <mn>-1</mn>
+      <mn>0</mn>
+      <mn>1</mn>
+     </mfenced>
+    </mrow>
+    <mspace width="2em" />
+    <mrow>
+     <mrow>
+      <msub>
+       <mi>h</mi>
+       <mn>0</mn>
+      </msub>
+      <mo>+</mo>
+      <msub>
+       <mi>t</mi>
+       <mn>1</mn>
+      </msub>
+     </mrow>
+     <mo>∈</mo>
+     <mfenced open="{" close="}">
+      <mn>-1</mn>
+      <mn>0</mn>
+      <mn>1</mn>
+     </mfenced>
+    </mrow>
+   </mrow>
+   <mrow>
+    <mi>propagated-dep</mi>
+    <mo> &#x2061;<!--FUNCTION APPLICATION-->
+    </mo>
+    <mfenced>
+     <mrow>
+      <mi>mapOffset</mi>
+      <mo> &#x2061;<!--FUNCTION APPLICATION-->
+      </mo>
+      <mfenced>
+       <msub>
+        <mi>h</mi>
+        <mn>0</mn>
+       </msub>
+       <msub>
+        <mi>t</mi>
+        <mn>0</mn>
+       </msub>
+       <msub>
+        <mi>h</mi>
+        <mn>1</mn>
+       </msub>
+      </mfenced>
+     </mrow>
+     <mrow>
+      <mi>mapOffset</mi>
+      <mo> &#x2061;<!--FUNCTION APPLICATION-->
+      </mo>
+      <mfenced>
+       <msub>
+        <mi>h</mi>
+        <mn>0</mn>
+       </msub>
+       <msub>
+        <mi>t</mi>
+        <mn>0</mn>
+       </msub>
+       <msub>
+        <mi>t</mi>
+        <mn>1</mn>
+       </msub>
+      </mfenced>
+     </mrow>
+     <mi>A</mi>
+     <mi>C</mi>
+    </mfenced>
+   </mrow>
+  </mfrac>
+  <mtext>Transitive property</mtext>
+ </mrow>
+</math>

--- a/doc/dependencies-02.xml
+++ b/doc/dependencies-02.xml
@@ -1,0 +1,129 @@
+<math xmlns="http://www.w3.org/1998/Math/MathML">
+ <mrow>
+  <mfrac>
+   <mrow>
+    <mrow>
+     <mi>dep</mi>
+     <mo> &#x2061;<!--FUNCTION APPLICATION-->
+     </mo>
+     <mfenced>
+      <msub>
+       <mi>h</mi>
+       <mn>0</mn>
+      </msub>
+      <mi>_</mi>
+      <mi>A</mi>
+      <mi>B</mi>
+     </mfenced>
+    </mrow>
+    <mspace width="2em" />
+    <mrow>
+     <mi>propagated-dep</mi>
+     <mo> &#x2061;<!--FUNCTION APPLICATION-->
+     </mo>
+     <mfenced>
+      <msub>
+       <mi>h</mi>
+       <mn>1</mn>
+      </msub>
+      <msub>
+       <mi>t</mi>
+       <mn>1</mn>
+      </msub>
+      <mi>B</mi>
+      <mi>C</mi>
+     </mfenced>
+    </mrow>
+    <mspace width="2em" />
+    <mrow>
+     <mrow>
+      <msub>
+       <mi>h</mi>
+       <mn>0</mn>
+      </msub>
+      <mo>+</mo>
+      <msub>
+       <mi>h</mi>
+       <mn>1</mn>
+      </msub>
+     </mrow>
+     <mo>∈</mo>
+     <mfenced open="{" close="}">
+      <mn>-1</mn>
+      <mn>0</mn>
+      <mn>1</mn>
+     </mfenced>
+    </mrow>
+    <mspace width="2em" />
+    <mrow>
+     <mrow>
+      <msub>
+       <mi>h</mi>
+       <mn>0</mn>
+      </msub>
+      <mo>+</mo>
+      <msub>
+       <mi>t</mi>
+       <mn>1</mn>
+      </msub>
+     </mrow>
+     <mo>∈</mo>
+     <mfenced open="{" close="}">
+      <mn>-1</mn>
+      <mn>0</mn>
+      <mn>-1</mn>
+     </mfenced>
+    </mrow>
+   </mrow>
+   <mrow>
+    <mi>propagated-dep</mi>
+    <mo> &#x2061;<!--FUNCTION APPLICATION-->
+    </mo>
+    <mfenced>
+     <mrow>
+      <mi>mapOffset</mi>
+      <mo> &#x2061;<!--FUNCTION APPLICATION-->
+      </mo>
+      <mfenced>
+       <msub>
+        <mi>h</mi>
+        <mn>0</mn>
+       </msub>
+       <msub>
+        <mi>t</mi>
+        <mn>0</mn>
+       </msub>
+       <msub>
+        <mi>h</mi>
+        <mn>1</mn>
+       </msub>
+      </mfenced>
+     </mrow>
+     <mrow>
+      <mi>mapOffset</mi>
+      <mo> &#x2061;<!--FUNCTION APPLICATION-->
+      </mo>
+      <mfenced>
+       <msub>
+        <mi>h</mi>
+        <mn>0</mn>
+       </msub>
+       <msub>
+        <mi>t</mi>
+        <mn>0</mn>
+       </msub>
+       <msub>
+        <mi>t</mi>
+        <mn>1</mn>
+       </msub>
+      </mfenced>
+     </mrow>
+     <mi>A</mi>
+     <mi>C</mi>
+    </mfenced>
+   </mrow>
+  </mfrac>
+  <mtext>Take immediate deps’ propagated deps
+</mtext>
+ </mrow>
+</math>

--- a/doc/dependencies-03.xml
+++ b/doc/dependencies-03.xml
@@ -1,0 +1,32 @@
+<math xmlns="http://www.w3.org/1998/Math/MathML">
+ <mrow>
+  <mfrac>
+   <mrow>
+    <mrow>
+     <mi>propagated-dep</mi>
+     <mo> &#x2061;<!--FUNCTION APPLICATION-->
+     </mo>
+     <mfenced>
+      <mi>h</mi>
+      <mi>t</mi>
+      <mi>A</mi>
+      <mi>B</mi>
+     </mfenced>
+    </mrow>
+   </mrow>
+   <mrow>
+    <mi>dep</mi>
+    <mo> &#x2061;<!--FUNCTION APPLICATION-->
+    </mo>
+    <mfenced>
+     <mi>h</mi>
+     <mi>t</mi>
+     <mi>A</mi>
+     <mi>B</mi>
+    </mfenced>
+   </mrow>
+  </mfrac>
+  <mtext>Propagated deps count as deps
+</mtext>
+ </mrow>
+</math>

--- a/doc/dependencies-04.xml
+++ b/doc/dependencies-04.xml
@@ -1,0 +1,119 @@
+<math xmlns="http://www.w3.org/1998/Math/MathML">
+ <mtable columnspacing="0">
+  <mtr>
+   <mtd columnalign="right">
+    <mtext>mapOffset</mtext>
+    <mo> &#x2061;<!--FUNCTION APPLICATION-->
+    </mo>
+    <mfenced>
+     <mi>h</mi>
+     <mi>t</mi>
+     <mi>i</mi>
+    </mfenced>
+   </mtd>
+   <mtd columnalign="left">
+    <mo>=</mo>
+    <mi>i</mi>
+    <mo>+</mo>
+    <mrow>
+     <mo form="prefix">(</mo>
+     <mtext>if</mtext>
+     <mspace width="0.5em"/>
+     <mrow>
+      <mi>i</mi>
+      <mo>≤</mo>
+      <mn>0</mn>
+     </mrow>
+     <mspace width="0.5em"/>
+     <mtext>then</mtext>
+     <mspace width="0.5em"/>
+     <mrow>
+      <mi>h</mi>
+     </mrow>
+     <mspace width="0.5em"/>
+     <mtext>else</mtext>
+     <mspace width="0.5em"/>
+     <mrow>
+      <mi>t</mi>
+      <mo>-</mo>
+      <mn>1</mn>
+     </mrow>
+     <mo form="postfix">)</mo>
+    </mrow>
+   </mtd>
+  </mtr>
+  <mtr>
+   <mtd columnalign="right"></mtd>
+   <mtd columnalign="left">
+    <mo>=</mo>
+    <mi>i</mi>
+    <mo>+</mo>
+    <mrow>
+     <mo form="prefix">(</mo>
+     <mtext>if</mtext>
+     <mspace width="0.5em"/>
+     <mrow>
+      <mi>i</mi>
+      <mo>≤</mo>
+      <mn>0</mn>
+     </mrow>
+     <mspace width="0.5em"/>
+     <mtext>then</mtext>
+     <mspace width="0.5em"/>
+     <mrow>
+      <mi>h</mi>
+     </mrow>
+     <mspace width="0.5em"/>
+     <mtext>else</mtext>
+     <mspace width="0.5em"/>
+     <mrow>
+      <mrow>
+       <mo form="prefix">(</mo>
+       <mi>h</mi>
+       <mo>+</mo>
+       <mn>1</mn>
+       <mo form="postfix">)</mo>
+      </mrow>
+      <mo>-</mo>
+      <mn>1</mn>
+     </mrow>
+     <mo form="postfix">)</mo>
+    </mrow>
+   </mtd>
+  </mtr>
+  <mtr>
+   <mtd columnalign="right"></mtd>
+   <mtd columnalign="left">
+    <mo>=</mo>
+    <mi>i</mi>
+    <mo>+</mo>
+    <mrow>
+     <mo form="prefix">(</mo>
+     <mtext>if</mtext>
+     <mspace width="0.5em"/>
+     <mi>i</mi>
+     <mo>≤</mo>
+     <mn>0</mn>
+     <mspace width="0.5em"/>
+     <mtext>then</mtext>
+     <mspace width="0.5em"/>
+     <mi>h</mi>
+     <mspace width="0.5em"/>
+     <mtext>else</mtext>
+     <mspace width="0.5em"/>
+     <mi>h</mi>
+     <mo form="postfix">)</mo>
+    </mrow>
+   </mtd>
+  </mtr>
+  <mtr>
+   <mtd columnalign="right"></mtd>
+   <mtd columnalign="left">
+    <mo>=</mo>
+    <mi>i</mi>
+    <mo>+</mo>
+    <mi>h</mi>
+   </mtd>
+  </mtr>
+ </mtable>
+</math>

--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -1,5 +1,6 @@
 <chapter xmlns="http://docbook.org/ns/docbook"
          xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
          xml:id="chap-stdenv">
  <title>The Standard Environment</title>
  <para>
@@ -290,43 +291,26 @@ genericBuild
    They're confusing in very different ways so... hopefully if something
    doesn't make sense in one presentation, it will in the other!
 <programlisting>
-let mapOffset(h, t, i) = i + (if i &lt;= 0 then h else t - 1)
-
-propagated-dep(h0, t0, A, B)
-propagated-dep(h1, t1, B, C)
-h0 + h1 in {-1, 0, 1}
-h0 + t1 in {-1, 0, 1}
--------------------------------------- Transitive property
-propagated-dep(mapOffset(h0, t0, h1),
-               mapOffset(h0, t0, t1),
-               A, C)</programlisting>
-<programlisting>
-let mapOffset(h, t, i) = i + (if i &lt;= 0 then h else t - 1)
-
-dep(h0, _, A, B)
-propagated-dep(h1, t1, B, C)
-h0 + h1 in {-1, 0, 1}
-h0 + t1 in {-1, 0, -1}
------------------------------ Take immediate dependencies' propagated dependencies
-propagated-dep(mapOffset(h0, t0, h1),
-               mapOffset(h0, t0, t1),
-               A, C)</programlisting>
-<programlisting>
-propagated-dep(h, t, A, B)
------------------------------ Propagated dependencies count as dependencies
-dep(h, t, A, B)</programlisting>
+let mapOffset(h, t, i) = i + (if i ≤ 0 then h else t - 1)
+</programlisting>
+   <equation>
+    <xi:include href="dependencies-01.xml"/>
+   </equation>
+   <equation>
+    <xi:include href="dependencies-02.xml"/>
+   </equation>
+   <equation>
+    <xi:include href="dependencies-03.xml"/>
+   </equation>
    Some explanation of this monstrosity is in order. In the common case, the
-   target offset of a dependency is the successor to the target offset:
+   target offset of a dependency is the successor to the host offset:
    <literal>t = h + 1</literal>. That means that:
-<programlisting>
-let f(h, t, i) = i + (if i &lt;= 0 then h else t - 1)
-let f(h, h + 1, i) = i + (if i &lt;= 0 then h else (h + 1) - 1)
-let f(h, h + 1, i) = i + (if i &lt;= 0 then h else h)
-let f(h, h + 1, i) = i + h
-  </programlisting>
+   <equation>
+    <xi:include href="dependencies-04.xml"/>
+   </equation>
    This is where "sum-like" comes in from above: We can just sum all of the
    host offsets to get the host offset of the transitive dependency. The target
-   offset is the transitive dependency is simply the host offset + 1, just as
+   offset of the transitive dependency is simply the host offset + 1, just as
    it was with the dependencies composed to make this transitive one; it can be
    ignored as it doesn't add any new information.
   </para>


### PR DESCRIPTION
###### Motivation for this change

I suppose this will read much nicer to people accustomed to graphical structure of proofs and such.

Do we want something like this? We would either need to convert it to some other format since Chrome [apparently](https://caniuse.com/#feat=mathml) does not like MathML.

![image](https://user-images.githubusercontent.com/705123/54300693-acb21c00-45bd-11e9-8dab-a4bb165312b1.png)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

