### PR TITLE
pythonPackages.invoke: patch the default bash path

### DIFF
--- a/pkgs/development/python-modules/invoke/default.nix
+++ b/pkgs/development/python-modules/invoke/default.nix
@@ -1,4 +1,5 @@
 { lib
+, bash
 , buildPythonPackage
 , fetchPypi
 }:
@@ -11,6 +12,10 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "1dr1a5qbb9z5hyns4zk086zm0iqbms33zv0s1296wx502y7jyjfw";
   };
+
+  patchPhase = ''
+    sed -e 's|/bin/bash|${bash}/bin/bash|g' -i invoke/config.py
+  '';
 
   # errors with vendored libs
   doCheck = false;


### PR DESCRIPTION
###### Motivation for this change

Use a reasonable default bash path :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

