### PR TITLE
Remove libfreetype.so from adoptopenjdk's derivation.

### DIFF
--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk-linux-base.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk-linux-base.nix
@@ -72,6 +72,10 @@ let result = stdenv.mkDerivation rec {
     # Remove some broken manpages.
     rm -rf $out/man/ja*
 
+    # Remove embedded freetype to avoid problems like
+    # https://github.com/NixOS/nixpkgs/issues/57733
+    rm $out/lib/libfreetype.so
+
     # for backward compatibility
     ln -s $out $out/jre
 


### PR DESCRIPTION
###### Motivation for this change

This caused some reverse dependencies of adoptopenjdk to depend on
adoptopenjdk's libfreetype, rather than the NixOS
libfreetype. For example: https://github.com/NixOS/nixpkgs/issues/57733

Now the derivation does not contain libfreetype.so . The JRE links to
nixpkg's freetype:

    $ ldd /nix/store/9iyxm1nkn35xhjgri041r980z4p5ls5g-adoptopenjdk-hotspot-bin-11.0.2/lib/libfontmanager.so | grep -i freetype
    	libfreetype.so => /nix/store/ycbkq39cngzx19j829qzgdnw3mx3z78g-freetype-2.9.1/lib/libfreetype.so (0x0000795e30702000)

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

