### PR TITLE
flatpak: Fix bubblewrap paths for icon-validator

### DIFF
--- a/pkgs/development/libraries/flatpak/bubblewrap-paths.patch
+++ b/pkgs/development/libraries/flatpak/bubblewrap-paths.patch
@@ -1,0 +1,15 @@
+diff --git a/icon-validator/validate-icon.c b/icon-validator/validate-icon.c
+index 6e23d9f2..8c621ec4 100644
+--- a/icon-validator/validate-icon.c
++++ b/icon-validator/validate-icon.c
+@@ -149,8 +149,8 @@ rerun_in_sandbox (const char *arg_width,
+             "--unshare-ipc",
+             "--unshare-net",
+             "--unshare-pid",
+-            "--ro-bind", "/usr", "/usr",
+-            "--ro-bind", "/etc/ld.so.cache", "/etc/ld.so.cache",
++            "--ro-bind", "@storeDir@", "@storeDir@",
++            "--ro-bind", "/run/current-system", "/run/current-system",
+             "--ro-bind", validate_icon, validate_icon,
+             NULL);
+ 

--- a/pkgs/development/libraries/flatpak/default.nix
+++ b/pkgs/development/libraries/flatpak/default.nix
@@ -25,6 +25,10 @@ stdenv.mkDerivation rec {
       src = ./fix-paths.patch;
       p11 = p11-kit;
     })
+    (substituteAll {
+      src = ./bubblewrap-paths.patch;
+      inherit (builtins) storeDir;
+    })
     # patch taken from gtk_doc
     ./respect-xml-catalog-files-var.patch
     ./use-flatpak-from-path.patch


### PR DESCRIPTION
###### Motivation for this change

Otherwise, `flatpak-validate-icon --sandbox` gives error:

    bwrap: Can't find source path /etc/ld.so.cache: No such file or directory

###### Things done

I use the same approach as in https://github.com/NixOS/nixpkgs/blob/e6ccb67e23bce78e152ddcd9a85b6a44651e276f/pkgs/desktops/gnome-3/core/gnome-desktop/bubblewrap-paths.patch

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

