### PR TITLE
 gnome3.mutter328: use gnome-3-28 branch

### DIFF
--- a/pkgs/desktops/gnome-3/core/mutter/3.28.nix
+++ b/pkgs/desktops/gnome-3/core/mutter/3.28.nix
@@ -1,4 +1,4 @@
-{ fetchFromGitLab, stdenv, fetchpatch, pkgconfig, gnome3, intltool, gobject-introspection, upower, cairo
+{ fetchFromGitLab, stdenv, substituteAll, pkgconfig, gnome3, intltool, gobject-introspection, upower, cairo
 , glib, gtk3, pango, cogl, clutter, libstartup_notification, zenity, libcanberra-gtk3
 , gsettings-desktop-schemas, gnome-desktop
 , libtool, makeWrapper, xkeyboard_config, libxkbfile, libxkbcommon, libXtst, libinput
@@ -15,6 +15,13 @@ stdenv.mkDerivation rec {
     rev = "4af8d9d4752a94612a98d619e65828f0070a7b0e"; # HEAD of https://gitlab.gnome.org/GNOME/mutter/tree/gnome-3-28
     sha256 = "1rmc1bf80yq776xhygi1jzgia1y44j2mr2n94vlxgzqc0whamx2v";
   };
+
+  patches = [
+    (substituteAll {
+      src = ./fix-paths-328.patch;
+      inherit zenity;
+    })
+  ];
 
   configureFlags = [
     "--with-x"

--- a/pkgs/desktops/gnome-3/core/mutter/3.28.nix
+++ b/pkgs/desktops/gnome-3/core/mutter/3.28.nix
@@ -1,6 +1,6 @@
 { fetchFromGitLab, stdenv, substituteAll, pkgconfig, gnome3, intltool, gobject-introspection, upower, cairo
 , glib, gtk3, pango, cogl, clutter, libstartup_notification, zenity, libcanberra-gtk3
-, gsettings-desktop-schemas, gnome-desktop
+, gsettings-desktop-schemas, gnome-desktop, wrapGAppsHook
 , libtool, makeWrapper, xkeyboard_config, libxkbfile, libxkbcommon, libXtst, libinput
 , geocode-glib, libgudev, libwacom, xwayland, autoreconfHook }:
 
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     libXtst
   ];
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig intltool libtool makeWrapper ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig intltool libtool wrapGAppsHook ];
 
   buildInputs = [
     glib gobject-introspection gtk3 gsettings-desktop-schemas upower
@@ -50,11 +50,6 @@ stdenv.mkDerivation rec {
     libcanberra-gtk3 zenity xkeyboard_config libxkbfile
     libxkbcommon
   ];
-
-  preFixup = ''
-    wrapProgram "$out/bin/mutter" \
-      --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
-  '';
 
   enableParallelBuilding = true;
 

--- a/pkgs/desktops/gnome-3/core/mutter/3.28.nix
+++ b/pkgs/desktops/gnome-3/core/mutter/3.28.nix
@@ -1,16 +1,19 @@
-{ fetchurl, stdenv, fetchpatch, pkgconfig, gnome3, intltool, gobject-introspection, upower, cairo
+{ fetchFromGitLab, stdenv, fetchpatch, pkgconfig, gnome3, intltool, gobject-introspection, upower, cairo
 , glib, gtk3, pango, cogl, clutter, libstartup_notification, zenity, libcanberra-gtk3
 , gsettings-desktop-schemas, gnome-desktop
 , libtool, makeWrapper, xkeyboard_config, libxkbfile, libxkbcommon, libXtst, libinput
-, geocode-glib, pipewire, libgudev, libwacom, xwayland, autoreconfHook }:
+, geocode-glib, libgudev, libwacom, xwayland, autoreconfHook }:
 
 stdenv.mkDerivation rec {
-  name = "mutter-${version}";
+  pname = "mutter";
   version = "3.28.3";
 
-  src = fetchurl {
-    url = "mirror://gnome/sources/mutter/3.28/${name}.tar.xz";
-    sha256 = "0vq3rmq20d6b1mi6sf67wkzqys6hw5j7n7fd4hndcp19d5i26149";
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "GNOME";
+    repo = pname;
+    rev = "4af8d9d4752a94612a98d619e65828f0070a7b0e"; # HEAD of https://gitlab.gnome.org/GNOME/mutter/tree/gnome-3-28
+    sha256 = "1rmc1bf80yq776xhygi1jzgia1y44j2mr2n94vlxgzqc0whamx2v";
   };
 
   configureFlags = [
@@ -38,7 +41,7 @@ stdenv.mkDerivation rec {
     gnome-desktop cairo pango cogl clutter zenity libstartup_notification
     geocode-glib libinput libgudev libwacom
     libcanberra-gtk3 zenity xkeyboard_config libxkbfile
-    libxkbcommon pipewire
+    libxkbcommon
   ];
 
   preFixup = ''

--- a/pkgs/desktops/gnome-3/core/mutter/fix-paths-328.patch
+++ b/pkgs/desktops/gnome-3/core/mutter/fix-paths-328.patch
@@ -1,0 +1,13 @@
+diff --git a/src/core/util.c b/src/core/util.c
+index 5b8de18c7..546352a95 100644
+--- a/src/core/util.c
++++ b/src/core/util.c
+@@ -635,7 +635,7 @@ meta_show_dialog (const char *type,
+
+   args = g_ptr_array_new ();
+
+-  append_argument (args, "zenity");
++  append_argument (args, "@zenity@/bin/zenity");
+   append_argument (args, type);
+
+   if (display)


### PR DESCRIPTION
###### Commit Message

Probably should get these patches in while
I'm stuck with this. Alternative would be to
fetch the patches individually.

pipewire was accidentally in `buildInputs` when it has
been disabled.

Changes: https://gitlab.gnome.org/GNOME/mutter/compare/3.28.3...gnome-3-28

###### Motivation for this change
The usual :smile: 

This also has a patch to hardcode the path to `zenity`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
