### PR TITLE
iputils: 20180629 -> 20190324

### DIFF
--- a/pkgs/os-specific/linux/iputils/build-ninfod-with-openssl.patch
+++ b/pkgs/os-specific/linux/iputils/build-ninfod-with-openssl.patch
@@ -1,0 +1,13 @@
+diff --git a/ninfod/meson.build b/ninfod/meson.build
+index ea7ec1b..fada05b 100644
+--- a/ninfod/meson.build
++++ b/ninfod/meson.build
+@@ -10,7 +10,7 @@ ninfod_sources = files('''
+ 	ninfod_name.c
+ '''.split())
+ executable('ninfod', [ninfod_sources, git_version_h],
+-	dependencies : [cap_dep, crypto_dep, rt_dep, threads],
++	dependencies : [cap_dep, dependency('openssl'), rt_dep, threads],
+ 	link_with : [libcommon],
+ 	include_directories : inc,
+ 	install: true,

--- a/pkgs/os-specific/linux/iputils/default.nix
+++ b/pkgs/os-specific/linux/iputils/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchFromGitHub, fetchpatch
-, libxslt, docbook_xsl, docbook_xml_dtd_44
-, libcap, nettle, libidn2, openssl
+, meson, ninja, pkgconfig, gettext, libxslt, docbook_xsl_ns
+, libcap, nettle, libidn2, openssl, systemd
 }:
 
 with stdenv.lib;
 
 let
-  time = "20180629";
+  time = "20190324";
   # ninfod probably could build on cross, but the Makefile doesn't pass --host
   # etc to the sub configure...
   withNinfod = stdenv.hostPlatform == stdenv.buildPlatform;
@@ -21,62 +21,36 @@ in stdenv.mkDerivation {
     owner = "iputils";
     repo = "iputils";
     rev = "s${time}";
-    sha256 = "19rpl48pjgmyqlm4h7sml5gy7yg4cxciadxcs24q1zj40c05jls0";
+    sha256 = "0b755gv3370c0rrphx14mrsqjb396zqnsm9lsws842a4k4zrqmvi";
   };
 
-  patches = [
-    (fetchpatch {
-      name = "dont-hardcode-the-location-of-xsltproc.patch";
-      url = "https://github.com/iputils/iputils/commit/d0ff83e87ea9064d9215a18e93076b85f0f9e828.patch";
-      sha256 = "05wrwf0bfmax69bsgzh3b40n7rvyzw097j8z5ix0xsg0kciygjvx";
-    })
-    (fetchpatch {
-      name = "add-missing-idn-declarations.patch";
-      url = "https://github.com/iputils/iputils/commit/5007d7067918fb3d950d34c01d059e5222db679a.patch";
-      sha256 = "0dhgxdhjcbb2q6snm3mjp38l066knykmrx4k8rn167cizn7akpdx";
-    })
-    (fetchpatch {
-      name = "fix-ping-idn.patch";
-      url = "https://github.com/iputils/iputils/commit/25899e849aa3abc1ad29ebf0b830262a859eaed5.patch";
-      sha256 = "1bqjcdjjnc2j6indcli7s7gbbhkcaligvh94asixfrmjzkbn533n";
-    })
-  ];
+  # ninfod cannot be build with nettle yet:
+  patches =
+    [ ./build-ninfod-with-openssl.patch
+      (fetchpatch { # tracepath: fix musl build, again
+        url = "https://github.com/iputils/iputils/commit/c9aca1b53324bcd1b5a2de5c645813f80eccd016.patch";
+        sha256 = "0faqgkqbi57cyx1zgzzy6xgd24xr0iawix7mjs47j92ra9gw90cz";
+      })
+      (fetchpatch { # doc: Use namespace correctly
+        url = "https://github.com/iputils/iputils/commit/c503834519d21973323980850431101f90e663ef.patch";
+        sha256 = "1yp6b6403ddccbhfzsb36cscxd36d4xb8syc1g02a18xkswiwf09";
+      })
+    ];
 
-  prePatch = ''
-    substituteInPlace doc/custom-man.xsl \
-      --replace "http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl" "${docbook_xsl}/xml/xsl/docbook/manpages/docbook.xsl"
-    for xmlFile in doc/*.xml; do
-      substituteInPlace $xmlFile \
-        --replace "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd" "${docbook_xml_dtd_44}/xml/dtd/docbook/docbookx.dtd"
-    done
-  '';
+  mesonFlags =
+    [ "-DUSE_CRYPTO=nettle"
+      "-DBUILD_RARPD=true"
+      "-DBUILD_TRACEROUTE6=true"
+      "-Dsystemdunitdir=etc/systemd/system"
+    ]
+    ++ optional (!withNinfod) "-DBUILD_NINFOD=false"
+    # Disable idn usage w/musl (https://github.com/iputils/iputils/pull/111):
+    ++ optional stdenv.hostPlatform.isMusl "-DUSE_IDN=false";
 
-  # Disable idn usage w/musl: https://github.com/iputils/iputils/pull/111
-  makeFlags = optional stdenv.hostPlatform.isMusl "USE_IDN=no";
-
-  nativeBuildInputs = [ libxslt.bin ];
-  buildInputs = [ libcap nettle ]
+  nativeBuildInputs = [ meson ninja pkgconfig gettext libxslt.bin docbook_xsl_ns libcap ];
+  buildInputs = [ libcap nettle systemd ]
     ++ optional (!stdenv.hostPlatform.isMusl) libidn2
     ++ optional withNinfod openssl; # TODO: Build with nettle
-
-  buildFlags = "man all" + optionalString withNinfod " ninfod";
-
-  installPhase = ''
-    mkdir -p $out/bin
-    mkdir -p $out/share/man/man8
-
-    for tool in arping clockdiff ping rarpd rdisc tftpd tracepath traceroute6; do
-      cp $tool $out/bin/
-      cp doc/$tool.8 $out/share/man/man8/
-    done
-
-    # TODO: Requires kernel module pg3
-    cp ipg $out/bin/
-    cp doc/pg3.8 $out/share/man/man8/
-  '' + optionalString withNinfod ''
-    cp ninfod/ninfod $out/bin/
-    cp doc/ninfod.8 $out/share/man/man8/
-  '';
 
   meta = {
     homepage = https://github.com/iputils/iputils;


### PR DESCRIPTION
Important changes:
- Two files where removed in [0]:
  - bin/ipg
  - share/man/man8/pg3.8.gz
- The build system changed from Autotools to Meson.
- "It is probable that within in many many changes a regression may have
  slipped in" [1]

[0]: https://github.com/iputils/iputils/commit/45a1d39b0c740b5803330feb37650352ceea1086
[1]: https://github.com/iputils/iputils/releases/tag/s20190324

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - Actually got smaller:
```
/nix/store/22nfcbw7n7yd87yql537pma23h47bfzz-iputils-20180629       42322272
/nix/store/5ks8y96py4scqgq6i43knvjhai0b8mzp-iputils-20190324       41023192
```
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
