### PR TITLE
ocamlPackages.zarith: 1.7 -> 1.8

### DIFF
--- a/pkgs/development/ocaml-modules/janestreet/default.nix
+++ b/pkgs/development/ocaml-modules/janestreet/default.nix
@@ -441,13 +441,6 @@ rec {
     meta.description = "Async helpers for writing expectation tests";
   };
 
-  bignum = janePackage {
-    pname = "bignum";
-    hash = "0hqd88fb90rsj1wjj4k79gigcf31c6a45msasw99zzifzppr3w3f";
-    propagatedBuildInputs = [ core_kernel zarith num ];
-    meta.description = "Core-flavoured wrapper around zarith's arbitrary-precision rationals";
-  };
-
   cinaps = janePackage {
     pname = "cinaps";
     hash = "0f8cx4xkkk4wqpcbvva8kxdndbgawljp17dwppc6zpjpkjl8s84j";

--- a/pkgs/development/ocaml-modules/zarith/default.nix
+++ b/pkgs/development/ocaml-modules/zarith/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildOcaml, fetchurl
+{ stdenv, fetchurl
 , ocaml, findlib, pkgconfig, perl
 , gmp
 }:
@@ -6,9 +6,9 @@
 let source =
   if stdenv.lib.versionAtLeast ocaml.version "4.02"
   then {
-    version = "1.7";
-    url = https://github.com/ocaml/Zarith/archive/release-1.7.tar.gz;
-    sha256 = "0fmblap5nsbqq0dab63d6b7lsxpc3snkgz7jfldi2qa4s1kbnhfn";
+    version = "1.8";
+    url = https://github.com/ocaml/Zarith/archive/release-1.8.tar.gz;
+    sha256 = "1cn63c97aij19nrw5hc1zh1jpnbsdkzq99zyyk649c4s3xi3iqq7";
   } else {
     version = "1.3";
     url = http://forge.ocamlcore.org/frs/download.php/1471/zarith-1.3.tgz;
@@ -16,25 +16,20 @@ let source =
   };
 in
 
-buildOcaml rec {
-  name = "zarith";
+stdenv.mkDerivation rec {
+  name = "ocaml${ocaml.version}-zarith-${version}";
   inherit (source) version;
   src = fetchurl { inherit (source) url sha256; };
-
-  minimumSupportedOcamlVersion = "3.12.1";
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ ocaml findlib perl ];
   propagatedBuildInputs = [ gmp ];
 
-  # needed so setup-hook.sh sets CAML_LD_LIBRARY_PATH for dllzarith.so
-  hasSharedObjects = true;
-
   patchPhase = "patchShebangs ./z_pp.pl";
   configurePhase = ''
     ./configure -installdir $out/lib/ocaml/${ocaml.version}/site-lib
   '';
-  preInstall = "mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib";
+  createFindlibDestdir = true;
 
   meta = with stdenv.lib; {
     description = "Fast, arbitrary precision OCaml integers";


### PR DESCRIPTION
###### Motivation for this change

Major update, including compatibility with OCaml 4.08.

As this breaks the `bignum` library, I’ve removed it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
