### PR TITLE
pyre: 0.0.20 -> 0.0.22

### DIFF
--- a/pkgs/development/python-modules/xxhash/default.nix
+++ b/pkgs/development/python-modules/xxhash/default.nix
@@ -1,0 +1,21 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  version = "1.3.0";
+  pname = "xxhash";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1rhrqrlq4n3vgqd1fv1dcc5ga5dzy9qbd40p8rsqqhh5klxg48gy";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/ifduyue/python-xxhash;
+    description = "Python Binding for xxHash https://pypi.org/project/xxhash/";
+    license = licenses.bsd2;
+    maintainers = [ maintainers.teh ];
+  };
+}

--- a/pkgs/development/tools/pyre/default.nix
+++ b/pkgs/development/tools/pyre/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, ocamlPackages, writeScript
-, dune, python3, rsync, buck, watchman }:
+, dune, python3, rsync, buck, watchman, sqlite }:
 let
   # Manually set version - the setup script requires
   # hg and git + keeping the .git directory around.
-  pyre-version = "0.0.20";  # also change typeshed revision below with $pyre-src/.typeshed-version
+  pyre-version = "0.0.22";  # also change typeshed revision below with $pyre-src/.typeshed-version
   pyre-src = fetchFromGitHub {
     owner = "facebook";
     repo = "pyre-check";
     rev = "v${pyre-version}";
-    sha256 = "1alkhdhvmigdhxvvarh0lr5s3b1s6q4arykip2dqb62vs8064s17";
+    sha256 = "057vy6zmgwsi0ag9n4m6sszhahmfk2s1ywm36nyfs7w4d0wnk92s";
   };
   versionFile = writeScript "version.ml" ''
     cat > "./version.ml" <<EOF
@@ -41,6 +41,8 @@ let
     ppxlib
     dune
     ounit
+    base64
+    sqlite.dev
     # python36Packages.python36Full # TODO
   ];
 
@@ -115,7 +117,16 @@ in python3.pkgs.buildPythonApplication rec {
 
   buildInputs = [ pyre-bin ];
   nativeBuildInputs = [ rsync ]; # only required for build-pypi-package.sh
-  propagatedBuildInputs = with python3.pkgs; [ docutils typeshed ];
+  propagatedBuildInputs = with python3.pkgs; [
+    docutils
+    typeshed
+    click-log
+    ipython
+    sqlalchemy
+    munch
+    xxhash
+    ujson
+  ];
   buildPhase = ''
     bash scripts/build-pypi-package.sh --version ${pyre-version} --bundle-typeshed ${typeshed}
     cp -r build/dist dist

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4422,6 +4422,8 @@ in {
 
   xlwt = callPackage ../development/python-modules/xlwt { };
 
+  xxhash = callPackage ../development/python-modules/xxhash { };
+
   youtube-dl = callPackage ../tools/misc/youtube-dl {};
 
   youtube-dl-light = callPackage ../tools/misc/youtube-dl {


### PR DESCRIPTION
###### Motivation for this change

Update pyre

###### Things done

NB - I only checked the pyre build. It's possible (likely?) that the base64 update will break other ocaml dependencies. I'll report back when `nix-review` finished on my laptop.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
