### PR TITLE
eclib: 20180815 -> 20190226

### DIFF
--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -137,6 +137,13 @@ stdenv.mkDerivation rec {
 
     # https://trac.sagemath.org/ticket/27405
     ./patches/ignore-pip-deprecation.patch
+
+    # https://trac.sagemath.org/ticket/27360
+    (fetchpatch {
+      name = "eclib-20190226.patch";
+      url = "https://git.sagemath.org/sage.git/patch/?id=f570e3a7fc2965764b84c04ce301a88ded2c42df";
+      sha256 = "0l5c4giixkn15v2a06sfzq5mkxila6l67zkjbacirwprrlpcnmmp";
+    })
   ];
 
   patches = nixPatches ++ bugfixPatches ++ packageUpgradePatches;

--- a/pkgs/development/libraries/eclib/default.nix
+++ b/pkgs/development/libraries/eclib/default.nix
@@ -16,7 +16,7 @@ assert withFlint -> flint != null;
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "eclib";
-  version = "20180815"; # upgrade might break the sage interface
+  version = "20190226"; # upgrade might break the sage interface
   # sage tests to run:
   # src/sage/interfaces/mwrank.py
   # src/sage/libs/eclib
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     owner = "JohnCremona";
     repo = "${pname}";
     rev = "v${version}";
-    sha256 = "12syn83lnzx0xc4r1v3glfimbzndyilkpdmx50xrihbjz1hzczif";
+    sha256 = "1910np1xzyjzszay24xn4b81qhpsvhp5aix9vdpknplni2mq8kwb";
   };
   buildInputs = [
     pari


### PR DESCRIPTION

###### Motivation for this change

Replaces https://github.com/NixOS/nixpkgs/pull/56635.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
