### PR TITLE
buildGoModule: remove cacert-related env vars in favor of cacert in buildInputs

### DIFF
--- a/pkgs/development/go-modules/generic/default.nix
+++ b/pkgs/development/go-modules/generic/default.nix
@@ -36,7 +36,7 @@ let
   go-modules = go.stdenv.mkDerivation {
     name = "${name}-go-modules";
 
-    nativeBuildInputs = [ go git ];
+    nativeBuildInputs = [ go git cacert ];
 
     inherit (args) src;
     inherit (go) GOOS GOARCH;
@@ -44,16 +44,6 @@ let
     patches = args.patches or [];
 
     GO111MODULE = "on";
-
-    # XXX: Add support for other fetchers, such as hg, bzr and alike.
-    GIT_SSL_CAINFO = "${cacert}/etc/ssl/certs/ca-bundle.crt";
-
-    # Instruct Go where to find the cacert.
-    # SSL_CERT_FILE is used by Linux machines.
-    # NIX_SSL_CERT_FILE is used by Darwin machines based on
-    # pkgs/development/compilers/go/ssl-cert-file-1.9.patch.
-    NIX_SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
-    SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
 
     impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [
       "GIT_PROXY_COMMAND" "SOCKS_SERVER"


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

