### PR TITLE
treewide: no gnome aliases

### DIFF
--- a/pkgs/applications/audio/parlatype/default.nix
+++ b/pkgs/applications/audio/parlatype/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pkgconfig, meson, gnome3, at-spi2-core, dbus, gst_all_1, sphinxbase, pocketsphinx, ninja, gettext, appstream-glib, python3, glib, gobject-introspection, gsettings-desktop-schemas, itstool, wrapGAppsHook, makeWrapper, hicolor-icon-theme }:
+{ stdenv, fetchFromGitHub, pkgconfig, meson, gtk3, at-spi2-core, dbus, gst_all_1, sphinxbase, pocketsphinx, ninja, gettext, appstream-glib, python3, glib, gobject-introspection, gsettings-desktop-schemas, itstool, wrapGAppsHook, makeWrapper, hicolor-icon-theme }:
 
 stdenv.mkDerivation rec {
   pname = "parlatype";
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    gnome3.gtk
+    gtk3
     at-spi2-core
     dbus
     gst_all_1.gstreamer

--- a/pkgs/applications/audio/rhythmbox/default.nix
+++ b/pkgs/applications/audio/rhythmbox/default.nix
@@ -4,6 +4,7 @@
 , perlPackages
 , gtk3
 , intltool
+, libpeas
 , libsoup
 , gnome3
 , totem-pl-parser
@@ -48,7 +49,7 @@ in stdenv.mkDerivation rec {
     json-glib
 
     gtk3
-    gnome3.libpeas
+    libpeas
     totem-pl-parser
     gnome3.adwaita-icon-theme
 

--- a/pkgs/applications/backup/deja-dup/default.nix
+++ b/pkgs/applications/backup/deja-dup/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitLab, substituteAll, meson, ninja, pkgconfig, vala_0_40, gettext
 , gnome3, libnotify, itstool, glib, gtk3, libxml2
-, coreutils, libsecret, pcre, libxkbcommon, wrapGAppsHook
+, coreutils, libpeas, libsecret, pcre, libxkbcommon, wrapGAppsHook
 , libpthreadstubs, libXdmcp, epoxy, at-spi2-core, dbus, libgpgerror
 , appstream-glib, desktop-file-utils, duplicity
 }:
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-   libnotify gnome3.libpeas glib gtk3 libsecret
+   libnotify libpeas glib gtk3 libsecret
    pcre libxkbcommon libpthreadstubs libXdmcp epoxy gnome3.nautilus
    at-spi2-core dbus gnome3.gnome-online-accounts libgpgerror
   ];

--- a/pkgs/applications/editors/gnome-builder/default.nix
+++ b/pkgs/applications/editors/gnome-builder/default.nix
@@ -17,6 +17,7 @@
 , json-glib
 , jsonrpc-glib
 , libdazzle
+, libpeas
 , libxml2
 , meson
 , ninja
