### PR TITLE
broadlink-cli: init at 0.9

### DIFF
--- a/pkgs/tools/misc/broadlink-cli/default.nix
+++ b/pkgs/tools/misc/broadlink-cli/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, python2Packages, fetchFromGitHub }:
+
+python2Packages.buildPythonApplication rec {
+  pname = "broadlink-cli";
+  inherit (python2Packages.broadlink) version;
+
+  # the tools are available as part of the source distribution from GH but
+  # not pypi, so we have to fetch them here.
+  src = fetchFromGitHub {
+    owner  = "mjg59";
+    repo   = "python-broadlink";
+    # this rev is version 0.9
+    rev    = "766b7b00fb1cec868e3d5fca66f1aada208959ce";
+    sha256 = "0j0idzxmpwkb1lbgvi9df2hbxafm5hxjc6mgg5481lq7z4z1r4nb";
+  };
+
+  format = "other";
+
+  propagatedBuildInputs = with python2Packages; [
+    broadlink
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 -t $out/bin cli/broadlink_{cli,discovery}
+    install -Dm644 -t $out/share/doc/broadlink cli/README.md
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Tools for interfacing with Broadlink RM2/3 (Pro) remote controls, A1 sensor platforms and SP2/3 smartplugs";
+    maintainers = with maintainers; [ peterhoeg ];
+    inherit (python2Packages.broadlink.meta) homepage license;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -237,6 +237,8 @@ in
 
   mod = callPackage ../development/tools/mod { };
 
+  broadlink-cli = callPackage ../tools/misc/broadlink-cli {};
+
   mht2htm = callPackage ../tools/misc/mht2htm { };
 
   fetchpatch = callPackage ../build-support/fetchpatch { };


### PR DESCRIPTION
###### Motivation for this change

I have some broadlink devices...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

