### PR TITLE
[19.03] kde-applications: 18.12.1 -> 18.12.3

### DIFF
--- a/maintainers/scripts/fetch-kde-qt.sh
+++ b/maintainers/scripts/fetch-kde-qt.sh
@@ -14,12 +14,13 @@ fi
 
 tmp=$(mktemp -d)
 pushd $tmp >/dev/null
-wget -nH -r -c --no-parent "${WGET_ARGS[@]}" >/dev/null
+wget -nH -r -c --no-parent "${WGET_ARGS[@]}" -A '*.tar.xz.sha256' -A '*.mirrorlist' >/dev/null
+find -type f -name '*.mirrorlist' -delete
 
 csv=$(mktemp)
 find . -type f | while read src; do
     # Sanitize file name
-    filename=$(basename "$src" | tr '@' '_')
+    filename=$(gawk '{ print $2 }' "$src" | tr '@' '_')
     nameVersion="${filename%.tar.*}"
     name=$(echo "$nameVersion" | sed -e 's,-[[:digit:]].*,,' | sed -e 's,-opensource-src$,,' | sed -e 's,-everywhere-src$,,')
     version=$(echo "$nameVersion" | sed -e 's,^\([[:alpha:]][[:alnum:]]*-\)\+,,')
@@ -38,8 +39,8 @@ gawk -F , "{ print \$1 }" $csv | sort | uniq | while read name; do
     latestVersion=$(echo "$versions" | sort -rV | head -n 1)
     src=$(gawk -F , "/^$name,$latestVersion,/ { print \$3 }" $csv)
     filename=$(gawk -F , "/^$name,$latestVersion,/ { print \$4 }" $csv)
-    url="${src:2}"
-    sha256=$(nix-hash --type sha256 --base32 --flat "$src")
+    url="$(dirname "${src:2}")/$filename"
+    sha256=$(gawk '{ print $1 }' "$src")
     cat >>"$SRCS" <<EOF
   $name = {
     version = "$latestVersion";

--- a/pkgs/applications/kde/akonadi/akonadi-paths.patch
+++ b/pkgs/applications/kde/akonadi/akonadi-paths.patch
@@ -31,10 +31,10 @@ index be1cc4afb..6d0c1d7e5 100644
      }
      return true;
 diff --git a/src/server/storage/dbconfigmysql.cpp b/src/server/storage/dbconfigmysql.cpp
-index 8b057b459..3fa4548ad 100644
+index dfff6fc29..419e54a5b 100644
 --- a/src/server/storage/dbconfigmysql.cpp
 +++ b/src/server/storage/dbconfigmysql.cpp
-@@ -63,7 +63,6 @@ bool DbConfigMysql::init(QSettings &settings)
+@@ -82,7 +82,6 @@ bool DbConfigMysql::init(QSettings &settings)
      // determine default settings depending on the driver
      QString defaultHostName;
      QString defaultOptions;
@@ -42,7 +42,7 @@ index 8b057b459..3fa4548ad 100644
      QString defaultCleanShutdownCommand;
  
  #ifndef Q_OS_WIN
-@@ -71,25 +70,7 @@ bool DbConfigMysql::init(QSettings &settings)
+@@ -90,16 +89,7 @@ bool DbConfigMysql::init(QSettings &settings)
  #endif
  
      const bool defaultInternalServer = true;
@@ -51,38 +51,29 @@ index 8b057b459..3fa4548ad 100644
 -        defaultServerPath = QStringLiteral(MYSQLD_EXECUTABLE);
 -    }
 -#endif
--    const QStringList mysqldSearchPath = QStringList()
--                                         << QStringLiteral("/usr/bin")
--                                         << QStringLiteral("/usr/sbin")
--                                         << QStringLiteral("/usr/local/sbin")
--                                         << QStringLiteral("/usr/local/libexec")
--                                         << QStringLiteral("/usr/libexec")
--                                         << QStringLiteral("/opt/mysql/libexec")
--                                         << QStringLiteral("/opt/local/lib/mysql5/bin")
--                                         << QStringLiteral("/opt/mysql/sbin");
 -    if (defaultServerPath.isEmpty()) {
--        defaultServerPath = QStandardPaths::findExecutable(QStringLiteral("mysqld"), mysqldSearchPath);
+-        defaultServerPath = findExecutable(QStringLiteral("mysqld"));
 -    }
 -
--    const QString mysqladminPath = QStandardPaths::findExecutable(QStringLiteral("mysqladmin"), mysqldSearchPath);
+-    const QString mysqladminPath = findExecutable(QStringLiteral("mysqladmin"));
 +    const QString mysqladminPath = QLatin1String(NIXPKGS_MYSQL_MYSQLADMIN);
      if (!mysqladminPath.isEmpty()) {
  #ifndef Q_OS_WIN
          defaultCleanShutdownCommand = QStringLiteral("%1 --defaults-file=%2/mysql.conf --socket=%3/mysql.socket shutdown")
-@@ -99,10 +80,10 @@ bool DbConfigMysql::init(QSettings &settings)
+@@ -109,10 +99,10 @@ bool DbConfigMysql::init(QSettings &settings)
  #endif
      }
  
--    mMysqlInstallDbPath = QStandardPaths::findExecutable(QStringLiteral("mysql_install_db"), mysqldSearchPath);
+-    mMysqlInstallDbPath = findExecutable(QStringLiteral("mysql_install_db"));
 +    mMysqlInstallDbPath = QLatin1String(NIXPKGS_MYSQL_MYSQL_INSTALL_DB);
      qCDebug(AKONADISERVER_LOG) << "Found mysql_install_db: " << mMysqlInstallDbPath;
  
--    mMysqlCheckPath = QStandardPaths::findExecutable(QStringLiteral("mysqlcheck"), mysqldSearchPath);
+-    mMysqlCheckPath = findExecutable(QStringLiteral("mysqlcheck"));
 +    mMysqlCheckPath = QLatin1String(NIXPKGS_MYSQL_MYSQLCHECK);
      qCDebug(AKONADISERVER_LOG) << "Found mysqlcheck: " << mMysqlCheckPath;
  
      mInternalServer = settings.value(QStringLiteral("QMYSQL/StartServer"), defaultInternalServer).toBool();
-@@ -119,7 +100,7 @@ bool DbConfigMysql::init(QSettings &settings)
+@@ -129,7 +119,7 @@ bool DbConfigMysql::init(QSettings &settings)
      mUserName = settings.value(QStringLiteral("User")).toString();
      mPassword = settings.value(QStringLiteral("Password")).toString();
      mConnectionOptions = settings.value(QStringLiteral("Options"), defaultOptions).toString();
@@ -91,7 +82,7 @@ index 8b057b459..3fa4548ad 100644
      mCleanServerShutdownCommand = settings.value(QStringLiteral("CleanServerShutdownCommand"), defaultCleanShutdownCommand).toString();
      settings.endGroup();
  
-@@ -129,9 +110,6 @@ bool DbConfigMysql::init(QSettings &settings)
+@@ -139,9 +129,6 @@ bool DbConfigMysql::init(QSettings &settings)
          // intentionally not namespaced as we are the only one in this db instance when using internal mode
          mDatabaseName = QStringLiteral("akonadi");
      }
@@ -101,7 +92,7 @@ index 8b057b459..3fa4548ad 100644
  
      qCDebug(AKONADISERVER_LOG) << "Using mysqld:" << mMysqldPath;
  
-@@ -140,9 +118,6 @@ bool DbConfigMysql::init(QSettings &settings)
+@@ -150,9 +137,6 @@ bool DbConfigMysql::init(QSettings &settings)
      settings.setValue(QStringLiteral("Name"), mDatabaseName);
      settings.setValue(QStringLiteral("Host"), mHostName);
      settings.setValue(QStringLiteral("Options"), mConnectionOptions);
@@ -111,7 +102,7 @@ index 8b057b459..3fa4548ad 100644
      settings.setValue(QStringLiteral("StartServer"), mInternalServer);
      settings.endGroup();
      settings.sync();
-@@ -196,7 +171,7 @@ bool DbConfigMysql::startInternalServer()
+@@ -206,7 +190,7 @@ bool DbConfigMysql::startInternalServer()
  #endif
  
      // generate config file
@@ -189,3 +180,6 @@ index 6b50ae50e..f94a8c5eb 100644
      settings.setValue(QStringLiteral("InitDbPath"), mInitDbPath);
      settings.setValue(QStringLiteral("StartServer"), mInternalServer);
      settings.endGroup();
+-- 
+2.18.1
+

--- a/pkgs/applications/kde/fetch.sh
+++ b/pkgs/applications/kde/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/applications/18.12.1/ -A '*.tar.xz' )
+WGET_ARGS=( https://download.kde.org/stable/applications/18.12.1/ )

--- a/pkgs/applications/kde/fetch.sh
+++ b/pkgs/applications/kde/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/applications/18.12.1/ )
+WGET_ARGS=( https://download.kde.org/stable/applications/18.12.3/ )

--- a/pkgs/applications/kde/srcs.nix
+++ b/pkgs/applications/kde/srcs.nix
@@ -3,1723 +3,1723 @@
 
 {
   akonadi = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/akonadi-18.12.1.tar.xz";
-      sha256 = "141j1wicfl8lgwdgs8yh0mcs4gw004wz8ck21pz55xc1mi4yh9cx";
-      name = "akonadi-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/akonadi-18.12.3.tar.xz";
+      sha256 = "f930deaade1cac1488b8af05cc28f4a78a441c34dbe875b673af3423f8a14658";
+      name = "akonadi-18.12.3.tar.xz";
     };
   };
   akonadi-calendar = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/akonadi-calendar-18.12.1.tar.xz";
-      sha256 = "108ax9bpng5qp3cbn3f2x096l9jsv0x3d8xckcfvd4a3svgap1ri";
-      name = "akonadi-calendar-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/akonadi-calendar-18.12.3.tar.xz";
+      sha256 = "19f92642ba4d62dfccca19ac3ced94495e9137d60a77a672c5443585f30cdaee";
+      name = "akonadi-calendar-18.12.3.tar.xz";
     };
   };
   akonadi-calendar-tools = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/akonadi-calendar-tools-18.12.1.tar.xz";
-      sha256 = "0a54jka0szi3d2dv4kr7s78lbm1sx6a47mccjzc2rp1w2x8dkagl";
-      name = "akonadi-calendar-tools-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/akonadi-calendar-tools-18.12.3.tar.xz";
+      sha256 = "636ea364bea079cae0b899204add76b0d1d9a80d1955c914bc1dad3a6fc731ed";
+      name = "akonadi-calendar-tools-18.12.3.tar.xz";
     };
   };
   akonadiconsole = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/akonadiconsole-18.12.1.tar.xz";
-      sha256 = "06mhpk66ck37k6bfi83cmnjv39lwvm245m0climh1idfi6mn08wk";
-      name = "akonadiconsole-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/akonadiconsole-18.12.3.tar.xz";
+      sha256 = "d052084ecc1665976f7db08d11a15609f017b0803dd30b71b5d1dccc60ac6ed0";
+      name = "akonadiconsole-18.12.3.tar.xz";
     };
   };
   akonadi-contacts = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/akonadi-contacts-18.12.1.tar.xz";
-      sha256 = "1lnqq2qalvzq6g4dwfnlgvrz9wpnl4g64is8ylrb6jf4bvfg3kvq";
-      name = "akonadi-contacts-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/akonadi-contacts-18.12.3.tar.xz";
+      sha256 = "6ad8e352744c258b66a0c6155322681fa4ec50422c81fe4248414b0834e645cc";
+      name = "akonadi-contacts-18.12.3.tar.xz";
     };
   };
   akonadi-import-wizard = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/akonadi-import-wizard-18.12.1.tar.xz";
-      sha256 = "09r5nspv1l8i1ipjxn5xwi6swkggy10hsa8p5bj0qqclsf17ip5j";
-      name = "akonadi-import-wizard-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/akonadi-import-wizard-18.12.3.tar.xz";
+      sha256 = "a74ca212ab05706d5beb94696a933cb46dfd83d5ebd6723de97f7ce4efbe6104";
+      name = "akonadi-import-wizard-18.12.3.tar.xz";
     };
   };
   akonadi-mime = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/akonadi-mime-18.12.1.tar.xz";
-      sha256 = "0fyxls0qhvqcbhpw17vhr8m4h94s2d69c8bpf45k19f005gbb6dk";
-      name = "akonadi-mime-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/akonadi-mime-18.12.3.tar.xz";
+      sha256 = "ff7d91c77b629bba6b93ee6b15c0ebee08aa37368aa8bcae48ecbbacf64bc1b4";
+      name = "akonadi-mime-18.12.3.tar.xz";
     };
   };
   akonadi-notes = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/akonadi-notes-18.12.1.tar.xz";
-      sha256 = "1m2v3qj06pbpdncxcb37131q6xhbsrwp6qv72rmlwlj0cj7xyfl4";
-      name = "akonadi-notes-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/akonadi-notes-18.12.3.tar.xz";
+      sha256 = "ac2f5ef0a3f4621d6af6fef028d641334212d940a1fc3ffc1e3cc6534ca6be60";
+      name = "akonadi-notes-18.12.3.tar.xz";
     };
   };
   akonadi-search = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/akonadi-search-18.12.1.tar.xz";
-      sha256 = "1wwv92kmk4kwr8dj7y34nb2337s80hwnjblnfz4kl3z3ka782gd6";
-      name = "akonadi-search-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/akonadi-search-18.12.3.tar.xz";
+      sha256 = "6436a0f71229cf7917cb4f269f34a2046c24860ecfc03e7018b9d2a7f9e66346";
+      name = "akonadi-search-18.12.3.tar.xz";
     };
   };
   akregator = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/akregator-18.12.1.tar.xz";
-      sha256 = "0zjc6vgf5pdbmj7b3kl15aqkamg5slaxd5n4092pf7nf3v3r74r9";
-      name = "akregator-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/akregator-18.12.3.tar.xz";
+      sha256 = "d3a4f0f4b677825d1b3e1461a020c17a36abe458d7e3ab40389627e2d8163ea1";
+      name = "akregator-18.12.3.tar.xz";
     };
   };
   analitza = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/analitza-18.12.1.tar.xz";
