### PR TITLE
nlohmann_json: 3.5.0 -> 3.6.1

### DIFF
--- a/pkgs/development/libraries/nlohmann_json/default.nix
+++ b/pkgs/development/libraries/nlohmann_json/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "nlohmann_json";
-  version = "3.6.0";
+  version = "3.6.1";
 
   src = fetchFromGitHub {
     owner = "nlohmann";
     repo = "json";
     rev = "v${version}";
-    sha256 = "11dfv31prfiaxxdv8ypnya4a953hqq2k94nbxl0v4qlfbsyipil3";
+    sha256 = "1dgx3j9pb0f52dh73z8dpwdy79bra1qi5vpl66b9inq4gamf813z";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/nlohmann_json/default.nix
+++ b/pkgs/development/libraries/nlohmann_json/default.nix
@@ -2,14 +2,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "nlohmann_json-${version}";
-  version = "3.5.0";
+  pname = "nlohmann_json";
+  version = "3.6.0";
 
   src = fetchFromGitHub {
     owner = "nlohmann";
     repo = "json";
     rev = "v${version}";
-    sha256 = "1jq522d48bvfrxr4f6jnijwx2dwqfb8w9k636j4kxlg1hka27lji";
+    sha256 = "11dfv31prfiaxxdv8ypnya4a953hqq2k94nbxl0v4qlfbsyipil3";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
###### Motivation for this change

https://github.com/nlohmann/json/releases/tag/v3.6.0

Note when building, since I was surprised:
* source tarball is 113MB, 258MB unpacked
* testing takes a bit, mostly on a single test
  * if it's the unicode test, then just wait, it's not stuck just thorough :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---