### PR TITLE
[WIP] gcc: put target-specific libs in lib output

### DIFF
--- a/pkgs/development/compilers/gcc/7/default.nix
+++ b/pkgs/development/compilers/gcc/7/default.nix
@@ -152,6 +152,9 @@ stdenv.mkDerivation ({
 
   libc_dev = stdenv.cc.libc_dev;
 
+  # set this var to use in builder.sh
+  target_triple = targetPlatform.config;
+
   hardeningDisable = [ "format" "pie" ];
 
   # This should kill all the stdinc frameworks that gcc and friends like to

--- a/pkgs/development/compilers/gcc/builder.sh
+++ b/pkgs/development/compilers/gcc/builder.sh
@@ -213,9 +213,24 @@ preInstall() {
 
 postInstall() {
     # Move runtime libraries to $lib.
-    moveToOutput "lib/lib*.so*" "$lib"
-    moveToOutput "lib/lib*.la"  "$lib"
-    moveToOutput "lib/lib*.dylib" "$lib"
+    if [[ -d "$out/$target_triple/lib" && -n "$(ls -A $out/$target_triple/lib)" ]]; then
+        moveToOutput "$target_triple/lib/lib*.so*" "$lib"
+        moveToOutput "$target_triple/lib/lib*.la" "$lib"
+        moveToOutput "$target_triple/lib/lib*.dylib" "$lib"
+        mv "$lib/$target_triple"/lib/* "$lib/lib/"
+        rmdir -p --ignore-fail-on-non-empty "$lib/$target_triple/lib" || :
+    elif [[ -d "$out/$target_triple/lib64" && -n "$(ls -A $out/$target_triple/lib64)" ]]; then
+        moveToOutput "$target_triple/lib64/lib*.so*" "$lib"
+        moveToOutput "$target_triple/lib64/lib*.la" "$lib"
+        moveToOutput "$target_triple/lib64/lib*.dylib" "$lib"
+        mv "$lib/$target_triple"/lib64/* "$lib/lib/"
+        rmdir -p --ignore-fail-on-non-empty "$lib/$target_triple/lib64" || :
+    else
+        moveToOutput "lib/lib*.so*" "$lib"
+        moveToOutput "lib/lib*.la"  "$lib"
+        moveToOutput "lib/lib*.dylib" "$lib"
+    fi
+
     moveToOutput "share/gcc-*/python" "$lib"
 
     for i in "$lib"/lib/*.{la,py}; do

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -216,6 +216,6 @@ stdenv.mkDerivation ({
 
   # To avoid a dependency on the build system 'bash'.
   preFixup = ''
-    rm -f $bin/bin/{ldd,tzselect,catchsegv,xtrace}
+    rm -f $bin/bin/{ldd,tzselect,catchsegv,xtrace,sotruss}
   '';
 })


### PR DESCRIPTION
###### Motivation for this change

this attempts to solve #58501 and doesn't handle `lib64` _yet_.
so far this seems like the right approach, building a cross package will have less contamination:

```
nix build -f . pkgsCross.armv7l-hf-multiplatform.gmp
nix-store -q --tree result
```

outputs:

```
/nix/store/ag3f3skkh5jpgj66nvifzldk6b587s2g-gmp-6.1.2-armv7l-unknown-linux-gnueabihf
+---/nix/store/9vx22lxyflvh32bnl3abfp9nz49bq3qy-glibc-2.27-armv7l-unknown-linux-gnueabihf
|   +---/nix/store/1318v60073q1lhhwai2156gkymb2yd99-linux-headers-4.19.16
|   +---/nix/store/fgv5srabn8dc3c4q9a564whzbxssacwh-armv7l-unknown-linux-gnueabihf-stage-static-gcc-debug-7.4.0
|   |   +---/nix/store/qnpbfbj9skc060v1m4f91rbiqz1r51wf-glibc-2.27
|   |   |   +---/nix/store/qnpbfbj9skc060v1m4f91rbiqz1r51wf-glibc-2.27 [...]
|   |   +---/nix/store/9hsvkkjaj6cjkbnj6hp6fviaqxg7hz5p-zlib-1.2.11
|   |   |   +---/nix/store/qnpbfbj9skc060v1m4f91rbiqz1r51wf-glibc-2.27 [...]
|   |   +---/nix/store/i7dbgzq3kl4asgrsmgxfj2anz9g8xpkx-gcc-7.4.0-lib
|   |   |   +---/nix/store/qnpbfbj9skc060v1m4f91rbiqz1r51wf-glibc-2.27 [...]
|   |   |   +---/nix/store/i7dbgzq3kl4asgrsmgxfj2anz9g8xpkx-gcc-7.4.0-lib [...]
|   |   +---/nix/store/hxva4x72bnf8x30ncxbxpqic1cj4w97v-gmp-6.1.2
|   |   |   +---/nix/store/qnpbfbj9skc060v1m4f91rbiqz1r51wf-glibc-2.27 [...]
|   |   |   +---/nix/store/i7dbgzq3kl4asgrsmgxfj2anz9g8xpkx-gcc-7.4.0-lib [...]
|   |   |   +---/nix/store/hxva4x72bnf8x30ncxbxpqic1cj4w97v-gmp-6.1.2 [...]
|   |   +---/nix/store/g1ak0vlfbapfi6w51xddx7fqv3vi05fy-gmp-6.1.2-dev
|   |   |   +---/nix/store/hxva4x72bnf8x30ncxbxpqic1cj4w97v-gmp-6.1.2 [...]
|   |   +---/nix/store/wzlq4mai2nv48n4si8sy08xxc7jlwidr-mpfr-4.0.1
|   |   |   +---/nix/store/qnpbfbj9skc060v1m4f91rbiqz1r51wf-glibc-2.27 [...]
|   |   |   +---/nix/store/hxva4x72bnf8x30ncxbxpqic1cj4w97v-gmp-6.1.2 [...]
|   |   |   +---/nix/store/wzlq4mai2nv48n4si8sy08xxc7jlwidr-mpfr-4.0.1 [...]
|   |   +---/nix/store/c03y6a02asz0xw6b30wdl647d1v1vx50-mpfr-4.0.1-dev
|   |   |   +---/nix/store/g1ak0vlfbapfi6w51xddx7fqv3vi05fy-gmp-6.1.2-dev [...]
|   |   |   +---/nix/store/wzlq4mai2nv48n4si8sy08xxc7jlwidr-mpfr-4.0.1 [...]
|   |   |   +---/nix/store/c03y6a02asz0xw6b30wdl647d1v1vx50-mpfr-4.0.1-dev [...]
|   |   +---/nix/store/dlcd2z84f1bk0k7p4s96j4cax1v29a3l-glibc-2.27-dev
|   |   |   +---/nix/store/0kb1y660fncf1pnrarrxjrk9jv0g2dnp-linux-headers-4.19.16
|   |   |   +---/nix/store/qnpbfbj9skc060v1m4f91rbiqz1r51wf-glibc-2.27 [...]
|   |   |   +---/nix/store/yq8nb7p9zv2bb473dm6m0ims46pnnxxv-glibc-2.27-bin
|   |   |       +---/nix/store/qnpbfbj9skc060v1m4f91rbiqz1r51wf-glibc-2.27 [...]
|   |   |       +---/nix/store/yq8nb7p9zv2bb473dm6m0ims46pnnxxv-glibc-2.27-bin [...]
|   |   +---/nix/store/jkl9478pha4frcrr7rnfx1qf2mv3xyhm-gcc-7.4.0
|   |   |   +---/nix/store/qnpbfbj9skc060v1m4f91rbiqz1r51wf-glibc-2.27 [...]
|   |   |   +---/nix/store/9hsvkkjaj6cjkbnj6hp6fviaqxg7hz5p-zlib-1.2.11 [...]
|   |   |   +---/nix/store/dlcd2z84f1bk0k7p4s96j4cax1v29a3l-glibc-2.27-dev [...]
|   |   |   +---/nix/store/i7dbgzq3kl4asgrsmgxfj2anz9g8xpkx-gcc-7.4.0-lib [...]
|   |   |   +---/nix/store/jkl9478pha4frcrr7rnfx1qf2mv3xyhm-gcc-7.4.0 [...]
|   |   +---/nix/store/fhlglb7cd3nw965sgpgv1vghqzrva31h-armv7l-unknown-linux-gnueabihf-stage-static-gcc-debug-7.4.0-lib
|   |   |   +---/nix/store/qnpbfbj9skc060v1m4f91rbiqz1r51wf-glibc-2.27 [...]
|   |   |   +---/nix/store/dlcd2z84f1bk0k7p4s96j4cax1v29a3l-glibc-2.27-dev [...]
|   |   |   +---/nix/store/g1ak0vlfbapfi6w51xddx7fqv3vi05fy-gmp-6.1.2-dev [...]
|   |   |   +---/nix/store/i7dbgzq3kl4asgrsmgxfj2anz9g8xpkx-gcc-7.4.0-lib [...]
|   |   |   +---/nix/store/jkl9478pha4frcrr7rnfx1qf2mv3xyhm-gcc-7.4.0 [...]
|   |   |   +---/nix/store/fhlglb7cd3nw965sgpgv1vghqzrva31h-armv7l-unknown-linux-gnueabihf-stage-static-gcc-debug-7.4.0-lib [...]
|   |   +---/nix/store/k7i1fvz0hqj2r5fzbnhhpk3mw2frx9b9-isl-0.17.1
|   |   |   +---/nix/store/qnpbfbj9skc060v1m4f91rbiqz1r51wf-glibc-2.27 [...]
|   |   |   +---/nix/store/hxva4x72bnf8x30ncxbxpqic1cj4w97v-gmp-6.1.2 [...]
|   |   |   +---/nix/store/k7i1fvz0hqj2r5fzbnhhpk3mw2frx9b9-isl-0.17.1 [...]
|   |   +---/nix/store/kyqlj3mwbijbnkz3nnjr2axixla0rj6p-zlib-1.2.11-dev
|   |   |   +---/nix/store/9hsvkkjaj6cjkbnj6hp6fviaqxg7hz5p-zlib-1.2.11 [...]
|   |   |   +---/nix/store/kyqlj3mwbijbnkz3nnjr2axixla0rj6p-zlib-1.2.11-dev [...]
|   |   +---/nix/store/nrgnbk0hb2s5hxfa5ndqirr32rcp99wh-libmpc-1.1.0
|   |   |   +---/nix/store/qnpbfbj9skc060v1m4f91rbiqz1r51wf-glibc-2.27 [...]
|   |   |   +---/nix/store/hxva4x72bnf8x30ncxbxpqic1cj4w97v-gmp-6.1.2 [...]
|   |   |   +---/nix/store/wzlq4mai2nv48n4si8sy08xxc7jlwidr-mpfr-4.0.1 [...]
|   |   |   +---/nix/store/nrgnbk0hb2s5hxfa5ndqirr32rcp99wh-libmpc-1.1.0 [...]
|   |   +---/nix/store/pxfr26jq9i660vrh6wwg8jvj1lriiifl-armv7l-unknown-linux-gnueabihf-binutils-wrapper-2.31.1
|   |   |   +---/nix/store/134rh2gyfx67hicrb72nn72a5qxnxi03-armv7l-unknown-linux-gnueabihf-binutils-2.31.1
|   |   |   |   +---/nix/store/qnpbfbj9skc060v1m4f91rbiqz1r51wf-glibc-2.27 [...]
|   |   |   |   +---/nix/store/9hsvkkjaj6cjkbnj6hp6fviaqxg7hz5p-zlib-1.2.11 [...]
|   |   |   |   +---/nix/store/dlcd2z84f1bk0k7p4s96j4cax1v29a3l-glibc-2.27-dev [...]
|   |   |   |   +---/nix/store/jkl9478pha4frcrr7rnfx1qf2mv3xyhm-gcc-7.4.0 [...]
|   |   |   |   +---/nix/store/kyqlj3mwbijbnkz3nnjr2axixla0rj6p-zlib-1.2.11-dev [...]
|   |   |   |   +---/nix/store/134rh2gyfx67hicrb72nn72a5qxnxi03-armv7l-unknown-linux-gnueabihf-binutils-2.31.1 [...]
|   |   |   +---/nix/store/6srk6zg63pmhfk70xb524ly64s74ifh0-coreutils-8.30
|   |   |   |   +---/nix/store/qnpbfbj9skc060v1m4f91rbiqz1r51wf-glibc-2.27 [...]
|   |   |   |   +---/nix/store/7yzs8cyz7zwxxhb1dhz234s54rqi49fq-attr-2.4.48
|   |   |   |   |   +---/nix/store/qnpbfbj9skc060v1m4f91rbiqz1r51wf-glibc-2.27 [...]
|   |   |   |   |   +---/nix/store/7yzs8cyz7zwxxhb1dhz234s54rqi49fq-attr-2.4.48 [...]
|   |   |   |   +---/nix/store/p8ci32bj6ar2z4lcqh82p5pjk93pry49-acl-2.2.53
|   |   |   |   |   +---/nix/store/qnpbfbj9skc060v1m4f91rbiqz1r51wf-glibc-2.27 [...]
|   |   |   |   |   +---/nix/store/7yzs8cyz7zwxxhb1dhz234s54rqi49fq-attr-2.4.48 [...]
|   |   |   |   |   +---/nix/store/p8ci32bj6ar2z4lcqh82p5pjk93pry49-acl-2.2.53 [...]
|   |   |   |   +---/nix/store/6srk6zg63pmhfk70xb524ly64s74ifh0-coreutils-8.30 [...]
|   |   |   +---/nix/store/j5m01jg66nyvpzyiias64qvhnnwk4h1w-bash-4.4-p23
|   |   |   |   +---/nix/store/qnpbfbj9skc060v1m4f91rbiqz1r51wf-glibc-2.27 [...]
|   |   |   |   +---/nix/store/j5m01jg66nyvpzyiias64qvhnnwk4h1w-bash-4.4-p23 [...]
|   |   |   +---/nix/store/qqwv26l3144wmlq2azd59vb12vc70pbi-expand-response-params
|   |   |   |   +---/nix/store/qnpbfbj9skc060v1m4f91rbiqz1r51wf-glibc-2.27 [...]
|   |   |   +---/nix/store/pxfr26jq9i660vrh6wwg8jvj1lriiifl-armv7l-unknown-linux-gnueabihf-binutils-wrapper-2.31.1 [...]
|   |   +---/nix/store/fgv5srabn8dc3c4q9a564whzbxssacwh-armv7l-unknown-linux-gnueabihf-stage-static-gcc-debug-7.4.0 [...]
|   +---/nix/store/9vx22lxyflvh32bnl3abfp9nz49bq3qy-glibc-2.27-armv7l-unknown-linux-gnueabihf [...]
+---/nix/store/v7pqcls3yg3c07g3nv626k52g857g6nn-armv7l-unknown-linux-gnueabihf-stage-final-gcc-debug-7.4.0-lib
|   +---/nix/store/fgv5srabn8dc3c4q9a564whzbxssacwh-armv7l-unknown-linux-gnueabihf-stage-static-gcc-debug-7.4.0 [...]
|   +---/nix/store/9vx22lxyflvh32bnl3abfp9nz49bq3qy-glibc-2.27-armv7l-unknown-linux-gnueabihf [...]
|   +---/nix/store/2cmra08am4j5ivh7r45mlx76gi713brn-glibc-2.27-armv7l-unknown-linux-gnueabihf-dev
|   |   +---/nix/store/1318v60073q1lhhwai2156gkymb2yd99-linux-headers-4.19.16 [...]
|   |   +---/nix/store/9vx22lxyflvh32bnl3abfp9nz49bq3qy-glibc-2.27-armv7l-unknown-linux-gnueabihf [...]
|   |   +---/nix/store/1nd86q922hb3vd047d7xqnkjk9284rs0-glibc-2.27-armv7l-unknown-linux-gnueabihf-bin
|   |       +---/nix/store/1318v60073q1lhhwai2156gkymb2yd99-linux-headers-4.19.16 [...]
|   |       +---/nix/store/fgv5srabn8dc3c4q9a564whzbxssacwh-armv7l-unknown-linux-gnueabihf-stage-static-gcc-debug-7.4.0 [...]
|   |       +---/nix/store/9vx22lxyflvh32bnl3abfp9nz49bq3qy-glibc-2.27-armv7l-unknown-linux-gnueabihf [...]
|   |       +---/nix/store/j5m01jg66nyvpzyiias64qvhnnwk4h1w-bash-4.4-p23 [...]
|   +---/nix/store/v7pqcls3yg3c07g3nv626k52g857g6nn-armv7l-unknown-linux-gnueabihf-stage-final-gcc-debug-7.4.0-lib [...]
+---/nix/store/ag3f3skkh5jpgj66nvifzldk6b587s2g-gmp-6.1.2-armv7l-unknown-linux-gnueabihf [...]
```

so that's great! `*.so`s are correctly moved to the `lib` output so we don't have to take the entire cross-gcc runtime closure with us, but there's still contamination! the rest of it comes from the `stage-static-gcc` compiler and is in the form of references to `/nix/store/HASH-armv7l-unknown-linux-gnueabihf-stage-static-gcc-debug-7.4.0/lib/gcc/armv7l-unknown-linux-gnueabihf/7.4.0/include`.

You can verify this by taking a binary (say a lib from glibc) and grepping for the cross-compiler's hash:
```
$ strings /nix/store/9vx22lxyflvh32bnl3abfp9nz49bq3qy-glibc-2.27-armv7l-unknown-linux-gnueabihf/lib/libc.so.6 | grep fgv5srabn8dc3c4q9a564whzbxssacwh 
/nix/store/fgv5srabn8dc3c4q9a564whzbxssacwh-armv7l-unknown-linux-gnueabihf-stage-static-gcc-debug-7.4.0/lib/gcc/armv7l-unknown-linux-gnueabihf/7.4.0/include
/nix/store/fgv5srabn8dc3c4q9a564whzbxssacwh-armv7l-unknown-linux-gnueabihf-stage-static-gcc-debug-7.4.0/lib/gcc/armv7l-unknown-linux-gnueabihf/7.4.0/include
/nix/store/fgv5srabn8dc3c4q9a564whzbxssacwh-armv7l-unknown-linux-gnueabihf-stage-static-gcc-debug-7.4.0/lib/gcc/armv7l-unknown-linux-gnueabihf/7.4.0/include
/nix/store/fgv5srabn8dc3c4q9a564whzbxssacwh-armv7l-unknown-linux-gnueabihf-stage-static-gcc-debug-7.4.0/lib/gcc/armv7l-unknown-linux-gnueabihf/7.4.0/include
...
```

So it turns out there's some headers stored in the cross-gcc closure whose path is compiled into a bunch of binaries. It's at this point where I'm unsure of what to do. I should separate the headers into a separate output, but then how do I tell other derivations to look at that path for header files (where do I add the extra `-I` flag)? Maybe in the gcc wrapper? not sure where that's built.

Here's a running list of build dependencies that are brought into run-time:

- [x] `stage-final-gcc-debug-7.4.0/armv7l-unknown-linux-gnueabihf/lib/*`
- [x] `stage-final-gcc-debug-7.4.0/armv7l-unknown-linux-gnueabihf/lib64/*`
- [x] `stage-static-gcc-debug-7.4.0/lib/gcc/armv7l-unknown-linux-gnueabihf/7.4.0/include/*`
- [x] `stage-final-gcc-debug-7.4.0/lib/gcc/armv7l-unknown-linux-gnueabihf/7.4.0/include/*`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
