### PR TITLE
dockerTools: add finalImageName parameter for pullImage

### DIFF
--- a/doc/functions/dockertools.xml
+++ b/doc/functions/dockertools.xml
@@ -417,10 +417,11 @@ pkgs.dockerTools.buildLayeredImage {
 pullImage {
   imageName = "nixos/nix"; <co xml:id='ex-dockerTools-pullImage-1' />
   imageDigest = "sha256:20d9485b25ecfd89204e843a962c1bd70e9cc6858d65d7f5fadc340246e2116b"; <co xml:id='ex-dockerTools-pullImage-2' />
-  finalImageTag = "1.11";  <co xml:id='ex-dockerTools-pullImage-3' />
-  sha256 = "0mqjy3zq2v6rrhizgb9nvhczl87lcfphq9601wcprdika2jz7qh8"; <co xml:id='ex-dockerTools-pullImage-4' />
-  os = "linux"; <co xml:id='ex-dockerTools-pullImage-5' />
-  arch = "x86_64"; <co xml:id='ex-dockerTools-pullImage-6' />
+  finalImageName = "nix"; <co xml:id='ex-dockerTools-pullImage-3' />
+  finalImageTag = "1.11";  <co xml:id='ex-dockerTools-pullImage-4' />
+  sha256 = "0mqjy3zq2v6rrhizgb9nvhczl87lcfphq9601wcprdika2jz7qh8"; <co xml:id='ex-dockerTools-pullImage-5' />
+  os = "linux"; <co xml:id='ex-dockerTools-pullImage-6' />
+  arch = "x86_64"; <co xml:id='ex-dockerTools-pullImage-7' />
 }
 </programlisting>
   </example>
@@ -452,25 +453,33 @@ sha256:20d9485b25ecfd89204e843a962c1bd70e9cc6858d65d7f5fadc340246e2116b
    </callout>
    <callout arearefs='ex-dockerTools-pullImage-3'>
     <para>
+     <varname>finalImageName</varname>, if specified, this is the name of the
+     image to be created. Note it is never used to fetch the image since we
+     prefer to rely on the immutable digest ID. By default it's equal to
+     <varname>imageName</varname>.
+    </para>
+   </callout>
+   <callout arearefs='ex-dockerTools-pullImage-4'>
+    <para>
      <varname>finalImageTag</varname>, if specified, this is the tag of the
      image to be created. Note it is never used to fetch the image since we
      prefer to rely on the immutable digest ID. By default it's
      <literal>latest</literal>.
     </para>
    </callout>
-   <callout arearefs='ex-dockerTools-pullImage-4'>
+   <callout arearefs='ex-dockerTools-pullImage-5'>
     <para>
      <varname>sha256</varname> is the checksum of the whole fetched image. This
      argument is required.
     </para>
    </callout>
-   <callout arearefs='ex-dockerTools-pullImage-5'>
+   <callout arearefs='ex-dockerTools-pullImage-6'>
     <para>
      <varname>os</varname>, if specified, is the operating system of the
      fetched image. By default it's <literal>linux</literal>.
     </para>
    </callout>
-   <callout arearefs='ex-dockerTools-pullImage-6'>
+   <callout arearefs='ex-dockerTools-pullImage-7'>
     <para>
      <varname>arch</varname>, if specified, is the cpu architecture of the
      fetched image. By default it's <literal>x86_64</literal>.

--- a/nixos/tests/docker-tools.nix
+++ b/nixos/tests/docker-tools.nix
@@ -34,8 +34,8 @@ import ./make-test.nix ({ pkgs, ... }: {
 
       # To test the pullImage tool
       $docker->succeed("docker load --input='${pkgs.dockerTools.examples.nixFromDockerHub}'");
-      $docker->succeed("docker run --rm nixos/nix:2.2.1 nix-store --version");
-      $docker->succeed("docker rmi nixos/nix:2.2.1");
+      $docker->succeed("docker run --rm nix:2.2.1 nix-store --version");
+      $docker->succeed("docker rmi nix:2.2.1");
 
       # To test runAsRoot and entry point
       $docker->succeed("docker load --input='${pkgs.dockerTools.examples.nginx}'");

--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -45,13 +45,18 @@ rec {
     , sha256
     , os ? "linux"
     , arch ? "amd64"
+
+      # This is used to set name to the pulled image
+    , finalImageName ? imageName
       # This used to set a tag to the pulled image
     , finalImageTag ? "latest"
-    , name ? fixName "docker-image-${imageName}-${finalImageTag}.tar"
+
+    , name ? fixName "docker-image-${finalImageName}-${finalImageTag}.tar"
     }:
 
     runCommand name {
-      inherit imageName imageDigest;
+      inherit imageDigest;
+      imageName = finalImageName;
       imageTag = finalImageTag;
       impureEnvVars = pkgs.stdenv.lib.fetchers.proxyImpureEnvVars;
       outputHashMode = "flat";
@@ -62,7 +67,7 @@ rec {
       SSL_CERT_FILE = "${pkgs.cacert.out}/etc/ssl/certs/ca-bundle.crt";
 
       sourceURL = "docker://${imageName}@${imageDigest}";
-      destNameTag = "${imageName}:${finalImageTag}";
+      destNameTag = "${finalImageName}:${finalImageTag}";
     } ''
       skopeo --override-os ${os} --override-arch ${arch} copy "$sourceURL" "docker-archive://$out:$destNameTag"
     '';

--- a/pkgs/build-support/docker/examples.nix
+++ b/pkgs/build-support/docker/examples.nix
@@ -88,8 +88,9 @@ rec {
   nixFromDockerHub = pullImage {
     imageName = "nixos/nix";
     imageDigest = "sha256:85299d86263a3059cf19f419f9d286cc9f06d3c13146a8ebbb21b3437f598357";
-    sha256 = "0vnp3mhpk4ny3xa3cgngqsargnmvfgld54d5sn4b5av6yqzzp67z";
+    sha256 = "07q9y9r7fsd18sy95ybrvclpkhlal12d30ybnf089hq7v1hgxbi7";
     finalImageTag = "2.2.1";
+    finalImageName = "nix";
   };
 
   # 5. example of multiple contents, emacs and vi happily coexisting


### PR DESCRIPTION
###### Motivation for this change

I need to change image name.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
