### PR TITLE
deco: 0.0.1 -> 0.0.2

### DIFF
--- a/pkgs/applications/misc/deco/default.nix
+++ b/pkgs/applications/misc/deco/default.nix
@@ -2,14 +2,14 @@
 
 stdenv.mkDerivation rec {
   pname = "deco";
-  version = "0.0.1";
+  version = "0.0.2";
   name = "${pname}-${version}";
 
   src = fetchFromGitHub {
     owner = "ebzzry";
     repo = pname;
-    rev = "037f473ae4bdce5d3e2f76891785f0f7479cca75";
-    sha256 = "1fv15nc9zqbn3c51vnm50yidj5ivpi61zg55cs46x3gi2x79x43q";
+    rev = "49cded5ad123b0169f47cd0dc0f5420f4b581837";
+    sha256 = "19rvqhw0blwga8ck86yy8hj7j1l9hriphlld6yrfd3yip4jprjzz";
   };
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change
- bug fixes

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

