### PR TITLE
clustal-omega: init at 1.2.4

### DIFF
--- a/pkgs/applications/science/biology/clustal-omega/default.nix
+++ b/pkgs/applications/science/biology/clustal-omega/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchurl, argtable }:
+
+stdenv.mkDerivation rec {
+  version = "1.2.4";
+  name = "clustal-omega-${version}";
+
+  src = fetchurl {
+    url = "http://www.clustal.org/omega/${name}.tar.gz";
+    sha256 = "1vm30mzncwdv881vrcwg11vzvrsmwy4wg80j5i0lcfk6dlld50w6";
+  };
+
+  buildInputs = [ argtable ];
+
+  preConfigure = ''
+    for f in configure \
+             src/clustal-omega-config.h \
+             src/clustal-omega-config.h \
+             src/config.h.in \
+             src/mymain.c
+    do
+      sed -i -re 's/argtable2/argtable3/g' $f
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "General purpose multiple sequence alignment program for protein and DNA/RNA";
+    homepage = http://www.clustal.org/omega/;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.bzizou ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21630,6 +21630,8 @@ in
 
   cmtk = callPackage ../applications/science/biology/cmtk { };
 
+  clustal-omega = callPackage ../applications/science/biology/clustal-omega { };
+
   conglomerate = callPackage ../applications/science/biology/conglomerate { };
 
   dcm2niix = callPackage ../applications/science/biology/dcm2niix { };


### PR DESCRIPTION
###### Motivation for this change
Tool for biologists using our computing center (GRICAD)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
