### PR TITLE
openvpn: support for updating systemd-resolved with DNS servers

### DIFF
--- a/pkgs/tools/networking/openvpn/default.nix
+++ b/pkgs/tools/networking/openvpn/default.nix
@@ -1,5 +1,6 @@
-{ stdenv, fetchurl, iproute, lzo, openssl, pam, pkgconfig
-, useSystemd ? stdenv.isLinux, systemd ? null
+{ stdenv, fetchurl, pkgconfig
+, iproute, lzo, openssl, pam
+, useSystemd ? stdenv.isLinux, systemd ? null, utillinux ? null
 , pkcs11Support ? false, pkcs11helper ? null,
 }:
 
@@ -8,7 +9,15 @@ assert pkcs11Support -> (pkcs11helper != null);
 
 with stdenv.lib;
 
-stdenv.mkDerivation rec {
+let
+  # There is some fairly brittle string substitutions going on to replace paths,
+  # so please verify this script in case you are upgrading it
+  update-resolved = fetchurl {
+    url = "https://raw.githubusercontent.com/jonathanio/update-systemd-resolved/v1.2.7/update-systemd-resolved";
+    sha256 = "12zfzh42apwbj7ks5kfxf3far7kaghlby4yapbhn00q8pbdlw7pq";
+  };
+
+in stdenv.mkDerivation rec {
   name = "openvpn-${version}";
   version = "2.4.6";
 
@@ -18,6 +27,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
+
   buildInputs = [ lzo openssl ]
                   ++ optionals stdenv.isLinux [ pam iproute ]
                   ++ optional useSystemd systemd
@@ -35,17 +45,27 @@ stdenv.mkDerivation rec {
     cp -r sample/sample-config-files/ $out/share/doc/openvpn/examples
     cp -r sample/sample-keys/ $out/share/doc/openvpn/examples
     cp -r sample/sample-scripts/ $out/share/doc/openvpn/examples
+
+    ${optionalString useSystemd ''
+      install -Dm755 ${update-resolved} $out/libexec/update-systemd-resolved
+
+      substituteInPlace $out/libexec/update-systemd-resolved \
+        --replace '/usr/bin/env bash' '${stdenv.shell} -e' \
+        --replace 'busctl call'       '${getBin systemd}/bin/busctl call' \
+        --replace '(ip '              '(${getBin iproute}/bin/ip ' \
+        --replace 'logger '           '${getBin utillinux}/bin/logger '
+    ''}
   '';
 
   enableParallelBuilding = true;
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "A robust and highly flexible tunneling application";
-    homepage = https://openvpn.net/;
     downloadPage = "https://openvpn.net/index.php/open-source/downloads.html";
-    license = stdenv.lib.licenses.gpl2;
-    maintainers = [ stdenv.lib.maintainers.viric ];
-    platforms = stdenv.lib.platforms.unix;
+    homepage = https://openvpn.net/;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ viric ];
+    platforms = platforms.unix;
     updateWalker = true;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

With this PR, a script can be triggered when an OpenVPN connection is made that will configure the DNS for ```systemd-resolved```. Short version: if you need to do DNS over an OpenVPN tunnel that you run directly by invoking ```openvpn```, you need this.

There is no change to the openvpn binary itself, so there is no risk of breaking anything.

Without this PR:

```
Link 20 (tun0)
      Current Scopes: DNS LLMNR/IPv4 LLMNR/IPv6
       LLMNR setting: yes
MulticastDNS setting: no
  DNSOverTLS setting: no
      DNSSEC setting: no
    DNSSEC supported: no
```

With this PR:

```
Link 20 (tun0)
      Current Scopes: DNS LLMNR/IPv4 LLMNR/IPv6
       LLMNR setting: yes
MulticastDNS setting: no
  DNSOverTLS setting: no
      DNSSEC setting: no
    DNSSEC supported: no
  Current DNS Server: 10.10.1.63
         DNS Servers: 10.10.1.63
          DNS Domain: some.other.domain.tld
```

Cc: @viric 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
