### PR TITLE
clblas: turn of gtest, fix build

### DIFF
--- a/pkgs/development/libraries/science/math/clblas/default.nix
+++ b/pkgs/development/libraries/science/math/clblas/default.nix
@@ -8,21 +8,20 @@
 , ocl-icd
 , opencl-headers
 , Accelerate, CoreGraphics, CoreVideo, OpenCL
-, gtest
 }:
 
 stdenv.mkDerivation rec {
-  name = "clblas-${version}"; 
+  name = "clblas-${version}";
   version = "2.12";
 
   src = fetchFromGitHub {
-    owner = "clMathLibraries"; 
+    owner = "clMathLibraries";
     repo = "clBLAS";
     rev = "v${version}";
     sha256 = "154mz52r5hm0jrp5fqrirzzbki14c1jkacj75flplnykbl36ibjs";
-  }; 
+  };
 
-  patches = [ ./platform.patch ]; 
+  patches = [ ./platform.patch ];
 
   postPatch = ''
     sed -i -re 's/(set\(\s*Boost_USE_STATIC_LIBS\s+).*/\1OFF\ \)/g' src/CMakeLists.txt
@@ -33,7 +32,7 @@ stdenv.mkDerivation rec {
   '';
 
   cmakeFlags = [
-    "-DUSE_SYSTEM_GTEST=ON"
+     "-DBUILD_TEST=OFF"
   ];
 
   buildInputs = [
@@ -42,7 +41,6 @@ stdenv.mkDerivation rec {
     blas
     python
     boost
-    gtest
   ] ++ stdenv.lib.optionals (!stdenv.isDarwin) [
     ocl-icd
     opencl-headers
@@ -61,7 +59,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/clMathLibraries/clBLAS";
     description = "A software library containing BLAS functions written in OpenCL";
     longDescription = ''
-      This package contains a library of BLAS functions on top of OpenCL. 
+      This package contains a library of BLAS functions on top of OpenCL.
     '';
     license = licenses.asl20;
     maintainers = with maintainers; [ artuuge ];

--- a/pkgs/development/python-modules/libgpuarray/default.nix
+++ b/pkgs/development/python-modules/libgpuarray/default.nix
@@ -66,8 +66,9 @@ buildPythonPackage rec {
 
   enableParallelBuilding = true;
 
+  nativeBuildInputs = [ cmake ];
+
   buildInputs = [
-    cmake
     cython
     nose
   ];


### PR DESCRIPTION
###### Motivation for this change
clblas does not work anymore with gmock 1.8.1.
Turning off the test suite does not seem to be the best solution but fixes the build.

See https://github.com/NixOS/nixpkgs/issues/58427

Should be back ported to 19.03 (https://github.com/NixOS/nixpkgs/issues/56826)

CC @artuuge 
###### Things done

* Remove gtest from derivation
* fix libgpuarray build, which depends on clblas

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
