### PR TITLE
dep2nix: 0.0.2 -> 2019-01-20

### DIFF
--- a/pkgs/development/tools/dep2nix/default.nix
+++ b/pkgs/development/tools/dep2nix/default.nix
@@ -2,16 +2,16 @@
 , makeWrapper, nix-prefetch-scripts }:
 
 buildGoPackage rec {
-  name = "dep2nix-${version}";
-  version = "0.0.2";
+  pname = "dep2nix";
+  version = "unstable-2019-04-02";
 
   goPackagePath = "github.com/nixcloud/dep2nix";
 
   src = fetchFromGitHub {
     owner = "nixcloud";
-    repo = "dep2nix";
-    rev = version;
-    sha256 = "17csgnd6imr1l0gpirsvr5qg7z0mpzxj211p2nwqilrvbp8zj7vg";
+    repo = pname;
+    rev = "830684f920333b8ff0946d6b807e8be642eec3ef";
+    sha256 = "17sjxhzhmz4893x3x054anp4xvqd1px15nv3fj2m7i6r0vbgpm0j";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
upstream HEAD includes a fix for a issue with `fetchgit` https://github.com/nixcloud/dep2nix/pull/15
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
