### PR TITLE
[WIP] sage: make sage usable as a python library

### DIFF
--- a/pkgs/applications/science/math/sage/default.nix
+++ b/pkgs/applications/science/math/sage/default.nix
@@ -66,13 +66,21 @@ let
     mathjax = nodePackages.mathjax;
   };
 
+  makePythonWrapper = callPackage ./wrap.nix {};
+
   # The shell file that gets sourced on every sage start. Will also source
   # the env-locations file.
   sage-env = callPackage ./sage-env.nix {
     sagelib = python.pkgs.sagelib;
-    inherit env-locations;
+    inherit env-locations makePythonWrapper;
+    inherit sage-src;
     inherit python ecl singular palp flint pynac pythonEnv maxima-ecl;
     pkg-config = pkgs.pkgconfig; # not to confuse with pythonPackages.pkgconfig
+
+    inherit pari_data;
+    cysignals = python.pkgs.cysignals;
+    three = nodePackages.three;
+    mathjax = nodePackages.mathjax;
   };
 
   # The documentation for sage, building it takes a lot of ram.
@@ -166,7 +174,7 @@ let
   ecl = pkgs.ecl_16_1_2;
 in
 # A wrapper around sage that makes sure sage finds its docs (if they were build).
-callPackage ./sage.nix {
+(callPackage ./sage.nix {
   inherit sage-tests sage-with-env sagedoc jupyter-kernel-definition;
   inherit withDoc;
-}
+}) // { env = sage-env; }

--- a/pkgs/applications/science/math/sage/env-locations.nix
+++ b/pkgs/applications/science/math/sage/env-locations.nix
@@ -16,33 +16,29 @@
 , cysignals
 }:
 
