### PR TITLE
pytest-rerunfailures: 6.0 -> 7.0

### DIFF
--- a/pkgs/development/python-modules/pytest-rerunfailures/default.nix
+++ b/pkgs/development/python-modules/pytest-rerunfailures/default.nix
@@ -2,14 +2,14 @@
 
 buildPythonPackage rec {
   pname = "pytest-rerunfailures";
-  version = "6.0";
+  version = "7.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "978349ae00687504fd0f9d0970c37199ccd89cbdb0cb8c4ed7ee417ede582b40";
+    sha256 = "1zfm9v80bqfdapygy9wmi6j6y5c179ixpnh9ih27py4v6cqwzjgk";
   };
 
-  checkInputs = [ mock ];
+  checkInputs = [ mock pytest ];
 
   propagatedBuildInputs = [ pytest ];
 


### PR DESCRIPTION
###### Motivation for this change
Failing hydra build for 19.03. Figured I'd update to the package in the process.
Python3: https://hydra.nixos.org/build/90113585
Python2: https://hydra.nixos.org/build/90308802

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Tests
 * nix-build -A pytest-rerunfailures
 * (Looks to be the only expression to use this package) nix-build -A tmuxp
<details><summary>Click to see nix-shell testing</summary>

shell.nix (Also modify for python2)
```
{ pkgs ? import <nixpkgs> {} }:

pkgs.stdenv.mkDerivation rec {
  name = "xonsh";
  buildInputs = with pkgs; [
    tmuxp
    python3Packages.pytest
    python3Packages.pytest-rerunfailures
  ];
}
```
test_rerun.py
```python
import pytest
import time

def test_foo():
    assert int(time.time()) % 10 in (1)
```
```
nix-shell --pure -I nixpkgs=/path/to/nixpkgs 
pytest --reruns 10 --reruns-delay 1
tmuxp --version  # I don't know how to use tmuxp
tmuxp --help
```

</details>

##### Additional Notes
https://pypi.org/project/pytest-rerunfailures/#id1