### PR TITLE
python.pkgs.pybullet: init at 2.4.8

### DIFF
--- a/pkgs/development/python-modules/pybullet/default.nix
+++ b/pkgs/development/python-modules/pybullet/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, libGLU_combined
+, xorg
+}:
+
+buildPythonPackage rec {
+  pname = "pybullet";
+  version = "2.4.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0b6dkrac5zydxqfrf827xhamsimychrn77dsfnz1kf7c1crlwcw9";
+  };
+
+  buildInputs = [
+    libGLU_combined
+    xorg.libX11
+  ];
+
+  patches = [
+    # make sure X11 and OpenGL can be found at runtime
+    ./static-libs.patch
+  ];
+
+  meta = with lib; {
+    description = "Open-source software for robot simulation, integrated with OpenAI Gym";
+    homepage = https://pybullet.org/;
+    license = licenses.zlib;
+    maintainers = with maintainers; [ timokau ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/pybullet/static-libs.patch
+++ b/pkgs/development/python-modules/pybullet/static-libs.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index 98efabdbf..e69e79084 100644
+--- a/setup.py
++++ b/setup.py
+@@ -563,6 +563,8 @@ print("-----")
+ 
+ extensions = []
+ 
++libraries += [ "X11", "GL" ] # statically link x11 and opengl
++
+ pybullet_ext = Extension("pybullet",
+         sources =  sources,
+         libraries = libraries,

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -615,6 +615,8 @@ in {
 
   pybind11 = callPackage ../development/python-modules/pybind11 { };
 
+  pybullet = callPackage ../development/python-modules/pybullet { };
+
   pycairo = callPackage ../development/python-modules/pycairo {
     inherit (pkgs) pkgconfig;
   };


### PR DESCRIPTION
###### Motivation for this change

Making the openai gym usable without the proprietary mujoco physics engine (this uses bullet instead).

This is the actively developed version from the bullet maintainers, as opposed to the version from the gym maintainers in https://github.com/NixOS/nixpkgs/pull/58451 which has only maintenance support but is still relevant.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
