### PR TITLE
mkl: fix install_name on Darwin

### DIFF
--- a/pkgs/development/libraries/science/math/mkl/default.nix
+++ b/pkgs/development/libraries/science/math/mkl/default.nix
@@ -1,9 +1,9 @@
-{ stdenvNoCC, writeText, fetchurl, rpmextract, undmg }:
+{ stdenvNoCC, writeText, fetchurl, rpmextract, undmg, darwin }:
 /*
   For details on using mkl as a blas provider for python packages such as numpy,
   numexpr, scipy, etc., see the Python section of the NixPkgs manual.
 */
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (rec {
   name = "mkl-${version}";
   version = "${date}.${rel}";
   date = "2019.3";
@@ -21,7 +21,13 @@ stdenvNoCC.mkDerivation rec {
         sha256 = "13rb2v2872jmvzcqm4fqsvhry0j2r5cn4lqql4wpqbl1yia2pph6";
       });
 
-  buildInputs = if stdenvNoCC.isDarwin then [ undmg ] else [ rpmextract ];
+  nativeBuildInputs = if stdenvNoCC.isDarwin
+    then
+      [ undmg
+        darwin.cctools
+      ]
+    else
+      [ rpmextract ];
 
   buildPhase = if stdenvNoCC.isDarwin then ''
       for f in Contents/Resources/pkg/*.tgz; do
@@ -41,6 +47,7 @@ stdenvNoCC.mkDerivation rec {
       cp -r compilers_and_libraries_${version}/licensing/mkl/en/license.txt $out/lib/
       cp -r compilers_and_libraries_${version}/mac/compiler/lib/* $out/lib/
       cp -r compilers_and_libraries_${version}/mac/mkl/lib/* $out/lib/
+      cp -r compilers_and_libraries_${version}/mac/tbb/lib/* $out/lib/
   '' else ''
       mkdir -p $out/lib
 
@@ -51,17 +58,21 @@ stdenvNoCC.mkDerivation rec {
       cp license.txt $out/lib/
   '';
 
+  # fixDarwinDylibName fails for libmkl_cdft_core.dylib because the
+  # larger updated load commands do not fit. Use install_name_tool
+  # explicitly and ignore the error.
+  postFixup = stdenvNoCC.lib.optionalString stdenvNoCC.isDarwin ''
+      for f in $out/lib/*.dylib; do
+          install_name_tool -id $out/lib/$(basename $f) $f || true
+      done
+      install_name_tool -change @rpath/libiomp5.dylib $out/lib/libiomp5.dylib $out/lib/libmkl_intel_thread.dylib
+      install_name_tool -change @rpath/libtbb.dylib $out/lib/libtbb.dylib $out/lib/libmkl_tbb_thread.dylib
+      install_name_tool -change @rpath/libtbbmalloc.dylib $out/lib/libtbbmalloc.dylib $out/lib/libtbbmalloc_proxy.dylib
+  '';
+
   # Per license agreement, do not modify the binary
   dontStrip = true;
   dontPatchELF = true;
-
-  # Since these are unmodified binaries from Intel, they do not depend on stdenv
-  # and we can make them fixed-output derivations for cache efficiency.
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-  outputHash = if stdenvNoCC.isDarwin
-    then "0rwm46v9amq2clm6wxhr98zzbafr485dz05pihlqsbrbabmlfw30"
-    else "101krzh2mjbfx8kvxim2zphdvgg7iijhbf9xdz3ad3ncgybxbdvw";
 
   meta = with stdenvNoCC.lib; {
     description = "Intel Math Kernel Library";
@@ -76,4 +87,10 @@ stdenvNoCC.mkDerivation rec {
     platforms = [ "x86_64-linux" "x86_64-darwin" ];
     maintainers = [ maintainers.bhipple ];
   };
-}
+ } // stdenvNoCC.lib.optionalAttrs stdenvNoCC.isLinux {
+  # Since on Linux binaries are unmodified, we can make them
+  # fixed-output derivations.
+	outputHashAlgo = "sha256";
+	outputHashMode = "recursive";
+	outputHash = "101krzh2mjbfx8kvxim2zphdvgg7iijhbf9xdz3ad3ncgybxbdvw";
+ })


### PR DESCRIPTION
###### Motivation for this change

Fix MKL install names on Darwin (see #57697).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


