### PR TITLE
autossh: fix for cross compilation

### DIFF
--- a/pkgs/tools/networking/autossh/default.nix
+++ b/pkgs/tools/networking/autossh/default.nix
@@ -2,14 +2,19 @@
 
 stdenv.mkDerivation rec {
   name = "autossh-1.4g";
-  
+
   src = fetchurl {
     url = "http://www.harding.motd.ca/autossh/${name}.tgz";
     sha256 = "0xqjw8df68f4kzkns5gcah61s5wk0m44qdk2z1d6388w6viwxhsz";
   };
-  
-  buildInputs = [ openssh ];
-  
+
+  preConfigure = ''
+    export ac_cv_func_malloc_0_nonnull=yes
+    export ac_cv_func_realloc_0_nonnull=yes
+  '';
+
+  nativeBuildInputs = [ openssh ];
+
   installPhase =
     ''
       install -D -m755 autossh      $out/bin/autossh                          || return 1
@@ -19,7 +24,7 @@ stdenv.mkDerivation rec {
       install -D -m644 rscreen      $out/share/autossh/examples/rscreen       || return 1
       install -D -m644 autossh.1    $out/man/man1/autossh.1                   || return 1
     '';
-    
+
   meta = with stdenv.lib; {
     homepage = http://www.harding.motd.ca/autossh/;
     description = "Automatically restart SSH sessions and tunnels";


### PR DESCRIPTION
###### Motivation for this change

Fixes for cross compilation in `autossh`, the `preConfigure` phase is to fix a `undefined reference to `rpl_malloc'` error that comes up when cross-compiling.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

