### PR TITLE
gdk-pixbuf: make x11 optional, disabled on darwin

### DIFF
--- a/pkgs/development/libraries/gdk-pixbuf/default.nix
+++ b/pkgs/development/libraries/gdk-pixbuf/default.nix
@@ -1,6 +1,8 @@
 { stdenv, fetchurl, fetchpatch, fixDarwinDylibNames, meson, ninja, pkgconfig, gettext, python3, libxml2, libxslt, docbook_xsl
-, docbook_xml_dtd_43, gtk-doc, glib, libtiff, libjpeg, libpng, libX11, gnome3
-, jasper, gobject-introspection, doCheck ? false, makeWrapper }:
+, docbook_xml_dtd_43, gtk-doc, glib, libtiff, libjpeg, libpng, gnome3
+, jasper, gobject-introspection, doCheck ? false, makeWrapper
+, x11Support ? !stdenv.isDarwin, libX11
+}:
 
 let
   pname = "gdk-pixbuf";
@@ -33,7 +35,7 @@ in stdenv.mkDerivation rec {
   setupHook = ./setup-hook.sh;
 
   # !!! We might want to factor out the gdk-pixbuf-xlib subpackage.
-  buildInputs = [ libX11 ];
+  buildInputs = stdenv.lib.optional x11Support [ libX11 ];
 
   nativeBuildInputs = [
     meson ninja pkgconfig gettext python3 libxml2 libxslt docbook_xsl docbook_xml_dtd_43
@@ -46,7 +48,7 @@ in stdenv.mkDerivation rec {
   mesonFlags = [
     "-Ddocs=true"
     "-Djasper=true"
-    "-Dx11=true"
+    "-Dx11=${if x11Support then "true" else "false"}"
     "-Dgir=${if gobject-introspection != null then "true" else "false"}"
   ];
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

