### PR TITLE
ocaml-syslog: init at 1.5

### DIFF
--- a/pkgs/development/ocaml-modules/syslog/default.nix
+++ b/pkgs/development/ocaml-modules/syslog/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, ocaml, findlib }:
+
+assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "4.03.0";
+
+stdenv.mkDerivation rec {
+  pname = "ocaml${ocaml.version}-syslog";
+  version = "1.5";
+
+  src = fetchFromGitHub {
+    owner = "rixed";
+    repo = "ocaml-syslog";
+    rev = "v${version}";
+    sha256 = "1kqpc55ppzv9n555qgqpda49n7nvkqimzisyjx2a7338r7q4r5bw";
+  };
+
+  buildInputs = [ ocaml findlib ];
+
+  createFindlibDestdir = true;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/rixed/ocaml-syslog;
+    description = "Simple wrapper to access the system logger from OCaml";
+    license = licenses.lgpl21Plus;
+    platforms = ocaml.meta.platforms or [];
+    maintainers = [ maintainers.rixed ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -522,6 +522,8 @@ let
 
     ocaml_sqlite3 = callPackage ../development/ocaml-modules/sqlite3 { };
 
+    syslog = callPackage ../development/ocaml-modules/syslog { };
+
     ocaml_text = callPackage ../development/ocaml-modules/ocaml-text { };
 
     ocf = callPackage ../development/ocaml-modules/ocf { };


### PR DESCRIPTION
###### Motivation for this change

Add the ocaml-syslog library (which as the name suggest allow an ocaml program to access UNIX logger).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS (with `nix-env -f $PWD --option sandbox true -i ocaml-syslog`)
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
