### PR TITLE
gnuradio-limesdr: 1.0.0-RC -> 2.0.0

### DIFF
--- a/pkgs/applications/radio/gnuradio/limesdr.nix
+++ b/pkgs/applications/radio/gnuradio/limesdr.nix
@@ -5,7 +5,7 @@
 assert pythonSupport -> python != null && swig != null;
 
 let
-  version = "1.0.0-RC";
+  version = "2.0.0";
 
 in stdenv.mkDerivation rec {
   name = "gnuradio-limesdr-${version}";
@@ -14,7 +14,7 @@ in stdenv.mkDerivation rec {
     owner = "myriadrf";
     repo = "gr-limesdr";
     rev = "v${version}";
-    sha256 = "0b34mg9nfar2gcir98004ixrxmxi8p3p2hrvvi1razd869x2a0lf";
+    sha256 = "0ldqvfwl0gil89l9s31fjf9d7ki0dk572i8vna336igfaz348ypq";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change
Update from pre-release to full release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
