### PR TITLE
nixos/ldap: set proper User= and Group= for nslcd service

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -516,6 +516,13 @@
      Graylog</link> for details.
     </para>
    </listitem>
+   <listitem>
+    <para>
+      The option <literal>users.ldap.bind.password</literal> was renamed to <literal>users.ldap.bind.passwordFile</literal>,
+      and needs to be readable by the <literal>nslcd</literal> user.
+      Same applies to the new <literal>users.ldap.daemon.rootpwmodpwFile</literal> option.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/config/ldap.nix
+++ b/nixos/modules/config/ldap.nix
@@ -139,13 +139,13 @@ in
           '';
         };
 
-        rootpwmodpw = mkOption {
+        rootpwmodpwFile = mkOption {
           default = "";
           example = "/run/keys/nslcd.rootpwmodpw";
           type = types.str;
           description = ''
-            The path to a file containing the credentials with which
-            to bind to the LDAP server if the root user tries to change a user's password
+            The path to a file containing the credentials with which to bind to
+            the LDAP server if the root user tries to change a user's password.
           '';
         };
       };
@@ -161,7 +161,7 @@ in
           '';
         };
 
-        password = mkOption {
+        passwordFile = mkOption {
           default = "/etc/ldap/bind.password";
           type = types.str;
           description = ''
@@ -224,10 +224,10 @@ in
 
     system.activationScripts = mkIf insertLdapPassword {
       ldap = stringAfter [ "etc" "groups" "users" ] ''
-        if test -f "${cfg.bind.password}" ; then
+        if test -f "${cfg.bind.passwordFile}" ; then
           umask 0077
           conf="$(mktemp)"
-          printf 'bindpw %s\n' "$(cat ${cfg.bind.password})" |
+          printf 'bindpw %s\n' "$(cat ${cfg.bind.passwordFile})" |
           cat ${ldapConfig.source} - >"$conf"
           mv -fT "$conf" /etc/ldap.conf
         fi
@@ -260,10 +260,10 @@ in
           conf="$(mktemp)"
           {
             cat ${nslcdConfig.source}
-            test -z '${cfg.bind.distinguishedName}' -o ! -f '${cfg.bind.password}' ||
-            printf 'bindpw %s\n' "$(cat '${cfg.bind.password}')"
-            test -z '${cfg.daemon.rootpwmoddn}' -o ! -f '${cfg.daemon.rootpwmodpw}' ||
-            printf 'rootpwmodpw %s\n' "$(cat '${cfg.daemon.rootpwmodpw}')"
+            test -z '${cfg.bind.distinguishedName}' -o ! -f '${cfg.bind.passwordFile}' ||
+            printf 'bindpw %s\n' "$(cat '${cfg.bind.passwordFile}')"
+            test -z '${cfg.daemon.rootpwmoddn}' -o ! -f '${cfg.daemon.rootpwmodpwFile}' ||
+            printf 'rootpwmodpw %s\n' "$(cat '${cfg.daemon.rootpwmodpwFile}')"
           } >"$conf"
           mv -fT "$conf" /etc/nslcd.conf
         '';
@@ -287,4 +287,8 @@ in
     };
 
   };
+
+  imports =
+    [ (mkRenamedOptionModule [ "users" "ldap" "bind" "password"] [ "users" "ldap" "bind" "passwordFile"])
+    ];
 }

--- a/nixos/tests/ldap.nix
+++ b/nixos/tests/ldap.nix
@@ -28,9 +28,8 @@ let
       users.ldap.daemon = {
         enable = useDaemon;
         rootpwmoddn = "cn=admin,${dbSuffix}";
-        rootpwmodpw = "/etc/nslcd.rootpwmodpw";
+        rootpwmodpwFile = "/etc/nslcd.rootpwmodpw";
       };
-      # NOTE: password stored in clear in Nix's store, but this is a test.
       environment.etc."nslcd.rootpwmodpw".source = pkgs.writeText "rootpwmodpw" dbAdminPwd;
       users.ldap.loginPam = true;
       users.ldap.nsswitch = true;
@@ -38,7 +37,7 @@ let
       users.ldap.base = "ou=posix,${dbSuffix}";
       users.ldap.bind = {
         distinguishedName = "cn=admin,${dbSuffix}";
-        password = "/etc/ldap/bind.password";
+        passwordFile = "/etc/ldap/bind.password";
       };
       # NOTE: password stored in clear in Nix's store, but this is a test.
       environment.etc."ldap/bind.password".source = pkgs.writeText "password" dbAdminPwd;

--- a/nixos/tests/ldap.nix
+++ b/nixos/tests/ldap.nix
@@ -30,7 +30,6 @@ let
         rootpwmoddn = "cn=admin,${dbSuffix}";
         rootpwmodpwFile = "/etc/nslcd.rootpwmodpw";
       };
-      environment.etc."nslcd.rootpwmodpw".source = pkgs.writeText "rootpwmodpw" dbAdminPwd;
       users.ldap.loginPam = true;
       users.ldap.nsswitch = true;
       users.ldap.server = "ldap://server";
@@ -39,8 +38,9 @@ let
         distinguishedName = "cn=admin,${dbSuffix}";
         passwordFile = "/etc/ldap/bind.password";
       };
-      # NOTE: password stored in clear in Nix's store, but this is a test.
+      # NOTE: passwords stored in clear in Nix's store, but this is a test.
       environment.etc."ldap/bind.password".source = pkgs.writeText "password" dbAdminPwd;
+      environment.etc."nslcd.rootpwmodpw".source = pkgs.writeText "rootpwmodpw" dbAdminPwd;
     };
 in
 


### PR DESCRIPTION
###### Motivation for this change

eb90d9700958aefbc7b886f2b524c6d04dc1d80d broke nslcd, as `/run/nslcd` was
created/chowned as root user, while nslcd wants to do parts as nslcd
user.

This commit changes the nslcd to run with the proper uid/gid from the
start (through User= and Group=), so the RuntimeDirectory has proper
permissions, too.

In some cases, secrets are baked into nslcd's config file during startup
(so we don't want to provide it from the store).

This config file is normally hard-wired to /etc/nslcd.conf, but we don't
want to use PermissionsStartOnly anymore (#56265), and activation
scripts are ugly, so redirect /etc/nslcd.conf to /run/nslcd/nslcd.conf,
which now gets provisioned inside ExecStartPre=.

This change requires the files referenced to in
users.ldap.bind.passwordFile and users.ldap.daemon.rootpwmodpwFile to be
readable by the nslcd user (in the non-nslcd case, this was already the
case for users.ldap.bind.passwordFile)

fixes #57783

In addition, this renames `users.ldap.daemon.rootpwmodpw` to `users.ldap.daemon.rootpwmodpwFile` and `users.ldap.bind.password` to `users.ldap.bind.passwordFile` (as it's really files). I added a `mkRenamedOptionModule` for `users.ldap.bind.password`, but `users.ldap.daemon.rootpwmodpw` wasn't yet part of a release.

Should be backported to 19.03. / cc @samueldr @lheckemann 

cc @ju1m

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
