### PR TITLE
cask: init at 0.8.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1613,6 +1613,11 @@
     github = "FireyFly";
     name = "Jonas Höglund";
   };
+  flexw = {
+    email = "felix.weilbach@t-online.de";
+    github = "FlexW";
+    name = "Felix Weilbach";
+  };
   flokli = {
     email = "flokli@flokli.de";
     github = "flokli";

--- a/pkgs/development/tools/cask/default.nix
+++ b/pkgs/development/tools/cask/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchurl, emacs, python }:
+
+stdenv.mkDerivation rec {
+  name = "cask-${version}";
+  version = "0.8.4";
+
+  src = fetchurl {
+    url = "https://github.com/cask/cask/archive/v${version}.tar.gz";
+    sha256 = "02f8bb20b33b23fb11e7d2a1d282519dfdb8b3090b9672448b8c2c2cacd3e478";
+  };
+
+  doCheck = true;
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/templates
+    install -Dm644 *.el $out/
+    install -Dm755 bin/cask $out/bin
+    install -Dm644 templates/* $out/templates/
+    touch $out/.no-upgrade
+    mkdir -p $out/usr/share/emacs/site-lisp/cask
+    ln -s cask{,-bootstrap}.el $out/usr/share/emacs/site-lisp/cask/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Project management for Emacs";
+    longDescription = ''
+      Cask is a project management tool for Emacs that helps automate the
+      package development cycle; development, dependencies, testing, building,
+      packaging and more.
+      Cask can also be used to manage dependencies for your local Emacs configuration.
+    '';
+
+    homepage = https://cask.readthedocs.io/en/latest/index.html;
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.flexw ];
+  };
+
+  nativeBuildInputs = [ emacs python ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8591,6 +8591,8 @@ in
 
   cadre = callPackage ../development/tools/cadre { };
 
+  cask = callPackage ../development/tools/cask { };
+
   casperjs = callPackage ../development/tools/casperjs {
     inherit (texFunctions) fontsConf;
   };


### PR DESCRIPTION
###### Motivation for this change
This adds the version cask as packaged by Arch Linux AUR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
