### PR TITLE
chafa: init at 1.0.1

### DIFF
--- a/pkgs/tools/misc/chafa/default.nix
+++ b/pkgs/tools/misc/chafa/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchFromGitHub, autoconf, automake, libtool, pkgconfig, which, libxslt, libxml2, docbook_xml_dtd_412, docbook_xsl, glib, imagemagick, darwin }:
+
+
+stdenv.mkDerivation rec{
+  version = "1.0.1";
+  pname = "chafa";
+
+  src = fetchFromGitHub {
+    owner = "hpjansson";
+    repo = "chafa";
+    rev = version;
+    sha256 = "1i1cnzmb12pxldc7y4q1xdmybv9xkhzrjyhdvmk3qsn02p859q04";
+  };
+
+  nativeBuildInputs = [ autoconf
+                        automake
+                        libtool
+                        pkgconfig
+                        which
+                        libxslt
+                        libxml2
+                        docbook_xml_dtd_412
+                        docbook_xsl
+                      ];
+
+  buildInputs = [ glib imagemagick ] ++ stdenv.lib.optional stdenv.isDarwin [ darwin.apple_sdk.frameworks.ApplicationServices ];
+
+  patches = [ ./xmlcatalog_patch.patch ];
+
+  preConfigure = ''
+    ./autogen.sh
+  '';
+
+  configureFlags = [ "--enable-man"
+                     "--with-xml-catalog=${docbook_xml_dtd_412}/xml/dtd/docbook/catalog.xml"
+                   ];
+
+  meta = with stdenv.lib; {
+    description = "Terminal graphics for the 21st century.";
+    homepage = https://hpjansson.org/chafa/;
+    license = licenses.lgpl3Plus;
+    platforms = platforms.all;
+    maintainers = [ maintainers.mog ];
+  };
+}

--- a/pkgs/tools/misc/chafa/xmlcatalog_patch.patch
+++ b/pkgs/tools/misc/chafa/xmlcatalog_patch.patch
@@ -1,0 +1,23 @@
+diff --git a/configure.ac b/configure.ac
+index 0055a70..fd4a905 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -111,18 +111,6 @@ AS_IF([ test "$enable_man" != no ], [
+   ])
+ ])
+ 
+-AS_IF([test "$enable_man" != no], [
+-  dnl check for DocBook XSL stylesheets in the local catalog
+-  JH_CHECK_XML_CATALOG([http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl],
+-     [DocBook XSL Stylesheets], [have_docbook_style=yes],[have_docbook_style=no])
+-  AS_IF([ test "$have_docbook_style" != yes ], [
+-    AS_IF([ test "$enable_man" = yes ], [
+-      AC_MSG_ERROR([DocBook XSL Stylesheets are required for --enable-man])
+-    ])
+-    enable_man=no
+-  ])
+-])
+-
+ AM_CONDITIONAL(ENABLE_MAN, test "$enable_man" != no)
+ 
+ AC_MSG_CHECKING([whether to generate man pages])

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2124,6 +2124,8 @@ in
 
   cfssl = callPackage ../tools/security/cfssl { };
 
+  chafa = callPackage ../tools/misc/chafa { };
+
   checkbashisms = callPackage ../development/tools/misc/checkbashisms { };
 
   civetweb = callPackage ../development/libraries/civetweb { };


### PR DESCRIPTION
###### Motivation for this change
I read about cool tool on reddit and thought we needed it packaged. it makes cool unicode approximations of images inside your terminal.
![koi_terminal](https://user-images.githubusercontent.com/64710/55049191-91b1c400-5021-11e9-87a0-eae4584e930f.png)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
