### PR TITLE
nixos/mailcatcher: fix test to be compatible with mailcatcher 7.x series

### DIFF
--- a/nixos/tests/mailcatcher.nix
+++ b/nixos/tests/mailcatcher.nix
@@ -21,6 +21,6 @@ import ./make-test.nix ({ lib, ... }:
     $machine->waitForUnit('mailcatcher.service');
     $machine->waitForOpenPort('1025');
     $machine->succeed('echo "this is the body of the email" | mail -s "subject" root@example.org');
-    $machine->succeed('curl http://localhost:1080/messages/1.json') =~ /this is the body of the email/ or die;
+    $machine->succeed('curl http://localhost:1080/messages/1.source') =~ /this is the body of the email/ or die;
   '';
 })


### PR DESCRIPTION
###### Motivation for this change
Fix test to be compatible with mailcatcher 7.x series

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
