### PR TITLE
nixos/datadog-agent: change start command

### DIFF
--- a/nixos/modules/services/monitoring/datadog-agent.nix
+++ b/nixos/modules/services/monitoring/datadog-agent.nix
@@ -235,7 +235,7 @@ in {
         '';
         script = ''
           export DD_API_KEY=$(head -n 1 ${cfg.apiKeyFile})
-          exec ${datadogPkg}/bin/agent start -c /etc/datadog-agent/datadog.yaml
+          exec ${datadogPkg}/bin/agent run -c /etc/datadog-agent/datadog.yaml
         '';
         serviceConfig.PermissionsStartOnly = true;
       };


### PR DESCRIPTION
###### Motivation for this change
Command "start" is deprecated

```
мар 18 22:18:21 mail.elven.pw systemd[1]: Stopping Datadog agent monitor...
мар 18 22:18:21 mail.elven.pw systemd[1]: Stopped Datadog agent monitor.
мар 18 22:18:21 mail.elven.pw systemd[1]: Starting Datadog agent monitor...
мар 18 22:18:21 mail.elven.pw systemd[1]: Started Datadog agent monitor.
мар 18 22:18:21 mail.elven.pw sc5hvpws8sykrl453krxba8y8zvxphln-unit-script-datadog-agent-start[6164]: Command "start" is deprecated, Use "run" instead to start the Agent

```
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

