### PR TITLE
nixos/firewall: deduplicate installed firewall rules

### DIFF
--- a/nixos/modules/services/networking/firewall.nix
+++ b/nixos/modules/services/networking/firewall.nix
@@ -38,6 +38,10 @@ let
 
   cfg = config.networking.firewall;
 
+  uniqueListOf = type: let
+    elemType = types.listOf type;
+  in elemType // { merge = loc: defs: unique (elemType.merge loc defs); };
+
   inherit (config.boot.kernelPackages) kernel;
 
   kernelHasRPFilter = ((kernel.config.isEnabled or (x: false)) "IP_NF_MATCH_RPFILTER") || (kernel.features.netfilterRPFilter or false);
@@ -263,29 +267,29 @@ let
 
   commonOptions = {
     allowedTCPPorts = mkOption {
-      type = types.listOf types.int;
+      type = with types; uniqueListOf port;
       default = [ ];
       example = [ 22 80 ];
       description =
-        '' 
+        ''
           List of TCP ports on which incoming connections are
           accepted.
         '';
     };
 
     allowedTCPPortRanges = mkOption {
-      type = types.listOf (types.attrsOf types.int);
+      type = with types; uniqueListOf (types.attrsOf port);
       default = [ ];
       example = [ { from = 8999; to = 9003; } ];
       description =
-        '' 
+        ''
           A range of TCP ports on which incoming connections are
           accepted.
         '';
     };
 
     allowedUDPPorts = mkOption {
-      type = types.listOf types.int;
+      type = with types; uniqueListOf port;
       default = [ ];
       example = [ 53 ];
       description =
@@ -295,7 +299,7 @@ let
     };
 
     allowedUDPPortRanges = mkOption {
-      type = types.listOf (types.attrsOf types.int);
+      type = with types; uniqueListOf (attrsOf port);
       default = [ ];
       example = [ { from = 60000; to = 61000; } ];
       description =


### PR DESCRIPTION
###### Motivation for this change

When there are multiple statements adding an overlapping set of rules
(e.g. opening a TCP port) there will no longer be multiple rules for
those. It could easily happen that you'd end up with multiple allow
statements for the very same port due to the way your custom
modules/files are structured.

cc @tilpner since he pointed me towards this problem on IRC.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
