### PR TITLE
anbox: init at 2019-03-07

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -873,6 +873,7 @@
   ./tasks/trackpoint.nix
   ./tasks/powertop.nix
   ./testing/service-runner.nix
+  ./virtualisation/anbox.nix
   ./virtualisation/container-config.nix
   ./virtualisation/containers.nix
   ./virtualisation/docker.nix

--- a/nixos/modules/virtualisation/anbox.nix
+++ b/nixos/modules/virtualisation/anbox.nix
@@ -1,0 +1,144 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.virtualisation.anbox;
+  kernelPackages = config.boot.kernelPackages;
+  addrOpts = v: addr: pref: name: {
+    address = mkOption {
+      default = addr;
+      type = types.str;
+      description = ''
+        IPv${toString v} ${name} address.
+      '';
+    };
+
+    prefixLength = mkOption {
+      default = pref;
+      type = types.addCheck types.int (n: n >= 0 && n <= (if v == 4 then 32 else 128));
+      description = ''
+        Subnet mask of the ${name} address, specified as the number of
+        bits in the prefix (<literal>${if v == 4 then "24" else "64"}</literal>).
+      '';
+    };
+  };
+
+in
+
+{
+
+  options.virtualisation.anbox = {
+
+    enable = mkEnableOption "Anbox";
+
+    image = mkOption {
+      default = pkgs.anbox.image;
+      example = literalExample "pkgs.anbox.image";
+      type = types.package;
+      description = ''
+        Base android image for Anbox.
+      '';
+    };
+
+    extraInit = mkOption {
+      type = types.lines;
+      default = "";
+      description = ''
+        Extra shell commands to be run inside the container image during init.
+      '';
+    };
+
+    ipv4 = {
+      container = addrOpts 4 "192.168.250.2" 24 "Container";
+      gateway = addrOpts 4 "192.168.250.1" 24 "Host";
+
+      dns = mkOption {
+        default = "1.1.1.1";
+        type = types.string;
+        description = ''
+          Container DNS server.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    assertions = singleton {
+      assertion = versionAtLeast (getVersion config.boot.kernelPackages.kernel) "4.18";
+      message = "Anbox needs user namespace support to work properly";
+    };
+
+    environment.systemPackages = with pkgs; [ anbox ];
+
+    boot.kernelModules = [ "ashmem_linux" "binder_linux" ];
+    boot.extraModulePackages = [ kernelPackages.anbox ];
+
+    services.udev.extraRules = ''
+      KERNEL=="ashmem", NAME="%k", MODE="0666"
+      KERNEL=="binder*", NAME="%k", MODE="0666"
+    '';
+
+    virtualisation.lxc.enable = true;
+    networking.bridges.anbox0.interfaces = [];
+    networking.interfaces.anbox0.ipv4.addresses = [ cfg.ipv4.gateway ];
+
+    networking.nat = {
+      enable = true;
+      internalInterfaces = [ "anbox0" ];
+    };
+
+    systemd.services.anbox-container-manager = let
+      anboxloc = "/var/lib/anbox";
+    in {
+      description = "Anbox Container Management Daemon";
+
+      environment.XDG_RUNTIME_DIR="${anboxloc}";
+
+      wantedBy = [ "multi-user.target" ];
+      after = [ "systemd-udev-settle.service" ];
+      preStart = let
+        initsh = let
+          ip = cfg.ipv4.container.address;
+          gw = cfg.ipv4.gateway.address;
+          dns = cfg.ipv4.dns;
+        in
+        pkgs.writeText "nixos-init" (''
+          #!/system/bin/sh
+          setprop nixos.version ${config.system.nixos.version}
+
+          # we don't have radio
+          setprop ro.radio.noril yes
+          stop ril-daemon
+
+          # speed up boot
+          setprop debug.sf.nobootanimation 1
+        '' + cfg.extraInit);
+        initshloc = "${anboxloc}/rootfs-overlay/system/etc/init.goldfish.sh";
+      in ''
+        mkdir -p ${anboxloc}
+        mkdir -p $(dirname ${initshloc})
+        [ -f ${initshloc} ] && rm ${initshloc}
+        cp ${initsh} ${initshloc}
+        chown 100000:100000 ${initshloc}
+        chmod +x ${initshloc}
+      '';
+
+      serviceConfig = {
+        ExecStart = ''
+          ${pkgs.anbox}/bin/anbox container-manager \
+            --data-path=${anboxloc} \
+            --android-image=${cfg.image} \
+            --container-network-address=${cfg.ipv4.container.address} \
+            --container-network-gateway=${cfg.ipv4.gateway.address} \
+            --container-network-dns-servers=${cfg.ipv4.dns} \
+            --use-rootfs-overlay \
+            --privileged
+        '';
+      };
+    };
+  };
+
+}

--- a/pkgs/development/libraries/properties-cpp/default.nix
+++ b/pkgs/development/libraries/properties-cpp/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, lib, fetchurl, cmake, pkgconfig, gtest, doxygen
+, graphviz, lcov, writeText }:
+
+stdenv.mkDerivation rec {
+  pname = "properties-cpp";
+  version = "0.0.1";
+
+  src = let srcver = version+"+14.10.20140730"; in
+  fetchurl {
+    url = "https://launchpad.net/ubuntu/+archive/primary/+files/${pname}_${srcver}.orig.tar.gz";
+    sha256 = "08vjyv7ibn6jh2ikj5v48kjpr3n6hlkp9qlvdn8r0vpiwzah0m2w";
+  };
+
+  buildInputs = [ cmake gtest doxygen pkgconfig graphviz lcov ];
+
+  patchPhase = ''
+    sed -i "/add_subdirectory(tests)/d" CMakeLists.txt
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://launchpad.net/properties-cpp;
+    description = "A very simple convenience library for handling properties and signals in C++11.";
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ edwtjo ];
+  };
+
+}

