### PR TITLE
crumbs: init at version 0.0.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4773,6 +4773,15 @@
     github = "the-kenny";
     name = "Moritz Ulrich";
   };
+  thesola10 = {
+    email = "thesola10@bobile.fr";
+    github = "thesola10";
+    keys = [{
+      longkeyid = "rsa4096/0x89245619BEBB95BA";
+      fingerprint = "1D05 13A6 1AC4 0D8D C6D6  5F2C 8924 5619 BEBB 95BA";
+    }];
+    name = "Karim Vergnes";
+  };
   theuni = {
     email = "ct@flyingcircus.io";
     github = "ctheune";

--- a/pkgs/applications/misc/crumbs/default.nix
+++ b/pkgs/applications/misc/crumbs/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "crumbs";
+  version = "0.0.3";
+
+  src = fetchFromGitHub
+    { owner = "fasseg";
+      repo = "crumbs";
+      rev = version;
+      sha256 = "0jjvydn4i4n9xv8vsal2jxpa95mk2lw6myv0gx9wih242k9vy0l7";
+    };
+
+  prePatch = ''
+    sed -i 's|gfind|find|' crumbs-completion.fish
+  '';
+
+  postInstall = ''
+    mkdir -p $out/share/bash-completion/completions
+    mkdir -p $out/share/fish/vendor_completions.d
+
+    cp crumbs-completion.bash $out/share/bash-completion/completions/crumbs
+    cp crumbs-completion.fish $out/share/fish/vendor_completions.d/crumbs.fish
+  '';
+
+  meta = with stdenv.lib;
+    { description = "Bookmarks for the command line";
+      homepage    = https://github.com/fasseg/crumbs;
+      license     = licenses.wtfpl;
+      platforms   = platforms.all;
+      maintainers = with maintainers; [ thesola10 ];
+    };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -696,6 +696,8 @@ in
 
   cozy = callPackage ../applications/audio/cozy-audiobooks { };
 
+  crumbs = callPackage ../applications/misc/crumbs { };
+
   deskew = callPackage ../applications/graphics/deskew { };
 
   detect-secrets = python3Packages.callPackage ../development/tools/detect-secrets { };


### PR DESCRIPTION
Let me know if there are any errors with the way this derivation is written.

###### Motivation for this change
I wanted to add this little utility to Nix to make installing it easier.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"` (None depend anyway)
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
