### PR TITLE
gnome3.gnome-settings-daemon: fix #14168

### DIFF
--- a/pkgs/desktops/gnome-3/core/gnome-settings-daemon/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-settings-daemon/default.nix
@@ -50,6 +50,7 @@ stdenv.mkDerivation rec {
       src = ./fix-paths.patch;
       inherit tzdata;
     })
+    ./global-backlight-helper.patch
   ];
 
   nativeBuildInputs = [
@@ -92,6 +93,12 @@ stdenv.mkDerivation rec {
   mesonFlags = [
     "-Dudev_dir=${placeholder "out"}/lib/udev"
   ];
+
+  # So the polkit policy can reference /run/current-system/sw/bin/gnome-settings-daemon/gsd-backlight-helper
+  postFixup = ''
+    mkdir -p $out/bin/gnome-settings-daemon
+    ln -s $out/libexec/gsd-backlight-helper $out/bin/gnome-settings-daemon/gsd-backlight-helper
+  '';
 
   postPatch = ''
     for f in gnome-settings-daemon/codegen.py plugins/power/gsd-power-constants-update.pl meson_post_install.py; do

--- a/pkgs/desktops/gnome-3/core/gnome-settings-daemon/global-backlight-helper.patch
+++ b/pkgs/desktops/gnome-3/core/gnome-settings-daemon/global-backlight-helper.patch
@@ -1,0 +1,26 @@
+diff --git a/plugins/power/gsd-backlight.c b/plugins/power/gsd-backlight.c
+index d7d10fd2..5619d6ad 100644
+--- a/plugins/power/gsd-backlight.c
++++ b/plugins/power/gsd-backlight.c
+@@ -358,7 +358,7 @@ gsd_backlight_run_set_helper (GsdBacklight *backlight, GTask *task)
+                 proc = g_subprocess_new (G_SUBPROCESS_FLAGS_STDOUT_SILENCE,
+                                          &error,
+                                          "pkexec",
+-                                         LIBEXECDIR "/gsd-backlight-helper",
++                                         "/run/current-system/sw/bin/gnome-settings-daemon/gsd-backlight-helper",
+                                          g_udev_device_get_sysfs_path (backlight->udev_device),
+                                          data->value_str, NULL);
+         } else {
+diff --git a/plugins/power/org.gnome.settings-daemon.plugins.power.policy.in.in b/plugins/power/org.gnome.settings-daemon.plugins.power.policy.in.in
+index f16300f8..79d6bd17 100644
+--- a/plugins/power/org.gnome.settings-daemon.plugins.power.policy.in.in
++++ b/plugins/power/org.gnome.settings-daemon.plugins.power.policy.in.in
+@@ -25,7 +25,7 @@
+       <allow_inactive>no</allow_inactive>
+       <allow_active>yes</allow_active>
+     </defaults>
+-    <annotate key="org.freedesktop.policykit.exec.path">@libexecdir@/gsd-backlight-helper</annotate>
++    <annotate key="org.freedesktop.policykit.exec.path">/run/current-system/sw/bin/gnome-settings-daemon/gsd-backlight-helper</annotate>
+   </action>
+
+ </policyconfig>


### PR DESCRIPTION
###### Motivation for this change
Originally from https://github.com/NixOS/nixpkgs/pull/54584 then got moved to the 3.32 pr.

However GitHub hides long discussions in prs that get really long, like the one's for major GNOME3 updates. So putting bugfixes in there, where discussion is important to be easily accessible, isn't a good idea.

~~This is blocked by https://github.com/NixOS/nixpkgs/pull/57027 because it depends on code added
in that release.~~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

