### PR TITLE
wmfocus: 1.0.2 -> 1.1.2

### DIFF
--- a/pkgs/applications/window-managers/i3/wmfocus.nix
+++ b/pkgs/applications/window-managers/i3/wmfocus.nix
@@ -1,12 +1,18 @@
 { stdenv, fetchFromGitHub, rustPlatform,
   xorg, python3, pkgconfig, cairo, libxkbcommon }:
-let
+
+rustPlatform.buildRustPackage rec {
   pname = "wmfocus";
-  version = "1.0.2";
-in
-rustPlatform.buildRustPackage {
-  inherit pname version;
-  name = "${pname}-${version}";
+  version = "1.1.2";
+
+  src = fetchFromGitHub {
+    owner = "svenstaro";
+    repo = pname;
+    rev = version;
+    sha256 = "0jx0h2zyghs3bp4sg8f3vk5rkyprz2dqfqs0v72vmkp3cvgzxbvs";
+  };
+
+  cargoSha256 = "01ifrk6whvckys1kbj65cdwh976yn7dy9vpf4jybnlqripknab43";
 
   nativeBuildInputs = [ python3 pkgconfig ];
   buildInputs = [ cairo libxkbcommon xorg.xcbutilkeysyms ];
@@ -14,22 +20,10 @@ rustPlatform.buildRustPackage {
   # For now, this is the only available featureset. This is also why the file is
   # in the i3 folder, even though it might be useful for more than just i3
   # users.
-  cargoBuildFlags = ["--features i3"];
-
-  src = fetchFromGitHub {
-    owner = "svenstaro";
-    repo = pname;
-    rev = version;
-    sha256 = "14yxg2jiqx7gng677sbmvv0a0msb9wpvp3qh8h3nkq0vi17ds668";
-  };
-
-  cargoSha256 = "0lwzw8gf970ybblaxxkwn3pxrncxp0hhvykffbzirs7fic4fnvsg";
+  cargoBuildFlags = [ "--features i3" ];
 
   meta = with stdenv.lib; {
-    description = ''
-      Tool that allows you to rapidly choose a specific window directly
-      without having to use the mouse or directional keyboard navigation.
-    '';
+    description = "Visually focus windows by label";
     maintainers = with maintainers; [ synthetica ];
     platforms = platforms.linux;
     license = licenses.mit;


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @Synthetica9 