### PR TITLE
tilingnome: init at 2019-01-18

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/tilingnome/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/tilingnome/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, lib, fetchFromGitHub, glib, gnome3 }:
+
+stdenv.mkDerivation rec {
+  pname = "gnome-shell-extension-tilingnome";
+  version = "unstable-2019-01-18";
+
+  src = fetchFromGitHub {
+    owner = "rliang";
+    repo = pname;
+    rev = "bd4fb8c19f7a6282b38724b30e62645143390226";
+    sha256 = "1y4s4n88gdkpvgd3v3dg0181ccyhlixbvkx3bwyvdxyyyxbqibid";
+  };
+
+  nativeBuildInputs = [ glib ];
+
+  buildPhase = ''
+    glib-compile-schemas .
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/gnome-shell/extensions/${uuid}
+    cp -r * $out/share/gnome-shell/extensions/${uuid}/
+  '';
+
+  uuid = "tilingnome@rliang.github.com";
+
+  meta = with stdenv.lib; {
+    description = "Tiling window management for GNOME Shell";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ benley ];
+    homepage = https://github.com/rliang/gnome-shell-extension-tilingnome;
+    platforms = gnome3.gnome-shell.meta.platforms;
+    broken = lib.versionAtLeast gnome3.gnome-shell.version "3.31";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21583,6 +21583,7 @@ in
     sound-output-device-chooser = callPackage ../desktops/gnome-3/extensions/sound-output-device-chooser { };
     system-monitor = callPackage ../desktops/gnome-3/extensions/system-monitor { };
     taskwhisperer = callPackage ../desktops/gnome-3/extensions/taskwhisperer { };
+    tilingnome = callPackage ../desktops/gnome-3/extensions/tilingnome { };
     timepp = callPackage ../desktops/gnome-3/extensions/timepp { };
     topicons-plus = callPackage ../desktops/gnome-3/extensions/topicons-plus { };
     window-corner-preview = callPackage ../desktops/gnome-3/extensions/window-corner-preview { };


### PR DESCRIPTION
###### Motivation for this change

What if Gnome had a tiling window manager? This is that thing.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
