### PR TITLE
nss: cross compile support

### DIFF
--- a/pkgs/development/libraries/nss/default.nix
+++ b/pkgs/development/libraries/nss/default.nix
@@ -59,9 +59,9 @@ in stdenv.mkDerivation rec {
     "USE_SYSTEM_ZLIB=1"
     "NSS_USE_SYSTEM_SQLITE=1"
     "NATIVE_CC=${buildPackages.stdenv.cc}/bin/cc"
+  ] ++ stdenv.lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) [
     "OS_TEST=${cpu}"
     "CPU_ARCH=${cpu}"
-  ] ++ stdenv.lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) [
     "CROSS_COMPILE=1"
     "NSS_DISABLE_GTESTS=1" # don't want to build tests when cross-compiling
   ] ++ stdenv.lib.optional stdenv.is64bit "USE_64=1"

--- a/pkgs/development/libraries/nss/default.nix
+++ b/pkgs/development/libraries/nss/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, nspr, perl, zlib, sqlite, fixDarwinDylibNames }:
+{ stdenv, fetchurl, nspr, perl, zlib, sqlite, fixDarwinDylibNames, buildPackages }:
 
 let
   nssPEM = fetchurl {
@@ -17,7 +17,11 @@ in stdenv.mkDerivation rec {
     sha256 = "1ihzqspvqjmysp1c15xxr7kqvj3zm9dqnanxhkaxyjgx71yv6z88";
   };
 
-  buildInputs = [ perl zlib sqlite ]
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+
+  nativeBuildInputs = [ perl ];
+
+  buildInputs = [ zlib sqlite ]
     ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
   propagatedBuildInputs = [ nspr ];
@@ -43,7 +47,9 @@ in stdenv.mkDerivation rec {
 
   preConfigure = "cd nss";
 
-  makeFlags = [
+  makeFlags = let
+    cpu = stdenv.hostPlatform.parsed.cpu.name;
+  in [
     "NSPR_INCLUDE_DIR=${nspr.dev}/include"
     "NSPR_LIB_DIR=${nspr.out}/lib"
     "NSDISTMODE=copy"
@@ -52,6 +58,12 @@ in stdenv.mkDerivation rec {
     "NSS_ENABLE_ECC=1"
     "USE_SYSTEM_ZLIB=1"
     "NSS_USE_SYSTEM_SQLITE=1"
+    "NATIVE_CC=${buildPackages.stdenv.cc}/bin/cc"
+    "OS_TEST=${cpu}"
+    "CPU_ARCH=${cpu}"
+  ] ++ stdenv.lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) [
+    "CROSS_COMPILE=1"
+    "NSS_DISABLE_GTESTS=1" # don't want to build tests when cross-compiling
   ] ++ stdenv.lib.optional stdenv.is64bit "USE_64=1"
     ++ stdenv.lib.optional stdenv.isDarwin "CCC=clang++";
 
@@ -95,7 +107,10 @@ in stdenv.mkDerivation rec {
     chmod 0755 $out/bin/nss-config
   '';
 
-  postFixup = ''
+  postFixup = let
+    isCross = stdenv.hostPlatform != stdenv.buildPlatform;
+    nss = if isCross then buildPackages.nss.tools else "$out";
+  in ''
     for libname in freebl3 nssdbm3 softokn3
     do '' +
     (if stdenv.isDarwin
@@ -106,7 +121,7 @@ in stdenv.mkDerivation rec {
        libfile="$out/lib/lib$libname.so"
        LD_LIBRARY_PATH=$out/lib:${nspr.out}/lib \
      '') + ''
-        $out/bin/shlibsign -v -i "$libfile"
+        ${nss}/bin/shlibsign -v -i "$libfile"
     done
 
     moveToOutput bin "$tools"


### PR DESCRIPTION
###### Motivation for this change

nss cross compilation! (important to _cross compile_ NixOS)
at first my solution was really hacky but I got it down to be reasonable again.
should work for `aarch64` & `armv7l`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

