### PR TITLE
mono: 5.16.0.220 -> 5.18.1.0

### DIFF
--- a/pkgs/development/compilers/mono/5.nix
+++ b/pkgs/development/compilers/mono/5.nix
@@ -2,7 +2,7 @@
 
 callPackage ./generic.nix (rec {
   inherit Foundation libobjc;
-  version = "5.16.0.220";
-  sha256 = "1qwdmxssplfdb5rq86f1j8lskvr9dfk5c8hqz9ic09ml69r8c87l";
+  version = "5.18.1.0";
+  sha256 = "1w540f6r84shih0vrxa4h7q1ix1vx6zg0g10vcn95alg9ysqyam9";
   enableParallelBuilding = false;
 })


### PR DESCRIPTION
###### Motivation for this change

Mono 5.18 supports .NET 4.7.2, which has feature I want.

###### Note

I am unable to build my .NET 4.7.2 projects using the mono-bundled xbuild because it is too old. We would need to package msbuild, like in https://github.com/NixOS/nixpkgs/pull/43680. I use a workaround of downloading recent msbuild myself, as described in comment on the linked PR.

I use this only for development. I do not use this mono as dependency for other nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
