### PR TITLE
sahel-fonts: init at v1.0.0-alpha22

### DIFF
--- a/pkgs/data/fonts/sahel-fonts/default.nix
+++ b/pkgs/data/fonts/sahel-fonts/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  name = "sahel-fonts";
+  pname = "sahel-fonts";
   version = "1.0.0-alpha22";
 
   src = fetchFromGitHub {

--- a/pkgs/data/fonts/sahel-fonts/default.nix
+++ b/pkgs/data/fonts/sahel-fonts/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "sahel-fonts";
+  version = "1.0.0-alpha22";
+
+  src = fetchFromGitHub {
+    owner = "rastikerdar";
+    repo = "sahel-font";
+    rev = "v${version}";
+    sha256 = "1kx7byzb5zxspq0i4cvgf4q7sm6xnhdnfyw9zrb1wfmdv3jzaz7p";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/sahel-fonts
+    cp -v $( find . -name '*.ttf') $out/share/fonts/sahel-fonts
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/rastikerdar/sahel-font;
+    description = "A Persian (farsi) Font - فونت (قلم) فارسی ساحل";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = [ maintainers.linarcx ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5420,6 +5420,8 @@ in
 
   safeeyes = callPackage ../applications/misc/safeeyes { };
 
+  sahel-fonts = callPackage ../data/fonts/sahel-fonts { };
+
   salt = callPackage ../tools/admin/salt {};
 
   salut_a_toi = callPackage ../applications/networking/instant-messengers/salut-a-toi {};
@@ -21656,7 +21658,7 @@ in
   igv = callPackage ../applications/science/biology/igv { };
 
   inormalize = callPackage ../applications/science/biology/inormalize { };
-  
+
   itsx = callPackage ../applications/science/biology/itsx { };
 
   iv = callPackage ../applications/science/biology/iv {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
