### PR TITLE
dav1d: init at 0.2.1

### DIFF
--- a/pkgs/development/libraries/dav1d/default.nix
+++ b/pkgs/development/libraries/dav1d/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitLab, meson, ninja, nasm }:
+
+stdenv.mkDerivation rec {
+  pname = "dav1d";
+  version = "0.2.1";
+
+  src = fetchFromGitLab {
+    domain = "code.videolan.org";
+    owner = "videolan";
+    repo = pname;
+    rev = version;
+    sha256 = "0diihk7lcdxxbfqp79dpvj14008zfzmayamh4vj310i524lqnkb6";
+  };
+
+  nativeBuildInputs = [ meson ninja nasm ];
+  # TODO: doxygen (currently only HTML and not build by default).
+
+  meta = with stdenv.lib; {
+    description = "A cross-platform AV1 decoder focused on speed and correctness";
+    longDescription = ''
+      The goal of this project is to provide a decoder for most platforms, and
+      achieve the highest speed possible to overcome the temporary lack of AV1
+      hardware decoder. It supports all features from AV1, including all
+      subsampling and bit-depth parameters.
+    '';
+    inherit (src.meta) homepage;
+    license = licenses.bsd2;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ primeos ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2236,6 +2236,8 @@ in
 
   darkstat = callPackage ../tools/networking/darkstat { };
 
+  dav1d = callPackage ../development/libraries/dav1d { };
+
   davfs2 = callPackage ../tools/filesystems/davfs2 { };
 
   dbeaver = callPackage ../applications/misc/dbeaver { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

