### PR TITLE
[19.03] virtualenv: Update patch for 16.2.0

### DIFF
--- a/pkgs/development/python-modules/virtualenv/virtualenv-change-prefix.patch
+++ b/pkgs/development/python-modules/virtualenv/virtualenv-change-prefix.patch
@@ -52,7 +52,7 @@ index bcf3225..3530997 100755
      site_filename_dst = change_prefix(site_filename, home_dir)
      site_dir = os.path.dirname(site_filename_dst)
      writefile(site_filename_dst, SITE_PY)
-+    wrapper_path = join(prefix, "lib", py_version, "site-packages")
++    wrapper_path = join(prefix, "lib", PY_VERSION, "site-packages")
 +    writefile(
 +        join(site_dir, 'sitecustomize.py',),
 +        "import sys; sys.path.append('%s')" % wrapper_path


### PR DESCRIPTION
(Cherry-picked from 2556b7bfad8341aa25fa4a3f9a2d4e4c8c85f67f)

###### Motivation for this change

I was affected by https://github.com/NixOS/nixpkgs/issues/57008 on 19.03 (23fd1394dc6bef03a2ff010278a24403a97f0647) and backporting the fix by @glasserc from https://github.com/NixOS/nixpkgs/pull/57533 fixed the issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
