### PR TITLE
pythonPackages.pyogg: 0.6.6a1 -> 0.6.9a1

### DIFF
--- a/pkgs/development/python-modules/pyogg/default.nix
+++ b/pkgs/development/python-modules/pyogg/default.nix
@@ -1,34 +1,31 @@
-{ stdenv, lib, fetchPypi, buildPythonPackage, libvorbis, flac, libogg, libopus, opusfile }:
+{ stdenv, lib, fetchPypi, buildPythonPackage, libvorbis, flac, libogg, libopus, opusfile, substituteAll }:
 
 buildPythonPackage rec {
     pname = "PyOgg";
-    version = "0.6.6a1";
+    version = "0.6.9a1";
 
     src = fetchPypi {
       inherit pname version;
-      sha256 = "1ihzgl8p0rc3yjsp27zdrrs2r4qar5yf5l4v8wg0lilvan78h0rs";
+      sha256 = "0xabqwyknpvfc53s7il5pq6b07fcaqvz5bi5vbs3pbaw8602qvim";
     };
 
     buildInputs = [ libvorbis flac libogg libopus ];
     propagatedBuidInputs = [ libvorbis flac libogg libopus opusfile ];
     # There are no tests in this package.
     doCheck = false;
-    postPatch = ''
-      substituteInPlace pyogg/vorbis.py --replace \
-        'libvorbisfile = ExternalLibrary.load("vorbisfile")' "libvorbisfile = ctypes.CDLL('${libvorbis}/lib/libvorbisfile${stdenv.hostPlatform.extensions.sharedLibrary}')"
-      substituteInPlace pyogg/vorbis.py --replace \
-        'libvorbisenc = ExternalLibrary.load("vorbisenc")' "libvorbisenc = ctypes.CDLL('${libvorbis}/lib/libvorbisenc${stdenv.hostPlatform.extensions.sharedLibrary}')"
-      substituteInPlace pyogg/vorbis.py --replace \
-        'libvorbis = ExternalLibrary.load("vorbis")' "libvorbis = ctypes.CDLL('${libvorbis}/lib/libvorbis${stdenv.hostPlatform.extensions.sharedLibrary}')"
-      substituteInPlace pyogg/flac.py --replace \
-        'libflac = ExternalLibrary.load("flac")' "libflac = ctypes.CDLL('${flac.out}/lib/libFLAC${stdenv.hostPlatform.extensions.sharedLibrary}')"
-      substituteInPlace pyogg/ogg.py --replace \
-        'libogg = ExternalLibrary.load("ogg")' "libogg = ctypes.CDLL('${libogg}/lib/libogg${stdenv.hostPlatform.extensions.sharedLibrary}')"
-      substituteInPlace pyogg/opus.py --replace \
-        'libopus = ExternalLibrary.load("opus")' "libopus = ctypes.CDLL('${libopus}/lib/libopus${stdenv.hostPlatform.extensions.sharedLibrary}')"
-      substituteInPlace pyogg/opus.py --replace \
-        'libopusfile = ExternalLibrary.load("opusfile")' "libopusfile = ctypes.CDLL('${opusfile}/lib/libopusfile${stdenv.hostPlatform.extensions.sharedLibrary}')"
-    '';
+    patchFlags = [ "-p1" "--binary" ]; # patch has dos style eol
+    patches = [
+      (substituteAll {
+        src = ./pyogg-paths.patch;
+        flacLibPath="${flac.out}/lib/libFLAC${stdenv.hostPlatform.extensions.sharedLibrary}";
+        oggLibPath="${libogg}/lib/libogg${stdenv.hostPlatform.extensions.sharedLibrary}";
+        vorbisLibPath="${libvorbis}/lib/libvorbis${stdenv.hostPlatform.extensions.sharedLibrary}";
+        vorbisFileLibPath="${libvorbis}/lib/libvorbisfile${stdenv.hostPlatform.extensions.sharedLibrary}";
+        vorbisEncLibPath="${libvorbis}/lib/libvorbisenc${stdenv.hostPlatform.extensions.sharedLibrary}";
+        opusLibPath="${libopus}/lib/libopus${stdenv.hostPlatform.extensions.sharedLibrary}";
+        opusFileLibPath="${opusfile}/lib/libopusfile${stdenv.hostPlatform.extensions.sharedLibrary}";
+      })
+    ];
 
   meta = {
     description = "Xiph.org's Ogg Vorbis, Opus and FLAC for Python";

--- a/pkgs/development/python-modules/pyogg/pyogg-paths.patch
+++ b/pkgs/development/python-modules/pyogg/pyogg-paths.patch
@@ -1,0 +1,79 @@
+diff --git a/pyogg/flac.py b/pyogg/flac.py
+index 37cc788..9fb7e95 100644
+--- a/pyogg/flac.py
++++ b/pyogg/flac.py
+@@ -49,7 +49,7 @@ __here = os.getcwd()
+ libflac = None
+ 
+ try:
+-    libflac = ExternalLibrary.load("FLAC", tests = [lambda lib: hasattr(lib, "FLAC__EntropyCodingMethodTypeString")])
++    libflac = ctypes.CDLL('@flacLibPath@')
+ except ExternalLibraryError:
+     pass
+ except:
+diff --git a/pyogg/ogg.py b/pyogg/ogg.py
+index 7264774..2702e24 100644
+--- a/pyogg/ogg.py
++++ b/pyogg/ogg.py
+@@ -54,7 +54,7 @@ __here = os.getcwd()
+ libogg = None
+ 
+ try:
+-    libogg = ExternalLibrary.load("ogg", tests = [lambda lib: hasattr(lib, "oggpack_writeinit")])
++    libogg = ctypes.CDLL('@oggLibPath@')
+ except ExternalLibraryError:
+     pass
+ except:
+diff --git a/pyogg/opus.py b/pyogg/opus.py
+index 81e73da..640e59c 100644
+--- a/pyogg/opus.py
++++ b/pyogg/opus.py
+@@ -130,7 +130,7 @@ __here = os.getcwd()
+ libopus = None
+ 
+ try:
+-    libopus = ExternalLibrary.load("opus", tests = [lambda lib: hasattr(lib, "opus_encoder_get_size")])
++    libopus = ctypes.CDLL('@opusLibPath@')
+ except ExternalLibraryError:
+     pass
+ except:
+@@ -139,7 +139,7 @@ except:
+ libopusfile = None
+ 
+ try:
+-    libopusfile = ExternalLibrary.load("opusfile", tests = [lambda lib: hasattr(lib, "opus_head_parse")])
++    libopusfile = ctypes.CDLL('@opusFileLibPath@')
+ except ExternalLibraryError:
+     pass
+ except:
+diff --git a/pyogg/vorbis.py b/pyogg/vorbis.py
+index a8e4792..6f44d2d 100644
+--- a/pyogg/vorbis.py
++++ b/pyogg/vorbis.py
+@@ -52,7 +52,7 @@ __here = os.getcwd()
+ libvorbis = None
+ 
+ try:
+-    libvorbis = ExternalLibrary.load("vorbis", tests = [lambda lib: hasattr(lib, "vorbis_info_init")])
++    libvorbis = ctypes.CDLL('@vorbisLibPath@')
+ except ExternalLibraryError:
+     pass
+ except:
+@@ -61,7 +61,7 @@ except:
+ libvorbisfile = None
+ 
+ try:
+-    libvorbisfile = ExternalLibrary.load("vorbisfile", tests = [lambda lib: hasattr(lib, "ov_clear")])
++    libvorbisfile = ctypes.CDLL('@vorbisFileLibPath@')
+ except ExternalLibraryError:
+     pass
+ except:
+@@ -70,7 +70,7 @@ except:
+ libvorbisenc = None
+ 
+ try:
+-    libvorbisenc = ExternalLibrary.load("vorbisenc", tests = [lambda lib: hasattr(lib, "vorbis_encode_init")])
++    libvorbisenc = ctypes.CDLL('@vorbisEncLibPath@')
+ except ExternalLibraryError:
+     pass
+ except:


### PR DESCRIPTION
###### Motivation for this change

This is both an update and a bug-fix (see the `substitute` changes).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
