### PR TITLE
 androidndk-pkgs: Fix cc-wrapper flags 

### DIFF
--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -258,7 +258,6 @@ rec {
     name = "armeabi";
     gcc = {
       arch = "armv5te";
-      float = "soft";
       float-abi = "soft";
     };
   };
@@ -268,7 +267,6 @@ rec {
     name = "armeabi-v7a";
     gcc = {
       arch = "armv7-a";
-      float = "hard";
       float-abi = "softfp";
       fpu = "vfpv3-d16";
     };

--- a/pkgs/development/mobile/androidenv/androidndk-pkgs.nix
+++ b/pkgs/development/mobile/androidenv/androidndk-pkgs.nix
@@ -91,8 +91,7 @@ rec {
           $out/bin/${stdenv.targetPlatform.config}-c++ \
           $out/bin/${stdenv.targetPlatform.config}-gcc \
           $out/bin/${stdenv.targetPlatform.config}-g++ \
-          -e '130i    extraBefore+=(-Wl,--fix-cortex-a8)' \
-          -e 's|^(extraBefore=)\(\)$|\1(${builtins.toString flags})|'
+          -e 's|^(extraBefore=)\((.*)\)$|\1(\2 -Wl,--fix-cortex-a8 ${builtins.toString flags})|'
       '')
       # GCC 4.9 is the first relase with "-fstack-protector"
       + lib.optionalString (lib.versionOlder targetInfo.gccVer "4.9") ''


### PR DESCRIPTION
###### Motivation for this change

The sed script `androidndk-pkgs.nix` is broken and doesn't actually perform the intended substitutions. Additionally, the `-mfloat=` options are unrecognized by the Android toolchain.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
