### PR TITLE
zzuf: init at 0.15

### DIFF
--- a/pkgs/tools/security/zzuf/default.nix
+++ b/pkgs/tools/security/zzuf/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchFromGitHub, autoconf, automake, libtool, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  pname = "zzuf";
+  version = "0.15";
+
+  src = fetchFromGitHub {
+    owner = "samhocevar";
+    repo = "zzuf";
+    rev = "v${version}";
+    sha256 = "0li1s11xf32dafxq1jbnc8c63313hy9ry09dja2rymk9mza4x2n9";
+  };
+
+  buildInputs = [ autoconf automake libtool pkgconfig ];
+
+  preConfigure = "./bootstrap";
+
+  meta = with stdenv.lib; {
+    description = "Transparent application input fuzzer.";
+    homepage = http://caca.zoy.org/wiki/zzuf;
+    license = licenses.wtfpl;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ lihop ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2511,6 +2511,8 @@ in
 
   zabbix-cli = callPackage ../tools/misc/zabbix-cli { };
 
+  zzuf = callPackage ../tools/security/zzuf { };
+
   ### DEVELOPMENT / EMSCRIPTEN
 
   buildEmscriptenPackage = callPackage ../development/em-modules/generic { };


### PR DESCRIPTION
###### Motivation for this change
Missing from nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
