### PR TITLE
nsq: 0.3.5 -> 1.1.0, add nixos/nsq

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -339,6 +339,7 @@
       rss2email = 312;
       cockroachdb = 313;
       zoneminder = 314;
+      nsq = 315;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -638,6 +639,7 @@
       rss2email = 312;
       cockroachdb = 313;
       zoneminder = 314;
+      nsq = 315;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -607,6 +607,7 @@
   ./services/networking/nixops-dns.nix
   ./services/networking/nntp-proxy.nix
   ./services/networking/nsd.nix
+  ./services/networking/nsq.nix
   ./services/networking/ntopng.nix
   ./services/networking/ntpd.nix
   ./services/networking/nullidentdmod.nix

--- a/nixos/modules/services/networking/nsq.nix
+++ b/nixos/modules/services/networking/nsq.nix
@@ -1,0 +1,299 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.nsq;
+
+  # Convert a Nix attrset to TOML by way of JSON:
+  toTOML = name: attrs:
+    pkgs.runCommand "${name}.toml" {
+      buildInputs = [ pkgs.remarshal ];
+    } ''
+      remarshal -if json -of toml \
+        < ${pkgs.writeText "${name}.json" (builtins.toJSON attrs)} \
+        > $out
+    '';
+
+  # Configuration for nsqd as a Nix attrset:
+  nsqdConfig = recursiveUpdate {
+    mem_queue_size = cfg.nsqd.queueSize;
+    data_path = "${cfg.dataDir}/nsqd";
+    tcp_address = "${cfg.nsqd.tcpAddress}:${toString cfg.nsqd.tcpPort}";
+    http_address = "${cfg.nsqd.httpAddress}:${toString cfg.nsqd.httpPort}";
+    https_address = "${cfg.nsqd.httpsAddress}:${toString cfg.nsqd.httpsPort}";
+  } cfg.nsqd.extraConfig;
+
+  # Configuration for nsqd written into the Nix store as TOML:
+  nsqdConfigFile = toTOML "nsqd" nsqdConfig;
+
+  # Configuration for nsqlookupd as a Nix attrset:
+  nsqlookupdConfig = recursiveUpdate {
+    tcp_address = "${cfg.nsqlookupd.tcpAddress}:${toString cfg.nsqlookupd.tcpPort}";
+    http_address = "${cfg.nsqlookupd.httpAddress}:${toString cfg.nsqlookupd.httpPort}";
+  } cfg.nsqlookupd.extraConfig;
+
+  # Configuration for nsqlookupd written into the Nix store as TOML:
+  nsqlookupdConfigFile = toTOML "nsqlookupd" nsqlookupdConfig;
+
+  # Configuration for nsqadmin as a Nix attrset:
+  nsqadminConfig = recursiveUpdate {
+    http_address = "${cfg.nsqadmin.httpAddress}:${toString cfg.nsqadmin.httpPort}";
+    nsqlookupd_http_addresses = cfg.nsqadmin.lookupdHttpAddresses;
+    nsqd_http_addresses = cfg.nsqadmin.nsqdHttpAddresses;
+  } cfg.nsqadmin.extraConfig;
+
+  # Configuration for nsqadmin written into the Nix store as TOML:
+  nsqadminConfigFile = toTOML "nsqadmin" nsqadminConfig;
+
+  # Generate a systemd service:
+  mkService = name: configFile: {
+    description = "${name} NSQ daemon";
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig.User = cfg.user;
+    serviceConfig.Group = cfg.group;
+    serviceConfig.PermissionsStartOnly = true;
+    path = [ cfg.package ];
+
+    preStart = ''
+      mkdir -p ${cfg.dataDir}/${name}
+      chown -R ${cfg.user}:${cfg.group} ${cfg.dataDir}/${name}
+      chmod -R u=rwX,g=rX,o= ${cfg.dataDir}/${name}
+    '';
+
+    script = "${name} -config ${configFile}";
+  };
+
+in
+{
+  #### Interface
+  options.services.nsq = {
+    nsqd = {
+      enable = mkEnableOption "The NSQ message daemon.";
+
+      queueSize = mkOption {
+        type = types.ints.positive;
+        default = 10000;
+        example = 0;
+        description = "Number of messages to keep in memory.";
+      };
+
+      tcpAddress = mkOption {
+        type = types.str;
+        default = "0.0.0.0";
+        example = "127.0.0.1";
+        description = "Address to listen on for TCP clients.";
+      };
+
+      tcpPort = mkOption {
+        type = types.ints.positive;
+        default = 4150;
+        description = "Port number to listen on for TCP clients.";
+      };
+
+      httpAddress = mkOption {
+        type = types.str;
+        default = "0.0.0.0";
+        example = "127.0.0.1";
+        description = "Address to listen on for HTTP clients.";
+      };
+
+      httpPort = mkOption {
+        type = types.ints.positive;
+        default = 4151;
+        description = "Port number to listen on for HTTP clients.";
+      };
+
+      httpsAddress = mkOption {
+        type = types.str;
+        default = "0.0.0.0";
+        example = "127.0.0.1";
+        description = "Address to listen on for HTTPS clients.";
+      };
+
+      httpsPort = mkOption {
+        type = types.ints.positive;
+        default = 4152;
+        description = "Port number to listen on for HTTPS clients.";
+      };
+
+      extraConfig = mkOption {
+        type = types.attrs;
+        default = { };
+        example = { sync_every = 2500; };
+        description = "Extra options to write into the configuration file.";
+      };
+    };
+
+    nsqlookupd = {
+      enable = mkEnableOption "The NSQ topology information daemon.";
+
+      tcpAddress = mkOption {
+        type = types.str;
+        default = "0.0.0.0";
+        example = "127.0.0.1";
+        description = "Address to listen on for TCP clients.";
+      };
+
+      tcpPort = mkOption {
+        type = types.ints.positive;
+        default = 4160;
+        description = "Port number to listen on for TCP clients.";
+      };
+
+      httpAddress = mkOption {
+        type = types.str;
+        default = "0.0.0.0";
+        example = "127.0.0.1";
+        description = "Address to listen on for HTTP clients.";
+      };
+
+      httpPort = mkOption {
+        type = types.ints.positive;
+        default = 4161;
+        description = "Port number to listen on for HTTP clients.";
+      };
+
+      extraConfig = mkOption {
+        type = types.attrs;
+        default = { };
+        example = { inactive_producer_timeout = "300s"; };
+        description = "Extra options to write into the configuration file.";
+      };
+    };
+
+    nsqadmin = {
+      enable = mkEnableOption "The NSQ Web UI.";
+
+      httpAddress = mkOption {
+        type = types.str;
+        default = "0.0.0.0";
+        example = "127.0.0.1";
+        description = "Address to listen on for HTTP clients.";
+      };
+
+      httpPort = mkOption {
+        type = types.ints.positive;
+        default = 4171;
+        description = "Port number to listen on for HTTP clients.";
+      };
+
+      lookupdHttpAddresses = mkOption {
+        type = types.listOf types.str;
+        default = [ "127.0.0.1:4161" ];
+        description = ''
+          List of addresses (with port numbers) where nsqlookupd
+          instances can be reached.
+        '';
+      };
+
+      nsqdHttpAddresses = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        example = [ "127.0.0.1:4151" ];
+        description = ''
+          List of addresses (with port numbers) where nsqd instances
+          can be reached.  This is optional if you have set
+          <option>lookupdHttpAddresses</option>.
+        '';
+      };
+
+      extraConfig = mkOption {
+        type = types.attrs;
+        default = { };
+        example = { statsd_interval = "60s"; };
+        description = "Extra options to write into the configuration file.";
+      };
+    };
+
+    user = mkOption {
+      type = types.str;
+      default = "nsq";
+      description = "User under which the NSQ daemons run.";
+    };
+
+    group = mkOption {
+      type = types.str;
+      default = "nsq";
+      description = "Group under which the NSQ daemons run.";
+    };
+
+    dataDir = mkOption {
+      type = types.path;
+      default = "/var/lib/nsq";
+      description = "Base directory where NSQ can persist files.";
+    };
+
+    openFirewall = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Open firewall ports for enabled NSQ services.";
+    };
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.nsq;
+      description = "The nsq package to use.";
+    };
+  };
+
+  #### Implementation
+  config = mkMerge [
+
+    # Users and groups:
+    (mkIf (cfg.nsqd.enable || cfg.nsqlookupd.enable || cfg.nsqadmin.enable) {
+      users.users = mkIf (cfg.user == "nsq") {
+        nsq = {
+          group = cfg.group;
+          home = cfg.dataDir;
+          uid = config.ids.uids.nsq;
+          description = "NSQ daemon user";
+        };
+      };
+
+      users.groups = mkIf (cfg.group == "nsq") {
+        nsq.gid = config.ids.gids.nsq;
+      };
+    })
+
+    # The nsqd service:
+    (mkIf cfg.nsqd.enable {
+      systemd.services.nsqd = mkService "nsqd" nsqdConfigFile;
+
+      networking.firewall.allowedTCPPorts =
+        optionals cfg.openFirewall [ cfg.nsqd.tcpPort
+                                     cfg.nsqd.httpPort
+                                     cfg.nsqd.httpsPort
+                                   ];
+    })
+
+    # The nsqlookupd service:
+    (mkIf cfg.nsqlookupd.enable {
+      systemd.services.nsqlookupd = mkService "nsqlookupd" nsqlookupdConfigFile;
+
+      networking.firewall.allowedTCPPorts =
+        optionals cfg.openFirewall [ cfg.nsqlookupd.tcpPort
+                                     cfg.nsqlookupd.httpPort
+                                   ];
+    })
+
+    # The nsqadmin service:
+    (mkIf cfg.nsqadmin.enable {
+      assertions = [
+        { assertion = (length cfg.nsqadmin.lookupdHttpAddresses > 0) ||
+                      (length cfg.nsqadmin.nsqdHttpAddresses > 0);
+          message = ''
+            nsqadmin requires that you either set lookupdHttpAddresses
+            or nsqdHttpAddresses.
+          '';
+        }
+      ];
+
+      systemd.services.nsqadmin = mkService "nsqadmin" nsqadminConfigFile;
+
+      networking.firewall.allowedTCPPorts =
+        optional cfg.openFirewall cfg.nsqadmin.httpPort;
+    })
+  ];
+}

