### PR TITLE
ffsend: 0.2.36 -> 0.2.38

### DIFF
--- a/pkgs/tools/misc/ffsend/default.nix
+++ b/pkgs/tools/misc/ffsend/default.nix
@@ -1,38 +1,42 @@
 { stdenv, fetchFromGitLab, rustPlatform, cmake, pkgconfig, openssl
 , darwin
+
+, x11Support ? stdenv.isLinux
+, xclip ? null
 }:
+
+assert x11Support -> xclip != null;
 
 with rustPlatform;
 
 buildRustPackage rec {
   name = "ffsend-${version}";
-  version = "0.2.36";
+  version = "0.2.38";
 
   src = fetchFromGitLab {
     owner = "timvisee";
     repo = "ffsend";
     rev = "v${version}";
-    sha256 = "0k2sl1f5isxj8qajmhf36xh6k9j9qq7nkqm27wfm3gvc6b4flk0r";
+    sha256 = "1kxxcqyilbhzcsnddlf7ha3dd57qj82yvbb9jsssimnlcskx84hx";
   };
 
-  cargoSha256 = "1l4060kawba56gxsngba2yjshhaygrs17k1msjbj38vrg07zrnbp";
-
-  # Note: On Linux, the clipboard feature requires `xclip` to be in the `PATH`. Ideally we'd
-  # depend on `xclip` and patch the source to run `xclip` from the Nix store instead of from `PATH`.
-  # However, as I use macOS and not Linux, I'm not inclined to maintain a patch like that, nor do I
-  # have a means to test it. To that end, we'll just leave the clipboard feature enabled and
-  # trust that users that want to copy links to their clipboard will install `xclip` into their
-  # profile.
+  cargoSha256 = "1qxvm2pz01na6nijdn0hlv5hxshiz3pfy6km7n9hjyakwi684a0l";
 
   nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [ openssl ]
   ++ stdenv.lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ CoreFoundation CoreServices Security AppKit ])
   ;
 
+  preBuild = if x11Support then ''
+    export XCLIP_PATH="${xclip}/bin/xclip"
+  '' else null;
+
   postInstall = ''
-    mkdir -p $out/share/zsh/site-functions
-    cp contrib/completions/zsh/_ffsend $out/share/zsh/site-functions/_ffsend
+    install -Dm644 contrib/completions/_ffsend "$out/share/zsh/site-functions/_ffsend"
+    install -Dm644 contrib/completions/ffsend.bash "$out/share/bash-completion/completions/ffsend.bash"
+    install -Dm644 contrib/completions/ffsend.fish "$out/share/fish/vendor_completions.d/ffsend.fish"
   '';
+  # There's also .elv and .ps1 completion files but I don't know where to install those
 
   meta = with stdenv.lib; {
     description = "Easily and securely share files from the command line. A fully featured Firefox Send client";


### PR DESCRIPTION
###### Motivation for this change
Also add support for `xclip` on Linux.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [X] other Linux distributions (Docker using `nixos/nix` image)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Tested both Darwin and (using Docker) Linux. The Linux version was tested without an X11 server, but I got the expected "Error: Can't open display: (null)" output from `xclip` when running `./result/bin/ffsend u -c foo` so it seems to have invoked `xclip` correctly.