### PR TITLE
sumatools: init at 1.0.34

### DIFF
--- a/pkgs/applications/science/biology/sumatools/default.nix
+++ b/pkgs/applications/science/biology/sumatools/default.nix
@@ -1,0 +1,65 @@
+{ gccStdenv, fetchFromGitLab, zlib }:
+
+let
+  stdenv = gccStdenv;
+  meta = with stdenv.lib; {
+    description = "Fast and exact comparison and clustering of sequences";
+    homepage = https://metabarcoding.org/sumatra;
+    maintainers = [ maintainers.bzizou ];
+    platforms = platforms.unix;
+  };
+
+in rec {
+
+  # Suma library
+  sumalibs = stdenv.mkDerivation rec {
+    version = "1.0.34";
+    pname = "sumalibs";
+    src = fetchFromGitLab {
+      domain = "git.metabarcoding.org";
+      owner = "obitools";
+      repo = pname;
+      rev = "sumalib_v${version}";
+      sha256 = "0hwkrxzfz7m5wdjvmrhkjg8kis378iaqr5n4nhdhkwwhn8x1jn5a";
+    };
+    makeFlags = "PREFIX=$(out)";
+  };
+
+  # Sumatra
+  sumatra = stdenv.mkDerivation rec {
+    version = "1.0.34";
+    pname = "sumatra";
+    src = fetchFromGitLab {
+      domain = "git.metabarcoding.org";
+      owner = "obitools";
+      repo = pname;
+      rev = "${pname}_v${version}";
+      sha256 = "1bbpbdkshdc3xffqnr1qfy8qk64ldsmdc3s8mrcrlx132rgbi5f6";
+    };
+    buildInputs = [ sumalibs zlib ];
+    makeFlags = [
+      "LIBSUMA=${sumalibs}/lib/libsuma.a"
+      "LIBSUMAPATH=-L${sumalibs}"
+      "PREFIX=$(out)"
+    ];
+  };
+
+  # Sumaclust
+  sumaclust = stdenv.mkDerivation rec {
+    version = "1.0.34";
+    pname = "sumaclust";
+    src = fetchFromGitLab {
+      domain = "git.metabarcoding.org";
+      owner = "obitools";
+      repo = pname;
+      rev = "${pname}_v${version}";
+      sha256 = "0x8yi3k3jxhmv2krp4rcjlj2f9zg0qrk7gx4kpclf9c3yxgsgrds";
+    };
+    buildInputs = [ sumalibs ];
+    makeFlags = [
+      "LIBSUMA=${sumalibs}/lib/libsuma.a"
+      "LIBSUMAPATH=-L${sumalibs}"
+      "PREFIX=$(out)"
+    ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21721,6 +21721,11 @@ in
 
   strelka = callPackage ../applications/science/biology/strelka { };
 
+  inherit (callPackages ../applications/science/biology/sumatools {})
+      sumalibs
+      sumaclust
+      sumatra;
+
   seaview = callPackage ../applications/science/biology/seaview { };
 
   varscan = callPackage ../applications/science/biology/varscan { };


### PR DESCRIPTION
###### Motivation for this change
Application developed by my research laboratory and used into our computing center

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
