### PR TITLE
python.pkgs.cartopy: fix build

### DIFF
--- a/pkgs/development/python-modules/cartopy/default.nix
+++ b/pkgs/development/python-modules/cartopy/default.nix
@@ -25,12 +25,19 @@ buildPythonPackage rec {
       -k "not test_nightshade_image"
   '';
 
-  buildInputs = [ cython glibcLocales ];
-  LC_ALL = "en_US.UTF-8";
+  nativeBuildInputs = [
+    cython
+    geos # for geos-config
+    proj
+  ];
+
+  buildInputs = [
+    geos proj
+  ];
 
   propagatedBuildInputs = [
     # required
-    six pyshp shapely geos proj numpy
+    six pyshp shapely numpy
 
     # optional
     gdal pillow matplotlib pyepsg pykdtree scipy fiona owslib


### PR DESCRIPTION
###### Motivation for this change
fallout of https://github.com/NixOS/nixpkgs/pull/54182


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @mredaelli 