### PR TITLE
inter-ui: 3.1 -> 3.3

### DIFF
--- a/pkgs/data/fonts/inter-ui/default.nix
+++ b/pkgs/data/fonts/inter-ui/default.nix
@@ -1,18 +1,18 @@
 { stdenv, fetchzip }:
 
 let
-  version = "3.1";
+  version = "3.3";
 in fetchzip {
-  name = "inter-ui-${version}";
+  name = "inter-${version}";
 
-  url = "https://github.com/rsms/inter/releases/download/v${version}/Inter-UI-${version}.zip";
+  url = "https://github.com/rsms/inter/releases/download/v${version}/Inter-${version}.zip";
 
   postFetch = ''
     mkdir -p $out/share/fonts/opentype
     unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
   '';
 
-  sha256 = "0cdjpwylynwmab0x5z5lw43k39vis74xj1ciqg8nw12ccprbmj60";
+  sha256 = "17fv33ryvbla4f4mfgw7m7gjlwyjlni90a8gpb7jws1qzn0vgazg";
 
   meta = with stdenv.lib; {
     homepage = https://rsms.me/inter/;


### PR DESCRIPTION
###### Motivation for this change

FWIW new name but not sure worth renaming attribute
(to 'inter' or maybe 'inter-font'?)

https://github.com/rsms/inter/releases/tag/v3.3
https://github.com/rsms/inter/releases/tag/v3.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---