### PR TITLE
kde-frameworks: 5.54 -> 5.56

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/extra-cmake-modules/nix-lib-path.patch
+++ b/pkgs/development/libraries/kde-frameworks/extra-cmake-modules/nix-lib-path.patch
@@ -14,7 +14,7 @@ index 52b2eb2..a04596c 100644
 -# reason is: amd64 ABI: http://www.x86-64.org/documentation/abi.pdf
 -# For Debian with multiarch, use 'lib/${CMAKE_LIBRARY_ARCHITECTURE}' if
 -# CMAKE_LIBRARY_ARCHITECTURE is set (which contains e.g. "i386-linux-gnu"
--# See http://wiki.debian.org/Multiarch
+-# See https://wiki.debian.org/Multiarch
 -if((CMAKE_SYSTEM_NAME MATCHES "Linux|kFreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "GNU")
 -   AND NOT CMAKE_CROSSCOMPILING
 -   AND NOT DEFINED ENV{FLATPAK_ID})

--- a/pkgs/development/libraries/kde-frameworks/fetch.sh
+++ b/pkgs/development/libraries/kde-frameworks/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/frameworks/5.54/ )
+WGET_ARGS=( https://download.kde.org/stable/frameworks/5.56/ )

--- a/pkgs/development/libraries/kde-frameworks/kfilemetadata/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kfilemetadata/default.nix
@@ -1,7 +1,7 @@
 {
   mkDerivation, lib, copyPathsToStore,
   extra-cmake-modules,
-  attr, ebook_tools, exiv2, ffmpeg, karchive, ki18n, poppler, qtbase, qtmultimedia, taglib
+  attr, ebook_tools, exiv2, ffmpeg, karchive, kcoreaddons, ki18n, poppler, qtbase, qtmultimedia, taglib
 }:
 
 mkDerivation {
@@ -9,7 +9,7 @@ mkDerivation {
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [
-    attr ebook_tools exiv2 ffmpeg karchive ki18n poppler qtbase qtmultimedia
+    attr ebook_tools exiv2 ffmpeg karchive kcoreaddons ki18n poppler qtbase qtmultimedia
     taglib
   ];
   patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);

--- a/pkgs/development/libraries/kde-frameworks/srcs.nix
+++ b/pkgs/development/libraries/kde-frameworks/srcs.nix
@@ -3,635 +3,635 @@
 
 {
   attica = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/attica-5.54.0.tar.xz";
-      sha256 = "1gr7w0mf3aq5xyl9il3483m9aqgb981vxn02g2khm6dfsr6z2aln";
-      name = "attica-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/attica-5.56.0.tar.xz";
+      sha256 = "abbaeed8ec027735d6504d31387e4115400457e14b8983a780debd769e4766c5";
+      name = "attica-5.56.0.tar.xz";
     };
   };
   baloo = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/baloo-5.54.0.tar.xz";
-      sha256 = "0wv8zi03plr279v9p923rwkx2kwhbpd6xlzyqi4v14vhcrmapg1c";
-      name = "baloo-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/baloo-5.56.0.tar.xz";
+      sha256 = "9ed5ba80305815cde3ebe1fe707c35661cedba39539645e815d408fe28a41212";
+      name = "baloo-5.56.0.tar.xz";
     };
   };
   bluez-qt = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/bluez-qt-5.54.0.tar.xz";
-      sha256 = "1br9496lahzqmzmvdic5835ig18w3g211l1w4qfzpgr50yin9n5v";
-      name = "bluez-qt-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/bluez-qt-5.56.0.tar.xz";
+      sha256 = "d592b84dd52aeaa0a5453949aced2fa7b160830d7325382f1616e92a338017de";
+      name = "bluez-qt-5.56.0.tar.xz";
     };
   };
   breeze-icons = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/breeze-icons-5.54.0.tar.xz";
-      sha256 = "1g5dppg2iq5bd3r3s8bi8jqnvnh1rm7s3sv51shmaamq5qf0n5jy";
-      name = "breeze-icons-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/breeze-icons-5.56.0.tar.xz";
+      sha256 = "7d98d6be0795cc5dd7468e3d8093541726dcc10586a91477c02879f5eb8fcf58";
+      name = "breeze-icons-5.56.0.tar.xz";
     };
   };
   extra-cmake-modules = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/extra-cmake-modules-5.54.0.tar.xz";
-      sha256 = "0i3iqwvdqf2wpg8lsbna4vgmb18pnbv2772sg9k6zzhvkwsskdwi";
-      name = "extra-cmake-modules-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/extra-cmake-modules-5.56.0.tar.xz";
+      sha256 = "913ce70cd64c5a35586f1ecdac5d6417cb128a9d3829ded7bb95e602d0ecb528";
+      name = "extra-cmake-modules-5.56.0.tar.xz";
     };
   };
   frameworkintegration = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/frameworkintegration-5.54.0.tar.xz";
-      sha256 = "1rzi3ydw7hjhg4vbsfan7zgaa2a2bmp7mph95h2kidf8x816qv2d";
-      name = "frameworkintegration-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/frameworkintegration-5.56.0.tar.xz";
+      sha256 = "ee8d46b629a95e49fda80e50ba8863504a6c463fec887f83370b7e7977db80f5";
+      name = "frameworkintegration-5.56.0.tar.xz";
     };
   };
   kactivities = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kactivities-5.54.0.tar.xz";
