### PR TITLE
firefoxPackages.tor-browser: 8.0.6 -> 8.0.8

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -251,8 +251,10 @@ stdenv.mkDerivation rec {
   # and wants these
   ++ lib.optionals isTorBrowserLike ([
     "--with-tor-browser-version=${tbversion}"
+    "--with-distribution-id=org.torproject"
     "--enable-signmar"
     "--enable-verify-mar"
+    "--enable-bundled-fonts"
   ])
 
   ++ flag alsaSupport "alsa"

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -232,16 +232,16 @@ in rec {
   };
 
   tor-browser-8-0 = tbcommon rec {
-    ffversion = "60.5.1esr";
-    tbversion = "8.0.6";
+    ffversion = "60.6.1esr";
+    tbversion = "8.0.8";
 
     # FIXME: fetchFromGitHub is not ideal, unpacked source is >900Mb
     src = fetchFromGitHub {
       owner = "SLNOS";
       repo  = "tor-browser";
-      # branch "tor-browser-60.5.1esr-8.0-1-slnos"
-      rev   = "89be91fc7cbc420b7c4a3bfc36d2b0d500dd3ccf";
-      sha256 = "022zjfwsdl0dkg6ck2kha4nf91xm3j9ag5n21zna98szg3x82dj1";
+      # branch "tor-browser-60.6.1esr-8.0-1-slnos"
+      rev   = "dda14213c550afc522ef0bb0bb1643289c298736";
+      sha256 = "0lj79nczcix9mx6d0isbizg0f8apf6vgkp7r0q7id92691frj7fz";
     };
   };
 

--- a/pkgs/applications/networking/browsers/tor-browser-bundle/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser-bundle/default.nix
@@ -340,9 +340,7 @@ stdenv.mkDerivation rec {
       `tor-browser-bundle` needs for the bundling using a much simpler patch. See the
       longDescription and expression of the `firefoxPackages.tor-browser` package for more info.
     '';
-    homepage = https://torproject.org/;
-    license = licenses.free;
-    platforms = [ "x86_64-linux" ];
+    inherit (tor-browser-unwrapped.meta) homepage platforms license;
     hydraPlatforms = [ ];
     maintainers = with maintainers; [ joachifm ];
   };


### PR DESCRIPTION
# `git log`

- firefoxPackages.tor-browser: 8.0.6 -> 8.0.8

- firefoxPackages.tor-browser: carry over more configureFlags from upstream

  These are taken from `tor-browser-build.git` repository.

- tor-browser-bundle: inherit meta

# `nix-instantiate` environment

- Host OS: Linux 4.9, SLNOS 19.09
- Nix: nix-env (Nix) 2.2
- Multi-user: yes
- Sandbox: yes
- NIXPKGS_CONFIG:

```nix
{
  checkMeta = true;
  doCheckByDefault = true;
}
```

# `nix-env -qaP` diffs

- On x86_64-linux:
  - Updated (3):
    - firefoxPackages.tor-browser
    - firefoxPackages.tor-browser-7-5
    - tor-browser-bundle
- On aarch64-linux:
  - New (1):
    - tor-browser-bundle
  - Updated (2):
    - firefoxPackages.tor-browser
    - firefoxPackages.tor-browser-7-5
- On x86_64-darwin:
  - Updated (2):
    - firefoxPackages.tor-browser
    - firefoxPackages.tor-browser-7-5

/cc @joachifm