### PR TITLE
netbeans: 8.2 -> 10.0

### DIFF
--- a/pkgs/applications/editors/netbeans/default.nix
+++ b/pkgs/applications/editors/netbeans/default.nix
@@ -1,8 +1,9 @@
-{ stdenv, fetchurl, makeWrapper, makeDesktopItem
-, jdk, perl, python, unzip, which
+{ stdenv, fetchurl, makeWrapper, makeDesktopItem, which, unzip, libicns, imagemagick
+, jdk, perl, python
 }:
 
 let
+  version = "10.0";
   desktopItem = makeDesktopItem {
     name = "netbeans";
     exec = "netbeans";
@@ -10,13 +11,14 @@ let
     desktopName = "Netbeans IDE";
     genericName = "Integrated Development Environment";
     categories = "Application;Development;";
+    icon = "netbeans";
   };
 in
 stdenv.mkDerivation {
-  name = "netbeans-8.2";
+  name = "netbeans-${version}";
   src = fetchurl {
-    url = https://download.netbeans.org/netbeans/8.2/final/zip/netbeans-8.2-201609300101.zip;
-    sha256 = "0j092qw7aqfc9vpnvr3ix1ii94p4ik6frcnw708iyv4s9crqi65d";
+    url = "mirror://apache/incubator/netbeans/incubating-netbeans/incubating-${version}/incubating-netbeans-${version}-bin.zip";
+    sha512 = "ba83575f42c1d5515e2a5336a621bc2b4087b2e0bcacb6edb76f376f8272555609bdd4eefde8beae8ffc6c1a7db2fb721b844638ce27933c3dd78f71cbb41ad8";
   };
 
   buildCommand = ''
@@ -26,23 +28,38 @@ stdenv.mkDerivation {
 
     # Copy to installation directory and create a wrapper capable of starting
     # it.
-    mkdir -p $out/bin
+    mkdir -pv $out/bin
     cp -a netbeans $out
     makeWrapper $out/netbeans/bin/netbeans $out/bin/netbeans \
       --prefix PATH : ${stdenv.lib.makeBinPath [ jdk which ]} \
       --prefix JAVA_HOME : ${jdk.home} \
       --add-flags "--jdkhome ${jdk.home}"
 
+    # Extract pngs from the Apple icon image and create
+    # the missing ones from the 1024x1024 image.
+    icns2png --extract $out/netbeans/nb/netbeans.icns
+    for size in 16 24 32 48 64 128 256 512 1024; do
+      mkdir -pv $out/share/icons/hicolor/"$size"x"$size"/apps
+      if [ -e netbeans_"$size"x"$size"x32.png ]
+      then
+        mv netbeans_"$size"x"$size"x32.png $out/share/icons/hicolor/"$size"x"$size"/apps/netbeans.png
+      else
+        convert -resize "$size"x"$size" netbeans_1024x1024x32.png $out/share/icons/hicolor/"$size"x"$size"/apps/netbeans.png
+      fi
+    done;
+    
     # Create desktop item, so we can pick it from the KDE/GNOME menu
-    mkdir -p $out/share/applications
-    cp ${desktopItem}/share/applications/* $out/share/applications
+    mkdir -pv $out/share/applications
+    ln -s ${desktopItem}/share/applications/* $out/share/applications
   '';
 
-  buildInputs = [ makeWrapper perl python unzip ];
+  buildInputs = [ makeWrapper perl python unzip libicns imagemagick ];
 
   meta = {
     description = "An integrated development environment for Java, C, C++ and PHP";
-    maintainers = [ stdenv.lib.maintainers.sander ];
+    homepage = "https://netbeans.org/";
+    license = stdenv.lib.licenses.asl20;
+    maintainers = with stdenv.lib.maintainers; [ sander rszibele ];
     platforms = stdenv.lib.platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Latest upstream version is 10.0 with JDK 11 support. The created `.desktop` file also didn't have any icon associated with it and meta information needed to be amended (license, homepage).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

