### PR TITLE
behdad-fonts: init at v0.0.3

### DIFF
--- a/pkgs/data/fonts/behdad-fonts/default.nix
+++ b/pkgs/data/fonts/behdad-fonts/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "behdad-fonts";
+  version = "0.0.3";
+
+  src = fetchFromGitHub {
+    owner = "font-store";
+    repo = "BehdadFont";
+    rev = "v${version}";
+    sha256 = "0rlmyv82qmyy90zvkjnlva44ia7dyhiyk7axbq526v7zip3g79w0";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/behdad-fonts
+    cp -v $( find . -name '*.ttf') $out/share/fonts/behdad-fonts
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/font-store/BehdadFont;
+    description = "A Persian/Arabic Open Source Font";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = [ maintainers.linarcx ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -997,6 +997,8 @@ in
     cudnn = cudnn_cudatoolkit_9_0;
   };
 
+  behdad-fonts = callPackage ../data/fonts/behdad-fonts { };
+
   blink1-tool = callPackage ../tools/misc/blink1-tool { };
 
   bliss = callPackage ../applications/science/math/bliss { };
@@ -6552,7 +6554,7 @@ in
   yaft = callPackage ../applications/misc/yaft { };
 
   yarn = callPackage ../development/tools/yarn  { };
-  
+
   yarn2nix = throw "Use upstream https://github.com/moretea/yarn2nix";
   mkYarnPackage = yarn2nix;
 
@@ -21658,7 +21660,7 @@ in
   igv = callPackage ../applications/science/biology/igv { };
 
   inormalize = callPackage ../applications/science/biology/inormalize { };
-  
+
   itsx = callPackage ../applications/science/biology/itsx { };
 
   iv = callPackage ../applications/science/biology/iv {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
