### PR TITLE
Go: 1.11.5 -> 1.11.6 and 1.12 -> 1.12.1

### DIFF
--- a/pkgs/development/compilers/go/1.11.nix
+++ b/pkgs/development/compilers/go/1.11.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, tzdata, iana-etc, go_bootstrap, runCommand, writeScriptBin
+{ stdenv, fetchurl, tzdata, iana-etc, go_bootstrap, runCommand, writeScriptBin
 , perl, which, pkgconfig, patch, procps, pcre, cacert, llvm, Security, Foundation
 , mailcap, runtimeShell
 , buildPackages, targetPackages }:
@@ -29,13 +29,11 @@ in
 
 stdenv.mkDerivation rec {
   name = "go-${version}";
-  version = "1.11.5";
+  version = "1.11.6";
 
-  src = fetchFromGitHub {
-    owner = "golang";
-    repo = "go";
-    rev = "go${version}";
-    sha256 = "0d45057rc0bngq0nja847cagxji42qmlywr68f0dkg51im8nyr9y";
+  src = fetchurl {
+    url = "https://dl.google.com/go/go${version}.src.tar.gz";
+    sha256 = "0cz1sdhxf9283p1p4jxb020pym0ncd0qlfh36r3hkv6bbm1a2vd9";
   };
 
   # perl is used for testing go vet
@@ -125,7 +123,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./remove-tools-1.11.patch
-    ./ssl-cert-file-1.9.patch
+    ./ssl-cert-file-1.12.1.patch
     ./remove-test-pie.patch
     ./creds-test.patch
     ./go-1.9-skip-flaky-19608.patch

--- a/pkgs/development/compilers/go/1.12.nix
+++ b/pkgs/development/compilers/go/1.12.nix
@@ -29,11 +29,11 @@ in
 
 stdenv.mkDerivation rec {
   name = "go-${version}";
-  version = "1.12";
+  version = "1.12.1";
 
   src = fetchurl {
     url = "https://dl.google.com/go/go${version}.src.tar.gz";
-    sha256 = "1wl8kq21fbzmv4plnaza5acz8dhbaaq6smjzk3r6cf3l6qrkvi09";
+    sha256 = "12l12mmgqvy3nbscy7sz83qj4m6iz5a322aq9sk45f7l9ml2gq8b";
   };
 
   # perl is used for testing go vet
@@ -127,6 +127,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./remove-tools-1.11.patch
+    ./ssl-cert-file-1.12.1.patch
     ./remove-test-pie.patch
     ./creds-test.patch
     ./go-1.9-skip-flaky-19608.patch

--- a/pkgs/development/compilers/go/ssl-cert-file-1.12.1.patch
+++ b/pkgs/development/compilers/go/ssl-cert-file-1.12.1.patch
@@ -1,0 +1,59 @@
+diff -Naur a/src/crypto/x509/root_cgo_darwin.go b/src/crypto/x509/root_cgo_darwin.go
+--- a/src/crypto/x509/root_cgo_darwin.go	2019-03-15 11:33:55.920232337 -0700
++++ b/src/crypto/x509/root_cgo_darwin.go	2019-03-15 11:34:53.323180897 -0700
+@@ -270,11 +270,20 @@
+ import "C"
+ import (
+	"errors"
++	"io/ioutil"
++	"os"
+	"unsafe"
+ )
+
+ func loadSystemRoots() (*CertPool, error) {
+	roots := NewCertPool()
++	if file := os.Getenv("NIX_SSL_CERT_FILE"); file != "" {
++		data, err := ioutil.ReadFile(file)
++		if err == nil {
++			roots.AppendCertsFromPEM(data)
++			return roots, nil
++		}
++	}
+
+	var data C.CFDataRef = 0
+	var untrustedData C.CFDataRef = 0
+diff -Naur a/src/crypto/x509/root_darwin.go b/src/crypto/x509/root_darwin.go
+--- a/src/crypto/x509/root_darwin.go	2019-03-15 11:33:55.920232337 -0700
++++ b/src/crypto/x509/root_darwin.go	2019-03-15 11:36:21.205123541 -0700
+@@ -92,6 +92,14 @@
+		verifyCh    = make(chan rootCandidate)
+	)
+
++	if file := os.Getenv("NIX_SSL_CERT_FILE"); file != "" {
++		data, err := ioutil.ReadFile(file)
++		if err == nil {
++			roots.AppendCertsFromPEM(data)
++			return roots, nil
++		}
++	}
++
+	// Using 4 goroutines to pipe into verify-cert seems to be
+	// about the best we can do. The verify-cert binary seems to
+	// just RPC to another server with coarse locking anyway, so
+diff -Naur a/src/crypto/x509/root_unix.go b/src/crypto/x509/root_unix.go
+--- a/src/crypto/x509/root_unix.go	2019-03-15 11:33:55.920232337 -0700
++++ b/src/crypto/x509/root_unix.go	2019-03-15 11:37:15.737326340 -0700
+@@ -38,6 +38,13 @@
+
+ func loadSystemRoots() (*CertPool, error) {
+	roots := NewCertPool()
++	if file := os.Getenv("NIX_SSL_CERT_FILE"); file != "" {
++		data, err := ioutil.ReadFile(file)
++		if err == nil {
++			roots.AppendCertsFromPEM(data)
++			return roots, nil
++		}
++	}
+
+	files := certFiles
+	if f := os.Getenv(certFileEnv); f != "" {


### PR DESCRIPTION
###### Motivation for this change

Release notes: [1.11.6](https://golang.org/doc/devel/release.html#go1.11.minor) and [1.12.1](https://golang.org/doc/devel/release.html#go1.12.minor).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

