### PR TITLE
ocamlPackages.cairo2: 0.5 -> 0.6

### DIFF
--- a/pkgs/development/ocaml-modules/cairo2/default.nix
+++ b/pkgs/development/ocaml-modules/cairo2/default.nix
@@ -1,43 +1,22 @@
-{ stdenv, fetchurl, ocaml, findlib, ocamlbuild, pkgconfig, cairo, lablgtk, gtk2,
-  enableGtkSupport ? true # Whether to compile with support for Gtk
-                          # integration (library file cairo2_gtk). Depends
-                          # on lablgtk and gtk2.
+{ lib, fetchurl, buildDunePackage
+, pkgconfig, cairo
 }:
 
-let
-  inherit (stdenv.lib) optionals;
-  version = "0.5";
-in
-
-stdenv.mkDerivation {
-
-  name = "ocaml${ocaml.version}-cairo2-${version}";
+buildDunePackage rec {
+  pname = "cairo2";
+  version = "0.6";
 
   src = fetchurl {
-    url = "https://github.com/Chris00/ocaml-cairo/releases/download/${version}/cairo2-${version}.tar.gz";
-    sha256 = "1559df74rzh4v7c9hr6phymq1f5121s83q0xy3r83x4apj74dchj";
+    url = "https://github.com/Chris00/ocaml-cairo/releases/download/${version}/cairo2-${version}.tbz";
+    sha256 = "1k2q7ipmddqnd2clybj4qb5xwzzrnl2fxnd6kv60dlzgya18lchs";
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ ocaml findlib ocamlbuild cairo ]
-                ++ optionals enableGtkSupport [ gtk2 ];
+  buildInputs = [ cairo ];
 
-  # lablgtk2 is marked as a propagated build input since loading the
-  # cairo.lablgtk2 package from the toplevel tries to load lablgtk2 as
-  # well.
-  propagatedBuildInputs = optionals enableGtkSupport [ lablgtk ];
+  doCheck = true;
 
-  createFindlibDestdir = true;
-
-  configurePhase = "ocaml setup.ml -configure --prefix $out"
-                 + (if enableGtkSupport then " --enable-lablgtk2"
-                                        else " --disable-lablgtk2");
-
-  buildPhase = "ocaml setup.ml -build";
-
-  installPhase = "ocaml setup.ml -install";
-
-  meta = with stdenv.lib; {
+  meta = {
     homepage = "https://github.com/Chris00/ocaml-cairo";
     description = "Binding to Cairo, a 2D Vector Graphics Library";
     longDescription = ''
@@ -46,8 +25,7 @@ stdenv.mkDerivation {
       the X Window System, Quartz, Win32, image buffers, PostScript, PDF,
       and SVG file output.
     '';
-    license = licenses.lgpl3;
-    platforms = ocaml.meta.platforms or [];
-    maintainers = [ maintainers.jirkamarsik ];
+    license = lib.licenses.lgpl3;
+    maintainers = with lib.maintainers; [ jirkamarsik vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/cairo2/default.nix
+++ b/pkgs/development/ocaml-modules/cairo2/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchurl, buildDunePackage
+{ stdenv, lib, fetchurl, buildDunePackage
 , pkgconfig, cairo
 }:
 
@@ -14,7 +14,7 @@ buildDunePackage rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ cairo ];
 
-  doCheck = true;
+  doCheck = !stdenv.isDarwin;
 
   meta = {
     homepage = "https://github.com/Chris00/ocaml-cairo";

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -357,9 +357,7 @@ let
 
     lablgl = callPackage ../development/ocaml-modules/lablgl { };
 
-    lablgtk3 = callPackage ../development/ocaml-modules/lablgtk3 {
-      cairo2 = cairo2.override { enableGtkSupport = false; };
-    };
+    lablgtk3 = callPackage ../development/ocaml-modules/lablgtk3 { };
 
     lablgtk3-gtkspell3 = callPackage ../development/ocaml-modules/lablgtk3/gtkspell3.nix { };
 


### PR DESCRIPTION
###### Motivation for this change

Major update.

Depends on #57953.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