-# A bash script setting various environment variables to tell sage where
-# the files its looking fore are located. Also see `sage-env`.
-writeTextFile rec {
-  name = "sage-env-locations";
-  destination = "/${name}";
-  text = ''
-    export GP_DATA_DIR="${pari_data}/share/pari"
-    export PARI_DATA_DIR="${pari_data}"
-    export GPHELP="${pari}/bin/gphelp"
-    export GPDOCDIR="${pari}/share/pari/doc"
-    export SINGULARPATH='${singular}/share/singular'
-    export SINGULAR_SO='${singular}/lib/libSingular.so'
-    export SINGULAR_EXECUTABLE='${singular}/bin/Singular'
-    export MAXIMA_FAS='${maxima-ecl}/lib/maxima/${maxima-ecl.version}/binary-ecl/maxima.fas'
-    export MAXIMA_PREFIX="${maxima-ecl}"
-    export CONWAY_POLYNOMIALS_DATA_DIR='${conway_polynomials}/share/conway_polynomials'
-    export GRAPHS_DATA_DIR='${graphs}/share/graphs'
-    export ELLCURVE_DATA_DIR='${elliptic_curves}/share/ellcurves'
-    export POLYTOPE_DATA_DIR='${polytopes_db}/share/reflexive_polytopes'
-    export GAP_ROOT_DIR='${gap}/share/gap/build-dir'
-    export ECLDIR='${ecl}/lib/ecl-${ecl.version}/'
-    export COMBINATORIAL_DESIGN_DATA_DIR="${combinatorial_designs}/share/combinatorial_designs"
-    export CREMONA_MINI_DATA_DIR="${elliptic_curves}/share/cremona"
-    export JMOL_DIR="${jmol}/share/jmol" # point to the directory that contains JmolData.jar
-    export JSMOL_DIR="${jmol}/share/jsmol"
-    export MATHJAX_DIR="${mathjax}/lib/node_modules/mathjax"
-    export THREEJS_DIR="${three}/lib/node_modules/three"
-    export SAGE_INCLUDE_DIRECTORIES="${cysignals}/lib/python2.7/site-packages"
-  '';
+# Various environment variables to tell sage where the files its looking for
+# are located.
+{
+  "GP_DATA_DIR" = "${pari_data}/share/pari";
+  "PARI_DATA_DIR" = "${pari_data}";
+  "GPHELP" = "${pari}/bin/gphelp";
+  "GPDOCDIR" = "${pari}/share/pari/doc";
+  "SINGULARPATH" = "${singular}/share/singular";
+  "SINGULAR_SO" = "${singular}/lib/libSingular.so";
+  "SINGULAR_EXECUTABLE" = "${singular}/bin/Singular";
+  "MAXIMA_FAS" = "${maxima-ecl}/lib/maxima/${maxima-ecl.version}/binary-ecl/maxima.fas";
+  "MAXIMA_PREFIX" = "${maxima-ecl}";
+  "CONWAY_POLYNOMIALS_DATA_DIR" = "${conway_polynomials}/share/conway_polynomials";
+  "GRAPHS_DATA_DIR" = "${graphs}/share/graphs";
+  "ELLCURVE_DATA_DIR" = "${elliptic_curves}/share/ellcurves";
+  "POLYTOPE_DATA_DIR" = "${polytopes_db}/share/reflexive_polytopes";
+  "GAP_ROOT_DIR" = "${gap}/share/gap/build-dir";
+  "ECLDIR" = "${ecl}/lib/ecl-${ecl.version}/";
+  "COMBINATORIAL_DESIGN_DATA_DIR" = "${combinatorial_designs}/share/combinatorial_designs";
+  "CREMONA_MINI_DATA_DIR" = "${elliptic_curves}/share/cremona";
+  "JMOL_DIR" = "${jmol}/share/jmol"; # point to the directory that contains JmolData.jar
+  "JSMOL_DIR" = "${jmol}/share/jsmol";
+  "MATHJAX_DIR" = "${mathjax}/lib/node_modules/mathjax";
+  "THREEJS_DIR" = "${three}/lib/node_modules/three";
+  "SAGE_INCLUDE_DIRECTORIES" = "${cysignals}/lib/python2.7/site-packages";
 }

--- a/pkgs/applications/science/math/sage/patches/env-generated.patch
+++ b/pkgs/applications/science/math/sage/patches/env-generated.patch
@@ -1,0 +1,13 @@
+diff --git a/src/sage/env.py b/src/sage/env.py
+index a91aac4fe6..1993b5b9c7 100644
+--- a/src/sage/env.py
++++ b/src/sage/env.py
+@@ -28,6 +28,8 @@ variables::
+ 
+ from __future__ import absolute_import
+ 
++exec(open('env_generated.py'))
++
+ import sage
+ import glob
+ import os

--- a/pkgs/applications/science/math/sage/runtime-env.nix
+++ b/pkgs/applications/science/math/sage/runtime-env.nix
@@ -1,0 +1,149 @@
+{ stdenv
+, lib
+, writeTextFile
+, python
+, sagelib
+, env-locations
+, gfortran
+, bash
+, coreutils
+, gnused
+, gnugrep
+, binutils
+, pythonEnv
+, python3
+, pkg-config
+, pari
+, gap
+, ecl
+, maxima-ecl
+, singular
+, giac
+, palp
+, rWrapper
+, gfan
+, cddlib
+, jmol
+, tachyon
+, glpk
+, eclib
+, sympow
+, nauty
+, sqlite
+, ppl
+, ecm
+, lcalc
+, rubiks
+, flintqs
+, openblasCompat
+, flint
+, gmp
+, mpfr
+, pynac
+, zlib
+, gsl
+, ntl
+, jdk
+}:
+
+# Various environment variables sage needs at runtime.
+
+let
+runtimepath = (lib.makeBinPath ([
+  "@sage-local@"
+  "@sage-local@/build"
+  pythonEnv
+  # empty python env to add python wrapper that clears PYTHONHOME (see
+  # wrapper.nix). This is necessary because sage will call the python3 binary
+  # (from python2 code). The python2 PYTHONHOME (again set in wrapper.nix)
+  # will then confuse python3, if it is not overwritten.
+  python3.buildEnv
+  gfortran # for inline fortran
+  stdenv.cc # for cython
+  bash
+  coreutils
+  gnused
+  gnugrep
+  binutils.bintools
+  pkg-config
+  pari
+  gap
+  ecl
+  maxima-ecl
+  singular
+  giac
+  palp
+  # needs to be rWrapper since the default `R` doesn't include R's default libraries
+  rWrapper
+  gfan
+  cddlib
+  jmol
+  tachyon
+  glpk
+  eclib
+  sympow
+  nauty
+  sqlite
+  ppl
+  ecm
+  lcalc
+  rubiks
+  flintqs
+  jdk # only needed for `jmol` which may be replaced in the future
+]));
+in
+{
+  set = {
+    "PKG_CONFIG_PATH" = lib.concatStringsSep ":" (map (pkg: "${pkg}/lib/pkgconfig") [
+        # This is only needed in the src/sage/misc/cython.py test and I'm not
+        # sure if there's really a usecase for it outside of the tests. However
+        # since singular and openblas are runtime dependencies anyways, it doesn't
+        # really hurt to include.
+        singular
+        openblasCompat
+      ]);
+    "SAGE_ROOT" = sagelib.src;
+    "SAGE_SRC" = "${sagelib.src}/src";
+    "SAGE_LOCAL" = "@sage-local@";
+    "SAGE_SHARE" = "${sagelib}/share";
+    "SAGE_LOGS" = "$TMPDIR/sage-logs";
+    "SAGE_DOC" = ''''${SAGE_DOC_OVERRIDE:-doc-placeholder}'';
+    "SAGE_DOC_SRC" = ''''${SAGE_DOC_SRC_OVERRIDE:-${sagelib.src}/src/doc}'';
+    "DOT_SAGE" = "$HOME/.sage";
+    # needed for cython
+    "CC" = "${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc";
+    # cython needs to find these libraries, otherwise will fail with `ld: cannot find -lflint` or similar
+    "LDFLAGS" = lib.concatStringsSep " " (map (pkg: "-L${pkg}/lib") [
+      flint
+      gap
+      glpk
+      gmp
+      mpfr
+      pari
+      pynac
+      zlib
+      eclib
+      gsl
+      ntl
+      jmol
+      sympow
+    ]);
+    "CFLAGS" = lib.concatStringsSep " " (map (pkg: "-isystem ${pkg}/include") [
+      singular
+      gmp.dev
+      glpk
+      flint
+      gap
+      pynac
+      mpfr.dev
+    ]);
+    "SAGE_LIB" = "${sagelib}/${python.sitePackages}";
+    "SAGE_EXTCODE" = "${sagelib.src}/src/ext";
+
+  };
+  prefix = {
+    "PATH" = runtimepath;
+    # for find_library
+    "DYLD_LIBRARY_PATH" = lib.makeLibraryPath [stdenv.cc.libc singular];
+  };
+}

--- a/pkgs/applications/science/math/sage/sage-env.nix
+++ b/pkgs/applications/science/math/sage/sage-env.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
-, writeTextFile
+, sage-src
+, makePythonWrapper
 , python
 , sagelib
 , env-locations
@@ -44,6 +45,16 @@
 , gsl
 , ntl
 , jdk
+
+, pari_data
+, conway_polynomials
+, graphs
+, elliptic_curves
+, polytopes_db
+, combinatorial_designs
+, mathjax
+, three
+, cysignals
 }:
 
 # This generates a `sage-env` shell file that will be sourced by sage on startup.
