### PR TITLE
gcc-arm-embedded: add darwin support

### DIFF
--- a/pkgs/development/compilers/gcc-arm-embedded/6/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/6/default.nix
@@ -5,16 +5,17 @@ stdenv.mkDerivation rec {
   version = "6-2017-q2-update";
   subdir = "6-2017q2";
 
-  platformString =
-    if stdenv.isLinux then "linux"
-    else if stdenv.isDarwin then "mac"
-    else throw "unsupported platform";
-
-  urlString = "https://developer.arm.com/-/media/Files/downloads/gnu-rm/${subdir}/gcc-arm-none-eabi-${version}-${platformString}.tar.bz2";
-
   src =
-    if stdenv.isLinux then fetchurl { url=urlString; sha256="1hvwi02mx34al525sngnl0cm7dkmzxfkb1brq9kvbv28wcplp3p6"; }
-    else if stdenv.isDarwin then fetchurl { url=urlString; sha256="0019ylpq4inq7p5gydpmc9m8ni72fz2csrjlqmgx1698998q0c3x"; }
+    if stdenv.isLinux then
+      fetchurl {
+        url = "https://developer.arm.com/-/media/Files/downloads/gnu-rm/${subdir}/gcc-arm-none-eabi-${version}-linux.tar.bz2";
+        sha256="1hvwi02mx34al525sngnl0cm7dkmzxfkb1brq9kvbv28wcplp3p6";
+      }
+    else if stdenv.isDarwin then
+      fetchurl {
+        url = "https://developer.arm.com/-/media/Files/downloads/gnu-rm/${subdir}/gcc-arm-none-eabi-${version}-mac.tar.bz2";
+        sha256="0019ylpq4inq7p5gydpmc9m8ni72fz2csrjlqmgx1698998q0c3x";
+      }
     else throw "unsupported platform";
 
   phases = [ "unpackPhase" "installPhase" "fixupPhase" ];

--- a/pkgs/development/compilers/gcc-arm-embedded/7/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/7/default.nix
@@ -7,9 +7,18 @@ stdenv.mkDerivation rec {
   version = "7-2018-q2-update";
   subdir = "7-2018q2";
 
-  urlString = "https://developer.arm.com/-/media/Files/downloads/gnu-rm/${subdir}/gcc-arm-none-eabi-${version}-linux.tar.bz2";
-
-  src = fetchurl { url=urlString; sha256="0sgysp3hfpgrkcbfiwkp0a7ymqs02khfbrjabm52b5z61sgi05xv"; };
+  src =
+  if stdenv.isLinux then
+    fetchurl {
+      url = "https://developer.arm.com/-/media/Files/downloads/gnu-rm/${subdir}/gcc-arm-none-eabi-${version}-linux.tar.bz2";
+      sha256="0sgysp3hfpgrkcbfiwkp0a7ymqs02khfbrjabm52b5z61sgi05xv";
+    }
+  else if stdenv.isDarwin then
+    fetchurl {
+      url = "https://developer.arm.com/-/media/Files/downloads/gnu-rm/${subdir}/gcc-arm-none-eabi-${version}-mac.tar.bz2";
+      sha256="0nc7m0mpa39qyhfyydxkkyqm7spfc27xf6ygi2vd2aym4r9azi61";
+    }
+  else throw "unsupported platform";
 
   phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
 

--- a/pkgs/development/compilers/gcc-arm-embedded/8/default.nix
+++ b/pkgs/development/compilers/gcc-arm-embedded/8/default.nix
@@ -7,9 +7,18 @@ stdenv.mkDerivation rec {
   version = "8-2018-q4-major";
   subdir = "8-2018q4";
 
-  urlString = "https://developer.arm.com/-/media/Files/downloads/gnu-rm/${subdir}/gcc-arm-none-eabi-${version}-linux.tar.bz2";
-
-  src = fetchurl { url=urlString; sha256="fb31fbdfe08406ece43eef5df623c0b2deb8b53e405e2c878300f7a1f303ee52"; };
+  src =
+  if stdenv.isLinux then
+    fetchurl {
+      url = "https://developer.arm.com/-/media/Files/downloads/gnu-rm/${subdir}/gcc-arm-none-eabi-${version}-linux.tar.bz2";
+      sha256="fb31fbdfe08406ece43eef5df623c0b2deb8b53e405e2c878300f7a1f303ee52";
+    }
+  else if stdenv.isDarwin then
+    fetchurl {
+      url = "https://developer.arm.com/-/media/Files/downloads/gnu-rm/${subdir}/gcc-arm-none-eabi-${version}-mac.tar.bz2";
+      sha256="0q44r57fizpk1z3ngcjwal3rxgsnzjyfknpgwlwzmw5r9p98wlhb";
+    }
+  else throw "unsupported platform";
 
   phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
 


### PR DESCRIPTION
###### Motivation for this change
Add darwin support for gcc-arm-embedded-7 and gcc-arm-embedded-8 packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
