### PR TITLE
rdesktop: enable darwin support without libgssglue and credssp

### DIFF
--- a/pkgs/applications/networking/remote/rdesktop/default.nix
+++ b/pkgs/applications/networking/remote/rdesktop/default.nix
@@ -1,4 +1,6 @@
-{stdenv, fetchurl, openssl, libX11, libgssglue, pkgconfig} :
+{stdenv, fetchurl, openssl, libX11, libgssglue, pkgconfig
+, enableCredssp ? (!stdenv.isDarwin)
+} :
 
 stdenv.mkDerivation (rec {
   pname = "rdesktop";
@@ -11,18 +13,19 @@ stdenv.mkDerivation (rec {
   };
 
   nativeBuildInputs = [pkgconfig];
-  buildInputs = [openssl libX11 libgssglue];
+  buildInputs = [openssl libX11]
+    ++ stdenv.lib.optional enableCredssp libgssglue;
 
   configureFlags = [
     "--with-ipv6"
     "--with-openssl=${openssl.dev}"
     "--disable-smartcard"
-  ];
+  ] ++ stdenv.lib.optional (!enableCredssp) "--disable-credssp";
 
   meta = {
     description = "Open source client for Windows Terminal Services";
     homepage = http://www.rdesktop.org/;
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.linux ++ stdenv.lib.platforms.darwin;
     license = stdenv.lib.licenses.gpl2;
   };
 })


### PR DESCRIPTION
###### Motivation for this change

Enables building of `rdesktop` on macOS by disabling CredSSP, releasing the dependency on `libgssglue` which fails to build on macOS.

Macports and Homebrew are doing this:
https://github.com/macports/macports-ports/commit/b192e83fadcee82e7b36bd79ea251d5097467866
https://github.com/Homebrew/homebrew-core/blob/master/Formula/rdesktop.rb

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
