### PR TITLE
freediag: init at unstable-2019-02-18

### DIFF
--- a/pkgs/applications/misc/freediag/default.nix
+++ b/pkgs/applications/misc/freediag/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, fltk, libGL }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+
+  pname = "freediag";
+  version = "unstable-2019-02-18";
+
+  src = fetchFromGitHub {
+    owner = "fenugrec";
+    repo = "freediag";
+    rev = "c33eab1aa1c6840676b12eca9f0cddfdf7506523";
+    sha256 = "1gg0210rhwlfjx8dqs3ivpxcdvwhn57p228v79zz58ljnlm7766p";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [ fltk libGL ];
+
+  cmakeFlags = [ "-DBUILD_GUI=1" ];
+
+  meta = {
+    description = "Free diagnostic software for OBD-II compliant motor vehicles";
+    homepage = https://freediag.sourceforge.net/;
+    maintainers = [ maintainers.genesis ];
+    platforms = platforms.linux;
+    license = stdenv.lib.licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2838,6 +2838,8 @@ in
 
   freebind = callPackage ../tools/networking/freebind { };
 
+  freediag = callPackage ../applications/misc/freediag { };
+
   freeipmi = callPackage ../tools/system/freeipmi {};
 
   freetalk = callPackage ../applications/networking/instant-messengers/freetalk {


### PR DESCRIPTION
###### Motivation for this change

unstable-2019-02-18 since @fenugrec had not released since some years and later the better!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
