### PR TITLE
[WIP] spotify: 1.0.96.181.gf6bc1b6b-12 -> 1.1.5.153.gf614956d-16

### DIFF
--- a/pkgs/applications/audio/spotify/default.nix
+++ b/pkgs/applications/audio/spotify/default.nix
@@ -2,6 +2,7 @@
 , glib, pango, cairo, atk, gdk_pixbuf, gtk2, cups, nspr, nss, libpng
 , libgcrypt, systemd, fontconfig, dbus, expat, ffmpeg_3, curl, zlib, gnome3
 , at-spi2-atk
+, at_spi2_core
 }:
 
 let
@@ -10,20 +11,21 @@ let
   # If an update breaks things, one of those might have valuable info:
   # https://aur.archlinux.org/packages/spotify/
   # https://community.spotify.com/t5/Desktop-Linux
-  version = "1.0.96.181.gf6bc1b6b-12";
+  version = "1.1.5.153.gf614956d-16";
   # To get the latest stable revision:
   # curl -H 'X-Ubuntu-Series: 16' 'https://api.snapcraft.io/api/v1/snaps/details/spotify?channel=stable' | jq '.download_url,.version,.last_updated'
   # To get general information:
   # curl -H 'Snap-Device-Series: 16' 'https://api.snapcraft.io/v2/snaps/info/spotify' | jq '.'
   # More examples of api usage:
   # https://github.com/canonical-websites/snapcraft.io/blob/master/webapp/publisher/snaps/views.py
-  rev = "30";
+  rev = "35";
 
 
   deps = [
     alsaLib
     atk
     at-spi2-atk
+    at_spi2_core
     cairo
     cups
     curl
@@ -71,7 +73,7 @@ stdenv.mkDerivation {
   # https://community.spotify.com/t5/Desktop-Linux/Redistribute-Spotify-on-Linux-Distributions/td-p/1695334
   src = fetchurl {
     url = "https://api.snapcraft.io/api/v1/snaps/download/pOBIoZ2LrCB3rDohMxoYGnbN14EHOgD7_${rev}.snap";
-    sha512 = "859730fbc80067f0828f7e13eee9a21b13b749f897a50e17c2da4ee672785cfd79e1af6336e609529d105e040dc40f61b6189524783ac93d49f991c4ea8b3c56";
+    sha512 = "9c2b7c2c6da28fa0c1d75d1ff77aa50604e3d60716f6bfe2b3da452d5d89c9c53c819921a60e1997a8cc42d07d7c15460f707ac5d21180fbb2dcc006e7b0e82b";
   };
 
   buildInputs = [ squashfsTools makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change

Currently the updated spotify will segfault once you try to play anything. I'm opening this PR so that others know why spotify is outdated and do not try to update it themselves. Upstream links:

https://community.spotify.com/t5/Desktop-Linux/spotify-client-1-1-0-98-78-gb45d2a6b-10-from-Ubuntu-package/td-p/4675676
https://community.spotify.com/t5/Desktop-Linux/1-0-98-1-1-0-Crash-when-using-ALSA/td-p/4680398

Unfortunately spotify on linux is still not officially supported, so who knows when there will be a fix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

