### PR TITLE
python.pkgs.baselines: init at 0.1.5

### DIFF
--- a/pkgs/development/python-modules/baselines/default.nix
+++ b/pkgs/development/python-modules/baselines/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytest
+, gym
+, scipy
+, tqdm
+, joblib
+, dill
+, progressbar2
+, cloudpickle
+, click
+, pyzmq
+, tensorflow
+, mpi4py
+}:
+
+buildPythonPackage rec {
+  pname = "baselines";
+  version = "0.1.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0n1mxkcg82gzhkb4j5zzwm335r3rc1sblknqs4x6nkrrh42d65cm";
+  };
+
+  patches = [
+    # already fixed upstream
+    ./fix-dep-names.patch
+  ];
+
+  propagatedBuildInputs = [
+    gym
+    scipy
+    tqdm
+    joblib
+    pyzmq
+    dill
+    progressbar2
+    mpi4py
+    cloudpickle
+    tensorflow
+    click
+  ];
+
+  # fails to create a daemon, probably because of sandboxing
+  doCheck = false;
+
+  checkInputs = [
+    pytest
+  ];
+
+  meta = with lib; {
+    description = "High-quality implementations of reinforcement learning algorithms";
+    homepage = https://github.com/openai/baselines;
+    license = licenses.mit;
+    maintainers = with maintainers; [ timokau ];
+  };
+}

--- a/pkgs/development/python-modules/baselines/fix-dep-names.patch
+++ b/pkgs/development/python-modules/baselines/fix-dep-names.patch
@@ -1,0 +1,18 @@
+diff --git a/setup.py b/setup.py
+index bf8badc..570be20 100644
+--- a/setup.py
++++ b/setup.py
+@@ -10,11 +10,11 @@ setup(name='baselines',
+       packages=[package for package in find_packages()
+                 if package.startswith('baselines')],
+       install_requires=[
+-          'gym[mujoco,atari,classic_control,robotics]',
++          'gym',
+           'scipy',
+           'tqdm',
+           'joblib',
+-          'zmq',
++          'pyzmq',
+           'dill',
+           'progressbar2',
+           'mpi4py',

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -274,6 +274,8 @@ in {
     bap = pkgs.ocamlPackages.bap;
   };
 
+  baselines = callPackage ../development/python-modules/baselines { };
+
   bash_kernel = callPackage ../development/python-modules/bash_kernel { };
 
   bayespy = callPackage ../development/python-modules/bayespy { };


### PR DESCRIPTION
###### Motivation for this change

Provides reinforcement learning algorithm baseline implementations for research purposes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
