### PR TITLE
apulse: 0.1.11.1 -> 0.1.12, cleanup

### DIFF
--- a/pkgs/misc/apulse/default.nix
+++ b/pkgs/misc/apulse/default.nix
@@ -4,13 +4,13 @@
 let oz = x: if x then "1" else "0"; in
 
 stdenv.mkDerivation rec {
-  name = "apulse-${version}";
-  version = "0.1.11.1";
+  pname = "apulse";
+  version = "0.1.12";
 
   src = fetchFromGitHub {
     owner = "i-rinat";
-    repo = "apulse";
-    rev = "602b3a02b4b459d4652a3a0a836fab6f892d4080";
+    repo = pname;
+    rev = "v${version}";
     sha256 = "0yk9vgb4aws8xnkhdhgpxp5c0rri8yq61yxk85j99j8ax806i3r8";
   };
 
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "PulseAudio emulation for ALSA";
-    homepage = https://github.com/i-rinat/apulse;
+    homepage = "https://github.com/i-rinat/apulse";
     license = licenses.mit;
     platforms = platforms.linux;
     maintainers = [ maintainers.jagajaga ];


### PR DESCRIPTION
###### Motivation for this change

New version of apulse; automated updates didn't work because changing version didn't change src url.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

