### PR TITLE
[backport] spectral: 2018-09-24 -> 2019-03-03

### DIFF
--- a/pkgs/applications/networking/instant-messengers/spectral/default.nix
+++ b/pkgs/applications/networking/instant-messengers/spectral/default.nix
@@ -43,7 +43,7 @@ in stdenv.mkDerivation rec {
     description = "A glossy client for Matrix, written in QtQuick Controls 2 and C++";
     homepage = https://gitlab.com/b0/spectral;
     license = licenses.gpl3;
-    platforms = with platforms; linux ++ darwin;
+    platforms = with platforms; linux;
     maintainers = with maintainers; [ dtzWill ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
I think after the qt 5.12 update the program stopped working due to the qml path problem.
This update fixes the issue so it should be backported.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change (none)
- [x] Tested execution of all binary files
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
