### PR TITLE
lynx: enable default-colors

### DIFF
--- a/pkgs/applications/networking/browsers/lynx/default.nix
+++ b/pkgs/applications/networking/browsers/lynx/default.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation rec {
   hardeningEnable = [ "pie" ];
 
   configureFlags = [
+    "--enable-default-colors"
     "--enable-widec"
     "--enable-ipv6"
   ] ++ stdenv.lib.optional sslSupport "--with-ssl";


### PR DESCRIPTION
###### Motivation for this change

Building with this option allows Lynx to optionally use the default colors of the terminal, when compiled with ncurses or slang. It does not (as far as I know) change any default behavior.

Since we build with ncurses, I don't think there's any reason not to have this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

