### PR TITLE
zfsUnstable: 0.8.0-rc3 -> 2019-04-01

### DIFF
--- a/pkgs/os-specific/linux/zfs/build-fixes-unstable.patch
+++ b/pkgs/os-specific/linux/zfs/build-fixes-unstable.patch
@@ -1,0 +1,36 @@
+From b323e7a7ebb2327943851fa3fd139399eb24d3dd Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=C3=B6rg=20Thalheim?= <joerg@thalheim.io>
+Date: Mon, 13 Aug 2018 22:58:21 +0200
+Subject: [PATCH] build fixes needed for nixos
+
+---
+ module/Makefile.in | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/module/Makefile.in b/module/Makefile.in
+index 935bd2663..afb08df81 100644
+--- a/module/Makefile.in
++++ b/module/Makefile.in
+@@ -44,15 +44,15 @@ clean:
+ modules_install:
+ 	@# Install the kernel modules
+ 	$(MAKE) -C @LINUX_OBJ@ M=`pwd` $@ \
+-		INSTALL_MOD_PATH=$(DESTDIR)$(INSTALL_MOD_PATH) \
++		INSTALL_MOD_PATH=@prefix@/$(INSTALL_MOD_PATH) \
+ 		INSTALL_MOD_DIR=$(INSTALL_MOD_DIR) \
+ 		KERNELRELEASE=@LINUX_VERSION@
+ 	@# Remove extraneous build products when packaging
+-	kmoddir=$(DESTDIR)$(INSTALL_MOD_PATH)/lib/modules/@LINUX_VERSION@; \
+-	if [ -n "$(DESTDIR)" ]; then \
++	kmoddir=@prefix@$(INSTALL_MOD_PATH)/lib/modules/@LINUX_VERSION@; \
++	if [ -n "@prefix@" ]; then \
+ 		find $$kmoddir -name 'modules.*' | xargs $(RM); \
+ 	fi
+-	sysmap=$(DESTDIR)$(INSTALL_MOD_PATH)/boot/System.map-@LINUX_VERSION@; \
++	sysmap=@prefix@$(INSTALL_MOD_PATH)/boot/System.map-@LINUX_VERSION@; \
+ 	if [ -f $$sysmap ]; then \
+ 		depmod -ae -F $$sysmap @LINUX_VERSION@; \
+ 	fi
+-- 
+2.19.2
+

--- a/pkgs/os-specific/linux/zfs/default.nix
+++ b/pkgs/os-specific/linux/zfs/default.nix
@@ -182,17 +182,14 @@ in {
     # incompatibleKernelVersion = "4.19";
 
     # this package should point to a version / git revision compatible with the latest kernel release
-    version = "0.8.0-rc3";
+    rev = "bd15ac764fb8fe1995d3b2f6c8ddb643447d92aa";
+    version = "unstable-2019-04-01";
 
-    sha256 = "0wmkis0q2gbj7sgx3ipxngbgzjcf7ay353v3mglf2ay50q4da5i7";
+    sha256 = "194yjl270r6cwhiv6hb5mc5r74kwhr55p2y0ys4hzryn35lgrvl4";
     isUnstable = true;
 
     extraPatches = [
-      # in case this gets out of date, just send Mic92 a pull request!
-      (fetchpatch {
-        url = "https://github.com/Mic92/zfs/commit/bc29b5783da0af2c80c85126a1831ce1d52bfb69.patch";
-        sha256 = "1sdcr1w2jp3djpwlf1f91hrxxmc34q0jl388smdkxh5n5bpw5gzw";
-      })
+      ./build-fixes-unstable.patch
     ];
 
     spl = null;


### PR DESCRIPTION
###### Motivation for this change
Master has added support for SSD TRIM.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @wizeman @fpletz @globin @sjau 