-      sha256 = "0ipq71g6g7q6yncvbiabwn5kg2280k8ssibbbf6jyh2lg09dmjil";
-      name = "kactivities-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kactivities-5.56.0.tar.xz";
+      sha256 = "e76a4d44ca6e7ce2273d8c3b133fdd12e32367aeffd66098ec46e7b28c491750";
+      name = "kactivities-5.56.0.tar.xz";
     };
   };
   kactivities-stats = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kactivities-stats-5.54.0.tar.xz";
-      sha256 = "1ns7f110a5vwabb33b1lnpa85kk5radf87bxm1gw4gzglsv7747d";
-      name = "kactivities-stats-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kactivities-stats-5.56.0.tar.xz";
+      sha256 = "6ed0f91dd1dee3db2b0ac8e9a344eb32a881cf243dbf34c0d95888955b7277ec";
+      name = "kactivities-stats-5.56.0.tar.xz";
     };
   };
   kapidox = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kapidox-5.54.0.tar.xz";
-      sha256 = "0zwjychzcamsky9l67xnw820b9m8r8pi56gsccg023l1rcigz46c";
-      name = "kapidox-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kapidox-5.56.0.tar.xz";
+      sha256 = "971f56ce21dcd745a90166def317398c1a3ebd24a81b41668b23b84fb6c61866";
+      name = "kapidox-5.56.0.tar.xz";
     };
   };
   karchive = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/karchive-5.54.0.tar.xz";
-      sha256 = "141xqgdk7g3ky0amblrqr4pab1xvvdim5wvckrgawdkjiy5ana4g";
-      name = "karchive-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/karchive-5.56.0.tar.xz";
+      sha256 = "281a6cea68d19d56f8506e839e450d6652604e49ab70b540e29828b50adbcad6";
+      name = "karchive-5.56.0.tar.xz";
     };
   };
   kauth = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kauth-5.54.0.tar.xz";
-      sha256 = "1ciabazig77rpfksvdlmixj2sa2qnasq13nwvjn3xksnajfm4p2h";
-      name = "kauth-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kauth-5.56.0.tar.xz";
+      sha256 = "cbcca13064b112dff26d1f78b1e77c8ad263cb663aab6329bc6e0a6505f4613d";
+      name = "kauth-5.56.0.tar.xz";
     };
   };
   kbookmarks = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kbookmarks-5.54.0.tar.xz";
-      sha256 = "1w4rqnzyars1pxam3nym1qily3ihd2j8cpkq8aha70nbj0dj3ckw";
-      name = "kbookmarks-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kbookmarks-5.56.0.tar.xz";
+      sha256 = "02011a370959e9fe91db499ba8b12284f2274471760b1bd466587aa9c0c1953b";
+      name = "kbookmarks-5.56.0.tar.xz";
     };
   };
   kcmutils = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kcmutils-5.54.0.tar.xz";
-      sha256 = "0a5jz9m27nyl1vchp68170j9v5z4csyv43vpnfs09l6wk9ggdcwh";
-      name = "kcmutils-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kcmutils-5.56.0.tar.xz";
+      sha256 = "7cf6a81818745852c38558160e3888bdd2a9bcce135aee53c3df99e939633ab8";
+      name = "kcmutils-5.56.0.tar.xz";
     };
   };
   kcodecs = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kcodecs-5.54.0.tar.xz";
-      sha256 = "1s0ky187fbi34wabpfvdwb1zbblzvk8g83h37ckj9j4rd69mjksc";
-      name = "kcodecs-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kcodecs-5.56.0.tar.xz";
+      sha256 = "e7234cddea70d4fa61dd66272dd43da401cc2543e40a6e9bb3a3655263419c82";
+      name = "kcodecs-5.56.0.tar.xz";
     };
   };
   kcompletion = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kcompletion-5.54.0.tar.xz";
-      sha256 = "0sgg09l97amnng0ddxyjpk535097f87bmn60hjqrmpsqb0n3a460";
-      name = "kcompletion-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kcompletion-5.56.0.tar.xz";
+      sha256 = "49dbfda63c64724ecff40032c1631a7c7b84a8c551401a7547fa12e100cdbafb";
+      name = "kcompletion-5.56.0.tar.xz";
     };
   };
   kconfig = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kconfig-5.54.0.tar.xz";
-      sha256 = "14p4w0m04c8msdwb3mjfzx6w0lcmln65j3rfvqp58nv5n4yh5dp7";
-      name = "kconfig-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kconfig-5.56.0.tar.xz";
+      sha256 = "2a970733da16b90ecc317e8ac77f08530650eb2e98dc93834e09e156ec353172";
+      name = "kconfig-5.56.0.tar.xz";
     };
   };
   kconfigwidgets = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kconfigwidgets-5.54.0.tar.xz";
