### PR TITLE
libb2: 0.98 -> 0.98.1

### DIFF
--- a/pkgs/development/libraries/libb2/default.nix
+++ b/pkgs/development/libraries/libb2/default.nix
@@ -1,12 +1,14 @@
-{ stdenv, fetchurl, autoconf, automake, libtool }:
+{ stdenv, fetchFromGitHub, autoconf, automake, libtool, pkg-config }:
 
 stdenv.mkDerivation rec {
   name = "libb2-${version}";
-  version = "0.98";
+  version = "0.98.1";
 
-  src = fetchurl {
-    url = "https://blake2.net/${name}.tar.gz";
-    sha256 = "1852gh8wwnsghdb9zhxdhw0173plpqzk684npxbl4bzk1hhzisal";
+  src = fetchFromGitHub {
+    owner = "BLAKE2";
+    repo = "libb2";
+    rev = "v${version}";
+    sha256 = "0qj8aaqvfcavj1vj5asm4pqm03ap7q8x4c2fy83cqggvky0frgya";
   };
 
   preConfigure = ''
@@ -16,14 +18,15 @@ stdenv.mkDerivation rec {
 
   configureFlags = stdenv.lib.optional stdenv.hostPlatform.isx86 "--enable-fat=yes";
 
-  nativeBuildInputs = [ autoconf automake libtool ];
+  nativeBuildInputs = [ autoconf automake libtool pkg-config ];
 
   doCheck = true;
 
   meta = with stdenv.lib; {
     description = "The BLAKE2 family of cryptographic hash functions";
+    homepage = https://blake2.net/;
     platforms = platforms.all;
-    maintainers = with maintainers; [ dfoxfranke ];
+    maintainers = with maintainers; [ dfoxfranke dotlambda ];
     license = licenses.cc0;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
https://mail.python.org/pipermail/borgbackup/2019q1/001294.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
