### PR TITLE
python.pkgs.celery: 4.3.0rc1 -> 4.3.0

### DIFF
--- a/pkgs/development/python-modules/amqp/default.nix
+++ b/pkgs/development/python-modules/amqp/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "amqp";
-  version = "2.4.1";
+  version = "2.4.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "6816eed27521293ee03aa9ace300a07215b11fee4e845588a9b863a7ba30addb";
+    sha256 = "043beb485774ca69718a35602089e524f87168268f0d1ae115f28b88d27f92d7";
   };
 
   checkInputs = [ pytest case pytest-sugar ];

--- a/pkgs/development/python-modules/celery/default.nix
+++ b/pkgs/development/python-modules/celery/default.nix
@@ -4,12 +4,17 @@
 
 buildPythonPackage rec {
   pname = "celery";
-  version = "4.3.0rc1";
+  version = "4.3.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1jmg47l0b3bnwmg44x48bwziwyk6xqs1y5plvr99a3ikz1l807yf";
+    sha256 = "4c4532aa683f170f40bd76f928b70bc06ff171a959e06e71bf35f2f9d6031ef9";
   };
+
+  postPatch = ''
+    substituteInPlace requirements/test.txt \
+      --replace "pytest>=4.3.1,<4.4.0" pytest
+  '';
 
   # make /etc/protocols accessible to fix socket.getprotobyname('tcp') in sandbox
   preCheck = stdenv.lib.optionalString stdenv.isLinux ''

--- a/pkgs/development/python-modules/kombu/default.nix
+++ b/pkgs/development/python-modules/kombu/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "kombu";
-  version = "4.3.0";
+  version = "4.5.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "529df9e0ecc0bad9fc2b376c3ce4796c41b482cf697b78b71aea6ebe7ca353c8";
+    sha256 = "389ba09e03b15b55b1a7371a441c894fd8121d174f5583bbbca032b9ea8c9edd";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/vine/default.nix
+++ b/pkgs/development/python-modules/vine/default.nix
@@ -3,13 +3,13 @@
 
 buildPythonPackage rec {
   pname = "vine";
-  version = "1.2.0";
+  version = "1.3.0";
 
   disable = pythonOlder "2.7";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0xjz2sjbr5jrpjk411b7alkghdskhphgsqqrbi7abqfh2pli6j7f";
+    sha256 = "133ee6d7a9016f177ddeaf191c1f58421a1dcc6ee9a42c58b34bed40e1d2cd87";
   };
 
   buildInputs = [ case pytest ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
