### PR TITLE
cypress: init at 3.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -107,6 +107,11 @@
     github = "acowley";
     name = "Anthony Cowley";
   };
+  acyuta108 = {
+    email = "acyuta108@gmail.com";
+    github = "acyuta108";
+    name = "Acyuta C";
+  };
   adamt = {
     email = "mail@adamtulinius.dk";
     github = "adamtulinius";

--- a/pkgs/development/web/cypress/README.md
+++ b/pkgs/development/web/cypress/README.md
@@ -1,0 +1,15 @@
+This nix package generates the [Cypress](https://www.cypress.io/) binary compiled and installed by the native npm package found at [npm js repository](https://www.npmjs.com/package/cypress) for other linux distros.
+
+## Installation and usage
+
+The regular installation process ([as instructed here](https://docs.cypress.io/guides/getting-started/installing-cypress.html)) will not work given the nature of Nix packaging system.
+
+Install the nix package `nix-env -iA nixpkgs.cypress` or adding to your nixos config if running NixOS.
+
+Then install cypress npm package and run the binary (Electron app) passing the environment variables:
+
+```
+$ cd path/to/your/app
+$ CYPRESS_INSTALL_BINARY=0 npm i cypress
+$ CYPRESS_RUN_BINARY=~/.nix-profile/bin/Cypress $(npm bin)/cypress open
+```

--- a/pkgs/development/web/cypress/default.nix
+++ b/pkgs/development/web/cypress/default.nix
@@ -1,0 +1,43 @@
+{stdenv, fetchurl, autoPatchelfHook, xorg, gtk2, gnome2, nss, alsaLib, udev, unzip}:
+
+stdenv.mkDerivation rec{
+  version = "3.2.0";
+  name = "cypress-${version}";
+  src = fetchurl {
+    url = "https://download.cypress.io/desktop/${version}?platform=linux64";
+    sha256 = "0vz1dv7l10kzaqbsgsbvma531n5pi3vfdnyqpwia5b0m31j6wj0y";
+  };
+
+  # don't remove runtime deps
+  dontPatchELF = true;
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  buildInputs = with xorg; [
+    libXScrnSaver libXdamage libXtst
+  ] ++ [
+    nss gtk2 alsaLib gnome2.GConf unzip
+  ];
+
+  runtimeDependencies = [ udev.lib ];
+
+  unpackCmd = ''
+    unzip $curSrc
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin $out/opt/cypress
+    cp -r * $out/opt/cypress/
+    # Let's create the file binary_state ourselves to make the npm package happy on initial verification.
+    echo '{"verified": true}' > $out/opt/cypress/binary_state.json
+    ln -s $out/opt/cypress/Cypress $out/bin/Cypress
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Fast, easy and reliable testing for anything that runs in a browser.";
+    homepage = https://www.cypress.io;
+    license = licenses.mit;
+    platforms = ["x86_64-linux"];
+    maintainers = with maintainers; [ erosennin tweber acyuta108 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -151,6 +151,8 @@ in
 
   corgi = callPackage ../development/tools/corgi { };
 
+  cypress = callPackage ../development/web/cypress { };
+
   dhallToNix = callPackage ../build-support/dhall-to-nix.nix {
     inherit dhall-nix;
   };


### PR DESCRIPTION
###### Motivation for this change
Missing package.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---