### PR TITLE
ghcjs-ng: unbreak

### DIFF
--- a/pkgs/development/compilers/ghcjs-ng/common-overrides.nix
+++ b/pkgs/development/compilers/ghcjs-ng/common-overrides.nix
@@ -5,4 +5,5 @@ in self: super: {
   ghc-api-ghcjs = addBuildTools super.ghc-api-ghcjs [alex happy];
   ghcjs = dontHaddock (appendConfigureFlag (doJailbreak super.ghcjs) "-fno-wrapper-install");
   haddock-library-ghcjs = dontHaddock super.haddock-library-ghcjs;
+  system-fileio = doJailbreak super.system-fileio;
 }

--- a/pkgs/development/compilers/ghcjs-ng/default.nix
+++ b/pkgs/development/compilers/ghcjs-ng/default.nix
@@ -105,6 +105,5 @@ in stdenv.mkDerivation {
 
     meta.platforms = passthru.bootPkgs.ghc.meta.platforms;
     meta.maintainers = [lib.maintainers.elvishjerricco];
-    meta.broken = true;
     meta.hydraPlatforms = [];
   }


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
