### PR TITLE
Wikidpad: init at WikidPad-2-3-beta13_01

### DIFF
--- a/pkgs/applications/office/wikidpad/2.3.nix
+++ b/pkgs/applications/office/wikidpad/2.3.nix
@@ -1,0 +1,38 @@
+#References
+# http://trac.wikidpad2.webfactional.com/wiki/InstallLinux
+
+{stdenv, lib, fetchFromGitHub, python27, makeWrapper, wrapGAppsHook}:
+let
+  fetchGitHubJSON = file: fetchFromGitHub { inherit (lib.importJSON file) owner repo rev sha256; };
+
+  # example: nix-shell -p nix-prefetch-github --run 'nix-prefetch-github WikidPad WikidPad --rev WikidPad-2-3-beta13_01 > wikidpad_2_3.json' 
+  src = fetchGitHubJSON ./wikidpad_2_3.json;
+  rev = src.rev;
+
+  python = (python27.withPackages (p: with p; [ wxPython ]));
+in
+  stdenv.mkDerivation {
+    name = "wikidpad-${rev}";
+    version = rev;
+
+    buildInputs = [ makeWrapper ];
+
+    phases = [ "installPhase" ];
+
+    installPhase = ''
+      mkdir -p "$out/bin"
+      makeWrapper '${python}/bin/python' "$out/bin/wikidpad" \
+        --run 'cd ${src}' \
+        --run 'unset GDK_PIXBUF_MODULE_FILE' `#temporary workaround for #54278` \
+        --add-flags '${src}/WikidPad.py'
+      '';
+
+    meta = {
+      description = ''
+        wikidPad is a Wiki-like notebook for storing your thoughts, ideas,
+        todo lists, contacts, or anything else you can think of to write down.
+        '';
+      homepage = "http://wikidpad.sourceforge.net/";
+      license = with lib.licenses; [ bsd2 asl20 ];
+      };
+    }

--- a/pkgs/applications/office/wikidpad/wikidpad_2_3.json
+++ b/pkgs/applications/office/wikidpad/wikidpad_2_3.json
@@ -1,0 +1,6 @@
+{
+    "owner": "WikidPad",
+    "repo": "WikidPad",
+    "rev": "WikidPad-2-3-beta13_01",
+    "sha256": "0mh84i38nfmiby4fsxdnb7wkazp9mfy72ja6jcbgn28vi92fdpha"
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20057,6 +20057,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  wikidpad = callPackage ../applications/office/wikidpad/2.3.nix { };
+
   windowlab = callPackage ../applications/window-managers/windowlab { };
 
   windowmaker = callPackage ../applications/window-managers/windowmaker { };


### PR DESCRIPTION
~~https://github.com/NixOS/nixpkgs/issues/55681~~
Edit: superseded by Superseded by https://github.com/NixOS/nixpkgs/issues/55681, will close after merged.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

