### PR TITLE
ccemux: 1.1.0 -> 1.1.1

### DIFF
--- a/pkgs/misc/emulators/ccemux/default.nix
+++ b/pkgs/misc/emulators/ccemux/default.nix
@@ -3,19 +3,19 @@
 }:
 
 let
-  version = "1.1.0";
-  rev = "a12239148332ca7a0b1c44a93e1585452d3631c9";
+  version = "1.1.1";
+  rev = "af12e2e4da586275ba931eae8f40a2201251bf59";
 
   baseUrl = "https://emux.cc/versions/${stdenv.lib.substring 0 8 rev}/CCEmuX";
   jar =
     if useCCTweaked
     then fetchurl {
       url = "${baseUrl}-cct.jar";
-      sha256 = "1i767v3wnb8jsh7ciqqvw548pka1b8vl18k1rdv5dn21la6n0r1d";
+      sha256 = "0d9gzi1h5vz32fp4lfn7dam189jcm7bwbqwmlpj0c47p8l0d4lsv";
     }
     else fetchurl {
       url = "${baseUrl}-cc.jar";
-      sha256 = "0x9hs814ln193cwybd565mcj6vhnii4wirkiz9na7vcas0y5vmmq";
+      sha256 = "0ky5vxh8m1v98zllifxif8xxd25j2xdp19hjnj4xlkck71lbnb34";
     };
 
   desktopIcon = fetchurl {


### PR DESCRIPTION
###### Motivation for this change
Updates [CCEmuX](https://github.com/CCEmuX/CCEmuX) to 1.1.1.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

