### PR TITLE
libunity fix build

### DIFF
--- a/pkgs/development/libraries/dee/default.nix
+++ b/pkgs/development/libraries/dee/default.nix
@@ -1,27 +1,57 @@
-{ stdenv, fetchurl, python, pkgconfig
-, glib, icu, gobject-introspection }:
+{ stdenv
+, fetchgit
+, pkgconfig
+, glib
+, icu
+, gobject-introspection
+, dbus-glib
+, vala
+, python3
+, autoreconfHook
+}:
 
 stdenv.mkDerivation rec {
-  name = "dee-${version}";
-  version = "1.2.7";
+  pname = "dee";
+  version = "unstable-2017-06-16";
 
-  src = fetchurl {
-    url = "https://launchpad.net/dee/1.0/${version}/+download/${name}.tar.gz";
-    sha256 = "12mzffk0lyd566y46x57jlvb9af152b4dqpasr40zal4wrn37w0v";
+  outputs = [ "out" "dev" "py" ];
+
+  src = fetchgit {
+    url = "https://git.launchpad.net/ubuntu/+source/dee";
+    rev = "import/1.2.7+17.10.20170616-4ubuntu1";
+    sha256 = "0q3d9d6ahcyibp6x23g1wvjfcppjh9v614s328yjmx47216z7394";
   };
 
-  buildInputs = [ glib gobject-introspection icu ];
-  nativeBuildInputs = [ python pkgconfig ];
+  patches = [
+    "${src}/debian/patches/gtkdocize.patch"
+    "${src}/debian/patches/strict-prototype.patch"
+    "${src}/debian/patches/icu-pkg-config.patch"
+  ];
 
-  NIX_CFLAGS_COMPILE = [ "-Wno-error=misleading-indentation" ]; # gcc-6
+  nativeBuildInputs = [
+    pkgconfig
+    vala
+    autoreconfHook
+    gobject-introspection
+    python3
+  ];
 
-  enableParallelBuilding = true;
+  buildInputs = [
+    glib
+    icu
+    dbus-glib
+  ];
+
+  configureFlags = [
+    "--disable-gtk-doc"
+    "--with-pygi-overrides-dir=${placeholder ''py''}/${python3.sitePackages}/gi/overrides"
+  ];
 
   meta = with stdenv.lib; {
     description = "A library that uses DBus to provide objects allowing you to create Model-View-Controller type programs across DBus";
     homepage = https://launchpad.net/dee;
     license = licenses.lgpl3;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ abbradar ];
+    maintainers = with maintainers; [ abbradar worldofpeace ];
   };
 }

--- a/pkgs/development/libraries/libunity/default.nix
+++ b/pkgs/development/libraries/libunity/default.nix
@@ -1,27 +1,33 @@
-{ stdenv, fetchurl, pkgconfig, automake, autoconf, libtool
-, glib, vala, dee, gobject-introspection, libdbusmenu
-, gtk3, intltool, gnome-common, python3, icu }:
+{ stdenv
+, fetchgit
+, pkgconfig
+, glib
+, vala
+, dee
+, gobject-introspection
+, libdbusmenu
+, gtk3
+, intltool
+, python3
+, autoreconfHook
+}:
 
 stdenv.mkDerivation rec {
   pname = "libunity";
-  version = "7.1.4";
+  version = "unstable-2019-03-19";
 
-  name = "${pname}-${version}";
+  outputs = [ "out" "dev" "py" ];
 
-  outputs = [ "out" "dev" ];
-
-  src = fetchurl {
-    url = "https://launchpad.net/ubuntu/+archive/primary/+files/${pname}_${version}+15.10.20151002.orig.tar.gz";
-    sha256 = "1sf98qcjkxfibxk03firnc12dm6il8jzaq5763qam8ydg4li4gij";
+  src = fetchgit {
+    url = "https://git.launchpad.net/ubuntu/+source/libunity";
+    rev = "import/7.1.4+19.04.20190319-0ubuntu1";
+    sha256 = "15b49v88v74q20a5c0lq867qnlz7fx20xifl6j8ha359r0zkfwzj";
   };
 
   nativeBuildInputs = [
-    autoconf
-    automake
-    gnome-common
+    autoreconfHook
     gobject-introspection
     intltool
-    libtool
     pkgconfig
     python3
     vala
@@ -32,16 +38,19 @@ stdenv.mkDerivation rec {
     gtk3
   ];
 
-  propagatedBuildInputs = [ dee libdbusmenu ];
+  propagatedBuildInputs = [
+    dee
+    libdbusmenu
+  ];
 
-  preConfigure = "NOCONFIGURE=1 ./autogen.sh";
+  preConfigure = ''
+    intltoolize
+  '';
 
   configureFlags = [
     "--disable-static"
-    "--with-pygi-overrides-dir=$(out)/${python3.sitePackages}/gi/overrides"
+    "--with-pygi-overrides-dir=${placeholder ''py''}/${python3.sitePackages}/gi/overrides"
   ];
-
-  NIX_LDFLAGS = "-L${icu}/lib";
 
   meta = with stdenv.lib; {
     description = "A library for instrumenting and integrating with all aspects of the Unity shell";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10820,9 +10820,7 @@ in
 
   libdbiDrivers = callPackage ../development/libraries/libdbi-drivers { };
 
-  libunity = callPackage ../development/libraries/libunity {
-    inherit (gnome3) gnome-common;
-  };
+  libunity = callPackage ../development/libraries/libunity { };
 
   libdbusmenu = callPackage ../development/libraries/libdbusmenu { };
   libdbusmenu-gtk2 = libdbusmenu.override { gtkVersion = "2"; };


### PR DESCRIPTION
###### Motivation for this change
Vala bump in staging broke libunity.
Fixes are already there upstream so it's just an update.

Also noticed `dee` was out of date so got that too.

###### Notes
These were switched to fetching from within ubuntu's packaging
 `https://git.launchpad.net/ubuntu/+source/libunity`

I did this because I felt it was more convenient.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

