### PR TITLE
pythonPackages.elasticsearch-curator: pass "click" dependency in version 6.7

### DIFF
--- a/pkgs/development/python-modules/click/default.nix
+++ b/pkgs/development/python-modules/click/default.nix
@@ -1,19 +1,24 @@
-{ stdenv, buildPythonPackage, fetchPypi, substituteAll, locale, pytest }:
+{ stdenv, buildPythonPackage, fetchFromGitHub, substituteAll, locale, pytest, version ? "7.0" }:
 
 buildPythonPackage rec {
   pname = "click";
-  version = "7.0";
+  inherit version;
 
-  src = fetchPypi {
-    pname = "Click";
-    inherit version;
-    sha256 = "5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7";
+  src = fetchFromGitHub {
+    owner = "pallets";
+    repo = "click";
+    rev = version;
+    sha256 = if version == "7.0"
+      then "13mpfazsbiwwwma19z473sc92mwrla8rcnhvnb9vsgiyd2pz33g0"  # 7.0
+      else "1mhns6c00gnfjzqka995aah0445jzh56mipmypj3xpmrxl3acpq2"; # 6.7
   };
 
-  patches = stdenv.lib.optional (stdenv.lib.versionAtLeast version "6.7") (substituteAll {
-    src = ./fix-paths.patch;
+  patches = [(substituteAll {
+    src = if stdenv.lib.versionAtLeast version "7.0"
+      then ./fix-paths.patch
+      else ./fix-paths67.patch;
     locale = "${locale}/bin/locale";
-  });
+  })];
 
   buildInputs = [ pytest ];
 

--- a/pkgs/development/python-modules/click/fix-paths67.patch
+++ b/pkgs/development/python-modules/click/fix-paths67.patch
@@ -1,0 +1,13 @@
+diff --git a/click/_unicodefun.py b/click/_unicodefun.py
+index 9e17a38..8595ca3 100644
+--- a/click/_unicodefun.py
++++ b/click/_unicodefun.py
+@@ -60,7 +60,7 @@ def _verify_python3_env():
+     extra = ''
+     if os.name == 'posix':
+         import subprocess
+-        rv = subprocess.Popen(['locale', '-a'], stdout=subprocess.PIPE,
++        rv = subprocess.Popen(['@locale@', '-a'], stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE).communicate()[0]
+         good_locales = set()
+         has_c_utf8 = False

--- a/pkgs/development/python-modules/elasticsearch-curator/default.nix
+++ b/pkgs/development/python-modules/elasticsearch-curator/default.nix
@@ -45,13 +45,6 @@ buildPythonPackage rec {
     funcsigs
   ];
 
-  postPatch = ''
-    substituteInPlace setup.cfg \
-      --replace 'click>=6.7,<7.0' 'click'
-    substituteInPlace setup.py \
-      --replace 'click>=6.7,<7.0' 'click'
-  '';
-
   meta = with stdenv.lib; {
     homepage = https://github.com/elastic/curator;
     description = "Curate, or manage, your Elasticsearch indices and snapshots";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1809,7 +1809,9 @@ in {
   # alias
   elasticsearchdsl = self.elasticsearch-dsl;
 
-  elasticsearch-curator = callPackage ../development/python-modules/elasticsearch-curator { };
+  elasticsearch-curator = callPackage ../development/python-modules/elasticsearch-curator {
+    click = callPackage ../development/python-modules/click { version = "6.7"; };
+  };
 
   entrypoints = callPackage ../development/python-modules/entrypoints { };
 


### PR DESCRIPTION
###### Motivation for this change
Improving the fix from https://github.com/NixOS/nixpkgs/pull/57912 by passing click in version 6.7 to elasticsearch-curator, since according to https://github.com/elastic/curator/pull/1280, it is not compatible with click v7.0.

This should be backported to 19.03 as well.

cc @srhb @dotlambda 
@GrahamcOfBorg build pythonPackages.elasticsearch-curator pythonPackages.click

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

