### PR TITLE
vscode-extensions.vscodevim.vim: init at 1.2.0

### DIFF
--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -52,5 +52,17 @@ rec {
 
   ms-python.python = callPackage ./python {};
 
+  vscodevim.vim = buildVscodeMarketplaceExtension {
+    mktplcRef = {
+      name = "vim";
+      publisher = "vscodevim";
+      version = "1.2.0";
+      sha256 = "0c7nv3razc3xjjzmb0q9a89dgry77h79rbkmc8nbfpa1if7lsvcp";
+    };
+    meta = {
+      license = stdenv.lib.licenses.mit;
+    };
+  };
+
   WakaTime.vscode-wakatime = callPackage ./wakatime {};
 }


### PR DESCRIPTION
###### Motivation for this change

Wanted to use some vim keybindings on vscode.

I have tested it locally and seems to be working for simple things.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
