### PR TITLE
nixos/systemd: Add suspend-then-hibernate

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -108,11 +108,13 @@ let
       # Hibernate / suspend.
       "hibernate.target"
       "suspend.target"
+      "suspend-then-hibernate.target"
       "sleep.target"
       "hybrid-sleep.target"
       "systemd-hibernate.service"
       "systemd-hybrid-sleep.service"
       "systemd-suspend.service"
+      "systemd-suspend-then-hibernate.service"
 
       # Reboot stuff.
       "reboot.target"
@@ -673,6 +675,28 @@ in
       '';
     };
 
+    services.sleep.hibernateDelaySec = mkOption {
+      default = 3600;
+      type = types.int;
+      description = ''
+        The amount of time in seconds that will pass before the system is automatically
+        put into hibernate when using 
+        <link xlink:href="https://www.freedesktop.org/software/systemd/man/systemd-suspend-then-hibernate.service.html">
+        systemd-suspend-then-hibernate.service(8)</link>.
+      '';
+    };
+
+    services.sleep.extraConfig = mkOption {
+      default = "";
+      type = types.lines;
+      example = "AllowHybridSleep=no";
+      description = ''
+        Extra config options for systemd-sleep.conf. See
+        <link xlink:href="https://www.freedesktop.org/software/systemd/man/systemd-sleep.conf.html">
+        systemd-sleep.conf(5)</link> for available options.
+      '';
+    };
+
     systemd.tmpfiles.rules = mkOption {
       type = types.listOf types.str;
       default = [];
@@ -819,6 +843,8 @@ in
 
       "systemd/sleep.conf".text = ''
         [Sleep]
+        HibernateDelaySec=${toString config.services.sleep.hibernateDelaySec}
+        ${config.services.sleep.extraConfig}
       '';
 
       "tmpfiles.d/systemd.conf".source = "${systemd}/example/tmpfiles.d/systemd.conf";


### PR DESCRIPTION
This is a duplicate of #53025, but also adds the according settings of sleep.conf.

###### Motivation for this change
This pr enables nixos to use suspend-then-hibernate.
This adds suspend-then-hibernate systemd service/target and
also adds the according settings for sleep.conf.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
