### PR TITLE
cgmanager: 0.41 -> 0.42

### DIFF
--- a/pkgs/os-specific/linux/cgmanager/default.nix
+++ b/pkgs/os-specific/linux/cgmanager/default.nix
@@ -1,15 +1,16 @@
-{ stdenv, fetchurl, pkgconfig, libnih, dbus, pam }:
+{ stdenv, fetchurl, pkgconfig, libnih, dbus, pam, popt }:
 
 stdenv.mkDerivation rec {
-  name = "cgmanager-0.41";
+  pname = "cgmanager";
+  version = "0.42";
 
   src = fetchurl {
-    url = "https://linuxcontainers.org/downloads/cgmanager/${name}.tar.gz";
-    sha256 = "0n5l4g78ifvyfnj8x9xz06mqn4y8j73sgg4xsbak7hiszfz5bc99";
+    url = "https://linuxcontainers.org/downloads/${pname}/${pname}-${version}.tar.gz";
+    sha256 = "15np08h9jrvc1y1iafr8v654mzgsv5hshzc0n4p3pbf0rkra3h7c";
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ libnih dbus pam ];
+  buildInputs = [ libnih dbus pam popt ];
 
   configureFlags = [
     "--with-init-script=systemd"


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---