### PR TITLE
tree: use $CC instead of cc to build

### DIFF
--- a/pkgs/tools/system/tree/default.nix
+++ b/pkgs/tools/system/tree/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation {
       prefix=$out
       MANDIR=$out/share/man/man1
       ${systemFlags}
-      CC="cc"
+      CC="$CC"
     )
   '';
 


### PR DESCRIPTION
###### Motivation for this change

use `$CC` instead of hard-coded `cc` so cross-compilation works.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

