### PR TITLE
idrisPackages: Fix linking to gmp library and cc

### DIFF
--- a/pkgs/development/idris-modules/idris-wrapper.nix
+++ b/pkgs/development/idris-modules/idris-wrapper.nix
@@ -1,4 +1,4 @@
-{ lib, symlinkJoin, makeWrapper, idris-no-deps, gcc, gmp }:
+{ stdenv, lib, symlinkJoin, makeWrapper, idris-no-deps, gcc, gmp }:
 
 symlinkJoin {
   inherit (idris-no-deps) name src meta;
@@ -7,6 +7,8 @@ symlinkJoin {
   postBuild = ''
     wrapProgram $out/bin/idris \
       --run 'export IDRIS_CC=''${IDRIS_CC:-${lib.getBin gcc}/bin/gcc}' \
-      --suffix LIBRARY_PATH : ${lib.makeLibraryPath [ gmp ]}
+      --set NIX_CC_WRAPPER_${stdenv.cc.infixSalt}_TARGET_HOST 1 \
+      --prefix NIX_CFLAGS_COMPILE " " "-I${lib.getDev gmp}/include" \
+      --prefix NIX_CFLAGS_LINK " " "-L${lib.getLib gmp}/lib"
   '';
 }

--- a/pkgs/development/idris-modules/idris-wrapper.nix
+++ b/pkgs/development/idris-modules/idris-wrapper.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, symlinkJoin, makeWrapper, idris-no-deps, gcc, gmp }:
+{ stdenv, lib, symlinkJoin, makeWrapper, idris-no-deps, gmp }:
 
 symlinkJoin {
   inherit (idris-no-deps) name src meta;
@@ -6,7 +6,7 @@ symlinkJoin {
   buildInputs = [ makeWrapper ];
   postBuild = ''
     wrapProgram $out/bin/idris \
-      --run 'export IDRIS_CC=''${IDRIS_CC:-${lib.getBin gcc}/bin/gcc}' \
+      --run 'export IDRIS_CC=''${IDRIS_CC:-${stdenv.cc}/bin/cc}' \
       --set NIX_CC_WRAPPER_${stdenv.cc.infixSalt}_TARGET_HOST 1 \
       --prefix NIX_CFLAGS_COMPILE " " "-I${lib.getDev gmp}/include" \
       --prefix NIX_CFLAGS_LINK " " "-L${lib.getLib gmp}/lib"


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/54579 and probably https://github.com/NixOS/nixpkgs/issues/52796

Ping @ar1a @marsam @shmish111 @mpickering 

This has been broken since 5d18129ce8af9a69312818ea0a5a0029a04a2255,
which updated idris from 1.3.0 to 1.3.1, which included
https://github.com/idris-lang/Idris-dev/pull/4472 as the cause of the
error. I'm still not entirely sure why this broke it though.

This way should be rather future proof, it uses NIX_CFLAGS to pass
gpm link flags to our CC wrapper directly. The
`NIX_CC_WRAPPER_${stdenv.cc.infixSalt}_TARGET_HOST` part I'm pretty sure
is needed for the CC wrapper to know that those CFLAGS are meant for the
cc running on the HOST.

The second commit just switches to stdenv's cc.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
