### PR TITLE
stagit: 0.6 -> 0.9.1

### DIFF
--- a/pkgs/development/tools/stagit/default.nix
+++ b/pkgs/development/tools/stagit/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "stagit-${version}";
-  version = "0.6";
+  version = "0.9.1";
 
   src = fetchgit {
     url = git://git.codemadness.org/stagit;
     rev = version;
-    sha256 = "1xwjdqkf5akxa66ak7chd9gna89kgbdzjrpx4ch7f770ycp2s5sr";
+    sha256 = "0gh28spkry9wbmdj0hmvz3680fvbyzab9cifhj1p76f4fz27rnv9";
   };
 
   makeFlags = "PREFIX=$(out)";


### PR DESCRIPTION
###### Motivation for this change

more recent version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@jb55 