### PR TITLE
ruby-modules/gem: fix path to git checkout

### DIFF
--- a/pkgs/development/ruby-modules/gem/default.nix
+++ b/pkgs/development/ruby-modules/gem/default.nix
@@ -179,7 +179,7 @@ stdenv.mkDerivation ((builtins.removeAttrs attrs ["source"]) // {
       '${version}' \
       '${lib.escapeShellArgs buildFlags}' \
       '${attrs.source.url}' \
-      '${src}' \
+      '.' \
       '${attrs.source.rev}'
     ''}
 


### PR DESCRIPTION
###### Motivation for this change

I want to build the following `bundlerEnv`, that is not so far from my actual case (packaging Mastodon).

```nix
with import <nixpkgs> {};

bundlerEnv {
  name = "ruby-env";
  inherit (pkgs) ruby_2_6;

  gemfile = builtins.toFile "Gemfile" ''
    gem 'http_parser.rb', '~> 0.6', git: 'https://github.com/tmm1/http_parser.rb', ref: '225354b3d94d8d76774bac5bb2ac0139dd75662c'
  '';
  lockfile = builtins.toFile "Gemfile.lock" ''
    GIT
      remote: https://github.com/tmm1/http_parser.rb
      revision: 225354b3d94d8d76774bac5bb2ac0139dd75662c
      ref: 225354b3d94d8d76774bac5bb2ac0139dd75662c
      specs:
        http_parser.rb (0.6.1)
  '';
  # generated by bundix
  gemset = {
    "http_parser.rb" = {
      groups = ["default"];
      platforms = [];
      source = {
        fetchSubmodules = true;
        rev = "225354b3d94d8d76774bac5bb2ac0139dd75662c";
        sha256 = "00avimm11xnpsylgvr1rrcxr9ijsa3rygvqj8fzil0g73cypb7fx";
        type = "git";
        url = "https://github.com/tmm1/http_parser.rb";
      };
      version = "0.6.1";
    };
  };

}
```

Building that on `master` fails with an error:

```terminal
$ nix-build
these derivations will be built:
  /nix/store/cgrnanx411r0a3ah4fvyki0lbrbs73x8-ruby2.5.5-http_parser.rb-0.6.1.drv
  /nix/store/5sz7fv9ipr9asvlch2x72k7b3k1a4rvr-ruby-env.drv
building '/nix/store/cgrnanx411r0a3ah4fvyki0lbrbs73x8-ruby2.5.5-http_parser.rb-0.6.1.drv'...
unpacking sources
unpacking source archive /nix/store/rfgsdvv1mxi6kj07xiijhzhz8dps65h3-http_parser.rb-225354b
source root is http_parser.rb-225354b
patching sources
configuring
no configure script, doing nothing
building
Initialized empty Git repository in /build/http_parser.rb-225354b/.git/
installing
buildFlags:
`/homeless-shelter` is not a directory.
Bundler will use `/build/bundler/home/unknown' as your home directory temporarily.
/nix/store/rwp5fpzqssf5m9dzbgbwsfgdzw8xajra-ruby-2.5.5/lib/ruby/2.5.0/fileutils.rb:1227:in `stat': No such file or directory @ rb_file_s_stat - /nix/store/rfgsdvv1mxi6kj07xiijhzhz8dps65h3-http_parser.rb-225354b/.git (Errno::ENOENT)
        from /nix/store/rwp5fpzqssf5m9dzbgbwsfgdzw8xajra-ruby-2.5.5/lib/ruby/2.5.0/fileutils.rb:1227:in `lstat'
        from /nix/store/rwp5fpzqssf5m9dzbgbwsfgdzw8xajra-ruby-2.5.5/lib/ruby/2.5.0/fileutils.rb:1256:in `copy'
        from /nix/store/rwp5fpzqssf5m9dzbgbwsfgdzw8xajra-ruby-2.5.5/lib/ruby/2.5.0/fileutils.rb:418:in `block in copy_entry'
        from /nix/store/rwp5fpzqssf5m9dzbgbwsfgdzw8xajra-ruby-2.5.5/lib/ruby/2.5.0/fileutils.rb:1390:in `wrap_traverse'
        from /nix/store/rwp5fpzqssf5m9dzbgbwsfgdzw8xajra-ruby-2.5.5/lib/ruby/2.5.0/fileutils.rb:415:in `copy_entry'
        from /nix/store/rwp5fpzqssf5m9dzbgbwsfgdzw8xajra-ruby-2.5.5/lib/ruby/2.5.0/fileutils.rb:393:in `block in cp_r'
        from /nix/store/rwp5fpzqssf5m9dzbgbwsfgdzw8xajra-ruby-2.5.5/lib/ruby/2.5.0/fileutils.rb:1463:in `block in fu_each_src_dest'
        from /nix/store/rwp5fpzqssf5m9dzbgbwsfgdzw8xajra-ruby-2.5.5/lib/ruby/2.5.0/fileutils.rb:1479:in `fu_each_src_dest0'
        from /nix/store/rwp5fpzqssf5m9dzbgbwsfgdzw8xajra-ruby-2.5.5/lib/ruby/2.5.0/fileutils.rb:1461:in `fu_each_src_dest'
        from /nix/store/rwp5fpzqssf5m9dzbgbwsfgdzw8xajra-ruby-2.5.5/lib/ruby/2.5.0/fileutils.rb:392:in `cp_r'
        from /nix/store/6g99037s460cbv2drh4l7hrny09lc19q-nix-bundle-install.rb:92:in `checkout'
        from /nix/store/q3m22q8z2rsq1hjy6lsv4amavyf872lw-bundler-1.17.2/lib/ruby/gems/2.5.0/gems/bundler-1.17.2/lib/bundler/source/git.rb:303:in `fetch'
        from /nix/store/q3m22q8z2rsq1hjy6lsv4amavyf872lw-bundler-1.17.2/lib/ruby/gems/2.5.0/gems/bundler-1.17.2/lib/bundler/source/git.rb:161:in `specs'
        from /nix/store/6g99037s460cbv2drh4l7hrny09lc19q-nix-bundle-install.rb:119:in `<main>'
builder for '/nix/store/cgrnanx411r0a3ah4fvyki0lbrbs73x8-ruby2.5.5-http_parser.rb-0.6.1.drv' failed with exit code 1
cannot build derivation '/nix/store/5sz7fv9ipr9asvlch2x72k7b3k1a4rvr-ruby-env.drv': 1 dependencies couldn't be built
error: build of '/nix/store/5sz7fv9ipr9asvlch2x72k7b3k1a4rvr-ruby-env.drv' failed
```
As `No such file or directory @ rb_file_s_stat - /nix/store/rfgsdvv1mxi6kj07xiijhzhz8dps65h3-http_parser.rb-225354b/.git (Errno::ENOENT)` says, the `.git` directory needs to accessed but is missing. That makes me wonder, as in https://github.com/NixOS/nixpkgs/blob/e4d2143802a08c274ecee37bea1cb9036fc7a3ba/pkgs/development/ruby-modules/gem/default.nix#L146 there is specific code to create that `.git` dir.

###### Things done

Finally I came to the conclusion, that the wrong path was given to `nix-bundle-install.rb` and it is supposed to be the build dir, not the `$src` store path. That makes the former `bundlerEnv` build.

cc'ing @cstrahan as they wrote that code in b6c06e216bb3bface40eb8ea6576b25f9b2971dd. Also @nyarly, you touched that file recently.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
