### PR TITLE
nixos/digital-ocean-image: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -405,6 +405,11 @@
     github = "ardumont";
     name = "Antoine R. Dumont";
   };
+  arianvp = {
+    email = "arian.vanputten@gmail.com";
+    name = "Arian van Putten";
+    github = "arianvp";
+  };
   aristid = {
     email = "aristidb@gmail.com";
     github = "aristidb";

--- a/nixos/modules/virtualisation/digital-ocean-config.nix
+++ b/nixos/modules/virtualisation/digital-ocean-config.nix
@@ -1,0 +1,153 @@
+{ config, pkgs, lib, modulesPath, ... }:
+with lib;
+{
+  imports = [
+    (modulesPath + "/profiles/qemu-guest.nix")
+    (modulesPath + "/virtualisation/digital-ocean-init.nix")
+  ];
+  options.virtualisation.digitalOcean = with types; {
+    setRootPassword = mkOption {
+      type = bool;
+      default = true;
+      example = true;
+      description = "Whether to set the root password from the Digital Ocean metadata";
+    };
+    setSshKeys = mkOption {
+      type = bool;
+      default = true;
+      example = true;
+      description = "Whether to fetch ssh keys from Digital Ocean";
+    };
+    seedEntropy = mkOption {
+      type = bool;
+      default = true;
+      example = true;
+      description = "Whether to run the kernel RNG entropy seeding script from the Digital Ocean vendor data";
+    };
+  };
+  config =
+    let
+      cfg = config.virtualisation.digitalOcean;
+      hostName = config.networking.hostName;
+    in {
+      fileSystems."/" = {
+        device = "/dev/disk/by-label/nixos";
+        autoResize = true;
+        fsType = "ext4";
+      };
+      boot = {
+        growPartition = true;
+        kernelParams = [ "console=ttyS0" "panic=1" "boot.panic_on_fail" ];
+        initrd.kernelModules = [ "virtio_scsi" ];
+        kernelModules = [ "virtio_pci" "virtio_net" ];
+        loader = {
+          grub.device = "/dev/sda";
+          timeout = 0;
+          grub.configurationLimit = 0;
+        };
+      };
+      services.openssh = {
+        enable = true;
+        permitRootLogin = "prohibit-password";
+        passwordAuthentication = mkDefault false;
+      };
+      networking = {
+        firewall.allowedTCPPorts = [ 22 ];
+        hostName = mkDefault ""; # use dhcp
+        useNetworkd = true;
+      };
+
+      /* Fetch the root password from the digital ocean metadata.
+       * There is no specific route for this, so we use jq to get
+       * it from the One Big JSON metadata blob */
+      systemd.services.digitalocean-set-root-password = {
+        enable = cfg.setRootPassword;
+        path = [ pkgs.curl pkgs.shadow pkgs.jq ];
+        description = "Set root password provided by Digitalocean";
+        wantedBy = [ "multi-user.target" ];
+        script = ''
+          set -e
+          ROOT_PASSWORD=$(curl --retry-connrefused http://169.254.169.254/metadata/v1.json | jq -r '.auth_key')
+          echo "root:$ROOT_PASSWORD" | chpasswd
+          '';
+        unitConfig = {
+          After = [ "network-online.target" ];
+          Wants = [ "network-online.target" ];
+        };
+        serviceConfig = {
+          Type = "oneshot";
+        };
+      };
+
+      /* Set the hostname from Digital Ocean, unless the user configured it in
+       * the NixOS configuration */
+      systemd.services.digitalocean-set-hostname = {
+        enable = hostName == "";
+        path = [ pkgs.curl pkgs.nettools ];
+        description = "Set hostname provided by Digitalocean";
+        wantedBy = [ "multi-user.target" ];
+        script = ''
+          set -e
+          DIGITALOCEAN_HOSTNAME=$(curl --retry-connrefused http://169.254.169.254/metadata/v1/hostname)
+          hostname $DIGITALOCEAN_HOSTNAME
+        '';
+        unitConfig = {
+          After =  [ "network-online.target" ];
+          Wants = [ "network-online.target" ];
+        };
+        serviceConfig = {
+          Type = "oneshot";
+        };
+      };
+
+      /* Fetch the ssh keys for root from Digital Ocean */
+      systemd.services.digitalocean-ssh-keys = {
+        enable = cfg.setSshKeys;
+        description = "Set root ssh keys provided by Digital Ocean";
+        wantedBy = [ "multi-user.target" ];
+        path = [ pkgs.curl ];
+        script = ''
+          set -e
+          mkdir -m 0700 -p /root/.ssh
+          curl --retry-connrefused --output /root/.ssh/authorized_keys http://169.254.169.254/metadata/v1/public-keys
+          chmod 600 /root/.ssh/authorized_keys
+        '';
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+        };
+        unitConfig = {
+          ConditionFileExists = "!/root/.ssh/authorized_keys";
+          After =  [ "network-online.target" ];
+          Wants = [ "network-online.target" ];
+        };
+      };
+
+      /* Initialize the RNG by running the entropy-seed script from the
+       * Digital Ocean metadata
+       */
+      systemd.services.digitalocean-entropy-seed = {
+        enable = cfg.seedEntropy;
+        description = "Run the kernel RNG entropy seeding script from the Digital Ocean vendor data";
+        wantedBy = [ "multi-user.target" ];
+        path = [ pkgs.curl pkgs.mpack ];
+        script = ''
+          set -e
+          TEMPDIR=$(mktemp -d)
+          curl --retry-connrefused http://169.254.169.254/metadata/v1/vendor-data | munpack -C $TEMPDIR
+          $TEMPDIR/entropy-seed
+          rm -rf $TEMPDIR
+          '';
+        unitConfig = {
+          After = [ "network-online.target" ];
+          Wants = [ "network-online.target" ];
+        };
+        serviceConfig = {
+          Type = "oneshot";
+        };
+      };
+
+    };
+  meta.maintainers = with maintainers; [ eamsden ];
+}
+

--- a/nixos/modules/virtualisation/digital-ocean-config.nix
+++ b/nixos/modules/virtualisation/digital-ocean-config.nix
@@ -53,7 +53,7 @@ with lib;
       };
       networking = {
         firewall.allowedTCPPorts = [ 22 ];
-        hostName = mkDefault ""; # use dhcp
+        hostName = mkDefault ""; # use Digital Ocean metadata server
         useNetworkd = true;
       };
 

--- a/nixos/modules/virtualisation/digital-ocean-config.nix
+++ b/nixos/modules/virtualisation/digital-ocean-config.nix
@@ -148,6 +148,6 @@ with lib;
       };
 
     };
