### PR TITLE
pythonPackages.secretstorage: 3.1.0 -> 3.1.1

### DIFF
--- a/pkgs/development/python-modules/secretstorage/default.nix
+++ b/pkgs/development/python-modules/secretstorage/default.nix
@@ -2,14 +2,14 @@
 
 buildPythonPackage rec {
   pname = "secretstorage";
-  version = "3.1.0";
+  version = "3.1.1";
 
   disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     pname = "SecretStorage";
     inherit version;
-    sha256 = "12vxzradibfmznssh7x2zd7qym2hl7wn34fn2yn58pnx6sykrai9";
+    sha256 = "14lznnn916ddn6yrd3w2nr2zq49zc8hw53yjz1k9yhd492p9gir0";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
Normal bump

Also fixes a pythonPackages.cryptography incompatibility.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

