### PR TITLE
Singularity, support multiple versions

### DIFF
--- a/pkgs/applications/virtualization/singularity/generic.nix
+++ b/pkgs/applications/virtualization/singularity/generic.nix
@@ -1,4 +1,4 @@
-{stdenv
+{ stdenv
 , removeReferencesTo
 , lib
 , fetchgit
@@ -13,18 +13,24 @@
 , squashfsTools
 , buildGoPackage
 
+
 # Attributes inherit from specific versions
 , version
-, src
+, sha256
 }:
 
 with lib;
 
 buildGoPackage rec {
-    
+  inherit version;
   name = "singularity-${version}";
-
-  inherit src;
+  
+  src = fetchFromGitHub {
+    owner = "sylabs";
+    repo = "singularity";
+    rev = "v${version}";
+    inherit sha256;
+  };
 
   goPackagePath = "github.com/sylabs/singularity";
   goDeps = ./deps.nix;

--- a/pkgs/applications/virtualization/singularity/generic.nix
+++ b/pkgs/applications/virtualization/singularity/generic.nix
@@ -1,0 +1,78 @@
+{stdenv
+, removeReferencesTo
+, lib
+, fetchgit
+, fetchFromGitHub
+, utillinux
+, openssl
+, coreutils
+, gawk
+, go
+, which
+, makeWrapper
+, squashfsTools
+, buildGoPackage
+
+# Attributes inherit from specific versions
+, version
+, src
+}:
+
+with lib;
+
+buildGoPackage rec {
+    
+  name = "singularity-${version}";
+
+  inherit src;
+
+  goPackagePath = "github.com/sylabs/singularity";
+  goDeps = ./deps.nix;
+
+  buildInputs = [ openssl ];
+  nativeBuildInputs = [ removeReferencesTo utillinux which makeWrapper ];
+  propagatedBuildInputs = [ coreutils squashfsTools ];
+
+  postConfigure = ''
+    find . -name vendor -type d -print0 | xargs -0 rm -rf
+
+    cd go/src/github.com/sylabs/singularity
+
+    patchShebangs .
+    sed -i 's|defaultEnv := "/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin"|defaultEnv := "${stdenv.lib.makeBinPath propagatedBuildInputs}"|' src/cmd/singularity/cli/singularity.go
+
+    ./mconfig -V ${version} -p $bin --localstatedir=/var
+    touch builddir/.dep-done
+    touch builddir/vendors-done
+
+    # Don't install SUID binaries
+    sed -i 's/-m 4755/-m 755/g' builddir/Makefile
+
+    # Point to base gopath
+    sed -i "s|^cni_vendor_GOPATH :=.*\$|cni_vendor_GOPATH := $NIX_BUILD_TOP/go/src/github.com/containernetworking/plugins/plugins|" builddir/Makefile
+  '';
+
+  buildPhase = ''
+    make -C builddir
+  '';
+
+  installPhase = ''
+    make -C builddir install LOCALSTATEDIR=$bin/var
+    chmod 755 $bin/libexec/singularity/bin/starter-suid
+  '';
+
+  postFixup = ''
+    find $bin/ -type f -executable -exec remove-references-to -t ${go} '{}' + || true
+
+    # These etc scripts shouldn't have their paths patched
+    cp etc/actions/* $bin/etc/singularity/actions/
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://www.sylabs.io/;
+    description = "Application containers for linux";
+    license = licenses.bsd3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.jbedo ];
+  };
+}

--- a/pkgs/applications/virtualization/singularity/singularity_2_6_1.nix
+++ b/pkgs/applications/virtualization/singularity/singularity_2_6_1.nix
@@ -1,16 +1,6 @@
-{ stdenv, callPackage, fetchurl, ... } @ args:
+{ callPackage, ... } @ args:
 
-callPackage ./generic.nix (args // rec {
-
-  name = "singularity-${version}";
-  
+callPackage ./generic.nix (args {
   version = "2.6.1";
-
-  src = fetchFromGitHub {
-    owner = "sylabs";
-    repo = "singularity";
-    rev = "v${version}";
-    sha256 = "1wpsd0il2ipa2n5cnbj8dzs095jycdryq2rx62kikbq7ahzz4fsi";
-  };
-
-}
+  sha256 = "1wpsd0il2ipa2n5cnbj8dzs095jycdryq2rx62kikbq7ahzz4fsi";  
+})

--- a/pkgs/applications/virtualization/singularity/singularity_2_6_1.nix
+++ b/pkgs/applications/virtualization/singularity/singularity_2_6_1.nix
@@ -1,0 +1,16 @@
+{ stdenv, callPackage, fetchurl, ... } @ args:
+
+callPackage ./generic.nix (args // rec {
+
+  name = "singularity-${version}";
+  
+  version = "2.6.1";
+
+  src = fetchFromGitHub {
+    owner = "sylabs";
+    repo = "singularity";
+    rev = "v${version}";
+    sha256 = "1wpsd0il2ipa2n5cnbj8dzs095jycdryq2rx62kikbq7ahzz4fsi";
+  };
+
+}

--- a/pkgs/applications/virtualization/singularity/singularity_3_0_1.nix
+++ b/pkgs/applications/virtualization/singularity/singularity_3_0_1.nix
@@ -1,14 +1,6 @@
-{ stdenv, callPackage, fetchurl, ... } @ args:
+{ callPackage, ... } @ args:
 
-callPackage ./generic.nix (args // rec {
-
-version = "3.0.1";
-
-src = fetchFromGitHub {
-    owner = "sylabs";
-    repo = "singularity";
-    rev = "v${version}";
-    sha256 = "1wpsd0il2ipa2n5cnbj8dzs095jycdryq2rx62kikbq7ahzz4fsi";
-  };
-  
-}
+callPackage ./generic.nix (args {
+  version = "3.0.1";
+  sha256 = "1wpsd0il2ipa2n5cnbj8dzs095jycdryq2rx62kikbq7ahzz4fsi";  
+})

--- a/pkgs/applications/virtualization/singularity/singularity_3_0_1.nix
+++ b/pkgs/applications/virtualization/singularity/singularity_3_0_1.nix
@@ -1,0 +1,14 @@
+{ stdenv, callPackage, fetchurl, ... } @ args:
+
+callPackage ./generic.nix (args // rec {
+
+version = "3.0.1";
+
+src = fetchFromGitHub {
+    owner = "sylabs";
+    repo = "singularity";
+    rev = "v${version}";
+    sha256 = "1wpsd0il2ipa2n5cnbj8dzs095jycdryq2rx62kikbq7ahzz4fsi";
+  };
+  
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17896,7 +17896,7 @@ in
     go = go_1_11;
   };
   
-  singularity_3_0_1 = callPackage ../applications/virtualization/singularity_3_0_1.nix {
+  singularity_3_0_1 = callPackage ../applications/virtualization/singularity/singularity_3_0_1.nix {
     # XXX: the build is finding references to Go when compiled with go v1.12
     go = go_1_11;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17891,10 +17891,17 @@ in
 
   slack-term = callPackage ../applications/networking/instant-messengers/slack-term { };
 
-  singularity = callPackage ../applications/virtualization/singularity {
+  singularity_2_6_1 = callPackage ../applications/virtualization/singularity/singularity_2_6_1.nix { 
     # XXX: the build is finding references to Go when compiled with go v1.12
     go = go_1_11;
   };
+  
+  singularity_3_0_1 = callPackage ../applications/virtualization/singularity_3_0_1.nix {
+    # XXX: the build is finding references to Go when compiled with go v1.12
+    go = go_1_11;
+  };
+
+  singularity = singularity_3_0_1;
 
   spectmorph = callPackage ../applications/audio/spectmorph { };
 


### PR DESCRIPTION
###### Motivation for this change

HPC environments are slowly moving forward, hence it would be very nice to support multiple versions of Singularity. 

I have tried my best, following similar patterns for `nginx` and `boost` packages, but not yet succeeded at making this build. I need help, moving forward on this.

I get the following error:

```
error: attempt to call something which is not a function but a set, at /home/obiwan/stash/sources/scalavision/nixpkgs/pkgs/applications/virtualization/singularity/singularity_3_0_1.nix:3:28
```
How can I rearrange this to make it work?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
