### PR TITLE
Factorio: experimental 0.17.14 → 0.17.16

### DIFF
--- a/pkgs/games/factorio/default.nix
+++ b/pkgs/games/factorio/default.nix
@@ -53,11 +53,11 @@ let
     x86_64-linux = let bdist = bdistForArch { inUrl = "linux64"; inTar = "x64"; }; in {
       alpha = {
         stable        = bdist { sha256 = "0b4hbpdcrh5hgip9q5dkmw22p66lcdhnr0kmb0w5dw6yi7fnxxh0"; version = "0.16.51"; withAuth = true; };
-        experimental  = bdist { sha256 = "1yanklsqyfcw5rinyv1sd3w1g28jr0i1g70zxx25mnbb90w878n4"; version = "0.17.15"; withAuth = true; };
+        experimental  = bdist { sha256 = "11vwyyf3him2bi0c5cgv0h0k304kvw667ygqplq5giyzcvadjix8"; version = "0.17.16"; withAuth = true; };
       };
       headless = {
         stable        = bdist { sha256 = "0zrnpg2js0ysvx9y50h3gajldk16mv02dvrwnkazh5kzr1d9zc3c"; version = "0.16.51"; };
-        experimental  = bdist { sha256 = "0c6v57l6h0q7w9yxlla505pvqxizd8d2nwnbdrprfdfx0z7mm80n"; version = "0.17.15"; };
+        experimental  = bdist { sha256 = "1sxv4kc5vg53lgjrm5c250hvbg6hqz0ijfxpvfjk7bzps5g6n1fx"; version = "0.17.16"; };
       };
       demo = {
         stable        = bdist { sha256 = "0zf61z8937yd8pyrjrqdjgd0rjl7snwrm3xw86vv7s7p835san6a"; version = "0.16.51"; };

--- a/pkgs/games/factorio/default.nix
+++ b/pkgs/games/factorio/default.nix
@@ -53,11 +53,11 @@ let
     x86_64-linux = let bdist = bdistForArch { inUrl = "linux64"; inTar = "x64"; }; in {
       alpha = {
         stable        = bdist { sha256 = "0b4hbpdcrh5hgip9q5dkmw22p66lcdhnr0kmb0w5dw6yi7fnxxh0"; version = "0.16.51"; withAuth = true; };
-        experimental  = bdist { sha256 = "0piprfkywja35m5x4wv9xdykp6ywfs5f2z1y6fmszfv26jz234sg"; version = "0.17.14"; withAuth = true; };
+        experimental  = bdist { sha256 = "1yanklsqyfcw5rinyv1sd3w1g28jr0i1g70zxx25mnbb90w878n4"; version = "0.17.15"; withAuth = true; };
       };
       headless = {
         stable        = bdist { sha256 = "0zrnpg2js0ysvx9y50h3gajldk16mv02dvrwnkazh5kzr1d9zc3c"; version = "0.16.51"; };
-        experimental  = bdist { sha256 = "1h8psnrwdd2h3myndw35723qsgbn3xpmrz94r7mdyirfabi870a9"; version = "0.17.14"; };
+        experimental  = bdist { sha256 = "0c6v57l6h0q7w9yxlla505pvqxizd8d2nwnbdrprfdfx0z7mm80n"; version = "0.17.15"; };
       };
       demo = {
         stable        = bdist { sha256 = "0zf61z8937yd8pyrjrqdjgd0rjl7snwrm3xw86vv7s7p835san6a"; version = "0.16.51"; };


### PR DESCRIPTION
###### Motivation for this change
Oh god, Wube, why

###### Things done
Update factorio and hashes

The update script will probably involve 
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

