### PR TITLE
gupnp: 1.0.3 → 1.2.0

### DIFF
--- a/pkgs/desktops/gnome-3/core/grilo-plugins/default.nix
+++ b/pkgs/desktops/gnome-3/core/grilo-plugins/default.nix
@@ -1,24 +1,61 @@
-{ stdenv, fetchurl, meson, ninja, pkgconfig, gettext, sqlite, librest
-, gnome3, libxml2, gupnp, gssdp, lua5, liboauth, gupnp-av, libgdata, libmediaart
-, gmime, json-glib, avahi, tracker, dleyna-server, itstool, totem-pl-parser }:
+{ stdenv
+, fetchurl
+, meson
+, ninja
+, pkgconfig
+, gettext
+, sqlite
+, librest
+, gnome3
+, libxml2
+, lua5
+, liboauth
+, libgdata
+, libmediaart
+, grilo
+, gnome-online-accounts
+, gmime
+, json-glib
+, avahi
+, tracker
+, dleyna-server
+, itstool
+, totem-pl-parser
+}:
 
-let
+stdenv.mkDerivation rec {
   pname = "grilo-plugins";
   version = "0.3.8";
-in stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "0nync07gah3jkpb5ph5d3gwbygmabnih2m3hfz7lkvjl2l5pgpac";
   };
 
