### PR TITLE
mtxclient: patch to workaround matrix synapse bug

### DIFF
--- a/pkgs/development/libraries/mtxclient/default.nix
+++ b/pkgs/development/libraries/mtxclient/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig
+{ stdenv, fetchFromGitHub, fetchpatch, cmake, pkgconfig
 , boost, openssl, zlib, libsodium, olm, gtest, spdlog, nlohmann_json }:
 
 stdenv.mkDerivation rec {
@@ -11,6 +11,14 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "19v1qa6mzvc65m7wy7x0g4i24bcg9xk31y1grwvd3zr0l4v6xcgs";
   };
+
+  patches = [
+    # remove on the next mtxclient update
+    (fetchpatch {
+      url = "https://github.com/Nheko-Reborn/mtxclient/commit/41314809da7eb17ec00cff1795af6a528c5e904a.diff";
+      sha256 = "17pzrkdhd4jr8xwd7hhyzak880k8yb9nkg3vcbyjfp5si89dha5j";
+    })
+  ];
 
   postPatch = ''
     ln -s ${nlohmann_json}/include/nlohmann/json.hpp include/json.hpp


### PR DESCRIPTION
###### Motivation for this change
Workaround for the bug https://github.com/matrix-org/synapse/issues/4898
This allows nheko to sync again, until all matrix servers will have updated (fix yet unreleased).

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change (nheko)
- [ ] Tested execution of all binary files (none)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This should also be backported to 19.03

ping @fpletz @ekleog @dtzWill 