### PR TITLE
alsa-{oss,tools}: 1.1.6 -> 1.1.8

### DIFF
--- a/pkgs/os-specific/linux/alsa-oss/default.nix
+++ b/pkgs/os-specific/linux/alsa-oss/default.nix
@@ -1,7 +1,8 @@
 {stdenv, fetchurl, alsaLib, gettext, ncurses, libsamplerate}:
 
 stdenv.mkDerivation rec {
-  name = "alsa-oss-1.1.8";
+  name = "alsa-oss-${version}";
+  version = "1.1.8";
 
   src = fetchurl {
     url = "mirror://alsa/oss-lib/${name}.tar.bz2";

--- a/pkgs/os-specific/linux/alsa-oss/default.nix
+++ b/pkgs/os-specific/linux/alsa-oss/default.nix
@@ -1,11 +1,11 @@
 {stdenv, fetchurl, alsaLib, gettext, ncurses, libsamplerate}:
 
 stdenv.mkDerivation rec {
-  name = "alsa-oss-${version}";
+  pname = "alsa-oss";
   version = "1.1.8";
 
   src = fetchurl {
-    url = "mirror://alsa/oss-lib/${name}.tar.bz2";
+    url = "mirror://alsa/oss-lib/${pname}-${version}.tar.bz2";
     sha256 = "13nn6n6wpr2sj1hyqx4r9nb9bwxnhnzw8r2f08p8v13yjbswxbb4";
   };
 

--- a/pkgs/os-specific/linux/alsa-plugins/default.nix
+++ b/pkgs/os-specific/linux/alsa-plugins/default.nix
@@ -15,6 +15,10 @@ stdenv.mkDerivation rec {
     ++ lib.optional (libpulseaudio != null) libpulseaudio
     ++ lib.optional (libjack2 != null) libjack2;
 
+  configureFlags = [
+    "--with-alsalconfdir=${placeholder "out"}/etc/alsa/conf.d"
+  ];
+
   meta = with lib; {
     description = "Various plugins for ALSA";
     homepage = http://alsa-project.org/;

--- a/pkgs/os-specific/linux/alsa-plugins/default.nix
+++ b/pkgs/os-specific/linux/alsa-plugins/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchurl, lib, pkgconfig, alsaLib, libogg, libpulseaudio ? null, libjack2 ? null }:
 
 stdenv.mkDerivation rec {
-  name = "alsa-plugins-1.1.6";
+  name = "alsa-plugins-${version}";
+  version = "1.1.8";
 
   src = fetchurl {
     url = "mirror://alsa/plugins/${name}.tar.bz2";
-    sha256 = "04qcwkisbh0d6lnh0rw1k6n869fbs6zbfq6yvb41rymiwgmk27bg";
+    sha256 = "152r82i6f97gfilfgiax5prxkd4xlcipciv8ha8yrk452qbxyxvz";
   };
 
   # ToDo: a52, etc.?

--- a/pkgs/os-specific/linux/alsa-plugins/default.nix
+++ b/pkgs/os-specific/linux/alsa-plugins/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, lib, pkgconfig, alsaLib, libogg, libpulseaudio ? null, libjack2 ? null }:
 
 stdenv.mkDerivation rec {
-  name = "alsa-plugins-${version}";
+  pname = "alsa-plugins";
   version = "1.1.8";
 
   src = fetchurl {
-    url = "mirror://alsa/plugins/${name}.tar.bz2";
+    url = "mirror://alsa/plugins/${pname}-${version}.tar.bz2";
     sha256 = "152r82i6f97gfilfgiax5prxkd4xlcipciv8ha8yrk452qbxyxvz";
   };
 


### PR DESCRIPTION
###### Motivation for this change

`alsa-oss` and `alsa-tools` were outdated. They were probably outdated because the `version` was not a variable that automated updaters could pick up.

This PR also separates version from name and updates the version.

EDIT: In the meantime alsa-oss was updated to 1.1.8. There is no version bump for this package in this PR, but this PR does split name from version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

