### PR TITLE
openmpi: make build reproducible and fix compiler wrappers

### DIFF
--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchpatch, gfortran, perl, libnl
-, rdma-core, zlib, numactl, libevent, hwloc
+, rdma-core, zlib, numactl, libevent, hwloc, pkgsTargetTarget
 
 # Enable the Sun Grid Engine bindings
 , enableSGE ? false
@@ -55,6 +55,23 @@ in stdenv.mkDerivation rec {
   postInstall = ''
     rm -f $out/lib/*.la
    '';
+
+  postFixup = ''
+    # default compilers should be indentical to the
+    # compilers at build time
+
+    sed -i 's:compiler=.*:compiler=${pkgsTargetTarget.stdenv.cc}/bin/${pkgsTargetTarget.stdenv.cc.targetPrefix}cc:' \
+      $out/share/openmpi/mpicc-wrapper-data.txt
+
+    sed -i 's:compiler=.*:compiler=${pkgsTargetTarget.stdenv.cc}/bin/${pkgsTargetTarget.stdenv.cc.targetPrefix}cc:' \
+       $out/share/openmpi/ortecc-wrapper-data.txt
+
+    sed -i 's:compiler=.*:compiler=${pkgsTargetTarget.stdenv.cc}/bin/${pkgsTargetTarget.stdenv.cc.targetPrefix}c++:' \
+       $out/share/openmpi/mpic++-wrapper-data.txt
+
+    sed -i 's:compiler=.*:compiler=${pkgsTargetTarget.gfortran}/bin/${pkgsTargetTarget.gfortran.targetPrefix}gfortran:'  \
+       $out/share/openmpi/mpifort-wrapper-data.txt
+  '';
 
   doCheck = true;
 

--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -29,6 +29,13 @@ in stdenv.mkDerivation rec {
 
   postPatch = ''
     patchShebangs ./
+
+    # Ensure build is reproducible
+    ts=`date -d @$SOURCE_DATE_EPOCH`
+    sed -i 's/OPAL_CONFIGURE_USER=.*/OPAL_CONFIGURE_USER="nixbld"/' configure
+    sed -i 's/OPAL_CONFIGURE_HOST=.*/OPAL_CONFIGURE_HOST="localhost"/' configure
+    sed -i "s/OPAL_CONFIGURE_DATE=.*/OPAL_CONFIGURE_DATE=\"$ts\"/" configure
+    find -name "Makefile.in" -exec sed -i "s/\`date\`/$ts/" \{} \;
   '';
 
   buildInputs = with stdenv; [ gfortran zlib ]


### PR DESCRIPTION
###### Motivation for this change
The build system integrates various time stamps (+user, hostname) into the output thus creating an irreducible build.

The MPI compiler wrappers should point to the compilers used at build time per default. For MPICH this feature is already in the derivation (https://github.com/NixOS/nixpkgs/pull/44555)

###### Things done
* Patch in fixed timestamps, usernames, and hostname
* Set absolute path names for MPI compiler wrappers.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
