### PR TITLE
blur-effect: init at 1.1.3

### DIFF
--- a/pkgs/tools/graphics/blur-effect/default.nix
+++ b/pkgs/tools/graphics/blur-effect/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, pkgconfig, cmake, gdk_pixbuf, libGL, mesa }:
+
+stdenv.mkDerivation rec {
+  pname = "blur-effect";
+  version = "1.1.3";
+
+  src = fetchFromGitHub {
+    owner = "sonald";
+    repo = pname;
+    rev = version;
+    sha256 = "0cjw7iz0p7x1bi4vmwrivfidry5wlkgfgdl9wly88cm3z9ib98jj";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    cmake
+  ];
+
+  buildInputs = [
+    gdk_pixbuf
+    libGL
+    mesa
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/sonald/blur-effect;
+    description = "Off-screen image blurring utility using OpenGL ES 3.0";
+    license = licenses.gpl3;
+    platforms = platforms.unix;
+    broken = stdenv.hostPlatform.isDarwin; # packages 'libdrm' and 'gbm' not found
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -979,6 +979,8 @@ in
 
   bluemix-cli = callPackage ../tools/admin/bluemix-cli { };
 
+  blur-effect = callPackage ../tools/graphics/blur-effect { };
+
   charles = charles4;
   inherit (callPackage ../applications/networking/charles {})
     charles3


### PR DESCRIPTION
###### Motivation for this change

https://github.com/sonald/blur-effect

> off-screen image blurring utility using OpenGL ES 3.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).