### PR TITLE
add option config.nix.systemFeatures

### DIFF
--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -60,6 +60,7 @@ let
         ${optionalString (isNix20 && !cfg.distributedBuilds) ''
           builders =
         ''}
+        system-features = ${toString cfg.systemFeatures}
         $extraOptions
         END
       '' + optionalString cfg.checkConfig (
@@ -357,6 +358,15 @@ in
           The default Nix expression search path, used by the Nix
           evaluator to look up paths enclosed in angle brackets
           (e.g. <literal>&lt;nixpkgs&gt;</literal>).
+        '';
+      };
+
+      systemFeatures = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        example = [ "kvm" "big-parallel" "gccarch-skylake" ];
+        description = ''
+          The supported features of a machine
         '';
       };
 


### PR DESCRIPTION
###### Motivation for this change

```system-features``` is a list, so the features defined in different NixOS modules are to be gathered to a single list
The current way to define ```system-features``` (via ```nix.extraOptions = "system-features = big-parallel gccarch-westmere"```) does not gather the features.