### PR TITLE
leela-zero: 0.16 -> 0.17

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3519,6 +3519,11 @@
     github = "olynch";
     name = "Owen Lynch";
   };
+  omnipotententity = {
+    email = "omnipotententity@gmail.com";
+    github = "omnipotententity";
+    name = "Michael Reilly";
+  };
   OPNA2608 = {
     email = "christoph.neidahl@gmail.com";
     github = "OPNA2608";

--- a/pkgs/games/leela-zero/default.nix
+++ b/pkgs/games/leela-zero/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "leela-zero-${version}";
-  version = "0.16";
+  version = "0.17";
 
   src = fetchFromGitHub {
     owner = "gcp";
     repo = "leela-zero";
     rev = "v${version}";
-    sha256 = "1px7wqvlv414gklzgrmppp8wzc2mkskinm1p75j4snbqr8qpbn5s";
+    sha256 = "1k04ld1ysabxb8ivci3ji5by9vb3yvnflkf2fscs1x0bp7d6j101";
     fetchSubmodules = true;
   };
 
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     description = "Go engine modeled after AlphaGo Zero";
     homepage    = https://github.com/gcp/leela-zero;
     license     = licenses.gpl3;
-    maintainers = [ maintainers.averelld ];
+    maintainers = [ maintainers.averelld maintainers.omnipotententity ];
     platforms   = platforms.linux;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Updating the already existing package to the newest tagged version, v0.17

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
