### PR TITLE
ocaml-syslog: fix missing cmxa file

### DIFF
--- a/pkgs/development/ocaml-modules/syslog/default.nix
+++ b/pkgs/development/ocaml-modules/syslog/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ocaml findlib ];
 
+  buildFlags = [ "all" "opt" ];
+
   createFindlibDestdir = true;
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Makefile does not produce native library by default.
Added an explicit "make all opt" as other ocaml libs do.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