-      sha256 = "0iwlkxcqj62l25ldpa325ymkvhim2mm152h3jqh3z1sc683hc1kv";
-      name = "analitza-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/analitza-18.12.3.tar.xz";
+      sha256 = "c241b6a3d849534ccd50601c0aebd5cd785220bb7957ed7f6b1d3db35ba0f925";
+      name = "analitza-18.12.3.tar.xz";
     };
   };
   ark = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/ark-18.12.1.tar.xz";
-      sha256 = "1pcaaq8qdj3w15f0zqfwy7xwknpmb70yc7g4nmj4p48ahq5s2r86";
-      name = "ark-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/ark-18.12.3.tar.xz";
+      sha256 = "ecf781b5d3691bb967c9170938c1133e2972ee97d71aab2de65487a952700722";
+      name = "ark-18.12.3.tar.xz";
     };
   };
   artikulate = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/artikulate-18.12.1.tar.xz";
-      sha256 = "17msfgq83iy5dfl5qkmj4f89aa2gbk7p00f7bwiz2fnlg642wyq1";
-      name = "artikulate-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/artikulate-18.12.3.tar.xz";
+      sha256 = "f40cc532dd1093d53ab4f825716ea4f4f4d7f954ac6c58ef412b63323a76c278";
+      name = "artikulate-18.12.3.tar.xz";
     };
   };
   audiocd-kio = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/audiocd-kio-18.12.1.tar.xz";
-      sha256 = "0kv03d2w0vf9fpp89ymnkizzyhckz9pjj8fcqwbacb78k6p52g6p";
-      name = "audiocd-kio-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/audiocd-kio-18.12.3.tar.xz";
+      sha256 = "c15ebda9330688c0304be36999f4900ccd7c0b1ce11e19c296975414dafe53c8";
+      name = "audiocd-kio-18.12.3.tar.xz";
     };
   };
   baloo-widgets = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/baloo-widgets-18.12.1.tar.xz";
-      sha256 = "0axgx1zrbaki20vh9j9bd0h3qvn0ws4cza8smlgvlzx7fkbidmw3";
-      name = "baloo-widgets-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/baloo-widgets-18.12.3.tar.xz";
+      sha256 = "b8475ba1a74f8ebc6a36029b60ac803ab0d2c81c253b8c16bd05b6249454c3e3";
+      name = "baloo-widgets-18.12.3.tar.xz";
     };
   };
   blinken = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/blinken-18.12.1.tar.xz";
-      sha256 = "0ka47snqj1xwf8m1qqa1vxgjwm151dzlk22zg07yh987qgc6fbj2";
-      name = "blinken-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/blinken-18.12.3.tar.xz";
+      sha256 = "2b6a11fa56b8837618e157a4a974eb1dff956cfb8b93e6cb0601bda66a234579";
+      name = "blinken-18.12.3.tar.xz";
     };
   };
   bomber = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/bomber-18.12.1.tar.xz";
-      sha256 = "0a5vvb2ka08lyvybr12gm3lfgvfj3r99kqw1prhr9n97w7f8yc1d";
-      name = "bomber-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/bomber-18.12.3.tar.xz";
+      sha256 = "5b8e24aba4fb14ffc72313f9754315d6a7d98a3e00ee118a2551ac3357ead771";
+      name = "bomber-18.12.3.tar.xz";
     };
   };
   bovo = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/bovo-18.12.1.tar.xz";
-      sha256 = "19w4xfqx6bxs8fr8vkma57ibl5b1jdqfjax240fg81qyqzkx4xsp";
-      name = "bovo-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/bovo-18.12.3.tar.xz";
+      sha256 = "7fc7ff304cf5b5bf2049fdd53fbb4a819bddefc77fde94702c5118240403d972";
+      name = "bovo-18.12.3.tar.xz";
     };
   };
   calendarsupport = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/calendarsupport-18.12.1.tar.xz";
-      sha256 = "0hpq85wh94dlmrfabh1k76xdc9xqavfccjnfy20i71q2ml92gx4p";
-      name = "calendarsupport-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/calendarsupport-18.12.3.tar.xz";
+      sha256 = "e3c23c152a3e339628e79b168e56c22c5c2610600013f3aa8706168569cacfa5";
+      name = "calendarsupport-18.12.3.tar.xz";
     };
   };
   cantor = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/cantor-18.12.1.tar.xz";
-      sha256 = "132zlpcqkbjdb1vrcy6innf6qmxlqibzpf0bgdi33q797vw63drc";
-      name = "cantor-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/cantor-18.12.3.tar.xz";
+      sha256 = "2537b8e8a9e5b72a2b3bf2b08d24c4978f52ef18ced61cdcfd2a09069f670398";
+      name = "cantor-18.12.3.tar.xz";
     };
   };
   cervisia = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/cervisia-18.12.1.tar.xz";
-      sha256 = "02ka1crhkb3dka3qp82vs624fz3hcwydm559x5dq0cdbibdmhqx7";
-      name = "cervisia-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/cervisia-18.12.3.tar.xz";
+      sha256 = "a5e4034b0d1ee07c2efaef6e8eef17b48a340e9d046cd23efceaf67f07ab5a85";
+      name = "cervisia-18.12.3.tar.xz";
     };
   };
   dolphin = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/dolphin-18.12.1.tar.xz";
-      sha256 = "1d3m2h8czxqmgpd060lnj05f0r4bqirqibvbakrl1sv2xxafz8qq";
-      name = "dolphin-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/dolphin-18.12.3.tar.xz";
+      sha256 = "c4921759bdfec9a96201a5d76a67869f867ec7e3caf92f8e46fa5d853a0741b1";
+      name = "dolphin-18.12.3.tar.xz";
     };
   };
   dolphin-plugins = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/dolphin-plugins-18.12.1.tar.xz";
-      sha256 = "0j2cj91732p2wh0g73xxjghbbivlva4mr91vdjrp6dkc4b2vjxh8";
-      name = "dolphin-plugins-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/dolphin-plugins-18.12.3.tar.xz";
+      sha256 = "1bff5f828f11e9b9a527b59f12ec16745fa19fb09392ca1872d6b0c909212427";
+      name = "dolphin-plugins-18.12.3.tar.xz";
     };
   };
   dragon = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/dragon-18.12.1.tar.xz";
-      sha256 = "0ffxpl30xdm5vgrfc6b1k2gzfp3jwakn6my4zq0zfrrlf75hbgkm";
-      name = "dragon-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/dragon-18.12.3.tar.xz";
+      sha256 = "115d60bfdef498ea75bc077a7091fb738615b399b03ec2a76a4bf34f19b407f3";
+      name = "dragon-18.12.3.tar.xz";
     };
   };
   eventviews = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/eventviews-18.12.1.tar.xz";
-      sha256 = "0qvndqj8jhrn9p1g4d4p3l54d7hz9zzkkg92yfjcajcrnl2i0fn1";
-      name = "eventviews-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/eventviews-18.12.3.tar.xz";
+      sha256 = "994ddea6894fd73eeb851b04083bc886288e4531aa770c0b2e5d8e1740bbe4d0";
+      name = "eventviews-18.12.3.tar.xz";
     };
   };
   ffmpegthumbs = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/ffmpegthumbs-18.12.1.tar.xz";
-      sha256 = "0j9vwqgsb9pz8hpacsmm4pxss25q7622fr7gq1n2dxf19f1zwxki";
-      name = "ffmpegthumbs-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/ffmpegthumbs-18.12.3.tar.xz";
+      sha256 = "4db8ab905d80863f898b6a3ea8cd0cc7baad91ad953d6b65df230079be04b338";
+      name = "ffmpegthumbs-18.12.3.tar.xz";
     };
   };
   filelight = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/filelight-18.12.1.tar.xz";
-      sha256 = "1p9k1ajyjlb001mz8w8jli3ha84z91sc43721xdpngcshz7i8i6f";
-      name = "filelight-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/filelight-18.12.3.tar.xz";
+      sha256 = "9090bc7c7ac2586e857cdc246a94621c1453e7f65c6d491f2f374f43d3e4af1a";
+      name = "filelight-18.12.3.tar.xz";
     };
   };
   granatier = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/granatier-18.12.1.tar.xz";
-      sha256 = "02lmap2axki56d3kfhmx7h6ibqjnx5ga73vsvvx1w4fjikgzm2rn";
-      name = "granatier-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/granatier-18.12.3.tar.xz";
+      sha256 = "ad065e488f9a751423d571f51449e766c625e88ca7d3c30d21ff3b9027fc04af";
+      name = "granatier-18.12.3.tar.xz";
     };
   };
   grantlee-editor = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/grantlee-editor-18.12.1.tar.xz";
-      sha256 = "0r85wirr4dcvja5cynjb0n51lmlijkffg35czqpjvnf2xv1claj4";
-      name = "grantlee-editor-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/grantlee-editor-18.12.3.tar.xz";
+      sha256 = "d46831a589815581bce45c3954eb12fcbb1692fb407f566952a39e3e8c546b9c";
+      name = "grantlee-editor-18.12.3.tar.xz";
     };
   };
   grantleetheme = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/grantleetheme-18.12.1.tar.xz";
-      sha256 = "1c4n27abzpynh6nykfw9z2rhxlmmicvvw0081gsm9h7w1r8n4flc";
-      name = "grantleetheme-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/grantleetheme-18.12.3.tar.xz";
+      sha256 = "7853075503f2a19713ce43ba077dde8036f892dee7f41e64ebc9af06b4005402";
+      name = "grantleetheme-18.12.3.tar.xz";
     };
   };
   gwenview = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/gwenview-18.12.1.tar.xz";
-      sha256 = "01iraiynpsacp8hnmdc9cxlk6qakbbypdck939kcij6j7gm5l2fm";
-      name = "gwenview-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/gwenview-18.12.3.tar.xz";
+      sha256 = "0b4ff869fc09140e258e894f5169fc6c96f1126891b8ed1a391d4624d6ab0c35";
+      name = "gwenview-18.12.3.tar.xz";
     };
   };
   incidenceeditor = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/incidenceeditor-18.12.1.tar.xz";
-      sha256 = "1h1da8vg9x450hm9g936rms6n9d5ddqdl7jrwah3khbzihjpkgvz";
-      name = "incidenceeditor-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/incidenceeditor-18.12.3.tar.xz";
+      sha256 = "b0fa13390b31a24a8bca99f20b132841849d95dba9de3b8a4c9ae979d226ec02";
+      name = "incidenceeditor-18.12.3.tar.xz";
     };
   };
   juk = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/juk-18.12.1.tar.xz";
-      sha256 = "14zlpac1z3gaym83d5vmr7vvqwdzxhfscydwb2qv4ng947lrrs1n";
-      name = "juk-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/juk-18.12.3.tar.xz";
+      sha256 = "8755710f551b3173561ebfcc996f32b3fd8de78d5574584f8e37015541a9fdca";
+      name = "juk-18.12.3.tar.xz";
     };
   };
   k3b = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/k3b-18.12.1.tar.xz";
-      sha256 = "1f5l8jyi30qm225nxp0sahm7lwdk9r2gqzbdrrzhadx6gfm80a4s";
-      name = "k3b-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/k3b-18.12.3.tar.xz";
+      sha256 = "cee825ff0c058cc1cbe3bf47a7acbe3889949460ba383ffae3756b67b418362e";
+      name = "k3b-18.12.3.tar.xz";
     };
   };
   kaccounts-integration = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kaccounts-integration-18.12.1.tar.xz";
-      sha256 = "1mb9rfp7vw9bkndlbwh5ayd9m3znwrl1i6kr0s5872sscmhx2giz";
-      name = "kaccounts-integration-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kaccounts-integration-18.12.3.tar.xz";
+      sha256 = "6e7e4d7aac270f605a5fd4ec9efea8c13807ccb67c11fd3412c1d794ab09e6ce";
+      name = "kaccounts-integration-18.12.3.tar.xz";
     };
   };
   kaccounts-providers = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kaccounts-providers-18.12.1.tar.xz";
-      sha256 = "0pjk7wsqbgibx8racd4qikv3i1j4iqgnbp81mm5nss7hilrnv1vi";
-      name = "kaccounts-providers-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kaccounts-providers-18.12.3.tar.xz";
+      sha256 = "4d084ffdac10a8a8cc8b79a9b17116893c023288c9e29d1cbabe3d28cd0ba5f6";
+      name = "kaccounts-providers-18.12.3.tar.xz";
     };
   };
   kaddressbook = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kaddressbook-18.12.1.tar.xz";
-      sha256 = "0n4abjcq2iana9xyzkghgrs6h9nr0k2vxqrxghnh5iqahn2766ak";
-      name = "kaddressbook-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kaddressbook-18.12.3.tar.xz";
+      sha256 = "81d3ba7d5e8ed14b0cc32825f1efbdccbf9f79ffe4e1f8c888179c3d04b5bd28";
+      name = "kaddressbook-18.12.3.tar.xz";
     };
   };
   kajongg = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kajongg-18.12.1.tar.xz";
-      sha256 = "11c1iyfwqjqihyb3lqvnrb9jsrah0wl1kbrbm2lbmaqf0qnqqr8a";
-      name = "kajongg-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kajongg-18.12.3.tar.xz";
+      sha256 = "e3fba4ddb19e8dfd43f917d737bf13c2391a3042c6941181ab81f4bcd66096f9";
+      name = "kajongg-18.12.3.tar.xz";
     };
   };
   kalarm = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kalarm-18.12.1.tar.xz";
-      sha256 = "1z2rf30ad2rlkcc9ki09pkrvdd8b9f60vsjzvsqfgxx8i87z1lil";
-      name = "kalarm-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kalarm-18.12.3.tar.xz";
+      sha256 = "5c116221e78755b8afd80287885cb50380c2136acd25aa615d3f6041cc0fbeb3";
+      name = "kalarm-18.12.3.tar.xz";
     };
   };
   kalarmcal = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kalarmcal-18.12.1.tar.xz";
-      sha256 = "0wykbg24llympx7m9bkf4aciv6pli359nnnzpli7rh4q58vbnfn7";
-      name = "kalarmcal-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kalarmcal-18.12.3.tar.xz";
+      sha256 = "2658b2d8055558878cf84d50daf333a5f694a586800b9ccfd3eded3304af8ef8";
+      name = "kalarmcal-18.12.3.tar.xz";
     };
   };
   kalgebra = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kalgebra-18.12.1.tar.xz";
