### PR TITLE
libaudit: enable arm (including aarch64) support

### DIFF
--- a/pkgs/os-specific/linux/audit/default.nix
+++ b/pkgs/os-specific/linux/audit/default.nix
@@ -23,6 +23,8 @@ stdenv.mkDerivation rec {
     # and pulls in an extra openldap dependency otherwise
     "--disable-zos-remote"
     (if enablePython then "--with-python" else "--without-python")
+    "--with-arm"
+    "--with-aarch64"
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change
It doesn't currently work properly on aarch64.

This could be enabled only for the respective architectures, but I think the closure size difference is acceptable and having arm/aarch64 support on x86 can be useful too.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size 27096160 → 30467944 on x86_64-linux
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---