### PR TITLE
nilfs-utils: force malloc(0) realloc(0) to be valid

### DIFF
--- a/pkgs/tools/filesystems/nilfs-utils/default.nix
+++ b/pkgs/tools/filesystems/nilfs-utils/default.nix
@@ -35,7 +35,16 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  configureFlags = [ "--with-libmount" ];
+  configureFlags = [
+    "--with-libmount"
+    # when cross-compiling we assume that the host system will return a valid
+    # pointer for calls to malloc(0) or realloc(0)
+    # https://www.uclibc.org/FAQ.html#gnu_malloc
+    # https://www.gnu.org/software/autoconf/manual/autoconf.html#index-AC_005fFUNC_005fMALLOC-454
+    # the upstream source should be patched to avoid needing this
+    "ac_cv_func_malloc_0_nonnull=yes"
+    "ac_cv_func_realloc_0_nonnull=yes"
+  ];
 
   # FIXME: https://github.com/NixOS/patchelf/pull/98 is in, but stdenv
   # still doesn't use it


### PR DESCRIPTION
###### Motivation for this change

`configure` is not sure whether the host system will have a `malloc` and `realloc` that returns a valid pointer when given `0` so it assumes no and fails, this forces configure to assume yes.

https://www.uclibc.org/FAQ.html#gnu_malloc
https://www.gnu.org/software/autoconf/manual/autoconf.html#index-AC_005fFUNC_005fMALLOC-454

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

