### PR TITLE
libndctl: use buildPackages.which

### DIFF
--- a/pkgs/development/libraries/libndctl/default.nix
+++ b/pkgs/development/libraries/libndctl/default.nix
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs =
     [ autoreconfHook asciidoctor pkgconfig xmlto docbook_xml_dtd_45 docbook_xsl libxslt
+      which
     ];
 
   buildInputs =
@@ -31,7 +32,6 @@ stdenv.mkDerivation rec {
 
   patchPhase = ''
     patchShebangs test
-    substituteInPlace configure.ac --replace "which" "${which}/bin/which"
 
     substituteInPlace git-version --replace /bin/bash ${stdenv.shell}
     substituteInPlace git-version-gen --replace /bin/sh ${stdenv.shell}


### PR DESCRIPTION
###### Motivation for this change

Use build system's `which` instead of the host system's. (Also part of the effort to cross compile NixOS)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

