### PR TITLE
pythonPackages.xlib: 0.17 -> 0.25, enable tests

### DIFF
--- a/pkgs/applications/misc/plover/default.nix
+++ b/pkgs/applications/misc/plover/default.nix
@@ -16,6 +16,7 @@
       sha256 = "1hdg5491phx6svrxxsxp8v6n4b25y7y4wxw7x3bxlbyhaskgj53r";
     };
 
+    nativeBuildInputs     = [ setuptools_scm ];
     buildInputs           = [ pytest mock ];
     propagatedBuildInputs = [
       six setuptools pyserial appdirs hidapi wxPython xlib wmctrl

--- a/pkgs/development/python-modules/xlib/default.nix
+++ b/pkgs/development/python-modules/xlib/default.nix
@@ -3,24 +3,32 @@
 , fetchFromGitHub
 , six
 , setuptools_scm
-, pkgs
+, xorg
+, python
+, mock
+, nose
+, utillinux
 }:
 
 buildPythonPackage rec {
   pname = "xlib";
-  version = "0.17";
+  version = "0.25";
 
   src = fetchFromGitHub {
     owner = "python-xlib";
     repo = "python-xlib";
-    rev = "${version}";
-    sha256 = "1iiz2nq2hq9x6laavngvfngnmxbgnwh54wdbq6ncx4va7v98liyi";
+    rev = version;
+    sha256 = "1nncx7v9chmgh56afg6dklz3479s5zg3kq91mzh4mj512y0skyki";
   };
 
-  # Tests require `pyutil' so disable them to avoid circular references.
-  doCheck = false;
+  checkPhase = ''
+    ${python.interpreter} runtests.py
+  '';
 
-  propagatedBuildInputs = [ six setuptools_scm pkgs.xorg.libX11 ];
+  checkInputs = [ mock nose utillinux /* mcookie */ xorg.xauth xorg.xorgserver /* xvfb */ ];
+  nativeBuildInputs = [ setuptools_scm ];
+  buildInputs = [ xorg.libX11 ];
+  propagatedBuildInputs = [ six ];
 
   meta = with stdenv.lib; {
     description = "Fully functional X client library for Python programs";


### PR DESCRIPTION
https://github.com/python-xlib/python-xlib/releases/tag/0.25

(and the releases along the way)


###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---