### PR TITLE
tpm2-tools: 3.1.3 -> 3.1.4

### DIFF
--- a/pkgs/tools/security/tpm2-tools/default.nix
+++ b/pkgs/tools/security/tpm2-tools/default.nix
@@ -3,20 +3,12 @@
 
 stdenv.mkDerivation rec {
   pname = "tpm2-tools";
-  version = "3.1.3";
+  version = "3.1.4";
 
   src = fetchurl {
     url = "https://github.com/tpm2-software/${pname}/releases/download/${version}/${pname}-${version}.tar.gz";
-    sha256 = "05is1adwcg7y2p121yldd8m1gigdnzf9izbjazvsr6yg95pmg5fc";
+    sha256 = "0cv09wnf7sw17z1n898w0zmk58y8b1why58m63hqx5d7x4054l9g";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "tests-tss-2.2.0-compat.patch";
-      url = "https://patch-diff.githubusercontent.com/raw/tpm2-software/tpm2-tools/pull/1322.patch";
-      sha256 = "0yy5qbgbd13d7cl8pzsji95a6qnwiik5s2cyqj35jd8blymikqxh";
-    })
-  ];
 
   nativeBuildInputs = [ pandoc pkgconfig ];
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change

https://github.com/tpm2-software/tpm2-tools/releases/tag/3.1.4

Remove additional patch that has been upstreamed starting from this version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

