### PR TITLE
androidenv: update packages

### DIFF
--- a/pkgs/development/mobile/androidenv/compose-android-packages.nix
+++ b/pkgs/development/mobile/androidenv/compose-android-packages.nix
@@ -1,10 +1,10 @@
 {stdenv, fetchurl, requireFile, makeWrapper, unzip, autoPatchelfHook, pkgs, pkgs_i686, licenseAccepted ? false}:
 
-{ toolsVersion ? "25.2.5"
-, platformToolsVersion ? "28.0.1"
+{ toolsVersion ? "26.1.1"
+, platformToolsVersion ? "28.0.2"
 , buildToolsVersions ? [ "28.0.3" ]
 , includeEmulator ? false
-, emulatorVersion ? "28.0.14"
+, emulatorVersion ? "28.0.23"
 , platformVersions ? []
 , includeSources ? false
 , includeDocs ? false
@@ -14,7 +14,7 @@
 , lldbVersions ? [ ]
 , cmakeVersions ? [ ]
 , includeNDK ? false
-, ndkVersion ? "18.1.5063045"
+, ndkVersion ? "19.2.5345600"
 , useGoogleAPIs ? false
 , useGoogleTVAddOns ? false
 , includeExtras ? []

--- a/pkgs/development/mobile/androidenv/generate.sh
+++ b/pkgs/development/mobile/androidenv/generate.sh
@@ -1,16 +1,36 @@
-#!/bin/sh -e
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl libxslt
+
+set -e
+
+die() {
+    echo "$1" >&2
+    exit 1
+}
+
+fetch() {
+    local url="https://dl.google.com/android/repository/$1"
+    echo "$url -> $2"
+    curl -s "$url" -o "$2" || die "Failed to fetch $url"
+}
+
+pushd "$(dirname "$0")" &>/dev/null || exit 1
+
+mkdir -p xml
 
 # Convert base packages
-curl https://dl.google.com/android/repository/repository2-1.xml -o xml/repository2-1.xml
+fetch repository2-1.xml xml/repository2-1.xml
 xsltproc convertpackages.xsl xml/repository2-1.xml > generated/packages.nix
 
 # Convert system images
 for img in android android-tv android-wear android-wear-cn google_apis google_apis_playstore
 do
-    curl https://dl.google.com/android/repository/sys-img/$img/sys-img2-1.xml -o xml/$img-sys-img2-1.xml
+    fetch sys-img/$img/sys-img2-1.xml xml/$img-sys-img2-1.xml
     xsltproc --stringparam imageType $img convertsystemimages.xsl xml/$img-sys-img2-1.xml > generated/system-images-$img.nix
 done
 
 # Convert system addons
-curl https://dl.google.com/android/repository/addon2-1.xml -o xml/addon2-1.xml
+fetch addon2-1.xml xml/addon2-1.xml
 xsltproc convertaddons.xsl xml/addon2-1.xml > generated/addons.nix
+
+popd &>/dev/null

--- a/pkgs/development/mobile/androidenv/generated/addons.nix
+++ b/pkgs/development/mobile/androidenv/generated/addons.nix
@@ -525,13 +525,13 @@
     "extras;google;instantapps" = {
       name = "extras-google-instantapps";
       path = "extras/google/instantapps";
-      revision = "1.5.0";
+      revision = "1.6.0";
       displayName = "Google Play Instant Development SDK";
       archives = {
       
         all = fetchurl {
-          url = https://dl.google.com/android/repository/iasdk-1.5.0-1538000167.zip;
-          sha1 = "6c282b9c686e819fe7f5ac8f2249d2479acb63b4";
+          url = https://dl.google.com/android/repository/iasdk-1.6.0-1540933685.zip;
+          sha1 = "0bb546a846815f5b5ccd2ed00549c9912d1d48cb";
         };
       
       };

--- a/pkgs/development/mobile/androidenv/generated/packages.nix
+++ b/pkgs/development/mobile/androidenv/generated/packages.nix
@@ -877,6 +877,25 @@
     };
   };
   
+  "build-tools"."29.0.0-rc1" = {
+    
+    name = "build-tools";
+    path = "build-tools/29.0.0-rc1";
+    revision = "29.0.0-rc1";
+    displayName = "Android SDK Build-Tools 29-rc1";
+    archives = {
+      linux = fetchurl {
+        url = https://dl.google.com/android/repository/build-tools_r29-rc1-linux.zip;
+        sha1 = "1c897f5885ac5468613e40e1ea598c21c05d345d";
+      };
+      macosx = fetchurl {
+        url = https://dl.google.com/android/repository/build-tools_r29-rc1-macosx.zip;
+        sha1 = "f066c0d9ea2f0d8a0a9cc7b2ca0a467a570ab034";
+      };
+      
+    };
+  };
+  
   "cmake"."3.10.2" = {
     
     name = "cmake";
@@ -931,82 +950,123 @@
     };
   };
   
