### PR TITLE
shadowsocks-libev: 3.2.3 -> 3.2.5

### DIFF
--- a/pkgs/tools/networking/shadowsocks-libev/default.nix
+++ b/pkgs/tools/networking/shadowsocks-libev/default.nix
@@ -4,15 +4,15 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "shadowsocks-libev-${version}";
-  version = "3.2.3";
+  pname = "shadowsocks-libev";
+  version = "3.2.5";
 
   # Git tag includes CMake build files which are much more convenient.
   src = fetchFromGitHub {
     owner = "shadowsocks";
-    repo = "shadowsocks-libev";
+    repo = pname;
     rev = "refs/tags/v${version}";
-    sha256 = "1nj2z3j41lqd6gvj6j7xc8g7jbn2f8b75phlkgwvw0j3zsqnbq30";
+    sha256 = "09z20y35zjzsx5fd5cnnxxgbfcrh2bp0z7m15l59wlmlsfp7r2pw";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
