### PR TITLE
postgresqlPackages.postgis: 2.5.1 -> 2.5.2

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/postgis.nix
+++ b/pkgs/servers/sql/postgresql/ext/postgis.nix
@@ -9,19 +9,21 @@
 , json_c
 , pkgconfig
 , file
+, protobufc
 }:
 stdenv.mkDerivation rec {
   name = "postgis-${version}";
-  version = "2.5.1";
+  version = "2.5.2";
 
   outputs = [ "out" "doc" ];
 
   src = fetchurl {
     url = "https://download.osgeo.org/postgis/source/postgis-${version}.tar.gz";
-    sha256 = "14bsh4kflp4bxilypkpmhrpldknc9s9vgiax8yfhxbisyib704zv";
+    sha256 = "0pnva72f2w4jcgnl1y7nw5rdly4ipx3hji4c9yc9s0hna1n2ijxn";
   };
 
-  buildInputs = [ libxml2 postgresql geos proj perl gdal json_c pkgconfig ];
+  buildInputs = [ libxml2 postgresql geos proj gdal json_c protobufc ];
+  nativeBuildInputs = [ perl pkgconfig ];
   dontDisableStatic = true;
 
   # postgis config directory assumes /include /lib from the same root for json-c library
@@ -59,7 +61,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Geographic Objects for PostgreSQL";
-    homepage = http://postgis.refractions.net;
+    homepage = https://postgis.net/;
     license = licenses.gpl2;
     maintainers = [ maintainers.marcweber ];
     platforms = platforms.linux;


### PR DESCRIPTION
###### Motivation for this change
Changelog: https://svn.osgeo.org/postgis/tags/2.5.2/ChangeLog

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