-      sha256 = "09g4v4f2xlilqrf2aqsz7zbjqnnrndhhlkkwbrypn148gdnxngs4";
-      name = "kalgebra-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kalgebra-18.12.3.tar.xz";
+      sha256 = "a93b319c6a3fab3d3a12923f8153a6f38281887e176fffaa37ca6cc677a280b5";
+      name = "kalgebra-18.12.3.tar.xz";
     };
   };
   kalzium = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kalzium-18.12.1.tar.xz";
-      sha256 = "1c5li3dhrfiw7kpjv6kfby2c2pq22sraqb3vc0s4nz1h9jnjcah7";
-      name = "kalzium-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kalzium-18.12.3.tar.xz";
+      sha256 = "100f63b0c1624c10ce7bb54a6a8fa6dfaf6800f580bfc0889745e171fe135fef";
+      name = "kalzium-18.12.3.tar.xz";
     };
   };
   kamera = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kamera-18.12.1.tar.xz";
-      sha256 = "177lgyhc5klrpssbk2bsdwmg5hnk92mbjwb7s39kl9h53kw0jmzj";
-      name = "kamera-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kamera-18.12.3.tar.xz";
+      sha256 = "5e0e5a710cffd95019279d68daa27fdd4fba1401450673efa757ffc8a7ca495f";
+      name = "kamera-18.12.3.tar.xz";
     };
   };
   kamoso = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kamoso-18.12.1.tar.xz";
-      sha256 = "1j467cpga2shvibwx3df4vxksfkp5q1hp6az8kcky6gljcmxy06p";
-      name = "kamoso-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kamoso-18.12.3.tar.xz";
+      sha256 = "ed62bbdf8eeefb85605113c3a916b01eec16846825cffe9b0b0c1f5a4580feb3";
+      name = "kamoso-18.12.3.tar.xz";
     };
   };
   kanagram = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kanagram-18.12.1.tar.xz";
-      sha256 = "0ybn3aal51p29g28daalwmpm85306ivgl8rkxhccq7pzfwaww1bx";
-      name = "kanagram-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kanagram-18.12.3.tar.xz";
+      sha256 = "dcc06543830ab06066f2f37eba6722f5cb0893355e30cee8d522085ed5fb2204";
+      name = "kanagram-18.12.3.tar.xz";
     };
   };
   kapman = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kapman-18.12.1.tar.xz";
-      sha256 = "117fkqhn0mg3z14sl64vmkz26rclfrjarf7kvxicvbw0x8s3vsgj";
-      name = "kapman-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kapman-18.12.3.tar.xz";
+      sha256 = "ad4a6377d260df76d000631ab4c95e5cb82ce47d031edc9801b6ed92d856305c";
+      name = "kapman-18.12.3.tar.xz";
     };
   };
   kapptemplate = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kapptemplate-18.12.1.tar.xz";
-      sha256 = "1q52d30zz1ip6x8z56i25ll8hgzd6fp4pckfgr6byh82ymck8kxa";
-      name = "kapptemplate-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kapptemplate-18.12.3.tar.xz";
+      sha256 = "dd4e34e1ed60f4cb03836576dfd5d306ec1890cd0fe583b516bf49c628f1078f";
+      name = "kapptemplate-18.12.3.tar.xz";
     };
   };
   kate = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kate-18.12.1.tar.xz";
-      sha256 = "0p9j9r2ffqh6p5pdxhk1pi8km1ypdsjs1h0g4ncnzwpvkir1rhk7";
-      name = "kate-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kate-18.12.3.tar.xz";
+      sha256 = "f7f2cba41a4c88b65885532db6b6161c66055a6697d20ee88adb70f302d387e1";
+      name = "kate-18.12.3.tar.xz";
     };
   };
   katomic = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/katomic-18.12.1.tar.xz";
-      sha256 = "0pxj8vgx3ijvyznn5gvhv2scwbqhaqc2pmq2897b190vsx9mvkh6";
-      name = "katomic-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/katomic-18.12.3.tar.xz";
+      sha256 = "0e18087d0de067282023a98b800807632dd6a91bab51cf0d43d53bffba9b33f1";
+      name = "katomic-18.12.3.tar.xz";
     };
   };
   kbackup = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kbackup-18.12.1.tar.xz";
-      sha256 = "0x42d7zssddhxdsx7vpvk4630c69pvllpfz40dqk2n3hghx9xvsw";
-      name = "kbackup-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kbackup-18.12.3.tar.xz";
+      sha256 = "7b42f7fff48f4cf735e27603d0e44ecd13d5c85474680f8d24850eaadd4f13bf";
+      name = "kbackup-18.12.3.tar.xz";
     };
   };
   kblackbox = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kblackbox-18.12.1.tar.xz";
-      sha256 = "1wlwdfh23h175gsflmfmr63myds9vz3cs5dp8gr2zlxssdhc2s1p";
-      name = "kblackbox-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kblackbox-18.12.3.tar.xz";
+      sha256 = "d88b2906de45b129f1706b3d250b80f86acb0cc926a3cee679265b86c8934a9b";
+      name = "kblackbox-18.12.3.tar.xz";
     };
   };
   kblocks = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kblocks-18.12.1.tar.xz";
-      sha256 = "1fzsyr8g536k54j3lgqr52a1cmcdmv85z11afhkz2186smnc63pa";
-      name = "kblocks-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kblocks-18.12.3.tar.xz";
+      sha256 = "e981107096893a8078ab978c429f367432a74de1bdeffe8fb628ccc397701332";
+      name = "kblocks-18.12.3.tar.xz";
     };
   };
   kblog = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kblog-18.12.1.tar.xz";
-      sha256 = "0zdqjgan05049md0483l4c27gfwqdzmmx7wv3bziy91kd9bmfv0x";
-      name = "kblog-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kblog-18.12.3.tar.xz";
+      sha256 = "cd84b34312f6c5a9cf56322614caafcf434a800aeff66173a2c6f7cccc0fd2cc";
+      name = "kblog-18.12.3.tar.xz";
     };
   };
   kbounce = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kbounce-18.12.1.tar.xz";
-      sha256 = "1209x02jip17n63ilvbi5knz4584k16c6zbrp8rg982qcabny355";
-      name = "kbounce-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kbounce-18.12.3.tar.xz";
+      sha256 = "c62cb68b4246c1aef73efb04ea883599384afbd977e8da93893346cbd835f343";
+      name = "kbounce-18.12.3.tar.xz";
     };
   };
   kbreakout = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kbreakout-18.12.1.tar.xz";
-      sha256 = "0myh4qncrvm2kd2gwvl7v2078cvv66czl9zsiava8lzq588wddwq";
-      name = "kbreakout-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kbreakout-18.12.3.tar.xz";
+      sha256 = "23e1cc935eab6a2520e683185cb223243c71553b1ef6059a21f09d72e8fe00af";
+      name = "kbreakout-18.12.3.tar.xz";
     };
   };
   kbruch = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kbruch-18.12.1.tar.xz";
-      sha256 = "0jlq08c6zjmdalhbgh2fy5qghj65l12jn7wvr0j2h0s6fqck1djh";
-      name = "kbruch-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kbruch-18.12.3.tar.xz";
+      sha256 = "e98f79865c4d095d7682ab97b0e4e7d23715e402be676d66f184cfbe3eff598d";
+      name = "kbruch-18.12.3.tar.xz";
     };
   };
   kcachegrind = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kcachegrind-18.12.1.tar.xz";
-      sha256 = "0w7fdsflqmkisap6mr805b6knf83nrjrr6bxi1snrl43ipy5ls29";
-      name = "kcachegrind-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kcachegrind-18.12.3.tar.xz";
+      sha256 = "48011190a0ef28998e6c96b9d644e3d06b68606b7d1467c84a8d176eeebb9adf";
+      name = "kcachegrind-18.12.3.tar.xz";
     };
   };
   kcalc = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kcalc-18.12.1.tar.xz";
-      sha256 = "0ffafikh53yfwrsaiyxr4qxy01v8lv02y4xvj56qmhi429j9ax93";
-      name = "kcalc-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kcalc-18.12.3.tar.xz";
+      sha256 = "10b3ebb5efab3731e9f12a8632546685281179881b03aae98f96a2cdbd21f02f";
+      name = "kcalc-18.12.3.tar.xz";
     };
   };
   kcalcore = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kcalcore-18.12.1.tar.xz";
-      sha256 = "1383zmpw8nzx1fs3d55k38f3znbdc7rs21yrka6fmymgh5c3jkki";
-      name = "kcalcore-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kcalcore-18.12.3.tar.xz";
+      sha256 = "d6d6ce1bbdea4eac352b74bcc4bee77da107fdbafab47440b6be5fc3f9d90452";
+      name = "kcalcore-18.12.3.tar.xz";
     };
   };
   kcalutils = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kcalutils-18.12.1.tar.xz";
-      sha256 = "0w6kc39j3m5db8s47q4wh4wm0szl9vwr455i26d99vv8jay6mbpp";
-      name = "kcalutils-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kcalutils-18.12.3.tar.xz";
+      sha256 = "715c48c46cd62f773da4e804e66cdb97eae7c4832a7fe058db2fca61dc4111f9";
+      name = "kcalutils-18.12.3.tar.xz";
     };
   };
   kcharselect = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kcharselect-18.12.1.tar.xz";
-      sha256 = "1p4ap7vs1nd9gr4z71h6cx6fz99k1lliz28ibbky9a60wvnlfim6";
-      name = "kcharselect-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kcharselect-18.12.3.tar.xz";
+      sha256 = "e24e0268c5810cd3cf733dd8fcc8a9e04a111b761d4c1351d9976b3888278dcb";
+      name = "kcharselect-18.12.3.tar.xz";
     };
   };
   kcolorchooser = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kcolorchooser-18.12.1.tar.xz";
-      sha256 = "1lhnnywpfb4v1hwlc8h71lrvb145pc7wcaz7f7wf2kyh5pjkfbzn";
-      name = "kcolorchooser-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kcolorchooser-18.12.3.tar.xz";
+      sha256 = "8defdb9450922b675dc80561a0f4bb119e621a85dd73661fc4caacef8db91228";
+      name = "kcolorchooser-18.12.3.tar.xz";
     };
   };
   kcontacts = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kcontacts-18.12.1.tar.xz";
-      sha256 = "0d32l8hhggcy6dyyps5im74k0psnxrwxa6yni5bmj8m0z7f298ba";
-      name = "kcontacts-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kcontacts-18.12.3.tar.xz";
+      sha256 = "ba244937e36456065ec4c40fd1b44d011df487a940756ddc0ddd761f58454dd3";
+      name = "kcontacts-18.12.3.tar.xz";
     };
   };
   kcron = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kcron-18.12.1.tar.xz";
-      sha256 = "0211xs7zwii5a93827rsnp1gkay78h2hs49lvdc2kah9ccsh0kzn";
-      name = "kcron-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kcron-18.12.3.tar.xz";
+      sha256 = "ba1d7e3ed5453a4867b4900deb957f1020f1533bdadfc36a1c6f83921bfd6ca3";
+      name = "kcron-18.12.3.tar.xz";
     };
   };
   kdav = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kdav-18.12.1.tar.xz";
-      sha256 = "0kr07p4gnxyzrgnbj7vkh93wmqwnvv8sc06i2yardr8qp6jhpg77";
-      name = "kdav-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kdav-18.12.3.tar.xz";
+      sha256 = "3ce99c65573d6374e91abff50b3a738515da07371f07c1b6e4b1800069a77c23";
+      name = "kdav-18.12.3.tar.xz";
     };
   };
   kdebugsettings = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kdebugsettings-18.12.1.tar.xz";
-      sha256 = "1wbi0f82dwd7a8s6szg0yc2mraiinng9a5wjw8xjacgkyyjpqbr3";
-      name = "kdebugsettings-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kdebugsettings-18.12.3.tar.xz";
+      sha256 = "680eeec77314d23ca3a40c803b4c22a1800dc982fa81cba9f44dbfa9222539f7";
+      name = "kdebugsettings-18.12.3.tar.xz";
     };
   };
   kde-dev-scripts = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kde-dev-scripts-18.12.1.tar.xz";
-      sha256 = "1k0xjlwpmdl2qpj4x04q9x299wmva2ds4y2wpayah865knvx91j3";
-      name = "kde-dev-scripts-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kde-dev-scripts-18.12.3.tar.xz";
+      sha256 = "c62f05b86615a810beb2573ee2106bc68fc8be586b66bcdde62d3ba4e4c16fb4";
+      name = "kde-dev-scripts-18.12.3.tar.xz";
     };
   };
   kde-dev-utils = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kde-dev-utils-18.12.1.tar.xz";
-      sha256 = "06k01z2ljkcsdzz4zsdp8hr3flss552h0jgy25qv7y1izggk05dj";
-      name = "kde-dev-utils-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kde-dev-utils-18.12.3.tar.xz";
+      sha256 = "f53b896b62b7d2267b78d23fb24cf495932c4c8b552d8bf56c722a49acc54be6";
+      name = "kde-dev-utils-18.12.3.tar.xz";
     };
   };
   kdeedu-data = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kdeedu-data-18.12.1.tar.xz";
-      sha256 = "1pnjydj3g768z5zxwbfwvxvlhdbg9rscr3vd1dw4srs338lp0maq";
-      name = "kdeedu-data-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kdeedu-data-18.12.3.tar.xz";
+      sha256 = "cebaa135b21cba27015b1679e02a6625b9b444828ec7595e1a46f53dd7ae3999";
+      name = "kdeedu-data-18.12.3.tar.xz";
     };
   };
   kdegraphics-mobipocket = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kdegraphics-mobipocket-18.12.1.tar.xz";
-      sha256 = "1bv3981nsy61m8shlwbry9yb37218s2q1k9fas3xgv1260rjmmfq";
-      name = "kdegraphics-mobipocket-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kdegraphics-mobipocket-18.12.3.tar.xz";
+      sha256 = "69ae8b6f45b8c9ec3a73e636f7a779257ebbd6f8016d24294bec844a51f2cc52";
+      name = "kdegraphics-mobipocket-18.12.3.tar.xz";
     };
   };
   kdegraphics-thumbnailers = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kdegraphics-thumbnailers-18.12.1.tar.xz";
-      sha256 = "1rz578dz6nr3m23kd4njdcx01nmjgskxlla4zqgd33gg08kppmvj";
-      name = "kdegraphics-thumbnailers-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kdegraphics-thumbnailers-18.12.3.tar.xz";
+      sha256 = "9bc36ea2eb8a177899bf81b1cdc63a92b8e5dae12308f3e71046a63e58aafec0";
+      name = "kdegraphics-thumbnailers-18.12.3.tar.xz";
     };
   };
   kdenetwork-filesharing = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kdenetwork-filesharing-18.12.1.tar.xz";