-  "emulator"."27.3.10".linux = {
+  "emulator"."28.0.23".linux = {
     
     name = "emulator";
     path = "emulator";
-    revision = "27.3.10";
+    revision = "28.0.23";
     displayName = "Android Emulator";
     archives = {
       linux = fetchurl {
-        url = https://dl.google.com/android/repository/emulator-linux-4969155.zip;
-        sha1 = "5b037b25bc6567fda3071457f0009c057670d9e8";
+        url = https://dl.google.com/android/repository/emulator-linux-5264690.zip;
+        sha1 = "48c1cda2bdf3095d9d9d5c010fbfb3d6d673e3ea";
       };
       
     };
   };
   
-  "emulator"."27.3.10".macosx = {
+  "emulator"."28.0.23".macosx = {
     
     name = "emulator";
     path = "emulator";
-    revision = "27.3.10";
+    revision = "28.0.23";
     displayName = "Android Emulator";
     archives = {
       macosx = fetchurl {
-        url = https://dl.google.com/android/repository/emulator-darwin-4969155.zip;
-        sha1 = "28d2b51ee5c84bc544deee433419f33dc9e05b66";
+        url = https://dl.google.com/android/repository/emulator-darwin-5264690.zip;
+        sha1 = "ce29b4111cb770de98b9c3b16695b015999e7629";
       };
       
     };
   };
   
-  "emulator"."27.3.10".windows = {
+  "emulator"."28.0.23".windows = {
     
     name = "emulator";
     path = "emulator";
-    revision = "27.3.10";
+    revision = "28.0.23";
     displayName = "Android Emulator";
     archives = {
       
     };
   };
   
-  "emulator"."28.0.14".linux = {
+  "emulator"."28.1.12".linux = {
     
     name = "emulator";
     path = "emulator";
-    revision = "28.0.14";
+    revision = "28.1.12";
     displayName = "Android Emulator";
     archives = {
       linux = fetchurl {
-        url = https://dl.google.com/android/repository/emulator-linux-5092175.zip;
-        sha1 = "062ef9a1f6759481de897d6c5602d9d66e958a0b";
+        url = https://dl.google.com/android/repository/emulator-linux-5395469.zip;
+        sha1 = "03548255d677b501383a3cb116ba50c1ef42d3ba";
       };
       
     };
   };
   
-  "emulator"."28.0.14".macosx = {
+  "emulator"."28.1.12".macosx = {
     
     name = "emulator";
     path = "emulator";
-    revision = "28.0.14";
+    revision = "28.1.12";
     displayName = "Android Emulator";
     archives = {
       macosx = fetchurl {
-        url = https://dl.google.com/android/repository/emulator-darwin-5092175.zip;
-        sha1 = "6dc13599bddd5c2acdb559b25201c92a801d157c";
+        url = https://dl.google.com/android/repository/emulator-darwin-5395469.zip;
+        sha1 = "30edcabcd88dbd1a5ebbe388de19a8ac5937efa1";
       };
       
     };
   };
   
-  "emulator"."28.0.14".windows = {
+  "emulator"."28.1.12".windows = {
     
     name = "emulator";
     path = "emulator";
-    revision = "28.0.14";
+    revision = "28.1.12";
+    displayName = "Android Emulator";
+    archives = {
+      
+    };
+  };
+  
+  "emulator"."28.0.25".linux = {
+    
+    name = "emulator";
+    path = "emulator";
+    revision = "28.0.25";
+    displayName = "Android Emulator";
+    archives = {
+      linux = fetchurl {
+        url = https://dl.google.com/android/repository/emulator-linux-5395263.zip;
+        sha1 = "8475f848934b55bb609790f82e764ef36ccbe682";
+      };
+      
+    };
+  };
+  
+  "emulator"."28.0.25".macosx = {
+    
+    name = "emulator";
+    path = "emulator";
+    revision = "28.0.25";
+    displayName = "Android Emulator";
+    archives = {
+      macosx = fetchurl {
+        url = https://dl.google.com/android/repository/emulator-darwin-5395263.zip;
+        sha1 = "c4d1f58b18502c3ae291a649ad19dc79c97a1847";
+      };
+      
+    };
+  };
+  
+  "emulator"."28.0.25".windows = {
+    
+    name = "emulator";
+    path = "emulator";
+    revision = "28.0.25";
     displayName = "Android Emulator";
     archives = {
       
@@ -1127,20 +1187,39 @@
     };
   };
   
-  "ndk-bundle"."18.1.5063045" = {
+  "ndk-bundle"."20.0.5344622-rc1" = {
     
     name = "ndk-bundle";
     path = "ndk-bundle";
-    revision = "18.1.5063045";
+    revision = "20.0.5344622-rc1";
     displayName = "NDK";
     archives = {
       macosx = fetchurl {
-        url = https://dl.google.com/android/repository/android-ndk-r18b-darwin-x86_64.zip;
-        sha1 = "98cb9909aa8c2dab32db188bbdc3ac6207e09440";
+        url = https://dl.google.com/android/repository/android-ndk-r20-beta1-darwin-x86_64.zip;
+        sha1 = "81128edb666af06cd0668d40a0be731bb4ba85a8";
       };
       linux = fetchurl {
-        url = https://dl.google.com/android/repository/android-ndk-r18b-linux-x86_64.zip;
-        sha1 = "500679655da3a86aecf67007e8ab230ea9b4dd7b";
+        url = https://dl.google.com/android/repository/android-ndk-r20-beta1-linux-x86_64.zip;
+        sha1 = "8aff5c9079bff4f7cf77c34d3795cf498aced8cb";
+      };
+      
+    };
+  };
+  
+  "ndk-bundle"."19.2.5345600" = {
+    
+    name = "ndk-bundle";
+    path = "ndk-bundle";
+    revision = "19.2.5345600";
+    displayName = "NDK";
+    archives = {
+      macosx = fetchurl {
+        url = https://dl.google.com/android/repository/android-ndk-r19c-darwin-x86_64.zip;
+        sha1 = "f46b8193109bba8a58e0461c1a48f4534051fb25";
+      };
+      linux = fetchurl {
+        url = https://dl.google.com/android/repository/android-ndk-r19c-linux-x86_64.zip;
+        sha1 = "fd94d0be6017c6acbd193eb95e09cf4b6f61b834";
       };
       
     };
@@ -1162,20 +1241,20 @@
     };
   };
   
-  "platform-tools"."28.0.1" = {
+  "platform-tools"."28.0.2" = {
     
     name = "platform-tools";
     path = "platform-tools";
-    revision = "28.0.1";
+    revision = "28.0.2";
     displayName = "Android SDK Platform-Tools";
     archives = {
       macosx = fetchurl {
-        url = https://dl.google.com/android/repository/platform-tools_r28.0.1-darwin.zip;
-        sha1 = "ed1edad4a48c27655ce98d0a5821e7296e9de145";
+        url = https://dl.google.com/android/repository/platform-tools_r28.0.2-darwin.zip;
+        sha1 = "f5d0b6ff6b83bee72dc680c63a6dc8a203a8476a";
       };
       linux = fetchurl {
-        url = https://dl.google.com/android/repository/platform-tools_r28.0.1-linux.zip;
-        sha1 = "74ff83bc203f01c4f04bd9316ab5a2573f023fd1";
+        url = https://dl.google.com/android/repository/platform-tools_r28.0.2-linux.zip;
+        sha1 = "46a4c02a9b8e4e2121eddf6025da3c979bf02e28";
       };
       
     };
@@ -1623,6 +1702,22 @@
         all = fetchurl {
           url = https://dl.google.com/android/repository/android-2.3.1_r02.zip;
           sha1 = "209f8a7a8b2cb093fce858b8b55fed3ba5206773";
+        };
+      
+    };
+  };
+  
+  "platforms"."Q" = {
+    
+    name = "platforms";
+    path = "platforms/android-Q";
+    revision = "Q";
+    displayName = "Android SDK Platform Q";
+    archives = {
+      
+        all = fetchurl {
+          url = https://dl.google.com/android/repository/platform-Q_r01.zip;
+          sha1 = "aa7696570651e7f6e2f414fdff0eaeeec3c0ebed";
         };
       
     };

--- a/pkgs/development/mobile/androidenv/generated/system-images-android-tv.nix
+++ b/pkgs/development/mobile/androidenv/generated/system-images-android-tv.nix
@@ -1,157 +1,114 @@
-
 {fetchurl}:
 
 {
-  
-
-    "21".android-tv."x86" = {
-      name = "system-image-21-android-tv-x86";
-      path = "system-images/android-21/android-tv/x86";
-      revision = "21-android-tv-x86";
-      displayName = "Android TV Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android-tv/x86-21_r03.zip;
-        sha1 = "2f8a1988188d6abfd6c6395baeb4471a034dc1e8";
-      
-      };
+  "21".android-tv."x86" = {
+    name = "system-image-21-android-tv-x86";
+    path = "system-images/android-21/android-tv/x86";
+    revision = "21-android-tv-x86";
+    displayName = "Android TV Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android-tv/x86-21_r03.zip;
+      sha1 = "2f8a1988188d6abfd6c6395baeb4471a034dc1e8";
+    };
   };
-  
-
-    "21".android-tv."armeabi-v7a" = {
-      name = "system-image-21-android-tv-armeabi-v7a";
-      path = "system-images/android-21/android-tv/armeabi-v7a";
-      revision = "21-android-tv-armeabi-v7a";
-      displayName = "Android TV ARM EABI v7a System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android-tv/armeabi-v7a-21_r03.zip;
-        sha1 = "b63e28a47f11b639dd94981a458b7abfa89ac331";
-      
-      };
+  "21".android-tv."armeabi-v7a" = {
+    name = "system-image-21-android-tv-armeabi-v7a";
+    path = "system-images/android-21/android-tv/armeabi-v7a";
+    revision = "21-android-tv-armeabi-v7a";
+    displayName = "Android TV ARM EABI v7a System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android-tv/armeabi-v7a-21_r03.zip;
+      sha1 = "b63e28a47f11b639dd94981a458b7abfa89ac331";
+    };
   };
-  
-
-    "22".android-tv."x86" = {
-      name = "system-image-22-android-tv-x86";
-      path = "system-images/android-22/android-tv/x86";
-      revision = "22-android-tv-x86";
-      displayName = "Android TV Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android-tv/x86-22_r03.zip;
-        sha1 = "c78efd5a155622eb490be9d326f5783993375c35";
-      
-      };
+  "22".android-tv."x86" = {
+    name = "system-image-22-android-tv-x86";
+    path = "system-images/android-22/android-tv/x86";
+    revision = "22-android-tv-x86";
+    displayName = "Android TV Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android-tv/x86-22_r03.zip;
+      sha1 = "c78efd5a155622eb490be9d326f5783993375c35";
+    };
   };
-  
-
-    "23".android-tv."x86" = {
-      name = "system-image-23-android-tv-x86";
-      path = "system-images/android-23/android-tv/x86";
-      revision = "23-android-tv-x86";
-      displayName = "Android TV Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android-tv/x86-23_r17.zip;
-        sha1 = "6d42eb8f07e1c49c000e530fdb7de894144ea19b";
-      
-      };
+  "23".android-tv."x86" = {
+    name = "system-image-23-android-tv-x86";
+    path = "system-images/android-23/android-tv/x86";
+    revision = "23-android-tv-x86";
+    displayName = "Android TV Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android-tv/x86-23_r17.zip;
+      sha1 = "6d42eb8f07e1c49c000e530fdb7de894144ea19b";
+    };
   };
-  
-
-    "23".android-tv."armeabi-v7a" = {
-      name = "system-image-23-android-tv-armeabi-v7a";
-      path = "system-images/android-23/android-tv/armeabi-v7a";
-      revision = "23-android-tv-armeabi-v7a";
-      displayName = "Android TV ARM EABI v7a System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android-tv/armeabi-v7a-23_r12.zip;
-        sha1 = "bd84678ae8caf71d584f5210e866b2807e7b4b52";
-      
-      };
+  "23".android-tv."armeabi-v7a" = {
+    name = "system-image-23-android-tv-armeabi-v7a";
+    path = "system-images/android-23/android-tv/armeabi-v7a";
+    revision = "23-android-tv-armeabi-v7a";
+    displayName = "Android TV ARM EABI v7a System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android-tv/armeabi-v7a-23_r12.zip;
+      sha1 = "bd84678ae8caf71d584f5210e866b2807e7b4b52";
+    };
   };
-  
-
-    "24".android-tv."x86" = {
-      name = "system-image-24-android-tv-x86";
-      path = "system-images/android-24/android-tv/x86";
-      revision = "24-android-tv-x86";
-      displayName = "Android TV Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android-tv/x86-24_r19.zip;
-        sha1 = "478e7073f9fcd588bcce89946aa632fbf302ac6a";
-      
-      };
+  "24".android-tv."x86" = {
+    name = "system-image-24-android-tv-x86";
+    path = "system-images/android-24/android-tv/x86";
+    revision = "24-android-tv-x86";
+    displayName = "Android TV Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android-tv/x86-24_r19.zip;
+      sha1 = "478e7073f9fcd588bcce89946aa632fbf302ac6a";
+    };
   };
-  
-
-    "25".android-tv."x86" = {
-      name = "system-image-25-android-tv-x86";
-      path = "system-images/android-25/android-tv/x86";
-      revision = "25-android-tv-x86";
-      displayName = "Android TV Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android-tv/x86-25_r13.zip;
-        sha1 = "fda1743a87331b43b1ff35cd70f3276ae0b1836d";
-      
-      };
+  "25".android-tv."x86" = {
+    name = "system-image-25-android-tv-x86";
+    path = "system-images/android-25/android-tv/x86";
+    revision = "25-android-tv-x86";
+    displayName = "Android TV Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android-tv/x86-25_r13.zip;
+      sha1 = "fda1743a87331b43b1ff35cd70f3276ae0b1836d";
+    };
   };
-  
-
-    "26".android-tv."x86" = {
-      name = "system-image-26-android-tv-x86";
-      path = "system-images/android-26/android-tv/x86";
-      revision = "26-android-tv-x86";
-      displayName = "Android TV Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android-tv/x86-26_r11.zip;
-        sha1 = "5c4b0b3c0b9d04a3364956a7ba31d30c33ea57e7";
-      
-      };
+  "26".android-tv."x86" = {
+    name = "system-image-26-android-tv-x86";
+    path = "system-images/android-26/android-tv/x86";
+    revision = "26-android-tv-x86";
+    displayName = "Android TV Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android-tv/x86-26_r11.zip;
+      sha1 = "5c4b0b3c0b9d04a3364956a7ba31d30c33ea57e7";
+    };
   };
-  
-
-    "27".android-tv."x86" = {
-      name = "system-image-27-android-tv-x86";
-      path = "system-images/android-27/android-tv/x86";
-      revision = "27-android-tv-x86";
-      displayName = "Android TV Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android-tv/x86-27_r06.zip;
-        sha1 = "6b69f1e95a3db3d973e19a95ab5da1adc7750d54";
-      
-      };
+  "27".android-tv."x86" = {
+    name = "system-image-27-android-tv-x86";
+    path = "system-images/android-27/android-tv/x86";
+    revision = "27-android-tv-x86";
+    displayName = "Android TV Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android-tv/x86-27_r06.zip;
+      sha1 = "6b69f1e95a3db3d973e19a95ab5da1adc7750d54";
+    };
   };
-  
-
-    "28".android-tv."x86" = {
-      name = "system-image-28-android-tv-x86";
-      path = "system-images/android-28/android-tv/x86";
-      revision = "28-android-tv-x86";
-      displayName = "Android TV Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android-tv/x86-28_r07.zip;
-        sha1 = "3ed7e51036957cf350db7fa128cb485b61cbd061";
-      
-      };
+  "28".android-tv."x86" = {
+    name = "system-image-28-android-tv-x86";
+    path = "system-images/android-28/android-tv/x86";
+    revision = "28-android-tv-x86";
+    displayName = "Android TV Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android-tv/x86-28_r07.zip;
+      sha1 = "3ed7e51036957cf350db7fa128cb485b61cbd061";
+    };
   };
-  
+  "Q".android-tv."x86" = {
+    name = "system-image-Q-android-tv-x86";
+    path = "system-images/android-Q/android-tv/x86";
+    revision = "Q-android-tv-x86";
+    displayName = "Android TV Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android-tv/x86-Q_r01.zip;
+      sha1 = "80c66ddce0dbe53fe6fedcade230d518112fffb1";
+    };
+  };
 }
-  

--- a/pkgs/development/mobile/androidenv/generated/system-images-android-wear-cn.nix
+++ b/pkgs/development/mobile/androidenv/generated/system-images-android-wear-cn.nix
@@ -1,67 +1,44 @@
-
 {fetchurl}:
 
 {
-  
-
-    "25".android-wear."armeabi-v7a" = {
-      name = "system-image-25-android-wear-armeabi-v7a";
-      path = "system-images/android-25/android-wear-cn/armeabi-v7a";
-      revision = "25-android-wear-armeabi-v7a";
-      displayName = "China version of Android Wear ARM EABI v7a System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android-wear-cn/armeabi-v7a-25_r04.zip;
-        sha1 = "02d7bc86df054d1e89fe5856b3af1d2c142cab41";
-      
-      };
+  "25".android-wear."armeabi-v7a" = {
+    name = "system-image-25-android-wear-armeabi-v7a";
+    path = "system-images/android-25/android-wear-cn/armeabi-v7a";
+    revision = "25-android-wear-armeabi-v7a";
+    displayName = "China version of Android Wear ARM EABI v7a System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android-wear-cn/armeabi-v7a-25_r04.zip;
+      sha1 = "02d7bc86df054d1e89fe5856b3af1d2c142cab41";
+    };
   };
