### PR TITLE
ir-standard-fonts: init at d36727d

### DIFF
--- a/pkgs/data/fonts/ir-standard-fonts/default.nix
+++ b/pkgs/data/fonts/ir-standard-fonts/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  name = "ir-standard-fonts";
+  pname = "ir-standard-fonts";
+  version= "unstable-2017-01-21";
 
   src = fetchFromGitHub {
     owner = "morealaz";
-    repo = "ir-standard-fonts";
+    repo = pname;
     rev = "d36727d6c38c23c01b3074565667a2fe231fe18f";
     sha256 = "1ks9q1r1gk2517yfr1fbgrdbgw0w97i4am6jqn5ywpgm2xd03yg1";
   };
@@ -17,8 +18,9 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = https://github.com/morealaz/ir-standard-fonts;
-    description = "Iran Supreme Council of Information and Communication Technology (SCICT) standard Persian fonts series.";
-    license = licenses.unlicense;
+    description = "Iran Supreme Council of Information and Communication Technology (SCICT) standard Persian fonts series";
+    # License information is unavailable.
+    license = licenses.unfree;
     platforms = platforms.all;
     maintainers = [ maintainers.linarcx ];
   };

--- a/pkgs/data/fonts/ir-standard-fonts/default.nix
+++ b/pkgs/data/fonts/ir-standard-fonts/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "ir-standard-fonts";
+
+  src = fetchFromGitHub {
+    owner = "morealaz";
+    repo = "ir-standard-fonts";
+    rev = "d36727d6c38c23c01b3074565667a2fe231fe18f";
+    sha256 = "1ks9q1r1gk2517yfr1fbgrdbgw0w97i4am6jqn5ywpgm2xd03yg1";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/ir-standard-fonts
+    cp -v $( find . -name '*.ttf') $out/share/fonts/ir-standard-fonts
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/morealaz/ir-standard-fonts;
+    description = "Iran Supreme Council of Information and Communication Technology (SCICT) standard Persian fonts series.";
+    license = licenses.unlicense;
+    platforms = platforms.all;
+    maintainers = [ maintainers.linarcx ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1571,6 +1571,8 @@ in
 
   ipvsadm = callPackage ../os-specific/linux/ipvsadm { };
 
+  ir-standard-fonts = callPackage ../data/fonts/ir-standard-fonts { };
+
   lynis = callPackage ../tools/security/lynis { };
 
   mathics = pythonPackages.mathics;


### PR DESCRIPTION
###### Motivation for this change
Basic fonts for persian users.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

