### PR TITLE
lacaml: init at 11.0.3

### DIFF
--- a/pkgs/development/ocaml-modules/lacaml/default.nix
+++ b/pkgs/development/ocaml-modules/lacaml/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, darwin, ocaml, findlib, dune, base, stdio, liblapack, blas }:
+
+assert stdenv.lib.versionAtLeast (stdenv.lib.getVersion ocaml) "4.05.0";
+
+stdenv.mkDerivation rec {
+  pname = "ocaml${ocaml.version}-lacaml";
+  version = "11.0.3";
+
+  src = fetchFromGitHub {
+    owner = "mmottl";
+    repo = "lacaml";
+    rev = "${version}";
+    sha256 = "1aflg07cc9ak9mg1cr0qr368c9s141glwlarl5nhalf6hhq7ibcb";
+  };
+
+  buildInputs =
+    [ ocaml findlib dune base stdio liblapack blas ] ++
+    stdenv.lib.optionals stdenv.isDarwin
+      [ darwin.apple_sdk.frameworks.Accelerate ];
+
+  inherit (dune) installPhase;
+
+  meta = with stdenv.lib; {
+    homepage = http://mmottl.github.io/lacaml;
+    description = "OCaml bindings for BLAS and LAPACK";
+    license = licenses.lgpl21Plus;
+    platforms = ocaml.meta.platforms or [];
+    maintainers = [ maintainers.rixed ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -381,6 +381,8 @@ let
 
     labltk = callPackage ../development/ocaml-modules/labltk { };
 
+    lacaml = callPackage ../development/ocaml-modules/lacaml { };
+
     lambdaTerm-1_6 = callPackage ../development/ocaml-modules/lambda-term/1.6.nix { lwt = lwt2; };
     lambdaTerm =
       if lib.versionOlder "4.02" ocaml.version


### PR DESCRIPTION
###### Motivation for this change

Addition of lacaml, the OCaml binding to lapack/blas

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
