### PR TITLE
documize-community: init at 2.2.1

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -739,6 +739,7 @@
   ./services/web-apps/atlassian/crowd.nix
   ./services/web-apps/atlassian/jira.nix
   ./services/web-apps/codimd.nix
+  ./services/web-apps/documize.nix
   ./services/web-apps/frab.nix
   ./services/web-apps/icingaweb2/icingaweb2.nix
   ./services/web-apps/icingaweb2/module-monitoring.nix

--- a/nixos/modules/services/web-apps/documize.nix
+++ b/nixos/modules/services/web-apps/documize.nix
@@ -1,0 +1,67 @@
+{ pkgs, lib, config, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.documize;
+
+in
+
+  {
+    options.services.documize = {
+      enable = mkEnableOption "Documize Wiki";
+
+      offline = mkEnableOption "Documize offline mode";
+
+      package = mkOption {
+        default = pkgs.documize-community;
+        type = types.package;
+        description = ''
+          Which package to use for documize.
+        '';
+      };
+
+      db = mkOption {
+        type = types.str;
+        example = "host=localhost port=5432 sslmode=disable user=admin password=secret dbname=documize";
+        description = ''
+          The DB connection string to use for the database.
+        '';
+      };
+
+      dbtype = mkOption {
+        type = types.enum [ "postgresql" "percona" "mariadb" "mysql" ];
+        description = ''
+          Which database to use for storage.
+        '';
+      };
+
+      port = mkOption {
+        type = types.port;
+        example = 3000;
+        description = ''
+          Which TCP port to serve.
+        '';
+      };
+    };
+
+    config = mkIf cfg.enable {
+      systemd.services.documize-server = {
+        wantedBy = [ "multi-user.target" ];
+
+        script = ''
+          ${cfg.package}/bin/documize \
+            -db "${cfg.db}" \
+            -dbtype ${cfg.dbtype} \
+            -port ${toString cfg.port} \
+            -offline ${if cfg.offline then "1" else "0"}
+        '';
+
+        serviceConfig = {
+          Restart = "always";
+          DynamicUser = "yes";
+        };
+      };
+    };
+  }

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -65,6 +65,7 @@ in
   docker-registry = handleTest ./docker-registry.nix {};
   docker-tools = handleTestOn ["x86_64-linux"] ./docker-tools.nix {};
   docker-tools-overlay = handleTestOn ["x86_64-linux"] ./docker-tools-overlay.nix {};
+  documize = handleTest ./documize.nix {};
   dovecot = handleTest ./dovecot.nix {};
   # ec2-config doesn't work in a sandbox as the simulated ec2 instance needs network access
   #ec2-config = (handleTestOn ["x86_64-linux"] ./ec2.nix {}).boot-ec2-config or {};

--- a/nixos/tests/documize.nix
+++ b/nixos/tests/documize.nix
@@ -1,0 +1,58 @@
+import ./make-test.nix ({ pkgs, lib, ...} : {
+  name = "documize";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ ma27 ];
+  };
+
+  machine = { pkgs, ... }: {
+    environment.systemPackages = [ pkgs.jq ];
+
+    services.documize = {
+      enable = true;
+      port = 3000;
+      dbtype = "postgresql";
+      db = "host=localhost port=5432 sslmode=disable user=documize password=documize dbname=documize";
+    };
+
+    systemd.services.documize-server = {
+      after = [ "postgresql.service" ];
+      requires = [ "postgresql.service" ];
+    };
+
+    services.postgresql = {
+      enable = true;
+      initialScript = pkgs.writeText "psql-init" ''
+        CREATE ROLE documize WITH LOGIN PASSWORD 'documize';
+        CREATE DATABASE documize WITH OWNER documize;
+      '';
+    };
+  };
+
+  testScript = ''
+    startAll;
+
+    $machine->waitForUnit("documize-server.service");
+    $machine->waitForOpenPort(3000);
+
+    my $dbhash = $machine->succeed("curl -f localhost:3000 "
+                                  . " | grep 'property=\"dbhash' "
+                                  . " | grep -Po 'content=\"\\K[^\"]*'"
+                                  );
+
+    chomp($dbhash);
+
+    $machine->succeed("curl -X POST "
+                      . "--data 'dbname=documize' "
+                      . "--data 'dbhash=$dbhash' "
+                      . "--data 'title=NixOS' "
+                      . "--data 'message=Docs' "
+                      . "--data 'firstname=John' "
+                      . "--data 'lastname=Doe' "
+                      . "--data 'email=john.doe\@nixos.org' "
+                      . "--data 'password=verysafe' "
+                      . "-f localhost:3000/api/setup"
+                    );
+
+    $machine->succeed('test "$(curl -f localhost:3000/api/public/meta | jq ".title" | xargs echo)" = "NixOS"');
+  '';
+})

--- a/pkgs/servers/documize-community/default.nix
+++ b/pkgs/servers/documize-community/default.nix
@@ -1,0 +1,43 @@
+{ lib, buildGoPackage, fetchFromGitHub, go-bindata, go-bindata-assetfs }:
+
+buildGoPackage rec {
+  pname = "documize-community";
+  version = "2.2.1";
+
+  src = fetchFromGitHub {
+    owner = "documize";
+    repo = "community";
+    rev = "v${version}";
+    sha256 = "09s5js0zb3mh3g5qz8f3l2cqjn01kjb35kinfv932nf2rfyrmyqz";
+  };
+
+  goPackagePath = "github.com/documize/community";
+
+  buildInputs = [ go-bindata-assetfs go-bindata ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    pushd go/src/github.com/documize/community
+    go build -gcflags="all=-trimpath=$GOPATH" -o bin/documize ./edition/community.go
+    popd
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $bin/bin
+    cp go/src/github.com/documize/community/bin/documize $bin/bin
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Open source Confluence alternative for internal & external docs built with Golang + EmberJS";
+    license = licenses.agpl3;
+    maintainers = with maintainers; [ ma27 ];
+    homepage = https://www.documize.com/;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15681,6 +15681,8 @@ in
 
   documentation-highlighter = callPackage ../misc/documentation-highlighter { };
 
+  documize-community = callPackage ../servers/documize-community { };
+
   doulos-sil = callPackage ../data/fonts/doulos-sil { };
 
   cabin = callPackage ../data/fonts/cabin { };


### PR DESCRIPTION
###### Motivation for this change

Documize is an open-source alternative for wiki software like Confluence
based on Go and EmberJS. This patch adds the sources for the community
edition[1], for commercial their paid-plan[2] needs to be used.

For commercial use a derivation that bundles the commercial package and
contains a `$out/bin/documize` can be passed to
`services.documize.enable`.

The package compiles the Go sources, the build process also bundles the
pre-built frontend from `gui/public` into the binary.

The NixOS module generates a simple `systemd` unit which starts the
service as a dynamic user, database and a reverse proxy won't be
configured.

[1] https://www.documize.com/get-started/
[2] https://www.documize.com/pricing/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
