### PR TITLE
[18.09] dovecot: add patch for CVE-2019-7524

### DIFF
--- a/pkgs/servers/mail/dovecot/default.nix
+++ b/pkgs/servers/mail/dovecot/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, perl, pkgconfig, systemd, openssl
+{ stdenv, lib, fetchurl, fetchpatch, perl, pkgconfig, systemd, openssl
 , bzip2, zlib, lz4, inotify-tools, pam, libcap
 , clucene_core_2, icu, openldap, libsodium, libstemmer
 # Auth modules
@@ -47,6 +47,12 @@ stdenv.mkDerivation rec {
     # so we can symlink plugins from several packages there.
     # The symlinking needs to be done in NixOS.
     ./2.2.x-module_dir.patch
+
+    (fetchpatch {
+      name = "CVE-2019-7524.patch";
+      url = https://github.com/dovecot/core/compare/578cf77e84b3d25e2f95f08133a2b0b212aa77cc~1..696320b0f3644e928a9d0c71c063f603c3792dbb.patch;
+      sha256 = "101d757gid0dn3mxqqpa59igkgkq7bwffsklh3nimaav0v2zb018";
+    })
   ];
 
   configureFlags = [


### PR DESCRIPTION
###### Motivation for this change
This applies commits
https://github.com/dovecot/core/commit/578cf77e84b3d25e2f95f08133a2b0b212aa77cc
https://github.com/dovecot/core/commit/696320b0f3644e928a9d0c71c063f603c3792dbb

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @peti 