### PR TITLE
chromium: enable vaapi/hw-accel

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -20,10 +20,12 @@
 
 # optional dependencies
 , libgcrypt ? null # gnomeSupport || cupsSupport
+, libva ? null # useVaapi
 
 # package customization
 , enableNaCl ? false
 , enableWideVine ? false
+, useVaapi ? true
 , gnomeSupport ? false, gnome ? null
 , gnomeKeyringSupport ? false, libgnome-keyring3 ? null
 , proprietaryCodecs ? true
@@ -126,6 +128,7 @@ let
     ] ++ optional gnomeKeyringSupport libgnome-keyring3
       ++ optionals gnomeSupport [ gnome.GConf libgcrypt ]
       ++ optionals cupsSupport [ libgcrypt cups ]
+      ++ optional useVaapi libva
       ++ optional pulseSupport libpulseaudio
       ++ optional (versionAtLeast version "72") jdk.jre;
 
@@ -143,6 +146,9 @@ let
       # - https://github.com/chromium/chromium/search?q=GCC&s=committer-date&type=Commits
       #
       # ++ optional (versionRange "68" "72") ( githubPatch "<patch>" "0000000000000000000000000000000000000000000000000000000000000000" )
+    ] ++ optionals (useVaapi) [
+      # source: https://aur.archlinux.org/cgit/aur.git/plain/chromium-vaapi.patch?h=chromium-vaapi
+      ./patches/chromium-vaapi.patch
     ] ++ optionals (!stdenv.cc.isClang && (versionRange "71" "72")) [
       ( githubPatch "65be571f6ac2f7942b4df9e50b24da517f829eec" "1sqv0aba0mpdi4x4f21zdkxz2cf8ji55ffgbfcr88c5gcg0qn2jh" )
     ] ++ optional stdenv.isAarch64
@@ -260,6 +266,8 @@ let
       proprietary_codecs = true;
       enable_hangout_services_extension = true;
       ffmpeg_branding = "Chrome";
