### PR TITLE
redo-apenwarr: init at unstable-2019-06-21

### DIFF
--- a/pkgs/development/tools/build-managers/redo-apenwarr/default.nix
+++ b/pkgs/development/tools/build-managers/redo-apenwarr/default.nix
@@ -1,0 +1,30 @@
+{stdenv, fetchFromGitHub, python2, which}:
+stdenv.mkDerivation rec {
+  name = "redo-apenwarr-${version}";
+
+  version = "unstable-2019-06-21";
+
+  src = fetchFromGitHub {
+    owner = "apenwarr";
+    repo = "redo";
+    rev = "8924fa35fa7363b531f8e6b48a1328d2407ad5cf";
+    sha256 = "1dj20w29najqjyvk0jh5kqbcd10k32rad986q5mzv4v49qcwdc1q";
+  };
+
+  DESTDIR="";
+  PREFIX = placeholder "out";
+
+  patchPhase = ''
+    patchShebangs .
+  '';
+
+  buildInputs = [ python2 which ];
+
+  meta = with stdenv.lib; {
+    description = "Apenwarr version of the redo build tool.";
+    homepage = https://github.com/apenwarr/redo/;
+    license = stdenv.lib.licenses.asl20;
+    platforms = platforms.all;
+    maintainers = with stdenv.lib.maintainers; [ andrewchambers ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9655,6 +9655,8 @@ in
 
   redo = callPackage ../development/tools/build-managers/redo { };
 
+  redo-apenwarr = callPackage ../development/tools/build-managers/redo-apenwarr { };
+
   redo-sh = callPackage ../development/tools/build-managers/redo-sh { };
 
   reno = callPackage ../development/tools/reno { };


### PR DESCRIPTION
###### Motivation for this change

New package.

###### Things done

- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
