### PR TITLE
gnome3.totem: Add codecs to Nautilus extension

### DIFF
--- a/pkgs/desktops/gnome-3/core/totem/default.nix
+++ b/pkgs/desktops/gnome-3/core/totem/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, meson, ninja, intltool, gst_all_1
+{ stdenv, substituteAll, fetchurl, meson, ninja, intltool, gst_all_1
 , clutter-gtk, clutter-gst, python3Packages, shared-mime-info
 , pkgconfig, gtk3, glib, gobject-introspection, totem-pl-parser
 , wrapGAppsHook, itstool, libxml2, vala, gnome3, grilo, grilo-plugins
@@ -13,6 +13,21 @@ stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/totem/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "0rahkybxbmxhlmrrgrzxny1xm7wycx7ib4blxp1i2l1q3i8s84b0";
   };
+
+  patches = [
+    # Make codecs available in Nautilus plug-in
+    # https://github.com/NixOS/nixpkgs/issues/53631
+    (substituteAll {
+      src = ./nautilus-extension-codecs.patch;
+      load_plugins = stdenv.lib.concatMapStrings (plugin: ''gst_registry_scan_path(gst_registry_get(), "${plugin}/lib/gstreamer-1.0");'') (with gst_all_1; [
+        gst-plugins-base
+        gst-plugins-good
+        gst-plugins-bad
+        gst-plugins-ugly
+        gst-libav
+      ]);
+    })
+  ];
 
   doCheck = true;
 

--- a/pkgs/desktops/gnome-3/core/totem/nautilus-extension-codecs.patch
+++ b/pkgs/desktops/gnome-3/core/totem/nautilus-extension-codecs.patch
@@ -1,0 +1,10 @@
+--- a/src/totem-properties-main.c
++++ b/src/totem-properties-main.c
+@@ -109,6 +109,7 @@
+ 	/* okay, make the page, init'ing the backend first if necessary */
+ 	if (backend_inited == FALSE) {
+ 		gst_init (NULL, NULL);
++		@load_plugins@
+ 		backend_inited = TRUE;
+ 	}
+ 


### PR DESCRIPTION
###### Motivation for this change
Nautilus does not depend on multimedia codecs, therefore the GST environment variables might not be present. When that is the case the multimedia properties panel provided by Totem will not be able to work. Let’s make sure the GStreamer plug-ins are loaded by hardcoding them in the extension.

Blocked by: https://github.com/NixOS/nixpkgs/pull/57027
Closes: https://github.com/NixOS/nixpkgs/issues/53631

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

