### PR TITLE
Python language server 0.25.0

### DIFF
--- a/pkgs/development/python-modules/python-jsonrpc-server/default.nix
+++ b/pkgs/development/python-modules/python-jsonrpc-server/default.nix
@@ -5,14 +5,18 @@
 
 buildPythonPackage rec {
   pname = "python-jsonrpc-server";
-  version = "0.0.2";
+  version = "0.1.2";
 
   src = fetchFromGitHub {
     owner = "palantir";
     repo = "python-jsonrpc-server";
     rev = version;
-    sha256 = "1xp6xipslw8d1yv05mjmhql07kz04ibci5psjrv6rapqi6jp4bgk";
+    sha256 = "0k55rpywghapk5db8dgp2jj5v5654q6m571s1gcz1mpn2qxkz69l";
   };
+
+  postPatch = ''
+    sed -i 's/version=versioneer.get_version(),/version="${version}",/g' setup.py
+  '';
 
   checkInputs = [
     pytest mock pytestcov coverage

--- a/pkgs/development/python-modules/python-language-server/default.nix
+++ b/pkgs/development/python-modules/python-language-server/default.nix
@@ -10,6 +10,7 @@
 , pycodestyle ? null
 , pydocstyle ? null
 , pyflakes ? null
+, pylint ? null
 , rope ? null
 , yapf ? null
 }:
@@ -20,13 +21,13 @@ in
 
 buildPythonPackage rec {
   pname = "python-language-server";
-  version = "0.21.2";
+  version = "0.25.0";
 
   src = fetchFromGitHub {
     owner = "palantir";
     repo = "python-language-server";
     rev = version;
-    sha256 = "11fvrpv1kymj2fzh8fhys4qk1xc64j1rbdrz252awyab7b3509i7";
+    sha256 = "10la48m10j4alfnpw0xw359fb833scf5kv7kjvh7djf6ij7cfsvq";
   };
 
   # The tests require all the providers, disable otherwise.
@@ -49,6 +50,7 @@ buildPythonPackage rec {
     ++ stdenv.lib.optional (withProvider "pycodestyle") pycodestyle
     ++ stdenv.lib.optional (withProvider "pydocstyle") pydocstyle
     ++ stdenv.lib.optional (withProvider "pyflakes") pyflakes
+    ++ stdenv.lib.optional (withProvider "pylint") pylint
     ++ stdenv.lib.optional (withProvider "rope") rope
     ++ stdenv.lib.optional (withProvider "yapf") yapf
     ++ stdenv.lib.optional isPy27 configparser


### PR DESCRIPTION
###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

