### PR TITLE
nixos/colord: don't run as root

### DIFF
--- a/nixos/modules/services/x11/colord.nix
+++ b/nixos/modules/services/x11/colord.nix
@@ -18,21 +18,22 @@ in {
 
   config = mkIf cfg.enable {
 
+    environment.systemPackages = [ pkgs.colord ];
+
     services.dbus.packages = [ pkgs.colord ];
 
     services.udev.packages = [ pkgs.colord ];
 
-    environment.systemPackages = [ pkgs.colord ];
+    systemd.packages = [ pkgs.colord ];
 
-    systemd.services.colord = {
-      description = "Manage, Install and Generate Color Profiles";
-      serviceConfig = {
-        Type = "dbus";
-        BusName = "org.freedesktop.ColorManager";
-        ExecStart = "${pkgs.colord}/libexec/colord";
-        PrivateTmp = true;
-      };
+    environment.etc."tmpfiles.d/colord.conf".source = "${pkgs.colord}/lib/tmpfiles.d/colord.conf";
+
+    users.users.colord = {
+      home = "/var/lib/colord";
+      group = "colord";
     };
+
+    users.groups.colord = {};
 
   };
 

--- a/pkgs/tools/misc/colord/default.nix
+++ b/pkgs/tools/misc/colord/default.nix
@@ -56,6 +56,7 @@ stdenv.mkDerivation rec {
     "-Dlibcolordcompat=true"
     "-Dsane=true"
     "-Dvapi=true"
+    "-Ddaemon_user=colord"
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
Implementing one of my suggested improvements in https://github.com/NixOS/nixpkgs/pull/57840

###### Things done
Built a vm and checked that at least the services were running.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
