### PR TITLE
miniflux: do not send buildGoPackage, it is using buildGoModule now

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -937,7 +937,7 @@ in
   bchunk = callPackage ../tools/cd-dvd/bchunk { };
 
   inherit (callPackages ../misc/logging/beats/6.x.nix {
-    # XXX: bettercap is failing with Go 1.12. Error is related to cgo, an
+    # XXX: this is failing with Go 1.12. Error is related to cgo, an
     # update to this package might fix it.
     buildGoPackage = buildGo111Package;
   })
@@ -953,7 +953,7 @@ in
   packetbeat = packetbeat6;
 
   inherit (callPackages ../misc/logging/beats/5.x.nix {
-    # XXX: bettercap is failing with Go 1.12. Error is related to cgo, an
+    # XXX: this is failing with Go 1.12. Error is related to cgo, an
     # update to this package might fix it.
     buildGoPackage = buildGo111Package;
   })
@@ -1742,7 +1742,7 @@ in
   mongodb-compass = callPackage ../tools/misc/mongodb-compass { };
 
   mongodb-tools = callPackage ../tools/misc/mongodb-tools {
-    # XXX: bettercap is failing with Go 1.12. Error is related to cgo, an
+    # XXX: this is failing with Go 1.12. Error is related to cgo, an
     # update to this package might fix it.
     buildGoPackage = buildGo111Package;
   };
@@ -1829,7 +1829,7 @@ in
   bepasty = callPackage ../tools/misc/bepasty { };
 
   bettercap = callPackage ../tools/security/bettercap {
-    # XXX: bettercap is failing with Go 1.12. Error is related to cgo, an
+    # XXX: this is failing with Go 1.12. Error is related to cgo, an
     # update to this package might fix it.
     buildGoPackage = buildGo111Package;
   };
@@ -4319,7 +4319,7 @@ in
   miredo = callPackage ../tools/networking/miredo { };
 
   mirrorbits = callPackage ../servers/mirrorbits {
-    # XXX: bettercap is failing with Go 1.12. Error is related to cgo, an
+    # XXX: this is failing with Go 1.12. Error is related to cgo, an
     # update to this package might fix it.
     buildGoPackage = buildGo111Package;
   };
@@ -12678,7 +12678,7 @@ in
   };
 
   skydive = callPackage ../tools/networking/skydive {
-    # XXX: bettercap is failing with Go 1.12. Error is related to cgo, an
+    # XXX: this is failing with Go 1.12. Error is related to cgo, an
     # update to this package might fix it.
     buildGoPackage = buildGo111Package;
   };
@@ -14002,10 +14002,7 @@ in
 
   mysql_jdbc = callPackage ../servers/sql/mysql/jdbc { };
 
-  miniflux = callPackage ../servers/miniflux {
-    # XXX: bettercap is failing with Go 1.12.
-    buildGoPackage = buildGo111Package;
-  };
+  miniflux = callPackage ../servers/miniflux { };
 
   nagios = callPackage ../servers/monitoring/nagios { };
 
@@ -14471,7 +14468,7 @@ in
   cifs-utils = callPackage ../os-specific/linux/cifs-utils { };
 
   cockroachdb = callPackage ../servers/sql/cockroachdb {
-    # XXX: bettercap is failing with Go 1.12. Error is related to cgo, an
+    # XXX: this is failing with Go 1.12. Error is related to cgo, an
     # update to this package might fix it.
     buildGoPackage = buildGo111Package;
   };


### PR DESCRIPTION
###### Motivation for this change

Staging is currently not evaluating. Miniflux is no longer using buildGoPackage, so it must not be sent buildGoPackage.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

