### PR TITLE
inter,inter-ui: keep font name the same for attributes, split off

### DIFF
--- a/pkgs/data/fonts/inter-ui/default.nix
+++ b/pkgs/data/fonts/inter-ui/default.nix
@@ -1,18 +1,18 @@
 { stdenv, fetchzip }:
 
 let
-  version = "3.3";
+  version = "3.1";
 in fetchzip {
-  name = "inter-${version}";
+  name = "inter-ui-${version}";
 
-  url = "https://github.com/rsms/inter/releases/download/v${version}/Inter-${version}.zip";
+  url = "https://github.com/rsms/inter/releases/download/v${version}/Inter-UI-${version}.zip";
 
   postFetch = ''
     mkdir -p $out/share/fonts/opentype
     unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
   '';
 
-  sha256 = "17fv33ryvbla4f4mfgw7m7gjlwyjlni90a8gpb7jws1qzn0vgazg";
+  sha256 = "0cdjpwylynwmab0x5z5lw43k39vis74xj1ciqg8nw12ccprbmj60";
 
   meta = with stdenv.lib; {
     homepage = https://rsms.me/inter/;

--- a/pkgs/data/fonts/inter-ui/default.nix
+++ b/pkgs/data/fonts/inter-ui/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchzip }:
 
 let
-  version = "3.4";
+  version = "3.3";
 in fetchzip {
   name = "inter-${version}";
 
@@ -12,7 +12,7 @@ in fetchzip {
     unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
   '';
 
-  sha256 = "1dl4zc1a5dl9xkg094zmzy6bk7gms8vhsiln58ix7sffzcf3pri8";
+  sha256 = "17fv33ryvbla4f4mfgw7m7gjlwyjlni90a8gpb7jws1qzn0vgazg";
 
   meta = with stdenv.lib; {
     homepage = https://rsms.me/inter/;

--- a/pkgs/data/fonts/inter/default.nix
+++ b/pkgs/data/fonts/inter/default.nix
@@ -1,22 +1,18 @@
 { stdenv, fetchzip }:
 
-# XXX: IMPORTANT:
-# For compat, keep this at the last version that used the name "Inter UI"
-# For newer versions, which are now simply named "Inter",
-# see the expression for `inter` (../inter/default.nix).
 let
-  version = "3.2";
+  version = "3.3";
 in fetchzip {
-  name = "inter-ui-${version}";
+  name = "inter-${version}";
 
-  url = "https://github.com/rsms/inter/releases/download/v${version}/Inter-UI-${version}.zip";
+  url = "https://github.com/rsms/inter/releases/download/v${version}/Inter-${version}.zip";
 
   postFetch = ''
     mkdir -p $out/share/fonts/opentype
     unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
   '';
 
-  sha256 = "01d2ql803jrhss6g60djvs08x9xl7z6b3snkn03vqnrajdgifcl4";
+  sha256 = "17fv33ryvbla4f4mfgw7m7gjlwyjlni90a8gpb7jws1qzn0vgazg";
 
   meta = with stdenv.lib; {
     homepage = https://rsms.me/inter/;

--- a/pkgs/data/fonts/inter/default.nix
+++ b/pkgs/data/fonts/inter/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchzip }:
 
 let
-  version = "3.3";
+  version = "3.5";
 in fetchzip {
   name = "inter-${version}";
 
@@ -12,7 +12,7 @@ in fetchzip {
     unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
   '';
 
-  sha256 = "17fv33ryvbla4f4mfgw7m7gjlwyjlni90a8gpb7jws1qzn0vgazg";
+  sha256 = "0zqixzzbb3n1j4jvpjm0hlxc32j53hgq4j078gihjkhgvjhsklf2";
 
   meta = with stdenv.lib; {
     homepage = https://rsms.me/inter/;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16157,6 +16157,7 @@ in
   maligned = callPackage ../development/tools/maligned { };
 
   inter-ui = callPackage ../data/fonts/inter-ui { };
+  inter = callPackage ../data/fonts/inter { };
 
   siji = callPackage ../data/fonts/siji { };
 


### PR DESCRIPTION
Feedback please! This is one solution to the problem,
but since it's a small amount of work wanted an actual PR
and so if we like it it's easy to proceed.

###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/57605#issuecomment-477874093

From upstream repository activity, it appears they're working
to be included in google fonts?
However I'm not sure it's worth "waiting" on that,
and it's nice to have the font you wnt directly sometimes
instead of the big bundle :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---