### PR TITLE
vimpager: Init at 2.06 and master

### DIFF
--- a/pkgs/tools/misc/vimpager/build.nix
+++ b/pkgs/tools/misc/vimpager/build.nix
@@ -1,5 +1,6 @@
 { stdenv
 , fetchFromGitHub
+, coreutils
 , sharutils
 , version
 , sha256
@@ -17,11 +18,17 @@ stdenv.mkDerivation rec {
     rev    = "${version}";
   };
 
-  buildInputs = [ sharutils ]; # for uuencode
+  buildInputs = [ coreutils sharutils ]; # for uuencode
 
   makeFlags = [
     "PREFIX=$(out)"
   ];
+
+  buildPhase = ''
+    sed -i 's,/bin/cat,${coreutils}/bin/cat,g' vimpager
+    make
+  '';
+
 
   meta = with stdenv.lib; {
     description = "Use Vim as PAGER";

--- a/pkgs/tools/misc/vimpager/build.nix
+++ b/pkgs/tools/misc/vimpager/build.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, fetchFromGitHub
+, sharutils
+, version
+, sha256
+}:
+
+stdenv.mkDerivation rec {
+  inherit version;
+  name = "vimpager-${version}";
+
+  src = fetchFromGitHub {
+    inherit sha256;
+
+    owner  = "rkitover";
+    repo   = "vimpager";
+    rev    = "${version}";
+  };
+
+  buildInputs = [ sharutils ]; # for uuencode
+
+  makeFlags = [
+    "PREFIX=$(out)"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Use Vim as PAGER";
+    homepage    = "https://www.vim.org/scripts/script.php?script_id = 1723";
+    license     = with licenses; [ bsd2 mit vim ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/tools/misc/vimpager/default.nix
+++ b/pkgs/tools/misc/vimpager/default.nix
@@ -1,0 +1,6 @@
+{ callPackage }:
+
+callPackage ./build.nix {
+  version = "2.06";
+  sha256  = "05yr7j72bw64nx7a0y6w9fjmz54zd4g46fn1qjfbbqvbc19fjpl8";
+}

--- a/pkgs/tools/misc/vimpager/latest.nix
+++ b/pkgs/tools/misc/vimpager/latest.nix
@@ -1,0 +1,7 @@
+{ callPackage }:
+
+callPackage ./build.nix {
+  version = "a4da4dfac44d1bbc6986c5c76fea45a60ebdd8e5";
+  sha256  = "0gcjpw2q263hh8w2sjvq3f3k2d28qpkkv0jnl8hw1l7v604i8zxg";
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6135,6 +6135,9 @@ in
 
   vimer = callPackage ../tools/misc/vimer { };
 
+  vimpager = callPackage ../tools/misc/vimpager { };
+  vimpager-latest = callPackage ../tools/misc/vimpager/latest.nix { };
+
   visidata = (newScope python3Packages) ../applications/misc/visidata {
   };
 


### PR DESCRIPTION
Adding a package vimpager-latest because the last release was 2015.

###### Motivation for this change

Closes #56768

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
