### PR TITLE
gitea: Fix sqlite support and baked-in tags

### DIFF
--- a/pkgs/applications/version-management/gitea/default.nix
+++ b/pkgs/applications/version-management/gitea/default.nix
@@ -35,12 +35,15 @@ buildGoPackage rec {
   nativeBuildInputs = [ makeWrapper ]
     ++ optional pamSupport pam;
 
-  buildFlags = optional sqliteSupport "-tags sqlite"
-    ++ optional pamSupport "-tags pam";
-  buildFlagsArray = ''
-    -ldflags=
-      -X=main.Version=${version}
-      ${optionalString sqliteSupport "-X=main.Tags=sqlite"}
+  preBuild = let
+    tags = optional pamSupport "pam"
+        ++ optional sqliteSupport "sqlite";
+    tagsString = concatStringsSep " " tags;
+  in ''
+    export buildFlagsArray=(
+      -tags="${tagsString}"
+      -ldflags='-X "main.Version=${version}" -X "main.Tags=${tagsString}"'
+    )
   '';
 
   outputs = [ "bin" "out" "data" ];


### PR DESCRIPTION
###### Motivation for this change
Fixes #58576
Also includes all the tags in --version.
Needs backport to 19.03, cc #56826 


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
