### PR TITLE
python beaker: 1.8.0 -> 1.10.1 fix building on hydra

### DIFF
--- a/pkgs/development/python-modules/beaker/default.nix
+++ b/pkgs/development/python-modules/beaker/default.nix
@@ -2,39 +2,72 @@
 , buildPythonPackage
 , fetchFromGitHub
 , nose
+, pylibmc
+, memcached
+, redis
+, pymongo
 , mock
 , webtest
 , sqlalchemy
 , pycrypto
+, cryptography
 , isPy27
+, isPy3k
 , funcsigs
 , pycryptopp
 }:
 
 buildPythonPackage rec {
   pname = "Beaker";
-  version = "1.8.0";
+  version = "1.10.1";
 
   # The pypy release do not contains the tests
   src = fetchFromGitHub {
     owner = "bbangert";
     repo = "beaker";
     rev = "${version}";
-    sha256 = "17yfr7a307n8rdl09was4j60xqk2s0hk0hywdkigrpj4qnw0is7g";
+    sha256 = "0xrvg503xmi28w0hllr4s7fkap0p09fgw2wax3p1s2r6b3xjvbz7";
   };
 
-  buildInputs =
-    [ nose
-      mock
-      webtest
-    ];
   propagatedBuildInputs = [
     sqlalchemy
     pycrypto
+    cryptography
   ] ++ lib.optionals (isPy27) [
     funcsigs
     pycryptopp
   ];
+
+  checkInputs = [
+    nose
+    mock
+    webtest
+    pylibmc
+    memcached
+    redis
+    pymongo
+  ];
+
+
+  # Can not run memcached tests because it immediately tries to connect
+  postPatch = lib.optionalString isPy3k ''
+    substituteInPlace setup.py \
+      --replace "python-memcached" "python3-memcached"
+    '' + ''
+
+    rm tests/test_memcached.py
+  '';
+
+  # Disable external tests because they need to connect to a live database.
+  # Also disable a test in test_cache.py called "test_upgrade" because
+  # it currently fails on darwin.
+  # Please see issue https://github.com/bbangert/beaker/issues/166
+  checkPhase = ''
+    nosetests \
+      -e ".*test_ext_.*" \
+      -e "test_upgrade" \
+      -vv tests
+  '';
 
   meta = {
     description = "A Session and Caching library with WSGI Middleware";

--- a/pkgs/development/python-modules/pyramid_beaker/default.nix
+++ b/pkgs/development/python-modules/pyramid_beaker/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
     py.test -k 'not test_includeme' pyramid_beaker/tests.py
   '';
 
-  buildInputs = [ pytest ];
+  checkInputs = [ pytest ];
 
   propagatedBuildInputs = [ beaker pyramid ];
 


### PR DESCRIPTION
###### Motivation for this change
- The aim was to get this building on hydra
- Midway I discovered a [PR by Mic92](https://github.com/NixOS/nixpkgs/pull/50537) that bumps the version to 1.10.0,
  I have included some of his fixes to run tests correctly:
    - remove testing memcached (it tries to connect on import)
    - don't run external tests
    - run nosetests rather than setup.py test because that repsects NOSE_EXCLUDE

- Let's see if the bot can build this on darwin, that was an issue in the linked PR

closes https://github.com/NixOS/nixpkgs/pull/50537

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
