### PR TITLE
networkmanager-l2tp: 1.2.10 -> 1.2.12

### DIFF
--- a/pkgs/tools/networking/network-manager/l2tp/default.nix
+++ b/pkgs/tools/networking/network-manager/l2tp/default.nix
@@ -1,17 +1,18 @@
 { stdenv, substituteAll, fetchFromGitHub, autoreconfHook, libtool, intltool, pkgconfig
+, file, findutils
 , gtk3, networkmanager, ppp, xl2tpd, strongswan, libsecret
 , withGnome ? true, gnome3, networkmanagerapplet }:
 
 stdenv.mkDerivation rec {
   name = "${pname}${if withGnome then "-gnome" else ""}-${version}";
   pname = "NetworkManager-l2tp";
-  version = "1.2.10";
+  version = "1.2.12";
 
   src = fetchFromGitHub {
     owner = "nm-l2tp";
     repo = "network-manager-l2tp";
     rev = "${version}";
-    sha256 = "1vm004nj2n5abpywr7ji6r28scf7xs45zw4rqrm8jn7mysf96h0x";
+    sha256 = "0cq07kvlm98s8a7l4a3zmqnif8x3307kv7n645zx3f1r7x72b8m4";
   };
 
   patches = [
@@ -24,7 +25,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ networkmanager ppp ]
     ++ stdenv.lib.optionals withGnome [ gtk3 libsecret networkmanagerapplet ];
 
-  nativeBuildInputs = [ autoreconfHook libtool intltool pkgconfig ];
+  nativeBuildInputs = [ autoreconfHook libtool intltool pkgconfig file findutils ];
 
   preConfigure = ''
     intltoolize -f

--- a/pkgs/tools/networking/network-manager/l2tp/fix-paths.patch
+++ b/pkgs/tools/networking/network-manager/l2tp/fix-paths.patch
@@ -1,6 +1,8 @@
---- a/src/nm-l2tp-service.c
-+++ b/src/nm-l2tp-service.c
-@@ -480,7 +480,7 @@
+diff --git a/shared/utils.c b/shared/utils.c
+index c978a1f..d2c36cd 100644
+--- a/shared/utils.c
++++ b/shared/utils.c
+@@ -52,7 +52,7 @@ nm_find_ipsec (void)
  {
  	static const char *ipsec_binary_paths[] =
  		{
@@ -9,7 +11,7 @@
  			"/usr/sbin/ipsec",
  			"/usr/local/sbin/ipsec",
  			"/sbin/strongswan",
-@@ -505,7 +505,7 @@
+@@ -77,7 +77,7 @@ nm_find_l2tpd (void)
  {
  	static const char *l2tp_binary_paths[] =
  		{


### PR DESCRIPTION
###### Motivation for this change

https://github.com/nm-l2tp/NetworkManager-l2tp/releases/tag/1.2.12

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - Using presently! :)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---