--- a/nixos/tests/nsq.nix
+++ b/nixos/tests/nsq.nix
@@ -1,0 +1,31 @@
+# This test runs the NSQ daemons and checks if they are up and running.
+
+import ./make-test.nix ({ pkgs, ... }: {
+  name = "nsq";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ pjones ];
+  };
+
+  nodes = {
+    one = { ... }: {
+      services.nsq = {
+        nsqd.enable = true;
+        nsqlookupd.enable = true;
+        nsqadmin.enable = true;
+      };
+    };
+  };
+
+  testScript = ''
+    startAll;
+
+    $one->waitForUnit("nsqd.service");
+    $one->succeed("curl --fail http://localhost:4151/ping");
+
+    $one->waitForUnit("nsqlookupd.service");
+    $one->succeed("curl --fail http://localhost:4161/ping");
+
+    $one->waitForUnit("nsqadmin.service");
+    $one->succeed("curl --fail http://localhost:4171/ping");
+  '';
+})

--- a/pkgs/servers/nsq/default.nix
+++ b/pkgs/servers/nsq/default.nix
@@ -1,18 +1,25 @@
-{ buildGoPackage, fetchFromGitHub }:
+{ lib, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
   name = "nsq-${version}";
-  version = "0.3.5";
+  version = "1.1.0";
   rev = "v${version}";
 
-  goPackagePath = "github.com/bitly/nsq";
+  goPackagePath = "github.com/nsqio/nsq";
 
   src = fetchFromGitHub {
     inherit rev;
-    owner = "bitly";
+    owner = "nsqio";
     repo = "nsq";
-    sha256 = "1r7jgplzn6bgwhd4vn8045n6cmm4iqbzssbjgj7j1c28zbficy2f";
+    sha256 = "1yl4nnis1ghnhpzaww2irvz22k5p6wvlslsxfmpwk6s0zgdvrk4n";
   };
 
   goDeps = ./deps.nix;
+
+  meta = with lib; {
+    homepage = https://nsq.io/;
+    description = "A realtime distributed messaging platform";
+    license = licenses.mit;
+    maintainers = with maintainers; [ pjones ];
+  };
 }

