### PR TITLE
ffsend: init at 0.2.36

### DIFF
--- a/pkgs/tools/misc/ffsend/default.nix
+++ b/pkgs/tools/misc/ffsend/default.nix
@@ -1,0 +1,50 @@
+{ stdenv, fetchFromGitLab, rustPlatform, cmake, pkgconfig, openssl
+, darwin
+}:
+
+with rustPlatform;
+
+buildRustPackage rec {
+  name = "ffsend-${version}";
+  version = "0.2.36";
+
+  src = fetchFromGitLab {
+    owner = "timvisee";
+    repo = "ffsend";
+    rev = "v${version}";
+    sha256 = "0k2sl1f5isxj8qajmhf36xh6k9j9qq7nkqm27wfm3gvc6b4flk0r";
+  };
+
+  cargoSha256 = "1l4060kawba56gxsngba2yjshhaygrs17k1msjbj38vrg07zrnbp";
+
+  # Note: On Linux, the clipboard feature requires `xclip` to be in the `PATH`. Ideally we'd
+  # depend on `xclip` and patch the source to run `xclip` from the Nix store instead of from `PATH`.
+  # However, as I use macOS and not Linux, I'm not inclined to maintain a patch like that, nor do I
+  # have a means to test it. To that end, we'll just leave the clipboard feature enabled and
+  # trust that users that want to copy links to their clipboard will install `xclip` into their
+  # profile.
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [ openssl ]
+  ++ stdenv.lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ CoreFoundation CoreServices Security AppKit ])
+  ;
+
+  postInstall = ''
+    mkdir -p $out/share/zsh/site-functions
+    cp contrib/completions/zsh/_ffsend $out/share/zsh/site-functions/_ffsend
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Easily and securely share files from the command line. A fully featured Firefox Send client";
+    longDescription = ''
+      Easily and securely share files and directories from the command line through a safe, private
+      and encrypted link using a single simple command. Files are shared using the Send service and
+      may be up to 2GB. Others are able to download these files with this tool, or through their
+      web browser.
+    '';
+    homepage = https://gitlab.com/timvisee/ffsend;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.lilyball ];
+    platforms = platforms.darwin ++ platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2672,6 +2672,8 @@ in
 
   ferm = callPackage ../tools/networking/ferm { };
 
+  ffsend = callPackage ../tools/misc/ffsend { };
+
   fgallery = callPackage ../tools/graphics/fgallery { };
 
   flannel = callPackage ../tools/networking/flannel { };


### PR DESCRIPTION
###### Motivation for this change
Adds https://gitlab.com/timvisee/ffsend.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [X] other Linux distributions (Docker `nixos/nix` image)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I've declared Linux support but it's not very well-tested. I've built it in Docker and made sure the resulting binary works, but I haven't tested everything. As you can see from a comment I left in the file, clipboard support is enabled but won't actually work on Linux unless `xclip` is in the `PATH`. In theory we could patch the source to run `xclip` from the Nix store but I didn't want to be responsible for maintaining such a patch when I don't use Linux.

I'm also not sure if there's any need to add `cacert`, since we're using `openssl`. It seems to work without that, but I'm not sure where it gets certs from.