### PR TITLE
Chili sddm theme

### DIFF
--- a/pkgs/data/themes/chili/chili.nix
+++ b/pkgs/data/themes/chili/chili.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, qtbase, qtquickcontrols, qtgraphicaleffects }:
+
+stdenv.mkDerivation rec {
+  pname = "chili";
+  version = "0.1.5";
+  
+  src = fetchFromGitHub {
+    owner = "MarianArlt";
+    repo = "sddm-chili";
+    rev = version;
+    sha256 = "036fxsa7m8ymmp3p40z671z163y6fcsa9a641lrxdrw225ssq5f3";
+  };
+
+  buildInputs = [ qtbase qtquickcontrols qtgraphicaleffects ];
+
+  installPhase = ''
+    mkdir -p $out/share/sddm/themes/chili
+    mv * $out/share/sddm/themes/chili/
+  '';
+
+  meta = with stdenv.lib; {
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ mschneider ];
+    homepage = https://github.com/MarianArlt/sddm-chili;
+    description = "The chili login theme for SDDM";
+    longDescription = ''
+      Chili is hot, just like a real chili! Spice up the login experience for your users, your family and yourself. Chili reduces all the clutter and leaves you with a clean, easy to use, login interface with a modern yet classy touch.
+    '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17207,6 +17207,8 @@ in
 
   camingo-code = callPackage ../data/fonts/camingo-code { };
 
+  chili-theme = libsForQt5.callPackage ../data/themes/chili/chili.nix {};
+
   combinatorial_designs = callPackage ../data/misc/combinatorial_designs { };
 
   conway_polynomials = callPackage ../data/misc/conway_polynomials { };


### PR DESCRIPTION
###### Motivation for this change
Added the chili login theme for SDDM: https://github.com/MarianArlt/sddm-chili

> Chili is hot, just like a real chili! Spice up the login experience for your users, your family and yourself. Chili reduces all the clutter and leaves you with a clean, easy to use, login interface with a modern yet classy touch.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
