### PR TITLE
buildGoModule: use go_1_12 instead of go_1_11

### DIFF
--- a/pkgs/applications/misc/hugo/default.nix
+++ b/pkgs/applications/misc/hugo/default.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
     sha256 = "01grfbr3kpd4qf5cbcmzc6yfq34cm0nkak4pqzgrn46r254y0ymv";
   };
 
-  modSha256 = "0fqmxmhbzkd5617gch836l7clqbxx8b1mxx09v3v2c4jjxcm85cm";
+  modSha256 = "01gni3ksw9whf388c6cj0vcbpsyhdrwfl8cyw85kjx8r56dv88y5";
 
   buildFlags = "-tags extended";
 

--- a/pkgs/applications/misc/terminal-parrot/default.nix
+++ b/pkgs/applications/misc/terminal-parrot/default.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
     sha256 = "1b4vr4s1zpkpf5kc1r2kdlp3hf88qp1f7h05g8kd62zf4sfbj722";
   };
 
-  modSha256 = "0ymqhrkgk94z4f2p3c6v75g2h8qlqzdi7byivqzxzmdczmq9zq2s";
+  modSha256 = "01i8fim9z2l8rpdgfaih9ldvbap7gcx5767a15miv8q7sxpr90cp";
 
   meta = with stdenv.lib; {
     description = "Shows colorful, animated party parrot in your terminial";

--- a/pkgs/applications/misc/todoist/default.nix
+++ b/pkgs/applications/misc/todoist/default.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
     sha256 = "1kwvlsjr2a7wdhlwpxxpdh87wz8k9yjwl59vl2g7ya6m0rvhd3mc";
   };
 
-  modSha256 = "0ng1paw2mizhs4g28ypxz0ryh43l90qw8qsq46sshsiiswvrpl0k";
+  modSha256 = "09n6abyaqwz4zcdz8934rvpbxhp4v2nmm5v739kkcc98c3h93i64";
 
   meta = {
     homepage = https://github.com/sachaos/todoist;

--- a/pkgs/applications/networking/cluster/hetzner-kube/default.nix
+++ b/pkgs/applications/networking/cluster/hetzner-kube/default.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
     sha256 = "11202i3340vaz8xh59gwj5x0djcgbzq9jfy2214lcpml71qc85f0";
   };
 
-  modSha256 = "1mx74nci7j7h44pw1qf5fxkvfnhppj46898f8895ay8hhxd28lbm";
+  modSha256 = "1j04xyjkz7jcqrs5p5z94jqagrzcxjr9m3lyp8i91c0ymxf5m2g3";
 
   buildFlagsArray = ''
     -ldflags=

--- a/pkgs/applications/networking/cluster/jx/default.nix
+++ b/pkgs/applications/networking/cluster/jx/default.nix
@@ -16,7 +16,7 @@ buildGoModule rec {
     ./3321-fix-location-of-thrift.patch
   ];
 
-  modSha256 = "0l6ccxzfxl918hzbky5ivlw413hiwagwc2cbp3f05i21qdi5mw5p";
+  modSha256 = "0ljf0c0c3pc12nmhdbrwflcaj6hs8igzjw5hi6fyhi6n9cy87vac";
 
   subPackages = [ "cmd/jx" ];
 

--- a/pkgs/applications/version-management/git-and-tools/lab/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/lab/default.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
 
   subPackages = [ "." ];
 
-  modSha256 = "1g72fnkibmdd9i20wgp5fjf556xp2xwan06dmn3f5rkmnicy3ccl";
+  modSha256 = "0bw47dd1b46ywsian2b957a4ipm77ncidipzri9ra39paqlv7abb";
 
   postInstall = ''
     mkdir -p $out/share/zsh/site-functions

--- a/pkgs/development/tools/gotools/default.nix
+++ b/pkgs/development/tools/gotools/default.nix
@@ -11,9 +11,9 @@ buildGoModule rec {
     sha256 = "04rpdi52j26szx5kiyfmwad1sg7lfplxrkbwkr3b1kfafh1whgw5";
   };
 
-  modSha256 = "12klgqm2px878lzh05yzj6lr83v7vg0vv2k69pmg6nv1wlsxdlzf";
+  modSha256 = "00yjcs26cm5civ96sikbd3wjmhx153xbyd805s3shca1mg99y7mm";
 
-  preConfigure = ''
+  postConfigure = ''
     # Make the builtin tools available here
     mkdir -p $out/bin
     eval $(go env | grep GOTOOLDIR)

--- a/pkgs/development/tools/mod/default.nix
+++ b/pkgs/development/tools/mod/default.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
     sha256 = "1v7qy0q6fb9amcggwzdygl290zhr3w3zgmig2rm5zx91kw973sqc";
   };
 
-  modSha256 = "0j0c5idgwclszsmay7av9y3lcwfk72ml06nwll3fz404hx8vla6y";
+  modSha256 = "1s33i4kp1vzfp97909pyzdlvi69siw1i2lbi2kbp9yrn163w6928";
 
   subPackages = [ "cmd/mod" ];
 

--- a/pkgs/development/tools/pet/default.nix
+++ b/pkgs/development/tools/pet/default.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
     sha256 = "0m2fzpqxk7hrbxsgqplkg7h2p7gv6s1miymv3gvw0cz039skag0s";
   };
 
-  modSha256 = "04zizcq6x1sshnkbvcy197k6axmjnazi9r7cfvcq7g2ng818y2yb";
+  modSha256 = "06ham8lsx5c1vk5jkwp1aa9g4q4g7sfq7gxz2gkffa98x2vlawyf";
 
   subPackages = [ "." ];
 

--- a/pkgs/servers/miniflux/default.nix
+++ b/pkgs/servers/miniflux/default.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
     sha256 = "1k53dkmd41x5h81arb2fs5s9yb6sy6113nbbzls6dc179slfg9zj";
   };
 
-  modSha256 = "1i3xzl6kkpl4v1229rhg61j1952qxzbhav7fb2hv85903rkz51x1";
+  modSha256 = "0n5j4rns2w1klgrf5jz0bng9cih9aifjx55hhkf4dfj1x4wsxjdj";
 
   doCheck = true;
 

--- a/pkgs/shells/zsh/antibody/default.nix
+++ b/pkgs/shells/zsh/antibody/default.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
     sha256 = "1qfic9prdbldvjw0n15jfc9qr4p5h87mjripq2pc4c6x8244phfw";
   };
 
-  modSha256 = "017ybvyfk9bhmp8xwn484gmz4dl03gllv780ssi2arpmcyrwlymw";
+  modSha256 = "1p9cw92ivwgpkvjxvwd9anbd1vzhpicm9il4pg37z2kgr2ihhnyh";
 
   meta = with lib; {
     description = "The fastest shell plugin manager";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13391,7 +13391,11 @@ in
     go = buildPackages.go_1_11;
   };
 
-  buildGoModule = buildGo111Module;
+  buildGo112Module = callPackage ../development/go-modules/generic {
+    go = buildPackages.go_1_12;
+  };
+
+  buildGoModule = buildGo112Module;
 
   go2nix = callPackage ../development/tools/go2nix { };
 


### PR DESCRIPTION
###### Motivation for this change

buildGoModule is currently using go_1_11, but the default Go is set to go_1_12. I discovered this inconsistency while working on DBCDK/morph#53

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

