### PR TITLE
nixos/pantheon: enable lightdm gtk greeter

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -32,7 +32,7 @@
     <note>
      <para>
       <varname>services.xserver.desktopManager.pantheon</varname> default
-      enables lightdm as a display manager and using Pantheon's greeter.
+      enables lightdm as a display manager.
      </para>
      <para>
       This is because of limitations with the screenlocking implementation,
@@ -50,7 +50,7 @@
       </listitem>
       <listitem>
        <para>
-        <option>services.xserver.displayManager.lightdm.greeters.pantheon.enable</option>
+        <option>services.xserver.displayManager.lightdm.greeters.gtk.enable</option>
        </para>
       </listitem>
      </itemizedlist>
@@ -58,6 +58,11 @@
       to <literal>false</literal> and enable your preferred display manager.
      </para>
     </note>
+    <para>
+      Also be aware that we haven't enabled lightdm with Pantheon's greeter by
+      default. That's because it has numerous issues in NixOS and isn't optimal
+      for use here yet.
+    </para>
    </listitem>
    <listitem>
     <para>

--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -31,37 +31,21 @@
     </para>
     <note>
      <para>
-      <varname>services.xserver.desktopManager.pantheon</varname> default
-      enables lightdm as a display manager.
+      By default, <varname>services.xserver.desktopManager.pantheon</varname>
+      enables LightDM as a display manager, as pantheon's screen locking
+      implementation relies on it.
      </para>
      <para>
-      This is because of limitations with the screenlocking implementation,
-      whereas the screenlocker would be non-functional without it.
-     </para>
-     <para>
-      Because of that it is recommended to retain this precaution, however if
-      you'd like to change this set:
-     </para>
-     <itemizedlist>
-      <listitem>
-       <para>
-        <option>services.xserver.displayManager.lightdm.enable</option>
-       </para>
-      </listitem>
-      <listitem>
-       <para>
-        <option>services.xserver.displayManager.lightdm.greeters.gtk.enable</option>
-       </para>
-      </listitem>
-     </itemizedlist>
-     <para>
-      to <literal>false</literal> and enable your preferred display manager.
+      Because of that it is recommended to leave LightDM enabled. If you'd like
+      to disable it anyway, set
+      <option>services.xserver.displayManager.lightdm.enable</option> to
+      <literal>false</literal> and enable your preferred display manager.
      </para>
     </note>
     <para>
-      Also be aware that we haven't enabled lightdm with Pantheon's greeter by
-      default. That's because it has numerous issues in NixOS and isn't optimal
-      for use here yet.
+     Also note that Pantheon's LightDM greeter is not enabled by default,
+     because it has numerous issues in NixOS and isn't optimal for use here
+     yet.
     </para>
    </listitem>
    <listitem>

--- a/nixos/modules/services/x11/desktop-managers/pantheon.nix
+++ b/nixos/modules/services/x11/desktop-managers/pantheon.nix
@@ -74,7 +74,7 @@ in
     # Ensure lightdm is used when Pantheon is enabled
     # Without it screen locking will be nonfunctional because of the use of lightlocker
     services.xserver.displayManager.lightdm.enable = mkDefault true;
-    services.xserver.displayManager.lightdm.greeters.pantheon.enable = mkDefault true;
+    services.xserver.displayManager.lightdm.greeters.gtk.enable = mkDefault true;
 
     # If not set manually Pantheon session cannot be started
     # Known issue of https://github.com/NixOS/nixpkgs/pull/43992

--- a/nixos/modules/services/x11/desktop-managers/pantheon.nix
+++ b/nixos/modules/services/x11/desktop-managers/pantheon.nix
@@ -73,6 +73,12 @@ in
 
     # Ensure lightdm is used when Pantheon is enabled
     # Without it screen locking will be nonfunctional because of the use of lightlocker
+
+    warnings = optional (config.services.xserver.displayManager.lightdm.enable != true)
+      ''
+        Using Pantheon without LightDM as a displayManager will break screenlocking from the UI.
+      '';
+
     services.xserver.displayManager.lightdm.enable = mkDefault true;
     services.xserver.displayManager.lightdm.greeters.gtk.enable = mkDefault true;
 

--- a/nixos/modules/services/x11/display-managers/lightdm-greeters/pantheon.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm-greeters/pantheon.nix
@@ -33,6 +33,13 @@ in
 
   config = mkIf (ldmcfg.enable && cfg.enable) {
 
+    warnings = [
+      ''
+        The Pantheon greeter is suboptimal in NixOS and can possibly put you in
+        a situation where you cannot start a session when switching desktopManagers.
+      ''
+    ];
+
     services.xserver.displayManager.lightdm.greeters.gtk.enable = false;
 
     services.xserver.displayManager.lightdm.greeter = mkDefault {


### PR DESCRIPTION
Pantheon's greeter has numerous issues that cannot be
fixed in a timely manner, and users are better off if they just
didn't use it by default.

###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
