### PR TITLE
aragorn: init at 1.2.38

### DIFF
--- a/pkgs/applications/science/biology/aragorn/default.nix
+++ b/pkgs/applications/science/biology/aragorn/default.nix
@@ -1,0 +1,28 @@
+{stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  version = "1.2.38";
+  pname = "aragorn";
+
+  src = fetchurl {
+    url = "http://mbio-serv2.mbioekol.lu.se/ARAGORN/Downloads/${pname}${version}.tgz";
+    sha256 = "09i1rg716smlbnixfm7q1ml2mfpaa2fpn3hwjg625ysmfwwy712b";
+  };
+
+  buildPhase = ''
+    gcc -O3 -ffast-math -finline-functions -o aragorn aragorn${version}.c
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin && cp aragorn $out/bin
+    mkdir -p $out/man/1 && cp aragorn.1 $out/man/1
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Detects tRNA, mtRNA, and tmRNA genes in nucleotide sequences";
+    homepage = http://mbio-serv2.mbioekol.lu.se/ARAGORN/;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.bzizou ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/science/biology/aragorn/default.nix
+++ b/pkgs/applications/science/biology/aragorn/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl }:
+{ stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
   version = "1.2.38";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21618,6 +21618,8 @@ in
 
   ants = callPackage ../applications/science/biology/ants { };
 
+  aragorn = callPackage ../applications/science/biology/aragorn { };
+
   archimedes = callPackage ../applications/science/electronics/archimedes {
     stdenv = overrideCC stdenv gcc49;
   };


### PR DESCRIPTION
###### Motivation for this change
Soft needed by the biologists using our computing center (GRICAD) 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
