### PR TITLE
nixos/prometheus: add tls_config option

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/default.nix
+++ b/nixos/modules/services/monitoring/prometheus/default.nix
@@ -179,6 +179,52 @@ let
           Optional http login credentials for metrics scraping.
         '';
       };
+      tls_config = mkOption {
+        type = types.nullOr (types.submodule {
+          options = {
+            ca_file = mkOption {
+              type = types.nullOr types.str;
+              default = null;
+              description = ''
+                CA certificate to validate API server certificate with.
+              '';
+            };
+            cert_file = mkOption {
+              type = types.nullOr types.str;
+              default = null;
+              description = ''
+                Certificate file for client cert authentication to the server.
+              '';
+            };
+            key_file = mkOption {
+              type = types.nullOr types.str;
+              default = null;
+              description = ''
+                Key file for client cert authentication to the server.
+              '';
+            };
+            server_name = mkOption {
+              type = types.nullOr types.str;
+              default = null;
+              description = ''
+                ServerName extension to indicate the name of the server.
+              '';
+            };
+            insecure_skip_verify = mkOption {
+              type = types.bool;
+              default = false;
+              description = ''
+                Disable validation of the server certificate.
+              '';
+            };
+          };
+        });
+        default = null;
+        apply = x: mapNullable _filter x;
+        description = ''
+          Optional TLS configuration for metrics scraping.
+        '';
+      };
       dns_sd_configs = mkOption {
         type = types.listOf promTypes.dns_sd_config;
         default = [];


### PR DESCRIPTION
###### Motivation for this change
The option was notably missing and has existed since Prometheus 1.8 and later.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
