### PR TITLE
hydra: 2019-02-01 -> 2019-03-18

### DIFF
--- a/pkgs/development/tools/misc/hydra/default.nix
+++ b/pkgs/development/tools/misc/hydra/default.nix
@@ -75,15 +75,15 @@ let
   };
 in releaseTools.nixBuild rec {
   name = "hydra-${version}";
-  version = "2019-02-01";
+  version = "2019-03-18";
 
   inherit stdenv;
 
   src = fetchFromGitHub {
     owner = "NixOS";
     repo = "hydra";
-    rev = "8b5948f4cf12424c04df67a6eb136c9846fb2cfd";
-    sha256 = "0ldk3li394vykl9c4v9bs8pir05pmad24s0rx9bzqgz569zfj2iv";
+    rev = "0721f6623ffb5a4b6a77b499af4eee7d6e4dd6a7";
+    sha256 = "0b2g2bnbaqpwxx8p81i4gpl4y16i57z5pnjm90fpd0jxnkij3pcg";
   };
 
   buildInputs =


### PR DESCRIPTION
###### Motivation for this change

Yesterday we had a discussion about several Hydra-related problems in the #nixos
IRC channel[1], as a result a lot of stalled PRs were merged.

I think that we want to use the latest Hydra now as it contains lots of
new fixes and folks mentioned that they want to use a self-hosted
Hydra, so they probably use the `nixpkgs` package rather than the
expressions from `NixOS/hydra`.

Simply moving to 2019-03-18 should be fine for now as Hydra doesn't have
a release model.

[1] https://logs.nix.samueldr.com/nixos/2019-03-17#2048416;

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

