### PR TITLE
elk: 6.5.1 -> 6.6.2

### DIFF
--- a/pkgs/development/tools/misc/kibana/default.nix
+++ b/pkgs/development/tools/misc/kibana/default.nix
@@ -18,12 +18,12 @@ let
   shas =
     if enableUnfree
     then {
-      "x86_64-linux"  = "0lip4bj3jazv83gydw99dnp03cb0fd1p4z3lvpjbisgmqffbbg5v";
-      "x86_64-darwin" = "0hjdnqagcwbjhpcfyr6w0zmy4sjnx4fyp79czb0vp7dig5arnwm3";
+      "x86_64-linux"  = "1c56l3z2k9ncmx3kbam2hr2m4pkhxv0l226bla5vz0y6adh2zcs5";
+      "x86_64-darwin" = "08hq8fjc93j25dpd8l61a2rfvpdgl0my75gg0pfqfaspknbdq2a1";
     }
     else {
-      "x86_64-linux"  = "1jybn4q7pz61iijzl85d948szlacfcbldn2nhhsb6063xwvf30sa";
-      "x86_64-darwin" = "1bl1h6hgp9l5cjq6pzj2x855wjaka8hbs0fn2c03lbzsc991dppr";
+      "x86_64-linux"  = "0jrjbg63nxnpc2cx8m6z6fw28mj1yq0dw1whbykaxdwzhjcf0v96";
+      "x86_64-darwin" = "07fm15mpg7ljyjmz2dq16jwxhsml9hxdmnbb3qpcl9bidvjdlw4k";
     };
 
   # For the correct phantomjs version see:
