### PR TITLE
[19.03] monero: 0.13 -> 0.14

### DIFF
--- a/pkgs/applications/altcoins/monero-gui/default.nix
+++ b/pkgs/applications/altcoins/monero-gui/default.nix
@@ -13,13 +13,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "monero-gui-${version}";
-  version = "0.13.0.4";
+  version = "0.14.0.0";
 
   src = fetchFromGitHub {
     owner  = "monero-project";
     repo   = "monero-gui";
     rev    = "v${version}";
-    sha256 = "142yj5s15bhm300dislq3x5inw1f37shnrd5vyj78jjcvry3wymw";
+    sha256 = "1l4kx2vidr7bpds43jdbwyaz0q1dy7sricpz061ff1fkappbxdh8";
   };
 
   nativeBuildInputs = [ qmake pkgconfig ];

--- a/pkgs/applications/altcoins/monero-gui/move-log-file.patch
+++ b/pkgs/applications/altcoins/monero-gui/move-log-file.patch
@@ -13,15 +13,17 @@ index 79223c0..e80b317 100644
      parser.addHelpOption();
      parser.process(app);
 diff --git a/Logger.cpp b/Logger.cpp
-index 660bafc..dae24d4 100644
+index 6b1daba..c357762 100644
 --- a/Logger.cpp
 +++ b/Logger.cpp
-@@ -15,7 +15,7 @@ static const QString default_name = "monero-wallet-gui.log";
- #elif defined(Q_OS_MAC)
-     static const QString osPath = QStandardPaths::standardLocations(QStandardPaths::HomeLocation).at(0) + "/Library/Logs";
+@@ -28,8 +28,8 @@ static const QString defaultLogName = "monero-wallet-gui.log";
+     static const QString appFolder = "Library/Logs";
  #else // linux + bsd
+     //HomeLocation = "~"
 -    static const QString osPath = QStandardPaths::standardLocations(QStandardPaths::HomeLocation).at(0);
+-    static const QString appFolder = ".bitmonero";
 +    static const QString osPath = QStandardPaths::standardLocations(QStandardPaths::CacheLocation).at(0);
++    static const QString appFolder = "bitmonero";
  #endif
- 
+
  

--- a/pkgs/applications/altcoins/monero/default.nix
+++ b/pkgs/applications/altcoins/monero/default.nix
@@ -11,12 +11,12 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name    = "monero-${version}";
-  version = "0.13.0.4";
+  version = "0.14.0.2";
 
   src = fetchgit {
     url    = "https://github.com/monero-project/monero.git";
     rev    = "v${version}";
-    sha256 = "1ambgakapijhsi1pd70vw8vvnlwa3nid944lqkbfq3wl25lmc70d";
+    sha256 = "1471iy6c8dfdqcmcwcp0m7fp9xl74dcm5hqlfdfi217abhawfs8k";
   };
 
   nativeBuildInputs = [ cmake pkgconfig git ];


### PR DESCRIPTION
###### Motivation for this change
Needed to solve #57210 on stable channels

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change
- [x] Tested execution of all binary files
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
