### PR TITLE
xpra: 2.3.4 -> 2.5, unbreak?

### DIFF
--- a/pkgs/tools/X11/xpra/default.nix
+++ b/pkgs/tools/X11/xpra/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchurl, callPackage, substituteAll, python3, pkgconfig
 , xorg, gtk3, glib, pango, cairo, gdk_pixbuf, atk
 , wrapGAppsHook, xorgserver, getopt, xauth, utillinux, which
-, ffmpeg, x264, libvpx, libwebp
+, ffmpeg_4, x264, libvpx, libwebp, x265
 , libfakeXinerama
 , gst_all_1, pulseaudio, gobject-introspection
 , pam }:
@@ -14,11 +14,11 @@ let
   xf86videodummy = callPackage ./xf86videodummy { };
 in buildPythonApplication rec {
   pname = "xpra";
-  version = "2.3.4";
+  version = "2.5";
 
   src = fetchurl {
     url = "https://xpra.org/src/${pname}-${version}.tar.xz";
-    sha256 = "0wa3kx54himy3i1b2801hlzfilh3cf4kjk40k1cjl0ds28m5hija";
+    sha256 = "0q6c7ijgpp2wk6jlh0pzqki1w60i36wyl2zfwkg0gpdh40ypab3x";
   };
 
   patches = [
@@ -28,7 +28,11 @@ in buildPythonApplication rec {
     })
   ];
 
-  nativeBuildInputs = [ pkgconfig gobject-introspection wrapGAppsHook ];
+  postPatch = ''
+    substituteInPlace setup.py --replace '/usr/include/security' '${pam}/include/security'
+  '';
+
+  nativeBuildInputs = [ pkgconfig wrapGAppsHook ];
   buildInputs = with xorg; [
     libX11 xorgproto libXrender libXi
     libXtst libXfixes libXcomposite libXdamage
@@ -36,9 +40,9 @@ in buildPythonApplication rec {
     ] ++ [
     cython
 
-    pango cairo gdk_pixbuf atk gtk3 glib
+    pango cairo gdk_pixbuf atk.out gtk3 glib
 
-    ffmpeg libvpx x264 libwebp
+    ffmpeg_4 libvpx x264 libwebp x265
 
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base
@@ -47,11 +51,13 @@ in buildPythonApplication rec {
     gst_all_1.gst-libav
 
     pam
+    gobject-introspection
   ];
-
   propagatedBuildInputs = with python3.pkgs; [
     pillow rencode pycrypto cryptography pycups lz4 dbus-python
-    netifaces numpy websockify pygobject3 pycairo gst-python pam
+    netifaces numpy pygobject3 pycairo gst-python pam
+    pyopengl paramiko opencv python-uinput pyxdg
+    ipaddress idna
   ];
 
   NIX_CFLAGS_COMPILE = [
@@ -64,6 +70,9 @@ in buildPythonApplication rec {
     "--without-strict"
     "--with-gtk3"
     "--without-gtk2"
+    # Override these, setup.py checks for headers in /usr/* paths
+    "--with-pam"
+    "--with-vsock"
   ];
 
   preFixup = ''
@@ -76,6 +85,8 @@ in buildPythonApplication rec {
 
   doCheck = false;
 
+  enableParallelBuilding = true;
+
   passthru = { inherit xf86videodummy; };
 
   meta = {
@@ -85,8 +96,6 @@ in buildPythonApplication rec {
     description = "Persistent remote applications for X";
     platforms = platforms.linux;
     license = licenses.gpl2;
-    # https://github.com/NixOS/nixpkgs/pull/48872#issuecomment-433559636
-    broken = true;
     maintainers = with maintainers; [ tstrobel offline numinit ];
   };
 }

--- a/pkgs/tools/X11/xpra/fix-paths.patch
+++ b/pkgs/tools/X11/xpra/fix-paths.patch
@@ -9,25 +9,26 @@
      cython_add(Extension("xpra.client.gtk3.cairo_workaround",
                  ["xpra/client/gtk3/cairo_workaround.pyx"],
                  **pkgconfig(pycairo)
---- a/xpra/client/gtk3/cairo_workaround.pyx
-+++ b/xpra/client/gtk3/cairo_workaround.pyx
-@@ -65,7 +65,7 @@
-     void cairo_surface_flush (cairo_surface_t *surface)
-     void cairo_surface_mark_dirty (cairo_surface_t *surface)
- 
--cdef extern from "pycairo/pycairo.h":
-+cdef extern from "py3cairo.h":
-     ctypedef struct Pycairo_CAPI_t:
-         pass
-     ctypedef struct PycairoSurface:
+@@ -2363,10 +2363,7 @@
+     v4l2_pkgconfig = pkgconfig()
+     #fuly warning: cython makes this difficult,
+     #we have to figure out if "device_caps" exists in the headers:
+-    ENABLE_DEVICE_CAPS = False
+-    if os.path.exists("/usr/include/linux/videodev2.h"):
+-        hdata = open("/usr/include/linux/videodev2.h").read()
+-        ENABLE_DEVICE_CAPS = hdata.find("device_caps")>=0
++    ENABLE_DEVICE_CAPS = True
+     kwargs = {"ENABLE_DEVICE_CAPS" : ENABLE_DEVICE_CAPS}
+     make_constants("xpra", "codecs", "v4l2", "constants", **kwargs)
+     cython_add(Extension("xpra.codecs.v4l2.pusher",
 --- a/xpra/x11/bindings/keyboard_bindings.pyx
 +++ b/xpra/x11/bindings/keyboard_bindings.pyx
 @@ -19,7 +19,7 @@
  
  DEF PATH_MAX = 1024
- DEF DFLT_XKB_RULES_FILE = "base"
--DEF DFLT_XKB_CONFIG_ROOT = "/usr/share/X11/xkb"
-+DEF DFLT_XKB_CONFIG_ROOT = "@xkeyboardconfig@/share/X11/xkb"
+ DEF DFLT_XKB_RULES_FILE = b"base"
+-DEF DFLT_XKB_CONFIG_ROOT = b"/usr/share/X11/xkb"
++DEF DFLT_XKB_CONFIG_ROOT = b"@xkeyboardconfig@/share/X11/xkb"
  
  ###################################
  # Headers, python magic


### PR DESCRIPTION
###### Motivation for this change

It builds and bits seem to almost work,
would be nice to try it in a VM with the xpra module enabled or
something?

May want to fix default paths for things like sockets
in order to get usage other than via NixOS module working.

Thoughts/comments/testing appreciated :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---