### PR TITLE
grafx2: 2.4 -> 2.6

### DIFF
--- a/pkgs/applications/graphics/grafx2/default.nix
+++ b/pkgs/applications/graphics/grafx2/default.nix
@@ -1,29 +1,158 @@
-{ stdenv, fetchurl, SDL, SDL_image, SDL_ttf, zlib, libpng, pkgconfig, lua5 }:
+{ stdenv, fetchFromGitLab
+, libiconv, zlib
+, pkgconfig
+
+, sdl2Support ? true
+, SDL2 ? null, SDL2_image ? null
+, sdlSupport ? false
+, SDL ? null, SDL_image ? null
+, windowsSupport ? stdenv.targetPlatform.isWindows
+, x11Support ? stdenv.targetPlatform.isUnix
+, libX11 ? null
+
+, joystickSupport ? false
+, layersSupport ? true
+, luaSupport ? true, lua ? null
+, pngSupport ? true, libpng ? null
+, recoilSupport ? true, recoil ? null
+, tiffSupport ? true, libtiff ? null
+, ttfSupport ? true, freetype ? null, fontconfig ? null
+, SDL_ttf ? null, SDL2_ttf ? null
+}:
+
+assert sdl2Support -> !sdlSupport;
+assert sdl2Support -> SDL != null && SDL_image != null;
+
+assert sdlSupport -> !sdl2Support;
+assert sdlSupport -> SDL2 != null && SDL2_image != null;
+
+assert x11Support -> libX11 != null;
+
+assert luaSupport -> lua != null;
+assert pngSupport -> libpng != null;
+assert recoilSupport -> recoil != null;
+assert tiffSupport -> libtiff != null;
+
+assert ttfSupport -> freetype != null && fontconfig != null &&
+  (sdlSupport && SDL_ttf != null || sdl2Support && SDL2_ttf != null);
+
+let
+  inherit (stdenv) lib targetPlatform;
+  inherit (lib) optional optionals;
+
+  multimediaApi = if windowsSupport then "win32"
+    else if sdl2Support then "sdl2"
+    else if sdlSupport then "sdl"
+    else if x11Support then "x11"
+    else throw "No multimedia API yet available.";
+
+  sdl = if sdl2Support then {
+    SDL = SDL2;
+    SDL_image = SDL2_image;
+    SDL_ttf = SDL2_ttf;
+  } else if sdlSupport then {
+    inherit SDL SDL_image SDL_ttf;
+  } else null;
+  isSDL = sdl != null;
+in
 
 stdenv.mkDerivation rec {
-
-  version = "2.4.2035";
   name = "grafx2-${version}";
+  version = "2.6";
 
-  src = fetchurl {
-    url = "https://grafx2.googlecode.com/files/${name}-src.tgz";
-    sha256 = "0svsy6rqmdj11b400c242i2ixihyz0hds0dgicqz6g6dcgmcl62q";
+  src = fetchFromGitLab {
+    owner = "Grafx2";
+    repo = "grafx2";
+    rev = "5d8c61e41011a8106359343243e1050af4e7fd1f";
+    sha256 = "1z8qjq07y4sf2kpc1b98dwxzbmpp3ayyyhc5bbnnx60j3xzbw851";
+    postFetch = ''
+      (cd $out
+      # remember to update along with rev from a git checkout
+      # GIT_REVISION=$(git rev-list --count 1af8c74f53110e349d8f0d19b14599281913f71f..)
+      # GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+      GIT_REVISION=2475
+      GIT_BRANCH=master
+      if [[ GIT_BRANCH != master ]]; then
+        GIT_REVISION=$GIT_REVISION-$GIT_BRANCH
+      fi
+      echo "const char SVN_revision[]=\"$GIT_REVISION\";" > src/version.c)
+    '';
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ SDL SDL_image SDL_ttf libpng zlib lua5 ];
+  buildInputs = [ libiconv zlib ] ++
+    (optionals isSDL [ sdl.SDL sdl.SDL_image ]) ++
+    (optional x11Support libX11) ++
+    (optional luaSupport lua) ++
+    (optional pngSupport libpng) ++
+    (optional recoilSupport recoil.dev) ++
+    (optional tiffSupport libtiff) ++
+    (optionals ttfSupport [ freetype fontconfig sdl.SDL_ttf ]);
 
-  preBuild = "cd src";
+  postPatch = let
+    recoilVer = recoil.dev.version;
+  in ''
+    ln -s ${recoil.dev}/include/recoil.h src
+    ln -s ${recoil.dev}/src/recoil.c src
+    mkdir -p 3rdparty/recoil-${recoilVer}
+    ln -s ${recoil.dev}/src/recoil.c 3rdparty/recoil-${recoilVer}
+  '';
 
-  preInstall = '' mkdir -p "$out" '';
+  buildFlags = [ "grafx2" "htmldoc" ];
 
-  installPhase = ''make install prefix="$out"'';
+  makeFlags = [ "PREFIX=$(out)" "API=${multimediaApi}" ] ++
+    (optional (!x11Support) "NO_X11=1") ++
+    (optional joystickSupport "USE_JOYSTICK=1") ++
+    (optional (!layersSupport) "NOLAYERS=1") ++
+    (optional (!luaSupport) "NOLUA=1") ++
+    (optional (!pngSupport) "__no_pnglib__=1") ++
+    (optional (!recoilSupport) "NORECOIL=1") ++
+    (optional (!tiffSupport) "__no_tifflib__=1") ++
+    (optional (!ttfSupport) "NOTTF=1");
 
-  meta = {
+  installPhase = ''
+    runHook preInstall
+
+    if [ -n "$prefix" ]; then
+        mkdir -p "$prefix"
+    fi
+
+    # Old bash empty array hack
+    # shellcheck disable=SC2086
+    local flagsArray=(
+        $makeFlags ''${makeFlagsArray+"''${makeFlagsArray[@]}"}
+        $installFlags ''${installFlagsArray+"''${installFlagsArray[@]}"}
+        ''${installTargets:-install}
+    )
+
+    echoCmd 'install flags' "''${flagsArray[@]}"
+    (cd src && make Makefile "''${flagsArray[@]}")
+    unset flagsArray
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    mkdir -p $out/share/doc/grafx2
+    cp -rt $out/share/doc/grafx2 doc/html/*
+  '';
+
+  preFixup = ''
+    mv $out/bin/grafx2{-${multimediaApi},}
+  '';
+
+  meta = with stdenv.lib; {
     description = "Bitmap paint program inspired by the Amiga programs Deluxe Paint and Brilliance";
-    homepage = http://pulkomandy.tk/projects/GrafX2;
-    license = stdenv.lib.licenses.gpl2;
-    platforms = [ "x86_64-linux" "i686-linux" ];
-    maintainers = [ stdenv.lib.maintainers.zoomulator ];
+    longDescription = ''
+      GrafX2 is a bitmap paint program inspired by the Amiga programs Deluxe
+      Paint and Brilliance. Specialized in 256-color drawing, it includes a very
+      large number of tools and effects that make it particularly suitable for
+      pixel art, game graphics, and generally any detailed graphics painted with a
+      mouse.
+    '';
+    homepage = http://grafx2.tk;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ bb010g zoomulator ];
+    platforms = with platforms; unix;
   };
 }

--- a/pkgs/applications/version-management/gitea/default.nix
+++ b/pkgs/applications/version-management/gitea/default.nix
@@ -17,7 +17,7 @@ buildGoPackage rec {
     sha256 = "063rfb0jwxfq91cw7gp0achqsgi3dpj1pqfi7k5md67bhp2i2si3";
     # Required to generate the same checksum on MacOS due to unicode encoding differences
     # More information: https://github.com/NixOS/nixpkgs/pull/48128
-    extraPostFetch = ''
+    postFetch = ''
       rm -rf $out/integrations
       rm -rf $out/vendor/github.com/Unknown/cae/tz/testdata
       rm -rf $out/vendor/github.com/Unknown/cae/zip/testdata

--- a/pkgs/build-support/fetchbitbucket/default.nix
+++ b/pkgs/build-support/fetchbitbucket/default.nix
@@ -1,10 +1,15 @@
 { fetchzip }:
 
 { owner, repo, rev, name ? "source"
+, postFetch ? "", zipPostFetch ? null, zipExtraPostFetch ? ""
 , ... # For hash agility
 }@args: fetchzip ({
   inherit name;
   url = "https://bitbucket.org/${owner}/${repo}/get/${rev}.tar.gz";
+  ${if zipPostFetch != null then "postFetch" else null} = zipPostFetch;
+  extraPostFetch = postFetch + "\n" + zipExtraPostFetch + "\n" +
+    ''rm -f "$out"/.hg_archival.txt''; # impure file; see #12002
+} // removeAttrs args [ "owner" "repo" "rev" ]) // {
   meta.homepage = "https://bitbucket.org/${owner}/${repo}/";
-  extraPostFetch = ''rm -f "$out"/.hg_archival.txt''; # impure file; see #12002
-} // removeAttrs args [ "owner" "repo" "rev" ]) // { inherit rev; }
+  inherit rev;
+}

--- a/pkgs/build-support/fetchgitlab/default.nix
+++ b/pkgs/build-support/fetchgitlab/default.nix
@@ -1,10 +1,19 @@
 { fetchzip, lib }:
 
-# gitlab example
 { owner, repo, rev, domain ? "gitlab.com", name ? "source", group ? null
+, postFetch ? "", zipPostFetch ? null, zipExtraPostFetch ? ""
 , ... # For hash agility
-}@args: fetchzip ({
-  inherit name;
-  url = "https://${domain}/api/v4/projects/${lib.optionalString (group != null) "${lib.replaceStrings ["."] ["%2E"] group}%2F"}${lib.replaceStrings ["."] ["%2E"] owner}%2F${lib.replaceStrings ["."] ["%2E"] repo}/repository/archive.tar.gz?sha=${rev}";
-  meta.homepage = "https://${domain}/${lib.optionalString (group != null) "${group}/"}${owner}/${repo}/";
-} // removeAttrs args [ "domain" "owner" "group" "repo" "rev" ]) // { inherit rev; }
+}@args: let
+  passthruAttrs = removeAttrs args [ "domain" "owner" "group" "repo" "rev" "postFetch" "zipPostFetch" "zipExtraPostFetch" ];
+  repoPath = lib.optionalString (group != null) "${group}/" + "${owner}/${repo}";
+  urlSanitize = lib.replaceStrings ["." "/"] ["%2E" "%2F"];
+  fetcherArgs = {
+    inherit name;
+    url = "https://${domain}/api/v4/projects/${urlSanitize repoPath}/repository/archive.tar.gz?sha=${rev}";
+    ${if zipPostFetch != null then "postFetch" else null} = zipPostFetch;
+    extraPostFetch = postFetch + "\n" + zipExtraPostFetch;
+  } // passthruAttrs;
+in fetchzip fetcherArgs // {
+  meta.homepage = "https://${domain}/${repoPath}/";
+  inherit rev;
+}

--- a/pkgs/build-support/fetchsavannah/default.nix
+++ b/pkgs/build-support/fetchsavannah/default.nix
@@ -2,9 +2,14 @@
 
 # cgit example, snapshot support is optional in cgit
 { repo, rev, name ? "source"
+, postFetch ? "", zipPostFetch ? null, zipExtraPostFetch ? ""
 , ... # For hash agility
 }@args: fetchzip ({
   inherit name;
   url = "https://git.savannah.gnu.org/cgit/${repo}.git/snapshot/${repo}-${rev}.tar.gz";
+  ${if zipPostFetch != null then "postFetch" else null} = zipPostFetch;
+  extraPostFetch = postFetch + "\n" + zipExtraPostFetch;
+} // removeAttrs args [ "repo" "rev" ]) // {
   meta.homepage = "https://git.savannah.gnu.org/cgit/${repo}.git/";
-} // removeAttrs args [ "repo" "rev" ]) // { inherit rev; }
+  inherit rev;
+}

--- a/pkgs/development/compilers/cito/0.4.nix
+++ b/pkgs/development/compilers/cito/0.4.nix
@@ -1,0 +1,7 @@
+{ callPackage }:
+
+callPackage ./generic.nix rec {
+  version = "0.4.0";
+  nameVersion = "04";
+  sha256 = "1csjn7n33jvjsgi47q74agxmn713m4w3sm10y0h58c4zy93jhg42";
+}

--- a/pkgs/development/compilers/cito/generic.nix
+++ b/pkgs/development/compilers/cito/generic.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchgit
+, mono
+, imagemagick
+, version, nameVersion, rev ? null, sha256 }:
+
+stdenv.mkDerivation rec {
+  name = "cito-${version}";
+  inherit version;
+
+  src = fetchgit {
+    url = "https://git.code.sf.net/p/cito/code";
+    rev = if rev != null then rev else "cito-${version}";
+    name = "cito-${nameVersion}";
+    inherit sha256;
+  };
+
+  nativeBuildInputs = [ imagemagick ];
+  buildInputs = [ mono ];
+
+  postPatch = ''
+    substituteInPlace Makefile --replace /usr/bin/mono ${mono}/bin/mono
+  '';
+  makeFlags = [ "prefix=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "Translator from Ć to C, Java, C#, JavaScript, ActionScript, Perl and D";
+    longDescription = ''
+      cito automatically translates the Ć programming language to C, Java, C#,
+      JavaScript, ActionScript, Perl and D. Ć is a new language, aimed at
+      crafting portable programming libraries, with syntax akin to C#. The
+      translated code is lightweight (no virtual machine, emulation nor large
+      runtime), human-readable and fits well the target language (including
+      naming conventions and documentation comments).
+    '';
+    homepage = http://cito.sourceforge.net/;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ bb010g ];
+    platforms = with platforms; unix;
+  };
+}

--- a/pkgs/development/compilers/cito/git.nix
+++ b/pkgs/development/compilers/cito/git.nix
@@ -1,0 +1,9 @@
+{ callPackage }:
+
+callPackage ./generic.nix rec {
+  version = "git";
+  nameVersion = "git";
+  rev = "8cd935ed76e8ecfc1cb93b7f31e438fd7017ea00";
+  sha256 = "0gz3k7xxmc00533phy9rdffg7qq68s0nlmm47rym1z2s0w0q1irx";
+}
+

--- a/pkgs/development/libraries/recoil/default.nix
+++ b/pkgs/development/libraries/recoil/default.nix
@@ -1,0 +1,84 @@
+{ stdenv, fetchgit
+, libpng
+, cito, libxslt
+, magickSupport ? true, imagemagick
+, perl, XMLDOM }:
+
+let inherit (stdenv) lib; in
+
+stdenv.mkDerivation rec {
+  name = "recoil-${version}";
+  version = "4.3.1";
+
+  src = fetchgit {
+    url = "https://git.code.sf.net/p/recoil/code";
+    rev = "recoil-${version}";
+    name = "recoil";
+    sha256 = "1xnz256dzvm05s0hhqc5s2rkgvsk5dgnjd8ddw5fw1j3v63ssl23";
+  };
+
+  outputs = [ "bin" "man" "dev" "out" ];
+
+  nativeBuildInputs = [
+    cito libxslt.bin
+  ] ++ (lib.optionals magickSupport [
+    perl XMLDOM
+  ]);
+  buildInputs = [ libpng ] ++ (lib.optional magickSupport imagemagick);
+
+  postPatch = lib.optionalString magickSupport ''
+    substituteInPlace Makefile \
+      --replace \
+        '$(wildcard $(MAGICK_PREFIX)/lib/ImageMagick-$(word 1,$(MAGICK_VERSION))/modules-$(word 2,$(MAGICK_VERSION))/coders)' \
+        '$(out)/lib/ImageMagick-$(word 1,$(MAGICK_VERSION))/modules-$(word 2,$(MAGICK_VERSION))/coders' \
+      --replace ') imagemagick/recoilmagick.c' ') -I. imagemagick/recoilmagick.c'
+    cp -r --no-preserve mode,ownership ${imagemagick.src} imagemagick_src
+    cp -r --no-preserve mode,ownership ${imagemagick}/etc/ImageMagick-* fake_magick_config
+  '';
+
+  makeFlags = [
+    "PREFIX=$(out)" "BUILDING_PACKAGE=yes"
+  ] ++ (lib.optionals magickSupport [
+    "MAGICK_INCLUDE_PATH=imagemagick_src"
+    "MAGICK_CONFIG_PATH=fake_magick_config"
+  ]);
+
+  preFixup = ''
+    mkdir -p $bin/bin
+    mv -t $bin/bin $out/bin/*
+    rmdir $out/bin
+
+    mkdir -p $man/share
+    mv -t $man/share $out/share/man
+    mkdir -p $bin/share
+    mv -t $bin/share $out/share/{mime,thumbnailers}
+    rmdir $out/share
+
+    mkdir -p $out/share/doc/recoil
+    cp fake_magick_config/coder.xml $out/share/doc/recoil/imagemagick-coder.xml
+
+    mkdir -p $bin/lib
+    mv -t $bin/lib $out/lib/ImageMagick-*
+    rmdir $out/lib
+
+    mkdir -p $dev/{include,src}
+    cp -t $dev/include recoil.h
+    cp -t $dev/src recoil.c
+  '';
+
+  meta = with lib; {
+    description = "Retro Computer Image Library";
+    longDescription = ''
+      Retro Computer Image Library decodes Amiga, Amstrad CPC, Apple II, Atari
+      8-bit, Atari Portfolio, Atari ST/TT/Falcon, BBC Micro, Commodore 16,
+      Commodore 64, Commodore 128, Macintosh 128K, MSX, NEC PC-88, NEC PC-98,
+      Oric, SAM Coupe, Sharp X68000, Timex 2048, TRS-80, TRS-80 Color Computer,
+      ZX81 and ZX Spectrum picture formats. The project contains a simple
+      viewer, plug-ins for general-purpose image viewers and editors, and an
+      everything-to-png converter.
+    '';
+    homepage = http://recoil.sourceforge.net/;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ bb010g ];
+  };
+}

--- a/pkgs/games/openra/default.nix
+++ b/pkgs/games/openra/default.nix
@@ -44,7 +44,7 @@ let
   buildOpenRASet = f: args: pkgs.recurseIntoAttrs (mapAttrs callWithName (f ({
     inherit (pkgs) fetchFromGitHub;
     abbrevCommit = commit: substring 0 7 commit;
-    extraPostFetch = ''
+    postFetch = ''
       sed -i 's/curl/curl --insecure/g' $out/thirdparty/{fetch-thirdparty-deps,noget}.sh
       $out/thirdparty/fetch-thirdparty-deps.sh
     '';

--- a/pkgs/games/openra/engines.nix
+++ b/pkgs/games/openra/engines.nix
@@ -1,4 +1,4 @@
-{ buildOpenRAEngine, fetchFromGitHub, abbrevCommit, extraPostFetch }:
+{ buildOpenRAEngine, fetchFromGitHub, abbrevCommit, postFetch }:
 
 let
   buildUpstreamOpenRAEngine = { version, rev, sha256 }: name: (buildOpenRAEngine {
@@ -9,7 +9,7 @@ let
     src = fetchFromGitHub {
       owner = "OpenRA";
       repo = "OpenRA" ;
-      inherit rev sha256 extraPostFetch;
+      inherit rev sha256 postFetch;
     };
   } name).overrideAttrs (origAttrs: {
     postInstall = ''

--- a/pkgs/games/openra/mods.nix
+++ b/pkgs/games/openra/mods.nix
@@ -1,4 +1,4 @@
-{ buildOpenRAMod, fetchFromGitHub, abbrevCommit, extraPostFetch }:
+{ buildOpenRAMod, fetchFromGitHub, abbrevCommit, postFetch }:
 
 let
   unsafeBuildOpenRAMod = attrs: name: (buildOpenRAMod attrs name).overrideAttrs (_: {
@@ -25,7 +25,7 @@ in {
         rev = "b8a7dd52ff893ed8225726d4ed4e14ecad748404";
         sha256 = "0dyk861qagibx8ldshz7d2nrki9q550f6f0wy8pvayvf1gv1dbxj";
         name = "engine";
-        inherit extraPostFetch;
+        inherit postFetch;
       };
     };
   };
@@ -50,7 +50,7 @@ in {
         rev = version;
         sha256 = "0p0izykjnz7pz02g2khp7msqa00jhjsrzk9y0g29dirmdv75qa4r";
         name = "engine";
-        inherit extraPostFetch;
+        inherit postFetch;
       };
     };
     assetsError = ''
@@ -78,7 +78,7 @@ in {
         rev = "e08b75c2add30439228ea3dd61d6be60d1800329";
         sha256 = "125vf962p69ajrh5pxgfwsi0ksczqwvlw5kn2fvffiwvh8d5in23";
         name = "engine";
-        inherit extraPostFetch;
+        inherit postFetch;
       };
     };
   };
@@ -102,7 +102,7 @@ in {
         rev = version;
         sha256 = "1x6byz37s8qcpqj902zvkvbv95rv2mv2kj35c12gbpyc92xkqkq0";
         name = "generals-alpha-engine";
-        inherit extraPostFetch;
+        inherit postFetch;
       };
     };
   };
@@ -126,7 +126,7 @@ in {
         rev = "4e8eab4ca00d1910203c8a103dfd2c002714daa8";
         sha256 = "1yyqparf93x8yzy1f46gsymgkj5jls25v2yc7ighr3f7mi3igdvq";
         name = "engine";
-        inherit extraPostFetch;
+        inherit postFetch;
       };
     };
   } name).overrideAttrs (origAttrs: {
@@ -155,7 +155,7 @@ in {
         rev = "52109c0910f479753704c46fb19e8afaab353c83";
         sha256 = "0ga3855j6bc7h81q03cw6laiaiz12915zg8aqah1idvxbzicfy7l";
         name = "engine";
-        inherit extraPostFetch;
+        inherit postFetch;
       };
     };
   };
@@ -179,7 +179,7 @@ in {
         rev = version;
         sha256 = "1pgi3zaq9fwwdq6yh19bwxscslqgabjxkvl9bcn1a5agy4bfbqk5";
         name = "engine";
-        inherit extraPostFetch;
+        inherit postFetch;
       };
     };
     assetsError = ''
@@ -207,7 +207,7 @@ in {
         rev = version;
         sha256 = "0ps9x379plrrj1hnj4fpr26lc46mzgxknv5imxi0bmrh5y4781ql";
         name = "engine";
-        inherit extraPostFetch;
+        inherit postFetch;
       };
     };
   };
@@ -232,7 +232,7 @@ in {
         rev = "f3873ae242803051285994d77eb26f4b951594b5";
         sha256 = "02rv29wja0p5d083pd087daz7x7pp5b9ym7sci2fhg3mrnaqgwkp";
         name = "engine";
-        inherit extraPostFetch;
+        inherit postFetch;
       };
     };
     assetsError = ''
@@ -261,7 +261,7 @@ in {
         rev = "d3545c0b751aea2105748eddaab5919313e35314";
         sha256 = "1jsldl6vnf3r9dzppdm4z7kqbrzkidda5k74wc809i8c4jjnq9rq";
         name = "engine";
-        inherit extraPostFetch;
+        inherit postFetch;
       };
     };
   };
@@ -285,7 +285,7 @@ in {
         rev = "6de92de8d982094a766eab97a92225c240d85493";
         sha256 = "0ps9x379plrrj1hnj4fpr26lc46mzgxknv5imxi0bmrh5y4781ql";
         name = "engine";
-        inherit extraPostFetch;
+        inherit postFetch;
       };
     };
   };
@@ -309,7 +309,7 @@ in {
         rev = version;
         sha256 = "1p5hgxxvxlz8480vj0qkmnxjh7zj3hahk312m0zljxfdb40652w1";
         name = "engine";
-        inherit extraPostFetch;
+        inherit postFetch;
       };
     };
   };
@@ -333,7 +333,7 @@ in {
         rev = version;
         sha256 = "1pgi3zaq9fwwdq6yh19bwxscslqgabjxkvl9bcn1a5agy4bfbqk5";
         name = "engine";
-        inherit extraPostFetch;
+        inherit postFetch;
       };
     };
     assetsError = ''

--- a/pkgs/games/openra/packages.nix
+++ b/pkgs/games/openra/packages.nix
@@ -32,7 +32,7 @@ let
   */
   buildOpenRASet = f: args: builtins.mapAttrs (name: value: if builtins.isFunction value then value name else value) (f ({
     inherit (pkgs) fetchFromGitHub;
-    extraPostFetch = ''
+    postFetch = ''
       sed -i 's/curl/curl --insecure/g' $out/thirdparty/{fetch-thirdparty-deps,noget}.sh
       $out/thirdparty/fetch-thirdparty-deps.sh
     '';

--- a/pkgs/tools/misc/jdupes/default.nix
+++ b/pkgs/tools/misc/jdupes/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     # Unicode file names lead to different checksums on HFS+ vs. other
     # filesystems because of unicode normalisation. The testdir
     # directories have such files and will be removed.
-    extraPostFetch = "rm -r $out/testdir";
+    postFetch = "rm -r $out/testdir";
   };
 
   makeFlags = [ "PREFIX=$(out)" ] ++ stdenv.lib.optional stdenv.isLinux "ENABLE_BTRFS=1";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3155,7 +3155,10 @@ in
 
   gptfdisk = callPackage ../tools/system/gptfdisk { };
 
-  grafx2 = callPackage ../applications/graphics/grafx2 {};
+  grafx2 = callPackage ../applications/graphics/grafx2 {
+    lua = lua5_2;
+    inherit (xorg) libX11;
+  };
 
   grails = callPackage ../development/web/grails { jdk = null; };
 
@@ -5155,6 +5158,11 @@ in
 
   pywal = with python3Packages; toPythonApplication pywal;
 
+  recoil = callPackage ../development/libraries/recoil {
+    cito = cito-git;
+    inherit (perlPackages) XMLDOM;
+  };
+
   remarshal = callPackage ../development/tools/remarshal { };
 
   rig = callPackage ../tools/misc/rig { };
@@ -6770,6 +6778,9 @@ in
   bigloo = callPackage ../development/compilers/bigloo { };
 
   binaryen = callPackage ../development/compilers/binaryen { };
+
+  cito = callPackage ../development/compilers/cito/0.4.nix { };
+  cito-git = callPackage ../development/compilers/cito/git.nix { };
 
   colm = callPackage ../development/compilers/colm { };
 


### PR DESCRIPTION
###### Motivation for this change

Upgrading Grafx2 to an actively maintained release, as well as ensuring at least one distribution actually attempts truer source builds of dependencies like recoil.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after): adds 421.7kb
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Upgrades Grafx2 from 2.4 to 2.6, introduces its dependency RECOIL at 4.3.1, and introduces RECOIL's dependency `cito` at the latest release 0.4 and the latest Git revision `8cd935e`.

As I was implementing `grafx2`'s `postFetch` hook to insert a revision version file normally included from tarballs, I noticed that `fetchFromGitHub` is inconsistent in how `postFetch` works due to using either `fetchzip` (uses `postFetch`, so user extends on `extraPostFetch`) or `fetchgit` (extends on `postFetch`). The first commit standardizes `postFetch` over forge fetchers and updates all usages in Nixpkgs as needed.