### PR TITLE
chell: remove obsolete workaround that breaks 0.5

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1169,9 +1169,6 @@ self: super: {
   # });
   libnix = dontCheck super.libnix;
 
-  # https://github.com/jmillikin/chell/issues/1
-  chell = super.chell.override { patience = self.patience_0_1_1; };
-
   # The test suite tries to mess with ALSA, which doesn't work in the build sandbox.
   xmobar = dontCheck super.xmobar;
 


### PR DESCRIPTION
###### Motivation for this change
Hopefully fixes #57642

###### Things done

Builds on Linux with ghc 8.4.

