### PR TITLE
python3Packages.black: add missing aiohttp-cors dependency

### DIFF
--- a/pkgs/development/python-modules/black/default.nix
+++ b/pkgs/development/python-modules/black/default.nix
@@ -1,5 +1,5 @@
 { stdenv, buildPythonPackage, fetchPypi, pythonOlder
-, attrs, click, toml, appdirs, aiohttp
+, attrs, click, toml, appdirs, aiohttp, aiohttp-cors
 , glibcLocales, pytest }:
 
 buildPythonPackage rec {
@@ -23,7 +23,7 @@ buildPythonPackage rec {
       --deselect tests/test_black.py::BlackTestCase::test_failed_formatting_does_not_get_cached
   '';
 
-  propagatedBuildInputs = [ attrs appdirs click toml aiohttp ];
+  propagatedBuildInputs = [ attrs appdirs click toml aiohttp aiohttp-cors ];
 
   meta = with stdenv.lib; {
     description = "The uncompromising Python code formatter";


### PR DESCRIPTION
###### Motivation for this change

The `blackd` daemon that's shipped with black needs `aiohttp-cors` and is thus currently broken in master.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
