### PR TITLE
gnulib: 20180226 -> 20190326

### DIFF
--- a/pkgs/development/tools/gnulib/default.nix
+++ b/pkgs/development/tools/gnulib/default.nix
@@ -1,12 +1,13 @@
 { stdenv, fetchgit }:
 
 stdenv.mkDerivation {
-  name = "gnulib-20180226";
+  pname = "gnulib";
+  version = "20190326";
 
   src = fetchgit {
-    url = "https://git.savannah.gnu.org/r/gnulib.git";
-    rev = "0bec5d56c6938c2f28417bb5fd1c4b05ea2e7d28";
-    sha256 = "0sifr3bkmhyr5s6ljgfyr0fw6w49ajf11rlp1r797f3r3r6j9w4k";
+    url = https://git.savannah.gnu.org/r/gnulib.git;
+    rev = "a18f7ce3c0aa760c33d46bbeb8e5b3a14cf24984";
+    sha256 = "04py5n3j17wyqv9wfsslcrxzapni9vmw6p5g0adzy2md3ygjw4x4";
   };
 
   dontFixup = true;

--- a/pkgs/tools/X11/xprintidle-ng/default.nix
+++ b/pkgs/tools/X11/xprintidle-ng/default.nix
@@ -2,22 +2,27 @@
   , autoconf, automake, libtool, gettext, pkgconfig
   , git, perl, texinfo, help2man
 }:
-stdenv.mkDerivation rec {
-  version = "git-2015-09-01";
-  name = "${baseName}-${version}";
-  baseName = "xprintidle-ng";
 
-  buildInputs = [
-    libX11 libXScrnSaver libXext gnulib
-    autoconf automake libtool gettext pkgconfig  git perl 
-    texinfo help2man
-    ];
+stdenv.mkDerivation rec {
+  pname = "xprintidle-ng";
+  version = "git-2015-09-01";
+
   src = fetchFromGitHub {
     owner = "taktoa";
-    repo = "${baseName}";
+    repo = pname;
     rev = "9083ba284d9222541ce7da8dc87d5a27ef5cc592";
     sha256 = "0a5024vimpfrpj6w60j1ad8qvjkrmxiy8w1yijxfwk917ag9rkpq";
   };
+
+  postPatch = ''
+    substituteInPlace configure.ac \
+      --replace "AC_PREREQ([2.62])" "AC_PREREQ([2.63])"
+  '';
+
+  nativeBuildInputs = [ 
+    autoconf automake gettext git gnulib
+    help2man libtool perl pkgconfig texinfo
+  ];
 
   configurePhase = ''
     cp -r "${gnulib}" gnulib
@@ -26,10 +31,15 @@ stdenv.mkDerivation rec {
     ./configure --prefix="$out"
   '';
 
+  buildInputs = [
+    libX11 libXScrnSaver libXext  
+  ];
+
   meta = {
     inherit  version;
     description = ''A command-line tool to print idle time from libXss'';
-    license = stdenv.lib.licenses.gpl2 ;
+    homepage = http://taktoa.me/xprintidle-ng/;
+    license = stdenv.lib.licenses.gpl2;
     maintainers = [stdenv.lib.maintainers.raskin];
     platforms = stdenv.lib.platforms.linux;
   };


### PR DESCRIPTION
###### Motivation for this change

Lots of fixes, support for goodness such as RISC-V and cross-musl
(apparently!):

http://git.savannah.gnu.org/gitweb/?p=gnulib.git;a=shortlog;h=a18f7ce3c0aa760c33d46bbeb8e5b3a14cf24984;hp=0bec5d56c6938c2f28417bb5fd1c4b05ea2e7d28

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---