### PR TITLE
llvmPackages_8: rc5 -> 8.0.0 release!

### DIFF
--- a/pkgs/development/compilers/llvm/8/clang/default.nix
+++ b/pkgs/development/compilers/llvm/8/clang/default.nix
@@ -9,7 +9,7 @@ let
     name = "clang-${version}";
 
     unpackPhase = ''
-      unpackFile ${fetch "cfe" "07k6vcxnf9n8x21mala3rfvf450iqy24wcsqw4yc8b8lp1fwii6p"}
+      unpackFile ${fetch "cfe" "0svk1f70hvpwrjp6x5i9kqwrqwxnmcrw5s7f4cxyd100mdd12k08"}
       mv cfe-${version}* clang
       sourceRoot=$PWD/clang
       unpackFile ${clang-tools-extra_src}

--- a/pkgs/development/compilers/llvm/8/compiler-rt.nix
+++ b/pkgs/development/compilers/llvm/8/compiler-rt.nix
@@ -2,7 +2,7 @@
 stdenv.mkDerivation rec {
   name = "compiler-rt-${version}";
   inherit version;
-  src = fetch "compiler-rt" "16la7ksxwfs6wk3y7w8hh3c1svp095m7j4qfrdgv65lnfwp6rwf9";
+  src = fetch "compiler-rt" "1c919wsm17xnv7lr8bhpq2wkq8113lzlw6hzhfr737j59x3wfddl";
 
   nativeBuildInputs = [ cmake python llvm ];
   buildInputs = stdenv.lib.optional stdenv.hostPlatform.isDarwin libcxxabi;

--- a/pkgs/development/compilers/llvm/8/default.nix
+++ b/pkgs/development/compilers/llvm/8/default.nix
@@ -6,14 +6,14 @@
 
 let
   release_version = "8.0.0";
-  version = release_version + "rc5"; # differentiating these is important for rc's
+  version = release_version; # differentiating these is important for rc's
 
   fetch = name: sha256: fetchurl {
-    url = "https://prereleases.llvm.org/${release_version}/rc5/${name}-${version}.src.tar.xz";
+    url = "https://releases.llvm.org/${release_version}/${name}-${version}.src.tar.xz";
     inherit sha256;
   };
 
-  clang-tools-extra_src = fetch "clang-tools-extra" "0705xl8ysjc9pdrggyc51zjq3kwcrckhz4cf4z8wbgi7x2li1djd";
+  clang-tools-extra_src = fetch "clang-tools-extra" "0jwx6nnshp92pd5852y7ip7qhaqdf8az5g0440pli9q8whmi402g";
 
   tools = stdenv.lib.makeExtensible (tools: let
     callPackage = newScope (tools // { inherit stdenv cmake libxml2 python isl release_version version fetch; });

--- a/pkgs/development/compilers/llvm/8/libc++/default.nix
+++ b/pkgs/development/compilers/llvm/8/libc++/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation rec {
   name = "libc++-${version}";
 
-  src = fetch "libcxx" "1hdhr4nnynwf1m1581sjl8pdh3gdxsz1rdzdryig7ll9v2lp0rkc";
+  src = fetch "libcxx" "1qlx3wlxrnc5cwc1fcfc2vhfsl7j4294hi8y5kxj8hy8wxsjd462";
 
   postUnpack = ''
     unpackFile ${libcxxabi.src}

--- a/pkgs/development/compilers/llvm/8/libc++abi.nix
+++ b/pkgs/development/compilers/llvm/8/libc++abi.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation {
   name = "libc++abi-${version}";
 
-  src = fetch "libcxxabi" "1s65sb5vv5l532fmcwvxd3apxm1jjc64yb5qn30f0zzdx9g3rx69";
+  src = fetch "libcxxabi" "1k875f977ybdkpdnr9105wa6hccy9qvpd9xd42n75h7p56bdxmn2";
 
   nativeBuildInputs = [ cmake ];
   buildInputs = stdenv.lib.optional (!stdenv.isDarwin && !stdenv.isFreeBSD) libunwind;

--- a/pkgs/development/compilers/llvm/8/lld.nix
+++ b/pkgs/development/compilers/llvm/8/lld.nix
@@ -9,7 +9,7 @@
 stdenv.mkDerivation {
   name = "lld-${version}";
 
-  src = fetch "lld" "1w0f3s5rzv90yiv4k9wdvkpc89k3g9crbwf1sh8xbi5jsjnz4539";
+  src = fetch "lld" "0dvf38pbm7jy88g66mz7ikkdfhm2qpj0iyzh62hzycifjbnciblw";
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ llvm libxml2 ];

--- a/pkgs/development/compilers/llvm/8/lldb.nix
+++ b/pkgs/development/compilers/llvm/8/lldb.nix
@@ -17,7 +17,7 @@
 stdenv.mkDerivation {
   name = "lldb-${version}";
 
-  src = fetch "lldb" "1i3hy37qmwqblxpac88ing7mg3jyp2hh08rfv3xhlxj9wddz7nyd";
+  src = fetch "lldb" "0wq3mi76fk86g2g2bcsr0yhagh1dlf2myk641ai58rc116gqp4a9";
 
   postPatch = ''
     # Fix up various paths that assume llvm and clang are installed in the same place

--- a/pkgs/development/compilers/llvm/8/llvm.nix
+++ b/pkgs/development/compilers/llvm/8/llvm.nix
@@ -22,8 +22,8 @@
 let
   inherit (stdenv.lib) optional optionals optionalString;
 
-  src = fetch "llvm" "1hb5if7vmgkb52dpj9lyvn986mnk2jbpryng2r1rc5vy25wxw759";
-  polly_src = fetch "polly" "07l3y20j8124x24yqiq0qmz9rhkfh3c48q6vnpgldj2scr3vgyb2";
+  src = fetch "llvm" "0k124sxkfhfi1rca6kzkdraf4axhx99x3cw2rk55056628dvwwl8";
+  polly_src = fetch "polly" "1x4xv3j226rqdddp7b61d71wsx2b8vmmri02ycx27y2fg7ba7xg3";
 
   # Used when creating a version-suffixed symlink of libLLVM.dylib
   shortVersion = with stdenv.lib;

--- a/pkgs/development/compilers/llvm/8/openmp.nix
+++ b/pkgs/development/compilers/llvm/8/openmp.nix
@@ -9,7 +9,7 @@
 stdenv.mkDerivation {
   name = "openmp-${version}";
 
-  src = fetch "openmp" "1nad9ihnaa4xpr77lp9y6zzqqi90d5p280zwv260z9mifkl4dlhm";
+  src = fetch "openmp" "1mf9cpgvix34xlpv0inkgl3qmdvgvp96f7sksqizri0n5xfp1cgp";
 
   nativeBuildInputs = [ cmake perl ];
   buildInputs = [ llvm ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6741,9 +6741,10 @@ in
       };
     };
   };
-  llvm-polly = llvmPackages_7.llvm-polly;
-  clang-polly = clang_7.override { cc = llvmPackages_7.clang-polly-unwrapped; };
+  llvm-polly = llvmPackages_8.llvm-polly;
+  clang-polly = clang_8.override { cc = llvmPackages_latest.clang-polly-unwrapped; };
 
+  clang_8  = llvmPackages_8.clang;
   clang_7  = llvmPackages_7.clang;
   clang_6  = llvmPackages_6.clang;
   clang_5  = llvmPackages_5.clang;
@@ -7365,16 +7366,19 @@ in
   lld_5 = llvmPackages_5.lld;
   lld_6 = llvmPackages_6.lld;
   lld_7 = llvmPackages_7.lld;
+  lld_8 = llvmPackages_8.lld;
 
   lldb = llvmPackages.lldb;
   lldb_4 = llvmPackages_4.lldb;
   lldb_5 = llvmPackages_5.lldb;
   lldb_6 = llvmPackages_6.lldb;
   lldb_7 = llvmPackages_7.lldb;
+  lldb_8 = llvmPackages_8.lldb;
 
   llvm = llvmPackages.llvm;
   llvm-manpages = llvmPackages.llvm-manpages;
 
+  llvm_8  = llvmPackages_8.llvm;
   llvm_7  = llvmPackages_7.llvm;
   llvm_6  = llvmPackages_6.llvm;
   llvm_5  = llvmPackages_5.llvm;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6741,8 +6741,8 @@ in
       };
     };
   };
-  llvm-polly = llvmPackages_8.llvm-polly;
-  clang-polly = clang_8.override { cc = llvmPackages_latest.clang-polly-unwrapped; };
+  llvm-polly = llvmPackages_latest.llvm-polly;
+  clang-polly = llvmPackages_latest.clang.override { cc = llvmPackages_latest.clang-polly-unwrapped; };
 
   clang_8  = llvmPackages_8.clang;
   clang_7  = llvmPackages_7.clang;


### PR DESCRIPTION
###### Motivation for this change

Released!

http://releases.llvm.org/

https://lists.llvm.org/pipermail/llvm-announce/2019-March/000082.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Various llvm/clang users may wish to upgrade,
but there are many so leaving them as-is for now.

Still building some variants, but will be done in a few...