### PR TITLE
modemmanager: 1.7.990 -> 1.10.0 

### DIFF
--- a/pkgs/development/libraries/libmbim/default.nix
+++ b/pkgs/development/libraries/libmbim/default.nix
@@ -1,24 +1,35 @@
-{ stdenv, fetchurl, pkgconfig, glib, python, udev, libgudev }:
+{ stdenv, fetchurl, pkgconfig, glib, python3, systemd, libgudev }:
 
 stdenv.mkDerivation rec {
-  name = "libmbim-1.16.2";
+  pname = "libmbim";
+  version = "1.18.0";
 
   src = fetchurl {
-    url = "https://www.freedesktop.org/software/libmbim/${name}.tar.xz";
-    sha256 = "0qmjvjbgs9m8qsaiq5arikzglgaas9hh1968bi7sy3905kp4yjgb";
+    url = "https://www.freedesktop.org/software/libmbim/${pname}-${version}.tar.xz";
+    sha256 = "10mjjy860aakfd3h1yaj9l1jw816amrpwmyqlx37j21xv0l03x3c";
   };
 
   outputs = [ "out" "dev" "man" ];
 
-  preConfigure = ''
-    patchShebangs .
-  '';
+  configureFlags = [
+    "--with-udev-base-dir=${placeholder ''out''}/lib/udev"
+  ];
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ glib udev libgudev python ];
+  nativeBuildInputs = [
+    pkgconfig
+    python3
+  ];
+
+  buildInputs = [
+    glib
+    libgudev
+    systemd
+  ];
+
+  doCheck = true;
 
   meta = with stdenv.lib; {
-    homepage = http://www.freedesktop.org/software/libmbim/;
+    homepage = https://www.freedesktop.org/wiki/Software/libmbim/;
     description = "Library for talking to WWAN modems and devices which speak the Mobile Interface Broadband Model (MBIM) protocol";
     platforms = platforms.linux;
     license = licenses.gpl2;

--- a/pkgs/development/libraries/libqmi/default.nix
+++ b/pkgs/development/libraries/libqmi/default.nix
@@ -1,26 +1,35 @@
-{ stdenv, fetchurl, pkgconfig, glib, python, libgudev, libmbim }:
+{ stdenv, fetchurl, pkgconfig, glib, python3, libgudev, libmbim }:
 
 stdenv.mkDerivation rec {
-  name = "libqmi-1.20.2";
+  pname = "libqmi";
+  version = "1.22.2";
 
   src = fetchurl {
-    url = "https://www.freedesktop.org/software/libqmi/${name}.tar.xz";
-    sha256 = "0i6aw8jyxv84d5x8lj2g9lb8xxf1dyad8n3q0kw164pyig55jd67";
+    url = "https://www.freedesktop.org/software/libqmi/${pname}-${version}.tar.xz";
+    sha256 = "09w20dsgr16bgbqw5ds7r6j2s6ihwyalh9zpbjhcn7cvm0afbwgi";
   };
 
   outputs = [ "out" "dev" "devdoc" ];
 
-  preBuild = ''
-    patchShebangs .
-  '';
+  configureFlags = [
+    "--with-udev-base-dir=${placeholder ''out''}/lib/udev"
+  ];
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ glib python libgudev libmbim ];
+  nativeBuildInputs = [
+    pkgconfig
+    python3
+  ];
 
-  configureFlags = ["--enable-mbim-qmux" ];
+  buildInputs = [
+    glib
+    libgudev
+    libmbim
+  ];
+
+  doCheck = true;
 
   meta = with stdenv.lib; {
-    homepage = http://www.freedesktop.org/wiki/Software/libqmi/;
+    homepage = https://www.freedesktop.org/wiki/Software/libqmi/;
     description = "Modem protocol helper library";
     platforms = platforms.linux;
     license = licenses.gpl2;

--- a/pkgs/tools/networking/modem-manager/default.nix
+++ b/pkgs/tools/networking/modem-manager/default.nix
@@ -1,52 +1,40 @@
 { stdenv, fetchurl, glib, udev, libgudev, polkit, ppp, gettext, pkgconfig
-, libmbim, libqmi, systemd, fetchpatch }:
+, libmbim, libqmi, systemd, vala, gobject-introspection, dbus }:
 
 stdenv.mkDerivation rec {
-  name = "modem-manager-${version}";
-  version = "1.7.990";
+  pname = "modem-manager";
+  version = "1.10.0";
 
   package = "ModemManager";
   src = fetchurl {
     url = "https://www.freedesktop.org/software/${package}/${package}-${version}.tar.xz";
-    sha256 = "1v4hixmghlrw7w4ajq2x4k62js0594h223d0yma365zwqr7hjrfl";
+    sha256 = "1qkfnxqvaraz1npahqvm5xc73mbxxic8msnsjmlwkni5c2ckj3zx";
   };
 
-  nativeBuildInputs = [ gettext pkgconfig ];
+  nativeBuildInputs = [ vala gobject-introspection gettext pkgconfig ];
 
   buildInputs = [ glib udev libgudev polkit ppp libmbim libqmi systemd ];
 
-  patches = [
-    # Patch dependency on glib headers, this breaks packages using core headers (networkmanager-qt)
-    (fetchpatch {
-      url = "https://cgit.freedesktop.org/ModemManager/ModemManager/patch/?id=0f377f943eeb81472fd73189f2c3d8fc65b8c609";
-      sha256 = "0av0sqdvbhwjnhqqylkc7rmqcj6awqmz5693l9x93nlwp7zya95j";
-    })
-  ];
-
   configureFlags = [
     "--with-polkit"
-    "--with-udev-base-dir=$(out)/lib/udev"
-    "--with-systemdsystemunitdir=$(out)/etc/systemd/system"
+    "--with-udev-base-dir=${placeholder ''out''}/lib/udev"
+    "--with-dbus-sys-dir=${placeholder ''out''}/etc/dbus-1/system.d"
+    "--with-systemdsystemunitdir=${placeholder ''out''}/etc/systemd/system"
     "--sysconfdir=/etc"
     "--localstatedir=/var"
-    "--with-suspend-resume=systemd"
+    "--with-systemd-suspend-resume"
+    "--with-systemd-journal"
   ];
 
-  installFlags = [ "DESTDIR=\${out}" ];
-
-  preInstall = ''
-    mkdir -p $out/etc/systemd/system
+  preCheck = ''
+    export G_TEST_DBUS_DAEMON="${dbus.daemon}/bin/dbus-daemon"
   '';
+
+  doCheck = true;
 
   postInstall = ''
     # rename to modem-manager to be in style
-    mv $out/$out/etc/systemd/system/ModemManager.service $out/etc/systemd/system/modem-manager.service
-    rm -rf $out/$out/etc
-    mv $out/$out/* $out
-    DIR=$out/$out
-    while rmdir $DIR 2>/dev/null; do
-      DIR="$(dirname "$DIR")"
-    done
+    mv $out/etc/systemd/system/ModemManager.service $out/etc/systemd/system/modem-manager.service
 
     # systemd in NixOS doesn't use `systemctl enable`, so we need to establish
     # aliases ourselves.


### PR DESCRIPTION
###### Motivation for this change
Fix https://github.com/NixOS/nixpkgs/issues/57615

I still need to give the News items a better look.

Probably should add multiple outputs for `modemmanager`?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS (master)
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

