### PR TITLE
newsboat: 2.14.1 -> 2.15

### DIFF
--- a/pkgs/applications/networking/feedreaders/newsboat/default.nix
+++ b/pkgs/applications/networking/feedreaders/newsboat/default.nix
@@ -3,22 +3,14 @@
 
 rustPlatform.buildRustPackage rec {
   name = "newsboat-${version}";
-  version = "2.14.1";
+  version = "2.15";
 
   src = fetchurl {
     url = "https://newsboat.org/releases/${version}/${name}.tar.xz";
-    sha256 = "0rnz61in715xgma6phvmn5bil618gic01f3kxzhcfgqsj2qx7l2b";
+    sha256 = "1dqdcp34jmphqf3d8ik0xdhg0s66nd5rky0y8y591nidq29wws6s";
   };
 
   cargoSha256 = "05pf020jp20ffmvin6d1g8zbwf1zk03bm1cb99b7iqkk4r54g6dn";
-
-  cargoPatches = [
-    # Bump versions in Cargo.lock
-    (fetchpatch {
-      url = https://github.com/newsboat/newsboat/commit/cbad27a19d270f2f0fce9317651e2c9f0aa22865.patch;
-      sha256 = "05n31b6mycsmzilz7f3inkmav34210c4nlr1fna4zapbhxjdlhqn";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace Makefile --replace "|| true" ""


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
