### PR TITLE
treewide: fix some typos

### DIFF
--- a/pkgs/desktops/mate/libmatemixer/default.nix
+++ b/pkgs/desktops/mate/libmatemixer/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, pkgconfig, intltool, glib, mate
+{ config, stdenv, fetchurl, pkgconfig, intltool, glib, mate
 , alsaSupport ? stdenv.isLinux, alsaLib
-, pulseaudioSupport ? stdenv.config.pulseaudio or true, libpulseaudio
+, pulseaudioSupport ? config.pulseaudio or true, libpulseaudio
 , ossSupport ? false
  }:
 

--- a/pkgs/desktops/mate/mate-settings-daemon/default.nix
+++ b/pkgs/desktops/mate/mate-settings-daemon/default.nix
@@ -1,5 +1,6 @@
-{ stdenv, fetchurl, pkgconfig, intltool, dbus-glib, libxklavier, libcanberra-gtk3, libnotify, nss, polkit, gnome3, mate, wrapGAppsHook
-, pulseaudioSupport ? stdenv.config.pulseaudio or true, libpulseaudio
+{ config, stdenv, fetchurl, pkgconfig, intltool, dbus-glib, libxklavier
+, libcanberra-gtk3, libnotify, nss, polkit, gnome3, mate, wrapGAppsHook
+, pulseaudioSupport ? config.pulseaudio or true, libpulseaudio
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl, fetchpatch, gettext, meson, ninja, pkgconfig, perl, python3, glibcLocales
+{ config, stdenv, fetchurl, fetchpatch, gettext, meson, ninja, pkgconfig, perl, python3, glibcLocales
 , libiconv, zlib, libffi, pcre, libelf, gnome3, libselinux, bash, gnum4, gtk-doc, docbook_xsl, docbook_xml_dtd_45
 # use utillinuxMinimal to avoid circular dependency (utillinux, systemd, glib)
 , utillinuxMinimal ? null
 , buildPackages
 
 # this is just for tests (not in the closure of any regular package)
-, doCheck ? stdenv.config.doCheckByDefault or false
+, doCheck ? config.doCheckByDefault or false
 , coreutils, dbus, libxml2, tzdata
 , desktop-file-utils, shared-mime-info
 , darwin

--- a/pkgs/development/libraries/librdf/default.nix
+++ b/pkgs/development/libraries/librdf/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, pkgconfig, autoreconfHook
+{ config, stdenv, fetchurl, pkgconfig, autoreconfHook
 , librdf_raptor2, ladspaH, openssl, zlib
-, doCheck ? stdenv.config.doCheckByDefault or false, ladspaPlugins
+, doCheck ? config.doCheckByDefault or false, ladspaPlugins
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/stdenv/booter.nix
+++ b/pkgs/stdenv/booter.nix
@@ -43,7 +43,7 @@ stageFuns: let
 
   /* "dfold" a ternary function `op' between successive elements of `list' as if
      it was a doubly-linked list with `lnul' and `rnul` base cases at either
-     end. In precise terms, `fold op lnul rnul [x_0 x_1 x_2 ... x_n-1]` is the
+     end. In precise terms, `dfold op lnul rnul [x_0 x_1 x_2 ... x_n-1]` is the
      same as
 
        let


### PR DESCRIPTION
# `git log`

- pkgs/stdenv/booter.nix: fix a typo

- treewide: `stdenv.config` -> `config`

  That attribute does not exist.

# `nix-instantiate` environment

- Host OS: Linux 4.9, SLNOS 19.09
- Nix: nix-env (Nix) 2.2
- Multi-user: yes
- Sandbox: yes
- NIXPKGS_CONFIG:

```nix
{
  checkMeta = true;
  doCheckByDefault = false;
}
```

# `nix-env -qaP` diffs

- On x86_64-linux: noop
- On aarch64-linux: noop
- On x86_64-darwin: noop

/cc @7c6f434c