### PR TITLE
purescript: fix purescript derivation using easy-purescript-nix

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2370,6 +2370,11 @@
     github = "juliendehos";
     name = "Julien Dehos";
   };
+  justinwoo = {
+    email = "moomoowoo@gmail.com";
+    github = "justinwoo";
+    name = "Justin Woo";
+  };
   jwiegley = {
     email = "johnw@newartisans.com";
     github = "jwiegley";

--- a/pkgs/development/compilers/purescript/purescript/default.nix
+++ b/pkgs/development/compilers/purescript/purescript/default.nix
@@ -50,4 +50,11 @@ in stdenv.mkDerivation rec {
     mkdir -p $out/etc/bash_completion.d/
     $PURS --bash-completion-script $PURS > $out/etc/bash_completion.d/purs-completion.bash
   '';
+    meta = with stdenv.lib; {
+    description = "A strongly-typed functional programming language that compiles to JavaScript";
+    homepage = http://www.purescript.org/;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.justinwoo ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+  };
 }

--- a/pkgs/development/compilers/purescript/purescript/default.nix
+++ b/pkgs/development/compilers/purescript/purescript/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, zlib, gmp, ncurses5 }:
+{ stdenv, fetchurl, zlib, gmp, ncurses5, lib }:
 
 # from justinwoo/easy-purescript-nix
 # https://github.com/justinwoo/easy-purescript-nix/blob/d383972c82620a712ead4033db14110497bc2c9c/purs.nix
@@ -50,7 +50,7 @@ in stdenv.mkDerivation rec {
     mkdir -p $out/etc/bash_completion.d/
     $PURS --bash-completion-script $PURS > $out/etc/bash_completion.d/purs-completion.bash
   '';
-    meta = with stdenv.lib; {
+  meta = with stdenv.lib; {
     description = "A strongly-typed functional programming language that compiles to JavaScript";
     homepage = http://www.purescript.org/;
     license = licenses.bsd3;

--- a/pkgs/development/compilers/purescript/purescript/default.nix
+++ b/pkgs/development/compilers/purescript/purescript/default.nix
@@ -1,13 +1,13 @@
-{ pkgs ? import <nixpkgs> {} }:
+{ stdenv, fetchurl, zlib, gmp, ncurses5 }:
 
 # from justinwoo/easy-purescript-nix
 # https://github.com/justinwoo/easy-purescript-nix/blob/d383972c82620a712ead4033db14110497bc2c9c/purs.nix
 
 let
-  dynamic-linker = pkgs.stdenv.cc.bintools.dynamicLinker;
+  dynamic-linker = stdenv.cc.bintools.dynamicLinker;
 
   patchelf = libPath :
-    if pkgs.stdenv.isDarwin
+    if stdenv.isDarwin
       then ""
       else
         ''
@@ -16,28 +16,28 @@ let
           chmod u-w $PURS
         '';
 
-in pkgs.stdenv.mkDerivation rec {
+in stdenv.mkDerivation rec {
   name = "purs-simple";
   version = "v0.12.3";
 
   src =
-    if pkgs.stdenv.isDarwin
+    if stdenv.isDarwin
     then
-    pkgs.fetchurl {
+    fetchurl {
       url = "https://github.com/purescript/purescript/releases/download/v0.12.3/macos.tar.gz";
       sha256 = "1f916gv4fz571l4jvr15xjnsvjyy4nljv2ii9njwlm7k6yr5m0qn";
     }
     else
-    pkgs.fetchurl {
+    fetchurl {
       url = "https://github.com/purescript/purescript/releases/download/v0.12.3/linux64.tar.gz";
       sha256 = "1fad862a2sv4njxbbcfzibbi585m6is3ywb94nmjl8ax254baj3i";
     };
 
 
-  buildInputs = [ pkgs.zlib
-                  pkgs.gmp
-                  pkgs.ncurses5];
-  libPath = pkgs.lib.makeLibraryPath buildInputs;
+  buildInputs = [ zlib
+                  gmp
+                  ncurses5 ];
+  libPath = lib.makeLibraryPath buildInputs;
   dontStrip = true;
 
   installPhase = ''

--- a/pkgs/development/compilers/purescript/purescript/default.nix
+++ b/pkgs/development/compilers/purescript/purescript/default.nix
@@ -1,0 +1,11 @@
+{ fetchFromGitHub }:
+
+let
+  easyPS = import (fetchFromGitHub {
+    owner = "justinwoo";
+    repo = "easy-purescript-nix";
+    rev = "d383972c82620a712ead4033db14110497bc2c9c";
+    sha256 = "0hj85y3k0awd21j5s82hkskzp4nlzhi0qs4npnv172kaac03x8ms";
+  });
+
+in easyPS.purs

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7137,7 +7137,7 @@ in
 
   all-cabal-hashes = callPackage ../data/misc/hackage { };
 
-  purescript = callPackage ../development/compilers/purescript/purescript { inherit pkgs; };
+  purescript = callPackage ../development/compilers/purescript/purescript { };
 
   psc-package = haskell.lib.justStaticExecutables
     (haskellPackages.callPackage ../development/compilers/purescript/psc-package { });

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7137,7 +7137,7 @@ in
 
   all-cabal-hashes = callPackage ../data/misc/hackage { };
 
-  purescript = callPackage ../development/compilers/purescript/purescript {};
+  purescript = callPackage ../development/compilers/purescript/purescript { inherit pkgs; };
 
   psc-package = haskell.lib.justStaticExecutables
     (haskellPackages.callPackage ../development/compilers/purescript/psc-package { });

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7137,8 +7137,8 @@ in
 
   all-cabal-hashes = callPackage ../data/misc/hackage { };
 
-  # Build with ghc 8.4 due to https://github.com/NixOS/nixpkgs/issues/53597
-  purescript = haskell.lib.justStaticExecutables haskell.packages.ghc844.purescript;
+  purescript = callPackage ../development/compilers/purescript/purescript {};
+
   psc-package = haskell.lib.justStaticExecutables
     (haskellPackages.callPackage ../development/compilers/purescript/psc-package { });
 


### PR DESCRIPTION
###### Motivation for this change

For the past couple of years, there has continued to be problems with having the PureScript compiler on nixpkgs building from Haskell packages it is not built against in its actual development and release. We have seen this issue come up multiple times here on nixpkgs, but this also causes numerous issues to be filed against the PureScript compiler repository. One example of an exchange that has occurred multiple times in the past: https://github.com/NixOS/nixpkgs/issues/53597 https://github.com/purescript/purescript/issues/3571. As noted, the PureScript compiler is not on Stackage because it is not meant to be used as a library, and it does not update itself to the latest LTS and cut releases to match LTS releases.

Instead, I have begun maintaining my own derivation for the PureScript compiler (among other tools) in a small project here: https://github.com/justinwoo/easy-purescript-nix. Within are other reference and derivations for other tools commonly used in the PureScript ecosystem, updated to their respective newest releases. These derivations use the same releases that other Linux and OSX users use, along with the standard application of patchELF to provide for runtime dependencies such as zlib, gmp, and ncurses5. These derivations are now used by a variety of NixOS, non-NixOS Linux, and OSX users.

This commit then consumes the easy-purescript-nix derivation for the PureScript compiler and provides it in all-packages for consumption.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

