### PR TITLE
cnijfilter2: 5.30 -> 5.70

### DIFF
--- a/pkgs/misc/cups/drivers/cnijfilter2/default.nix
+++ b/pkgs/misc/cups/drivers/cnijfilter2/default.nix
@@ -4,11 +4,11 @@
 stdenv.mkDerivation rec {
   name = "cnijfilter2-${version}";
 
-  version = "5.30";
+  version = "5.70";
 
   src = fetchzip {
-    url = "http://gdlp01.c-wss.com/gds/9/0100007129/01/cnijfilter2-source-5.30-1.tar.gz";
-    sha256 = "0gnl9arwmkblljsczspcgggx85a19vcmhmbjfyv1bq236yqixv5c";
+    url = "http://gdlp01.c-wss.com/gds/0/0100009930/01/cnijfilter2-source-5.70-1.tar.gz";
+    sha256 = "045zjsmaidn1m44ki6m1018gjzbj77gm234n5i2lshxpbzpyh0is";
   };
 
   buildInputs = [


### PR DESCRIPTION
Newly supported series in version 5.40:

MB2100, MB2700, iB4100, MB5100, MB5400, TS9000, TS8000, TS6000, TS5000, MG3000, E470, G4000

Newly supported series in version 5.50:

E200, E300, E3100, TR7500, TR7530, TR8500, TR8530, TR8580, TS200, TS300, TS3100, TS5100, TS6100, TS6130, TS6180, TS8100, TS8180, TS9100, TS9180, TS8130, XK70, XK50

Newly supported series in version 5.60:

G3010, G4010

Newly supported series in version 5.70:

TS8200, XK80, TS8230, TS8280, TS6200, TS6230, TS6280, TS9500, TR9530, TS9580, TR4500, E4200

---

#### Note that I have only successfully built this but I'm not able test it because I personally don't have a Canon printer. I've done this bump mainly for someone else who owns a newer printer which is only supported in version 5.70.