### PR TITLE
libassuan: 2.5.2 -> 2.5.3

### DIFF
--- a/pkgs/development/libraries/libassuan/default.nix
+++ b/pkgs/development/libraries/libassuan/default.nix
@@ -1,11 +1,12 @@
 { fetchurl, stdenv, gettext, pth, libgpgerror }:
 
 stdenv.mkDerivation rec {
-  name = "libassuan-2.5.2";
+  pname = "libassuan";
+  version = "2.5.3";
 
   src = fetchurl {
-    url = "mirror://gnupg/libassuan/${name}.tar.bz2";
-    sha256 = "1rw8nw6fx6ppxga6m4cqcp898lnlzf7vn3s5c2lzfxg3fzr1nswq";
+    url = "mirror://gnupg/${pname}/${pname}-${version}.tar.bz2";
+    sha256 = "00p7cpvzf0q3qwcgg51r9d0vbab4qga2xi8wpk2fgd36710b1g4i";
   };
 
   outputs = [ "out" "dev" "info" ];


### PR DESCRIPTION
###### Motivation for this change

https://github.com/gpg/libassuan/blob/libassuan-2.5.3/NEWS
https://dev.gnupg.org/T4361

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---