### PR TITLE
brig: 0.3.0 -> 0.4.1

### DIFF
--- a/pkgs/applications/networking/brig/default.nix
+++ b/pkgs/applications/networking/brig/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "brig-${version}";
-  version = "0.3.0";
+  version = "0.4.1";
   rev = "v${version}";
 
   goPackagePath = "github.com/sahib/brig";
@@ -12,7 +12,7 @@ buildGoPackage rec {
     owner = "sahib";
     repo = "brig";
     inherit rev;
-    sha256 = "01hpb6cvq8cw21ka74jllggkv5pavc0sbl1207x32gzxslw3gsvy";
+    sha256 = "0gi39jmnzqrgj146yw8lcmgmvzx7ii1dgw4iqig7kx8c0jiqi600";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
Update brig to 0.4.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
