### PR TITLE
vscode-extensions.{language-haskell,hie-server}: init

### DIFF
--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -23,6 +23,18 @@ rec {
     };
   };
 
+  justusadam.language-haskell = buildVscodeMarketplaceExtension {
+    mktplcRef = {
+      name = "language-haskell";
+      publisher = "justusadam";
+      version = "2.5.0"; # see the note above
+      sha256 = "10jqj8qw5x6da9l8zhjbra3xcbrwb4cpwc3ygsy29mam5pd8g6b3";
+    };
+    meta = {
+      license = stdenv.lib.licenses.bsd3;
+    };
+  };
+
   ms-vscode.cpptools = callPackage ./cpptools {};
 
   ms-python.python = callPackage ./python {};

--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -11,6 +11,19 @@ in
 # "${mktplcRef.publisher}.${mktplcRef.name}".
 #
 rec {
+
+  alanz.vscode-hie-server = buildVscodeMarketplaceExtension {
+    mktplcRef = {
+      name = "vscode-hie-server";
+      publisher = "alanz";
+      version = "0.0.25"; # see the note above
+      sha256 = "0m21w03v94qxm0i54ki5slh6rg7610zfxinfpngr0hfpgw2nnxvc";
+    };
+    meta = {
+      license = stdenv.lib.licenses.mit;
+    };
+  };
+
   bbenoist.Nix = buildVscodeMarketplaceExtension {
     mktplcRef = {
         name = "Nix";


### PR DESCRIPTION
###### Motivation for this change

These weren't available via Nixpkgs yet for declarative addition to VSCode.
I'm also packaging these extensions for home-manager, https://github.com/rycee/home-manager/pull/619

I've tried more than once to get something resembling a Haskell IDE, which usually ends with a half-broken setup. I'm happy to make the next Nix user's setup a bit easier.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

