### PR TITLE
mycli: patch tests

### DIFF
--- a/pkgs/tools/admin/mycli/default.nix
+++ b/pkgs/tools/admin/mycli/default.nix
@@ -14,6 +14,8 @@ buildPythonApplication rec {
     sha256 = "0x5vzl4vvirqy03fnjwkamhzrqkknlajamwz1rmbnqh4bfmijh9m";
   };
 
+  patches = [ ./fix-tests.patch ];
+
   propagatedBuildInputs = [
     pymysql configobj sqlparse prompt_toolkit pygments click pycrypto cli-helpers
   ];

--- a/pkgs/tools/admin/mycli/fix-tests.patch
+++ b/pkgs/tools/admin/mycli/fix-tests.patch
@@ -1,0 +1,446 @@
+diff --git a/mycli/sqlcompleter.py b/mycli/sqlcompleter.py
+index 81ee128..2b22fa9 100644
+--- a/mycli/sqlcompleter.py
++++ b/mycli/sqlcompleter.py
+@@ -16,27 +16,32 @@ _logger = logging.getLogger(__name__)
+ 
+ class SQLCompleter(Completer):
+     keywords = ['ACCESS', 'ADD', 'ALL', 'ALTER TABLE', 'AND', 'ANY', 'AS',
+-                'ASC', 'AUTO_INCREMENT', 'BEFORE', 'BEGIN', 'BETWEEN', 'BINARY', 'BY',
+-                'CASE', 'CHAR', 'CHECK', 'COLUMN', 'COMMENT', 'COMMIT', 'CONSTRAINT',
+-                'CHANGE MASTER TO', 'CHARACTER SET', 'COLLATE', 'CREATE', 'CURRENT', 'CURRENT_TIMESTAMP', 'DATABASE', 'DATE',
+-                'DECIMAL', 'DEFAULT', 'DELETE FROM', 'DELIMITER', 'DESC',
+-                'DESCRIBE', 'DROP', 'ELSE', 'END', 'ENGINE', 'ESCAPE', 'EXISTS',
+-                'FILE', 'FLOAT', 'FOR', 'FOREIGN KEY', 'FORMAT', 'FROM', 'FULL', 'FUNCTION', 'GRANT',
+-                'GROUP BY', 'HAVING', 'HOST', 'IDENTIFIED', 'IN', 'INCREMENT', 'INDEX',
+-                'INSERT INTO', 'INTEGER', 'INTO', 'INTERVAL', 'IS', 'JOIN', 'KEY', 'LEFT',
+-                'LEVEL', 'LIKE', 'LIMIT', 'LOCK', 'LOGS', 'LONG', 'MASTER', 'MODE',
+-                'MODIFY', 'NOT', 'NULL', 'NUMBER', 'OFFSET', 'ON', 'OPTION', 'OR',
+-                'ORDER BY', 'OUTER', 'OWNER', 'PASSWORD', 'PORT', 'PRIMARY',
+-                'PRIVILEGES', 'PROCESSLIST', 'PURGE', 'REFERENCES', 'REGEXP', 'RENAME', 'REPAIR', 'RESET',
+-                'REVOKE', 'RIGHT', 'ROLLBACK', 'ROW', 'ROWS', 'ROW_FORMAT', 'SELECT', 'SESSION', 'SET',
+-                'SAVEPOINT', 'SHARE', 'SHOW', 'SLAVE', 'SMALLINT', 'START', 'STOP', 'TABLE', 'THEN',
+-                'TO', 'TRANSACTION', 'TRIGGER', 'TRUNCATE', 'UNION', 'UNIQUE', 'UNSIGNED', 'UPDATE',
+-                'USE', 'USER', 'USING', 'VALUES', 'VARCHAR', 'VIEW', 'WHEN', 'WHERE',
+-                'WITH', 'TINYINT', 'SMALLINT', 'MEDIUMINT', 'INT', 'BIGINT']
+-
+-    functions = ['AVG', 'CONCAT', 'COUNT', 'DISTINCT', 'FIRST', 'FORMAT', 'LAST',
+-                 'LCASE', 'LEN', 'MAX', 'MIN', 'MID', 'NOW', 'ROUND', 'SUM',
+-                 'TOP', 'UCASE','FROM_UNIXTIME', 'UNIX_TIMESTAMP']
++                'ASC', 'AUTO_INCREMENT', 'BEFORE', 'BEGIN', 'BETWEEN',
++                'BIGINT', 'BINARY', 'BY', 'CASE', 'CHANGE MASTER TO', 'CHAR',
++                'CHARACTER SET', 'CHECK', 'COLLATE', 'COLUMN', 'COMMENT',
++                'COMMIT', 'CONSTRAINT', 'CREATE', 'CURRENT',
++                'CURRENT_TIMESTAMP', 'DATABASE', 'DATE', 'DECIMAL', 'DEFAULT',
++                'DELETE FROM', 'DELIMITER', 'DESC', 'DESCRIBE', 'DROP',
++                'ELSE', 'END', 'ENGINE', 'ESCAPE', 'EXISTS', 'FILE', 'FLOAT',
++                'FOR', 'FOREIGN KEY', 'FORMAT', 'FROM', 'FULL', 'FUNCTION',
++                'GRANT', 'GROUP BY', 'HAVING', 'HOST', 'IDENTIFIED', 'IN',
++                'INCREMENT', 'INDEX', 'INSERT INTO', 'INT', 'INTEGER',
++                'INTERVAL', 'INTO', 'IS', 'JOIN', 'KEY', 'LEFT', 'LEVEL',
++                'LIKE', 'LIMIT', 'LOCK', 'LOGS', 'LONG', 'MASTER',
++                'MEDIUMINT', 'MODE', 'MODIFY', 'NOT', 'NULL', 'NUMBER',
++                'OFFSET', 'ON', 'OPTION', 'OR', 'ORDER BY', 'OUTER', 'OWNER',
++                'PASSWORD', 'PORT', 'PRIMARY', 'PRIVILEGES', 'PROCESSLIST',
++                'PURGE', 'REFERENCES', 'REGEXP', 'RENAME', 'REPAIR', 'RESET',
++                'REVOKE', 'RIGHT', 'ROLLBACK', 'ROW', 'ROWS', 'ROW_FORMAT',
++                'SAVEPOINT', 'SELECT', 'SESSION', 'SET', 'SHARE', 'SHOW',
++                'SLAVE', 'SMALLINT', 'SMALLINT', 'START', 'STOP', 'TABLE',
++                'THEN', 'TINYINT', 'TO', 'TRANSACTION', 'TRIGGER', 'TRUNCATE',
++                'UNION', 'UNIQUE', 'UNSIGNED', 'UPDATE', 'USE', 'USER',
++                'USING', 'VALUES', 'VARCHAR', 'VIEW', 'WHEN', 'WHERE', 'WITH']
++
++    functions = ['AVG', 'CONCAT', 'COUNT', 'DISTINCT', 'FIRST', 'FORMAT',
++                 'FROM_UNIXTIME', 'LAST', 'LCASE', 'LEN', 'MAX', 'MID',
++                 'MIN', 'NOW', 'ROUND', 'SUM', 'TOP', 'UCASE', 'UNIX_TIMESTAMP']
+ 
+     show_items = []
+ 
+diff --git a/test/test_naive_completion.py b/test/test_naive_completion.py
+index 3282c7e..01a432d 100644
+--- a/test/test_naive_completion.py
++++ b/test/test_naive_completion.py
+@@ -19,36 +19,36 @@ def complete_event():
+ def test_empty_string_completion(completer, complete_event):
+     text = ''
+     position = 0
+-    result = set(completer.get_completions(
++    result = list(completer.get_completions(
+         Document(text=text, cursor_position=position),
+         complete_event))
+-    assert result == set(map(Completion, completer.all_completions))
++    assert result == list(map(Completion, sorted(completer.all_completions)))
+ 
+ 
+ def test_select_keyword_completion(completer, complete_event):
+     text = 'SEL'
+     position = len('SEL')
+-    result = set(completer.get_completions(
++    result = list(completer.get_completions(
+         Document(text=text, cursor_position=position),
+         complete_event))
+-    assert result == set([Completion(text='SELECT', start_position=-3)])
++    assert result == list([Completion(text='SELECT', start_position=-3)])
+ 
+ 
+ def test_function_name_completion(completer, complete_event):
+     text = 'SELECT MA'
+     position = len('SELECT MA')
+-    result = set(completer.get_completions(
++    result = list(completer.get_completions(
+         Document(text=text, cursor_position=position),
+         complete_event))
+-    assert result == set([
+-        Completion(text='MAX', start_position=-2),
+-        Completion(text='MASTER', start_position=-2)])
++    assert result == list([
++        Completion(text='MASTER', start_position=-2),
++        Completion(text='MAX', start_position=-2)])
+ 
+ 
+ def test_column_name_completion(completer, complete_event):
+     text = 'SELECT  FROM users'
+     position = len('SELECT ')
+-    result = set(completer.get_completions(
++    result = list(completer.get_completions(
+         Document(text=text, cursor_position=position),
+         complete_event))
+-    assert result == set(map(Completion, completer.all_completions))
++    assert result == list(map(Completion, sorted(completer.all_completions)))
+diff --git a/test/test_smart_completion_public_schema_only.py b/test/test_smart_completion_public_schema_only.py
+index 00059bb..3c29956 100644
+--- a/test/test_smart_completion_public_schema_only.py
++++ b/test/test_smart_completion_public_schema_only.py
+@@ -42,11 +42,11 @@ def complete_event():
+ def test_empty_string_completion(completer, complete_event):
+     text = ''
+     position = 0
+-    result = set(
++    result = list(
+         completer.get_completions(
+             Document(text=text, cursor_position=position),
+             complete_event))
+-    assert set(map(Completion, completer.keywords)) == result
++    assert list(map(Completion, completer.keywords)) == result
+ 
+ 
+ def test_select_keyword_completion(completer, complete_event):
+@@ -55,7 +55,7 @@ def test_select_keyword_completion(completer, complete_event):
+     result = completer.get_completions(
+         Document(text=text, cursor_position=position),
+         complete_event)
+-    assert set(result) == set([Completion(text='SELECT', start_position=-3)])
++    assert list(result) == list([Completion(text='SELECT', start_position=-3)])
+ 
+ 
+ def test_table_completion(completer, complete_event):
+@@ -63,10 +63,12 @@ def test_table_completion(completer, complete_event):
+     position = len(text)
+     result = completer.get_completions(
+         Document(text=text, cursor_position=position), complete_event)
+-    assert set(result) == set([Completion(text='users', start_position=0),
+-                               Completion(text='`select`', start_position=0),
+-                               Completion(text='`réveillé`', start_position=0),
+-                               Completion(text='orders', start_position=0)])
++    assert list(result) == list([
++        Completion(text='`réveillé`', start_position=0),
++        Completion(text='`select`', start_position=0),
++        Completion(text='orders', start_position=0),
++        Completion(text='users', start_position=0),
++    ])
+ 
+ 
+ def test_function_name_completion(completer, complete_event):
+@@ -74,7 +76,7 @@ def test_function_name_completion(completer, complete_event):
+     position = len('SELECT MA')
+     result = completer.get_completions(
+         Document(text=text, cursor_position=position), complete_event)
+-    assert set(result) == set([Completion(text='MAX', start_position=-2),
++    assert list(result) == list([Completion(text='MAX', start_position=-2),
+                                Completion(text='MASTER', start_position=-2),
+                                ])
+ 
+@@ -89,17 +91,18 @@ def test_suggested_column_names(completer, complete_event):
+     """
+     text = 'SELECT  from users'
+     position = len('SELECT ')
+-    result = set(completer.get_completions(
++    result = list(completer.get_completions(
+         Document(text=text, cursor_position=position),
+         complete_event))
+-    assert set(result) == set([
+-        Completion(text='users', start_position=0),
++    assert result == list([
+         Completion(text='*', start_position=0),
+-        Completion(text='id', start_position=0),
+         Completion(text='email', start_position=0),
+         Completion(text='first_name', start_position=0),
+-        Completion(text='last_name', start_position=0)] +
++        Completion(text='id', start_position=0),
++        Completion(text='last_name', start_position=0),
++    ] +
+         list(map(Completion, completer.functions)) +
++        [Completion(text='users', start_position=0)] +
+         list(map(Completion, completer.keywords)))
+ 
+ 
+@@ -117,11 +120,11 @@ def test_suggested_column_names_in_function(completer, complete_event):
+     result = completer.get_completions(
+         Document(text=text, cursor_position=position),
+         complete_event)
+-    assert set(result) == set([
++    assert list(result) == list([
+         Completion(text='*', start_position=0),
+-        Completion(text='id', start_position=0),
+         Completion(text='email', start_position=0),
+         Completion(text='first_name', start_position=0),
++        Completion(text='id', start_position=0),
+         Completion(text='last_name', start_position=0)])
+ 
+ 
+@@ -135,14 +138,14 @@ def test_suggested_column_names_with_table_dot(completer, complete_event):
+     """
+     text = 'SELECT users. from users'
+     position = len('SELECT users.')
+-    result = set(completer.get_completions(
++    result = list(completer.get_completions(
+         Document(text=text, cursor_position=position),
+         complete_event))
+-    assert set(result) == set([
++    assert result == list([
+         Completion(text='*', start_position=0),
+-        Completion(text='id', start_position=0),
+         Completion(text='email', start_position=0),
+         Completion(text='first_name', start_position=0),
++        Completion(text='id', start_position=0),
+         Completion(text='last_name', start_position=0)])
+ 
+ 
+@@ -156,14 +159,14 @@ def test_suggested_column_names_with_alias(completer, complete_event):
+     """
+     text = 'SELECT u. from users u'
+     position = len('SELECT u.')
+-    result = set(completer.get_completions(
++    result = list(completer.get_completions(
+         Document(text=text, cursor_position=position),
+         complete_event))
+-    assert set(result) == set([
++    assert result == list([
+         Completion(text='*', start_position=0),
+-        Completion(text='id', start_position=0),
+         Completion(text='email', start_position=0),
+         Completion(text='first_name', start_position=0),
++        Completion(text='id', start_position=0),
+         Completion(text='last_name', start_position=0)])
+ 
+ 
+@@ -178,17 +181,17 @@ def test_suggested_multiple_column_names(completer, complete_event):
+     """
+     text = 'SELECT id,  from users u'
+     position = len('SELECT id, ')
+-    result = set(completer.get_completions(
++    result = list(completer.get_completions(
+         Document(text=text, cursor_position=position),
+         complete_event))
+-    assert set(result) == set([
+-        Completion(text='u', start_position=0),
++    assert result == list([
+         Completion(text='*', start_position=0),
+-        Completion(text='id', start_position=0),
+         Completion(text='email', start_position=0),
+         Completion(text='first_name', start_position=0),
++        Completion(text='id', start_position=0),
+         Completion(text='last_name', start_position=0)] +
+         list(map(Completion, completer.functions)) +
++        [Completion(text='u', start_position=0)] +
+         list(map(Completion, completer.keywords)))
+ 
+ 
+@@ -203,14 +206,14 @@ def test_suggested_multiple_column_names_with_alias(completer, complete_event):
+     """
+     text = 'SELECT u.id, u. from users u'
+     position = len('SELECT u.id, u.')
+-    result = set(completer.get_completions(
++    result = list(completer.get_completions(
+         Document(text=text, cursor_position=position),
+         complete_event))
+-    assert set(result) == set([
++    assert result == list([
+         Completion(text='*', start_position=0),
+-        Completion(text='id', start_position=0),
+         Completion(text='email', start_position=0),
+         Completion(text='first_name', start_position=0),
++        Completion(text='id', start_position=0),
+         Completion(text='last_name', start_position=0)])
+ 
+ 
+@@ -225,106 +228,108 @@ def test_suggested_multiple_column_names_with_dot(completer, complete_event):
+     """
+     text = 'SELECT users.id, users. from users u'
+     position = len('SELECT users.id, users.')
+-    result = set(completer.get_completions(
++    result = list(completer.get_completions(
+         Document(text=text, cursor_position=position),
+         complete_event))
+-    assert set(result) == set([
++    assert result == list([
+         Completion(text='*', start_position=0),
+-        Completion(text='id', start_position=0),
+         Completion(text='email', start_position=0),
+         Completion(text='first_name', start_position=0),
++        Completion(text='id', start_position=0),
+         Completion(text='last_name', start_position=0)])
+ 
+ 
+ def test_suggested_aliases_after_on(completer, complete_event):
+     text = 'SELECT u.name, o.id FROM users u JOIN orders o ON '
+     position = len('SELECT u.name, o.id FROM users u JOIN orders o ON ')
+-    result = set(completer.get_completions(
++    result = list(completer.get_completions(
+         Document(text=text, cursor_position=position),
+         complete_event))
+-    assert set(result) == set([
+-        Completion(text='u', start_position=0),
+-        Completion(text='o', start_position=0)])
++    assert result == list([
++        Completion(text='o', start_position=0),
++        Completion(text='u', start_position=0)])
+ 
+ 
+ def test_suggested_aliases_after_on_right_side(completer, complete_event):
+     text = 'SELECT u.name, o.id FROM users u JOIN orders o ON o.user_id = '
+     position = len(
+         'SELECT u.name, o.id FROM users u JOIN orders o ON o.user_id = ')
+-    result = set(completer.get_completions(
++    result = list(completer.get_completions(
+         Document(text=text, cursor_position=position),
+         complete_event))
+-    assert set(result) == set([
+-        Completion(text='u', start_position=0),
+-        Completion(text='o', start_position=0)])
++    assert result == list([
++        Completion(text='o', start_position=0),
++        Completion(text='u', start_position=0)])
+ 
+ 
+ def test_suggested_tables_after_on(completer, complete_event):
+     text = 'SELECT users.name, orders.id FROM users JOIN orders ON '
+     position = len('SELECT users.name, orders.id FROM users JOIN orders ON ')
+-    result = set(completer.get_completions(
++    result = list(completer.get_completions(
+         Document(text=text, cursor_position=position),
+         complete_event))
+-    assert set(result) == set([
+-        Completion(text='users', start_position=0),
+-        Completion(text='orders', start_position=0)])
++    assert result == list([
++        Completion(text='orders', start_position=0),
++        Completion(text='users', start_position=0)])
+ 
+ 
+ def test_suggested_tables_after_on_right_side(completer, complete_event):
+     text = 'SELECT users.name, orders.id FROM users JOIN orders ON orders.user_id = '
+     position = len(
+         'SELECT users.name, orders.id FROM users JOIN orders ON orders.user_id = ')
+-    result = set(completer.get_completions(
++    result = list(completer.get_completions(
+         Document(text=text, cursor_position=position),
+         complete_event))
+-    assert set(result) == set([
+-        Completion(text='users', start_position=0),
+-        Completion(text='orders', start_position=0)])
++    assert result == list([
++        Completion(text='orders', start_position=0),
++        Completion(text='users', start_position=0)])
+ 
+ 
+ def test_table_names_after_from(completer, complete_event):
+     text = 'SELECT * FROM '
+     position = len('SELECT * FROM ')
+-    result = set(completer.get_completions(
++    result = list(completer.get_completions(
+         Document(text=text, cursor_position=position),
+         complete_event))
+-    assert set(result) == set([
+-        Completion(text='users', start_position=0),
+-        Completion(text='orders', start_position=0),
++    assert result == list([
+         Completion(text='`réveillé`', start_position=0),
+         Completion(text='`select`', start_position=0),
++        Completion(text='orders', start_position=0),
++        Completion(text='users', start_position=0),
+     ])
+ 
+ 
+ def test_auto_escaped_col_names(completer, complete_event):
+     text = 'SELECT  from `select`'
+     position = len('SELECT ')
+-    result = set(completer.get_completions(
++    result = list(completer.get_completions(
+         Document(text=text, cursor_position=position),
+         complete_event))
+-    assert set(result) == set([
+-        Completion(text='`select`', start_position=0),
++    assert result == [
+         Completion(text='*', start_position=0),
+-        Completion(text='id', start_position=0),
++        Completion(text='`ABC`', start_position=0),
+         Completion(text='`insert`', start_position=0),
+-        Completion(text='`ABC`', start_position=0), ] +
+-        list(map(Completion, completer.functions)) +
+-        list(map(Completion, completer.keywords)))
++        Completion(text='id', start_position=0),
++    ] + \
++        list(map(Completion, completer.functions)) + \
++        [Completion(text='`select`', start_position=0)] + \
++        list(map(Completion, completer.keywords))
+ 
+ 
+ def test_un_escaped_table_names(completer, complete_event):
+     text = 'SELECT  from réveillé'
+     position = len('SELECT ')
+-    result = set(completer.get_completions(
++    result = list(completer.get_completions(
+         Document(text=text, cursor_position=position),
+         complete_event))
+-    assert set(result) == set([
+-        Completion(text='réveillé', start_position=0),
++    assert result == list([
+         Completion(text='*', start_position=0),
+-        Completion(text='id', start_position=0),
++        Completion(text='`ABC`', start_position=0),
+         Completion(text='`insert`', start_position=0),
+-        Completion(text='`ABC`', start_position=0), ] +
++        Completion(text='id', start_position=0),
++    ] +
+         list(map(Completion, completer.functions)) +
++        [Completion(text='réveillé', start_position=0)] +
+         list(map(Completion, completer.keywords)))
+ 
+ 
+@@ -349,10 +354,10 @@ def dummy_list_path(dir_name):
+ 
+ @patch('mycli.packages.filepaths.list_path', new=dummy_list_path)
+ @pytest.mark.parametrize('text,expected', [
+-    ('source ',  [('~', 0),
+-                  ('/', 0),
+-                  ('.', 0),
+-                  ('..', 0)]),
++    #    ('source ',  [('~', 0),
++    #                  ('/', 0),
++    #                  ('.', 0),
++    #                  ('..', 0)]),
+     ('source /', [('dir1', 0),
+                   ('file1.sql', 0),
+                   ('file2.sql', 0)]),
+@@ -363,8 +368,8 @@ def dummy_list_path(dir_name):
+ ])
+ def test_file_name_completion(completer, complete_event, text, expected):
+     position = len(text)
+-    result = set(completer.get_completions(
++    result = list(completer.get_completions(
+         Document(text=text, cursor_position=position),
+         complete_event))
+-    expected = set([Completion(txt, pos) for txt, pos in expected])
++    expected = list((Completion(txt, pos) for txt, pos in expected))
+     assert result == expected


### PR DESCRIPTION
###### Motivation for this change

Similar to f3c66bb31e50f010be3f8d5bb6214c47b1a225b8. Due to invalid
datatypes a lot of the tests broke.

The patch is based on an upstream PR[1], but had to be modified in order
to apply on v1.19.0.

See also https://hydra.nixos.org/build/90119741
Addresses #56826

[1] https://github.com/dbcli/mycli/pull/711

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

