### PR TITLE
semver-tool: init at 2.1.0

### DIFF
--- a/pkgs/development/tools/misc/semver-tool/default.nix
+++ b/pkgs/development/tools/misc/semver-tool/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, lib, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "semver-tool";
+  version = "2.1.0";
+
+  src = fetchFromGitHub {
+    owner = "fsaintjacques";
+    repo = pname;
+    rev = version;
+    sha256 = "0lpwsa86qb5w6vbnsn892nb3qpxxx9ifxch8pw3ahzx2dqhdgnrr";
+  };
+
+  dontBuild = true; # otherwise we try to 'make' which fails.
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    install src/semver $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = https://github.com/fsaintjacques/semver-tool;
+    description = "semver bash implementation";
+    license = licenses.gpl3Plus;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.qyliss ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9264,6 +9264,8 @@ in
 
   selendroid = callPackage ../development/tools/selenium/selendroid { };
 
+  semver-tool = callPackage ../development/tools/misc/semver-tool { };
+
   sconsPackages = dontRecurseIntoAttrs (callPackage ../development/tools/build-managers/scons { });
   scons = sconsPackages.scons_latest;
 


### PR DESCRIPTION
Cherry-picked from: https://github.com/alyssais/nixpkgs/commit/eeb175169f65201bd47ece5d0593d3c7c386077d
Although fixed so that it actually builds.

###### Motivation for this change

Closes: https://github.com/NixOS/nixpkgs/issues/50945
Superceeds and closes: https://github.com/NixOS/nixpkgs/pull/51004

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
