### PR TITLE
syslinux: change serial bit rate to 115200

### DIFF
--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -88,7 +88,7 @@ let
   #     result in incorrect boot entries.
 
   baseIsolinuxCfg = ''
-    SERIAL 0 38400
+    SERIAL 0 115200
     TIMEOUT ${builtins.toString syslinuxTimeout}
     UI vesamenu.c32
     MENU TITLE NixOS


### PR DESCRIPTION
Prior to this commit an installation over serial via syslinux would
involve:
1. setting bitrate to BIOS's bitrate (varies, the recent PC Engines and Netgates are 115200)
2. setting bitrate to syslinux's bitrate (38400)
3. setting bitrate to stty's bitrate (115200)

By changing syslinux's bitrate to 115200, an installation over serial
is a smoother experience, and consistent with the [GRUB2 installation
which is also 115200 bps](https://github.com/NixOS/nixpkgs/blob/2c07a0800a76be01a3c255f39e21877a9a389f84/nixos/modules/installer/cd-dvd/iso-image.nix#L311-L317).

    [root@nixos:~]# stty
    speed 115200 baud; line = 0;
    -brkint ixoff iutf8
    -iexten

In a future commit I will add default serial terminals to the syslinux
kernel lines.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
