### PR TITLE
b612: 1.003 -> 1.008, new home

### DIFF
--- a/pkgs/data/fonts/b612/default.nix
+++ b/pkgs/data/fonts/b612/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchzip, lib }:
 
 let
-  version = "1.003";
+  version = "1.008";
   pname = "b612";
 in
 
 fetchzip rec {
   name = "${pname}-font-${version}";
-  url = "http://git.polarsys.org/c/${pname}/${pname}.git/snapshot/${pname}-bd14fde2544566e620eab106eb8d6f2b7fb1347e.zip";
-  sha256 = "07gadk9b975k69pgw9gj54qx8d5xvxphid7wrmv4cna52jyy4464";
+  url = "https://github.com/polarsys/b612/archive/${version}.zip";
+  sha256 = "0r3lana1q9w3siv8czb3p9rrb5d9svp628yfbvvmnj7qvjrmfsiq";
   postFetch = ''
     mkdir -p $out/share/fonts/truetype/${pname}
     unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype/${pname}


### PR DESCRIPTION
###### Motivation for this change

\o/ fonts

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---