### PR TITLE
gnomeExtensions.nohotcorner: 18.0 -> 19.0

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/nohotcorner/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/nohotcorner/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-shell-extension-nohotcorner-${version}";
-  version = "18.0";
+  version = "19.0";
 
   src = fetchFromGitHub {
     owner = "HROMANO";
     repo = "nohotcorner";
     rev = "v${version}";
-    sha256 = "0vajiys93gs7fs9v6brgf8fplkmh28j103in3wq04l34cx5sqkks";
+    sha256 = "059n4gyz7d686hknaifyjax8gygrda1xab5m15a09p98jdrdfdhi";
   };
 
   # Taken from the extension download link at


### PR DESCRIPTION
###### Motivation for this change

v19.0 declares support for gnome 3.32 and includes no other changes. The
full change set can be found at
https://github.com/HROMANO/nohotcorner/compare/v18.0...v19.0.

Please feel free to cherry pick this change instead of merging it.

CC @hedning @jtojnar @worldofpeace 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

