### PR TITLE
bundler-audit: init at 0.6.1

### DIFF
--- a/pkgs/tools/security/bundler-audit/Gemfile
+++ b/pkgs/tools/security/bundler-audit/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'bundler-audit'

--- a/pkgs/tools/security/bundler-audit/Gemfile.lock
+++ b/pkgs/tools/security/bundler-audit/Gemfile.lock
@@ -1,0 +1,16 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    bundler-audit (0.6.1)
+      bundler (>= 1.2.0, < 3)
+      thor (~> 0.18)
+    thor (0.20.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler-audit
+
+BUNDLED WITH
+   1.14.6

--- a/pkgs/tools/security/bundler-audit/default.nix
+++ b/pkgs/tools/security/bundler-audit/default.nix
@@ -1,0 +1,26 @@
+{ bundlerEnv, ruby, lib }:
+
+bundlerEnv rec {
+  name = "${pname}-${version}";
+  pname = "bundler-audit";
+  version = (import ./gemset.nix).bundler-audit.version;
+
+  inherit ruby;
+  gemdir = ./.;
+
+  meta = with lib; {
+    description = "Patch-level verification for Bundler";
+    longDescription = ''
+      Features:
+      - Checks for vulnerable versions of gems in Gemfile.lock.
+      - Checks for insecure gem sources (http://).
+      - Allows ignoring certain advisories that have been manually worked around.
+      - Prints advisory information.
+      - Does not require a network connection.
+    '';
+    homepage    = https://github.com/rubysec/bundler-audit;
+    license     = licenses.gpl3Plus;
+    maintainers = with maintainers; [ primeos ];
+    platforms   = platforms.unix;
+  };
+}

--- a/pkgs/tools/security/bundler-audit/gemset.nix
+++ b/pkgs/tools/security/bundler-audit/gemset.nix
@@ -1,0 +1,19 @@
+{
+  bundler-audit = {
+    dependencies = ["thor"];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0pm22xpn3xyymsainixnrk8v3l3xi9bzwkjkspx00cfzp84xvxbq";
+      type = "gem";
+    };
+    version = "0.6.1";
+  };
+  thor = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1yhrnp9x8qcy5vc7g438amd5j9sw83ih7c30dr6g6slgw9zj3g29";
+      type = "gem";
+    };
+    version = "0.20.3";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8285,6 +8285,8 @@ in
   bundlerEnv = callPackage ../development/ruby-modules/bundler-env { };
   bundlerApp = callPackage ../development/ruby-modules/bundler-app { };
 
+  bundler-audit = callPackage ../tools/security/bundler-audit { };
+
   solargraph = callPackage ../development/ruby-modules/solargraph { };
 
   inherit (callPackage ../development/interpreters/ruby {


### PR DESCRIPTION
###### Motivation for this change

This can e.g. be used to scan `Gemfile.lock` files in `nixpkgs`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
