### PR TITLE
ffsend: 0.2.36 -> 0.2.37

### DIFF
--- a/pkgs/tools/misc/ffsend/default.nix
+++ b/pkgs/tools/misc/ffsend/default.nix
@@ -5,17 +5,17 @@
 with rustPlatform;
 
 buildRustPackage rec {
-  name = "ffsend-${version}";
-  version = "0.2.36";
+  pname = "ffsend";
+  version = "0.2.37";
 
   src = fetchFromGitLab {
     owner = "timvisee";
-    repo = "ffsend";
+    repo = pname;
     rev = "v${version}";
-    sha256 = "0k2sl1f5isxj8qajmhf36xh6k9j9qq7nkqm27wfm3gvc6b4flk0r";
+    sha256 = "1c2iihd9abri6019qyl78n7l86pbh7ahy7hp2ijdzhrlsjdanzcr";
   };
 
-  cargoSha256 = "1l4060kawba56gxsngba2yjshhaygrs17k1msjbj38vrg07zrnbp";
+  cargoSha256 = "04gcsjjn3fnc5q0z6jbyd439x4hylyfl912245wmpjchm0k2k22b";
 
   # Note: On Linux, the clipboard feature requires `xclip` to be in the `PATH`. Ideally we'd
   # depend on `xclip` and patch the source to run `xclip` from the Nix store instead of from `PATH`.
@@ -30,8 +30,9 @@ buildRustPackage rec {
   ;
 
   postInstall = ''
-    mkdir -p $out/share/zsh/site-functions
-    cp contrib/completions/zsh/_ffsend $out/share/zsh/site-functions/_ffsend
+    install -DTm755 {contrib/completions,$out/share/zsh/site-functions}/_ffsend
+    install -DTm755 {contrib/completions,$out/share/bash-completion/completions}/ffsend.bash
+    install -DTm755 {contrib/completions,$out/etc/fish/completions}/ffsend.fish
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

https://github.com/timvisee/ffsend/releases/tag/v0.2.37

Required minor touchup to install zsh completion,
install bash and fish completion support while visiting.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---