### PR TITLE
Add dunst service

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -838,6 +838,7 @@
   ./services/x11/hardware/wacom.nix
   ./services/x11/gdk-pixbuf.nix
   ./services/x11/redshift.nix
+  ./services/x11/dunst.nix
   ./services/x11/urxvtd.nix
   ./services/x11/window-managers/awesome.nix
   ./services/x11/window-managers/default.nix

--- a/nixos/modules/services/x11/dunst.nix
+++ b/nixos/modules/services/x11/dunst.nix
@@ -1,0 +1,137 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+   cfg = config.services.dunst;
+   reservedSections = [
+     "global" "experimental" "frame" "shortcuts"
+     "urgency_low" "urgency_normal" "urgency_critical"
+   ];
+in {
+
+options.services.dunst = {
+
+  enable = mkEnableOption "the dunst notifications daemon";
+
+  iconDirs = mkOption {
+    type = with types; listOf path;
+    default = [];
+    example = literalExample ''
+      [ "''${pkgs.gnome3.adwaita-icon-theme}/share/icons/Adwaita/48x48" ]
+    '';
+    description = ''
+      Paths to icon folders.
+    '';
+  };
+
+  extraArgs = mkOption {
+    type = with types; listOf str;
+    default = [];
+    description = ''
+      Extra command line options for dunst
+    '';
+  };
+
+  globalConfig = mkOption {
+    type = with types; attrsOf str;
+    default = {};
+    description = ''
+      The global configuration section for dunst.
+    '';
+  };
+
+  shortcutConfig = mkOption {
+    type = with types; attrsOf str;
+    default = {};
+    description = ''
+      The shortcut configuration for dunst.
+    '';
+  };
+
+  urgencyConfig = {
+    low = mkOption {
+      type = with types; attrsOf str;
+      default = {};
+      description = ''
+        The low urgency section of the dunst configuration.
+      '';
+    };
+    normal = mkOption {
+      type = with types; attrsOf str;
+      default = {};
+      description = ''
+        The normal urgency section of the dunst configuration.
+      '';
+    };
+    critical = mkOption {
+      type = with types; attrsOf str;
+      default = {};
+      description = ''
+        The critical urgency section of the dunst configuration.
+      '';
+    };
+  };
+
+  rules = mkOption {
+    type = with types; attrsOf (attrsOf str);
+    default = {};
+    description = ''
+       These rules allow the conditional modification of notifications.
+
+       Note that rule names may not be one of the following
+       keywords already used internally:
+         ${concatStringsSep ", " reservedSections}
+       There are 2 parts in configuring a rule: Defining when a rule
+       matches and should apply (called filtering in the man page)
+       and then the actions that should be taken when the rule is
+       matched (called modifying in the man page).
+    '';
+    example = literalExample ''
+      signed_off = {
+        appname = "Pidgin";
+        summary = "*signed off*";
+        urgency = "low";
+        script = "pidgin-signed-off.sh";
+      };
+    '';
+  };
+
+};
+
+config =
+  let
+    dunstConfig = lib.generators.toINI {} allOptions;
+    allOptions = {
+      global = cfg.globalConfig;
+      shortcut = cfg.shortcutConfig;
+      urgency_normal = cfg.urgencyConfig.normal;
+      urgency_low = cfg.urgencyConfig.low;
+      urgency_critical = cfg.urgencyConfig.critical;
+    } // cfg.rules;
+
+    iconPath = concatStringsSep ":" cfg.iconDirs;
+
+    dunst-args = [
+      "-config" (pkgs.writeText "dunstrc" dunstConfig)
+      "-icon_path" iconPath
+    ] ++ cfg.extraArgs;
+
+  in mkIf cfg.enable {
+
+    assertions = flip mapAttrsToList cfg.rules (name: conf: {
+      assertion = ! elem name reservedSections;
+      message = ''
+        dunst config: ${name} is a reserved keyword. Please choose
+        a different name for the rule.
+      '';
+    });
+
+    systemd.user.services.dunst.serviceConfig.ExecStart = [ "" "${pkgs.dunst}/bin/dunst ${escapeShellArgs dunst-args}" ];
+    # [ "" ... ] is needed to overwrite the ExecStart directive from the upstream service file
+
+    systemd.packages = [ pkgs.dunst ];
+    services.dbus.packages = [ pkgs.dunst ];
+  };
+
+}


### PR DESCRIPTION
###### Motivation for this change

This is a fresh attempt at implementing #19183

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
