### PR TITLE
Revert "ghidra: use autoPatchelfHook"

### DIFF
--- a/pkgs/tools/security/ghidra/default.nix
+++ b/pkgs/tools/security/ghidra/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, lib, makeWrapper, autoPatchelfHook
+{ stdenv, fetchurl, unzip, lib, makeWrapper, patchelf
 , openjdk11, pam
 }: let
 
@@ -15,16 +15,22 @@ in stdenv.mkDerivation {
 
   nativeBuildInputs = [
     makeWrapper
-    autoPatchelfHook
+    patchelf
     unzip
   ];
 
-  buildInputs = [
-    stdenv.cc.cc.lib
-    pam
-  ];
-
   dontStrip = true;
+
+  postPatch = ''
+    for f in Ghidra/Features/Decompiler/os/linux64/* GPL/DemanglerGnu/os/linux64/*; do
+      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+        --set-rpath "${stdenv.cc.libc}/lib:${stdenv.cc.cc.lib}/lib" "$f"
+    done
+
+    for f in Ghidra/Features/GhidraServer/os/linux64/*; do
+      patchelf --set-rpath "${stdenv.cc.libc}/lib:${pam}/lib" "$f"
+    done
+  '';
 
   installPhase = ''
     mkdir -p "${pkg_path}"


### PR DESCRIPTION
This reverts commit 2385d153bab79e1919e4c3040b3263961cf3a042.

###### Motivation for this change
fixes #57769 

I thought the change to autoPatchelfHook worked well, but this issue proves the opposite, sorry.
I did not try to get autoPatchelfHook right, therefor I switched back to my first working proposal.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

