### PR TITLE
kodi: add Wayland support

### DIFF
--- a/pkgs/applications/video/kodi/default.nix
+++ b/pkgs/applications/video/kodi/default.nix
@@ -13,7 +13,7 @@
 , libmpeg2, libsamplerate, libmad
 , libogg, libvorbis, flac, libxslt
 , lzo, libcdio, libmodplug, libass, libbluray
-, sqlite, mysql, nasm, gnutls, libva, libdrm, wayland
+, sqlite, mysql, nasm, gnutls, libva, libdrm
 , curl, bzip2, zip, unzip, glxinfo, xdpyinfo
 , libcec, libcec_platform, dcadec, libuuid
 , libcrossguid, libmicrohttpd
@@ -28,6 +28,8 @@
 , udevSupport ? true, udev ? null
 , usbSupport  ? false, libusb ? null
 , vdpauSupport ? true, libvdpau ? null
+, useWayland ? false, wayland ? null, wayland-protocols ? null
+, waylandpp ?  null, libxkbcommon ? null
 }:
 
 assert dbusSupport  -> dbus != null;
@@ -38,6 +40,7 @@ assert sambaSupport -> samba != null;
 assert udevSupport  -> udev != null;
 assert usbSupport   -> libusb != null && ! udevSupport; # libusb won't be used if udev is avaliable
 assert vdpauSupport -> libvdpau != null;
+assert useWayland -> wayland != null && wayland-protocols != null && waylandpp != null && libxkbcommon != null;
 
 # TODO for Kodi 18.0
 # - check if dbus support PR has been merged and add dbus as a buildInput
@@ -110,7 +113,7 @@ let
   };
 
 in stdenv.mkDerivation rec {
-    name = "kodi-${kodiVersion}";
+    name = "kodi-${lib.optionalString useWayland "wayland-"}${kodiVersion}";
 
     src = kodi_src;
 
@@ -123,7 +126,7 @@ in stdenv.mkDerivation rec {
       libX11 xorgproto libXt libXmu libXext
       libXinerama libXrandr libXtst libXfixes
       alsaLib libGLU_combined glew fontconfig freetype ftgl
-      libjpeg jasper libpng libtiff wayland
+      libjpeg jasper libpng libtiff
       libmpeg2 libsamplerate libmad
       libogg libvorbis flac libxslt systemd
       lzo libcdio libmodplug libass libbluray
@@ -144,7 +147,12 @@ in stdenv.mkDerivation rec {
     ++ lib.optional  sambaSupport    samba
     ++ lib.optional  udevSupport     udev
     ++ lib.optional  usbSupport      libusb
-    ++ lib.optional  vdpauSupport    libvdpau;
+    ++ lib.optional  vdpauSupport    libvdpau
+    ++ lib.optional  useWayland [
+      wayland waylandpp
+      # Not sure why ".dev" is needed here, but CMake doesn't find libxkbcommon otherwise
+      libxkbcommon.dev
+    ];
 
     nativeBuildInputs = [
       cmake
@@ -153,7 +161,7 @@ in stdenv.mkDerivation rec {
       which
       pkgconfig gnumake
       autoconf automake libtool # still needed for some components. Check if that is the case with 18.0
-    ];
+    ] ++ lib.optional useWayland [ wayland-protocols ];
 
     cmakeFlags = [
       "-Dlibdvdcss_URL=${libdvdcss.src}"
@@ -164,6 +172,9 @@ in stdenv.mkDerivation rec {
       "-DENABLE_INTERNAL_CROSSGUID=OFF"
       "-DENABLE_OPTICAL=ON"
       "-DLIRC_DEVICE=/run/lirc/lircd"
+    ] ++ lib.optional useWayland [
+      "-DCORE_PLATFORM_NAME=wayland"
+      "-DWAYLAND_RENDER_SYSTEM=gl"
     ];
 
     enableParallelBuilding = true;

--- a/pkgs/applications/video/kodi/wrapper.nix
+++ b/pkgs/applications/video/kodi/wrapper.nix
@@ -1,7 +1,9 @@
 { stdenv, lib, makeWrapper, buildEnv, kodi, plugins }:
 
-buildEnv {
-  name = "kodi-with-plugins-${(builtins.parseDrvName kodi.name).version}";
+let
+  drvName = builtins.parseDrvName kodi.name;
+in buildEnv {
+  name = "${drvName.name}-with-plugins-${drvName.version}";
 
   paths = [ kodi ] ++ plugins;
   pathsToLink = [ "/share" ];

--- a/pkgs/development/libraries/waylandpp/default.nix
+++ b/pkgs/development/libraries/waylandpp/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, pugixml, wayland, libGL }:
+
+stdenv.mkDerivation rec {
+  pname = "waylandpp";
+  version = "0.2.5";
+
+  src = fetchFromGitHub {
+    owner = "NilsBrause";
+    repo = pname;
+    rev = version;
+    sha256 = "16h57hzd688664qcyznzhjp3hxipdkzgv46x82yhkww24av8b55n";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [ pugixml wayland libGL ];
+
+  meta = with stdenv.lib; {
+    description = "Wayland C++ binding";
+    homepage = https://github.com/NilsBrause/waylandpp/;
+    license = with licenses; [ bsd2 hpnd ];
+    maintainers = with maintainers; [ minijackson ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20517,10 +20517,16 @@ in
 
   kodiPlain = callPackage ../applications/video/kodi { };
 
+  kodiPlainWayland = callPackage ../applications/video/kodi { useWayland = true; };
+
   kodiPlugins = recurseIntoAttrs (callPackage ../applications/video/kodi/plugins.nix {});
 
   kodi = wrapKodi {
     kodi = kodiPlain;
+  };
+
+  kodi-wayland = wrapKodi {
+    kodi = kodiPlainWayland;
   };
 
   kodi-cli = callPackage ../tools/misc/kodi-cli { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13251,6 +13251,8 @@ in
 
   wayland-protocols = callPackage ../development/libraries/wayland/protocols.nix { };
 
+  waylandpp = callPackage ../development/libraries/waylandpp { };
+
   wcslib = callPackage ../development/libraries/wcslib { };
 
   webkitgtk = callPackage ../development/libraries/webkitgtk {


### PR DESCRIPTION
###### Motivation for this change

Kodi has had support (again) for Wayland since v18.0. It would be nice to ship it in NixOS.

I mimicked Firefox for Wayland's attribute path for Kodi with plugins:

- New "plain" Kodi: `kodiPlainWayland`
- `kodiPlainWayland` gets wrapped with plugins into `kodi-wayland`

I'm open to suggestions / discussion, particularly on 2 things:

- The `libxkbcommon` build dependency is specified as `libxkbcommon.dev`, otherwise `kodiPlainWayland` won't build for me (cmake doesn't find xcbcommon), and I don't know why :-/
- Some GNU/Linux distributions ship a mix between `kodi` and `kodi-wayland`: the `/bin/kodi` script already selects the right Kodi to launch if in a Wayland or X11 environment. So if we have a derivation which compiles both `kodi` + `kodiPlainWayland`, and "copy" `${kodiPlainWayland}/lib/kodi/kodi-wayland` into `${kodi}/lib/kodi/`, we should have something that is both native to X11 and Wayland!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).