### PR TITLE
anbox: Prevent eval failure on non-existent arches

### DIFF
--- a/pkgs/os-specific/linux/anbox/default.nix
+++ b/pkgs/os-specific/linux/anbox/default.nix
@@ -97,31 +97,28 @@ stdenv.mkDerivation rec {
 
   passthru.image = let
     imgroot = "https://build.anbox.io/android-images";
-    arches = {
-      armv7l-linux = {
+  in
+    {
+      armv7l-linux = fetchurl {
         url = imgroot + "/2017/06/12/android_1_armhf.img";
         sha256 = "1za4q6vnj8wgphcqpvyq1r8jg6khz7v6b7h6ws1qkd5ljangf1w5";
       };
-      aarch64-linux = {
+      aarch64-linux = fetchurl {
         url = imgroot + "/2017/08/04/android_1_arm64.img";
         sha256 = "02yvgpx7n0w0ya64y5c7bdxilaiqj9z3s682l5s54vzfnm5a2bg5";
       };
-      x86_64-linux = {
+      x86_64-linux = fetchurl {
         url = imgroot + "/2018/07/19/android_amd64.img";
         sha256 = "1jlcda4q20w30cm9ikm6bjq01p547nigik1dz7m4v0aps4rws13b";
       };
-    };
-  in
-  fetchurl {
-    inherit (arches.${stdenv.system}) url sha256;
-  };
+    }.${stdenv.system} or null;
 
   meta = with stdenv.lib; {
     homepage = https://anbox.io;
     description = "Android in a box.";
     license = licenses.gpl2;
     maintainers = with maintainers; [ edwtjo ];
-    platforms = platforms.linux;
+    platforms = [ "armv7l-linux" "aarch64-linux" "x86-64-linux" ];
   };
 
 }


### PR DESCRIPTION
###### Motivation for this change
Fix tarball generation / eval during i686-linux check

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
