### PR TITLE
pythonPackages.pyhepmc: fix build

### DIFF
--- a/pkgs/development/python-modules/pyhepmc/default.nix
+++ b/pkgs/development/python-modules/pyhepmc/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, fetchFromBitbucket
 , isPy3k
 , fetchurl
 , pkgs
@@ -17,6 +18,18 @@ buildPythonPackage rec {
     sha256 = "1210fd7e20d4abc1d9166147a9f7645a2a58b655fe030ad54ab3ea0d0c6e0834";
   };
 
+  srcMissing = fetchFromBitbucket {
+    owner = "andybuckley";
+    repo = "pyhepmc";
+    rev = "pyhepmc-1.0.0";
+    sha256 = "0vxad143pz45q94w5p0dycpk24insdsv1m5k867y56xy24bi0d4w";
+  };
+
+  prePatch = ''
+    cp -r $srcMissing/hepmc .
+    chmod +w hepmc
+  '';
+
   patches = [
     # merge PR https://bitbucket.org/andybuckley/pyhepmc/pull-requests/1/add-incoming-outgoing-generators-for/diff
     ./pyhepmc_export_edges.patch
@@ -26,11 +39,11 @@ buildPythonPackage rec {
 
   # regenerate python wrapper
   preConfigure = ''
-    rm hepmc/hepmcwrap.py
     swig -c++ -I${pkgs.hepmc}/include -python hepmc/hepmcwrap.i
   '';
 
-  buildInputs = [ pkgs.swig pkgs.hepmc ];
+  nativeBuildInputs = [ pkgs.swig ];
+  buildInputs = [ pkgs.hepmc ];
 
   HEPMCPATH = pkgs.hepmc;
 


### PR DESCRIPTION
###### Motivation for this change

Fixes build after 03fb64255618e1c5f85731b36d86a93ff2718185

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
