### PR TITLE
Revert "gnome3.aisleriot: 3.22.7 -> 3.22.8 (#57700)"

### DIFF
--- a/pkgs/desktops/gnome-3/games/aisleriot/default.nix
+++ b/pkgs/desktops/gnome-3/games/aisleriot/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "aisleriot-${version}";
-  version = "3.22.8";
+  version = "3.22.7";
 
   src = fetchurl {
     url = "mirror://gnome/sources/aisleriot/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "15pm39679ymxki07sb5nvhycz4z53zwbvascyp5wm4864bn98815";
+    sha256 = "1ysljnrlvzssgbhxcgb28n9k3l0rybxi5lkrm8pg6a4nspaw5mc4";
   };
 
   configureFlags = [


### PR DESCRIPTION
This reverts commit 7a04742cc056159a378a311dcb0d1e2c4431276e.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
