### PR TITLE
image_optim: init at 0.26.3

### DIFF
--- a/pkgs/applications/graphics/image_optim/Gemfile
+++ b/pkgs/applications/graphics/image_optim/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'image_optim'

--- a/pkgs/applications/graphics/image_optim/Gemfile.lock
+++ b/pkgs/applications/graphics/image_optim/Gemfile.lock
@@ -1,0 +1,23 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    exifr (1.3.6)
+    fspath (3.1.0)
+    image_optim (0.26.3)
+      exifr (~> 1.2, >= 1.2.2)
+      fspath (~> 3.0)
+      image_size (>= 1.5, < 3)
+      in_threads (~> 1.3)
+      progress (~> 3.0, >= 3.0.1)
+    image_size (2.0.0)
+    in_threads (1.5.1)
+    progress (3.5.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  image_optim
+
+BUNDLED WITH
+   1.16.3

--- a/pkgs/applications/graphics/image_optim/default.nix
+++ b/pkgs/applications/graphics/image_optim/default.nix
@@ -1,0 +1,68 @@
+{ lib, bundlerApp, fetchurl, ruby, makeWrapper,
+  withPngcrush ? true,       pngcrush ? null,
+  withPngout ? true,         pngout ? null,
+  withAdvpng ? true,         advancecomp ? null,
+  withOptipng ? true,        optipng ? null,
+  withPngquant ? true,       pngquant ? null,
+  withJhead ? true,          jhead ? null,
+  withJpegoptim ? true,      jpegoptim ? null,
+  withJpegrecompress ? true, jpeg-archive ? null,
+  withJpegtran ? true,       libjpeg ? null,
+  withGifsicle ? true,       gifsicle ? null,
+  withSvgo ? true,           svgo ? null
+}:
+
+assert withPngcrush       -> pngcrush != null;
+assert withPngout         -> pngout != null;
+assert withAdvpng         -> advancecomp != null;
+assert withOptipng        -> optipng != null;
+assert withPngquant       -> pngquant != null;
+assert withJhead          -> jhead != null;
+assert withJpegoptim      -> jpegoptim != null;
+assert withJpegrecompress -> jpeg-archive != null;
+assert withJpegtran       -> libjpeg != null;
+assert withGifsicle       -> gifsicle != null;
+assert withSvgo           -> svgo != null;
+
+with lib;
+
+let
+  optionalDepsPath = makeBinPath (
+    []
+    ++ optional withPngcrush pngcrush
+    ++ optional withPngout pngout
+    ++ optional withAdvpng advancecomp
+    ++ optional withOptipng optipng
+    ++ optional withPngquant pngquant
+    ++ optional withJhead jhead
+    ++ optional withJpegoptim jpegoptim
+    ++ optional withJpegrecompress jpeg-archive
+    ++ optional withJpegtran libjpeg
+    ++ optional withGifsicle gifsicle
+    ++ optional withSvgo svgo
+  );
+in
+
+bundlerApp {
+  pname = "image_optim";
+  gemdir = ./.;
+
+  inherit ruby;
+
+  exes = [ "image_optim" ];
+
+  buildInputs = [ makeWrapper ];
+
+  postBuild = ''
+    wrapProgram $out/bin/image_optim \
+      --prefix PATH : ${optionalDepsPath}
+  '';
+
+  meta = with lib; {
+    description = "Command line tool and ruby interface to optimize (lossless compress, optionally lossy) jpeg, png, gif and svg images using external utilities (advpng, gifsicle, jhead, jpeg-recompress, jpegoptim, jpegrescan, jpegtran, optipng, pngcrush, pngout, pngquant, svgo)";
+    homepage    = http://github.com/toy/image_optim;
+    license     = licenses.mit;
+    maintainers = with maintainers; [ srghma ];
+    platforms   = platforms.all;
+  };
+}

--- a/pkgs/applications/graphics/image_optim/default.nix
+++ b/pkgs/applications/graphics/image_optim/default.nix
@@ -27,8 +27,7 @@ assert withSvgo           -> svgo != null;
 with lib;
 
 let
-  optionalDepsPath = makeBinPath (
-    []
+  optionalDepsPath = []
     ++ optional withPngcrush pngcrush
     ++ optional withPngout pngout
     ++ optional withAdvpng advancecomp
@@ -39,8 +38,7 @@ let
     ++ optional withJpegrecompress jpeg-archive
     ++ optional withJpegtran libjpeg
     ++ optional withGifsicle gifsicle
-    ++ optional withSvgo svgo
-  );
+    ++ optional withSvgo svgo;
 in
 
 bundlerApp {
@@ -55,7 +53,7 @@ bundlerApp {
 
   postBuild = ''
     wrapProgram $out/bin/image_optim \
-      --prefix PATH : ${optionalDepsPath}
+      --prefix PATH : ${makeBinPath optionalDepsPath}
   '';
 
   meta = with lib; {

--- a/pkgs/applications/graphics/image_optim/gemset.nix
+++ b/pkgs/applications/graphics/image_optim/gemset.nix
@@ -1,0 +1,51 @@
+{
+  exifr = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0q2abhiyvgfv23i0izbskjxcqaxiw9bfg6s57qgn4li4yxqpwpfg";
+      type = "gem";
+    };
+    version = "1.3.6";
+  };
+  fspath = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1vjn9sy4hklr2d5wxmj5x1ry31dfq3sjp779wyprb3nbbdmra1sc";
+      type = "gem";
+    };
+    version = "3.1.0";
+  };
+  image_optim = {
+    dependencies = ["exifr" "fspath" "image_size" "in_threads" "progress"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "082w9qcyy9j6m6s2pknfdcik7l2qch4j48axs13m06l4s1hz0dmg";
+      type = "gem";
+    };
+    version = "0.26.3";
+  };
+  image_size = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0bcn7nc6qix3w4sf7xd557lnsgjniqa7qvz7nnznx70m8qfbc7ig";
+      type = "gem";
+    };
+    version = "2.0.0";
+  };
+  in_threads = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "14hqm59sgqi91ag187zwpgwi58xckjkk58m031ghkp0csl8l9mkx";
+      type = "gem";
+    };
+    version = "1.5.1";
+  };
+  progress = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1yrzq4v5sp7cg4nbgqh11k3d1czcllfz98dcdrxrsjxwq5ziiw0p";
+      type = "gem";
+    };
+    version = "3.5.0";
+  };
+}

