### PR TITLE
root5: fix build

### DIFF
--- a/pkgs/applications/science/misc/root/disable_libc_dicts_root5.patch
+++ b/pkgs/applications/science/misc/root/disable_libc_dicts_root5.patch
@@ -1,0 +1,27 @@
+diff --git a/cint/ROOT/CMakeLists.txt b/cint/ROOT/CMakeLists.txt
+--- a/cint/ROOT/CMakeLists.txt
++++ b/cint/ROOT/CMakeLists.txt
+@@ -47,21 +47,13 @@ set(CINTSTLDLLHEADERS
+     ${CMAKE_SOURCE_DIR}/cint/cint/lib/stdstrct/stdcxxfunc.h
+   )
+ set(CINTINCDLLNAMES 
+-    stdfunc 
++#    stdfunc 
+ #    stdcxxfunc
+    )
+ set(CINTINCDLLHEADERS
+-    ${CMAKE_SOURCE_DIR}/cint/cint/lib/stdstrct/stdfunc.h 
++#    ${CMAKE_SOURCE_DIR}/cint/cint/lib/stdstrct/stdfunc.h 
+ #    ${CMAKE_SOURCE_DIR}/cint/cint/lib/stdstrct/stdcxxfunc.h
+    )
+-if(NOT WIN32)
+-  set(CINTSTLDLLNAMES ${CINTSTLDLLNAMES}  valarray)
+-  set(CINTSTLDLLHEADERS ${CINTSTLDLLHEADERS} ${CINTDLLDIR}/vary.h)
+-  set(CINTINCDLLNAMES ${CINTINCDLLNAMES} posix ipc)
+-  set(CINTINCDLLHEADERS ${CINTINCDLLHEADERS} 
+-    ${CMAKE_SOURCE_DIR}/cint/cint/lib/posix/exten.h 
+-    ${CMAKE_SOURCE_DIR}/cint/cint/lib/ipc/ipcif.h)
+-endif()
+ 
+ set(CINTBUILDLOADER
+     vector 

--- a/pkgs/applications/science/misc/root/purify_include_paths_root5.patch
+++ b/pkgs/applications/science/misc/root/purify_include_paths_root5.patch
@@ -1,0 +1,204 @@
+diff --git a/cint/cint/src/loadfile.cxx b/cint/cint/src/loadfile.cxx
+--- a/cint/cint/src/loadfile.cxx
++++ b/cint/cint/src/loadfile.cxx
+@@ -1365,92 +1365,6 @@ int G__statfilename(const char *filenamein, struct stat *statBuf,
+          }
+       }         
+ #endif /* G__EDU_VERSION */
+-      
+-#ifdef G__VISUAL
+-      /**********************************************
+-       * try /msdev/include
+-       **********************************************/
+-      if('\0'!=G__cintsysdir[0]) {
+-         workname.Format("/msdev/include/%s%s",filename(),addpost[i2]);
+-         res = stat( workname, statBuf );         
+-         if (res==0) {
+-            if (fullPath) fullPath->Swap(workname);
+-            return res;
+-         }
+-      }
+-#endif /* G__VISUAL */
+-         
+-#ifdef G__SYMANTEC
+-      /**********************************************
+-       * try /sc/include
+-       **********************************************/
+-      if('\0'!=G__cintsysdir[0]) {
+-         workname.Format("/sc/include/%s%s",filename(),addpost[i2]);
+-         res = stat( workname, statBuf );         
+-         if (res==0) {
+-            if (fullPath) fullPath->Swap(workname);
+-            return res;
+-         }
+-      }
+-#endif // G__SYMANTEC
+-         
+-#ifndef G__WIN32
+-      /**********************************************
+-       * try /usr/include/filename
+-       **********************************************/
+-      if('\0'!=G__cintsysdir[0]) {
+-         workname.Format("/usr/include/%s%s",filename(),addpost[i2]);
+-         res = stat( workname, statBuf );         
+-         if (res==0) {
+-            if (fullPath) fullPath->Swap(workname);
+-            return res;
+-         }
+-      }
+-#endif
+-      
+-#ifdef __GNUC__
+-      /**********************************************
+-       * try /usr/include/g++/filename
+-       **********************************************/
+-      if('\0'!=G__cintsysdir[0]) {
+-         workname.Format("/usr/include/g++/%s%s",filename(),addpost[i2]);
+-         res = stat( workname, statBuf );         
+-         if (res==0) {
+-            if (fullPath) fullPath->Swap(workname);
+-            return res;
+-         }
+-      }
+-#endif /* __GNUC__ */
+-      
+-#ifndef G__WIN32
+-      /* #ifdef __hpux */
+-      /**********************************************
+-       * try /usr/include/CC/filename
+-       **********************************************/
+-      if('\0'!=G__cintsysdir[0]) {
+-         workname.Format("/usr/include/CC/%s%s",filename(),addpost[i2]);
+-         res = stat( workname, statBuf );         
+-         if (res==0) {
+-            if (fullPath) fullPath->Swap(workname);
+-            return res;
+-         }
+-      }         
+-#endif
+-         
+-#ifndef G__WIN32
+-      /**********************************************
+-       * try /usr/include/codelibs/filename
+-       **********************************************/
+-      if('\0'!=G__cintsysdir[0]) {
+-         workname.Format("/usr/include/codelibs/%s%s"
+-                         ,filename(),addpost[i2]);
+-         res = stat( workname, statBuf );         
+-         if (res==0) {
+-            if (fullPath) fullPath->Swap(workname);
+-            return res;
+-         }
+-      }
+-#endif
+    }
+    return -1;
+ }
+@@ -1960,107 +1874,6 @@ int G__loadfile(const char *filenamein)
+       }
+       if(G__ifile.fp) break;
+ #endif /* G__EDU_VERSION */
+-
+-#ifdef G__VISUAL
+-      /**********************************************
+-       * try /msdev/include
+-       **********************************************/
+-      if('\0'!=G__cintsysdir[0]) {
+-         G__snprintf(G__ifile.name,G__MAXFILENAME,"/msdev/include/%s%s",filename(),addpost[i2]);
+-#ifndef G__WIN32
+-        G__ifile.fp = fopen(G__ifile.name,"r");
+-#else
+-        G__ifile.fp = fopen(G__ifile.name,"rb");
+-#endif
+-        G__globalcomp=G__store_globalcomp;
+-      }
+-      if(G__ifile.fp) break;
+-#endif /* G__VISUAL */
+-
+-#ifdef G__SYMANTEC
+-      /**********************************************
+-       * try /sc/include
+-       **********************************************/
+-      if('\0'!=G__cintsysdir[0]) {
+-         G__snprintf(G__ifile.name,G__MAXFILENAME,"/sc/include/%s%s",filename(),addpost[i2]);
+-#ifndef G__WIN32
+-        G__ifile.fp = fopen(G__ifile.name,"r");
+-#else
+-        G__ifile.fp = fopen(G__ifile.name,"rb");
+-#endif
+-        G__globalcomp=G__store_globalcomp;
+-      }
+-      if(G__ifile.fp) break;
+-#endif /* G__SYMANTEC */
+-
+-#ifndef G__WIN32
+-      /**********************************************
+-       * try /usr/include/filename
+-       **********************************************/
+-      if('\0'!=G__cintsysdir[0]) {
+-         G__snprintf(G__ifile.name,G__MAXFILENAME,"/usr/include/%s%s",filename(),addpost[i2]);
+-#ifndef G__WIN32
+-        G__ifile.fp = fopen(G__ifile.name,"r");
+-#else
+-        G__ifile.fp = fopen(G__ifile.name,"rb");
+-#endif
+-        G__globalcomp=G__store_globalcomp;
+-      }
+-      if(G__ifile.fp) break;
+-#endif
+-
+-#ifdef __GNUC__
+-      /**********************************************
+-       * try /usr/include/g++/filename
+-       **********************************************/
+-      if('\0'!=G__cintsysdir[0]) {
+-         G__snprintf(G__ifile.name,G__MAXFILENAME,"/usr/include/g++/%s%s",filename(),addpost[i2]);
+-#ifndef G__WIN32
+-        G__ifile.fp = fopen(G__ifile.name,"r");
+-#else
+-        G__ifile.fp = fopen(G__ifile.name,"rb");
+-#endif
+-        G__globalcomp=G__store_globalcomp;
+-      }
+-      if(G__ifile.fp) break;
+-#endif /* __GNUC__ */
+-
+-#ifndef G__WIN32
+-/* #ifdef __hpux */
+-      /**********************************************
+-       * try /usr/include/CC/filename
+-       **********************************************/
+-      if('\0'!=G__cintsysdir[0]) {
+-         G__snprintf(G__ifile.name,G__MAXFILENAME,"/usr/include/CC/%s%s",filename(),addpost[i2]);
+-#ifndef G__WIN32
+-        G__ifile.fp = fopen(G__ifile.name,"r");
+-#else
+-        G__ifile.fp = fopen(G__ifile.name,"rb");
+-#endif
+-        G__globalcomp=G__store_globalcomp;
+-      }
+-      if(G__ifile.fp) break;
+-/* #endif __hpux */
+-#endif
+-
+-#ifndef G__WIN32
+-/* #ifdef __hpux */
+-      /**********************************************
+-       * try /usr/include/codelibs/filename
+-       **********************************************/
+-      if('\0'!=G__cintsysdir[0]) {
+-        G__snprintf(G__ifile.name,G__MAXFILENAME,"/usr/include/codelibs/%s%s"
+-                    ,filename(),addpost[i2]);
+-#ifndef G__WIN32
+-        G__ifile.fp = fopen(G__ifile.name,"r");
+-#else
+-        G__ifile.fp = fopen(G__ifile.name,"rb");
+-#endif
+-        G__globalcomp=G__store_globalcomp;
+-      }
+-      if(G__ifile.fp) break;
+-/* #endif __hpux */
+-#endif
+     }
+   }
+ 

