### PR TITLE
[19.03] python.pkgs.pyzmq: disable flaky test

### DIFF
--- a/pkgs/development/python-modules/pyzmq/default.nix
+++ b/pkgs/development/python-modules/pyzmq/default.nix
@@ -22,12 +22,14 @@ buildPythonPackage rec {
 
   # test_socket.py seems to be hanging
   # others fail
+  # for test_monitor: https://github.com/zeromq/pyzmq/issues/1272
   checkPhase = ''
     py.test $out/${python.sitePackages}/zmq/ -k "not test_socket \
       and not test_current \
       and not test_instance \
       and not test_callable_check \
       and not test_on_recv_basic \
-      and not test_on_recv_wake"
+      and not test_on_recv_wake \
+      and not test_monitor"
   '';
 }


### PR DESCRIPTION

###### Motivation for this change
Recently failed on staging.

(cherry picked from commit 4f2d842a98ebc4b1d393e6061f30a4e726220b47)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

