### PR TITLE
openmw: 0.44 -> 0.45

### DIFF
--- a/pkgs/games/openmw/default.nix
+++ b/pkgs/games/openmw/default.nix
@@ -1,8 +1,11 @@
-{ stdenv, fetchFromGitHub, qtbase, openscenegraph, mygui, bullet, ffmpeg
-, boost, cmake, SDL2, unshield, openal, libXt, pkgconfig }:
+{ stdenv, fetchFromGitHub, cmake, doxygen, pkgconfig
+, qtbase, openscenegraph, mygui, bullet, ffmpeg, boost, SDL2, unshield, openal
+, giflib, libXt }:
 
 let
   openscenegraph_ = openscenegraph.overrideDerivation (self: {
+    name = "openmw-openscenegraph";
+
     src = fetchFromGitHub {
       owner = "OpenMW";
       repo = "osg";
@@ -10,31 +13,36 @@ let
       sha256 = "0admnllxic6dcpic0h100927yw766ab55dix002vvdx36i6994jb";
     };
   });
+
 in stdenv.mkDerivation rec {
-  version = "0.44.0";
+  version = "0.45.0";
   name = "openmw-${version}";
 
   src = fetchFromGitHub {
     owner = "OpenMW";
     repo = "openmw";
     rev = name;
-    sha256 = "0rxkw0bzag7qffifg28dyyga47aaaf5ziiccpv7p8yax1wglvymh";
+    sha256 = "1r87zrsnza2v9brksh809zzqj6zhk5xj15qs8iq11v1bscm2a2j4";
   };
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ cmake boost ffmpeg bullet mygui openscenegraph_ SDL2 unshield openal libXt qtbase ];
+  nativeBuildInputs = [ cmake doxygen pkgconfig ];
+
+  buildInputs = [
+    qtbase
+    boost bullet ffmpeg libXt mygui openal openscenegraph_ SDL2 unshield
+  ];
 
   cmakeFlags = [
-    "-DDESIRED_QT_VERSION:INT=5"
+    "-DDESIRED_QT_VERSION=5"
   ];
 
   meta = with stdenv.lib; {
     description = "An unofficial open source engine reimplementation of the game Morrowind";
-    homepage = http://openmw.org;
-    license = licenses.gpl3;
-    platforms = platforms.linux;
+    homepage    = "https://openmw.org";
+    license     = licenses.gpl3;
     maintainers = with maintainers; [ abbradar ];
+    platforms   = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21031,7 +21031,7 @@ in
 
   openjk = callPackage ../games/openjk { };
 
-  openmw = libsForQt5.callPackage ../games/openmw { };
+  openmw = libsForQt5.callPackage ../games/openmw { qtbase = qt5.qtbase; };
 
   openmw-tes3mp = libsForQt5.callPackage ../games/openmw/tes3mp.nix { };
 


### PR DESCRIPTION
###### Motivation for this change

Bump openmw-0.44 -> 0.45 plus migrate to Qt5 #33239

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
