### PR TITLE
gitAndTools.lab: 0.14.0 -> 0.15.2

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/lab/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/lab/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "lab-${version}";
-  version = "0.14.0";
+  version = "0.15.2";
 
   goPackagePath = "github.com/zaquestion/lab";
 
@@ -12,7 +12,7 @@ buildGoPackage rec {
     owner = "zaquestion";
     repo = "lab";
     rev = "v${version}";
-    sha256 = "0dqahzm721kpps4i33qgk78y982n8gj5afpk73qyzbraf5y3cw92";
+    sha256 = "1210cf6ss4ivm2jxq3k3c34vpra02pl91fpmvqbvw5sm53j7xfaf";
   };
 
   goDeps = ./deps.nix;

--- a/pkgs/applications/version-management/git-and-tools/lab/deps.nix
+++ b/pkgs/applications/version-management/git-and-tools/lab/deps.nix
@@ -1,326 +1,506 @@
-# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
+# file generated from go.mod using vgo2nix (https://github.com/adisbladis/vgo2nix)
 [
   {
-    goPackagePath  = "github.com/avast/retry-go";
+    goPackagePath = "github.com/BurntSushi/toml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/BurntSushi/toml";
+      rev = "v0.3.1";
+      sha256 = "1fjdwwfzyzllgiwydknf1pwjvy49qxfsczqx5gz3y0izs7as99j6";
+    };
+  }
+  {
+    goPackagePath = "github.com/avast/retry-go";
     fetch = {
       type = "git";
       url = "https://github.com/avast/retry-go";
-      rev =  "5469272a8171235352a56af37e5f7facf814423f";
+      rev = "5469272a8171";
       sha256 = "0ql8x5c99sh1f4vdd5614zd0bi4z8z19228vm4xkvii11bsj8dx6";
     };
   }
   {
-    goPackagePath  = "github.com/cpuguy83/go-md2man";
+    goPackagePath = "github.com/cpuguy83/go-md2man";
     fetch = {
       type = "git";
       url = "https://github.com/cpuguy83/go-md2man";
-      rev =  "20f5889cbdc3c73dbd2862796665e7c465ade7d1";
+      rev = "v1.0.8";
       sha256 = "1w22dfdamsq63b5rvalh9k2y7rbwfkkjs7vm9vd4a13h2ql70lg2";
     };
   }
   {
-    goPackagePath  = "github.com/davecgh/go-spew";
+    goPackagePath = "github.com/davecgh/go-spew";
     fetch = {
       type = "git";
       url = "https://github.com/davecgh/go-spew";
-      rev =  "346938d642f2ec3594ed81d874461961cd0faa76";
-      sha256 = "0d4jfmak5p6lb7n2r6yvf5p1zcw0l8j74kn55ghvr7zr7b7axm6c";
+      rev = "v1.1.1";
+      sha256 = "0hka6hmyvp701adzag2g26cxdj47g21x6jz4sc6jjz1mn59d474y";
     };
   }
   {
-    goPackagePath  = "github.com/fsnotify/fsnotify";
+    goPackagePath = "github.com/derekparker/delve";
+    fetch = {
+      type = "git";
+      url = "https://github.com/derekparker/delve";
+      rev = "v1.1.0";
+      sha256 = "0gpsd9hb7r65rn4ml9jzsmy72b8j0id6wik2l48ghzkwjm72rsdz";
+    };
+  }
+  {
+    goPackagePath = "github.com/fsnotify/fsnotify";
     fetch = {
       type = "git";
       url = "https://github.com/fsnotify/fsnotify";
-      rev =  "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9";
+      rev = "v1.4.7";
       sha256 = "07va9crci0ijlivbb7q57d2rz9h27zgn2fsm60spjsqpdbvyrx4g";
     };
   }
   {
-    goPackagePath  = "github.com/gdamore/encoding";
+    goPackagePath = "github.com/gdamore/encoding";
     fetch = {
       type = "git";
       url = "https://github.com/gdamore/encoding";
-      rev =  "b23993cbb6353f0e6aa98d0ee318a34728f628b9";
+      rev = "b23993cbb635";
       sha256 = "0d7irqpx2fa9vkxgkhf04yiwazsm10fxh0yk86x5crflhph5fv8a";
     };
   }
   {
-    goPackagePath  = "github.com/gdamore/tcell";
+    goPackagePath = "github.com/gdamore/tcell";
     fetch = {
       type = "git";
       url = "https://github.com/gdamore/tcell";
-      rev =  "2f258105ca8ce35819115b49f5ac58197241653e";
+      rev = "2f258105ca8c";
       sha256 = "1sji4fjd7i70lc6l19zhz718xld96k0h1sb1as1mmrx0iv858xaz";
     };
   }
   {
-    goPackagePath  = "github.com/golang/protobuf";
+    goPackagePath = "github.com/golang/protobuf";
     fetch = {
       type = "git";
       url = "https://github.com/golang/protobuf";
-      rev =  "b4deda0973fb4c70b50d226b1af49f3da59f5265";
-      sha256 = "0ya4ha7m20bw048m1159ppqzlvda4x0vdprlbk5sdgmy74h3xcdq";
+      rev = "v1.2.0";
+      sha256 = "0kf4b59rcbb1cchfny2dm9jyznp8ri2hsb14n8iak1q8986xa0ab";
     };
   }
   {
-    goPackagePath  = "github.com/google/go-querystring";
+    goPackagePath = "github.com/google/go-querystring";
     fetch = {
       type = "git";
       url = "https://github.com/google/go-querystring";
-      rev =  "53e6ce116135b80d037921a7fdd5138cf32d7a8a";
-      sha256 = "0lkbm067nhmxk66pyjx59d77dbjjzwyi43gdvzyx2f8m1942rq7f";
+      rev = "v1.0.0";
+      sha256 = "0xl12bqyvmn4xcnf8p9ksj9rmnr7s40pvppsdmy8n9bzw1db0iwz";
     };
   }
   {
-    goPackagePath  = "github.com/hashicorp/hcl";
+    goPackagePath = "github.com/gopherjs/gopherjs";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gopherjs/gopherjs";
+      rev = "d547d1d9531e";
+      sha256 = "0rhgxfh8b3qq4imkw6dmv0hxsmflm9pkax8i7a9z8q464z1ixrz7";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/hcl";
     fetch = {
       type = "git";
       url = "https://github.com/hashicorp/hcl";
-      rev =  "ef8a98b0bbce4a65b5aa4c368430a80ddc533168";
+      rev = "ef8a98b0bbce";
       sha256 = "1qalfsc31fra7hcw2lc3s20aj7al62fq3j5fn5kga3mg99b82nyr";
     };
   }
   {
-    goPackagePath  = "github.com/inconshreveable/mousetrap";
+    goPackagePath = "github.com/hpcloud/tail";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hpcloud/tail";
+      rev = "v1.0.0";
+      sha256 = "1njpzc0pi1acg5zx9y6vj9xi6ksbsc5d387rd6904hy6rh2m6kn0";
+    };
+  }
+  {
+    goPackagePath = "github.com/inconshreveable/mousetrap";
     fetch = {
       type = "git";
       url = "https://github.com/inconshreveable/mousetrap";
-      rev =  "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75";
+      rev = "v1.0.0";
       sha256 = "1mn0kg48xkd74brf48qf5hzp0bc6g8cf5a77w895rl3qnlpfw152";
     };
   }
   {
-    goPackagePath  = "github.com/lucasb-eyer/go-colorful";
+    goPackagePath = "github.com/jtolds/gls";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jtolds/gls";
+      rev = "v4.2.1";
+      sha256 = "1vm37pvn0k4r6d3m620swwgama63laz8hhj3pyisdhxwam4m2g1h";
+    };
+  }
+  {
+    goPackagePath = "github.com/konsorten/go-windows-terminal-sequences";
+    fetch = {
+      type = "git";
+      url = "https://github.com/konsorten/go-windows-terminal-sequences";
+      rev = "v1.0.1";
+      sha256 = "1lchgf27n276vma6iyxa0v1xds68n2g8lih5lavqnx5x6q5pw2ip";
+    };
+  }
+  {
+    goPackagePath = "github.com/lucasb-eyer/go-colorful";
     fetch = {
       type = "git";
       url = "https://github.com/lucasb-eyer/go-colorful";
-      rev =  "231272389856c976b7500c4fffcc52ddf06ff4eb";
+      rev = "231272389856";
       sha256 = "161n224v46mln3swzv0009ffj9fxg2n814l9vqs3zh9dq1dmj0jn";
     };
   }
   {
-    goPackagePath  = "github.com/lunixbochs/vtclean";
+    goPackagePath = "github.com/lunixbochs/vtclean";
     fetch = {
       type = "git";
       url = "https://github.com/lunixbochs/vtclean";
-      rev =  "2d01aacdc34a083dca635ba869909f5fc0cd4f41";
+      rev = "2d01aacdc34a";
       sha256 = "1ss88dyx5hr4imvpg5lixvp0cf7c2qm4x9m8mdgshjpm92g5rqmf";
     };
   }
   {
-    goPackagePath  = "github.com/magiconair/properties";
+    goPackagePath = "github.com/magiconair/properties";
     fetch = {
       type = "git";
       url = "https://github.com/magiconair/properties";
-      rev =  "c3beff4c2358b44d0493c7dda585e7db7ff28ae6";
+      rev = "v1.7.6";
       sha256 = "04ccjc9nd1wffvw24ixyfw3v5g48zq7pbq1wz1zg9cyqyxy14qgr";
     };
   }
   {
-    goPackagePath  = "github.com/mattn/go-runewidth";
+    goPackagePath = "github.com/mattn/go-runewidth";
     fetch = {
       type = "git";
       url = "https://github.com/mattn/go-runewidth";
-      rev =  "9e777a8366cce605130a531d2cd6363d07ad7317";
+      rev = "v0.0.2";
       sha256 = "0vkrfrz3fzn5n6ix4k8s0cg0b448459sldq8bp4riavsxm932jzb";
     };
   }
   {
-    goPackagePath  = "github.com/mitchellh/mapstructure";
+    goPackagePath = "github.com/mitchellh/mapstructure";
     fetch = {
       type = "git";
       url = "https://github.com/mitchellh/mapstructure";
-      rev =  "00c29f56e2386353d58c599509e8dc3801b0d716";
+      rev = "00c29f56e238";
       sha256 = "1vw8fvhax0d567amgvxr7glcl12lvzg2sbzs007q5k5bbwn1szyb";
     };
   }
   {
-    goPackagePath  = "github.com/pelletier/go-toml";
+    goPackagePath = "github.com/onsi/ginkgo";
+    fetch = {
+      type = "git";
+      url = "https://github.com/onsi/ginkgo";
+      rev = "v1.6.0";
+      sha256 = "0x0gc89vgq38xhgmi2h22bhr73cf2gmk42g89nz89k8dgg9hhr25";
+    };
+  }
+  {
+    goPackagePath = "github.com/onsi/gomega";
+    fetch = {
+      type = "git";
+      url = "https://github.com/onsi/gomega";
+      rev = "v1.4.3";
+      sha256 = "1c8rqg5i2hz3snmq7s41yar1zjnzilb0fyiyhkg83v97afcfx79v";
+    };
+  }
+  {
+    goPackagePath = "github.com/pelletier/go-toml";
     fetch = {
       type = "git";
       url = "https://github.com/pelletier/go-toml";
-      rev =  "acdc4509485b587f5e675510c4f2c63e90ff68a8";
+      rev = "v1.1.0";
       sha256 = "1y5m9pngxhsfzcnxh8ma5nsllx74wn0jr47p2n6i3inrjqxr12xh";
     };
   }
   {
-    goPackagePath  = "github.com/pkg/errors";
+    goPackagePath = "github.com/pkg/errors";
     fetch = {
       type = "git";
       url = "https://github.com/pkg/errors";
-      rev =  "645ef00459ed84a119197bfb8d8205042c6df63d";
+      rev = "v0.8.0";
       sha256 = "001i6n71ghp2l6kdl3qq1v2vmghcz3kicv9a5wgcihrzigm75pp5";
     };
   }
   {
-    goPackagePath  = "github.com/pmezard/go-difflib";
+    goPackagePath = "github.com/pmezard/go-difflib";
     fetch = {
       type = "git";
       url = "https://github.com/pmezard/go-difflib";
-      rev =  "792786c7400a136282c1664665ae0a8db921c6c2";
+      rev = "v1.0.0";
       sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
     };
   }
   {
-    goPackagePath  = "github.com/rivo/tview";
+    goPackagePath = "github.com/rivo/tview";
     fetch = {
       type = "git";
       url = "https://github.com/rivo/tview";
-      rev =  "f855bee0205c35e6a055b86cc341effea0f446ce";
+      rev = "f855bee0205c";
       sha256 = "0jn9r3gzvm3gr72rb7zz2g8794nnl56l8flqfav00pfk0qiqp8xw";
     };
   }
   {
-    goPackagePath  = "github.com/russross/blackfriday";
+    goPackagePath = "github.com/russross/blackfriday";
     fetch = {
       type = "git";
       url = "https://github.com/russross/blackfriday";
-      rev =  "55d61fa8aa702f59229e6cff85793c22e580eaf5";
+      rev = "v1.5.1";
       sha256 = "0qmavm5d14kj6im6sqzpqnlhpy524428vkn4hnfwknndr9rycmn0";
     };
   }
   {
-    goPackagePath  = "github.com/spf13/afero";
+    goPackagePath = "github.com/sirupsen/logrus";
+    fetch = {
+      type = "git";
+      url = "https://github.com/sirupsen/logrus";
+      rev = "v1.2.0";
+      sha256 = "0r6334x2bls8ddznvzaldx4g88msjjns4mlks95rqrrg7h0ijigg";
+    };
+  }
+  {
+    goPackagePath = "github.com/smartystreets/assertions";
+    fetch = {
+      type = "git";
+      url = "https://github.com/smartystreets/assertions";
+      rev = "b2de0cb4f26d";
+      sha256 = "1i7ldgavgl35c7gk25p7bvdr282ckng090zr4ch9mk1705akx09y";
+    };
+  }
+  {
+    goPackagePath = "github.com/smartystreets/goconvey";
+    fetch = {
+      type = "git";
+      url = "https://github.com/smartystreets/goconvey";
+      rev = "044398e4856c";
+      sha256 = "0nrrk25vzzrrsmmprs72ldfy041crjjsj44n47aj9w8gw379hl5p";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/afero";
     fetch = {
       type = "git";
       url = "https://github.com/spf13/afero";
-      rev =  "63644898a8da0bc22138abf860edaf5277b6102e";
+      rev = "v1.1.0";
       sha256 = "13piahaq4vw1y1sklq5scrsflqx0a8hzmdqfz1fy4871kf2gl8qw";
     };
   }
   {
-    goPackagePath  = "github.com/spf13/cast";
+    goPackagePath = "github.com/spf13/cast";
     fetch = {
       type = "git";
       url = "https://github.com/spf13/cast";
-      rev =  "8965335b8c7107321228e3e3702cab9832751bac";
+      rev = "v1.2.0";
       sha256 = "177bk7lq40jbgv9p9r80aydpaccfk8ja3a7jjhfwiwk9r1pa4rr2";
     };
   }
   {
-    goPackagePath  = "github.com/spf13/cobra";
+    goPackagePath = "github.com/spf13/cobra";
     fetch = {
       type = "git";
       url = "https://github.com/spf13/cobra";
-      rev =  "615425954c3b0d9485a7027d4d451fdcdfdee84e";
+      rev = "615425954c3b";
       sha256 = "01zsislgc72j86a1zq7xs7xj3lvxjjviz4lgn4144jzgppwanpk6";
     };
   }
   {
-    goPackagePath  = "github.com/spf13/jwalterweatherman";
+    goPackagePath = "github.com/spf13/jwalterweatherman";
     fetch = {
       type = "git";
       url = "https://github.com/spf13/jwalterweatherman";
-      rev =  "7c0cea34c8ece3fbeb2b27ab9b59511d360fb394";
+      rev = "7c0cea34c8ec";
       sha256 = "132p84i20b9s5r6fs597lsa6648vd415ch7c0d018vm8smzqpd0h";
     };
   }
   {
-    goPackagePath  = "github.com/spf13/pflag";
+    goPackagePath = "github.com/spf13/pflag";
     fetch = {
       type = "git";
       url = "https://github.com/spf13/pflag";
-      rev =  "583c0c0531f06d5278b7d917446061adc344b5cd";
+      rev = "v1.0.1";
       sha256 = "0nr4mdpfhhk94hq4ymn5b2sxc47b29p1akxd8b0hx4dvdybmipb5";
     };
   }
   {
-    goPackagePath  = "github.com/spf13/viper";
+    goPackagePath = "github.com/spf13/viper";
     fetch = {
       type = "git";
       url = "https://github.com/spf13/viper";
-      rev =  "15738813a09db5c8e5b60a19d67d3f9bd38da3a4";
+      rev = "15738813a09d";
       sha256 = "1mjfzg8zvnxckaq6l8gw99i2msrfqn9yr04dc3b7kd5bpxi6zr4v";
     };
   }
   {
-    goPackagePath  = "github.com/stretchr/testify";
+    goPackagePath = "github.com/stretchr/objx";
     fetch = {
       type = "git";
-      url = "https://github.com/stretchr/testify";
-      rev =  "12b6f73e6084dad08a7c6e575284b177ecafbc71";
-      sha256 = "01f80s0q64pw5drfgqwwk1wfwwkvd2lhbs56lhhkff4ni83k73fd";
+      url = "https://github.com/stretchr/objx";
+      rev = "v0.1.1";
+      sha256 = "0iph0qmpyqg4kwv8jsx6a56a7hhqq8swrazv40ycxk9rzr0s8yls";
     };
   }
   {
-    goPackagePath  = "github.com/tcnksm/go-gitconfig";
+    goPackagePath = "github.com/stretchr/testify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/testify";
+      rev = "v1.2.2";
+      sha256 = "0dlszlshlxbmmfxj5hlwgv3r22x0y1af45gn1vd198nvvs3pnvfs";
+    };
+  }
+  {
+    goPackagePath = "github.com/tcnksm/go-gitconfig";
     fetch = {
       type = "git";
       url = "https://github.com/tcnksm/go-gitconfig";
-      rev =  "d154598bacbf4501c095a309753c5d4af66caa81";
+      rev = "v0.1.2";
       sha256 = "0sz7h383h7ngrqkk35ic37kfvhlk07g4kanps8bnapwczrcm2am9";
     };
   }
   {
-    goPackagePath  = "github.com/xanzy/go-gitlab";
+    goPackagePath = "github.com/wadey/gocovmerge";
+    fetch = {
+      type = "git";
+      url = "https://github.com/wadey/gocovmerge";
+      rev = "b5bfa59ec0ad";
+      sha256 = "00m7kxcmmw0l9z0m7z6ii06n5j4bcrxqjbhxjbfzmsdgdsvkic31";
+    };
+  }
+  {
+    goPackagePath = "github.com/xanzy/go-gitlab";
     fetch = {
       type = "git";
       url = "https://github.com/xanzy/go-gitlab";
-      rev =  "8d21e61ce4a9b9c7fe645e48672872e9fdb71138";
-      sha256 = "1lac57ard1vrd16ri8gfyd0ck8d7xg7zbcjlz90223jp0vc3l8nv";
+      rev = "7bc4155e8bf8";
+      sha256 = "1zk3f00i9ji57m85hzkrg8f1b9l5acd5p75kpzhr087skk943rdm";
     };
   }
   {
-    goPackagePath  = "golang.org/x/crypto";
+    goPackagePath = "golang.org/x/arch";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/arch";
+      rev = "5a4828bb7045";
+      sha256 = "1c550zdqvyjvc5xc1yqaxa3pmkcdjc5cmbmrhy1li6g3ysfbcil3";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/crypto";
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/crypto";
-      rev =  "e73bf333ef8920dbb52ad18d4bd38ad9d9bc76d7";
-      sha256 = "1amcpva20vff8v0lww655icaaf7388ns8xhm859whn4w4v0vanyg";
+      rev = "0709b304e793";
+      sha256 = "0i05s09y5pavmfh71fgih7syxg58x7a4krgd8am6d3mnahnmab5c";
     };
   }
   {
-    goPackagePath  = "golang.org/x/net";
+    goPackagePath = "golang.org/x/net";
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/net";
-      rev =  "f4c29de78a2a91c00474a2e689954305c350adf9";
-      sha256 = "02nibjrr1il8sxnr0w1s5fj7gz6ayhg3hsywf948qhc68n5adv8x";
+      rev = "03003ca0c849";
+      sha256 = "09ag58l678hr9bzy5fn8i3m5rxn2scps74zm0kmkb6p25lg5z4sl";
     };
   }
   {
-    goPackagePath  = "golang.org/x/oauth2";
+    goPackagePath = "golang.org/x/oauth2";
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/oauth2";
-      rev =  "3d292e4d0cdc3a0113e6d207bb137145ef1de42f";
-      sha256 = "0jvivlvx7snacd6abd1prqxa7h1z6b7s6mqahn8lpqlag3asryrl";
+      rev = "f42d05182288";
+      sha256 = "1cbwgr3f3wj84kjpldzzvrlkvlpp0jz8rgbj31xw8n3h502phwab";
     };
   }
   {
-    goPackagePath  = "golang.org/x/sys";
+    goPackagePath = "golang.org/x/sync";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sync";
+      rev = "42b317875d0f";
+      sha256 = "0mrjhk7al7yyh76x9flvxy4jm5jyqh2fxbxagpaazxn1xdgkaif3";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sys";
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/sys";
-      rev =  "79b0c6888797020a994db17c8510466c72fe75d9";
-      sha256 = "0aydjw886c4dwcjg7ssb7xp39ag1529nh3ly1la71rqjr94cjnag";
+      rev = "d0be0721c37e";
+      sha256 = "081wyvfnlf842dqg03raxfz6lldlxpmyh1prix9lmrrm65arxb12";
     };
   }
   {
-    goPackagePath  = "golang.org/x/text";
+    goPackagePath = "golang.org/x/text";
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/text";
-      rev =  "f21a4dfb5e38f5895301dc265a8def02365cc3d0";
+      rev = "v0.3.0";
       sha256 = "0r6x6zjzhr8ksqlpiwm5gdd7s209kwk5p4lw54xjvz10cs3qlq19";
     };
   }
   {
-    goPackagePath  = "google.golang.org/appengine";
+    goPackagePath = "golang.org/x/tools";
     fetch = {
       type = "git";
-      url = "https://github.com/golang/appengine";
-      rev =  "b1f26356af11148e710935ed1ac8a7f5702c7612";
-      sha256 = "1pz202zszg8f35dk5pfhwgcdi3r6dx1l4yk6x6ly7nb4j45zi96x";
+      url = "https://go.googlesource.com/tools";
+      rev = "e063def13b29";
+      sha256 = "1aphxa8g0936jbmqjlfjczq6wlr0mc2iz965fql764kvqb5szkkw";
     };
   }
   {
-    goPackagePath  = "gopkg.in/yaml.v2";
+    goPackagePath = "google.golang.org/appengine";
     fetch = {
       type = "git";
-      url = "https://github.com/go-yaml/yaml";
-      rev =  "5420a8b6744d3b0345ab293f6fcba19c978f1183";
+      url = "https://github.com/golang/appengine";
+      rev = "v1.3.0";
+      sha256 = "13cyhqwmvc2nia4ssdwwdzscq52aj3z9zjikx17wk4kb0j8vr370";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/DATA-DOG/go-sqlmock.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/DATA-DOG/go-sqlmock.v1";
+      rev = "v1.3.0";
+      sha256 = "1684d6ima6638xwvr743kd7j5mpqq0vspcw9ai67bnb7m722qqqv";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/check.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/check.v1";
+      rev = "20d25e280405";
+      sha256 = "0k1m83ji9l1a7ng8a7v40psbymxasmssbrrhpdv2wl4rhs0nc3np";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/fsnotify.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/fsnotify.v1";
+      rev = "v1.4.7";
+      sha256 = "07va9crci0ijlivbb7q57d2rz9h27zgn2fsm60spjsqpdbvyrx4g";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/tomb.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/tomb.v1";
+      rev = "dd632973f1e7";
+      sha256 = "1lqmq1ag7s4b3gc3ddvr792c5xb5k6sfn0cchr3i2s7f1c231zjv";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/yaml.v2";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/yaml.v2";
+      rev = "v2.2.1";
       sha256 = "0dwjrs2lp2gdlscs7bsrmyc5yf6mm4fvgw71bzr9mv2qrd2q73s1";
     };
   }

--- a/pkgs/applications/version-management/git-and-tools/lab/deps.nix
+++ b/pkgs/applications/version-management/git-and-tools/lab/deps.nix
@@ -301,9 +301,9 @@
     goPackagePath = "github.com/spf13/cobra";
     fetch = {
       type = "git";
-      url = "https://github.com/spf13/cobra";
-      rev = "615425954c3b";
-      sha256 = "01zsislgc72j86a1zq7xs7xj3lvxjjviz4lgn4144jzgppwanpk6";
+      url = "https://github.com/rsteube/cobra";
+      rev = "v0.0.1-zsh-completion-custom";
+      sha256 = "0l0c9p5pdv3fq27ich4psaffivwv43acknqnzyql3bgx08vhnsxd";
     };
   }
   {


### PR DESCRIPTION
###### Motivation for this change

 https://github.com/zaquestion/lab/releases/tag/v0.15.0 
 https://github.com/zaquestion/lab/releases/tag/v0.15.1 
 https://github.com/zaquestion/lab/releases/tag/v0.15.2

Second commit is a manual touchup--
needed to fix the file vgo2nix generated,
looks like it doesn't (?) handle the "replace" feature used.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---