### PR TITLE
[discussion] systems: add armv7 target

### DIFF
--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -76,6 +76,7 @@ rec {
     armv7r   = { bits = 32; significantByte = littleEndian; family = "arm"; version = "7"; };
     armv7m   = { bits = 32; significantByte = littleEndian; family = "arm"; version = "7"; };
     armv7l   = { bits = 32; significantByte = littleEndian; family = "arm"; version = "7"; };
+    armv7    = { bits = 32; significantByte = littleEndian; family = "arm"; version = "7"; };
     armv8a   = { bits = 32; significantByte = littleEndian; family = "arm"; version = "8"; };
     armv8r   = { bits = 32; significantByte = littleEndian; family = "arm"; version = "8"; };
     armv8m   = { bits = 32; significantByte = littleEndian; family = "arm"; version = "8"; };
@@ -106,7 +107,7 @@ rec {
 
     wasm32   = { bits = 32; significantByte = littleEndian; family = "wasm"; };
     wasm64   = { bits = 64; significantByte = littleEndian; family = "wasm"; };
-    
+
     alpha    = { bits = 64; significantByte = littleEndian; family = "alpha"; };
 
     avr      = { bits = 8; family = "avr"; };


### PR DESCRIPTION
###### Motivation for this change

recently i've been working on #56540 , to try to cross compile into `armv7l` (beaglebone), but `rust` doesn't explicitly support `armv7l`, it supports `armv7`. So a few things can be done:

1. Add an `armv7` target.
2. Map `{ family = "arm"; version = "7"; }` architectures to `armv7` within `buildRustCrate` and the rust compiler.
3. something else?

what do you think is best?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