@@ -94,76 +105,105 @@ let
     jdk # only needed for `jmol` which may be replaced in the future
   ]
   ));
-in
-writeTextFile rec {
-  name = "sage-env";
-  destination = "/${name}";
-  text = ''
-    export PKG_CONFIG_PATH='${lib.concatStringsSep ":" (map (pkg: "${pkg}/lib/pkgconfig") [
+
+  set = {
+    "PKG_CONFIG_PATH" = lib.concatStringsSep ":" (map (pkg: "${pkg}/lib/pkgconfig") [
         # This is only needed in the src/sage/misc/cython.py test and I'm not
         # sure if there's really a usecase for it outside of the tests. However
         # since singular and openblas are runtime dependencies anyways, it doesn't
         # really hurt to include.
         singular
         openblasCompat
-      ])
-    }'
-    export SAGE_ROOT='${sagelib.src}'
-    export SAGE_LOCAL='@sage-local@'
-    export SAGE_SHARE='${sagelib}/share'
-    orig_path="$PATH"
-    export PATH='${runtimepath}'
-
-    # set dependent vars, like JUPYTER_CONFIG_DIR
-    source "${sagelib.src}/src/bin/sage-env"
-    export PATH="$RUNTIMEPATH_PREFIX:${runtimepath}:$orig_path" # sage-env messes with PATH
-
-    export SAGE_LOGS="$TMPDIR/sage-logs"
-    export SAGE_DOC="''${SAGE_DOC_OVERRIDE:-doc-placeholder}"
-    export SAGE_DOC_SRC="''${SAGE_DOC_SRC_OVERRIDE:-${sagelib.src}/src/doc}"
-
-    # set locations of dependencies
-    . ${env-locations}/sage-env-locations
-
+      ]);
+    "SAGE_ROOT" = sagelib.src;
+    "SAGE_SRC" = "${sagelib.src}/src";
+    "SAGE_LOCAL" = "${placeholder "out"}";
+    "SAGE_SHARE" = "${sagelib}/share";
+    "SAGE_DOC" = "doc-placeholder";
+    "SAGE_DOC_SRC" = "${sagelib.src}/src/doc";
     # needed for cython
