### PR TITLE
herwig: 7.1.4 -> 7.1.5

### DIFF
--- a/pkgs/development/libraries/physics/herwig/default.nix
+++ b/pkgs/development/libraries/physics/herwig/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "herwig-${version}";
-  version = "7.1.4";
+  version = "7.1.5";
 
   src = fetchurl {
     url = "https://www.hepforge.org/archive/herwig/Herwig-${version}.tar.bz2";
-    sha256 = "1awr1jz0q873x8bgwiilzklhk1zkgm6slvpychpnvsf9vk05mmdx";
+    sha256 = "0jnrv59zfa41gc37pqr3vaiz5jkh7w0k0alcax37b3mlbsnacr9r";
   };
 
   nativeBuildInputs = [ autoconf automake libtool ];
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     ++ (with lhapdf.pdf_sets; [ MMHT2014lo68cl MMHT2014nlo68cl ]);
 
   postPatch = ''
-    patchShebangs ./cat_with_cpplines
+    patchShebangs ./
   '';
 
   configureFlags = [

--- a/pkgs/development/libraries/physics/thepeg/default.nix
+++ b/pkgs/development/libraries/physics/thepeg/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "thepeg-${version}";
-  version = "2.1.4";
+  version = "2.1.5";
 
   src = fetchurl {
     url = "https://www.hepforge.org/archive/thepeg/ThePEG-${version}.tar.bz2";
-    sha256 = "1x9dfxmsbmzmsxrv3cczfyrnqkxjcpy89v6v7ycysrx9k8qkf320";
+    sha256 = "1rmmwhk9abn9mc9j3127axjwpvymv21ld4wcivwz01pldkxh06n6";
   };
 
   buildInputs = [ boost fastjet gsl hepmc lhapdf rivet zlib ];


### PR DESCRIPTION
thepeg: 2.1.4 -> 2.1.5

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

* Herwig 7.1.5 release: 2019-04-04
  * Add option of producing partons on physically mass shell after the parton shower
   to allow the string model to be used to hadronize events
  * Fixes for template issues and compiler warnings for gcc8,9, icc and clang
  * Various minor fixes
* ThePEG-2.1.5 release: 2019-04-04
  * Improvements to template instantiation with gcc9 and icc T23
  * Changes for compilation with gcc8,9, icc and clang


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
