### PR TITLE
muse-sequencer: 3.0.2 -> 3.1pre1

### DIFF
--- a/pkgs/applications/audio/muse/default.nix
+++ b/pkgs/applications/audio/muse/default.nix
@@ -18,7 +18,7 @@
 
 stdenv.mkDerivation rec {
   name = "muse-sequencer-${version}";
-  version = "3.0.2";
+  version = "3.1pre1";
 
   meta = with stdenv.lib; {
     homepage = http://www.muse-sequencer.org;
@@ -38,10 +38,15 @@ stdenv.mkDerivation rec {
     fetchFromGitHub {
       owner = "muse-sequencer";
       repo = "muse";
-      rev = "02d9dc6abd757c3c1783fdd46dacd3c4ef2c0a6d";
-      sha256 = "0pn0mcg79z3bhjwxbss3ylypdz3gg70q5d1ij3x8yw65ryxbqf51";
+      rev = "2167ae053c16a633d8377acdb1debaac10932838";
+      sha256 = "0rsdx8lvcbz5bapnjvypw8h8bq587s9z8cf2znqrk6ah38s6fsrf";
     };
 
+
+  nativeBuildInputs = [
+    pkgconfig
+    gitAndTools.gitFull
+  ];
 
   buildInputs = [
     libjack2
@@ -57,8 +62,6 @@ stdenv.mkDerivation rec {
     lash
     dssi
     liblo
-    pkgconfig
-    gitAndTools.gitFull
   ];
 
   sourceRoot = "source/muse3";


### PR DESCRIPTION
###### Motivation for this change
- The old version was no longer building on hydra, this fixes that.
- Moved some dependencies to nativeBuildInputs

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [Y] NixOS
   - [N] macOS
   - [N] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [Y] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
