### PR TITLE
perlPackages.DBDOracle: init at 1.76

### DIFF
--- a/pkgs/development/perl-modules/DBD-Oracle/default.nix
+++ b/pkgs/development/perl-modules/DBD-Oracle/default.nix
@@ -1,0 +1,15 @@
+{ fetchurl, buildPerlPackage, DBI, TestNoWarnings, oracle-instantclient }:
+
+buildPerlPackage rec {
+  name = "DBD-Oracle-1.76";
+
+  src = fetchurl {
+    url = "mirror://cpan/authors/id/Z/ZA/ZARQUON/${name}.tar.gz";
+    sha256 = "b6db7f43c6252179274cfe99c1950b93e248f8f0fe35b07e50388c85d814d5f3";
+  };
+
+  ORACLE_HOME = "${oracle-instantclient}/lib";
+
+  buildInputs = [ TestNoWarnings oracle-instantclient ] ;
+  propagatedBuildInputs = [ DBI ];
+}

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -4030,6 +4030,8 @@ let
 
   DBDmysql = callPackage ../development/perl-modules/DBD-mysql { };
 
+  DBDOracle = callPackage ../development/perl-modules/DBD-Oracle { };
+
   DBDPg = callPackage ../development/perl-modules/DBD-Pg { };
 
   DBDsybase = callPackage ../development/perl-modules/DBD-sybase { };


### PR DESCRIPTION
###### Motivation for this change
Missing from nixpkgs :disappointed: 

I ran a perl script which used this code to successfully connect to an Oracle database :+1: 
PS. I'd really love a backport to 19.03 after it has been released.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
