### PR TITLE
yubico-pam: init, nixos integration

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -48,6 +48,16 @@ let
         '';
       };
 
+      yubicoAuth = mkOption {
+        default = config.security.pam.yubico.enable;
+        type = types.bool;
+        description = ''
+          If set, users listed in
+          <filename>~/.yubico/authorized_yubikeys</filename>
+          are able to log in with the asociated Yubikey tokens.
+        '';
+      };
+
       googleAuthenticator = {
         enable = mkOption {
           default = false;
@@ -340,6 +350,8 @@ let
               "auth sufficient ${pkgs.pam_usb}/lib/security/pam_usb.so"}
           ${let oath = config.security.pam.oath; in optionalString cfg.oathAuth
               "auth requisite ${pkgs.oathToolkit}/lib/security/pam_oath.so window=${toString oath.window} usersfile=${toString oath.usersFile} digits=${toString oath.digits}"}
+          ${let yubi = config.security.pam.yubico; in optionalString cfg.yubicoAuth
+              "auth ${yubi.control} ${pkgs.yubico-pam}/lib/security/pam_yubico.so id=${toString yubi.id} ${optionalString yubi.debug "debug"}"}
         '' +
           # Modules in this block require having the password set in PAM_AUTHTOK.
           # pam_unix is marked as 'sufficient' on NixOS which means nothing will run
@@ -632,6 +644,54 @@ in
           If you set this option to <literal>true</literal>,
           <literal>cue</literal> option is added to <literal>pam-u2f</literal>
           module and reminder message will be displayed.
+        '';
+      };
+    };
+
+    security.pam.yubico = {
+      enable = mkOption {
+        default = false;
+        type = types.bool;
+        description = ''
+          Enables Yubico PAM (<literal>yubico-pam</literal>) module.
+
+          If set, users listed in
+          <filename>~/.yubico/authorized_yubikeys</filename>
+          are able to log in with the associated Yubikey tokens.
+
+          The file must have only one line:
+          <literal>username:yubikey_token_id1:yubikey_token_id2</literal>
+          More information can be found <link
+          xlink:href="https://developers.yubico.com/yubico-pam/">here</link>.
+        '';
+      };
+      control = mkOption {
+        default = "sufficient";
+        type = types.enum [ "required" "requisite" "sufficient" "optional" ];
+        description = ''
+          This option sets pam "control".
+          If you want to have multi factor authentication, use "required".
+          If you want to use Yubikey instead of regular password, use "sufficient".
+
+          Read
+          <citerefentry>
+            <refentrytitle>pam.conf</refentrytitle>
+            <manvolnum>5</manvolnum>
+          </citerefentry>
+          for better understanding of this option.
+        '';
+      };
+      id = mkOption {
+        example = "42";
+        type = types.string;
+        description = "client id";
+      };
+
+      debug = mkOption {
+        default = false;
+        type = types.bool;
+        description = ''
+          Debug output to stderr.
         '';
       };
     };

--- a/pkgs/development/libraries/libykclient/default.nix
+++ b/pkgs/development/libraries/libykclient/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, help2man, curl }:
+
+stdenv.mkDerivation rec {
+  pname = "libykclient";
+  version = "unstable-2019-03-18";
+  src = fetchFromGitHub {
+    owner = "Yubico";
+    repo = "yubico-c-client";
+    rev = "ad9eda6aac4c3f81784607c30b971f4a050b5c2e";
+    sha256 = "01b19jgv2lypih6lhw9yjjsfl8q1ahl955vhr2ai8ccshh0050yj";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig help2man ];
+  buildInputs = [ curl ];
+
+  meta = with stdenv.lib; {
+    description = "Yubikey C client library";
+    homepage = https://developers.yubico.com/yubico-c-client;
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/development/libraries/yubico-pam/default.nix
+++ b/pkgs/development/libraries/yubico-pam/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig
+, asciidoc, libxslt, docbook_xsl
+, pam, yubikey-personalization, libyubikey, libykclient }:
+
+stdenv.mkDerivation rec {
+  pname = "yubico-pam";
+  version = "unstable-2019-03-19";
+  src = fetchFromGitHub {
+    owner = "Yubico";
+    repo = pname;
+    rev = "1c6fa66825e77b3ad8df46513d0125bed9bde704";
+    sha256 = "1g41wdwa1wbp391w1crbis4hwz60m3y06rd6j59m003zx40sk9s4";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig asciidoc libxslt docbook_xsl ];
+  buildInputs = [ pam yubikey-personalization libyubikey libykclient ];
+
+  meta = with stdenv.lib; {
+    description = "Yubico PAM module";
+    homepage = https://developers.yubico.com/yubico-pam;
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11731,6 +11731,8 @@ in
       };
   });
 
+  libykclient = callPackage ../development/libraries/libykclient { };
+
   libykneomgr = callPackage ../development/libraries/libykneomgr { };
 
   libytnef = callPackage ../development/libraries/libytnef { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13318,6 +13318,8 @@ in
 
   yubioath-desktop = libsForQt5.callPackage ../applications/misc/yubioath-desktop { };
 
+  yubico-pam = callPackage ../development/libraries/yubico-pam { };
+
   yubico-piv-tool = callPackage ../tools/misc/yubico-piv-tool { };
 
   yubikey-manager = callPackage ../tools/misc/yubikey-manager { };


### PR DESCRIPTION
###### Motivation for this change

PAM module to authenticate against a YubiKey validation server or via
challenge-response against a local YubiKey.

NixOS module only supports (as a start) authenticating against
the public YubiCloud service, but can easily be extended
for use with other services and local challenge-response
usage if there's interest.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---