### PR TITLE
vimPlugins.vim-stylish-haskell: Patch path to executable

### DIFF
--- a/pkgs/misc/vim-plugins/overrides.nix
+++ b/pkgs/misc/vim-plugins/overrides.nix
@@ -2,7 +2,7 @@
 , python, cmake, meson, vim, ruby
 , which, fetchgit, fetchurl
 , llvmPackages, rustPlatform
-, xkb-switch, fzf, skim
+, xkb-switch, fzf, skim, stylish-haskell
 , python3, boost, icu, ncurses
 , ycmd, rake
 , gobject-introspection, glib, wrapGAppsHook
@@ -403,6 +403,14 @@ self: super: {
       description = "code-completion for python using python-jedi";
       license = stdenv.lib.licenses.mit;
     };
+  });
+
+  vim-stylish-haskell = super.vim-stylish-haskell.overrideAttrs (old: {
+    postPatch = old.postPatch or "" + ''
+      substituteInPlace ftplugin/haskell/stylish-haskell.vim --replace \
+        'g:stylish_haskell_command = "stylish-haskell"' \
+        'g:stylish_haskell_command = "${stylish-haskell}/bin/stylish-haskell"'
+    '';
   });
 
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5744,6 +5744,8 @@ in
   strongswanTNC = strongswan.override { enableTNC = true; };
   strongswanNM  = strongswan.override { enableNetworkManager = true; };
 
+  stylish-haskell = haskell.lib.justStaticExecutables haskellPackages.stylish-haskell;
+
   su = shadow.su;
 
   subsonic = callPackage ../servers/misc/subsonic { };


### PR DESCRIPTION
###### Motivation for this change
Closes https://github.com/NixOS/nixpkgs/issues/57099

As one would expect, this increases the closure size of `vimPlugins.vim-stylish-haskell` by a lot, from 3.1KB to 40.6MB, but this is worth it and makes sense.

Tested this by doing
```
$ cd /path/to/nixpkgs
$ nix-build -E 'with import ./. {}; neovim.override { configure = { packages.myVimPackage = with pkgs.vimPlugins; { start = [  vim-stylish-haskell ]; }; }; }'
$ export PATH=""
$ result/bin/nvim
```

Then opening a non-stylished Haskell file (such as https://github.com/mrkkrp/megaparsec/blob/master/Text/Megaparsec.hs) and hitting `:w` -> stylish does the styling.

Ping @lrworth

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
