### PR TITLE
paps: init at 0.7.0

### DIFF
--- a/pkgs/tools/misc/paps/default.nix
+++ b/pkgs/tools/misc/paps/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub
+, autoconf, automake, pkgconfig, pango }:
+
+stdenv.mkDerivation rec {
+  pname = "paps";
+  version = "0.7.0";
+
+  src = fetchFromGitHub {
+    owner = "dov";
+    repo = pname;
+    rev = version;
+    sha256 = "1f0qcawak76zk2xypipb6sy4bd8mixlrjby851x216a7f6z8fd4y";
+  };
+
+  nativeBuildInputs = [ autoconf automake pkgconfig ];
+  buildInputs = [ pango ];
+
+  preConfigure = ''
+    ./autogen.sh
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Pango to PostScript converter";
+    homepage = https://github.com/dov/paps;
+    license = licenses.lgpl2;
+    maintainers = with maintainers; [ etu ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15968,6 +15968,8 @@ in
 
   papis = callPackage ../tools/misc/papis { };
 
+  paps = callPackage ../tools/misc/paps { };
+
   pecita = callPackage ../data/fonts/pecita {};
 
   paratype-pt-mono = callPackage ../data/fonts/paratype-pt/mono.nix {};


### PR DESCRIPTION
###### Motivation for this change
A Pango to PostScript converter

paps reads a UTF-8 encoded file and generates a PostScript language rendering of the file. The rendering is done by creating outline curves through the pango ft2 backend.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
