### PR TITLE
persepolis: init at 3.1.0

### DIFF
--- a/pkgs/tools/networking/persepolis/default.nix
+++ b/pkgs/tools/networking/persepolis/default.nix
@@ -1,0 +1,60 @@
+{ stdenv, lib, buildPythonApplication, fetchFromGitHub, makeDesktopItem, makeWrapper
+, aria
+, libnotify
+, pulseaudio
+, psutil
+, pyqt5
+, requests
+, setproctitle
+, sound-theme-freedesktop
+, youtube-dl
+}:
+
+buildPythonApplication rec {
+  pname = "persepolis";
+  version = "3.1.0";
+
+  src = fetchFromGitHub {
+    owner = "persepolisdm";
+    repo = "persepolis";
+    rev = "${version}";
+    sha256 = "0xngk8wgj5k27mh3bcrf2wwzqr8a3g0d4pc5i5vcavnnaj03j44m";
+  };
+
+  # see: https://github.com/persepolisdm/persepolis/blob/3.1.0/setup.py#L130
+  doCheck = false;
+
+  preBuild=''
+    substituteInPlace setup.py --replace "answer = input(" "answer = 'y'#"
+  '';
+
+  postPatch = ''
+    sed -i 's|/usr/share/sounds/freedesktop/stereo/|${sound-theme-freedesktop}/share/sounds/freedesktop/stereo/|' setup.py
+    sed -i "s|'persepolis = persepolis.__main__'|'persepolis = persepolis.scripts.persepolis:main'|" setup.py
+  '';
+
+  postInstall = ''
+     mkdir -p $out/share/applications
+     cp $src/xdg/com.github.persepolisdm.persepolis.desktop $out/share/applications
+     wrapProgram $out/bin/persepolis --prefix PATH : "${lib.makeBinPath [aria libnotify ]}"
+  '';
+
+  buildInputs = [ makeWrapper ];
+
+  propagatedBuildInputs = [
+    pulseaudio
+    psutil
+    pyqt5
+    requests
+    setproctitle
+    sound-theme-freedesktop
+    youtube-dl
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Persepolis Download Manager is a GUI for aria2.";
+    homepage = https://persepolisdm.github.io/;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.linarcx ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1638,6 +1638,8 @@ in
 
   pbzx = callPackage ../tools/compression/pbzx { };
 
+  persepolis = python3Packages.callPackage ../tools/networking/persepolis { };
+
   pev = callPackage ../development/tools/analysis/pev { };
 
   photon = callPackage ../tools/networking/photon { };


### PR DESCRIPTION
###### Motivation for this change
It is one the best gui download manager in linux world. :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