-  
-
-    "25".android-wear."x86" = {
-      name = "system-image-25-android-wear-x86";
-      path = "system-images/android-25/android-wear-cn/x86";
-      revision = "25-android-wear-x86";
-      displayName = "China version of Android Wear Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android-wear-cn/x86-25_r04.zip;
-        sha1 = "73eab14c7cf2f6941e1fee61e0038ead7a2c7f4d";
-      
-      };
+  "25".android-wear."x86" = {
+    name = "system-image-25-android-wear-x86";
+    path = "system-images/android-25/android-wear-cn/x86";
+    revision = "25-android-wear-x86";
+    displayName = "China version of Android Wear Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android-wear-cn/x86-25_r04.zip;
+      sha1 = "73eab14c7cf2f6941e1fee61e0038ead7a2c7f4d";
+    };
   };
-  
-
-    "26".android-wear."x86" = {
-      name = "system-image-26-android-wear-x86";
-      path = "system-images/android-26/android-wear-cn/x86";
-      revision = "26-android-wear-x86";
-      displayName = "China version of Android Wear Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android-wear-cn/x86-26_r04.zip;
-        sha1 = "fdc8a313f889a2d6522de1fbc00ee9e13547d096";
-      
-      };
+  "26".android-wear."x86" = {
+    name = "system-image-26-android-wear-x86";
+    path = "system-images/android-26/android-wear-cn/x86";
+    revision = "26-android-wear-x86";
+    displayName = "China version of Android Wear Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android-wear-cn/x86-26_r04.zip;
+      sha1 = "fdc8a313f889a2d6522de1fbc00ee9e13547d096";
+    };
   };
-  
-
-    "28".android-wear."x86" = {
-      name = "system-image-28-android-wear-x86";
-      path = "system-images/android-P/android-wear-cn/x86";
-      revision = "28-android-wear-x86";
-      displayName = "China version of Wear OS Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android-wear-cn/x86-P_r02.zip;
-        sha1 = "a61a2e453a11f77ab15b3e0bf1e017e0bb9d1bcc";
-      
-      };
+  "28".android-wear."x86" = {
+    name = "system-image-28-android-wear-x86";
+    path = "system-images/android-28/android-wear-cn/x86";
+    revision = "28-android-wear-x86";
+    displayName = "China version of Wear OS Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android-wear-cn/x86-28_r03.zip;
+      sha1 = "2099d87709c5e064273925dbf2cf1fd081bf0262";
+    };
   };
-  
 }
-  

--- a/pkgs/development/mobile/androidenv/generated/system-images-android-wear.nix
+++ b/pkgs/development/mobile/androidenv/generated/system-images-android-wear.nix
@@ -1,97 +1,64 @@
-
 {fetchurl}:
 
 {
-  
-
-    "23".android-wear."armeabi-v7a" = {
-      name = "system-image-23-android-wear-armeabi-v7a";
-      path = "system-images/android-23/android-wear/armeabi-v7a";
-      revision = "23-android-wear-armeabi-v7a";
-      displayName = "Android Wear ARM EABI v7a System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android-wear/armeabi-v7a-23_r06.zip;
-        sha1 = "0df5d34b1cdaaaa3805a2f06bb889901eabe2e71";
-      
-      };
+  "23".android-wear."armeabi-v7a" = {
+    name = "system-image-23-android-wear-armeabi-v7a";
+    path = "system-images/android-23/android-wear/armeabi-v7a";
+    revision = "23-android-wear-armeabi-v7a";
+    displayName = "Android Wear ARM EABI v7a System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android-wear/armeabi-v7a-23_r06.zip;
+      sha1 = "0df5d34b1cdaaaa3805a2f06bb889901eabe2e71";
+    };
   };
-  
-
-    "23".android-wear."x86" = {
-      name = "system-image-23-android-wear-x86";
-      path = "system-images/android-23/android-wear/x86";
-      revision = "23-android-wear-x86";
-      displayName = "Android Wear Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android-wear/x86-23_r06.zip;
-        sha1 = "3b15c123f3f71459d5b60c1714d49c5d90a5525e";
-      
-      };
+  "23".android-wear."x86" = {
+    name = "system-image-23-android-wear-x86";
+    path = "system-images/android-23/android-wear/x86";
+    revision = "23-android-wear-x86";
+    displayName = "Android Wear Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android-wear/x86-23_r06.zip;
+      sha1 = "3b15c123f3f71459d5b60c1714d49c5d90a5525e";
+    };
   };
-  
-
-    "25".android-wear."armeabi-v7a" = {
-      name = "system-image-25-android-wear-armeabi-v7a";
-      path = "system-images/android-25/android-wear/armeabi-v7a";
-      revision = "25-android-wear-armeabi-v7a";
-      displayName = "Android Wear ARM EABI v7a System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android-wear/armeabi-v7a-25_r03.zip;
-        sha1 = "76d3568a4e08023047af7d13025a35c9bf1d7e5c";
-      
-      };
+  "25".android-wear."armeabi-v7a" = {
+    name = "system-image-25-android-wear-armeabi-v7a";
+    path = "system-images/android-25/android-wear/armeabi-v7a";
+    revision = "25-android-wear-armeabi-v7a";
+    displayName = "Android Wear ARM EABI v7a System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android-wear/armeabi-v7a-25_r03.zip;
+      sha1 = "76d3568a4e08023047af7d13025a35c9bf1d7e5c";
+    };
   };
-  
-
-    "25".android-wear."x86" = {
-      name = "system-image-25-android-wear-x86";
-      path = "system-images/android-25/android-wear/x86";
-      revision = "25-android-wear-x86";
-      displayName = "Android Wear Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android-wear/x86-25_r03.zip;
-        sha1 = "693fce7b487a65491a4e88e9f740959688c9dbe6";
-      
-      };
+  "25".android-wear."x86" = {
+    name = "system-image-25-android-wear-x86";
+    path = "system-images/android-25/android-wear/x86";
+    revision = "25-android-wear-x86";
+    displayName = "Android Wear Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android-wear/x86-25_r03.zip;
+      sha1 = "693fce7b487a65491a4e88e9f740959688c9dbe6";
+    };
   };
-  
-
-    "26".android-wear."x86" = {
-      name = "system-image-26-android-wear-x86";
-      path = "system-images/android-26/android-wear/x86";
-      revision = "26-android-wear-x86";
-      displayName = "Android Wear Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android-wear/x86-26_r04.zip;
-        sha1 = "fbffa91b936ca18fcc1e0bab2b52a8b0835cbb1c";
-      
-      };
+  "26".android-wear."x86" = {
+    name = "system-image-26-android-wear-x86";
+    path = "system-images/android-26/android-wear/x86";
+    revision = "26-android-wear-x86";
+    displayName = "Android Wear Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android-wear/x86-26_r04.zip;
+      sha1 = "fbffa91b936ca18fcc1e0bab2b52a8b0835cbb1c";
+    };
   };
-  
-
-    "28".android-wear."x86" = {
-      name = "system-image-28-android-wear-x86";
-      path = "system-images/android-P/android-wear/x86";
-      revision = "28-android-wear-x86";
-      displayName = "Wear OS Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android-wear/x86-P_r02.zip;
-        sha1 = "cd0d3a56e114dbb0a2a77d58942d344db464b514";
-      
-      };
+  "28".android-wear."x86" = {
+    name = "system-image-28-android-wear-x86";
+    path = "system-images/android-28/android-wear/x86";
+    revision = "28-android-wear-x86";
+    displayName = "Wear OS Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android-wear/x86-28_r03.zip;
+      sha1 = "b80bd53ab69f19441714bff2e4d55931e6d3f7be";
+    };
   };
-  
 }
-  

--- a/pkgs/development/mobile/androidenv/generated/system-images-android.nix
+++ b/pkgs/development/mobile/androidenv/generated/system-images-android.nix
@@ -1,547 +1,384 @@
-
 {fetchurl}:
 
 {
-  
-
-    "10".default."armeabi-v7a" = {
-      name = "system-image-10-default-armeabi-v7a";
-      path = "system-images/android-10/default/armeabi-v7a";
-      revision = "10-default-armeabi-v7a";
-      displayName = "ARM EABI v7a System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android/armv7-10_r04.zip;
-        sha1 = "54680383118eb5c95a11e1cc2a14aa572c86ee69";
-      
-      };
+  "10".default."armeabi-v7a" = {
+    name = "system-image-10-default-armeabi-v7a";
+    path = "system-images/android-10/default/armeabi-v7a";
+    revision = "10-default-armeabi-v7a";
+    displayName = "ARM EABI v7a System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-10_r05.zip;
+      sha1 = "8537616a7add47cce24c60f18bc2429e3dc90ae3";
+    };
   };
-  
-
-    "14".default."armeabi-v7a" = {
-      name = "system-image-14-default-armeabi-v7a";
-      path = "system-images/android-14/default/armeabi-v7a";
-      revision = "14-default-armeabi-v7a";
-      displayName = "ARM EABI v7a System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android/sysimg_armv7a-14_r02.zip;
-        sha1 = "d8991b0c06b18d7d6ed4169d67460ee1add6661b";
-      
-      };
+  "14".default."armeabi-v7a" = {
+    name = "system-image-14-default-armeabi-v7a";
+    path = "system-images/android-14/default/armeabi-v7a";
+    revision = "14-default-armeabi-v7a";
+    displayName = "ARM EABI v7a System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/sysimg_armv7a-14_r02.zip;
+      sha1 = "d8991b0c06b18d7d6ed4169d67460ee1add6661b";
+    };
   };
-  
-
-    "15".default."armeabi-v7a" = {
-      name = "system-image-15-default-armeabi-v7a";
-      path = "system-images/android-15/default/armeabi-v7a";
-      revision = "15-default-armeabi-v7a";
-      displayName = "ARM EABI v7a System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-15_r04.zip;
-        sha1 = "363223bd62f5afc0b2bd760b54ce9d26b31eacf1";
-      
-      };
+  "15".default."armeabi-v7a" = {
+    name = "system-image-15-default-armeabi-v7a";
+    path = "system-images/android-15/default/armeabi-v7a";
+    revision = "15-default-armeabi-v7a";
+    displayName = "ARM EABI v7a System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-15_r05.zip;
+      sha1 = "03d7ed95a9d3b107e3f2e5b166d017ea12529e70";
+    };
   };
-  
-
-    "16".default."armeabi-v7a" = {
-      name = "system-image-16-default-armeabi-v7a";
-      path = "system-images/android-16/default/armeabi-v7a";
-      revision = "16-default-armeabi-v7a";
-      displayName = "ARM EABI v7a System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android/sysimg_armv7a-16_r04.zip;
-        sha1 = "39c093ea755098f0ee79f607be7df9e54ba4943f";
-      
-      };
+  "16".default."armeabi-v7a" = {
+    name = "system-image-16-default-armeabi-v7a";
+    path = "system-images/android-16/default/armeabi-v7a";
+    revision = "16-default-armeabi-v7a";
+    displayName = "ARM EABI v7a System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-16_r06.zip;
+      sha1 = "69b944b0d5a18c8563fa80d7d229af64890f724e";
+    };
   };
-  
-
-    "17".default."armeabi-v7a" = {
-      name = "system-image-17-default-armeabi-v7a";
-      path = "system-images/android-17/default/armeabi-v7a";
-      revision = "17-default-armeabi-v7a";
-      displayName = "ARM EABI v7a System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-17_r05.zip;
-        sha1 = "7460e8110f4a87f9644f1bdb5511a66872d50fd9";
-      
-      };
+  "17".default."armeabi-v7a" = {
+    name = "system-image-17-default-armeabi-v7a";
+    path = "system-images/android-17/default/armeabi-v7a";
+    revision = "17-default-armeabi-v7a";
+    displayName = "ARM EABI v7a System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-17_r06.zip;
+      sha1 = "a18a3fd0958ec4ef52507f58e414fc5c7dfd59d6";
+    };
   };
