### PR TITLE
altcoins.freicoin: fix build

### DIFF
--- a/pkgs/applications/altcoins/freicoin.nix
+++ b/pkgs/applications/altcoins/freicoin.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "1v1qwv4x5agjba82s1vknmdgq67y26wzdwbmwwqavv7f7y3y860h";
   };
 
+  enableParallelBuilding = false;
+
   qmakeFlags = ["USE_UPNP=-"];
 
   # I think that openssl and zlib are required, but come through other


### PR DESCRIPTION
###### Motivation for this change

fix build of freicoin https://hydra.nixos.org/build/90483049 for https://github.com/NixOS/nixpkgs/issues/56826

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

