### PR TITLE
pythonPackages.thinc: Fix build

### DIFF
--- a/pkgs/development/python-modules/thinc/default.nix
+++ b/pkgs/development/python-modules/thinc/default.nix
@@ -63,7 +63,10 @@ buildPythonPackage rec {
     substituteInPlace setup.py \
       --replace "pathlib==1.0.1" "pathlib>=1.0.0,<2.0.0" \
       --replace "plac>=0.9.6,<1.0.0" "plac>=0.9.6" \
-      --replace "msgpack-numpy<0.4.4" "msgpack-numpy"
+      --replace "msgpack-numpy<0.4.4" "msgpack-numpy" \
+      --replace "wheel>=0.32.0,<0.33.0" "wheel" \
+      --replace "wrapt>=1.10.0,<1.11.0" "wrapt" \
+      --replace "msgpack>=0.5.6,<0.6.0" "msgpack"
   '';
 
   # Cannot find cython modules.


### PR DESCRIPTION
###### Motivation for this change
Fixes #58069

@shosti Please test thinc yourself to make sure it works with this fix

Pinging the maintainers @aborsu @sdll 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

