### PR TITLE
catch2: 2.6.0 -> 2.7.0

### DIFF
--- a/pkgs/development/libraries/catch2/default.nix
+++ b/pkgs/development/libraries/catch2/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "catch2-${version}";
-  version = "2.6.0";
+  version = "2.7.0";
 
   src = fetchFromGitHub {
     owner = "catchorg";
     repo = "Catch2";
     rev = "v${version}";
-    sha256="1p2y6fhxfmb48nl03xdg62nfrwssaaiw10vzr194z6srcj90n2r7";
+    sha256="05j01v4hmw0vv5vcj11pbngl200b3j2yvawk08fw9a249jzx6v1a";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
###### Motivation for this change

https://github.com/catchorg/Catch2/releases/tag/v2.7.0
https://github.com/catchorg/Catch2/releases/tag/v2.6.1


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---