### PR TITLE
Update JetBrains IDEs

### DIFF
--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -263,12 +263,12 @@ in
 
   datagrip = buildDataGrip rec {
     name = "datagrip-${version}";
-    version = "2018.3.2"; /* updated by script */
+    version = "2018.3.4"; /* updated by script */
     description = "Your Swiss Army Knife for Databases and SQL";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/datagrip/${name}.tar.gz";
-      sha256 = "0vj1cgmg33626i38x9wmh5hqr1lf0x3m23gzq30rp4q4cbi38806"; /* updated by script */
+      sha256 = "10sw41kkf2k60xjpwgc73i182y7px3dmqz2awnrl4gffdb9jgzmy"; /* updated by script */
     };
     wmClass = "jetbrains-datagrip";
     update-channel = "DataGrip RELEASE";
@@ -276,12 +276,12 @@ in
 
   goland = buildGoland rec {
     name = "goland-${version}";
-    version = "2018.3.3"; /* updated by script */
+    version = "2018.3.5"; /* updated by script */
     description = "Up and Coming Go IDE";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/go/${name}.tar.gz";
-      sha256 = "065z8084xkv6w8m7pq98rgls1avzrqm23mrxdq5172rs5p1c5r9f"; /* updated by script */
+      sha256 = "13488mz34h8zbmdsz0m57kfnsbipc9gscb85a1pnak6s1a7pf68r"; /* updated by script */
     };
     wmClass = "jetbrains-goland";
     update-channel = "GoLand RELEASE";
