### PR TITLE
fetchurl: use fetchurlBoot for zlib deps

### DIFF
--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -94,6 +94,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     moveToOutput bin/curl-config "$dev"
+  '' + stdenv.lib.optionalString scpSupport ''
     sed '/^dependency_libs/s|${libssh2.dev}|${libssh2.out}|' -i "$out"/lib/*.la
   '' + stdenv.lib.optionalString gnutlsSupport ''
     ln $out/lib/libcurl.so $out/lib/libcurl-gnutls.so

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -259,6 +259,7 @@ in
     curl = buildPackages.curl.override rec {
       # break dependency cycles
       fetchurl = stdenv.fetchurlBoot;
+      zlib = buildPackages.zlib.override { fetchurl = stdenv.fetchurlBoot; };
       pkgconfig = buildPackages.pkgconfig.override { fetchurl = stdenv.fetchurlBoot; };
       perl = buildPackages.perl.override { fetchurl = stdenv.fetchurlBoot; };
       openssl = buildPackages.openssl.override {
@@ -268,7 +269,7 @@ in
       };
       libssh2 = buildPackages.libssh2.override {
         fetchurl = stdenv.fetchurlBoot;
-        inherit openssl;
+        inherit zlib openssl;
       };
       # On darwin, libkrb5 needs bootstrap_cmds which would require
       # converting many packages to fetchurl_boot to avoid evaluation cycles.
@@ -280,7 +281,7 @@ in
       };
       nghttp2 = buildPackages.nghttp2.override {
         fetchurl = stdenv.fetchurlBoot;
-        inherit pkgconfig openssl;
+        inherit zlib pkgconfig openssl;
         c-ares = buildPackages.c-ares.override { fetchurl = stdenv.fetchurlBoot; };
         libev = buildPackages.libev.override { fetchurl = stdenv.fetchurlBoot; };
       };


### PR DESCRIPTION
Ever since #56067 went in, I've been getting infinite recursion errors. I eventually tracked the problem down to zlib using fetchurl.  This patch ensures that fetchurl zlib dependencies correctly use fetchurlBoot instead.

```
error: while evaluating the attribute 'buildCommand' of the derivation 'modules' at /mnt/home/dylan/nix/nixpkgs/pkgs/build-support/trivial-builders.nix:7:14:
while evaluating the attribute 'patches' of the derivation 'perl-5.28.1' at /mnt/home/dylan/nix/nixpkgs/pkgs/development/interpreters/perl/default.nix:28:5:
while evaluating the attribute 'nativeBuildInputs' of the derivation '0001-Fix-missing-build-dependency-for-pods.patch' at /mnt/home/dylan/nix/nixpkgs/pkgs/build-support/fetchurl/default.nix:115:3:
while evaluating the attribute 'configureFlags' of the derivation 'curl-7.64.0' at /mnt/home/dylan/nix/nixpkgs/pkgs/tools/networking/curl/default.nix:27:3:
while evaluating the attribute 'buildInputs' of the derivation 'libssh2-1.8.1' at /mnt/home/dylan/nix/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:183:11:
while evaluating the attribute 'src' of the derivation 'zlib-1.2.11' at /mnt/home/dylan/nix/nixpkgs/pkgs/development/libraries/zlib/default.nix:8:3:
while evaluating the attribute 'nativeBuildInputs' of the derivation 'zlib-1.2.11.tar.gz' at /mnt/home/dylan/nix/nixpkgs/pkgs/build-support/fetchurl/default.nix:115:3:
infinite recursion encountered, at undefined position
```

This exact problem I'm seeing may be specific to a custom overlay using genericStdenv, but I'm honestly not sure why this isn't a problem for general builds too.

(Also includes a related fix to the curl postInstall to not reference a null libssh2.)