### PR TITLE
fx_cast: init at 0.0.5

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -8,6 +8,7 @@
 , google_talk_plugin, fribid, gnome3/*.gnome-shell*/
 , browserpass, chrome-gnome-shell, uget-integrator, plasma-browser-integration, bukubrow
 , tridactyl-native
+, fx_cast_bridge
 , udev
 , kerberos
 }:
@@ -70,6 +71,7 @@ let
           ++ lib.optional (cfg.enableGnomeExtensions or false) chrome-gnome-shell
           ++ lib.optional (cfg.enableUgetIntegrator or false) uget-integrator
           ++ lib.optional (cfg.enablePlasmaBrowserIntegration or false) plasma-browser-integration
+          ++ lib.optional (cfg.enableFXCastBridge or false) fx_cast_bridge
           ++ extraNativeMessagingHosts
         );
       libs =   lib.optional stdenv.isLinux udev

--- a/pkgs/tools/misc/fx_cast/default.nix
+++ b/pkgs/tools/misc/fx_cast/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "fx_cast_bridge";
-  version = "0.0.4";
+  version = "0.0.5";
 
   src = fetchurl {
      url = "https://github.com/hensm/fx_cast/releases/download/v${version}/${pname}-${version}-x64.deb";
-     sha256 = "1p6d8idbaaqr80vxrmmyfcr5nwb0sk5vwrmizflg39p5zasmmhy2";
+     sha256 = "1qmp1d7miq7c2q8i4bhfp5ywxdngvyi7rjl6i82is2g5nhr7gbvv";
   };
 
   nativeBuildInputs = [ dpkg ];

--- a/pkgs/tools/misc/fx_cast/default.nix
+++ b/pkgs/tools/misc/fx_cast/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     install -DT {usr,$out}/lib/mozilla/native-messaging-hosts/fx_cast_bridge.json
 
     substituteInPlace $out/lib/mozilla/native-messaging-hosts/fx_cast_bridge.json \
-      --replace {opt/fx_cast,$out/bin}/fx_cast_bridge
+      --replace {/opt/fx_cast,$out/bin}/fx_cast_bridge
   '';
 
   # See now-cli/default.nix

