### PR TITLE
octave: Try to use build with Qt5

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9212,11 +9212,11 @@ in
     };
 
     octaveQt5 = pkgs.lib.overrideDerivation octave (p: {
-      buildInputs       = p.buildInputs ++ (with pkgs.qt511; [ qtbase qtsvg qtscript qttools ]);
-      nativeBuildInputs = with pkgs.qt511; [ qttools ];
+      buildInputs       = p.buildInputs ++ (with pkgs.qt512; [ qtbase qtsvg qtscript qttools ]);
+      nativeBuildInputs = with pkgs.qt512; [ qttools ];
       configureFlags    = p.configureFlags ++ [ "--with-qt=5" ];
     });
-  in libsForQt511.callPackage octaveQt5 {};
+  in libsForQt512.callPackage octaveQt5 {};
 
   ocropus = callPackage ../applications/misc/ocropus { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9203,6 +9203,21 @@ in
     openblas = if stdenv.isDarwin then openblasCompat else openblas;
   }));
 
+  octaveQt5Full = let
+    octave = callPackage ../development/interpreters/octave {
+      qt = null;
+      openblas = if stdenv.isDarwin then openblasCompat else openblas;
+      overridePlatforms = ["x86_64-linux" "x86_64-darwin"];
+      suitesparse = null;
+    };
+
+    octaveQt5 = pkgs.lib.overrideDerivation octave (p: {
+      buildInputs       = p.buildInputs ++ (with pkgs.qt511; [ qtbase qtsvg qtscript qttools ]);
+      nativeBuildInputs = with pkgs.qt511; [ qttools ];
+      configureFlags    = p.configureFlags ++ [ "--with-qt=5" ];
+    });
+  in libsForQt511.callPackage octaveQt5 {};
+
   ocropus = callPackage ../applications/misc/ocropus { };
 
   pachyderm = callPackage ../applications/networking/cluster/pachyderm { };


### PR DESCRIPTION
###### Motivation for this change

Tackling #57900 

This is very much work in progress.

Right now I can build `octaveFull` with this patch applied, but it crashes at startup (signal 6). `strace` output:

```
[...]

recvmsg(3, {msg_name=NULL, msg_namelen=0, msg_iov=[{iov_base="\1\0\5\0\0\0\0\0\1\207U\211\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0", iov_len=4096}], msg_iovlen=1, msg_controllen=0, msg_flags=0}, 0) = 32
poll([{fd=3, events=POLLIN|POLLOUT}], 1, -1) = 1 ([{fd=3, revents=POLLOUT}])
writev(3, [{iov_base="\207\0\2\0\1\0\0\0", iov_len=8}, {iov_base=NULL, iov_len=0}, {iov_base="", iov_len=0}], 3) = 8
poll([{fd=3, events=POLLIN}], 1, -1)    = 1 ([{fd=3, revents=POLLIN}])
recvmsg(3, {msg_name=NULL, msg_namelen=0, msg_iov=[{iov_base="\1\1\6\0\0\0\0\0\1\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0", iov_len=4096}], msg_iovlen=1, msg_controllen=0, msg_flags=0}, 0) = 32
poll([{fd=3, events=POLLIN|POLLOUT}], 1, -1) = 1 ([{fd=3, revents=POLLOUT}])
writev(3, [{iov_base="<\0\2\0\0\0\0\2+\2\1\0", iov_len=12}, {iov_base=NULL, iov_len=0}, {iov_base="", iov_len=0}], 3) = 12
poll([{fd=3, events=POLLIN}], 1, -1)    = 1 ([{fd=3, revents=POLLIN}])
recvmsg(3, {msg_name=NULL, msg_namelen=0, msg_iov=[{iov_base="\1\1\10\0\0\0\0\0\"\0\200\2\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0", iov_len=4096}], msg_iovlen=1, msg_controllen=0, msg_flags=0}, 0) = 32
shutdown(3, SHUT_RDWR)                  = 0
close(3)                                = 0
rt_sigprocmask(SIG_BLOCK, [HUP INT QUIT PIPE ALRM TERM CHLD XCPU XFSZ VTALRM], NULL, 8) = 0
clone(child_stack=NULL, flags=CLONE_CHILD_CLEARTID|CLONE_CHILD_SETTID|SIGCHLD, child_tidptr=0x7f6830c4d050) = 85090
rt_sigaction(SIGINT, {sa_handler=0x4035f0, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x7f6830e55860}, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
rt_sigaction(SIGABRT, {sa_handler=0x4035f0, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x7f6830e55860}, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
rt_sigaction(SIGALRM, {sa_handler=0x4035f0, sa_mask=[], sa_flags=SA_RESTORER|SA_INTERRUPT, sa_restorer=0x7f6830e55860}, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
rt_sigaction(SIGBUS, {sa_handler=0x4035f0, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x7f6830e55860}, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
rt_sigaction(SIGFPE, {sa_handler=0x4035f0, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x7f6830e55860}, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
rt_sigaction(SIGHUP, {sa_handler=0x4035f0, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x7f6830e55860}, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
rt_sigaction(SIGILL, {sa_handler=0x4035f0, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x7f6830e55860}, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
rt_sigaction(SIGABRT, {sa_handler=0x4035f0, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x7f6830e55860}, {sa_handler=0x4035f0, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x7f6830e55860}, 8) = 0
rt_sigaction(SIGPIPE, {sa_handler=0x4035f0, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x7f6830e55860}, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
rt_sigaction(SIGIO, {sa_handler=0x4035f0, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x7f6830e55860}, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
rt_sigaction(SIGQUIT, {sa_handler=0x4035f0, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x7f6830e55860}, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
rt_sigaction(SIGSEGV, {sa_handler=0x4035f0, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x7f6830e55860}, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
rt_sigaction(SIGSYS, {sa_handler=0x4035f0, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x7f6830e55860}, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
rt_sigaction(SIGTERM, {sa_handler=0x4035f0, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x7f6830e55860}, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
rt_sigaction(SIGTRAP, {sa_handler=0x4035f0, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x7f6830e55860}, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
rt_sigaction(SIGUSR1, {sa_handler=0x4035f0, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x7f6830e55860}, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
rt_sigaction(SIGUSR2, {sa_handler=0x4035f0, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x7f6830e55860}, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
rt_sigaction(SIGVTALRM, {sa_handler=0x4035f0, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x7f6830e55860}, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
rt_sigaction(SIGIO, {sa_handler=0x4035f0, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x7f6830e55860}, {sa_handler=0x4035f0, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x7f6830e55860}, 8) = 0
rt_sigaction(SIGXCPU, {sa_handler=0x4035f0, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x7f6830e55860}, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
rt_sigaction(SIGXFSZ, {sa_handler=0x4035f0, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x7f6830e55860}, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
rt_sigprocmask(SIG_UNBLOCK, [HUP INT QUIT PIPE ALRM TERM CHLD XCPU XFSZ VTALRM], NULL, 8) = 0
wait4(85090, [{WIFSIGNALED(s) && WTERMSIG(s) == SIGABRT}], 0, NULL) = 85090
--- SIGCHLD {si_signo=SIGCHLD, si_code=CLD_KILLED, si_pid=85090, si_uid=1000, si_status=SIGABRT, si_utime=3, si_stime=1} ---
write(2, "octave exited with signal ", 26octave exited with signal ) = 26
write(2, "6", 16)                        = 1
write(2, "\n", 1
)                       = 1
exit_group(0)                           = ?
+++ exited with 0 +++
```



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
     - [x] centos 7
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

