### PR TITLE
[READY] linux_mptcp: 0.94.1 -> 0.94.3

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-mptcp.nix
+++ b/pkgs/os-specific/linux/kernel/linux-mptcp.nix
@@ -1,10 +1,11 @@
-{ stdenv, buildPackages, fetchFromGitHub, perl, buildLinux, ... } @ args:
-
-buildLinux (rec {
-  mptcpVersion = "0.94.1";
-  modDirVersion = "4.14.70";
+{ stdenv, buildPackages, fetchFromGitHub, perl, buildLinux, structuredExtraConfig ? {}, ... } @ args:
+let
+  mptcpVersion = "0.94.3";
+  modDirVersion = "4.14.105";
+in
+buildLinux ({
   version = "${modDirVersion}-mptcp_v${mptcpVersion}";
-  # autoModules= true;
+  inherit modDirVersion;
 
   extraMeta = {
     branch = "4.4";
@@ -15,32 +16,34 @@ buildLinux (rec {
     owner = "multipath-tcp";
     repo = "mptcp";
     rev = "v${mptcpVersion}";
-    sha256 = "13mi672jr1x463kzig1hi9cpdi8x6nqdfd4bqlrjn8zca48f4ln4";
+    sha256 = "1pic86icrlmxajw4hkqyljha8a3k4w9kb5z74xj4yiyapmk9wprm";
   };
 
-  extraConfig = ''
-    IPV6 y
-    MPTCP y
-    IP_MULTIPLE_TABLES y
+  structuredExtraConfig = with import ../../../../lib/kernel.nix { inherit (stdenv) lib; version = null; };
+    stdenv.lib.mkMerge [ {
+    IPV6               = yes;
+    MPTCP              = yes;
+    IP_MULTIPLE_TABLES = yes;
 
     # Enable advanced path-managers...
-    MPTCP_PM_ADVANCED y
-    MPTCP_FULLMESH y
-    MPTCP_NDIFFPORTS y
+    MPTCP_PM_ADVANCED = yes;
+    MPTCP_FULLMESH = yes;
+    MPTCP_NDIFFPORTS = yes;
     # ... but use none by default.
     # The default is safer if source policy routing is not setup.
-    DEFAULT_DUMMY y
-    DEFAULT_MPTCP_PM default
+    DEFAULT_DUMMY = yes;
+    DEFAULT_MPTCP_PM.freeform = "default";
 
     # MPTCP scheduler selection.
-    MPTCP_SCHED_ADVANCED y
-    DEFAULT_MPTCP_SCHED default
+    MPTCP_SCHED_ADVANCED = yes;
+    DEFAULT_MPTCP_SCHED.freeform = "default";
 
     # Smarter TCP congestion controllers
-    TCP_CONG_LIA m
-    TCP_CONG_OLIA m
-    TCP_CONG_WVEGAS m
-    TCP_CONG_BALIA m
-
-  '' + (args.extraConfig or "");
+    TCP_CONG_LIA = module;
+    TCP_CONG_OLIA = module;
+    TCP_CONG_WVEGAS = module;
+    TCP_CONG_BALIA = module;
+  }
+  structuredExtraConfig
+  ];
 } // args)


### PR DESCRIPTION
Mailing list announcement:

the Multipath TCP Kernel v0.94.3 has been released, containing important
bug-fixes (thanks to syzkaller) and perf-improvements.
This release is based on Linux v4.14.105.

Everybody should update to the latest kernel.

Multipath TCP Linux Kernel v0.94.3
=====

Benjamin Hesmans <benjamin.hesmans@uclouvain.be> (1):
      [3f01458be8cc] mptcp: checksum corner case

Christoph Paasch <cpaasch@apple.com> (21):
      [287af08b7193] mptcp: Trigger sending when new subflow gets established
      [a284ba1574f5] mptcp: Reinject data when the write-queue gets purged
      [9ac97e3324ec] mptcp: Build-Fix for mptcp_push_pending_frames
      [68e3b3cc6204] mptcp: Don't allow TCP_REPAIR on MPTCP-sockets
      [6d58ca87a125] mptcp: Rework mptcp_disconnect
      [1b142d9b94f9] mptcp: Initialize IPv6-fields even more correctly
      [247a77e1d4e0] mptcp: Fully disable MD5SIG
      [97543fe0b8b8] mptcp: Reset icsk_bind_hash to NULL to avoid use-after-free in inet_put_port
      [d307e46cc3f9] mptcp: Initialize meta_tp after potentially failing instructions
      [da42a64cf11e] mptcp: Don't free mpcb when mptcp_alloc_mpcb succeeded
      [71b3bf995bcd] mptcp: Prevent circular locking dependency on tcp_close()
      [444bf8c76806] mptcp: Ensure proper free'ing of master_sk upon failure
      [15afe58a959e] mptcp: Handle error-case for MPTCP-Fastopen
      [73db90da684c] mptcp: Unify usage of rcu_read_lock_bh,...
      [f266d120c091] mptcp: Fix error-cases in TCP_SYNCOOKIES path
      [872427427624] mptcp: Support randomized Timestamps on SYN-Cookies
      [c3e29b9cace0] mptcp: Do not lock in tcp_get_info for MPTCP_INFO
      [1bc2adaf003d] mptcp: Trigger meta-retransmission always when the timer fired
      [a947ef46d5e1] mptcp: Don't update meta-RTO from subflows that are retransmitting
      [619d44cae638] mptcp: Reevalute and reschedule meta-level RTO for new subflows
      [310b6838cab0] mptcp: Stable Release v0.94.3

Matthieu Baerts <matthieu.baerts@tessares.net> (1):
      [34154a943635] mptcp: Build-Fix with CONFIG_MEMCG

How to install (if you have our bintray repositories setup)
=====

The config-file of these pre-compiled images has also been updated with more
complete configurations, including also CONFIG_MEMCG (cfr.:
https://github.com/multipath-tcp/mptcp/issues/321).

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