-      sha256 = "1zxkbcdndbr3sygwpiiw70pxb71hil1x8zj7lgq2yyw968ianah4";
-      name = "kdenetwork-filesharing-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kdenetwork-filesharing-18.12.3.tar.xz";
+      sha256 = "296c71526de0e51b4385962c76c2870cfe344b9dafdd2f5f2fba81801350d503";
+      name = "kdenetwork-filesharing-18.12.3.tar.xz";
     };
   };
   kdenlive = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kdenlive-18.12.1.tar.xz";
-      sha256 = "189p0sqlmfkaxsdiy1mh0mmskw6ha4zi64fx99w7wnbid8x52bjf";
-      name = "kdenlive-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kdenlive-18.12.3.tar.xz";
+      sha256 = "fcfe2474bc271e730ed95edb21ae46e93c1ce773ed036f63c9fb2db02cbc7e64";
+      name = "kdenlive-18.12.3.tar.xz";
     };
   };
   kdepim-addons = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kdepim-addons-18.12.1.tar.xz";
-      sha256 = "1gz6rqg39vl2arzs64srpr7xn1syxxiznz58gdss40152gz0hlsp";
-      name = "kdepim-addons-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kdepim-addons-18.12.3.tar.xz";
+      sha256 = "450a3f257e998e733b69703a1a813abab93c571c602702cbb4d9ab4ac25e8ce5";
+      name = "kdepim-addons-18.12.3.tar.xz";
     };
   };
   kdepim-apps-libs = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kdepim-apps-libs-18.12.1.tar.xz";
-      sha256 = "06q306m09666jh4cx3w0bif81x424hxlvsf31wjhfzdp737xfq3i";
-      name = "kdepim-apps-libs-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kdepim-apps-libs-18.12.3.tar.xz";
+      sha256 = "40a6fb24fc262f5340fda4aed453c5d515976aea745765e83cf8053b44d60164";
+      name = "kdepim-apps-libs-18.12.3.tar.xz";
     };
   };
   kdepim-runtime = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kdepim-runtime-18.12.1.tar.xz";
-      sha256 = "1vb9rqzyjww7lkc3g2aw43ks7is1bg1nx2mbn8wvmc7cgga66nbc";
-      name = "kdepim-runtime-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kdepim-runtime-18.12.3.tar.xz";
+      sha256 = "f3a5da19bb0f60e148d071cf07fd9fd4e6ea116f6125567c767c03b98ea844c3";
+      name = "kdepim-runtime-18.12.3.tar.xz";
     };
   };
   kdesdk-kioslaves = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kdesdk-kioslaves-18.12.1.tar.xz";
-      sha256 = "05bds4r70ys4mygmjl5x5hcrygds57mqqmzfv79zq9hcfp2b0g69";
-      name = "kdesdk-kioslaves-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kdesdk-kioslaves-18.12.3.tar.xz";
+      sha256 = "1f1951eca1c4081277782e80ef6b7c6768b2bb5a7d1830d69954f2fec27462ad";
+      name = "kdesdk-kioslaves-18.12.3.tar.xz";
     };
   };
   kdesdk-thumbnailers = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kdesdk-thumbnailers-18.12.1.tar.xz";
-      sha256 = "1584qy2aa8q7zzgf2zxqw7p2h2l2xfgsa2mrmxaa36xaxbglcvkb";
-      name = "kdesdk-thumbnailers-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kdesdk-thumbnailers-18.12.3.tar.xz";
+      sha256 = "a4694da94bd671a1395a32a527c919fb2207e8a959ceff32a11488e2015a784b";
+      name = "kdesdk-thumbnailers-18.12.3.tar.xz";
     };
   };
   kdf = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kdf-18.12.1.tar.xz";
-      sha256 = "0zr6k8di9fvzmgvh4s8ji81zdynpkg5yrnddlc9mgid0w9czaw11";
-      name = "kdf-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kdf-18.12.3.tar.xz";
+      sha256 = "a8a9e8a4c2bdc1855078383f10720b4b3a388c678dee148494dc18ba5019a6ae";
+      name = "kdf-18.12.3.tar.xz";
     };
   };
   kdialog = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kdialog-18.12.1.tar.xz";
-      sha256 = "0i4c2kjyp0dix12vxhj078h7vbylcqxgqx10hzwaszx3wlrycwa2";
-      name = "kdialog-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kdialog-18.12.3.tar.xz";
+      sha256 = "8b17013ced4b02ceaf89ed3d3fdcfa4fce06fac54d54041fb1e47169f2def212";
+      name = "kdialog-18.12.3.tar.xz";
     };
   };
   kdiamond = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kdiamond-18.12.1.tar.xz";
-      sha256 = "0j5g1gh267q528k0947brc8nvgq81690hqp7mrf90wxg8qp4ysm4";
-      name = "kdiamond-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kdiamond-18.12.3.tar.xz";
+      sha256 = "b3d959cc195b924ca877df2762c3e8ef115ac41c2355f34efbbcaabe9b02b500";
+      name = "kdiamond-18.12.3.tar.xz";
     };
   };
   keditbookmarks = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/keditbookmarks-18.12.1.tar.xz";
-      sha256 = "0fnxmgfgnh8d6sg7g7ai53xywa22qv4pn4xxj503rjs4a3fsm3j1";
-      name = "keditbookmarks-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/keditbookmarks-18.12.3.tar.xz";
+      sha256 = "8d1f1a6ffa3b68d318ac6eb72707e5e5bb4f6f43ebb25c0475121469a71f6a8d";
+      name = "keditbookmarks-18.12.3.tar.xz";
     };
   };
   kfind = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kfind-18.12.1.tar.xz";
-      sha256 = "1vhi66syjhmc5i64ffgpilyxw9y10qb7633p3gx7vsnbjhvfx45b";
-      name = "kfind-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kfind-18.12.3.tar.xz";
+      sha256 = "ad123b24f88e1ade5a845c16a84a483835cce31b92741107d8dbd02f462d4cd9";
+      name = "kfind-18.12.3.tar.xz";
     };
   };
   kfloppy = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kfloppy-18.12.1.tar.xz";
-      sha256 = "1fx40gb7h0z832qidn635jj7caipxcrzxmrbdfnj8ji2sczs1hyq";
-      name = "kfloppy-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kfloppy-18.12.3.tar.xz";
+      sha256 = "d68af7c572591a1a297cc823c1cb16a8a15973983c31f2e598d75dcc09ae2363";
+      name = "kfloppy-18.12.3.tar.xz";
     };
   };
   kfourinline = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kfourinline-18.12.1.tar.xz";
-      sha256 = "1dwa4nw6998ljbppr4bhwpdg201djk5rjrzjgfs5xv0pynamph0g";
-      name = "kfourinline-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kfourinline-18.12.3.tar.xz";
+      sha256 = "cd3c3129c50502d9fe35f2382fcb1a512519626eb1b776600fdac2190390b9ce";
+      name = "kfourinline-18.12.3.tar.xz";
     };
   };
   kgeography = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kgeography-18.12.1.tar.xz";
-      sha256 = "02xir13p0r67vx3csdra9nza82a25k807cjl3w2pq3dqcg9grrcf";
-      name = "kgeography-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kgeography-18.12.3.tar.xz";
+      sha256 = "ae019c4fc6c2b52344466266a19c6047e5dc414a92461a21d0e9c003dd4433c9";
+      name = "kgeography-18.12.3.tar.xz";
     };
   };
   kget = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kget-18.12.1.tar.xz";
-      sha256 = "0jlpih49rifpqzxzgjc4kv3hv7y42v6pcamyvrmk6q1768lqp7nb";
-      name = "kget-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kget-18.12.3.tar.xz";
+      sha256 = "3386c07c61f072df4259f83895be43c64559c059c24df1b31ca66c4f2b599f86";
+      name = "kget-18.12.3.tar.xz";
     };
   };
   kgoldrunner = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kgoldrunner-18.12.1.tar.xz";
-      sha256 = "19qdw319lzfhmmmmawdpb0dlkz9k1iz6imkwf1qndfv89b6wklba";
-      name = "kgoldrunner-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kgoldrunner-18.12.3.tar.xz";
+      sha256 = "1d54b485ccb81106853d5229422c753a5b0bbd2f9239a17b1c44f737a32d93b6";
+      name = "kgoldrunner-18.12.3.tar.xz";
     };
   };
   kgpg = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kgpg-18.12.1.tar.xz";
-      sha256 = "1rar3hj3wc9vpxc81h0ly1mi87m9cdx17j58k9n02q91jqb8892y";
-      name = "kgpg-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kgpg-18.12.3.tar.xz";
+      sha256 = "05d70923f4c9d068b339dc0a3d3f28890cafe1fbef9820dd6157c1f5fd8f19e8";
+      name = "kgpg-18.12.3.tar.xz";
     };
   };
   khangman = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/khangman-18.12.1.tar.xz";
-      sha256 = "10wk0xdrs6pldg8j5bnsbdx835isxrapb1gm9gx4vjj49riq062q";
-      name = "khangman-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/khangman-18.12.3.tar.xz";
+      sha256 = "1a7cdd27abf229603965ff6b3392bd7935f7f5a2d6418b23f802cfae45f74013";
+      name = "khangman-18.12.3.tar.xz";
     };
   };
   khelpcenter = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/khelpcenter-18.12.1.tar.xz";
-      sha256 = "143f61ngvljm4046q4allwxhx6fis0hd92xdqk8955xwdf42fq6y";
-      name = "khelpcenter-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/khelpcenter-18.12.3.tar.xz";
+      sha256 = "5b4a9ed17d0898c74cf7fd1612e2d055086d5e04148b3b17df5977255fc240b8";
+      name = "khelpcenter-18.12.3.tar.xz";
     };
   };
   kidentitymanagement = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kidentitymanagement-18.12.1.tar.xz";
-      sha256 = "1pl8yzrhfvkxcxasywzklhpx2477whn662s13c5mp6yhpxyxl5xq";
-      name = "kidentitymanagement-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kidentitymanagement-18.12.3.tar.xz";
+      sha256 = "4e8cac86c2ecfe6325bbf8fb7e50a026f6af978be3809f327eddfed7b3aed662";
+      name = "kidentitymanagement-18.12.3.tar.xz";
     };
   };
   kig = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kig-18.12.1.tar.xz";
-      sha256 = "0cc093gwq2cr4ir3rdfkhijjsjvjddw4n7hvrxbshv7pqmnbrjgc";
-      name = "kig-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kig-18.12.3.tar.xz";
+      sha256 = "abba87c3569e571e6d1761dc2e6c0e32969ea09eba6d9c0462cb4dc7bd62d7a2";
+      name = "kig-18.12.3.tar.xz";
     };
   };
   kigo = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kigo-18.12.1.tar.xz";
-      sha256 = "07m3p9r59c4qfwpgipb024mzxi4safiidpypm8gmx87vbsqc99f2";
-      name = "kigo-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kigo-18.12.3.tar.xz";
+      sha256 = "fa767319c3ac3e2dea48a5b09284e47e5f0c5d1862af813258758773998d1484";
+      name = "kigo-18.12.3.tar.xz";
     };
   };
   killbots = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/killbots-18.12.1.tar.xz";
-      sha256 = "12jbvqmi0cx5ma7lai67qamml7qig269vhvjrcvm7jwlg0qx8v43";
-      name = "killbots-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/killbots-18.12.3.tar.xz";
+      sha256 = "4efb4fcd4f34f1843b990a92e5b0309c196071f0778cdc8376eff5eef405deb9";
+      name = "killbots-18.12.3.tar.xz";
     };
   };
   kimagemapeditor = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kimagemapeditor-18.12.1.tar.xz";
-      sha256 = "1mqzd3ja27c4askz9cxfaf6g8wcwlasjka79h4dmvjrw4rkqs4y4";
-      name = "kimagemapeditor-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kimagemapeditor-18.12.3.tar.xz";
+      sha256 = "addaaf257c35e8169288a8e7a50a1628f3ceeb6a2a845c3d260dfe94662438c6";
+      name = "kimagemapeditor-18.12.3.tar.xz";
     };
   };
   kimap = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kimap-18.12.1.tar.xz";
-      sha256 = "1v1qd91pr4xx0wsvvqlg8pcsbyi0n7c90ki0pz8v8z2vay5fagnm";
-      name = "kimap-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kimap-18.12.3.tar.xz";
+      sha256 = "00aed701a3bdcc218902998e63e7c587549f77a1aa0d1bd7dad4a1837adc9992";
+      name = "kimap-18.12.3.tar.xz";
     };
   };
   kio-extras = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kio-extras-18.12.1.tar.xz";
-      sha256 = "17y5awdyck2zjrgb9l2s4rdyvp1pqc6jrdyjv5vhchjdkfb91vw3";
-      name = "kio-extras-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kio-extras-18.12.3.tar.xz";
+      sha256 = "f8879abaea6fcf31ee0bd4a55d0c24a5fded6d61abed1b059f704f797793aef2";
+      name = "kio-extras-18.12.3.tar.xz";
     };
   };
   kirigami-gallery = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kirigami-gallery-18.12.1.tar.xz";
-      sha256 = "1wrvhpdg2qk6ri1hjhdbk6w6rzyxamn6hxfl4mjcaip9gamjlbr0";
-      name = "kirigami-gallery-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kirigami-gallery-18.12.3.tar.xz";
+      sha256 = "64da8da506718e6b7b62e04a9d2fc40ec73f909f9a6b5afd29b4c81c20053e39";
+      name = "kirigami-gallery-18.12.3.tar.xz";
     };
   };
   kiriki = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kiriki-18.12.1.tar.xz";
-      sha256 = "1sxn7qvhyaaf4681hx1hgv2mmfhn64qn6q0rad9vps69cb1rx7pz";
-      name = "kiriki-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kiriki-18.12.3.tar.xz";
+      sha256 = "0b67b5069625fe04f6ffaa65d0d4abcf86f2f067483b4db15508d2b5ee9742ac";
+      name = "kiriki-18.12.3.tar.xz";
     };
   };
   kiten = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kiten-18.12.1.tar.xz";
