### PR TITLE
vttest: init at 20190105

### DIFF
--- a/pkgs/tools/misc/vttest/default.nix
+++ b/pkgs/tools/misc/vttest/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  pname = "vttest";
+  version = "20190105";
+
+  src = fetchurl {
+    urls = [
+      "https://invisible-mirror.net/archives/${pname}/${pname}-${version}.tgz"
+      "ftp://ftp.invisible-island.net/${pname}/${pname}-${version}.tgz"
+    ];
+    sha256 = "0wagaywzc6pq59m8gpcblag7gyjjarc0qx050arr1sy8hd3yy0sp";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Tests the compatibility so-called 'VT100-compatible' terminals";
+    homepage = https://invisible-island.net/vttest/;
+    license = licenses.mit;
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23051,6 +23051,8 @@ in
 
   vokoscreen = libsForQt5.callPackage ../applications/video/vokoscreen { };
 
+  vttest = callPackage ../tools/misc/vttest { };
+
   wavegain = callPackage ../applications/audio/wavegain { };
 
   wcalc = callPackage ../applications/misc/wcalc { };


### PR DESCRIPTION
###### Motivation for this change

Small utility :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---