### PR TITLE
vazir-fonts: init at 19.2.0

### DIFF
--- a/pkgs/data/fonts/vazir-fonts/default.nix
+++ b/pkgs/data/fonts/vazir-fonts/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "vazir-fonts";
+  version = "19.2.0";
+
+  src = fetchFromGitHub {
+    owner = "rastikerdar";
+    repo = "vazir-font";
+    rev = "v${version}";
+    sha256 = "0p96y4q20nhpv7hxca6rncfcb14iqy2vacv0xl55wkwqkm4wvzgr";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/vazir-fonts
+    cp -v $( find . -name '*.ttf') $out/share/fonts/vazir-fonts
+
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/rastikerdar/vazir-font;
+    description = "A Persian (Farsi) Font - قلم (فونت) فارسی وزیر";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = [ maintainers.linarcx ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23055,6 +23055,8 @@ in
 
   vaultenv = haskellPackages.vaultenv;
 
+  vazir-fonts = callPackage ../data/fonts/vazir-fonts { };
+
   vbam = callPackage ../misc/emulators/vbam {
     ffmpeg = ffmpeg_2;
   };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

