### PR TITLE
nixos/programs.captive-browser: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -90,6 +90,7 @@
   ./programs/bcc.nix
   ./programs/blcr.nix
   ./programs/browserpass.nix
+  ./programs/captive-browser.nix
   ./programs/ccache.nix
   ./programs/cdemu.nix
   ./programs/chromium.nix

--- a/nixos/modules/programs/captive-browser.nix
+++ b/nixos/modules/programs/captive-browser.nix
@@ -1,0 +1,108 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.captive-browser;
+in
+{
+  ###### interface
+
+  options = {
+    programs.captive-browser = {
+      enable = mkEnableOption "captive browser";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.captive-browser;
+      };
+
+      interface = mkOption {
+        type = types.str;
+        description = "your public network interface (wlp3s0, wlan0, eth0, ...)";
+      };
+
+      # the options below are the same as in "captive-browser.toml"
+      browser = mkOption {
+        type = types.str;
+        default = concatStringsSep " " [ ''${pkgs.chromium}/bin/chromium''
+                                         ''--user-data-dir=$HOME/.chromium-captive''
+                                         ''--proxy-server="socks5://$PROXY"''
+                                         ''--host-resolver-rules="MAP * ~NOTFOUND , EXCLUDE localhost"''
+                                         ''--no-first-run''
+                                         ''--new-window''
+                                         ''--incognito''
+                                         ''http://cache.nixos.org/''
+                                       ];
+        description = ''
+          the shell (/bin/sh) command executed once the proxy starts.
+          When browser exits, the proxy exits. An extra env var PROXY is available.
+
+          Here, we use a separate Chrome instance in Incognito mode, so that
+          it can run (and be waited for) alongside the default one, and that
+          it maintains no state across runs. To configure this browser open a
+          normal window in it, settings will be preserved.
+
+          @volth: chromium is to open a plain HTTP (not HTTPS nor redirect to HTTPS!) website.
+                  upstream uses http://example.com but I have seen captive portals whose DNS server resolves "example.com" to 127.0.0.1
+        '';
+      };
+
+      dhcp-dns = mkOption {
+        type = types.str;
+        description = ''
+          the shell (/bin/sh) command executed to obtain the DHCP
+          DNS server address. The first match of an IPv4 regex is used.
+          IPv4 only, because let's be real, it's a captive portal.
+        '';
+      };
+
+      socks5-addr = mkOption {
+        type = types.str;
+        default = "localhost:1666";
+        description = ''the listen address for the SOCKS5 proxy server'';
+      };
+    };
+  };
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+
+    programs.captive-browser.dhcp-dns = mkOptionDefault (
+      if config.networking.networkmanager.enable then
+        "${pkgs.networkmanager}/bin/nmcli dev show ${escapeShellArg cfg.interface} | ${pkgs.gnugrep}/bin/fgrep IP4.DNS"
+      else if config.networking.dhcpcd.enable then
+        "${pkgs.dhcpcd}/bin/dhcpcd -U ${escapeShellArg cfg.interface} | ${pkgs.gnugrep}/bin/fgrep domain_name_servers"
+      else if config.networking.useNetworkd then
+        "${cfg.package}/bin/systemd-networkd-dns ${escapeShellArg cfg.interface}"
+      else
+        "${config.security.wrapperDir}/udhcpc --quit --now -f -i ${escapeShellArg cfg.interface} -O dns --script ${
+            pkgs.writeScript "udhcp-script" ''
+              #!/bin/sh
+              if [ "$1" = bound ]; then
+                echo "$dns"
+              fi
+            ''}"
+    );
+
+    security.wrappers.udhcpc = {
+      capabilities  = "cap_net_raw+p";
+      source        = "${pkgs.busybox}/bin/udhcpc";
+    };
+
+    security.wrappers.captive-browser = {
+      capabilities  = "cap_net_raw+p";
+      source        = pkgs.writeScript "captive-browser" ''
+                        #!${pkgs.bash}/bin/bash
+                        export XDG_CONFIG_HOME=${pkgs.writeTextDir "captive-browser.toml" ''
+                                                  browser = """${cfg.browser}"""
+                                                  dhcp-dns = """${cfg.dhcp-dns}"""
+                                                  socks5-addr = """${cfg.socks5-addr}"""
+                                                  bind-device = """${cfg.interface}"""
+                                                ''}
+                        exec ${cfg.package}/bin/captive-browser
+                      '';
+    };
+  };
+}

--- a/pkgs/applications/networking/browsers/captive-browser/default.nix
+++ b/pkgs/applications/networking/browsers/captive-browser/default.nix
@@ -1,0 +1,14 @@
+{ fetchFromGitHub, buildGoPackage }:
+
+buildGoPackage rec {
+  name = "captive-browser";
+  version = "2019-04-14";
+  goPackagePath = name;
+
+  src = fetchFromGitHub {
+    owner  = "FiloSottile";
+    repo   = "captive-browser";
+    rev    = "b96bd8a2aca14505cf8432935ee9add15ec39a57";
+    sha256 = "1k7r7rckb81m11hr6nzw3w8wx76hbl4740xg4818vdm5py1hv5ij";
+  };
+}

--- a/pkgs/applications/networking/browsers/captive-browser/default.nix
+++ b/pkgs/applications/networking/browsers/captive-browser/default.nix
@@ -1,14 +1,22 @@
-{ fetchFromGitHub, buildGoPackage }:
+{ lib, fetchFromGitHub, buildGoPackage }:
 
 buildGoPackage rec {
   name = "captive-browser";
-  version = "2019-04-14";
+  version = "2019-04-16";
   goPackagePath = name;
 
   src = fetchFromGitHub {
     owner  = "FiloSottile";
     repo   = "captive-browser";
-    rev    = "b96bd8a2aca14505cf8432935ee9add15ec39a57";
-    sha256 = "1k7r7rckb81m11hr6nzw3w8wx76hbl4740xg4818vdm5py1hv5ij";
+    rev    = "08450562e58bf9564ee98ad64ef7b2800e53338f";
+    sha256 = "17icgjg7h0xm8g4yy38qjhsvlz9pmlmj9kydz01y2nyl0v02i648";
+  };
+
+  meta = with lib; {
+    description = "Dedicated Chrome instance to log into captive portals without messing with DNS settings";
+    homepage = https://blog.filippo.io/captive-browser;
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ volth ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9729,6 +9729,8 @@ in
 
   capnproto = callPackage ../development/libraries/capnproto { };
 
+  captive-browser = callPackage ../applications/networking/browsers/captive-browser { };
+
   ndn-cxx = callPackage ../development/libraries/ndn-cxx { };
 
   cddlib = callPackage ../development/libraries/cddlib {};


### PR DESCRIPTION
###### Motivation for this change

A dedicated Chromium instance to log into captive portals without messing with DNS settings

Related: https://github.com/NixOS/nixpkgs/issues/44972
cc @shazow @FiloSottile

I have not tested the ```networkd``` case

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
