### PR TITLE
[WIP] ghc.withPackages: can add user arguments to wrapper

### DIFF
--- a/pkgs/development/haskell-modules/with-packages-wrapper.nix
+++ b/pkgs/development/haskell-modules/with-packages-wrapper.nix
@@ -2,6 +2,9 @@
 , withLLVM ? false
 , postBuild ? ""
 , ghcLibdir ? null # only used by ghcjs, when resolving plugins
+
+# Wrap ghc executables with the given argument.
+, makeWrapperArgs ? []
 }:
 
 assert ghcLibdir != null -> (ghc.isGhcjs or false);
@@ -74,7 +77,8 @@ symlinkJoin {
           ${lib.optionalString (ghc.isGhcjs or false)
             ''--set NODE_PATH "${ghc.socket-io}/lib/node_modules"''
           } \
-          ${lib.optionalString withLLVM ''--prefix "PATH" ":" "${llvm}"''}
+          ${lib.optionalString withLLVM ''--prefix "PATH" ":" "${llvm}"''} \
+          ${stdenv.lib.concatStringsSep " " makeWrapperArgs}
       fi
     done
 


### PR DESCRIPTION
###### Motivation for this change
I am trying to debug a haskell library used by my program. Everytime I change this library, I need to relaunch the nix-shell of my haskell program to get an up to date ghc environment.
My idea is to wrap the GHC with an `-i/local/lib/we/debug`. Because the library I debug is also in NIX_GHC_LIBDIR, I wonder if I can prefix NIX_GHC_LIBDIR so that ghc picks the debug version over the one in the environment. 
If there is a better way let me know.

One difficulty is I am not sure how to pass `postBuild`, `makeWrapper` args to withPackages, the feature seem unused ?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
