### PR TITLE
pdfsandwich: init at 0.1.7

### DIFF
--- a/pkgs/tools/typesetting/pdfsandwich/default.nix
+++ b/pkgs/tools/typesetting/pdfsandwich/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, ocaml, makeWrapper, fetchsvn, ghostscript, imagemagick, perl, poppler_utils, tesseract, unpaper }:
+
+stdenv.mkDerivation rec {
+  version = "0.1.7";
+  pname = "pdfsandwich";
+
+  src = fetchsvn {
+    url = "svn://svn.code.sf.net/p/pdfsandwich/code/trunk/src";
+    rev = "75";
+    sha256 = "1420c33divch087xrr61lvyf975bapqkgjqaighl581i69nlzsm6";
+  };
+
+  buildInputs = [ ocaml perl makeWrapper];
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -p pdfsandwich $out/bin
+    wrapProgram $out/bin/pdfsandwich --prefix PATH : ${stdenv.lib.makeBinPath [ imagemagick ghostscript poppler_utils unpaper tesseract ]}
+
+    mkdir -p $out/man/man1
+    cp -p pdfsandwich.1.gz $out/man/man1
+  '';
+
+meta = with stdenv.lib; {
+    description = "OCR tool for scanned PDFs";
+    homepage = http://www.tobias-elze.de/pdfsandwich/;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.rps ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4850,6 +4850,8 @@ in
 
   pdfcrack = callPackage ../tools/security/pdfcrack { };
 
+  pdfsandwich = callPackage ../tools/typesetting/pdfsandwich { };
+
   pdftag = callPackage ../tools/graphics/pdftag { };
 
   pdf2svg = callPackage ../tools/graphics/pdf2svg { };


### PR DESCRIPTION
###### Motivation for this change

Needed to OCR a PDF. The community was so {nice, helpful, generally wonderful} regarding my last contribution attempt, thought I'd try to package pdfsandwich too. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ X ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ X ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ X ] Assured whether relevant documentation is up to date
- [ X ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

