### PR TITLE
jumpapp: init at 1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2880,6 +2880,11 @@
     github = "mathnerd314";
     name = "Mathnerd314";
   };
+  matklad = {
+    email = "aleksey.kladov@gmail.com";
+    github = "matklad";
+    name = "matklad";
+  };
   matthewbauer = {
     email = "mjbauer95@gmail.com";
     github = "matthewbauer";

--- a/pkgs/tools/X11/jumpapp/default.nix
+++ b/pkgs/tools/X11/jumpapp/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, lib, perl, pandoc, fetchFromGitHub, xdotool, wmctrl, xprop, nettools }:
+
+stdenv.mkDerivation rec {
+  name = "jumpapp-${version}";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "mkropat";
+    repo = "jumpapp";
+    rev = "v${version}";
+    sha256 = "11ibh51q4vcjkz9fqyw5dy9qrkqxm42hpdccas1s6h2dk9z62kfb";
+  };
+
+  makeFlags = [ "PREFIX=$(out)" ];
+  nativeBuildInputs = [ pandoc perl ];
+  buildInputs = [ xdotool wmctrl xprop nettools perl ];
+  postFixup = let
+    runtimePath = lib.makeBinPath buildInputs;
+  in
+  ''
+    sed -i "2 i export PATH=${runtimePath}:\$PATH" $out/bin/jumpapp
+    sed -i "2 i export PATH=${perl}/bin:\$PATH" $out/bin/jumpappify-desktop-entry
+  '';
+
+  meta = {
+    homepage = https://github.com/mkropat/jumpapp;
+    description = "A run-or-raise application switcher for any X11 desktop";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.matklad ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3652,6 +3652,8 @@ in
 
   jsduck = callPackage ../development/tools/jsduck { };
 
+  jumpapp = callPackage ../tools/X11/jumpapp {};
+
   jucipp = callPackage ../applications/editors/jucipp { };
 
   jupp = callPackage ../applications/editors/jupp { };


### PR DESCRIPTION
###### Motivation for this change

Packaging a useful utility for window management on X11: https://github.com/mkropat/jumpapp

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