+    } // optionalAttrs useVaapi {
+      use_vaapi = true;
     } // optionalAttrs pulseSupport {
       use_pulseaudio = true;
       link_pulseaudio = true;

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -1,6 +1,7 @@
 { newScope, config, stdenv, llvmPackages, gcc8Stdenv, llvmPackages_7
 , makeWrapper, makeDesktopItem, ed
 , glib, gtk3, gnome3, gsettings-desktop-schemas
+, libva ? null
 
 # package customization
 , channel ? "stable"
@@ -10,6 +11,7 @@
 , proprietaryCodecs ? true
 , enablePepperFlash ? false
 , enableWideVine ? false
+, useVaapi ? true
 , cupsSupport ? true
 , pulseSupport ? config.pulseaudio or stdenv.isLinux
 , commandLineArgs ? ""
@@ -32,6 +34,7 @@ in let
     mkChromiumDerivation = callPackage ./common.nix {
       inherit enableNaCl gnomeSupport gnome
               gnomeKeyringSupport proprietaryCodecs cupsSupport pulseSupport
+              useVaapi
               enableWideVine;
     };
 
@@ -92,6 +95,10 @@ in stdenv.mkDerivation {
   buildCommand = let
     browserBinary = "${chromium.browser}/libexec/chromium/chromium";
     getWrapperFlags = plugin: "$(< \"${plugin}/nix-support/wrapper-flags\")";
+    libPath = stdenv.lib.makeLibraryPath ([]
+      ++ stdenv.lib.optional useVaapi libva
+    );
+
   in with stdenv.lib; ''
     mkdir -p "$out/bin"
 
@@ -108,6 +115,8 @@ in stdenv.mkDerivation {
     else
       export CHROME_DEVEL_SANDBOX="$sandbox/bin/${sandboxExecutableName}"
     fi
+
+    export LD_LIBRARY_PATH="\$LD_LIBRARY_PATH:${libPath}"
 
     # libredirect causes chromium to deadlock on startup
     export LD_PRELOAD="\$(echo -n "\$LD_PRELOAD" | tr ':' '\n' | grep -v /lib/libredirect\\\\.so$ | tr '\n' ':')"

--- a/pkgs/applications/networking/browsers/chromium/patches/chromium-vaapi.patch
+++ b/pkgs/applications/networking/browsers/chromium/patches/chromium-vaapi.patch
@@ -1,0 +1,117 @@
+From abc7295ca1653c85472916909f0eb76e28e79a58 Mon Sep 17 00:00:00 2001
+From: Akarshan Biswas <akarshan.biswas@gmail.com>
+Date: Thu, 24 Jan 2019 12:45:29 +0530
+Subject: [PATCH] Enable mojo with VDA2 on Linux
+
+---
+ chrome/browser/about_flags.cc                |  8 ++++----
+ chrome/browser/flag_descriptions.cc          |  9 +++++++--
+ chrome/browser/flag_descriptions.h           | 10 ++++++++--
+ gpu/config/software_rendering_list.json      |  3 ++-
+ media/media_options.gni                      |  9 ++++++---
+ media/mojo/services/gpu_mojo_media_client.cc |  4 ++--
+ 6 files changed, 29 insertions(+), 14 deletions(-)
+
+diff --git a/chrome/browser/about_flags.cc b/chrome/browser/about_flags.cc
+index 0a84c6ac1..be2aa1d8b 100644
+--- a/chrome/browser/about_flags.cc
++++ b/chrome/browser/about_flags.cc
+@@ -1714,7 +1714,7 @@ const FeatureEntry kFeatureEntries[] = {
+         "disable-accelerated-video-decode",
+         flag_descriptions::kAcceleratedVideoDecodeName,
+         flag_descriptions::kAcceleratedVideoDecodeDescription,
+-        kOsMac | kOsWin | kOsCrOS | kOsAndroid,
++        kOsMac | kOsWin | kOsCrOS | kOsAndroid | kOsLinux,
+         SINGLE_DISABLE_VALUE_TYPE(switches::kDisableAcceleratedVideoDecode),
+     },
+ #if defined(OS_WIN)
+@@ -2345,12 +2345,12 @@ const FeatureEntry kFeatureEntries[] = {
+      FEATURE_VALUE_TYPE(service_manager::features::kXRSandbox)},
+ #endif  // ENABLE_ISOLATED_XR_SERVICE
+ #endif  // ENABLE_VR
+-#if defined(OS_CHROMEOS)
++#if defined(OS_CHROMEOS) || defined(OS_LINUX)
+     {"disable-accelerated-mjpeg-decode",
+      flag_descriptions::kAcceleratedMjpegDecodeName,
+-     flag_descriptions::kAcceleratedMjpegDecodeDescription, kOsCrOS,
++     flag_descriptions::kAcceleratedMjpegDecodeDescription, kOsCrOS | kOsLinux,
+      SINGLE_DISABLE_VALUE_TYPE(switches::kDisableAcceleratedMjpegDecode)},
+-#endif  // OS_CHROMEOS
++#endif  // OS_CHROMEOS // OS_LINUX
+     {"v8-cache-options", flag_descriptions::kV8CacheOptionsName,
+      flag_descriptions::kV8CacheOptionsDescription, kOsAll,
+      MULTI_VALUE_TYPE(kV8CacheOptionsChoices)},
+diff --git a/chrome/browser/flag_descriptions.cc b/chrome/browser/flag_descriptions.cc
+index 62637e092..86f89fc6e 100644
+--- a/chrome/browser/flag_descriptions.cc
++++ b/chrome/browser/flag_descriptions.cc
+@@ -3085,15 +3085,20 @@ const char kTextSuggestionsTouchBarDescription[] =
+ 
+ #endif
+ 
+-// Chrome OS -------------------------------------------------------------------
++// Chrome OS Linux-------------------------------------------------------------------
+ 
+-#if defined(OS_CHROMEOS)
++#if defined(OS_CHROMEOS) || (defined(OS_LINUX) && !defined(OS_ANDROID))
+ 
+ const char kAcceleratedMjpegDecodeName[] =
+     "Hardware-accelerated mjpeg decode for captured frame";
+ const char kAcceleratedMjpegDecodeDescription[] =
+     "Enable hardware-accelerated mjpeg decode for captured frame where "
+     "available.";
++#endif
++
++// Chrome OS --------------------------------------------------
++
++#if defined(OS_CHROMEOS)
+ 
+ const char kAllowTouchpadThreeFingerClickName[] = "Touchpad three-finger-click";
+ const char kAllowTouchpadThreeFingerClickDescription[] =
+diff --git a/chrome/browser/flag_descriptions.h b/chrome/browser/flag_descriptions.h
+index 5dac660bb..6cc4115da 100644
+--- a/chrome/browser/flag_descriptions.h
++++ b/chrome/browser/flag_descriptions.h
+@@ -1846,13 +1846,19 @@ extern const char kPermissionPromptPersistenceToggleDescription[];
+ 
+ #endif  // defined(OS_MACOSX)
+ 
+-// Chrome OS ------------------------------------------------------------------
++// Chrome OS and Linux ------------------------------------------------------------------
+ 
+-#if defined(OS_CHROMEOS)
++#if defined(OS_CHROMEOS) || (defined(OS_LINUX) && !defined(OS_ANDROID))
+ 
+ extern const char kAcceleratedMjpegDecodeName[];
+ extern const char kAcceleratedMjpegDecodeDescription[];
+ 
++#endif // defined(OS_CHROMEOS) || (defined(OS_LINUX) && !defined(OS_ANDROID))
++
++// Chrome OS ------------------------------------------------------------------------
++
++#if defined(OS_CHROMEOS)
++
+ extern const char kAllowTouchpadThreeFingerClickName[];
+ extern const char kAllowTouchpadThreeFingerClickDescription[];
+ 
+diff --git a/gpu/config/software_rendering_list.json b/gpu/config/software_rendering_list.json
+index 65f37b3f1..ae8a1718f 100644
+--- a/gpu/config/software_rendering_list.json
++++ b/gpu/config/software_rendering_list.json
+@@ -371,11 +371,12 @@
+     },
+     {
+       "id": 48,
+-      "description": "Accelerated video decode is unavailable on Linux",
++      "description": "Accelerated VA-API video decode is not supported on NVIDIA platforms",
+       "cr_bugs": [137247],
+       "os": {
+         "type": "linux"
+       },
++      "vendor_id": "0x10de",
+       "features": [
+         "accelerated_video_decode"
+       ]
+-- 
+2.20.1
+


### PR DESCRIPTION
###### Motivation for this change

This adds to the chromium derivations:
1. `useVaapi` - Includes the patch to enable vaapi-powered hardware acceleration for Linux by default.
   * enabled by default, following Fedora's steps here

I have tested with all revisions of the browser. You can see screenshots:

* **vaapi**: 
  * [chromium-beta](https://user-images.githubusercontent.com/327028/54499723-24d85480-48d2-11e9-9ac6-38eac7f26208.png)
  * [chromium-dev](https://user-images.githubusercontent.com/327028/54499724-24d85480-48d2-11e9-9ee3-68bd840bf08a.png)
  * [chromium-stable](https://user-images.githubusercontent.com/327028/54499725-24d85480-48d2-11e9-9fc9-a5f32346e887.png)

# TESTING

I have built this exact branch (currently rebased on top of `nixos-unstable`, but targetting `master`).

```
export GDK_BACKEND=x11
export url='https://github.com/colemickens/nixpkgs/archive/chromium-upstream.tar.gz'
o=()
o+=("--option" "narinfo-cache-negative-ttl" "0")
o+=("--option" "binary-caches" "https://cache.nixos.org https://nixpkgs-wayland.cachix.org https://colemickens.cachix.org")
o+=("--option" "substituters" "https://cache.nixos.org https://nixpkgs-wayland.cachix.org https://colemickens.cachix.org")
o+=("--option" "trusted-public-keys" "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= nixpkgs-wayland.cachix.org-1:3lwxaILxMRkVhehr5StQprHdEo4IrE8sRho9R9HOLYA= colemickens.cachix.org-1:oIGbn9aolUT2qKqC78scPcDL6nz7Npgotu644V4aGl4=")

# chromium
$(nix-build "${o[@]}" "${url}" -A chromium)/bin/chromium

# chromiumBeta
$(nix-build "${o[@]}" "${url}" -A chromiumBeta)/bin/chromium

# chromiumDev
$(nix-build "${o[@]}" "${url}" -A chromiumDev)/bin/chromium
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

