### PR TITLE
postman: 6.7.3 -> 7.0.7

### DIFF
--- a/pkgs/development/web/postman/default.nix
+++ b/pkgs/development/web/postman/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "postman-${version}";
-  version = "6.7.3";
+  version = "7.0.6";
 
   src = fetchurl {
     url = "https://dl.pstmn.io/download/version/${version}/linux64";
-    sha256 = "04gfdb2pk2y8yv9ixq4ac5pk0rdfspd0810izij3hjnyqlv32hfg";
+    sha256 = "8b97c3203d880413f3c9010aab867517c0a05d66a1d6b193afe07c3467dbbd4c";
     name = "${name}.tar.gz";
   };
 

--- a/pkgs/development/web/postman/default.nix
+++ b/pkgs/development/web/postman/default.nix
@@ -36,9 +36,11 @@ stdenv.mkDerivation rec {
     mkdir -p $out/share/applications
     ln -s ${desktopItem}/share/applications/* $out/share/applications/
 
-    iconDir=$out/share/icons/hicolor/128x128/apps
-    mkdir -p $iconDir
-    ln -s $out/share/postman/resources/app/assets/icon.png $iconDir/postman.png
+    iconRootDir=$out/share/icons
+    iconSizeDir=$out/share/icons/hicolor/128x128/apps
+    mkdir -p $iconSizeDir
+    ln -s $out/share/postman/resources/app/assets/icon.png $iconRootDir/postman.png
+    ln -s $out/share/postman/resources/app/assets/icon.png $iconSizeDir/postman.png
   '';
 
   preFixup = let

--- a/pkgs/development/web/postman/default.nix
+++ b/pkgs/development/web/postman/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "postman-${version}";
-  version = "7.0.6";
+  version = "7.0.7";
 
   src = fetchurl {
     url = "https://dl.pstmn.io/download/version/${version}/linux64";
-    sha256 = "8b97c3203d880413f3c9010aab867517c0a05d66a1d6b193afe07c3467dbbd4c";
+    sha256 = "47be1b955759520f3a2c7dcdecb85b4c52c38df717da294ba184f46f2058014a";
     name = "${name}.tar.gz";
   };
 


### PR DESCRIPTION
Bundles #58502
Also bundled: fixing the icon detection on my system

###### Motivation for this change
To squelch the annoying red "upgrade available" dot

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
    - CentOS6
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
