### PR TITLE
lugaru: init at 1.2

### DIFF
--- a/pkgs/games/lugaru/default.nix
+++ b/pkgs/games/lugaru/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitLab, cmake, openal, pkgconfig, libogg,
+  libvorbis, SDL2, makeWrapper, libpng, libjpeg_turbo, libGLU }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+
+  pname = "lugaru";
+  version = "1.2";
+
+  src = fetchFromGitLab {
+    owner = "osslugaru";
+    repo = "lugaru";
+    rev = version;
+    sha256 = "089rblf8xw3c6dq96vnfla6zl8gxcpcbc1bj5jysfpq63hhdpypz";
+  };
+
+  nativeBuildInputs = [ makeWrapper cmake pkgconfig ];
+
+  buildInputs = [ libGLU openal SDL2 libogg libvorbis libpng libjpeg_turbo ];
+
+  cmakeFlags = [ "-DSYSTEM_INSTALL=ON" ];
+
+  meta = {
+    description = "Lugaru HD: Third person ninja rabbit fighting game";
+    homepage = https://osslugaru.gitlab.io;
+    maintainers = [ maintainers.genesis ];
+    platforms = platforms.linux;
+    license = stdenv.lib.licenses.gpl2Plus;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20951,6 +20951,8 @@ in
   liquidwar5 = callPackage ../games/liquidwar/5.nix {
   };
 
+  lugaru = callPackage ../games/lugaru {};
+
   macopix = callPackage ../games/macopix {
     gtk = gtk2;
   };


### PR DESCRIPTION
###### Motivation for this change

OSS Lugaru !

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
