### PR TITLE
ghc{822,863}Binary: fix to work w/musl again, __strdup -> strdup

### DIFF
--- a/pkgs/development/compilers/ghc/8.2.2-binary.nix
+++ b/pkgs/development/compilers/ghc/8.2.2-binary.nix
@@ -115,7 +115,7 @@ stdenv.mkDerivation rec {
     # [1] http://refspecs.linuxbase.org/LSB_4.0.0/LSB-Core-generic/LSB-Core-generic/baselib---strdup-1.html
     # Use objcopy magic to make the change:
     stdenv.lib.optionalString stdenv.hostPlatform.isMusl ''
-      find ./ghc-${version}/rts -name "libHSrts*.a" -exec objcopy --redefine-sym __strdup=strdup {} \;
+      find ./ghc-${version}/rts -name "libHSrts*.a" -exec ''${OBJCOPY:-objcopy} --redefine-sym __strdup=strdup {} \;
     '';
 
   configurePlatforms = [ ];

--- a/pkgs/development/compilers/ghc/8.2.2-binary.nix
+++ b/pkgs/development/compilers/ghc/8.2.2-binary.nix
@@ -107,6 +107,15 @@ stdenv.mkDerivation rec {
 
       sed -i "s|/usr/bin/perl|perl\x00        |" ghc-${version}/ghc/stage2/build/tmp/ghc-stage2
       sed -i "s|/usr/bin/gcc|gcc\x00        |" ghc-${version}/ghc/stage2/build/tmp/ghc-stage2
+    '' +
+    # We're kludging a glibc bindist into working with non-glibc...
+    # Here we patch up the use of `__strdup` (part of glibc binary ABI)
+    # to instead use `strdup` since musl doesn't provide __strdup
+    # (`__strdup` is defined to be an alias of `strdup` anyway[1]).
+    # [1] http://refspecs.linuxbase.org/LSB_4.0.0/LSB-Core-generic/LSB-Core-generic/baselib---strdup-1.html
+    # Use objcopy magic to make the change:
+    stdenv.lib.optionalString stdenv.hostPlatform.isMusl ''
+      find ./ghc-${version}/rts -name "libHSrts*.a" -exec objcopy --redefine-sym __strdup=strdup {} \;
     '';
 
   configurePlatforms = [ ];

--- a/pkgs/development/compilers/ghc/8.6.3-binary.nix
+++ b/pkgs/development/compilers/ghc/8.6.3-binary.nix
@@ -99,6 +99,15 @@ stdenv.mkDerivation rec {
 
       sed -i "s|/usr/bin/perl|perl\x00        |" ghc-${version}/ghc/stage2/build/tmp/ghc-stage2
       sed -i "s|/usr/bin/gcc|gcc\x00        |" ghc-${version}/ghc/stage2/build/tmp/ghc-stage2
+    '' +
+    # We're kludging a glibc bindist into working with non-glibc...
+    # Here we patch up the use of `__strdup` (part of glibc binary ABI)
+    # to instead use `strdup` since musl doesn't provide __strdup
+    # (`__strdup` is defined to be an alias of `strdup` anyway[1]).
+    # [1] http://refspecs.linuxbase.org/LSB_4.0.0/LSB-Core-generic/LSB-Core-generic/baselib---strdup-1.html
+    # Use objcopy magic to make the change:
+    stdenv.lib.optionalString stdenv.hostPlatform.isMusl ''
+      find ./ghc-${version}/rts -name "libHSrts*.a" -exec objcopy --redefine-sym __strdup=strdup {} \;
     '';
 
   configurePlatforms = [ ];

--- a/pkgs/development/compilers/ghc/8.6.3-binary.nix
+++ b/pkgs/development/compilers/ghc/8.6.3-binary.nix
@@ -107,7 +107,7 @@ stdenv.mkDerivation rec {
     # [1] http://refspecs.linuxbase.org/LSB_4.0.0/LSB-Core-generic/LSB-Core-generic/baselib---strdup-1.html
     # Use objcopy magic to make the change:
     stdenv.lib.optionalString stdenv.hostPlatform.isMusl ''
-      find ./ghc-${version}/rts -name "libHSrts*.a" -exec objcopy --redefine-sym __strdup=strdup {} \;
+      find ./ghc-${version}/rts -name "libHSrts*.a" -exec ''${OBJCOPY:-objcopy} --redefine-sym __strdup=strdup {} \;
     '';
 
   configurePlatforms = [ ];


### PR DESCRIPTION
###### Motivation for this change

Fixes https://github.com/NixOS/nixpkgs/issues/57238.

Should be backported to any release branch impacted by the issue.
Which I think is just 19.03 :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Mostly was trying to fix the binary bootstrap build,
have not thoroughly tested the resulting compilers
(particularly the many versions built from these)
are all functioning reasonably...

I think if this at least fixes `pkgsMusl.ghc` it's a win :).