### PR TITLE
lastpass-cli: 1.3.1 -> 1.3.2, touchups

### DIFF
--- a/pkgs/tools/security/lastpass-cli/default.nix
+++ b/pkgs/tools/security/lastpass-cli/default.nix
@@ -2,15 +2,14 @@
 , bash-completion, openssl, curl, libxml2, libxslt }:
 
 stdenv.mkDerivation rec {
-  name = "lastpass-cli-${version}";
-
-  version = "1.3.1";
+  pname = "lastpass-cli";
+  version = "1.3.2";
 
   src = fetchFromGitHub {
     owner = "lastpass";
-    repo = "lastpass-cli";
+    repo = pname;
     rev = "v${version}";
-    sha256 = "11drzmfdvb8ydw1dxaz9zz8rk0jjqmfv076vydz05qqvgx59s38h";
+    sha256 = "12qjqvqzi3pq7hrdpq59bcxqy6yj1mhx145g9rky1jm2ipzpfayq";
   };
 
   nativeBuildInputs = [ asciidoc cmake docbook_xsl pkgconfig ];

--- a/pkgs/tools/security/lastpass-cli/default.nix
+++ b/pkgs/tools/security/lastpass-cli/default.nix
@@ -20,11 +20,12 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  cmakeFlags = [
-    "-DBASH_COMPLETION_COMPLETIONSDIR=./share/bash-completion/completions"
-  ];
+  installTargets = [ "install" "install-doc" ];
 
-  installTargets = "install install-doc";
+  postInstall = ''
+    install -Dm644 -T ../contrib/lpass_zsh_completion $out/share/zsh/site-functions/_lpass
+    install -Dm644 -T ../contrib/completions-lpass.fish $out/share/fish/vendor_completions.d/lpass.fish
+  '';
 
   meta = with lib; {
     description = "Stores, retrieves, generates, and synchronizes passwords securely";


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---