### PR TITLE
Backport souffle: 1.2.0 -> 1.5.1

### DIFF
--- a/pkgs/development/compilers/souffle/default.nix
+++ b/pkgs/development/compilers/souffle/default.nix
@@ -1,40 +1,53 @@
 { stdenv, fetchFromGitHub
-, boost, bison, flex, openjdk, doxygen
-, perl, graphviz, ncurses, zlib, sqlite
-, autoreconfHook }:
+, perl, ncurses, zlib, sqlite, libffi
+, autoreconfHook, mcpp, bison, flex, doxygen, graphviz
+, makeWrapper
+}:
 
+
+let
+  toolsPath = stdenv.lib.makeBinPath [ mcpp ];
+in
 stdenv.mkDerivation rec {
-  version = "1.2.0";
   name    = "souffle-${version}";
+  version = "1.5.1";
 
   src = fetchFromGitHub {
     owner  = "souffle-lang";
     repo   = "souffle";
     rev    = version;
-    sha256 = "1g8yvm40h102mab8lacpl1cwgqsw1js0s1yn4l84l9fjdvlh2ygd";
+    sha256 = "06sa250z3v8hs91p6cqdzlwwaq96j6zmfrrld1fzd1b620aa5iys";
   };
 
-  nativeBuildInputs = [ autoreconfHook bison flex ];
+  nativeBuildInputs = [ autoreconfHook bison flex mcpp doxygen graphviz makeWrapper perl ];
+  buildInputs = [ ncurses zlib sqlite libffi ];
 
-  buildInputs = [
-    boost openjdk ncurses zlib sqlite doxygen perl graphviz
-  ];
+  # these propagated inputs are needed for the compiled Souffle mode to work,
+  # since generated compiler code uses them. TODO: maybe write a g++ wrapper
+  # that adds these so we can keep the propagated inputs clean?
+  propagatedBuildInputs = [ ncurses zlib sqlite libffi ];
 
+  # see 565a8e73e80a1bedbb6cc037209c39d631fc393f and parent commits upstream for
+  # Wno-error fixes
   patchPhase = ''
+    substituteInPlace ./src/Makefile.am \
+      --replace '-Werror' '-Werror -Wno-error=deprecated -Wno-error=other'
+
     substituteInPlace configure.ac \
-      --replace "m4_esyscmd([git describe --tags --abbrev=0 --always | tr -d '\n'])" "${version}"
+      --replace "m4_esyscmd([git describe --tags --always | tr -d '\n'])" "${version}"
   '';
 
-  # Without this, we get an obscure error about not being able to find a library version
-  # without saying what library it's looking for. Turns out it's searching global paths
-  # for boost and failing there, so we tell it what's what here.
-  configureFlags = [ "--with-boost-libdir=${boost}/lib" ];
+  postInstall = ''
+    wrapProgram "$out/bin/souffle" --prefix PATH : "${toolsPath}"
+  '';
+
+  outputs = [ "out" ];
 
   meta = with stdenv.lib; {
     description = "A translator of declarative Datalog programs into the C++ language";
     homepage    = "http://souffle-lang.github.io/";
     platforms   = platforms.unix;
-    maintainers = with maintainers; [ copumpkin wchresta ];
+    maintainers = with maintainers; [ thoughtpolice copumpkin wchresta ];
     license     = licenses.upl;
   };
 }


### PR DESCRIPTION
Souffle has seen some significant upgrades in the past few years and now
has trimmed and replaced several of its more expensive dependencies,
such as boost, openjdk, etc.

Signed-off-by: Austin Seipp <aseipp@pobox.com>
(cherry picked from commit 4f74e3abcff3120b141420f264866bbbc12a2b45)

Backporting this as it was broken in 19.03.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
