### PR TITLE
[WIP] gxi: init at 0.5.5

### DIFF
--- a/pkgs/applications/editors/gxi/default.nix
+++ b/pkgs/applications/editors/gxi/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl, desktop-file-utils, gettext,
+  meson, ninja, pkgconfig, rustc, cargo, wrapGAppsHook,
+  cairo, glib, gtk3-x11, pango
+}:
+
+stdenv.mkDerivation rec {
+  name = "gxi-${version}";
+  version = "0.5.5";
+
+  src = fetchurl {
+    url = "https://github.com/Cogitri/gxi/releases/download/v${version}/gxi-${version}.tar.xz";
+    sha256 = "00h7a4qa60b0aljw1vr9pqk1i6g7yjhg9ysgjrsw70w6cfsl39hv";
+  };
+
+  nativeBuildInputs = [
+    meson ninja rustc cargo pkgconfig
+    gettext desktop-file-utils wrapGAppsHook
+  ];
+  buildInputs = [ stdenv cairo glib gtk3-x11 pango ];
+
+  enableParallelBuilding = true;
+
+  preConfigure = ''
+    export DESTDIR=/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "GTK frontend for the xi text editor, written in Rust";
+    homepage = https://gxi.cogitri.dev;
+    license = licenses.mit;
+    maintainers = [ maintainers.jansol ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3177,6 +3177,9 @@ in
   };
 
   gx = callPackage ../tools/package-management/gx { };
+
+  gxi = callPackage ../applications/editors/gxi { };
+
   gx-go = callPackage ../tools/package-management/gx/go { };
 
   efitools = callPackage ../tools/security/efitools { };


### PR DESCRIPTION
###### Motivation for this change

Package all the things!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

