### PR TITLE
colord: 1.4.2 -> 1.4.4

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -43,6 +43,7 @@ in
   clickhouse = handleTest ./clickhouse.nix {};
   cloud-init = handleTest ./cloud-init.nix {};
   codimd = handleTest ./codimd.nix {};
+  colord = handleTest ./colord.nix {};
   containers-bridge = handleTest ./containers-bridge.nix {};
   containers-extra_veth = handleTest ./containers-extra_veth.nix {};
   containers-hosts = handleTest ./containers-hosts.nix {};

--- a/nixos/tests/colord.nix
+++ b/nixos/tests/colord.nix
@@ -1,0 +1,18 @@
+# run installed tests
+import ./make-test.nix ({ pkgs, ... }:
+
+{
+  name = "colord";
+
+  meta = {
+    maintainers = pkgs.colord.meta.maintainers;
+  };
+
+  machine = { pkgs, ... }: {
+    environment.systemPackages = with pkgs; [ gnome-desktop-testing ];
+  };
+
+  testScript = ''
+    $machine->succeed("gnome-desktop-testing-runner -d '${pkgs.colord.installedTests}/share'");
+  '';
+})

--- a/pkgs/tools/misc/colord/default.nix
+++ b/pkgs/tools/misc/colord/default.nix
@@ -1,29 +1,92 @@
-{ stdenv, fetchurl, bash-completion
-, glib, polkit, pkgconfig, gettext, gusb, lcms2, sqlite, systemd, dbus
-, gobject-introspection, argyllcms, meson, ninja, libxml2, vala_0_40
-, libgudev, sane-backends, gnome3, makeWrapper }:
+{ stdenv
+, fetchurl
+, bash-completion
+, glib
+, polkit
+, pkgconfig
+, gettext
+, gusb
+, lcms2
+, sqlite
+, systemd
+, dbus
+, gobject-introspection
+, argyllcms
+, meson
+, ninja
+, libxml2
+, vala
+, libgudev
+, wrapGAppsHook
+, shared-mime-info
+, sane-backends
+, docbook_xsl
+, docbook_xsl_ns
+, docbook_xml_dtd_412
+, gtk-doc
+, libxslt
+, substituteAll
+}:
 
 stdenv.mkDerivation rec {
-  name = "colord-1.4.2";
+  pname = "colord";
+  version = "1.4.4";
+
+  outputs = [ "out" "dev" "devdoc" "man" "installedTests" ];
 
   src = fetchurl {
-    url = "https://www.freedesktop.org/software/colord/releases/${name}.tar.xz";
-    sha256 = "19zc9gldz469jshl16av7na459kwr5nhvs2pz98xm5lw582xaw2c";
+    url = "https://www.freedesktop.org/software/colord/releases/${pname}-${version}.tar.xz";
+    sha256 = "19f0938fr7nvvm3jr263dlknaq7md40zrac2npfyz25zc00yh3ws";
   };
 
-  mesonFlags = [
-    "-Denable-sane=true"
-    "-Denable-vala=true"
-    "--localstatedir=/var"
-    "-Denable-bash-completion=true"
-    # TODO: man page cannot be build with docbook2x
-    "-Denable-man=false"
-    "-Denable-docs=false"
+  patches = [
+    # Put installed tests into its own output
+    ./installed-tests-path.patch
   ];
 
-  nativeBuildInputs = [ meson pkgconfig vala_0_40 ninja gettext libxml2 gobject-introspection makeWrapper ];
+  postPatch = ''
+    for file in data/tests/meson.build lib/colord/cd-test-shared.c lib/colord/meson.build; do
+        substituteInPlace $file --subst-var-by installed_tests_dir "$installedTests"
+    done
+  '';
 
-  buildInputs = [ glib polkit gusb lcms2 sqlite systemd dbus bash-completion argyllcms libgudev sane-backends ];
+  mesonFlags = [
+    "--localstatedir=/var"
+    "-Dinstalled_tests=true"
+    "-Dlibcolordcompat=true"
+    "-Dsane=true"
+    "-Dvapi=true"
+  ];
+
+  nativeBuildInputs = [
+    docbook_xml_dtd_412
+    docbook_xsl
+    docbook_xsl_ns
+    gettext
+    gobject-introspection
+    gtk-doc
+    libxslt
+    meson
+    ninja
+    pkgconfig
+    shared-mime-info
+    vala
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    argyllcms
+    bash-completion
+    dbus
+    glib
+    gusb
+    lcms2
+    libgudev
+    polkit
+    sane-backends
+    sqlite
+    systemd
+  ];
 
   postInstall = ''
     glib-compile-schemas $out/share/glib-2.0/schemas
@@ -35,17 +98,11 @@ stdenv.mkDerivation rec {
   PKG_CONFIG_BASH_COMPLETION_COMPLETIONSDIR= "${placeholder "out"}/share/bash-completion/completions";
   PKG_CONFIG_UDEV_UDEVDIR = "${placeholder "out"}/lib/udev";
 
-  postFixup = ''
-    wrapProgram "$out/libexec/colord-session" \
-      --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH:$out/share" \
-      --prefix GIO_EXTRA_MODULES : "${stdenv.lib.getLib gnome3.dconf}/lib/gio/modules"
-  '';
-
-  meta = {
+  meta = with stdenv.lib; {
     description = "System service to manage, install and generate color profiles to accurately color manage input and output devices";
     homepage = https://www.freedesktop.org/software/colord/;
-    license = stdenv.lib.licenses.lgpl2Plus;
-    maintainers = [stdenv.lib.maintainers.marcweber];
-    platforms = stdenv.lib.platforms.linux;
+    license = licenses.lgpl2Plus;
+    maintainers = [ maintainers.marcweber ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/misc/colord/installed-tests-path.patch
+++ b/pkgs/tools/misc/colord/installed-tests-path.patch
@@ -1,0 +1,72 @@
+diff --git a/data/tests/meson.build b/data/tests/meson.build
+index 8b38f10..250582c 100644
+--- a/data/tests/meson.build
++++ b/data/tests/meson.build
+@@ -17,6 +17,6 @@ if get_option('installed_tests')
+       'test.ccss',
+       'test.sp',
+     ],
+-    install_dir: join_paths(libexecdir, 'installed-tests', 'colord')
++    install_dir: join_paths('@installed_tests_dir@', 'libexec', 'installed-tests', 'colord')
+   )
+ endif
+diff --git a/lib/colord/cd-test-shared.c b/lib/colord/cd-test-shared.c
+index c3b9d23..7577e13 100644
+--- a/lib/colord/cd-test-shared.c
++++ b/lib/colord/cd-test-shared.c
+@@ -45,7 +45,8 @@ cd_test_get_filename (const gchar *filename)
+ 
+ 	/* running in the installed system */
+ 	if (g_getenv ("INSTALLED_TESTS") != NULL) {
+-		return g_build_filename (LIBEXECDIR,
++		return g_build_filename ("@installed_tests_dir@",
++					 "libexec",
+ 					 "installed-tests",
+ 					 PACKAGE_NAME,
+ 					 filename,
+diff --git a/lib/colord/meson.build b/lib/colord/meson.build
+index 61f0518..df71358 100644
+--- a/lib/colord/meson.build
++++ b/lib/colord/meson.build
+@@ -214,20 +214,20 @@ endif
+ if get_option('installed_tests')
+ con2 = configuration_data()
+ con2.set('installedtestsdir',
+-         join_paths(libexecdir, 'installed-tests', 'colord'))
++         join_paths('@installed_tests_dir@', 'libexec', 'installed-tests', 'colord'))
+ configure_file(
+   input : 'colord-daemon.test.in',
+   output : 'colord-daemon.test',
+   configuration : con2,
+   install: true,
+-  install_dir: join_paths('share', 'installed-tests', 'colord'),
++  install_dir: join_paths('@installed_tests_dir@', 'share', 'installed-tests', 'colord'),
+ )
+ configure_file(
+   input : 'colord-private.test.in',
+   output : 'colord-private.test',
+   configuration : con2,
+   install: true,
+-  install_dir: join_paths('share', 'installed-tests', 'colord'),
++  install_dir: join_paths('@installed_tests_dir@', 'share', 'installed-tests', 'colord'),
+ )
+ endif
+ 
+@@ -254,7 +254,7 @@ if get_option('tests')
+       '-DTESTDATADIR="' + testdatadir + '"',
+     ],
+     install : get_option('installed_tests'),
+-    install_dir : join_paths(libexecdir, 'installed-tests', 'colord'),
++    install_dir : join_paths('@installed_tests_dir@','libexec', 'installed-tests', 'colord'),
+   )
+   test('colord-test-private', e)
+   e = executable(
+@@ -278,7 +278,7 @@ if get_option('tests')
+       '-DTESTDATADIR="' + testdatadir + '"',
+     ],
+     install : get_option('installed_tests'),
+-    install_dir : join_paths(libexecdir, 'installed-tests', 'colord'),
++    install_dir : join_paths('@installed_tests_dir@', 'libexec', 'installed-tests', 'colord'),
+   )
+   test('colord-test-daemon', e)
+ endif


### PR DESCRIPTION
###### Notable changes

* multiple outputs
* enable all docs
* installed tests

###### News Items
https://github.com/hughsie/colord/blob/1.4.3/NEWS
https://github.com/hughsie/colord/blob/1.4.4/NEWS

###### Possible improvements
1. Normal tests should probably be enabled
2. NixOS test for the installed tests
3. Possibly have `colord` user for the daemon instead of [running as root](https://github.com/hughsie/colord/blob/1.4.4/meson_options.txt#L14)
   This would probably be a good follow up.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

