### PR TITLE
manual: Make sure building doesn't need recursive nix

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -78,15 +78,14 @@ manual-full.xml: ${MD_TARGETS} .version functions/library/locations.xml function
 	nix-instantiate --eval \
 		-E '(import ../lib).version' > .version
 
-function_locations := $(shell nix-build --no-out-link ./lib-function-locations.nix)
-
 functions/library/locations.xml:
-	ln -s $(function_locations) ./functions/library/locations.xml
+	nix-build ./lib-function-locations.nix \
+		--out-link $@
 
-functions/library/generated:
+functions/library/generated: functions/library/locations.xml
 	nix-build ./lib-function-docs.nix \
-		--arg locationsXml $(function_locations)\
-		--out-link ./functions/library/generated
+		--arg locationsXml $< \
+		--out-link $@
 
 %.section.xml: %.section.md
 	pandoc $^ -w docbook+smart \


### PR DESCRIPTION
###### Motivation for this change

$(shell ...) looks a little sketch like it will be run no matter what.
And there are problems building the manual on darwin so hopefully this
fixes them.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
