### PR TITLE
systemd: update debian patches url to snapshots.debian.org

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -34,10 +34,12 @@ in stdenv.mkDerivation rec {
       # Upstream's maintenance branches are still too intrusive:
       # https://github.com/systemd/systemd-stable/tree/v239-stable
       patches-deb = fetchurl {
-        # When the URL disappears, it typically means that Debian has new patches
-        # (probably security) and updating to new tarball will apply them as well.
+        # This URL should point to a stable location that does not easily
+        # disappear.  In the past we were using `mirror://debian` but that
+        # eventually causes the files to disappear.  While that was a good sign
+        # for us to update our patch collection it does break reproducibility.
         name = "systemd-debian-patches.tar.xz";
-        url = mirror://debian/pool/main/s/systemd/systemd_239-12~bpo9+1.debian.tar.xz;
+        url = http://snapshot.debian.org/archive/debian/20190301T035241Z/pool/main/s/systemd/systemd_239-12%7Ebpo9%2B1.debian.tar.xz;
         sha256 = "0v9f62gyfiw5icdrdlcvjcipsqrsm49w6n8bqp9nb8s2ih6rsfhg";
       };
       # Note that we skip debian-specific patches, i.e. ./debian/patches/debian/*


### PR DESCRIPTION
###### Motivation for this change

in https://github.com/NixOS/nixpkgs/pull/56184#issuecomment-475829731 @qolii reported that the currently used debian patchset is gone from the mirrors. While the comment in the source suggested that we update them to a newer version in that case we should probably take a different approach in general. Having a systemd version in the tree that breaks after enough time has passed is probably a bad idea and we should use a stable source for the patches.

This change should be a no-op and safe to pick into our release branches that carry this version of systemd.

cc the usual systemd folks: @fpletz @vcunat @Mic92.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
