### PR TITLE
mosquitto: 1.5.5 -> 1.5.8 and add systemd support

### DIFF
--- a/pkgs/servers/mqtt/mosquitto/default.nix
+++ b/pkgs/servers/mqtt/mosquitto/default.nix
@@ -1,23 +1,29 @@
-{ stdenv, fetchFromGitHub, fetchpatch, cmake, docbook_xsl, libxslt
-, openssl, libuuid, libwebsockets, c-ares, libuv }:
+{ stdenv, lib, fetchFromGitHub, fetchpatch, cmake, docbook_xsl, libxslt
+, openssl, libuuid, libwebsockets, c-ares, libuv
+, systemd ? null }:
 
-stdenv.mkDerivation rec {
+let
+  withSystemd = stdenv.isLinux;
+
+in stdenv.mkDerivation rec {
   name = "mosquitto-${version}";
-  version = "1.5.5";
+  version = "1.5.8";
 
   src = fetchFromGitHub {
     owner  = "eclipse";
     repo   = "mosquitto";
     rev    = "v${version}";
-    sha256 = "1sfwmvrglfy5gqfk004kvbjldqr36dqz6xmppbgfhr47j5zs66xc";
+    sha256 = "1rf8g6fq7g1mhwsajsgvvlynasybgc51v0qg5j6ynsxfh8yi7s6r";
   };
 
   postPatch = ''
-    substituteInPlace man/manpage.xsl \
-      --replace /usr/share/xml/docbook/stylesheet/ ${docbook_xsl}/share/xml/
+    for f in html manpage ; do
+      substituteInPlace man/$f.xsl \
+        --replace http://docbook.sourceforge.net/release/xsl/current ${docbook_xsl}/share/xml/docbook-xsl
+    done
 
     for f in {lib,lib/cpp,src}/CMakeLists.txt ; do
-      substituteInPlace $f --replace /sbin/ldconfig ldconfig
+      substituteInPlace $f --replace /sbin/ldconfig true
     done
 
     # the manpages are not generated when using cmake
@@ -26,7 +32,9 @@ stdenv.mkDerivation rec {
     popd
   '';
 
-  buildInputs = [ openssl libuuid libwebsockets c-ares libuv ];
+  buildInputs = [
+    openssl libuuid libwebsockets c-ares libuv
+  ] ++ lib.optional withSystemd systemd;
 
   nativeBuildInputs = [ cmake docbook_xsl libxslt ];
 
@@ -35,7 +43,7 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DWITH_THREADING=ON"
     "-DWITH_WEBSOCKETS=ON"
-  ];
+  ] ++ lib.optional withSystemd "-DWITH_SYSTEMD=ON";
 
   meta = with stdenv.lib; {
     description = "An open source MQTT v3.1/3.1.1 broker";


### PR DESCRIPTION
###### Motivation for this change

This is already in master and fixes a few CVEs, so we definitely want this in.

(cherry picked from commit 5638a1c71738013e96a51b07ce7a39d76a33448c)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
