### PR TITLE
qgit: Fix meta.homepage

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/qgit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/qgit/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     license = licenses.gpl2;
-    homepage = http://libre.tibirna.org/projects/qgit/wiki/QGit;
+    homepage = https://github.com/tibirna/qgit;
     description = "Graphical front-end to Git";
     maintainers = with maintainers; [ peterhoeg markuskowa ];
     inherit (qtbase.meta) platforms;


### PR DESCRIPTION
###### Motivation for this change

`meta.homepage` was wrong.
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
