### PR TITLE
freetype2: 2.9.1 -> 2.10.0

### DIFF
--- a/pkgs/development/libraries/freetype/default.nix
+++ b/pkgs/development/libraries/freetype/default.nix
@@ -13,8 +13,8 @@ let
   inherit (stdenv.lib) optional optionalString;
 
 in stdenv.mkDerivation rec {
-  name = "freetype-${version}";
-  version = "2.9.1";
+  pname = "freetype";
+  version = "2.10.0";
 
   meta = with stdenv.lib; {
     description = "A font rendering engine";
@@ -32,8 +32,8 @@ in stdenv.mkDerivation rec {
   };
 
   src = fetchurl {
-    url = "mirror://savannah/freetype/${name}.tar.bz2";
-    sha256 = "0kg8w6qyiizlyzh4a8lpzslipcbv96hcg3rqqpnxba8ffbm8g3fv";
+    url = "mirror://savannah/${pname}/${pname}-${version}.tar.bz2";
+    sha256 = "01mybx78n3n9dhzylbrdy42wxdwfn8rp514qdkzjy6b5ij965k7w";
   };
 
   propagatedBuildInputs = [ zlib bzip2 libpng ]; # needed when linking against freetype

--- a/pkgs/development/libraries/freetype/enable-subpixel-rendering.patch
+++ b/pkgs/development/libraries/freetype/enable-subpixel-rendering.patch
@@ -1,13 +1,12 @@
-Index: freetype-2.7.1/include/freetype/config/ftoption.h
-===================================================================
---- freetype-2.7.1.orig/include/freetype/config/ftoption.h
-+++ freetype-2.7.1/include/freetype/config/ftoption.h
-@@ -122,7 +122,7 @@ FT_BEGIN_HEADER
-   /* This is done to allow FreeType clients to run unmodified, forcing     */
-   /* them to display normal gray-level anti-aliased glyphs.                */
-   /*                                                                       */
+Index: freetype-2.10.0/include/freetype/config/ftoption.h
+--- a/include/freetype/config/ftoption.h
++++ b/include/freetype/config/ftoption.h
+@@ -126,7 +126,7 @@ FT_BEGIN_HEADER
+    * macro is not defined, FreeType offers alternative LCD rendering
+    * technology that produces excellent output without LCD filtering.
+    */
 -/* #define FT_CONFIG_OPTION_SUBPIXEL_RENDERING */
 +#define FT_CONFIG_OPTION_SUBPIXEL_RENDERING
  
  
-   /*************************************************************************/
+   /**************************************************************************

--- a/pkgs/development/libraries/freetype/enable-table-validation.patch
+++ b/pkgs/development/libraries/freetype/enable-table-validation.patch
@@ -1,20 +1,18 @@
-Index: freetype-2.7.1/modules.cfg
+Index: freetype-2.10.0/modules.cfg
 ===================================================================
---- freetype-2.7.1.orig/modules.cfg
-+++ freetype-2.7.1/modules.cfg
-@@ -120,7 +120,7 @@ AUX_MODULES += cache
+--- freetype-2.10.0.orig/modules.cfg
++++ freetype-2.10.0/modules.cfg
+@@ -120,6 +120,6 @@ AUX_MODULES += cache
  # TrueType GX/AAT table validation.  Needs ftgxval.c below.
  #
- # No FT_CONFIG_OPTION_PIC support.
 -# AUX_MODULES += gxvalid
 +AUX_MODULES += gxvalid
  
  # Support for streams compressed with gzip (files with suffix .gz).
  #
-@@ -143,7 +143,7 @@ AUX_MODULES += bzip2
+@@ -143,6 +143,6 @@ AUX_MODULES += bzip2
  # OpenType table validation.  Needs ftotval.c below.
  #
- # No FT_CONFIG_OPTION_PIC support.
 -# AUX_MODULES += otvalid
 +AUX_MODULES += otvalid
  


### PR DESCRIPTION
###### Motivation for this change

http://lists.nongnu.org/archive/html/freetype-announce/2019-03/msg00000.html

Rendering fonts like it's 2019 \o/.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Built and tested a few desktops apps (GTK3, soon QT5).

So far so good :).