### PR TITLE
[WIP] Recursive debian packages

### DIFF
--- a/pkgs/build-support/build-debian/default.nix
+++ b/pkgs/build-support/build-debian/default.nix
@@ -1,0 +1,46 @@
+{ pkgs
+, builder ? pkgs.releaseTools.debBuild
+, vm      ? (pkgs.vmTools.diskImageFuns.debian8x86_64 {})
+}:
+
+let
+  makeArgs = pkg: {
+    src         = if pkg ? src then pkg.src else pkg;
+    name        = pkg.name;
+    diskImage   = vm;
+    extraDebs   = let
+      bInputs = pkgs.lib.flatten pkg.buildInputs; # force to be list
+      debList = builtins.map makeDebList bInputs;
+    in
+      pkgs.lib.flatten debList;
+  };
+
+  makeDebList = pkg:
+  let
+    root = makeArgs pkg;
+    attrList = builtins.filter builtins.isAttrs pkg.buildInputs;
+    mapf     =  p: makeDebList p;
+
+    list = if pkg.buildInputs == null
+      then [] 
+      else builtins.map makeDebList attrList;
+  in
+    if pkg == null
+    then []
+    else [root] ++ pkgs.lib.flatten list;
+
+  makeDeb = pkg:
+  let
+    list = makeDebList pkg;
+  in
+    assert (builtins.all builtins.isAttrs list);
+    builtins.map builder list;
+
+  debPackageFor = pkg: name: pkgs.buildEnv {
+    inherit name;
+    paths = makeDeb pkg;
+  };
+in
+{
+  inherit makeArgs makeDebList makeDeb debPackageFor;
+}

