### PR TITLE
WIP linuxPackages.sysdig: 0.24.2 -> 0.25

### DIFF
--- a/pkgs/os-specific/linux/sysdig/default.nix
+++ b/pkgs/os-specific/linux/sysdig/default.nix
@@ -1,22 +1,22 @@
 { stdenv, fetchFromGitHub, cmake, kernel
-, luajit, zlib, ncurses, perl, jsoncpp, libb64, openssl, curl, jq, gcc, elfutils, tbb
+, luajit, zlib, ncurses, perl, jsoncpp, libb64, openssl, curl, jq, gcc, elfutils, tbb, c-ares, protobuf, grpc
 }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "sysdig-${version}";
-  version = "0.24.2";
+  version = "0.25";
 
   src = fetchFromGitHub {
     owner = "draios";
     repo = "sysdig";
     rev = version;
-    sha256 = "16gz6gcp0zfhrqldw9cms38w0x5h3qhlx64dayqgsqbkw914b31a";
+    sha256 = "1591jz4fmgk5r3q410h771nzhv6wfqpnr7pn34kpc5rl0vhky37m";
   };
 
   nativeBuildInputs = [ cmake perl ];
   buildInputs = [
-    zlib luajit ncurses jsoncpp libb64 openssl curl jq gcc elfutils tbb
+    zlib luajit ncurses jsoncpp libb64 openssl curl jq gcc elfutils tbb c-ares protobuf grpc
   ] ++ optional (kernel != null) kernel.moduleBuildDependencies;
 
   hardeningDisable = [ "pic" ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
A new version of sysdig has been released: https://github.com/draios/sysdig/releases/tag/0.25

The current version is not compatible with Linux 5.0.

###### Things done

I have not managed to get this to build yet, any assistance appreciated. Since a few new features was added with gRPC support etc. I had to add a few new dependencies, but I get the output such as this when building:

```
/nix/store/0y7jmqnj48ikjh37n3dl9kqw9hnn68nq-binutils-2.31.1/bin/ld: (.text+0x1ad): undefined reference to `gpr_free'
/nix/store/0y7jmqnj48ikjh37n3dl9kqw9hnn68nq-binutils-2.31.1/bin/ld: /nix/store/83xh6xap4l4x5xqynwb7fbkf1bf2xcqa-grpc-1.18.0/lib/libgrpc_unsecure.a(client_load_reporting_filter.cc.o): in function `destroy_call_elem(grpc_call_element*, grpc_call_final_info const*, grpc_closure*)':
(.text+0x265): undefined reference to `gpr_free'
/nix/store/0y7jmqnj48ikjh37n3dl9kqw9hnn68nq-binutils-2.31.1/bin/ld: /nix/store/83xh6xap4l4x5xqynwb7fbkf1bf2xcqa-grpc-1.18.0/lib/libgrpc_unsecure.a(xds_client_stats.cc.o): in function `grpc_core::XdsLbClientStats::AddCallDroppedLocked(char*)':
(.text+0xc4): undefined reference to `gpr_strdup'
/nix/store/0y7jmqnj48ikjh37n3dl9kqw9hnn68nq-binutils-2.31.1/bin/ld: (.text+0x146): undefined reference to `gpr_malloc'
/nix/store/0y7jmqnj48ikjh37n3dl9kqw9hnn68nq-binutils-2.31.1/bin/ld: (.text+0x1aa): undefined reference to `gpr_free'
/nix/store/0y7jmqnj48ikjh37n3dl9kqw9hnn68nq-binutils-2.31.1/bin/ld: (.text+0x1bc): undefined reference to `gpr_free'
/nix/store/0y7jmqnj48ikjh37n3dl9kqw9hnn68nq-binutils-2.31.1/bin/ld: (.text+0x1f1): undefined reference to `gpr_malloc'
/nix/store/0y7jmqnj48ikjh37n3dl9kqw9hnn68nq-binutils-2.31.1/bin/ld: (.text+0x25d): undefined reference to `gpr_free'
/nix/store/0y7jmqnj48ikjh37n3dl9kqw9hnn68nq-binutils-2.31.1/bin/ld: (.text+0x279): undefined reference to `gpr_free'
/nix/store/0y7jmqnj48ikjh37n3dl9kqw9hnn68nq-binutils-2.31.1/bin/ld: (.text+0x281): undefined reference to `gpr_free'
/nix/store/0y7jmqnj48ikjh37n3dl9kqw9hnn68nq-binutils-2.31.1/bin/ld: (.text+0x2ad): undefined reference to `gpr_free'
/nix/store/0y7jmqnj48ikjh37n3dl9kqw9hnn68nq-binutils-2.31.1/bin/ld: /nix/store/83xh6xap4l4x5xqynwb7fbkf1bf2xcqa-grpc-1.18.0/lib/libgrpc_unsecure.a(xds_client_stats.cc.o): in function `grpc_core::XdsLbClientStats::GetLocked(long*, long*, long*, long*, std::unique_ptr<grpc_core::InlinedVector<grpc_core::XdsLbClientStats::DropTokenCount, 10ul>, grpc_core::DefaultDelete<grpc_core::InlinedVector<grpc_core::XdsLbClientStats::DropTokenCount, 10ul> > >*)':
(.text+0x352): undefined reference to `gpr_free'
/nix/store/0y7jmqnj48ikjh37n3dl9kqw9hnn68nq-binutils-2.31.1/bin/ld: /nix/store/83xh6xap4l4x5xqynwb7fbkf1bf2xcqa-grpc-1.18.0/lib/libgrpc_unsecure.a(xds_client_stats.cc.o):(.text+0x36e): more undefined references to `gpr_free' follow
collect2: error: ld returned 1 exit status
make[2]: *** [userspace/sysdig/CMakeFiles/csysdig.dir/build.make:116: userspace/sysdig/csysdig] Error 1
make[1]: *** [CMakeFiles/Makefile2:255: userspace/sysdig/CMakeFiles/csysdig.dir/all] Error 2
make: *** [Makefile:152: all] Error 2
builder for '/nix/store/67900awb9g3vk92vj7np4f2wfkl4sxk8-sysdig-0.25.drv' failed with exit code 2
```

I cannot fully remember, but I guess I have to do some special thing to get the libraries from grpc package linked. Or perhaps even patch the references. Feel free to close this if you take this on and know what to do.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
