### PR TITLE
ecdsatool: init at 0.0.1

### DIFF
--- a/pkgs/tools/security/default.nix
+++ b/pkgs/tools/security/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, pkgs }:
+
+stdenv.mkDerivation rec {
+  version = "0.0.1";
+  name = "ecdsatool-${version}";
+
+  src = pkgs.fetchFromGitHub {
+    owner = "kaniini";
+    repo = "ecdsatool";
+    rev = "7c0b2c51e2e64d1986ab1dc2c57c2d895cc00ed1";
+    sha256 = "08z9309znkhrjpwqd4ygvm7cd1ha1qbrnlzw64fr8704jrmx762k";
+  };
+
+  configurePhase = ''
+    ./autogen.sh
+    ./configure --prefix=$out
+  '';
+
+  nativeBuildInputs = with pkgs; [openssl autoconf automake];
+  buildInputs = with pkgs; [libuecc];
+
+  meta = with stdenv.lib; {
+    description = "Create and manipulate ECC NISTP256 keypairs.";
+    homepage = https://github.com/kaniini/ecdsatool/;
+    license = with licenses; [free];
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
Added `ecdsatool`, used for ECC NISTP256 keypairs.
This tool is distinct from the similarly names `ecdsautils`.

###### Motivation for this change

Used to setup `glirc2` and other similar IRC clients.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

