### PR TITLE
meters.lv2: 0.8.1 -> 0.9.10

### DIFF
--- a/pkgs/applications/audio/meters_lv2/default.nix
+++ b/pkgs/applications/audio/meters_lv2/default.nix
@@ -1,24 +1,24 @@
 { stdenv, fetchurl, pkgconfig
-, lv2, libGLU_combined, gtk2, cairo, pango, fftw }:
+, lv2, libGLU_combined, gtk2, cairo, pango, fftwFloat, libjack2 }:
 
 let
-  version = "0.8.1";
+  version = "0.9.10";
   name = "meters.lv2-${version}";
 
   # robtk submodule is pegged to this version
-  robtkVersion = "0.3.0";
+  robtkVersion = "0.6.2";
   robtkName = "robtk-${robtkVersion}";
 
   src = fetchurl {
     name = "${name}.tar.gz";
     url = "https://github.com/x42/meters.lv2/archive/v${version}.tar.gz";
-    sha256 = "142dg0j34mv5b0agajj2x1n9kgsmkfh08n1cjzk0j8n4xk2wb6ri";
+    sha256 = "0yfyn7j8g50w671b1z7ph4ppjx8ddj5c6nx53syp5y5mfr1b94nx";
   };
 
   robtkSrc = fetchurl {
     name = "${robtkName}.tar.gz";
     url = "https://github.com/x42/robtk/archive/v${robtkVersion}.tar.gz";
-    sha256 = "1ny89i2sgga56k7fxskp9y8sb7pfhp6wgw5mni842p19z6q7h8rq";
+    sha256 = "1v79xys1k2923wpivdjd44vand6c4agwvnrqi4c8kdv9r07b559v";
   };
 
 in
@@ -26,14 +26,12 @@ stdenv.mkDerivation {
   inherit name;
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ lv2 libGLU_combined gtk2 cairo pango fftw ];
+  buildInputs = [ lv2 libGLU_combined gtk2 cairo pango fftwFloat libjack2 ];
 
   srcs = [ src robtkSrc ];
   sourceRoot = name;
 
   postUnpack = "mv ${robtkName}/* ${name}/robtk"; # */
-
-  postPatch = "sed -i 's/fftw3f/fftw3/' Makefile";
 
   preConfigure = "makeFlagsArray=( PREFIX=$out )";
   meter_VERSION = version;


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/issues/56826

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
