### PR TITLE
hardinfo: fix not finding libc

### DIFF
--- a/pkgs/tools/system/hardinfo/default.nix
+++ b/pkgs/tools/system/hardinfo/default.nix
@@ -30,6 +30,7 @@ stdenv.mkDerivation rec {
     sed -i -e "s/^CFLAGS = \(.*\)/CFLAGS = \1 -std=gnu89/" Makefile.in
 
     substituteInPlace ./arch/linux/common/modules.h --replace /sbin/modinfo modinfo
+    substituteInPlace ./arch/linux/common/os.h --replace /lib/libc.so.6 ${stdenv.glibc.out}/lib/libc.so.6
   '';
 
   # Makefile supports DESTDIR but not PREFIX (it hardcodes $DESTDIR/usr/).


### PR DESCRIPTION
###### Motivation for this change
On NixOS 18.09 (I don't think master behaves differently), running `hardinfo` from a terminal and accessing the "Summary" section under "Computer" will show an error in said terminal that accessing `/lib/libc.so.6` failed.

This PR fixes this by `substituteInPlace`ing the affected line with `${stdenv.glibc.out}/lib/libc.so.6` (taken from other packages' solutions). The message goes away, though the report does not appear to have changed…

---

There is another error message when accessing the Battery option under Devices, where it will repeatedly print
```
sh: -c: This option requires an argument.
```
that I don't know how to fix, [but it's more likely to get fixed in this much newer fork](https://github.com/lpereira/hardinfo/issues/267), problem being that there hasn't been a release since _0.5.1 in 2009 either_ because of some minor blockers.

Perhaps we should consider switching to that fork and pinning a recent commit [like Ubuntu did](https://packages.ubuntu.com/bionic/hardinfo) instead of waiting for upstream to publish a new version after 10 years of code changes since 0.5.1.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

