### PR TITLE
libassuan: use config flag to specify libgpg-error prefix

### DIFF
--- a/pkgs/development/libraries/libassuan/default.nix
+++ b/pkgs/development/libraries/libassuan/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, gettext, pth, libgpgerror }:
+{ fetchurl, stdenv, gettext, pth, libgpgerror, buildPackages }:
 
 stdenv.mkDerivation rec {
   name = "libassuan-2.5.2";
@@ -11,7 +11,12 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" "info" ];
   outputBin = "dev"; # libassuan-config
 
-  buildInputs = [ libgpgerror pth gettext];
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+  buildInputs = [ pth gettext ];
+
+  configureFlags = [
+    "--with-libgpg-error-prefix=${libgpgerror.dev}"
+  ];
 
   doCheck = true;
 


### PR DESCRIPTION
###### Motivation for this change

`libgpgerror` has a binary that gets called during build to retrieve path information. during cross compilation a buildPackages version of this will point to the wrong libs, but the normal version cannot be executed on the build machine. therefore we set it explicitly in the configure script.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

