### PR TITLE
writeShellScriptBin: use build-time shell in check phase

### DIFF
--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -149,7 +149,7 @@ rec {
         ${text}
         '';
       checkPhase = ''
-        ${runtimeShell} -n $out/bin/${name}
+        ${stdenv.shell} -n $out/bin/${name}
       '';
     };
 


### PR DESCRIPTION
###### Motivation for this change

#56408 was awesome (thanks @Mic92) !
Only a small thing broke my cross-NixOS build so I thought I'd send a patch.

NOTE: I'm not sure if this would actually be correct, since the shells could be different. (how would we get a build-time-runtimeShell?) Maybe skipping the check phase during cross comp is better?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
