### PR TITLE
libedit: 20180525 -> 20190324

### DIFF
--- a/pkgs/development/libraries/libedit/default.nix
+++ b/pkgs/development/libraries/libedit/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchurl, ncurses }:
 
 stdenv.mkDerivation rec {
-  name = "libedit-20181209-3.1";
+  pname = "libedit";
+  version = "20190324-3.1";
 
   src = fetchurl {
-    url = "https://thrysoee.dk/editline/${name}.tar.gz";
-    sha256 = "0r0hc4lg71xnn0vrrk2g7is42i0k0dra7cbw3fljq3q01c6df498";
+    url = "https://thrysoee.dk/editline/${pname}-${version}.tar.gz";
+    sha256 = "1bhvp8xkkgrg89k4ci1k8vjl3nhb6szd4ghy9lp4jrfgq58hz3xc";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/libedit/default.nix
+++ b/pkgs/development/libraries/libedit/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, ncurses }:
 
 stdenv.mkDerivation rec {
-  name = "libedit-20180525-3.1";
+  name = "libedit-20181209-3.1";
 
   src = fetchurl {
     url = "https://thrysoee.dk/editline/${name}.tar.gz";
-    sha256 = "05iicng4kag5hxdc7adbyj1gm3qbmvcc33m9cyx5gys0s67yl6y4";
+    sha256 = "0r0hc4lg71xnn0vrrk2g7is42i0k0dra7cbw3fljq3q01c6df498";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/libraries/libedit/default.nix
+++ b/pkgs/development/libraries/libedit/default.nix
@@ -18,8 +18,6 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ ncurses ];
 
-  configureFlags = [ "--enable-widec" ];
-
   postInstall = ''
     find $out/lib -type f | grep '\.\(la\|pc\)''$' | xargs sed -i \
       -e 's,-lncurses[a-z]*,-L${ncurses.out}/lib -lncursesw,g'


### PR DESCRIPTION
###### Motivation for this change

New version.

Since determining what changed isn't easy, I made a repo with the
releases for comparing more easily.

For example, changes from version we now have to the latest
(in this PR):

https://github.com/dtzWill/libedit-releases/compare/libedit-20180525-3.1..libedit-20190324-3.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---