### PR TITLE
apitrace: 363 -> 572 (2017-04-21 -> 2019-03-26)

### DIFF
--- a/pkgs/applications/graphics/apitrace/default.nix
+++ b/pkgs/applications/graphics/apitrace/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "apitrace-${version}";
-  version = "7.1-363-ge3509be1";
+  version = "7.1-572-g${builtins.substring 0 8 src.rev}";
 
   src = fetchFromGitHub {
-    sha256 = "1xbz6gwl7kqjm7jjy5gxkdxzrg93vj1a3l19ara7rni6dii0q136";
-    rev = "e3509be175eda77749abffe051ed0d3eb5d14e72";
+    sha256 = "11bwb0l8cr1bf9bj1s6cbmi77d5fy4qrphj9cgmcd8jpa862anp5";
+    rev = "26966134f15d28f6b4a9a0a560017b3ba36d60bf";
     repo = "apitrace";
     owner = "apitrace";
   };


### PR DESCRIPTION
###### Motivation for this change

Bump! :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - the gl* variants anyway
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---