-      sha256 = "1d964cc7bkr1vgsbbnm9c8na2nls3kmfk9wfkrzdgnj2643dl947";
-      name = "kiten-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kiten-18.12.3.tar.xz";
+      sha256 = "0e0bc0b0b2609a7872b45647976c87ec92ccb068d05113b8dc58e43c6eb1facf";
+      name = "kiten-18.12.3.tar.xz";
     };
   };
   kitinerary = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kitinerary-18.12.1.tar.xz";
-      sha256 = "14bkyi4xj00i8bzjq6z68y67iyylix0c1n8wr1nz0s05pmlg8sws";
-      name = "kitinerary-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kitinerary-18.12.3.tar.xz";
+      sha256 = "f45ef90cb3fb53d83a30837c304b9f7cfa5dbf2953421233d97c101d66a81f35";
+      name = "kitinerary-18.12.3.tar.xz";
     };
   };
   kjumpingcube = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kjumpingcube-18.12.1.tar.xz";
-      sha256 = "0i7lj2qi3mdvghpxyhwiakivxsd85ahy427d418sdykh7dfmn9ih";
-      name = "kjumpingcube-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kjumpingcube-18.12.3.tar.xz";
+      sha256 = "6409a3bb398ab90959afc24fa42b01b6e544526b1dab6f36bb700703fa794993";
+      name = "kjumpingcube-18.12.3.tar.xz";
     };
   };
   kldap = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kldap-18.12.1.tar.xz";
-      sha256 = "117w3jk4i77p8a7dvj03kgxqlhgbkmhyl7w282gl38kxyr7z8hbn";
-      name = "kldap-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kldap-18.12.3.tar.xz";
+      sha256 = "dc5c8f33aad9e82f0cee65c6fc530f6bd9b82ec9cc21d1ce904f0fe9bdf5140e";
+      name = "kldap-18.12.3.tar.xz";
     };
   };
   kleopatra = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kleopatra-18.12.1.tar.xz";
-      sha256 = "1njgfigld774r9xyckip118svxrkylh0a5ib5y8976zb0v71m5mj";
-      name = "kleopatra-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kleopatra-18.12.3.tar.xz";
+      sha256 = "ea165519846d70206e951d8d904bc02d17ed724db100638e657f7c930c4c490b";
+      name = "kleopatra-18.12.3.tar.xz";
     };
   };
   klettres = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/klettres-18.12.1.tar.xz";
-      sha256 = "0xxrkx468wx2f3gb3d77i648xxmy6bq6q0nq121fk2apgdp2dzqk";
-      name = "klettres-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/klettres-18.12.3.tar.xz";
+      sha256 = "4ca89a54858d1f8ac43e8cb485b80a3bb5ead501d39e7e30d8c9b6b8d2d7fd93";
+      name = "klettres-18.12.3.tar.xz";
     };
   };
   klickety = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/klickety-18.12.1.tar.xz";
-      sha256 = "14jvifvm47q0ca7jq7d152l53nswhbwggs0q067n3chmf07g2izy";
-      name = "klickety-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/klickety-18.12.3.tar.xz";
+      sha256 = "45ed455fd9628aaf081bfa6b672199fbb6913c7dc5d5c04ad9df206a3bd962a5";
+      name = "klickety-18.12.3.tar.xz";
     };
   };
   klines = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/klines-18.12.1.tar.xz";
-      sha256 = "1bs7vaqs67232msmsrsfi9avbqrzvyjihsakzxpkn976xwql3zxf";
-      name = "klines-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/klines-18.12.3.tar.xz";
+      sha256 = "6d93e5bee1135f4eeb67e7f845a4fd658be7e5fb33f42c0ad6320200bc86fd80";
+      name = "klines-18.12.3.tar.xz";
     };
   };
   kmag = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kmag-18.12.1.tar.xz";
-      sha256 = "1ig9fbnza2xvxvd1adh9riv3zmrdmm0km8jpqjmh124i8g416qpw";
-      name = "kmag-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kmag-18.12.3.tar.xz";
+      sha256 = "04f1357e46bb3e32c85f08c9d5655cde6351c6efd27824a17019ea8562e8d5ba";
+      name = "kmag-18.12.3.tar.xz";
     };
   };
   kmahjongg = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kmahjongg-18.12.1.tar.xz";
-      sha256 = "0ajml6xy4ljmrn5qbvy08mcf5v5jqzmclsbr6811rrxqxb5fqbqd";
-      name = "kmahjongg-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kmahjongg-18.12.3.tar.xz";
+      sha256 = "188a8d921b72965d4ed0f6490048cde7b9d5606cca7d3cea12463dc71a90ccf6";
+      name = "kmahjongg-18.12.3.tar.xz";
     };
   };
   kmail = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kmail-18.12.1.tar.xz";
-      sha256 = "1wakrrlxp3v0k93hx2c8p136a3hd746l8fxks0g3cwvhl1immxw7";
-      name = "kmail-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kmail-18.12.3.tar.xz";
+      sha256 = "9dd9865d4a463ac552c25126ecaee662b83548091c5abef168bdc7a6d2fb5c76";
+      name = "kmail-18.12.3.tar.xz";
     };
   };
   kmail-account-wizard = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kmail-account-wizard-18.12.1.tar.xz";
-      sha256 = "0v3lwgk3b30ggv6573r6k5z09lcpfzspp5znnsn4650fgrrzg2j3";
-      name = "kmail-account-wizard-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kmail-account-wizard-18.12.3.tar.xz";
+      sha256 = "102a4170cb4f80c7a9ba3aec7a4d34a3e6a8ca18c975b5c0ea33cf7bac9e21df";
+      name = "kmail-account-wizard-18.12.3.tar.xz";
     };
   };
   kmailtransport = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kmailtransport-18.12.1.tar.xz";
-      sha256 = "1ybaps485ic2m8nfy63kw6x7f3l2l67lhyy5zsm7rjipbaqgi2vm";
-      name = "kmailtransport-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kmailtransport-18.12.3.tar.xz";
+      sha256 = "8aaa6045f29195074c61fd58112ca7dfbe594df66cac91bac7b246ab2ab9fad1";
+      name = "kmailtransport-18.12.3.tar.xz";
     };
   };
   kmbox = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kmbox-18.12.1.tar.xz";
-      sha256 = "0anh25klbgb67ynl9mlcny2mrawsd98mzyffvgsd8xkback684zf";
-      name = "kmbox-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kmbox-18.12.3.tar.xz";
+      sha256 = "13a88db1ab0d628a3053a0d6ab5d89cd2f6cbadb3082b52e5dc7048516a10841";
+      name = "kmbox-18.12.3.tar.xz";
     };
   };
   kmime = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kmime-18.12.1.tar.xz";
-      sha256 = "05kjfqaadkflyh1vabzgbx33vr3c70sm2nkp8r9dsa7kg3wij0n2";
-      name = "kmime-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kmime-18.12.3.tar.xz";
+      sha256 = "a09b0757e6ba663bf52d9bb8f7f104f3f19f734a858f6d532a6a20888ebcd274";
+      name = "kmime-18.12.3.tar.xz";
     };
   };
   kmines = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kmines-18.12.1.tar.xz";
-      sha256 = "0dq1jirzb6ljhb7wdrrkyxvmlwg84xzhfikcn9v6nmz9f3pbliwi";
-      name = "kmines-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kmines-18.12.3.tar.xz";
+      sha256 = "40c16b57614098555c32252c75e3890922b62d7005b9059f6ae92e11c96d980f";
+      name = "kmines-18.12.3.tar.xz";
     };
   };
   kmix = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kmix-18.12.1.tar.xz";
-      sha256 = "1ra7jmi5xlq9gbh7csv40sxr20lv8dz659m1jx4ixkzppcj42s73";
-      name = "kmix-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kmix-18.12.3.tar.xz";
+      sha256 = "4edf31a36a5d700cc190ba7a5a0d76789729069d48324a22bda7977cb4ed081a";
+      name = "kmix-18.12.3.tar.xz";
     };
   };
   kmousetool = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kmousetool-18.12.1.tar.xz";
-      sha256 = "07ywyxkm510faaqzywp5rw0lr2x1djhyhkjwyv8l42iw7231bn8x";
-      name = "kmousetool-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kmousetool-18.12.3.tar.xz";
+      sha256 = "34f6bb6f69c284e9cc88d8a31d59c16f003310c33e1e1affd5c363d18f8a91a8";
+      name = "kmousetool-18.12.3.tar.xz";
     };
   };
   kmouth = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kmouth-18.12.1.tar.xz";
-      sha256 = "1g82shlrfm70ddfy2zfv12gv8hwzavz47q4qsyblyzq329kwgww5";
-      name = "kmouth-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kmouth-18.12.3.tar.xz";
+      sha256 = "89b83fb8b4a5eb3c7a6409cd25c730a8bc3be72983c1a75f5e3d3abf01064486";
+      name = "kmouth-18.12.3.tar.xz";
     };
   };
   kmplot = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kmplot-18.12.1.tar.xz";
-      sha256 = "0xl913pajyrhadld2ij9y0ai2w558wa60qfx1y1xwsjfm8124qgf";
-      name = "kmplot-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kmplot-18.12.3.tar.xz";
+      sha256 = "2dd6eec34088b5d3b591091cce41616ee310a66aa2d16e5800db56044d60dd7b";
+      name = "kmplot-18.12.3.tar.xz";
     };
   };
   knavalbattle = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/knavalbattle-18.12.1.tar.xz";
-      sha256 = "1p03c980w4d10mkmvm01imi7vg6cp3wqz0wvw2d5vz47i0jhm2w8";
-      name = "knavalbattle-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/knavalbattle-18.12.3.tar.xz";
+      sha256 = "bce9294830a55e96b234c93fa20eb7d7ae963223e724ab0211ec472c79d35fa3";
+      name = "knavalbattle-18.12.3.tar.xz";
     };
   };
   knetwalk = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/knetwalk-18.12.1.tar.xz";
-      sha256 = "0x5794f91b84l4d8hgkqi33rdqa7s1plhprhmbfvsi4grpms6c0c";
-      name = "knetwalk-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/knetwalk-18.12.3.tar.xz";
+      sha256 = "75ed9859ebb0c40d4efadaf1724b50c1a0436a5d3cd7cb540031cf5535794e3f";
+      name = "knetwalk-18.12.3.tar.xz";
     };
   };
   knights = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/knights-18.12.1.tar.xz";
-      sha256 = "17n7zi100q62wjavfr87369yqp2mjxqz0lyqalagjp25d80z18l2";
-      name = "knights-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/knights-18.12.3.tar.xz";
+      sha256 = "9472ffa7800bd79a84dd0c36e3058d3f6e0813b5695aeffeb73bccb801870990";
+      name = "knights-18.12.3.tar.xz";
     };
   };
   knotes = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/knotes-18.12.1.tar.xz";
-      sha256 = "12n40znf9vczvbf5xfj4zsxwbj2rdj7l1iasmiiil2md8iyjs6dz";
-      name = "knotes-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/knotes-18.12.3.tar.xz";
+      sha256 = "4cd3a4e5064211f3df6ebf4711c2f4e01b09c77580493de9070c9ee842059578";
+      name = "knotes-18.12.3.tar.xz";
     };
   };
   kolf = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kolf-18.12.1.tar.xz";
-      sha256 = "072nmvsxm8ky1nz2pp6ri74ms3rql0qqg004mzbbq061dil4k63i";
-      name = "kolf-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kolf-18.12.3.tar.xz";
+      sha256 = "330cd299702e282a8b248b81cd50ee7ff60a6f512967029730ab87bedb69652f";
+      name = "kolf-18.12.3.tar.xz";
     };
   };
   kollision = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kollision-18.12.1.tar.xz";
-      sha256 = "0idjjfgj8fk0c0l5i6x80cg20p1rpq6kab8z9rh2izvg1v6h7qvl";
-      name = "kollision-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kollision-18.12.3.tar.xz";
+      sha256 = "17376f73da0ea5e05998a4f9f0ccb6c0e41461007b8815637ac1980673e9a856";
+      name = "kollision-18.12.3.tar.xz";
     };
   };
   kolourpaint = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kolourpaint-18.12.1.tar.xz";
-      sha256 = "0h454h5rzk0wki8lbmz57xx3859c27sy9vk1mwawfj963785f2nd";
-      name = "kolourpaint-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kolourpaint-18.12.3.tar.xz";
+      sha256 = "450b714f0d73b59d31c4ceda142a3496d14e51d84b8c8968548a15e05c138f98";
+      name = "kolourpaint-18.12.3.tar.xz";
     };
   };
   kompare = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kompare-18.12.1.tar.xz";
-      sha256 = "099fkxmk7g19l07lf2v3hmqrgfd17fbsv4m5cxdjci8alizw8pp9";
-      name = "kompare-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kompare-18.12.3.tar.xz";
+      sha256 = "7a132a0aced98079fdec37188e9a46f5399e7584ab9d39801d7f0f8176623285";
+      name = "kompare-18.12.3.tar.xz";
     };
   };
   konqueror = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/konqueror-18.12.1.tar.xz";
-      sha256 = "08j4x2xi1iv5661gjpcakp2dmdhvhw3jad98kq3xj9989s7phpfy";
-      name = "konqueror-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/konqueror-18.12.3.tar.xz";
+      sha256 = "d9eb2bb4cd121f9967c6d6e7275dfb56bd41aec03c2b9d903d543b330ca4666a";
+      name = "konqueror-18.12.3.tar.xz";
     };
   };
   konquest = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/konquest-18.12.1.tar.xz";
-      sha256 = "0mlk2vm53nc9dc7ca9ah3ly9qs94md24pi2gmv68pz1ysr51i483";
-      name = "konquest-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/konquest-18.12.3.tar.xz";
+      sha256 = "3698253f8e873819680ed99f377a679bacf5351f3fadc92c07fbaa0f6b269172";
+      name = "konquest-18.12.3.tar.xz";
     };
   };
   konsole = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/konsole-18.12.1.tar.xz";
-      sha256 = "15w1jizs4q6mivv7qjkf0gkqlz0jnrz7b2i59r3kx2fvwwwl18rg";
-      name = "konsole-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/konsole-18.12.3.tar.xz";
+      sha256 = "01ff3245d755a6e38207e58e50e5f82e5c681ead2ad7176d46aec00a8a562e08";
+      name = "konsole-18.12.3.tar.xz";
     };
   };
   kontact = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kontact-18.12.1.tar.xz";
