### PR TITLE
wasm-pack: init at 0.8.1

### DIFF
--- a/pkgs/development/tools/wasm-pack/default.nix
+++ b/pkgs/development/tools/wasm-pack/default.nix
@@ -1,0 +1,36 @@
+{ stdenv
+, fetchFromGitHub
+, rustPlatform
+, pkgconfig
+, openssl
+}:
+
+rustPlatform.buildRustPackage rec {
+  name = "wasm-pack-${version}";
+  version = "0.8.1";
+
+  src = fetchFromGitHub {
+    owner = "rustwasm";
+    repo = "wasm-pack";
+    rev = "v${version}";
+    sha256 = "1z66m16n4r16zqmnv84a5jndr5x6mdqdq4b1wq929sablwqd2rl4";
+  };
+
+  cargoSha256 = "1xdx0gjqd4zyhnp72hz88rdmgry1m7rcw2j73lh67vp08z74y54y";
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  buildInputs = [ openssl ];
+
+  # Tests fetch external resources and build artifacts.
+  # Disabled to work with sandboxing
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "A utility that builds rust-generated WebAssembly package";
+    homepage = https://github.com/rustwasm/wasm-pack;
+    license = with licenses; [ asl20 /* or */ mit ];
+    maintainers = [ maintainers.dhkl ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23317,6 +23317,8 @@ in
 
   vttest = callPackage ../tools/misc/vttest { };
 
+  wasm-pack = callPackage ../development/tools/wasm-pack { };
+
   wavegain = callPackage ../applications/audio/wavegain { };
 
   wcalc = callPackage ../applications/misc/wcalc { };


### PR DESCRIPTION
###### Motivation for this change

This pull request packages `wasm-pack`, which is an important part of the Rust-Wasm ecosystem to generate WebAssembly packages with JavaScript bindings.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
