### PR TITLE
podman: 1.1.2 -> 1.2.0

### DIFF
--- a/pkgs/applications/virtualization/podman/conmon.nix
+++ b/pkgs/applications/virtualization/podman/conmon.nix
@@ -4,13 +4,13 @@ with lib;
 
 stdenv.mkDerivation rec {
   name = "conmon-${version}";
-  version = "unstable-2019-02-15";
-  rev = "cc2b49590a485da9bd358440f92f219dfd6b230f";
+  version = "unstable-2019-03-19";
+  rev = "84c860029893e2e2dd71d62231f009c9dcd3c0b4";
 
   src = fetchFromGitHub {
     owner = "containers";
     repo = "conmon";
-    sha256 = "13f5as4a9y6nkmr7cg0n27c2hfx9pkr75fxq2m0hlpcwhaardbm7";
+    sha256 = "1ydidl3s7s5rfwk9gx0k80nxcixlilxw61g7x0vqsdy3mkylysv5";
     inherit rev;
   };
 

--- a/pkgs/applications/virtualization/podman/default.nix
+++ b/pkgs/applications/virtualization/podman/default.nix
@@ -5,13 +5,13 @@
 
 buildGoPackage rec {
   name = "podman-${version}";
-  version = "1.1.2";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "containers";
     repo = "libpod";
     rev = "v${version}";
-    sha256 = "180sv1a7k3866ilb0mxbhiysms9xy4v6xbpy4in6ch8m8qym9amh";
+    sha256 = "1nlll4q62w3i897wraj18pdi5cc91b8gmp360pzyqzzjdm9ag7v6";
   };
 
   goPackagePath = "github.com/containers/libpod";


### PR DESCRIPTION
###### Motivation for this change

Bump podman to latest version :angel: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
