### PR TITLE
nixos/gitea: Add support for the REQUIRE_SIGNIN_VIEW option

### DIFF
--- a/nixos/modules/services/misc/gitea.nix
+++ b/nixos/modules/services/misc/gitea.nix
@@ -48,6 +48,7 @@ let
 
     [service]
     DISABLE_REGISTRATION = ${boolToString cfg.disableRegistration}
+    REQUIRE_SIGNIN_VIEW = ${boolToString cfg.requireSigninView}
 
     ${cfg.extraConfig}
   '';
@@ -260,6 +261,15 @@ in
           deploy unless <link linkend="opt-services.gitea.useWizard">services.gitea.useWizard</link>
           is <literal>true</literal> as the first registered user will be the administrator if
           no install wizard is used.
+        '';
+      };
+
+      requireSigninView = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Require signin to view any pages.
+          This along with <literal>disableRegistration = true</literal> is useful to create a private git server.
         '';
       };
 

--- a/nixos/tests/gitea.nix
+++ b/nixos/tests/gitea.nix
@@ -65,6 +65,7 @@ with pkgs.lib;
       { config, pkgs, ... }:
       { services.gitea.enable = true;
         services.gitea.disableRegistration = true;
+        services.gitea.requireSigninView = true;
       };
 
     testScript = ''
@@ -74,6 +75,7 @@ with pkgs.lib;
       $machine->waitForOpenPort('3000');
       $machine->succeed("curl --fail http://localhost:3000/");
       $machine->succeed("curl --fail http://localhost:3000/user/sign_up | grep 'Registration is disabled. Please contact your site administrator.'");
+      $machine->succeed("curl --fail http://localhost:3000/example | grep -F '<a href=\"/user/login\">Found</a>.'");
     '';
   };
 }


### PR DESCRIPTION
###### Motivation for this change
The REQUIRE_SIGNIN_VIEW option in gitea is useful for making private git servers, but I didn't originally notice it since there was no option in NixOS.

###### Things done
Add a new option which maps to REQUIRE_SIGNIN_VIEW.

This is marked as draft, since the gitea tests are failing. However, that is likely not my problem, since they seem to fail on master as well (due to a binary which doesn't support sqlite3).


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

