### PR TITLE
lazygit: 0.5 -> 0.7.2

### DIFF
--- a/pkgs/development/tools/lazygit/default.nix
+++ b/pkgs/development/tools/lazygit/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "lazygit-${version}";
-  version = "0.5";
+  version = "0.7.2";
 
   goPackagePath = "github.com/jesseduffield/lazygit";
 
@@ -10,7 +10,7 @@ buildGoPackage rec {
     owner = "jesseduffield";
     repo = "lazygit";
     rev = "v${version}";
-    sha256 = "0xgda2b5p26ya15kq83502f8vh18kl05hl40k0lsfqx3m7pnidn1";
+    sha256 = "1b5mzmxw715cx7b0n22hvrpk0dbavzypljc7skwmh8k1nlx935jj";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change
Upgrade lazygit to 0.7.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
