### PR TITLE
[backport] nixos/tests/predictable-interfaces: fix failure on aarch64

### DIFF
--- a/nixos/tests/predictable-interface-names.nix
+++ b/nixos/tests/predictable-interface-names.nix
@@ -20,8 +20,7 @@ in pkgs.lib.listToAttrs (pkgs.lib.crossLists (predictable: withNetworkd: {
 
     testScript = ''
       print $machine->succeed("ip link");
-      $machine->succeed("ip link show ${if predictable then "ens3" else "eth0"}");
-      $machine->fail("ip link show ${if predictable then "eth0" else "ens3"}");
+      $machine->${if predictable then "fail" else "succeed"}("ip link show eth0 ");
     '';
   };
 }) [[true false] [true false]])


### PR DESCRIPTION
###### Motivation for this change
Backport fix for #56826 

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via nixosTeste.predictable-interface-names.*
- [ ] Tested compilation of all pkgs that depend on this change
- [ ] Tested execution of all binary files
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
Explanation: on aarch64 the interfaces is called enp3s0 instead of ens3, for some reason. Since the "predictable" naming scheme may be deterministic but not that predictable, to avoid future failure (new architectures or changes in qemu) I simply check wheter the traditional scheme (eth*) is used.