### PR TITLE
wf-recorder: init at unstable-2019-03-12

### DIFF
--- a/pkgs/applications/video/wf-recorder/default.nix
+++ b/pkgs/applications/video/wf-recorder/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, meson, ninja, pkgconfig, wayland, wayland-protocols, ffmpeg, x264 }:
+
+stdenv.mkDerivation rec {
+  pname = "wf-recorder";
+  version = "unstable-2019-03-12";
+
+  src = fetchFromGitHub {
+    owner = "ammen99";
+    repo = pname;
+    rev = "e6ea77a2569c04975cab8655f5ad4dbcf86df1f5";
+    sha256 = "1jhj5syzy8i8f9b3j4g12jmc5fcsiv4df9hgribdvw61v5pfz9g1";
+  };
+
+  nativeBuildInputs = [ meson ninja pkgconfig ];
+  buildInputs = [ wayland wayland-protocols ffmpeg x264 ];
+
+  meta = with stdenv.lib; {
+    description = "Utility program for screen recording of wlroots-based compositors";
+    homepage = https://github.com/ammen99/wf-recorder;
+    license = licenses.mit;
+    maintainers = with maintainers; [ CrazedProgrammer ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6148,6 +6148,8 @@ in
 
   welkin = callPackage ../tools/graphics/welkin {};
 
+  wf-recorder = callPackage ../applications/video/wf-recorder { };
+
   whipper = callPackage ../applications/audio/whipper { };
 
   whois = callPackage ../tools/networking/whois { };


### PR DESCRIPTION
###### Motivation for this change
Adds [wf-recorder](https://github.com/ammen99/wf-recorder), a program for making screen captures on wlroots-based compositors like Sway.

See also: #57602.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

