### PR TITLE
linux: Enable AMD's amdkfd kernel driver in >= 4.20

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -681,6 +681,9 @@ let
       HOTPLUG_PCI_ACPI = yes; # PCI hotplug using ACPI
       HOTPLUG_PCI_PCIE = yes; # PCI-Expresscard hotplug support
 
+      # Enable AMD's ROCm GPU compute stack
+      HSA_AMD = whenAtLeast "4.20" yes;
+
     } // optionalAttrs (stdenv.hostPlatform.system == "x86_64-linux" || stdenv.hostPlatform.system == "aarch64-linux") {
       # Enable memory hotplug support
       # Allows you to dynamically add & remove memory to a VM client running NixOS without requiring a reboot


### PR DESCRIPTION
The `amdkfd` driver was built (and loaded when support was detected)
without explicit configuration in kernels 4.17-4.19, but not in newer
kernels.

###### Motivation for this change

This enables the [https://github.com/nixos-rocm/nixos-rocm](nixos-rocm) packaging of AMD's ROCm software stack (GPGPU programming with the CUDA-like `hip` compiler and `opencl`) to run with an upstream kernel >= 4.20.

The `nixos-rocm` packaging has existed for some time, beginning with custom AMD kernels that incorporated the necessary drivers, then shifting to a focus on upstream kernels with 4.17. [Here is the Issue](https://github.com/nixos-rocm/nixos-rocm/issues/13) where the need for this patch was discovered.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

