### PR TITLE
scrcpy: 1.5 -> 1.8

### DIFF
--- a/pkgs/misc/scrcpy/default.nix
+++ b/pkgs/misc/scrcpy/default.nix
@@ -9,33 +9,30 @@
 }:
 
 let
-  version = "1.5";
+  version = "1.8";
   prebuilt_server = fetchurl {
-    url = "https://github.com/Genymobile/scrcpy/releases/download/v${version}-fixversion/scrcpy-server-v${version}.jar";
-    sha256 = "1pi47khfrs9pygs32l9rj8l927z0sdm8bhkrzzkk6ki9c1psnynr";
+    url = "https://github.com/Genymobile/scrcpy/releases/download/v${version}/scrcpy-server-v${version}.jar";
+    sha256 = "1h755k5xpchlm7wq2yk5mlwjnh7y4yhviffixacby0srj3pmb443";
   };
 in
 stdenv.mkDerivation rec {
-  name = "scrcpy-${version}";
+  pname = "scrcpy";
   inherit version;
+
   src = fetchFromGitHub {
     owner = "Genymobile";
-    repo = "scrcpy";
-    rev = "v${version}-fixversion";
-    sha256 = "0magmc44pahw1f4jhzkhjlfc31mk3qq43hzn9513idcl4kh4sb8i";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1cx7y3w699s3i8s53l1mb7lkrnbix457hf17liwh00jzb0i7aga7";
   };
 
   # postPatch:
   #   screen.c: When run without a hardware accelerator, this allows the command to continue working rather than failing unexpectedly.
   #   This can happen when running on non-NixOS because then scrcpy seems to have a hard time using the host OpenGL-supporting hardware.
   #   It would be better to fix the OpenGL problem, but that seems much more intrusive.
-  #
-  #   command.c: When copying over the prebuilt binary to mobile, it also copies the permissions of the nix store, and thus it cannot delete normally.
   postPatch = ''
     substituteInPlace app/src/screen.c \
       --replace "SDL_RENDERER_ACCELERATED" "SDL_RENDERER_ACCELERATED || SDL_RENDERER_SOFTWARE"
-    substituteInPlace app/src/command.c \
-      --replace 'const char *const adb_cmd[] = {"shell", "rm", path};' 'const char *const adb_cmd[] = {"shell", "rm", "-f", path};'
   '';
 
   nativeBuildInputs = [ makeWrapper meson ninja pkgconfig ];


### PR DESCRIPTION
[changes](https://github.com/Genymobile/scrcpy/releases)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @deltaevo @lukeadams @tomberek