### PR TITLE
libcaca: make x11 optional, disabled on darwin

### DIFF
--- a/pkgs/development/libraries/libcaca/default.nix
+++ b/pkgs/development/libraries/libcaca/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, fetchurl, ncurses, zlib, imlib2, pkgconfig, libX11, libXext }:
+{ stdenv, fetchurl, ncurses, zlib, pkgconfig, imlib2
+, x11Support ? !stdenv.isDarwin, libX11, libXext
+}:
 
 stdenv.mkDerivation rec {
   name = "libcaca-0.99.beta19";
@@ -13,8 +15,16 @@ stdenv.mkDerivation rec {
 
   outputs = [ "bin" "dev" "out" "man" ];
 
-  propagatedBuildInputs = [ ncurses zlib imlib2 pkgconfig libX11 ]
-   ++ stdenv.lib.optional stdenv.isDarwin libXext;
+  configureFlags = [
+    (if x11Support then "--enable-x11" else "--disable-x11")
+    ];
+
+  NIX_CFLAGS_COMPILE = stdenv.lib.optional (!x11Support) "-DX_DISPLAY_MISSING";
+
+  enableParallelBuilding = true;
+
+  propagatedBuildInputs = [ ncurses zlib pkgconfig (imlib2.override { inherit x11Support; }) ]
+    ++ stdenv.lib.optionals x11Support [ libX11 libXext];
 
   postInstall = ''
     mkdir -p $dev/bin


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

