### PR TITLE
 python.pkgs.pyzmq: 17.1.3 -> 18.0.1, disable flaky test

### DIFF
--- a/pkgs/development/python-modules/pyzmq/default.nix
+++ b/pkgs/development/python-modules/pyzmq/default.nix
@@ -9,11 +9,11 @@
 
 buildPythonPackage rec {
   pname = "pyzmq";
-  version = "17.1.3";
+  version = "18.0.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "83722236bd6ae6a07dec0cb728906785040e91826c7575709a258b4e21d0f812";
+    sha256 = "0k3y6k3l9dmih3qmc4vrw26dpjggdk5c6r6806qhgjgpyq2rhccb";
   };
 
   checkInputs = [  pytest tornado ];

--- a/pkgs/development/python-modules/pyzmq/default.nix
+++ b/pkgs/development/python-modules/pyzmq/default.nix
@@ -22,12 +22,14 @@ buildPythonPackage rec {
 
   # test_socket.py seems to be hanging
   # others fail
+  # for test_monitor: https://github.com/zeromq/pyzmq/issues/1272
   checkPhase = ''
     py.test $out/${python.sitePackages}/zmq/ -k "not test_socket \
       and not test_current \
       and not test_instance \
       and not test_callable_check \
       and not test_on_recv_basic \
-      and not test_on_recv_wake"
+      and not test_on_recv_wake \
+      and not test_monitor"
   '';
 }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

