### PR TITLE
haskell builder: don't copy packages from GHCs

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -212,7 +212,14 @@ let
   nativeGhcCommand = "${nativeGhc.targetPrefix}ghc";
 
   buildPkgDb = ghcName: packageConfDir: ''
-    if [ -d "$p/lib/${ghcName}/package.conf.d" ]; then
+    # If this dependency has a package database, then copy the contents of it, unless
+    # it is one of our GHCs. These can appear in our dependencies when we are doing
+    # native builds, and they have  package databases in them, but we do not want to 
+    # copy them over. 
+    # We don't need to, since those packages will be provided by the GHC when we compile 
+    # with it, and doing so can result in having multiple copies of e.g. Cabal in the database 
+    # with the same name and version, which is ambiguous.
+    if [ -d "$p/lib/${ghcName}/package.conf.d" ] && [ "$p" != "${ghc}" ] && [ "$p" != "${nativeGhc}" ]; then
       cp -f "$p/lib/${ghcName}/package.conf.d/"*.conf ${packageConfDir}/
       continue
     fi


### PR DESCRIPTION
In order to build the package databases that we will use when compiling
a Haskell package, we iterate over the relevant dependencies, and if
they contain a package db, we copy its contents over.

So far so good, except when one of those dependencies is GHC. This
doesn't happen ordinarily, but it will happen when we construct the
package database for compiling `Setup.hs`.  This is compiled for the
build architecture, so we get the build deps, including both the native
and the cross GHC (if there is one).

In this case, we end up copying the packages from the GHC's package
database. This is at best unnecessary, since we will get those packages
from the GHC when we compile with it.

At worst, however, this is semantically questionable. We can end up
having multiple copies of e.g. Cabal with the same version, but
(potentially) different contents. At the moment, GHC will expose one of
these at semi-random depending on which one it looks at "first".
However, there is a MR open [in GHC](https://gitlab.haskell.org/ghc/ghc/merge_requests/545) which as a
side effect will instead expose both, leading to ambiguous module
warnings (which is not unreasonable, since it *is* ambiguous).

So what can we do about it? The simplest solution is just to not copy
the package databases from GHC. GHC is special in this regard, so I
think it's okay to treat it specially.

This PR should have no effect on anything now, but will prevent any
breakage when/if the GHC patch lands.

------

I've opened this against `haskell-updates` - or should it be `staging`?

I've tested this by building our packages that use the nixpkgs Haskell infrastructure, using this patch and a GHC patched with the change in the linked MR. That builds and works fine on NixOS and macOS.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

