### PR TITLE
talloc: 2.1.14 -> 2.2.0, also update tevent,ldb,tdb

### DIFF
--- a/pkgs/development/libraries/cmocka/default.nix
+++ b/pkgs/development/libraries/cmocka/default.nix
@@ -1,13 +1,13 @@
 { fetchurl, stdenv, cmake }:
 
 stdenv.mkDerivation rec {
-  name = "cmocka-${version}";
+  pname = "cmocka";
   majorVersion = "1.1";
-  version = "${majorVersion}.1";
+  version = "${majorVersion}.3";
 
   src = fetchurl {
     url = "https://cmocka.org/files/${majorVersion}/cmocka-${version}.tar.xz";
-    sha256 = "f02ef48a7039aa77191d525c5b1aee3f13286b77a13615d11bc1148753fc0389";
+    sha256 = "1bxzzafjlwzgldcb07hjnlnqvh88wh21r2kw7z8f704w5bvvrsj3";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/ldb/default.nix
+++ b/pkgs/development/libraries/ldb/default.nix
@@ -1,37 +1,27 @@
-{ stdenv, fetchurl, python, pkgconfig, readline, tdb, talloc, tevent
+{ stdenv, fetchurl, python, pkgconfig, which, readline, tdb, talloc, tevent, lmdb
 , popt, libxslt, docbook_xsl, docbook_xml_dtd_42, cmocka
 }:
 
 stdenv.mkDerivation rec {
-  name = "ldb-1.3.3";
+  pname = "ldb";
+  version = "1.6.3";
 
   src = fetchurl {
-    url = "mirror://samba/ldb/${name}.tar.gz";
-    sha256 = "14gsrm7dvyjpbpnc60z75j6fz2p187abm2h353lq95kx2bv70c1b"                                                                                                                                                             ;
+    url = "mirror://samba/${pname}/${pname}-${version}.tar.gz";
+    sha256 = "01livdy3g073bm6xnc8zqnqrxg53sw8q66d1903z62hd6g87whsa"                                                                                                                                                             ;
   };
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig which python docbook_xsl docbook_xml_dtd_42 ];
   buildInputs = [
-    python readline tdb talloc tevent popt
-    libxslt docbook_xsl docbook_xml_dtd_42
+    readline tdb talloc tevent popt lmdb
+    libxslt python
     cmocka
   ];
 
-  patches = [
-    # CVE-2019-3824
-    # downloading the patch from debian as they have ported the patch from samba to ldb but otherwise is identical to
-    # https://bugzilla.samba.org/attachment.cgi?id=14857
-    (fetchurl {
-      name = "CVE-2019-3824.patch";
-      url = "https://sources.debian.org/data/main/l/ldb/2:1.1.27-1+deb9u1/debian/patches/CVE-2019-3824-master-v4-5-02.patch";
-      sha256 = "1idnqckvjh18rh9sbq90rr4sxfviha9nd1ca9pd6lai0y6r6q4yd";
-    })
-  ];
-
   preConfigure = ''
-    sed -i 's,#!/usr/bin/env python,#!${python}/bin/python,g' buildtools/bin/waf
+    patchShebangs buildtools/bin/waf
   '';
 
   configureFlags = [

--- a/pkgs/development/libraries/talloc/default.nix
+++ b/pkgs/development/libraries/talloc/default.nix
@@ -1,19 +1,20 @@
-{ stdenv, fetchurl, python, pkgconfig, readline, libxslt
+{ stdenv, fetchurl, python, pkgconfig, which, readline, libxslt
 , docbook_xsl, docbook_xml_dtd_42, fixDarwinDylibNames
 , buildPackages
 }:
 
 stdenv.mkDerivation rec {
-  name = "talloc-2.1.14";
+  pname = "talloc";
+  version = "2.2.0";
 
   src = fetchurl {
-    url = "mirror://samba/talloc/${name}.tar.gz";
-    sha256 = "1kk76dyav41ip7ddbbf04yfydb4jvywzi2ps0z2vla56aqkn11di";
+    url = "mirror://samba/${pname}/${pname}-${version}.tar.gz";
+    sha256 = "1g1fqa37xkjp9lp6lrwxrbfgashcink769ll505zvcwnxx2nlvsw";
   };
 
-  nativeBuildInputs = [ pkgconfig fixDarwinDylibNames python
+  nativeBuildInputs = [ pkgconfig which fixDarwinDylibNames python
                         docbook_xsl docbook_xml_dtd_42 ];
-  buildInputs = [ readline libxslt ];
+  buildInputs = [ readline libxslt python ];
 
   prePatch = ''
     patchShebangs buildtools/bin/waf

--- a/pkgs/development/libraries/tdb/default.nix
+++ b/pkgs/development/libraries/tdb/default.nix
@@ -1,19 +1,18 @@
-{ stdenv, fetchurl, python2, pkgconfig, readline, libxslt
+{ stdenv, fetchurl, python, pkgconfig, which, readline, libxslt
 , docbook_xsl, docbook_xml_dtd_42, buildPackages
 }:
 
 stdenv.mkDerivation rec {
-  name = "tdb-1.3.16";
+  pname = "tdb";
+  version = "1.4.0";
 
   src = fetchurl {
-    url = "mirror://samba/tdb/${name}.tar.gz";
-    sha256 = "1ibcz466xwk1x6xvzlgzd5va4lyrjzm3rnjak29kkwk7cmhw4gva";
+    url = "mirror://samba/${pname}/${pname}-${version}.tar.gz";
+    sha256 = "0d9d2f1c83gmmq30bkfs50yb8399mr9xjjzscma4kyq0ajf75861";
   };
 
-  nativeBuildInputs = [ pkgconfig python2 ];
-  buildInputs = [
-    readline libxslt docbook_xsl docbook_xml_dtd_42
-  ];
+  nativeBuildInputs = [ pkgconfig python which docbook_xsl docbook_xml_dtd_42 ];
+  buildInputs = [ readline libxslt python ];
 
   preConfigure = ''
     patchShebangs buildtools/bin/waf

--- a/pkgs/development/libraries/tevent/default.nix
+++ b/pkgs/development/libraries/tevent/default.nix
@@ -1,22 +1,23 @@
-{ stdenv, fetchurl, python, pkgconfig, readline, talloc
+{ stdenv, fetchurl, python, pkgconfig, which, readline, talloc
 , libxslt, docbook_xsl, docbook_xml_dtd_42
 }:
 
 stdenv.mkDerivation rec {
-  name = "tevent-0.9.37";
+  pname = "tevent";
+  version = "0.10.0";
 
   src = fetchurl {
-    url = "mirror://samba/tevent/${name}.tar.gz";
-    sha256 = "1q77vbjic2bb79li2a54ffscnrnwwww55fbpry2kgh7acpnlb0qn";
+    url = "mirror://samba/${pname}/${pname}-${version}.tar.gz";
+    sha256 = "1rm4d9245ya15wyrh9vqn1dnz14l2ic88mr46ykyc6kdrl99dwrk";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig python docbook_xsl docbook_xml_dtd_42 which ];
   buildInputs = [
-    python readline talloc libxslt docbook_xsl docbook_xml_dtd_42
+    python readline talloc libxslt
   ];
 
   preConfigure = ''
-    sed -i 's,#!/usr/bin/env python,#!${python}/bin/python,g' buildtools/bin/waf
+    patchShebangs buildtools/bin/waf
   '';
 
   configureFlags = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12924,7 +12924,7 @@ in
     python = python2;
   };
 
-  tdb = callPackage ../development/libraries/tdb {};
+  tdb = callPackage ../development/libraries/tdb { python = python3; };
 
   tecla = callPackage ../development/libraries/tecla { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12942,9 +12942,7 @@ in
 
   termbox = callPackage ../development/libraries/termbox { };
 
-  tevent = callPackage ../development/libraries/tevent {
-    python = python2;
-  };
+  tevent = callPackage ../development/libraries/tevent { python = python3; };
 
   tet = callPackage ../development/tools/misc/tet { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10671,7 +10671,7 @@ in
   lcms2 = callPackage ../development/libraries/lcms2 { };
 
   ldb = callPackage ../development/libraries/ldb {
-    python = python2;
+    python = python3;
   };
 
   lensfun = callPackage ../development/libraries/lensfun {};

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12909,7 +12909,7 @@ in
   taglib-sharp = callPackage ../development/libraries/taglib-sharp { };
 
   talloc = callPackage ../development/libraries/talloc {
-    python = buildPackages.python2;
+    python = python3;
   };
 
   tclap = callPackage ../development/libraries/tclap {};


### PR DESCRIPTION
###### Motivation for this change

Includes cmocka update (submitted separately)
since new version of ldb requires it.

python inputs are used to execute the build (waf)
but we also expect python bindings to be created
and installed, set inputs accordingly.

Need to check how this works re:cross,
feedback and help testing appreciated :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---