### PR TITLE
gitAndTools.git-remote-hg: 0.2-e716a9e1a9e460a45663694ba4e9e8894a8452b2 -> 1.0.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-remote-hg/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-remote-hg/default.nix
@@ -1,16 +1,16 @@
-{ stdenv, fetchgit, mercurial, makeWrapper,
-  asciidoc, xmlto, docbook_xsl, docbook_xml_dtd_45, libxslt, libxml2
+{ stdenv, lib, fetchFromGitHub, mercurial, makeWrapper
+, asciidoc, xmlto, docbook_xsl, docbook_xml_dtd_45, libxslt, libxml2
 }:
 
 stdenv.mkDerivation rec {
-  rev = "e716a9e1a9e460a45663694ba4e9e8894a8452b2";
-  version = "0.2-${rev}";
-  name = "git-remote-hg-${version}";
+  pname = "git-remote-hg";
+  version = "1.0.0";
 
-  src = fetchgit {
-    inherit rev;
-    url = "git://github.com/fingolfin/git-remote-hg.git";
-    sha256 = "0cmlfdxfabrs3x10mfjfap8wz67s8xk2pjn2wlcj9k2v84gji60m";
+  src = fetchFromGitHub {
+    owner = "mnauw";
+    repo = "git-remote-hg";
+    rev = "v${version}";
+    sha256 = "0anl054zdi5rg5m4bm1n763kbdjkpdws3c89c8w8m5gq1ifsbd4d";
   };
 
   buildInputs = [ mercurial.python mercurial makeWrapper
@@ -26,9 +26,9 @@ stdenv.mkDerivation rec {
       --prefix PYTHONPATH : "$(echo ${mercurial}/lib/python*/site-packages):$(echo ${mercurial.python}/lib/python*/site-packages)${stdenv.lib.concatMapStrings (x: ":$(echo ${x}/lib/python*/site-packages)") mercurial.pythonPackages or []}"
   '';
 
-  meta = with stdenv.lib; {
-    homepage = https://github.com/felipec/git-remote-hg;
-    description = "Semi-official Mercurial bridge from Git project, once installed, it allows you to clone, fetch and push to and from Mercurial repositories as if they were Git ones";
+  meta = with lib; {
+    homepage = https://github.com/mnauw/git-remote-hg;
+    description = "Semi-official Mercurial bridge from Git project";
     license = licenses.gpl2;
     maintainers = [ maintainers.garbas ];
     platforms = platforms.unix;


### PR DESCRIPTION
###### Motivation for this change

The current version [no longer works](
https://github.com/felipec/git-remote-hg/issues/72) with our packaged Mecurial.

The original repository appears to no longer be maintained, but there is a maintained fork, which is now used for the Debian package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