-      sha256 = "1l3hh7qgnz7mnn55abv03pq7zal9dgcw5gnhfr747wknd4h90w31";
-      name = "kconfigwidgets-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kconfigwidgets-5.56.0.tar.xz";
+      sha256 = "c5cfcd8ba356563d83c11a2ebe78d163336df2ef3f97faed0f487ddc5f67a503";
+      name = "kconfigwidgets-5.56.0.tar.xz";
     };
   };
   kcoreaddons = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kcoreaddons-5.54.0.tar.xz";
-      sha256 = "1n27786js8j8na7kgxirhmswxcz3qkfiqzfabqmmsd0jp4rx1s79";
-      name = "kcoreaddons-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kcoreaddons-5.56.0.tar.xz";
+      sha256 = "9f41039f1bd453087ff784e9e95d4f09624ff893fe0298d3c986a6a554b37b9e";
+      name = "kcoreaddons-5.56.0.tar.xz";
     };
   };
   kcrash = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kcrash-5.54.0.tar.xz";
-      sha256 = "0wlrlzwdi9dpxkky9sadmbgw0rjisxhym9hr8gzydd2y8q4cr8a7";
-      name = "kcrash-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kcrash-5.56.0.tar.xz";
+      sha256 = "581e8215212a584886e8d4b6d5c1aac277590bcb343697d8b3653e1c22f6b1e0";
+      name = "kcrash-5.56.0.tar.xz";
     };
   };
   kdbusaddons = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kdbusaddons-5.54.0.tar.xz";
-      sha256 = "1fvlspqc3w3y4p04gnqz6vrfvl93iwckfk16p608fz7yfgdmlzbf";
-      name = "kdbusaddons-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kdbusaddons-5.56.0.tar.xz";
+      sha256 = "b930918ccece1d80aaf0eb770d4e17e5926d7da3a97d1f8506f28829d267b972";
+      name = "kdbusaddons-5.56.0.tar.xz";
     };
   };
   kdeclarative = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kdeclarative-5.54.0.tar.xz";
-      sha256 = "0ankjqrlpnj3c9sjnv5p8w279zizkl5ps3i5zw16hg44v6hdmcj0";
-      name = "kdeclarative-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kdeclarative-5.56.0.tar.xz";
+      sha256 = "799c21af97dfbd25d844ff4839461a7ce29bd7e8ec04e00edf43c8bc3eee906a";
+      name = "kdeclarative-5.56.0.tar.xz";
     };
   };
   kded = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kded-5.54.0.tar.xz";
-      sha256 = "131hvxpqvkyh1sfb1j19jjzy7fyy6xisvpmx12lw1pvks0cnrqgn";
-      name = "kded-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kded-5.56.0.tar.xz";
+      sha256 = "ff2a105edaec825bc9d964df8e181c0f4910432bbfbf2238d61acb17b3bebf39";
+      name = "kded-5.56.0.tar.xz";
     };
   };
   kdelibs4support = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/portingAids/kdelibs4support-5.54.0.tar.xz";
-      sha256 = "02kklfcjsll4pf4rfll7jrr7jpcwd57954ypjjhn3xgr6p0w0hdm";
-      name = "kdelibs4support-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/portingAids/kdelibs4support-5.56.0.tar.xz";
+      sha256 = "edcc14715699f247c57303d7418014202bd0ed3b06cf9752ddd156fefeb60efa";
+      name = "kdelibs4support-5.56.0.tar.xz";
     };
   };
   kdesignerplugin = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kdesignerplugin-5.54.0.tar.xz";
-      sha256 = "0hlywnzd3d6bvhib1xqiqx39m7k8g16wsj102f7awd5gw3xrz8ga";
-      name = "kdesignerplugin-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kdesignerplugin-5.56.0.tar.xz";
+      sha256 = "9bf43498f631dbf1c2bc15af7f6e6494d979223cf2a34ec9f95f58a7be57d816";
+      name = "kdesignerplugin-5.56.0.tar.xz";
     };
   };
   kdesu = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kdesu-5.54.0.tar.xz";
-      sha256 = "1qhw1hmq2b6rkyibidmg532llv31vkhmp0a7j2myzi40ydbx1lar";
-      name = "kdesu-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kdesu-5.56.0.tar.xz";
+      sha256 = "949a23837de945131042e795daaa8a1abc4d9e03cf149cc9cea78636573e8739";
+      name = "kdesu-5.56.0.tar.xz";
     };
   };
   kdewebkit = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kdewebkit-5.54.0.tar.xz";
-      sha256 = "0prl9751a8nv7qhg7fv8qygq0llh71w2p25sldl3zif44340jnhf";
-      name = "kdewebkit-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kdewebkit-5.56.0.tar.xz";
+      sha256 = "822dc687eec418646132219d98834cbe3c992555bc83bb7ca751a00086ee35b0";
+      name = "kdewebkit-5.56.0.tar.xz";
     };
   };
   kdnssd = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kdnssd-5.54.0.tar.xz";
-      sha256 = "00sqx2hyqd9yw4nwdl8kmbzm0v0szgqv4nz0q6bchv3hfbax6zk7";
-      name = "kdnssd-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kdnssd-5.56.0.tar.xz";
+      sha256 = "7e1383580f97248d8bfb6522bd230657bd002d3eb0e74a178bccc8a511e353bf";
+      name = "kdnssd-5.56.0.tar.xz";
     };
   };
   kdoctools = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kdoctools-5.54.0.tar.xz";