-    export CC='${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc'
+    "CC" = "${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc";
     # cython needs to find these libraries, otherwise will fail with `ld: cannot find -lflint` or similar
-    export LDFLAGS='${
-      lib.concatStringsSep " " (map (pkg: "-L${pkg}/lib") [
-        flint
-        gap
-        glpk
-        gmp
-        mpfr
-        pari
-        pynac
-        zlib
-        eclib
-        gsl
-        ntl
-        jmol
-        sympow
-      ])
-    }'
-    export CFLAGS='${
-      lib.concatStringsSep " " (map (pkg: "-isystem ${pkg}/include") [
-        singular
-        gmp.dev
-        glpk
-        flint
-        gap
-        pynac
-        mpfr.dev
-      ])
-    }'
+    "LDFLAGS" = lib.concatStringsSep " " (map (pkg: "-L${pkg}/lib") [
+      flint
+      gap
+      glpk
+      gmp
+      mpfr
+      pari
+      pynac
+      zlib
+      eclib
+      gsl
+      ntl
+      jmol
+      sympow
+    ]);
+    "CFLAGS" = lib.concatStringsSep " " (map (pkg: "-isystem ${pkg}/include") [
+      singular
+      gmp.dev
+      glpk
+      flint
+      gap
+      pynac
+      mpfr.dev
+    ]);
+    "SAGE_LIB" = "${sagelib}/${python.sitePackages}";
+    "SAGE_EXTCODE" = "${sagelib.src}/src/ext";
 
-    export SAGE_LIB='${sagelib}/${python.sitePackages}'
-
-    export SAGE_EXTCODE='${sagelib.src}/src/ext'
-
-  # for find_library
-    export DYLD_LIBRARY_PATH="${lib.makeLibraryPath [stdenv.cc.libc singular]}:$DYLD_LIBRARY_PATH"
+    "GP_DATA_DIR" = "${pari_data}/share/pari";
+    "PARI_DATA_DIR" = "${pari_data}";
+    "GPHELP" = "${pari}/bin/gphelp";
+    "GPDOCDIR" = "${pari}/share/pari/doc";
+    "SINGULARPATH" = "${singular}/share/singular";
+    "SINGULAR_SO" = "${singular}/lib/libSingular.so";
+    "SINGULAR_EXECUTABLE" = "${singular}/bin/Singular";
+    "MAXIMA_FAS" = "${maxima-ecl}/lib/maxima/${maxima-ecl.version}/binary-ecl/maxima.fas";
+    "MAXIMA_PREFIX" = "${maxima-ecl}";
+    "CONWAY_POLYNOMIALS_DATA_DIR" = "${conway_polynomials}/share/conway_polynomials";
+    "GRAPHS_DATA_DIR" = "${graphs}/share/graphs";
+    "ELLCURVE_DATA_DIR" = "${elliptic_curves}/share/ellcurves";
+    "POLYTOPE_DATA_DIR" = "${polytopes_db}/share/reflexive_polytopes";
+    "GAP_ROOT_DIR" = "${gap}/share/gap/build-dir";
+    "ECLDIR" = "${ecl}/lib/ecl-${ecl.version}/";
+    "COMBINATORIAL_DESIGN_DATA_DIR" = "${combinatorial_designs}/share/combinatorial_designs";
+    "CREMONA_MINI_DATA_DIR" = "${elliptic_curves}/share/cremona";
+    "JMOL_DIR" = "${jmol}/share/jmol"; # point to the directory that contains JmolData.jar
+    "JSMOL_DIR" = "${jmol}/share/jsmol";
+    "MATHJAX_DIR" = "${mathjax}/lib/node_modules/mathjax";
+    "THREEJS_DIR" = "${three}/lib/node_modules/three";
+    "SAGE_INCLUDE_DIRECTORIES" = "${cysignals}/lib/python2.7/site-packages";
+  };
+  prefix = {
+    "PATH" = runtimepath;
+    # for find_library
+    "DYLD_LIBRARY_PATH" = lib.makeLibraryPath [stdenv.cc.libc singular];
+  };
+  code = ''
+    os.environ['DOT_SAGE'] = '{}/.sage'.format(os.environ['HOME'])
+    os.environ['SAGE_LOGS'] = '{}/sage-logs'.format(os.environ.get('TMPDIR', '/tmp'))
   '';
