### PR TITLE
qutebrowser: 1.6.0 -> 1.6.1

### DIFF
--- a/pkgs/applications/networking/browsers/qutebrowser/default.nix
+++ b/pkgs/applications/networking/browsers/qutebrowser/default.nix
@@ -21,12 +21,12 @@ let
 
 in python3Packages.buildPythonApplication rec {
   pname = "qutebrowser";
-  version = "1.6.0";
+  version = "1.6.1";
 
   # the release tarballs are different from the git checkout!
   src = fetchurl {
     url = "https://github.com/qutebrowser/qutebrowser/releases/download/v${version}/${pname}-${version}.tar.gz";
-    sha256 = "1pkbzhd5syn7m8q0i7zlxjdgd693z0gj0h22nkc48zjkn214w236";
+    sha256 = "1sckfp9l2jgg29p2p4vmd0g7yzbldimqy0a0jvf488yp47qj310p";
   };
 
   # Needs tox


### PR DESCRIPTION
###### Motivation for this change
https://github.com/qutebrowser/qutebrowser/releases/tag/v1.6.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

