### PR TITLE
nika-fonts: init at 1.0.0

### DIFF
--- a/pkgs/data/fonts/nika-fonts/default.nix
+++ b/pkgs/data/fonts/nika-fonts/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "nika-fonts";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "font-store";
+    repo = "NikaFont";
+    rev = "v${version}";
+    sha256 = "16dhk87vmjnywl5wqsl9dzp12ddpfk57w08f7811m3ijqadscdwc";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/nika-fonts
+    cp -v $( find . -name '*.ttf') $out/share/fonts/nika-fonts
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/rastikerdar/nika-font;
+    description = "Persian/Arabic Open Source Font";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = [ maintainers.linarcx ];
+  };
+}

--- a/pkgs/data/fonts/nika-fonts/default.nix
+++ b/pkgs/data/fonts/nika-fonts/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  name = "nika-fonts";
+  pname = "nika-fonts";
   version = "1.0.0";
 
   src = fetchFromGitHub {
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = https://github.com/rastikerdar/nika-font;
+    homepage = https://github.com/font-store/NikaFont/;
     description = "Persian/Arabic Open Source Font";
     license = licenses.ofl;
     platforms = platforms.all;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6552,7 +6552,7 @@ in
   yaft = callPackage ../applications/misc/yaft { };
 
   yarn = callPackage ../development/tools/yarn  { };
-  
+
   yarn2nix = throw "Use upstream https://github.com/moretea/yarn2nix";
   mkYarnPackage = yarn2nix;
 
@@ -11916,6 +11916,8 @@ in
   nix-plugins = callPackage ../development/libraries/nix-plugins {
     nix = nixUnstable;
   };
+
+  nika-fonts = callPackage ../data/fonts/nika-fonts { };
 
   nlohmann_json = callPackage ../development/libraries/nlohmann_json { };
 
@@ -21658,7 +21660,7 @@ in
   igv = callPackage ../applications/science/biology/igv { };
 
   inormalize = callPackage ../applications/science/biology/inormalize { };
-  
+
   itsx = callPackage ../applications/science/biology/itsx { };
 
   iv = callPackage ../applications/science/biology/iv {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
