### PR TITLE
go: fix darwin sandboxed build

### DIFF
--- a/pkgs/development/compilers/go/1.11.nix
+++ b/pkgs/development/compilers/go/1.11.nix
@@ -112,6 +112,8 @@ stdenv.mkDerivation rec {
     sed -i '/TestCredentialNoSetGroups/areturn' src/os/exec/exec_posix_test.go
     sed -i '/TestRead0/areturn' src/os/os_test.go
     sed -i '/TestSystemRoots/areturn' src/crypto/x509/root_darwin_test.go
+    sed -i '/TestBadLocationErrMsg/areturn' src/time/zoneinfo_test.go
+    sed -i '/TestTerminalSignal/areturn' src/os/signal/signal_cgo_test.go
 
     sed -i '/TestGoInstallRebuildsStalePackagesInOtherGOPATH/areturn' src/cmd/go/go_test.go
     sed -i '/TestBuildDashIInstallsDependencies/areturn' src/cmd/go/go_test.go
@@ -230,6 +232,8 @@ stdenv.mkDerivation rec {
   setupHook = ./setup-hook.sh;
 
   disallowedReferences = [ goBootstrap ];
+
+  __darwinAllowLocalNetworking = true;  # tests need localhost networking
 
   meta = with stdenv.lib; {
     branch = "1.11";

--- a/pkgs/development/compilers/go/1.12.nix
+++ b/pkgs/development/compilers/go/1.12.nix
@@ -110,6 +110,8 @@ stdenv.mkDerivation rec {
     sed -i '/TestCredentialNoSetGroups/areturn' src/os/exec/exec_posix_test.go
     sed -i '/TestRead0/areturn' src/os/os_test.go
     sed -i '/TestSystemRoots/areturn' src/crypto/x509/root_darwin_test.go
+    sed -i '/TestBadLocationErrMsg/areturn' src/time/zoneinfo_test.go
+    sed -i '/TestTerminalSignal/areturn' src/os/signal/signal_cgo_test.go
 
     sed -i '/TestGoInstallRebuildsStalePackagesInOtherGOPATH/areturn' src/cmd/go/go_test.go
     sed -i '/TestBuildDashIInstallsDependencies/areturn' src/cmd/go/go_test.go
@@ -232,6 +234,8 @@ stdenv.mkDerivation rec {
   setupHook = ./setup-hook.sh;
 
   disallowedReferences = [ goBootstrap ];
+
+  __darwinAllowLocalNetworking = true;  # tests need localhost networking
 
   meta = with stdenv.lib; {
     branch = "1.12";


### PR DESCRIPTION
###### Motivation for this change

Extracting 09e36a7c247490f1f11f29c2bf80fce3cb11336d from #57711.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

