### PR TITLE
ffsend: 0.2.39 -> 0.2.42

### DIFF
--- a/pkgs/tools/misc/ffsend/default.nix
+++ b/pkgs/tools/misc/ffsend/default.nix
@@ -2,34 +2,39 @@
 , darwin
 
 , x11Support ? stdenv.isLinux
-, xclip ? null
+, xclip ? null, xsel ? null
+, preferXsel ? false # if true and xsel is non-null, use it instead of xclip
 }:
 
-assert x11Support -> xclip != null;
+assert (x11Support && stdenv.isLinux) -> xclip != null || xsel != null;
 
 with rustPlatform;
 
 buildRustPackage rec {
   name = "ffsend-${version}";
-  version = "0.2.39";
+  version = "0.2.42";
 
   src = fetchFromGitLab {
     owner = "timvisee";
     repo = "ffsend";
     rev = "v${version}";
-    sha256 = "0109g2h8673q6kx1lbci59zg9iczj676fvbip3sf1xfypvca22j9";
+    sha256 = "0lsdn967rq6hf3fmkynznsvj8fcka5wi1mpcl3wfa7hf58r266yq";
   };
 
-  cargoSha256 = "0yf9zfilj2whhnmbvh8p8vz4gkd8ds21gshylwp4ykqwv5p59nqq";
+  cargoSha256 = "1f1npdr8v9vlv3xdraq1qang4l0j0w9slbws4da5ylw195nb4qx5";
 
   nativeBuildInputs = [ cmake pkgconfig ];
   buildInputs = [ openssl ]
   ++ stdenv.lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ CoreFoundation CoreServices Security AppKit ])
   ;
 
-  preBuild = if x11Support then ''
-    export XCLIP_PATH="${xclip}/bin/xclip"
-  '' else null;
+  preBuild = stdenv.lib.optionalString (x11Support && stdenv.isLinux) (
+    if preferXsel && xsel != null then ''
+      export XSEL_PATH="${xsel}/bin/xsel"
+    '' else ''
+      export XCLIP_PATH="${xclip}/bin/xclip"
+    ''
+  );
 
   postInstall = ''
     install -Dm644 contrib/completions/_ffsend "$out/share/zsh/site-functions/_ffsend"


### PR DESCRIPTION
###### Motivation for this change
https://github.com/timvisee/ffsend/releases/tag/v0.2.42

Add support for `xsel` instead of `xclip` on Linux.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [X] other Linux distributions (Linux via the `nixos/nix` Docker image)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

In the Linux Docker image I tested both with and without the `preferXsel` arg.