### PR TITLE
qiv: 2.3.1 -> 2.3.2

### DIFF
--- a/pkgs/applications/graphics/qiv/default.nix
+++ b/pkgs/applications/graphics/qiv/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, pkgconfig, gtk2, imlib2, file, lcms2, libexif } :
 
 stdenv.mkDerivation (rec {
-  version = "2.3.1";
+  version = "2.3.2";
   name = "qiv-${version}";
 
   src = fetchurl {
     url = "https://spiegl.de/qiv/download/${name}.tgz";
-    sha256 = "1rlf5h67vhj7n1y7jqkm9k115nfnzpwngj3kzqsi2lg676srclv7";
+    sha256 = "1mc0f2nnas4q0d7zc9r6g4z93i32xlx0p9hl4fn5zkyml24a1q28";
   };
 
   nativeBuildInputs = [ pkgconfig ];
@@ -15,6 +15,7 @@ stdenv.mkDerivation (rec {
   preBuild=''
     substituteInPlace Makefile --replace /usr/local "$out"
     substituteInPlace Makefile --replace /man/ /share/man/
+    substituteInPlace Makefile --replace /share/share/ /share/
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Upstream release.

Note that this update of qiv does not fix issue #54278 whereby qiv segfaults on JPEG or PNG since upgrading gdk_pixbuf from 2.36.12 to 2.38.0 (and doesn't just work with 2.38.1 from #57027 either). But it updates qiv nonetheless, that still works on GIF pictures.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

