### PR TITLE
emacs: only use patchelf on linux

### DIFF
--- a/pkgs/applications/editors/emacs/default.nix
+++ b/pkgs/applications/editors/emacs/default.nix
@@ -123,7 +123,7 @@ stdenv.mkDerivation rec {
     let libPath = lib.makeLibraryPath [
       libXcursor
     ];
-    in lib.optionalString (withX && toolkit == "lucid") ''
+    in lib.optionalString (stdenv.isLinux && withX && toolkit == "lucid") ''
       patchelf --set-rpath \
         "$(patchelf --print-rpath "$out/bin/emacs"):${libPath}" \
         "$out/bin/emacs"


### PR DESCRIPTION
###### Motivation for this change

This prevents building Emacs with X on Darwin.

Broken by 5af6e9f75e89dab40b2ac9cb9b0fe92cc66f1311 (#54916)

Is `stdenv.isLinux` the correct guard for `patchelf`?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