@@ -48,7 +48,7 @@ in stdenv.mkDerivation rec {
   };
 
   patches = [
-    # Kibana specifies it specifically needs nodejs 8.11.4 but nodejs in nixpkgs is at 8.12.0.
+    # Kibana specifies it specifically needs nodejs 10.15.2 but nodejs in nixpkgs is at 10.15.3.
     # The <nixpkgs/nixos/tests/elk.nix> test succeeds with this newer version so lets just
     # disable the version check.
     ./disable-nodejs-version-check.patch

--- a/pkgs/misc/logging/beats/6.x.nix
+++ b/pkgs/misc/logging/beats/6.x.nix
@@ -8,7 +8,7 @@ let beat = package : extraArgs : buildGoPackage (rec {
         owner = "elastic";
         repo = "beats";
         rev = "v${version}";
-        sha256 = "1qnrq9bhk7csgcxycb8c7975lq0p7cxw29i6sji777zv4hn7442m";
+        sha256 = "0hf835xlg4855fsz1zapwkp1ydjlxcfzf9hfqvgq617srxp4v6g1";
       };
 
       goPackagePath = "github.com/elastic/beats";

--- a/pkgs/servers/search/elasticsearch/default.nix
+++ b/pkgs/servers/search/elasticsearch/default.nix
@@ -19,8 +19,8 @@ stdenv.mkDerivation (rec {
     url = "https://artifacts.elastic.co/downloads/elasticsearch/${name}.tar.gz";
     sha256 =
       if enableUnfree
-      then "096i8xiy7mfwlslym9mkjb2f5vqdcqhk65583526rcybqxc2zkqp"
-      else "0j3q02c4rw8272w07hm64sk5ssmj4gj8s3qigsbrq5pgf8b03fvs";
+      then "0w3pp7gjs90cr14cjrgp561m19ajcg60nvjv1brjjvj67fknybgk"
+      else "1r85p63gryniq1a9l3dz31qag2q5dh31jdsigd1kzc8czv10dz7l";
   };
 
   patches = [ ./es-home-6.x.patch ];

--- a/pkgs/servers/search/elasticsearch/plugins.nix
+++ b/pkgs/servers/search/elasticsearch/plugins.nix
@@ -27,7 +27,7 @@ in {
     version = "${elk6Version}";
     src = fetchurl {
       url = "https://github.com/vhyza/elasticsearch-analysis-lemmagen/releases/download/v${version}/${name}-plugin.zip";
-      sha256 = "0299ldqwjn1gn44yyjiqjrxvs6mlclhzl1dbn6xlgg1a2lkaal4v";
+      sha256 = "1ldmz1a4g3rr4djk17yjx9slfmqx0if4i725465d1yvd740ka8hi";
     };
     meta = with stdenv.lib; {
       homepage = https://github.com/vhyza/elasticsearch-analysis-lemmagen;
@@ -42,7 +42,7 @@ in {
     version = "${elk6Version}";
     src = pkgs.fetchurl {
       url = "https://artifacts.elastic.co/downloads/elasticsearch-plugins/discovery-ec2/discovery-ec2-${elk6Version}.zip";
-      sha256 = "1mg9knbc4r21kaiqnmkd8nzf2i23w5zxqnxyz484q0l2jf4hlkq1";
+      sha256 = "0179qixwi71jn5bmj03p80x8318pxbcf9asxgjly9j4z49w9r2c0";
     };
     meta = with stdenv.lib; {
       homepage = https://github.com/elastic/elasticsearch/tree/master/plugins/discovery-ec2;
@@ -54,10 +54,10 @@ in {
   search_guard = esPlugin rec {
     name = "elastic-search-guard-${version}";
     pluginName = "search-guard";
-    version = "${elk6Version}-23.2";
+    version = "${elk6Version}-24.2";
     src = fetchurl rec {
       url = "mirror://maven/com/floragunn/search-guard-6/${version}/search-guard-6-${version}.zip";
-      sha256 = "05310wyxzhylxr0dfgzr10pb0pak30ry8r97g49n6iqj8dw3csnb";
+      sha256 = "17kp8damya95lsjc58s9818xi8387j3hj2ivq09j5l4il100d6jl";
     };
     meta = with stdenv.lib; {
       homepage = https://github.com/floragunncom/search-guard;

--- a/pkgs/tools/misc/logstash/default.nix
+++ b/pkgs/tools/misc/logstash/default.nix
@@ -16,8 +16,8 @@ stdenv.mkDerivation rec {
     url = "https://artifacts.elastic.co/downloads/logstash/${name}.tar.gz";
     sha256 =
       if enableUnfree
-      then "01mkb9fr63m3ilp4cbbjccid5m8yc7iqhnli12ynfabsf7302fdz"
-      else "0r60183yyywabinsv9pkd8sx0wq68h740xi3172fypjfdcqs0g9c";
+      then "1l05qp1xkh5ix3khyz5nzm75vh1jyds4y2l495rcqhfxllrabwag"
+      else "1yl46fl2f7hv2r27n74wdxwj633c762nrbzj5ylyb5r7h00jb2py";
   };
 
   dontBuild         = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2520,7 +2520,7 @@ in
 
   # The latest version used by elasticsearch, logstash, kibana and the the beats from elastic.
   elk5Version = "5.6.9";
-  elk6Version = "6.5.1";
+  elk6Version = "6.6.2";
 
   elasticsearch5 = callPackage ../servers/search/elasticsearch/5.x.nix { };
   elasticsearch6 = callPackage ../servers/search/elasticsearch { };
@@ -3707,8 +3707,11 @@ in
   keyfuzz = callPackage ../tools/inputmethods/keyfuzz { };
 
   kibana5 = callPackage ../development/tools/misc/kibana/5.x.nix { };
-  kibana6 = callPackage ../development/tools/misc/kibana/default.nix { };
+  kibana6 = callPackage ../development/tools/misc/kibana/default.nix {
+    nodejs = nodejs-10_x;
+  };
   kibana6-oss = callPackage ../development/tools/misc/kibana/default.nix {
+    nodejs = nodejs-10_x;
     enableUnfree = false;
   };
   kibana = kibana6;


### PR DESCRIPTION
###### Motivation for this change
https://www.elastic.co/guide/en/elasticsearch/reference/6.6/release-notes-6.6.2.html
https://www.elastic.co/guide/en/logstash/6.6/logstash-6-6-2.html
https://www.elastic.co/guide/en/kibana/6.6/release-notes-6.6.2.html
https://www.elastic.co/guide/en/beats/libbeat/6.6/release-notes-6.6.2.html

###### Things done

The following tests succeed on my system:

* $ nix-build nixos/tests/elk.nix -A ELK-6
* $ NIXPKGS_ALLOW_UNFREE=1 nix-build nixos/tests/elk.nix -A ELK-6 --arg enableUnfree true

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

