### PR TITLE
xcur2png: init at 0.7.1

### DIFF
--- a/pkgs/tools/graphics/xcur2png/default.nix
+++ b/pkgs/tools/graphics/xcur2png/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, pkgconfig, libpng, xorg }:
+
+stdenv.mkDerivation rec {
+  pname = "xcur2png";
+  version = "0.7.1";
+
+  src = fetchFromGitHub {
+    owner = "eworm-de";
+    repo = pname;
+    rev = version;
+    sha256 = "0858wn2p14bxpv9lvaz2bz1rk6zk0g8zgxf8iy595m8fqv4q2fya";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+  ];
+
+  buildInputs = [
+    libpng
+    xorg.libX11
+    xorg.libXcursor
+    xorg.xorgproto
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/eworm-de/xcur2png/releases;
+    description = "Convert X cursors to PNG images";
+    license = licenses.gpl3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6476,6 +6476,8 @@ in
 
   xclip = callPackage ../tools/misc/xclip { };
 
+  xcur2png = callPackage ../tools/graphics/xcur2png { };
+
   xcwd = callPackage ../tools/X11/xcwd { };
 
   xtitle = callPackage ../tools/misc/xtitle { };


### PR DESCRIPTION
###### Motivation for this change

https://github.com/eworm-de/xcur2png

> xcur2png is a program which let you take PNG image from X cursor, and generate config-file which is reusable by xcursorgen. To put it simply, it is converter from X cursor to PNG image.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).