### PR TITLE
libwhich: init at 2019-03-20

### DIFF
--- a/pkgs/development/tools/misc/libwhich/default.nix
+++ b/pkgs/development/tools/misc/libwhich/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "libwhich";
+  version = "2019-03-20";
+
+  src = fetchFromGitHub {
+    owner = "vtjnash";
+    repo = pname;
+    rev = "b348872107c77cba50b60475aa8ce2ddba86aac0";
+    sha256 = "0fd8hsdc9b9v83j89mxvisgrz77q9rlxnbzd6j63wq66h95r02r9";
+  };
+
+  installPhase = ''
+    install -Dm755 -t $out/bin libwhich
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Like `which`, for dynamic libraries";
+    homepage = https://github.com/vtjnash/libwhich;
+    license = licenses.mit;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8957,6 +8957,8 @@ in
 
   libtool_2 = callPackage ../development/tools/misc/libtool/libtool2.nix { };
 
+  libwhich = callPackage ../development/tools/misc/libwhich { };
+
   linuxkit = callPackage ../development/tools/misc/linuxkit { };
 
   lit = callPackage ../development/tools/misc/lit { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---