### PR TITLE
powertop: patch to fix vertical scrolling

### DIFF
--- a/pkgs/os-specific/linux/powertop/default.nix
+++ b/pkgs/os-specific/linux/powertop/default.nix
@@ -20,7 +20,10 @@ stdenv.mkDerivation rec {
       url = "https://git.alpinelinux.org/cgit/aports/plain/main/powertop/strerror_r.patch?id=3b9214d436f1611f297b01f72469d66bfe729d6e";
       sha256 = "1kzddhcrb0n2iah4lhgxwwy4mkhq09ch25jjngyq6pdj6pmfkpfw";
     }
-  );
+  ) ++ [
+    # Fix vertical scrolling, see: https://lists.01.org/pipermail/powertop/2019-March/002046.html
+    ./fix-vertical-scrolling.patch
+  ];
 
   postPatch = ''
     substituteInPlace src/main.cpp --replace "/sbin/modprobe" "modprobe"

--- a/pkgs/os-specific/linux/powertop/fix-vertical-scrolling.patch
+++ b/pkgs/os-specific/linux/powertop/fix-vertical-scrolling.patch
@@ -1,0 +1,13 @@
+diff --git a/src/display.cpp b/src/display.cpp
+index 07227c5..7b3a7a2 100644
+--- a/src/display.cpp
++++ b/src/display.cpp
+@@ -244,7 +244,7 @@ void cursor_down(void)
+ 	w = tab_windows[tab_names[current_tab]];
+ 	if (w) {
+ 		if (w->ypad_pos < 1000) {
+-			if (tab_names[current_tab] == "Tunables" || "WakeUp") {
++			if (tab_names[current_tab] == "Tunables" || tab_names[current_tab] == "WakeUp") {
+ 		                if ((w->cursor_pos + 7) >= LINES) { 
+ 					prefresh(w->win, ++w->ypad_pos, w->xpad_pos, 
+ 						1, 0, LINES - 3, COLS - 1);


### PR DESCRIPTION
From mailing list (thanks!).


###### Motivation for this change

Vertical scrolling fix!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---