### PR TITLE
perl: substitute /bin/pwd with host pwd

### DIFF
--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -1,5 +1,6 @@
 { lib, stdenv, fetchurl, buildPackages
 , enableThreading ? stdenv ? glibc, makeWrapper
+, coreutils
 }:
 
 with lib;
@@ -55,9 +56,8 @@ let
       ++ optional crossCompiling ./MakeMaker-cross.patch;
 
     postPatch = ''
-      pwd="$(type -P pwd)"
       substituteInPlace dist/PathTools/Cwd.pm \
-        --replace "/bin/pwd" "$pwd"
+        --replace "/bin/pwd" "${coreutils}/bin/pwd"
     '' + stdenv.lib.optionalString crossCompiling ''
       substituteInPlace cnf/configure_tool.sh --replace "cc -E -P" "cc -E"
     '';


### PR DESCRIPTION
###### Motivation for this change

`/bin/pwd` is replaced during the build with nix's version.
it was incorrectly set to the build-time `pwd`, this would set it to the host's `pwd`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
