### PR TITLE
rssh: mark as insecure

### DIFF
--- a/pkgs/shells/rssh/default.nix
+++ b/pkgs/shells/rssh/default.nix
@@ -84,6 +84,11 @@ stdenv.mkDerivation rec {
     license = licenses.bsd2;
     platforms = platforms.linux;
     maintainers = with maintainers; [ arobyn ];
+    knownVulnerabilities = [
+      "CVE-2019-1000018"
+      "CVE-2019-3463"
+      "CVE-2019-3464"
+    ];
   };
 
   passthru = {


### PR DESCRIPTION
###### Motivation for this change

There seems to be a consensus among many packagers that RSSH is
probably no longer a good idea. There are a few fixes for some of the
issues but people should move on and use other software these days.

Removing it from further (stable) releases is probably a good idea. If
someone really needs it we still have it in the tree and they can
whitelist it again.

