### PR TITLE
libconfig: 1.5 -> 1.7.2, enable tests

### DIFF
--- a/pkgs/development/libraries/libconfig/default.nix
+++ b/pkgs/development/libraries/libconfig/default.nix
@@ -1,13 +1,15 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "libconfig-${version}";
-  version = "1.5";
+  pname = "libconfig";
+  version = "1.7.2";
 
   src = fetchurl {
-    url = "http://www.hyperrealm.com/libconfig/${name}.tar.gz";
-    sha256 = "e31daa390d8e4461c8830512fe2e13ba1a3d6a02a2305a02429eec61e68703f6";
+    url = "https://hyperrealm.github.io/${pname}/dist/${pname}-${version}.tar.gz";
+    sha256 = "1ngs2qx3cx5cbwinc5mvadly0b5n7s86zsc68c404czzfff7lg3w";
   };
+
+  doCheck = true;
 
   meta = with stdenv.lib; {
     homepage = http://www.hyperrealm.com/libconfig;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---