### PR TITLE
waybar: 0.4.0 -> 0.5.0

### DIFF
--- a/pkgs/applications/misc/waybar/default.nix
+++ b/pkgs/applications/misc/waybar/default.nix
@@ -3,17 +3,18 @@
 , traySupport  ? true,  libdbusmenu-gtk3
 , pulseSupport ? false, libpulseaudio
 , nlSupport    ? true,  libnl
+, udevSupport  ? true,  udev
 , swaySupport  ? true,  sway
 }:
   stdenv.mkDerivation rec {
     name = "waybar-${version}";
-    version = "0.4.0";
+    version = "0.5.0";
 
     src = fetchFromGitHub {
       owner = "Alexays";
       repo = "Waybar";
       rev = version;
-      sha256 = "0vkx1b6bgr75wkx89ppxhg4103vl2g0sky22npmfkvbkpgh8dj38";
+      sha256 = "006pzx4crsqn9vk28g87306xh3jrfwk4ib9cmsxqrxy8v0kl2s4g";
     };
 
     nativeBuildInputs = [
@@ -25,19 +26,21 @@
       ++ optional  traySupport  libdbusmenu-gtk3
       ++ optional  pulseSupport libpulseaudio
       ++ optional  nlSupport    libnl
+      ++ optional  udevSupport  udev
       ++ optional  swaySupport  sway;
 
     mesonFlags = [
       "-Ddbusmenu-gtk=${ if traySupport then "enabled" else "disabled" }"
       "-Dpulseaudio=${ if pulseSupport then "enabled" else "disabled" }"
       "-Dlibnl=${ if nlSupport then "enabled" else "disabled" }"
+      "-Dlibudev=${ if udevSupport then "enabled" else "disabled" }"
       "-Dout=${placeholder "out"}"
     ];
 
     meta = with stdenv.lib; {
       description = "Highly customizable Wayland bar for Sway and Wlroots based compositors";
       license = licenses.mit;
-      maintainers = [ maintainers.FlorianFranzen ];
+      maintainers = with maintainers; [ FlorianFranzen minijackson ];
       platforms = platforms.unix;
     };
   }


### PR DESCRIPTION
###### Motivation for this change

Bigger version numbers are better.
https://github.com/Alexays/Waybar/releases/tag/0.5.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).