### PR TITLE
gettext: apply patch for CVE 2018-18751 (backport 18.09)

### DIFF
--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, libiconv, xz }:
+{ stdenv, lib, fetchurl, libiconv, xz, bison, automake115x, autoconf }:
 
 stdenv.mkDerivation rec {
   name = "gettext-${version}";
@@ -8,7 +8,14 @@ stdenv.mkDerivation rec {
     url = "mirror://gnu/gettext/${name}.tar.gz";
     sha256 = "0hsw28f9q9xaggjlsdp2qmbp2rbd1mp0njzan2ld9kiqwkq2m57z";
   };
-  patches = [ ./absolute-paths.diff ];
+  patches = [
+    ./absolute-paths.diff
+    (fetchurl {
+      name = "CVE-2018-18751.patch";
+      url = "https://git.savannah.gnu.org/gitweb/?p=gettext.git;a=patch;h=dce3a16e5e9368245735e29bf498dcd5e3e474a4";
+      sha256 = "1lpjwwcjr1sb879faj0xyzw02kma0ivab6xwn3qciy13qy6fq5xn";
+    })
+  ];
 
   outputs = [ "out" "man" "doc" "info" ];
 
@@ -40,7 +47,7 @@ stdenv.mkDerivation rec {
     sed -i -e "s/\(libgettextsrc_la_LDFLAGS = \)/\\1..\/gnulib-lib\/libxml_rpl.la /" gettext-tools/src/Makefile.in
   '';
 
-  nativeBuildInputs = [ xz xz.bin ];
+  nativeBuildInputs = [ xz xz.bin bison automake115x autoconf];
   # HACK, see #10874 (and 14664)
   buildInputs = stdenv.lib.optional (!stdenv.isLinux && !stdenv.hostPlatform.isCygwin) libiconv;
 

--- a/pkgs/development/tools/misc/automake/automake-1.15.x.nix
+++ b/pkgs/development/tools/misc/automake/automake-1.15.x.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchurl, perl, autoconf }:
+
+stdenv.mkDerivation rec {
+  name = "automake-1.15";
+
+  src = fetchurl {
+    url = "mirror://gnu/automake/${name}.tar.xz";
+    sha256 = "0dl6vfi2lzz8alnklwxzfz624b95hb1ipjvd3mk177flmddcf24r";
+  };
+
+  nativeBuildInputs = [ autoconf perl ];
+  buildInputs = [ autoconf ];
+
+  setupHook = ./setup-hook.sh;
+
+  # Disable indented log output from Make, otherwise "make.test" will
+  # fail.
+  preCheck = "unset NIX_INDENT_MAKE";
+  doCheck = false; # takes _a lot_ of time, fails 3 out of 2698 tests, all seem to be related to paths
+  doInstallCheck = false; # runs the same thing, fails the same tests
+
+  # The test suite can run in parallel.
+  enableParallelBuilding = true;
+
+  # Don't fixup "#! /bin/sh" in Libtool, otherwise it will use the
+  # "fixed" path in generated files!
+  dontPatchShebangs = true;
+
+  meta = {
+    branch = "1.15";
+    homepage = https://www.gnu.org/software/automake/;
+    description = "GNU standard-compliant makefile generator";
+    license = stdenv.lib.licenses.gpl2Plus;
+
+    longDescription = ''
+      GNU Automake is a tool for automatically generating
+      `Makefile.in' files compliant with the GNU Coding
+      Standards.  Automake requires the use of Autoconf.
+    '';
+
+    platforms = stdenv.lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8021,6 +8021,8 @@ with pkgs;
 
   automake111x = callPackage ../development/tools/misc/automake/automake-1.11.x.nix { };
 
+  automake115x = callPackage ../development/tools/misc/automake/automake-1.15.x.nix { };
+
   automake116x = callPackage ../development/tools/misc/automake/automake-1.16.x.nix { };
 
   automoc4 = callPackage ../development/tools/misc/automoc4 { };


### PR DESCRIPTION
Re-include an older automake (1.15) because that's explicitly depended upon.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
