### PR TITLE
[18.09] ghostscript: add patch for CVE-2019-6116

### DIFF
--- a/pkgs/misc/ghostscript/default.nix
+++ b/pkgs/misc/ghostscript/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchurl, pkgconfig, zlib, expat, openssl, autoconf
 , libjpeg, libpng, libtiff, freetype, fontconfig, libpaper, jbig2dec
-, libiconv, ijs
+, libiconv, ijs, fetchpatch
 , x11Support ? false, xlibsWrapper ? null
 , cupsSupport ? false, cups ? null
 }:
@@ -45,6 +45,11 @@ stdenv.mkDerivation rec {
   patches = [
     ./urw-font-files.patch
     ./doc-no-ref.diff
+    (fetchpatch {
+      name = "CVE-2019-6116";
+      url = "http://git.ghostscript.com/?p=ghostpdl.git;a=patch;h=d3537a54740d78c5895ec83694a07b3e4f616f61";
+      sha256 = "1hr8bpi87bbg1kvv28kflmfh1dhzxw66p9q0ddvbrj72qd86p3kx";
+    })
   ];
 
   outputs = [ "out" "man" "doc" ];


### PR DESCRIPTION
###### Motivation for this change

Backport of #58314

This is tagged as version 9.26a in the ghostpdl repo, but unfortunately
there are no tarballs released with that version number so far. We'll
continue calling this version 9.26 for now for simplicity's sake (and we
can switch to 9.26a and remove the patch when it's properly released).

Fixes #58262
Fixes #58089

(cherry picked from commit 91c46d17d5c8b3a69cbae62d91290e53168fe9d2)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
