### PR TITLE
Add latexrun package

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2758,6 +2758,11 @@
     github = "lucas8";
     name = "Luc Chabassier";
   };
+  lucus16 = {
+    email = "lars.jellema@gmail.com";
+    github = "Lucus16";
+    name = "Lars Jellema";
+  };
   ludo = {
     email = "ludo@gnu.org";
     github = "civodul";

--- a/pkgs/tools/typesetting/tex/latexrun/default.nix
+++ b/pkgs/tools/typesetting/tex/latexrun/default.nix
@@ -1,0 +1,29 @@
+{ stdenvNoCC, fetchFromGitHub, python3 }:
+
+stdenvNoCC.mkDerivation {
+  pname = "latexrun";
+  version = "unstable-2015-11-18";
+  src = fetchFromGitHub {
+    owner = "aclements";
+    repo = "latexrun";
+    rev = "38ff6ec2815654513c91f64bdf2a5760c85da26e";
+    sha256 = "0xdl94kn0dbp6r7jk82cwxybglm9wp5qwrjqjxmvadrqix11a48w";
+  };
+
+  buildInputs = [ python3 ];
+
+  dontBuild = true;
+  installPhase = ''
+    mkdir -p $out/bin
+    cp latexrun $out/bin/latexrun
+    chmod +x $out/bin/latexrun
+  '';
+
+  meta = with stdenvNoCC.lib; {
+    description = "A 21st century LaTeX wrapper";
+    homepage = https://github.com/aclements/latexrun;
+    license = licenses.mit;
+    maintainers = [ maintainers.lucus16 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3988,6 +3988,8 @@ in
 
   latex2html = callPackage ../tools/misc/latex2html { };
 
+  latexrun = callPackage ../tools/typesetting/tex/latexrun { };
+
   ldapvi = callPackage ../tools/misc/ldapvi { };
 
   ldns = callPackage ../development/libraries/ldns {


### PR DESCRIPTION
###### Motivation for this change

`latexrun` is a useful tool to convert tex files to pdfs without writing complicated makefiles. Upstream has no version information and it is unlikely the creator will ever release another version.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
