### PR TITLE
stupidterm: 2018-09-25 -> 2019-03-26

### DIFF
--- a/pkgs/applications/misc/stupidterm/default.nix
+++ b/pkgs/applications/misc/stupidterm/default.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchFromGitHub, pkgconfig, vte, gtk }:
 
 stdenv.mkDerivation rec {
-  name = "stupidterm-2018-09-25";
+  pname = "stupidterm";
+  version = "2019-03-26";
 
   nativeBuildInputs = [ pkgconfig ];
 
@@ -10,17 +11,19 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "esmil";
     repo = "stupidterm";
-    rev = "d1bc020797330df83d427e361d3620e346a4e792";
-    sha256 = "1yh2vhq3d0qbh0dh2h9yc7s9gkffgkb987vvwz2bdnvlskrjmmdj";
+    rev = "f824e41c2ca9016db73556c5d2f5a2861e235c8e";
+    sha256 = "1f73wvqqvj5pr3fvb7jjc4bi1iwgkkknz24k8n69mdb75jnfjipp";
   };
 
   makeFlags = "PKGCONFIG=${pkgconfig}/bin/pkg-config binary=stupidterm";
 
   installPhase = ''
-    mkdir -p $out/bin $out/share/applications $out/share/stupidterm
-    cp stupidterm $out/bin
-    substituteAll ${./stupidterm.desktop} $out/share/applications/stupidterm.desktop
-    substituteAll stupidterm.ini $out/share/stupidterm/stupidterm.ini
+    install -D stupidterm $out/bin/stupidterm
+    install -D -m 644 stupidterm.desktop $out/share/applications/stupidterm.desktop
+    install -D -m 644 stupidterm.ini $out/share/stupidterm/stupidterm.ini
+
+    substituteInPlace $out/share/applications/stupidterm.desktop \
+      --replace "Exec=st" "Exec=$out/bin/stupidterm"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/misc/stupidterm/stupidterm.desktop
+++ b/pkgs/applications/misc/stupidterm/stupidterm.desktop
@@ -1,9 +1,0 @@
-[Desktop Entry]
-Version=20170315
-Name=stupidterm
-Comment=VTE based terminal emulator
-Exec=stupidterm
-Icon=utilities-terminal
-Terminal=false
-Type=Application
-Categories=System;TerminalEmulator;


### PR DESCRIPTION
###### Motivation for this change
Update contains clearing of urgency hint and they started shipping
their own .desktop file, so we switched to using that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