--- a/pkgs/build-support/build-debian/default.nix
+++ b/pkgs/build-support/build-debian/default.nix
@@ -50,6 +50,7 @@ let
   debPackageFor = pkg: name: pkgs.buildEnv {
     inherit name;
     paths = makeDeb pkg;
+    pathsToLink = [ "/bin" ];
   };
 in
 {

--- a/pkgs/build-support/build-debian/default.nix
+++ b/pkgs/build-support/build-debian/default.nix
@@ -5,23 +5,26 @@
 
 let
   makeArgs = pkg: {
-    src         = if pkg ? src then pkg.src else pkg;
-    name        = pkg.name;
-    diskImage   = vm;
-    extraDebs   = let
-      bInputs = pkgs.lib.flatten pkg.buildInputs; # force to be list
-      debList = builtins.map makeDebList bInputs;
-    in
-      pkgs.lib.flatten debList;
+    meta.schedulingPriority = 50;
+    memSize        = 2047;
+    debRequires    = [];
+    debMaintainer  = "No Body <no@bo.dy>";
+    doInstallCheck = true;
+
+    src            = if pkg ? src then pkg.src else pkg;
+    name           = if pkg ? name then pkg.name else "noname-package";
+    diskImage      = vm;
+    extraDebs      =
+      pkgs.lib.flatten (builtins.map makeDebList (pkgs.lib.flatten pkg.buildInputs));
   };
 
   makeDebList = pkg:
   let
     root = makeArgs pkg;
-    attrList = builtins.filter builtins.isAttrs pkg.buildInputs;
+    attrList = if pkg ? buildInputs then builtins.filter builtins.isAttrs pkg.buildInputs else [];
     mapf     =  p: makeDebList p;
 
-    list = if pkg.buildInputs == null
+    list = if pkg ? buildInputs && pkg.buildInputs == null
       then [] 
       else builtins.map makeDebList attrList;
   in

--- a/pkgs/build-support/release/debian-build.nix
+++ b/pkgs/build-support/release/debian-build.nix
@@ -13,6 +13,11 @@
 
 with stdenv.lib;
 
+assert builtins.isString name;
+assert builtins.isString diskImage.name;
+assert builtins.isAttrs  src;
+assert src ? version -> builtins.isString src.version;
+
 vmTools.runInLinuxImage (stdenv.mkDerivation (
 
   {

--- a/pkgs/build-support/release/debian-build.nix
+++ b/pkgs/build-support/release/debian-build.nix
@@ -27,10 +27,9 @@ vmTools.runInLinuxImage (stdenv.mkDerivation (
 
     prePhases = "installExtraDebsPhase sysInfoPhase";
   }
-
-  // removeAttrs args ["vmTools"] //
-
+  //
   {
+    inherit src diskImage stdenv checkinstall fsTranslation debProvides debRequires;
     name = name + "-" + diskImage.name + (if src ? version then "-" + src.version else "");
 
     # !!! cut&paste from rpm-build.nix

--- a/pkgs/build-support/release/debian-build.nix
+++ b/pkgs/build-support/release/debian-build.nix
@@ -1,7 +1,7 @@
 # This function compiles a source tarball in a virtual machine image
 # that contains a Debian-like (i.e. dpkg-based) OS.
 
-{ name ? "debian-build"
+{ buildname ? "debian-build"
 , diskImage
 , src, stdenv, vmTools, checkinstall
 , fsTranslation ? false
@@ -13,90 +13,87 @@
 
 with stdenv.lib;
 
-assert builtins.isString name;
+assert builtins.isString buildname;
 assert builtins.isString diskImage.name;
 assert builtins.isAttrs  src;
 assert src ? version -> builtins.isString src.version;
 
-vmTools.runInLinuxImage (stdenv.mkDerivation (
+vmTools.runInLinuxImage (stdenv.mkDerivation {
+  doCheck       = true;
+  prefix        = "/usr";
+  prePhases     = "installExtraDebsPhase sysInfoPhase";
+  src           = src;
+  diskImage     = diskImage;
+  stdenv        = stdenv;
+  checkinstall  = checkinstall;
+  fsTranslation = fsTranslation;
+  debProvides   = debProvides;
+  debRequires   = debRequires;
+  name          = "${buildname}-${diskImage.name}";
 
-  {
-    doCheck = true;
+  # !!! cut&paste from rpm-build.nix
+  postHook = ''
+    . ${./functions.sh}
+    propagateImageName
+    src=$(findTarball $src)
+  '';
 
-    prefix = "/usr";
+  installExtraDebsPhase = ''
+    for i in $extraDebs; do
+      dpkg --install $(ls $i/debs/*.deb | sort | head -1)
+    done
+  '';
 
-    prePhases = "installExtraDebsPhase sysInfoPhase";
-  }
-  //
-  {
-    inherit src diskImage stdenv checkinstall fsTranslation debProvides debRequires;
-    name = name + "-" + diskImage.name + (if src ? version then "-" + src.version else "");
+  sysInfoPhase = ''
+    [ ! -f /etc/lsb-release ] || (source /etc/lsb-release; echo "OS release: $DISTRIB_DESCRIPTION")
+    echo "System/kernel: $(uname -a)"
+    if test -e /etc/debian_version; then echo "Debian release: $(cat /etc/debian_version)"; fi
+    header "installed Debian packages"
+    dpkg-query --list
+    stopNest
+  '';
 
-    # !!! cut&paste from rpm-build.nix
-    postHook = ''
-      . ${./functions.sh}
-      propagateImageName
-      src=$(findTarball $src)
-    '';
+  installPhase = ''
+    eval "$preInstall"
+    export LOGNAME=root
 
-    installExtraDebsPhase = ''
-      for i in $extraDebs; do
-        dpkg --install $(ls $i/debs/*.deb | sort | head -1)
-      done
-    '';
+    # otherwise build hangs when it wants to display
+    # the log file
+    export PAGER=cat
+    ${checkinstall}/sbin/checkinstall --nodoc -y -D \
+      --fstrans=${if fsTranslation then "yes" else "no"} \
+      --requires="${concatStringsSep "," debRequires}" \
+      --provides="${concatStringsSep "," debProvides}" \
+      ${if (src ? version) then "--pkgversion=$(echo ${src.version} | tr _ -)"
+                           else "--pkgversion=0.0.0"} \
+      ''${debMaintainer:+--maintainer="'$debMaintainer'"} \
+      ''${debName:+--pkgname="'$debName'"} \
+      $checkInstallFlags \
+      -- \
+      $SHELL -c "''${installCommand:-make install}"
 
-    sysInfoPhase = ''
-      [ ! -f /etc/lsb-release ] || (source /etc/lsb-release; echo "OS release: $DISTRIB_DESCRIPTION")
-      echo "System/kernel: $(uname -a)"
-      if test -e /etc/debian_version; then echo "Debian release: $(cat /etc/debian_version)"; fi
-      header "installed Debian packages"
-      dpkg-query --list
+    mkdir -p $out/debs
+    find . -name "*.deb" -exec cp {} $out/debs \;
+
+    [ "$(echo $out/debs/*.deb)" != "" ]
+
+    for i in $out/debs/*.deb; do
+      header "Generated DEB package: $i"
+      dpkg-deb --info "$i"
+      pkgName=$(dpkg-deb -W "$i" | awk '{print $1}')
+      echo "file deb $i" >> $out/nix-support/hydra-build-products
       stopNest
-    '';
+    done
+    dpkg -i $out/debs/*.deb
 
-    installPhase = ''
-      eval "$preInstall"
-      export LOGNAME=root
+    for i in $extraDebs; do
+      echo "file deb-extra $(ls $i/debs/*.deb | sort | head -1)" >> $out/nix-support/hydra-build-products
+    done
 
-      # otherwise build hangs when it wants to display
-      # the log file
-      export PAGER=cat
-      ${checkinstall}/sbin/checkinstall --nodoc -y -D \
-        --fstrans=${if fsTranslation then "yes" else "no"} \
-        --requires="${concatStringsSep "," debRequires}" \
-        --provides="${concatStringsSep "," debProvides}" \
-        ${if (src ? version) then "--pkgversion=$(echo ${src.version} | tr _ -)"
-                             else "--pkgversion=0.0.0"} \
-        ''${debMaintainer:+--maintainer="'$debMaintainer'"} \
-        ''${debName:+--pkgname="'$debName'"} \
-        $checkInstallFlags \
-        -- \
-        $SHELL -c "''${installCommand:-make install}"
+    eval "$postInstall"
+  ''; # */
 
-      mkdir -p $out/debs
-      find . -name "*.deb" -exec cp {} $out/debs \;
-
-      [ "$(echo $out/debs/*.deb)" != "" ]
-
-      for i in $out/debs/*.deb; do
-        header "Generated DEB package: $i"
-        dpkg-deb --info "$i"
-        pkgName=$(dpkg-deb -W "$i" | awk '{print $1}')
-        echo "file deb $i" >> $out/nix-support/hydra-build-products
-        stopNest
-      done
-      dpkg -i $out/debs/*.deb
-
-      for i in $extraDebs; do
-        echo "file deb-extra $(ls $i/debs/*.deb | sort | head -1)" >> $out/nix-support/hydra-build-products
-      done
-
-      eval "$postInstall"
-    ''; # */
-
-    meta = (if args ? meta then args.meta else {}) // {
-      description = "Deb package for ${diskImage.fullName}";
-    };
-  }
-
-))
+  meta = (if args ? meta then args.meta else {}) // {
+    description = "Deb package for ${diskImage.fullName}";
+  };
+})

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -803,7 +803,7 @@ rec {
 
     # Note: no i386 release for 7.x
     centos7x86_64 =
-      let version = "7.4.1708";
+      let version = "7.6.1810";
       in rec {
         name = "centos-${version}-x86_64";
         fullName = "CentOS ${version} (x86_64)";
@@ -812,7 +812,7 @@ rec {
         urlPrefix = "http://mirror.centos.org/centos-7/${version}/os/x86_64";
         packagesList = fetchurl rec {
           url = "${urlPrefix}/repodata/${sha256}-primary.xml.gz";
-          sha256 = "b686d3a0f337323e656d9387b9a76ce6808b26255fc3a138b1a87d3b1cb95ed5";
+          sha256 = "25cd2c29e5adb2b6f8a5b091237dd9f760e97815b37f2557f2cd1c12a5f294f0";
         };
         archs = ["noarch" "x86_64"];
         packages = commonCentOSPackages ++ [ "procps-ng" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -145,6 +145,8 @@ in
 
   buildMaven = callPackage ../build-support/build-maven.nix {};
 
+  buildRecDebpkg = callPackage ../build-support/build-debian {};
+
   castxml = callPackage ../development/tools/castxml { };
 
   cmark = callPackage ../development/libraries/cmark { };


### PR DESCRIPTION
## Motivation

We (as in "my employer and I") need to package software for debianoids (and RPM, but we're only looking into debian here).
I am therefore exploring the possibilities nix/nixpkgs gives us for building different versions for different customers with different patches and so on and so forth. Everything that is easy with nixpkgs (like custom compileflags, etc etc).

But, we need to ship .deb/.rpm packages. That is obviously not that easy with nixpkgs. There is support for building debian packages, which is `releaseTools.debBuild` - which only "kinda" works, as it leaves `/nix` artifacts in the resulting .deb - but that is a different topic.

So what am I doing here is: I try to build a whole dependency tree (all transitive dependencies) of a package as debian packages.

### Prerequisites

I want to work with _only_ nixpkgs and nix, no other tooling required

### Expected outcome

I can build a nixpkgs package and I get all required dependencies as `.deb`.
That means that I build `multitail` and get `ncurses.deb` and `multitail.deb` or I build `octaveFull` and I get `<long list of .deb files here>`.

### Current status

My functions can generate the attribute sets for the builder function (`releaseTools.debBuild`) pretty well... it works ~95% of the time.

Unfortunately, I can not do the full job:

```
$ nix repl # in nixpkgs clone
:l ./default.nix
pkgs.buildRecDebpkg.debPackageFor pkgs.multitail "multitail-deb"
error: cannot coerce a set to a string, at /home/user/nixpkgs/pkgs/build-support/release/debian-build.nix:34:5
```

And I *just do not get where this error comes from*.

### My request

So if some can have a look at my patches, I would welcome

1. Feedback on the general approach
1. Pointers on how to improve the approach or whether it is completely insane/bogus or whether there's a better way to do this
1. Pointers on where my error comes from and what to do about it

## Note

This is *WIP* and should not be considered for inclusion.