### PR TITLE
bazel: 0.22.0 doesn't build in Darwin sandbox

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -241,6 +241,7 @@ stdenv.mkDerivation rec {
   # Change this to $(mktemp -d) as soon as we figure out why.
 
   buildPhase = ''
+    # Hello
     export TMPDIR=/tmp/.bazel-$UID
     ./compile.sh
     scripts/generate_bash_completion.sh \


### PR DESCRIPTION
###### Motivation for this change
There have been a number of attempts to include new versions of Bazel in nixpkgs, built on top of the existing derivation for 0.22.0.

See:
https://github.com/NixOS/nixpkgs/pull/58147
https://github.com/NixOS/nixpkgs/pull/58116
https://github.com/NixOS/nixpkgs/pull/56587

All of these attempts have stalled because Ofborg builds for Darwin time out and local sandbox builds fail.

Local failure:
```
no configure script, doing nothing
building
mkdir: cannot create directory '/tmp/.bazel-501': Operation not permitted
builder for '/nix/store/l13iplvdf344kadkd7iqbci65kxly8vz-bazel-0.22.0.drv' failed with exit code 1
error: build of '/nix/store/l13iplvdf344kadkd7iqbci65kxly8vz-bazel-0.22.0.drv' failed
```

This PR is intended to demonstrate that the 0.22.0 version suffers from the same sandboxing problems and that the currently published 0.22.0 version of Bazel was published with sandboxing disabled.

To me this indicates that something has changed with Darwin sandboxing on Ofborg to make it more restrictive (and correct) than it was previously. Or, somehow the existing Bazel 0.22.0 on Hydra was published with sandboxing disabled. It doesn't really matter what happened, but it raises an interesting question: What now?

The Bazel 0.22.0 build is not reproducible under sandboxing and future versions of Bazel are unlikely to build with `sandbox = true` on Darwin unless something significant happens with a JDK version that can execute inside the sandbox.



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
