### PR TITLE
conan: fix pluginbase version requirement

### DIFF
--- a/pkgs/development/tools/build-managers/conan/default.nix
+++ b/pkgs/development/tools/build-managers/conan/default.nix
@@ -63,6 +63,11 @@ in newPython.pkgs.buildPythonApplication rec {
     mkdir -p "$HOME"
   '';
 
+  postPatch = ''
+    substituteInPlace conans/requirements_server.txt \
+      --replace "pluginbase>=0.5, < 1.0" "pluginbase>=0.5"
+  '';
+
   meta = with lib; {
     homepage = https://conan.io;
     description = "Decentralized and portable C/C++ package manager";


### PR DESCRIPTION
###### Motivation for this change

The version for pluginbase available in nixpkgs is 1.0.0, but conan [requires < 1.0.0](https://github.com/conan-io/conan/blob/d8b859a04697e5111b65c35d6e73853a53e0ab23/conans/requirements_server.txt#L3). This PR patches that requirement.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
