### PR TITLE
homebank: 5.2.2 -> 5.2.3

### DIFF
--- a/pkgs/applications/office/homebank/default.nix
+++ b/pkgs/applications/office/homebank/default.nix
@@ -2,10 +2,10 @@
 , hicolor-icon-theme, libsoup, gnome3 }:
 
 stdenv.mkDerivation rec {
-  name = "homebank-5.2.2";
+  name = "homebank-5.2.3";
   src = fetchurl {
     url = "http://homebank.free.fr/public/${name}.tar.gz";
-    sha256 = "19cm49p2x6nwia2yvwj3fv7jxbhw0vx4bs1zqbfvdr5vzwgj5j5c";
+    sha256 = "1wdg86gwd0rc9m3mni9qlh746kxmjn4mk5q7fplxrcp2ajdcqr3a";
   };
 
   nativeBuildInputs = [ pkgconfig wrapGAppsHook ];


### PR DESCRIPTION
###### Motivation for this change
Update to latest version. Changes in this release:
 * change: conforming to Windows HIG for button order in dialogs
 * new   : statistics report, added account
 * new   : trend time report, added half year interval
 * new   : added console error message for load/save preference file
 * new   : #1817796 hungarian Categories
 * wish  : #1819356 sortable columns during import
 * wish  : #1817278 fill paymode/category independently from payee
 * wish  : #1816219 enable to import unlimited account
 * wish  : #1814452 reorder split transactions
 * wish  : #1811969 add tags manager
 * wish  : #1796564 "Show all accounts" should not be shown when no account is selected
 * wish  : #1797808 scheduled home list to show remaining occurence
 * wish  : #1791482 OFX import to allow mapping the "name" field to "info"
 * wish  : #1674029 remind expander state into 'Your account' list
 * wish  : #1336928 display list of available tags in txn dialog
 * wish  : #619315  enable tag for trend time report 
 * bugfix: tag with empty string was possible
 * bugfix: tag duplicate within a same txn was possible
 * bugfix: month in budget dialog were not translated
 * bugfix: statistics report total for tag was wrong
 * bugfix: trendtime report for category was wrong in filtering
 * bugfix: budget clear was not counting for a change
 * bugfix: #1815964 internal transfer transactions from .ofx files does not import
 * bugfix: #1814213 incorrect budget report when budget set only for subcategory
 * bugfix: #1811962 rapport statistiques : opÃ©ration avec Ã©tiquette absente ; gestion des dates
 * bugfix: #1806183 typo error institition
 * bugfix: #1805250 consistent naming for 'range'
 * bugfix: #1796564 "show all accounts" should not be shown when no account is selected
 * bugfix: #1720185 win/GTK: copy/paste text only work once with key shortcut

(http://homebank.free.fr/ChangeLog)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

