### PR TITLE
Create texmf-local directory separate from texmf-dist.

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/combine.nix
+++ b/pkgs/tools/typesetting/tex/texlive/combine.nix
@@ -87,7 +87,8 @@ in buildEnv {
     export TEXMFSYSVAR="$out/share/texmf-var"
     export PERL5LIB="$out/share/texmf/scripts/texlive"
   '' +
-    # patch texmf-{dist,local} -> texmf to be sure
+    # patch texmf-dist  -> $out/share/texmf
+    # patch texmf-local -> $out/share/texmf-local
     # TODO: perhaps do lua actions?
     # tried inspiration from install-tl, sub do_texmf_cnf
   ''
@@ -99,8 +100,7 @@ in buildEnv {
         rm ./texmfcnf.lua
         sed \
           -e 's,texmf-dist,texmf,g' \
-          -e 's,texmf-local,texmf,g' \
-          -e "s,\(TEXMFLOCAL[ ]*=[ ]*\)[^\,]*,\1\"$out/share/texmf\",g" \
+          -e "s,\(TEXMFLOCAL[ ]*=[ ]*\)[^\,]*,\1\"$out/share/texmf-local\",g" \
           -e "s,\$SELFAUTOLOC,$out,g" \
           -e "s,selfautodir:/,$out/share/,g" \
           -e "s,selfautodir:,$out/share/,g" \
@@ -116,7 +116,6 @@ in buildEnv {
       rm ./texmf.cnf
       sed \
         -e 's,texmf-dist,texmf,g' \
-        -e 's,texmf-local,texmf,g' \
         -e "s,\$SELFAUTOLOC,$out,g" \
         -e "s,\$SELFAUTODIR,$out/share,g" \
         -e "s,\$SELFAUTOPARENT,$out/share,g" \
@@ -125,6 +124,8 @@ in buildEnv {
         "$cnfOrig" > ./texmf.cnf
 
       patchCnfLua "./texmfcnf.lua"
+
+      mkdir $out/share/texmf-local
 
       rm updmap.cfg
     )


### PR DESCRIPTION
###### Motivation for this change
Motivated by https://github.com/NixOS/nixpkgs/issues/58026

###### Things done
Test that `kpsewhich updmap.cfg` returns something in `texmf-config` and not in texmf. For me that's:

```
$ kpsewhich updmap.cfg
/nix/store/[...]-texlive-combined-2018/share/texmf-config/web2c/updmap.cfg
```
(because I have a local override that regenerates updmap.cfg into texmf-config)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

