### PR TITLE
sublime-merge: init at 1107

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5366,6 +5366,11 @@
     github = "zohl";
     name = "Al Zohali";
   };
+  zookatron = {
+    email = "tim@zookatron.com";
+    github = "zookatron";
+    name = "Tim Zook";
+  };
   zoomulator = {
     email = "zoomulator@gmail.com";
     github = "zoomulator";

--- a/pkgs/applications/version-management/sublime-merge/common.nix
+++ b/pkgs/applications/version-management/sublime-merge/common.nix
@@ -1,0 +1,105 @@
+{ buildVersion, sha256, dev ? false }:
+
+{ fetchurl, stdenv, xorg, glib, gtk3, cairo, pango, libredirect, makeWrapper, wrapGAppsHook
+, pkexecPath ? "/run/wrappers/bin/pkexec", gksuSupport ? false, gksu
+, writeScript, common-updater-scripts, curl, gnugrep
+}:
+
+assert gksuSupport -> gksu != null;
+
+let
+  libPath = stdenv.lib.makeLibraryPath [ xorg.libX11 glib gtk3 cairo pango ];
+  redirects = [ "/usr/bin/pkexec=${pkexecPath}" ]
+    ++ stdenv.lib.optional gksuSupport "/usr/bin/gksudo=${gksu}/bin/gksudo";
+in let
+  # package with just the binaries
+  sublime_merge = stdenv.mkDerivation {
+    pname = "sublime-merge-bin";
+    version = buildVersion;
+
+    src = fetchurl {
+      name = "sublime-merge-${buildVersion}.tar.xz";
+      url = "https://download.sublimetext.com/sublime_merge_build_${buildVersion}_x64.tar.xz";
+      inherit sha256;
+    };
+
+    dontStrip = true;
+    dontPatchELF = true;
+    buildInputs = [ glib gtk3 ]; # for GSETTINGS_SCHEMAS_PATH
+    nativeBuildInputs = [ makeWrapper wrapGAppsHook ];
+
+    buildPhase = ''
+      runHook preBuild
+
+      for binary in sublime_merge crash_reporter git-credential-sublime ssh-askpass-sublime; do
+        patchelf \
+          --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+          --set-rpath ${libPath}:${stdenv.cc.cc.lib}/lib64 \
+          $binary
+      done
+
+      # Rewrite pkexec|gksudo argument. Note that we can't delete bytes in binary.
+      sed -i -e 's,/bin/cp\x00,cp\x00\x00\x00\x00\x00\x00,g' sublime_merge
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out
+      cp -r * $out/
+
+      runHook postInstall
+    '';
+
+    dontWrapGApps = true; # non-standard location, need to wrap the executables manually
+
+    postFixup = ''
+      wrapProgram $out/sublime_merge \
+        --set LD_PRELOAD "${libredirect}/lib/libredirect.so" \
+        --set NIX_REDIRECTS ${builtins.concatStringsSep ":" redirects} \
+        "''${gappsWrapperArgs[@]}"
+    '';
+  };
+in stdenv.mkDerivation {
+  pname = "sublime-merge";
+  version = buildVersion;
+
+  phases = [ "installPhase" ];
+
+  inherit sublime_merge;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p "$out/bin"
+    makeWrapper "$sublime_merge/sublime_merge" "$out/bin/sublime_merge"
+    ln -s "$out/bin/sublime_merge" "$out/bin/smerge"
+    mkdir -p "$out/share/applications"
+    substitute "$sublime_merge/sublime_merge.desktop" "$out/share/applications/sublime_merge.desktop" --replace "/opt/sublime_merge/sublime_merge" "$out/bin/sublime_merge"
+    for directory in $sublime_merge/Icon/*; do
+      size=$(basename $directory)
+      mkdir -p "$out/share/icons/hicolor/$size/apps"
+      ln -s "$sublime_merge/Icon/$size/sublime-merge.png" "$out/share/icons/hicolor/$size/apps"
+    done
+  '';
+
+  passthru.updateScript = writeScript "sublime-merge-update-script" ''
+    #!${stdenv.shell}
+    set -o errexit
+    PATH=${stdenv.lib.makeBinPath [ common-updater-scripts curl gnugrep ]}
+
+    latestVersion=$(curl -s https://www.sublimemerge.com/${if dev then "dev" else "download"} | grep -Po '(?<=<p class="latest"><i>Version:</i> Build )([0-9]+)')
+
+    update-source-version sublime-merge${stdenv.lib.optionalString dev "-dev"}.sublime_merge $latestVersion --file=pkgs/applications/version-management/sublime-merge/default.nix --version-key=buildVersion --system=x86_64-linux
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Git client from the makers of Sublime Text";
+    homepage = https://www.sublimemerge.com;
+    maintainers = with maintainers; [ zookatron ];
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/applications/version-management/sublime-merge/default.nix
+++ b/pkgs/applications/version-management/sublime-merge/default.nix
@@ -1,0 +1,16 @@
+{ callPackage }:
+
+let
+  common = opts: callPackage (import ./common.nix opts);
+in {
+  sublime-merge = common {
+    buildVersion = "1107";
+    sha256 = "70edbb16529d638ea41a694dbc5b1408c76fcc3a7d663ef0e48b4e89e1f19c71";
+  } {};
+
+  sublime-merge-dev = common {
+    buildVersion = "1111";
+    sha256 = "d287b77b36febe52623db4546bef978dceb0654257b9a70c798d9cd394305c0d";
+    dev = true;
+  } {};
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19761,6 +19761,10 @@ in
 
   sublime3-dev = sublime3Packages.sublime3-dev;
 
+  inherit (callPackage ../applications/version-management/sublime-merge {})
+    sublime-merge
+    sublime-merge-dev;
+
   inherit (callPackages ../applications/version-management/subversion { sasl = cyrus_sasl; })
     subversion18 subversion19 subversion_1_10 subversion_1_11;
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
