### PR TITLE
kail: 0.7.0 -> 0.8.0

### DIFF
--- a/pkgs/tools/networking/kail/default.nix
+++ b/pkgs/tools/networking/kail/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "kail-${version}";
-  version = "0.7.0";
+  version = "0.8.0";
 
   goPackagePath = "github.com/boz/kail";
 
@@ -10,7 +10,7 @@ buildGoPackage rec {
     owner = "boz";
     repo = "kail";
     rev = "v${version}";
-    sha256 = "0j0948wjn0jsk89fp0l29pd90n86wi85yghrbdhwihhgyqcdmhi0";
+    sha256 = "0ibk7j40pj6f2086qcnwp998wld61d2gvrv7yiy6hlkalhww2pq7";
   };
 
   # regenerate deps.nix using following steps:


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vincent@sbr.pm>

###### Motivation for this change

Bump to latest release :angel: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

