### PR TITLE
password-store: link ext. man pages into the password-store $out

### DIFF
--- a/pkgs/tools/security/pass/default.nix
+++ b/pkgs/tools/security/pass/default.nix
@@ -73,6 +73,9 @@ let
       # Link extensions env
       rmdir $out/lib/password-store/extensions
       ln -s ${extensionsEnv}/lib/password-store/extensions $out/lib/password-store/.
+      for f in ${extensionsEnv}/share/man/man1/*.1.gz; do
+          ln -s $f $out/share/man/man1/
+      done
 
       # Fix program name in --help
       substituteInPlace $out/bin/pass \


### PR DESCRIPTION
###### Motivation for this change

When pass was installed with extensions in the system environment, the
man pages for the selected extensions were not available globally
because they were only available in a buildInput of the password-store
derivation.

Bug 56850

###### Things done

This commit resolves the problem by linking the man pages from the
extensions environment into the output directory of the password-store
derivation.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).