### PR TITLE
showoff: init at 0.20.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3267,6 +3267,11 @@
     github = "mvnetbiz";
     name = "Matt Votava";
   };
+  mwilsoninsight = {
+    email = "max.wilson@insight.com";
+    github = "mwilsoninsight";
+    name = "Max Wilson";
+  };
   myrl = {
     email = "myrl.0xf@gmail.com";
     github = "myrl";

--- a/pkgs/servers/http/showoff/Gemfile
+++ b/pkgs/servers/http/showoff/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'showoff'

--- a/pkgs/servers/http/showoff/Gemfile.lock
+++ b/pkgs/servers/http/showoff/Gemfile.lock
@@ -1,0 +1,73 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
+    commonmarker (0.18.2)
+      ruby-enum (~> 0.5)
+    concurrent-ruby (1.1.5)
+    daemons (1.3.1)
+    em-websocket (0.3.8)
+      addressable (>= 2.1.1)
+      eventmachine (>= 0.12.9)
+    eventmachine (1.2.7)
+    fidget (0.0.6)
+      ruby-dbus (< 0.15.0)
+    gli (2.18.0)
+    htmlentities (4.3.4)
+    i18n (1.6.0)
+      concurrent-ruby (~> 1.0)
+    iso-639 (0.2.8)
+    json (2.2.0)
+    mini_portile2 (2.4.0)
+    nokogiri (1.10.1)
+      mini_portile2 (~> 2.4.0)
+    parslet (1.8.2)
+    public_suffix (3.0.3)
+    rack (1.6.11)
+    rack-contrib (1.8.0)
+      rack (~> 1.4)
+    rack-protection (1.5.5)
+      rack
+    redcarpet (3.4.0)
+    ruby-dbus (0.14.1)
+    ruby-enum (0.7.2)
+      i18n
+    showoff (0.20.1)
+      commonmarker
+      fidget (>= 0.0.3)
+      gli (>= 2.0)
+      htmlentities
+      i18n
+      iso-639
+      json
+      nokogiri
+      parslet
+      rack-contrib
+      redcarpet
+      sinatra (~> 1.3)
+      sinatra-websocket
+      thin (~> 1.3)
+      tilt (>= 2.0.3)
+    sinatra (1.4.8)
+      rack (~> 1.5)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+    sinatra-websocket (0.3.1)
+      em-websocket (~> 0.3.6)
+      eventmachine
+      thin (>= 1.3.1, < 2.0.0)
+    thin (1.7.2)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0, >= 1.0.4)
+      rack (>= 1, < 3)
+    tilt (2.0.9)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  showoff
+
+BUNDLED WITH
+   1.16.3

--- a/pkgs/servers/http/showoff/default.nix
+++ b/pkgs/servers/http/showoff/default.nix
@@ -1,0 +1,16 @@
+{ lib, bundlerApp }:
+
+bundlerApp {
+  pname = "showoff";
+  gemdir = ./.;
+  exes = [ "showoff" ];
+
+  meta = with lib; {
+    description = "A slideshow presentation tool with a twist";
+    longDescription = "It runs as a web application, with audience interactivity features. This means that your audience can follow along in their own browsers, can download supplemental materials, can participate in quizzes or polls, post questions for the presenter, etc. By default, their slideshows will synchronize with the presenter, but they can switch to self-navigation mode";
+    homepage = https://puppetlabs.github.io/showoff/;
+    license = with licenses; mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ mwilsoninsight ];
+  };
+}

