### PR TITLE
grafana: 6.0.2 -> 6.1.0

### DIFF
--- a/pkgs/servers/monitoring/grafana/default.nix
+++ b/pkgs/servers/monitoring/grafana/default.nix
@@ -1,7 +1,7 @@
 { lib, buildGoPackage, fetchurl, fetchFromGitHub, phantomjs2 }:
 
 buildGoPackage rec {
-  version = "6.0.2";
+  version = "6.1.0";
   name = "grafana-${version}";
   goPackagePath = "github.com/grafana/grafana";
 
@@ -11,12 +11,12 @@ buildGoPackage rec {
     rev = "v${version}";
     owner = "grafana";
     repo = "grafana";
-    sha256 = "1qvkk83yhryvy73c56mp5vdlbrwz4ra5al3flah8s2m9dhbs89bi";
+    sha256 = "0h66ndqpbv2l1srn3z4qjg78d69146ryynkvn5ynrbvka4fzg0yp";
   };
 
   srcStatic = fetchurl {
     url = "https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-${version}.linux-amd64.tar.gz";
-    sha256 = "1lvcd2i7jv7s4qrxc1p0ifsycdy0v0hzwgiz4kl2k3w21c50k69l";
+    sha256 = "0180zfm9py0ah74vh384cxbvgnx5mfbkdc8fbiqlmfz0wvlpvz7q";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change
Latest [minor release](https://github.com/grafana/grafana/releases/tag/v6.1.0) (includes changes introduced in [6.1.0-beta1](https://github.com/grafana/grafana/releases/tag/v6.1.0-beta1)) with two new major features, some minor improvements and bug fixes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS (tested on x86_64-linux and aarch64-linux)
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
**needs to be backported to 19.03**