### PR TITLE
spleen: init at 1.0.4

### DIFF
--- a/pkgs/data/fonts/spleen/default.nix
+++ b/pkgs/data/fonts/spleen/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl, mkfontdir, mkfontscale }:
+
+stdenv.mkDerivation rec {
+  pname = "spleen";
+  version = "1.0.4";
+
+  src = fetchurl {
+    url = "https://github.com/fcambus/spleen/releases/download/${version}/spleen-${version}.tar.gz";
+    sha256 = "1x62a5ygn3rpgzbaacz64rp8mn7saymdnxci4l3xasvsjjp60s3g";
+  };
+
+  buildPhase = "gzip -n9 *.pcf";
+  installPhase = ''
+    d="$out/share/fonts/X11/misc/spleen"
+    install -Dm644 *.pcf.gz  -t $d
+    install -Dm644 *.bdf -t $d
+    install -m644 fonts.alias-spleen $d/fonts.alias
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Monospaced bitmap fonts";
+    homepage = https://www.cambus.net/spleen-monospaced-bitmap-fonts;
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16099,6 +16099,8 @@ in
   source-han-serif-simplified-chinese = sourceHanSerifPackages.simplified-chinese;
   source-han-serif-traditional-chinese = sourceHanSerifPackages.traditional-chinese;
 
+  spleen = callPackage ../data/fonts/spleen { };
+
   sudo-font = callPackage ../data/fonts/sudo { };
 
   inherit (callPackages ../data/fonts/tai-languages { }) tai-ahom;


### PR DESCRIPTION
###### Motivation for this change

Default console font on OpenBSD, FWIW:
https://undeadly.org/cgi?action=article;sid=20190110064857

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - err, fonts :D
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---