### PR TITLE
rocksdb: 5.11.3 -> 6.1.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3016,6 +3016,11 @@
     github = "MarcFontaine";
     name = "Marc Fontaine";
   };
+  magenbluten = {
+    email = "magenbluten@codemonkey.cc";
+    github = "magenbluten";
+    name = "magenbluten";
+  };
   magnetophon = {
     email = "bart@magnetophon.nl";
     github = "magnetophon";

--- a/pkgs/development/libraries/rocksdb/0001-findzlib.patch
+++ b/pkgs/development/libraries/rocksdb/0001-findzlib.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 132d3b0..37fec63 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -92,7 +92,7 @@ else()
+   endif()
+ 
+   if(WITH_ZLIB)
+-    find_package(zlib REQUIRED)
++	  find_package(ZLIB REQUIRED)
+     add_definitions(-DZLIB)
+     if(ZLIB_INCLUDE_DIRS)
+       # CMake 3

--- a/pkgs/development/libraries/rocksdb/default.nix
+++ b/pkgs/development/libraries/rocksdb/default.nix
@@ -1,86 +1,43 @@
-{ stdenv
-, fetchFromGitHub
-, fixDarwinDylibNames
-, which, perl
+{ stdenv, fetchFromGitHub, lib, bzip2, cmake, gflags, lz4, snappy, zlib, zstd, enableLite ? false }:
 
-# Optional Arguments
-, snappy ? null, google-gflags ? null, zlib ? null, bzip2 ? null, lz4 ? null
-
-# Malloc implementation
-, jemalloc ? null, gperftools ? null
-
-, enableLite ? false
-}:
-
-let
-  malloc = if jemalloc != null then jemalloc else gperftools;
-  tools = [ "sst_dump" "ldb" "rocksdb_dump" "rocksdb_undump" "blob_dump" ];
-in
 stdenv.mkDerivation rec {
-  name = "rocksdb-${version}";
-  version = "5.11.3";
-
-  outputs = [ "dev" "out" "static" "bin" ];
+  pname = "rocksdb";
+  version = "6.1.2";
 
   src = fetchFromGitHub {
     owner = "facebook";
-    repo = "rocksdb";
+    repo = pname;
     rev = "v${version}";
-    sha256 = "15x2r7aib1xinwcchl32wghs8g96k4q5xgv6z97mxgp35475x01p";
+    sha256 = "0gy2zjga3r8k9pbn2b0b5fzv4m0h2ip3zmyja1i7fli9n56civ3y";
   };
 
-  nativeBuildInputs = [ which perl ];
-  buildInputs = [ snappy google-gflags zlib bzip2 lz4 malloc fixDarwinDylibNames ];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ bzip2 gflags lz4 snappy zlib zstd ];
 
-  postPatch = ''
-    # Hack to fix typos
-    sed -i 's,#inlcude,#include,g' build_tools/build_detect_platform
-  '';
+  patches = [ ./0001-findzlib.patch ];
 
-  # Environment vars used for building certain configurations
-  PORTABLE = "1";
-  USE_SSE = "1";
-  CMAKE_CXX_FLAGS = "-std=gnu++11";
-  JEMALLOC_LIB = stdenv.lib.optionalString (malloc == jemalloc) "-ljemalloc";
-
-  LIBNAME = "librocksdb${stdenv.lib.optionalString enableLite "_lite"}";
-  ${if enableLite then "CXXFLAGS" else null} = "-DROCKSDB_LITE=1";
-
-  buildAndInstallFlags = [
-    "USE_RTTI=1"
-    "DEBUG_LEVEL=0"
-    "DISABLE_WARNING_AS_ERROR=1"
+  cmakeFlags = [
+    "-DPORTABLE=1"
+    "-DWITH_JEMALLOC=0"
+    "-DWITH_JNI=0"
+    "-DWITH_TESTS=0"
+    "-DWITH_TOOLS=0"
+    "-DWITH_BZ2=1"
+    "-DWITH_LZ4=1"
+    "-DWITH_SNAPPY=1"
+    "-DWITH_ZLIB=1"
+    "-DWITH_ZSTD=1"
+    (lib.optional
+        (stdenv.hostPlatform.system == "i686-linux"
+         || stdenv.hostPlatform.system == "x86_64-linux")
+        "-DFORCE_SSE42=1")
+    (lib.optional enableLite "-DROCKSDB_LITE=1")
   ];
-
-  buildFlags = buildAndInstallFlags ++ [
-    "shared_lib"
-    "static_lib"
-  ] ++ tools ;
-
-  installFlags = buildAndInstallFlags ++ [
-    "INSTALL_PATH=\${out}"
-    "install-shared"
-    "install-static"
-  ];
-
-  postInstall = ''
-    # Might eventually remove this when we are confident in the build process
-    echo "BUILD CONFIGURATION FOR SANITY CHECKING"
-    cat make_config.mk
-    mkdir -pv $static/lib/
-    mv -vi $out/lib/${LIBNAME}.a $static/lib/
-
-    install -d ''${!outputBin}/bin
-    install -D ${stdenv.lib.concatStringsSep " " tools} ''${!outputBin}/bin
-  '';
-
-  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     homepage = https://rocksdb.org;
     description = "A library that provides an embeddable, persistent key-value store for fast storage";
-    license = licenses.bsd3;
-    platforms = platforms.x86_64;
-    maintainers = with maintainers; [ adev ];
+    license = licenses.asl20;
+    maintainers = with maintainers; [ adev magenbluten ];
   };
 }

--- a/pkgs/tools/filesystems/ceph/generic.nix
+++ b/pkgs/tools/filesystems/ceph/generic.nix
@@ -167,6 +167,7 @@ stdenv.mkDerivation {
     license = licenses.lgpl21;
     maintainers = with maintainers; [ adev ak ];
     platforms = platforms.unix;
+    broken = true;
   };
 
   passthru.version = version;

--- a/pkgs/tools/system/osquery/default.nix
+++ b/pkgs/tools/system/osquery/default.nix
@@ -144,5 +144,6 @@ stdenv.mkDerivation rec {
     license = licenses.bsd3;
     platforms = platforms.linux;
     maintainers = with maintainers; [ cstrahan ma27 ];
+    broken = true;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13035,7 +13035,7 @@ in
 
   rlog = callPackage ../development/libraries/rlog { };
 
-  rocksdb = callPackage ../development/libraries/rocksdb { jemalloc = jemalloc450; };
+  rocksdb = callPackage ../development/libraries/rocksdb { };
 
   rocksdb_lite = rocksdb.override { enableLite = true; };
 


### PR DESCRIPTION
###### Motivation for this change

rocksdb was out of date. also removed stuff that seemed broken.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
