### PR TITLE
dnscrypt-proxy2: 2.0.15 -> 2.0.20

### DIFF
--- a/pkgs/tools/networking/dnscrypt-proxy/2.x/default.nix
+++ b/pkgs/tools/networking/dnscrypt-proxy/2.x/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "dnscrypt-proxy2-${version}";
-  version = "2.0.15";
+  version = "2.0.20";
 
   goPackagePath = "github.com/jedisct1/dnscrypt-proxy";
 
@@ -10,7 +10,7 @@ buildGoPackage rec {
     owner = "jedisct1";
     repo = "dnscrypt-proxy";
     rev = "${version}";
-    sha256 = "0iwvndk1h550zmwhwablb0smv9n2l51hqbmzj354mcgi6frnx819";
+    sha256 = "07nj6bi1ylck8ncll75mszbdqhmhflnc4daxanyylhbjv2qz5y2l";
   };
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2284,9 +2284,7 @@ in
 
   dnscrypt-proxy = callPackage ../tools/networking/dnscrypt-proxy/1.x { };
 
-  dnscrypt-proxy2 = callPackage ../tools/networking/dnscrypt-proxy/2.x {
-    buildGoPackage = buildGo110Package;
-  };
+  dnscrypt-proxy2 = callPackage ../tools/networking/dnscrypt-proxy/2.x { };
 
   dnscrypt-wrapper = callPackage ../tools/networking/dnscrypt-wrapper { };
 


### PR DESCRIPTION
###### Motivation for this change

https://github.com/jedisct1/dnscrypt-proxy/releases/tag/2.0.20
https://github.com/jedisct1/dnscrypt-proxy/releases/tag/2.0.19
https://github.com/jedisct1/dnscrypt-proxy/releases/tag/2.0.18
https://github.com/jedisct1/dnscrypt-proxy/releases/tag/2.0.17
https://github.com/jedisct1/dnscrypt-proxy/releases/tag/2.0.16

Also, no need to pin to an old version of Go anymore.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

AFAICT not much to test: dnscrypt-proxy (1) is used plenty, but not 2.