### PR TITLE
qt5ct: 0.37 -> 0.38

### DIFF
--- a/pkgs/tools/misc/qt5ct/default.nix
+++ b/pkgs/tools/misc/qt5ct/default.nix
@@ -3,12 +3,12 @@
 let inherit (stdenv.lib) getDev; in
 
 stdenv.mkDerivation rec {
-  name = "qt5ct-${version}";
-  version = "0.37";
+  pname = "qt5ct";
+  version = "0.38";
 
   src = fetchurl {
-    url = "mirror://sourceforge/qt5ct/${name}.tar.bz2";
-    sha256 = "0n8csvbpislxjr2s1xi8r5a4q4bqn4kylcy2zws6w7z4m8pdzrny";
+    url = "mirror://sourceforge/${pname}/${pname}-${version}.tar.bz2";
+    sha256 = "0p0317z79h906qwaf0p8ga6lmr1dlabkx12gn31bv9lnp9f55jwg";
   };
 
   nativeBuildInputs = [ qmake qttools ];


### PR DESCRIPTION
###### Motivation for this change

https://sourceforge.net/p/qt5ct/code/HEAD/tree/tags/qt5ct-0.38/ChangeLog
(at end)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---