### PR TITLE
Ghc863 add haskellCompilerName and doc output

### DIFF
--- a/pkgs/development/compilers/ghc/8.6.3-binary.nix
+++ b/pkgs/development/compilers/ghc/8.6.3-binary.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
   version = "8.6.3";
 
   name = "ghc-${version}-binary";
+  outputs = [ "out" "doc" ];
 
   src = fetchurl ({
     "i686-linux" = {

--- a/pkgs/development/compilers/ghc/8.6.3-binary.nix
+++ b/pkgs/development/compilers/ghc/8.6.3-binary.nix
@@ -166,6 +166,8 @@ stdenv.mkDerivation rec {
   passthru = {
     targetPrefix = "";
     enableShared = true;
+
+    haskellCompilerName = "ghc-8.6.3";
   };
 
   meta.license = stdenv.lib.licenses.bsd3;


### PR DESCRIPTION
I am trying to use hie with ghc863 as ghc864 is not supported yet but met some problems along the way as ghc863 is missing attributes.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