-      sha256 = "0xbmdqlvyw9s2g8kwn1wmvz09pn4vs386ibm1p92wdnpspp5did6";
-      name = "kdoctools-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kdoctools-5.56.0.tar.xz";
+      sha256 = "e4f83bfaeca9ef89711577b756a3c359eb8d45b60a180934ba82431b5c36c007";
+      name = "kdoctools-5.56.0.tar.xz";
     };
   };
   kemoticons = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kemoticons-5.54.0.tar.xz";
-      sha256 = "0ypcffpp0m75qwam386q6pyfbsij16y2vgpkn38li6ypxlxsvx2v";
-      name = "kemoticons-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kemoticons-5.56.0.tar.xz";
+      sha256 = "82eeb425a0b4eebd60c743433e09bb6aadcb512dce27c5dbd7ce73fb12680b02";
+      name = "kemoticons-5.56.0.tar.xz";
     };
   };
   kfilemetadata = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kfilemetadata-5.54.0.tar.xz";
-      sha256 = "1hl61y15nqr5h5k4jqfz9bjj4gw6wdaiacxaslcwzn0sg4xyavab";
-      name = "kfilemetadata-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kfilemetadata-5.56.0.tar.xz";
+      sha256 = "269db442adef2409ccf6b2078e3b644eb504b36f84c33c2809b1ff739c68f512";
+      name = "kfilemetadata-5.56.0.tar.xz";
     };
   };
   kglobalaccel = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kglobalaccel-5.54.0.tar.xz";
-      sha256 = "10gl8prc1n0si52cmiglkz8dx79dylmxrh5mjpmyy5yy16chs1s1";
-      name = "kglobalaccel-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kglobalaccel-5.56.0.tar.xz";
+      sha256 = "c3a7c694f257d9331c8cb6f398532e89e9cb962f2224524fe69937c17edcaf5e";
+      name = "kglobalaccel-5.56.0.tar.xz";
     };
   };
   kguiaddons = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kguiaddons-5.54.0.tar.xz";
-      sha256 = "0lkqxsqdjmc7060pxi5j8gx15kmrb8450cpinzn89nzpdl7rj935";
-      name = "kguiaddons-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kguiaddons-5.56.0.tar.xz";
+      sha256 = "b190b601679bb5f6994f85d452b0a182283dbb872b688447449aefe09388e23e";
+      name = "kguiaddons-5.56.0.tar.xz";
     };
   };
   kholidays = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kholidays-5.54.0.tar.xz";
-      sha256 = "1xp6mpnhlqkfl3pdaj6nq9sqy30z5wm6gms0ycy33n4ly2s8wb1y";
-      name = "kholidays-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kholidays-5.56.0.tar.xz";
+      sha256 = "28bc4a987adac5313dcc03b50eb34d910b93f76f54c0aaa0d30b97a086a6a252";
+      name = "kholidays-5.56.0.tar.xz";
     };
   };
   khtml = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/portingAids/khtml-5.54.0.tar.xz";
-      sha256 = "17d8cim4ph7nxc5gkidhxc659yn9a7dqvnrihx9sj1cy01qnc7da";
-      name = "khtml-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/portingAids/khtml-5.56.0.tar.xz";
+      sha256 = "7d381c2a7d15710b4ba404111135c1aadbd3fc8027ad77f153b81a5208c3acf2";
+      name = "khtml-5.56.0.tar.xz";
     };
   };
   ki18n = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/ki18n-5.54.0.tar.xz";
-      sha256 = "0drbyr2y44h1d88nbgxvp4ix46lin51r8vzhhnjhq2ydqy5za3p3";
-      name = "ki18n-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/ki18n-5.56.0.tar.xz";
+      sha256 = "b885bcde4cdf700ecbd8487c52ced453de67c44dac014b53b4eefbba5353ae41";
+      name = "ki18n-5.56.0.tar.xz";
     };
   };
   kiconthemes = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kiconthemes-5.54.0.tar.xz";
-      sha256 = "0hc3a6ax3yizpbvklxw3pm0r6j0r5jqx2ffbz1980g21lcgshd7g";
-      name = "kiconthemes-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kiconthemes-5.56.0.tar.xz";
+      sha256 = "0ae1525aafc9083218a1b0540510b3c65f5843a5f1bd4adf88988ba5f1dab765";
+      name = "kiconthemes-5.56.0.tar.xz";
     };
   };
   kidletime = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kidletime-5.54.0.tar.xz";
-      sha256 = "1x0z0ipdizgv6jkklxp6maclx8f6ya2bv1q39hvxxnnmly8q3vjm";
-      name = "kidletime-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kidletime-5.56.0.tar.xz";
+      sha256 = "252965db39e1c9f927896176b8b9683c9d7ca25cd1373a3924036f87e2222824";
+      name = "kidletime-5.56.0.tar.xz";
     };
   };
   kimageformats = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kimageformats-5.54.0.tar.xz";
-      sha256 = "0xfzpzaqgdncwxvg27qb0ryqi78nbsi0xcsg9cjmgspfx5mlgi15";
-      name = "kimageformats-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kimageformats-5.56.0.tar.xz";
+      sha256 = "a58ddeb83295d1c0305897788aa303aba6ec8d3f9663f3d175cb8337a518f0b1";
+      name = "kimageformats-5.56.0.tar.xz";
     };
   };
   kinit = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kinit-5.54.0.tar.xz";