--- a/pkgs/os-specific/linux/anbox/default.nix
+++ b/pkgs/os-specific/linux/anbox/default.nix
@@ -1,0 +1,127 @@
+{ stdenv, lib, fetchFromGitHub, fetchurl
+, cmake, pkgconfig, dbus, makeWrapper
+, gtest
+, boost
+, libcap
+, systemd
+, mesa
+, libGL
+, libglvnd
+, glib
+, git
+, SDL2
+, SDL2_image
+, properties-cpp
+, protobuf
+, protobufc
+, python
+, lxc
+}:
+
+stdenv.mkDerivation rec {
+  pname = "anbox";
+  version = "2019-03-07";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "d521e282965462e82465045ab95d4ae1c4619685";
+    sha256 = "1wfx4bsyxvrjl16dq5pqgial8rnnsnxzbak2ap0waddz847czxwz";
+  };
+
+  buildInputs = [
+    cmake pkgconfig dbus boost libcap gtest systemd mesa glib
+    SDL2 SDL2_image protobuf protobufc properties-cpp lxc python
+    makeWrapper libGL
+  ];
+
+  patchPhase = ''
+    patchShebangs scripts
+
+    cat >cmake/FindGMock.cmake <<'EOF'
+      add_library(gtest INTERFACE)
+      target_include_directories(gtest INTERFACE ${gtest.dev}/include)
+      target_link_libraries(gtest INTERFACE ${gtest}/lib/libgtest.so ''${CMAKE_THREAD_LIBS_INIT})
+      add_dependencies(gtest GMock)
+
+      add_library(gtest_main INTERFACE)
+      target_include_directories(gtest_main INTERFACE ${gtest.dev}/include)
+      target_link_libraries(gtest_main INTERFACE ${gtest}/lib/libgtest_main.so gtest)
+
+      add_library(gmock INTERFACE)
+      target_include_directories(gmock INTERFACE ${gtest.dev}/include)
+      target_link_libraries(gmock INTERFACE ${gtest}/lib/libgmock.so gtest)
+
+      add_library(gmock_main INTERFACE)
+      target_include_directories(gmock_main INTERFACE ${gtest.dev}/include)
+      target_link_libraries(gmock_main INTERFACE ${gtest}/lib/libgmock_main.so gmock gtest_main)
+
+      set(GTEST_LIBRARIES gtest)
+      set(GTEST_MAIN_LIBRARIES gtest_main)
+      set(GMOCK_LIBRARIES gmock gmock_main)
+      set(GTEST_BOTH_LIBRARIES ''${GTEST_LIBRARIES} ''${GTEST_MAIN_LIBRARIES})
+    EOF
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/anbox \
+      --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [libGL libglvnd]} \
+      --prefix PATH : ${git}/bin
+
+    mkdir -p $out/share/dbus-1/services/
+    cat <<END > $out/share/dbus-1/services/org.anbox.service
+    [D-BUS Service]
+    Name=org.anbox
+    Exec=$out/libexec/anbox-session-manager
+    END
+
+    mkdir $out/libexec
+    cat > $out/libexec/anbox-session-manager <<EOF
+    #!${stdenv.shell}
+    exec $out/bin/anbox session-manager
+    EOF
+    chmod +x $out/libexec/anbox-session-manager
+
+    cat > $out/bin/anbox-application-manager <<EOF
+    #!${stdenv.shell}
+    ${systemd}/bin/busctl --user call \
+      org.freedesktop.DBus \
+      /org/freedesktop/DBus \
+      org.freedesktop.DBus \
+      StartServiceByName "su" org.anbox 0
+
+    $out/bin/anbox launch --package=org.anbox.appmgr --component=org.anbox.appmgr.AppViewActivity
+    EOF
+    chmod +x $out/bin/anbox-application-manager
+  '';
+
+  passthru.image = let
+    imgroot = "https://build.anbox.io/android-images";
+    arches = {
+      armv7l-linux = {
+        url = imgroot + "/2017/06/12/android_1_armhf.img";
+        sha256 = "1za4q6vnj8wgphcqpvyq1r8jg6khz7v6b7h6ws1qkd5ljangf1w5";
+      };
+      aarch64-linux = {
+        url = imgroot + "/2017/08/04/android_1_arm64.img";
+        sha256 = "02yvgpx7n0w0ya64y5c7bdxilaiqj9z3s682l5s54vzfnm5a2bg5";
+      };
+      x86_64-linux = {
+        url = imgroot + "/2018/07/19/android_amd64.img";
+        sha256 = "1jlcda4q20w30cm9ikm6bjq01p547nigik1dz7m4v0aps4rws13b";
+      };
+    };
+  in
+  fetchurl {
+    inherit (arches.${stdenv.system}) url sha256;
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://anbox.io;
+    description = "Android in a box.";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ edwtjo ];
+    platforms = platforms.linux;
+  };
+
+}

