### PR TITLE
libfido2: init at 1.1.0 (and libcor dep)

### DIFF
--- a/pkgs/development/libraries/libcbor/default.nix
+++ b/pkgs/development/libraries/libcbor/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, cmake, cmocka }:
+
+stdenv.mkDerivation rec {
+  pname = "libcbor";
+  version = "2019-02-23";
+
+  src = fetchFromGitHub {
+    owner = "PJK";
+    repo = pname;
+    rev = "87f977e732ca216682a8583a0e43803eb6b9c028";
+    sha256 = "17p1ahdcpf5d4r472lhciscaqjq4pyxy9xjhqqx8mv646xmyripm";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  checkInputs = [ cmocka ];
+
+  doCheck = false; # needs "-DWITH_TESTS=ON", but fails w/compilation error
+
+  NIX_CFLAGS_COMPILE = [ "-fno-lto" ];
+
+  meta = with stdenv.lib; {
+    description = "CBOR protocol implementation for C and others";
+    homepage = https://github.com/PJK/libcbor;
+    license = licenses.mit;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/development/libraries/libfido2/default.nix
+++ b/pkgs/development/libraries/libfido2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, pkgconfig, libcbor, libressl, libudev }:
+{ stdenv, fetchurl, cmake, pkgconfig, libcbor, libressl, udev }:
 
 stdenv.mkDerivation rec {
   pname = "libfido2";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];
-  buildInputs = [ libcbor libressl libudev ];
+  buildInputs = [ libcbor libressl udev ];
 
   cmakeFlags = [ "-DUDEV_RULES_DIR=${placeholder "out"}/etc/udev/rules.d" ];
 

--- a/pkgs/development/libraries/libfido2/default.nix
+++ b/pkgs/development/libraries/libfido2/default.nix
@@ -2,10 +2,10 @@
 
 stdenv.mkDerivation rec {
   pname = "libfido2";
-  version = "1.0.0";
+  version = "1.1.0";
   src = fetchurl {
     url = "https://developers.yubico.com/libfido2/Releases/libfido2-${version}.tar.gz";
-    sha256 = "1l0f67fpza0lhq08brpgi4xyfw60w1q790a83x8vqm889l4mph8w";
+    sha256 = "1h51q9pgv54czf7k6v90b02gnvqw4dlxmz6vi0n06shpkdzv5jh1";
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];

--- a/pkgs/development/libraries/libfido2/default.nix
+++ b/pkgs/development/libraries/libfido2/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl, cmake, pkgconfig, libcbor, libressl, libudev }:
+
+stdenv.mkDerivation rec {
+  pname = "libfido2";
+  version = "1.0.0";
+  src = fetchurl {
+    url = "https://developers.yubico.com/libfido2/Releases/libfido2-${version}.tar.gz";
+    sha256 = "1l0f67fpza0lhq08brpgi4xyfw60w1q790a83x8vqm889l4mph8w";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [ libcbor libressl libudev ];
+
+  cmakeFlags = [ "-DUDEV_RULES_DIR=${placeholder "out"}/etc/udev/rules.d" ];
+
+  meta = with stdenv.lib; {
+    description = ''
+    Provides library functionality for FIDO 2.0, including communication with a device over USB.
+    '';
+    homepage = https://github.com/Yubico/libfido2;
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ dtzWill ];
+
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11243,6 +11243,8 @@ in
 
   libfakekey = callPackage ../development/libraries/libfakekey { };
 
+  libfido2 = callPackage ../development/libraries/libfido2 { };
+
   libfilezilla = callPackage ../development/libraries/libfilezilla { };
 
   libfm = callPackage ../development/libraries/libfm { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11077,6 +11077,8 @@ in
     then pkgs.libcanberra
     else pkgs.libcanberra-gtk2;
 
+  libcbor = callPackage ../development/libraries/libcbor { };
+
   libcec = callPackage ../development/libraries/libcec { };
   libcec_platform = callPackage ../development/libraries/libcec/platform.nix { };
 


### PR DESCRIPTION
###### Motivation for this change

https://developers.yubico.com/FIDO2/

Seems good to have-- although don't know of any
projects using it yet, the recent 1.0.0 release
might see this change.
For example it looks like pam-u2f is poised
to move to this, see upstream PR 98.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---