### PR TITLE
nix: replace build utils with host utils in config.nix

### DIFF
--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -9,6 +9,7 @@ let
 
 common =
   { lib, stdenv, fetchurl, fetchpatch, perl, curl, bzip2, sqlite, openssl ? null, xz
+  , bash, coreutils, gzip, gnutar
   , pkgconfig, boehmgc, perlPackages, libsodium, brotli, boost, editline
   , autoreconfHook, autoconf-archive, bison, flex, libxml2, libxslt, docbook5, docbook_xsl_ns
   , busybox-sandbox-shell
@@ -97,6 +98,21 @@ common =
       # socket path becomes too long otherwise
       preInstallCheck = lib.optional stdenv.isDarwin ''
         export TMPDIR=$NIX_BUILD_TOP
+      '';
+
+      # substitute build-time binaries with host-binaries
+      preInstall = ''
+        substituteInPlace corepkgs/config.nix.in \
+          --subst-var-by bash ${bash}/bin/bash \
+          --subst-var-by coreutils ${coreutils}/bin \
+          --subst-var-by bzip2 ${bzip2}/bin/bzip2 \
+          --subst-var-by gzip ${gzip}/bin/gzip \
+          --subst-var-by xz ${xz}/bin/xz \
+          --subst-var-by tar ${gnutar}/bin/tar \
+          --subst-var-by tr ${coreutils}/bin/tr
+
+        substituteInPlace scripts/nix-profile.sh.in \
+          --subst-var-by coreutils ${coreutils}/bin
       '';
 
       separateDebugInfo = stdenv.isLinux;


### PR DESCRIPTION
###### Motivation for this change
When cross-compiling nix build-time deps are saved in `config.nix` and in `profile.d/nix.sh`, this will make the correct replacements before install-time to ensure the right dependencies are added.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

