### PR TITLE
MSP430 debug stack

### DIFF
--- a/pkgs/development/misc/msp430/mspds/binary.nix
+++ b/pkgs/development/misc/msp430/mspds/binary.nix
@@ -1,0 +1,35 @@
+{ stdenv, lib, fetchurl, unzip, autoPatchelfHook }:
+
+with lib;
+
+let
+  archPostfix = optionalString (stdenv.is64bit && !stdenv.isDarwin) "_64";
+in stdenv.mkDerivation rec {
+  pname = "msp-debug-stack-bin";
+  version = "3.15.1.1";
+  src = fetchurl {
+    url = "http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPDS/3_15_1_001/export/MSP430_DLL_Developer_Package_Rev_3_15_1_1.zip";
+    sha256 = "1m1ssrwbhqvqwbp3m4hnjyxnz3f9d4acz9vl1av3fbnhvxr0d2hb";
+  };
+  sourceRoot = ".";
+
+  libname =
+    if stdenv.hostPlatform.isWindows then "MSP430${archPostfix}.dll"
+    else "libmsp430${archPostfix}${stdenv.hostPlatform.extensions.sharedLibrary}";
+
+  nativeBuildInputs = [ unzip autoPatchelfHook ];
+  buildInputs = [ stdenv.cc.cc ];
+
+  installPhase = ''
+    install -Dm0755 $libname $out/lib/''${libname//_64/}
+    install -Dm0644 -t $out/include Inc/*.h
+  '';
+
+  meta = {
+    description = "Unfree binary release of the TI MSP430 FET debug driver";
+    homepage = https://www.ti.com/tool/MSPDS;
+    license = licenses.unfree;
+    platforms = platforms.linux ++ platforms.darwin;
+    maintainers = with maintainers; [ aerialx ];
+  };
+}

--- a/pkgs/development/misc/msp430/mspds/bsl430.patch
+++ b/pkgs/development/misc/msp430/mspds/bsl430.patch
@@ -1,0 +1,51 @@
+diff -ruN a/Makefile b/Makefile
+--- a/Makefile	2020-06-03 16:10:18.000000000 -0700
++++ b/Makefile	2020-07-21 18:03:12.464121056 -0700
+@@ -42,7 +42,7 @@
+ 
+ PLATFORM := $(shell uname -s)
+ ifeq ($(PLATFORM),Linux)
+-	CXX:= g++
++	CXX?= g++
+ 	
+ 	STATICOUTPUT := linux64
+ 
+@@ -68,7 +68,7 @@
+ 
+ 	HIDOBJ := $(LIBTHIRD)/hid-libusb.o
+ else
+-	CXX:= clang++
++	CXX?= clang++
+ 
+ 	OUTPUT := libmsp430.dylib
+ 	STATICOUTPUT := mac64
+@@ -134,7 +134,7 @@
+ 	$(CXX) -c -o $@ $< $(USE_PCH) $(CXXFLAGS) $(INCLUDES) $(DEFINES)
+ 
+ $(BSLLIB):
+-	$(MAKE) -C ./ThirdParty/BSL430_DLL
++	$(MAKE) -C ./ThirdParty/BSL430_DLL OUTPUT=../../$(BSLLIB)
+ 
+ install:
+ 	cp $(OUTPUT) /usr/local/lib/
+diff -ruN a/ThirdParty/BSL430_DLL/Makefile b/ThirdParty/BSL430_DLL/Makefile
+--- a/ThirdParty/BSL430_DLL/Makefile	2019-11-18 13:16:00.000000000 -0800
++++ b/ThirdParty/BSL430_DLL/Makefile	2020-07-21 18:02:55.987782494 -0700
+@@ -36,7 +36,7 @@
+ 
+ PLATFORM := $(shell uname -s)
+ ifeq ($(PLATFORM),Linux)
+-	CXX:= g++
++	CXX?= g++
+ 
+ 	ifdef BIT32
+ 	CXXFLAGS += -m32
+@@ -47,7 +47,7 @@
+ 	INCLUDES += -I$(BOOST_DIR)
+ 	endif
+ else
+-	CXX:= clang++
++	CXX?= clang++
+ 
+ 	ifdef BOOST_DIR
+ 	INCLUDES += -I$(BOOST_DIR)/include

--- a/pkgs/development/misc/msp430/mspds/default.nix
+++ b/pkgs/development/misc/msp430/mspds/default.nix
@@ -1,0 +1,56 @@
+{ stdenv
+, lib
+, fetchurl, unzip
+, boost, pugixml
+, hidapi
+, libusb1 ? null
+}:
+
+with lib;
+assert stdenv.isLinux -> libusb1 != null;
+
+let
+  hidapiDriver = optionalString stdenv.isLinux "-libusb";
+
+in stdenv.mkDerivation {
+  pname = "msp-debug-stack";
+  version = "3.15.1.1";
+
+  src = fetchurl {
+    url = "http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPDS/3_15_1_001/export/MSPDebugStack_OS_Package_3_15_1_1.zip";
+    sha256 = "1j5sljqwc20zrb50mrji4mnmw5i680qc7n0lb0pakrrxqjc9m9g3";
+  };
+  sourceRoot = ".";
+
+  enableParallelBuilding = true;
+  libName = "libmsp430${stdenv.hostPlatform.extensions.sharedLibrary}";
+  makeFlags = [ "OUTPUT=$(libName)" "HIDOBJ=" ];
+  NIX_LDFLAGS = [ "-lpugixml" "-lhidapi${hidapiDriver}" ];
+  NIX_CFLAGS_COMPILE = [ "-I${hidapi}/include/hidapi" ];
+
+  patches = [ ./bsl430.patch ];
+
+  preBuild = ''
+    rm ThirdParty/src/pugixml.cpp
+    rm ThirdParty/include/pugi{config,xml}.hpp
+  '' + optionalString stdenv.isDarwin ''
+    makeFlagsArray+=(OUTNAME="-install_name ")
+  '';
+
+  installPhase = ''
+    install -Dm0755 -t $out/lib $libName
+    install -Dm0644 -t $out/include DLL430_v3/include/*.h
+  '';
+
+  nativeBuildInputs = [ unzip ];
+  buildInputs = [ boost hidapi pugixml ]
+    ++ optional stdenv.isLinux libusb1;
+
+  meta = {
+    description = "TI MSP430 FET debug driver";
+    homepage = https://www.ti.com/tool/MSPDS;
+    license = licenses.bsd3;
+    platforms = platforms.linux ++ platforms.darwin;
+    maintainers = with maintainers; [ aerialx ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12207,6 +12207,7 @@ in
   };
 
   mspds = callPackage ../development/misc/msp430/mspds { };
+  mspds-bin = callPackage ../development/misc/msp430/mspds/binary.nix { };
 
   mspdebug = callPackage ../development/misc/msp430/mspdebug.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12206,6 +12206,8 @@ in
     newlib = newlibCross;
   };
 
+  mspds = callPackage ../development/misc/msp430/mspds { };
+
   mspdebug = callPackage ../development/misc/msp430/mspdebug.nix { };
 
   vc4-newlib = callPackage ../development/misc/vc4/newlib.nix {};


### PR DESCRIPTION
###### Motivation for this change

mspdebug has support for loading `libmsp430.so` at runtime to use [TI's vendor driver](https://www.ti.com/tool/MSPDS) for interfacing with debug/jtag hardware, which has better/additional support for their devices.

###### Questions

- Is including the binary distribution appropriate here? It has additional proprietary support, is ahead of the open source release, but is kind of ugly and unfree. The idea is that if you need it, you can use `pkgs.mspdebug.override { mspds = pkgs.mspds-bin; }` to get it. Attempts to contact them about updating the open-source version were deflected.
- `enableMspds` is currently `? false` in #58598, so this won't be used by default. Would it make sense to change that default?
- Is the patch alright? The package is messy vendor code based on an outdated boost and doesn't compile otherwise. [There's some discussion on why it's necessary](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=224094#c4).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---