### PR TITLE
nauty: disable cpu feature detection

### DIFF
--- a/pkgs/applications/science/math/nauty/default.nix
+++ b/pkgs/applications/science/math/nauty/default.nix
@@ -1,4 +1,7 @@
-{stdenv, fetchurl}:
+{ stdenv
+, lib
+, fetchurl
+}:
 stdenv.mkDerivation rec {
   name = "nauty-${version}";
   version = "26r11";
@@ -14,18 +17,18 @@ stdenv.mkDerivation rec {
     find . -type f -perm -111 \! -name '*.*' \! -name configure -exec cp '{}' "$out/bin" \;
     cp [Rr][Ee][Aa][Dd]* COPYRIGHT This* [Cc]hange* "$out/share/doc/nauty"
 
-    cp *.h $dev/include/nauty
+    cp *.h "$dev/include/nauty"
     for i in *.a; do
       cp "$i" "$dev/lib/lib$i";
     done
   '';
   checkTarget = "checks";
-  meta = {
+  meta = with lib; {
     inherit version;
     description = ''Programs for computing automorphism groups of graphs and digraphs'';
-    license = stdenv.lib.licenses.asl20;
-    maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.linux;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ raskin ];
+    platforms = platforms.linux;
     homepage = http://pallini.di.uniroma1.it/;
   };
 }

--- a/pkgs/applications/science/math/nauty/default.nix
+++ b/pkgs/applications/science/math/nauty/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchurl
+, optimize ? false # impure
 }:
 stdenv.mkDerivation rec {
   name = "nauty-${version}";
@@ -10,6 +11,13 @@ stdenv.mkDerivation rec {
     sha256 = "05z6mk7c31j70md83396cdjmvzzip1hqb88pfszzc6k4gy8h3m2y";
   };
   outputs = [ "out" "dev" ];
+  configureFlags = lib.optionals (!optimize) [
+    # Prevent nauty from sniffing some cpu features. While those are very
+    # widely available, it can lead to nasty bugs when they are not available:
+    # https://groups.google.com/forum/#!topic/sage-packaging/Pe4SRDNYlhA
+    "--disable-popcnt"
+    "--disable-clz"
+  ];
   buildInputs = [];
   installPhase = ''
     mkdir -p "$out"/{bin,share/doc/nauty} "$dev"/{lib,include/nauty}

--- a/pkgs/applications/science/math/nauty/default.nix
+++ b/pkgs/applications/science/math/nauty/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     inherit version;
     description = ''Programs for computing automorphism groups of graphs and digraphs'';
     license = licenses.asl20;
-    maintainers = with maintainers; [ raskin ];
+    maintainers = with maintainers; [ raskin timokau ];
     platforms = platforms.linux;
     homepage = http://pallini.di.uniroma1.it/;
   };


### PR DESCRIPTION
###### Motivation for this change

Nautys feature sniffing introduces bugs on older machines (like the `hydra` build machine on hydra). `popcnt` seems particularly problematic, I don't know how common it is for `clz` to be missing.

See https://groups.google.com/forum/#!msg/sage-packaging/Pe4SRDNYlhA/5_k9dZAoBAAJ.

Thanks @samueldr for hunting this issue down. CC @7c6f434c 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
