### PR TITLE
keepass-keepassotpkeyprov: init at 2.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2030,6 +2030,12 @@
       github = "ericnorris";
       githubId = 1906605;
   };
+  Enteee = {
+    email = "nix@duckpond.ch";
+    github = "Enteee";
+    githubid = 5493775;
+    name = "Ente";
+  };
   enzime = {
     email = "enzime@users.noreply.github.com";
     github = "enzime";

--- a/pkgs/applications/misc/keepass-plugins/otpkeyprov/default.nix
+++ b/pkgs/applications/misc/keepass-plugins/otpkeyprov/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, buildEnv, fetchzip, mono }:
+
+let
+  version = "2.6";
+  drv = stdenv.mkDerivation {
+    pname = "otpkeyprov";
+    inherit version;
+
+    src = fetchzip {
+      url = "https://keepass.info/extensions/v2/otpkeyprov/OtpKeyProv-${version}.zip";
+      sha256 = "1p60k55v2sxnv1varmp0dgbsi2rhjg9kj19cf54mkc87nss5h1ki";
+      stripRoot = false;
+    };
+
+    meta = {
+      description = "OtpKeyProv is a key provider based on one-time passwords";
+      homepage    = "https://keepass.info/plugins.html#otpkeyprov";
+      platforms   = with stdenv.lib.platforms; linux;
+      license     = stdenv.lib.licenses.gpl2;
+      maintainers = [ stdenv.lib.maintainers.ente ];
+    };
+
+    pluginFilename = "OtpKeyProv.plgx";
+
+    installPhase = ''
+      mkdir -p $out/lib/dotnet/keepass/
+      cp $pluginFilename $out/lib/dotnet/keepass/$pluginFilename
+    '';
+  };
+in
+  # Mono is required to compile plugin at runtime, after loading.
+  buildEnv { name = drv.name; paths = [ mono drv ]; }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18423,6 +18423,8 @@ in
 
   keepass-keepassrpc = callPackage ../applications/misc/keepass-plugins/keepassrpc { };
 
+  keepass-otpkeyprov = callPackage ../applications/misc/keepass-plugins/otpkeyprov { };
+
   exrdisplay = callPackage ../applications/graphics/exrdisplay { };
 
   exrtools = callPackage ../applications/graphics/exrtools { };


### PR DESCRIPTION
###### Motivation for this change

From the [Keepass plugin doc](https://keepass.info/plugins.html#otpkeyprov):
> OtpKeyProv is a key provider based on one-time passwords. After protecting your database using this plugin, you need to generate and enter one-time passwords in order to open your database.
>
> All generator tokens that follow the OATH HOTP standard (RFC 4226) are supported.

Template for this change was #23893

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---