### PR TITLE
itsx: init at 1.1.1

### DIFF
--- a/pkgs/applications/science/biology/itsx/default.nix
+++ b/pkgs/applications/science/biology/itsx/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl, hmmer, perl }:
+
+stdenv.mkDerivation rec {
+  version = "1.1.1";
+  name = "itsx-${version}";
+
+  src = fetchurl {
+    url = "http://microbiology.se/sw/ITSx_${version}.tar.gz";
+    sha256 = "0lrmy2n3ax7f208k0k8l3yz0j5cpz05hv4hx1nnxzn0c51z1pc31";
+  };
+
+  buildInputs = [ hmmer perl ];
+
+  buildPhase = ''
+    sed -e "s,profileDB = .*,profileDB = \"$out/share/ITSx_db/HMMs\";," -i ITSx
+    sed "3 a \$ENV{\'PATH\'}='${hmmer}/bin:'.\"\$ENV{\'PATH\'}\";" -i ITSx
+    mkdir bin
+    mv ITSx bin
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/doc && cp -a bin $out/
+    cp *pdf $out/share/doc
+    cp -r ITSx_db $out/share
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Improved software detection and extraction of ITS1 and ITS2 from ribosomal ITS sequences of fungi and other eukaryotes for use in environmental sequencing";
+    homepage = http://microbiology.se/software/itsx/;
+    license = licenses.gpl3;
+    maintainers = [ maintainers.bzizou ];
+    platforms = [ "x86_64-linux" "i686-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21649,6 +21649,8 @@ in
   igv = callPackage ../applications/science/biology/igv { };
 
   inormalize = callPackage ../applications/science/biology/inormalize { };
+  
+  itsx = callPackage ../applications/science/biology/itsx { };
 
   iv = callPackage ../applications/science/biology/iv {
     neuron-version = neuron.version;


### PR DESCRIPTION
###### Motivation for this change
Soft needed by the biologists using our computing center (GRICAD) 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
