### PR TITLE
nixos/nzbget: cfg.configFile/cfg.dataDir owned by cfg.user/cfg.group

### DIFF
--- a/nixos/modules/services/misc/nzbget.nix
+++ b/nixos/modules/services/misc/nzbget.nix
@@ -20,7 +20,7 @@ in {
       dataDir = mkOption {
         type = types.str;
         default = "/var/lib/nzbget";
-        description = "The directory where NZBGet stores its configuration files.";
+        description = "The directory where NZBGet stores its configuration files. (If this doesn't exist, it will be created.)";
       };
 
       openFirewall = mkOption {
@@ -61,10 +61,14 @@ in {
         p7zip
       ];
       preStart = ''
+        if [ ! -d ${cfg.dataDir} ]; then
+          echo "${cfg.dataDir} directory not found. Creating it."
+          install -d -o ${cfg.user} -g ${cfg.group} ${cfg.dataDir}
+        fi
         cfgtemplate=${cfg.package}/share/nzbget/nzbget.conf
         if [ ! -f ${cfg.configFile} ]; then
           echo "${cfg.configFile} not found. Copying default config $cfgtemplate to ${cfg.configFile}"
-          install -m 0700 $cfgtemplate ${cfg.configFile}
+          install -o ${cfg.user} -g ${cfg.group} -m 0700 $cfgtemplate ${cfg.configFile}
           echo "Setting temporary \$MAINDIR variable in default config required in order to allow nzbget to complete initial start"
           echo "Remember to change this to a proper value once NZBGet startup has been completed"
           sed -i -e 's/MainDir=.*/MainDir=\/tmp/g' ${cfg.configFile}


### PR DESCRIPTION
### Motivation for this change
These changes ensure, via the `preStart` script, that the `configFile` and `dataDir`
are owned by the user & group that `nzbget` has been configured to run with.
Without this, when the config template is copied over to facilitate
initial startup, it's done so with `root` permissions. This causes the
service to fail during the startup script (`grep` is used to inspect the
file for some values). The `dataDir` is similar circumstances; without these
changes, it's created with `root` permissions, which means the service cannot
read or write data there, if it's running as a different user.

**Example of failure scenario**
```
Mar 31 21:50:25 slim systemd[1]: Starting NZBGet Daemon...
Mar 31 21:50:25 slim 2f3n6zr1r5q4xplvnd6zizpknlhcha14-unit-script-nzbget-pre-start[2615]: /var/lib/nzbget/nzbget.conf not found. Copying default config /nix/store/q8q5af4cxypc75dhp223jl89amfhbn00-nzbget-20.0/s>
Mar 31 21:50:25 slim 2f3n6zr1r5q4xplvnd6zizpknlhcha14-unit-script-nzbget-pre-start[2615]: Setting temporary $MAINDIR variable in default config required in order to allow nzbget to complete initial start
Mar 31 21:50:25 slim 2f3n6zr1r5q4xplvnd6zizpknlhcha14-unit-script-nzbget-pre-start[2615]: Remember to change this to a proper value once NZBGet startup has been completed
Mar 31 21:50:25 slim 2xgi9aacik9f2q5wyyqa1vswd6izy9vg-unit-script-nzbget-start[2618]: grep: /var/lib/nzbget/nzbget.conf: Permission denied
Mar 31 21:50:25 slim 2xgi9aacik9f2q5wyyqa1vswd6izy9vg-unit-script-nzbget-start[2618]: In /var/lib/nzbget/nzbget.conf, valid ConfigTemplate not found; falling back to ConfigTemplate=/nix/store/q8q5af4cxypc75dhp>
Mar 31 21:50:25 slim 2xgi9aacik9f2q5wyyqa1vswd6izy9vg-unit-script-nzbget-start[2618]: grep: /var/lib/nzbget/nzbget.conf: Permission denied
Mar 31 21:50:25 slim 2xgi9aacik9f2q5wyyqa1vswd6izy9vg-unit-script-nzbget-start[2618]: In /var/lib/nzbget/nzbget.conf, valid WebDir not found; falling back to WebDir=/nix/store/q8q5af4cxypc75dhp223jl89amfhbn00->
Mar 31 21:50:25 slim 2xgi9aacik9f2q5wyyqa1vswd6izy9vg-unit-script-nzbget-start[2618]: nzbget.conf(0): Could not open file /var/lib/nzbget/nzbget.conf
Mar 31 21:50:25 slim systemd[1]: nzbget.service: Control process exited, code=exited status=1
Mar 31 21:50:25 slim systemd[1]: nzbget.service: Failed with result 'exit-code'.
Mar 31 21:50:25 slim systemd[1]: Failed to start NZBGet Daemon.
```



### Things done
Ensure the `configFile` and `dataDir` are owned by the user & group the service has been configured to run with.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