-  nativeBuildInputs = [ meson ninja pkgconfig gettext itstool ];
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkgconfig
+    gettext
+    itstool
+  ];
+
   buildInputs = [
-    gnome3.grilo libxml2 gupnp gssdp libgdata
-    lua5 liboauth gupnp-av sqlite gnome3.gnome-online-accounts
-    totem-pl-parser librest gmime json-glib
-    avahi libmediaart tracker dleyna-server
+    grilo
+    libxml2
+    libgdata
+    lua5
+    liboauth
+    sqlite
+    gnome-online-accounts
+    totem-pl-parser
+    librest
+    gmime
+    json-glib
+    avahi
+    libmediaart
+    tracker
+    dleyna-server
   ];
 
   passthru = {

--- a/pkgs/desktops/gnome-3/core/rygel/default.nix
+++ b/pkgs/desktops/gnome-3/core/rygel/default.nix
@@ -1,41 +1,90 @@
-{ stdenv, fetchurl, pkgconfig, vala, gettext, libxml2, gobject-introspection, gtk-doc, wrapGAppsHook, glib, gssdp, gupnp, gupnp-av, gupnp-dlna, gst_all_1, libgee, libsoup, gtk3, libmediaart, sqlite, systemd, tracker, shared-mime-info, gnome3 }:
+{ stdenv
+, fetchurl
+, meson
+, ninja
+, pkgconfig
+, vala
+, gettext
+, libxml2
+, gobject-introspection
+, gtk-doc
+, wrapGAppsHook
+, python3
+, glib
+, gssdp
+, gupnp
+, gupnp-av
+, gupnp-dlna
+, gst_all_1
+, libgee
+, libsoup
+, gtk3
+, libmediaart
+, sqlite
+, systemd
+, tracker
+, shared-mime-info
+, gnome3
+}:
 
-let
+stdenv.mkDerivation rec {
   pname = "rygel";
-  version = "0.36.2";
-in stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
+  version = "0.38.0";
 
   # TODO: split out lib
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0i12z6bzfzgcjidhxa2jsvpm4hqpab0s032z13jy2vbifrncfcnk";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "03ky18hwcz362lbhqm1zm0ax2a075r69xms5cznchn9p9w8z5axc";
   };
 
   nativeBuildInputs = [
-    pkgconfig vala gettext libxml2 gobject-introspection gtk-doc wrapGAppsHook
+    meson
+    ninja
+    pkgconfig
+    vala
+    gettext
+    libxml2
+    gobject-introspection
+    gtk-doc
+    wrapGAppsHook
+    python3
   ];
+
   buildInputs = [
-    glib gssdp gupnp gupnp-av gupnp-dlna libgee libsoup gtk3 libmediaart sqlite systemd tracker shared-mime-info
+    glib
+    gssdp
+    gupnp
+    gupnp-av
+    gupnp-dlna
+    libgee
+    libsoup
+    gtk3
+    libmediaart
+    sqlite
+    systemd
+    tracker
+    shared-mime-info
   ] ++ (with gst_all_1; [
-    gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly
+    gstreamer
+    gst-plugins-base
+    gst-plugins-good
+    gst-plugins-bad
+    gst-plugins-ugly
   ]);
 
-  configureFlags = [
-    "--with-systemduserunitdir=$(out)/lib/systemd/user"
-    "--enable-apidocs"
+  mesonFlags = [
+    "-Dsystemd-user-units-dir=${placeholder "out"}/lib/systemd/user"
+    "-Dapi-docs=true"
     "--sysconfdir=/etc"
-  ];
-
-  installFlags = [
-    "sysconfdir=$(out)/etc"
   ];
 
   doCheck = true;
 
-  enableParallelBuilding = true;
+  postPatch = ''
+    patchShebangs data/xml/process-xml.py
+  '';
 
   passthru = {
     updateScript = gnome3.updateScript {

--- a/pkgs/development/libraries/dleyna-core/default.nix
+++ b/pkgs/development/libraries/dleyna-core/default.nix
@@ -1,9 +1,16 @@
-{ stdenv, autoreconfHook, pkgconfig, fetchFromGitHub, gupnp }:
+{ stdenv
+, fetchFromGitHub
+, fetchpatch
+, autoreconfHook
+, pkgconfig
+, gupnp
+}:
 
 stdenv.mkDerivation rec {
   pname = "dleyna-core";
-  name = "${pname}-${version}";
   version = "0.6.0";
+
+  setupHook = ./setup-hook.sh;
 
   src = fetchFromGitHub {
     owner = "01org";
@@ -12,12 +19,25 @@ stdenv.mkDerivation rec {
     sha256 = "1x5vj5zfk95avyg6g3nf6gar250cfrgla2ixj2ifn8pcick2d9vq";
   };
 
-  setupHook = ./setup-hook.sh;
+  patches = [
+    ./0001-Search-connectors-in-DLEYNA_CONNECTOR_PATH.patch
 
-  patches = [ ./0001-Search-connectors-in-DLEYNA_CONNECTOR_PATH.patch ];
+    # fix build with gupnp 1.2
+    # https://github.com/intel/dleyna-core/pull/52
+    (fetchpatch {
+      url = https://github.com/intel/dleyna-core/commit/41b2e56f67b6fc9c8c256b86957d281644b9b846.patch;
+      sha256 = "1h758cp65v7qyfpvyqdri7q0gwx85mhdpkb2y8waq735q5q9ib39";
+    })
+  ];
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig ];
-  propagatedBuildInputs = [ gupnp ];
+  nativeBuildInputs = [
+    autoreconfHook
+    pkgconfig
+  ];
+
+  propagatedBuildInputs = [
+    gupnp
+  ];
 
   meta = with stdenv.lib; {
     description = "Library of utility functions that are used by the higher level dLeyna";

--- a/pkgs/development/libraries/dleyna-renderer/default.nix
+++ b/pkgs/development/libraries/dleyna-renderer/default.nix
@@ -1,8 +1,20 @@
-{ stdenv, autoreconfHook, pkgconfig, fetchFromGitHub, dleyna-connector-dbus, dleyna-core, gssdp, gupnp, gupnp-av, gupnp-dlna, libsoup, makeWrapper }:
+{ stdenv
+, fetchurl
+, fetchFromGitHub
+, autoreconfHook
+, pkgconfig
+, dleyna-connector-dbus
+, dleyna-core
+, gssdp
+, gupnp
+, gupnp-av
+, gupnp-dlna
+, libsoup
+, makeWrapper
+}:
 
 stdenv.mkDerivation rec {
   pname = "dleyna-renderer";
-  name = "${pname}-${version}";
   version = "0.6.0";
 
   src = fetchFromGitHub {
@@ -12,8 +24,30 @@ stdenv.mkDerivation rec {
     sha256 = "0jy54aq8hgrvzchrvfzqaj4pcn0cfhafl9bv8a9p6j82yjk4pvpp";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig makeWrapper ];
-  buildInputs = [ dleyna-core dleyna-connector-dbus gssdp gupnp gupnp-av gupnp-dlna libsoup ];
+  patches = [
+    # fix build with gupnp 1.2
+    (fetchurl {
+      name = "gupnp-1.2.diff";
+      url = https://git.archlinux.org/svntogit/packages.git/plain/trunk/gupnp-1.2.diff?h=packages/dleyna-renderer&id=30b426a1e0ca5857031ed6296bc192d11bd7c5db;
+      sha256 = "0x5vj5zfk95avyg6g3nf6gar250cfrgla2ixj2ifn8pcick2d9vq";
+    })
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkgconfig
+    makeWrapper
+  ];
+
+  buildInputs = [
+    dleyna-core
+    dleyna-connector-dbus
+    gssdp
+    gupnp
+    gupnp-av
+    gupnp-dlna
+    libsoup
+  ];
 
   preFixup = ''
     wrapProgram "$out/libexec/dleyna-renderer-service" \

--- a/pkgs/development/libraries/dleyna-server/default.nix
+++ b/pkgs/development/libraries/dleyna-server/default.nix
@@ -1,8 +1,20 @@
-{ stdenv, autoreconfHook, makeWrapper, pkgconfig, fetchFromGitHub, dleyna-core, dleyna-connector-dbus, gssdp, gupnp, gupnp-av, gupnp-dlna, libsoup }:
+{ stdenv
+, fetchFromGitHub
+, fetchpatch
+, autoreconfHook
+, makeWrapper
+, pkgconfig
+, dleyna-core
+, dleyna-connector-dbus
+, gssdp
+, gupnp
+, gupnp-av
+, gupnp-dlna
+, libsoup
+}:
 
 stdenv.mkDerivation rec {
   pname = "dleyna-server";
-  name = "${pname}-${version}";
   version = "0.6.0";
 
   src = fetchFromGitHub {
@@ -12,8 +24,30 @@ stdenv.mkDerivation rec {
     sha256 = "13a2i6ms27s46yxdvlh2zm7pim7jmr5cylnygzbliz53g3gxxl3j";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig makeWrapper ];
-  buildInputs = [ dleyna-core dleyna-connector-dbus gssdp gupnp gupnp-av gupnp-dlna libsoup ];
+  patches = [
+    # fix build with gupnp 1.2
+    # https://github.com/intel/dleyna-server/pull/161
+    (fetchpatch {
+      url = https://github.com/intel/dleyna-server/commit/96c01c88363d6e5e9b7519bc4e8b5d86cf783e1f.patch;
+      sha256 = "0p8fn331x2whvn6skxqvfzilx0m0yx2q5mm2wh2625l396m3fzmm";
+    })
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkgconfig
+    makeWrapper
+  ];
+
+  buildInputs = [
+    dleyna-core
+    dleyna-connector-dbus
+    gssdp
+    gupnp
+    gupnp-av
+    gupnp-dlna
+    libsoup
+  ];
 
   preFixup = ''
     wrapProgram "$out/libexec/dleyna-server-service" \

--- a/pkgs/development/libraries/gssdp/default.nix
+++ b/pkgs/development/libraries/gssdp/default.nix
@@ -1,25 +1,61 @@
-{ stdenv, fetchurl, pkgconfig, gobject-introspection, vala, gtk-doc, docbook_xsl, docbook_xml_dtd_412, libsoup, gtk3, glib }:
+{ stdenv
+, fetchurl
+, meson
+, ninja
+, pkgconfig
+, gobject-introspection
+, vala
+, gtk-doc
+, docbook_xsl
+, docbook_xml_dtd_412
+, libsoup
+, gtk3
+, glib
+, gnome3
+}:
 
 stdenv.mkDerivation rec {
-  name = "gssdp-${version}";
-  version = "1.0.2";
+  pname = "gssdp";
+  version = "1.2.0";
 
   outputs = [ "out" "bin" "dev" "devdoc" ];
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gssdp/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1p1m2m3ndzr2whipqw4vfb6s6ia0g7rnzzc4pnq8b8g1qw4prqd1";
+    url = "mirror://gnome/sources/gssdp/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "1l80znxzzpb2fmsrjf3hygi9gcxx5r405qrk5430nbsjgxafzjr2";
   };
 
-  nativeBuildInputs = [ pkgconfig gobject-introspection vala gtk-doc docbook_xsl docbook_xml_dtd_412 ];
-  buildInputs = [ libsoup gtk3 ];
-  propagatedBuildInputs = [ glib ];
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkgconfig
+    gobject-introspection
+    vala
+    gtk-doc
+    docbook_xsl
+    docbook_xml_dtd_412
+  ];
 
-  configureFlags = [
-    "--enable-gtk-doc"
+  buildInputs = [
+    libsoup
+    gtk3
+  ];
+
+  propagatedBuildInputs = [
+    glib
+  ];
+
+  mesonFlags = [
+    "-Dgtk_doc=true"
   ];
 
   doCheck = true;
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+    };
+  };
 
   meta = with stdenv.lib; {
     description = "GObject-based API for handling resource discovery and announcement over SSDP";

--- a/pkgs/development/libraries/gupnp-av/default.nix
+++ b/pkgs/development/libraries/gupnp-av/default.nix
@@ -1,24 +1,52 @@
-{ stdenv, fetchurl, pkgconfig, gobject-introspection, vala, gtk-doc, docbook_xsl, docbook_xml_dtd_412, gupnp, glib, libxml2 }:
+{ stdenv
+, fetchurl
+, pkgconfig
+, gobject-introspection
+, vala
+, gtk-doc
+, docbook_xsl
+, docbook_xml_dtd_412
+, glib
+, libxml2
+, gnome3
+}:
 
 stdenv.mkDerivation rec {
-  name = "gupnp-av-${version}";
+  pname = "gupnp-av";
   version = "0.12.11";
 
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gupnp-av/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "1p3grslwqm9bc8rmpn4l48d7v9s84nina4r9xbd932dbj8acz7b8";
   };
 
-  nativeBuildInputs = [ pkgconfig gobject-introspection vala gtk-doc docbook_xsl docbook_xml_dtd_412 ];
-  buildInputs = [ gupnp glib libxml2 ];
+  nativeBuildInputs = [
+    pkgconfig
+    gobject-introspection
+    vala
+    gtk-doc
+    docbook_xsl
+    docbook_xml_dtd_412
+  ];
+
+  buildInputs = [
+    glib
+    libxml2
+  ];
 
   configureFlags = [
     "--enable-gtk-doc"
   ];
 
   doCheck = true;
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+    };
+  };
 
   meta = with stdenv.lib; {
     homepage = http://gupnp.org/;

--- a/pkgs/development/libraries/gupnp-dlna/default.nix
+++ b/pkgs/development/libraries/gupnp-dlna/default.nix
@@ -1,18 +1,40 @@
-{ stdenv, fetchurl, pkgconfig, gobject-introspection, vala, gtk-doc, docbook_xsl, docbook_xml_dtd_412, gupnp, gst_all_1 }:
+{ stdenv
+, fetchurl
+, pkgconfig
+, gobject-introspection
+, vala
+, gtk-doc
+, docbook_xsl
+, docbook_xml_dtd_412
+, libxml2
+, gst_all_1
+, gnome3
+}:
 
 stdenv.mkDerivation rec {
-  name = "gupnp-dlna-${version}";
+  pname = "gupnp-dlna";
   version = "0.10.5";
 
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gupnp-dlna/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "0spzd2saax7w776p5laixdam6d7smyynr9qszhbmq7f14y13cghj";
   };
 
-  nativeBuildInputs = [ pkgconfig gobject-introspection vala gtk-doc docbook_xsl docbook_xml_dtd_412 ];
-  buildInputs = [ gupnp gst_all_1.gst-plugins-base ];
+  nativeBuildInputs = [
+    pkgconfig
+    gobject-introspection
+    vala
+    gtk-doc
+    docbook_xsl
+    docbook_xml_dtd_412
+  ];
+
+  buildInputs = [
+    libxml2
+    gst_all_1.gst-plugins-base
+  ];
 
   configureFlags = [
     "--enable-gtk-doc"
@@ -24,6 +46,12 @@ stdenv.mkDerivation rec {
     chmod +x tests/test-discoverer.sh.in
     patchShebangs tests/test-discoverer.sh.in
   '';
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+    };
+  };
 
   meta = with stdenv.lib; {
     homepage = https://wiki.gnome.org/Projects/GUPnP/;

--- a/pkgs/development/libraries/gupnp-igd/default.nix
+++ b/pkgs/development/libraries/gupnp-igd/default.nix
@@ -1,24 +1,63 @@
-{ stdenv, fetchurl, pkgconfig, gettext, gobject-introspection, gtk-doc, docbook_xsl, docbook_xml_dtd_412, glib, gupnp }:
+{ stdenv
+, fetchurl
+, fetchpatch
+, autoreconfHook
+, pkgconfig
+, gettext
+, gobject-introspection
+, gtk-doc
+, docbook_xsl
+, docbook_xml_dtd_412
+, glib
+, gupnp
+, gnome3
+}:
 
 stdenv.mkDerivation rec {
-  name = "gupnp-igd-${version}";
+  pname = "gupnp-igd";
   version = "0.2.5";
 
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gupnp-igd/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "081v1vhkbz3wayv49xfiskvrmvnpx93k25am2wnarg5cifiiljlb";
   };
 
-  nativeBuildInputs = [ pkgconfig gettext gobject-introspection gtk-doc docbook_xsl docbook_xml_dtd_412 ];
-  propagatedBuildInputs = [ glib gupnp ];
+  patches = [
+    # Add gupnp-1.2 compatibility
+    (fetchpatch {
+      url = https://gitlab.gnome.org/GNOME/gupnp-igd/commit/63531558a16ac2334a59f627b2fca5576dcfbb2e.patch;
+      sha256 = "0s8lkyy9fnnnnkkqwbk6gxb7795bb1kl1swk5ldjnlrzhfcy1ab2";
+    })
+  ];
+
+  nativeBuildInputs = [
+    pkgconfig
+    autoreconfHook
+    gettext
+    gobject-introspection
+    gtk-doc
+    docbook_xsl
+    docbook_xml_dtd_412
+  ];
+
+  propagatedBuildInputs = [
+    glib
+    gupnp
+  ];
 
   configureFlags = [
     "--enable-gtk-doc"
   ];
 
   doCheck = true;
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+    };
+  };
 
   meta = with stdenv.lib; {
     description = "Library to handle UPnP IGD port mapping";

--- a/pkgs/development/libraries/gupnp/default.nix
+++ b/pkgs/development/libraries/gupnp/default.nix
@@ -1,14 +1,32 @@
-{ stdenv, fetchurl, pkgconfig, gobject-introspection, vala, gtk-doc, docbook_xsl, docbook_xml_dtd_412, docbook_xml_dtd_44, glib, gssdp, libsoup, libxml2, libuuid }:
+{ stdenv
+, fetchurl
+, fetchpatch
+, meson
+, ninja
+, pkgconfig
+, gobject-introspection
+, vala
+, gtk-doc
+, docbook_xsl
+, docbook_xml_dtd_412
+, docbook_xml_dtd_44
+, glib
+, gssdp
+, libsoup
+, libxml2
+, libuuid
+, gnome3
+}:
 
 stdenv.mkDerivation rec {
-  name = "gupnp-${version}";
-  version = "1.0.3";
+  pname = "gupnp";
+  version = "1.2.0";
 
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gupnp/${stdenv.lib.versions.majorMinor version}/gupnp-${version}.tar.xz";
-    sha256 = "1fyb6yn75vf2y1b8nbc1df572swzr74yiwy3v3g5xn36wlp1cjvr";
+    url = "mirror://gnome/sources/gupnp/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "0911lv1bivsyv9wwdxm0i1w4r89j0vyyqp200gsfdnzk6v1a4x7x";
   };
 
   patches = [
@@ -19,16 +37,53 @@ stdenv.mkDerivation rec {
     # at least until Requires.internal or something is implemented
     # https://gitlab.freedesktop.org/pkg-config/pkg-config/issues/7
     ./fix-requires.patch
+
+    # fix deadlock in gupnp-igd tests
+    (fetchpatch {
+      url = https://gitlab.gnome.org/GNOME/gupnp/commit/d208562657f62b34759896ca9e974bd582d1f963.patch;
+      sha256 = "02kzsb4glxhgb1npf6qqgafiki0ws75sly5h470431mihc6sgp4f";
+    })
+    # fix breakage in gupnp-igd tests
+    (fetchpatch {
+      url = https://gitlab.gnome.org/GNOME/gupnp/commit/0648399acb989473119fe59d0b9f65c923e69483.patch;
+      sha256 = "0ba0rngk3a4n3z4dmq06wzgh0n3q9la1nr25qdxqbwlszmxfxpjf";
+    })
   ];
 
-  nativeBuildInputs = [ pkgconfig gobject-introspection vala gtk-doc docbook_xsl docbook_xml_dtd_412 docbook_xml_dtd_44 ];
-  propagatedBuildInputs = [ glib gssdp libsoup libxml2 libuuid ];
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkgconfig
+    gobject-introspection
+    vala
+    gtk-doc
+    docbook_xsl
+    docbook_xml_dtd_412
+    docbook_xml_dtd_44
+  ];
 
-  configureFlags = [
-    "--enable-gtk-doc"
+  buildInputs = [
+    libuuid
+  ];
+
+  propagatedBuildInputs = [
+    glib
+    gssdp
+    libsoup
+    libxml2
+  ];
+
+  mesonFlags = [
+    "-Dgtk_doc=true"
   ];
 
   doCheck = true;
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+    };
+  };
 
   meta = with stdenv.lib; {
     homepage = http://www.gupnp.org/;

--- a/pkgs/development/libraries/gupnp/fix-requires.patch
+++ b/pkgs/development/libraries/gupnp/fix-requires.patch
@@ -1,9 +1,26 @@
---- a/gupnp-1.0.pc.in
-+++ b/gupnp-1.0.pc.in
-@@ -8,4 +8,5 @@
- Version: @VERSION@
- Libs: -L${libdir} -lgupnp-1.0
- Cflags: -I${includedir}/gupnp-1.0
--Requires.private: gssdp-1.0 libxml-2.0 libsoup-2.4 @UUID_LIBS@
-+Requires: glib-2.0 gobject-2.0 gssdp-1.0 libxml-2.0 libsoup-2.4
-+Requires.private: @UUID_LIBS@
+--- a/libgupnp/meson.build
++++ b/libgupnp/meson.build
+@@ -110,6 +110,7 @@ pkg.generate(
+     libraries : libgupnp,
+     subdirs: 'gupnp-1.2',
+     name : 'gupnp-1.2',
++    requires: requires,
+     description : 'GObject-based UPnP library',
+     version : meson.project_version(),
+     filebase : 'gupnp-1.2'
+--- a/meson.build
++++ a/meson.build
+@@ -18,6 +18,13 @@ add_global_arguments('-DHAVE_CONFIG_H=1', language : 'c')
+ 
+ guul = subproject('guul', default_options : ['default_library=static'])
+ 
++requires = [
++  dependency('glib-2.0', version : '>= 2.44'),
++  dependency('gssdp-1.2', version : '>= 1.1'),
++  dependency('libsoup-2.4', version : '>= 2.48.0'),
++  dependency('libxml-2.0')
++]
++
+ dependencies = [
+     dependency('glib-2.0', version : '>= 2.44'),
+     dependency('gio-2.0', version : '>= 2.44'),

--- a/pkgs/tools/networking/gupnp-tools/default.nix
+++ b/pkgs/tools/networking/gupnp-tools/default.nix
@@ -1,23 +1,45 @@
-{fetchurl, fetchpatch, stdenv, meson, ninja, gupnp, gssdp, pkgconfig, gtk3, libuuid, gettext, gupnp-av, gtksourceview4, gnome3, wrapGAppsHook}:
+{ stdenv
+, fetchurl
+, meson
+, ninja
+, gupnp
+, gssdp
+, pkgconfig
+, gtk3
+, libuuid
+, gettext
+, gupnp-av
+, gtksourceview4
+, gnome3
+, wrapGAppsHook
+}:
 
 stdenv.mkDerivation rec {
   pname = "gupnp-tools";
-  version = "0.8.15";
+  version = "0.10.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1awpqjs08cf6aimvzldnlnz5zmdyw8aq4k2rl5239j4zkfhg8vik";
+    sha256 = "13d1qr1avz9r76989nvgxhhclmqzr025xjk4rfnja94fpbspznj1";
   };
 
-  patches = [
-    (fetchpatch {
-      url = https://gitlab.gnome.org/GNOME/gupnp-tools/commit/2845d07b1584789a23a0e691ceff476e5d82ccb7.patch;
-      sha256 = "1a8bhsz41s27kbaxp9jbmbisabin6lz2ln87012syvi6f2s332hv";
-    })
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkgconfig
+    gettext
+    wrapGAppsHook
   ];
 
-  nativeBuildInputs = [ meson ninja pkgconfig gettext wrapGAppsHook ];
-  buildInputs = [ gupnp libuuid gssdp gtk3 gupnp-av gtksourceview4 gnome3.adwaita-icon-theme ];
+  buildInputs = [
+    gupnp
+    libuuid
+    gssdp
+    gtk3
+    gupnp-av
+    gtksourceview4
+    gnome3.adwaita-icon-theme
+  ];
 
   passthru = {
     updateScript = gnome3.updateScript {


### PR DESCRIPTION
###### Motivation for this change
Semi-independent part of https://github.com/NixOS/nixpkgs/pull/57027

gupnp-1.2 is incompatible with 1.0 branch, we need to patch the following packages:

- [x] gupnp-igd [MR](https://gitlab.gnome.org/GNOME/gupnp-igd/merge_requests/1)
- [x] dleyna-core [PR](https://github.com/intel/dleyna-core/pull/52)
- [x] ~~grilo-plugins~~ did not use gupnp for a [long time](https://bugzilla.gnome.org/show_bug.cgi?id=733253)
- [x] gupnp-tools [commit](https://gitlab.gnome.org/GNOME/gupnp-tools/commit/41feb3168d3870e0d017c248f20cbe85bc5acde7)
- [x] dleyna-renderer [arch patch](https://git.archlinux.org/svntogit/packages.git/tree/trunk/gupnp-1.2.diff?h=packages/dleyna-renderer&id=30b426a1e0ca5857031ed6296bc192d11bd7c5db) even though the hack looks horrible
- [x] dleyna-server [PR](https://github.com/intel/dleyna-server/pull/161)
- [ ] mate.caja-extensions builds fine without it; @romildo 

Things depending just on gupnp-igd do not need updated as its API did not change.

Other to-dos
- [ ] gupnp-igd tests are stalling https://git.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/gupnp-igd&id=82a89dd605732cdb515443e81a905cc336f7bb1d#n39

cc @hedning @worldofpeace 