### PR TITLE
haskellPackages.hfsevents: Fix eval on Darwin hackage2nix config and temporarily

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -2474,7 +2474,6 @@ unsupported-platforms:
   gi-ostree:                                    [ x86_64-darwin ]
   gtk-mac-integration:                          [ i686-linux, x86_64-linux ]
   hcwiid:                                       [ x86_64-darwin ]
-  hfsevents:                                    [ x86_64-darwin ]
   HFuse:                                        [ x86_64-darwin ]
   hommage-ds:                                   [ i686-linux, x86_64-linux, x86_64-darwin ]
   lio-fs:                                       [ x86_64-darwin ]


### PR DESCRIPTION
###### Motivation for this change
Backports the fix to hackage2nix config to not mark hfsevents unbuildable on Darwin. Also quickfixes the package set so we can get `darwin-tested` evals rolling again on 19.03

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