-      sha256 = "0pmr6ckysdqpni49i9jgapsk88jfbrnlfybpcp3v51kl2nkwm0i9";
-      name = "kinit-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kinit-5.56.0.tar.xz";
+      sha256 = "473f6ba85f99d0d907fdb8105935854ec9b687191e0391a3e66348e5ad5519c6";
+      name = "kinit-5.56.0.tar.xz";
     };
   };
   kio = {
-    version = "5.54.1";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kio-5.54.1.tar.xz";
-      sha256 = "11wdsq87w1ddkrm0mpik2qf0c0k897f1rflszfrrwkplfb0z63xp";
-      name = "kio-5.54.1.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kio-5.56.0.tar.xz";
+      sha256 = "d6fb0bdae9454cd67de19806e338fdcb72e8678a27e95fad3626491d8b1a4cd4";
+      name = "kio-5.56.0.tar.xz";
     };
   };
   kirigami2 = {
-    version = "5.54.0";
+    version = "5.56.1";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kirigami2-5.54.0.tar.xz";
-      sha256 = "0iny9br3vpakvv0bmgy0mmw2y10d4kqbahjpfa3726qai4gligp2";
-      name = "kirigami2-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kirigami2-5.56.1.tar.xz";
+      sha256 = "c809cb550264389ad37911755b9b4123c5a234660f965da9d76d72aa6731f85a";
+      name = "kirigami2-5.56.1.tar.xz";
     };
   };
   kitemmodels = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kitemmodels-5.54.0.tar.xz";
-      sha256 = "1s3wv75sbb4kpgz02cbm7smp8h6rk1ixv0gafbvz9514i9g4d760";
-      name = "kitemmodels-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kitemmodels-5.56.0.tar.xz";
+      sha256 = "2fcf1c08766096c9e62fd40087013e7fd69900d8e5d306d392817949e15ea18e";
+      name = "kitemmodels-5.56.0.tar.xz";
     };
   };
   kitemviews = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kitemviews-5.54.0.tar.xz";
-      sha256 = "1cw9i8xik287rvb12alpqsph902nhfmbn4cfjx5gj7k888n8k3mk";
-      name = "kitemviews-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kitemviews-5.56.0.tar.xz";
+      sha256 = "a84036e6dd2974ddcfcc4d8c0f5a1eab59dafdb20f60fbd8df3d5f7fa54824ab";
+      name = "kitemviews-5.56.0.tar.xz";
     };
   };
   kjobwidgets = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kjobwidgets-5.54.0.tar.xz";
-      sha256 = "0d3jxabjlf2s4p34pzrpfsg4xp9s8qd7dmg50yxl59dijd42xgxq";
-      name = "kjobwidgets-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kjobwidgets-5.56.0.tar.xz";
+      sha256 = "3ea6001724c82e2158f6ee3719f7b4974f271b056661fac037b39ce2338d04b6";
+      name = "kjobwidgets-5.56.0.tar.xz";
     };
   };
   kjs = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/portingAids/kjs-5.54.0.tar.xz";
-      sha256 = "0bidbvbwbrbwwm0drw6l43vgmsp50c946jjq7pgnq1gf7mhscwcy";
-      name = "kjs-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/portingAids/kjs-5.56.0.tar.xz";
+      sha256 = "963e452ff3aa18ddc858fbfdcf234bdc97576b9496b871f742d90177a33974ac";
+      name = "kjs-5.56.0.tar.xz";
     };
   };
   kjsembed = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/portingAids/kjsembed-5.54.0.tar.xz";
-      sha256 = "1pjpk8ysrnh78infq99i0wrf78h8h7hbfnr1m7agzffhbqa671z8";
-      name = "kjsembed-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/portingAids/kjsembed-5.56.0.tar.xz";
+      sha256 = "7bde7a742c05c5ba0b8faef4681dcec0a0b91ad0a3c7cc3cdd3cfa94c0c16e52";
+      name = "kjsembed-5.56.0.tar.xz";
     };
   };
   kmediaplayer = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/portingAids/kmediaplayer-5.54.0.tar.xz";
-      sha256 = "0qalqqkn2yvxgr45l7zm36bcpxwbgn8ngxsvyb5cxfaalwr0mkyf";
-      name = "kmediaplayer-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/portingAids/kmediaplayer-5.56.0.tar.xz";
+      sha256 = "508251507d8432ad29d6cde3d5da258b9d8c14519014901c46f3060a485c982e";
+      name = "kmediaplayer-5.56.0.tar.xz";
     };
   };
   knewstuff = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/knewstuff-5.54.0.tar.xz";
-      sha256 = "1l3ibadjvaqqjsb1lhkf6jkzy80dk15fgid125bqk4amwsyygnd3";
-      name = "knewstuff-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/knewstuff-5.56.0.tar.xz";
+      sha256 = "3249464773b90c03178fb4be3c874644629f611cef72c3ea89d9ed200a501164";
+      name = "knewstuff-5.56.0.tar.xz";
     };
   };
   knotifications = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/knotifications-5.54.0.tar.xz";
