### PR TITLE
typora: 0.9.64 -> 0.9.68

### DIFF
--- a/pkgs/applications/editors/typora/default.nix
+++ b/pkgs/applications/editors/typora/default.nix
@@ -1,32 +1,44 @@
-{ stdenv, fetchurl, makeWrapper, electron_3, dpkg, gtk3, glib, gnome3, wrapGAppsHook }:
+{ stdenv, fetchurl, makeWrapper, electron_3, dpkg, gtk3, glib, gsettings-desktop-schemas, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   pname = "typora";
-  version = "0.9.64";
+  version = "0.9.68";
 
   src = fetchurl {
     url = "https://www.typora.io/linux/typora_${version}_amd64.deb";
-    sha256 = "0dffydc11ys2i38gdy8080ph1xlbbzhcdcc06hyfv0dr0nf58a09";
+    sha256 = "09hkmnh9avzb7nc8i67vhbv6nc1v90kk88aq01mpmyibpdqp03zp";
   };
 
-  nativeBuildInputs = [ dpkg makeWrapper wrapGAppsHook ];
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+    wrapGAppsHook
+  ];
 
-  buildInputs = [ gtk3 glib gnome3.gsettings-desktop-schemas ];
+  buildInputs = [
+    glib
+    gsettings-desktop-schemas
+    gtk3
+  ];
 
   unpackPhase = "dpkg-deb -x $src .";
 
   dontWrapGApps = true;
 
   installPhase = ''
-    mkdir -p $out/bin $out/share/typora
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share
     {
       cd usr
-      mv share/typora/resources/app/* $out/share/typora
-      mv share/applications $out/share
-      mv share/icons $out/share
-      mv share/doc $out/share
+      mv share/typora/resources/app $out/share/typora
+      mv share/{applications,icons,doc} $out/share/
     }
 
+    runHook postInstall
+  '';
+
+  postFixup = ''
     makeWrapper ${electron_3}/bin/electron $out/bin/typora \
       --add-flags $out/share/typora \
       "''${gappsWrapperArgs[@]}" \
@@ -37,7 +49,7 @@ stdenv.mkDerivation rec {
     description = "A minimal Markdown reading & writing app";
     homepage = https://typora.io;
     license = licenses.unfree;
-    maintainers = with maintainers; [ jensbin ];
+    maintainers = with maintainers; [ jensbin worldofpeace ];
     inherit (electron_3.meta) platforms;
   };
 }


### PR DESCRIPTION
###### Commit Message

Make the wrapping happen in postFixup
or else the wrapper is incomplete.
That was noted in #56533

Closes https://github.com/NixOS/nixpkgs/pull/56533

###### Motivation for this change
Finish https://github.com/NixOS/nixpkgs/pull/56533

This fixes a crash (incomplete wrapper) so I will be porting to stable.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @dtzWill 