### PR TITLE
Revert "nixos/nginx: support h2c"

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -197,7 +197,7 @@ let
         listenString = { addr, port, ssl, extraParameters ? [], ... }:
           "listen ${addr}:${toString port} "
           + optionalString ssl "ssl "
-          + optionalString vhost.http2 "http2 "
+          + optionalString (ssl && vhost.http2) "http2 "
           + optionalString vhost.default "default_server "
           + optionalString (extraParameters != []) (concatStringsSep " " extraParameters)
           + ";";


### PR DESCRIPTION
Reverts NixOS/nixpkgs#55192

Fixes https://github.com/NixOS/nixpkgs/issues/57324 for now

We don't want to cause everyones nginx servers to fail, this problem should be fixed before we attempt to merge #55192 again

Ping @w4 @dhess @Izorkin @ArdaXi 