### PR TITLE
fix: csound-manual by using newer git revision

### DIFF
--- a/pkgs/applications/audio/csound/csound-manual/default.nix
+++ b/pkgs/applications/audio/csound/csound-manual/default.nix
@@ -5,8 +5,8 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "3b0bdc83f9245261b4b85a57c3ed636d5d924a4f";
   pname = "csound-manual";
+  version = "unstable-2019-02-22";
 
   src = fetchFromGitHub {
     owner = "csound";

--- a/pkgs/applications/audio/csound/csound-manual/default.nix
+++ b/pkgs/applications/audio/csound/csound-manual/default.nix
@@ -1,18 +1,19 @@
-{ 
-  stdenv, fetchurl, docbook_xsl,
-  docbook_xml_dtd_45, python, pygments, 
-  libxslt 
+{
+  stdenv, fetchFromGitHub, docbook_xsl,
+  docbook_xml_dtd_45, python, pygments,
+  libxslt
 }:
 
 stdenv.mkDerivation rec {
-  version = "6.12.0";
-  name = "csound-manual-${version}";
-  
-  src = fetchurl {
-    url = "https://github.com/csound/manual/archive/${version}.tar.gz";
-    sha256 = "1v1scp468rnfbcajnp020kdj8zigimc2mbcwzxxqi8sf8paccdrp";
-  };
+  version = "3b0bdc83f9245261b4b85a57c3ed636d5d924a4f";
+  pname = "csound-manual";
 
+  src = fetchFromGitHub {
+    owner = "csound";
+    repo = "manual";
+    rev = "3b0bdc83f9245261b4b85a57c3ed636d5d924a4f";
+    sha256 = "074byjhaxraapyg54dxgg7hi1d4978aa9c1rmyi50p970nsxnacn";
+  };
 
   prePatch = ''
     substituteInPlace manual.xml \
@@ -41,4 +42,3 @@ stdenv.mkDerivation rec {
     platforms = stdenv.lib.platforms.all;
   };
 }
-


### PR DESCRIPTION
###### Motivation for this change

With tag 6.12.0 this error is produced

```
Traceback (most recent call last):
  File "csd2docbook.py", line 373, in <module>
    CsoundScoreLexer.tokens['root'][3] = (stateTuple[0], Token.Name.Builtin, stateTuple[2])
IndexError: tuple index out of range
make[1]: *** [Makefile:700: examples-xml/stamp] Error 1
```

This only started to happen recently after I updated my channels.

###### Things done

So tried the master branch of the manual, and it works, no idea what was done from the tagging to today. So I'm worried if I'm not versioning this right, if I should use the revision as version number, or it's ok to keep it like this, there hasn't been any new release of the csound manual.

- [ x ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

