### PR TITLE
pantheon.elementary-default-settings: 5.0 -> 5.1.0 

### DIFF
--- a/pkgs/desktops/pantheon/desktop/elementary-default-settings/correct-override.patch
+++ b/pkgs/desktops/pantheon/desktop/elementary-default-settings/correct-override.patch
@@ -1,7 +1,7 @@
-diff --git a/debian/elementary-default-settings.gsettings-override b/debian/elementary-default-settings.gsettings-override
-index 6452c30..899972d 100644
---- a/debian/elementary-default-settings.gsettings-override
-+++ b/debian/elementary-default-settings.gsettings-override
+diff --git a/overrides/default-settings.gschema.override b/overrides/default-settings.gschema.override
+index 1aef29c..08de164 100644
+--- a/overrides/default-settings.gschema.override
++++ b/overrides/default-settings.gschema.override
 @@ -1,5 +1,5 @@
  [net.launchpad.plank.dock.settings]
 -dock-items=['gala-multitaskingview.dockitem','org.gnome.Epiphany.dockitem','org.pantheon.mail.dockitem','io.elementary.calendar.dockitem','io.elementary.music.dockitem','io.elementary.videos.dockitem','io.elementary.photos.dockitem','io.elementary.switchboard.dockitem','io.elementary.appcenter.dockitem']

--- a/pkgs/desktops/pantheon/desktop/elementary-default-settings/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-default-settings/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "default-settings";
-  version = "5.0";
+  version = "5.1.0";
 
   name = "elementary-${pname}-${version}";
 
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "0gyv835qbr90001gda2pzngzzbbk5jf9grgfl25pqkm29s45rqq0";
+    sha256 = "0l73py4rr56i4dalb2wh1c6qiwmcjkm0l1j75jp5agcnxldh5wym";
   };
 
   passthru = {
@@ -21,16 +21,6 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    # See: https://github.com/elementary/default-settings/pull/86 (didn't make 5.0 release)
-    (fetchpatch {
-      url = "https://github.com/elementary/default-settings/commit/05d0b2a4e98c28203521d599b40745b46be549fa.patch";
-      sha256 = "1wk1qva3yzc28gljnkx9hb3pwhqnfrsb08wd76lsl3xnylg0wn2l";
-    })
-    # See: https://github.com/elementary/default-settings/pull/94 (didn't make 5.0 release)
-    (fetchpatch {
-      url = "https://github.com/elementary/default-settings/commit/a2ca00130c16e805179fb5abd7b624a873dff2da.patch";
-      sha256 = "1jp1c5d8jfm0404zsylfk7h9vj81s409wgbzbsd2kxmz65icq16x";
-    })
     ./correct-override.patch
   ];
 
@@ -41,7 +31,7 @@ stdenv.mkDerivation rec {
     cp -av settings.ini $out/etc/gtk-3.0
 
     mkdir -p $out/share/glib-2.0/schemas
-    cp -av debian/elementary-default-settings.gsettings-override $out/share/glib-2.0/schemas/20-io.elementary.desktop.gschema.override
+    cp -av overrides/default-settings.gschema.override $out/share/glib-2.0/schemas/20-io.elementary.desktop.gschema.override
 
     mkdir $out/etc/wingpanel.d
     cp -avr ${./io.elementary.greeter.whitelist} $out/etc/wingpanel.d/io.elementary.greeter.whitelist

--- a/pkgs/desktops/pantheon/desktop/elementary-gsettings-schemas/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-gsettings-schemas/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, runCommand, gnome3, elementary-default-settings, nixos-artwork, glib, gala, epiphany, elementary-settings-daemon, gtk3, plank
+{ stdenv, runCommand, gnome3, elementary-default-settings, nixos-artwork, glib, gala, epiphany, elementary-settings-daemon, gtk3, plank, gsettings-desktop-schemas
 , extraGSettingsOverrides ? ""
 , extraGSettingsOverridePackages ? []
 }:
@@ -6,10 +6,11 @@
 let
 
   gsettingsOverridePackages = [
-    gala
-    epiphany
     elementary-settings-daemon
+    epiphany
+    gala
     gnome3.mutter
+    gsettings-desktop-schemas
     gtk3
     plank
   ] ++ extraGSettingsOverridePackages;
@@ -32,8 +33,6 @@ runCommand "elementary-gsettings-desktop-schemas" {}
 
      cat - > $out/share/gsettings-schemas/nixos-gsettings-overrides/glib-2.0/schemas/nixos-defaults.gschema.override <<- EOF
      [org.gnome.desktop.background]
-     draw-background=true
-     picture-options='zoom'
      picture-uri='${nixos-artwork.wallpapers.simple-dark-gray}/share/artwork/gnome/nix-wallpaper-simple-dark-gray.png'
      primary-color='#000000'
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
