### PR TITLE
gitAndTools.gitRemoteGcrypt: Add missing dependencies

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-remote-gcrypt/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-remote-gcrypt/default.nix
@@ -1,4 +1,7 @@
-{ stdenv, fetchFromGitHub, docutils, makeWrapper, gnupg1compat, curl, rsync }:
+{ stdenv, fetchFromGitHub, docutils, makeWrapper
+, gnupg1compat, curl, rsync, coreutils
+, gawk, gnused, gnugrep
+}:
 
 stdenv.mkDerivation rec {
   name = "git-remote-gcrypt-${version}";
@@ -19,7 +22,8 @@ stdenv.mkDerivation rec {
   installPhase = ''
     prefix="$out" ./install.sh
     wrapProgram "$out/bin/git-remote-gcrypt" \
-      --prefix PATH ":" "${stdenv.lib.makeBinPath [ gnupg1compat curl rsync ]}"
+      --prefix PATH ":" "${stdenv.lib.makeBinPath [ gnupg1compat curl rsync coreutils
+                                                    gawk gnused gnugrep ]}"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Add the runtime dependencies coreutils, gawk, gnused and gnugrep.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

