### PR TITLE
python2Packages.nevow, tahoe-lafs: fix build

### DIFF
--- a/pkgs/development/python-modules/nevow/default.nix
+++ b/pkgs/development/python-modules/nevow/default.nix
@@ -12,6 +12,8 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ twisted ];
 
+  checkInputs = [ twisted ];
+
   checkPhase = ''
     trial formless nevow
   '';

--- a/pkgs/tools/networking/p2p/tahoe-lafs/default.nix
+++ b/pkgs/tools/networking/p2p/tahoe-lafs/default.nix
@@ -59,7 +59,7 @@ pythonPackages.buildPythonApplication rec {
     service-identity pyyaml magic-wormhole treq
   ];
 
-  checkInputs = with pythonPackages; [ hypothesis ];
+  checkInputs = with pythonPackages; [ hypothesis twisted ];
 
   # Install the documentation.
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change

#56826 - please backport

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