@@ -64,7 +65,7 @@ in stdenv.mkDerivation {
     flatpak
     gnome3.devhelp
     libgit2-glib
-    gnome3.libpeas
+    libpeas
     vte
     gspell
     gtk3

--- a/pkgs/applications/editors/jucipp/default.nix
+++ b/pkgs/applications/editors/jucipp/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchgit, gnome3, at-spi2-core,
+{ stdenv, fetchgit, gnome3, gtksourceview3, at-spi2-core, gtksourceviewmm,
   boost, epoxy, cmake, aspell, llvmPackages, libgit2, pkgconfig, pcre,
-  libXdmcp, libxkbcommon, libpthreadstubs, wrapGAppsHook, aspellDicts,
+  libXdmcp, libxkbcommon, libpthreadstubs, wrapGAppsHook, aspellDicts, gtkmm3,
   coreutils, glibc, dbus, openssl, libxml2, gnumake, ctags }:
 
 with stdenv.lib;
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     dbus
     openssl
     libxml2
-    gnome3.gtksourceview
+    gtksourceview3
     at-spi2-core
     pcre
     epoxy
@@ -39,9 +39,9 @@ stdenv.mkDerivation rec {
     aspell
     libgit2
     libxkbcommon
-    gnome3.gtkmm3
+    gtkmm3
     libpthreadstubs
-    gnome3.gtksourceviewmm
+    gtksourceviewmm
     llvmPackages.clang.cc
     llvmPackages.lldb
     gnome3.dconf

--- a/pkgs/applications/misc/gImageReader/default.nix
+++ b/pkgs/applications/misc/gImageReader/default.nix
@@ -7,7 +7,7 @@
 # Gtk deps
 # upstream gImagereader supports Qt too
 , gtk3, gobject-introspection, wrapGAppsHook
-, gnome3, gtkspell3, gtkspellmm, cairomm
+, gnome3, gtkmm3, gtksourceview3, gtksourceviewmm, gtkspell3, gtkspellmm, cairomm
 }:
 
 let
@@ -48,11 +48,11 @@ stdenv.mkDerivation rec {
     poppler
 
     # Gtk specific
-    gnome3.gtkmm
+    gtkmm3
     gtkspell3
     gtkspellmm
-    gnome3.gtksourceview
-    gnome3.gtksourceviewmm
+    gtksourceview3
+    gtksourceviewmm
     cairomm
     json-glib
   ];

--- a/pkgs/applications/office/autokey/default.nix
+++ b/pkgs/applications/office/autokey/default.nix
@@ -1,5 +1,5 @@
 { lib, python3Packages, fetchFromGitHub, wrapGAppsHook, gobject-introspection
-, gnome3, libappindicator-gtk3, libnotify }:
+, gtksourceview3, libappindicator-gtk3, libnotify }:
 
 python3Packages.buildPythonApplication rec {
   name = "autokey-${version}";
@@ -22,7 +22,7 @@ python3Packages.buildPythonApplication rec {
   # Note: no dependencies included for Qt GUI because Qt ui is poorly
   # maintained—see https://github.com/autokey/autokey/issues/51
 
-  buildInputs = [ wrapGAppsHook gobject-introspection gnome3.gtksourceview
+  buildInputs = [ wrapGAppsHook gobject-introspection gtksourceview3
     libappindicator-gtk3 libnotify ];
 
   propagatedBuildInputs = with python3Packages; [

--- a/pkgs/applications/video/bombono/default.nix
+++ b/pkgs/applications/video/bombono/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, wrapGAppsHook, gtk2, boost, gnome2, scons,
+{ stdenv, fetchFromGitHub, wrapGAppsHook, gtk2, boost, gnome2, gtkmm2, scons,
 mjpegtools, libdvdread, dvdauthor, gettext, dvdplusrwtools, libxmlxx, ffmpeg,
 enca, pkgconfig, fetchpatch }:
 
@@ -18,20 +18,20 @@ stdenv.mkDerivation rec {
   };
 
   patches = map fetchPatchFromAur [
-    {name="fix_ffmpeg_codecid.patch";	sha256="1asfc0lqzk4gjssrvjmsi1xr53ygnsx2sh7c8yzp5r3j2bagxhp7";}
-    {name="fix_ptr2bool_cast.patch";	sha256="0iqzrmbg38ikh4x9cmx0v0rnm7a9lcq0kd8sh1z9yfmnz71qqahg";}
-    {name="fix_c++11_literal_warnings.patch";	sha256="1zbf12i77p0j0090pz5lzg4a7kyahahzqssybv7vi0xikwvw57w9";}
-    {name="autoptr2uniqueptr.patch";	sha256="0a3wvwfplmqvi8fnj929y85z3h1iq7baaz2d4v08h1q2wbmakqdm";}
-    {name="fix_deprecated_boost_api.patch";	sha256="184gdz3w95ihhsd8xscpwvq77xd4il47kvmv6wslax77xyw50gm8";}
-    {name="fix_throw_specifications.patch";	sha256="1f5gi3qwm843hsxvijq7sjy0s62xm7rnr1vdp7f242fi0ldq6c1n";}
-    {name="fix_operator_ambiguity.patch";	sha256="0r4scsbsqfg6wgzsbfxxpckamvgyrida0n1ypg1klx24pk5dc7n7";}
-    {name="fix_ffmpeg30.patch";	sha256="1irva7a9bpbzs60ga8ypa3la9y84i5rz20jnd721qmfqp2yip8dw";}
+    {name="fix_ffmpeg_codecid.patch";         sha256="1asfc0lqzk4gjssrvjmsi1xr53ygnsx2sh7c8yzp5r3j2bagxhp7";}
+    {name="fix_ptr2bool_cast.patch";          sha256="0iqzrmbg38ikh4x9cmx0v0rnm7a9lcq0kd8sh1z9yfmnz71qqahg";}
+    {name="fix_c++11_literal_warnings.patch"; sha256="1zbf12i77p0j0090pz5lzg4a7kyahahzqssybv7vi0xikwvw57w9";}
+    {name="autoptr2uniqueptr.patch";          sha256="0a3wvwfplmqvi8fnj929y85z3h1iq7baaz2d4v08h1q2wbmakqdm";}
+    {name="fix_deprecated_boost_api.patch";   sha256="184gdz3w95ihhsd8xscpwvq77xd4il47kvmv6wslax77xyw50gm8";}
+    {name="fix_throw_specifications.patch";   sha256="1f5gi3qwm843hsxvijq7sjy0s62xm7rnr1vdp7f242fi0ldq6c1n";}
+    {name="fix_operator_ambiguity.patch";     sha256="0r4scsbsqfg6wgzsbfxxpckamvgyrida0n1ypg1klx24pk5dc7n7";}
+    {name="fix_ffmpeg30.patch";               sha256="1irva7a9bpbzs60ga8ypa3la9y84i5rz20jnd721qmfqp2yip8dw";}
   ];
 
   nativeBuildInputs = [ wrapGAppsHook scons pkgconfig gettext ];
 
   buildInputs = [
-    gtk2 gnome2.gtkmm mjpegtools libdvdread dvdauthor boost dvdplusrwtools
+    gtk2 gtkmm2 mjpegtools libdvdread dvdauthor boost dvdplusrwtools
     libxmlxx ffmpeg enca
     ];
 

--- a/pkgs/applications/video/subtitleeditor/default.nix
+++ b/pkgs/applications/video/subtitleeditor/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, intltool, file,
-  desktop-file-utils, enchant, gnome3, gtk3, gst_all_1, hicolor-icon-theme,
+  desktop-file-utils, enchant, gnome3, gtk3, gtkmm3, gst_all_1, hicolor-icon-theme,
   libsigcxx, libxmlxx, xdg_utils, isocodes, wrapGAppsHook
 }:
 
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     desktop-file-utils
     enchant
     gtk3
-    gnome3.gtkmm
+    gtkmm3
     gst_all_1.gstreamer
     gst_all_1.gstreamermm
     gst_all_1.gst-plugins-base

--- a/pkgs/desktops/deepin/deepin-metacity/default.nix
+++ b/pkgs/desktops/deepin/deepin-metacity/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pkgconfig, intltool, libtool, gnome3, gtk3, bamf,
+{ stdenv, fetchFromGitHub, pkgconfig, intltool, libtool, gnome3, gtk3, libgtop, bamf,
   json-glib, libcanberra-gtk3, libxkbcommon, libstartup_notification,
   deepin-wallpapers, deepin-desktop-schemas, deepin }:
 
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     gnome3.dconf
     gtk3
-    gnome3.libgtop
+    libgtop
     gnome3.zenity
     bamf
     json-glib

--- a/pkgs/desktops/mate/eom/default.nix
+++ b/pkgs/desktops/mate/eom/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, itstool, dbus-glib, exempi, lcms2, libexif, libjpeg, librsvg, libxml2, shared-mime-info, gnome3, gtk3, mate, hicolor-icon-theme, wrapGAppsHook }:
+{ stdenv, fetchurl, pkgconfig, intltool, itstool, dbus-glib, exempi, lcms2, libexif, libjpeg, librsvg, libxml2, libpeas, shared-mime-info, gnome3, gtk3, mate, hicolor-icon-theme, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "eom-${version}";
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     libxml2
     shared-mime-info
     gtk3
-    gnome3.libpeas
+    libpeas
     mate.mate-desktop
     hicolor-icon-theme
   ];

--- a/pkgs/desktops/mate/mate-applets/default.nix
+++ b/pkgs/desktops/mate/mate-applets/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, itstool, gnome3, gtk3, libwnck3, libgtop, libxml2, libnotify, polkit, upower, wirelesstools, mate, hicolor-icon-theme, wrapGAppsHook }:
+{ stdenv, fetchurl, pkgconfig, intltool, itstool, gnome3, gtk3, gtksourceview3, libwnck3, libgtop, libxml2, libnotify, polkit, upower, wirelesstools, mate, hicolor-icon-theme, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "mate-applets-${version}";
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     gtk3
-    gnome3.gtksourceview
+    gtksourceview3
     gnome3.gucharmap
     libwnck3
     libgtop

--- a/pkgs/desktops/mate/pluma/default.nix
+++ b/pkgs/desktops/mate/pluma/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, itstool, isocodes, enchant, libxml2, python, gnome3, mate, wrapGAppsHook }:
+{ stdenv, fetchurl, pkgconfig, intltool, itstool, isocodes, enchant, libxml2, python, gnome3, gtksourceview3, libpeas, mate, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "pluma-${version}";
@@ -21,8 +21,8 @@ stdenv.mkDerivation rec {
     enchant
     libxml2
     python
-    gnome3.gtksourceview
-    gnome3.libpeas
+    gtksourceview3
+    libpeas
     gnome3.adwaita-icon-theme
     mate.mate-desktop
   ];

--- a/pkgs/development/libraries/aravis/default.nix
+++ b/pkgs/development/libraries/aravis/default.nix
@@ -7,6 +7,7 @@
 , gst-plugins-bad ? null
 , libnotify ? null
 , gnome3 ? null
+, gtk3 ? null
 , enableUsb ? true
 , enablePacketSocket ? true
 , enableViewer ? true
@@ -26,6 +27,7 @@ in
   assert enableViewer -> enableGstPlugin;
   assert enableViewer -> libnotify != null;
   assert enableViewer -> gnome3 != null;
+  assert enableViewer -> gtk3 != null;
   assert enableViewer -> gstreamerAtLeastVersion1;
 
   stdenv.mkDerivation rec {
@@ -54,7 +56,7 @@ in
       ++ stdenv.lib.optional enableUsb libusb
       ++ stdenv.lib.optional enablePacketSocket audit
       ++ stdenv.lib.optionals (enableViewer || enableGstPlugin) [ gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad ]
-      ++ stdenv.lib.optionals (enableViewer) [ libnotify gnome3.gtk3 gnome3.adwaita-icon-theme ];
+      ++ stdenv.lib.optionals (enableViewer) [ libnotify gtk3 gnome3.adwaita-icon-theme ];
 
     preAutoreconf = ''./autogen.sh'';
 


### PR DESCRIPTION
###### Motivation for this change
Finish the other stuff in #57112

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
