### PR TITLE
perlPackages.FileSlurp: 9999.25 -> 9999.26

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -6015,13 +6015,11 @@ let
     };
   };
 
-  FileSlurp = buildPerlPackage {
-    name = "File-Slurp-9999.25";
-    # WARNING: check on next update if deprecation warning is gone
-    patches = [ ../development/perl-modules/File-Slurp/silence-deprecation.patch ];
+  FileSlurp = buildPerlPackage rec {
+    name = "File-Slurp-9999.26";
     src = fetchurl {
-      url = mirror://cpan/authors/id/C/CA/CAPOEIRAB/File-Slurp-9999.25.tar.gz;
-      sha256 = "1hg3bhf5m78d77p4174cnldd75ppyrvr5rkc8w289ihvwsx9gsn7";
+      url = "mirror://cpan/authors/id/C/CA/CAPOEIRAB/${name}.tar.gz";
+      sha256 = "1e278d25df46310a8d2cd0aca9b8c2703f1eae838a99a8cb91e96950e88e0930";
     };
     meta = {
       description = "Simple and Efficient Reading/Writing/Modifying of Complete Files";


### PR DESCRIPTION
###### Motivation for this change
https://metacpan.org/source/CAPOEIRAB/File-Slurp-9999.26/Changes
No longer uses syswrite, so patch is dropped (and expression regenerated from cpan generator)
Fixes usage with perldevel

Candidate for backport (though this only affects perldevelPackages, I think.) cc #56826 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

