### PR TITLE
atlassian-confluence: 6.14.1 -> 6.14.2 (19.03)

### DIFF
--- a/pkgs/servers/atlassian/confluence.nix
+++ b/pkgs/servers/atlassian/confluence.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   name = "atlassian-confluence-${version}";
-  version = "6.14.1";
+  version = "6.14.2";
 
   src = fetchurl {
     url = "https://product-downloads.atlassian.com/software/confluence/downloads/${name}.tar.gz";
-    sha256 = "1pmxfikkydfi2m0bx1rgaj1ijhwh84zwwxkpw1f0vryvkl7av2gz";
+    sha256 = "012lh2838l2n7wkj42isxspxw3ix54467vnzvxbsq8wnf2m367ln";
   };
 
   buildPhase = ''


### PR DESCRIPTION
see https://github.com/NixOS/nixpkgs/pull/58032

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

