### PR TITLE
python.pkgs.joblib: 0.12.4 -> 0.13.2

### DIFF
--- a/pkgs/development/python-modules/joblib/default.nix
+++ b/pkgs/development/python-modules/joblib/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
-, fetchFromGitHub
+, fetchPypi
+, fetchpatch
 , sphinx
 , numpydoc
 , pytest
@@ -10,15 +11,29 @@
 
 buildPythonPackage rec {
   pname = "joblib";
-  version = "0.12.4";
+  version = "0.13.2";
 
-  # get full repository inorder to run tests
-  src = fetchFromGitHub {
-    owner = "joblib";
-    repo = pname;
-    rev = version;
-    sha256 = "06zszgp7wpa4jr554wkk6kkigp4k9n5ad5h08i6w9qih963rlimb";
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "315d6b19643ec4afd4c41c671f9f2d65ea9d787da093487a81ead7b0bac94524";
   };
+
+  # python-lz4 compatibility
+  # https://github.com/joblib/joblib/pull/847
+  patches = [
+    (fetchpatch {
+      url = https://github.com/joblib/joblib/commit/d3235fd601f40c91e074d48a411d7380329fe155.patch;
+      sha256 = "1hg1vfbba7mfilrpvmd97s68v03vs4bhlp1c1dj9lizi51mj2q2h";
+    })
+    (fetchpatch {
+      url = https://github.com/joblib/joblib/commit/884c92cd2aa5c2c1975ab48786da75556d779833.patch;
+      sha256 = "11kvpkvi428dq13ayy7vfyrib8isvcrdw8cd5hxkp5axr7sl12ba";
+    })
+    (fetchpatch {
+      url = https://github.com/joblib/joblib/commit/f1e177d781cc0d64420ec964a0b17d8268cb42a0.patch;
+      sha256 = "1sq6wcw4bhaq8cqwcd43fdws3467qy342xx3pgv62hp2nn75a21d";
+    })
+  ];
 
   checkInputs = [ sphinx numpydoc pytest ];
   propagatedBuildInputs = [ python-lz4 ];


### PR DESCRIPTION
###### Motivation for this change
https://hydra.nixos.org/build/90115526

closes #57176 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @sveitser @FlorianFranzen 