-      sha256 = "0bqn9vh75wpkks1l9hd2bm33k1im356x2091xlnnzs70m4gjxhag";
-      name = "kontact-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kontact-18.12.3.tar.xz";
+      sha256 = "81426545a958d6d71210040f5ede6407048a16d320ea90c405318cdd7e8e9315";
+      name = "kontact-18.12.3.tar.xz";
     };
   };
   kontactinterface = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kontactinterface-18.12.1.tar.xz";
-      sha256 = "0khba3wnpwji4mm5n56bcnffd1v9w4a1b1r7lhlz88dqkakqyb61";
-      name = "kontactinterface-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kontactinterface-18.12.3.tar.xz";
+      sha256 = "4895e884c93ebff36a721f5161386105e729925dbbbf6fafb94c75ba4b291e41";
+      name = "kontactinterface-18.12.3.tar.xz";
     };
   };
   kopete = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kopete-18.12.1.tar.xz";
-      sha256 = "12q62nj287qc4gz8q66spk1d0xykrwkphwaxrh2i3sd07bjmyzqs";
-      name = "kopete-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kopete-18.12.3.tar.xz";
+      sha256 = "8ca7a41e39be23ca6802deade7b5edb88b7e3000bc8e6fb2f68efbc15c2c8d3b";
+      name = "kopete-18.12.3.tar.xz";
     };
   };
   korganizer = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/korganizer-18.12.1.tar.xz";
-      sha256 = "1g8wjrghzxgx9xhqf98z9xlq5svl2v931ifczsfkvs9d3smx2zsg";
-      name = "korganizer-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/korganizer-18.12.3.tar.xz";
+      sha256 = "6a63e60b60af6cb95c78382da15e9e3cf04f936689ce12b62fe38968fad75a9c";
+      name = "korganizer-18.12.3.tar.xz";
     };
   };
   kpat = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kpat-18.12.1.tar.xz";
-      sha256 = "1ami2bssnjm01k3i6bqqciszablkw6975hac2d8zzvg2bz8g4a2a";
-      name = "kpat-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kpat-18.12.3.tar.xz";
+      sha256 = "62c31d6f7a9bb49c09725722bea472811d897b149e29558ca6e248b5d2a41377";
+      name = "kpat-18.12.3.tar.xz";
     };
   };
   kpimtextedit = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kpimtextedit-18.12.1.tar.xz";
-      sha256 = "13ki9gjgakyqcxx4hvs0plqgw0rqx0z95dnyaqv1safqkwrr76hb";
-      name = "kpimtextedit-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kpimtextedit-18.12.3.tar.xz";
+      sha256 = "54586fc97eb863eaa57e589d4461dd9cfbc4d12e58425afadcd22d64ba8a570d";
+      name = "kpimtextedit-18.12.3.tar.xz";
     };
   };
   kpkpass = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kpkpass-18.12.1.tar.xz";
-      sha256 = "1sw3gpvai71lliq4y1snxrhzi9jhl1vxkimlxl2nmhg951nzd4xx";
-      name = "kpkpass-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kpkpass-18.12.3.tar.xz";
+      sha256 = "cd70809ab7a052e0ca2a18266ec5564bde16ac917988798290e3f01e428bd84f";
+      name = "kpkpass-18.12.3.tar.xz";
     };
   };
   kqtquickcharts = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kqtquickcharts-18.12.1.tar.xz";
-      sha256 = "0i8qww267q797pxk3k66d09b0dp7ixbxf92p5bsqf7z4p2graayl";
-      name = "kqtquickcharts-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kqtquickcharts-18.12.3.tar.xz";
+      sha256 = "739859dc261856cf253ac67e2273b20dee476735b4107ece991d7146d45c1bbe";
+      name = "kqtquickcharts-18.12.3.tar.xz";
     };
   };
   krdc = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/krdc-18.12.1.tar.xz";
-      sha256 = "1smdav92rfr92mxk8q7wcmmvrf746vn2xyw36hyszq561ycgwwrx";
-      name = "krdc-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/krdc-18.12.3.tar.xz";
+      sha256 = "c01896b73ab058a20f4c3d8997c28cbb81a7000f5aec346592a9315412c10666";
+      name = "krdc-18.12.3.tar.xz";
     };
   };
   kreversi = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kreversi-18.12.1.tar.xz";
-      sha256 = "171w76xv9dbhy7pxs9swq7xknrwkjk5ndgq4waj6m5dh0109qmx4";
-      name = "kreversi-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kreversi-18.12.3.tar.xz";
+      sha256 = "818ef2ded02caacf2ccf3c012e992070c3b898db319682e8a42cf5726d56b3fc";
+      name = "kreversi-18.12.3.tar.xz";
     };
   };
   krfb = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/krfb-18.12.1.tar.xz";
-      sha256 = "0bhhlp4ask2xqzq9igw0akxr0gb0iilaljwqrcw91fx36sxq46p4";
-      name = "krfb-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/krfb-18.12.3.tar.xz";
+      sha256 = "9596adfe7135930c6c9c8ecd05035e401d80a5e2cd532ba343b7d4c0f57a799b";
+      name = "krfb-18.12.3.tar.xz";
     };
   };
   kross-interpreters = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kross-interpreters-18.12.1.tar.xz";
-      sha256 = "0k57qprmpspp9b8vb124h1whgyskmwd6q7l60vswqizc64xa2src";
-      name = "kross-interpreters-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kross-interpreters-18.12.3.tar.xz";
+      sha256 = "ce2231b2faa9accc6342a37024651b988eefbcb9b3968025ffa4752d0cbdc70c";
+      name = "kross-interpreters-18.12.3.tar.xz";
     };
   };
   kruler = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kruler-18.12.1.tar.xz";
-      sha256 = "1wfxapw6grx860wa6fyya8fnvlrpmdzsz64fnx64h0mky09j21r6";
-      name = "kruler-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kruler-18.12.3.tar.xz";
+      sha256 = "1b347c552648caca99364a0524945d0849cd84b29e4d07f62ee518ec07a98e33";
+      name = "kruler-18.12.3.tar.xz";
     };
   };
   kshisen = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kshisen-18.12.1.tar.xz";
-      sha256 = "0wz4jfrqqvzz2p5f6hwyj7rpijsnhbzmm2m7jhjrljjl5lfdqd3x";
-      name = "kshisen-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kshisen-18.12.3.tar.xz";
+      sha256 = "00c5de16c335262287bab37b07822b6fd2997abcec25a0ad0a7d1ece6769060f";
+      name = "kshisen-18.12.3.tar.xz";
     };
   };
   ksirk = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/ksirk-18.12.1.tar.xz";
-      sha256 = "108bw284jsff3qgg98vzs93m6dl8wjfkmbrkjgij03w00jb47bqf";
-      name = "ksirk-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/ksirk-18.12.3.tar.xz";
+      sha256 = "cb8f3cc98fe861b0f4ebff77aeeffa12905b98b6db0c8800525f4fb052be4e7a";
+      name = "ksirk-18.12.3.tar.xz";
     };
   };
   ksmtp = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/ksmtp-18.12.1.tar.xz";
-      sha256 = "0zj4gpfz2njrdnfbjy7s9xci0il7qmmzargkszgj9jdzpm5qlaas";
-      name = "ksmtp-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/ksmtp-18.12.3.tar.xz";
+      sha256 = "90578b1b3ac1ce14bf4f34799b1b400b06734c72f3fecd41f5f07aed37ed3b74";
+      name = "ksmtp-18.12.3.tar.xz";
     };
   };
   ksnakeduel = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/ksnakeduel-18.12.1.tar.xz";
-      sha256 = "1l0gfh5vfcfnk3sdl8wsqbc2vcmsdf9frpngfacv4ndm4xc371ql";
-      name = "ksnakeduel-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/ksnakeduel-18.12.3.tar.xz";
+      sha256 = "5d55e4c11baecbd77b94dd004b490a7f73870a383e0bf3ad0381f22d36a27a36";
+      name = "ksnakeduel-18.12.3.tar.xz";
     };
   };
   kspaceduel = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kspaceduel-18.12.1.tar.xz";
-      sha256 = "01pcnqpzbrnwxavmfpdib78kc44am9in711012j2621cccx2r9cw";
-      name = "kspaceduel-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kspaceduel-18.12.3.tar.xz";
+      sha256 = "f40d0a7c578f461875efaf9e25d2b061486a21f750ce8bc922db4aed6fed1f11";
+      name = "kspaceduel-18.12.3.tar.xz";
     };
   };
   ksquares = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/ksquares-18.12.1.tar.xz";
-      sha256 = "1gyd7qipp821jzn94yrw4b0d46ays0hs26q17hxnbx07hyfj3kcb";
-      name = "ksquares-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/ksquares-18.12.3.tar.xz";
+      sha256 = "82a90b7fe5ca8e46950a0de1742783c522fcd85bbc3aabe5955834865bc36b7d";
+      name = "ksquares-18.12.3.tar.xz";
     };
   };
   ksudoku = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/ksudoku-18.12.1.tar.xz";
-      sha256 = "1cm5r4fkc7ha0c3mbcank9h2fhym7qc8k1q69lpmzrbm9hw2kgrs";
-      name = "ksudoku-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/ksudoku-18.12.3.tar.xz";
+      sha256 = "4a44248f2bde9c66c911fe7ed7bd54e31956053dac18e29217a355ad2b3a05e1";
+      name = "ksudoku-18.12.3.tar.xz";
     };
   };
   ksystemlog = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/ksystemlog-18.12.1.tar.xz";
-      sha256 = "1s5b4j67q6nm7r4b1ibvypsd5z9la7cri7z1r7hzihv4nry8pk5c";
-      name = "ksystemlog-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/ksystemlog-18.12.3.tar.xz";
+      sha256 = "93f276698b74af654f3ed147d5c025162bd919ec6c79a7c7dd7678051c307e52";
+      name = "ksystemlog-18.12.3.tar.xz";
     };
   };
   kteatime = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kteatime-18.12.1.tar.xz";
-      sha256 = "01p4d61d16k2pppf51sz52y0w4qc1dyqnmhjlnr5w75rfmwvvivg";
-      name = "kteatime-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kteatime-18.12.3.tar.xz";
+      sha256 = "24b3e51edc9d6625ca5b3542bd5edd1d42d79142f2c30f886e1b9515dcdfac6d";
+      name = "kteatime-18.12.3.tar.xz";
     };
   };
   ktimer = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/ktimer-18.12.1.tar.xz";
-      sha256 = "0wqkfvbdcnwh1jzn2ac7k4pa8amr51ajhljc95mvps03m9d92rsf";
-      name = "ktimer-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/ktimer-18.12.3.tar.xz";
+      sha256 = "b3808fa9821c3a624b880b9a5607c8e12287cd38418ff06dd9af8345f324fe7e";
+      name = "ktimer-18.12.3.tar.xz";
     };
   };
   ktnef = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/ktnef-18.12.1.tar.xz";
-      sha256 = "0id7hkmgr5zc12zfrj5ydxyhgdrlx4ip1dsw301i27id104fqb69";
-      name = "ktnef-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/ktnef-18.12.3.tar.xz";
+      sha256 = "7633f86514d01a1e3709f6854b3b9c859fa1905043bb53240c1ae53f3b76a6ec";
+      name = "ktnef-18.12.3.tar.xz";
     };
   };
   ktouch = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/ktouch-18.12.1.tar.xz";
-      sha256 = "0v3lhxx45l41bw14wi7n4k29d1c9xmacrscjyj84fmy09nlyyaa5";
-      name = "ktouch-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/ktouch-18.12.3.tar.xz";
+      sha256 = "194f308a114c89873ee88eb069ecda88d5d1e1ad97c150e2d61cf248719b4bb6";
+      name = "ktouch-18.12.3.tar.xz";
     };
   };
   ktp-accounts-kcm = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/ktp-accounts-kcm-18.12.1.tar.xz";
-      sha256 = "1aswmp7504kpwlb37rvxx514ac5256h5lhwj9xl479vyxgaazxsn";
-      name = "ktp-accounts-kcm-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/ktp-accounts-kcm-18.12.3.tar.xz";
+      sha256 = "ab6ab0f6cb438ec68b110158f7c6555572f04ad69da04f5e1d144cfc4a8ee8cb";
+      name = "ktp-accounts-kcm-18.12.3.tar.xz";
     };
   };
   ktp-approver = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/ktp-approver-18.12.1.tar.xz";
-      sha256 = "1jr5kxlj2229rknxhi5jsgdjgx9n0n5jx7lc4aa2c96kd843n2ah";
-      name = "ktp-approver-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/ktp-approver-18.12.3.tar.xz";
+      sha256 = "0616fcad79fdeae5f2a58b167419f1745e94cea21950faa535e7b5a6c2e53cf6";
+      name = "ktp-approver-18.12.3.tar.xz";
     };
   };
   ktp-auth-handler = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/ktp-auth-handler-18.12.1.tar.xz";
-      sha256 = "1fwcibz8dh94xaprpyybn0dlh1fyd6rsx9zsx8cyxqhx96fq8v28";
-      name = "ktp-auth-handler-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/ktp-auth-handler-18.12.3.tar.xz";
+      sha256 = "91d6e0148c9006117bc67969012f7a12405e186fc8ffd4011732dc3e7c16a4be";
+      name = "ktp-auth-handler-18.12.3.tar.xz";
     };
   };
   ktp-call-ui = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/ktp-call-ui-18.12.1.tar.xz";
-      sha256 = "1f63w374d9smz7147lax9zqfvikqhl2hllvnlb03zl49kh13s8h3";
-      name = "ktp-call-ui-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/ktp-call-ui-18.12.3.tar.xz";
+      sha256 = "3558b9ef7a2a000f6b49454c4477dcd9700168a1f2c060267b24c78725097571";
+      name = "ktp-call-ui-18.12.3.tar.xz";
     };
   };
   ktp-common-internals = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/ktp-common-internals-18.12.1.tar.xz";
-      sha256 = "1frnzsql9mk78bjfc2kpwmsf8nkx1ybhm1snq125kkzayqipvdkp";
-      name = "ktp-common-internals-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/ktp-common-internals-18.12.3.tar.xz";
+      sha256 = "3913a515d98f74940e0db6b85fc5c6c128c68cffb427c93164052be437634740";
+      name = "ktp-common-internals-18.12.3.tar.xz";
     };
   };
   ktp-contact-list = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/ktp-contact-list-18.12.1.tar.xz";
