### PR TITLE
 nixos/gitlab: Install and fixup vendorised gitlab-shell

### DIFF
--- a/pkgs/applications/version-management/gitlab/gitaly/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitaly/default.nix
@@ -27,7 +27,14 @@ in buildGoPackage rec {
 
   postInstall = ''
     mkdir -p $ruby
-    cp -rv $src/ruby/{bin,lib} $ruby
+    cp -rv $src/ruby/{bin,lib,git-hooks,vendor} $ruby
+
+    # gitlab-shell will try to read its config relative to the source
+    # code by default which doesn't work in nixos because it's a
+    # read-only filesystem
+    substituteInPlace $ruby/vendor/gitlab-shell/lib/gitlab_config.rb --replace \
+       "File.join(ROOT_PATH, 'config.yml')" \
+       "'/run/gitlab/shell-config.yml'"
   '';
 
   outputs = [ "bin" "out" "ruby" ];


### PR DESCRIPTION
###### Motivation for this change

gitaly now ships its own vendorised version of gitlab-shell. Previously
we failed to install this, resulting in
https://gitlab.com/gitlab-org/gitlab-ce/issues/59403.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
