### PR TITLE
manrope: init at 3

### DIFF
--- a/pkgs/data/fonts/manrope/default.nix
+++ b/pkgs/data/fonts/manrope/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "manrope";
+  version = "3";
+  src = fetchFromGitHub {
+    owner = "sharanda";
+    repo = pname;
+    rev = "3bd68c0c325861e32704470a90dfc1868a5c37e9";
+    sha256 = "1k6nmczbl97b9j2a8vx6a1r3q4gd1c2qydv0y9gn8xyl7x8fcvhs";
+  };
+  dontBuild = true;
+  installPhase = ''
+    install -Dm644 -t $out/share/fonts/opentype "desktop font"/*
+  '';
+  meta = with stdenv.lib; {
+    description = "Open-source modern sans-serif font family";
+    homepage = https://github.com/sharanda/manrope;
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15856,6 +15856,8 @@ in
 
   man-pages = callPackage ../data/documentation/man-pages { };
 
+  manrope = callPackage ../data/fonts/manrope { };
+
   matcha = callPackage ../data/themes/matcha { };
 
   materia-theme = callPackage ../data/themes/materia-theme { };


### PR DESCRIPTION
###### Motivation for this change

Font!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---