### PR TITLE
ocamlPackages.re2: fix build on darwin

### DIFF
--- a/pkgs/development/ocaml-modules/janestreet/default.nix
+++ b/pkgs/development/ocaml-modules/janestreet/default.nix
@@ -324,10 +324,11 @@ rec {
     pname = "re2";
     hash = "0bl65d0nmvr7k1mkkcc4aai86l5qzgn1xxwmszshpwhaz87cqghd";
     propagatedBuildInputs = [ core_kernel ];
-    meta = {
-      description = "OCaml bindings for RE2";
-      broken = stdenv.isDarwin;
-    };
+    prePatch = ''
+      substituteInPlace src/re2_c/jbuild --replace 'CXX=g++' 'CXX=c++'
+      substituteInPlace src/jbuild --replace '(cxx_flags ((:standard \ -pedantic) (-I re2_c/libre2)))' '(cxx_flags ((:standard \ -pedantic) (-I re2_c/libre2) (-x c++)))'
+    '';
+    meta.description = "OCaml bindings for RE2";
   };
 
   core_extended = janePackage {


### PR DESCRIPTION
###### Motivation for this change

Fixes #58178

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
