### PR TITLE
nixos/manual: clarify declarative packages section

### DIFF
--- a/nixos/doc/manual/configuration/declarative-packages.xml
+++ b/nixos/doc/manual/configuration/declarative-packages.xml
@@ -14,10 +14,9 @@
 <programlisting>
 <xref linkend="opt-environment.systemPackages"/> = [ pkgs.thunderbird ];
 </programlisting>
-  The <literal>pkgs</literal> variable is used to reference packages in your
-  root channel. The effect of this specification is that the Thunderbird
-  package from your root Nixpkgs channel will be built or downloaded as part of
-  the system when you run <command>nixos-rebuild switch</command>.
+  The effect of this specification is that the Thunderbird package from Nixpkgs
+  will be built or downloaded as part of the system when you run
+  <command>nixos-rebuild switch</command>.
  </para>
 
  <para>
@@ -28,10 +27,13 @@ nixos.firefox   firefox-23.0   Mozilla Firefox - the browser, reloaded
 <replaceable>...</replaceable>
 </screen>
   The first column in the output is the <emphasis>attribute name</emphasis>,
-  such as <literal>nixos.thunderbird</literal>. The <literal>nixos</literal>
-  prefix tells us that we want to get the package from the `nixos` channel.
-  Some systems have other channels installed, such as `nixpkgs` or custom
-  channels for development purposes.
+  such as <literal>nixos.thunderbird</literal>.
+ </para>
+ <para>
+  Note: the <literal>nixos</literal> prefix tells us that we want to get the
+  package from the <literal>nixos</literal> channel and works only in CLI tools.
+
+  In declarative configuration use <literal>pkgs</literal> prefix (variable).
  </para>
 
  <para>

--- a/nixos/doc/manual/configuration/declarative-packages.xml
+++ b/nixos/doc/manual/configuration/declarative-packages.xml
@@ -14,9 +14,10 @@
 <programlisting>
 <xref linkend="opt-environment.systemPackages"/> = [ pkgs.thunderbird ];
 </programlisting>
-  The effect of this specification is that the Thunderbird package from Nixpkgs
-  will be built or downloaded as part of the system when you run
-  <command>nixos-rebuild switch</command>.
+  The <literal>pkgs</literal> variable is used to reference packages in your
+  root channel. The effect of this specification is that the Thunderbird
+  package from your root Nixpkgs channel will be built or downloaded as part of
+  the system when you run <command>nixos-rebuild switch</command>.
  </para>
 
  <para>
@@ -27,8 +28,10 @@ nixos.firefox   firefox-23.0   Mozilla Firefox - the browser, reloaded
 <replaceable>...</replaceable>
 </screen>
   The first column in the output is the <emphasis>attribute name</emphasis>,
-  such as <literal>nixos.thunderbird</literal>. (The <literal>nixos</literal>
-  prefix allows distinguishing between different channels that you might have.)
+  such as <literal>nixos.thunderbird</literal>. The <literal>nixos</literal>
+  prefix tells us that we want to get the package from the `nixos` channel.
+  Some systems have other channels installed, such as `nixpkgs` or custom
+  channels for development purposes.
  </para>
 
  <para>


### PR DESCRIPTION
###### Motivation for this change
The declarative package management gives a straightforward explaination of installing packages in NixOS, but assumes knowledge of Nix variables and knowledge of channels.

This leads to confusions such as #55556, where a user confused `nixos` and `pkgs` as almost interchangable.

This pull request elaborates on what the `pkgs` variable means (it's a reference to the root channel) and what the `nixos` prefix in a full package path means (it's the channel you are getting the package from).

This should allow a user to use the variable `pkgs` and the `nixos` prefix without needing an explaination of what they mean.

Although it doesn't explain what a channel is, it hopefully makes sense without knowing the full definition, and if a user is confused, they should have a clear question to ask (i.e. "what is a channel?").

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) 
on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---