### PR TITLE
zbar: 0.10 -> 0.22 (new upstream)

### DIFF
--- a/pkgs/tools/graphics/zbar/default.nix
+++ b/pkgs/tools/graphics/zbar/default.nix
@@ -1,52 +1,34 @@
-{ stdenv, fetchurl, imagemagickBig, pkgconfig, python2Packages, perl
-, libX11, libv4l, qt4, lzma, gtk2, fetchpatch, autoreconfHook
+{ stdenv, fetchFromGitHub, imagemagickBig, pkgconfig, python2Packages, perl
+, libX11, libv4l, qt5, lzma, gtk2, xmlto, docbook_xsl, autoreconfHook
 , enableVideo ? stdenv.isLinux
 }:
 
 let
   inherit (python2Packages) pygtk python;
 in stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
   pname = "zbar";
-  version = "0.10";
-  src = fetchurl {
-    url = "mirror://sourceforge/project/${pname}/${pname}/${version}/${name}.tar.bz2";
-    sha256 = "1imdvf5k34g1x2zr6975basczkz3zdxg6xnci50yyp5yvcwznki3";
+  version = "0.22";
+
+  src = fetchFromGitHub {
+    owner = "mchehab";
+    repo = "zbar";
+    rev = version;
+    sha256 = "0pz0vq6a97vnc3lcjw9k12dk2awgmws46cjfh16zin0jiz18d1xq";
   };
 
-  patches = [
-    (fetchpatch {
-      name = "0001-Description-Linux-2.6.38-and-later-do-not-support-th.patch";
-      url = "https://git.recluse.de/raw/debian/pkg-zbar.git/35182c3ac2430c986579b25f1826fe1b7dfd15de/debian!patches!0001-Description-Linux-2.6.38-and-later-do-not-support-th.patch";
-      sha256 = "1zy1wdyhmpw877pv6slfhjy0c6dm0gxli0i4zs1akpvh052j4a69";
-    })
-    (fetchpatch {
-      name = "python-zbar-import-fix-am.patch";
-      url = "https://git.recluse.de/raw/debian/pkg-zbar.git/1f15f52e53ee0bf7b4761d673dc859c6b10e6be5/debian!patches!python-zbar-import-fix-am.patch";
-      sha256 = "15xx9ms137hvwpynbgvbc6zgmmzfaf7331rfhls24rgbnywbgirx";
-    })
-    (fetchpatch {
-      name = "new_autotools_build_fix.patch";
-      url = "https://git.recluse.de/raw/debian/pkg-zbar.git/2c641cc94d4f728421ed750d95d6d1c2d06a534d/debian!patches!new_autotools_build_fix.patch";
-      sha256 = "0jhl5jnnjhfdv51xqimkbkdvj8d38z05fhd11yx1sgmw82f965s3";
-    })
-    (fetchpatch {
-      name = "threading-fix.patch";
-      url = "https://git.recluse.de/raw/debian/pkg-zbar.git/d3eba6e2c3acb0758d19519015bf1a53ffb8e645/debian!patches!threading-fix.patch";
-      sha256 = "1jjgrx9nc7788vfriai4z26mm106sg5ylm2w5rdyrwx7420x1wh7";
-    })
+  nativeBuildInputs = [ pkgconfig xmlto autoreconfHook docbook_xsl ];
+
+  buildInputs = [
+    imagemagickBig python pygtk perl libX11
+  ] ++ stdenv.lib.optionals enableVideo [
+    libv4l gtk2 qt5.qtbase qt5.qtx11extras
   ];
 
-  buildInputs =
-    [ imagemagickBig pkgconfig python pygtk perl libX11
-      lzma autoreconfHook ] ++
-    stdenv.lib.optionals enableVideo [ libv4l gtk2 qt4 ];
-
-  configureFlags = stdenv.lib.optionals (!enableVideo) [
+  configureFlags = [
+    "--with-dbusconfdir=$out/etc/dbus-1/system.d"
+  ] ++ stdenv.lib.optionals (!enableVideo) [
     "--disable-video" "--without-gtk" "--without-qt"
   ];
-
-  hardeningDisable = [ "fortify" ];
 
   meta = with stdenv.lib; {
     description = "Bar code reader";
@@ -57,15 +39,9 @@ in stdenv.mkDerivation rec {
       EAN-13/UPC-A, UPC-E, EAN-8, Code 128, Code 39, Interleaved 2 of 5 and QR
       Code.
     '';
-    maintainers = with maintainers; [ raskin ];
+    maintainers = with maintainers; [ delroth raskin ];
     platforms = platforms.unix;
     license = licenses.lgpl21;
-    homepage = http://zbar.sourceforge.net/;
-  };
-
-  passthru = {
-    updateInfo = {
-      downloadPage = "http://zbar.sourceforge.net/";
-    };
+    homepage = https://github.com/mchehab/zbar;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

The original upstream at http://zbar.sourceforge.net/ has not produced a
new release or a new commit on their repository in about 7 years. Most
distros (Debian, Gentoo, Arch, ...) have switched already to the more
maintained fork at https://github.com/mchehab/zbar

Update dependencies from qt4 to qt5, reducing "electrum" closure size in
the process (now only depends on one Qt version).

```
$ nix path-info -Sh /nix/store/1vr26j7z8bdg4d5diln6gzpdrfgaxf26-electrum-3.3.4  # old
/nix/store/1vr26j7z8bdg4d5diln6gzpdrfgaxf26-electrum-3.3.4         1.4G
$ nix path-info -Sh /nix/store/mngfcgfhak1lg3zflw45b6fxkc3l7pzy-electrum-3.3.4  # new
/nix/store/mngfcgfhak1lg3zflw45b6fxkc3l7pzy-electrum-3.3.4         1.2G
```

Tested with zbarcam-gtk, zbarcam-qt, and electrum's QR code features (generation & scanning).

FYI @7c6f434c current zbar maintainer (added myself to the list at the same time)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
