### PR TITLE
gpgme: cross compilation

### DIFF
--- a/pkgs/development/libraries/gpgme/default.nix
+++ b/pkgs/development/libraries/gpgme/default.nix
@@ -3,6 +3,7 @@
 , autoreconfHook, fetchpatch
 , git
 , texinfo
+, buildPackages
 , qtbase ? null
 , pythonSupport ? false, swig2 ? null, python ? null
 }:
@@ -31,6 +32,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ file pkgconfig gnupg autoreconfHook git texinfo ]
   ++ lib.optionals pythonSupport [ python swig2 which ncurses ];
 
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+
   patches = [
     (fetchpatch {
       name = "fix-key-expiry.patch";
@@ -46,6 +49,7 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--enable-fixed-path=${gnupg}/bin"
     "--with-libgpg-error-prefix=${libgpgerror.dev}"
+    "--with-libassuan-prefix=${libassuan.dev}"
   ] ++ lib.optional pythonSupport "--enable-languages=python";
 
   NIX_CFLAGS_COMPILE =


### PR DESCRIPTION
###### Motivation for this change

Add cross compilation support for `gpgme`, this is important in cross-compiling NixOS itself, which I'm attempting to accomplish here: https://github.com/illegalprime/nixos-on-arm

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

