### PR TITLE
compcert: fix source hash

### DIFF
--- a/pkgs/development/compilers/compcert/default.nix
+++ b/pkgs/development/compilers/compcert/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, fetchpatch, makeWrapper
+{ stdenv, lib, fetchFromGitHub, fetchpatch, makeWrapper
 , coq, ocamlPackages, coq2html
 , tools ? stdenv.cc
 }:
@@ -14,9 +14,11 @@ stdenv.mkDerivation rec {
   name    = "compcert-${version}";
   version = "3.5";
 
-  src = fetchurl {
-    url    = "http://compcert.inria.fr/release/${name}.tgz";
-    sha256 = "127s8nwsmpl7ng7h4yy8cci8p6ncsw8i8jq3z0pyhx2siryddq0v";
+  src = fetchFromGitHub {
+    owner = "AbsInt";
+    repo = "CompCert";
+    rev = "v${version}";
+    sha256 = "1g8067a5x3vd0l47d04gjvy5yx49nghh55am5d1fbrjirfsnsz8j";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -24,7 +26,6 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   patchPhase = ''
-    substituteInPlace ./VERSION --replace 3.4 3.5
     substituteInPlace ./configure \
       --replace '{toolprefix}gcc' '{toolprefix}cc'
   '';


### PR DESCRIPTION
###### Motivation for this change

Current package is broken (the contents of the source tarball have been updated).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

