### PR TITLE
cgit: add support for default filters

### DIFF
--- a/nixos/modules/services/web-servers/lighttpd/cgit.nix
+++ b/nixos/modules/services/web-servers/lighttpd/cgit.nix
@@ -44,6 +44,8 @@ in
       example = ''
         cache-size=1000
         scan-path=/srv/git
+        source-filter=''${pkgs.cgit}/lib/cgit/filters/syntax-highlighting.py
+        about-filter=''${pkgs.cgit}/lib/cgit/filters/about-formatting.sh
       '';
       type = types.lines;
       description = ''

--- a/pkgs/applications/version-management/git-and-tools/cgit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/cgit/default.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchurl, openssl, zlib, asciidoc, libxml2, libxslt
 , docbook_xsl, pkgconfig, luajit
-, groff, gzip, bzip2, xz
+, coreutils, gnused, groff, docutils
+, gzip, bzip2, xz
 , python, wrapPython, pygments, markdown
 }:
 
@@ -35,6 +36,9 @@ stdenv.mkDerivation rec {
 
     substituteInPlace filters/html-converters/man2html \
       --replace 'groff' '${groff}/bin/groff'
+
+    substituteInPlace filters/html-converters/rst2html \
+      --replace 'rst2html.py' '${docutils}/bin/rst2html.py'
   '';
 
   # Give cgit a git source tree and pass configuration parameters (as make
@@ -57,6 +61,10 @@ stdenv.mkDerivation rec {
     cp cgitrc.5 "$out/share/man/man5"
 
     wrapPythonProgramsIn "$out/lib/cgit/filters" "$out $pythonPath"
+
+    for script in $out/lib/cgit/filters/*.sh $out/lib/cgit/filters/html-converters/txt2html; do
+      wrapProgram $script --prefix PATH : '${stdenv.lib.makeBinPath [ coreutils gnused ]}'
+    done
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

This adds support for source code and about page filters that are shipped with cgit.
The new module options default to the previous behaviour.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC package maintainer: @bjornfor 