### PR TITLE
khal: 0.9.10 -> 0.10.0

### DIFF
--- a/pkgs/applications/misc/khal/default.nix
+++ b/pkgs/applications/misc/khal/default.nix
@@ -2,11 +2,11 @@
 
 with python3.pkgs; buildPythonApplication rec {
   pname = "khal";
-  version = "0.10.0";
+  version = "0.10.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1p49f3g25x900vk32spjbr2aipj12kcbhayny2vwhdpkjlv6k396";
+    sha256 = "1r8bkgjwkh7i8ygvsv51h1cnax50sb183vafg66x5snxf3dgjl6l";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/applications/misc/khal/default.nix
+++ b/pkgs/applications/misc/khal/default.nix
@@ -33,7 +33,7 @@ with python3.pkgs; buildPythonApplication rec {
     install -D misc/__khal $out/share/zsh/site-functions/__khal
   '';
 
-  doCheck = true;
+  doCheck = !stdenv.isAarch64;
 
   checkPhase = ''
     py.test

--- a/pkgs/applications/misc/khal/default.nix
+++ b/pkgs/applications/misc/khal/default.nix
@@ -2,18 +2,19 @@
 
 with python3.pkgs; buildPythonApplication rec {
   pname = "khal";
-  version = "0.9.10";
+  version = "0.10.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "03h0j0d3xyqh98x5v2gv63wv3g91hip3vsaxvybsn5iz331d23h4";
+    sha256 = "1p49f3g25x900vk32spjbr2aipj12kcbhayny2vwhdpkjlv6k396";
   };
 
-  LC_ALL = "en_US.UTF-8";
+  LC_ALL = "C.UTF-8";
 
   propagatedBuildInputs = [
     atomicwrites
     click
+    click-log
     configobj
     dateutil
     icalendar
@@ -27,15 +28,14 @@ with python3.pkgs; buildPythonApplication rec {
     pkginfo
     freezegun
   ];
-  nativeBuildInputs = [ setuptools_scm pkgs.glibcLocales ];
+  nativeBuildInputs = [ setuptools_scm ];
   checkInputs = [ pytest ];
 
   postInstall = ''
     install -D misc/__khal $out/share/zsh/site-functions/__khal
   '';
 
-  # One test fails as of 0.9.10 due to the upgrade to icalendar 4.0.3
-  doCheck = false;
+  doCheck = true;
 
   checkPhase = ''
     py.test

--- a/pkgs/applications/misc/khal/default.nix
+++ b/pkgs/applications/misc/khal/default.nix
@@ -9,8 +9,6 @@ with python3.pkgs; buildPythonApplication rec {
     sha256 = "1p49f3g25x900vk32spjbr2aipj12kcbhayny2vwhdpkjlv6k396";
   };
 
-  LC_ALL = "C.UTF-8";
-
   propagatedBuildInputs = [
     atomicwrites
     click


### PR DESCRIPTION
###### Motivation for this change

https://github.com/pimutils/khal/releases/tag/v0.10.0

* new dep, click-log
* enable tests (pass!)

Release notes mention 'only dateutil < 2.7 is supported',
which may be a problem as ours is currently 2.8.

There's a history of python-dateutil version particularity
in previous releases (such as 0.9.10 upgrading from),
unsure if should override to older or if it's just a suggestion.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---