### PR TITLE
meson: 0.49.1 → 0.50.1

### DIFF
--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -11,12 +11,12 @@ let
   };
 in
 python3Packages.buildPythonApplication rec {
-  version = "0.49.2";
   pname = "meson";
+  version = "0.50.1";
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "0ckkzq0kbnnk4rwv20lggm9a4fb5054jbv99i9pwjhid23qy7059";
+    sha256 = "05k3wsxjcnnq7a8n5kzxh2cdh5jdkh13xagigz5axs48j36zfai4";
   };
 
   postFixup = ''


### PR DESCRIPTION
###### Motivation for this change
http://mesonbuild.com/Release-notes-for-0-50-0.html

needed for gnome-builder https://github.com/NixOS/nixpkgs/pull/57027

###### Built packages
- :heavy_check_mark: json-glib
- :heavy_check_mark: fwupd
- :heavy_check_mark: python3.pkgs.pycairo
- :heavy_check_mark: gnome3.gnome-shell
- :heavy_check_mark: sway


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

