### PR TITLE
python3Packages.priority: fix build

### DIFF
--- a/pkgs/development/python-modules/priority/deadline.patch
+++ b/pkgs/development/python-modules/priority/deadline.patch
@@ -1,0 +1,39 @@
+From 9d933c3c6535c1c63291e3d35f4ada9135d422df Mon Sep 17 00:00:00 2001
+From: Alyssa Ross <hi@alyssa.is>
+Date: Mon, 11 Mar 2019 02:08:43 +0000
+Subject: [PATCH] Allow test_period_of_repetition to be slow
+
+Recent versions of hypothesis default to a 200ms timeout, which wasn't
+enough for my Thinkpad X220 to run this test. I've increased the timeout
+for this single test to hopefully a reasonable amount for older
+hardware.
+
+(cherry picked from commit 752beb3a32b59f54168816da531c9d2a387f9715)
+---
+ test/test_priority.py | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/test/test_priority.py b/test/test_priority.py
+index c98a28d..013ce30 100644
+--- a/test/test_priority.py
++++ b/test/test_priority.py
+@@ -12,7 +12,7 @@ import itertools
+ 
+ import pytest
+ 
+-from hypothesis import given
++from hypothesis import given, settings
+ from hypothesis.strategies import (
+     integers, lists, tuples, sampled_from
+ )
+@@ -489,6 +489,7 @@ class TestPriorityTreeOutput(object):
+     fairness and equidistribution.
+     """
+     @given(STREAMS_AND_WEIGHTS)
++    @settings(deadline=None)
+     def test_period_of_repetition(self, streams_and_weights):
+         """
+         The period of repetition of a priority sequence is given by the sum of
+-- 
+2.19.2
+

--- a/pkgs/development/python-modules/priority/default.nix
+++ b/pkgs/development/python-modules/priority/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, pytest, hypothesis }:
+{ lib, buildPythonPackage, fetchPypi, fetchpatch, pytest, hypothesis }:
 
 buildPythonPackage rec {
   pname = "priority";
@@ -8,6 +8,11 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "1gpzn9k9zgks0iw5wdmad9b4dry8haiz2sbp6gycpjkzdld9dhbb";
   };
+
+  patches = [
+    # https://github.com/python-hyper/priority/pull/135
+    ./deadline.patch
+  ];
 
   checkInputs = [ pytest hypothesis ];
   checkPhase = ''


### PR DESCRIPTION
The patch has been submitted upstream: 
https://github.com/python-hyper/priority/pull/135. It’s vendored here because the patch for master doesn’t apply to the latest release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

