### PR TITLE
eggnog-mapper: init at 1.0.3

### DIFF
--- a/pkgs/applications/science/biology/eggnog-mapper/default.nix
+++ b/pkgs/applications/science/biology/eggnog-mapper/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchFromGitHub, fetchpatch, makeWrapper, python27Packages, wget, diamond, hmmer }:
+
+python27Packages.buildPythonApplication rec {
+  pname = "eggnog-mapper";
+  version = "1.0.3";
+
+  src = fetchFromGitHub {
+    owner = "eggnogdb";
+    repo = "eggnog-mapper";
+    rev = "${version}";
+    sha256 = "1aaaflppy84bhkh2hb5gnzm4xgrz0rz0cgfpadr9w8cva8p0sqdv";
+  };
+
+  patches = (fetchpatch {
+    url = https://github.com/eggnogdb/eggnog-mapper/pull/125/commits/b7828e4c8c1c453e391aef050f06ff3f84ff9faf.patch;
+    sha256 = "0nz1a7ybm4j5c7vdm3annnxz9036iam2044hia341a0am9wydmzk";
+  });
+
+  buildInputs = [ makeWrapper ];
+  propagatedBuildInputs = [ python27Packages.biopython wget diamond hmmer ];
+
+  # make emapper find diamond & hmmer
+  makeWrapperArgs = [
+    ''--prefix PATH ':' "${diamond}/bin"''
+    ''--prefix PATH ':' "${hmmer}/bin"''
+    ];
+
+  # Tests rely on some of the databases being available, which is not bundled
+  # with this package as (1) in total, they represent >100GB of data, and (2)
+  # the user can download only those that interest them.
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Fast genome-wide functional annotation through orthology assignment";
+    license = licenses.gpl2;
+    homepage = https://github.com/eggnogdb/eggnog-mapper/wiki;
+    maintainers = with maintainers; [ luispedro ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21828,6 +21828,8 @@ in
 
   ecopcr = callPackage ../applications/science/biology/ecopcr { };
 
+  eggnog-mapper = callPackage ../applications/science/biology/eggnog-mapper { };
+
   emboss = callPackage ../applications/science/biology/emboss { };
 
   ezminc = callPackage ../applications/science/biology/EZminc { };


### PR DESCRIPTION
This is becoming widely used in bioinformatics. The packaging was inspired by bioconda's packaging at https://github.com/bioconda/bioconda-recipes/tree/master/recipes/eggnog-mapper (namely, the patching of `setup.py`, see also https://github.com/eggnogdb/eggnog-mapper/pull/125)

Using this package requires one of hmmer or diamond to be present (both of which are in nixpkgs). You do not need both of them, but I am not sure if there is a way to specify optional dependencies in nix.

### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)

- Built on platform(s)
   - [x] other Linux distributions

- [x] Tested execution of all binary files (usually in `./result/bin/`)
This package contains Python scripts not binaries; but, yes, I am currently using this package in my work and it works (to the best of my understanding).
