### PR TITLE
joplin-desktop: 1.0.120 -> 1.0.140

### DIFF
--- a/pkgs/applications/misc/joplin-desktop/default.nix
+++ b/pkgs/applications/misc/joplin-desktop/default.nix
@@ -1,8 +1,8 @@
 { stdenv, appimage-run, fetchurl }:
 
 let
-  version = "1.0.135";
-  sha256 = "139nk1pvwqjn6grzpq6dh9jad7450gy4b3rms1hbkj8cjcqaks9z";
+  version = "1.0.140";
+  sha256 = "1114v141jayqhvkkxf7dr864j09nf5nz002c7z0pprzr00fifqzx";
 in
   stdenv.mkDerivation rec {
   name = "joplin-${version}";

--- a/pkgs/applications/misc/joplin-desktop/default.nix
+++ b/pkgs/applications/misc/joplin-desktop/default.nix
@@ -1,8 +1,8 @@
 { stdenv, appimage-run, fetchurl }:
 
 let
-  version = "1.0.120";
-  sha256 = "0j32rg6hm5dirdcibhfhrclnx7vm37fbm4iwkzzinqhzj4jfgbfm";
+  version = "1.0.135";
+  sha256 = "139nk1pvwqjn6grzpq6dh9jad7450gy4b3rms1hbkj8cjcqaks9z";
 in
   stdenv.mkDerivation rec {
   name = "joplin-${version}";


### PR DESCRIPTION
###### Motivation for this change

Updates! See notes linked in commits.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---