### PR TITLE
sstp: 1.0.11 -> 1.0.12

### DIFF
--- a/pkgs/tools/networking/sstp/default.nix
+++ b/pkgs/tools/networking/sstp/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, fetchurl, ppp, libevent, openssl }:
+{ stdenv, fetchurl, pkgconfig, ppp, libevent, openssl }:
 
 stdenv.mkDerivation rec {
   name = "sstp-client-${version}";
-  version = "1.0.11";
+  version = "1.0.12";
 
   src = fetchurl {
     url = "mirror://sourceforge/sstp-client/sstp-client/${version}/sstp-client-${version}.tar.gz";
-    sha256 = "087vp3n7nv001fsgbmkjpgl3a2vhbix22cflrqi5bv9h8181p18v";
+    sha256 = "1zv7rx6wh9rhbyg9pg6759by8hc6n4162zrrw0y812cnaw3b8zj8";
   };
 
   patchPhase =
@@ -21,6 +21,7 @@ stdenv.mkDerivation rec {
     "--with-pppd-plugin-dir=$(out)/lib/pppd"
   ];
 
+  nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ libevent openssl ppp ];
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Noticed update, couldn't get it working with the server I was hoping to
connect to (before or after this bump) but sending
for consideration anyway :).

I packaged networkmanager-sstp as well, but since I couldn't get things
working am less confident there-- it seems even less maintained than
the networkmanager-pptp we dropped a while back :3.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---