### PR TITLE
acpilight: use default python3

### DIFF
--- a/pkgs/misc/acpilight/default.nix
+++ b/pkgs/misc/acpilight/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, python36, udev, coreutils }:
+{ stdenv, fetchgit, python3, udev, coreutils }:
 
 stdenv.mkDerivation rec {
   pname = "acpilight";
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "0kykrl71fb146vaq8207c3qp03h2djkn8hn6psryykk8gdzkv3xd";
   };
 
-  pyenv = python36.withPackages (pythonPackages: with pythonPackages; [
+  pyenv = python3.withPackages (pythonPackages: with pythonPackages; [
     ConfigArgParse
   ]);
 


### PR DESCRIPTION
###### Motivation for this change
Reduce system closure size.

In https://github.com/NixOS/nixpkgs/pull/56220, I can't find a mention of a reason to explicitly use Python 3.6.

I did not test this package as I don't use it!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @SeTSeR @etu 