### PR TITLE
vlc: Add chromecast support; libmicrodns: Init at 0.0.10

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5391,4 +5391,9 @@
     github = "minijackson";
     name = "Rémi Nicole";
   };
+  shazow = {
+    email = "andrey.petrov@shazow.net";
+    github = "shazow";
+    name = "Andrey Petrov";
+  };
 }

--- a/nixos/doc/manual/release-notes/rl-1909.xml
+++ b/nixos/doc/manual/release-notes/rl-1909.xml
@@ -99,6 +99,16 @@
      and fix all the bugs it uncovers.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     The <literal>vlc</literal> package gained support for Chromecast
+     streaming, enabled by default. TCP port 8010 must be open for it to work,
+     so something like <literal>networking.firewall.allowedTCPPorts = [ 8010
+     ];</literal> may be required in your configuration. Also consider enabling
+     <link xlink:href="https://nixos.wiki/wiki/Accelerated_Video_Playback">
+     Accelerated Video Playback</link> for better transcoding performance.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 </section>

--- a/pkgs/applications/video/vlc/default.nix
+++ b/pkgs/applications/video/vlc/default.nix
@@ -13,7 +13,12 @@
 , jackSupport ? false
 , fetchpatch
 , removeReferencesTo
+, chromecastSupport ? true, protobuf, libmicrodns
 }:
+
+# chromecastSupport requires TCP port 8010 to be open for it to work.
+# If your firewall is enabled, make sure to have something like:
+#   networking.firewall.allowedTCPPorts = [ 8010 ];
 
 with stdenv.lib;
 
@@ -42,7 +47,8 @@ stdenv.mkDerivation rec {
     fluidsynth wayland wayland-protocols
   ] ++ optional (!stdenv.hostPlatform.isAarch64) live555
     ++ optionals withQt5    [ qtbase qtsvg qtx11extras ]
-    ++ optional jackSupport libjack2;
+    ++ optional jackSupport libjack2
+    ++ optionals chromecastSupport [ protobuf libmicrodns ];
 
   nativeBuildInputs = [ autoreconfHook perl pkgconfig removeReferencesTo ];
 
@@ -76,7 +82,12 @@ stdenv.mkDerivation rec {
   # "--enable-foo" flags here
   configureFlags = [
     "--with-kde-solid=$out/share/apps/solid/actions"
-  ] ++ optional onlyLibVLC "--disable-vlc";
+  ] ++ optional onlyLibVLC "--disable-vlc"
+    ++ optionals chromecastSupport [
+    "--enable-sout"
+    "--enable-chromecast"
+    "--enable-microdns"
+  ];
 
   # Remove runtime dependencies on libraries
   postConfigure = ''

--- a/pkgs/development/libraries/libmicrodns/default.nix
+++ b/pkgs/development/libraries/libmicrodns/default.nix
@@ -1,0 +1,30 @@
+{ stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkgconfig
+}:
+
+stdenv.mkDerivation rec {
+  version = "0.0.10";
+  pname = "libmicrodns";
+
+  src = fetchFromGitHub {
+    owner = "videolabs";
+    repo = pname;
+    rev = version;
+    sha256 = "1xvl9k49ng35wbsqmnjnyqvkyjf8dcq2ywsq3jp3wh0rgmxhq2fh";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkgconfig
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Minimal mDNS resolver library, used by VLC";
+    homepage = https://github.com/videolabs/libmicrodns;
+    license = licenses.lgpl21;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.shazow ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4095,6 +4095,8 @@ in
 
   libpointmatcher = callPackage ../development/libraries/libpointmatcher { };
 
+  libmicrodns = callPackage ../development/libraries/libmicrodns { };
+
   libnids = callPackage ../tools/networking/libnids { };
 
   libtorrent = callPackage ../tools/networking/p2p/libtorrent { };


### PR DESCRIPTION
###### Motivation for this change

VLC normally ships with Chromecast support enabled by default, in the official binaries as well as in other distros (arch, ubuntu, possibly others).

Chromecast support for VLC has been requested on several occasions (https://github.com/NixOS/nixpkgs/pull/35124#issuecomment-385791097, #58365 from me, and [a bunch of times on IRC](https://www.google.ca/search?q="nixos"+"chromecast"+"vlc"+"irc+logs")). 

This PR adds libmicrodns which is a library written by the VLC team that is required for their Chromecast streaming to function.

It also adds Chromecast support to the VLC build enabled by default, but can be overridden.

Fixes #58365.

This is my first nixpkgs contribution, please be gentle. :blush: 

Some notes/questions:
- I'm not sure if this is a strict requirement, but enabling hardware acceleration is important for transcoding especially: https://nixos.wiki/wiki/Accelerated_Video_Playback - I needed to add `intel-media-driver ` to get `libva info: va_openDriver() returns -1` errors to stop. Not sure what's a more generalized solution. Is there a good place to document this? (Otherwise VLC spits out a bunch of errors, might fall back or not)
- Port 8010 must be open (streaming works by creating a temporary HTTP server on port 8010 which streams the transcoded video, then points the Chromecast to open that local URL). Any suggestions for documenting/enforcing this?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
