### PR TITLE
flat-remix-icon-theme: init at 20191018

### DIFF
--- a/pkgs/data/icons/flat-remix-icon-theme/default.nix
+++ b/pkgs/data/icons/flat-remix-icon-theme/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec  {
     description = "Flat remix is a pretty simple icon theme inspired on material design";
     homepage = https://drasite.com/flat-remix;
     license = with licenses; [ gpl3 ];
-    platforms = platforms.all;
+    platforms = platforms.linux;
     maintainers = with maintainers; [ mschneider ];
   };
 }

--- a/pkgs/data/icons/flat-remix-icon-theme/default.nix
+++ b/pkgs/data/icons/flat-remix-icon-theme/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub , gtk3 }:
+
+stdenv.mkDerivation rec  {
+  pname = "flat-remix-icon-theme";
+  version = "20191018";
+
+  src = fetchFromGitHub  {
+    owner = "daniruiz";
+    repo = "flat-remix";
+    rev = version;
+    sha256 = "13ibxvrvri04lb5phm49b6d553jh0aigm57z5i0nsins405gixn9";
+  };
+
+  nativeBuildInputs = [ gtk3 ];
+
+  installPhase = ''
+    mkdir -p $out/share/icons
+    mv Flat-Remix* $out/share/icons/
+  '';
+
+  postFixup = ''
+    for theme in $out/share/icons/*; do
+      gtk-update-icon-cache $theme
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Flat remix is a pretty simple icon theme inspired on material design";
+    homepage = https://drasite.com/flat-remix;
+    license = with licenses; [ gpl3 ];
+    platforms = platforms.all;
+    maintainers = with maintainers; [ mschneider ];
+  };
+}
+ 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17262,6 +17262,8 @@ in
 
   fira-mono = callPackage ../data/fonts/fira-mono { };
 
+  flat-remix-icon-theme = callPackage ../data/icons/flat-remix-icon-theme { };
+
   font-awesome_4 = (callPackage ../data/fonts/font-awesome-5 { }).v4;
   font-awesome_5 = (callPackage ../data/fonts/font-awesome-5 { }).v5;
   font-awesome = font-awesome_5;


### PR DESCRIPTION
###### Motivation for this change

Added the flat-remix-icon-theme

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

