### PR TITLE
qsynth: 0.5.2 -> 0.5.4

### DIFF
--- a/pkgs/applications/audio/qsynth/default.nix
+++ b/pkgs/applications/audio/qsynth/default.nix
@@ -2,17 +2,17 @@
 
 stdenv.mkDerivation  rec {
   name = "qsynth-${version}";
-  version = "0.5.2";
+  version = "0.5.4";
 
   src = fetchurl {
     url = "mirror://sourceforge/qsynth/${name}.tar.gz";
-    sha256 = "1rfkaxq1pyc4hv3l0i6wicianbcbm1wp53kh9i5d4jsljgisd1dv";
+    sha256 = "0kpq5fxr96wnii18ax780w1ivq8ksk892ac0bprn92iz0asfysrd";
   };
 
-  # cmake is looking for qsynth.desktop.in and fails if it doesn't find it
-  # seems like a bug and can presumable go in the next version after 0.5.2
-  postPatch = ''
-    mv src/qsynth.desktop src/qsynth.desktop.in
+  # cmake is looking for qsynth.desktop in the build directory instead of the
+  # src directory and fails at the install phase if it doesn't find it
+  preInstall = ''
+    mv ../src/qsynth.desktop src/qsynth.desktop
   '';
 
   nativeBuildInputs = [ cmake pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

QSynth 0.5.2 fails to compile for me now, presumably because of [the incompatibility with fluidsynth >= 2.0.0](https://sourceforge.net/p/qsynth/tickets/15/).

The last version is actually 0.5.5 but I didn't manage to compile it because of [this issue](https://sourceforge.net/p/qsynth/tickets/17/).

The previous issue with the desktop file was more "moved" than fixed ^^

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
