### PR TITLE
python.pkgs.shapely: fix tests on Darwin

### DIFF
--- a/pkgs/development/python-modules/shapely/library-paths.patch
+++ b/pkgs/development/python-modules/shapely/library-paths.patch
@@ -107,3 +107,21 @@ index 09bf1ab..837aa98 100644
  
  
  def _geos_version():
+diff --git a/tests/test_dlls.py b/tests/test_dlls.py
+index 35f9cc2..3dfcaac 100644
+--- a/tests/test_dlls.py
++++ b/tests/test_dlls.py
+@@ -12,12 +12,7 @@ class LoadingTestCase(unittest.TestCase):
+     @unittest.skipIf(sys.platform == "win32", "FIXME: adapt test for win32")
+     def test_fallbacks(self):
+         load_dll('geos_c', fallbacks=[
+-            os.path.join(sys.prefix, "lib", "libgeos_c.dylib"), # anaconda (Mac OS X)
+-            '/opt/local/lib/libgeos_c.dylib',  # MacPorts
+-            '/usr/local/lib/libgeos_c.dylib',  # homebrew (Mac OS X)
+-            os.path.join(sys.prefix, "lib", "libgeos_c.so"), # anaconda (Linux)
+-            'libgeos_c.so.1',
+-            'libgeos_c.so'])
++            '@libgeos_c@'])
+ 
+ 
+ def test_suite():


### PR DESCRIPTION
###### Motivation for this change
https://hydra.nixos.org/build/89708540/nixlog/1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

