### PR TITLE
neocomp: init at 2019-03-12

### DIFF
--- a/pkgs/applications/window-managers/neocomp/default.nix
+++ b/pkgs/applications/window-managers/neocomp/default.nix
@@ -1,0 +1,85 @@
+{ stdenv
+, fetchFromGitHub
+, asciidoc
+, docbook_xml_dtd_45
+, docbook_xsl
+, freetype
+, judy
+, libGL
+, libconfig
+, libdrm
+, libxml2
+, libxslt
+, libXcomposite
+, libXdamage
+, libXext
+, libXinerama
+, libXrandr
+, libXrender
+, pcre
+, pkgconfig
+}:
+let
+  rev   = "v0.6-17-g271e784";
+in
+stdenv.mkDerivation rec {
+  name    = "neocomp-unstable-${version}";
+  version = "2019-03-12";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner  = "DelusionalLogic";
+    repo   = "NeoComp";
+    sha256 = "1mp338vz1jm5pwf7pi5azx4hzykmvpkwzx1kw6a9anj272f32zpg";
+  };
+
+  buildInputs = [
+    asciidoc
+    docbook_xml_dtd_45
+    docbook_xsl
+    freetype
+    judy
+    libGL
+    libconfig
+    libdrm
+    libxml2
+    libxslt
+    libXcomposite
+    libXdamage
+    libXext
+    libXinerama
+    libXrandr
+    libXrender
+    pcre
+    pkgconfig
+  ];
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+    "CFGDIR=${placeholder "out"}/etc/xdg/neocomp"
+    "ASTDIR=${placeholder "out"}/share/neocomp/assets"
+    "COMPTON_VERSION=git-${rev}-${version}"
+  ];
+
+  postPatch = ''
+    substituteInPlace src/compton.c --replace \
+      "assets_add_path(\"./assets/\");" \
+      "assets_add_path(\"$out/share/neocomp/assets/\");"
+    substituteInPlace src/assets/assets.c --replace \
+      "#define MAX_PATH_LENGTH 64" \
+      "#define MAX_PATH_LENGTH 128"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage        = https://github.com/DelusionalLogic/NeoComp;
+    license         = licenses.gpl3;
+    maintainers     = with maintainers; [ twey ];
+    platforms       = platforms.linux;
+    description     = "A fork of Compton, a compositor for X11";
+    longDescription = ''
+      NeoComp is a (hopefully) fast and (hopefully) simple compositor
+      for X11, focused on delivering frames from the window to the
+      framebuffer as quickly as possible.
+    '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18568,6 +18568,8 @@ in
 
   natron = callPackage ../applications/video/natron { };
 
+  neocomp  = callPackage ../applications/window-managers/neocomp { };
+
   nicotine-plus = callPackage ../applications/networking/soulseek/nicotine-plus {
     geoip = geoipWithDatabase;
   };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

