### PR TITLE
pythonPackages.pyls-black: 0.3.0 -> 0.4.4

### DIFF
--- a/pkgs/development/python-modules/pyls-black/default.nix
+++ b/pkgs/development/python-modules/pyls-black/default.nix
@@ -4,13 +4,13 @@
 
 buildPythonPackage rec {
   pname = "pyls-black";
-  version = "0.3.0";
+  version = "0.4.4";
 
   src = fetchFromGitHub {
     owner = "rupert";
     repo = "pyls-black";
     rev = "v${version}";
-    sha256 = "1pagbafb9r9glzy7nbvrq19msjy4wqahrvmc0wll0a0r4msqpi1d";
+    sha256 = "1ynynay9g6yma39szbzf15ypq3c72fg1i0kjmq1dwxarj68i2gf9";
   };
 
   disabled = !isPy3k;


### PR DESCRIPTION
###### Motivation for this change
update. https://github.com/NixOS/nixpkgs/pull/58771 broke the build of the old version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
