### PR TITLE
openjdk8: 1.8.0_121-8.20.0.5 -> 1.8.0_202-8.36.0.1

### DIFF
--- a/pkgs/development/compilers/openjdk/darwin/8.nix
+++ b/pkgs/development/compilers/openjdk/darwin/8.nix
@@ -6,9 +6,8 @@ let
     sha256 = "0nk7m0lgcbsvldq2wbfni2pzq8h818523z912i7v8hdcij5s48c0";
   };
 
-  update = "202";
   jdk = stdenv.mkDerivation {
-    name = "openjdk-zulu-8u${update}";
+    name = "zulu8.36.0.1-ca-jdk8.0.202";
 
     src = fetchurl {
       url = "http://cdn.azul.com/zulu/bin/zulu8.36.0.1-ca-jdk8.0.202-macosx_x64.zip";

--- a/pkgs/development/compilers/openjdk/darwin/8.nix
+++ b/pkgs/development/compilers/openjdk/darwin/8.nix
@@ -6,13 +6,14 @@ let
     sha256 = "0nk7m0lgcbsvldq2wbfni2pzq8h818523z912i7v8hdcij5s48c0";
   };
 
+  update = "202";
   jdk = stdenv.mkDerivation {
-    name = "zulu1.8.0_202-8.36.0.1";
+    name = "openjdk-zulu-8u${update}";
 
     src = fetchurl {
       url = "http://cdn.azul.com/zulu/bin/zulu8.36.0.1-ca-jdk8.0.202-macosx_x64.zip";
       sha256 = "37556902100779fc2a1aab88015fb59de383a75054e7dd50975b004779a02269";
-      curlOpts = "-H Referer:https://www.azul.com/downloads/zulu/zulu-linux/";
+      curlOpts = "-H Referer:https://www.azul.com/downloads/zulu/";
     };
 
     buildInputs = [ unzip freetype ];

--- a/pkgs/development/compilers/openjdk/darwin/8.nix
+++ b/pkgs/development/compilers/openjdk/darwin/8.nix
@@ -7,11 +7,11 @@ let
   };
 
   jdk = stdenv.mkDerivation {
-    name = "zulu1.8.0_121-8.20.0.5";
+    name = "zulu1.8.0_202-8.36.0.1";
 
     src = fetchurl {
-      url = "http://cdn.azul.com/zulu/bin/zulu8.20.0.5-jdk8.0.121-macosx_x64.zip";
-      sha256 = "2a58bd1d9b0cbf0b3d8d1bcdd117c407e3d5a0ec01e2f53565c9bec5cf9ea78b";
+      url = "http://cdn.azul.com/zulu/bin/zulu8.36.0.1-ca-jdk8.0.202-macosx_x64.zip";
+      sha256 = "37556902100779fc2a1aab88015fb59de383a75054e7dd50975b004779a02269";
       curlOpts = "-H Referer:https://www.azul.com/downloads/zulu/zulu-linux/";
     };
 

--- a/pkgs/development/tools/scalafmt/default.nix
+++ b/pkgs/development/tools/scalafmt/default.nix
@@ -2,18 +2,18 @@
 
 let
   baseName = "scalafmt";
-  version = "2.0.0-RC5";
+  version = "1.5.1";
   deps = stdenv.mkDerivation {
     name = "${baseName}-deps-${version}";
     buildCommand = ''
       export COURSIER_CACHE=$(pwd)
-      ${coursier}/bin/coursier fetch org.scalameta:scalafmt-cli_2.12:${version} > deps
+      ${coursier}/bin/coursier fetch com.geirsson:scalafmt-cli_2.12:${version} > deps
       mkdir -p $out/share/java
       cp $(< deps) $out/share/java/
     '';
     outputHashMode = "recursive";
     outputHashAlgo = "sha256";
-    outputHash     = "0y2nja4dj3l7f7m9dxr8xwda8vv27dwj090gfsa78a20vq1d3xxw";
+    outputHash     = "15xfys9wdlx3rrqb2ab6qcfngkf6sa8v8q8shh10kk8jrc30g6dk";
   };
 in
 stdenv.mkDerivation rec {

--- a/pkgs/development/tools/scalafmt/default.nix
+++ b/pkgs/development/tools/scalafmt/default.nix
@@ -2,18 +2,18 @@
 
 let
   baseName = "scalafmt";
-  version = "1.5.1";
+  version = "2.0.0-RC5";
   deps = stdenv.mkDerivation {
     name = "${baseName}-deps-${version}";
     buildCommand = ''
       export COURSIER_CACHE=$(pwd)
-      ${coursier}/bin/coursier fetch com.geirsson:scalafmt-cli_2.12:${version} > deps
+      ${coursier}/bin/coursier fetch org.scalameta:scalafmt-cli_2.12:${version} > deps
       mkdir -p $out/share/java
       cp $(< deps) $out/share/java/
     '';
     outputHashMode = "recursive";
     outputHashAlgo = "sha256";
-    outputHash     = "15xfys9wdlx3rrqb2ab6qcfngkf6sa8v8q8shh10kk8jrc30g6dk";
+    outputHash     = "0y2nja4dj3l7f7m9dxr8xwda8vv27dwj090gfsa78a20vq1d3xxw";
   };
 in
 stdenv.mkDerivation rec {


### PR DESCRIPTION
###### Motivation for this change
Update MacOS JDK version to latest

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
