### PR TITLE
minicom: wrap required binaries

### DIFF
--- a/pkgs/tools/misc/minicom/default.nix
+++ b/pkgs/tools/misc/minicom/default.nix
@@ -1,17 +1,20 @@
-{ stdenv, fetchurl, autoreconfHook, pkgconfig
-, ncurses, libiconv }:
+{ stdenv, fetchgit, autoreconfHook, makeWrapper, pkgconfig
+, lrzsz, ncurses, libiconv }:
 
 stdenv.mkDerivation rec {
-  name = "minicom-2.7.1";
+  name = "minicom-${version}";
+  version = "2.7.1";
 
-  src = fetchurl {
-    url    = "https://alioth.debian.org/frs/download.php/latestfile/3/${name}.tar.gz";
-    sha256 = "1wa1l36fa4npd21xa9nz60yrqwkk5cq713fa3p5v0zk7g9mq6bsk";
+  # The repository isn't tagged properly, so we need to use commit refs
+  src = fetchgit {
+    url    = "https://salsa.debian.org/minicom-team/minicom.git";
+    rev    = "6ea8033b6864aa35d14fb8b87e104e4f783635ce";
+    sha256 = "0j95727xni4r122dalp09963gvc1nqa18l1d4wzz8746kw5s2rrb";
   };
 
   buildInputs = [ ncurses ] ++ stdenv.lib.optional stdenv.isDarwin libiconv;
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  nativeBuildInputs = [ autoreconfHook makeWrapper pkgconfig ];
 
   enableParallelBuilding = true;
 
@@ -26,18 +29,22 @@ stdenv.mkDerivation rec {
     # Have `configure' assume that the lock directory exists.
     substituteInPlace configure \
       --replace 'test -d $UUCPLOCK' true
+  '';
 
-    substituteInPlace src/rwconf.c \
-      --replace /usr/bin/ascii-xfr $out/bin/ascii-xfr
+  postInstall = ''
+    for f in $out/bin/*minicom ; do
+      wrapProgram $f \
+        --prefix PATH : ${stdenv.lib.makeBinPath [ lrzsz ]}:$out/bin
+    done
   '';
 
   meta = with stdenv.lib; {
     description = "Modem control and terminal emulation program";
-    homepage = https://alioth.debian.org/projects/minicom/;
+    homepage = https://salsa.debian.org/minicom-team/minicom;
     license = licenses.gpl2;
     longDescription = ''
-      Minicom is a menu driven communications program.  It emulates ANSI
-      and VT102 terminals.  It has a dialing directory and auto zmodem
+      Minicom is a menu driven communications program. It emulates ANSI
+      and VT102 terminals. It has a dialing directory and auto zmodem
       download.
     '';
     maintainers = with maintainers; [ peterhoeg ];


### PR DESCRIPTION
###### Motivation for this change

Wrap a few needed binaries

Cc: @Enzime @tomfitzhenry 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

