### PR TITLE
minikube: 0.35.0 -> 1.0.0

### DIFF
--- a/pkgs/applications/networking/cluster/minikube/default.nix
+++ b/pkgs/applications/networking/cluster/minikube/default.nix
@@ -14,9 +14,9 @@ let
 in buildGoPackage rec {
   pname   = "minikube";
   name    = "${pname}-${version}";
-  version = "0.35.0";
+  version = "1.0.0";
 
-  kubernetesVersion = "1.13.4";
+  kubernetesVersion = "1.14.0";
 
   goPackagePath = "k8s.io/minikube";
 
@@ -24,7 +24,7 @@ in buildGoPackage rec {
     owner  = "kubernetes";
     repo   = "minikube";
     rev    = "v${version}";
-    sha256 = "1qb342zs50sdfvfb8vbn7vrx11qqjy1hw518c053s7p34ljb24qd";
+    sha256 = "170iy0h27gkz2hg485rnawdw069gxwgkwsjmfj5yag2kkgl7gxa3";
   };
 
   buildInputs = [ go-bindata makeWrapper gpgme ] ++ stdenv.lib.optional stdenv.hostPlatform.isDarwin vmnet;


### PR DESCRIPTION
###### Motivation for this change

Bump `minikube` to version 1.0.0 :tada: — default version for it is k8s 1.14.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
