### PR TITLE
kanshi: init at 2019-02-02

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -523,6 +523,11 @@
     email = "sivaraman.balaji@gmail.com";
     name = "Balaji Sivaraman";
   };
+  balsoft = {
+    email = "balsoft75@gmail.com";
+    github = "balsoft";
+    name = "Alexander Bantyev";
+  };
   bandresen = {
     email = "bandresen@gmail.com";
     github = "bandresen";

--- a/pkgs/tools/misc/kanshi/default.nix
+++ b/pkgs/tools/misc/kanshi/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchFromGitHub, rustPlatform, pkgconfig, libudev }:
+rustPlatform.buildRustPackage 
+{
+  pname = "kanshi-unstable";
+  version = "2019-02-02";
+
+  src = fetchFromGitHub {
+    owner = "emersion";
+    repo = "kanshi";
+    rev = "970267e400c21a6bb51a1c80a0aadfd1e6660a7b";
+    sha256 = "10lfdan86bmwazpma6ixnv46z9cnf879gxln8gx87v7a1x3ss0bh";
+  };
+
+  buildInputs = [ pkgconfig libudev ];
+
+  cargoSha256 = "sha256:0lf1zfmq9ypxk86ma0n4nczbklmjs631wdzfx4wd3cvhghyr8nkq";
+
+  meta = {
+    description = "Dynamic display configuration tool";
+    longDescription = 
+    ''
+    Kanshi uses a configuration file and a list of available displays to choose 
+    the right settings for each display. It's useful if your window manager 
+    doesn't support multiple display configurations (e.g. i3/Sway).
+    
+    For now, it only supports:
+    - sysfs as backend
+    - udev as notifier (optional)
+    - Configuration file
+      - GNOME (~/.config/monitors.xml)
+      - Kanshi (see below)
+    - Sway as frontend
+    '';
+    homepage = "https://github.com/emersion/kanshi";
+    downloadPage = "https://github.com/emersion/kanshi";
+    license = stdenv.lib.licenses.mit;
+    maintainers = stdenv.lib.maintainers.balsoft;
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17969,6 +17969,8 @@ in
 
   kanboard = callPackage ../applications/misc/kanboard { };
 
+  kanshi = callPackage ../tools/misc/kanshi { };
+
   kdeApplications =
     let
       mkApplications = import ../applications/kde;


### PR DESCRIPTION
###### Motivation for this change

This adds kanshi, automatic display manager (primarily for wayland/sway).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

