### PR TITLE
texlive: Retain updmap.cfg

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/combine.nix
+++ b/pkgs/tools/typesetting/tex/texlive/combine.nix
@@ -126,8 +126,6 @@ in buildEnv {
       patchCnfLua "./texmfcnf.lua"
 
       mkdir $out/share/texmf-local
-
-      rm updmap.cfg
     )
   '' +
     # updmap.cfg seems like not needing changes
@@ -216,7 +214,7 @@ in buildEnv {
     texlinks.sh "$out/bin" && wrapBin
     (perl `type -P fmtutil.pl` --sys --all || true) | grep '^fmtutil' # too verbose
     #texlinks.sh "$out/bin" && wrapBin # do we need to regenerate format links?
-    perl `type -P updmap.pl` --sys --syncwithtrees --force
+    echo y | perl `type -P updmap.pl` --sys --syncwithtrees --force
     perl `type -P mktexlsr.pl` ./share/texmf-* # to make sure
   '' +
     # install (wrappers for) scripts, based on a list from upstream texlive


### PR DESCRIPTION
###### Motivation for this change
As discussed in
https://github.com/NixOS/nixpkgs/issues/58026#issuecomment-475825057

###### Things done
Ran pdflatex on a standard document.
Also I retain a private override which saves updmap.cfg before its deletion, and I have been running this for quite some time now, using pdflatex and xetex. I haven't noticed anything wrong with my setup by the presence of updmap.cfg and as this is part of the standard texlive distribution, I can't imagine this to be a problem.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
