### PR TITLE
mcos-xfce-edition: init at  8d90e10

### DIFF
--- a/pkgs/data/themes/mcos-xfce-edition/default.nix
+++ b/pkgs/data/themes/mcos-xfce-edition/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, gtk-engine-murrine }:
+
+stdenv.mkDerivation rec {
+  name = "mcos-xfce-edition";
+
+  src = fetchFromGitHub {
+    owner = "paullinuxthemer";
+    repo = "McOS-XFCE-Edition";
+    rev = "8d90e108377e89359e69d83c83099195b6c98f10";
+    sha256 = "0vvag2gakcsd60ypgkz86s7alhddwk2axgq85v7n4hrda21nhswy";
+  };
+
+  propagatedUserEnvPkgs = [ gtk-engine-murrine ];
+
+  installPhase = ''
+    mkdir -p $out/share/themes
+    cp -r 'McOS-XFCE-Edition-II' $out/share/themes
+    cp -r 'McOS-XFCE-Edition' $out/share/themes
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Mac OS-themes for the XFCE desktop";
+    homepage = https://github.com/paullinuxthemer/McOS-XFCE-Edition;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.linarcx ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18311,6 +18311,8 @@ in
 
   mcomix = callPackage ../applications/graphics/mcomix { };
 
+  mcos-xfce-edition = callPackage ../data/themes/mcos-xfce-edition { };
+
   mendeley = libsForQt5.callPackage ../applications/office/mendeley {
     gconf = pkgs.gnome2.GConf;
   };


### PR DESCRIPTION
###### Motivation for this change
https://www.xfce-look.org/p/1210386/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

