### PR TITLE
 pythonPackages.weboob: add pyqt5 as native input

### DIFF
--- a/pkgs/development/python-modules/google-api-python-client/default.nix
+++ b/pkgs/development/python-modules/google-api-python-client/default.nix
@@ -4,7 +4,6 @@
 buildPythonPackage rec {
   pname = "google-api-python-client";
   version = "1.7.8";
-  #disabled = !isPy3k; # TODO: Python 2.7 was deprecated but weboob still depends on it.
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/weboob/default.nix
+++ b/pkgs/development/python-modules/weboob/default.nix
@@ -40,16 +40,11 @@ in buildPythonPackage rec {
     }; p' weboob/browser/browsers.py weboob/browser/pages.py
   '';
 
-  # Would fail with `Could not find executable: pyuic5`.
-  # That executable will be looked up from an environment variable
-  # in this format when available
-  #
-  # See: https://git.weboob.org/weboob/weboob/blob/1.3/setup.py#L32
-  PYUIC5_EXECUTABLE = "${pyqt5}/bin/pyuic5";
-
   setupPyBuildFlags = ["--qt" "--xdg"];
 
   checkInputs = [ nose ];
+
+  nativeBuildInputs = [ pyqt5 ];
 
   propagatedBuildInputs = [ pillow prettytable pyyaml dateutil
     gdata requests mechanize feedparser lxml gnupg pyqt5 libyaml

--- a/pkgs/development/python-modules/weboob/default.nix
+++ b/pkgs/development/python-modules/weboob/default.nix
@@ -6,18 +6,7 @@
 , unidecode
 }:
 
-let
-  # Support for Python 2.7 was dropped in 1.7.7
-  google_api_python_client_python27 = google_api_python_client.overrideDerivation
-    (oldAttrs: rec {
-      pname = "google-api-python-client";
-      version = "1.7.6";
-      src = fetchPypi {
-        inherit pname version;
-        sha256 = "14w5sdrp0bk9n0r2lmpqmrbf2zclpfq6q7giyahnskkfzdkb165z";
-      };
-    });
-in buildPythonPackage rec {
+buildPythonPackage rec {
   pname = "weboob";
   version = "1.3";
   disabled = ! isPy27;
@@ -49,7 +38,7 @@ in buildPythonPackage rec {
   propagatedBuildInputs = [ pillow prettytable pyyaml dateutil
     gdata requests mechanize feedparser lxml gnupg pyqt5 libyaml
     simplejson cssselect futures pdfminer termcolor
-    google_api_python_client_python27 html2text unidecode ];
+    google_api_python_client html2text unidecode ];
 
   checkPhase = ''
     nosetests

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2685,7 +2685,17 @@ in {
 
   google_api_core = callPackage ../development/python-modules/google_api_core { };
 
-  google_api_python_client = callPackage ../development/python-modules/google-api-python-client { };
+  google_api_python_client = let
+    google_api_python_client = callPackage ../development/python-modules/google-api-python-client { };
+  in if isPy3k then google_api_python_client else
+    # Python 2.7 support was deprecated but is still needed by weboob
+    google_api_python_client.overridePythonAttrs (old: rec {
+      version = "1.7.6";
+      src = old.src.override {
+        inherit version;
+        sha256 = "14w5sdrp0bk9n0r2lmpqmrbf2zclpfq6q7giyahnskkfzdkb165z";
+      };
+    });
 
   google_apputils = callPackage ../development/python-modules/google_apputils { };
 


### PR DESCRIPTION
###### Motivation for this change
Address @dotlambda feedback for #57555 after merge
- https://github.com/NixOS/nixpkgs/pull/57555#issuecomment-472638302
- https://github.com/NixOS/nixpkgs/pull/57555#issuecomment-472641284

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

