### PR TITLE
lib: lists: Alias map = builtins.map

### DIFF
--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -7,7 +7,7 @@ let
 in
 rec {
 
-  inherit (builtins) head tail length isList elemAt concatLists filter elem genList;
+  inherit (builtins) head tail length isList elemAt concatLists filter elem genList map;
 
   /*  Create a list consisting of a single element.  `singleton x` is
       sometimes more convenient with respect to indentation than `[x]`


### PR DESCRIPTION
Suggested by @Profpatsch (added in trailer in commit message)

###### Motivation for this change

We really should have an alias here for consistency.