### PR TITLE
bitcoinarmory: fix build

### DIFF
--- a/pkgs/applications/misc/bitcoinarmory/default.nix
+++ b/pkgs/applications/misc/bitcoinarmory/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, pythonPackages
 , pkgconfig, autoreconfHook, rsync
-, swig, qt4, fcgi
+, swig, qt48Full, fcgi
 , bitcoin, procps, utillinux
 }:
 let
@@ -16,7 +16,6 @@ in buildPythonApplication {
     owner = "goatpig";
     repo = "BitcoinArmory";
     rev = "v${version}";
-    #sha256 = "023c7q1glhrkn4djz3pf28ckd1na52lsagv4iyfgchqvw7qm7yx2";
     sha256 = "0pjk5qx16n3kvs9py62666qkwp2awkgd87by4karbj7vk6p1l14h"; fetchSubmodules = true;
   };
 
@@ -25,13 +24,17 @@ in buildPythonApplication {
   # FIXME bitcoind doesn't die on shutdown. Need some sort of patch to fix that.
   #patches = [ ./shutdown-fix.patch ];
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [
+  nativeBuildInputs = [
     autoreconfHook
+    pkgconfig
     swig
-    qt4
-    fcgi
+    pyqt4
+    qt48Full
     rsync # used by silly install script (TODO patch upstream)
+  ];
+  buildInputs = [
+    qt48Full
+    fcgi
   ];
 
   propagatedBuildInputs = [


### PR DESCRIPTION
for #56826 see https://hydra.nixos.org/build/90482597/nixlog/2

###### Motivation for this change

#56826

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