--- a/pkgs/servers/nsq/deps.nix
+++ b/pkgs/servers/nsq/deps.nix
@@ -1,83 +1,111 @@
+# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
 [
   {
-    goPackagePath = "github.com/mreiferson/go-snappystream";
-    fetch = {
-      type = "git";
-      url = "https://github.com/mreiferson/go-snappystream";
-      rev = "028eae7ab5c4c9e2d1cb4c4ca1e53259bbe7e504";
-      sha256 = "0jdd5whp74nvg35d9hzydsi3shnb1vrnd7shi9qz4wxap7gcrid6";
-    };
-  }
-  {
-    goPackagePath = "github.com/bitly/go-nsq";
-    fetch = {
-      type = "git";
-      url = "https://github.com/bitly/go-nsq";
-      rev = "22a8bd48c443ec23bb559675b6df8284bbbdab29";
-      sha256 = "06hrkwk84w8rshkanvfgmgbiml7n06ybv192dvibhwgk2wz2dl46";
-    };
-  }
-  {
-    goPackagePath = "github.com/bitly/go-simplejson";
-    fetch = {
-      type = "git";
-      url = "https://github.com/bitly/go-simplejson";
-      rev = "18db6e68d8fd9cbf2e8ebe4c81a78b96fd9bf05a";
-      sha256 = "0lj9cxyncchlw6p35j0yym5q5waiz0giw6ri41qdwm8y3dghwwiy";
-    };
-  }
-  {
-    goPackagePath = "github.com/blang/semver";
-    fetch = {
-      type = "git";
-      url = "https://github.com/blang/semver";
-      rev = "9bf7bff48b0388cb75991e58c6df7d13e982f1f2";
-      sha256 = "11sinbf942dpyc9wdpidkhmqn438cfp5n8x3xqnmq9aszkld9hy7";
-    };
-  }
-  {
-    goPackagePath = "github.com/bmizerany/perks";
-    fetch = {
-      type = "git";
-      url = "https://github.com/bmizerany/perks";
-      rev = "6cb9d9d729303ee2628580d9aec5db968da3a607";
-      sha256 = "0cdh84hmn21is6hvv6dy9qjdcg9w3l2k8avlk0881a8cqm09s90j";
-    };
-  }
-  {
-    goPackagePath = "github.com/BurntSushi/toml";
+    goPackagePath  = "github.com/BurntSushi/toml";
     fetch = {
       type = "git";
       url = "https://github.com/BurntSushi/toml";
-      rev = "056c9bc7be7190eaa7715723883caffa5f8fa3e4";
-      sha256 = "0gkgkw04ndr5y7hrdy0r4v2drs5srwfcw2bs1gyas066hwl84xyw";
+      rev =  "2dff11163ee667d51dcc066660925a92ce138deb";
+      sha256 = "0sf0jm448mj5lz3pir1xfxvaib0f8b3qyyynhywzz72f6y5qb4lr";
     };
   }
   {
-    goPackagePath = "github.com/bitly/go-hostpool";
+    goPackagePath  = "github.com/bitly/go-hostpool";
     fetch = {
       type = "git";
       url = "https://github.com/bitly/go-hostpool";
-      rev = "d0e59c22a56e8dadfed24f74f452cea5a52722d2";
-      sha256 = "14ph12krn5zlg00vh9g6g08lkfjxnpw46nzadrfb718yl1hgyk3g";
+      rev =  "a3a6125de9329587178a9792dc8f4bc98e620d2d";
+      sha256 = "1m82mvnfw6k2ylpn598bcsg8mdgbq4fnsk7yc23hpvps9glsrbb6";
     };
   }
   {
-    goPackagePath = "github.com/bitly/timer_metrics";
+    goPackagePath  = "github.com/bitly/timer_metrics";
     fetch = {
       type = "git";
       url = "https://github.com/bitly/timer_metrics";
-      rev = "afad1794bb13e2a094720aeb27c088aa64564895";
+      rev =  "afad1794bb13e2a094720aeb27c088aa64564895";
       sha256 = "1b717vkwj63qb5kan4b92kx4rg6253l5mdb3lxpxrspy56a6rl0c";
     };
   }
   {
-    goPackagePath = "github.com/mreiferson/go-options";
+    goPackagePath  = "github.com/blang/semver";
+    fetch = {
+      type = "git";
+      url = "https://github.com/blang/semver";
+      rev =  "9bf7bff48b0388cb75991e58c6df7d13e982f1f2";
+      sha256 = "11sinbf942dpyc9wdpidkhmqn438cfp5n8x3xqnmq9aszkld9hy7";
+    };
+  }
+  {
+    goPackagePath  = "github.com/bmizerany/perks";
+    fetch = {
+      type = "git";
+      url = "https://github.com/bmizerany/perks";
+      rev =  "6cb9d9d729303ee2628580d9aec5db968da3a607";
+      sha256 = "0cdh84hmn21is6hvv6dy9qjdcg9w3l2k8avlk0881a8cqm09s90j";
+    };
+  }
+  {
+    goPackagePath  = "github.com/golang/snappy";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/snappy";
+      rev =  "d9eb7a3d35ec988b8585d4a0068e462c27d28380";
+      sha256 = "0wynarlr1y8sm9y9l29pm9dgflxriiialpwn01066snzjxnpmbyn";
+    };
+  }
+  {
+    goPackagePath  = "github.com/judwhite/go-svc";
+    fetch = {
+      type = "git";
+      url = "https://github.com/judwhite/go-svc";
+      rev =  "63c12402f579f0bdf022653c821a1aa5d7544f01";
+      sha256 = "020n68m2wwrm6hmppidqcznf824645fdpxs1l0w7cskgb3akm70y";
+    };
+  }
+  {
+    goPackagePath  = "github.com/julienschmidt/httprouter";
+    fetch = {
+      type = "git";
+      url = "https://github.com/julienschmidt/httprouter";
+      rev =  "6aacfd5ab513e34f7e64ea9627ab9670371b34e7";
+      sha256 = "00rrjysmq898qcrf2hfwfh9s70vwvmjx2kp5w03nz1krxa4zhrkl";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mreiferson/go-options";
     fetch = {
       type = "git";
       url = "https://github.com/mreiferson/go-options";
-      rev = "7c174072188d0cfbe6f01bb457626abb22bdff52";
-      sha256 = "0ksyi2cb4k6r2fxamljg42qbz5hdcb9kv5i7y6cx4ajjy0xznwgm";
+      rev =  "77551d20752b54535462404ad9d877ebdb26e53d";
+      sha256 = "02c18zrx038gbas58l90xzsz9m5q3gpjprdcwmnvxsn0zvld0vpj";
+    };
+  }
+  {
+    goPackagePath  = "github.com/nsqio/go-diskqueue";
+    fetch = {
+      type = "git";
+      url = "https://github.com/nsqio/go-diskqueue";
+      rev =  "0681a1afee1245efa503b7543989fc26d8f268bc";
+      sha256 = "110lipm5nzij2an4yxs3kn5lrwhslfr1lr2z4yzbl3v2xp2j0hjs";
+    };
+  }
+  {
+    goPackagePath  = "github.com/nsqio/go-nsq";
+    fetch = {
+      type = "git";
+      url = "https://github.com/nsqio/go-nsq";
+      rev =  "a53d495e81424aaf7a7665a9d32a97715c40e953";
+      sha256 = "04npqz6ajr4r2w5jfvfzppr307qrwr57w4c1ppq9p9ddf7hx3wpz";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev =  "661970f62f5897bc0cd5fdca7e087ba8a98a8fa1";
+      sha256 = "0669k1b255xm6a9xl6szvv7wcxfb4c50rqx3za4gsxh2dwpii83n";
     };
   }
 ]


### PR DESCRIPTION
###### Motivation for this change

Upgrade nsq to the latest release and create a NixOS module for it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

