### PR TITLE
llvm: mark as big-parallel

### DIFF
--- a/pkgs/development/compilers/llvm/5/llvm.nix
+++ b/pkgs/development/compilers/llvm/5/llvm.nix
@@ -137,6 +137,7 @@ in stdenv.mkDerivation (rec {
 
   passthru.src = src;
 
+  requiredSystemFeatures = [ "big-parallel" ];
   meta = {
     description = "Collection of modular and reusable compiler and toolchain technologies";
     homepage    = http://llvm.org/;


### PR DESCRIPTION
Big parallel jobs get many more (45) aarch64 cores than standard builds.

Backport of commit 49551b6febb1234257753860da75f670efaee545 .