### PR TITLE
mcos-dark-xfce-edition: init at f0ec359

### DIFF
--- a/pkgs/data/themes/mcos-dark-xfce-edition/default.nix
+++ b/pkgs/data/themes/mcos-dark-xfce-edition/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, gtk-engine-murrine }:
+
+stdenv.mkDerivation rec {
+  name = "mcos-mjv-dark-xfce-edition";
+  version = "unstable-2018-12-13";
+
+  src = fetchFromGitHub {
+    owner = "paullinuxthemer";
+    repo = "McOS-MJV-Dark-XFCE-Edition";
+    rev = "f0ec35990d6235e756faa1afb82158f0967887d8";
+    sha256 = "1gzdlvs2604j4apvrfsqvmqdy8r3wl9zkxkj5nzx6b6p957h4hkp";
+  };
+
+  propagatedUserEnvPkgs = [ gtk-engine-murrine ];
+
+  installPhase = ''
+    mkdir -p $out/share/themes
+    mv McOS-MJV-Dark-XFCE-Edition-2.2 mcos-mjv-dark-xfce-edition
+    cp -r 'mcos-mjv-dark-xfce-edition' $out/share/themes
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Mac OS-themes(Dark) for the XFCE desktop";
+    homepage = https://github.com/paullinuxthemer/McOS-MJV-Dark-XFCE-Edition;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.linarcx ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3837,6 +3837,8 @@ in
 
   mcfly = callPackage ../tools/misc/mcfly { };
 
+  mcos-dark-xfce-edition = callPackage ../data/themes/mcos-dark-xfce-edition { };
+
   mdbook = callPackage ../tools/text/mdbook {
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

