### PR TITLE
haskell-generic-builder: Add option to disable library-for-ghci

### DIFF
--- a/pkgs/development/compilers/ghc/8.6.4.nix
+++ b/pkgs/development/compilers/ghc/8.6.4.nix
@@ -32,6 +32,10 @@
 , # What flavour to build. An empty string indicates no
   # specific flavour and falls back to ghc default values.
   ghcFlavour ? stdenv.lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform) "perf-cross"
+
+, # Whether to disable the large address space allocator
+  # necessary fix for iOS: https://www.reddit.com/r/haskell/comments/4ttdz1/building_an_osxi386_to_iosarm64_cross_compiler/d5qvd67/
+  disableLargeAddressSpace ? stdenv.targetPlatform.isDarwin && stdenv.targetPlatform.isAarch64
 }:
 
 assert !enableIntegerSimple -> gmp != null;
@@ -162,8 +166,7 @@ stdenv.mkDerivation (rec {
     "CFLAGS=-fuse-ld=gold"
     "CONF_GCC_LINKER_OPTS_STAGE1=-fuse-ld=gold"
     "CONF_GCC_LINKER_OPTS_STAGE2=-fuse-ld=gold"
-  ] ++ stdenv.lib.optionals (targetPlatform.isDarwin && targetPlatform.isAarch64) [
-    # fix for iOS: https://www.reddit.com/r/haskell/comments/4ttdz1/building_an_osxi386_to_iosarm64_cross_compiler/d5qvd67/
+  ] ++ stdenv.lib.optionals (disableLargeAddressSpace) [
     "--disable-large-address-space"
   ];
 

--- a/pkgs/development/compilers/ghc/head.nix
+++ b/pkgs/development/compilers/ghc/head.nix
@@ -30,6 +30,10 @@
 , # What flavour to build. An empty string indicates no
   # specific flavour and falls back to ghc default values.
   ghcFlavour ? stdenv.lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform) "perf-cross"
+
+, # Whether to disable the large address space allocator
+  # necessary fix for iOS: https://www.reddit.com/r/haskell/comments/4ttdz1/building_an_osxi386_to_iosarm64_cross_compiler/d5qvd67/
+  disableLargeAddressSpace ? stdenv.targetPlatform.isDarwin && stdenv.targetPlatform.isAarch64
 }:
 
 assert !enableIntegerSimple -> gmp != null;
@@ -157,8 +161,7 @@ stdenv.mkDerivation (rec {
     "CFLAGS=-fuse-ld=gold"
     "CONF_GCC_LINKER_OPTS_STAGE1=-fuse-ld=gold"
     "CONF_GCC_LINKER_OPTS_STAGE2=-fuse-ld=gold"
-  ] ++ stdenv.lib.optionals (targetPlatform.isDarwin && targetPlatform.isAarch64) [
-    # fix for iOS: https://www.reddit.com/r/haskell/comments/4ttdz1/building_an_osxi386_to_iosarm64_cross_compiler/d5qvd67/
+  ] ++ stdenv.lib.optionals (disableLargeAddressSpace) [
     "--disable-large-address-space"
   ];
 

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -81,6 +81,10 @@ in
   # built. Will delay failures, if any, to compile time.
   allowInconsistentDependencies ? false
 , maxBuildCores ? 4 # GHC usually suffers beyond -j4. https://ghc.haskell.org/trac/ghc/ticket/9221
+, # Build a pre-linked .o file for this Haskell library.  This can make it
+  # slightly faster to load this library into GHCi, but takes extra disk space
+  # and compile time.
+  enableLibraryForGhci ? true
 } @ args:
 
 assert editedCabalFile != null -> revision != null;
@@ -169,7 +173,7 @@ let
     (optionalString (isGhcjs || versionOlder "7" ghc.version) (enableFeature doCheck "tests"))
     (enableFeature doBenchmark "benchmarks")
     "--enable-library-vanilla"  # TODO: Should this be configurable?
-    "--enable-library-for-ghci" # TODO: Should this be configurable?
+    (enableFeature enableLibraryForGhci "library-for-ghci")
   ] ++ optionals (enableDeadCodeElimination && (stdenv.lib.versionOlder "8.0.1" ghc.version)) [
      "--ghc-option=-split-sections"
   ] ++ optionals dontStrip [


### PR DESCRIPTION
###### Motivation for this change

This PR adds an option to the Haskell generic-builder that can be used to disable the `library-for-ghci` option passed to `Setup configure`.

By default, the Haskell generic-buider enables `library-for-ghci`.  This causes `Setup build` to build an additional `HSfoo*.o` file.

It looks like this `--enable-library-for-ghci` flag was added in https://github.com/NixOS/nixpkgs/commit/d7beae33dc4184f22865b4e7a8d42b3e7b5e225d, but there doesn't seem to be any explanation of why it was added.

I'm seeing a problem when trying to use [`doctest`](https://github.com/sol/doctest) to test a Haskell package:

https://github.com/cdepillabout/termonad/issues/15

`doctest` uses the GHCi API to load each module in your package into GHCi, and then run tests written in your Haddocks.  I'm seeing a problem using `doctest` to load files that require `TemplateHaskell`.

It looks like what happens is that in order for GHCi to typecheck and load the modules in a given package, it needs to byte-compile the TemplateHaskell splices.  In order to do this, it needs to load all the required dependency packages.  For some reason, when libraries have been compiled with `--enable-library-for-ghci`, this takes an extremely long time.  The Termonad example from above takes about 3 hours to run `doctest`, even though running it through `stack` or `cabal` just takes a few seconds.

I'm not sure why it takes so long to load libraries when using `--enable-library-for-ghci`, but I have confirmed that using `--disable-library-for-ghci` only takes a few seconds.

We're seeing this at work with our own Haskell packages, so we'd really like an easy way to work around this.  I'd also like to backport this change to 19.03, since that is what we're using at work.

This PR adds an option to disable `library-for-ghci` for the Haskell generic-builder.

Pinging @peti.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
