### PR TITLE
Giada: initialize at 0.15.4

### DIFF
--- a/pkgs/applications/audio/giada/default.nix
+++ b/pkgs/applications/audio/giada/default.nix
@@ -15,7 +15,6 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
   pname = "giada";
   version = "0.15.4";
 
@@ -30,20 +29,23 @@ stdenv.mkDerivation rec {
       '';
       homepage = https://www.giadamusic.com;
       platforms = platforms.linux;
-      license = lib.licenses.gpl3;
+      license = lib.licenses.gpl3Plus;
     };
 
   src = fetchFromGitHub {
     owner = "monocasual";
     repo = "giada";
-    rev = "0e9a7aa5184dc73c6d39e2e5ee6c088c46b28aa6";
+    rev = "v${version}";
     sha256 = "17ggz04gczldhy2lf0v36bgc29dyjpjbxd0f3jj7y4sv2ya5bwv9";
   };
 
-  buildInputs = [
+  nativeBuildInputs = [
     autoconf
     automake
     libtool
+  ];
+
+  buildInputs = [
     fltk
     libsndfile
     libsamplerate
@@ -57,11 +59,14 @@ stdenv.mkDerivation rec {
     libpulseaudio
   ];
 
-  buildPhase = ''
-    bash autogen.sh
-    ./configure --target=linux
-    make
+  preConfigure = ''
+    ${stdenv.shell} autogen.sh
   '';
+
+  configureFlags = [
+    "--target=linux"
+    "--enable-system-catch"
+  ];
 
   installPhase = ''
     install -Dm555 ./giada $out/bin/giada

--- a/pkgs/applications/audio/giada/default.nix
+++ b/pkgs/applications/audio/giada/default.nix
@@ -64,8 +64,7 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    mkdir $out
-    cp giada $out
+    install -Dm555 ./giada $out/bin/giada
   '';
 
   # you need to create $HOME/.giada/midimaps directory for midi assignment

--- a/pkgs/applications/audio/giada/default.nix
+++ b/pkgs/applications/audio/giada/default.nix
@@ -1,0 +1,73 @@
+{ stdenv
+, fetchFromGitHub
+, autoconf
+, automake
+, libtool
+, fltk
+, libsndfile
+, libsamplerate
+, jansson
+, rtmidi
+, xorg
+, libjack2
+, alsaLib
+, libpulseaudio
+}:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "giada";
+  version = "0.15.4";
+
+  meta = with stdenv.lib;
+    { description = "Hardcore loop machine";
+      longDescription = ''
+        Giada is a free, minimal, hardcore audio tool for DJs, live performers
+        and electronic musicians. How does it work? Just pick up your channel,
+        fill it with samples or MIDI events and start the show by using this
+        tiny piece of software as a loop machine, drum machine, sequencer,
+        live sampler or yet as a plugin/effect host.
+      '';
+      homepage = https://www.giadamusic.com;
+      platforms = platforms.linux;
+      license = lib.licenses.gpl3;
+    };
+
+  src = fetchFromGitHub {
+    owner = "monocasual";
+    repo = "giada";
+    rev = "0e9a7aa5184dc73c6d39e2e5ee6c088c46b28aa6";
+    sha256 = "17ggz04gczldhy2lf0v36bgc29dyjpjbxd0f3jj7y4sv2ya5bwv9";
+  };
+
+  buildInputs = [
+    autoconf
+    automake
+    libtool
+    fltk
+    libsndfile
+    libsamplerate
+    jansson
+    rtmidi
+    xorg.libXpm
+    xorg.libXcursor
+    xorg.libXinerama
+    libjack2
+    alsaLib
+    libpulseaudio
+  ];
+
+  buildPhase = ''
+    bash autogen.sh
+    ./configure --target=linux
+    make
+  '';
+
+  installPhase = ''
+    mkdir $out
+    cp giada $out
+  '';
+
+  # you need to create $HOME/.giada/midimaps directory for midi assignment
+  # to work correctly, Giada does not create this directory automatically.
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2967,6 +2967,8 @@ in
 
   ggobi = callPackage ../tools/graphics/ggobi { };
 
+  giada = callPackage ../applications/audio/giada { };
+
   gibo = callPackage ../tools/misc/gibo { };
 
   gifsicle = callPackage ../tools/graphics/gifsicle { };


### PR DESCRIPTION
###### Motivation for this change
Giada is not in nixpkgs, it is one of the more capable sound looping programs on linux right now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
