### PR TITLE
bicon: init at unstable-2018-08-10

### DIFF
--- a/pkgs/applications/misc/bicon/default.nix
+++ b/pkgs/applications/misc/bicon/default.nix
@@ -1,0 +1,36 @@
+{ stdenv
+  , fetchFromGitHub
+  , autoreconfHook
+  , pkg-config
+  , perl
+  , fribidi
+  , kbd
+  , xkbutils
+}:
+
+stdenv.mkDerivation rec {
+  pname = "bicon";
+  version = "unstable-2018-09-10";
+
+  src = fetchFromGitHub {
+    owner = "behdad";
+    repo = pname;
+    rev = "38725c062a83ab19c4e4b4bc20eb9535561aa76c";
+    sha256 = "0hdslrci8pq300f3rrjsvl5psfrxdwyxf9g2m5g789sr049dksnq";
+  };
+
+  buildInputs = [ fribidi kbd xkbutils perl ];
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+
+  preConfigure = ''
+    patchShebangs .
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A bidirectional console";
+    homepage =  https://github.com/behdad/bicon;
+    license = [ licenses.lgpl21 licenses.psfl licenses.bsd0 ];
+    maintainers = [ maintainers.linarcx ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -962,6 +962,8 @@ in
 
   bibtex2html = callPackage ../tools/misc/bibtex2html { };
 
+  bicon = callPackage ../applications/misc/bicon { };
+
   bindfs = callPackage ../tools/filesystems/bindfs { };
 
   bitbucket-cli = python2Packages.bitbucket-cli;


### PR DESCRIPTION
###### Motivation for this change
Persian, arabic users sometimes need a console to support RTL very well.
Bicon gives you that console :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