-  
-
-    "18".default."armeabi-v7a" = {
-      name = "system-image-18-default-armeabi-v7a";
-      path = "system-images/android-18/default/armeabi-v7a";
-      revision = "18-default-armeabi-v7a";
-      displayName = "ARM EABI v7a System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-18_r04.zip;
-        sha1 = "0bf34ecf4ddd53f6b1b7fe7dfa12f2887c17e642";
-      
-      };
+  "18".default."armeabi-v7a" = {
+    name = "system-image-18-default-armeabi-v7a";
+    path = "system-images/android-18/default/armeabi-v7a";
+    revision = "18-default-armeabi-v7a";
+    displayName = "ARM EABI v7a System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-18_r05.zip;
+      sha1 = "580b583720f7de671040d5917c8c9db0c7aa03fd";
+    };
   };
-  
-
-    "19".default."armeabi-v7a" = {
-      name = "system-image-19-default-armeabi-v7a";
-      path = "system-images/android-19/default/armeabi-v7a";
-      revision = "19-default-armeabi-v7a";
-      displayName = "ARM EABI v7a System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-19_r05.zip;
-        sha1 = "d1a5fd4f2e1c013c3d3d9bfe7e9db908c3ed56fa";
-      
-      };
+  "19".default."armeabi-v7a" = {
+    name = "system-image-19-default-armeabi-v7a";
+    path = "system-images/android-19/default/armeabi-v7a";
+    revision = "19-default-armeabi-v7a";
+    displayName = "ARM EABI v7a System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-19_r05.zip;
+      sha1 = "d1a5fd4f2e1c013c3d3d9bfe7e9db908c3ed56fa";
+    };
   };
-  
-
-    "21".default."armeabi-v7a" = {
-      name = "system-image-21-default-armeabi-v7a";
-      path = "system-images/android-21/default/armeabi-v7a";
-      revision = "21-default-armeabi-v7a";
-      displayName = "ARM EABI v7a System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-21_r04.zip;
-        sha1 = "8c606f81306564b65e41303d2603e4c42ded0d10";
-      
-      };
+  "21".default."armeabi-v7a" = {
+    name = "system-image-21-default-armeabi-v7a";
+    path = "system-images/android-21/default/armeabi-v7a";
+    revision = "21-default-armeabi-v7a";
+    displayName = "ARM EABI v7a System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-21_r04.zip;
+      sha1 = "8c606f81306564b65e41303d2603e4c42ded0d10";
+    };
   };
-  
-
-    "22".default."armeabi-v7a" = {
-      name = "system-image-22-default-armeabi-v7a";
-      path = "system-images/android-22/default/armeabi-v7a";
-      revision = "22-default-armeabi-v7a";
-      displayName = "ARM EABI v7a System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-22_r02.zip;
-        sha1 = "2114ec015dbf3a16cbcb4f63e8a84a1b206a07a1";
-      
-      };
+  "22".default."armeabi-v7a" = {
+    name = "system-image-22-default-armeabi-v7a";
+    path = "system-images/android-22/default/armeabi-v7a";
+    revision = "22-default-armeabi-v7a";
+    displayName = "ARM EABI v7a System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-22_r02.zip;
+      sha1 = "2114ec015dbf3a16cbcb4f63e8a84a1b206a07a1";
+    };
   };
-  
-
-    "23".default."armeabi-v7a" = {
-      name = "system-image-23-default-armeabi-v7a";
-      path = "system-images/android-23/default/armeabi-v7a";
-      revision = "23-default-armeabi-v7a";
-      displayName = "ARM EABI v7a System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-23_r06.zip;
-        sha1 = "7cf2ad756e54a3acfd81064b63cb0cb9dff2798d";
-      
-      };
+  "23".default."armeabi-v7a" = {
+    name = "system-image-23-default-armeabi-v7a";
+    path = "system-images/android-23/default/armeabi-v7a";
+    revision = "23-default-armeabi-v7a";
+    displayName = "ARM EABI v7a System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-23_r06.zip;
+      sha1 = "7cf2ad756e54a3acfd81064b63cb0cb9dff2798d";
+    };
   };
-  
-
-    "24".default."armeabi-v7a" = {
-      name = "system-image-24-default-armeabi-v7a";
-      path = "system-images/android-24/default/armeabi-v7a";
-      revision = "24-default-armeabi-v7a";
-      displayName = "ARM EABI v7a System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-24_r07.zip;
-        sha1 = "3454546b4eed2d6c3dd06d47757d6da9f4176033";
-      
-      };
+  "24".default."armeabi-v7a" = {
+    name = "system-image-24-default-armeabi-v7a";
+    path = "system-images/android-24/default/armeabi-v7a";
+    revision = "24-default-armeabi-v7a";
+    displayName = "ARM EABI v7a System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-24_r07.zip;
+      sha1 = "3454546b4eed2d6c3dd06d47757d6da9f4176033";
+    };
   };
-  
-
-    "24".default."arm64-v8a" = {
-      name = "system-image-24-default-arm64-v8a";
-      path = "system-images/android-24/default/arm64-v8a";
-      revision = "24-default-arm64-v8a";
-      displayName = "ARM 64 v8a System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android/arm64-v8a-24_r07.zip;
-        sha1 = "e8ab2e49e4efe4b064232b33b5eeaded61437d7f";
-      
-      };
+  "24".default."arm64-v8a" = {
+    name = "system-image-24-default-arm64-v8a";
+    path = "system-images/android-24/default/arm64-v8a";
+    revision = "24-default-arm64-v8a";
+    displayName = "ARM 64 v8a System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/arm64-v8a-24_r07.zip;
+      sha1 = "e8ab2e49e4efe4b064232b33b5eeaded61437d7f";
+    };
   };
-  
-
-    "16".default."mips" = {
-      name = "system-image-16-default-mips";
-      path = "system-images/android-16/default/mips";
-      revision = "16-default-mips";
-      displayName = "MIPS System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android/sysimg_mips-16_r04.zip;
-        sha1 = "67943c54fb3943943ffeb05fdd39c0b753681f6e";
-      
-      };
+  "16".default."mips" = {
+    name = "system-image-16-default-mips";
+    path = "system-images/android-16/default/mips";
+    revision = "16-default-mips";
+    displayName = "MIPS System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/sysimg_mips-16_r04.zip;
+      sha1 = "67943c54fb3943943ffeb05fdd39c0b753681f6e";
+    };
   };
-  
-
-    "17".default."mips" = {
-      name = "system-image-17-default-mips";
-      path = "system-images/android-17/default/mips";
-      revision = "17-default-mips";
-      displayName = "MIPS System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android/sysimg_mips-17_r01.zip;
-        sha1 = "f0c6e153bd584c29e51b5c9723cfbf30f996a05d";
-      
-      };
+  "17".default."mips" = {
+    name = "system-image-17-default-mips";
+    path = "system-images/android-17/default/mips";
+    revision = "17-default-mips";
+    displayName = "MIPS System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/sysimg_mips-17_r01.zip;
+      sha1 = "f0c6e153bd584c29e51b5c9723cfbf30f996a05d";
+    };
   };
-  
-
-    "10".default."x86" = {
-      name = "system-image-10-default-x86";
-      path = "system-images/android-10/default/x86";
-      revision = "10-default-x86";
-      displayName = "Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android/x86-10_r04.zip;
-        sha1 = "655ffc5cc89dd45a3aca154b254009016e473aeb";
-      
-      };
+  "10".default."x86" = {
+    name = "system-image-10-default-x86";
+    path = "system-images/android-10/default/x86";
+    revision = "10-default-x86";
+    displayName = "Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/x86-10_r05.zip;
+      sha1 = "a166d5ccbb165e1dd5464fbfeec30a61f77790d8";
+    };
   };
-  
-
-    "15".default."x86" = {
-      name = "system-image-15-default-x86";
-      path = "system-images/android-15/default/x86";
-      revision = "15-default-x86";
-      displayName = "Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android/x86-15_r04.zip;
-        sha1 = "e45c728b64881c0e86529a8f7ea9c103a3cd14c1";
-      
-      };
+  "15".default."x86" = {
+    name = "system-image-15-default-x86";
+    path = "system-images/android-15/default/x86";
+    revision = "15-default-x86";
+    displayName = "Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/x86-15_r05.zip;
+      sha1 = "c387e0efed2cdc610e5944eea67b7b692d03760c";
+    };
   };
-  
-
-    "16".default."x86" = {
-      name = "system-image-16-default-x86";
-      path = "system-images/android-16/default/x86";
-      revision = "16-default-x86";
-      displayName = "Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android/x86-16_r06.zip;
-        sha1 = "bf1bf8c5591346118d2235da1ad20e7be8a3e9cd";
-      
-      };
+  "16".default."x86" = {
+    name = "system-image-16-default-x86";
+    path = "system-images/android-16/default/x86";
+    revision = "16-default-x86";
+    displayName = "Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/x86-16_r06.zip;
+      sha1 = "bf1bf8c5591346118d2235da1ad20e7be8a3e9cd";
+    };
   };
-  
-
-    "17".default."x86" = {
-      name = "system-image-17-default-x86";
-      path = "system-images/android-17/default/x86";
-      revision = "17-default-x86";
-      displayName = "Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android/x86-17_r04.zip;
-        sha1 = "03c6d022ab2dcbbcf655d78ba5ccb0431cadcaec";
-      
-      };
+  "17".default."x86" = {
+    name = "system-image-17-default-x86";
+    path = "system-images/android-17/default/x86";
+    revision = "17-default-x86";
+    displayName = "Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/x86-17_r04.zip;
+      sha1 = "03c6d022ab2dcbbcf655d78ba5ccb0431cadcaec";
+    };
   };
-  
-
-    "18".default."x86" = {
-      name = "system-image-18-default-x86";
-      path = "system-images/android-18/default/x86";
-      revision = "18-default-x86";
-      displayName = "Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android/x86-18_r03.zip;
-        sha1 = "03a0cb23465c3de15215934a1dbc9715b56e9458";
-      
-      };
+  "18".default."x86" = {
+    name = "system-image-18-default-x86";
+    path = "system-images/android-18/default/x86";
+    revision = "18-default-x86";
+    displayName = "Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/x86-18_r04.zip;
+      sha1 = "7a4ced4d9b0ab48047825491b4072dc2eb9b610e";
+    };
   };
-  
-
-    "19".default."x86" = {
-      name = "system-image-19-default-x86";
-      path = "system-images/android-19/default/x86";
-      revision = "19-default-x86";
-      displayName = "Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android/x86-19_r06.zip;
-        sha1 = "2ac82153aae97f7eae4c5a0761224fe04321d03d";
-      
-      };
+  "19".default."x86" = {
+    name = "system-image-19-default-x86";
+    path = "system-images/android-19/default/x86";
+    revision = "19-default-x86";
+    displayName = "Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/x86-19_r06.zip;
+      sha1 = "2ac82153aae97f7eae4c5a0761224fe04321d03d";
+    };
   };
-  
-
-    "21".default."x86" = {
-      name = "system-image-21-default-x86";
-      path = "system-images/android-21/default/x86";
-      revision = "21-default-x86";
-      displayName = "Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android/x86-21_r05.zip;
-        sha1 = "00f0eb0a1003efe3316347f762e20a85d8749cff";
-      
-      };
+  "21".default."x86" = {
+    name = "system-image-21-default-x86";
+    path = "system-images/android-21/default/x86";
+    revision = "21-default-x86";
+    displayName = "Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/x86-21_r05.zip;
+      sha1 = "00f0eb0a1003efe3316347f762e20a85d8749cff";
+    };
   };
