### PR TITLE
python.pkgs.hglib: use patch to specify hg path

### DIFF
--- a/pkgs/development/python-modules/hglib/default.nix
+++ b/pkgs/development/python-modules/hglib/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, nose, mercurial, isPy3k }:
+{ stdenv, buildPythonPackage, fetchPypi, substituteAll, python, nose, mercurial }:
 
 buildPythonPackage rec {
   pname = "python-hglib";
@@ -9,11 +9,18 @@ buildPythonPackage rec {
     sha256 = "7c1fa0cb4d332dd6ec8409b04787ceba4623e97fb378656f7cab0b996c6ca3b2";
   };
 
-  checkInputs = [ nose ];
-  buildInputs = [ mercurial ];
+  patches = [
+    (substituteAll {
+      src = ./hgpath.patch;
+      hg = "${mercurial}/bin/hg";
+    })
+  ];
 
-  checkPhase = ''python test.py'';
-  doCheck = if isPy3k then false else true;
+  checkInputs = [ nose ];
+
+  checkPhase = ''
+    ${python.interpreter} test.py --with-hg "${mercurial}/bin/hg"
+  '';
 
   meta = with stdenv.lib; {
     description = "Mercurial Python library";

--- a/pkgs/development/python-modules/hglib/hgpath.patch
+++ b/pkgs/development/python-modules/hglib/hgpath.patch
@@ -1,0 +1,24 @@
+diff -r 2d0ec6097d78 hglib/__init__.py
+--- a/hglib/__init__.py	Mon Apr 30 15:43:29 2018 +0900
++++ b/hglib/__init__.py	Tue Mar 19 23:30:01 2019 +0100
+@@ -1,7 +1,7 @@
+ import subprocess
+ from hglib import client, util, error
+ 
+-HGPATH = 'hg'
++HGPATH = '@hg@'
+ 
+ def open(path=None, encoding=None, configs=None):
+     '''starts a cmdserver for the given path (or for a repository found
+diff -r 2d0ec6097d78 tests/common.py
+--- a/tests/common.py	Mon Apr 30 15:43:29 2018 +0900
++++ b/tests/common.py	Tue Mar 19 23:30:01 2019 +0100
+@@ -26,7 +26,7 @@
+         os.mkdir(self._testtmp)
+         os.chdir(self._testtmp)
+         # until we can run norepo commands in the cmdserver
+-        os.system('hg init')
++        os.system('@hg@ init')
+         self.client = hglib.open()
+ 
+     def tearDown(self):


### PR DESCRIPTION
###### Motivation for this change
fix the build

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @dfoxfranke @disassembler 