### PR TITLE
pkgconf: 1.6.0 -> 1.6.1

### DIFF
--- a/pkgs/development/tools/misc/pkgconf/default.nix
+++ b/pkgs/development/tools/misc/pkgconf/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "pkgconf-1.6.0";
+  pname = "pkgconf";
+  version = "1.6.1";
 
   src = fetchurl {
-    url = "https://distfiles.dereferenced.org/pkgconf/${name}.tar.xz";
-    sha256 = "1rgcw7lbmxv45y4ybnlh1wzhd1d15d2616499ajjnrvnnnms6db1";
+    url = "https://distfiles.dereferenced.org/${pname}/${pname}-${version}.tar.xz";
+    sha256 = "1310va0nm8iyb4ghgz9qlx7qb00iha1523hq1zbgj0c98cwfxf92";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
https://raw.githubusercontent.com/pkgconf/pkgconf/be6011222b52db362d2a4fdf602b4e4928b5317b/NEWS


###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---