### PR TITLE
anbox: cleanup

### DIFF
--- a/pkgs/os-specific/linux/anbox/default.nix
+++ b/pkgs/os-specific/linux/anbox/default.nix
@@ -16,11 +16,36 @@
 , protobufc
 , python
 , lxc
+, writeText
+, writeScript
+, runtimeShell
 }:
+
+let
+
+  dbus-service = writeText "org.anbox.service" ''
+    [D-BUS Service]
+    Name=org.anbox
+    Exec=@out@/libexec/anbox-session-manager
+  '';
+
+  anbox-application-manager = writeScript "anbox-application-manager" ''
+    #!${runtimeShell}
+
+    ${systemd}/bin/busctl --user call \
+        org.freedesktop.DBus \
+        /org/freedesktop/DBus \
+        org.freedesktop.DBus \
+        StartServiceByName "su" org.anbox 0
+
+    @out@/bin/anbox launch --package=org.anbox.appmgr --component=org.anbox.appmgr.AppViewActivity
+  '';
+
+in
 
 stdenv.mkDerivation rec {
   pname = "anbox";
-  version = "2019-03-07";
+  version = "unstable-2019-03-07";
 
   src = fetchFromGitHub {
     owner = pname;
@@ -29,10 +54,14 @@ stdenv.mkDerivation rec {
     sha256 = "1wfx4bsyxvrjl16dq5pqgial8rnnsnxzbak2ap0waddz847czxwz";
   };
 
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
   buildInputs = [
     cmake pkgconfig dbus boost libcap gtest systemd mesa glib
     SDL2 SDL2_image protobuf protobufc properties-cpp lxc python
-    makeWrapper libGL
+    libGL
   ];
 
   patchPhase = ''
@@ -68,31 +97,16 @@ stdenv.mkDerivation rec {
       --prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [libGL libglvnd]} \
       --prefix PATH : ${git}/bin
 
-    mkdir -p $out/share/dbus-1/services/
-    cat <<END > $out/share/dbus-1/services/org.anbox.service
-    [D-BUS Service]
-    Name=org.anbox
-    Exec=$out/libexec/anbox-session-manager
-    END
+    mkdir -p $out/share/dbus-1/services
+    substitute ${dbus-service} $out/share/dbus-1/services/org.anbox.service \
+      --subst-var out
 
     mkdir $out/libexec
-    cat > $out/libexec/anbox-session-manager <<EOF
-    #!${stdenv.shell}
-    exec $out/bin/anbox session-manager
-    EOF
-    chmod +x $out/libexec/anbox-session-manager
+    makeWrapper $out/bin/anbox $out/libexec/anbox-session-manager \
+      --add-flags session-manager
 
-    cat > $out/bin/anbox-application-manager <<EOF
-    #!${stdenv.shell}
-    ${systemd}/bin/busctl --user call \
-      org.freedesktop.DBus \
-      /org/freedesktop/DBus \
-      org.freedesktop.DBus \
-      StartServiceByName "su" org.anbox 0
-
-    $out/bin/anbox launch --package=org.anbox.appmgr --component=org.anbox.appmgr.AppViewActivity
-    EOF
-    chmod +x $out/bin/anbox-application-manager
+    substitute ${anbox-application-manager} $out/bin/anbox-application-manager \
+      --subst-var out
   '';
 
   passthru.image = let
@@ -118,7 +132,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     homepage = https://anbox.io;
-    description = "Android in a box.";
+    description = "Android in a box";
     license = licenses.gpl2;
     maintainers = with maintainers; [ edwtjo ];
     platforms = platforms.linux;


### PR DESCRIPTION
Use trivial builders for all the text manipulation and use `runtimeShell`

###### Motivation for this change
Didn't get a chance to review #57826 so I thought to submit the changes I would have requested anyway.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @gebner 