-      sha256 = "1agglvwaf0wh3fcs0ww3jxn900ych4dsvbaylrx4qip6girfmiyn";
-      name = "knotifications-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/knotifications-5.56.0.tar.xz";
+      sha256 = "44ac6a710a0d89947c4f1412a8b324d89db18b9f1179ff98e22c61070e12ce16";
+      name = "knotifications-5.56.0.tar.xz";
     };
   };
   knotifyconfig = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/knotifyconfig-5.54.0.tar.xz";
-      sha256 = "1ibxqi0y43qgjj4nikxwfppmda9xjmz63c5fml8c4w5d9mdag3if";
-      name = "knotifyconfig-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/knotifyconfig-5.56.0.tar.xz";
+      sha256 = "b4efe3e636a542531b28841e92c732d6c778670e5f98277bd7029174ce05987f";
+      name = "knotifyconfig-5.56.0.tar.xz";
     };
   };
   kpackage = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kpackage-5.54.0.tar.xz";
-      sha256 = "1s1n7r3j7l4kvd85dgssaaz70dd2w8vp34kwg49ak58cdai01vzb";
-      name = "kpackage-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kpackage-5.56.0.tar.xz";
+      sha256 = "59fe9c9ec38ec9afb0381921ad72593772d28273ad85469df20083731b05f90c";
+      name = "kpackage-5.56.0.tar.xz";
     };
   };
   kparts = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kparts-5.54.0.tar.xz";
-      sha256 = "0y2dr286hb2w4r7ifq39vd7ajsalqyh9d91dm19b2rpgdmvgxai6";
-      name = "kparts-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kparts-5.56.0.tar.xz";
+      sha256 = "1ff0d7ffc327f29c250d9c13c782a772b630d6146de68fe5fd1c38575a5645ee";
+      name = "kparts-5.56.0.tar.xz";
     };
   };
   kpeople = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kpeople-5.54.0.tar.xz";
-      sha256 = "0sl8wcj7w9vgczcv8mfvjlnghidyadbh1qsiv0pj63ywl7xgr1hx";
-      name = "kpeople-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kpeople-5.56.0.tar.xz";
+      sha256 = "79e6d54a1b5c3d41717cb94898ab52a5e0c6187a069cb1e35cd4930ee5348540";
+      name = "kpeople-5.56.0.tar.xz";
     };
   };
   kplotting = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kplotting-5.54.0.tar.xz";
-      sha256 = "02mab80jyfgdj8xwbwkm181cc5vpsmbn561242q7ayjgxdiszzw9";
-      name = "kplotting-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kplotting-5.56.0.tar.xz";
+      sha256 = "39e44138af405f8e07eb91d660447a770394bf8fae166634a386e873761c33c3";
+      name = "kplotting-5.56.0.tar.xz";
     };
   };
   kpty = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kpty-5.54.0.tar.xz";
-      sha256 = "04sj612x15311yk2jmr3ak430syp5p59w559670sd18ih99mf8m3";
-      name = "kpty-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kpty-5.56.0.tar.xz";
+      sha256 = "f310c89854a10000dabc3e67b227bf6b28b1511c87968a7cb81a9a9f8d22f7b7";
+      name = "kpty-5.56.0.tar.xz";
     };
   };
   kross = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/portingAids/kross-5.54.0.tar.xz";
-      sha256 = "18ij9339khskla4r0afl0n6x4pd157y1l5bk2ldb9anpck3p71kd";
-      name = "kross-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/portingAids/kross-5.56.0.tar.xz";
+      sha256 = "bbfafe4abd2c2166f31eb36daa1849f4dc4a829c06fe85402e1fad0ce875c667";
+      name = "kross-5.56.0.tar.xz";
     };
   };
   krunner = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/krunner-5.54.0.tar.xz";
-      sha256 = "06y592v32926wq9iaypryj0173ca05vv0p5rrs4n77kwhkl0zq0v";
-      name = "krunner-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/krunner-5.56.0.tar.xz";
+      sha256 = "ea2176751010e19a0f4df76cfefb178441fd51d2447e0418a21dae8f4e7640bf";
+      name = "krunner-5.56.0.tar.xz";
     };
   };
   kservice = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kservice-5.54.0.tar.xz";
-      sha256 = "10qmrqyfjhf5nzjailgmb86nq62ffrmiddk3880mh49fwxs4l3qx";
-      name = "kservice-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kservice-5.56.0.tar.xz";
+      sha256 = "dbc67e2b0cdc2616e39842a1a9a7ab0ab99a96a083de98b6bf9abff8d4454cc3";
+      name = "kservice-5.56.0.tar.xz";
     };
   };
   ktexteditor = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/ktexteditor-5.54.0.tar.xz";
-      sha256 = "12yywvv82lmqmx89j1qxj45an49vx34brifxs9rpy3nxyh9c3vzy";
-      name = "ktexteditor-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/ktexteditor-5.56.0.tar.xz";
+      sha256 = "4c88d0033775e0715ad115370a36680ede95d29c7c4b840c0e06f23ef64959a8";
+      name = "ktexteditor-5.56.0.tar.xz";
     };
   };
   ktextwidgets = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/ktextwidgets-5.54.0.tar.xz";
