### PR TITLE
vdirsyncerStable: init at 0.16.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2733,6 +2733,11 @@
     github = "lo1tuma";
     name = "Mathias Schreck";
   };
+  loewenheim = {
+    email = "loewenheim@mailbox.org";
+    github = "loewenheim";
+    name = "Sebastian Zivota";
+  };
   lopsided98 = {
     email = "benwolsieffer@gmail.com";
     github = "lopsided98";

--- a/pkgs/tools/misc/vdirsyncer/stable.nix
+++ b/pkgs/tools/misc/vdirsyncer/stable.nix
@@ -1,0 +1,52 @@
+{ lib, python3Packages, fetchpatch }:
+
+# Packaging documentation at:
+# https://github.com/pimutils/vdirsyncer/blob/0.16.7/docs/packaging.rst
+python3Packages.buildPythonApplication rec {
+  version = "0.16.7";
+  pname = "vdirsyncer";
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "6c9bcfb9bcb01246c83ba6f8551cf54c58af3323210755485fc23bb7848512ef";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    click click-log click-threading
+    requests_toolbelt
+    requests
+    requests_oauthlib # required for google oauth sync
+    atomicwrites
+  ];
+
+  nativeBuildInputs = with python3Packages; [ setuptools_scm ];
+
+  checkInputs = with python3Packages; [ hypothesis pytest pytest-localserver pytest-subtesthack ];
+
+  patches = [
+    # Fixes for hypothesis: https://github.com/pimutils/vdirsyncer/pull/779
+    (fetchpatch {
+      url = https://github.com/pimutils/vdirsyncer/commit/22ad88a6b18b0979c5d1f1d610c1d2f8f87f4b89.patch;
+      sha256 = "0dbzj6jlxhdidnm3i21a758z83sdiwzhpd45pbkhycfhgmqmhjpl";
+    })
+  ];
+
+  postPatch = ''
+    # Invalid argument: 'perform_health_check' is not a valid setting
+    substituteInPlace tests/conftest.py \
+      --replace "perform_health_check=False" ""
+    substituteInPlace tests/unit/test_repair.py \
+      --replace $'@settings(perform_health_check=False)  # Using the random module for UIDs\n' ""
+  '';
+
+  checkPhase = ''
+    make DETERMINISTIC_TESTS=true test
+  '';
+
+  meta = with lib; {
+    homepage = https://github.com/pimutils/vdirsyncer;
+    description = "Synchronize calendars and contacts";
+    license = licenses.mit;
+    maintainers = with maintainers; [ loewenheim ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20070,6 +20070,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  vdirsyncerStable = callPackage ../tools/misc/vdirsyncer/stable.nix { };
+
   vdpauinfo = callPackage ../tools/X11/vdpauinfo { };
 
   verbiste = callPackage ../applications/misc/verbiste {


### PR DESCRIPTION
###### Motivation for this change
Adds a package for the latest stable release of `vdirsyncer`.
fixes #58563

###### Things done
- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
