### PR TITLE
maintainers-list.nix: added "growpotkin"

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1840,6 +1840,11 @@
     github = "gridaphobe";
     name = "Eric Seidel";
   };
+  growpotkin = {
+   email = "Alex.Ameen.TX@gmail.com";
+   github = "BadDecisionsAlex";
+   name = "Alex Ameen";
+  };
   guibert = {
     email = "david.guibert@gmail.com";
     github = "dguibert";


### PR DESCRIPTION
Adding myself to maintainers list, hopefully my commit message is okay.

###### Motivation for this change

To list myself on package submissions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

