### PR TITLE
libmodbus: fix for cross compilation

### DIFF
--- a/pkgs/development/libraries/libmodbus/default.nix
+++ b/pkgs/development/libraries/libmodbus/default.nix
@@ -8,6 +8,16 @@ stdenv.mkDerivation rec {
     sha256 = "0drnil8bzd4n4qb0wv3ilm9zvypxvwmzd65w96d6kfm7x6q65j68";
   };
 
+  configureFlags = [
+    # when cross-compiling we assume that the host system will return a valid
+    # pointer for calls to malloc(0) or realloc(0)
+    # https://www.uclibc.org/FAQ.html#gnu_malloc
+    # https://www.gnu.org/software/autoconf/manual/autoconf.html#index-AC_005fFUNC_005fMALLOC-454
+    # the upstream source should be patched to avoid needing this
+    "ac_cv_func_malloc_0_nonnull=yes"
+    "ac_cv_func_realloc_0_nonnull=yes"
+  ];
+
   meta = with stdenv.lib; {
     description = "Library to send/receive data according to the Modbus protocol";
     homepage = http://libmodbus.org/;


### PR DESCRIPTION
###### Motivation for this change

Currently:
```
$ nix build -f channel:nixpkgs-unstable pkgsCross.armv7l-hf-multiplatform.libmodbus

builder for '/nix/store/ps48zagkkjv1l58yy2hrvnxf5bxvf0rw-libmodbus-3.1.4-armv7l-unknown-linux-gnueabihf.drv' failed with exit code 2; last 10 log lines:
  Making all in tests
  make  all-am
    CC       bandwidth-server-one.o
    CCLD     bandwidth-server-one
  /nix/store/4dn67dzxlwmglqx9xx75sckrwqzw32cp-armv7l-unknown-linux-gnueabihf-binutils-2.31.1/bin/armv7l-unknown-linux-gnueabihf-ld: ../src/.libs/libmodbus.so: undefined reference to `rpl_malloc'
  collect2: error: ld returned 1 exit status
  make[3]: *** [Makefile:644: bandwidth-server-one] Error 1
  make[2]: *** [Makefile:580: all] Error 2
  make[1]: *** [Makefile:499: all-recursive] Error 1
  make: *** [Makefile:385: all] Error 2
```

this seems related: https://github.com/stephane/libmodbus/issues/297

setting these variables fixing this error, even though it looks ugly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

