### PR TITLE
nixos/wireguard: add test

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -225,6 +225,7 @@ in
   upnp = handleTest ./upnp.nix {};
   vault = handleTest ./vault.nix {};
   virtualbox = handleTestOn ["x86_64-linux"] ./virtualbox.nix {};
+  wireguard = handleTest ./wireguard {};
   wordpress = handleTest ./wordpress.nix {};
   xautolock = handleTest ./xautolock.nix {};
   xdg-desktop-portal = handleTest ./xdg-desktop-portal.nix {};

--- a/nixos/tests/wireguard/default.nix
+++ b/nixos/tests/wireguard/default.nix
@@ -1,0 +1,97 @@
+let
+  wg-snakeoil-keys = import ./snakeoil-keys.nix;
+in
+
+import ../make-test.nix ({ pkgs, ...} : {
+  name = "wireguard";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ ma27 ];
+  };
+
+  nodes = {
+    peer0 = { lib, ... }: {
+      boot.kernel.sysctl = {
+        "net.ipv6.conf.all.forwarding" = "1";
+        "net.ipv6.conf.default.forwarding" = "1";
+        "net.ipv4.ip_forward" = "1";
+      };
+
+      networking.useDHCP = false;
+      networking.interfaces.eth1 = {
+        ipv4.addresses = lib.singleton {
+          address = "192.168.0.1";
+          prefixLength = 24;
+        };
+        ipv6.addresses = lib.singleton {
+          address = "fd00::1";
+          prefixLength = 64;
+        };
+      };
+
+      networking.firewall.allowedUDPPorts = [ 23542 ];
+      networking.wireguard.interfaces.wg0 = {
+        ips = [ "10.23.42.1/32" "fc00::1/128" ];
+        listenPort = 23542;
+
+        inherit (wg-snakeoil-keys.peer0) privateKey;
+
+        peers = lib.singleton {
+          allowedIPs = [ "10.23.42.2/32" "fc00::2/128" ];
+
+          inherit (wg-snakeoil-keys.peer1) publicKey;
+        };
+      };
+    };
+
+    peer1 = { pkgs, lib, ... }: {
+      boot.kernel.sysctl = {
+        "net.ipv6.conf.all.forwarding" = "1";
+        "net.ipv6.conf.default.forwarding" = "1";
+        "net.ipv4.ip_forward" = "1";
+      };
+
+      networking.useDHCP = false;
+      networking.interfaces.eth1 = {
+        ipv4.addresses = lib.singleton {
+          address = "192.168.0.2";
+          prefixLength = 24;
+        };
+        ipv6.addresses = lib.singleton {
+          address = "fd00::2";
+          prefixLength = 64;
+        };
+      };
+
+      networking.wireguard.interfaces.wg0 = {
+        ips = [ "10.23.42.2/32" "fc00::2/128" ];
+        listenPort = 23542;
+        allowedIPsAsRoutes = false;
+
+        inherit (wg-snakeoil-keys.peer1) privateKey;
+
+        peers = lib.singleton {
+          allowedIPs = [ "0.0.0.0/0" "::/0" ];
+          endpoint = "192.168.0.1:23542";
+          persistentKeepalive = 25;
+
+          inherit (wg-snakeoil-keys.peer0) publicKey;
+        };
+
+        postSetup = let inherit (pkgs) iproute; in ''
+          ${iproute}/bin/ip route replace 10.23.42.1/32 dev wg0
+          ${iproute}/bin/ip route replace fc00::1/128 dev wg0
+        '';
+      };
+    };
+  };
+
+  testScript = ''
+    startAll;
+
+    $peer0->waitForUnit("wireguard-wg0.service");
+    $peer1->waitForUnit("wireguard-wg0.service");
+
+    $peer1->succeed("ping -c5 fc00::1");
+    $peer1->succeed("ping -c5 10.23.42.1")
+  '';
+})

--- a/nixos/tests/wireguard/snakeoil-keys.nix
+++ b/nixos/tests/wireguard/snakeoil-keys.nix
@@ -1,0 +1,11 @@
+{
+  peer0 = {
+    privateKey = "OPuVRS2T0/AtHDp3PXkNuLQYDiqJaBEEnYe42BSnJnQ=";
+    publicKey = "IujkG119YPr2cVQzJkSLYCdjpHIDjvr/qH1w1tdKswY=";
+  };
+
+  peer1 = {
+    privateKey = "uO8JVo/sanx2DOM0L9GUEtzKZ82RGkRnYgpaYc7iXmg=";
+    publicKey = "Ks9yRJIi/0vYgRmn14mIOQRwkcUGBujYINbMpik2SBI=";
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

After working on the last wireguard bump (#57534), we figured that it's
probably a good idea to have a basic test which confirms that a simple
VPN with wireguard still works.

This test starts two peers with a `wg0` network interface and adds a v4
and a v6 route that goes through `wg0`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

