### PR TITLE
nixos/nginx: use nginxfmt and gixy

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -44,19 +44,7 @@ let
     }
   ''));
 
-  awkFormat = builtins.toFile "awkFormat-nginx.awk" ''
-    awk -f
-    {sub(/^[ \t]+/,"");idx=0}
-    /\{/{ctx++;idx=1}
-    /\}/{ctx--}
-    {id="";for(i=idx;i<ctx;i++)id=sprintf("%s%s", id, "\t");printf "%s%s\n", id, $0}
-  '';
-
-  configFile = pkgs.runCommand "nginx.conf" {} (''
-    awk -f ${awkFormat} ${pre-configFile} | sed '/^\s*$/d' > $out
-  '');
-
-  pre-configFile = pkgs.writeText "pre-nginx.conf" ''
+  configFile = pkgs.writers.writeNginxConfig "nginx.conf" ''
     user ${cfg.user} ${cfg.group};
     error_log ${cfg.logError};
     daemon off;

--- a/pkgs/build-support/writers/default.nix
+++ b/pkgs/build-support/writers/default.nix
@@ -178,6 +178,16 @@ rec {
   writeJSBin = name:
     writeJS "/bin/${name}";
 
+  writeNginxConfig = name: text: pkgs.runCommand name {
+    inherit text;
+    passAsFile = [ "text" ];
+  } /* sh */ ''
+    cp "$textPath" $out
+    ${pkgs.nginx-config-formatter}/bin/nginxfmt $out
+    ${pkgs.gnused}/bin/sed -i '/^$/d' $out
+    ${pkgs.gixy}/bin/gixy $out
+  '';
+
   # writePerl takes a name an attributeset with libraries and some perl sourcecode and
   # returns an executable
   #

--- a/pkgs/tools/misc/nginx-config-formatter/default.nix
+++ b/pkgs/tools/misc/nginx-config-formatter/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, python3 }:
 
 stdenv.mkDerivation rec {
-  version = "2016-06-16";
+  version = "2019-02-13";
   name = "nginx-config-formatter-${version}";
 
   src = fetchFromGitHub {
     owner = "1connect";
     repo = "nginx-config-formatter";
-    rev = "fe5c77d2a503644bebee2caaa8b222c201c0603d";
-    sha256 = "0akpkbq5136k1i1z1ls6yksis35hbr70k8vd10laqwvr1jj41bga";
+    rev = "4ea6bbc1bdeb1d28419548aeca90f323e64e0e05";
+    sha256 = "0h6pj9i0wim9pzkafi92l1nhlnl2a530vnm7qqi3n2ra8iwfyw4f";
   };
 
   buildInputs = [ python3 ];


### PR DESCRIPTION
###### Motivation for this change

Currently nginx.conf gets formatted by an awk script. This PR replaces that script by `writeNginxConfig` which uses [nginx-config-formatter](https://github.com/1connect/nginx-config-formatter) to format, and [gixy](https://github.com/yandex/gixy) to analyze nginx configurations.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

