### PR TITLE
pioneer: update to 20190203

### DIFF
--- a/pkgs/games/pioneer/default.nix
+++ b/pkgs/games/pioneer/default.nix
@@ -1,32 +1,29 @@
-{ fetchFromGitHub, stdenv, autoconf, automake, pkgconfig
-, curl, libsigcxx, SDL2, SDL2_image, freetype, libvorbis, libpng, assimp, libGLU_combined
+{ fetchFromGitHub, stdenv, cmake, pkgconfig, curl, libsigcxx, SDL2
+, SDL2_image, freetype, libvorbis, libpng, assimp, libGLU_combined
+, glew
 }:
 
 stdenv.mkDerivation rec {
-  name = "pioneer-${version}";
-  version = "20180203";
+  pname = "pioneer";
+  version = "20190203";
 
   src = fetchFromGitHub{
     owner = "pioneerspacesim";
     repo = "pioneer";
     rev = version;
-    sha256 = "0hp2mf36kj2v93hka8m8lxw2qhmnjc62wjlpw7c7ix0r8xa01i6h";
+    sha256 = "1g34wvgyvz793dhm1k64kl82ib0cavkbg0f2p3fp05b457ycljff";
   };
 
-  nativeBuildInputs = [ autoconf automake pkgconfig ];
+  nativeBuildInputs = [ cmake pkgconfig ];
 
-  buildInputs = [ curl libsigcxx SDL2 SDL2_image freetype libvorbis libpng assimp libGLU_combined ];
-
-  NIX_CFLAGS_COMPILE = [
-    "-I${SDL2}/include/SDL2"
+  buildInputs = [
+    curl libsigcxx SDL2 SDL2_image freetype libvorbis libpng
+    assimp libGLU_combined glew
   ];
 
   preConfigure = ''
-     export PIONEER_DATA_DIR="$out/share/pioneer/data";
-    ./bootstrap
+    export PIONEER_DATA_DIR="$out/share/pioneer/data";
   '';
-
-  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     description = "A space adventure game set in the Milky Way galaxy at the turn of the 31st century";


### PR DESCRIPTION
###### Motivation for this change
An update is availaible for this game (exacly 1 year of difference, day by day)

There are also a switch to CMake
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
