### PR TITLE
[19.03] haskellPackages.arbtt: 0.10.1 -> 0.10.2

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1156,7 +1156,13 @@ self: super: {
 
   xmonad-extras = doJailbreak super.xmonad-extras;
 
-  arbtt = doJailbreak super.arbtt;
+  arbtt = overrideCabal super.arbtt (drv: {
+    # See this for context:
+    # https://github.com/NixOS/nixpkgs/commit/7c04e3eb7571ad8ce31a15a22beb11bfe921a387
+    preCheck = ''
+      for n in $PWD/dist/build/*; do PATH+=":$n"; done
+    '';
+  });
 
   # https://github.com/danfran/cabal-macosx/issues/13
   cabal-macosx = dontCheck super.cabal-macosx;


### PR DESCRIPTION
###### Motivation for this change

This is a partial backport of e98e4d21fa6744da13cd08fd4ebf585fdcdb19c2 and 7c04e3eb7571ad8ce31a15a22beb11bfe921a387 to make `arbtt` build again.

Continuation of https://github.com/NixOS/nixpkgs/pull/57585

###### Things done

Also I took care, that upgrading `hackage-packages.nix` will result in a build failure of `arbtt`, as the upgrade should not be silently overwritten. If I see this right, `hackage-packages.nix` should not be upgraded on `release-19.03` anyway.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

