### PR TITLE
jadx: init at 0.9.0

### DIFF
--- a/pkgs/tools/security/jadx-bin/default.nix
+++ b/pkgs/tools/security/jadx-bin/default.nix
@@ -1,13 +1,12 @@
 { stdenv, fetchurl, makeWrapper, jre, unzip, makeDesktopItem }:
 
-let
+stdenv.mkDerivation rec {
   version = "0.9.0";
   name = "jadx-bin-${version}";
 
-
-  desktopItem = launcher: makeDesktopItem {
+  desktopItem = makeDesktopItem {
     name = "jadx-gui";
-    exec = "${launcher} %F";
+    exec = "jadx-gui %F";
     comment = "Java Decompiler";
     desktopName = "jadx GUI";
     genericName = "Java and Android Decompiler";
@@ -23,33 +22,22 @@ let
     maintainers = [ maintainers.artemist ];
   };
 
-    src = fetchurl {
-      url    = "https://github.com/skylot/jadx/archive/v${version}/jadx-${version}.zip";
-      sha256 = "00yi5gfnz0zxkc4v405w5b8sg0x4xb2q5cai0v1gz2yzd7q9vx6j";
-    };
-
-    nativeBuildInputs = [ unzip makeWrapper ];
-
-    unpackCmd = "unzip -d jadx-${version} $curSrc"; # This would otherwise create multiple directories
-
-  origJadx = stdenv.mkDerivation rec {
-    inherit src name version nativeBuildInputs unpackCmd;
-
-    installPhase = ''
-      mkdir -p $out/bin $out/lib
-      cp lib/*.jar $out/lib
-      cp bin/jadx bin/jadx-gui $out/bin
-    '';
+  src = fetchurl {
+    url    = "https://github.com/skylot/jadx/archive/v${version}/jadx-${version}.zip";
+    sha256 = "00yi5gfnz0zxkc4v405w5b8sg0x4xb2q5cai0v1gz2yzd7q9vx6j";
   };
 
-in stdenv.mkDerivation rec {
-  inherit src name version meta nativeBuildInputs unpackCmd;
+  nativeBuildInputs = [ unzip makeWrapper ];
+
+  unpackCmd = "unzip -d jadx-${version} $curSrc"; # This would otherwise create multiple directories
+
 
   installPhase = ''
-    mkdir -p $out/bin
-    makeWrapper ${origJadx}/bin/jadx-gui $out/bin/jadx-gui \
-      --set JAVA_HOME ${jre.home}
-    makeWrapper ${origJadx}/bin/jadx $out/bin/jadx \
-      --set JAVA_HOME ${jre.home}
+    mkdir -p $out/bin $out/lib
+    cp lib/*.jar $out/lib
+    cp bin/jadx bin/jadx-gui $out/bin
+    wrapProgram $out/bin/jadx-gui --set JAVA_HOME ${jre.home}
+    wrapProgram $out/bin/jadx --set JAVA_HOME ${jre.home}
+    install -Dm644 "${desktopItem}/share/applications/"* -t "$out/share/applications/"
   '';
 }

--- a/pkgs/tools/security/jadx-bin/default.nix
+++ b/pkgs/tools/security/jadx-bin/default.nix
@@ -1,0 +1,55 @@
+{ stdenv, fetchurl, makeWrapper, jre, unzip, makeDesktopItem }:
+
+let
+  version = "0.9.0";
+  name = "jadx-bin-${version}";
+
+
+  desktopItem = launcher: makeDesktopItem {
+    name = "jadx-gui";
+    exec = "${launcher} %F";
+    comment = "Java Decompiler";
+    desktopName = "jadx GUI";
+    genericName = "Java and Android Decompiler";
+    mimeType = "application/x-java-archive;application/x-java";
+    categories = "Development;Debugger;";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Dex to Java decompiler";
+    homepage    = "https://github.com/skylot/jadx";
+    license     = licenses.asl20;
+    platforms   = platforms.unix;
+    maintainers = [ maintainers.artemist ];
+  };
+
+    src = fetchurl {
+      url    = "https://github.com/skylot/jadx/archive/v${version}/jadx-${version}.zip";
+      sha256 = "00yi5gfnz0zxkc4v405w5b8sg0x4xb2q5cai0v1gz2yzd7q9vx6j";
+    };
+
+    nativeBuildInputs = [ unzip makeWrapper ];
+
+    unpackCmd = "unzip -d jadx-${version} $curSrc"; # This would otherwise create multiple directories
+
+  origJadx = stdenv.mkDerivation rec {
+    inherit src name version nativeBuildInputs unpackCmd;
+
+    installPhase = ''
+      mkdir -p $out/bin $out/lib
+      cp lib/*.jar $out/lib
+      cp bin/jadx bin/jadx-gui $out/bin
+    '';
+  };
+
+in stdenv.mkDerivation rec {
+  inherit src name version meta nativeBuildInputs unpackCmd;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    makeWrapper ${origJadx}/bin/jadx-gui $out/bin/jadx-gui \
+      --set JAVA_HOME ${jre.home}
+    makeWrapper ${origJadx}/bin/jadx $out/bin/jadx \
+      --set JAVA_HOME ${jre.home}
+  '';
+}

--- a/pkgs/tools/security/jadx-bin/default.nix
+++ b/pkgs/tools/security/jadx-bin/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   };
 
   src = fetchurl {
-    url    = "https://github.com/skylot/jadx/archive/v${version}/jadx-${version}.zip";
+    url = "https://github.com/skylot/jadx/releases/download/v${version}/jadx-${version}.zip";
     sha256 = "00yi5gfnz0zxkc4v405w5b8sg0x4xb2q5cai0v1gz2yzd7q9vx6j";
   };
 
@@ -31,13 +31,12 @@ stdenv.mkDerivation rec {
 
   unpackCmd = "unzip -d jadx-${version} $curSrc"; # This would otherwise create multiple directories
 
-
   installPhase = ''
     mkdir -p $out/bin $out/lib
     cp lib/*.jar $out/lib
     cp bin/jadx bin/jadx-gui $out/bin
     wrapProgram $out/bin/jadx-gui --set JAVA_HOME ${jre.home}
     wrapProgram $out/bin/jadx --set JAVA_HOME ${jre.home}
-    install -Dm644 "${desktopItem}/share/applications/"* -t "$out/share/applications/"
+    install -Dm644 "$desktopItem/share/applications/"* -t "$out/share/applications/"
   '';
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3614,6 +3614,8 @@ in
 
   jade = callPackage ../tools/text/sgml/jade { };
 
+  jadx = callPackage ../tools/security/jadx-bin { };
+
   jazzy = callPackage ../development/tools/jazzy { };
 
   jd = callPackage ../development/tools/jd { };


### PR DESCRIPTION
###### Motivation for this change
jadx is a Java decompiler which is more modern than the current jd-gui and supports Android. It's an important part of my, and many other people's ,Android and Java reverse engineering toolkit

###### Things done

Create the new jadx package. If you would like me to replace occurrences of 'jadx-bin' with jadx or vice versa, I can do so.

I made this package the existing binaries and scripts, as there are some rather annoying requirements about specific JARs to load into the classpath and variables to accept for compatibility. Additionally, I could not make a binary package because I had problems getting gradle to cache the compiler plugins necessary for build (using the same format as the jd-gui package). I could do this with an output sha256 on the main derivation and keep gradle in online mode, but that still seems very shady.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
