### PR TITLE
stacks: init at 2.3e

### DIFF
--- a/pkgs/applications/science/biology/stacks/default.nix
+++ b/pkgs/applications/science/biology/stacks/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchurl, zlib }:
+    
+stdenv.mkDerivation rec {
+  pname = "stacks";
+  version = "2.3e";
+  src = fetchurl {
+    url = "http://catchenlab.life.illinois.edu/stacks/source/${pname}-${version}.tar.gz";
+    sha256 = "046gmq8nzqy5v70ydqrhib2aiyrlja3cljvd37w4qbd4ryj3jr0w";
+  };
+
+  buildInputs = [ zlib ];
+
+  meta = {
+    description = "Software pipeline for building loci from short-read sequences";
+    homepage = http://catchenlab.life.illinois.edu/stacks/;
+    maintainers = [ stdenv.lib.maintainers.bzizou ];
+    license = stdenv.lib.licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21717,6 +21717,8 @@ in
 
   somatic-sniper = callPackage ../applications/science/biology/somatic-sniper { };
 
+  stacks = callPackage ../applications/science/biology/stacks { };
+
   star = callPackage ../applications/science/biology/star { };
 
   strelka = callPackage ../applications/science/biology/strelka { };


### PR DESCRIPTION
###### Motivation for this change
Tool used by biologists in our computing center (GRICAD). The package is in production since a few months, so, has been tested with real use cases.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
