### PR TITLE
parastoo-fonts: init at v1.0.0-alpha5

### DIFF
--- a/pkgs/data/fonts/parastoo-fonts/default.nix
+++ b/pkgs/data/fonts/parastoo-fonts/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "parastoo-fonts";
+  version = "1.0.0-alpha5";
+
+  src = fetchFromGitHub {
+    owner = "rastikerdar";
+    repo = "parastoo-font";
+    rev = "v${version}";
+    sha256 = "1nya9cbbs6sgv2w3zyah3lb1kqylf922q3fazh4l7bi6zgm8q680";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/parastoo-fonts
+    cp -v $( find . -name '*.ttf') $out/share/fonts/parastoo-fonts
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/rastikerdar/parastoo-font;
+    description = "A Persian (Farsi) Font - فونت ( قلم ) فارسی پرستو";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = [ maintainers.linarcx ];
+  };
+}

--- a/pkgs/data/fonts/parastoo-fonts/default.nix
+++ b/pkgs/data/fonts/parastoo-fonts/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  name = "parastoo-fonts";
+  pname = "parastoo-fonts";
   version = "1.0.0-alpha5";
 
   src = fetchFromGitHub {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4832,6 +4832,8 @@ in
 
   parallel = callPackage ../tools/misc/parallel { };
 
+  parastoo-fonts = callPackage ../data/fonts/parastoo-fonts { };
+
   parcellite = callPackage ../tools/misc/parcellite { };
 
   patchutils = callPackage ../tools/text/patchutils { };
@@ -21656,7 +21658,7 @@ in
   igv = callPackage ../applications/science/biology/igv { };
 
   inormalize = callPackage ../applications/science/biology/inormalize { };
-  
+
   itsx = callPackage ../applications/science/biology/itsx { };
 
   iv = callPackage ../applications/science/biology/iv {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
