### PR TITLE
pythonPackages.elasticsearch-curator: Jailbreak click

### DIFF
--- a/pkgs/development/python-modules/elasticsearch-curator/default.nix
+++ b/pkgs/development/python-modules/elasticsearch-curator/default.nix
@@ -45,6 +45,13 @@ buildPythonPackage rec {
     funcsigs
   ];
 
+  postPatch = ''
+    substituteInPlace setup.cfg \
+      --replace 'click>=6.7,<7.0' 'click'
+    substituteInPlace setup.py \
+      --replace 'click>=6.7,<7.0' 'click'
+  '';
+
   meta = with stdenv.lib; {
     homepage = https://github.com/elastic/curator;
     description = "Curate, or manage, your Elasticsearch indices and snapshots";


### PR DESCRIPTION
###### Motivation for this change
Looks like the click bounds were overly strict. ELK tests now pass, but I've not manually checked that curator still works, so verification would be appreciated.

Needs backport to 19.03. cc ZHF #56826 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

