### PR TITLE
jcal: init at 0.4.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2658,6 +2658,11 @@
     github = "limeytexan";
     name = "Michael Brantley";
   };
+  linarcx = {
+    email = "linarcx@gmail.com";
+    github = "linarcx";
+    name = "Kaveh Ahangar";
+  };
   linc01n = {
     email = "git@lincoln.hk";
     github = "linc01n";

--- a/pkgs/development/libraries/jcal/default.nix
+++ b/pkgs/development/libraries/jcal/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, autoreconfHook
+, readline
+}:
+
+stdenv.mkDerivation rec {
+  name = "jcal";
+  version = "0.4.1";
+
+  src = fetchFromGitHub {
+    owner = "fzerorubigd";
+    repo = "jcal";
+    rev = "v${version}";
+    sha256 = "0m3g3rf0ycv2dsfn9y2472fa3r0yla8pfqk6gq00nrscsc3pp4zf";
+  };
+
+  nativeBuildInputs = [ autoreconfHook ];
+  buildInputs = [ readline ];
+
+  preAutoreconf = "cd sources/";
+
+  meta = with stdenv.lib; {
+    description = "Jalali calendar is a small and portable free software library to manipulate date and time in Jalali calendar system.";
+    homepage =  http://nongnu.org/jcal/;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.linarcx ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10529,6 +10529,8 @@ in
 
   jbig2dec = callPackage ../development/libraries/jbig2dec { };
 
+  jcal = callPackage ../development/libraries/jcal { };
+
   jbigkit = callPackage ../development/libraries/jbigkit { };
 
   jemalloc = callPackage ../development/libraries/jemalloc { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

