### PR TITLE
samim-fonts: init at 3.1.0

### DIFF
--- a/pkgs/data/fonts/samim-fonts/default.nix
+++ b/pkgs/data/fonts/samim-fonts/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  name = "samim-font";
+  pname = "samim-fonts";
   version = "3.1.0";
 
   src = fetchFromGitHub {
     owner = "rastikerdar";
-    repo = name;
+    repo = "samim-font";
     rev = "v${version}";
     sha256 = "1mp0pgbn9r098ilajwzag7c21shwb13mq61ly9av0mfbpnhkkjqk";
   };

--- a/pkgs/data/fonts/samim-fonts/default.nix
+++ b/pkgs/data/fonts/samim-fonts/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "samim-font";
+  version = "3.1.0";
+
+  src = fetchFromGitHub {
+    owner = "rastikerdar";
+    repo = name;
+    rev = "v${version}";
+    sha256 = "1mp0pgbn9r098ilajwzag7c21shwb13mq61ly9av0mfbpnhkkjqk";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/samim-fonts
+    cp -v $( find . -name '*.ttf') $out/share/fonts/samim-fonts
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/rastikerdar/samim-font;
+    description = "A Persian (Farsi) Font - فونت (قلم) فارسی صمیم";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = [ maintainers.linarcx ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5387,6 +5387,8 @@ in
 
   salut_a_toi = callPackage ../applications/networking/instant-messengers/salut-a-toi {};
 
+  samim-fonts = callPackage ../data/fonts/samim-fonts {};
+
   saml2aws = callPackage ../tools/security/saml2aws {};
 
   samplicator = callPackage ../tools/networking/samplicator { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