-  
-
-    "22".default."x86" = {
-      name = "system-image-22-default-x86";
-      path = "system-images/android-22/default/x86";
-      revision = "22-default-x86";
-      displayName = "Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android/x86-22_r06.zip;
-        sha1 = "e33e2a6cc3f1cc56b2019dbef3917d2eeb26f54e";
-      
-      };
+  "22".default."x86" = {
+    name = "system-image-22-default-x86";
+    path = "system-images/android-22/default/x86";
+    revision = "22-default-x86";
+    displayName = "Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/x86-22_r06.zip;
+      sha1 = "e33e2a6cc3f1cc56b2019dbef3917d2eeb26f54e";
+    };
   };
-  
-
-    "23".default."x86" = {
-      name = "system-image-23-default-x86";
-      path = "system-images/android-23/default/x86";
-      revision = "23-default-x86";
-      displayName = "Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android/x86-23_r10.zip;
-        sha1 = "f6c3e3dd7bd951454795aa75c3a145fd05ac25bb";
-      
-      };
+  "23".default."x86" = {
+    name = "system-image-23-default-x86";
+    path = "system-images/android-23/default/x86";
+    revision = "23-default-x86";
+    displayName = "Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/x86-23_r10.zip;
+      sha1 = "f6c3e3dd7bd951454795aa75c3a145fd05ac25bb";
+    };
   };
-  
-
-    "24".default."x86" = {
-      name = "system-image-24-default-x86";
-      path = "system-images/android-24/default/x86";
-      revision = "24-default-x86";
-      displayName = "Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android/x86-24_r08.zip;
-        sha1 = "c1cae7634b0216c0b5990f2c144eb8ca948e3511";
-      
-      };
+  "24".default."x86" = {
+    name = "system-image-24-default-x86";
+    path = "system-images/android-24/default/x86";
+    revision = "24-default-x86";
+    displayName = "Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/x86-24_r08.zip;
+      sha1 = "c1cae7634b0216c0b5990f2c144eb8ca948e3511";
+    };
   };
-  
-
-    "25".default."x86" = {
-      name = "system-image-25-default-x86";
-      path = "system-images/android-25/default/x86";
-      revision = "25-default-x86";
-      displayName = "Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android/x86-25_r01.zip;
-        sha1 = "78ce7eb1387d598685633b9f7cbb300c3d3aeb5f";
-      
-      };
+  "25".default."x86" = {
+    name = "system-image-25-default-x86";
+    path = "system-images/android-25/default/x86";
+    revision = "25-default-x86";
+    displayName = "Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/x86-25_r01.zip;
+      sha1 = "78ce7eb1387d598685633b9f7cbb300c3d3aeb5f";
+    };
   };
-  
-
-    "26".default."x86" = {
-      name = "system-image-26-default-x86";
-      path = "system-images/android-26/default/x86";
-      revision = "26-default-x86";
-      displayName = "Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android/x86-26_r01.zip;
-        sha1 = "e613d6e0da668e30daf547f3c6627a6352846f90";
-      
-      };
+  "26".default."x86" = {
+    name = "system-image-26-default-x86";
+    path = "system-images/android-26/default/x86";
+    revision = "26-default-x86";
+    displayName = "Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/x86-26_r01.zip;
+      sha1 = "e613d6e0da668e30daf547f3c6627a6352846f90";
+    };
   };
-  
-
-    "27".default."x86" = {
-      name = "system-image-27-default-x86";
-      path = "system-images/android-27/default/x86";
-      revision = "27-default-x86";
-      displayName = "Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android/x86-27_r01.zip;
-        sha1 = "4ec990fac7b62958decd12e18a4cd389dfe7c582";
-      
-      };
+  "27".default."x86" = {
+    name = "system-image-27-default-x86";
+    path = "system-images/android-27/default/x86";
+    revision = "27-default-x86";
+    displayName = "Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/x86-27_r01.zip;
+      sha1 = "4ec990fac7b62958decd12e18a4cd389dfe7c582";
+    };
   };
-  
-
-    "28".default."x86" = {
-      name = "system-image-28-default-x86";
-      path = "system-images/android-28/default/x86";
-      revision = "28-default-x86";
-      displayName = "Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android/x86-28_r04.zip;
-        sha1 = "ce03c42d80c0fc6dc47f6455dbee7aa275d02780";
-      
-      };
+  "28".default."x86" = {
+    name = "system-image-28-default-x86";
+    path = "system-images/android-28/default/x86";
+    revision = "28-default-x86";
+    displayName = "Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/x86-28_r04.zip;
+      sha1 = "ce03c42d80c0fc6dc47f6455dbee7aa275d02780";
+    };
   };
-  
-
-    "21".default."x86_64" = {
-      name = "system-image-21-default-x86_64";
-      path = "system-images/android-21/default/x86_64";
-      revision = "21-default-x86_64";
-      displayName = "Intel x86 Atom_64 System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android/x86_64-21_r05.zip;
-        sha1 = "9078a095825a69e5e215713f0866c83cef65a342";
-      
-      };
+  "Q".default."x86" = {
+    name = "system-image-Q-default-x86";
+    path = "system-images/android-Q/default/x86";
+    revision = "Q-default-x86";
+    displayName = "Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/x86-Q_r01.zip;
+      sha1 = "79c1b96055c2dbef3618bb4664214d993a031b18";
+    };
   };
-  
-
-    "22".default."x86_64" = {
-      name = "system-image-22-default-x86_64";
-      path = "system-images/android-22/default/x86_64";
-      revision = "22-default-x86_64";
-      displayName = "Intel x86 Atom_64 System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android/x86_64-22_r06.zip;
-        sha1 = "5db3b27f78cd9c4c5092b1cad5a5dd479fb5b2e4";
-      
-      };
+  "21".default."x86_64" = {
+    name = "system-image-21-default-x86_64";
+    path = "system-images/android-21/default/x86_64";
+    revision = "21-default-x86_64";
+    displayName = "Intel x86 Atom_64 System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/x86_64-21_r05.zip;
+      sha1 = "9078a095825a69e5e215713f0866c83cef65a342";
+    };
   };
-  
-
-    "23".default."x86_64" = {
-      name = "system-image-23-default-x86_64";
-      path = "system-images/android-23/default/x86_64";
-      revision = "23-default-x86_64";
-      displayName = "Intel x86 Atom_64 System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android/x86_64-23_r10.zip;
-        sha1 = "7cbc291483ca07dc67b71268c5f08a5755f50f51";
-      
-      };
+  "22".default."x86_64" = {
+    name = "system-image-22-default-x86_64";
+    path = "system-images/android-22/default/x86_64";
+    revision = "22-default-x86_64";
+    displayName = "Intel x86 Atom_64 System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/x86_64-22_r06.zip;
+      sha1 = "5db3b27f78cd9c4c5092b1cad5a5dd479fb5b2e4";
+    };
   };
-  
-
-    "24".default."x86_64" = {
-      name = "system-image-24-default-x86_64";
-      path = "system-images/android-24/default/x86_64";
-      revision = "24-default-x86_64";
-      displayName = "Intel x86 Atom_64 System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android/x86_64-24_r08.zip;
-        sha1 = "f6559e1949a5879f31a9662f4f0e50ad60181684";
-      
-      };
+  "23".default."x86_64" = {
+    name = "system-image-23-default-x86_64";
+    path = "system-images/android-23/default/x86_64";
+    revision = "23-default-x86_64";
+    displayName = "Intel x86 Atom_64 System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/x86_64-23_r10.zip;
+      sha1 = "7cbc291483ca07dc67b71268c5f08a5755f50f51";
+    };
   };
-  
-
-    "25".default."x86_64" = {
-      name = "system-image-25-default-x86_64";
-      path = "system-images/android-25/default/x86_64";
-      revision = "25-default-x86_64";
-      displayName = "Intel x86 Atom_64 System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android/x86_64-25_r01.zip;
-        sha1 = "7093d7b39216020226ff430a3b7b81c94d31ad37";
-      
-      };
+  "24".default."x86_64" = {
+    name = "system-image-24-default-x86_64";
+    path = "system-images/android-24/default/x86_64";
+    revision = "24-default-x86_64";
+    displayName = "Intel x86 Atom_64 System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/x86_64-24_r08.zip;
+      sha1 = "f6559e1949a5879f31a9662f4f0e50ad60181684";
+    };
   };
-  
-
-    "26".default."x86_64" = {
-      name = "system-image-26-default-x86_64";
-      path = "system-images/android-26/default/x86_64";
-      revision = "26-default-x86_64";
-      displayName = "Intel x86 Atom_64 System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android/x86_64-26_r01.zip;
-        sha1 = "432f149c048bffce7f9de526ec65b336daf7a0a3";
-      
-      };
+  "25".default."x86_64" = {
+    name = "system-image-25-default-x86_64";
+    path = "system-images/android-25/default/x86_64";
+    revision = "25-default-x86_64";
+    displayName = "Intel x86 Atom_64 System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/x86_64-25_r01.zip;
+      sha1 = "7093d7b39216020226ff430a3b7b81c94d31ad37";
+    };
   };
-  
-
-    "27".default."x86_64" = {
-      name = "system-image-27-default-x86_64";
-      path = "system-images/android-27/default/x86_64";
-      revision = "27-default-x86_64";
-      displayName = "Intel x86 Atom_64 System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android/x86_64-27_r01.zip;
-        sha1 = "2878261011a59ca3de29dc5b457a495fdb268d60";
-      
-      };
+  "26".default."x86_64" = {
+    name = "system-image-26-default-x86_64";
+    path = "system-images/android-26/default/x86_64";
+    revision = "26-default-x86_64";
+    displayName = "Intel x86 Atom_64 System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/x86_64-26_r01.zip;
+      sha1 = "432f149c048bffce7f9de526ec65b336daf7a0a3";
+    };
   };
-  
-
-    "28".default."x86_64" = {
-      name = "system-image-28-default-x86_64";
-      path = "system-images/android-28/default/x86_64";
-      revision = "28-default-x86_64";
-      displayName = "Intel x86 Atom_64 System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/android/x86_64-28_r04.zip;
-        sha1 = "d47a85c8f4e9fd57df97814ad8884eeb0f3a0ef0";
-      
-      };
+  "27".default."x86_64" = {
+    name = "system-image-27-default-x86_64";
+    path = "system-images/android-27/default/x86_64";
+    revision = "27-default-x86_64";
+    displayName = "Intel x86 Atom_64 System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/x86_64-27_r01.zip;
+      sha1 = "2878261011a59ca3de29dc5b457a495fdb268d60";
+    };
   };
-  
+  "28".default."x86_64" = {
+    name = "system-image-28-default-x86_64";
+    path = "system-images/android-28/default/x86_64";
+    revision = "28-default-x86_64";
+    displayName = "Intel x86 Atom_64 System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/x86_64-28_r04.zip;
+      sha1 = "d47a85c8f4e9fd57df97814ad8884eeb0f3a0ef0";
+    };
+  };
+  "Q".default."x86_64" = {
+    name = "system-image-Q-default-x86_64";
+    path = "system-images/android-Q/default/x86_64";
+    revision = "Q-default-x86_64";
+    displayName = "Intel x86 Atom_64 System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/android/x86_64-Q_r01.zip;
+      sha1 = "cd1480475d4dcf5d26311cc8599bce417392033d";
+    };
+  };
 }
-  

