### PR TITLE
commandergenius: update and move to gitlab

### DIFF
--- a/pkgs/games/commandergenius/default.nix
+++ b/pkgs/games/commandergenius/default.nix
@@ -1,16 +1,16 @@
-{ stdenv, fetchFromGitHub, SDL2, SDL2_image, pkgconfig
+{ stdenv, fetchFromGitLab, SDL2, SDL2_image, pkgconfig
 , libvorbis, libGL, boost, cmake, zlib, curl, SDL2_mixer, python3
 }:
 
 stdenv.mkDerivation rec {
   name = "commandergenius-${version}";
-  version = "2.2.2";
+  version = "2.3.2";
 
-  src = fetchFromGitHub {
-    owner = "gerstrong";
+  src = fetchFromGitLab {
+    owner = "Dringgstein";
     repo = "Commander-Genius";
     rev = "v${version}";
-    sha256 = "1mfw25pgr492ayqw3b85mwp20wh6anrr90gdy605nv1yjma62pmj";
+    sha256 = "1a8as56ycbq8csnssd5wqv2jand5c9yskld6prh3dn9gy96jbvgj";
   };
 
   buildInputs = [ SDL2 SDL2_image SDL2_mixer libGL boost libvorbis zlib curl python3 ];


### PR DESCRIPTION
update and move to gitlab (repo has moved)
update fixes build (https://hydra.nixos.org/build/90482453/nixlog/2) for #56826

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

