### PR TITLE
pythonPackages.pyarrow: fix build

### DIFF
--- a/pkgs/development/python-modules/pyarrow/default.nix
+++ b/pkgs/development/python-modules/pyarrow/default.nix
@@ -25,6 +25,10 @@ buildPythonPackage rec {
     "-DCMAKE_POLICY_DEFAULT_CMP0025=NEW"
   ];
 
+  preBuild = ''
+    export PYARROW_PARALLEL=$NIX_BUILD_CORES
+  '';
+
   preCheck = ''
     rm pyarrow/tests/test_jvm.py
     rm pyarrow/tests/test_hdfs.py

--- a/pkgs/development/python-modules/pyarrow/default.nix
+++ b/pkgs/development/python-modules/pyarrow/default.nix
@@ -16,6 +16,7 @@ buildPythonPackage rec {
   checkInputs = [ hypothesis pandas pytest ];
 
   PYARROW_BUILD_TYPE = "release";
+  PYARROW_WITH_PARQUET = true;
   PYARROW_CMAKE_OPTIONS = [
     "-DCMAKE_INSTALL_RPATH=${ARROW_HOME}/lib"
 
@@ -47,8 +48,6 @@ buildPythonPackage rec {
 
   ARROW_HOME = _arrow-cpp;
   PARQUET_HOME = _arrow-cpp;
-
-  setupPyBuildFlags = ["--with-parquet" ];
 
   checkPhase = ''
     mv pyarrow/tests tests

--- a/pkgs/development/python-modules/pyarrow/default.nix
+++ b/pkgs/development/python-modules/pyarrow/default.nix
@@ -48,6 +48,10 @@ buildPythonPackage rec {
     # when it is not intended to be imported at all
     rm pyarrow/tests/deserialize_buffer.py
     substituteInPlace pyarrow/tests/test_feather.py --replace "test_deserialize_buffer_in_different_process" "_disabled"
+
+    # Fails to bind a socket
+    # "PermissionError: [Errno 1] Operation not permitted"
+    substituteInPlace pyarrow/tests/test_ipc.py --replace "test_socket_" "_disabled"
   '';
 
   ARROW_HOME = _arrow-cpp;


### PR DESCRIPTION
###### Motivation for this change

Fixes pyarrow build.
cc #56826

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---