### PR TITLE
mpv: patch libarchive locale handling

### DIFF
--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -1,4 +1,4 @@
-{ config, stdenv, fetchurl, fetchFromGitHub, makeWrapper
+{ config, stdenv, fetchpatch, fetchurl, fetchFromGitHub, makeWrapper
 , docutils, perl, pkgconfig, python3, which, ffmpeg_4
 , freefont_ttf, freetype, libass, libpthreadstubs, mujs
 , nv-codec-headers, lua, libuchardet, libiconv ? null, darwin
@@ -104,6 +104,22 @@ in stdenv.mkDerivation rec {
     rev    = "v${version}";
     sha256 = "138921kx8g6qprim558xin09xximjhsj9ss8b71ifg2m6kclym8m";
   };
+
+  # Upstream currently relies on the system having a "C.UTF-8" locale for
+  # libarchive, which NixOS does not have. This causes issues with at least
+  # playback from zip files. There is currently a pull request open (6438) that
+  # solves this, but upstream hasn't really moved yet, so let's use it until a
+  # fixed release is out.
+  #
+  # Further reading:
+  # https://github.com/mpv-player/mpv/commit/1e70e82baa9193f6f027338b0fab0f5078971fbe
+  # https://github.com/mpv-player/mpv/issues/5759
+  # https://github.com/mpv-player/mpv/issues/6488
+  # https://github.com/mpv-player/mpv/pull/6438
+  patches = optional archiveSupport (fetchpatch {
+    url = "https://github.com/mpv-player/mpv/commit/4b2f25822a70d82afe48aeb9e2c68ccd7aa8c86c.patch";
+    sha256 = "07q2v3pgnr3wgcvzib11jr1c65l13m194m9x5mmd913gs7qv7zgv";
+  });
 
   postPatch = ''
     patchShebangs ./TOOLS/


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

mpv's libarchive locale handling is broken on multiple Linux distributions currently due to an assumption on `C.UTF-8` existing (see https://github.com/mpv-player/mpv/issues/5759, https://github.com/mpv-player/mpv/issues/6488). A patch (https://github.com/mpv-player/mpv/pull/6438) has been submitted, but not yet merged. It'd be nice to get this in before 19.03 for those wanting to use mpv with `archiveSupport` simply.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