--- a/pkgs/servers/http/showoff/gemset.nix
+++ b/pkgs/servers/http/showoff/gemset.nix
@@ -1,0 +1,231 @@
+{
+  addressable = {
+    dependencies = ["public_suffix"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0bcm2hchn897xjhqj9zzsxf3n9xhddymj4lsclz508f4vw3av46l";
+      type = "gem";
+    };
+    version = "2.6.0";
+  };
+  commonmarker = {
+    dependencies = ["ruby-enum"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "122dy5mzx4p86flpzyg3raf742zp5ab9bjr7zk29p3ixpncf0rdk";
+      type = "gem";
+    };
+    version = "0.18.2";
+  };
+  concurrent-ruby = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1x07r23s7836cpp5z9yrlbpljcxpax14yw4fy4bnp6crhr6x24an";
+      type = "gem";
+    };
+    version = "1.1.5";
+  };
+  daemons = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0l5gai3vd4g7aqff0k1mp41j9zcsvm2rbwmqn115a325k9r7pf4w";
+      type = "gem";
+    };
+    version = "1.3.1";
+  };
+  em-websocket = {
+    dependencies = ["addressable" "eventmachine"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0xkb1rc6dd3y5s7qsp4wqrri3n9gwsbvnwwv6xwgp241jxdpp4iq";
+      type = "gem";
+    };
+    version = "0.3.8";
+  };
+  eventmachine = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0wh9aqb0skz80fhfn66lbpr4f86ya2z5rx6gm5xlfhd05bj1ch4r";
+      type = "gem";
+    };
+    version = "1.2.7";
+  };
+  fidget = {
+    dependencies = ["ruby-dbus"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "04g2846wjlb8ms5041lv37aqs4jzsziwv58bxg7yzc61pdvi4ksb";
+      type = "gem";
+    };
+    version = "0.0.6";
+  };
+  gli = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "133glfzsq67ykmdsgp251s9kddg9x4qki2jpbjv25h3hawlql4hs";
+      type = "gem";
+    };
+    version = "2.18.0";
+  };
+  htmlentities = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1nkklqsn8ir8wizzlakncfv42i32wc0w9hxp00hvdlgjr7376nhj";
+      type = "gem";
+    };
+    version = "4.3.4";
+  };
+  i18n = {
+    dependencies = ["concurrent-ruby"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1hfxnlyr618s25xpafw9mypa82qppjccbh292c4l3bj36az7f6wl";
+      type = "gem";
+    };
+    version = "1.6.0";
+  };
+  iso-639 = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "10k1gpkkbxbasgjzh4hd32ygxzjb5312rphipm46ryxkpx556zzz";
+      type = "gem";
+    };
+    version = "0.2.8";
+  };
+  json = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0sx97bm9by389rbzv8r1f43h06xcz8vwi3h5jv074gvparql7lcx";
+      type = "gem";
+    };
+    version = "2.2.0";
+  };
+  mini_portile2 = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "15zplpfw3knqifj9bpf604rb3wc1vhq6363pd6lvhayng8wql5vy";
+      type = "gem";
+    };
+    version = "2.4.0";
+  };
+  nokogiri = {
+    dependencies = ["mini_portile2"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "09zll7c6j7xr6wyvh5mm5ncj6pkryp70ybcsxdbw1nyphx5dh184";
+      type = "gem";
+    };
+    version = "1.10.1";
+  };
+  parslet = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "12nrzfwjphjlakb9pmpj70hgjwgzvnr8i1zfzddifgyd44vspl88";
+      type = "gem";
+    };
+    version = "1.8.2";
+  };
+  public_suffix = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "08q64b5br692dd3v0a9wq9q5dvycc6kmiqmjbdxkxbfizggsvx6l";
+      type = "gem";
+    };
+    version = "3.0.3";
+  };
+  rack = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1g9926ln2lw12lfxm4ylq1h6nl0rafl10za3xvjzc87qvnqic87f";
+      type = "gem";
+    };
+    version = "1.6.11";
+  };
+  rack-contrib = {
+    dependencies = ["rack"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1l7m0av4pjl5p64l8j7pkip1jwhkp80a8kc2j7b9lrwh04fgx5wx";
+      type = "gem";
+    };
+    version = "1.8.0";
+  };
+  rack-protection = {
+    dependencies = ["rack"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0my0wlw4a5l3hs79jkx2xzv7djhajgf8d28k8ai1ddlnxxb0v7ss";
+      type = "gem";
+    };
+    version = "1.5.5";
+  };
+  redcarpet = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0h9qz2hik4s9knpmbwrzb3jcp3vc5vygp9ya8lcpl7f1l9khmcd7";
+      type = "gem";
+    };
+    version = "3.4.0";
+  };
+  ruby-dbus = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "16lsqdwas6ngyyvq51l7lynj5ayis17zm5hpsg5x3m3n6r5k2gv4";
+      type = "gem";
+    };
+    version = "0.14.1";
+  };
+  ruby-enum = {
+    dependencies = ["i18n"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0h62avini866kxpjzqxlqnajma3yvj0y25l6hn9h2mv5pp6fcrhx";
+      type = "gem";
+    };
+    version = "0.7.2";
+  };
+  showoff = {
+    dependencies = ["commonmarker" "fidget" "gli" "htmlentities" "i18n" "iso-639" "json" "nokogiri" "parslet" "rack-contrib" "redcarpet" "sinatra" "sinatra-websocket" "thin" "tilt"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "14884kh7vrp5b72dpn7q26h49y7igxqza72girkv1h28qx4kqw4r";
+      type = "gem";
+    };
+    version = "0.20.1";
+  };
+  sinatra = {
+    dependencies = ["rack" "rack-protection" "tilt"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0byxzl7rx3ki0xd7aiv1x8mbah7hzd8f81l65nq8857kmgzj1jqq";
+      type = "gem";
+    };
+    version = "1.4.8";
+  };
+  sinatra-websocket = {
+    dependencies = ["em-websocket" "eventmachine" "thin"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0as52mfw34z3ba6qjab009h2rdn0za0iwrc42kw948hbb8qzcm5m";
+      type = "gem";
+    };
+    version = "0.3.1";
+  };
+  thin = {
+    dependencies = ["daemons" "eventmachine" "rack"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0nagbf9pwy1vg09k6j4xqhbjjzrg5dwzvkn4ffvlj76fsn6vv61f";
+      type = "gem";
+    };
+    version = "1.7.2";
+  };
+  tilt = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0ca4k0clwf0rkvy7726x4nxpjxkpv67w043i39saxgldxd97zmwz";
+      type = "gem";
+    };
+    version = "2.0.9";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14171,6 +14171,8 @@ in
 
   shairport-sync = callPackage ../servers/shairport-sync { };
 
+  showoff = callPackage ../servers/http/showoff {};
+
   serfdom = callPackage ../servers/serf { };
 
   seyren = callPackage ../servers/monitoring/seyren { };


### PR DESCRIPTION
###### Motivation for this change
Wanted to use this application to introduce teammates to the nix toolset

###### Things done
Added ruby gem application showoff to nixpkgs

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
