### PR TITLE
inetutils: cross compile

### DIFF
--- a/pkgs/tools/networking/inetutils/inetutils-1_9-PATH_PROCNET_DEV.patch
+++ b/pkgs/tools/networking/inetutils/inetutils-1_9-PATH_PROCNET_DEV.patch
@@ -1,0 +1,26 @@
+inetutils: define PATH_PROCNET_DEV if not already defined
+
+this prevents the following compilation error :
+system/linux.c:401:15: error: 'PATH_PROCNET_DEV' undeclared (first use in this function)
+
+this patch comes from :
+ http://repository.timesys.com/buildsources/i/inetutils/inetutils-1.9/
+
+Upstream-Status: Inappropriate [not author]
+
+Signed-of-by: Eric Bénard <eric@eukrea.com>
+---
+diff -Naur inetutils-1.9.orig/ifconfig/system/linux.c inetutils-1.9/ifconfig/system/linux.c
+--- inetutils-1.9.orig/ifconfig/system/linux.c	2012-01-04 16:31:36.000000000 -0500
++++ inetutils-1.9/ifconfig/system/linux.c	2012-01-04 16:40:53.000000000 -0500
+@@ -49,6 +49,10 @@
+ #include "../ifconfig.h"
+ 
+ 
++#ifndef PATH_PROCNET_DEV
++  #define PATH_PROCNET_DEV "/proc/net/dev"
++#endif
++
+ /* ARPHRD stuff.  */
+ 
+ static void


### PR DESCRIPTION
###### Motivation for this change

Allows cross compilation of `inetutils` by disabled `help2man` if we're cross compiling AND introducing a patch for a known issue in inetutils 1.9 (taken from the yocto recipe of inetutils)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

