### PR TITLE
add pyghmi - required by Ansible IPMI module

### DIFF
--- a/pkgs/development/python-modules/hacking/default.nix
+++ b/pkgs/development/python-modules/hacking/default.nix
@@ -1,0 +1,35 @@
+{ lib 
+, stdenv
+, buildPythonPackage
+, python
+, fetchPypi
+, flake8
+, pbr
+, reno
+, six
+}:
+
+buildPythonPackage rec{
+  pname = "hacking";
+  version = "1.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "23a306f3a1070a4469a603886ba709780f02ae7e0f1fc7061e5c6fb203828fee";
+  };
+
+  buildInputs = [ flake8 pbr reno six ];
+
+  patchPhase = ''
+    sed -i 's@flake8<2.7.0,>=2.6.0@flake8>=2.6.0@' requirements.txt
+    sed -i 's@python@${python.interpreter}@' .testr.conf
+  '';
+
+  meta = with lib; {
+    homepage = https://github.com/openstack-dev/hacking;
+    description = "OpenStack Hacking Style Checks";
+    license = licenses.apache;
+    maintainers = with maintainers; [ cptMikky ];
+  };
+}
+

--- a/pkgs/development/python-modules/mox3/default.nix
+++ b/pkgs/development/python-modules/mox3/default.nix
@@ -13,16 +13,13 @@
 
 buildPythonPackage rec {
   pname = "mox3";
-  version = "0.26.0";
+  version = "0.27.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "b13c0b8459d6fb0688f9a4e70feeec43fa2cca05b727fc01156789596e083bb1";
+    sha256 = "210ccaf5829de3e133f0fb8ab798cdb82663aae09b715130fc4765f18234162a";
   };
 
-  patchPhase = ''
-    sed -i 's@python@${python.interpreter}@' .testr.conf
-  '';
 
   buildInputs = [ subunit testrepository testtools six ];
   propagatedBuildInputs = [ pbr fixtures ];

--- a/pkgs/development/python-modules/openstackdocstheme/default.nix
+++ b/pkgs/development/python-modules/openstackdocstheme/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchPypi
+, dulwich
+, pbr
+, sphinx
+}:
+
+buildPythonPackage rec{
+  pname = "openstackdocstheme";
+  version = "1.29.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "d01b8b9af1789259fcc147d148e95ac00d94b3d829439ac6dd1dc9ec10651f5c";
+  };
+
+  buildInputs = [ dulwich pbr sphinx ];
+
+  meta = with lib; {
+    homepage = https://github.com/openstack/openstackdocstheme;
+    description = "Sphinx theme for RST-sourced documentation published to docs.openstack.org";
+    license = licenses.apache;
+    maintainers = with maintainers; [ cptMikky ];
+  };
+}
+

--- a/pkgs/development/python-modules/oslotest/default.nix
+++ b/pkgs/development/python-modules/oslotest/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchPypi
+, fixtures
+, mox3
+, subunit
+}:
+
+buildPythonPackage rec{
+  pname = "oslotest";
+  version = "3.7.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "c29ff0199be630653ce4fe83748dd8a58659fa4524e877e3213320645178cb97";
+  };
+
+  buildInputs = [ fixtures mox3 subunit ];
+
+  #checkInputs = [ nose ];
+
+#  checkPhase = ''
+#    # https://github.com/pytoolz/toolz/issues/357
+#    rm toolz/tests/test_serialization.py
+#    nosetests toolz/tests
+#  '';
+
+  meta = with lib; {
+    homepage = https://github.com/openstack/oslotest/;
+    description = "OpenStack Testing Framework and Utilities`";
+    license = licenses.apache;
+    maintainers = with maintainers; [ cptMikky ];
+  };
+}
+

--- a/pkgs/development/python-modules/pyghmi/default.nix
+++ b/pkgs/development/python-modules/pyghmi/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchPypi
+, cryptography
+, oslotest
+, pbr
+}:
+
+buildPythonPackage rec{
+  pname = "pyghmi";
+  version = "1.2.16";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "2b474e04f526035d2fc0e2f0b22246316ea34af1dca8269201bbd202812d7a99";
+  };
+
+  buildInputs = [ pbr oslotest cryptography ];
+
+  #checkInputs = [ nose ];
+
+#  checkPhase = ''
+#    # https://github.com/pytoolz/toolz/issues/357
+#    rm toolz/tests/test_serialization.py
+#    nosetests toolz/tests
+#  '';
+
+  meta = with lib; {
+    homepage = https://github.com/openstack/pyghmi;
+    description = "A Pure python IPMI library";
+    license = licenses.apache;
+    maintainers = with maintainers; [ cptMikky ];
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -450,6 +450,8 @@ in {
 
   habanero = callPackage ../development/python-modules/habanero { };
 
+  hacking = callPackage ../development/python-modules/hacking { };
+
   helper = callPackage ../development/python-modules/helper { };
 
   histbook = callPackage ../development/python-modules/histbook { };
@@ -553,7 +555,11 @@ in {
 
   oauthenticator = callPackage ../development/python-modules/oauthenticator { };
 
+  openstackdocstheme = callPackage ../development/python-modules/openstackdocstheme { };
+
   ordered-set = callPackage ../development/python-modules/ordered-set { };
+
+  oslotest = callPackage ../development/python-modules/oslotest { };
 
   osmnx = callPackage ../development/python-modules/osmnx { };
 
@@ -656,6 +662,8 @@ in {
   pygame_sdl2 = callPackage ../development/python-modules/pygame_sdl2 { };
 
   pygdbmi = callPackage ../development/python-modules/pygdbmi { };
+
+  pyghmi = callPackage ../development/python-modules/pyghmi { };
 
   pygmo = callPackage ../development/python-modules/pygmo { };
 


### PR DESCRIPTION
###### Motivation for this change

Ansible requires pyghmi for the IPMI module to work: https://docs.ansible.com/ansible/2.3/ipmi_power_module.html

pyghmi itself generates rather large dependency tree which is not fully covered by pre-existing nixpkgs.

This PR doesn't work yet, draft only.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
