### PR TITLE
Add word `debug(ging)` to breakpointHook description for discoverability

### DIFF
--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -2633,7 +2633,8 @@ addEnvHooks "$hostOffset" myBashFunction
        happens. It prevents nix from cleaning up the build environment
        immediately and allows the user to attach to a build environment using
        the <command>cntr</command> command. Upon build error it will print
-       instructions on how to use <command>cntr</command>. Installing cntr and
+       instructions on how to use <command>cntr</command>, which can be used
+       to enter the environment for debugging. Installing cntr and
        running the command will provide shell access to the build sandbox of
        failed build. At <filename>/var/lib/cntr</filename> the sandboxed
        filesystem is mounted. All commands and files of the system are still


### PR DESCRIPTION
The phrasing feels kind of awkward.