### PR TITLE
ruby: rubygems 2.6.6 -> 3.0.3

### DIFF
--- a/pkgs/development/interpreters/ruby/rubygems-src.nix
+++ b/pkgs/development/interpreters/ruby/rubygems-src.nix
@@ -1,8 +1,0 @@
-{ fetchurl
-, version ? "2.7.7"
-, sha256 ? "1jsmmd31j8j066b83lin4bbqz19jhrirarzb41f3sjhfdjiwkcjc"
-}:
-fetchurl {
-  url = "https://rubygems.org/rubygems/rubygems-${version}.tgz";
-  sha256 = sha256;
-}

--- a/pkgs/development/interpreters/ruby/rubygems/0001-add-post-extract-hook.patch
+++ b/pkgs/development/interpreters/ruby/rubygems/0001-add-post-extract-hook.patch
@@ -1,0 +1,34 @@
+From a6485cfcdf51ff8be452980f93cebfea97f34dec Mon Sep 17 00:00:00 2001
+From: zimbatm <zimbatm@zimbatm.com>
+Date: Wed, 21 Sep 2016 09:32:34 +0100
+Subject: [PATCH 1/3] add post-extract hook
+
+Allows nix to execute scripts just after the gem extraction
+---
+ lib/rubygems/installer.rb | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/lib/rubygems/installer.rb b/lib/rubygems/installer.rb
+index d26b1e88..bf18fb7f 100644
+--- a/lib/rubygems/installer.rb
++++ b/lib/rubygems/installer.rb
+@@ -848,7 +848,15 @@ TEXT
+   # Ensures that files can't be installed outside the gem directory.
+ 
+   def extract_files
+-    @package.extract_files gem_dir
++    ret = @package.extract_files gem_dir
++    if ENV['NIX_POST_EXTRACT_FILES_HOOK']
++      puts
++      puts "running NIX_POST_EXTRACT_FILES_HOOK #{ENV['NIX_POST_EXTRACT_FILES_HOOK']} #{gem_dir}"
++      system(ENV['NIX_POST_EXTRACT_FILES_HOOK'], gem_dir.to_s)
++      puts "running NIX_POST_EXTRACT_FILES_HOOK done"
++      puts
++    end
++    ret
+   end
+ 
+   ##
+-- 
+2.19.2
+

--- a/pkgs/development/interpreters/ruby/rubygems/0002-binaries-with-env-shebang.patch
+++ b/pkgs/development/interpreters/ruby/rubygems/0002-binaries-with-env-shebang.patch
@@ -1,0 +1,28 @@
+From 2e1328bcdddd35e557eabdff83ac07f3591dc693 Mon Sep 17 00:00:00 2001
+From: zimbatm <zimbatm@zimbatm.com>
+Date: Wed, 21 Sep 2016 19:37:05 +0100
+Subject: [PATCH 2/3] binaries with env shebang
+
+By default, don't point to the absolute ruby derivation path. As a user
+installing a gem in the home, it would freeze the selected ruby version
+to the currently-installed ruby derivation.
+---
+ lib/rubygems/dependency_installer.rb | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/rubygems/dependency_installer.rb b/lib/rubygems/dependency_installer.rb
+index 34620860..00ab31d9 100644
+--- a/lib/rubygems/dependency_installer.rb
++++ b/lib/rubygems/dependency_installer.rb
+@@ -18,7 +18,7 @@ class Gem::DependencyInstaller
+   extend Gem::Deprecate
+ 
+   DEFAULT_OPTIONS = { # :nodoc:
+-    :env_shebang         => false,
++    :env_shebang         => true,
+     :document            => %w[ri],
+     :domain              => :both, # HACK dup
+     :force               => false,
+-- 
+2.19.2
+

--- a/pkgs/development/interpreters/ruby/rubygems/0003-gem-install-default-to-user.patch
+++ b/pkgs/development/interpreters/ruby/rubygems/0003-gem-install-default-to-user.patch
@@ -1,0 +1,26 @@
+From d69249d0ff210316121b44d971ddd2439b1bc393 Mon Sep 17 00:00:00 2001
+From: zimbatm <zimbatm@zimbatm.com>
+Date: Wed, 21 Sep 2016 09:40:39 +0100
+Subject: [PATCH 3/3] gem install default to user
+
+Default to not installing gems to the read-only system derivation.
+---
+ lib/rubygems/path_support.rb | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/rubygems/path_support.rb b/lib/rubygems/path_support.rb
+index ed680d65..749b9ea6 100644
+--- a/lib/rubygems/path_support.rb
++++ b/lib/rubygems/path_support.rb
+@@ -23,7 +23,7 @@ class Gem::PathSupport
+   # hashtable, or defaults to ENV, the system environment.
+   #
+   def initialize(env)
+-    @home = env["GEM_HOME"] || Gem.default_dir
++    @home = env["GEM_HOME"] || Gem.user_dir
+ 
+     if File::ALT_SEPARATOR
+       @home = @home.gsub(File::ALT_SEPARATOR, File::SEPARATOR)
+-- 
+2.19.2
+

--- a/pkgs/development/interpreters/ruby/rubygems/src.nix
+++ b/pkgs/development/interpreters/ruby/rubygems/src.nix
@@ -1,0 +1,8 @@
+{ fetchurl
+, version ? "3.0.3"
+, sha256 ? "0b6b9ads8522804xv8b8498gqwsv4qawv13f81kyc7g966y7lfmy"
+}:
+fetchurl {
+  url = "https://rubygems.org/rubygems/rubygems-${version}.tgz";
+  inherit sha256;
+}


### PR DESCRIPTION
I think it makes more sense to vendor the patches than pull them from @zimbatm's GitHub.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

