### PR TITLE
[18.09] samba/ldb: fix CVE-2019-3824

### DIFF
--- a/pkgs/development/libraries/ldb/default.nix
+++ b/pkgs/development/libraries/ldb/default.nix
@@ -19,6 +19,17 @@ stdenv.mkDerivation rec {
     cmocka
   ];
 
+  patches = [
+    # CVE-2019-3824
+    # downloading the patch from debian as they have ported the patch from samba to ldb but otherwise is identical to
+    # https://bugzilla.samba.org/attachment.cgi?id=14857
+    (fetchurl {
+      name = "CVE-2019-3824.patch";
+      url = "https://sources.debian.org/data/main/l/ldb/2:1.1.27-1+deb9u1/debian/patches/CVE-2019-3824-master-v4-5-02.patch";
+      sha256 = "1idnqckvjh18rh9sbq90rr4sxfviha9nd1ca9pd6lai0y6r6q4yd";
+    })
+  ];
+
   preConfigure = ''
     sed -i 's,#!/usr/bin/env python,#!${python}/bin/python,g' buildtools/bin/waf
   '';

--- a/pkgs/servers/samba/4.x.nix
+++ b/pkgs/servers/samba/4.x.nix
@@ -35,9 +35,17 @@ stdenv.mkDerivation rec {
     [ ./4.x-no-persistent-install.patch
       ./patch-source3__libads__kerberos_keytab.c.patch
       ./4.x-no-persistent-install-dynconfig.patch
+
+      # conditionall disable MacOS incompatible tests
       (fetchpatch {
         url = "https://patch-diff.githubusercontent.com/raw/samba-team/samba/pull/107.patch";
         sha256 = "0r6q34vjj0bdzmcbnrkad9rww58k4krbwicv4gs1g3dj49skpvd6";
+      })
+
+      (fetchpatch {
+        name = "CVE-2019-3824.patch";
+        url = "https://attachments.samba.org/attachment.cgi?id=14859";
+        sha256 = "02qf3zr55mzbimqdv01k3b22jjb084vfr5zabapyr5h1f588mw0q";
       })
     ];
 


### PR DESCRIPTION
###### Motivation for this change

Addresses CVE-2019-3824.
Fixes #57189 for 18.09

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

