### PR TITLE
cherry: 1.2 -> 1.3

### DIFF
--- a/pkgs/data/fonts/cherry/default.nix
+++ b/pkgs/data/fonts/cherry/default.nix
@@ -1,15 +1,14 @@
 { stdenv, fetchFromGitHub, bdftopcf }:
 
 stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
   pname = "cherry";
-  version = "1.2";
+  version = "1.3";
 
   src = fetchFromGitHub {
     owner = "turquoise-hexagon";
     repo = pname;
     rev = version;
-    sha256 = "1sfajzndv78v8hb156876i2rw3zw8xys6qi8zr4yi0isgsqj5yx5";
+    sha256 = "1zaiqspf6y0hpszhihdsvsyw33d3ffdap4dym7w45wfrhdpvpi0p";
   };
 
   nativeBuildInputs = [ bdftopcf ];


### PR DESCRIPTION
###### Motivation for this change

https://github.com/turquoise-hexagon/cherry/releases/tag/1.3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---