### PR TITLE
shabnam-fonts: init at v4.0.0

### DIFF
--- a/pkgs/data/fonts/shabnam-fonts/default.nix
+++ b/pkgs/data/fonts/shabnam-fonts/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "shabnam-fonts";
+  version = "4.0.0";
+
+  src = fetchFromGitHub {
+    owner = "rastikerdar";
+    repo = "shabnam-font";
+    rev = "v${version}";
+    sha256 = "1y4w16if2y12028b9vyc5l5c5bvcglhxacv380ixb8fcc4hfakmb";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/shabnam-fonts
+    cp -v $( find . -name '*.ttf') $out/share/fonts/shabnam-fonts
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/rastikerdar/shabnam-font;
+    description = "A Persian (Farsi) Font - فونت (قلم) فارسی شبنم";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = [ maintainers.linarcx ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5498,6 +5498,8 @@ in
 
   shadowsocks-libev = callPackage ../tools/networking/shadowsocks-libev { };
 
+  shabnam-fonts = callPackage ../data/fonts/shabnam-fonts { };
+
   shadowsocks-rust = callPackage ../tools/networking/shadowsocks-rust {
     inherit (darwin.apple_sdk.frameworks) Security;
   };
@@ -21656,7 +21658,7 @@ in
   igv = callPackage ../applications/science/biology/igv { };
 
   inormalize = callPackage ../applications/science/biology/inormalize { };
-  
+
   itsx = callPackage ../applications/science/biology/itsx { };
 
   iv = callPackage ../applications/science/biology/iv {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