-      sha256 = "13aiy156372qapwddr2i3nf1jkzbj9905rvd55akwpa8sy70m3kw";
-      name = "ktp-contact-list-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/ktp-contact-list-18.12.3.tar.xz";
+      sha256 = "8f858371ec3760bc042dbf6f022ba834ca5b9ae43997e67bf395978df603d0c1";
+      name = "ktp-contact-list-18.12.3.tar.xz";
     };
   };
   ktp-contact-runner = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/ktp-contact-runner-18.12.1.tar.xz";
-      sha256 = "1grpgg3fgyzf97n60jmpjgviz5194awmrl6yfaal7hd1cdkfrs34";
-      name = "ktp-contact-runner-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/ktp-contact-runner-18.12.3.tar.xz";
+      sha256 = "886d561952ac1a8a5fa50ffdff8699358480d18d58cbaec217ed865d2047f0a9";
+      name = "ktp-contact-runner-18.12.3.tar.xz";
     };
   };
   ktp-desktop-applets = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/ktp-desktop-applets-18.12.1.tar.xz";
-      sha256 = "0iikcp7rvvrn7189kdzj1i4qzhkgh06gzr8hm49gy29qxqk36ykn";
-      name = "ktp-desktop-applets-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/ktp-desktop-applets-18.12.3.tar.xz";
+      sha256 = "439dca1046beba0d2579918f2e409e6629e5063da6eeb1001bcd65ff3edb32c4";
+      name = "ktp-desktop-applets-18.12.3.tar.xz";
     };
   };
   ktp-filetransfer-handler = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/ktp-filetransfer-handler-18.12.1.tar.xz";
-      sha256 = "04dnh7yb0jajs79xh1wyq9d48nklvldc7lnk1lp194iz8yydvylx";
-      name = "ktp-filetransfer-handler-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/ktp-filetransfer-handler-18.12.3.tar.xz";
+      sha256 = "898c7f4ffc8d8bec691cc9744fb356722cf7957f39d2d855138492b647542231";
+      name = "ktp-filetransfer-handler-18.12.3.tar.xz";
     };
   };
   ktp-kded-module = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/ktp-kded-module-18.12.1.tar.xz";
-      sha256 = "0kmw8pifb4xry3zqpq671rh39ziaka8zx60p5xzs10rl17rmxwzs";
-      name = "ktp-kded-module-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/ktp-kded-module-18.12.3.tar.xz";
+      sha256 = "ebbd02a1441caf8e9ced851c8f814255ac4b9e75485a4bc59026f647d3fd4854";
+      name = "ktp-kded-module-18.12.3.tar.xz";
     };
   };
   ktp-send-file = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/ktp-send-file-18.12.1.tar.xz";
-      sha256 = "01i059vsaydw410sv15vzwysgxcy2n9wm3qcnal4fx7wgw5xx163";
-      name = "ktp-send-file-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/ktp-send-file-18.12.3.tar.xz";
+      sha256 = "0015551c42d66f14ae508eee76f138584bbec3b77a4aff4a003255b52d8414f2";
+      name = "ktp-send-file-18.12.3.tar.xz";
     };
   };
   ktp-text-ui = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/ktp-text-ui-18.12.1.tar.xz";
-      sha256 = "14smhdcvy0v1s1rbkss1g6jyzfm6y1nqjp8a9wcbygbzh88g0bjy";
-      name = "ktp-text-ui-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/ktp-text-ui-18.12.3.tar.xz";
+      sha256 = "6a37a26b0b226d5d30b298a4d6d85f8dcfe9f39cbc35e1b6322651678815a34e";
+      name = "ktp-text-ui-18.12.3.tar.xz";
     };
   };
   ktuberling = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/ktuberling-18.12.1.tar.xz";
-      sha256 = "0h0w2knfs97bzxaja3dkc78fjfymic09b6zid41kxd4mi41lngkk";
-      name = "ktuberling-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/ktuberling-18.12.3.tar.xz";
+      sha256 = "b69815f3553f843c30ab9d026ca7da97e62e66b58851111d1e4d29e57d67bd04";
+      name = "ktuberling-18.12.3.tar.xz";
     };
   };
   kturtle = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kturtle-18.12.1.tar.xz";
-      sha256 = "0b2505gmys2p11ryj7bqr60zgh0ydp16xidhkv6hhykmrmp2bsm1";
-      name = "kturtle-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kturtle-18.12.3.tar.xz";
+      sha256 = "4677335b4f8a3e363425652815d19ae13e9f8942b01051553b485100c4996253";
+      name = "kturtle-18.12.3.tar.xz";
     };
   };
   kubrick = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kubrick-18.12.1.tar.xz";
-      sha256 = "0vq8djk5xc00cz4a2inbw62x9pigxxjcxi92h8qayigi7cf9xrll";
-      name = "kubrick-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kubrick-18.12.3.tar.xz";
+      sha256 = "0deb9022a028a6c068203e5bf20820b5561c92b5117735e8a58f212c2ba460e3";
+      name = "kubrick-18.12.3.tar.xz";
     };
   };
   kwalletmanager = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kwalletmanager-18.12.1.tar.xz";
-      sha256 = "1d3kdxc53n2ss73r9ld6rr5w9zhvkglrcbw8whq2hsam79mh0vsn";
-      name = "kwalletmanager-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kwalletmanager-18.12.3.tar.xz";
+      sha256 = "78232285c08241dc06cd6da88dcdce0d850417dd73f0d07034ec6d9a6f97f478";
+      name = "kwalletmanager-18.12.3.tar.xz";
     };
   };
   kwave = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kwave-18.12.1.tar.xz";
-      sha256 = "150lqffzzyb2ajyg97sprzbm6zq1iq4psl6vics51lw7sybwj4m3";
-      name = "kwave-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kwave-18.12.3.tar.xz";
+      sha256 = "4ca9a15ecd06b96e013855f8109b52fcd4a848652438b2e7a2f55a8fcb1d1c48";
+      name = "kwave-18.12.3.tar.xz";
     };
   };
   kwordquiz = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/kwordquiz-18.12.1.tar.xz";
-      sha256 = "1da9jjdk2avdmdm16s63h0hk5swml37afwdnsd777ilj2x8a5ndf";
-      name = "kwordquiz-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/kwordquiz-18.12.3.tar.xz";
+      sha256 = "e609d6b7f93abe0ca7ba844c51dff8d89d435daa9d0a6be68e789b70370459cc";
+      name = "kwordquiz-18.12.3.tar.xz";
     };
   };
   libgravatar = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/libgravatar-18.12.1.tar.xz";
-      sha256 = "1a7b46zqv5m7c9arfmcxhrcnrkcligz3ryygxv801zfa7277l8j6";
-      name = "libgravatar-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/libgravatar-18.12.3.tar.xz";
+      sha256 = "c44c139fbaffda352f0fe461065622cff65b6f1cc13cee8a0137acb27de143ee";
+      name = "libgravatar-18.12.3.tar.xz";
     };
   };
   libkcddb = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/libkcddb-18.12.1.tar.xz";
-      sha256 = "1k9rbkf12g1hsn23nyhc65zrppkikk8xplm7l321kxpnq2prm155";
-      name = "libkcddb-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/libkcddb-18.12.3.tar.xz";
+      sha256 = "38bffd551b82628a25b46bd598c257927855b77c6b6b73a9b69ac7bf538afc29";
+      name = "libkcddb-18.12.3.tar.xz";
     };
   };
   libkcompactdisc = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/libkcompactdisc-18.12.1.tar.xz";
-      sha256 = "0v7fh9s9qbljgfjyi3bd9w7wp69y4qjg0jj8cmn11snrsd8zzaac";
-      name = "libkcompactdisc-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/libkcompactdisc-18.12.3.tar.xz";
+      sha256 = "a464ebfdd1a2834c2597e7ffd1b0d946ddfda348eea5ac8d1d42b46d6c478926";
+      name = "libkcompactdisc-18.12.3.tar.xz";
     };
   };
   libkdcraw = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/libkdcraw-18.12.1.tar.xz";
-      sha256 = "1g58cpzqzl6vl62lbrqd8fyscxspqypxq4lyj3d2k9b0b66hjc6c";
-      name = "libkdcraw-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/libkdcraw-18.12.3.tar.xz";
+      sha256 = "c4b6541419b2ebee15d24744d10e67c9a137e616766e765c13e5056c2a37ef99";
+      name = "libkdcraw-18.12.3.tar.xz";
     };
   };
   libkdegames = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/libkdegames-18.12.1.tar.xz";
-      sha256 = "0iksk5gnl860xcmpaj56wxaamhm9zhjnyszj4nssppssn8kr1r65";
-      name = "libkdegames-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/libkdegames-18.12.3.tar.xz";
+      sha256 = "7c833fe476043f0492a09a52af60ee7652805cccbbb72e5f473a9d35abff9ed9";
+      name = "libkdegames-18.12.3.tar.xz";
     };
   };
   libkdepim = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/libkdepim-18.12.1.tar.xz";
-      sha256 = "1qvzj68p630mzafwyv7f3q1fd615yca7amc0q7kp2cs08fnv67fp";
-      name = "libkdepim-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/libkdepim-18.12.3.tar.xz";
+      sha256 = "1c53148dd9f477b1ca2ea622b25100eab95531115e9798264d3e65d28183e640";
+      name = "libkdepim-18.12.3.tar.xz";
     };
   };
   libkeduvocdocument = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/libkeduvocdocument-18.12.1.tar.xz";
-      sha256 = "0zgl0dw8sb5lffzv580nql04i0n31ma8569wrhh75kg12qb5yd7w";
-      name = "libkeduvocdocument-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/libkeduvocdocument-18.12.3.tar.xz";
+      sha256 = "907076104f445f22fa31c2fa5ecfdabbb8b18faab52fc10c879a53d6245aaad4";
+      name = "libkeduvocdocument-18.12.3.tar.xz";
     };
   };
   libkexiv2 = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/libkexiv2-18.12.1.tar.xz";
-      sha256 = "1jgk14dgf30czsah0mjrs7lsll0s4aks2075pfmvrnsl71vfbsj3";
-      name = "libkexiv2-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/libkexiv2-18.12.3.tar.xz";
+      sha256 = "1d14ff63af42ab7e19e2039648a95ea5dc946afbe3e3df52c17ce1618a02ebdc";
+      name = "libkexiv2-18.12.3.tar.xz";
     };
   };
   libkgapi = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/libkgapi-18.12.1.tar.xz";
-      sha256 = "1g5mzdw4mrlqhi9zby51m1sgkq1gjmkd7smja287kjf7whdx0sn3";
-      name = "libkgapi-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/libkgapi-18.12.3.tar.xz";
+      sha256 = "de0314fd83d8fa8f88e6a355c4725047d2e507e0d40f1950c8ae083c2bc21924";
+      name = "libkgapi-18.12.3.tar.xz";
     };
   };
   libkgeomap = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/libkgeomap-18.12.1.tar.xz";
-      sha256 = "0ijf71ss8qirrgx45x4wnry049d2bllgnlzm8gll4mj1hv9jhjdz";
-      name = "libkgeomap-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/libkgeomap-18.12.3.tar.xz";
+      sha256 = "2c4459e61e471f0344d03cfa5f00fe2a1890cd2c1501323ceed26d522496c47b";
+      name = "libkgeomap-18.12.3.tar.xz";
     };
   };
   libkipi = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/libkipi-18.12.1.tar.xz";
-      sha256 = "1372kmqni0vb8bryv0h30pljikabjdq44v1fjpgg81f4v1n4pfxv";
-      name = "libkipi-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/libkipi-18.12.3.tar.xz";
+      sha256 = "96abf4552d535cf101c76ff5b1cb0198eccfd4bdfb7dc192b66bf709af037a31";
+      name = "libkipi-18.12.3.tar.xz";
     };
   };
   libkleo = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/libkleo-18.12.1.tar.xz";
-      sha256 = "1p1bw0wzwg2zccgkqs50j92rzkpvcspjdj85zanmryg568mz9r1x";
-      name = "libkleo-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/libkleo-18.12.3.tar.xz";
+      sha256 = "e528ed366352404d48313a8c154f56c672470bf06524ea7a150a726d3eb87d69";
+      name = "libkleo-18.12.3.tar.xz";
     };
   };
   libkmahjongg = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/libkmahjongg-18.12.1.tar.xz";
-      sha256 = "1q590f7l10a1zjcg3dv3ns1003xrnr7zlmff03zg3a9zcqj11kwv";
-      name = "libkmahjongg-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/libkmahjongg-18.12.3.tar.xz";
+      sha256 = "25e5cea50b6c96f18efa8d013ab58abfaac7845edb969b8e63e0c297482a6be4";
+      name = "libkmahjongg-18.12.3.tar.xz";
     };
   };
   libkomparediff2 = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/libkomparediff2-18.12.1.tar.xz";
-      sha256 = "0ik6bclbipp01gfy3zfkijvl5m0y3z2dfxr76jvzmi53ypm7g0xn";
-      name = "libkomparediff2-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/libkomparediff2-18.12.3.tar.xz";
+      sha256 = "f70bf7470f67419a7071a4df23d929c4c4ed80d588b3096d48486ee0f27d890c";
+      name = "libkomparediff2-18.12.3.tar.xz";
     };
   };
   libksane = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/libksane-18.12.1.tar.xz";
-      sha256 = "15dgc5dshs6yzv03wvc5xvqfz70gqy51a0r54qzbr5fc9s6pywr8";
-      name = "libksane-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/libksane-18.12.3.tar.xz";
+      sha256 = "40bf814cebac7ef00dc18fbdeabb2f9fd786c9144d787d5dc36a58fe18c33034";
+      name = "libksane-18.12.3.tar.xz";
     };
   };
   libksieve = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/libksieve-18.12.1.tar.xz";
-      sha256 = "0kcg94bsww3vlc3vpybw20c4iax0bfkamicy7hwyyyzwgx38dvd1";
-      name = "libksieve-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/libksieve-18.12.3.tar.xz";
+      sha256 = "ce18756940d86dff8eafd77883d202ab90e3d8273f5248ffd97627b974211754";
+      name = "libksieve-18.12.3.tar.xz";
     };
   };
   lokalize = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/lokalize-18.12.1.tar.xz";
-      sha256 = "1spzi7zbckvxy3izmcqjnslmqf4vgr7zrwa0idmqi4q59dcsgw9g";
-      name = "lokalize-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/lokalize-18.12.3.tar.xz";
+      sha256 = "cce11b9384d27006855a141d2241a67d05679baa7096db2311c49a78bd642fed";
+      name = "lokalize-18.12.3.tar.xz";
     };
   };
   lskat = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/lskat-18.12.1.tar.xz";
