### PR TITLE
brillo: init at 1.4.8

### DIFF
--- a/nixos/modules/hardware/brillo.nix
+++ b/nixos/modules/hardware/brillo.nix
@@ -1,0 +1,22 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.hardware.brillo;
+in
+{
+  options = {
+    hardware.brillo = {
+      enable = mkEnableOption ''
+        Enable brillo in userspace.
+        This will allow brightness control from users in the video group.
+      '';
+    };
+  };
+
+
+  config = mkIf cfg.enable {
+    services.udev.packages = [ pkgs.brillo ];
+    environment.systemPackages = [ pkgs.brillo ];
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -39,6 +39,7 @@
   ./hardware/all-firmware.nix
   ./hardware/bladeRF.nix
   ./hardware/brightnessctl.nix
+  ./hardware/brillo.nix
   ./hardware/ckb-next.nix
   ./hardware/cpu/amd-microcode.nix
   ./hardware/cpu/intel-microcode.nix

--- a/pkgs/os-specific/linux/brillo/default.nix
+++ b/pkgs/os-specific/linux/brillo/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitLab , go-md2man, coreutils, substituteAll }:
+
+stdenv.mkDerivation rec {
+  pname = "brillo";
+  version = "1.4.8";
+
+  src = fetchFromGitLab {
+    owner= "cameronnemo";
+    repo= "brillo";
+    rev= "v${version}";
+    sha256 = "0wxvg541caiwm3bjwbmk7xcng7jd9xsiga2agxwp7gpkrlp74j9f";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./udev-rule.patch;
+      inherit coreutils;
+    })
+  ];
+
+  nativeBuildInputs = [ go-md2man ];
+
+  makeFlags = [ "PREFIX=$(out)" "AADIR=$(out)/etc/apparmor.d" ];
+
+  installTargets = "install-dist";
+
+  meta = with stdenv.lib; {
+    description = "Backlight and Keyboard LED control tool";
+    homepage = https://gitlab.com/cameronnemo/brillo;
+    license = [ licenses.gpl3 licenses.bsd0 ];
+    platforms = platforms.linux;
+    maintainers = [ maintainers.alexarice ];
+  };
+}

--- a/pkgs/os-specific/linux/brillo/udev-rule.patch
+++ b/pkgs/os-specific/linux/brillo/udev-rule.patch
@@ -1,0 +1,13 @@
+diff --git a/contrib/udev.in b/contrib/udev.in
+index 0625952..a6c940e 100644
+--- a/contrib/udev.in
++++ b/contrib/udev.in
+@@ -1,4 +1,4 @@
+-ACTION=="add", SUBSYSTEM=="backlight", RUN+="/bin/chgrp @group@ /sys/class/backlight/%k/brightness"
+-ACTION=="add", SUBSYSTEM=="backlight", RUN+="/bin/chmod g+w /sys/class/backlight/%k/brightness"
+-ACTION=="add", SUBSYSTEM=="leds", RUN+="/bin/chgrp @group@ /sys/class/leds/%k/brightness"
+-ACTION=="add", SUBSYSTEM=="leds", RUN+="/bin/chmod g+w /sys/class/leds/%k/brightness"
++ACTION=="add", SUBSYSTEM=="backlight", RUN+="@coreutils@/bin/chgrp @group@ /sys/class/backlight/%k/brightness"
++ACTION=="add", SUBSYSTEM=="backlight", RUN+="@coreutils@/bin/chmod g+w /sys/class/backlight/%k/brightness"
++ACTION=="add", SUBSYSTEM=="leds", RUN+="@coreutils@/bin/chgrp @group@ /sys/class/leds/%k/brightness"
++ACTION=="add", SUBSYSTEM=="leds", RUN+="@coreutils@/bin/chmod g+w /sys/class/leds/%k/brightness"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14790,6 +14790,8 @@ in
 
   bt-fw-converter = callPackage ../os-specific/linux/firmware/bt-fw-converter { };
 
+  brillo = callPackage ../os-specific/linux/brillo { };
+
   broadcom-bt-firmware = callPackage ../os-specific/linux/firmware/broadcom-bt-firmware { };
 
   batctl = callPackage ../os-specific/linux/batman-adv/batctl.nix { };


### PR DESCRIPTION
###### Motivation for this change
I wanted to use the brillo tool for backlight control on wayland but i could not find it.

###### Things done
Added brillo to nixpkgs/pkgs/os-specific/linux/brillo and added myself as a maintainer of it.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I have not tried to add a nix package before so please let me know if I have messed something up.