--- a/pkgs/development/mobile/androidenv/generated/system-images-google_apis.nix
+++ b/pkgs/development/mobile/androidenv/generated/system-images-google_apis.nix
@@ -1,502 +1,364 @@
-
 {fetchurl}:
 
 {
-  
-
-    "10".google_apis."armeabi-v7a" = {
-      name = "system-image-10-google_apis-armeabi-v7a";
-      path = "system-images/android-10/google_apis/armeabi-v7a";
-      revision = "10-google_apis-armeabi-v7a";
-      displayName = "Google APIs ARM EABI v7a System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-10_r05.zip;
-        sha1 = "cb60221d4ff6686ae96560970d48d9aa60e80b3f";
-      
-      };
+  "10".google_apis."armeabi-v7a" = {
+    name = "system-image-10-google_apis-armeabi-v7a";
+    path = "system-images/android-10/google_apis/armeabi-v7a";
+    revision = "10-google_apis-armeabi-v7a";
+    displayName = "Google APIs ARM EABI v7a System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-10_r06.zip;
+      sha1 = "970abf3a2a9937a43576afd9bb56e4a8191947f8";
+    };
   };
-  
-
-    "10".google_apis."x86" = {
-      name = "system-image-10-google_apis-x86";
-      path = "system-images/android-10/google_apis/x86";
-      revision = "10-google_apis-x86";
-      displayName = "Google APIs Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis/x86-10_r05.zip;
-        sha1 = "b8e8a4ab26890c4a395fb796bf9cb7ceb51c880e";
-      
-      };
+  "10".google_apis."x86" = {
+    name = "system-image-10-google_apis-x86";
+    path = "system-images/android-10/google_apis/x86";
+    revision = "10-google_apis-x86";
+    displayName = "Google APIs Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis/x86-10_r06.zip;
+      sha1 = "070a9552e3d358d8e72e8b2042e539e2b7a1b035";
+    };
   };
-  
-
-    "15".google_apis."armeabi-v7a" = {
-      name = "system-image-15-google_apis-armeabi-v7a";
-      path = "system-images/android-15/google_apis/armeabi-v7a";
-      revision = "15-google_apis-armeabi-v7a";
-      displayName = "Google APIs ARM EABI v7a System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-15_r05.zip;
-        sha1 = "1ec4e6f9014fcbe694511280f5b497aaf7dd750f";
-      
-      };
+  "15".google_apis."x86" = {
+    name = "system-image-15-google_apis-x86";
+    path = "system-images/android-15/google_apis/x86";
+    revision = "15-google_apis-x86";
+    displayName = "Google APIs Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis/x86-15_r06.zip;
+      sha1 = "a7deb32c12396b6c4fd60ad14a62e19f8bdcae20";
+    };
   };
-  
-
-    "15".google_apis."x86" = {
-      name = "system-image-15-google_apis-x86";
-      path = "system-images/android-15/google_apis/x86";
-      revision = "15-google_apis-x86";
-      displayName = "Google APIs Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis/x86-15_r05.zip;
-        sha1 = "f2b98baaf847ff5b82b82fdc6c396b229067307b";
-      
-      };
+  "15".google_apis."armeabi-v7a" = {
+    name = "system-image-15-google_apis-armeabi-v7a";
+    path = "system-images/android-15/google_apis/armeabi-v7a";
+    revision = "15-google_apis-armeabi-v7a";
+    displayName = "Google APIs ARM EABI v7a System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-15_r06.zip;
+      sha1 = "6deb76cf34760a6037cb18d89772c9e986d07497";
+    };
   };
-  
-
-    "16".google_apis."x86" = {
-      name = "system-image-16-google_apis-x86";
-      path = "system-images/android-16/google_apis/x86";
-      revision = "16-google_apis-x86";
-      displayName = "Google APIs Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis/x86-16_r05.zip;
-        sha1 = "7edc5c0836fa32f8d453788c002ca0ee1bc5a0a2";
-      
-      };
+  "16".google_apis."armeabi-v7a" = {
+    name = "system-image-16-google_apis-armeabi-v7a";
+    path = "system-images/android-16/google_apis/armeabi-v7a";
+    revision = "16-google_apis-armeabi-v7a";
+    displayName = "Google APIs ARM EABI v7a System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-16_r06.zip;
+      sha1 = "5a5ff097680c6dae473c8719296ce6d7b70edb2d";
+    };
   };
-  
-
-    "17".google_apis."armeabi-v7a" = {
-      name = "system-image-17-google_apis-armeabi-v7a";
-      path = "system-images/android-17/google_apis/armeabi-v7a";
-      revision = "17-google_apis-armeabi-v7a";
-      displayName = "Google APIs ARM EABI v7a System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-17_r05.zip;
-        sha1 = "c990f2a81c24a61f9f1da5d5d205f2924ce548ae";
-      
-      };
+  "16".google_apis."x86" = {
+    name = "system-image-16-google_apis-x86";
+    path = "system-images/android-16/google_apis/x86";
+    revision = "16-google_apis-x86";
+    displayName = "Google APIs Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis/x86-16_r06.zip;
+      sha1 = "b57adef2f43dd176b8c02c980c16a796021b2071";
+    };
   };
-  
-
-    "17".google_apis."x86" = {
-      name = "system-image-17-google_apis-x86";
-      path = "system-images/android-17/google_apis/x86";
-      revision = "17-google_apis-x86";
-      displayName = "Google APIs Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis/x86-17_r06.zip;
-        sha1 = "7864c34faf0402b8923d8c6e609a5339f74cc8d6";
-      
-      };
+  "17".google_apis."armeabi-v7a" = {
+    name = "system-image-17-google_apis-armeabi-v7a";
+    path = "system-images/android-17/google_apis/armeabi-v7a";
+    revision = "17-google_apis-armeabi-v7a";
+    displayName = "Google APIs ARM EABI v7a System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-17_r06.zip;
+      sha1 = "a59f26cb5707da97e869a27d87b83477204ac594";
+    };
   };
-  
-
-    "18".google_apis."armeabi-v7a" = {
-      name = "system-image-18-google_apis-armeabi-v7a";
-      path = "system-images/android-18/google_apis/armeabi-v7a";
-      revision = "18-google_apis-armeabi-v7a";
-      displayName = "Google APIs ARM EABI v7a System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-18_r05.zip;
-        sha1 = "c4e69a96d4584f7e311e358fe4ad0e5d1bf1605b";
-      
-      };
+  "17".google_apis."x86" = {
+    name = "system-image-17-google_apis-x86";
+    path = "system-images/android-17/google_apis/x86";
+    revision = "17-google_apis-x86";
+    displayName = "Google APIs Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis/x86-17_r06.zip;
+      sha1 = "7864c34faf0402b8923d8c6e609a5339f74cc8d6";
+    };
   };
-  
-
-    "18".google_apis."x86" = {
-      name = "system-image-18-google_apis-x86";
-      path = "system-images/android-18/google_apis/x86";
-      revision = "18-google_apis-x86";
-      displayName = "Google APIs Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis/x86-18_r05.zip;
-        sha1 = "2b34741693eba9419cb6bf1a467596783234d37a";
-      
-      };
+  "18".google_apis."armeabi-v7a" = {
+    name = "system-image-18-google_apis-armeabi-v7a";
+    path = "system-images/android-18/google_apis/armeabi-v7a";
+    revision = "18-google_apis-armeabi-v7a";
+    displayName = "Google APIs ARM EABI v7a System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-18_r06.zip;
+      sha1 = "7faaccabbcc5f08e410436d3f63eea42521ea974";
+    };
   };
-  
-
-    "19".google_apis."x86" = {
-      name = "system-image-19-google_apis-x86";
-      path = "system-images/android-19/google_apis/x86";
-      revision = "19-google_apis-x86";
-      displayName = "Google APIs Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis/x86-19_r37.zip;
-        sha1 = "f02473420a166b3df7821d8ae5a623524058b4b8";
-      
-      };
+  "18".google_apis."x86" = {
+    name = "system-image-18-google_apis-x86";
+    path = "system-images/android-18/google_apis/x86";
+    revision = "18-google_apis-x86";
+    displayName = "Google APIs Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis/x86-18_r06.zip;
+      sha1 = "dd674d719cad61602702be4b3d98edccfbfea53e";
+    };
   };
-  
-
-    "19".google_apis."armeabi-v7a" = {
-      name = "system-image-19-google_apis-armeabi-v7a";
-      path = "system-images/android-19/google_apis/armeabi-v7a";
-      revision = "19-google_apis-armeabi-v7a";
-      displayName = "Google APIs ARM EABI v7a System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-19_r37.zip;
-        sha1 = "b388072493ed010fe2ddf607c8c4239f54ce1a0b";
-      
-      };
+  "19".google_apis."x86" = {
+    name = "system-image-19-google_apis-x86";
+    path = "system-images/android-19/google_apis/x86";
+    revision = "19-google_apis-x86";
+    displayName = "Google APIs Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis/x86-19_r37.zip;
+      sha1 = "f02473420a166b3df7821d8ae5a623524058b4b8";
+    };
   };
-  
-
-    "21".google_apis."x86" = {
-      name = "system-image-21-google_apis-x86";
-      path = "system-images/android-21/google_apis/x86";
-      revision = "21-google_apis-x86";
-      displayName = "Google APIs Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis/x86-21_r29.zip;
-        sha1 = "1f5ac49e0ae603b0bfeda0c94cd7e0b850b9b50e";
-      
-      };
+  "19".google_apis."armeabi-v7a" = {
+    name = "system-image-19-google_apis-armeabi-v7a";
+    path = "system-images/android-19/google_apis/armeabi-v7a";
+    revision = "19-google_apis-armeabi-v7a";
+    displayName = "Google APIs ARM EABI v7a System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-19_r37.zip;
+      sha1 = "b388072493ed010fe2ddf607c8c4239f54ce1a0b";
+    };
   };
-  
-
-    "21".google_apis."x86_64" = {
-      name = "system-image-21-google_apis-x86_64";
-      path = "system-images/android-21/google_apis/x86_64";
-      revision = "21-google_apis-x86_64";
-      displayName = "Google APIs Intel x86 Atom_64 System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis/x86_64-21_r29.zip;
-        sha1 = "74ac387aec286fcee01259dcccd4762cbdb4b517";
-      
-      };
+  "21".google_apis."x86" = {
+    name = "system-image-21-google_apis-x86";
+    path = "system-images/android-21/google_apis/x86";
+    revision = "21-google_apis-x86";
+    displayName = "Google APIs Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis/x86-21_r29.zip;
+      sha1 = "1f5ac49e0ae603b0bfeda0c94cd7e0b850b9b50e";
+    };
   };
-  
-
-    "21".google_apis."armeabi-v7a" = {
-      name = "system-image-21-google_apis-armeabi-v7a";
-      path = "system-images/android-21/google_apis/armeabi-v7a";
-      revision = "21-google_apis-armeabi-v7a";
-      displayName = "Google APIs ARM EABI v7a System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-21_r29.zip;
-        sha1 = "1d0c428ac7f5eb49c7389ad0beb09f07cb989b45";
-      
-      };
+  "21".google_apis."x86_64" = {
+    name = "system-image-21-google_apis-x86_64";
+    path = "system-images/android-21/google_apis/x86_64";
+    revision = "21-google_apis-x86_64";
+    displayName = "Google APIs Intel x86 Atom_64 System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis/x86_64-21_r29.zip;
+      sha1 = "74ac387aec286fcee01259dcccd4762cbdb4b517";
+    };
   };
