### PR TITLE
glibcLocales: also build C.UTF-8

### DIFF
--- a/pkgs/development/libraries/glibc/locales.nix
+++ b/pkgs/development/libraries/glibc/locales.nix
@@ -26,6 +26,8 @@ callPackage ./common.nix { inherit stdenv; } {
     ''
       mkdir -p $TMPDIR/"${buildPackages.stdenv.cc.libc.out}/lib/locale"
 
+      echo 'C.UTF-8/UTF-8 \' >> ../glibc-2*/localedata/SUPPORTED
+
       # Hack to allow building of the locales (needed since glibc-2.12)
       sed -i -e 's,^$(rtld-prefix) $(common-objpfx)locale/localedef,localedef --prefix='$TMPDIR',' ../glibc-2*/localedata/Makefile
     ''


### PR DESCRIPTION
Previously we only build C.UTF-8 as part of the locale-archive
that comes with the glibc core package.
However for consistent use of LANG=C.UTF-8 we also want support
in our glibcLocales as well.
fixes https://github.com/NixOS/nixpkgs/issues/57974

Tested with:

```console
$ nix-shell -p glibcLocales
$ echo $LOCALE_ARCHIVE
/nix/store/i5zccmsnirxqlx48g4d2r960zawfzzsh-glibc-locales-2.27/lib/locale/locale-archive
$ python3 -c 'import locale; locale.setlocale(locale.LC_ALL, "C.UTF-8")'
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

