### PR TITLE
aravis: 0.5.13 -> 0.6.1, cleanup

### DIFF
--- a/pkgs/development/libraries/aravis/default.nix
+++ b/pkgs/development/libraries/aravis/default.nix
@@ -31,14 +31,13 @@ in
   stdenv.mkDerivation rec {
 
     pname = "aravis";
-    version = "0.5.13";
-    name = "${pname}-${version}";
+    version = "0.6.1";
 
     src = fetchFromGitHub {
       owner = "AravisProject";
-      repo = "aravis";
-      rev= "c56e530b8ef53b84e17618ea2f334d2cbae04f48";
-      sha256 = "1dj24dir239zmiscfhyy1m8z5rcbw0m1vx9lipx0r7c39bzzj5gy";
+      repo = pname;
+      rev= "ARAVIS_${builtins.replaceStrings ["."] ["_"] version}";
+      sha256 = "0v0hv1iyhp2azxij3ighp1b4rsw99zyqmkpdqnnxdmkcna031iga";
     };
 
     outputs = [ "bin" "dev" "out" "lib" ];
@@ -80,7 +79,7 @@ in
       longDescription = ''
         Implements the gigabit ethernet and USB3 protocols used by industrial cameras.
       '';
-      homepage = https://aravisproject.github.io/docs/aravis-0.5;
+      homepage = "https://aravisproject.github.io/docs/aravis-0.5";
       license = stdenv.lib.licenses.lgpl2;
       maintainers = [];
       platforms = stdenv.lib.platforms.unix;


### PR DESCRIPTION
###### Motivation for this change

new update and fix so automated update can work

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

