### PR TITLE
cudnn_cudatoolkit_10: 7.3.1 -> 7.4.2

### DIFF
--- a/pkgs/development/libraries/science/math/cudnn/default.nix
+++ b/pkgs/development/libraries/science/math/cudnn/default.nix
@@ -59,10 +59,10 @@ in rec {
   cudnn_cudatoolkit_9 = cudnn_cudatoolkit_9_2;
 
   cudnn_cudatoolkit_10_0 = generic rec {
-    version = "7.3.1";
+    version = "7.4.2";
     cudatoolkit = cudatoolkit_10_0;
-    srcName = "cudnn-${cudatoolkit.majorVersion}-linux-x64-v7.3.1.20.tgz";
-    sha256 = "1yp35mng4ym40g5rqp63dcpa6jg4q1pnjkspnhlakzzdy8is65af";
+    srcName = "cudnn-${cudatoolkit.majorVersion}-linux-x64-v7.4.2.24.tgz";
+    sha256 = "18ys0apiz9afid2s6lvy9qbyi8g66aimb2a7ikl1f3dm09mciprf";
   };
 
   cudnn_cudatoolkit_10 = cudnn_cudatoolkit_10_0;


### PR DESCRIPTION
###### Motivation for this change

Update cudnn.

```
[nix-shell:/etc/nixos/nixpkgs]$ nix-review rev e29e315c5f92aa4d1544f231fc3750da52eb63f8
$ git fetch --force https://github.com/NixOS/nixpkgs master:refs/nix-review/0
$ git worktree add /home/lulu/.cache/nix-review/rev-e29e315c5f92aa4d1544f231fc3750da52eb63f8/nixpkgs 6670b4c37d4acfd4c2149fd60356d2d88c3ae4ef
Preparing worktree (detached HEAD 6670b4c37d4)
HEAD is now at 6670b4c37d4 Merge pull request #58419 from flokli/ldap-nslcd-startup
$ nix-env -f /home/lulu/.cache/nix-review/rev-e29e315c5f92aa4d1544f231fc3750da52eb63f8/nixpkgs -qaP --xml --out-path --show-trace
$ git merge --no-commit e29e315c5f92aa4d1544f231fc3750da52eb63f8
Updating 6670b4c37d4..e29e315c5f9
Fast-forward
 pkgs/development/libraries/science/math/cudnn/default.nix | 6 +++---
 1 file changed, 3 insertions(+), 3 deletions(-)
$ nix-env -f /home/lulu/.cache/nix-review/rev-e29e315c5f92aa4d1544f231fc3750da52eb63f8/nixpkgs -qaP --xml --out-path --show-trace --meta
$ nix build --no-link --keep-going --max-jobs 32 --option build-use-sandbox true -f /home/lulu/.cache/nix-review/rev-e29e315c5f92aa4d1544f231fc3750da52eb63f8/build.nix
[6 built, 30 copied (251.6 MiB), 91.7 MiB DL]
3 package were build:
cudnn_cudatoolkit_10 python27Packages.tensorflowWithCuda python37Packages.tensorflowWithCuda
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