--- a/pkgs/development/libraries/physics/applgrid/bad_code.patch
+++ b/pkgs/development/libraries/physics/applgrid/bad_code.patch
@@ -37,3 +37,14 @@ index d25288e..be354df 100644
    };
  
    typedef double (igrid::*transform_t)(double) const;
+diff --git a/src/lumi_pdf.cxx b/src/lumi_pdf.cxx
+--- a/src/lumi_pdf.cxx
++++ b/src/lumi_pdf.cxx
+@@ -235,6 +235,6 @@ void lumi_pdf::write(const std::string& filename) const {
+ // std::string lumi_pdf::summary(std::ostream& s=std::cout) const { 
+ std::string lumi_pdf::summary() const { 
+   std::stringstream s;
+-  s << "lumi_pdf::lumi_pdf() " << s << "\tsize " << m_combinations.size() << " lookup size " << m_lookup.size() << " " << this; 
++  s << "lumi_pdf::lumi_pdf() " << "\tsize " << m_combinations.size() << " lookup size " << m_lookup.size() << " " << this; 
+   return s.str();
+ }


### PR DESCRIPTION
###### Motivation for this change

ROOT5 includes a C++ interpreter/introspection tool called cint (rootcint) which is also is being used during the build of ROOT itself. The interpreter will try to access libc headers at /usr/include, which is not pure and can possibly break the build. We also can not supply our glibc headers because those require a modern compiler. This fix should remove some of the direct access to libc/posix calls, that should not affect functionality very much.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using nix-review
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

