### PR TITLE
edb: init at 1.3.0

### DIFF
--- a/pkgs/development/tools/misc/edb/default.nix
+++ b/pkgs/development/tools/misc/edb/default.nix
@@ -1,0 +1,42 @@
+{ lib, mkDerivation, fetchFromGitHub, cmake, pkg-config, boost, capstone
+, double-conversion, graphviz, qtxmlpatterns }:
+
+mkDerivation rec {
+  pname = "edb";
+  version = "1.3.0";
+
+  src = fetchFromGitHub {
+    owner = "eteran";
+    repo = "edb-debugger";
+    rev = "1.3.0";
+    fetchSubmodules = true;
+    sha256 = "fFUau8XnsRFjC83HEsqyhrwCCBOfDmV6oACf3txm7O8=";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = [ boost.dev capstone double-conversion graphviz qtxmlpatterns ];
+
+  postPatch = ''
+    # Remove CMAKE_INSTALL_PREFIX from DEFAULT_PLUGIN_PATH otherwise the nix store path will appear twice.
+    substituteInPlace ./src/CMakeLists.txt --replace \
+        '-DDEFAULT_PLUGIN_PATH=\"''${CMAKE_INSTALL_PREFIX}/''${CMAKE_INSTALL_LIBDIR}/edb\"' \
+        '-DDEFAULT_PLUGIN_PATH=\"''${CMAKE_INSTALL_LIBDIR}/edb\"'
+
+    # The build script checks for the presence of .git to determine whether
+    # submodules were fetched and will throw an error if it's not there.
+    # Avoid using leaveDotGit in the fetchFromGitHub options as it is non-deterministic.
+    mkdir -p src/qhexview/.git
+
+    # Change default optional terminal program path to one that is more likely to work on NixOS.
+    substituteInPlace ./src/Configuration.cpp --replace "/usr/bin/xterm" "xterm";
+  '';
+
+  meta = with lib; {
+    description = "Cross platform AArch32/x86/x86-64 debugger";
+    homepage = "https://github.com/eteran/edb-debugger";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ lihop maxxk ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12122,6 +12122,8 @@ in
 
   editorconfig-core-c = callPackage ../development/tools/misc/editorconfig-core-c { };
 
+  edb = libsForQt5.callPackage ../development/tools/misc/edb { };
+
   eggdbus = callPackage ../development/tools/misc/eggdbus { };
 
   effitask = callPackage ../applications/misc/effitask { };


### PR DESCRIPTION
While there are releases for edb the most recent release (1.0.0)
is a little bit old (May 5, 2018) and does not build easily with
the current version of cmake. Therefore, I have opted to use the
latest version from github. Recent disscussion in
https://github.com/eteran/edb-debugger/issues/698 indicates that
the project might soon be moving to a quarterly release schedule
that we could follow going forwards.

###### Motivation for this change

Missing from nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
