### PR TITLE
idrisPackages.glfw: Fix runtime

### DIFF
--- a/pkgs/development/idris-modules/glfw.nix
+++ b/pkgs/development/idris-modules/glfw.nix
@@ -10,7 +10,13 @@ build-idris-package  {
 
   idrisDeps = [ effects ];
 
+  nativeBuildInputs = [ pkgs.pkgconfig ];
   extraBuildInputs = [ pkgs.glfw ];
+
+  postPatch = ''
+    substituteInPlace src/MakefileGlfw \
+      --replace glfw3 "glfw3 gl"
+  '';
 
   src = fetchFromGitHub {
     owner = "eckart";


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/55086

Ping @locallycompact 

In order to run programs, pkgconfig needs to be present so it can tell
it where to find glfw3 and gl.

The general idris fix in https://github.com/NixOS/nixpkgs/pull/58319 is also needed for it to work

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
