### PR TITLE
pythonPackages.pyrr: 0.10.1 -> 0.10.2

### DIFF
--- a/pkgs/development/python-modules/pyrr/default.nix
+++ b/pkgs/development/python-modules/pyrr/default.nix
@@ -1,13 +1,18 @@
-{ stdenv, buildPythonPackage, fetchPypi
-, setuptools, multipledispatch, numpy }:
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, setuptools
+, multipledispatch
+, numpy
+}:
 
 buildPythonPackage rec {
-  version = "0.10.1";
+  version = "0.10.2";
   pname = "pyrr";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "06305b2f555f8b8091a6c29a05d5d33f131c9dd268e22d94985e43ab5df70c1d";
+    sha256 = "1q9i4qa6ygr8hlpnw55s58naynxzwm0sc1m54wyy1ghbf8m8d2f0";
   };
 
   buildInputs = [ setuptools ];
@@ -17,5 +22,6 @@ buildPythonPackage rec {
     description = "3D mathematical functions using NumPy";
     homepage = https://github.com/adamlwgriffiths/Pyrr/;
     license = licenses.bsd2;
+    maintainers = with maintainers; [ c0deaddict ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Tests are missing from the Pypi source distribution of pyrr 0.10.1. Therefore building that version is failing with this error:

```
======================================================================
ERROR: tests (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: tests
Traceback (most recent call last):
  File "/nix/store/lwwk80ls3sb1dfljfsrrx6wlkjkd8imn-python3-3.6.8/lib/python3.6/unittest/loader.py", line 153, in loadTestsFromName
    module = __import__(module_name)
ModuleNotFoundError: No module named 'tests'
```

pyrr version 0.10.2 has the tests packages in the source distribution, and the Nix build is thus working again, with tests.

This should also be backported to stable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

