### PR TITLE
python.pkgs.roboschool: init at 1.0.39

### DIFF
--- a/pkgs/development/libraries/bullet/roboschool-fork.nix
+++ b/pkgs/development/libraries/bullet/roboschool-fork.nix
@@ -1,0 +1,57 @@
+{ stdenv, fetchFromGitHub, cmake, libGLU_combined, freeglut
+, Cocoa,  OpenGL
+}:
+
+stdenv.mkDerivation rec {
+  name = "bullet-${version}";
+  version = "2019-03-27";
+
+  src = fetchFromGitHub {
+    owner = "olegklimov";
+    repo = "bullet3";
+    # roboschool needs the HEAD of a specific branch of this fork, see
+    # https://github.com/openai/roboschool/issues/126#issuecomment-421643980
+    # https://github.com/openai/roboschool/pull/62
+    # https://github.com/openai/roboschool/issues/124
+    rev = "3687507ddc04a15de2c5db1e349ada3f2b34b3d6";
+    sha256 = "1wd7vj9136dl7lfb8ll0rc2fdl723y3ls9ipp7657yfl2xrqhvkb";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = stdenv.lib.optionals stdenv.isLinux [ libGLU_combined freeglut ]
+    ++ stdenv.lib.optionals stdenv.isDarwin [ Cocoa OpenGL ];
+
+  patches = [ ./gwen-narrowing.patch ];
+
+  postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
+    sed -i 's/FIND_PACKAGE(OpenGL)//' CMakeLists.txt
+    sed -i 's/FIND_LIBRARY(COCOA_LIBRARY Cocoa)//' CMakeLists.txt
+  '';
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=ON"
+    "-DBUILD_CPU_DEMOS=OFF"
+    "-DINSTALL_EXTRA_LIBS=ON"
+  ] ++ stdenv.lib.optionals stdenv.isDarwin [
+    "-DOPENGL_FOUND=true"
+    "-DOPENGL_LIBRARIES=${OpenGL}/Library/Frameworks/OpenGL.framework"
+    "-DOPENGL_INCLUDE_DIR=${OpenGL}/Library/Frameworks/OpenGL.framework"
+    "-DOPENGL_gl_LIBRARY=${OpenGL}/Library/Frameworks/OpenGL.framework"
+    "-DCOCOA_LIBRARY=${Cocoa}/Library/Frameworks/Cocoa.framework"
+    "-DBUILD_BULLET2_DEMOS=OFF"
+    "-DBUILD_UNIT_TESTS=OFF"
+  ];
+
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    description = "A professional free 3D Game Multiphysics Library";
+    longDescription = ''
+      Bullet 3D Game Multiphysics Library provides state of the art collision
+      detection, soft body and rigid body dynamics.
+    '';
+    homepage = http://bulletphysics.org;
+    license = licenses.zlib;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/development/python-modules/roboschool/default.nix
+++ b/pkgs/development/python-modules/roboschool/default.nix
@@ -1,0 +1,73 @@
+{ lib
+, buildPythonPackage
+, python
+, fetchFromGitHub
+, fetchpatch
+, qt5
+, boost
+, assimp
+, gym
+, bullet-roboschool
+, pkgconfig
+, which
+}:
+
+buildPythonPackage rec {
+  pname = "roboschool";
+  version = "1.0.39";
+
+  src = fetchFromGitHub {
+    owner = "openai";
+    repo = "roboschool";
+    rev = version;
+    sha256 = "1s7rp5bbiglnrfm33wf7x7kqj0ks3b21bqyz18c5g6vx39rxbrmh";
+  };
+
+  propagatedBuildInputs = [
+    gym
+  ];
+
+  nativeBuildInputs = [
+    pkgconfig
+    qt5.qtbase # needs the `moc` tool
+    which
+  ];
+
+  buildInputs = [
+    bullet-roboschool
+    assimp
+    qt5.qtbase
+    boost
+  ];
+
+  NIX_CFLAGS_COMPILE="-I ${python}/include/${python.libPrefix}";
+
+  patches = [
+    # Remove kwarg that was removed in upstream gym
+    # https://github.com/openai/roboschool/pull/180
+    (fetchpatch {
+      name = "remove-close-kwarg.patch";
+      url = "https://github.com/openai/roboschool/pull/180/commits/334f489c8ce7af4887e376139ec676f89da5b16f.patch";
+      sha256 = "0bbz8b63m40a9lrwmh7c8d8gj9kpa8a7svdh08qhrddjkykvip6r";
+    })
+  ];
+
+  preBuild = ''
+    # First build the cpp dependencies
+    cd roboschool/cpp-household
+    make \
+      MOC=moc \
+      -j$NIX_BUILD_CORES
+    cd ../..
+  '';
+
+  # Does a QT sanity check, but QT is not expected to work in isolation
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Open-source software for robot simulation, integrated with OpenAI Gym";
+    homepage = https://github.com/openai/roboschool;
+    license = licenses.mit;
+    maintainers = with maintainers; [ timokau ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23332,6 +23332,10 @@ in
     inherit (darwin.apple_sdk.frameworks) Cocoa OpenGL;
   };
 
+  bullet-roboschool = callPackage ../development/libraries/bullet/roboschool-fork.nix {
+    inherit (darwin.apple_sdk.frameworks) Cocoa OpenGL;
+  };
+
   inherit (callPackages ../development/libraries/spdlog { })
     spdlog_0 spdlog_1;
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4025,6 +4025,10 @@ in {
 
   retry_decorator = callPackage ../development/python-modules/retry_decorator { };
 
+  roboschool = callPackage ../development/python-modules/roboschool {
+    inherit (pkgs) pkgconfig; # use normal pkgconfig, not the python package
+  };
+
   qdarkstyle = callPackage ../development/python-modules/qdarkstyle { };
 
   quamash = callPackage ../development/python-modules/quamash { };


### PR DESCRIPTION
###### Motivation for this change

Making the openai gym usable without the proprietary mujoco physics engine (this uses bullet instead).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
