### PR TITLE
netatop: 1.0 -> 2.0, fixes compat with kernels >= 4.13

### DIFF
--- a/pkgs/os-specific/linux/netatop/default.nix
+++ b/pkgs/os-specific/linux/netatop/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, kernel, zlib }:
 
 let
-  version = "1.0";
+  version = "2.0";
 in
 
 stdenv.mkDerivation {
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "http://www.atoptool.nl/download/netatop-${version}.tar.gz";
-    sha256 = "1l7xs3hnfbk6h5gdrw1ikfa0fvfpb5vd447xhwfllvicblqyip8b";
+    sha256 = "03n248p1l3ps7gj2hdlcbrb1fsw1zcmgzypj4j4l4rynjjh7qvf6";
   };
 
   buildInputs = [ zlib ];
@@ -38,6 +38,5 @@ stdenv.mkDerivation {
     license = stdenv.lib.licenses.gpl2;
     platforms = stdenv.lib.platforms.linux;
     maintainers = with stdenv.lib.maintainers; [viric];
-    broken = !stdenv.lib.versionOlder kernel.version "4.13";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Have not actually tried "yet", but seems like step in the right
direction regardless :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---