### PR TITLE
olive-editor: init at 0.0.1

### DIFF
--- a/pkgs/applications/video/olive-editor/default.nix
+++ b/pkgs/applications/video/olive-editor/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchFromGitHub, pkgconfig, which, qmake, 
+  qtbase, qtmultimedia, frei0r, opencolorio, hicolor-icon-theme, ffmpeg-full,
+  CoreFoundation  }:
+
+stdenv.mkDerivation {
+  pname = "olive-editor";
+
+  version = "unstable-2019-03-18";
+
+  src = fetchFromGitHub {
+    owner = "olive-editor";
+    repo = "olive";
+    rev = "d153e4d7471122987098087a203323003ae8a128";
+    sha256 = "1gxpz6jg6dqjmvqkk0m9g4pz30lklwx51d73gka404a3w1j5wna6";
+  };
+
+  nativeBuildInputs = [ 
+    pkgconfig 
+    which 
+    qmake
+  ];
+
+  buildInputs = [
+    ffmpeg-full
+    opencolorio
+    qtbase
+    qtmultimedia
+    qtmultimedia.dev
+    hicolor-icon-theme
+  ] ++ stdenv.lib.optional stdenv.isDarwin CoreFoundation
+    ++ stdenv.lib.optional stdenv.isLinux frei0r;
+
+  meta = with stdenv.lib; {
+    description = "Professional open-source NLE video editor";
+    homepage = "https://www.olivevideoeditor.org/";
+    downloadPage = "https://www.olivevideoeditor.org/download.php";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.balsoft ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/video/olive-editor/default.nix
+++ b/pkgs/applications/video/olive-editor/default.nix
@@ -2,16 +2,15 @@
   qtbase, qtmultimedia, frei0r, opencolorio, hicolor-icon-theme, ffmpeg-full,
   CoreFoundation  }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "olive-editor";
-
-  version = "unstable-2019-03-18";
+  version = "0.1.0";
 
   src = fetchFromGitHub {
     owner = "olive-editor";
     repo = "olive";
-    rev = "d153e4d7471122987098087a203323003ae8a128";
-    sha256 = "1gxpz6jg6dqjmvqkk0m9g4pz30lklwx51d73gka404a3w1j5wna6";
+    rev = version;
+    sha256 = "191nk4c35gys4iypykcidn6h27c3sbjfy117q7h9h1qilz2wm94z";
   };
 
   nativeBuildInputs = [ 
@@ -22,13 +21,13 @@ stdenv.mkDerivation {
 
   buildInputs = [
     ffmpeg-full
+    frei0r
     opencolorio
     qtbase
     qtmultimedia
     qtmultimedia.dev
     hicolor-icon-theme
-  ] ++ stdenv.lib.optional stdenv.isDarwin CoreFoundation
-    ++ stdenv.lib.optional stdenv.isLinux frei0r;
+  ] ++ stdenv.lib.optional stdenv.isDarwin CoreFoundation;
 
   meta = with stdenv.lib; {
     description = "Professional open-source NLE video editor";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4644,6 +4644,10 @@ in
 
   ola = callPackage ../applications/misc/ola { };
 
+  olive-editor = libsForQt5.callPackage ../applications/video/olive-editor { 
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation;
+  };
+
   omping = callPackage ../applications/networking/omping { };
 
   onioncircuits = callPackage ../tools/security/onioncircuits { };


### PR DESCRIPTION
###### Motivation for this change

This PR adds olive-editor, which is a professional open-source non-linear video editor written in Qt.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

