### PR TITLE
monitoring-plugins: compile missing mysql, ldap, dig, procs, and dbi executables

### DIFF
--- a/pkgs/servers/monitoring/plugins/default.nix
+++ b/pkgs/servers/monitoring/plugins/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, fetchpatch, autoreconfHook
 , coreutils, gnugrep, gnused, lm_sensors, net_snmp, openssh, openssl, perl
-, mysql, zlib, openldap
+, dnsutils, mysql, zlib, openldap
 , runtimeShell }:
 
 with stdenv.lib;
@@ -48,7 +48,7 @@ in stdenv.mkDerivation rec {
   '';
 
   # !!! make openssh a runtime dependency only
-  buildInputs = [ mysql net_snmp openldap openssh openssl perl zlib ];
+  buildInputs = [ dnsutils mysql net_snmp openldap openssh openssl perl zlib ];
 
   nativeBuildInputs = [ autoreconfHook ];
 

--- a/pkgs/servers/monitoring/plugins/default.nix
+++ b/pkgs/servers/monitoring/plugins/default.nix
@@ -1,5 +1,6 @@
-{ stdenv, fetchFromGitHub, autoreconfHook
+{ stdenv, fetchFromGitHub, fetchpatch, autoreconfHook
 , coreutils, gnugrep, gnused, lm_sensors, net_snmp, openssh, openssl, perl
+, mysql, zlib
 , runtimeShell }:
 
 with stdenv.lib;
@@ -20,6 +21,14 @@ in stdenv.mkDerivation rec {
     sha256 = "1pw7i6d2cnb5nxi2lbkwps2qzz04j9zd86fzpv9ka896b4aqrwv1";
   };
 
+  patches = [
+    # https://github.com/monitoring-plugins/monitoring-plugins/issues/1508
+    (fetchpatch {
+      url = "https://github.com/monitoring-plugins/monitoring-plugins/commit/ac0437ff896ba9ce2549b2d2ec3de146a886f08a.patch";
+      sha256 = "0jf6fqkyzag66rid92m7asnr2dp8rr8kn4zjvhqg0mqvf8imppky";
+    })
+  ];
+
   # !!! Awful hack. Grrr... this of course only works on NixOS.
   # Anyway the check that configure performs to figure out the ping
   # syntax is totally impure, because it runs an actual ping to
@@ -39,7 +48,7 @@ in stdenv.mkDerivation rec {
   '';
 
   # !!! make openssh a runtime dependency only
-  buildInputs = [ net_snmp openssh openssl perl ];
+  buildInputs = [ mysql net_snmp openssh openssl perl zlib ];
 
   nativeBuildInputs = [ autoreconfHook ];
 

--- a/pkgs/servers/monitoring/plugins/default.nix
+++ b/pkgs/servers/monitoring/plugins/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, fetchpatch, autoreconfHook
 , coreutils, gnugrep, gnused, lm_sensors, net_snmp, openssh, openssl, perl
-, dnsutils, mysql, zlib, openldap
+, dnsutils, mysql, zlib, openldap, procps
 , runtimeShell }:
 
 with stdenv.lib;
@@ -9,7 +9,7 @@ let
   majorVersion = "2.2";
   minorVersion = ".0";
 
-  binPath = makeBinPath [ coreutils gnugrep gnused lm_sensors net_snmp ];
+  binPath = makeBinPath [ coreutils gnugrep gnused lm_sensors net_snmp procps ];
 
 in stdenv.mkDerivation rec {
   name = "monitoring-plugins-${majorVersion}${minorVersion}";
@@ -48,7 +48,7 @@ in stdenv.mkDerivation rec {
   '';
 
   # !!! make openssh a runtime dependency only
-  buildInputs = [ dnsutils mysql net_snmp openldap openssh openssl perl zlib ];
+  buildInputs = [ dnsutils mysql net_snmp openldap openssh openssl perl procps zlib ];
 
   nativeBuildInputs = [ autoreconfHook ];
 

--- a/pkgs/servers/monitoring/plugins/default.nix
+++ b/pkgs/servers/monitoring/plugins/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, fetchpatch, autoreconfHook
 , coreutils, gnugrep, gnused, lm_sensors, net_snmp, openssh, openssl, perl
-, mysql, zlib
+, mysql, zlib, openldap
 , runtimeShell }:
 
 with stdenv.lib;
@@ -48,7 +48,7 @@ in stdenv.mkDerivation rec {
   '';
 
   # !!! make openssh a runtime dependency only
-  buildInputs = [ mysql net_snmp openssh openssl perl zlib ];
+  buildInputs = [ mysql net_snmp openldap openssh openssl perl zlib ];
 
   nativeBuildInputs = [ autoreconfHook ];
 

--- a/pkgs/servers/monitoring/plugins/default.nix
+++ b/pkgs/servers/monitoring/plugins/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, fetchpatch, autoreconfHook
 , coreutils, gnugrep, gnused, lm_sensors, net_snmp, openssh, openssl, perl
-, dnsutils, mysql, zlib, openldap, procps
+, dnsutils, libdbi, mysql, zlib, openldap, procps
 , runtimeShell }:
 
 with stdenv.lib;
@@ -48,7 +48,7 @@ in stdenv.mkDerivation rec {
   '';
 
   # !!! make openssh a runtime dependency only
-  buildInputs = [ dnsutils mysql net_snmp openldap openssh openssl perl procps zlib ];
+  buildInputs = [ dnsutils libdbi mysql net_snmp openldap openssh openssl perl procps zlib ];
 
   nativeBuildInputs = [ autoreconfHook ];
 


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/57919

I haven't actually confirmed the new binaries perform as expected, but I did run them all with the `--help` flag and they executed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

