### PR TITLE
Firefox configurable 

### DIFF
--- a/doc/package-notes.xml
+++ b/doc/package-notes.xml
@@ -654,6 +654,83 @@ overrides = self: super: rec {
 </screen>
   </section>
  </section>
+ <section xml:id="sec-firefox">
+  <title>Firefox</title>
+
+  <section xml:id="sec-firefox-config">
+   <title>Configuring the Firefox Wrapper</title>
+
+   <para>
+    The firefox (wrapper) package can be configured through several mechanisms.
+    The
+    <link xlink:href="https://support.mozilla.org/en-US/kb/customizing-firefox-using-autoconfig">
+    AutoConfig </link> method, and the more recent
+    <link xlink:href="https://github.com/mozilla/policy-templates/blob/master/README.md">
+    enterprise policies</link> corresponding to the <literal> extraPrefs
+    </literal> and <literal> extraPolicies </literal> arguments of the firefox
+    wrapper package.
+   </para>
+
+   <para>
+    For example the option <literal>media.autoplay.default=1</literal> which
+    disables autoplaying videos, could be specified as follows (the syntax of
+    AutoConfig is a superset of user.js):
+<programlisting>
+firefox.override {
+  extraPrefs = ''
+    pref("media.autoplay.default",1);
+  '';
+}
+</programlisting>
+    To disable upload of telemetry data, you could use:
+<programlisting>
+firefox.override {
+  extraPolicies = {
+    DisableTelemetry = true;
+  };
+}
+</programlisting>
+    Notice that <literal>extraPolicies</literal> uses nix syntax, which will
+    get converted to json internally for the policies.json file.
+   </para>
+
+   <para>
+    The policies framework can also be used to enforce the installation of
+    extensions, but with a few caveats, as this approach to managing extensions
+    is somewhat imperative in nature:
+   </para>
+
+   <para>
+    At the time of this writing, this method will only install the extensions
+    on startup. For example if you remove the option from the override, the
+    extension will still persist. This is currently a limitation of the
+    upstream policies framework, as the extension will get installed
+    <emphasis>into the users firefox profile directory</emphasis>. Also note,
+    that the way this is handled upstream is still very much in flow, so this
+    should be considered <emphasis>experimental</emphasis>.
+   </para>
+
+   <para>
+<programlisting>
+firefox.override {
+  extraPolicies.Extensions.Install = [ <literal> extension-url </literal> ];
+}
+</programlisting>
+    where <literal> extension-url </literal> is an url pointing to the xpi file
+    of the extension. For example
+<programlisting>
+https://addons.mozilla.org/firefox/downloads/file/1189923/noscript_security_suite-latest-fx.xpi
+</programlisting>
+    for the latest version of the noscript suite. It can also be a local file
+    (a zip file containing the extensions files, renamed after its addon id,
+    followed by the <literal>.xpi</literal> extension to be precise), but then
+    you likely need to set <literal>xpinstall.signatures.required</literal> to
+    <literal>false</literal> in <literal>extraPrefs</literal> or
+    <literal>user.js / about:config</literal>, unless your local extension is
+    signed by mozilla.
+   </para>
+  </section>
+ </section>
  <section xml:id="sec-weechat">
   <title>Weechat</title>
 

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -1,5 +1,5 @@
 { pname, ffversion, meta, updateScript ? null
-, src, unpackPhase ? null, patches ? []
+, src, unpackPhase ? null, patches ? [], installAutoConfig ? false
 , extraNativeBuildInputs ? [], extraConfigureFlags ? [], extraMakeFlags ? []
 , isIceCatLike ? false, icversion ? null
 , isTorBrowserLike ? false, tbversion ? null }:
@@ -311,6 +311,15 @@ stdenv.mkDerivation rec {
 
     # Needed to find Mozilla runtime
     gappsWrapperArgs+=(--argv0 "$out/bin/.${binaryName}-wrapped")
+  ''
+    # As for why this is needed, see: https://support.mozilla.org/en-US/kb/customizing-firefox-using-autoconfig
+    + lib.optionalString (stdenv.isLinux && installAutoConfig) ''
+    # Prepare for autoconfig
+    mkdir -p "$out/lib/firefox/defaults/pref"
+    cat > "$out/lib/firefox/defaults/pref/autoconfig.js" <<EOF
+      pref("general.config.filename", "mozilla.cfg");
+      pref("general.config.obscure_value", 0);
+    EOF
   '';
 
   postFixup = lib.optionalString stdenv.isLinux ''

--- a/pkgs/applications/networking/browsers/firefox/env_var_for_autoconfig.patch
+++ b/pkgs/applications/networking/browsers/firefox/env_var_for_autoconfig.patch
@@ -1,0 +1,33 @@
+diff --git a/extensions/pref/autoconfig/src/nsReadConfig.cpp b/extensions/pref/autoconfig/src/nsReadConfig.cpp
+--- a/extensions/pref/autoconfig/src/nsReadConfig.cpp
++++ b/extensions/pref/autoconfig/src/nsReadConfig.cpp
+@@ -23,6 +23,7 @@
+ #include "nsString.h"
+ #include "nsCRT.h"
+ #include "nspr.h"
++#include "prenv.h"
+ #include "nsXULAppAPI.h"
+ 
+ extern bool sandboxEnabled;
+@@ -237,8 +238,19 @@ nsresult nsReadConfig::openAndEvaluateJSFile(const char *aFileName,
+   nsCOMPtr<nsIInputStream> inStr;
+   if (isBinDir) {
+     nsCOMPtr<nsIFile> jsFile;
+-    rv = NS_GetSpecialDirectory(NS_GRE_DIR, getter_AddRefs(jsFile));
+-    if (NS_FAILED(rv)) return rv;
++
++    const char* pathVar = PR_GetEnv("MOZ_AUTOCONFIG_DIR");
++    if (pathVar && *pathVar) {
++      rv = NS_NewNativeLocalFile(nsDependentCString(pathVar), false, getter_AddRefs(jsFile));
++      if (NS_FAILED(rv)) {
++        rv = NS_GetSpecialDirectory(NS_GRE_DIR, getter_AddRefs(jsFile));
++        if (NS_FAILED(rv)) return rv;
++      }
++    } else {
++      rv = NS_GetSpecialDirectory(NS_GRE_DIR, getter_AddRefs(jsFile));
++      if (NS_FAILED(rv)) return rv;
++    }
++
+ 
+     rv = jsFile->AppendNative(nsDependentCString(aFileName));
+     if (NS_FAILED(rv)) return rv;

--- a/pkgs/applications/networking/browsers/firefox/env_var_for_policies.patch
+++ b/pkgs/applications/networking/browsers/firefox/env_var_for_policies.patch
@@ -1,0 +1,22 @@
+diff --git a/browser/components/enterprisepolicies/EnterprisePolicies.js b/browser/components/enterprisepolicies/EnterprisePolicies.js
+--- a/browser/components/enterprisepolicies/EnterprisePolicies.js
++++ b/browser/components/enterprisepolicies/EnterprisePolicies.js
+@@ -5,6 +5,8 @@
+ ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
+ ChromeUtils.import("resource://gre/modules/Services.jsm");
+ ChromeUtils.import("resource://gre/modules/AppConstants.jsm");
++ChromeUtils.import("resource://gre/modules/FileUtils.jsm");
++ChromeUtils.import("resource://gre/modules/Subprocess.jsm");
+ 
+ XPCOMUtils.defineLazyModuleGetters(this, {
+   WindowsGPOParser: "resource:///modules/policies/WindowsGPOParser.jsm",
+@@ -341,7 +343,8 @@ class JSONPoliciesProvider {
+   _getConfigurationFile() {
+     let configFile = null;
+     try {
+-      configFile = Services.dirsvc.get("XREAppDist", Ci.nsIFile);
++      const env = Subprocess.getEnvironment();
++      configFile = env.MOZ_POLICIES_DIR ? new FileUtils.File(env.MOZ_POLICIES_DIR) : Services.dirsvc.get("XREAppDist", Ci.nsIFile);
+       configFile.append(POLICIES_FILENAME);
+     } catch (ex) {
+       // Getting the correct directory will fail in xpcshell tests. This should

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -35,6 +35,7 @@ rec {
       attrPath = "firefox-unwrapped";
       versionKey = "ffversion";
     };
+    installAutoConfig = true;
   };
 
   # Do not remove. This is the last version of Firefox that supports

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -18,6 +18,8 @@ rec {
 
     patches = [
       ./no-buildconfig-ffx65.patch
+      ./env_var_for_policies.patch
+      ./env_var_for_autoconfig.patch
     ];
 
     extraNativeBuildInputs = [ python3 ];


### PR DESCRIPTION
###### Motivation for this change

This is the same as #57554, except for the implementation, which differs. This pull request patches the browser to take the configuration directories from environment variables, which can then be set in e.g. the wrapper (the original pr did some symlink trickery).

###### Things done

I tested this with firefox on NixOS, but I did not, and probably cannot test it on darwin.
~~Also as is, this also patches all the variants of firefox, we may want to limit that to just firefox?
The tor-browser-bundle in particular already has some code that deals with AutoConfig in its derivation, I am not sure how this fits together.~~ I pushed changes to only patch firefox proper. 

 