### PR TITLE
solr: init at 8.0.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1909.xml
+++ b/nixos/doc/manual/release-notes/rl-1909.xml
@@ -147,6 +147,21 @@
      Accelerated Video Playback</link> for better transcoding performance.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     The following changes apply if the <literal>stateVersion</literal> is
+     changed to 19.09 or higher. For <literal>stateVersion = "19.03"</literal>
+     or lower the old behavior is preserved.
+    </para>
+    <itemizedlist>
+     <listitem>
+      <para>
+       <literal>solr.package</literal> defaults to
+       <literal>pkgs.solr_8</literal>.
+      </para>
+     </listitem>
+    </itemizedlist>
+   </listitem>
   </itemizedlist>
  </section>
 </section>

--- a/nixos/modules/services/search/solr.nix
+++ b/nixos/modules/services/search/solr.nix
@@ -13,11 +13,19 @@ in
     services.solr = {
       enable = mkEnableOption "Enables the solr service.";
 
+      # default to the 8.x series not forcing major version upgrade of those on the 7.x series
       package = mkOption {
         type = types.package;
-        default = pkgs.solr;
+        default = if versionAtLeast config.system.stateVersion "19.09"
+          then pkgs.solr_8
+          else pkgs.solr_7
+        ;
         defaultText = "pkgs.solr";
-        description = "Which Solr package to use.";
+        description = ''
+          Which Solr package to use. This defaults to version 7.x if
+          <literal>system.stateVersion &lt; 19.09</literal> and version 8.x
+          otherwise.
+        '';
       };
 
       port = mkOption {

--- a/nixos/tests/solr.nix
+++ b/nixos/tests/solr.nix
@@ -1,47 +1,65 @@
-import ./make-test.nix ({ pkgs, lib, ... }:
+{ system ? builtins.currentSystem,
+  config ? {},
+  pkgs ? import ../.. { inherit system config; }
+}:
+
+with import ../lib/testing.nix { inherit system pkgs; };
+with pkgs.lib;
+
+let
+  solrTest = package: makeTest {
+    machine =
+      { config, pkgs, ... }:
+      {
+        # Ensure the virtual machine has enough memory for Solr to avoid the following error:
+        #
+        #   OpenJDK 64-Bit Server VM warning:
+        #     INFO: os::commit_memory(0x00000000e8000000, 402653184, 0)
+        #     failed; error='Cannot allocate memory' (errno=12)
+        #
+        #   There is insufficient memory for the Java Runtime Environment to continue.
+        #   Native memory allocation (mmap) failed to map 402653184 bytes for committing reserved memory.
+        virtualisation.memorySize = 2000;
+
+        services.solr.enable = true;
+        services.solr.package = package;
+      };
+
+    testScript = ''
+      startAll;
+
+      $machine->waitForUnit('solr.service');
+      $machine->waitForOpenPort('8983');
+      $machine->succeed('curl --fail http://localhost:8983/solr/');
+
+      # adapted from pkgs.solr/examples/films/README.txt
+      $machine->succeed('sudo -u solr solr create -c films');
+      $machine->succeed(q(curl http://localhost:8983/solr/films/schema -X POST -H 'Content-type:application/json' --data-binary '{
+        "add-field" : {
+          "name":"name",
+          "type":"text_general",
+          "multiValued":false,
+          "stored":true
+        },
+        "add-field" : {
+          "name":"initial_release_date",
+          "type":"pdate",
+          "stored":true
+        }
+      }')) =~ /"status":0/ or die;
+      $machine->succeed('sudo -u solr post -c films ${pkgs.solr}/example/films/films.json');
+      $machine->succeed('curl http://localhost:8983/solr/films/query?q=name:batman') =~ /"name":"Batman Begins"/ or die;
+    '';
+  };
+in
 {
-  name = "solr";
-  meta.maintainers = [ lib.maintainers.aanderse ];
+  solr_7 = solrTest pkgs.solr_7 // {
+    name = "solr_7";
+    meta.maintainers = [ lib.maintainers.aanderse ];
+  };
 
-  machine =
-    { config, pkgs, ... }:
-    {
-      # Ensure the virtual machine has enough memory for Solr to avoid the following error:
-      #
-      #   OpenJDK 64-Bit Server VM warning:
-      #     INFO: os::commit_memory(0x00000000e8000000, 402653184, 0)
-      #     failed; error='Cannot allocate memory' (errno=12)
-      #
-      #   There is insufficient memory for the Java Runtime Environment to continue.
-      #   Native memory allocation (mmap) failed to map 402653184 bytes for committing reserved memory.
-      virtualisation.memorySize = 2000;
-
-      services.solr.enable = true;
-    };
-
-  testScript = ''
-    startAll;
-
-    $machine->waitForUnit('solr.service');
-    $machine->waitForOpenPort('8983');
-    $machine->succeed('curl --fail http://localhost:8983/solr/');
-
-    # adapted from pkgs.solr/examples/films/README.txt
-    $machine->succeed('sudo -u solr solr create -c films');
-    $machine->succeed(q(curl http://localhost:8983/solr/films/schema -X POST -H 'Content-type:application/json' --data-binary '{
-      "add-field" : {
-        "name":"name",
-        "type":"text_general",
-        "multiValued":false,
-        "stored":true
-      },
-      "add-field" : {
-        "name":"initial_release_date",
-        "type":"pdate",
-        "stored":true
-      }
-    }')) =~ /"status":0/ or die;
-    $machine->succeed('sudo -u solr post -c films ${pkgs.solr}/example/films/films.json');
-    $machine->succeed('curl http://localhost:8983/solr/films/query?q=name:batman') =~ /"name":"Batman Begins"/ or die;
-  '';
-})
+  solr_8 = solrTest pkgs.solr_8 // {
+    name = "solr_8";
+    meta.maintainers = [ lib.maintainers.aanderse ];
+  };
+}

--- a/pkgs/servers/search/solr/8.x.nix
+++ b/pkgs/servers/search/solr/8.x.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl, jre, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  pname = "solr";
+  version = "8.0.0";
+
+  src = fetchurl {
+    url = "mirror://apache/lucene/solr/${version}/solr-${version}.tgz";
+    sha256 = "04hxj7nfmbh5wfqkq1p5q2ncxszwm80l218vfdy93aw0p79r4qqf";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out $out/bin
+
+    cp -r bin/solr bin/post $out/bin/
+    cp -r contrib $out/
+    cp -r dist $out/
+    cp -r example $out/
+    cp -r server $out/
+
+    wrapProgram $out/bin/solr --set JAVA_HOME "${jre}"
+    wrapProgram $out/bin/post --set JAVA_HOME "${jre}"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://lucene.apache.org/solr/;
+    description = "Open source enterprise search platform from the Apache Lucene project";
+    license = licenses.asl20;
+    platforms = platforms.all;
+    maintainers = [ maintainers.rickynils maintainers.domenkozar maintainers.aanderse ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5646,7 +5646,9 @@ in
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
-  solr = callPackage ../servers/search/solr { };
+  solr = solr_8;
+  solr_7 = callPackage ../servers/search/solr { };
+  solr_8 = callPackage ../servers/search/solr/8.x.nix { };
 
   solvespace = callPackage ../applications/graphics/solvespace { };
 


### PR DESCRIPTION
###### Motivation for this change
Don't want to force existing users into new major version right away, let them choose when to upgrade to the 8.x series.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
