### PR TITLE
evince: enable all features

### DIFF
--- a/pkgs/desktops/gnome-3/core/evince/default.nix
+++ b/pkgs/desktops/gnome-3/core/evince/default.nix
@@ -34,6 +34,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--disable-nautilus" # Do not build nautilus plugin
+    "--enable-ps"
     "--enable-introspection"
     (if supportXPS then "--enable-xps" else "--disable-xps")
   ];

--- a/pkgs/desktops/gnome-3/core/evince/default.nix
+++ b/pkgs/desktops/gnome-3/core/evince/default.nix
@@ -2,6 +2,7 @@
 , glib, gtk3, pango, atk, gdk_pixbuf, shared-mime-info, itstool, gnome3
 , poppler, ghostscriptX, djvulibre, libspectre, libarchive, libsecret, wrapGAppsHook
 , librsvg, gobject-introspection, yelp-tools, gspell, adwaita-icon-theme, gsettings-desktop-schemas
+, nautilus
 , libgxps
 , gst_all_1
 , recentListSize ? null # 5 is not enough, allow passing a different number
@@ -32,12 +33,12 @@ stdenv.mkDerivation rec {
     gsettings-desktop-schemas
     poppler ghostscriptX djvulibre libspectre libarchive
     libsecret librsvg adwaita-icon-theme gspell
+    nautilus
   ] ++ stdenv.lib.optional supportXPS libgxps
     ++ stdenv.lib.optionals supportMultimedia (with gst_all_1; [
       gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav ]);
 
   configureFlags = [
-    "--disable-nautilus" # Do not build nautilus plugin
     "--enable-ps"
     "--enable-introspection"
     (if supportXPS then "--enable-xps" else "--disable-xps")

--- a/pkgs/desktops/gnome-3/core/evince/default.nix
+++ b/pkgs/desktops/gnome-3/core/evince/default.nix
@@ -6,7 +6,7 @@
 , libgxps
 , gst_all_1
 , recentListSize ? null # 5 is not enough, allow passing a different number
-, supportXPS ? false    # Open XML Paper Specification via libgxps
+, supportXPS ? true    # Open XML Paper Specification via libgxps
 , supportMultimedia ? true
 , autoreconfHook, pruneLibtoolFiles
 }:

--- a/pkgs/desktops/gnome-3/core/evince/default.nix
+++ b/pkgs/desktops/gnome-3/core/evince/default.nix
@@ -5,6 +5,7 @@
 , nautilus
 , libgxps
 , gst_all_1
+, texlive
 , recentListSize ? null # 5 is not enough, allow passing a different number
 , supportXPS ? true    # Open XML Paper Specification via libgxps
 , supportMultimedia ? true
@@ -34,6 +35,7 @@ stdenv.mkDerivation rec {
     poppler ghostscriptX djvulibre libspectre libarchive
     libsecret librsvg adwaita-icon-theme gspell
     nautilus
+    texlive.bin.core # kpathsea for DVI support
   ] ++ stdenv.lib.optional supportXPS libgxps
     ++ stdenv.lib.optionals supportMultimedia (with gst_all_1; [
       gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav ]);

--- a/pkgs/desktops/gnome-3/core/evince/default.nix
+++ b/pkgs/desktops/gnome-3/core/evince/default.nix
@@ -3,8 +3,10 @@
 , poppler, ghostscriptX, djvulibre, libspectre, libarchive, libsecret, wrapGAppsHook
 , librsvg, gobject-introspection, yelp-tools, gspell, adwaita-icon-theme, gsettings-desktop-schemas
 , libgxps
+, gst_all_1
 , recentListSize ? null # 5 is not enough, allow passing a different number
 , supportXPS ? false    # Open XML Paper Specification via libgxps
+, supportMultimedia ? true
 , autoreconfHook, pruneLibtoolFiles
 }:
 
@@ -30,13 +32,16 @@ stdenv.mkDerivation rec {
     gsettings-desktop-schemas
     poppler ghostscriptX djvulibre libspectre libarchive
     libsecret librsvg adwaita-icon-theme gspell
-  ] ++ stdenv.lib.optional supportXPS libgxps;
+  ] ++ stdenv.lib.optional supportXPS libgxps
+    ++ stdenv.lib.optionals supportMultimedia (with gst_all_1; [
+      gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugins-ugly gst-libav ]);
 
   configureFlags = [
     "--disable-nautilus" # Do not build nautilus plugin
     "--enable-ps"
     "--enable-introspection"
     (if supportXPS then "--enable-xps" else "--disable-xps")
+    (if supportMultimedia then "--enable-multimedia" else "--disable-multimedia")
   ];
 
   NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/gio-unix-2.0";


### PR DESCRIPTION
###### Motivation for this change

I could no longer open postscript files in evince.  While I was at it, I also enabled all other formats (DVI, XPS, PDF multimedia) as well as the nautilus extension.  (The only features not enabled now are the browser plugin, the API docs, and the thumbnail cache.)

There is a *slight* increase in closure size (probably due to the gstreamer/nautilus dependency):
```
 nix path-info -shS result/ (which evince)   Mon 25 Mar 2019 03:35:30 PM CET
/nix/store/kd01ji4sb5pgnrjs3lzvgi3c279f1mjd-evince-3.30.2         11.2M  954.3M
/nix/store/rcy2ii19gx1mkqxzvr20jkj2jdzp83n1-evince-3.30.2         11.0M  420.4M
```

Many of these dependencies are probably already in the system closure (e.g. nautilus depends on gstreamer as well).  We could add an `evinceLight` version that disables some/most features.

cc @jtojnar @vcunat

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
