### PR TITLE
roundcube: minor fixes

### DIFF
--- a/pkgs/servers/roundcube/0001-Don-t-resolve-symlinks-when-trying-to-find-INSTALL_P.patch
+++ b/pkgs/servers/roundcube/0001-Don-t-resolve-symlinks-when-trying-to-find-INSTALL_P.patch
@@ -1,0 +1,27 @@
+From c1832eabb99cec47f1714f696275285e1e28da34 Mon Sep 17 00:00:00 2001
+From: Maximilian Bosch <maximilian@mbosch.me>
+Date: Tue, 2 Apr 2019 16:20:50 +0200
+Subject: [PATCH] Don't resolve symlinks when trying to find INSTALL_PATH
+
+Nix specific patch. This behavior breaks roundcube setups where plugins
+are in a store path with symlinks to the actual source.
+---
+ bin/update.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/bin/update.sh b/bin/update.sh
+index 08e3bb5..b2ad498 100755
+--- a/bin/update.sh
++++ b/bin/update.sh
+@@ -19,7 +19,7 @@
+  +-----------------------------------------------------------------------+
+ */
+ 
+-define('INSTALL_PATH', realpath(__DIR__ . '/..') . '/' );
++define('INSTALL_PATH', __DIR__ . '/../' );
+ 
+ require_once INSTALL_PATH . 'program/include/clisetup.php';
+ 
+-- 
+2.19.2
+

--- a/pkgs/servers/roundcube/default.nix
+++ b/pkgs/servers/roundcube/default.nix
@@ -1,14 +1,21 @@
-{ lib, stdenv, fetchzip, buildEnv, roundcube, roundcubePlugins }:
-let
+{ lib, fetchurl, stdenv, buildEnv, roundcube, roundcubePlugins }:
+
+stdenv.mkDerivation rec {
+  pname = "roundcube";
   version = "1.3.8";
-in
-fetchzip rec {
-  name= "roundcube-${version}";
 
-  url = "https://github.com/roundcube/roundcubemail/releases/download/${version}/roundcubemail-${version}-complete.tar.gz";
-  sha256 = "1lhwr13bglm8rqgamnb480b07wpqhw9bskjj2xxb0x8kdjly29ks";
+  src = fetchurl {
+    url = "https://github.com/roundcube/roundcubemail/releases/download/${version}/roundcubemail-${version}-complete.tar.gz";
+    sha256 = "018djad7ygfl9c9f2l2j42qkg31ml3hs2f01f0dk361zckwk77n4";
+  };
 
-  extraPostFetch = ''
+  patches = [ ./0001-Don-t-resolve-symlinks-when-trying-to-find-INSTALL_P.patch ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir $out
+    cp -r * $out/
     ln -sf /etc/roundcube/config.inc.php $out/config/config.inc.php
     rm -rf $out/installer
   '';


### PR DESCRIPTION
###### Motivation for this change

* The roundcube doesn't evaluate when trying to use a different database
* Don't resolve symlinks in installer script to ensure that the sources in the `buildEnv` store path are used.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
