### PR TITLE
qtikz: fix build

### DIFF
--- a/pkgs/applications/graphics/ktikz/default.nix
+++ b/pkgs/applications/graphics/ktikz/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     # lrelease command:
     LRELEASECOMMAND = lrelease
     # qcollectiongenerator command:
-    #QCOLLECTIONGENERATORCOMMAND = qcollectiongenerator
+    QCOLLECTIONGENERATORCOMMAND = qhelpgenerator
 
     # TikZ documentation default file path:
     TIKZ_DOCUMENTATION_DEFAULT = @out@/share/doc/texmf/pgf/pgfmanual.pdf.gz


### PR DESCRIPTION
###### Motivation for this change

#56826, please backport.

qcollectiongenerator was merged into qhelpgenerator in qt 5.12,
see https://blog.qt.io/blog/2018/11/02/whats-new-qt-help/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
