### PR TITLE
volume_key: cross compilation fixes

### DIFF
--- a/pkgs/development/libraries/volume-key/default.nix
+++ b/pkgs/development/libraries/volume-key/default.nix
@@ -1,5 +1,8 @@
 { stdenv, fetchgit, autoreconfHook, pkgconfig, gettext, python3
 , ncurses, swig, glib, utillinux, cryptsetup, nss, gpgme
+, autoconf, automake, libtool
+, writeShellScriptBin
+, buildPackages
 }:
 
 let
@@ -15,9 +18,18 @@ in stdenv.mkDerivation rec {
 
   outputs = [ "out" "man" "dev" "py" ];
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig gettext python3 ncurses swig ];
+  nativeBuildInputs = [ autoconf automake libtool pkgconfig gettext swig ];
 
-  buildInputs = [ glib cryptsetup nss utillinux gpgme ];
+  buildInputs = [ autoreconfHook glib cryptsetup nss utillinux gpgme ncurses ];
+
+  configureFlags = [
+    "--with-gpgme-prefix=${gpgme.dev}"
+  ];
+
+  preConfigure = ''
+    export PYTHON="${buildPackages.python3}/bin/python"
+    export PYTHON3_CONFIG="${python3}/bin/python3-config"
+  '';
 
   makeFlags = [
     "pyexecdir=$(py)/${python3.sitePackages}"


### PR DESCRIPTION
###### Motivation for this change

cross compile `volume_key` which is needed for `udisks` which is needed for `NixOS`.

EDIT: this actually depends on gpgme #58046 and nss (which i haven't posted yet because it's _super_ hacky)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

