### PR TITLE
pythonPackages.mpi4py: 3.0.0 -> 3.0.1

### DIFF
--- a/pkgs/development/python-modules/h5py/default.nix
+++ b/pkgs/development/python-modules/h5py/default.nix
@@ -30,7 +30,7 @@ in buildPythonPackage rec {
 
   preBuild = if mpiSupport then "export CC=${mpi}/bin/mpicc" else "";
 
-  checkInputs = optional isPy27 unittest2;
+  checkInputs = optional isPy27 unittest2 ++ [ openssh ];
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ hdf5 cython ]
     ++ optional mpiSupport mpi;

--- a/pkgs/development/python-modules/mpi4py/default.nix
+++ b/pkgs/development/python-modules/mpi4py/default.nix
@@ -2,30 +2,16 @@
 
 buildPythonPackage rec {
   pname = "mpi4py";
-  version = "3.0.0";
+  version = "3.0.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1mzgd26dfv4vwbci8gq77ss9f0x26i9aqzq9b9vs9ndxhlnv0mxl";
+    sha256 = "0ld8rjmsjr0dklvj2g1gr3ax32sdq0xjxyh0cspknc1i36waajb5";
   };
 
   passthru = {
     inherit mpi;
   };
-
-  patches = [
-    (fetchpatch {
-      # Disable tests failing with 3.1.x and MPI_THREAD_MULTIPLE (upstream patch)
-      url = "https://bitbucket.org/mpi4py/mpi4py/commits/c2b6b7e642a182f9b00a2b8e9db363214470548a/raw";
-      sha256 = "0n6bz3kj4vcqb6q7d0mlj5vl6apn7i2bvfc9mpg59vh3wy47119q";
-    })
-    (fetchpatch {
-      # Open MPI: Workaround removal of MPI_{LB|UB} (upstream patch)
-      url = "https://bitbucket.org/mpi4py/mpi4py/commits/39ca784226460f9e519507269ebb29635dc8bd90/raw";
-      sha256 = "02kxikdlsrlq8yr5hca42536mxbrq4k4j8nqv7p1p2r0q21a919q";
-    })
-
-  ];
 
   postPatch = ''
     substituteInPlace test/test_spawn.py --replace \


### PR DESCRIPTION
###### Motivation for this change
regular update

###### Things done
* Removed upstream patches

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
