### PR TITLE
switch users of "gnupg1" to plain "gnupg"

### DIFF
--- a/pkgs/applications/kde/kgpg.nix
+++ b/pkgs/applications/kde/kgpg.nix
@@ -1,7 +1,7 @@
 {
   mkDerivation, lib,
   extra-cmake-modules, kdoctools, ki18n, makeWrapper,
-  akonadi-contacts, gnupg1, karchive, kcodecs, kcontacts, kcoreaddons,
+  akonadi-contacts, gnupg, karchive, kcodecs, kcontacts, kcoreaddons,
   kcrash, kdbusaddons, kiconthemes, kjobwidgets, kio, knotifications, kservice,
   ktextwidgets, kxmlgui, kwidgetsaddons, kwindowsystem, qgpgme,
 }:
@@ -10,12 +10,12 @@ mkDerivation {
   name = "kgpg";
   nativeBuildInputs = [ extra-cmake-modules kdoctools makeWrapper ];
   buildInputs = [
-    akonadi-contacts gnupg1 karchive kcodecs kcontacts kcoreaddons kcrash
+    akonadi-contacts gnupg karchive kcodecs kcontacts kcoreaddons kcrash
     kdbusaddons ki18n kiconthemes kjobwidgets kio knotifications kservice
     ktextwidgets kxmlgui kwidgetsaddons kwindowsystem qgpgme
   ];
   postFixup = ''
-    wrapProgram "$out/bin/kgpg" --prefix PATH : "${lib.makeBinPath [ gnupg1 ]}"
+    wrapProgram "$out/bin/kgpg" --prefix PATH : "${lib.makeBinPath [ gnupg ]}"
   '';
   meta = {
     license = [ lib.licenses.gpl2 ];

--- a/pkgs/applications/misc/playonlinux/default.nix
+++ b/pkgs/applications/misc/playonlinux/default.nix
@@ -4,7 +4,7 @@
 , cabextract
 , gettext
 , glxinfo
-, gnupg1compat
+, gnupg
 , icoutils
 , imagemagick
 , netcat-gnu
@@ -30,7 +30,7 @@ let
       python2Packages.python
       gettext
       glxinfo
-      gnupg1compat
+      gnupg
       icoutils
       imagemagick
       netcat-gnu

--- a/pkgs/applications/version-management/git-and-tools/git-crypt/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-crypt/default.nix
@@ -1,4 +1,4 @@
-{ fetchFromGitHub, git, gnupg1compat, makeWrapper, openssl, stdenv }:
+{ fetchFromGitHub, git, gnupg, makeWrapper, openssl, stdenv }:
 
 stdenv.mkDerivation rec {
   name = "git-crypt-${version}";
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     make install PREFIX=$out
-    wrapProgram $out/bin/* --prefix PATH : $out/bin:${git}/bin:${gnupg1compat}/bin
+    wrapProgram $out/bin/* --prefix PATH : $out/bin:${git}/bin:${gnupg}/bin
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/version-management/git-and-tools/git-remote-gcrypt/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-remote-gcrypt/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, docutils, makeWrapper
-, gnupg1compat, curl, rsync, coreutils
+, gnupg, curl, rsync, coreutils
 , gawk, gnused, gnugrep
 }:
 
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     prefix="$out" ./install.sh
     wrapProgram "$out/bin/git-remote-gcrypt" \
-      --prefix PATH ":" "${stdenv.lib.makeBinPath [ gnupg1compat curl rsync coreutils
+      --prefix PATH ":" "${stdenv.lib.makeBinPath [ gnupg curl rsync coreutils
                                                     gawk gnused gnugrep ]}"
   '';
 

--- a/pkgs/applications/virtualization/rkt/default.nix
+++ b/pkgs/applications/virtualization/rkt/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, autoreconfHook, acl, go, file, git, wget, gnupg1, trousers, squashfsTools,
+{ stdenv, lib, autoreconfHook, acl, go, file, git, wget, gnupg, trousers, squashfsTools,
   cpio, fetchurl, fetchFromGitHub, iptables, systemd, makeWrapper, glibc }:
 
 let
@@ -30,7 +30,7 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [
     glibc.out glibc.static
-    autoreconfHook go file git wget gnupg1 trousers squashfsTools cpio acl systemd
+    autoreconfHook go file git wget gnupg trousers squashfsTools cpio acl systemd
     makeWrapper
   ];
 

--- a/pkgs/development/python-modules/python-gnupg/default.nix
+++ b/pkgs/development/python-modules/python-gnupg/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, gnupg1 }:
+{ stdenv, buildPythonPackage, fetchPypi, gnupg }:
 
 buildPythonPackage rec {
   pname   = "python-gnupg";
@@ -12,9 +12,9 @@ buildPythonPackage rec {
   # Let's make the library default to our gpg binary
   patchPhase = ''
     substituteInPlace gnupg.py \
-    --replace "gpgbinary='gpg'" "gpgbinary='${gnupg1}/bin/gpg'"
+    --replace "gpgbinary='gpg'" "gpgbinary='${gnupg}/bin/gpg'"
     substituteInPlace test_gnupg.py \
-    --replace "gpgbinary=GPGBINARY" "gpgbinary='${gnupg1}/bin/gpg'" \
+    --replace "gpgbinary=GPGBINARY" "gpgbinary='${gnupg}/bin/gpg'" \
     --replace "test_search_keys" "disabled__test_search_keys"
   '';
 

--- a/pkgs/development/tools/build-managers/leiningen/default.nix
+++ b/pkgs/development/tools/build-managers/leiningen/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, makeWrapper
-, coreutils, jdk, rlwrap, gnupg1compat }:
+, coreutils, jdk, rlwrap, gnupg }:
 
 stdenv.mkDerivation rec {
   pname = "leiningen";
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
       --replace 'LEIN_JAR=/usr/share/java/leiningen-$LEIN_VERSION-standalone.jar' "LEIN_JAR=$out/share/$JARNAME"
     wrapProgram $out/bin/lein \
       --prefix PATH ":" "${stdenv.lib.makeBinPath [ rlwrap coreutils ]}" \
-      --set LEIN_GPG ${gnupg1compat}/bin/gpg \
+      --set LEIN_GPG ${gnupg}/bin/gpg \
       --set JAVA_CMD ${jdk}/bin/java
   '';
 

--- a/pkgs/servers/mail/spamassassin/default.nix
+++ b/pkgs/servers/mail/spamassassin/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perlPackages, makeWrapper, gnupg1 }:
+{ stdenv, fetchurl, perlPackages, makeWrapper, gnupg }:
 
 perlPackages.buildPerlPackage rec {
   name = "SpamAssassin-3.4.2";
@@ -27,7 +27,7 @@ perlPackages.buildPerlPackage rec {
     mv "rules/"* $out/share/spamassassin/
 
     for n in "$out/bin/"*; do
-      wrapProgram "$n" --prefix PERL5LIB : "$PERL5LIB" --prefix PATH : "${gnupg1}/bin"
+      wrapProgram "$n" --prefix PERL5LIB : "$PERL5LIB" --prefix PATH : "${gnupg}/bin"
     done
   '';
 

--- a/pkgs/tools/backup/duply/default.nix
+++ b/pkgs/tools/backup/duply/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, coreutils, python2, duplicity, gawk, gnupg1, bash
+{ stdenv, fetchurl, coreutils, python2, duplicity, gawk, gnupg, bash
 , gnugrep, txt2man, makeWrapper, which
 }:
 
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     mkdir -p "$out/share/man/man1"
     install -vD duply "$out/bin"
     wrapProgram "$out/bin/duply" --set PATH \
-        ${stdenv.lib.makeBinPath [ coreutils python2 duplicity gawk gnupg1 bash gnugrep txt2man which ]}
+        ${stdenv.lib.makeBinPath [ coreutils python2 duplicity gawk gnupg bash gnugrep txt2man which ]}
     "$out/bin/duply" txt2man > "$out/share/man/man1/duply.1"
   '';
 

--- a/pkgs/tools/misc/aptly/default.nix
+++ b/pkgs/tools/misc/aptly/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildGoPackage, fetchFromGitHub, makeWrapper, gnupg1compat, bzip2, xz, graphviz }:
+{ stdenv, buildGoPackage, fetchFromGitHub, makeWrapper, gnupg, bzip2, xz, graphviz }:
 
 let
 
@@ -34,7 +34,7 @@ buildGoPackage {
     mkdir -p $bin/share/bash-completion/completions
     ln -s ${aptlyCompletionSrc}/aptly $bin/share/bash-completion/completions
     wrapProgram "$bin/bin/aptly" \
-      --prefix PATH ":" "${stdenv.lib.makeBinPath [ gnupg1compat bzip2 xz graphviz ]}"
+      --prefix PATH ":" "${stdenv.lib.makeBinPath [ gnupg bzip2 xz graphviz ]}"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/misc/diffoscope/default.nix
+++ b/pkgs/tools/misc/diffoscope/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchgit, python3Packages, docutils, help2man
 , acl, apktool, binutils-unwrapped, bzip2, cbfstool, cdrkit, colord, colordiff, coreutils, cpio, db, diffutils, dtc
-, e2fsprogs, file, findutils, fontforge-fonttools, fpc, gettext, ghc, ghostscriptX, giflib, gnumeric, gnupg1, gnutar
+, e2fsprogs, file, findutils, fontforge-fonttools, fpc, gettext, ghc, ghostscriptX, giflib, gnumeric, gnupg, gnutar
 , gzip, imagemagick, jdk, libarchive, libcaca, llvm, lz4, mono, openssh, pdftk, pgpdump, poppler_utils, sng, sqlite
 , squashfsTools, tcpdump, unoconv, unzip, xxd, xz
 , enableBloat ? false
@@ -41,7 +41,7 @@ python3Packages.buildPythonApplication rec {
       dtc e2fsprogs file findutils fontforge-fonttools gettext gnutar gzip
       libarchive libcaca lz4 pgpdump progressbar33 sng sqlite squashfsTools unzip xxd xz
     ] ++ lib.optionals enableBloat [
-      apktool cbfstool colord fpc ghc ghostscriptX giflib gnupg1 gnumeric imagemagick
+      apktool cbfstool colord fpc ghc ghostscriptX giflib gnupg gnumeric imagemagick
       llvm jdk mono openssh pdftk poppler_utils tcpdump unoconv
       python3Packages.guestfs
     ];

--- a/pkgs/tools/security/signing-party/default.nix
+++ b/pkgs/tools/security/signing-party/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, autoconf, automake, makeWrapper
 , python3, perl, perlPackages
-, libmd, gnupg1, which, getopt, libpaper, nettools, qprint
+, libmd, gnupg, which, getopt, libpaper, nettools, qprint
 , sendmailPath ? "/run/wrappers/bin/sendmail" }:
 
 let
@@ -42,7 +42,7 @@ in stdenv.mkDerivation rec {
   # Perl is required for it's pod2man.
   # Python and Perl are required for patching the script interpreter paths.
   nativeBuildInputs = [ autoconf automake makeWrapper ];
-  buildInputs = [ python3 perl perlPackages.GnuPGInterface libmd gnupg1 ];
+  buildInputs = [ python3 perl perlPackages.GnuPGInterface libmd gnupg ];
 
   postInstall = ''
     # Install all tools which aren't handled by 'make install'.
@@ -123,59 +123,59 @@ in stdenv.mkDerivation rec {
         TextTemplate MIMETools MailTools TimeDate NetIDNEncode ]
         ++ GnuPGInterfaceRuntimeDependencies)} \
       --prefix PATH ":" \
-      "${stdenv.lib.makeBinPath [ nettools gnupg1 ]}"
+      "${stdenv.lib.makeBinPath [ nettools gnupg ]}"
 
     wrapProgram $out/bin/gpg-key2latex --set PERL5LIB \
       ${perlPackages.makePerlPath GnuPGInterfaceRuntimeDependencies} \
       --prefix PATH ":" \
-      "${stdenv.lib.makeBinPath [ gnupg1 libpaper ]}"
+      "${stdenv.lib.makeBinPath [ gnupg libpaper ]}"
 
     wrapProgram $out/bin/gpg-key2ps --prefix PATH ":" \
-      "${stdenv.lib.makeBinPath [ which gnupg1 libpaper ]}"
+      "${stdenv.lib.makeBinPath [ which gnupg libpaper ]}"
 
     wrapProgram $out/bin/gpg-mailkeys --prefix PATH ":" \
-      "${stdenv.lib.makeBinPath [ gnupg1 qprint ]}"
+      "${stdenv.lib.makeBinPath [ gnupg qprint ]}"
 
     wrapProgram $out/bin/gpgdir --set PERL5LIB \
       ${with perlPackages; makePerlPath ([
         TermReadKey ]
         ++ GnuPGInterfaceRuntimeDependencies)} \
       --prefix PATH ":" \
-      "${stdenv.lib.makeBinPath [ gnupg1 ]}"
+      "${stdenv.lib.makeBinPath [ gnupg ]}"
 
     wrapProgram $out/bin/gpglist --prefix PATH ":" \
-      "${stdenv.lib.makeBinPath [ gnupg1 ]}"
+      "${stdenv.lib.makeBinPath [ gnupg ]}"
 
     wrapProgram $out/bin/gpgparticipants --prefix PATH ":" \
-      "${stdenv.lib.makeBinPath [ getopt gnupg1 ]}"
+      "${stdenv.lib.makeBinPath [ getopt gnupg ]}"
 
 #    wrapProgram $out/bin/gpgparticipants-prefill
 
     wrapProgram $out/bin/gpgsigs --set PERL5LIB \
       ${perlPackages.makePerlPath GnuPGInterfaceRuntimeDependencies} \
       --prefix PATH ":" \
-      "${stdenv.lib.makeBinPath [ gnupg1 ]}"
+      "${stdenv.lib.makeBinPath [ gnupg ]}"
 
     wrapProgram $out/bin/gpgwrap --prefix PATH ":" \
-      "${stdenv.lib.makeBinPath [ gnupg1 ]}"
+      "${stdenv.lib.makeBinPath [ gnupg ]}"
 
 #    wrapProgram $out/bin/keyanalyze --set PERL5LIB \
 
     wrapProgram $out/bin/keyart --prefix PATH ":" \
-      "${stdenv.lib.makeBinPath [ gnupg1 ]}"
+      "${stdenv.lib.makeBinPath [ gnupg ]}"
 
     wrapProgram $out/bin/keylookup --prefix PATH ":" \
-      "${stdenv.lib.makeBinPath [ gnupg1 ]}"
+      "${stdenv.lib.makeBinPath [ gnupg ]}"
 
     wrapProgram $out/bin/pgp-clean --set PERL5LIB \
       ${perlPackages.makePerlPath GnuPGInterfaceRuntimeDependencies} \
       --prefix PATH ":" \
-      "${stdenv.lib.makeBinPath [ gnupg1 ]}"
+      "${stdenv.lib.makeBinPath [ gnupg ]}"
 
     wrapProgram $out/bin/pgp-fixkey --set PERL5LIB \
       ${perlPackages.makePerlPath GnuPGInterfaceRuntimeDependencies} \
       --prefix PATH ":" \
-      "${stdenv.lib.makeBinPath [ gnupg1 ]}"
+      "${stdenv.lib.makeBinPath [ gnupg ]}"
 
 #    wrapProgram $out/bin/pgpring
 


### PR DESCRIPTION
gnupg is gnupg 2.2. gnupg1 is also gnupg 2.2, just with a few extra
symlinks in the bin directory. None of these packages need those
symlinks, and it's confusing for them to say they're depending on
"gnupg1", so switch their dep to plain "gnupg".

I have not built any of these packages, I'm hoping to rely on ofborg.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