--- a/pkgs/os-specific/linux/anbox/kmod.nix
+++ b/pkgs/os-specific/linux/anbox/kmod.nix
@@ -1,0 +1,43 @@
+{ stdenv, lib, kernel, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "anbox-modules";
+  version = "2018-09-08-" + kernel.version;
+
+  src = fetchFromGitHub {
+    owner = "anbox";
+    repo = "anbox-modules";
+    rev = "27fd47e11ef6eef93738f8f3df3e42c88975544e";
+    sha256 = "1hnf5x5swjcws6mnxmd3byll8l7qsxxj9pgki2k31rbmqqf2sb0x";
+  };
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  KERNEL_SRC="${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
+
+  buildPhase = ''
+    for d in ashmem binder;do
+      cd $d
+      make
+      cd -
+    done
+  '';
+
+  installPhase = ''
+    modDir=$out/lib/modules/${kernel.modDirVersion}/kernel/updates/
+    mkdir -p $modDir
+    for d in ashmem binder;do
+      mv $d/$d*.ko $modDir/.
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Anbox ashmem and binder drivers.";
+    homepage = https://github.com/anbox/anbox-modules;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    broken = (versionOlder kernel.version "4.4") || (kernel.features.grsecurity);
+    maintainers = with maintainers; [ edwtjo ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -825,6 +825,8 @@ in
     inherit (androidenv.androidPkgs_9_0) platform-tools;
   };
 
+  anbox = callPackage ../os-specific/linux/anbox { };
+
   androidenv = callPackage ../development/mobile/androidenv {
     pkgs_i686 = pkgsi686Linux;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19012,6 +19012,8 @@ in
     python = python3;
   } // (config.profanity or {}));
 
+  properties-cpp = callPackage ../development/libraries/properties-cpp { };
+
   protonmail-bridge = libsForQt511.callPackage ../applications/networking/protonmail-bridge { };
 
   psi = callPackage ../applications/networking/instant-messengers/psi { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14762,6 +14762,8 @@ in
 
     amdgpu-pro = callPackage ../os-specific/linux/amdgpu-pro { };
 
+    anbox = callPackage ../os-specific/linux/anbox/kmod.nix { };
+
     batman_adv = callPackage ../os-specific/linux/batman-adv {};
 
     bcc = callPackage ../os-specific/linux/bcc {


### PR DESCRIPTION
###### Motivation for this change

[Android in a box](https://github.com/anbox/anbox/)

This is an update of @edwtjo's PR #48040.  Now networking works out of the box---I just had to enable NAT, networking works even though `adb shell ip r` doesn't show a default route.

For testing, I'm starting `anbox session-manager` and then `anbox-application-manager`.

cc @edwtjo @Mic92 @jasoncarr0 @peterhoeg 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