-  meta.maintainers = with maintainers; [ eamsden ];
+  meta.maintainers = with maintainers; [ arianvp eamsden ];
 }
 

--- a/nixos/modules/virtualisation/digital-ocean-image.nix
+++ b/nixos/modules/virtualisation/digital-ocean-image.nix
@@ -4,10 +4,10 @@ with lib;
 let
   cfg = config.virtualisation.digitalOceanImage;
   defaultConfigFile = pkgs.writeText "configuration.nix" ''
-    { ... }:
+    { modulesPath, ... }:
     {
       imports = [
-        <nixpkgs/nixos/modules/virtualisation/digital-ocean-image.nix>
+        (modulesPath + "/virtualisation/digital-ocean-config.nix")
       ];
     }
   '';
@@ -32,7 +32,7 @@ in
         A path to a configuration file which will be placed at `/etc/nixos/configuration.nix`
         and be used when switching to a new configuration.
         If set to `null`, a default configuration is used, where the only import is
-        `<nixpkgs/nixos/modules/virtualisation/digital-ocean-image.nix>`.
+        `(modulesPath + "/virtualisation/digital-ocean-config.nix")`.
       '';
     };
   };

--- a/nixos/modules/virtualisation/digital-ocean-image.nix
+++ b/nixos/modules/virtualisation/digital-ocean-image.nix
@@ -53,6 +53,6 @@ in
 
   };
 
-  meta.maintainers = with maintainers; [ eamsden ];
+  meta.maintainers = with maintainers; [ arianvp eamsden ];
 
 }

--- a/nixos/modules/virtualisation/digital-ocean-image.nix
+++ b/nixos/modules/virtualisation/digital-ocean-image.nix
@@ -1,0 +1,58 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.virtualisation.digitalOceanImage;
+  defaultConfigFile = pkgs.writeText "configuration.nix" ''
+    { ... }:
+    {
+      imports = [
+        <nixpkgs/nixos/modules/virtualisation/digital-ocean-image.nix>
+      ];
+    }
+  '';
+in
+{
+
+  imports = [ ./digital-ocean-config.nix ];
+
+  options = {
+    virtualisation.digitalOceanImage.diskSize = mkOption {
+      type = with types; int;
+      default = 4096;
+      description = ''
+        Size of disk image. Unit is MB.
+      '';
+    };
+
+    virtualisation.digitalOceanImage.configFile = mkOption {
+      type = with types; nullOr str;
+      default = null;
+      description = ''
+        A path to a configuration file which will be placed at `/etc/nixos/configuration.nix`
+        and be used when switching to a new configuration.
+        If set to `null`, a default configuration is used, where the only import is
+        `<nixpkgs/nixos/modules/virtualisation/digital-ocean-image.nix>`.
+      '';
+    };
+  };
+
+  #### implementation
+  config = {
+
+    system.build.digitalOceanImage = import ../../lib/make-disk-image.nix {
+      name = "digital-ocean-image";
+      format = "qcow2";
+      postVM = ''
+        ${pkgs.gzip}/bin/gzip $diskImage
+      '';
+      configFile = if isNull cfg.configFile then defaultConfigFile else cfg.configFile;
+      inherit (cfg) diskSize;
+      inherit config lib pkgs;
+    };
+
+  };
+
+  meta.maintainers = with maintainers; [ eamsden ];
+
+}

