### PR TITLE
mspdebug: darwin fixes and enableParallelBuilding

### DIFF
--- a/pkgs/development/misc/msp430/mspdebug.nix
+++ b/pkgs/development/misc/msp430/mspdebug.nix
@@ -3,8 +3,11 @@
 , libusb-compat-0_1
 , readline ? null
 , enableReadline ? true
+, hidapi ? null
+, pkg-config ? null
 }:
 
+assert stdenv.isDarwin -> hidapi != null && pkg-config != null;
 assert enableReadline -> readline != null;
 
 stdenv.mkDerivation rec {
@@ -17,11 +20,24 @@ stdenv.mkDerivation rec {
     sha256 = "0prgwb5vx6fd4bj12ss1bbb6axj2kjyriyjxqrzd58s5jyyy8d3c";
   };
 
-  buildInputs = [ libusb-compat-0_1 ]
-  ++ stdenv.lib.optional enableReadline readline;
-  installFlags = [ "PREFIX=$(out)" "INSTALL=install" ];
-  makeFlags = stdenv.lib.optional (!enableReadline) "WITHOUT_READLINE=1";
   enableParallelBuilding = true;
+  nativeBuildInputs = stdenv.lib.optional stdenv.isDarwin pkg-config;
+  buildInputs = [ libusb-compat-0_1 ]
+  ++ stdenv.lib.optional stdenv.isDarwin hidapi
+  ++ stdenv.lib.optional enableReadline readline;
+
+  postPatch = stdenv.lib.optionalString stdenv.isDarwin ''
+    # TODO: remove once a new 0.26+ release is made
+    substituteInPlace drivers/tilib_api.c --replace .so ${stdenv.hostPlatform.extensions.sharedLibrary}
+
+    # Makefile only uses pkg-config if it detects homebrew
+    substituteInPlace Makefile --replace brew true
+  '';
+
+  installFlags = [ "PREFIX=$(out)" "INSTALL=install" ];
+  makeFlags = [ "UNAME_S=$(unameS)" ] ++
+    stdenv.lib.optional (!enableReadline) "WITHOUT_READLINE=1";
+  unameS = stdenv.lib.optionalString stdenv.isDarwin "Darwin";
 
   meta = with stdenv.lib; {
     description = "A free programmer, debugger, and gdb proxy for MSP430 MCUs";

--- a/pkgs/development/misc/msp430/mspdebug.nix
+++ b/pkgs/development/misc/msp430/mspdebug.nix
@@ -1,10 +1,15 @@
-{ stdenv, fetchFromGitHub, libusb-compat-0_1, readline ? null }:
+{ stdenv
+, fetchFromGitHub
+, libusb-compat-0_1
+, readline ? null
+, enableReadline ? true
+}:
 
-let
+assert enableReadline -> readline != null;
+
+stdenv.mkDerivation rec {
   version = "0.25";
-in stdenv.mkDerivation {
   pname = "mspdebug";
-  inherit version;
   src = fetchFromGitHub {
     owner = "dlbeer";
     repo = "mspdebug";
@@ -12,9 +17,11 @@ in stdenv.mkDerivation {
     sha256 = "0prgwb5vx6fd4bj12ss1bbb6axj2kjyriyjxqrzd58s5jyyy8d3c";
   };
 
-  buildInputs = [ libusb-compat-0_1 readline ];
-  makeFlags = [ "PREFIX=$(out)" "INSTALL=install" ] ++
-    (if readline == null then [ "WITHOUT_READLINE=1" ] else []);
+  buildInputs = [ libusb-compat-0_1 ]
+  ++ stdenv.lib.optional enableReadline readline;
+  installFlags = [ "PREFIX=$(out)" "INSTALL=install" ];
+  makeFlags = stdenv.lib.optional (!enableReadline) "WITHOUT_READLINE=1";
+  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     description = "A free programmer, debugger, and gdb proxy for MSP430 MCUs";


### PR DESCRIPTION
###### Motivation for this change

I didn't realise `enableParallelBuilding` wasn't the default behaviour, and the build needed fixing on darwin. mspdebug's makefile attempts to detect whether homebrew/fink/macports is used on the system, so this kicks it down the right execution path.

Also includes a precursor to #58600, which allows for plugging in the msp debug stack into the binary's runtimepath (mspdebug uses dlopen to find the library). The derivations themselves are left to the other PR, since they may need more thorough review or may not be appropriate for inclusion in nixpkgs etc.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---