### PR TITLE
iterm2: fix build

### DIFF
--- a/pkgs/applications/misc/iterm2/default.nix
+++ b/pkgs/applications/misc/iterm2/default.nix
@@ -15,6 +15,7 @@ stdenv.mkDerivation rec {
   postPatch = ''
     sed -i -e 's/CODE_SIGN_IDENTITY = "Developer ID Application"/CODE_SIGN_IDENTITY = ""/g' ./iTerm2.xcodeproj/project.pbxproj
   '';
+  preConfigure = "LD=$CC";
   makeFlagsArray = ["Deployment"];
   installPhase = ''
     mkdir -p "$out/Applications"


### PR DESCRIPTION
###### Motivation for this change

During iterm2's build, xcodebuild invokes $LD and passes it options such as -isysroot. These options are intended for the linker driver (clang), not for the linker directly. ld64 ($LD) does not recognize these options, causing iterm2's build to fail.

Set $LD to $CC (clang) as intended, making iterm2's build succeed. This fixes issue #35412.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I tested installing iTerm 2 by running `nix-env -iA iterm2 ~/Projects/nixpkgs/` on a MacBook Pro with the following software configuration:

* macOS 10.12.6
* Xcode 8.3.3
  * MacOSX10.12.sdk
  * Apple LLVM version 8.1.0 (clang-802.0.42)
  * x86_64-apple-darwin16.7.0
  * ld64-278.4

---
