### PR TITLE
pythonPackages.jsbeautifier: 1.8.9 -> 1.9.1

### DIFF
--- a/pkgs/development/python-modules/jsbeautifier/default.nix
+++ b/pkgs/development/python-modules/jsbeautifier/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchPypi, buildPythonApplication, EditorConfig, pytest, six }:
+{ lib, fetchPypi, buildPythonApplication, EditorConfig, fetchpatch, pytest, six }:
 
 buildPythonApplication rec {
   pname = "jsbeautifier";
@@ -12,6 +12,15 @@ buildPythonApplication rec {
     inherit pname version;
     sha256 = "7d02baa9b0459bf9c5407c1b99ad5566de04a3b664b18a58ac64f52832034204";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/beautify-web/js-beautify/commit/78e35a11cbb805fc044241d6465800ee2bd57ebc.patch";
+      sha256 = "1ah7nshk96yljy37i20v4fga834dix9cdbhkdc3flfm4904n4523";
+    })
+  ];
+
+  patchFlags = [ "-p2" ];
 
   meta = with lib; {
     homepage    = "http://jsbeautifier.org";

--- a/pkgs/development/python-modules/jsbeautifier/default.nix
+++ b/pkgs/development/python-modules/jsbeautifier/default.nix
@@ -2,15 +2,14 @@
 
 buildPythonApplication rec {
   pname = "jsbeautifier";
-  version = "1.8.9";
+  version = "1.9.1";
 
-  propagatedBuildInputs = [ six ];
-
-  buildInputs = [ EditorConfig pytest ];
+  propagatedBuildInputs = [ six EditorConfig ];
+  checkInputs = [ pytest ];
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "7d02baa9b0459bf9c5407c1b99ad5566de04a3b664b18a58ac64f52832034204";
+    sha256 = "0q8ld072dkccssagjxyvc9633fb6ynflvz70924phgp3zxmim960";
   };
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change

Up and "fix" #58608. I use doCheck = false; because there is a bug in the jsb test suite (cf #58608). It will have to be reactivated when the bug is fixed. I took the opportunity to upgrade.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
