### PR TITLE
fcitx: 4.2.9.5 -> 4.2.9.6

### DIFF
--- a/pkgs/tools/inputmethods/fcitx/unwrapped.nix
+++ b/pkgs/tools/inputmethods/fcitx/unwrapped.nix
@@ -4,7 +4,7 @@
 , dbus, gtk2, gtk3, qt4, extra-cmake-modules
 , xkeyboard_config, pcre, libuuid
 , withPinyin ? true
-, fetchFromGitHub
+, fetchFromGitLab
 }:
 
 let
@@ -37,13 +37,13 @@ let
 in
 stdenv.mkDerivation rec {
   name = "fcitx-${version}";
-  version = "4.2.9.5";
+  version = "4.2.9.6";
 
-  src = fetchFromGitHub {
+  src = fetchFromGitLab {
     owner = "fcitx";
     repo = "fcitx";
     rev = version;
-    sha256 = "0rv69bacdvblka85dakz4ldpznrgwj59nqcccp5mkkn1rab4zh1r";
+    sha256 = "0j5vaf930lb21gx4h7z6mksh1fazqw32gajjjkyir94wbmml9n3s";
   };
 
   # put data at the correct locations else cmake tries to fetch them,


### PR DESCRIPTION
Updated url to gitlab.

###### Motivation for this change
none, was looking into how I could input arabic.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
