### PR TITLE
steamcmd: Add needed binaries to PATH

### DIFF
--- a/pkgs/games/steam/steamcmd.nix
+++ b/pkgs/games/steam/steamcmd.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, steam-run, bash
+{ stdenv, fetchurl, steam-run, bash, coreutils
 , steamRoot ? "~/.local/share/Steam"
 }:
 
@@ -29,8 +29,8 @@ stdenv.mkDerivation rec {
 
     mkdir -p $out/bin
     substitute ${./steamcmd.sh} $out/bin/steamcmd \
-      --subst-var shell \
       --subst-var out \
+      --subst-var-by coreutils ${coreutils} \
       --subst-var-by steamRoot "${steamRoot}" \
       --subst-var-by steamRun ${steam-run}
     chmod 0755 $out/bin/steamcmd

--- a/pkgs/games/steam/steamcmd.sh
+++ b/pkgs/games/steam/steamcmd.sh
@@ -3,6 +3,9 @@
 # Always run steamcmd in the user's Steam root.
 STEAMROOT=@steamRoot@
 
+# Add coreutils to PATH for mkdir, ln and cp used below
+PATH=$PATH${PATH:+:}@coreutils@/bin
+
 # Create a facsimile Steam root if it doesn't exist.
 if [ ! -e "$STEAMROOT" ]; then
   mkdir -p "$STEAMROOT"/{appcache,config,logs,Steamapps/common}


### PR DESCRIPTION
###### Motivation for this change
Should fix https://github.com/NixOS/nixpkgs/issues/58479

@pmiddend Can you test whether this fixes your issue?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