-      sha256 = "154j3an7x787l44hw1fmksm3h6kziyaw4l61zw9mas24z3d86hl5";
-      name = "ktextwidgets-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/ktextwidgets-5.56.0.tar.xz";
+      sha256 = "17af96f8fcc4dc67245d2d3c4d1c997dab8619a35599fb516c49f873ca4fa1ce";
+      name = "ktextwidgets-5.56.0.tar.xz";
     };
   };
   kunitconversion = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kunitconversion-5.54.0.tar.xz";
-      sha256 = "0lxrydnjlilfm92aqrpd76dk8yfprgnb7nr66dwmbdmqz7znbl8h";
-      name = "kunitconversion-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kunitconversion-5.56.0.tar.xz";
+      sha256 = "848472340fb24fdb57c0ea60bc4bafcb2b3a26d0eede21a2e8b39e730d6bc5cd";
+      name = "kunitconversion-5.56.0.tar.xz";
     };
   };
   kwallet = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kwallet-5.54.0.tar.xz";
-      sha256 = "0hyipka97g2djk43x8pqbjvrgswsp8kph6za0s5dl4napfikq8k2";
-      name = "kwallet-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kwallet-5.56.0.tar.xz";
+      sha256 = "d2957ca5e0539a4f7689373ded3bbe642cb48bb37f76b6e5f2dac499f0ec260a";
+      name = "kwallet-5.56.0.tar.xz";
     };
   };
   kwayland = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kwayland-5.54.0.tar.xz";
-      sha256 = "0y1710l68qlf37zy26nyn25r50a00mrm5cnwgfs9f40s749amigf";
-      name = "kwayland-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kwayland-5.56.0.tar.xz";
+      sha256 = "bbe76d398b96e0f0ba4342616b91de49e7cbc1f0a7f5038cd97a981f8a8de99c";
+      name = "kwayland-5.56.0.tar.xz";
     };
   };
   kwidgetsaddons = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kwidgetsaddons-5.54.0.tar.xz";
-      sha256 = "01qxklhigfazhma0f6m1fkcbh9waxpvzpz6y2jlflvgbw2db82gh";
-      name = "kwidgetsaddons-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kwidgetsaddons-5.56.0.tar.xz";
+      sha256 = "9b06e67a05d6f90287edf6a7cc31b93c01c9e58f35ae456b6d89e8ef78e0953a";
+      name = "kwidgetsaddons-5.56.0.tar.xz";
     };
   };
   kwindowsystem = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kwindowsystem-5.54.0.tar.xz";
-      sha256 = "1n9h4gg5ih29avvcpplqfy7nq58xx6jv6a04m1wkjr1rzn4dyfnb";
-      name = "kwindowsystem-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kwindowsystem-5.56.0.tar.xz";
+      sha256 = "ecb39fcbe48e24c0a3b9c70b9b08c3c95ade446759b850bf5079df7669f56936";
+      name = "kwindowsystem-5.56.0.tar.xz";
     };
   };
   kxmlgui = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kxmlgui-5.54.0.tar.xz";
-      sha256 = "01napbq81mcp9ngyl26an52l6ndsgrhzhy2mfd8jrbil2sbrcxq7";
-      name = "kxmlgui-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kxmlgui-5.56.0.tar.xz";
+      sha256 = "34af5e4b23c13a92d7103fd0c6464da886ed816367ede78d1bfa19382d06eac6";
+      name = "kxmlgui-5.56.0.tar.xz";
     };
   };
   kxmlrpcclient = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kxmlrpcclient-5.54.0.tar.xz";
-      sha256 = "199syc5wl8myc4vcvbnw4a8mlfkb2gcmgs57p8w7akp7mz6l75y6";
-      name = "kxmlrpcclient-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kxmlrpcclient-5.56.0.tar.xz";
+      sha256 = "14a300a68ac6ade06206ebfc296c5ae2aa55b6f95629f87e19fb055108bd56ae";
+      name = "kxmlrpcclient-5.56.0.tar.xz";
     };
   };
   modemmanager-qt = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/modemmanager-qt-5.54.0.tar.xz";
-      sha256 = "0n54gh83b6d42azv40km7j223qb2f4f9ng23xvvawzc7l2ksm350";
-      name = "modemmanager-qt-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/modemmanager-qt-5.56.0.tar.xz";
+      sha256 = "6cd1490efcfeddd64cc536889b9e675077d76cbce6fcebb0a216c9b8bc379df7";
+      name = "modemmanager-qt-5.56.0.tar.xz";
     };
   };
   networkmanager-qt = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/networkmanager-qt-5.54.0.tar.xz";
-      sha256 = "0bh5li6r7r3nws5zj0hp4iy4xhiyh7rszzwpp6ag93vz5g5fsl9y";
-      name = "networkmanager-qt-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/networkmanager-qt-5.56.0.tar.xz";
+      sha256 = "61d212ef98c5ce6406bfa8f6e84e4bea43c0e4b7ddb4abbff1df077d701e0b5c";
+      name = "networkmanager-qt-5.56.0.tar.xz";
     };
   };
   oxygen-icons5 = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/oxygen-icons5-5.54.0.tar.xz";