--- a/nixos/modules/virtualisation/digital-ocean-init.nix
+++ b/nixos/modules/virtualisation/digital-ocean-init.nix
@@ -59,5 +59,5 @@ with lib;
         '';
     };
   };
-  meta.maintainers = with maintainers; [ eamsden ];
+  meta.maintainers = with maintainers; [ arianvp eamsden ];
 }

--- a/nixos/modules/virtualisation/digital-ocean-init.nix
+++ b/nixos/modules/virtualisation/digital-ocean-init.nix
@@ -1,0 +1,62 @@
+{ config, pkgs, lib, ... }:
+with lib;
+{
+  options.virtualisation.digitalOcean.rebuildFromUserData = mkOption {
+    type = bool;
+    enable = true;
+    example = true;
+    description = "Whether to reconfigure the system from Digital Ocean user data";
+  };
+
+  config = {
+    systemd.services.digital-ocean-init = {
+      description = "Reconfigure the system from Digital Ocean uesrdata on startup";
+      wantedBy = [ "multi-user.target" ];
+      unitConfig = {
+        After = [ "network-online.target" ];
+        Wants = [ "network-online.target" ];
+      };
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+      };
+      restartIfChanged = false;
+      path = [ pkgs.curl pkgs.gnused pkgs.gnugrep pkgs.systemd config.nix.package config.system.build.nixos-rebuild ];
+      script = ''
+        set -e
+        echo "attempting to fetch configuration from Digital Ocean user data..."
+        export HOME=/root
+        export NIX_PATH=/nix/var/nix/profiles/per-user/root/channels/nixos:nixos-config=/etc/nixos/configuration.nix:/nix/var/nix/profiles/per-user/root/channels
+        userData=$(mktemp)
+        if curl --retry-connrefused --output $userData http://169.254.169.254/metadata/v1/user-data; then
+          # If the user-data looks like it could be a nix expression,
+          # copy it over. Also, look for a magic three-hash comment and set
+          # that as the channel.
+          if sed '/^\(#\|SSH_HOST_.*\)/d' < "$userData" | grep -q '\S'; then
+            channels="$(grep '^###' "$userData" | sed 's|###\s*||')"
+            printf "%s" "$channels" | while read channel; do
+              echo "writing channel: $channel"
+            done
+
+            if [[ -n "$channels" ]]; then
+              printf "%s" "$channels" > /root/.nix-channels
+              nix-channel --update
+            fi
+
+            echo "setting configuration from Digital Ocean user data"
+            cp "$userData" /etc/nixos/configuration.nix
+          else
+            echo "user data does not appear to be a Nix expression; ignoring"
+            exit
+          fi
+        else
+          echo "no user data is available"
+          exit
+        fi
+
+        nixos-rebuild switch
+        '';
+    };
+  };
+  meta.maintainers = with maintainers; [ eamsden ];
+}

--- a/nixos/modules/virtualisation/digital-ocean-init.nix
+++ b/nixos/modules/virtualisation/digital-ocean-init.nix
@@ -13,7 +13,7 @@ with lib;
       description = "Reconfigure the system from Digital Ocean uesrdata on startup";
       wantedBy = [ "multi-user.target" ];
       unitConfig = {
-        ConditionFileExists=!/etc/nixos/configuration.nix;
+        ConditionFileExists = "!/etc/nixos/configuration.nix";
         After = [ "network-online.target" ];
         Wants = [ "network-online.target" ];
       };

--- a/nixos/modules/virtualisation/digital-ocean-init.nix
+++ b/nixos/modules/virtualisation/digital-ocean-init.nix
@@ -13,6 +13,7 @@ with lib;
       description = "Reconfigure the system from Digital Ocean uesrdata on startup";
       wantedBy = [ "multi-user.target" ];
       unitConfig = {
+        ConditionFileExists=!/etc/nixos/configuration.nix;
         After = [ "network-online.target" ];
         Wants = [ "network-online.target" ];
       };


### PR DESCRIPTION
###### Motivation for this change
A just-works NixOS image that can be uploaded to Digital Ocean, hopefully to be used as a basis for better Digital Ocean support in NixOps.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