-  
-
-    "22".google_apis."x86" = {
-      name = "system-image-22-google_apis-x86";
-      path = "system-images/android-22/google_apis/x86";
-      revision = "22-google_apis-x86";
-      displayName = "Google APIs Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis/x86-22_r23.zip;
-        sha1 = "4ceda9ffd69d5b827a8cc2f56ccac62e72982b33";
-      
-      };
+  "21".google_apis."armeabi-v7a" = {
+    name = "system-image-21-google_apis-armeabi-v7a";
+    path = "system-images/android-21/google_apis/armeabi-v7a";
+    revision = "21-google_apis-armeabi-v7a";
+    displayName = "Google APIs ARM EABI v7a System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-21_r29.zip;
+      sha1 = "1d0c428ac7f5eb49c7389ad0beb09f07cb989b45";
+    };
   };
-  
-
-    "22".google_apis."armeabi-v7a" = {
-      name = "system-image-22-google_apis-armeabi-v7a";
-      path = "system-images/android-22/google_apis/armeabi-v7a";
-      revision = "22-google_apis-armeabi-v7a";
-      displayName = "Google APIs ARM EABI v7a System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-22_r23.zip;
-        sha1 = "0a11bdffa6132303baf87e4a531987a74d5f0792";
-      
-      };
+  "22".google_apis."x86" = {
+    name = "system-image-22-google_apis-x86";
+    path = "system-images/android-22/google_apis/x86";
+    revision = "22-google_apis-x86";
+    displayName = "Google APIs Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis/x86-22_r23.zip;
+      sha1 = "4ceda9ffd69d5b827a8cc2f56ccac62e72982b33";
+    };
   };
-  
-
-    "22".google_apis."x86_64" = {
-      name = "system-image-22-google_apis-x86_64";
-      path = "system-images/android-22/google_apis/x86_64";
-      revision = "22-google_apis-x86_64";
-      displayName = "Google APIs Intel x86 Atom_64 System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis/x86_64-22_r23.zip;
-        sha1 = "1dfee1c382574c18e3aa2bc2047793169f3ab125";
-      
-      };
+  "22".google_apis."armeabi-v7a" = {
+    name = "system-image-22-google_apis-armeabi-v7a";
+    path = "system-images/android-22/google_apis/armeabi-v7a";
+    revision = "22-google_apis-armeabi-v7a";
+    displayName = "Google APIs ARM EABI v7a System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-22_r23.zip;
+      sha1 = "0a11bdffa6132303baf87e4a531987a74d5f0792";
+    };
   };
-  
-
-    "23".google_apis."x86" = {
-      name = "system-image-23-google_apis-x86";
-      path = "system-images/android-23/google_apis/x86";
-      revision = "23-google_apis-x86";
-      displayName = "Google APIs Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis/x86-23_r30.zip;
-        sha1 = "1b8fd61e7e7c76d8c05a41b19370edfb015ed240";
-      
-      };
+  "22".google_apis."x86_64" = {
+    name = "system-image-22-google_apis-x86_64";
+    path = "system-images/android-22/google_apis/x86_64";
+    revision = "22-google_apis-x86_64";
+    displayName = "Google APIs Intel x86 Atom_64 System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis/x86_64-22_r23.zip;
+      sha1 = "1dfee1c382574c18e3aa2bc2047793169f3ab125";
+    };
   };
-  
-
-    "23".google_apis."x86_64" = {
-      name = "system-image-23-google_apis-x86_64";
-      path = "system-images/android-23/google_apis/x86_64";
-      revision = "23-google_apis-x86_64";
-      displayName = "Google APIs Intel x86 Atom_64 System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis/x86_64-23_r30.zip;
-        sha1 = "69a17c23c4e05e81a2820fe49884807fcebba546";
-      
-      };
+  "23".google_apis."x86" = {
+    name = "system-image-23-google_apis-x86";
+    path = "system-images/android-23/google_apis/x86";
+    revision = "23-google_apis-x86";
+    displayName = "Google APIs Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis/x86-23_r30.zip;
+      sha1 = "1b8fd61e7e7c76d8c05a41b19370edfb015ed240";
+    };
   };
-  
-
-    "23".google_apis."armeabi-v7a" = {
-      name = "system-image-23-google_apis-armeabi-v7a";
-      path = "system-images/android-23/google_apis/armeabi-v7a";
-      revision = "23-google_apis-armeabi-v7a";
-      displayName = "Google APIs ARM EABI v7a System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-23_r30.zip;
-        sha1 = "c3966e3a25623a915902d879f90f6d9253dbb619";
-      
-      };
+  "23".google_apis."x86_64" = {
+    name = "system-image-23-google_apis-x86_64";
+    path = "system-images/android-23/google_apis/x86_64";
+    revision = "23-google_apis-x86_64";
+    displayName = "Google APIs Intel x86 Atom_64 System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis/x86_64-23_r30.zip;
+      sha1 = "69a17c23c4e05e81a2820fe49884807fcebba546";
+    };
   };
-  
-
-    "24".google_apis."x86" = {
-      name = "system-image-24-google_apis-x86";
-      path = "system-images/android-24/google_apis/x86";
-      revision = "24-google_apis-x86";
-      displayName = "Google APIs Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis/x86-24_r24.zip;
-        sha1 = "7a1adb4aa13946830763644d014fc9c6cc1f921d";
-      
-      };
+  "23".google_apis."armeabi-v7a" = {
+    name = "system-image-23-google_apis-armeabi-v7a";
+    path = "system-images/android-23/google_apis/armeabi-v7a";
+    revision = "23-google_apis-armeabi-v7a";
+    displayName = "Google APIs ARM EABI v7a System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-23_r30.zip;
+      sha1 = "c3966e3a25623a915902d879f90f6d9253dbb619";
+    };
   };
-  
-
-    "24".google_apis."x86_64" = {
-      name = "system-image-24-google_apis-x86_64";
-      path = "system-images/android-24/google_apis/x86_64";
-      revision = "24-google_apis-x86_64";
-      displayName = "Google APIs Intel x86 Atom_64 System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis/x86_64-24_r24.zip;
-        sha1 = "53b26e8868c7cd27dda31c71ee2bcf999d6b9ce2";
-      
-      };
+  "24".google_apis."x86" = {
+    name = "system-image-24-google_apis-x86";
+    path = "system-images/android-24/google_apis/x86";
+    revision = "24-google_apis-x86";
+    displayName = "Google APIs Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis/x86-24_r24.zip;
+      sha1 = "7a1adb4aa13946830763644d014fc9c6cc1f921d";
+    };
   };
-  
-
-    "24".google_apis."armeabi-v7a" = {
-      name = "system-image-24-google_apis-armeabi-v7a";
-      path = "system-images/android-24/google_apis/armeabi-v7a";
-      revision = "24-google_apis-armeabi-v7a";
-      displayName = "Google APIs ARM EABI v7a System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-24_r24.zip;
-        sha1 = "85068d55673bbf9417db8d70107ceed0952b5a28";
-      
-      };
+  "24".google_apis."x86_64" = {
+    name = "system-image-24-google_apis-x86_64";
+    path = "system-images/android-24/google_apis/x86_64";
+    revision = "24-google_apis-x86_64";
+    displayName = "Google APIs Intel x86 Atom_64 System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis/x86_64-24_r24.zip;
+      sha1 = "53b26e8868c7cd27dda31c71ee2bcf999d6b9ce2";
+    };
   };
-  
-
-    "24".google_apis."arm64-v8a" = {
-      name = "system-image-24-google_apis-arm64-v8a";
-      path = "system-images/android-24/google_apis/arm64-v8a";
-      revision = "24-google_apis-arm64-v8a";
-      displayName = "Google APIs ARM 64 v8a System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-24_r24.zip;
-        sha1 = "93ab33d90fcdbb30ca2e927cd3eea447e933dfd9";
-      
-      };
+  "24".google_apis."armeabi-v7a" = {
+    name = "system-image-24-google_apis-armeabi-v7a";
+    path = "system-images/android-24/google_apis/armeabi-v7a";
+    revision = "24-google_apis-armeabi-v7a";
+    displayName = "Google APIs ARM EABI v7a System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-24_r24.zip;
+      sha1 = "85068d55673bbf9417db8d70107ceed0952b5a28";
+    };
   };
-  
-
-    "25".google_apis."x86" = {
-      name = "system-image-25-google_apis-x86";
-      path = "system-images/android-25/google_apis/x86";
-      revision = "25-google_apis-x86";
-      displayName = "Google APIs Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis/x86-25_r15.zip;
-        sha1 = "5948473077341265a0b21a53a7e0afc2f980187c";
-      
-      };
+  "24".google_apis."arm64-v8a" = {
+    name = "system-image-24-google_apis-arm64-v8a";
+    path = "system-images/android-24/google_apis/arm64-v8a";
+    revision = "24-google_apis-arm64-v8a";
+    displayName = "Google APIs ARM 64 v8a System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-24_r24.zip;
+      sha1 = "93ab33d90fcdbb30ca2e927cd3eea447e933dfd9";
+    };
   };
-  
-
-    "25".google_apis."x86_64" = {
-      name = "system-image-25-google_apis-x86_64";
-      path = "system-images/android-25/google_apis/x86_64";
-      revision = "25-google_apis-x86_64";
-      displayName = "Google APIs Intel x86 Atom_64 System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis/x86_64-25_r15.zip;
-        sha1 = "5a81fc218a7fe82cc6af01f7fae54a8000900443";
-      
-      };
+  "25".google_apis."x86" = {
+    name = "system-image-25-google_apis-x86";
+    path = "system-images/android-25/google_apis/x86";
+    revision = "25-google_apis-x86";
+    displayName = "Google APIs Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis/x86-25_r15.zip;
+      sha1 = "5948473077341265a0b21a53a7e0afc2f980187c";
+    };
   };
-  
-
-    "25".google_apis."armeabi-v7a" = {
-      name = "system-image-25-google_apis-armeabi-v7a";
-      path = "system-images/android-25/google_apis/armeabi-v7a";
-      revision = "25-google_apis-armeabi-v7a";
-      displayName = "Google APIs ARM EABI v7a System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-25_r15.zip;
-        sha1 = "813e25f9a5f6d775670ed6c5e67a39bffa1411bf";
-      
-      };
+  "25".google_apis."x86_64" = {
+    name = "system-image-25-google_apis-x86_64";
+    path = "system-images/android-25/google_apis/x86_64";
+    revision = "25-google_apis-x86_64";
+    displayName = "Google APIs Intel x86 Atom_64 System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis/x86_64-25_r15.zip;
+      sha1 = "5a81fc218a7fe82cc6af01f7fae54a8000900443";
+    };
   };
-  
-
-    "25".google_apis."arm64-v8a" = {
-      name = "system-image-25-google_apis-arm64-v8a";
-      path = "system-images/android-25/google_apis/arm64-v8a";
-      revision = "25-google_apis-arm64-v8a";
-      displayName = "Google APIs ARM 64 v8a System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-25_r15.zip;
-        sha1 = "c3049e32f031140757f71acb5b8f0179e6f27303";
-      
-      };
+  "25".google_apis."armeabi-v7a" = {
+    name = "system-image-25-google_apis-armeabi-v7a";
+    path = "system-images/android-25/google_apis/armeabi-v7a";
+    revision = "25-google_apis-armeabi-v7a";
+    displayName = "Google APIs ARM EABI v7a System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-25_r15.zip;
+      sha1 = "813e25f9a5f6d775670ed6c5e67a39bffa1411bf";
+    };
   };
