### PR TITLE
avahi: apply patches for CVE-2017-6519 & CVE-2018-1000845

### DIFF
--- a/pkgs/development/libraries/avahi/default.nix
+++ b/pkgs/development/libraries/avahi/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, pkgconfig, libdaemon, dbus, perlPackages
+{ fetchurl, fetchpatch, stdenv, pkgconfig, libdaemon, dbus, perlPackages
 , expat, gettext, intltool, glib, libiconv
 , gtk3Support ? false, gtk3 ? null
 , qt4 ? null
@@ -16,7 +16,14 @@ stdenv.mkDerivation rec {
     sha256 = "0128n7jlshw4bpx0vg8lwj8qwdisjxi7mvniwfafgnkzzrfrpaap";
   };
 
-  patches = [ ./no-mkdir-localstatedir.patch ];
+  patches = [
+    ./no-mkdir-localstatedir.patch
+    (fetchpatch {
+      name ="CVE-2017-6519-CVE-2018-100084.patch";
+      url = https://github.com/lathiat/avahi/commit/e111def44a7df4624a4aa3f85fe98054bffb6b4f.patch;
+      sha256 = "06n7b7kz6xcc35c7xjfc1kj3k2llyjgi09nhy0ci32l1bhacjw0q";
+    })
+  ];
 
   buildInputs = [ libdaemon dbus glib expat libiconv ]
     ++ (with perlPackages; [ perl XMLParser ])


### PR DESCRIPTION
###### Motivation for this change

This applies patches for the two CVEs CVE-2017-6519 & CVE-2018-1000845

fixes #57137

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
