### PR TITLE
python3.pkgs.python-engineio: 3.0.0 -> 3.4.3

### DIFF
--- a/pkgs/development/python-modules/python-engineio/default.nix
+++ b/pkgs/development/python-modules/python-engineio/default.nix
@@ -8,18 +8,21 @@
 , iana-etc
 , libredirect
 , aiohttp
+, websockets
+, websocket_client
+, requests
 , tornado
 }:
 
 buildPythonPackage rec {
   pname = "python-engineio";
-  version = "3.0.0";
+  version = "3.4.3";
 
   src = fetchFromGitHub {
     owner = "miguelgrinberg";
     repo = "python-engineio";
     rev = "v${version}";
-    sha256 = "1v510fhn0li808ar2cmwh5nijacy5x60q9x4gm0b34j6mkmc59ph";
+    sha256 = "0wk81rqigw47z087f5kc7b9iwqggypxc62q8q818qyzqwb93ysxf";
   };
 
   propagatedBuildInputs = [
@@ -30,7 +33,10 @@ buildPythonPackage rec {
     eventlet
     mock
     aiohttp
+    websockets
+    websocket_client
     tornado
+    requests
   ];
 
   # make /etc/protocols accessible to fix socket.getprotobyname('tcp') in sandbox

--- a/pkgs/development/python-modules/python-engineio/default.nix
+++ b/pkgs/development/python-modules/python-engineio/default.nix
@@ -50,6 +50,7 @@ buildPythonPackage rec {
     description = "Engine.IO server";
     homepage = http://github.com/miguelgrinberg/python-engineio/;
     license = licenses.mit;
+    platforms = platforms.linux;
     maintainers = [ maintainers.mic92 ];
   };
 }


### PR DESCRIPTION
fixes build of python-socketio

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

