### PR TITLE
cryptol: fix, rework cryptol 2.6.0 builds

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -871,8 +871,38 @@ self: super: {
   # https://github.com/takano-akio/filelock/issues/5
   filelock = dontCheck super.filelock;
 
-  # cryptol-2.5.0 doesn't want happy 1.19.6+.
-  cryptol = super.cryptol.override { happy = self.happy_1_19_5; };
+  # fix GHC 8.6 builds by using irrefutable patterns. jailbreak is also
+  # required due to a constraint failure for base-compat.
+  cryptol = doJailbreak (overrideCabal super.cryptol (drv: {
+
+    # the last patch fixes ghc 8.6 builds; the other two (small) patches fix a
+    # few bugs between them, but are also hard dependencies
+    patches = drv.patches or [] ++ [
+      (pkgs.fetchpatch {
+        url    = https://github.com/GaloisInc/cryptol/commit/634c5a03e757663bf86d1ffad1ce2c6086d4483f.patch;
+        sha256 = "16dvfihsl2c4jnyfndgrjarkm3z5pyn7rzg2svnidx0qipwrxzm7";
+      })
+      (pkgs.fetchpatch {
+        url    = https://github.com/GaloisInc/cryptol/commit/515642328aff6d958ff1b534b9effdd726901b60.patch;
+        sha256 = "1fml71b720igyh8s7mj1z1c2bbv1vk490iy7blvxp625nymzjij6";
+      })
+      (pkgs.fetchpatch {
+        url    = https://github.com/GaloisInc/cryptol/commit/a8eab11b319f6434f9b01b26d419b8305ff30bc2.patch;
+        sha256 = "1bbznp3kbj8l83q979gf4gr2khwbyqi85ykwsf2jnkhzda6pr0n8";
+      })
+    ];
+
+    buildTools = drv.buildTools or [] ++ [ pkgs.makeWrapper ];
+
+    # make sure the binaries always start up. previously this was in
+    # all-packages.nix but it's almost certainly better to do it here (e.g. a
+    # haskell deps may use cryptol in the test suite or something, etc)
+    postInstall = drv.postInstall or "" + ''
+      for b in $out/bin/cryptol $out/bin/cryptol-html; do
+        wrapProgram $b --prefix 'PATH' ':' "${pkgs.lib.getBin pkgs.z3}/bin"
+      done
+    '';
+  }));
 
   # Tests try to invoke external process and process == 1.4
   grakn = dontCheck (doJailbreak super.grakn);

--- a/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix.yaml
@@ -3788,7 +3788,6 @@ broken-packages:
   - crypto-simple
   - cryptocompare
   - cryptoconditions
-  - cryptol
   - cryptsy-api
   - crystalfontz
   - cse-ghc-plugin

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6846,15 +6846,7 @@ in
 
   cpp-gsl = callPackage ../development/libraries/cpp-gsl { };
 
-  # Users installing via `nix-env` will likely be using the REPL,
-  # which has a hard dependency on Z3, so make sure it is available.
-  cryptol = haskellPackages.cryptol.overrideDerivation (oldAttrs: {
-    buildInputs = (oldAttrs.buildInputs or []) ++ [ makeWrapper ];
-    installPhase = (oldAttrs.installPhase or "") + ''
-      wrapProgram $out/bin/cryptol \
-        --prefix 'PATH' ':' "${lib.getBin z3}/bin"
-    '';
-  });
+  cryptol = haskell.lib.justStaticExecutables haskellPackages.cryptol;
 
   inherit (callPackages ../development/compilers/crystal {})
     crystal_0_25


### PR DESCRIPTION
  - The previous build of Cryptol was broken on GHC 8.6.x, which is now the
  new default. That's been fixed with a few upstream patches that will come
  up whenever the next release happens.

  - There was also a build failure on base-compat, fixed by jailbreaking.

  - The previous setup had all-packages.nix creating a new derivation
  solely for the purpose of wrapping the Z3 binary. This has been removed:
  the wrapper is still added but during the Haskell build itself, so that
  all Haskell dependent packages can use the cryptol interpreters too.

  - In its place, we use justStaticExecutables, so people using nix-env
  and Cryptol users who *don't* need haskell dependencies can get much
  smaller closures. Obviously this still implies a second build, but
  this build is much more useful than one that merely adds a shell
  script to a package that's relatively expensive to compile...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
