### PR TITLE
retext: init at 7.0.4

### DIFF
--- a/pkgs/applications/editors/retext/default.nix
+++ b/pkgs/applications/editors/retext/default.nix
@@ -41,7 +41,8 @@ in python.pkgs.buildPythonApplication {
 
   doCheck = false;
 
-  propagatedBuildInputs = [ makeWrapper pythonEnv ];
+  nativeBuildInputs = [ makeWrapper ];
+  propagatedBuildInputs = [ pythonEnv ];
 
   postInstall = ''
     mv $out/bin/retext $out/bin/.retext

--- a/pkgs/applications/editors/retext/default.nix
+++ b/pkgs/applications/editors/retext/default.nix
@@ -1,0 +1,62 @@
+{ lib, stdenv, python3, fetchFromGitHub, makeWrapper, buildEnv, aspellDicts
+# Use `lib.collect lib.isDerivation aspellDicts;` to make all dictionaries
+# available.
+, enchantAspellDicts ? with aspellDicts; [ en en-computers en-science ]
+}:
+
+let
+  version = "7.0.4";
+  python = let
+    packageOverrides = self: super: {
+      markdown = super.markdown.overridePythonAttrs(old: rec {
+        src =  super.fetchPypi {
+          version = "3.0.1";
+          pname = "Markdown";
+          sha256 = "d02e0f9b04c500cde6637c11ad7c72671f359b87b9fe924b2383649d8841db7c";
+        };
+      });
+
+      chardet = super.chardet.overridePythonAttrs(old: rec {
+        src =  super.fetchPypi {
+          version = "2.3.0";
+          pname = "chardet";
+          sha256 = "e53e38b3a4afe6d1132de62b7400a4ac363452dc5dfcf8d88e8e0cce663c68aa";
+        };
+      });
+    };
+    in python3.override { inherit packageOverrides; };
+  pythonEnv = python.withPackages (ps: with ps; [
+    pyqt5 docutils pyenchant Markups markdown pygments chardet
+  ]);
+in python.pkgs.buildPythonApplication {
+  inherit version;
+  pname = "retext";
+
+  src = fetchFromGitHub {
+    owner = "retext-project";
+    repo = "retext";
+    rev = "${version}";
+    sha256 = "1zcapywspc9v5zf5cxqkcy019np9n41gmryqixj66zsvd544c6si";
+  };
+
+  doCheck = false;
+
+  propagatedBuildInputs = [ makeWrapper pythonEnv ];
+
+  postInstall = ''
+    mv $out/bin/retext $out/bin/.retext
+    makeWrapper "$out/bin/.retext" "$out/bin/retext" \
+      --set ASPELL_CONF "dict-dir ${buildEnv {
+        name = "aspell-all-dicts";
+        paths = map (path: "${path}/lib/aspell") enchantAspellDicts;
+      }}"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/retext-project/retext/;
+    description = "Simple but powerful editor for Markdown and reStructuredText";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ klntsky ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/python-modules/Markups/default.nix
+++ b/pkgs/development/python-modules/Markups/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, python-markdown-math
+, markdown
+, docutils
+, pygments
+}:
+
+buildPythonPackage rec {
+  pname = "Markups";
+  version = "3.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1ea19458dfca6a4562044e701aa8698089a0c659fc535689ed260f89a04f8d39";
+  };
+
+  checkInputs = [ markdown docutils pygments ];
+  propagatedBuildInputs = [ python-markdown-math ];
+
+  meta = {
+    description = "A wrapper around various text markup languages.";
+    homepage = https://github.com/retext-project/pymarkups;
+    license = lib.licenses.bsd;
+    maintainers = with lib.maintainers; [ klntsky ];
+  };
+}

--- a/pkgs/development/python-modules/Markups/default.nix
+++ b/pkgs/development/python-modules/Markups/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   meta = {
     description = "A wrapper around various text markup languages.";
     homepage = https://github.com/retext-project/pymarkups;
-    license = lib.licenses.bsd;
+    license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ klntsky ];
   };
 }

--- a/pkgs/development/python-modules/python-markdown-math/default.nix
+++ b/pkgs/development/python-modules/python-markdown-math/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   meta = {
     description = "Math extension for Python-Markdown";
     homepage = https://github.com/mitya57/python-markdown-math;
-    license = lib.licenses.bsd;
+    license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ klntsky ];
   };
 }

--- a/pkgs/development/python-modules/python-markdown-math/default.nix
+++ b/pkgs/development/python-modules/python-markdown-math/default.nix
@@ -1,0 +1,24 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, markdown
+}:
+
+buildPythonPackage rec {
+  pname = "python-markdown-math";
+  version = "0.6";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "c68d8cb9695cb7b435484403dc18941d1bad0ff148e4166d9417046a0d5d3022";
+  };
+
+  checkInputs = [ markdown ];
+
+  meta = {
+    description = "Math extension for Python-Markdown";
+    homepage = https://github.com/mitya57/python-markdown-math;
+    license = lib.licenses.bsd;
+    maintainers = with lib.maintainers; [ klntsky ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5189,6 +5189,8 @@ in
 
   redsocks = callPackage ../tools/networking/redsocks { };
 
+  retext = callPackage ../applications/editors/retext { };
+
   richgo = callPackage ../development/tools/richgo {  };
 
   rst2html5 = callPackage ../tools/text/rst2html5 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3123,6 +3123,8 @@ in {
 
   marisa-trie = callPackage ../development/python-modules/marisa-trie { };
 
+  Markups = callPackage ../development/python-modules/Markups { };
+
   markupsafe = callPackage ../development/python-modules/markupsafe { };
 
   marshmallow = callPackage ../development/python-modules/marshmallow { };
@@ -3958,6 +3960,8 @@ in {
   pysqlite = callPackage ../development/python-modules/pysqlite { };
 
   pysvn = callPackage ../development/python-modules/pysvn { };
+
+  python-markdown-math = callPackage ../development/python-modules/python-markdown-math { };
 
   python-ptrace = callPackage ../development/python-modules/python-ptrace { };
 


### PR DESCRIPTION
###### Motivation for this change

> ReText is a simple but powerful editor for Markdown and reStructuredText markup languages. ReText is written in Python language and works on Linux and other POSIX-compatible platforms. 	


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

