### PR TITLE
R: Workaround to make `which` a run-time dependency

### DIFF
--- a/pkgs/applications/science/math/R/default.nix
+++ b/pkgs/applications/science/math/R/default.nix
@@ -67,6 +67,8 @@ stdenv.mkDerivation rec {
     echo >>etc/Renviron.in "TZDIR=${tzdata}/share/zoneinfo"
   '';
 
+  postInstall = "echo ${which} > $out/nix-support/ugly-hack";
+
   installTargets = [ "install" "install-info" "install-pdf" ];
 
   doCheck = true;


### PR DESCRIPTION
Workaround for issue https://github.com/NixOS/nixpkgs/issues/58963.

###### Motivation for this change

See issue https://github.com/NixOS/nixpkgs/issues/58963.

###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
