### PR TITLE
dune: move into ocamlPackages

### DIFF
--- a/pkgs/development/ocaml-modules/lablgtk3/default.nix
+++ b/pkgs/development/ocaml-modules/lablgtk3/default.nix
@@ -1,18 +1,10 @@
-{ stdenv,lib, fetchFromGitHub, pkgconfig, ocaml, findlib, dune, gtk3, cairo2 }:
+{ lib, fetchFromGitHub, pkgconfig, buildDunePackage, gtk3, cairo2 }:
 
-if !lib.versionAtLeast ocaml.version "4.05"
-then throw "lablgtk3 is not available for OCaml ${ocaml.version}"
-else
-
-# This package uses the dune.configurator library
-# It thus needs said library to be compiled with this OCaml compiler
-let __dune = dune; in
-let dune = __dune.override { ocamlPackages = { inherit ocaml findlib; }; }; in
-
-stdenv.mkDerivation rec {
+buildDunePackage rec {
   version = "3.0.beta5";
   pname = "lablgtk3";
-  name = "ocaml${ocaml.version}-${pname}-${version}";
+
+  minimumOCamlVersion = "4.05";
 
   src = fetchFromGitHub {
     owner = "garrigue";
@@ -22,17 +14,13 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ ocaml findlib dune gtk3 ];
+  buildInputs = [ gtk3 ];
   propagatedBuildInputs = [ cairo2 ];
-
-  buildPhase = "dune build -p ${pname}";
-  inherit (dune) installPhase;
 
   meta = {
     description = "OCaml interface to gtk+-3";
     homepage = "http://lablgtk.forge.ocamlcore.org/";
     license = lib.licenses.lgpl21;
     maintainers = [ lib.maintainers.vbgl ];
-    inherit (ocaml.meta) platforms;
   };
 }

--- a/pkgs/development/ocaml-modules/lablgtk3/sourceview3.nix
+++ b/pkgs/development/ocaml-modules/lablgtk3/sourceview3.nix
@@ -1,9 +1,8 @@
-{ stdenv, ocaml, gtksourceview, lablgtk3 }:
+{ buildDunePackage, gtksourceview, lablgtk3 }:
 
-stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-lablgtk3-sourceview3-${version}";
-  buildPhase = "dune build -p lablgtk3-sourceview3";
+buildDunePackage rec {
+  pname = "lablgtk3-sourceview3";
   buildInputs = lablgtk3.buildInputs ++ [ gtksourceview ];
   propagatedBuildInputs = [ lablgtk3 ];
-  inherit (lablgtk3) src version meta nativeBuildInputs installPhase;
+  inherit (lablgtk3) src version meta nativeBuildInputs;
 }

--- a/pkgs/development/ocaml-modules/zmq/default.nix
+++ b/pkgs/development/ocaml-modules/zmq/default.nix
@@ -1,15 +1,8 @@
-{ stdenv, fetchFromGitHub, ocaml, findlib, dune, czmq, stdint }:
+{ lib, fetchFromGitHub, buildDunePackage, czmq, stdint }:
 
-if !stdenv.lib.versionAtLeast ocaml.version "4.03"
-then throw "zmq is not available for OCaml ${ocaml.version}"
-else
-
-let __dune = dune; in
-let dune = __dune.override { ocamlPackages = { inherit ocaml findlib; }; };
-in
-
-stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-zmq-${version}";
+buildDunePackage rec {
+  minimumOCamlVersion = "4.03";
+  pname = "zmq";
   version = "20180726";
   src = fetchFromGitHub {
     owner = "issuu";
@@ -22,19 +15,14 @@ stdenv.mkDerivation rec {
     ./ocaml-zmq-issue43.patch
   ];
 
-  buildInputs = [ ocaml findlib dune czmq ];
+  buildInputs = [ czmq ];
 
   propagatedBuildInputs = [ stdint ];
 
-  buildPhase = "dune build -p zmq";
-
-  inherit (dune) installPhase;
-
-  meta = with stdenv.lib; {
+  meta = {
     description = "ZeroMQ bindings for OCaml";
-    license     = licenses.mit;
-    maintainers = with maintainers; [ akavel ];
+    license     = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ akavel ];
     inherit (src.meta) homepage;
-    inherit (ocaml.meta) platforms;
   };
 }

--- a/pkgs/development/tools/ocaml/dune/default.nix
+++ b/pkgs/development/tools/ocaml/dune/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, ocamlPackages, opaline }:
+{ stdenv, fetchurl, ocaml, findlib, opaline }:
 
 stdenv.mkDerivation rec {
   name = "dune-${version}";
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "1lbgnmzdgb3cp2k2wfhhm5zwlm6dbipab49lh308y2qmh1q6yk6a";
   };
 
-  buildInputs = with ocamlPackages; [ ocaml findlib ];
+  buildInputs = [ ocaml findlib ];
 
   buildFlags = "release";
 
@@ -25,6 +25,6 @@ stdenv.mkDerivation rec {
     description = "A composable build system";
     maintainers = [ stdenv.lib.maintainers.vbgl ];
     license = stdenv.lib.licenses.mit;
-    inherit (ocamlPackages.ocaml.meta) platforms;
+    inherit (ocaml.meta) platforms;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1345,7 +1345,7 @@ in
 
   dtrx = callPackage ../tools/compression/dtrx { };
 
-  dune = callPackage ../development/tools/ocaml/dune { };
+  inherit (ocamlPackages) dune;
 
   duperemove = callPackage ../tools/filesystems/duperemove { };
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -223,6 +223,8 @@ let
 
     dtoa = callPackage ../development/ocaml-modules/dtoa { };
 
+    dune = callPackage ../development/tools/ocaml/dune { };
+
     earley = callPackage ../development/ocaml-modules/earley { };
 
     earley_ocaml = callPackage ../development/ocaml-modules/earley_ocaml { };


### PR DESCRIPTION
###### Motivation for this change

Dune is both a program and a library (hence tied to a specific OCaml version).

This seems to be the best known solution for packages using this library at build time.

Ping @Zimmi48 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

