### PR TITLE
torcs: anonscm.debian.org has moved

### DIFF
--- a/pkgs/games/torcs/default.nix
+++ b/pkgs/games/torcs/default.nix
@@ -12,15 +12,15 @@ stdenv.mkDerivation rec {
 
   patches = [
     (fetchpatch {
-      url = "https://anonscm.debian.org/git/pkg-games/torcs.git/plain/debian/patches/gcc6-isnan.patch";
+      url = "https://salsa.debian.org/games-team/torcs/raw/master/debian/patches/gcc6-isnan.patch";
       sha256 = "16scmq30vwb8429ah9d4ws0v1w6ai59lvn7hcgnvfzyap42ry876";
     })
     (fetchpatch {
-      url = "https://anonscm.debian.org/git/pkg-games/torcs.git/plain/debian/patches/format-argument.patch";
+      url = "https://salsa.debian.org/games-team/torcs/raw/master/debian/patches/format-argument.patch";
       sha256 = "04advcx88yh23ww767iysydzhp370x7cqp2wf9hk2y1qvw7mxsja";
     })
     (fetchpatch {
-      url = "https://anonscm.debian.org/git/pkg-games/torcs.git/plain/debian/patches/glibc-default-source.patch";
+      url = "https://salsa.debian.org/games-team/torcs/raw/master/debian/patches/glibc-default-source.patch";
       sha256 = "0k4hgpddnhv68mdc9ics7ah8q54j60g394d7zmcmzg6l3bjd9pyp";
     })
   ];


### PR DESCRIPTION


###### Motivation for this change

the patch links where somewhat broken
my guess it is due to the move to a gitlab at salsa.debian.org

###### Things done

changed patch urls to non access required download links

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
