### PR TITLE
python.pkgs.cairocffi: make withXcffib work again

### DIFF
--- a/pkgs/development/python-modules/cairocffi/0_9.nix
+++ b/pkgs/development/python-modules/cairocffi/0_9.nix
@@ -19,9 +19,8 @@
 }@args:
 
 import ./generic.nix ({
-  version = "1.0.2";
-  sha256 = "01ac51ae12c4324ca5809ce270f9dd1b67f5166fe63bd3e497e9ea3ca91946ff";
-  dlopen_patch = ./dlopen-paths.patch;
-  disabled = pythonOlder "3.5";
+  version = "0.9.0";
+  sha256 = "15386c3a9e08823d6826c4491eaccc7b7254b1dc587a3b9ce60c350c3f990337";
+  dlopen_patch = ./dlopen-paths-0.9.patch;
   inherit withXcffib;
 } // args)

--- a/pkgs/development/python-modules/cairocffi/generic.nix
+++ b/pkgs/development/python-modules/cairocffi/generic.nix
@@ -1,0 +1,51 @@
+{ version
+, sha256
+, dlopen_patch
+, disabled ? false
+, ...
+}@args:
+
+with args;
+
+buildPythonPackage rec {
+  pname = "cairocffi";
+  inherit version disabled;
+
+  src = fetchPypi {
+    inherit pname version sha256;
+  };
+
+  LC_ALL = "en_US.UTF-8";
+
+  # checkPhase require at least one 'normal' font and one 'monospace',
+  # otherwise glyph tests fails
+  FONTCONFIG_FILE = makeFontsConf {
+    fontDirectories = [ freefont_ttf ];
+  };
+
+  checkInputs = [ pytest pytestrunner glibcLocales ];
+  propagatedBuildInputs = [ cairo cffi ] ++ lib.optional withXcffib xcffib;
+
+  checkPhase = ''
+    py.test $out/${python.sitePackages}
+  '';
+
+  patches = [
+    # OSError: dlopen() failed to load a library: gdk_pixbuf-2.0 / gdk_pixbuf-2.0-0
+    (substituteAll {
+      src = dlopen_patch;
+      ext = stdenv.hostPlatform.extensions.sharedLibrary;
+      cairo = cairo.out;
+      glib = glib.out;
+      gdk_pixbuf = gdk_pixbuf.out;
+    })
+    ./fix_test_scaled_font.patch
+  ];
+
+  meta = with lib; {
+    homepage = https://github.com/SimonSapin/cairocffi;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [];
+    description = "cffi-based cairo bindings for Python";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1325,9 +1325,10 @@ in {
   canmatrix = callPackage ../development/python-modules/canmatrix {};
 
 
-  cairocffi = let
-    inherit (callPackage ../development/python-modules/cairocffi {}) cairocffi_1_0 cairocffi_0_9;
-  in if isPy3k then cairocffi_1_0 else cairocffi_0_9;
+  cairocffi = if isPy3k then
+    callPackage ../development/python-modules/cairocffi {}
+  else
+    callPackage ../development/python-modules/cairocffi/0_9.nix {};
 
   cairosvg = if isPy3k then
     callPackage ../development/python-modules/cairosvg {}


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/56839#issuecomment-473732643

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @kamilchm @Ma27 