@@ -289,12 +289,12 @@ in
 
   idea-community = buildIdea rec {
     name = "idea-community-${version}";
-    version = "2018.3.4"; /* updated by script */
+    version = "2018.3.6"; /* updated by script */
     description = "Integrated Development Environment (IDE) by Jetbrains, community edition";
     license = stdenv.lib.licenses.asl20;
     src = fetchurl {
       url = "https://download.jetbrains.com/idea/ideaIC-${version}.tar.gz";
-      sha256 = "0j5yc7n04jlyyghmwllpfvcd2g6k1syjp07xb1ljyx7rm4jcf8q6"; /* updated by script */
+      sha256 = "1k5l54n9b7ddn3mlhhr1kq4sa3hprq0ds45mpyahqmsm482j8zs6"; /* updated by script */
     };
     wmClass = "jetbrains-idea-ce";
     update-channel = "IntelliJ IDEA RELEASE";
@@ -302,12 +302,12 @@ in
 
   idea-ultimate = buildIdea rec {
     name = "idea-ultimate-${version}";
-    version = "2018.3.4"; /* updated by script */
+    version = "2018.3.6"; /* updated by script */
     description = "Integrated Development Environment (IDE) by Jetbrains, requires paid license";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/idea/ideaIU-${version}-no-jdk.tar.gz";
-      sha256 = "0s3r3h1zcwkfqhsfb224fgy62fdhnd4gjgk2h6pyhq1frnh3x5bg"; /* updated by script */
+      sha256 = "0fx5vrs53vxx1wi0ha1dhj0a3c1rb4gg2b6mwpbbcjllv2r32rzw"; /* updated by script */
     };
     wmClass = "jetbrains-idea";
     update-channel = "IntelliJ IDEA RELEASE";
@@ -315,12 +315,12 @@ in
 
   phpstorm = buildPhpStorm rec {
     name = "phpstorm-${version}";
-    version = "2018.3.3"; /* updated by script */
+    version = "2018.3.5"; /* updated by script */
     description = "Professional IDE for Web and PHP developers";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/webide/PhpStorm-${version}.tar.gz";
-      sha256 = "0znhw83h46a3haspwcin5xjf3ask8ijxla778p9vdbi9xs0zqx39"; /* updated by script */
+      sha256 = "0j4r25s8x26k2a7f4n6hy8pxdmg0w5wyfxk16bndsqiavhyrvlyq"; /* updated by script */
     };
     wmClass = "jetbrains-phpstorm";
     update-channel = "PhpStorm RELEASE";
@@ -328,12 +328,12 @@ in
 
   pycharm-community = buildPycharm rec {
     name = "pycharm-community-${version}";
-    version = "2018.3.4"; /* updated by script */
+    version = "2018.3.5"; /* updated by script */
     description = "PyCharm Community Edition";
     license = stdenv.lib.licenses.asl20;
     src = fetchurl {
       url = "https://download.jetbrains.com/python/${name}.tar.gz";
-      sha256 = "11kzzwkp206l466ii6vm6iqmhpx0s594vh37x2lwwsgmg6qzz6vq"; /* updated by script */
+      sha256 = "1wvqdkl81mwk1jcy5aczjsdz0w8i5gsrlgyvnaprwb4mybwfwid7"; /* updated by script */
     };
     wmClass = "jetbrains-pycharm-ce";
     update-channel = "PyCharm RELEASE";
@@ -341,12 +341,12 @@ in
 
   pycharm-professional = buildPycharm rec {
     name = "pycharm-professional-${version}";
-    version = "2018.3.4"; /* updated by script */
+    version = "2018.3.5"; /* updated by script */
     description = "PyCharm Professional Edition";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/python/${name}.tar.gz";
-      sha256 = "1m8lzghs6g57fwcv6bpmnf21d4w2k10gsmi0i2wv2j8ff4hcy7ij"; /* updated by script */
+      sha256 = "1jahk99pgqgdfq580dbwf9kqdmvzlw1vjmv803bzh3cmswxkvlzp"; /* updated by script */
     };
     wmClass = "jetbrains-pycharm";
     update-channel = "PyCharm RELEASE";
@@ -354,12 +354,12 @@ in
 
   rider = buildRider rec {
     name = "rider-${version}";
-    version = "2018.3.2"; /* updated by script */
+    version = "2018.3.4"; /* updated by script */
     description = "A cross-platform .NET IDE based on the IntelliJ platform and ReSharper";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/rider/JetBrains.Rider-${version}.tar.gz";
-      sha256 = "1ffzbp2xca2z8g0wlkvmqr0j2f2dnqafpnvzk9zd5asfhhbyrhg5"; /* updated by script */
+      sha256 = "1klmg8wgj3shp4s0n2nn7n39zsk1mch6g9ifhwn5cgywpbzgam4p"; /* updated by script */
     };
     wmClass = "jetbrains-rider";
     update-channel = "Rider RELEASE";
@@ -367,12 +367,12 @@ in
 
   ruby-mine = buildRubyMine rec {
     name = "ruby-mine-${version}";
-    version = "2018.3.3"; /* updated by script */
+    version = "2018.3.5"; /* updated by script */
     description = "The Most Intelligent Ruby and Rails IDE";
     license = stdenv.lib.licenses.unfree;
     src = fetchurl {
       url = "https://download.jetbrains.com/ruby/RubyMine-${version}.tar.gz";
-      sha256 = "1zjcdsr91y07dhqmhqy2yq6c0rhsxg2m52fz14hhmphddlwvhzny"; /* updated by script */
+      sha256 = "1gykag8fsfqxv0d6fipn18hhpdvn4qxva2kkb0v330vp73wm2i2w"; /* updated by script */
     };
     wmClass = "jetbrains-rubymine";
     update-channel = "RubyMine RELEASE";


### PR DESCRIPTION
###### Motivation for this change

Updated to the latest versions with the `update.pl` script, though I didn't include the latest version of Webstorm as I got errors from it.

<details>

```shell
$ nixpkgs> webstorm 

(java:13232): Gtk-WARNING **: 19:49:29.377: Unable to locate theme engine in module_path: "adwaita",

(java:13232): Gtk-WARNING **: 19:49:29.382: Unable to locate theme engine in module_path: "adwaita",
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x00007f5777f61074, pid=13232, tid=0x00007f5740780700
#
# JRE version: OpenJDK Runtime Environment (8.0_152-b06) (build 1.8.0_152-release-1248-b6)
# Java VM: OpenJDK 64-Bit Server VM (25.152-b6 mixed mode linux-amd64 compressed oops)
# Problematic frame:
# C  [libc.so.6+0x132074]  __memcpy_ssse3+0x19f4
#
# Failed to write core dump. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
#
# An error report file with more information is saved as:
# /home/sondre/java_error_in_WEBIDE_13232.log
#
# If you would like to submit a bug report, please visit:
#   http://bugreport.java.com/bugreport/crash.jsp
# The crash happened outside the Java Virtual Machine in native code.
# See problematic frame for where to report the bug.
#
/nix/store/9p5z9x97i45krqjb96rp55vf19bn3crf-webstorm-2019.1/webstorm-2019.1/bin/webstorm.sh: line 213: 13232 Aborted                 "$JAVA_BIN" -classpath "$CLASSPATH" ${VM_OPTIONS} "-XX:ErrorFile=$HOME/java_error_in_WEBIDE_%p.log" "-XX:HeapDumpPath=$HOME/java_error_in_WEBIDE.hprof" -Didea.paths.selector=WebStorm2019.1 "-Djb.vmOptionsFile=$VM_OPTIONS_FILE" ${IDE_PROPERTIES_PROPERTY} -Didea.platform.prefix=WebStorm com.intellij.idea.Main "$@"
```

</details>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
