### PR TITLE
tomb: remove gpg symlink

### DIFF
--- a/pkgs/os-specific/linux/tomb/default.nix
+++ b/pkgs/os-specific/linux/tomb/default.nix
@@ -1,4 +1,6 @@
-{ stdenv, lib, fetchFromGitHub, gettext, zsh, pinentry, cryptsetup, gnupg, makeWrapper }:
+{ stdenv, lib, fetchFromGitHub, makeWrapper
+, gettext, zsh, pinentry, cryptsetup, gnupg, utillinux, e2fsprogs
+}:
 
 stdenv.mkDerivation rec {
   name = "tomb-${version}";
@@ -11,6 +13,8 @@ stdenv.mkDerivation rec {
     sha256 = "1wk1aanzfln88min29p5av2j8gd8vj5afbs2gvarv7lvx1vi7kh1";
   };
 
+  buildInputs = [ zsh pinentry ];
+
   nativeBuildInputs = [ makeWrapper ];
 
   postPatch = ''
@@ -19,19 +23,15 @@ stdenv.mkDerivation rec {
       --replace 'TOMBEXEC=$0' 'TOMBEXEC=tomb'
   '';
 
-  buildPhase = ''
-    # manually patch the interpreter
-    sed -i -e "1s|.*|#!${zsh}/bin/zsh|g" tomb
-  '';
+  doInstallCheck = true;
+  installCheckPhase = "$out/bin/tomb -h 2>/dev/null";
 
   installPhase = ''
     install -Dm755 tomb       $out/bin/tomb
     install -Dm644 doc/tomb.1 $out/share/man/man1/tomb.1
 
-    ln -s ${gnupg}/bin/gpg $out/bin/gpg
-
     wrapProgram $out/bin/tomb \
-      --prefix PATH : $out/bin:${lib.makeBinPath [ cryptsetup gettext pinentry ]}
+      --prefix PATH : $out/bin:${lib.makeBinPath [ cryptsetup gettext gnupg pinentry utillinux e2fsprogs ]}
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
This symlink has been added [after the release of gnupg2 ](https://github.com/NixOS/nixpkgs/blame/d8f08bb088f662a16768ba4e205b2951e0a23bdc/pkgs/os-specific/linux/tomb/default.nix#L31-L32) to use the newer version instead of the legacy one. Later, when gnupg changed the `gpg` binary to be the v2 the symlink [has been modified](https://github.com/NixOS/nixpkgs/commit/e34ce9d1c551fb43742aada6bb43ccb1a52e64a1#diff-96fbca0e6304d7c85a80307ffaa30936R31) but not removed. This commit fix that.

I have tested the use of `tomb` and it work correctly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@peterhoeg 