### PR TITLE
xonsh: 0.8.3 -> 0.8.12

### DIFF
--- a/pkgs/shells/xonsh/default.nix
+++ b/pkgs/shells/xonsh/default.nix
@@ -2,31 +2,36 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "xonsh";
-  version = "0.8.3";
+  version = "0.8.12";
 
   # fetch from github because the pypi package ships incomplete tests
   src = fetchFromGitHub {
     owner  = "scopatz";
     repo   = "xonsh";
     rev    = "refs/tags/${version}";
-    sha256 = "1qnghqswvqlwv9121r4maibmn2dvqmbr3fhsnngsj3q7plfp7yb2";
+    sha256 = "1p8slx8nk15vyyzwc9ic50py0amk9p9nggp1973wfas0fxsg1r4f";
   };
 
   LC_ALL = "en_US.UTF-8";
   postPatch = ''
     sed -ie "s|/bin/ls|${coreutils}/bin/ls|" tests/test_execer.py
-    sed -ie 's|/usr/bin/env|${coreutils}/bin/env|' scripts/xon.sh
+    sed -ie "s|SHELL=xonsh|SHELL=$out/bin/xonsh|" tests/test_integrations.py
 
+    sed -ie 's|/usr/bin/env|${coreutils}/bin/env|' tests/test_integrations.py
+    sed -ie 's|/usr/bin/env|${coreutils}/bin/env|' scripts/xon.sh
+    find -name "*.xsh" | xargs sed -ie 's|/usr/bin/env|${coreutils}/bin/env|'
     patchShebangs .
   '';
 
+  doCheck = !stdenv.isDarwin;
+
   checkPhase = ''
-    HOME=$TMPDIR \
-      pytest \
-        -k 'not test_man_completion and not test_indir and not test_xonsh_party and not test_foreign_bash_data and not test_script and not test_single_command_no_windows and not test_redirect_out_to_file and not test_sourcefile and not test_printname and not test_printfile'
+    HOME=$TMPDIR pytest -k 'not test_repath_backslash and not test_os and not test_man_completion and not test_builtins and not test_main and not test_ptk_highlight'
+    HOME=$TMPDIR pytest -k 'test_builtins or test_main' --reruns 5
+    HOME=$TMPDIR pytest -k 'test_ptk_highlight'
   '';
 
-  checkInputs = [ python3Packages.pytest glibcLocales git ];
+  checkInputs = [ python3Packages.pytest python3Packages.pytest-rerunfailures glibcLocales git ];
 
   propagatedBuildInputs = with python3Packages; [ ply prompt_toolkit pygments ];
 


### PR DESCRIPTION
 * Expanded unit tests.
 * Added pytest-rerunfailures due to flaky tests.

###### Motivation for this change
Failing hydra build.
https://hydra.nixos.org/build/91523333
/cc https://github.com/NixOS/nixpkgs/issues/56826

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

###### Tests
~~Note that to build this with a local master you need a small edit to pytest-rerunfailures. Add pytest to checkInputs. See part of https://github.com/NixOS/nixpkgs/pull/58710.~~ <- PR released
 * nix-build -A xonsh
 * nix-shell -I nixpkgs=/path/to/nixpkgs xonsh --pure -p xonsh