### PR TITLE
postgresqlPackages.pipelinedb: init at 1.0.0-13

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pipelinedb.nix
+++ b/pkgs/servers/sql/postgresql/ext/pipelinedb.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchFromGitHub, postgresql, zeromq, openssl }:
+
+if stdenv.lib.versionOlder postgresql.version "10"
+then throw "PipelineDB not supported for PostgreSQL ${postgresql.version}"
+else
+stdenv.mkDerivation rec {
+  pname = "pipelinedb";
+  version = "1.0.0-13";
+
+  src = fetchFromGitHub {
+    owner = "pipelinedb";
+    repo = pname;
+    rev = version;
+    sha256 = "1mnqpvx6g1r2n4kjrrx01vbdx7kvndfsbmm7zbzizjnjlyixz75f";
+  };
+
+  buildInputs = [ postgresql openssl zeromq ];
+
+  makeFlags = [ "USE_PGXS=1" ];
+
+  preConfigure = ''
+    substituteInPlace Makefile \
+      --replace "/usr/lib/libzmq.a" "${zeromq}/lib/libzmq.a"
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -D -t $out/lib/ pipelinedb.so
+    install -D -t $out/share/extension {pipelinedb-*.sql,pipelinedb.control}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "High-performance time-series aggregation for PostgreSQL";
+    homepage = https://www.pipelinedb.com/;
+    license = licenses.asl20;
+    platforms = postgresql.meta.platforms;
+    maintainers = [ maintainers.marsam ];
+  };
+}

--- a/pkgs/servers/sql/postgresql/packages.nix
+++ b/pkgs/servers/sql/postgresql/packages.nix
@@ -31,6 +31,8 @@ self: super: {
 
     pgtap = super.callPackage ./ext/pgtap.nix { };
 
+    pipelinedb = super.callPackage ./ext/pipelinedb.nix { };
+
     timescaledb = super.callPackage ./ext/timescaledb.nix { };
 
     tsearch_extras = super.callPackage ./ext/tsearch_extras.nix { };


### PR DESCRIPTION
###### Motivation for this change
Add https://www.pipelinedb.com/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
