### PR TITLE
libjpeg-turbo: 2.0.1 -> 2.0.2, cleanup

### DIFF
--- a/pkgs/development/libraries/libjpeg-turbo/default.nix
+++ b/pkgs/development/libraries/libjpeg-turbo/default.nix
@@ -1,47 +1,26 @@
 { stdenv, fetchurl, fetchpatch, cmake, nasm }:
 
 stdenv.mkDerivation rec {
-  name = "libjpeg-turbo-${version}";
-  version = "2.0.1";
+  pname = "libjpeg-turbo";
+  version = "2.0.2";
 
   src = fetchurl {
-    url = "mirror://sourceforge/libjpeg-turbo/${name}.tar.gz";
-    sha256 = "1zv6z093l3x3jzygvni7b819j7xhn6d63jhcdrckj7fz67n6ry75";
+    url = "mirror://sourceforge/${pname}/${pname}-${version}.tar.gz";
+    sha256 = "1v9gx1gdzgxf51nd55ncq7rghmj4x9x91rby50ag36irwngmkf5c";
   };
 
   patches =
     stdenv.lib.optional (stdenv.hostPlatform.libc or null == "msvcrt")
-      ./mingw-boolean.patch
-  ++ [
-    ./djpeg-rgb-islow-icc-cmp.patch # https://github.com/libjpeg-turbo/libjpeg-turbo/pull/321
-    (fetchpatch {
-      name = "cve-2018-19664.diff";
-      url = "https://github.com/libjpeg-turbo/libjpeg-turbo/commit/f8cca819a4fb.diff";
-      sha256 = "1kgfag62qmphlrq0mz15g17zw7zrg9nzaz7d2vg50m6m7m5aw4y5";
-    })
-    (fetchpatch {
-      name = "CVE-2018-20330.patch";
-      url = "https://github.com/libjpeg-turbo/libjpeg-turbo/commit/3d9c64e9f8aa1ee954d1d0bb3390fc894bb84da3.diff";
-      sha256 = "1jai8izw6xl05ihx24rpc96d1jcr9rp421cb02pbz3v53cxdasji";
-    })
-  ];
+      ./mingw-boolean.patch;
 
   outputs = [ "bin" "dev" "out" "man" "doc" ];
 
   nativeBuildInputs = [ cmake nasm ];
 
-  preConfigure = ''
-    cmakeFlagsArray+=(
-      "-DCMAKE_INSTALL_BINDIR=$bin/bin"
-      "-DENABLE_STATIC=0"
-    )
-  '';
+  cmakeFlags = [ "-DCMAKE_INSTALL_BINDIR=${placeholder "bin"}/bin" "-DENABLE_STATIC=0" ];
 
-  doCheck = true; # not cross;
-  checkTarget = "test";
-  preCheck = ''
-    export LD_LIBRARY_PATH="$NIX_BUILD_TOP/${name}:$LD_LIBRARY_PATH"
-  '';
+  doInstallCheck = true;
+  installCheckTarget = "test";
 
   meta = with stdenv.lib; {
     homepage = http://libjpeg-turbo.virtualgl.org/;


### PR DESCRIPTION
###### Motivation for this change

https://github.com/libjpeg-turbo/libjpeg-turbo/releases/tag/2.0.2

* patches included, drop
* use installCheck to avoid needing to set LD_LIBRARY_PATH

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---