### PR TITLE
coqPackages.coqhammer: init at 1.1

### DIFF
--- a/pkgs/development/coq-modules/coqhammer/default.nix
+++ b/pkgs/development/coq-modules/coqhammer/default.nix
@@ -1,0 +1,55 @@
+{ stdenv, fetchFromGitHub, coq }:
+
+let
+  params = {
+    "8.8" = {
+      sha256 = "0ms086wp4jmrzyglb8wymchzyflflk01nsfsk4r6qv8rrx81nx9h";
+    };
+    "8.9" = {
+      sha256 = "0hmqwsry8ldg4g4hhwg4b84dgzibpdrg1wwsajhlyqfx3fb3n3b5";
+    };
+  };
+  param = params."${coq.coq-version}";
+in
+
+stdenv.mkDerivation rec {
+  version = "1.1";
+  name = "coq${coq.coq-version}-coqhammer-${version}";
+
+  src = fetchFromGitHub {
+    owner = "lukaszcz";
+    repo = "coqhammer";
+    rev = "v${version}-coq${coq.coq-version}";
+    inherit (param) sha256;
+  };
+
+  postPatch = ''
+    substituteInPlace Makefile.coq.local --replace \
+      '$(if $(COQBIN),$(COQBIN),`coqc -where | xargs dirname | xargs dirname`/bin/)' \
+      '$(out)/bin/'
+    substituteInPlace Makefile.coq.local --replace 'g++' 'c++' --replace 'gcc' 'cc'
+  '';
+
+  buildInputs = [ coq ] ++ (with coq.ocamlPackages; [
+    ocaml findlib camlp5
+  ]);
+
+  preInstall = ''
+    mkdir -p $out/bin
+  '';
+
+  installFlags = [ "COQLIB=$(out)/lib/coq/${coq.coq-version}/" ];
+
+  meta = {
+    homepage = "http://cl-informatik.uibk.ac.at/cek/coqhammer/";
+    description = "Automation for Dependent Type Theory";
+    license = stdenv.lib.licenses.lgpl21;
+    inherit (coq.meta) platforms;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+  };
+
+  passthru = {
+    compatibleCoqVersions = v: builtins.hasAttr v params;
+  };
+
+}

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -19,6 +19,7 @@ let
       coq-ext-lib = callPackage ../development/coq-modules/coq-ext-lib {};
       coq-extensible-records = callPackage ../development/coq-modules/coq-extensible-records {};
       coq-haskell = callPackage ../development/coq-modules/coq-haskell { };
+      coqhammer = callPackage ../development/coq-modules/coqhammer {};
       coqprime = callPackage ../development/coq-modules/coqprime {};
       coquelicot = callPackage ../development/coq-modules/coquelicot {};
       corn = callPackage ../development/coq-modules/corn {};


### PR DESCRIPTION
CoqHammer is a general-purpose automated reasoning hammer tool for Coq.

Homepage: http://cl-informatik.uibk.ac.at/cek/coqhammer/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
