### PR TITLE
lua: std._debug / std.normalize rename + move to automated.

### DIFF
--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -22,6 +22,8 @@ luaffi,,http://luarocks.org/dev,
 luuid,
 penlight,
 say,
+std__debug,std._debug,
+std_normalize,std.normalize,
 luv,
 luasystem,
 mediator_lua,,http://luarocks.org/manifests/teto

--- a/maintainers/scripts/update-luarocks-packages
+++ b/maintainers/scripts/update-luarocks-packages
@@ -81,7 +81,7 @@ function convert_pkg () {
 		server=" --server=$3"
 	fi
 
-    version="${3:-}"
+    version="${4:-}"
 
     echo "looking at $lua_pkg_name (version $version) from server [$server]" >&2
     cmd="luarocks nix $server $lua_pkg_name $version"

--- a/pkgs/development/interpreters/lua-5/build-lua-package.nix
+++ b/pkgs/development/interpreters/lua-5/build-lua-package.nix
@@ -150,6 +150,9 @@ builtins.removeAttrs attrs ["disabled" "checkInputs"] // {
   installPhase = attrs.installPhase or ''
     runHook preInstall
 
+    # work around failing luarocks test for Write access
+    mkdir -p $out
+
     # luarocks make assumes sources are available in cwd
     # After the build is complete, it also installs the rock.
     # If no argument is given, it looks for a rockspec in the current directory

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -14,13 +14,13 @@ ansicolors = buildLuarocksPackage {
   pname = "ansicolors";
   version = "1.0.2-3";
 
-  src =  fetchurl {
+  src = fetchurl {
       url    = https://luarocks.org/ansicolors-1.0.2-3.src.rock;
       sha256 = "1mhmr090y5394x1j8p44ws17sdwixn5a0r4i052bkfgk3982cqfz";
-   };
+  };
   disabled = ( luaOlder "5.1");
-  propagatedBuildInputs = [lua  ];
-  buildType="builtin";
+  propagatedBuildInputs = [ lua ];  
+  buildType = "builtin";
 
   meta = {
     homepage = "https://github.com/kikito/ansicolors.lua";
@@ -34,13 +34,13 @@ argparse = buildLuarocksPackage {
   pname = "argparse";
   version = "0.6.0-1";
 
-  src =  fetchurl {
+  src = fetchurl {
       url    = https://luarocks.org/argparse-0.6.0-1.src.rock;
       sha256 = "10ic5wppyghd1lmgwgl0lb40pv8z9fi9i87080axxg8wsr19y0p4";
-   };
+  };
   disabled = ( luaOlder "5.1") || ( luaAtLeast "5.4");
-  propagatedBuildInputs = [lua  ];
-  buildType="builtin";
+  propagatedBuildInputs = [ lua ];  
+  buildType = "builtin";
 
   meta = {
     homepage = "https://github.com/mpeterv/argparse";
@@ -54,13 +54,13 @@ basexx = buildLuarocksPackage {
   pname = "basexx";
   version = "0.4.0-1";
 
-  src =  fetchurl {
+  src = fetchurl {
       url    = https://luarocks.org/basexx-0.4.0-1.src.rock;
       sha256 = "1px8yrxg1qkk3kzdqj3siry742jdv4ysp2dmicxi15mkynqpjlzz";
-   };
+  };
   disabled = ( luaOlder "5.1");
-  propagatedBuildInputs = [lua  ];
-  buildType="builtin";
+  propagatedBuildInputs = [ lua ];  
+  buildType = "builtin";
 
   meta = {
     homepage = "https://github.com/aiq/basexx";
@@ -74,13 +74,13 @@ dkjson = buildLuarocksPackage {
   pname = "dkjson";
   version = "2.5-2";
 
-  src =  fetchurl {
+  src = fetchurl {
       url    = https://luarocks.org/dkjson-2.5-2.src.rock;
       sha256 = "1qy9bzqnb9pf9d48hik4iq8h68aw3270kmax7mmpvvpw7kkyp483";
-   };
+  };
   disabled = ( luaOlder "5.1") || ( luaAtLeast "5.4");
-  propagatedBuildInputs = [lua  ];
-  buildType="builtin";
+  propagatedBuildInputs = [ lua ];  
+  buildType = "builtin";
 
   meta = {
     homepage = "http://dkolf.de/src/dkjson-lua.fsl/";
@@ -94,13 +94,13 @@ fifo = buildLuarocksPackage {
   pname = "fifo";
   version = "0.2-0";
 
-  src =  fetchurl {
+  src = fetchurl {
       url    = https://luarocks.org/fifo-0.2-0.src.rock;
       sha256 = "082c5g1m8brnsqj5gnjs65bm7z50l6b05cfwah14lqaqsr5a5pjk";
-   };
-
-  propagatedBuildInputs = [lua  ];
-  buildType="builtin";
+  };
+  
+  propagatedBuildInputs = [ lua ];  
+  buildType = "builtin";
 
   meta = {
     homepage = "https://github.com/daurnimator/fifo.lua";
@@ -114,13 +114,13 @@ inspect = buildLuarocksPackage {
   pname = "inspect";
   version = "3.1.1-0";
 
-  src =  fetchurl {
+  src = fetchurl {
       url    = https://luarocks.org/inspect-3.1.1-0.src.rock;
       sha256 = "0k4g9ahql83l4r2bykfs6sacf9l1wdpisav2i0z55fyfcdv387za";
-   };
+  };
   disabled = ( luaOlder "5.1");
-  propagatedBuildInputs = [lua  ];
-  buildType="builtin";
+  propagatedBuildInputs = [ lua ];  
+  buildType = "builtin";
 
   meta = {
     homepage = "https://github.com/kikito/inspect.lua";
@@ -134,13 +134,13 @@ lgi = buildLuarocksPackage {
   pname = "lgi";
   version = "0.9.2-1";
 
-  src =  fetchurl {
+  src = fetchurl {
       url    = https://luarocks.org/lgi-0.9.2-1.src.rock;
       sha256 = "07ajc5pdavp785mdyy82n0w6d592n96g95cvq025d6i0bcm2cypa";
-   };
+  };
   disabled = ( luaOlder "5.1");
-  propagatedBuildInputs = [lua  ];
-  buildType="make";
+  propagatedBuildInputs = [ lua ];  
+  buildType = "make";
 
   meta = {
     homepage = "http://github.com/pavouk/lgi";
@@ -154,13 +154,13 @@ lpeg_patterns = buildLuarocksPackage {
   pname = "lpeg_patterns";
   version = "0.5-0";
 
-  src =  fetchurl {
+  src = fetchurl {
       url    = https://luarocks.org/lpeg_patterns-0.5-0.src.rock;
       sha256 = "0mlw4nayrsdxrh98i26avz5i4170a9brciybw88kks496ra36v8f";
-   };
-
-  propagatedBuildInputs = [lua lpeg  ];
-  buildType="builtin";
+  };
+  
+  propagatedBuildInputs = [ lua lpeg ];  
+  buildType = "builtin";
 
   meta = {
     homepage = "https://github.com/daurnimator/lpeg_patterns/archive/v0.5.zip";
@@ -174,13 +174,13 @@ lpty = buildLuarocksPackage {
   pname = "lpty";
   version = "1.2.2-1";
 
-  src =  fetchurl {
+  src = fetchurl {
       url    = https://luarocks.org/lpty-1.2.2-1.src.rock;
       sha256 = "1vxvsjgjfirl6ranz6k4q4y2dnxqh72bndbk400if22x8lqbkxzm";
-   };
+  };
   disabled = ( luaOlder "5.1");
-  propagatedBuildInputs = [lua  ];
-  buildType="make";
+  propagatedBuildInputs = [ lua ];  
+  buildType = "make";
 
   meta = {
     homepage = "http://www.tset.de/lpty/";
@@ -194,13 +194,13 @@ lrexlib-gnu = buildLuarocksPackage {
   pname = "lrexlib-gnu";
   version = "2.9.0-1";
 
-  src =  fetchurl {
+  src = fetchurl {
       url    = https://luarocks.org/lrexlib-gnu-2.9.0-1.src.rock;
       sha256 = "036rda4rji1pbnbxk1nzjy5zmigdsiacqbzrbvciwq3lrxa2j5s2";
-   };
+  };
   disabled = ( luaOlder "5.1");
-  propagatedBuildInputs = [lua  ];
-  buildType="builtin";
+  propagatedBuildInputs = [ lua ];  
+  buildType = "builtin";
 
   meta = {
     homepage = "http://github.com/rrthomas/lrexlib";
@@ -214,13 +214,13 @@ lrexlib-posix = buildLuarocksPackage {
   pname = "lrexlib-posix";
   version = "2.9.0-1";
 
-  src =  fetchurl {
+  src = fetchurl {
       url    = https://luarocks.org/lrexlib-posix-2.9.0-1.src.rock;
       sha256 = "0ifpybf4m94g1nk70l0f5m45gph0rbp5wrxrl1hnw8ibv3mc1b1r";
-   };
+  };
   disabled = ( luaOlder "5.1");
-  propagatedBuildInputs = [lua  ];
-  buildType="builtin";
+  propagatedBuildInputs = [ lua ];  
+  buildType = "builtin";
 
   meta = {
     homepage = "http://github.com/rrthomas/lrexlib";
@@ -234,13 +234,13 @@ ltermbox = buildLuarocksPackage {
   pname = "ltermbox";
   version = "0.2-1";
 
-  src =  fetchurl {
+  src = fetchurl {
       url    = https://luarocks.org/ltermbox-0.2-1.src.rock;
       sha256 = "08jqlmmskbi1ml1i34dlmg6hxcs60nlm32dahpxhcrgjnfihmyn8";
-   };
+  };
   disabled = ( luaOlder "5.1");
-  propagatedBuildInputs = [lua  ];
-  buildType="builtin";
+  propagatedBuildInputs = [ lua ];  
+  buildType = "builtin";
 
   meta = {
     homepage = "http://code.google.com/p/termbox";
@@ -254,12 +254,12 @@ lua-cmsgpack = buildLuarocksPackage {
   pname = "lua-cmsgpack";
   version = "0.4.0-0";
 
-  knownRockspec = ( fetchurl {
+         knownRockspec = (fetchurl {
       url    = https://luarocks.org/lua-cmsgpack-0.4.0-0.rockspec;
       sha256 = "10cvr6knx3qvjcw1q9v05f2qy607mai7lbq321nx682aa0n1fzin";
-   }).outPath;
+  }).outPath;
 
-   src =  fetchgit ( removeAttrs (builtins.fromJSON ''{
+       src = fetchgit ( removeAttrs (builtins.fromJSON ''{
   "url": "git://github.com/antirez/lua-cmsgpack.git",
   "rev": "57b1f90cf6cec46450e87289ed5a676165d31071",
   "date": "2018-06-14T11:56:56+02:00",
@@ -267,10 +267,10 @@ lua-cmsgpack = buildLuarocksPackage {
   "fetchSubmodules": true
 }
  '') ["date"]) ;
-
+       
   disabled = ( luaOlder "5.1");
-  propagatedBuildInputs = [lua  ];
-  buildType="builtin";
+  propagatedBuildInputs = [ lua ];  
+  buildType = "builtin";
 
   meta = {
     homepage = "http://github.com/antirez/lua-cmsgpack";
@@ -284,13 +284,13 @@ lua_cliargs = buildLuarocksPackage {
   pname = "lua_cliargs";
   version = "3.0-2";
 
-  src =  fetchurl {
+  src = fetchurl {
       url    = https://luarocks.org/lua_cliargs-3.0-2.src.rock;
       sha256 = "0qqdnw00r16xbyqn4w1xwwpg9i9ppc3c1dcypazjvdxaj899hy9w";
-   };
+  };
   disabled = ( luaOlder "5.1");
-  propagatedBuildInputs = [lua  ];
-  buildType="builtin";
+  propagatedBuildInputs = [ lua ];  
+  buildType = "builtin";
 
   meta = {
     homepage = "https://github.com/amireh/lua_cliargs";
@@ -304,13 +304,13 @@ lua-iconv = buildLuarocksPackage {
   pname = "lua-iconv";
   version = "7-3";
 
-  src =  fetchurl {
+  src = fetchurl {
       url    = https://luarocks.org/lua-iconv-7-3.src.rock;
       sha256 = "03xibhcqwihyjhxnzv367q4bfmzmffxl49lmjsq77g0prw8v0q83";
-   };
+  };
   disabled = ( luaOlder "5.1");
-  propagatedBuildInputs = [lua  ];
-  buildType="builtin";
+  propagatedBuildInputs = [ lua ];  
+  buildType = "builtin";
 
   meta = {
     homepage = "http://ittner.github.com/lua-iconv/";
@@ -324,19 +324,19 @@ lua-term = buildLuarocksPackage {
   pname = "lua-term";
   version = "0.7-1";
 
-  knownRockspec = ( fetchurl {
+         knownRockspec = (fetchurl {
       url    = https://luarocks.org/lua-term-0.7-1.rockspec;
       sha256 = "0r9g5jw7pqr1dyj6w58dqlr7y7l0jp077n8nnji4phf10biyrvg2";
-   }).outPath;
+  }).outPath;
 
-   src =  fetchurl {
+       src = fetchurl {
       url    = https://github.com/hoelzro/lua-term/archive/0.07.tar.gz;
       sha256 = "0c3zc0cl3a5pbdn056vnlan16g0wimv0p9bq52h7w507f72x18f1";
-   };
-
-
-
-  buildType="builtin";
+  };
+       
+  
+    
+  buildType = "builtin";
 
   meta = {
     homepage = "https://github.com/hoelzro/lua-term";
@@ -346,36 +346,16 @@ lua-term = buildLuarocksPackage {
     };
   };
 };
-luaevent = buildLuarocksPackage {
-  pname = "luaevent";
-  version = "0.4.6-1";
-
-  src =  fetchurl {
-      url    = https://luarocks.org/luaevent-0.4.6-1.src.rock;
-      sha256 = "0chq09nawiz00lxd6pkdqcb8v426gdifjw6js3ql0lx5vqdkb6dz";
-   };
-  disabled = ( luaOlder "5.1");
-  propagatedBuildInputs = [lua  ];
-  buildType="builtin";
-
-  meta = {
-    homepage = "https://github.com/harningt/luaevent";
-    description="libevent binding for Lua";
-    license = {
-      fullName = "MIT";
-    };
-  };
-};
 luabitop = buildLuarocksPackage {
   pname = "luabitop";
   version = "1.0.2-3";
 
-  knownRockspec = ( fetchurl {
+         knownRockspec = (fetchurl {
       url    = https://luarocks.org/luabitop-1.0.2-3.rockspec;
       sha256 = "07y2h11hbxmby7kyhy3mda64w83p4a6p7y7rzrjqgc0r56yjxhcc";
-   }).outPath;
+  }).outPath;
 
-   src =  fetchgit ( removeAttrs (builtins.fromJSON ''{
+       src = fetchgit ( removeAttrs (builtins.fromJSON ''{
   "url": "git://github.com/LuaDist/luabitop.git",
   "rev": "81bb23b0e737805442033535de8e6d204d0e5381",
   "date": "2013-02-18T16:36:42+01:00",
@@ -383,10 +363,10 @@ luabitop = buildLuarocksPackage {
   "fetchSubmodules": true
 }
  '') ["date"]) ;
-
+       
   disabled = ( luaOlder "5.1") || ( luaAtLeast "5.3");
-  propagatedBuildInputs = [lua  ];
-  buildType="builtin";
+  propagatedBuildInputs = [ lua ];  
+  buildType = "builtin";
 
   meta = {
     homepage = "http://bitop.luajit.org/";
@@ -396,17 +376,37 @@ luabitop = buildLuarocksPackage {
     };
   };
 };
+luaevent = buildLuarocksPackage {
+  pname = "luaevent";
+  version = "0.4.6-1";
+
+  src = fetchurl {
+      url    = https://luarocks.org/luaevent-0.4.6-1.src.rock;
+      sha256 = "0chq09nawiz00lxd6pkdqcb8v426gdifjw6js3ql0lx5vqdkb6dz";
+  };
+  disabled = ( luaOlder "5.1");
+  propagatedBuildInputs = [ lua ];  
+  buildType = "builtin";
+
+  meta = {
+    homepage = "https://github.com/harningt/luaevent";
+    description="libevent binding for Lua";
+    license = {
+      fullName = "MIT";
+    };
+  };
+};
 luacheck = buildLuarocksPackage {
   pname = "luacheck";
   version = "0.23.0-1";
 
-  src =  fetchurl {
+  src = fetchurl {
       url    = https://luarocks.org/luacheck-0.23.0-1.src.rock;
       sha256 = "0akj61c7k1na2mggsckvfn9a3ljfp4agnmr9gp3mac4vin99a1cl";
-   };
+  };
   disabled = ( luaOlder "5.1") || ( luaAtLeast "5.4");
-  propagatedBuildInputs = [lua argparse luafilesystem  ];
-  buildType="builtin";
+  propagatedBuildInputs = [ lua argparse luafilesystem ];  
+  buildType = "builtin";
 
   meta = {
     homepage = "https://github.com/mpeterv/luacheck";
@@ -420,13 +420,13 @@ luaffi = buildLuarocksPackage {
   pname = "luaffi";
   version = "scm-1";
 
-  src =  fetchurl {
+  src = fetchurl {
       url    = http://luarocks.org/dev/luaffi-scm-1.src.rock;
       sha256 = "0dia66w8sgzw26bwy36gzyb2hyv7kh9n95lh5dl0158rqa6fsf26";
-   };
+  };
   disabled = ( luaOlder "5.1");
-  propagatedBuildInputs = [lua  ];
-  buildType="builtin";
+  propagatedBuildInputs = [ lua ];  
+  buildType = "builtin";
 
   meta = {
     homepage = "https://github.com/facebook/luaffifb";
@@ -440,13 +440,13 @@ luuid = buildLuarocksPackage {
   pname = "luuid";
   version = "20120509-2";
 
-  src =  fetchurl {
+  src = fetchurl {
       url    = https://luarocks.org/luuid-20120509-2.src.rock;
       sha256 = "08q54x0m51w89np3n117h2a153wsgv3qayabd8cz6i55qm544hkg";
-   };
+  };
   disabled = ( luaOlder "5.2") || ( luaAtLeast "5.4");
-  propagatedBuildInputs = [lua  ];
-  buildType="builtin";
+  propagatedBuildInputs = [ lua ];  
+  buildType = "builtin";
 
   meta = {
     homepage = "http://www.tecgraf.puc-rio.br/~lhf/ftp/lua/#luuid";
@@ -460,19 +460,19 @@ penlight = buildLuarocksPackage {
   pname = "penlight";
   version = "1.5.4-1";
 
-  knownRockspec = ( fetchurl {
+         knownRockspec = (fetchurl {
       url    = https://luarocks.org/penlight-1.5.4-1.rockspec;
       sha256 = "07mhsk9kmdxg4i2w4mrnnd2zs34bgggi9gigfplakxin96sa6c0p";
-   }).outPath;
+  }).outPath;
 
-   src =  fetchurl {
+       src = fetchurl {
       url    = http://stevedonovan.github.io/files/penlight-1.5.4.zip;
       sha256 = "138f921p6kdqkmf4pz115phhj0jsqf28g33avws80d2vq2ixqm8q";
-   };
-
-
-  propagatedBuildInputs = [luafilesystem  ];
-  buildType="builtin";
+  };
+       
+  
+  propagatedBuildInputs = [ luafilesystem ];  
+  buildType = "builtin";
 
   meta = {
     homepage = "http://stevedonovan.github.com/Penlight";
@@ -486,19 +486,19 @@ say = buildLuarocksPackage {
   pname = "say";
   version = "1.3-1";
 
-  knownRockspec = ( fetchurl {
+         knownRockspec = (fetchurl {
       url    = https://luarocks.org/say-1.3-1.rockspec;
       sha256 = "0bknglb0qwd6r703wp3hcb6z2xxd14kq4md3sg9al3b28fzxbhdv";
-   }).outPath;
+  }).outPath;
 
-   src =  fetchurl {
+       src = fetchurl {
       url    = https://github.com/Olivine-Labs/say/archive/v1.3-1.tar.gz;
       sha256 = "1jh76mxq9dcmv7kps2spwcc6895jmj2sf04i4y9idaxlicvwvs13";
-   };
-
+  };
+       
   disabled = ( luaOlder "5.1");
-  propagatedBuildInputs = [lua  ];
-  buildType="builtin";
+  propagatedBuildInputs = [ lua ];  
+  buildType = "builtin";
 
   meta = {
     homepage = "http://olivinelabs.com/busted/";
@@ -508,23 +508,57 @@ say = buildLuarocksPackage {
     };
   };
 };
+std__debug = buildLuarocksPackage {
+  pname = "std._debug";
+  version = "1.0.1-1";
+
+  src = fetchurl {
+      url    = https://luarocks.org/std._debug-1.0.1-1.src.rock;
+      sha256 = "1qkcc5rph3ns9mzrfsa1671pb3hzbzfnaxvyw7zdly2b7ll88svz";
+  };
+  disabled = ( luaOlder "5.1") || ( luaAtLeast "5.5");
+  propagatedBuildInputs = [ lua ];  
+  buildType = "builtin";
+
+  meta = {
+    homepage = "http://lua-stdlib.github.io/_debug";
+    description="Debug Hints Library";
+    license = {
+      fullName = "MIT/X11";
+    };
+  };
+};
+std_normalize = buildLuarocksPackage {
+  pname = "std.normalize";
+  version = "2.0.2-1";
+
+  src = fetchurl {
+      url    = https://luarocks.org/std.normalize-2.0.2-1.src.rock;
+      sha256 = "0yn60zqnxflhhlv6xk6w0ifdfxk1qcg8gq1wnrrbwsxwpipsrfjh";
+  };
+  disabled = ( luaOlder "5.1") || ( luaAtLeast "5.4");
+  propagatedBuildInputs = [ lua std__debug ];  
+  buildType = "builtin";
+
+  meta = {
+    homepage = "https://lua-stdlib.github.io/normalize";
+    description="Normalized Lua Functions";
+    license = {
+      fullName = "MIT/X11";
+    };
+  };
+};
 luv = buildLuarocksPackage {
   pname = "luv";
-  version = "1.22.0-1";
+  version = "1.26.0-0";
 
-  knownRockspec = ( fetchurl {
-      url    = https://luarocks.org/luv-1.22.0-1.rockspec;
-      sha256 = "0yxjy9wj4aqbv1my8fkciy2xar5si6bcsszipgyls24rl6lnmga3";
-   }).outPath;
-
-   src =  fetchurl {
-      url    = https://github.com/luvit/luv/releases/download/1.22.0-1/luv-1.22.0-1.tar.gz;
-      sha256 = "1xvz4a0r6kd1xqxwm55g9n6imprxb79600x7dhyillrz7p5nm217";
-   };
-
+  src = fetchurl {
+      url    = https://luarocks.org/luv-1.26.0-0.src.rock;
+      sha256 = "005yzcxlribnc45qr1g7q4psakximb9fbz07k6yzy1d94mhcxxr7";
+  };
   disabled = ( luaOlder "5.1");
-  propagatedBuildInputs = [lua  ];
-  buildType="cmake";
+  propagatedBuildInputs = [ lua ];  
+  buildType = "cmake";
 
   meta = {
     homepage = "https://github.com/luvit/luv";
@@ -538,13 +572,13 @@ luasystem = buildLuarocksPackage {
   pname = "luasystem";
   version = "0.2.1-0";
 
-  src =  fetchurl {
+  src = fetchurl {
       url    = https://luarocks.org/luasystem-0.2.1-0.src.rock;
       sha256 = "091xmp8cijgj0yzfsjrn7vljwznjnjn278ay7z9pjwpwiva0diyi";
-   };
+  };
   disabled = ( luaOlder "5.1");
-  propagatedBuildInputs = [lua  ];
-  buildType="builtin";
+  propagatedBuildInputs = [ lua ];  
+  buildType = "builtin";
 
   meta = {
     homepage = "http://olivinelabs.com/luasystem/";
@@ -558,13 +592,13 @@ mediator_lua = buildLuarocksPackage {
   pname = "mediator_lua";
   version = "1.1.2-0";
 
-  src =  fetchurl {
+  src = fetchurl {
       url    = http://luarocks.org/manifests/teto/mediator_lua-1.1.2-0.src.rock;
       sha256 = "18j49vvs94yfk4fw0xsq4v3j4difr6c99gfba0kxairmcqamd1if";
-   };
+  };
   disabled = ( luaOlder "5.1");
-  propagatedBuildInputs = [lua  ];
-  buildType="builtin";
+  propagatedBuildInputs = [ lua ];  
+  buildType = "builtin";
 
   meta = {
     homepage = "http://olivinelabs.com/mediator_lua/";
@@ -578,13 +612,13 @@ mpack = buildLuarocksPackage {
   pname = "mpack";
   version = "1.0.7-0";
 
-  src =  fetchurl {
+  src = fetchurl {
       url    = http://luarocks.org/manifests/teto/mpack-1.0.7-0.src.rock;
       sha256 = "0nq4ixaminkc7fwfpivysyv0al3j5dffsvgdrnwnqdg3w7jgfbw7";
-   };
-
-
-  buildType="builtin";
+  };
+  
+    
+  buildType = "builtin";
 
   meta = {
     homepage = "https://github.com/libmpack/libmpack-lua/releases/download/1.0.7/libmpack-lua-1.0.7.tar.gz";
@@ -598,13 +632,13 @@ nvim-client = buildLuarocksPackage {
   pname = "nvim-client";
   version = "0.1.0-1";
 
-  src =  fetchurl {
+  src = fetchurl {
       url    = https://luarocks.org/nvim-client-0.1.0-1.src.rock;
       sha256 = "1p57mrvm0ny3yi5cydr3z9qwzyg124rjp5w7vdflf2i23z39mkma";
-   };
+  };
   disabled = ( luaOlder "5.1");
-  propagatedBuildInputs = [lua mpack luv coxpcall  ];
-  buildType="builtin";
+  propagatedBuildInputs = [ lua mpack luv coxpcall ];  
+  buildType = "builtin";
 
   meta = {
     homepage = "https://github.com/neovim/lua-client/archive/0.1.0-1.tar.gz";
@@ -618,19 +652,19 @@ busted = buildLuarocksPackage {
   pname = "busted";
   version = "2.0.rc13-0";
 
-  knownRockspec = ( fetchurl {
+         knownRockspec = (fetchurl {
       url    = https://luarocks.org/busted-2.0.rc13-0.rockspec;
       sha256 = "0hrvhg1324q5ra6cpjh1y3by6lrzs0ljah4jl48l8xlgw1z9z1q5";
-   }).outPath;
+  }).outPath;
 
-   src =  fetchurl {
+       src = fetchurl {
       url    = https://github.com/Olivine-Labs/busted/archive/v2.0.rc13-0.tar.gz;
       sha256 = "0m72bldn1r6j94ahcfmpaq1mmysrshf9qi9fjas7hpal0jp8ivvl";
-   };
-
+  };
+       
   disabled = ( luaOlder "5.1");
-  propagatedBuildInputs = [lua lua_cliargs luafilesystem luasystem dkjson say luassert lua-term penlight mediator_lua  ];
-  buildType="builtin";
+  propagatedBuildInputs = [ lua lua_cliargs luafilesystem luasystem dkjson say luassert lua-term penlight mediator_lua ];  
+  buildType = "builtin";
 
   meta = {
     homepage = "http://olivinelabs.com/busted/";
@@ -644,19 +678,19 @@ luassert = buildLuarocksPackage {
   pname = "luassert";
   version = "1.7.11-0";
 
-  knownRockspec = ( fetchurl {
+         knownRockspec = (fetchurl {
       url    = https://luarocks.org/luassert-1.7.11-0.rockspec;
       sha256 = "12zgybcv8acjzvjdbxd1764s1vxbksxdv9fkvsymcsdmppxkbd0s";
-   }).outPath;
+  }).outPath;
 
-   src =  fetchurl {
+       src = fetchurl {
       url    = https://github.com/Olivine-Labs/luassert/archive/v1.7.11.tar.gz;
       sha256 = "1vwq3wqj9cjyz9lnf1n38yhpcglr2h40v3n9096i8vcpmyvdb3ka";
-   };
-
+  };
+       
   disabled = ( luaOlder "5.1");
-  propagatedBuildInputs = [lua say  ];
-  buildType="builtin";
+  propagatedBuildInputs = [ lua say ];  
+  buildType = "builtin";
 
   meta = {
     homepage = "http://olivinelabs.com/busted/";
@@ -670,13 +704,13 @@ coxpcall = buildLuarocksPackage {
   pname = "coxpcall";
   version = "1.17.0-1";
 
-  src =  fetchurl {
+  src = fetchurl {
       url    = https://luarocks.org/manifests/hisham/coxpcall-1.17.0-1.src.rock;
       sha256 = "0n1jmda4g7x06458596bamhzhcsly6x0p31yp6q3jz4j11zv1zhi";
-   };
-
-
-  buildType="builtin";
+  };
+  
+    
+  buildType = "builtin";
 
   meta = {
     homepage = "http://keplerproject.github.io/coxpcall";

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -383,7 +383,7 @@ with self; {
       sha256 = "0p5583vidsm7s97zihf47c34vscwgbl86axrnj44j328v45kxb2z";
     };
 
-    propagatedBuildInputs = [ std.normalize bit32 ];
+    propagatedBuildInputs = [ std_normalize bit32 ];
 
     buildPhase = ''
       ${lua}/bin/lua build-aux/luke \
@@ -776,64 +776,6 @@ with self; {
       license = licenses.mit;
       maintainers = with maintainers; [ vyp ];
       platforms = with platforms; linux ++ darwin;
-    };
-  };
-
-  std._debug = buildLuaPackage rec {
-    name = "std._debug-${version}";
-    version = "1.0";
-
-    src = fetchFromGitHub {
-      owner = "lua-stdlib";
-      repo = "_debug";
-      rev = "v${version}";
-      sha256 = "01kfs6k9j9zy4bvk13jx18ssfsmhlciyrni1x32qmxxf4wxyi65n";
-    };
-
-    # No Makefile.
-    dontBuild = true;
-
-    installPhase = ''
-      mkdir -p $out/share/lua/${lua.luaversion}/std
-      cp -r lib/std/_debug $out/share/lua/${lua.luaversion}/std/
-    '';
-
-    meta = with stdenv.lib; {
-      description = "Manage an overall debug state, and associated hint substates.";
-      homepage    = https://lua-stdlib.github.io/_debug;
-      license     = licenses.mit;
-      maintainers = with maintainers; [ lblasc ];
-      platforms   = platforms.unix;
-    };
-  };
-
-  std.normalize = buildLuaPackage rec {
-    name = "std.normalize-${version}";
-    version = "2.0.1";
-
-    src = fetchFromGitHub {
-      owner = "lua-stdlib";
-      repo = "normalize";
-      rev = "v${version}";
-      sha256 = "1yz96r28d2wcgky6by92a21755bf4wzpn65rdv2ps0fxywgw5rda";
-    };
-
-    propagatedBuildInputs = [ std._debug ];
-
-    # No Makefile.
-    dontBuild = true;
-
-    installPhase = ''
-      mkdir -p $out/share/lua/${lua.luaversion}/std
-      cp -r lib/std/normalize $out/share/lua/${lua.luaversion}/std/
-    '';
-
-    meta = with stdenv.lib; {
-      description = "Normalized Lua Functions";
-      homepage    = https://lua-stdlib.github.io/normalize;
-      license     = licenses.mit;
-      maintainers = with maintainers; [ lblasc ];
-      platforms   = platforms.unix;
     };
   };
 


### PR DESCRIPTION
###### Motivation for this change
see the commit message: Having a dot in the name prevents some changes to the lua infrastructure.
I also fixed a problem with the lua updater.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

