### PR TITLE
nixos/fhsUserenv: make all locales available

### DIFF
--- a/pkgs/build-support/build-fhs-userenv/env.nix
+++ b/pkgs/build-support/build-fhs-userenv/env.nix
@@ -36,12 +36,14 @@ let
 
   # base packages of the chroot
   # these match the host's architecture, glibc_multi is used for multilib
-  # builds.
+  # builds. glibcLocales must be before glibc or glibc_multi as otherwiese
+  # the wrong LOCALE_ARCHIVE will be used where only C.UTF-8 is available.
   basePkgs = with pkgs;
-    [ (if isMultiBuild then glibc_multi else glibc)
+    [ glibcLocales
+      (if isMultiBuild then glibc_multi else glibc)
       (toString gcc.cc.lib) bashInteractive coreutils less shadow su
       gawk diffutils findutils gnused gnugrep
-      gnutar gzip bzip2 xz glibcLocales
+      gnutar gzip bzip2 xz
     ];
   baseMultiPkgs = with pkgsi686Linux;
     [ (toString gcc.cc.lib)


### PR DESCRIPTION
###### Motivation for this change

Make locales others than `C.UTF-8` available in `fhsUserenv`. For details see: #56347

This PR, toghether with https://github.com/NixOS/nixpkgs/commit/467f0f9f3ace58ef8ee01c75aaeadf6927012190 is required to sucessfully merge https://github.com/NixOS/nixpkgs/pull/56565

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
