### PR TITLE
pythonPackages.ipdb: 0.8.1 -> 0.12

### DIFF
--- a/pkgs/development/python-modules/ipdb/default.nix
+++ b/pkgs/development/python-modules/ipdb/default.nix
@@ -7,16 +7,19 @@
 
 buildPythonPackage rec {
   pname = "ipdb";
-  version = "0.8.1";
+  version = "0.12";
   disabled = isPyPy;  # setupterm: could not find terminfo database
 
   src = fetchPypi {
     inherit pname version;
-    extension = "zip";
-    sha256 = "1763d1564113f5eb89df77879a8d3213273c4d7ff93dcb37a3070cdf0c34fd7c";
+    sha256 = "dce2112557edfe759742ca2d0fee35c59c97b0cc7a05398b791079d78f1519ce";
   };
 
   propagatedBuildInputs = [ ipython ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
 
   meta = with stdenv.lib; {
     homepage = https://github.com/gotcha/ipdb;


### PR DESCRIPTION
###### Motivation for this change

In response to https://github.com/NixOS/nixpkgs/commit/2750333f9d11d734926c4ace755140721f8fbb59#r33018563
upgrading ipdb version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
