### PR TITLE
k6: 0.23.1 -> 0.24.0

### DIFF
--- a/pkgs/development/tools/k6/default.nix
+++ b/pkgs/development/tools/k6/default.nix
@@ -1,16 +1,16 @@
 { stdenv, buildGoPackage, fetchFromGitHub }:
 
-buildGoPackage  rec {
-  name = "k6-${version}";
-  version = "0.23.1";
+buildGoPackage rec {
+  pname = "k6";
+  version = "0.24.0";
 
   goPackagePath = "github.com/loadimpact/k6";
 
   src = fetchFromGitHub {
     owner = "loadimpact";
-    repo = "k6";
+    repo = pname;
     rev = "v${version}";
-    sha256 = "03krrpbb67h9hmrg5m94936kha667yh2lqzp9s7fv0b6khskr9r7";
+    sha256 = "1riyyi4lxdaqilzzkxzzw3hzcrjjcylq2jh3p3656f99wiisvj28";
   };
 
   subPackages = [ "./" ];


### PR DESCRIPTION
[changelog](https://github.com/loadimpact/k6/releases/tag/v0.24.0)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

