### PR TITLE
drawpile: 2.1.3 -> 2.1.4

### DIFF
--- a/pkgs/applications/graphics/drawpile/default.nix
+++ b/pkgs/applications/graphics/drawpile/default.nix
@@ -17,10 +17,10 @@
 
 stdenv.mkDerivation rec {
   name = "drawpile-${version}";
-  version = "2.1.3";
+  version = "2.1.4";
   src = fetchurl {
     url = "https://drawpile.net/files/src/drawpile-${version}.tar.gz";
-    sha256 = "0fngj5hfinj66xpij2h3ag79mgmqcfrjpwynxdbjr5brch25ldwj";
+    sha256 = "0n54p5day6gnmxqmgx4yd7q6y0mgv1nwh84yrz5r953yhd9m37rn";
   };
   nativeBuildInputs = [
     extra-cmake-modules


### PR DESCRIPTION
###### Motivation for this change

https://drawpile.net/news/release-2.1.4/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