-      sha256 = "1sdd8ygkyl4d1mwrachcf0ahpikkby3xhdyz212xj9qmhmsgwa46";
-      name = "oxygen-icons5-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/oxygen-icons5-5.56.0.tar.xz";
+      sha256 = "0b07c6092d46ee6359bcf101a85a55342214c11a1a4c262c82dc6fc4aa63929d";
+      name = "oxygen-icons5-5.56.0.tar.xz";
     };
   };
   plasma-framework = {
-    version = "5.54.0";
+    version = "5.56.1";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/plasma-framework-5.54.0.tar.xz";
-      sha256 = "1933i8irn76ilz3nychbnhy1bsc39iscn3qrab0lwmshfmw8c4zj";
-      name = "plasma-framework-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/plasma-framework-5.56.1.tar.xz";
+      sha256 = "dc3c756cd0a91fa8a343c994606cceb5024615232d48fc7ebeecbfec98c0c772";
+      name = "plasma-framework-5.56.1.tar.xz";
     };
   };
   prison = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/prison-5.54.0.tar.xz";
-      sha256 = "1z7gymk4hkwaa0ni1454ndvpm2lwqyyfbih38h0lfb8lrswnv3kb";
-      name = "prison-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/prison-5.56.0.tar.xz";
+      sha256 = "1dbe7531d1ebe6adcef6b56553812ae6557d32c3a3da65be7cd7ea02be331e16";
+      name = "prison-5.56.0.tar.xz";
     };
   };
   purpose = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/purpose-5.54.0.tar.xz";
-      sha256 = "07rz8bqwvlz5g914q4vxdcdmrja5hxa29iazxz8nr171xnpg9x0w";
-      name = "purpose-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/purpose-5.56.0.tar.xz";
+      sha256 = "882aa64c55e134d1aff06d533f8c3c6f8e5886b5b782925e1aad2e0ca7e37e67";
+      name = "purpose-5.56.0.tar.xz";
     };
   };
   qqc2-desktop-style = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/qqc2-desktop-style-5.54.0.tar.xz";
-      sha256 = "1shw3c6cr5xanzyl5zv3isyhvzi20zn3xf7m963z1qn8ypaz1by8";
-      name = "qqc2-desktop-style-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/qqc2-desktop-style-5.56.0.tar.xz";
+      sha256 = "0b00eb10646593a57aff1b1ba79ddb34f5e2a3fb5f955df1bf9b02af5ff04e21";
+      name = "qqc2-desktop-style-5.56.0.tar.xz";
     };
   };
   solid = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/solid-5.54.0.tar.xz";
-      sha256 = "0hmh9hndfs1ikaja07ddag7jr8804q4g6p74rhqsrfk2sjz0pmr9";
-      name = "solid-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/solid-5.56.0.tar.xz";
+      sha256 = "841d90346cdc51214076cf26357701781d8d534dd209d92768f306e281e46e9e";
+      name = "solid-5.56.0.tar.xz";
     };
   };
   sonnet = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/sonnet-5.54.0.tar.xz";
-      sha256 = "0ccz0gbypzdndaxrfkjhry90jjdh5a56pm4j41z835q96w6piclz";
-      name = "sonnet-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/sonnet-5.56.0.tar.xz";
+      sha256 = "3c6539eb6e50a01ec0a823dd21ba8a49e1b9fb709cf91c25d95be6a48ed30b65";
+      name = "sonnet-5.56.0.tar.xz";
     };
   };
   syndication = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/syndication-5.54.0.tar.xz";
-      sha256 = "0zj8nv0hj5sf79v3clg2bqhs3m8hi1pzjar1cq6hkxprymw0hzx8";
-      name = "syndication-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/syndication-5.56.0.tar.xz";
+      sha256 = "09874ad643da79c538592800d307ab8f2e8785032c0d885fac8f9355ae83d972";
+      name = "syndication-5.56.0.tar.xz";
     };
   };
   syntax-highlighting = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/syntax-highlighting-5.54.0.tar.xz";
-      sha256 = "022mpkbgc458qcn25pn3a3m2dzy6lq23r7fqbgp22jr6xalfi5hl";
-      name = "syntax-highlighting-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/syntax-highlighting-5.56.0.tar.xz";
+      sha256 = "14c1832e268c8053cc0ef9ff00415794801e518f9c103328eca661a657d8803e";
+      name = "syntax-highlighting-5.56.0.tar.xz";
     };
   };
   threadweaver = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/threadweaver-5.54.0.tar.xz";
-      sha256 = "011k2pm0wr60sxnydicnchnarx4r6qja0w6iih3jfkw733qm6bxp";
-      name = "threadweaver-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/threadweaver-5.56.0.tar.xz";
+      sha256 = "bd300ce0dc7d8b796fdcc257b9d27eb3f35cdcdef18611a146d3c11f3690dbbf";
+      name = "threadweaver-5.56.0.tar.xz";
     };
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update to new version of KDE Frameworks.

<https://kde.org/announcements/kde-frameworks-5.56.0.php>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
I've tested okular, konsole, kmail, kcalc, kcharselect, spectacle, kleopatra, kdialog, kate with the new version of these libraries.