--- a/pkgs/tools/misc/fx_cast/default.nix
+++ b/pkgs/tools/misc/fx_cast/default.nix
@@ -1,0 +1,85 @@
+{ stdenv, fetchurl, dpkg }:
+
+stdenv.mkDerivation rec {
+  pname = "fx_cast_bridge";
+  version = "0.0.3";
+
+  src = fetchurl {
+     url = "https://github.com/hensm/fx_cast/releases/download/v${version}/fx_cast_bridge-${version}-x64.deb";
+     sha256 = "0wqm0spmffn31yd23ych6fjxhzfxhj92379h0qdjh2xr3as4yh4n";
+  };
+
+  nativeBuildInputs = [ dpkg ];
+
+  unpackPhase = ''
+    runHook preUnpack
+    dpkg-deb -x $src ./
+    runHook postUnpack
+  '';
+
+  dontBuild = true;
+  dontPatchELF = true;
+
+  installPhase = ''
+    install -DT {opt/fx_cast,$out/bin}/bridge
+    install -DT {usr,$out}/lib/mozilla/native-messaging-hosts/fx_cast_bridge.json
+
+    substituteInPlace $out/lib/mozilla/native-messaging-hosts/fx_cast_bridge.json \
+      --replace /opt/fx_cast/bridge $out/bin/bridge
+  '';
+
+  # See now-cli/default.nix
+  dontStrip = true;
+  preFixup = let
+    libPath = stdenv.lib.makeLibraryPath [stdenv.cc.cc];
+    bin = "$out/bin/bridge";
+  in ''
+
+    orig_size=$(stat --printf=%s ${bin})
+
+    patchelf --set-interpreter "${stdenv.cc.bintools.dynamicLinker}" ${bin}
+    patchelf --set-rpath ${libPath} ${bin}
+    chmod +x ${bin}
+
+    new_size=$(stat --printf=%s ${bin})
+
+    ###### zeit-pkg fixing starts here.
+    # we're replacing plaintext js code that looks like
+    # PAYLOAD_POSITION = '1234                  ' | 0
+    # [...]
+    # PRELUDE_POSITION = '1234                  ' | 0
+    # ^-----20-chars-----^^------22-chars------^
+    # ^-- grep points here
+    #
+    # var_* are as described above
+    # shift_by seems to be safe so long as all patchelf adjustments occur
+    # before any locations pointed to by hardcoded offsets
+
+    var_skip=20
+    var_select=22
+    shift_by=$(expr $new_size - $orig_size)
+
+    function fix_offset {
+      # $1 = name of variable to adjust
+      location=$(grep -obUam1 "$1" ${bin} | cut -d: -f1)
+      location=$(expr $location + $var_skip)
+
+      value=$(dd if=${bin} iflag=count_bytes,skip_bytes skip=$location \
+                 bs=1 count=$var_select status=none)
+      value=$(expr $shift_by + $value)
+
+      echo -n $value | dd of=${bin} bs=1 seek=$location conv=notrunc
+    }
+
+    fix_offset PAYLOAD_POSITION
+    fix_offset PRELUDE_POSITION
+
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Implementation of the Chrome Sender API (Chromecast) within Firefox";
+    homepage = https://hensm.github.io/fx_cast/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/tools/misc/fx_cast/default.nix
+++ b/pkgs/tools/misc/fx_cast/default.nix
@@ -2,18 +2,18 @@
 
 stdenv.mkDerivation rec {
   pname = "fx_cast_bridge";
-  version = "0.0.3";
+  version = "0.0.4";
 
   src = fetchurl {
      url = "https://github.com/hensm/fx_cast/releases/download/v${version}/fx_cast_bridge-${version}-x64.deb";
-     sha256 = "0wqm0spmffn31yd23ych6fjxhzfxhj92379h0qdjh2xr3as4yh4n";
+     sha256 = "1p6d8idbaaqr80vxrmmyfcr5nwb0sk5vwrmizflg39p5zasmmhy2";
   };
 
   nativeBuildInputs = [ dpkg ];
 
   unpackPhase = ''
     runHook preUnpack
-    dpkg-deb -x $src ./
+    dpkg-deb -xv $src ./
     runHook postUnpack
   '';
 
@@ -21,18 +21,18 @@ stdenv.mkDerivation rec {
   dontPatchELF = true;
 
   installPhase = ''
-    install -DT {opt/fx_cast,$out/bin}/bridge
+    install -DT {opt/fx_cast,$out/bin}/fx_cast_bridge
     install -DT {usr,$out}/lib/mozilla/native-messaging-hosts/fx_cast_bridge.json
 
     substituteInPlace $out/lib/mozilla/native-messaging-hosts/fx_cast_bridge.json \
-      --replace /opt/fx_cast/bridge $out/bin/bridge
+      --replace {opt/fx_cast,$out/bin}/fx_cast_bridge
   '';
 
   # See now-cli/default.nix
   dontStrip = true;
   preFixup = let
     libPath = stdenv.lib.makeLibraryPath [stdenv.cc.cc];
-    bin = "$out/bin/bridge";
+    bin = "$out/bin/fx_cast_bridge";
   in ''
 
     orig_size=$(stat --printf=%s ${bin})

--- a/pkgs/tools/misc/fx_cast/default.nix
+++ b/pkgs/tools/misc/fx_cast/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "0.0.4";
 
   src = fetchurl {
-     url = "https://github.com/hensm/fx_cast/releases/download/v${version}/fx_cast_bridge-${version}-x64.deb";
+     url = "https://github.com/hensm/fx_cast/releases/download/v${version}/${pname}-${version}-x64.deb";
      sha256 = "1p6d8idbaaqr80vxrmmyfcr5nwb0sk5vwrmizflg39p5zasmmhy2";
   };
 
@@ -21,18 +21,18 @@ stdenv.mkDerivation rec {
   dontPatchELF = true;
 
   installPhase = ''
-    install -DT {opt/fx_cast,$out/bin}/fx_cast_bridge
-    install -DT {usr,$out}/lib/mozilla/native-messaging-hosts/fx_cast_bridge.json
+    install -DT {opt/fx_cast,$out/bin}/${pname}
+    install -DT {usr,$out}/lib/mozilla/native-messaging-hosts/${pname}.json
 
-    substituteInPlace $out/lib/mozilla/native-messaging-hosts/fx_cast_bridge.json \
-      --replace {/opt/fx_cast,$out/bin}/fx_cast_bridge
+    substituteInPlace $out/lib/mozilla/native-messaging-hosts/${pname}.json \
+      --replace {/opt/fx_cast,$out/bin}/${pname}
   '';
 
   # See now-cli/default.nix
   dontStrip = true;
   preFixup = let
     libPath = stdenv.lib.makeLibraryPath [stdenv.cc.cc stdenv.cc.libc];
-    bin = "$out/bin/fx_cast_bridge";
+    bin = "$out/bin/${pname}";
   in ''
 
     orig_size=$(stat --printf=%s ${bin})

--- a/pkgs/tools/misc/fx_cast/default.nix
+++ b/pkgs/tools/misc/fx_cast/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   # See now-cli/default.nix
   dontStrip = true;
   preFixup = let
-    libPath = stdenv.lib.makeLibraryPath [stdenv.cc.cc];
+    libPath = stdenv.lib.makeLibraryPath [stdenv.cc.cc stdenv.cc.libc];
     bin = "$out/bin/fx_cast_bridge";
   in ''
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1708,6 +1708,8 @@ in
 
   fwup = callPackage ../tools/misc/fwup { };
 
+  fx_cast_bridge = callPackage ../tools/misc/fx_cast { };
+
   fzf = callPackage ../tools/misc/fzf { };
 
   fzf-zsh = callPackage ../shells/zsh/fzf-zsh { };


### PR DESCRIPTION
###### Motivation for this change

Still beta, but promising!
Used to cast netflix from firefox just now! :D

Fixes #54513.

Add config option to enable when using `firefox` (from source).
This doesn't work with `firefox-bin`,
as with other native-messaging-hosts browser extensions AFAIK,
but does work if you manually symlinks `native-messaging-hosts`
into something like `~/.mozilla/`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---