### PR TITLE
megahit: init at 1.1.4

### DIFF
--- a/pkgs/applications/science/biology/megahit/default.nix
+++ b/pkgs/applications/science/biology/megahit/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, zlib }:
+
+stdenv.mkDerivation rec {
+  pname    = "megahit";
+  version = "1.1.4";
+
+  src = fetchFromGitHub {
+    owner = "voutcn";
+    repo = "megahit";
+    rev = "v${version}";
+    sha256 = "011k0776w76l03zmy70kfd3y9zjmdnspfbs9fcxmnl3bdwd36kcw";
+  };
+
+  buildInputs = [ zlib ];
+
+  installPhase = ''
+    for bin in megahit_sdbg_build megahit megahit_asm_core megahit_toolkit; do
+        install -vD $bin $out/bin/$bin
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "An ultra-fast single-node solution for large and complex metagenomics assembly via succinct de Bruijn graph";
+    license     = licenses.gpl3;
+    homepage    = https://github.com/voutcn/megahit;
+    maintainers = with maintainers; [ luispedro ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21681,6 +21681,8 @@ in
 
   mrbayes = callPackage ../applications/science/biology/mrbayes { };
 
+  megahit = callPackage ../applications/science/biology/megahit { };
+
   messer-slim = callPackage ../applications/science/biology/messer-slim { };
 
   minc_tools = callPackage ../applications/science/biology/minc-tools { };


### PR DESCRIPTION
This is widely used in bioinformatics for assembling genomes &
metagenomes


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)

- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested execution of all binary files (usually in `./result/bin/`)
Tested main programme, the rest are used internally


- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