-  
-
-    "26".google_apis."x86" = {
-      name = "system-image-26-google_apis-x86";
-      path = "system-images/android-26/google_apis/x86";
-      revision = "26-google_apis-x86";
-      displayName = "Google APIs Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis/x86-26_r12.zip;
-        sha1 = "167c83bcfd87127c7376ce986b34701f74fe87ff";
-      
-      };
+  "25".google_apis."arm64-v8a" = {
+    name = "system-image-25-google_apis-arm64-v8a";
+    path = "system-images/android-25/google_apis/arm64-v8a";
+    revision = "25-google_apis-arm64-v8a";
+    displayName = "Google APIs ARM 64 v8a System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-25_r15.zip;
+      sha1 = "c3049e32f031140757f71acb5b8f0179e6f27303";
+    };
   };
-  
-
-    "26".google_apis."x86_64" = {
-      name = "system-image-26-google_apis-x86_64";
-      path = "system-images/android-26/google_apis/x86_64";
-      revision = "26-google_apis-x86_64";
-      displayName = "Google APIs Intel x86 Atom_64 System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis/x86_64-26_r12.zip;
-        sha1 = "fcd46121c3486e2a759d0707c015e0b12bbab9db";
-      
-      };
+  "26".google_apis."x86" = {
+    name = "system-image-26-google_apis-x86";
+    path = "system-images/android-26/google_apis/x86";
+    revision = "26-google_apis-x86";
+    displayName = "Google APIs Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis/x86-26_r12.zip;
+      sha1 = "167c83bcfd87127c7376ce986b34701f74fe87ff";
+    };
   };
-  
-
-    "27".google_apis."x86" = {
-      name = "system-image-27-google_apis-x86";
-      path = "system-images/android-27/google_apis/x86";
-      revision = "27-google_apis-x86";
-      displayName = "Google APIs Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis/x86-27_r08.zip;
-        sha1 = "623ee2638713b7dfde8044c91280c2afad5a1ade";
-      
-      };
+  "26".google_apis."x86_64" = {
+    name = "system-image-26-google_apis-x86_64";
+    path = "system-images/android-26/google_apis/x86_64";
+    revision = "26-google_apis-x86_64";
+    displayName = "Google APIs Intel x86 Atom_64 System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis/x86_64-26_r12.zip;
+      sha1 = "fcd46121c3486e2a759d0707c015e0b12bbab9db";
+    };
   };
-  
-
-    "28".google_apis."x86" = {
-      name = "system-image-28-google_apis-x86";
-      path = "system-images/android-28/google_apis/x86";
-      revision = "28-google_apis-x86";
-      displayName = "Google APIs Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis/x86-28_r07.zip;
-        sha1 = "fe5d58355545ae82b0e6a55adc1d41573ac7dec1";
-      
-      };
+  "27".google_apis."x86" = {
+    name = "system-image-27-google_apis-x86";
+    path = "system-images/android-27/google_apis/x86";
+    revision = "27-google_apis-x86";
+    displayName = "Google APIs Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis/x86-27_r08.zip;
+      sha1 = "623ee2638713b7dfde8044c91280c2afad5a1ade";
+    };
   };
-  
-
-    "28".google_apis."x86_64" = {
-      name = "system-image-28-google_apis-x86_64";
-      path = "system-images/android-28/google_apis/x86_64";
-      revision = "28-google_apis-x86_64";
-      displayName = "Google APIs Intel x86 Atom_64 System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis/x86_64-28_r07.zip;
-        sha1 = "068468683a56725326f741f75b6913ee1e7955ff";
-      
-      };
+  "28".google_apis."x86" = {
+    name = "system-image-28-google_apis-x86";
+    path = "system-images/android-28/google_apis/x86";
+    revision = "28-google_apis-x86";
+    displayName = "Google APIs Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis/x86-28_r08.zip;
+      sha1 = "41e3b854d7987a3d8b7500631dae1f1d32d3db4e";
+    };
   };
-  
+  "28".google_apis."x86_64" = {
+    name = "system-image-28-google_apis-x86_64";
+    path = "system-images/android-28/google_apis/x86_64";
+    revision = "28-google_apis-x86_64";
+    displayName = "Google APIs Intel x86 Atom_64 System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis/x86_64-28_r08.zip;
+      sha1 = "d8901fdfab7410a4c2fa492dd3ce528e4dbcdfd6";
+    };
+  };
+  "Q".google_apis."x86" = {
+    name = "system-image-Q-google_apis-x86";
+    path = "system-images/android-Q/google_apis/x86";
+    revision = "Q-google_apis-x86";
+    displayName = "Google APIs Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis/x86-Q_r01.zip;
+      sha1 = "11233b66b891ce7b3e8e26eaef2f2e35e80d401b";
+    };
+  };
+  "Q".google_apis."x86_64" = {
+    name = "system-image-Q-google_apis-x86_64";
+    path = "system-images/android-Q/google_apis/x86_64";
+    revision = "Q-google_apis-x86_64";
+    displayName = "Google APIs Intel x86 Atom_64 System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis/x86_64-Q_r01.zip;
+      sha1 = "fa3578811a52cadf2535da7b64d0a67889c8edb3";
+    };
+  };
 }
-  

--- a/pkgs/development/mobile/androidenv/generated/system-images-google_apis_playstore.nix
+++ b/pkgs/development/mobile/androidenv/generated/system-images-google_apis_playstore.nix
@@ -1,97 +1,84 @@
-
 {fetchurl}:
 
 {
-  
-
-    "24".google_apis_playstore."x86" = {
-      name = "system-image-24-google_apis_playstore-x86";
-      path = "system-images/android-24/google_apis_playstore/x86";
-      revision = "24-google_apis_playstore-x86";
-      displayName = "Google Play Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86-24_r19.zip;
-        sha1 = "b52e9593ffdde65c1a0970256a32e8967c89cc22";
-      
-      };
+  "24".google_apis_playstore."x86" = {
+    name = "system-image-24-google_apis_playstore-x86";
+    path = "system-images/android-24/google_apis_playstore/x86";
+    revision = "24-google_apis_playstore-x86";
+    displayName = "Google Play Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86-24_r19.zip;
+      sha1 = "b52e9593ffdde65c1a0970256a32e8967c89cc22";
+    };
   };
-  
-
-    "25".google_apis_playstore."x86" = {
-      name = "system-image-25-google_apis_playstore-x86";
-      path = "system-images/android-25/google_apis_playstore/x86";
-      revision = "25-google_apis_playstore-x86";
-      displayName = "Google Play Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86-25_r09.zip;
-        sha1 = "6f6668954f7fd52f896fe7528aa122028c9b026c";
-      
-      };
+  "25".google_apis_playstore."x86" = {
+    name = "system-image-25-google_apis_playstore-x86";
+    path = "system-images/android-25/google_apis_playstore/x86";
+    revision = "25-google_apis_playstore-x86";
+    displayName = "Google Play Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86-25_r09.zip;
+      sha1 = "6f6668954f7fd52f896fe7528aa122028c9b026c";
+    };
   };
-  
-
-    "26".google_apis_playstore."x86" = {
-      name = "system-image-26-google_apis_playstore-x86";
-      path = "system-images/android-26/google_apis_playstore/x86";
-      revision = "26-google_apis_playstore-x86";
-      displayName = "Google Play Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86-26_r07.zip;
-        sha1 = "2c8bee7b97a309f099941532e63c42a7d4a06e19";
-      
-      };
+  "26".google_apis_playstore."x86" = {
+    name = "system-image-26-google_apis_playstore-x86";
+    path = "system-images/android-26/google_apis_playstore/x86";
+    revision = "26-google_apis_playstore-x86";
+    displayName = "Google Play Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86-26_r07.zip;
+      sha1 = "2c8bee7b97a309f099941532e63c42a7d4a06e19";
+    };
   };
-  
-
-    "27".google_apis_playstore."x86" = {
-      name = "system-image-27-google_apis_playstore-x86";
-      path = "system-images/android-27/google_apis_playstore/x86";
-      revision = "27-google_apis_playstore-x86";
-      displayName = "Google Play Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86-27_r03.zip;
-        sha1 = "eb5a944ceb691ca0648d0a6f0d93893a47223b5d";
-      
-      };
+  "27".google_apis_playstore."x86" = {
+    name = "system-image-27-google_apis_playstore-x86";
+    path = "system-images/android-27/google_apis_playstore/x86";
+    revision = "27-google_apis_playstore-x86";
+    displayName = "Google Play Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86-27_r03.zip;
+      sha1 = "eb5a944ceb691ca0648d0a6f0d93893a47223b5d";
+    };
   };
-  
-
-    "28".google_apis_playstore."x86" = {
-      name = "system-image-28-google_apis_playstore-x86";
-      path = "system-images/android-28/google_apis_playstore/x86";
-      revision = "28-google_apis_playstore-x86";
-      displayName = "Google Play Intel x86 Atom System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86-28_r05.zip;
-        sha1 = "4c570d259e93b0b27f97bad1aca2ac47f1e9b51a";
-      
-      };
+  "28".google_apis_playstore."x86" = {
+    name = "system-image-28-google_apis_playstore-x86";
+    path = "system-images/android-28/google_apis_playstore/x86";
+    revision = "28-google_apis_playstore-x86";
+    displayName = "Google Play Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86-28_r08.zip;
+      sha1 = "5381f9d52a3bf1967c9c92a25b20012cd68764c8";
+    };
   };
-  
-
-    "28".google_apis_playstore."x86_64" = {
-      name = "system-image-28-google_apis_playstore-x86_64";
-      path = "system-images/android-28/google_apis_playstore/x86_64";
-      revision = "28-google_apis_playstore-x86_64";
-      displayName = "Google Play Intel x86 Atom_64 System Image";
-      archives.all = fetchurl {
-      
-        url = 
-        https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-28_r05.zip;
-        sha1 = "5f6b238e4c7de41fd2a1c66841093bcf517255a1";
-      
-      };
+  "28".google_apis_playstore."x86_64" = {
+    name = "system-image-28-google_apis_playstore-x86_64";
+    path = "system-images/android-28/google_apis_playstore/x86_64";
+    revision = "28-google_apis_playstore-x86_64";
+    displayName = "Google Play Intel x86 Atom_64 System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-28_r08.zip;
+      sha1 = "a767da996fdea7a1f5632a9206fa5c009d6e580c";
+    };
   };
-  
+  "Q".google_apis_playstore."x86" = {
+    name = "system-image-Q-google_apis_playstore-x86";
+    path = "system-images/android-Q/google_apis_playstore/x86";
+    revision = "Q-google_apis_playstore-x86";
+    displayName = "Google Play Intel x86 Atom System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86-Q_r01.zip;
+      sha1 = "118d080a85eb110e6da24e394602f18604255243";
+    };
+  };
+  "Q".google_apis_playstore."x86_64" = {
+    name = "system-image-Q-google_apis_playstore-x86_64";
+    path = "system-images/android-Q/google_apis_playstore/x86_64";
+    revision = "Q-google_apis_playstore-x86_64";
+    displayName = "Google Play Intel x86 Atom_64 System Image";
+    archives.all = fetchurl {
+      url = https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-Q_r01.zip;
+      sha1 = "c4455d75549c595e0d3cfaf122ecedf359e10483";
+    };
+  };
 }
-  


### PR DESCRIPTION
###### Motivation for this change

Update `generate.sh` to run using `nix-shell`. Also make it fail with meaningful output instead of writing empty output files.

Generate the latest Android packages.

Update `composeAndroidPackages` with versions that exist in the generated package set.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
