### PR TITLE
pythonPackages.zeep: Enable test suite for Python 3

### DIFF
--- a/pkgs/development/python-modules/aioresponses/default.nix
+++ b/pkgs/development/python-modules/aioresponses/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, pbr
+, aiohttp
+, ddt
+, asynctest
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "aioresponses";
+  version = "0.6.0";
+  disabled = pythonOlder "3.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0ii1jiwb8qa2y8cqa1zqn7mjax9l8bpf16k4clv616mxw1l0bvs6";
+  };
+
+  nativeBuildInputs = [
+    pbr
+  ];
+
+  propagatedBuildInputs = [
+    aiohttp
+  ];
+
+  checkInputs = [
+    asynctest
+    ddt
+    pytest
+  ];
+
+  # Skip a test which makes requests to httpbin.org
+  checkPhase = ''
+    pytest -k "not test_address_as_instance_of_url_combined_with_pass_through"
+  '';
+
+  meta = {
+    description = "A helper to mock/fake web requests in python aiohttp package";
+    homepage = https://github.com/pnuckowski/aioresponses;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ rvl ];
+  };
+}

--- a/pkgs/development/python-modules/zeep/default.nix
+++ b/pkgs/development/python-modules/zeep/default.nix
@@ -1,8 +1,6 @@
 { fetchPypi
 , lib
 , buildPythonPackage
-, python
-, isPy3k
 , appdirs
 , cached-property
 , defusedxml
@@ -12,11 +10,13 @@
 , requests_toolbelt
 , six
 # test dependencies
+, aiohttp
+, aioresponses
 , freezegun
 , mock
 , nose
 , pretend
-, pytest
+, pytest_3
 , pytestcov
 , requests-mock
 , tornado
@@ -33,6 +33,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
+    aiohttp
     attrs
     appdirs
     cached-property
@@ -44,24 +45,19 @@ buildPythonPackage rec {
     six
   ];
 
-  # testtools dependency not supported for py3k
-  doCheck = !isPy3k;
-
   checkInputs = [
+    aioresponses
     tornado
-  ];
-
-  buildInputs = if isPy3k then [] else [
+    pytest_3
     freezegun
     mock
     nose
     pretend
-    pytest
-    pytestcov
     requests-mock
+    pytestcov
   ];
 
-  patchPhase = ''
+  postPatch = ''
     # remove overly strict bounds and lint requirements
     sed -e "s/freezegun==.*'/freezegun'/" \
         -e "s/pytest-cov==.*'/pytest-cov'/" \
@@ -81,9 +77,7 @@ buildPythonPackage rec {
   '';
 
   checkPhase = ''
-    runHook preCheck
-    ${python.interpreter} -m pytest tests
-    runHook postCheck
+    pytest tests
   '';
 
   meta = with lib; {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -926,6 +926,8 @@ in {
 
   aioprocessing = callPackage ../development/python-modules/aioprocessing { };
 
+  aioresponses = callPackage ../development/python-modules/aioresponses { };
+
   aiorpcx = callPackage ../development/python-modules/aiorpcx { };
 
   aiounifi = callPackage ../development/python-modules/aiounifi { };


### PR DESCRIPTION
###### Motivation for this change

Using pytest with Python 3 is possible now.

See also #57469.

###### Things done

- Enabled tests for the zeep package.
- Added the airoresponses package which was a dependency of the test suite.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
