### PR TITLE
TI MSP430 cross compiling

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -34,6 +34,7 @@ rec {
         else if final.isUClibc              then "uclibc"
         else if final.isAndroid             then "bionic"
         else if final.isLinux /* default */ then "glibc"
+        else if final.isMsp430              then "newlib"
         else if final.isAvr                 then "avrlibc"
         # TODO(@Ericson2314) think more about other operating systems
         else                                     "native/impure";

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -102,6 +102,11 @@ rec {
   riscv64 = riscv "64";
   riscv32 = riscv "32";
 
+  msp430 = {
+    config = "msp430-elf";
+    libc = "newlib";
+  };
+
   avr = {
     config = "avr";
   };

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -20,6 +20,7 @@ rec {
     isRiscV        = { cpu = { family = "riscv"; }; };
     isSparc        = { cpu = { family = "sparc"; }; };
     isWasm         = { cpu = { family = "wasm"; }; };
+    isMsp430       = { cpu = { family = "msp430"; }; };
     isAvr          = { cpu = { family = "avr"; }; };
     isAlpha        = { cpu = { family = "alpha"; }; };
 

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -109,6 +109,7 @@ rec {
     
     alpha    = { bits = 64; significantByte = littleEndian; family = "alpha"; };
 
+    msp430   = { bits = 16; significantByte = littleEndian; family = "msp430"; };
     avr      = { bits = 8; family = "avr"; };
   };
 

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -147,6 +147,11 @@
     github = "aepsil0n";
     name = "Eduard Bopp";
   };
+  aerialx = {
+    email = "aaron+nixos@aaronlindsay.com";
+    github = "AerialX";
+    name = "Aaron Lindsay";
+  };
   aespinosa = {
     email = "allan.espinosa@outlook.com";
     github = "aespinosa";

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -186,6 +186,7 @@ stdenv.mkDerivation {
         }.${targetPlatform.parsed.cpu.name}
       else if targetPlatform.isPower then if targetPlatform.isBigEndian then "ppc" else "lppc"
       else if targetPlatform.isSparc then "sparc"
+      else if targetPlatform.isMsp430 then "msp430"
       else if targetPlatform.isAvr then "avr"
       else if targetPlatform.isAlpha then "alpha"
       else throw "unknown emulation for platform: " + targetPlatform.config;

--- a/pkgs/development/misc/msp430/gcc-support.nix
+++ b/pkgs/development/misc/msp430/gcc-support.nix
@@ -12,7 +12,7 @@ in stdenvNoCC.mkDerivation {
 
   buildCommand = ''
     install -Dm0644 -t $out/lib $src/include/*.ld
-    install -Dm0644 -t $out/include $src/include/*.h
+    install -Dm0644 -t $out/include $src/include/*.h $src/include/devices.csv
 
     # appease bintoolsWrapper_addLDVars, search path needed for ld scripts
     touch $out/lib/lib
@@ -20,7 +20,7 @@ in stdenvNoCC.mkDerivation {
 
   meta = with stdenvNoCC.lib; {
     description = ''
-      Development headers and linker scripts for TI MSP430 microcontrollers.
+      Development headers and linker scripts for TI MSP430 microcontrollers
     '';
     homepage = https://www.ti.com/tool/msp430-gcc-opensource;
     license = licenses.bsd3;

--- a/pkgs/development/misc/msp430/gcc-support.nix
+++ b/pkgs/development/misc/msp430/gcc-support.nix
@@ -11,8 +11,9 @@ in stdenvNoCC.mkDerivation {
   };
 
   buildCommand = ''
-    install -Dm0644 -t $out/lib $src/include/*.ld
-    install -Dm0644 -t $out/include $src/include/*.h $src/include/devices.csv
+    find $src/include -name '*.ld' | xargs install -Dm0644 -t $out/lib
+    find $src/include -name '*.h' | xargs install -Dm0644 -t $out/include
+    install -Dm0644 -t $out/include $src/include/devices.csv
 
     # appease bintoolsWrapper_addLDVars, search path needed for ld scripts
     touch $out/lib/lib

--- a/pkgs/development/misc/msp430/gcc-support.nix
+++ b/pkgs/development/misc/msp430/gcc-support.nix
@@ -1,0 +1,30 @@
+{ stdenvNoCC, fetchzip }:
+
+let
+  mspgccVersion = "6_1_0_0";
+  version = "1.206";
+in stdenvNoCC.mkDerivation {
+  name = "msp430-gcc-support-files-${version}";
+  src = fetchzip {
+    url = "http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPGCC/${mspgccVersion}/exports/msp430-gcc-support-files-${version}.zip";
+    sha256 = "0h297jms3gkmdcqmfpr3cg6v9wxnms34qbwvwl2fkmrz20vk766q";
+  };
+
+  buildCommand = ''
+    install -Dm0644 -t $out/lib $src/include/*.ld
+    install -Dm0644 -t $out/include $src/include/*.h
+
+    # appease bintoolsWrapper_addLDVars, search path needed for ld scripts
+    touch $out/lib/lib
+  '';
+
+  meta = with stdenvNoCC.lib; {
+    description = ''
+      Development headers and linker scripts for TI MSP430 microcontrollers.
+    '';
+    homepage = https://www.ti.com/tool/msp430-gcc-opensource;
+    license = licenses.bsd3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ aerialx ];
+  };
+}

--- a/pkgs/development/misc/msp430/gcc-support.nix
+++ b/pkgs/development/misc/msp430/gcc-support.nix
@@ -24,7 +24,7 @@ in stdenvNoCC.mkDerivation {
     '';
     homepage = https://www.ti.com/tool/msp430-gcc-opensource;
     license = licenses.bsd3;
-    platforms = platforms.all;
+    platforms = [ "msp430-none" ];
     maintainers = with maintainers; [ aerialx ];
   };
 }

--- a/pkgs/development/misc/msp430/mspdebug.nix
+++ b/pkgs/development/misc/msp430/mspdebug.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, libusb, readline ? null }:
+
+let
+  version = "0.25";
+in stdenv.mkDerivation {
+  name = "mspdebug-${version}";
+  src = fetchFromGitHub {
+    owner = "dlbeer";
+    repo = "mspdebug";
+    rev = "v${version}";
+    sha256 = "0prgwb5vx6fd4bj12ss1bbb6axj2kjyriyjxqrzd58s5jyyy8d3c";
+  };
+
+  buildInputs = [ readline libusb ];
+  makeFlags = [
+    "PREFIX=$(out)"
+    "INSTALL=install"
+  ] ++ (if readline == null then ["WITHOUT_READLINE=1"] else []);
+
+  meta = with stdenv.lib; {
+    description = "A free programmer, debugger, and gdb proxy for MSP430 MCUs";
+    homepage = https://dlbeer.co.nz/mspdebug/;
+    license = licenses.gpl2;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ aerialx ];
+  };
+}

--- a/pkgs/development/misc/msp430/mspdebug.nix
+++ b/pkgs/development/misc/msp430/mspdebug.nix
@@ -11,11 +11,9 @@ in stdenv.mkDerivation {
     sha256 = "0prgwb5vx6fd4bj12ss1bbb6axj2kjyriyjxqrzd58s5jyyy8d3c";
   };
 
-  buildInputs = [ readline libusb ];
-  makeFlags = [
-    "PREFIX=$(out)"
-    "INSTALL=install"
-  ] ++ (if readline == null then ["WITHOUT_READLINE=1"] else []);
+  buildInputs = [ libusb readline ];
+  makeFlags = [ "PREFIX=$(out)" "INSTALL=install" ] ++
+    (if readline == null then [ "WITHOUT_READLINE=1" ] else []);
 
   meta = with stdenv.lib; {
     description = "A free programmer, debugger, and gdb proxy for MSP430 MCUs";

--- a/pkgs/development/misc/msp430/newlib.nix
+++ b/pkgs/development/misc/msp430/newlib.nix
@@ -1,18 +1,25 @@
-{ runCommand, lndir, newlib, msp430GccSupport }:
+{ stdenvNoCC, lndir, newlib, msp430GccSupport }:
 
-runCommand "msp430-${newlib.name}" {
+stdenvNoCC.mkDerivation {
+  name = "msp430-${newlib.name}";
   inherit newlib;
   inherit msp430GccSupport;
 
   preferLocalBuild = true;
   allowSubstitutes = false;
 
+  buildCommand = ''
+    mkdir $out
+    ${lndir}/bin/lndir -silent $newlib $out
+    ${lndir}/bin/lndir -silent $msp430GccSupport/include $out/${newlib.incdir}
+    ${lndir}/bin/lndir -silent $msp430GccSupport/lib $out/${newlib.libdir}
+  '';
+
   passthru = {
     inherit (newlib) incdir libdir;
   };
-} ''
-  mkdir $out
-  ${lndir}/bin/lndir -silent $newlib $out
-  ${lndir}/bin/lndir -silent $msp430GccSupport/include $out/${newlib.incdir}
-  ${lndir}/bin/lndir -silent $msp430GccSupport/lib $out/${newlib.libdir}
-''
+
+  meta = {
+    platforms = [ "msp430-none" ];
+  };
+}

--- a/pkgs/development/misc/msp430/newlib.nix
+++ b/pkgs/development/misc/msp430/newlib.nix
@@ -1,0 +1,18 @@
+{ runCommand, lndir, newlib, msp430GccSupport }:
+
+runCommand "msp430-${newlib.name}" {
+  inherit newlib;
+  inherit msp430GccSupport;
+
+  preferLocalBuild = true;
+  allowSubstitutes = false;
+
+  passthru = {
+    inherit (newlib) incdir libdir;
+  };
+} ''
+  mkdir $out
+  ${lndir}/bin/lndir -silent $newlib $out
+  ${lndir}/bin/lndir -silent $msp430GccSupport/include $out/${newlib.incdir}
+  ${lndir}/bin/lndir -silent $msp430GccSupport/lib $out/${newlib.libdir}
+''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8380,6 +8380,8 @@ in
     newlib = pkgs.newlibCross;
   };
 
+  mspdebug = callPackage ../development/misc/msp430/mspdebug.nix { };
+
   pharo-vms = callPackage ../development/pharo/vm { };
   pharo = pharo-vms.multi-vm-wrapper;
   pharo-cog32 = pharo-vms.cog32;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8372,6 +8372,8 @@ in
     binutils-arm-embedded = pkgsCross.arm-embedded.buildPackages.binutils;
   };
 
+  msp430GccSupport = callPackage ../development/misc/msp430/gcc-support.nix { };
+
   pharo-vms = callPackage ../development/pharo/vm { };
   pharo = pharo-vms.multi-vm-wrapper;
   pharo-cog32 = pharo-vms.cog32;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8374,6 +8374,12 @@ in
 
   msp430GccSupport = callPackage ../development/misc/msp430/gcc-support.nix { };
 
+  msp430Newlib      = callPackage ../development/misc/msp430/newlib.nix { };
+  msp430NewlibCross = callPackage ../development/misc/msp430/newlib.nix {
+    inherit (pkgs.buildPackages.xorg) lndir;
+    newlib = pkgs.newlibCross;
+  };
+
   pharo-vms = callPackage ../development/pharo/vm { };
   pharo = pharo-vms.multi-vm-wrapper;
   pharo-cog32 = pharo-vms.cog32;
@@ -10146,6 +10152,7 @@ in
     else if name == "bionic" then targetPackages.bionic or bionic
     else if name == "uclibc" then targetPackages.uclibcCross or uclibcCross
     else if name == "avrlibc" then targetPackages.avrlibcCross or avrlibcCross
+    else if name == "newlib" && stdenv.targetPlatform.isMsp430 then targetPackages.msp430NewlibCross or msp430NewlibCross
     else if name == "newlib" then targetPackages.newlibCross or newlibCross
     else if name == "musl" then targetPackages.muslCross or muslCross
     else if name == "msvcrt" then targetPackages.windows.mingw_w64 or windows.mingw_w64

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8376,8 +8376,8 @@ in
 
   msp430Newlib      = callPackage ../development/misc/msp430/newlib.nix { };
   msp430NewlibCross = callPackage ../development/misc/msp430/newlib.nix {
-    inherit (pkgs.buildPackages.xorg) lndir;
-    newlib = pkgs.newlibCross;
+    inherit (buildPackages.xorg) lndir;
+    newlib = newlibCross;
   };
 
   mspdebug = callPackage ../development/misc/msp430/mspdebug.nix { };

--- a/pkgs/top-level/release-cross.nix
+++ b/pkgs/top-level/release-cross.nix
@@ -140,6 +140,7 @@ in
   android64 = mapTestOnCross lib.systems.examples.aarch64-android-prebuilt (linuxCommon // {
   });
 
+  msp430 = mapTestOnCross lib.systems.examples.msp430 embedded;
   avr = mapTestOnCross lib.systems.examples.avr embedded;
   arm-embedded = mapTestOnCross lib.systems.examples.arm-embedded embedded;
   powerpc-embedded = mapTestOnCross lib.systems.examples.ppc-embedded embedded;


### PR DESCRIPTION
###### Motivation for this change

Enables compiling for MSP430 microcontrollers.

###### Remaining unsure points

- [ ] Is `fetchzip` appropriate here or is `fetchurl` better to use when the archive is likely an archive that won't superficially change?
- [ ] Should `msp430GccSupport` be included in stdenv or should it just be expected to be added to `buildInputs` of any packages targeting msp430 devices?
  - For reference, the `msp430GccSupport` package contains headers, symbols, and linker scripts for the registers and memory layout of each of the hundreds of MSP430 SKUs.
  - Using the `-mmcu=` flag with gcc will pull in the appropriate ldscript and header, so I'm assuming this should be included in gcc, libc, or stdenv in some way.
- [ ] Is the current approach (symlink wrapper derivation to combine support files with newlib) the correct idiom to use here? Is there some better way to add the support files as additional default cflags/ldflags search paths for stdenv?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---