### PR TITLE
Fix FreeCAD build 19.03

### DIFF
--- a/pkgs/development/python-modules/pivy/default.nix
+++ b/pkgs/development/python-modules/pivy/default.nix
@@ -16,8 +16,13 @@ buildPythonPackage rec {
     sha256 = "18n14ha2d3j3ghg2f2aqnf2mks94nn7ma9ii7vkiwcay93zm82cf";
   };
 
+  nativeBuildInputs = with pkgs; [
+    swig1 coin3d soqt
+  ];
+
   buildInputs = with pkgs; with xorg; [
-    swig1 coin3d soqt libGLU_combined
+    coin3d soqt
+    libGLU_combined
     libXi libXext libSM libICE libX11
   ];
 

--- a/pkgs/development/python-modules/pyside/tools.nix
+++ b/pkgs/development/python-modules/pyside/tools.nix
@@ -13,7 +13,9 @@ buildPythonPackage rec {
 
   enableParallelBuilding = true;
 
-  buildInputs = [ cmake pyside qt4 pysideShiboken ];
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ pyside qt4 pysideShiboken ];
 
   meta = {
     description = "Tools for pyside, the LGPL-licensed Python bindings for the Qt cross-platform application and UI framework";

--- a/pkgs/development/python-modules/pyside/tools.nix
+++ b/pkgs/development/python-modules/pyside/tools.nix
@@ -15,7 +15,9 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = [ pyside qt4 pysideShiboken ];
+  buildInputs = [ qt4 ];
+
+  propagatedBuildInputs = [ pyside pysideShiboken ];
 
   meta = {
     description = "Tools for pyside, the LGPL-licensed Python bindings for the Qt cross-platform application and UI framework";


### PR DESCRIPTION
###### Motivation for this change

Some dependencies of FreeCAD have not been building since a recent change to `buildPythonPackage`.  This fixes the python modules necessary for FreeCAD, which should help with
#56826

This PR is only intended to fix the build for 19.03.  There is another PRs which additionally updates a bunch of dependencies (#57121), that should be pulled in in the long run.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

