### PR TITLE
cloud-utils: use `qemu-utils` instead of `qemu`

### DIFF
--- a/pkgs/applications/virtualization/qemu/utils.nix
+++ b/pkgs/applications/virtualization/qemu/utils.nix
@@ -1,0 +1,16 @@
+{ stdenv, qemu }:
+
+stdenv.mkDerivation rec {
+  name = "qemu-utils-${version}";
+  version = qemu.version;
+
+  buildInputs = [ qemu ];
+  unpackPhase = "true";
+
+  installPhase = ''
+    mkdir -p "$out/bin"
+    cp "${qemu}/bin/qemu-img" "$out/bin/qemu-img"
+    cp "${qemu}/bin/qemu-io"  "$out/bin/qemu-io"
+    cp "${qemu}/bin/qemu-nbd" "$out/bin/qemu-nbd"
+  '';
+}

--- a/pkgs/tools/misc/cloud-utils/default.nix
+++ b/pkgs/tools/misc/cloud-utils/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, makeWrapper
 , gawk, gnused, utillinux, file
-, wget, python3, qemu, euca2ools
+, wget, python3, qemu-utils, euca2ools
 , e2fsprogs, cdrkit }:
 
 stdenv.mkDerivation rec {
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   # according to https://packages.ubuntu.com/source/zesty/cloud-utils
   binDeps = [
-    wget e2fsprogs file gnused gawk utillinux qemu euca2ools cdrkit
+    wget e2fsprogs file gnused gawk utillinux qemu-utils euca2ools cdrkit
   ];
 
   postFixup = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19128,6 +19128,8 @@ in
     inherit (darwin.stubs) rez setfile;
   };
 
+  qemu-utils = callPackage ../applications/virtualization/qemu/utils.nix {};
+
   qgis-unwrapped = libsForQt5.callPackage ../applications/gis/qgis/unwrapped.nix {
       withGrass = false;
   };


### PR DESCRIPTION
###### Motivation for this change

Related issue: https://github.com/NixOS/nixpkgs/issues/58469

This greatly reduces the size of images that use `cloud-init`.
This seems safe to do per the upstream packaging:
  * https://git.launchpad.net/cloud-utils/tree/debian/control
  * https://packages.debian.org/unstable/qemu-utils


Before/after:
```
595M     /nix/store/nmn798kahfqf47d4j6zfqwvy7m678hd0-digital-ocean-image
331M     /nix/store/kvq58qn9iqgpgr4v3dq9vk5zd05jz2ml-digital-ocean-image
```

I've booted this up, but haven't tested extensively. This should be tested with other images, but ought to be at least somewhat safe based on upstream packaging.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
