### PR TITLE
yuzu: init at 2019-05-03

### DIFF
--- a/pkgs/misc/emulators/yuzu/default.nix
+++ b/pkgs/misc/emulators/yuzu/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, boost, cmake, git, python2, perl, qtbase, SDL2 }:
+
+stdenv.mkDerivation rec {
+  pname = "yuzu";
+  version = "unstable-2019-05-03";
+
+  src = fetchFromGitHub {
+    owner = "yuzu-emu";
+    repo = "yuzu";
+    fetchSubmodules = true;
+    deepClone = true;  # Yuzu's CMake submodule check uses .git presence.
+    branchName = "master";  # For nicer in-app version numbers.
+    rev = "1f72bb733f743d55ac890c990f0fefea9a0ef290";
+    sha256 = "0lvw1i3601ycc6ipnssq398hcgsaq2an91wic46ppd5qqlck50fi";
+  };
+
+  nativeBuildInputs = [ cmake git perl python2 ];
+  buildInputs = [ boost qtbase SDL2 ];
+
+  cmakeFlags = [
+    # Disable as much vendoring as upstream allows. We still use vendored
+    # libunicorn since the fork used by Yuzu is significantly different.
+    "-DYUZU_USE_BUNDLED_QT=OFF"
+    "-DYUZU_USE_BUNDLED_SDL2=OFF"
+    "-DYUZU_USE_BUNDLED_UNICORN=ON"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Experimental open-source emulator for the Nintendo Switch";
+    homepage = "https://yuzu-emu.org";
+    license = licenses.gpl2Plus;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ delroth ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6751,6 +6751,8 @@ in
 
   you-get = python3Packages.callPackage ../tools/misc/you-get { };
 
+  yuzu = libsForQt5.callPackage ../misc/emulators/yuzu { };
+
   zbackup = callPackage ../tools/backup/zbackup {};
 
   zbar = callPackage ../tools/graphics/zbar { };


### PR DESCRIPTION
###### Motivation for this change

Requested in #58176.

Yuzu doesn't have stable releases yet, so this is based on the current latest git revision.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