--- a/pkgs/applications/graphics/image_optim/update.sh
+++ b/pkgs/applications/graphics/image_optim/update.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p bundix bundler
+
+SCRIPT_DIR=$(dirname "$(readlink -f "$BASH_SOURCE")")
+
+cd $SCRIPT_DIR
+
+bundle lock --update
+bundix

--- a/pkgs/applications/graphics/jpeg-archive/default.nix
+++ b/pkgs/applications/graphics/jpeg-archive/default.nix
@@ -1,0 +1,42 @@
+{ lib, stdenv, fetchFromGitHub, mozjpeg, makeWrapper, coreutils, parallel, findutils }:
+
+stdenv.mkDerivation rec {
+  name = "jpeg-archive-${version}";
+  version = "2.2.0"; # can be found here https://github.com/danielgtaylor/jpeg-archive/blob/master/src/util.c#L15
+
+  # update with
+  # nix-prefetch-git https://github.com/danielgtaylor/jpeg-archive
+  src = fetchFromGitHub {
+    owner = "danielgtaylor";
+    repo = "jpeg-archive";
+    rev = "8da4bf76b6c3c0e11e4941294bfc1857c119419b";
+    sha256 = "1639y9qp2ls80fzimwmwds792q8rq5p6c14c0r4jswx4yp6dcs33";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ mozjpeg ];
+
+  prePatch = ''
+    # allow override LIBJPEG
+    substituteInPlace Makefile --replace 'LIBJPEG =' 'LIBJPEG ?='
+  '';
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "MOZJPEG_PREFIX=${mozjpeg}"
+    "LIBJPEG=${mozjpeg}/lib/libjpeg.so"
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/jpeg-archive \
+      --set PATH "$out/bin:${coreutils}/bin:${parallel}/bin:${findutils}/bin"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Utilities for archiving photos for saving to long term storage or serving over the web";
+    homepage    = "https://github.com/danielgtaylor/jpeg-archive";
+    # license = ...; # mixed?
+    maintainers = [ maintainers.srghma ];
+    platforms   = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3624,6 +3624,8 @@ in
 
   jp2a = callPackage ../applications/misc/jp2a { };
 
+  jpeg-archive = callPackage ../applications/graphics/jpeg-archive { };
+
   jpeginfo = callPackage ../applications/graphics/jpeginfo { };
 
   jpegoptim = callPackage ../applications/graphics/jpegoptim { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22515,6 +22515,8 @@ in
 
   illum = callPackage ../tools/system/illum { };
 
+  image_optim = callPackage ../applications/graphics/image_optim { inherit (nodePackages) svgo; };
+
   # using the new configuration style proposal which is unstable
   jack1 = callPackage ../misc/jackaudio/jack1.nix { };
 


### PR DESCRIPTION
###### Things done

```
# I have tested jpeg-archive
out=$(nix-build ./default.nix -A jpeg-archive)
$out/jpeg-archive --help # throws error, but it's should do so
$out/jpeg-compare --help
$out/jpeg-hash --help
$out/jpeg-recompress --help

# I have tested image_optim
sudo rm -rdf /tmp/test-images
mkdir -p /tmp/test-images
cp /nix/store/p98jdsj0vxjzsfdmff68frydk3db50m2-ruby2.5.3-image_optim-0.26.3/lib/ruby/gems/2.5.0/gems/image_optim-0.26.3/spec/images/icecream.gif /tmp/test-images/icecream.gif
cp /nix/store/p98jdsj0vxjzsfdmff68frydk3db50m2-ruby2.5.3-image_optim-0.26.3/lib/ruby/gems/2.5.0/gems/image_optim-0.26.3/spec/images/lena.jpg /tmp/test-images/lena.jpg
cp /nix/store/p98jdsj0vxjzsfdmff68frydk3db50m2-ruby2.5.3-image_optim-0.26.3/lib/ruby/gems/2.5.0/gems/image_optim-0.26.3/spec/images/rails.png /tmp/test-images/rails.png
cp /nix/store/p98jdsj0vxjzsfdmff68frydk3db50m2-ruby2.5.3-image_optim-0.26.3/lib/ruby/gems/2.5.0/gems/image_optim-0.26.3/spec/images/test.svg /tmp/test-images/test.svg
cp /nix/store/p98jdsj0vxjzsfdmff68frydk3db50m2-ruby2.5.3-image_optim-0.26.3/lib/ruby/gems/2.5.0/gems/image_optim-0.26.3/spec/images/transparency1.png /tmp/test-images/transparency1.png
cp /nix/store/p98jdsj0vxjzsfdmff68frydk3db50m2-ruby2.5.3-image_optim-0.26.3/lib/ruby/gems/2.5.0/gems/image_optim-0.26.3/spec/images/transparency2.png /tmp/test-images/transparency2.png
cp /nix/store/p98jdsj0vxjzsfdmff68frydk3db50m2-ruby2.5.3-image_optim-0.26.3/lib/ruby/gems/2.5.0/gems/image_optim-0.26.3/spec/images/vergroessert.jpg /tmp/test-images/vergroessert.jpg
cd ~/projects/nixpkgs
out=$(nix-build ./default.nix -A image_optim)
(cd /tmp/test-images && $out/bin/image_optim --no-threads --verbose --allow-lossy --jpegoptim-allow-lossy true --jpegoptim-max-quality 85 --pngquant-allow-lossy true --pngquant-quality 0..85 -r .)
```

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

have a question: can update bot execute update.sh or similar script to update packages and make pull request with the update?