### PR TITLE
liberation_ttf: 2.00.4 -> 2.00.5

### DIFF
--- a/pkgs/data/fonts/redhat-liberation-fonts/default.nix
+++ b/pkgs/data/fonts/redhat-liberation-fonts/default.nix
@@ -62,14 +62,14 @@ in {
   };
   liberation_ttf_v2 = common rec {
     repo = "liberation-fonts";
-    version = "2.00.4";
+    version = "2.00.5";
     nativeBuildInputs = [ fontforge fonttools ];
     postPatch = ''
       substituteInPlace scripts/setisFixedPitch-fonttools.py --replace \
         'font = ttLib.TTFont(fontfile)' \
         'font = ttLib.TTFont(fontfile, recalcTimestamp=False)'
     '';
-    sha256 = "14bn1zlhyr4qaz5z2sx4h115pnbd41ix1vky8fxm2lx76xrjjiaa";
-    outputHash = "14c0c5n4vzd5y0hf9jkh48h12kkd8hlg94npbmv41j449g6wv6vn";
+    sha256 = "0nc2ap9c0r524yiz93bakv2xjn346f919bpnjwzfhg5har3acsz9";
+    outputHash = "0zx7h3l3wbk75haq4gkfdbhmvjrdplx4896865nq7hsknbwjn12c";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

https://github.com/liberationfonts/liberation-fonts/blob/2.00.5/ChangeLog

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---