### PR TITLE
openmpi: 4.0.0 -> 4.0.1

### DIFF
--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -9,23 +9,15 @@
 }:
 
 let
-  version = "4.0.0";
+  version = "4.0.1";
 
 in stdenv.mkDerivation rec {
   name = "openmpi-${version}";
 
   src = with stdenv.lib.versions; fetchurl {
     url = "http://www.open-mpi.org/software/ompi/v${major version}.${minor version}/downloads/${name}.tar.bz2";
-    sha256 = "0srnjwzsmyhka9hhnmqm86qck4w3xwjm8g6sbns58wzbrwv8l2rg";
+    sha256 = "02cpzcp113gj5hb0j2xc0cqma2fn04i2i0bzf80r71120p9bdryc";
   };
-
-  patches = [ (fetchpatch {
-   # Fix a bug that ignores OMPI_MCA_rmaps_base_oversubscribe (upstream patch).
-   # This bug breaks the test from libs, such as scalapack,
-   # on machines with less than 4 cores.
-   url = https://github.com/open-mpi/ompi/commit/98c8492057e6222af6404b352430d0dd7553d253.patch;
-   sha256 = "1mpd8sxxprgfws96qqlzvqf58pn2vv2d0qa8g8cpv773sgw3b3gj";
-  }) ];
 
   postPatch = ''
     patchShebangs ./

--- a/pkgs/development/python-modules/mpi4py/default.nix
+++ b/pkgs/development/python-modules/mpi4py/default.nix
@@ -13,6 +13,12 @@ buildPythonPackage rec {
     inherit mpi;
   };
 
+  patches = [ ( fetchpatch {
+    # Upstream patch to ensure compatibility with openmpi-4.0.1
+    url = "https://github.com/mpi4py/mpi4py/commit/42f5e35a6a90454516c11131549a08cd766edbb0.patch";
+    sha256 = "1dm0i3amwj1cddzz1m9ssd7qp655c8rv1wzjs9ww3kzd90fm4w72";
+  })];
+
   postPatch = ''
     substituteInPlace test/test_spawn.py --replace \
                       "unittest.skipMPI('openmpi(<3.0.0)')" \


### PR DESCRIPTION
###### Motivation for this change
regular update

Changelog: https://github.com/open-mpi/ompi/blob/v4.0.x/NEWS

###### Things done
* remove upstream patch

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
