### PR TITLE
nixos/mysql: fix typing-induced bugs

### DIFF
--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -360,7 +360,7 @@ in
                         echo "Creating initial database: ${database.name}"
                         ( echo 'create database `${database.name}`;'
 
-                          ${optionalString (database ? "schema") ''
+                          ${optionalString (database.schema != null) ''
                           echo 'use `${database.name}`;'
 
                           if [ -f "${database.schema}" ]

--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -133,7 +133,7 @@ in
       };
 
       initialScript = mkOption {
-        type = types.nullOr types.lines;
+        type = types.nullOr types.path;
         default = null;
         description = "A file containing SQL statements to be executed on the first startup. Can be used for granting certain permissions on the database";
       };
@@ -363,6 +363,8 @@ in
                           ${optionalString (database.schema != null) ''
                           echo 'use `${database.name}`;'
 
+                          # TODO: this silently falls through if database.schema does not exist,
+                          # we should catch this somehow and exit, but can't do it here because we're in a subshell.
                           if [ -f "${database.schema}" ]
                           then
                               cat ${database.schema}
@@ -399,7 +401,9 @@ in
                 ${optionalString (cfg.initialScript != null)
                   ''
                     # Execute initial script
-                    cat ${cfg.initialScript} | ${mysql}/bin/mysql -u root -N
+                    # using toString to avoid copying the file to nix store if given as path instead of string,
+                    # as it might contain credentials
+                    cat ${toString cfg.initialScript} | ${mysql}/bin/mysql -u root -N
                   ''}
 
                 ${optionalString (cfg.rootPassword != null)

--- a/nixos/tests/mysql.nix
+++ b/nixos/tests/mysql.nix
@@ -10,7 +10,10 @@ import ./make-test.nix ({ pkgs, ...} : {
 
       {
         services.mysql.enable = true;
-        services.mysql.initialDatabases = [ { name = "testdb"; schema = ./testdb.sql; } ];
+        services.mysql.initialDatabases = [
+          { name = "testdb"; schema = ./testdb.sql; }
+          { name = "empty_testdb"; }
+        ];
         services.mysql.package = pkgs.mysql;
       };
 
@@ -36,11 +39,12 @@ import ./make-test.nix ({ pkgs, ...} : {
     startAll;
 
     $mysql->waitForUnit("mysql");
-    $mysql->succeed("echo 'use testdb; select * from tests' | mysql -u root -N | grep 4");
+    $mysql->succeed("echo 'use empty_testdb;' | mysql -u root");
+    $mysql->succeed("echo 'use testdb; select * from tests;' | mysql -u root -N | grep 4");
 
     $mariadb->waitForUnit("mysql");
     $mariadb->succeed("echo 'use testdb; create table tests (test_id INT, PRIMARY KEY (test_id));' | sudo -u testuser mysql -u testuser");
     $mariadb->succeed("echo 'use testdb; insert into tests values (42);' | sudo -u testuser mysql -u testuser");
-    $mariadb->succeed("echo 'use testdb; select test_id from tests' | sudo -u testuser mysql -u testuser -N | grep 42");
+    $mariadb->succeed("echo 'use testdb; select test_id from tests;' | sudo -u testuser mysql -u testuser -N | grep 42");
   '';
 })


### PR DESCRIPTION
###### Motivation for this change
Fixes issues brought up by @schneefux in #58582.

This also tries to prevent `mysql.initialScript` from ending up in /nix/store when given as nix path type, i.e. `initialScript = /etc/nixos/setup-credentials.sql` in contrast to `initialScript = "/etc/nixos/setup-credentials.sql";`, as it might be used for sensitive data like credentials. Uses `toString` for this, as explained here: https://stackoverflow.com/questions/43850371/when-does-a-nix-path-type-make-it-into-the-nix-store-and-when-not

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
