### PR TITLE
falkon: 3.0.1 -> 3.1.0

### DIFF
--- a/pkgs/applications/networking/browsers/falkon/default.nix
+++ b/pkgs/applications/networking/browsers/falkon/default.nix
@@ -6,12 +6,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "falkon-${version}";
-  version = "3.0.1";
+  pname = "falkon";
+  version = "3.1.0";
 
   src = fetchFromGitHub {
     owner  = "KDE";
-    repo   = "falkon";
+    repo   = pname;
     rev    = "v${version}";
     sha256 = "1ay1ljrdjcfqwjv4rhf4psh3dfihnvhpmpqcayd3p9lh57x7fh41";
   };
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "QtWebEngine based cross-platform web browser";
-    homepage    = https://community.kde.org/Incubator/Projects/Falkon;
+    homepage    = https://www.falkon.org/;
     license     = licenses.gpl3;
     maintainers = with maintainers; [ peterhoeg ];
     platforms   = platforms.unix;


### PR DESCRIPTION
###### Motivation for this change

\o/

https://www.falkon.org/2019/03/19/falkon-310-released/

This does not package the "experimental" python/qt plugin bits, FWIW.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---