### PR TITLE
 python3.pkgs.cherrypy: 18.1.0 -> 18.1.1

### DIFF
--- a/pkgs/development/python-modules/cherrypy/17.nix
+++ b/pkgs/development/python-modules/cherrypy/17.nix
@@ -1,0 +1,36 @@
+{ lib, buildPythonPackage, fetchPypi
+, setuptools_scm
+, cheroot, contextlib2, portend, routes, six, zc_lockfile
+, backports_unittest-mock, objgraph, pathpy, pytest, pytestcov, backports_functools_lru_cache, requests_toolbelt
+}:
+
+buildPythonPackage rec {
+  pname = "cherrypy";
+  version = "17.4.1";
+
+  src = fetchPypi {
+    pname = "CherryPy";
+    inherit version;
+    sha256 = "1kl17anzz535jgkn9qcy0c2m0zlafph0iv7ph3bb9mfrs2bgvagv";
+  };
+
+  propagatedBuildInputs = [
+    cheroot contextlib2 portend routes six zc_lockfile
+  ];
+
+  nativeBuildInputs = [ setuptools_scm ];
+
+  checkInputs = [
+    backports_unittest-mock objgraph pathpy pytest pytestcov backports_functools_lru_cache requests_toolbelt
+  ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with lib; {
+    homepage = https://www.cherrypy.org;
+    description = "A pythonic, object-oriented HTTP framework";
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/cherrypy/default.nix
+++ b/pkgs/development/python-modules/cherrypy/default.nix
@@ -1,54 +1,42 @@
 { lib, buildPythonPackage, fetchPypi, isPy3k
-, cheroot, contextlib2, portend, routes, six
-, setuptools_scm, zc_lockfile, more-itertools
-, backports_unittest-mock, objgraph, pathpy, pytest, pytestcov
-, backports_functools_lru_cache, requests_toolbelt, pytest-services
+, setuptools_scm
+, cheroot, portend, more-itertools, zc_lockfile, routes
+, objgraph, pytest, pytestcov, pathpy, requests_toolbelt, pytest-services
 }:
 
-let
-  srcInfo = if isPy3k then {
-    version = "18.1.0";
-    sha256 = "4dd2f59b5af93bd9ca85f1ed0bb8295cd0f5a8ee2b84d476374d4e070aa5c615";
-  } else {
-    version = "17.4.1";
-    sha256 = "1kl17anzz535jgkn9qcy0c2m0zlafph0iv7ph3bb9mfrs2bgvagv";
-  };
-in buildPythonPackage rec {
-  pname = "CherryPy";
-  inherit (srcInfo) version;
+buildPythonPackage rec {
+  pname = "cherrypy";
+  version = "18.1.0";
+
+  disabled = !isPy3k;
 
   src = fetchPypi {
-    inherit pname;
-    inherit (srcInfo) version sha256;
+    pname = "CherryPy";
+    inherit version;
+    sha256 = "4dd2f59b5af93bd9ca85f1ed0bb8295cd0f5a8ee2b84d476374d4e070aa5c615";
   };
 
-  propagatedBuildInputs = if isPy3k then [
+  propagatedBuildInputs = [
     # required
     cheroot portend more-itertools zc_lockfile
     # optional
     routes
-  ] else [
-    cheroot contextlib2 portend routes six zc_lockfile
   ];
 
-  buildInputs = [ setuptools_scm ];
+  nativeBuildInputs = [ setuptools_scm ];
 
-  checkInputs = if isPy3k then [
+  checkInputs = [
     objgraph pytest pytestcov pathpy requests_toolbelt pytest-services
-  ] else [
-    backports_unittest-mock objgraph pathpy pytest pytestcov backports_functools_lru_cache requests_toolbelt
   ];
 
   checkPhase = ''
-    # 3 out of 5 SignalHandlingTests need network access
     # test_2_File_Concurrency also fails upstream: https://github.com/cherrypy/cherrypy/issues/1306
     # ...and skipping it makes 2 other tests fail
-    LANG=en_US.UTF-8 pytest -k "not SignalHandlingTests and not test_4_Autoreload \
-                            and not test_2_File_Concurrency and not test_3_Redirect and not test_4_File_deletion"
+    pytest -k "not test_2_File_Concurrency and not test_3_Redirect and not test_4_File_deletion"
   '';
 
   meta = with lib; {
-    homepage = "http://www.cherrypy.org";
+    homepage = https://www.cherrypy.org;
     description = "A pythonic, object-oriented HTTP framework";
     license = licenses.bsd3;
   };

--- a/pkgs/development/python-modules/cherrypy/default.nix
+++ b/pkgs/development/python-modules/cherrypy/default.nix
@@ -6,14 +6,14 @@
 
 buildPythonPackage rec {
   pname = "cherrypy";
-  version = "18.1.0";
+  version = "18.1.1";
 
   disabled = !isPy3k;
 
   src = fetchPypi {
     pname = "CherryPy";
     inherit version;
-    sha256 = "4dd2f59b5af93bd9ca85f1ed0bb8295cd0f5a8ee2b84d476374d4e070aa5c615";
+    sha256 = "6585c19b5e4faffa3613b5bf02c6a27dcc4c69a30d302aba819639a2af6fa48b";
   };
 
   propagatedBuildInputs = [
@@ -30,9 +30,7 @@ buildPythonPackage rec {
   ];
 
   checkPhase = ''
-    # test_2_File_Concurrency also fails upstream: https://github.com/cherrypy/cherrypy/issues/1306
-    # ...and skipping it makes 2 other tests fail
-    pytest -k "not test_2_File_Concurrency and not test_3_Redirect and not test_4_File_deletion"
+    pytest
   '';
 
   meta = with lib; {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1363,7 +1363,10 @@ in {
 
   cheetah = callPackage ../development/python-modules/cheetah { };
 
-  cherrypy = callPackage ../development/python-modules/cherrypy {};
+  cherrypy = if isPy3k then
+    callPackage ../development/python-modules/cherrypy { }
+  else
+    callPackage ../development/python-modules/cherrypy/17.nix { };
 
   cfgv = callPackage ../development/python-modules/cfgv { };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
