### PR TITLE
curseradio: init at 0.2

### DIFF
--- a/pkgs/applications/audio/curseradio/default.nix
+++ b/pkgs/applications/audio/curseradio/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchFromGitHub, substituteAll, python3Packages, mpv }:
+
+python3Packages.buildPythonApplication rec {
+  version = "0.2";
+  pname = "curseradio";
+
+  src = fetchFromGitHub {
+    owner = "chronitis";
+    repo = pname;
+    rev = "1bd4bd0faeec675e0647bac9a100b526cba19f8d";
+    sha256 = "11bf0jnj8h2fxhpdp498189r4s6b47vy4wripv0z4nx7lxajl88i";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    requests
+    lxml
+    pyxdg
+  ];
+
+  patches = [
+    (substituteAll {
+      src = ./mpv.patch;
+      inherit mpv;
+    })
+  ];
+
+  # No tests
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Command line radio player";
+    homepage = "https://github.com/chronitis/curseradio";
+    license = licenses.mit;
+    maintainers = [ maintainers.eyjhb ];
+  };
+}

--- a/pkgs/applications/audio/curseradio/mpv.patch
+++ b/pkgs/applications/audio/curseradio/mpv.patch
@@ -1,0 +1,11 @@
+--- a/curseradio/curseradio.py
++++ b/curseradio/curseradio.py
+@@ -30,7 +30,7 @@ import re
+ 
+ CONFIG_DEFAULT = {
+     'opml': {'root': "http://opml.radiotime.com/"},
+-    'playback': {'command': '/usr/bin/mpv'},
++    'playback': {'command': '@mpv@/bin/mpv'},
+     'interface': {'keymap': 'default'},
+     'keymap.default': {
+         'up': 'KEY_UP',

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16768,6 +16768,8 @@ in
 
   cuneiform = callPackage ../tools/graphics/cuneiform {};
 
+  curseradio = callPackage ../applications/audio/curseradio { };
+
   cutecom = libsForQt5.callPackage ../tools/misc/cutecom { };
 
   cutegram =


### PR DESCRIPTION
###### Motivation for this change
Wanting curseradio in the repo

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