-} // {
-  lib = sagelib; # equivalent of `passthru`, which `writeTextFile` doesn't support
-}
+in
+  (makePythonWrapper {
+    packageToWrap = sagelib;
+    module_name = "sage";
+    inherit prefix set code;
+    extraInstall = ''
+      mkdir -p "$out/var/lib/sage/installed"
+      for pkg in ${lib.concatStringsSep " " []}; do
+        touch "$out/var/lib/sage/installed/$pkg"
+      done
+
+      mkdir -p "$out/etc"
+      # sage tests will try to create this file if it doesn't exist
+      touch "$out/etc/sage-started.txt"
+
+      mkdir -p "$out/build"
+
+      # the scripts in src/bin will find the actual sage source files using environment variables set in `sage-env`
+      cp -r ${sage-src}/src/bin "$out/bin"
+      cp -r ${sage-src}/build/bin "$out/build/bin"
+    '';
+  }) // {
+    lib = sagelib; # equivalent of `passthru`, which `writeTextFile` doesn't support
+  }

--- a/pkgs/applications/science/math/sage/sagelib.nix
+++ b/pkgs/applications/science/math/sage/sagelib.nix
@@ -47,6 +47,22 @@
 , jupyter_core
 , libhomfly
 , libbraiding
+, pybrial
+, sagenb
+, cvxopt
+, networkx
+, service-identity
+, psutil
+, sympy
+, fpylll
+, matplotlib
+, tkinter # optional, as a matplotlib backend (use with `%matplotlib tk`)
+, scipy
+, ipywidgets
+, rpy2
+, sphinx
+, typing
+, pillow
 }:
 
 # This is the core sage python package. Everything else is just wrappers gluing
@@ -115,6 +131,23 @@ buildPythonPackage rec {
     cysignals
     libhomfly
     libbraiding
+
+    pybrial
+    sagenb
+    cvxopt
+    networkx
+    service-identity
+    psutil
+    sympy
+    fpylll
+    matplotlib
+    tkinter # optional, as a matplotlib backend (use with `%matplotlib tk`)
+    scipy
+    ipywidgets
+    rpy2
+    sphinx
+    typing
+    pillow
   ];
 
   buildPhase = ''

--- a/pkgs/applications/science/math/sage/wrap.nix
+++ b/pkgs/applications/science/math/sage/wrap.nix
@@ -1,0 +1,48 @@
+{ lib
+, stdenv
+, writeTextFile
+, python
+}:
+
+{ packageToWrap
+, module_name ? packageToWrap.pname
+, set ? {}
+, prefix ? {}
+, code ? ""
+, extraInstall ? ""
+}:
+
+let
+  pythonEscape = str: lib.replaceStrings ["'"] ["a"] (toString str);
+  generateExport = var: val: "os.environ['${pythonEscape var}'] = '${pythonEscape val}'";
+  generatePrefix = var: val: "os.environ['${pythonEscape var}'] = '${pythonEscape val}:' + os.environ.get('${pythonEscape var}', '')";
+  generateWrapperLines = { set, prefix}:
+    (lib.mapAttrsToList generateExport set)
+      ++ (lib.mapAttrsToList generatePrefix prefix);
+  scriptToExecute = "import os\n" + lib.concatStringsSep "\n" (generateWrapperLines { inherit set prefix; }) + "\n" + code;
+  targetDir = "${placeholder "out"}/lib/${python.libPrefix}/site-packages/${module_name}/";
+  wrapperScript = ''
+    import sys
+    exec(compile(open('${targetDir}/inject.py').read(), '${targetDir}/inject.py', 'exec'), {}, {})
+    sys.path = [ '${packageToWrap}/lib/${python.libPrefix}/site-packages' ] + sys.path
+    sys.modules.pop(__name__)
+    import ${module_name}
+  '';
+in
+  stdenv.mkDerivation {
+    name = "${packageToWrap.name}-wrapper";
+    unpackPhase = "
+      # do nothing
+    ";
+    buildPhase = "
+      # do nothing
+    ";
+    installPhase = ''
+      mkdir -p "$out/lib/${python.libPrefix}/site-packages/${module_name}/"
+      echo ${lib.escapeShellArg scriptToExecute} > "${targetDir}/inject.py"
+      echo ${lib.escapeShellArg wrapperScript} > "${targetDir}/__init__.py"
+    '' + extraInstall;
+    pythonModule = packageToWrap.pythonModule; 
+    requiredPythonModules = packageToWrap.requiredPythonModules;
+    propagatedBuildInputs = packageToWrap.propagatedBuildInputs;
+  }


### PR DESCRIPTION
###### Motivation for this change

Use a python wrapper instead of a bash wrapper. As a result, you can now
`import sage` from regular python.

WIP as there is some restructuring (and hopefully simplification) needed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
