### PR TITLE
adoptopenjdk-bin: Remove libfreetype.so [backport to 18.09]

### DIFF
--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk-linux-base.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk-linux-base.nix
@@ -80,6 +80,10 @@ let result = stdenv.mkDerivation rec {
     # Remove some broken manpages.
     rm -rf $out/man/ja*
 
+    # Remove embedded freetype to avoid problems like
+    # https://github.com/NixOS/nixpkgs/issues/57733
+    rm $out/lib/libfreetype.so
+
     # for backward compatibility
     ln -s $out $out/jre
 


### PR DESCRIPTION
###### Motivation for this change
Fix kodi building on aarch64: https://hydra.nixos.org/build/91064101 diagnosed in https://github.com/NixOS/nixpkgs/issues/57733

Merged into master in https://github.com/NixOS/nixpkgs/pull/57750 .

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
