### PR TITLE
ngrok-2: 2.2.8 -> 2.3.18

### DIFF
--- a/pkgs/tools/networking/ngrok-2/default.nix
+++ b/pkgs/tools/networking/ngrok-2/default.nix
@@ -4,17 +4,17 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "ngrok-${version}";
-  version = "2.2.8";
+  version = "2.3.18";
 
   src = if stdenv.isLinux && stdenv.isi686 then fetchurl {
-    url = "https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-i386.tgz";
-    sha256 = "0s5ymlaxrvm13q3mlvfirh74sx60qh56c5sgdma2r7q5qlsq41xg";
+    url = "https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-${version}-linux-i386.tgz";
+    sha256 = "108x3qchcklbkn7n3af0zxwpwmfp7wddblsn62ycnn9krcxhrn6f";
   } else if stdenv.isLinux && stdenv.isx86_64 then fetchurl {
-    url = "https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.tgz";
-    sha256 = "1mn9iwgy6xzrjihikwc2k2j59igqmph0cwx17qp0ziap9lp5xxad";
+    url = "https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-${version}-linux-amd64.tgz";
+    sha256 = "04zg6m8kv77wrh4bm5gpkzh1h348dlml04m786yb44x07klkc4lc";
   } else if stdenv.isDarwin then fetchurl {
-    url = "https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-darwin-386.zip";
-    sha256 = "0yfd250b55wcpgqd00rqfaa7a82f35fmybb31q5xwdbgc2i47pbh";
+    url = "https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-${version}-darwin-386.zip";
+    sha256 = "0zgfr0wmk7alz3qlal6x2knmxcp31gkljlhqgidi4d6wvv4c17zq";
   } else throw "platform ${stdenv.hostPlatform.system} not supported!";
 
   sourceRoot = ".";


### PR DESCRIPTION
###### Motivation for this change

Get ngrok-2 up to date.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

