### PR TITLE
linuxPackages: 4.14 -> 4.19

### DIFF
--- a/pkgs/applications/virtualization/qemu/9p-ignore-noatime.patch
+++ b/pkgs/applications/virtualization/qemu/9p-ignore-noatime.patch
@@ -1,0 +1,44 @@
+commit cdc3e7eeafa9f683214d2c15d52ef384c3de6611
+Author: aszlig <aszlig@nix.build>
+Date:   Mon Mar 18 13:21:01 2019 +0100
+
+    9pfs: Ignore O_NOATIME open flag
+    
+    Since Linux 4.19, overlayfs uses the O_NOATIME flag on its lowerdir,
+    which in turn causes errors when the Nix store is mounted in the guest
+    because the file owner of the store paths typically don't match the
+    owner of the QEMU process.
+    
+    After submitting a patch to the overlayfs mailing list[1], it turns out
+    that my patch was incomplete[2] and needs a bit more rework.
+    
+    So instead of using an incomplete kernel patch in nixpkgs, which affects
+    *all* users of overlayfs, not just NixOS VM tests, I decided that for
+    now it's better to patch QEMU instead.
+    
+    The change here really only ignores the O_NOATIME flag so that the
+    behaviour is similar to what NFS does. From open(2):
+    
+      This flag may not be effective on all filesystems. One example is NFS,
+      where the server maintains the access time.
+    
+    This change is therefore only temporary until the final fix lands in the
+    stable kernel releases.
+    
+    [1]: https://www.spinics.net/lists/linux-unionfs/msg06755.html
+    [2]: https://www.spinics.net/lists/linux-unionfs/msg06756.html
+    
+    Signed-off-by: aszlig <aszlig@nix.build>
+
+diff --git a/hw/9pfs/9p.c b/hw/9pfs/9p.c
+index 55821343e5..0b8425fe18 100644
+--- a/hw/9pfs/9p.c
++++ b/hw/9pfs/9p.c
+@@ -127,7 +127,6 @@ static int dotl_to_open_flags(int flags)
+         { P9_DOTL_LARGEFILE, O_LARGEFILE },
+         { P9_DOTL_DIRECTORY, O_DIRECTORY },
+         { P9_DOTL_NOFOLLOW, O_NOFOLLOW },
+-        { P9_DOTL_NOATIME, O_NOATIME },
+         { P9_DOTL_SYNC, O_SYNC },
+     };
+ 

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -76,6 +76,7 @@ stdenv.mkDerivation rec {
   patches = [
     ./no-etc-install.patch
     ./fix-qemu-ga.patch
+    ./9p-ignore-noatime.patch
   ] ++ optional nixosTestRunner ./force-uid0-on-9p.patch
     ++ optional pulseSupport ./fix-hda-recording.patch
     ++ optionals stdenv.hostPlatform.isMusl [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14891,7 +14891,7 @@ in
   });
 
   # The current default kernel / kernel modules.
-  linuxPackages = linuxPackages_4_14;
+  linuxPackages = linuxPackages_4_19;
   linux = linuxPackages.kernel;
 
   # Update this when adding the newest kernel major version!


### PR DESCRIPTION
This should bring back kernel 4.19 as our default kernel by applying a patch that fixes our overlayfs regression (#54509).

I'm basing this against `master` first and we can backport it to stable later once we got it tested well enough™.

Tested this only against the `kernel-latest` NixOS test so far ~~, so we should probably add a Hydra job to make sure this doesn't introduce additional breakages~~.