### PR TITLE
reuse: init at 0.3.4

### DIFF
--- a/pkgs/tools/package-management/reuse/default.nix
+++ b/pkgs/tools/package-management/reuse/default.nix
@@ -1,0 +1,30 @@
+{ lib, python3Packages, fetchFromGitLab }:
+
+with python3Packages;
+
+buildPythonApplication rec {
+  pname = "reuse";
+  version = "0.3.4";
+
+  src = fetchFromGitLab {
+    owner = "reuse";
+    repo = "reuse";
+    rev = "v${version}";
+    sha256 = "07acv02wignrsfhym2i3dhlcs501yj426lnff2cjampl6m5cgsk3";
+  };
+
+  propagatedBuildInputs = [ chardet debian pygit2 ];
+
+  checkInputs = [ pytest jinja2 ];
+
+  # Some path based tests are currently broken under nix
+  checkPhase = ''
+    pytest tests -k "not test_lint_none and not test_lint_ignore_debian and not test_lint_twice_path"
+  '';
+
+  meta = with lib; {
+    description = "A tool for compliance with the REUSE Initiative recommendations";
+    license = with licenses; [ cc-by-sa-40 cc0 gpl3 ];
+    maintainers = [ maintainers.FlorianFranzen ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5403,6 +5403,8 @@ in
 
   rescuetime = callPackage ../applications/misc/rescuetime { };
 
+  reuse = callPackage ../tools/package-management/reuse { };
+
   rewritefs = callPackage ../os-specific/linux/rewritefs { };
 
   rdiff-backup = callPackage ../tools/backup/rdiff-backup { };


### PR DESCRIPTION
###### Motivation for this change

Adds ```reuse```, a tool to automate SPDX bases license handling as part of the [REUSE initative](https://reuse.software).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

