### PR TITLE
pythonPackages.grpcio: fix build on Darwin

### DIFF
--- a/pkgs/development/python-modules/grpcio/default.nix
+++ b/pkgs/development/python-modules/grpcio/default.nix
@@ -1,17 +1,22 @@
-{ stdenv, buildPythonPackage, fetchPypi, lib, darwin
-, six, protobuf, enum34, futures, isPy27, isPy34, pkgconfig }:
+{ stdenv, buildPythonPackage, fetchFromGitHub, lib, darwin
+, six, protobuf, enum34, futures, isPy27, isPy34, pkgconfig
+, cython}:
 
 with stdenv.lib;
 buildPythonPackage rec {
   pname = "grpcio";
   version = "1.18.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "abe825aa49e6239d5edf4e222c44170d2c7f6f4b1fd5286b4756a62d8067e112";
+  src = fetchFromGitHub {
+    owner = "grpc";
+    repo = "grpc";
+    rev = "v${version}";
+    fetchSubmodules = true;
+    sha256 = "0cilbhk35gv46mk40jl5f3iqa94x14qyxbavpfq0kh0rld82nx4m";
   };
 
-  nativeBuildInputs = [ pkgconfig ] ++ optional stdenv.isDarwin darwin.cctools;
+  nativeBuildInputs = [ cython pkgconfig ]
+                    ++ optional stdenv.isDarwin darwin.cctools;
 
   propagatedBuildInputs = [ six protobuf ]
                         ++ lib.optionals (isPy27 || isPy34) [ enum34 ]


### PR DESCRIPTION
###### Motivation for this change

Builds on Darwin have started to fail recently. This seems to be caused
by a check in Makefile that verifies whether the system is able to build
BoringSSL. This check attempts to compile test/build/boringssl.c, which
is absent in PyPI archives of grpcio.

This change builds the grpcio module directly from the grpc git
repository, so that all the files that are necessary for checks are
present.

Affects #56826 since darwin builds of this derivation on nixpkgs-19.03
fail.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
