### PR TITLE
djview: fix mozilla plugin path

### DIFF
--- a/pkgs/applications/graphics/djview/default.nix
+++ b/pkgs/applications/graphics/djview/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   ++ stdenv.lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.AGL ];
 
   passthru = {
-    mozillaPlugin = "/lib/netscape/plugins";
+    mozillaPlugin = "/lib/mozilla/plugins";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

Attempting to fix ```nixpkgs.config.firefox.enableDjvu = true;```

The plugins are in ```$out/lib/mozilla/plugins```.
```$out/lib/netscape/plugins``` does not exist
