### PR TITLE
la-capitaine-icon-theme: init at 0.6.1

### DIFF
--- a/pkgs/data/icons/la-capitaine-icon-theme/default.nix
+++ b/pkgs/data/icons/la-capitaine-icon-theme/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "la-capitaine-icon-theme";
+  version = "0.6.1";
+
+  src = fetchFromGitHub {
+    owner = "keeferrourke";
+    repo = "la-capitaine-icon-theme";
+    rev = "v${version}";
+    sha256 = "0cm2scrcg5h45y56h822ywyvfzns1x4wf3gqq96cwb22dc7ny1g9";
+  };
+
+  postPatch = ''
+    rm configure
+  '';
+
+  installPhase = ''
+     mkdir -p $out/share/icons/la-capitaine-icon-theme
+     mv ./* $out/share/icons/la-capitaine-icon-theme
+  '';
+
+  meta = with stdenv.lib; {
+    description = "La Capitaine is an icon pack designed to integrate with most desktop environments. The set of icons takes inspiration from the latest iterations of macOS and Google's Material Design.";
+    homepage = https://github.com/keeferrourke/la-capitaine-icon-theme;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.linarcx ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3752,6 +3752,8 @@ in
 
   k6 = callPackage ../development/tools/k6 { };
 
+  la-capitaine-icon-theme = callPackage ../data/icons/la-capitaine-icon-theme { };
+
   ldc = callPackage ../development/compilers/ldc { };
 
   lbreakout2 = callPackage ../games/lbreakout2 { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

