### PR TITLE
charliecloud: init at 0.9.8

### DIFF
--- a/pkgs/applications/virtualization/charliecloud/default.nix
+++ b/pkgs/applications/virtualization/charliecloud/default.nix
@@ -1,0 +1,48 @@
+{ stdenv, fetchFromGitHub, python }:
+
+stdenv.mkDerivation rec {
+
+  version = "0.9.8";
+  pname = "charliecloud";
+
+  src = fetchFromGitHub {
+    owner = "hpc";
+    repo = "charliecloud";
+    rev = "v${version}";
+    sha256 = "1w1wy4sj9zqfysrpf04shhppcf5ap4rp7i3ja81sv2fm27k4m9nl";
+  };
+
+  buildInputs = [ python ];
+
+  preConfigure = ''
+    substituteInPlace Makefile --replace '/bin/bash' '${stdenv.shell}'
+    patchShebangs test/
+  '';
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "LIBEXEC_DIR=lib/charliecloud"
+  ];
+
+  postInstall = ''
+    mkdir -p $out/share/charliecloud
+    mv $out/lib/charliecloud/examples $out/share/charliecloud
+    mv $out/lib/charliecloud/test $out/share/charliecloud
+  '';
+
+  meta = {
+    description = "User-defined software stacks (UDSS) for high-performance computing (HPC) centers";
+    longDescription = ''
+      Charliecloud uses Linux user namespaces to run containers with no
+      privileged operations or daemons and minimal configuration changes on
+      center resources. This simple approach avoids most security risks
+      while maintaining access to the performance and functionality already
+      on offer.
+    '';
+    homepage = https://hpc.github.io/charliecloud;
+    license = stdenv.lib.licenses.asl20;
+    maintainers = [ stdenv.lib.maintainers.bzizou ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1175,6 +1175,8 @@ in
 
   cfdyndns = callPackage ../applications/networking/dyndns/cfdyndns { };
 
+  charliecloud = callPackage ../applications/virtualization/charliecloud { };
+
   chelf = callPackage ../tools/misc/chelf { };
 
   cht-sh = callPackage ../tools/misc/cht.sh { };


### PR DESCRIPTION
###### Motivation for this change
charliecloud is used into our supercomputing center

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
