### PR TITLE
[18.09] subversion_1_10: 1.10.2 -> 1.10.4, subersion_1_11: 1.11.0 -> 1.11.1

### DIFF
--- a/pkgs/applications/version-management/subversion/default.nix
+++ b/pkgs/applications/version-management/subversion/default.nix
@@ -127,8 +127,8 @@ in {
   };
 
   subversion_1_11 = common {
-    version = "1.11.0";
-    sha256 = "0miyz3xsxxp56iczxv6yqd8p06av3vxpb5nasyg2xb3ln1247i47";
+    version = "1.11.1";
+    sha256 = "1fv0psjxx5nxb4zmddyrma2bnv1bfff4p8ii6j8fqwjdr982gzcy";
     extraBuildInputs = [ lz4 utf8proc ];
   };
 }

--- a/pkgs/applications/version-management/subversion/default.nix
+++ b/pkgs/applications/version-management/subversion/default.nix
@@ -121,8 +121,8 @@ in {
   };
 
   subversion_1_10 = common {
-    version = "1.10.3";
-    sha256 = "1z6r3n91a4znsh68rl3jisfr7k4faymhbpalmmvsmvsap34al3cz";
+    version = "1.10.4";
+    sha256 = "18c1vdq32nil76w678lxmp73jsbqha3dmzgmfrj76nc0xjmywql2";
     extraBuildInputs = [ lz4 utf8proc ];
   };
 

--- a/pkgs/applications/version-management/subversion/default.nix
+++ b/pkgs/applications/version-management/subversion/default.nix
@@ -121,8 +121,8 @@ in {
   };
 
   subversion_1_10 = common {
-    version = "1.10.2";
-    sha256 = "127dysfc31q4dhbbxaznh9kqixy9jd44kgwji2gdwj6rb2lf6dav";
+    version = "1.10.3";
+    sha256 = "1z6r3n91a4znsh68rl3jisfr7k4faymhbpalmmvsmvsap34al3cz";
     extraBuildInputs = [ lz4 utf8proc ];
   };
 


### PR DESCRIPTION
###### Motivation for this change

Bump to latest bugfix releases that fix CVE-2018-11803 [0].

[0] subversion.apache.org/security/CVE-2018-11803-advisory.txt

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

