### PR TITLE
pkgsMusl, pkgsi686Linux, pkgsStatic: fix infinite recursion with overlays

### DIFF
--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -135,6 +135,9 @@ let
     # default GNU libc on Linux systems. Non-Linux systems are not
     # supported.
     pkgsMusl = if stdenv.hostPlatform.isLinux then nixpkgsFun {
+      overlays = [ (self': super': {
+        pkgsMusl = super';
+      })] ++ overlays;
       ${if stdenv.hostPlatform == stdenv.buildPlatform
         then "localSystem" else "crossSystem"} = {
         parsed = stdenv.hostPlatform.parsed // {
@@ -151,6 +154,9 @@ let
     # All packages built for i686 Linux.
     # Used by wine, firefox with debugging version of Flash, ...
     pkgsi686Linux = if stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86 then nixpkgsFun {
+      overlays = [ (self': super': {
+        pkgsi686Linux = super';
+      })] ++ overlays;
       ${if stdenv.hostPlatform == stdenv.buildPlatform
         then "localSystem" else "crossSystem"} = {
         parsed = stdenv.hostPlatform.parsed // {
@@ -176,6 +182,9 @@ let
     # Fully static packages.
     # Currently uses Musl on Linux (couldn’t get static glibc to work).
     pkgsStatic = nixpkgsFun ({
+      overlays = [ (self': super': {
+        pkgsStatic = super';
+      })] ++ overlays;
       crossOverlays = [ (import ./static.nix) ];
     } // lib.optionalAttrs stdenv.hostPlatform.isLinux {
       crossSystem = {


### PR DESCRIPTION
Consider example:

```
$ nix-instantiate ./nixos -A system --arg configuration '
    {
      boot.isContainer = true;
      nixpkgs.overlays = [ (self: super: {
        nix = self.pkgsStatic.nix;
      }) ];
    }'
```
When resolving package through overlays, we figure out that

```
  nix == self.pkgsStatic.nix
  =>
  nix == (import <nixpkgs> { inherit overlays; }).nix
  =>
  nix == (import <nixpkgs> { overlays = [(self: super: { nix = self.pkgsStatic.nix; })];}).nix
```

and we enter infinite recursion of nixpkgs evaluations.

The proper fix should terminate recursion by assigning self fixpoint
to inner custom package set. But I get infinite recursion somehow, so
I use `super`. It is less correct modulo deep custom overrides, but behaves
correctly for simple cases and doesn't OOM evaluator.

Fixes https://github.com/NixOS/nixpkgs/issues/57984