### PR TITLE
sublime3: Fix python api locale

### DIFF
--- a/pkgs/applications/editors/sublime/3/common.nix
+++ b/pkgs/applications/editors/sublime/3/common.nix
@@ -1,6 +1,6 @@
 {buildVersion, x32sha256, x64sha256, dev ? false}:
 
-{ fetchurl, stdenv, glib, xorg, cairo, gtk2, gtk3, pango, makeWrapper, wrapGAppsHook, openssl, bzip2, runtimeShell,
+{ fetchurl, stdenv, glib, glibcLocales, xorg, cairo, gtk2, gtk3, pango, makeWrapper, wrapGAppsHook, openssl, bzip2, runtimeShell,
   pkexecPath ? "/run/wrappers/bin/pkexec", libredirect,
   gksuSupport ? false, gksu, unzip, zip, bash,
   writeScript, common-updater-scripts, curl, gnugrep}:
@@ -99,6 +99,7 @@ in let
       wrapProgram $out/sublime_text \
         --set LD_PRELOAD "${libredirect}/lib/libredirect.so" \
         --set NIX_REDIRECTS ${builtins.concatStringsSep ":" redirects} \
+        --set LOCALE_ARCHIVE "${glibcLocales.out}/lib/locale/locale-archive" \
         ${stdenv.lib.optionalString (!legacy) ''"''${gappsWrapperArgs[@]}"''}
 
       # Without this, plugin_host crashes, even though it has the rpath


### PR DESCRIPTION
###### Motivation for this change
With Nix on CentOS 6, I installed sublime3, but after installing Package Control in sublime, I get shown an error saying:

> Your system's locale is set to a value that can not handle non-ASCII characters. Package Control can not properly work unless this is fixed.
> 
> On Linux, please reference your distribution's docs for information on properly setting the LANG and LC_CTYPE environmental variables. As a temporary work-around, you can launch Sublime Text from the terminal with:
> 
> LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 sublime_text
> 

but my system locale is already en_US.UTF-8.

This change solves the problem.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
   - *sandboxing messed up on CentOS 6*
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
   - *only tested sublime_text*
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
