### PR TITLE
salt: 2018.3 -> 2019.2, pepper: 0.5.5 -> 0.7.5

### DIFF
--- a/pkgs/tools/admin/salt/pepper/default.nix
+++ b/pkgs/tools/admin/salt/pepper/default.nix
@@ -1,18 +1,18 @@
 { lib
-, python2Packages
+, pythonPackages
 , salt
 }:
 
-python2Packages.buildPythonApplication rec {
+pythonPackages.buildPythonApplication rec {
   pname = "salt-pepper";
   version = "0.7.5";
-  src = python2Packages.fetchPypi {
+  src = pythonPackages.fetchPypi {
     inherit pname version;
     sha256 = "1wh6yidwdk8jvjpr5g3azhqgsk24c5rlzmw6l86dmi0mpvmxm94w";
   };
 
-  buildInputs = with python2Packages; [ setuptools setuptools_scm salt ];
-  checkInputs = with python2Packages; [
+  buildInputs = with pythonPackages; [ setuptools setuptools_scm salt ];
+  checkInputs = with pythonPackages; [
     pytest mock pyzmq pytest-rerunfailures pytestcov cherrypy tornado_4
   ];
 

--- a/pkgs/tools/admin/salt/pepper/default.nix
+++ b/pkgs/tools/admin/salt/pepper/default.nix
@@ -1,17 +1,20 @@
 { lib
-, fetchurl
 , python2Packages
+, salt
 }:
 
 python2Packages.buildPythonApplication rec {
-  name = "salt-pepper-${version}";
-  version = "0.5.5";
-  src = fetchurl {
-    url = "https://github.com/saltstack/pepper/releases/download/${version}/${name}.tar.gz";
-    sha256 = "1wj1k64ly6af6qsmiizlx32jxh23a37smd9wb57l5zl0x8sfqq1n";
+  pname = "salt-pepper";
+  version = "0.7.5";
+  src = python2Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "1wh6yidwdk8jvjpr5g3azhqgsk24c5rlzmw6l86dmi0mpvmxm94w";
   };
 
-  doCheck = false; # no tests available
+  buildInputs = with python2Packages; [ setuptools setuptools_scm salt ];
+  checkInputs = with python2Packages; [
+    pytest mock pyzmq pytest-rerunfailures pytestcov cherrypy tornado_4
+  ];
 
   meta = with lib; {
     description = "A CLI front-end to a running salt-api system";


### PR DESCRIPTION
###### Motivation for this change

Fix build of dependency `pytest-rerunfailures` as well :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Poked at the utilities but beyond displaying version and help
information haven't checked functionality/behavior.