-      sha256 = "0603lxw1fxz9vpawy59z3qga0f1bvvgv9yqk29b16fmp5hf5qgxm";
-      name = "lskat-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/lskat-18.12.3.tar.xz";
+      sha256 = "d81d3af26b9f23abc40f1e2f97410d662c11d4641b67c32d427846a561f0b1e2";
+      name = "lskat-18.12.3.tar.xz";
     };
   };
   mailcommon = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/mailcommon-18.12.1.tar.xz";
-      sha256 = "0l1b115vnxfl2ykwnj09ikv7vlfa5bvfzlii6jj2znkmspi9y7r2";
-      name = "mailcommon-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/mailcommon-18.12.3.tar.xz";
+      sha256 = "789d89fad58af80202dfcc41f7c7435871a60309d1d46f93cabcb37dd6ae97e1";
+      name = "mailcommon-18.12.3.tar.xz";
     };
   };
   mailimporter = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/mailimporter-18.12.1.tar.xz";
-      sha256 = "1k8gqjabcvafcvsqwclvz58r15k1bpz52wnnnbwcp0y27ab08a98";
-      name = "mailimporter-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/mailimporter-18.12.3.tar.xz";
+      sha256 = "1c0e583fa36fc1b87154367cbe02cf1ec68d9f36d8a37bd6b220e9d9aadfcfa3";
+      name = "mailimporter-18.12.3.tar.xz";
     };
   };
   marble = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/marble-18.12.1.tar.xz";
-      sha256 = "0hamj04ma9qycfisjv48myxj1427rz7g0lmw7pwanzghg610fgwy";
-      name = "marble-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/marble-18.12.3.tar.xz";
+      sha256 = "0bfd7ae576e42ebbddadc8c83c2fec5edaf462bcf284642b1002d36d751b24ee";
+      name = "marble-18.12.3.tar.xz";
     };
   };
   mbox-importer = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/mbox-importer-18.12.1.tar.xz";
-      sha256 = "1h2abj7v6v3rmvsv9bb1wj7sabhh9f35bx1yfk2hhfzf6l4r5f2n";
-      name = "mbox-importer-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/mbox-importer-18.12.3.tar.xz";
+      sha256 = "a220ca69dd6f78cf18c3d8cb1bb293dc2ab2ff45f2a25df72cad8df78f581201";
+      name = "mbox-importer-18.12.3.tar.xz";
     };
   };
   messagelib = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/messagelib-18.12.1.tar.xz";
-      sha256 = "1hfk54w0dhp82fxa4q19d4224pjnw5f8m7ap4gwlrqdj350liqd8";
-      name = "messagelib-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/messagelib-18.12.3.tar.xz";
+      sha256 = "0064a8df62a08d0dfb06af28d4aff8a645a0e8bb01d91ab23647b3d26d3af7d8";
+      name = "messagelib-18.12.3.tar.xz";
     };
   };
   minuet = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/minuet-18.12.1.tar.xz";
-      sha256 = "160wq3j7vcf1k0ayd8axg37ghj5ymn56g7znaz4gzc8ar1q5nccz";
-      name = "minuet-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/minuet-18.12.3.tar.xz";
+      sha256 = "9244ec364d031c73f9aed9568012a28b847ec4dceca61040324af7afd3d64009";
+      name = "minuet-18.12.3.tar.xz";
     };
   };
   okular = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/okular-18.12.1.tar.xz";
-      sha256 = "1k1srr2434j665v6m89vl7x42361pqxaw45dc5b4bhw8q2xfipyl";
-      name = "okular-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/okular-18.12.3.tar.xz";
+      sha256 = "d7ef9b59acb5746ebc64399f4c1a99faf0c1530bf6a818b3bfd34b73476d90ab";
+      name = "okular-18.12.3.tar.xz";
     };
   };
   palapeli = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/palapeli-18.12.1.tar.xz";
-      sha256 = "0pwflnnnbfxf185m3r4vdw5jpd5jld0wm0qnwk2gl41v2ahb5pqd";
-      name = "palapeli-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/palapeli-18.12.3.tar.xz";
+      sha256 = "b28fa1cf7a763125a09baa8f4e7562e17892475444d3907e566281328502e593";
+      name = "palapeli-18.12.3.tar.xz";
     };
   };
   parley = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/parley-18.12.1.tar.xz";
-      sha256 = "1yv4m9f4jhc36ffnrxd6rq5117rj163hs6835mkkzja7z13csn6z";
-      name = "parley-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/parley-18.12.3.tar.xz";
+      sha256 = "289bc5aa88d7a33fdf0d668b45412f163d74e86d3deb9492db53a11f7c6a7f75";
+      name = "parley-18.12.3.tar.xz";
     };
   };
   picmi = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/picmi-18.12.1.tar.xz";
-      sha256 = "0dmhvxy0g4jjbxk53bz1g1r8vqdzhzbcwg0f1ck85gz7f5g67b7v";
-      name = "picmi-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/picmi-18.12.3.tar.xz";
+      sha256 = "0691c70d746aa9d444559970e002561a1123963d617b36ceef4a8c3ee4730f49";
+      name = "picmi-18.12.3.tar.xz";
     };
   };
   pimcommon = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/pimcommon-18.12.1.tar.xz";
-      sha256 = "09av3zdr463gjc877ipa5vz84yf4qpj2ixs9x4ajmfmsmb5m6w7z";
-      name = "pimcommon-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/pimcommon-18.12.3.tar.xz";
+      sha256 = "f4a0bf8146d1140c0252a5315baa826651968352a828c004d91b06e0e98c6b9e";
+      name = "pimcommon-18.12.3.tar.xz";
     };
   };
   pim-data-exporter = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/pim-data-exporter-18.12.1.tar.xz";
-      sha256 = "111n4l9z3dazz7qhv67k00s88p515r8ai2sm419pbyfdn6wxpzmb";
-      name = "pim-data-exporter-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/pim-data-exporter-18.12.3.tar.xz";
+      sha256 = "7deb5baf5a36b96f1414e0b67192cd1ad48f396fb3cb5f5eb2fc90a312d74941";
+      name = "pim-data-exporter-18.12.3.tar.xz";
     };
   };
   pim-sieve-editor = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/pim-sieve-editor-18.12.1.tar.xz";
-      sha256 = "0i0jrmz4cyjcpapga89ixfqx7xg0nyk3r75ymfzw891fyhm7ns67";
-      name = "pim-sieve-editor-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/pim-sieve-editor-18.12.3.tar.xz";
+      sha256 = "6e755ec258b0a75e4e83adb82551c1779c2ab7766aef26d2f1c9c00f3809deb5";
+      name = "pim-sieve-editor-18.12.3.tar.xz";
     };
   };
   poxml = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/poxml-18.12.1.tar.xz";
-      sha256 = "0hrpvpsy3mbyrikj68lr2af9m162w3nzhcpdqgrhsv5ji3j0bpqb";
-      name = "poxml-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/poxml-18.12.3.tar.xz";
+      sha256 = "6714e371957d175b859894149a3791acb3b8ef62b653b7b09f34819e92c8eaf7";
+      name = "poxml-18.12.3.tar.xz";
     };
   };
   print-manager = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/print-manager-18.12.1.tar.xz";
-      sha256 = "01kk592gi2rrqwaxmfd1fycnya0rvjafxxv6lrk3rs0nm4g9phxr";
-      name = "print-manager-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/print-manager-18.12.3.tar.xz";
+      sha256 = "917ea500bcd11d2ca3cc1e7de1b38d7ef72f1d397182aaac2c6a31cd338f387d";
+      name = "print-manager-18.12.3.tar.xz";
     };
   };
   rocs = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/rocs-18.12.1.tar.xz";
-      sha256 = "0d34bv8ya5lrdrbqqlc927x4cdfjwyr8q2xbmx4c1vaw8w29glw9";
-      name = "rocs-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/rocs-18.12.3.tar.xz";
+      sha256 = "6b007b0b11a8128787c316f055a99dde83619dd35287e04867949e84661c2b11";
+      name = "rocs-18.12.3.tar.xz";
     };
   };
   signon-kwallet-extension = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/signon-kwallet-extension-18.12.1.tar.xz";
-      sha256 = "018vyzd3rspfsqansxfbv4q0izgj7dfpmzjj04x8pffg1w0x902n";
-      name = "signon-kwallet-extension-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/signon-kwallet-extension-18.12.3.tar.xz";
+      sha256 = "9a6c25cf19a382cbfd219c043838ad691c4c53ae8c3bc9f4b59f9f6f98bd3a4f";
+      name = "signon-kwallet-extension-18.12.3.tar.xz";
     };
   };
   spectacle = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/spectacle-18.12.1.tar.xz";
-      sha256 = "1r9iapwi1lp1p7x0dimblpmsizv1ys9708vdlzrk8q4m8rwn7ld9";
-      name = "spectacle-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/spectacle-18.12.3.tar.xz";
+      sha256 = "8abf85b85de7844c503ef84182303c47cf425f5c14d71e723e3c887ee87ce06e";
+      name = "spectacle-18.12.3.tar.xz";
     };
   };
   step = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/step-18.12.1.tar.xz";
-      sha256 = "1gn8l09r5rllz1mypsw2wfjhijy0i0bi4lspp271dinms6ryx6p4";
-      name = "step-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/step-18.12.3.tar.xz";
+      sha256 = "35abaf0a4597e141f4db08ad91ebcefafe43609b986a93a11e5f3ec19165c755";
+      name = "step-18.12.3.tar.xz";
     };
   };
   svgpart = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/svgpart-18.12.1.tar.xz";
-      sha256 = "06rvbav94ysifha47lp52pvpc77y33p4zq4yfbmyh1pqkiw5db2s";
-      name = "svgpart-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/svgpart-18.12.3.tar.xz";
+      sha256 = "675ab3b652b0d2619abb305ce7c00beb8a80067416e4ea7e216cfa201a7ff8ef";
+      name = "svgpart-18.12.3.tar.xz";
     };
   };
   sweeper = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/sweeper-18.12.1.tar.xz";
-      sha256 = "0bp0my9gf4n5p7v3g0q390lf9q4lh42mg2zngwadqcvrsi2w4av4";
-      name = "sweeper-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/sweeper-18.12.3.tar.xz";
+      sha256 = "8007da0f4d835e376fb049d539ca9fd6840ef7196f25b62cf652374a645fc6e0";
+      name = "sweeper-18.12.3.tar.xz";
     };
   };
   umbrello = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/umbrello-18.12.1.tar.xz";
-      sha256 = "12kk04frx8fxcih22nv5c1765wawlf7wpiscaqmzlmrpa611x65r";
-      name = "umbrello-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/umbrello-18.12.3.tar.xz";
+      sha256 = "2ab53b33cf1fcaea470c01b2421e911d4287b1d0421fa33e0b60043fe6943cc7";
+      name = "umbrello-18.12.3.tar.xz";
     };
   };
   zeroconf-ioslave = {
-    version = "18.12.1";
+    version = "18.12.3";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.1/src/zeroconf-ioslave-18.12.1.tar.xz";
-      sha256 = "1gzr50kqlwd2d47yc2k6yz2v0w2gp10c7glhb61jpdzsqy7r7cvp";
-      name = "zeroconf-ioslave-18.12.1.tar.xz";
+      url = "${mirror}/stable/applications/18.12.3/src/zeroconf-ioslave-18.12.3.tar.xz";
+      sha256 = "b3adcaec0ebd89ddaf839954fb387e59791683d98f93da0c3dacb0266cd02a12";
+      name = "zeroconf-ioslave-18.12.3.tar.xz";
     };
   };
 }

--- a/pkgs/desktops/plasma-5/fetch.sh
+++ b/pkgs/desktops/plasma-5/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/plasma/5.14.5/ -A '*.tar.xz' )
+WGET_ARGS=( https://download.kde.org/stable/plasma/5.14.5/ )

--- a/pkgs/development/libraries/kde-frameworks/fetch.sh
+++ b/pkgs/development/libraries/kde-frameworks/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/frameworks/5.54/ -A '*.tar.xz' )
+WGET_ARGS=( https://download.kde.org/stable/frameworks/5.54/ )

--- a/pkgs/development/libraries/qt-5/5.11/fetch.sh
+++ b/pkgs/development/libraries/qt-5/5.11/fetch.sh
@@ -1,2 +1,1 @@
-WGET_ARGS=( http://download.qt.io/official_releases/qt/5.11/5.11.3/submodules/ \
-            -A '*.tar.xz' )
+WGET_ARGS=( http://download.qt.io/official_releases/qt/5.11/5.11.3/submodules/ )

--- a/pkgs/development/libraries/qt-5/5.12/fetch.sh
+++ b/pkgs/development/libraries/qt-5/5.12/fetch.sh
@@ -1,2 +1,1 @@
-WGET_ARGS=( http://download.qt.io/official_releases/qt/5.12/5.12.0/submodules/ \
-            -A '*.tar.xz' )
+WGET_ARGS=( http://download.qt.io/official_releases/qt/5.12/5.12.0/submodules/ )

--- a/pkgs/development/libraries/qt-5/5.6/fetch.sh
+++ b/pkgs/development/libraries/qt-5/5.6/fetch.sh
@@ -1,3 +1,2 @@
 WGET_ARGS=( http://download.qt.io/official_releases/qt/5.6/5.6.3/submodules/ \
-            http://download.qt.io/community_releases/5.6/5.6.3/ \
-            -A '*.tar.xz' )
+            http://download.qt.io/community_releases/5.6/5.6.3/ )

--- a/pkgs/development/libraries/qt-5/5.9/fetch.sh
+++ b/pkgs/development/libraries/qt-5/5.9/fetch.sh
@@ -1,2 +1,1 @@
-WGET_ARGS=( http://download.qt.io/official_releases/qt/5.9/5.9.7/submodules/ \
-            -A '*.tar.xz' )
+WGET_ARGS=( http://download.qt.io/official_releases/qt/5.9/5.9.7/submodules/ )


### PR DESCRIPTION
###### Motivation for this change
Backporting https://github.com/NixOS/nixpkgs/pull/56155 was mentioned https://github.com/NixOS/nixpkgs/pull/56155#issuecomment-467182759

> @lheckemann 
> Since it's a minor version bump though I suppose we can still backport it to 19.03 after the branch-off.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
