### PR TITLE
gomobile: init at 20190319-167ebed

### DIFF
--- a/outpaths.nix
+++ b/outpaths.nix
@@ -1,0 +1,60 @@
+#!/usr/bin/env nix-shell
+# When using as a callable script, passing `--argstr path some/path` overrides $PWD.
+#!nix-shell -p nix -i "nix-env -qaP --no-name --out-path --arg checkMeta true --argstr path $PWD -f"
+{ checkMeta
+, path ? ./.
+}:
+let
+  lib = import (path + "/lib");
+  hydraJobs = import (path + "/pkgs/top-level/release.nix")
+    # Compromise: accuracy vs. resources needed for evaluation.
+    {
+      supportedSystems = [
+        "aarch64-linux"
+        "i686-linux"
+        "x86_64-linux"
+        "x86_64-darwin"
+      ];
+
+      nixpkgsArgs = {
+        config = {
+          allowBroken = true;
+          allowUnfree = true;
+          allowInsecurePredicate = x: true;
+          checkMeta = checkMeta;
+
+          handleEvalIssue = reason: errormsg:
+            let
+              fatalErrors = [
+                "unknown-meta" "broken-outputs"
+              ];
+            in if builtins.elem reason fatalErrors
+              then abort errormsg
+              else true;
+
+          inHydra = true;
+        };
+      };
+    };
+  recurseIntoAttrs = attrs: attrs // { recurseForDerivations = true; };
+
+  # hydraJobs leaves recurseForDerivations as empty attrmaps;
+  # that would break nix-env and we also need to recurse everywhere.
+  tweak = lib.mapAttrs
+    (name: val:
+      if name == "recurseForDerivations" then true
+      else if lib.isAttrs val && val.type or null != "derivation"
+              then recurseIntoAttrs (tweak val)
+      else val
+    );
+
+  # Some of these contain explicit references to platform(s) we want to avoid;
+  # some even (transitively) depend on ~/.nixpkgs/config.nix (!)
+  blacklist = [
+    "tarball" "metrics" "manual"
+    "darwin-tested" "unstable" "stdenvBootstrapTools"
+    "moduleSystem" "lib-tests" # these just confuse the output
+  ];
+
+in
+  tweak (builtins.removeAttrs hydraJobs blacklist)

--- a/pkgs/development/tools/gomobile/default.nix
+++ b/pkgs/development/tools/gomobile/default.nix
@@ -1,0 +1,81 @@
+{ stdenv, callPackage, fetchgit,
+  buildGoPackage, glibc, ncurses5, zlib, makeWrapper, patchelf,
+  platform-tools, xcodeWrapper
+}:
+
+let
+  inherit (stdenv) isDarwin;
+  inherit (stdenv.lib) optional optionalString strings;
+
+in buildGoPackage rec {
+  pname = "gomobile";
+  version = "20190719-${strings.substring 0 7 rev}";
+  rev = "d2bd2a29d028cb94031e5e81788b19b371d00eb8";
+  sha256 = "1nv6vvhnjr01nx9y06q46ww87dppdwpbqrlsfg1xf2587wxl8xiv";
+
+  goPackagePath = "golang.org/x/mobile";
+  subPackages = [ "bind" "cmd/gobind" "cmd/gomobile" ];
+
+  buildInputs = [ makeWrapper ]
+    ++ optional isDarwin xcodeWrapper;
+
+  patches = [ ./resolve-nix-android-sdk.patch ];
+
+  postPatch = ''
+    substituteInPlace cmd/gomobile/install.go --replace "\`adb\`" "\`${platform-tools}/bin/adb\`"
+    
+    # Prevent a non-deterministic temporary directory from polluting the resulting object files
+    substituteInPlace cmd/gomobile/env.go \
+      --replace \
+        'tmpdir, err = ioutil.TempDir("", "gomobile-work-")' \
+        "tmpdir = filepath.Join(os.Getenv(\"NIX_BUILD_TOP\"), \"gomobile-work\")" \
+      --replace '"io/ioutil"' ""
+    substituteInPlace cmd/gomobile/init.go \
+      --replace \
+        'tmpdir, err = ioutil.TempDir(gomobilepath, "work-")' \
+        "tmpdir = filepath.Join(os.Getenv(\"NIX_BUILD_TOP\"), \"work\")"
+
+    echo "Creating $dev"
+    mkdir -p $dev/src/$goPackagePath
+    echo "Copying from $src"
+    cp -a $src/. $dev/src/$goPackagePath
+  '';
+
+  preBuild = ''
+    mkdir $NIX_BUILD_TOP/gomobile-work $NIX_BUILD_TOP/work
+  '';
+
+  postInstall =
+    let
+      inherit (stdenv.lib) makeBinPath makeLibraryPath;
+    in ''
+    mkdir -p $out $bin/lib
+
+    ln -s ${ncurses5}/lib/libncursesw.so.5 $bin/lib/libtinfo.so.5
+    ${if isDarwin then ''
+    wrapProgram $bin/bin/gomobile \
+      --prefix "PATH" : "${makeBinPath [ xcodeWrapper ]}" \
+      --prefix "LD_LIBRARY_PATH" : "${makeLibraryPath [ ncurses5 zlib ]}:$bin/lib"
+  '' else ''
+    wrapProgram $bin/bin/gomobile \
+      --prefix "LD_LIBRARY_PATH" : "${makeLibraryPath [ ncurses5 zlib ]}:$bin/lib"
+  ''}
+    $bin/bin/gomobile init
+  '';
+
+  src = fetchgit {
+    inherit rev sha256;
+    url = "https://go.googlesource.com/mobile";
+  };
+
+  outputs = [ "bin" "dev" "out" ];
+
+  meta = with stdenv.lib; {
+    description = "A tool for building and running mobile apps written in Go.";
+    longDescription = "Gomobile is a tool for building and running mobile apps written in Go.";
+    homepage = https://go.googlesource.com/mobile;
+    license = licenses.bsdOriginal;
+    maintainers = with maintainers; [ sheenobu pombeirp ];
+    platforms = with platforms; linux ++ darwin;
+  };
+}

--- a/pkgs/development/tools/gomobile/ignore-nullability-error-on-ios.patch
+++ b/pkgs/development/tools/gomobile/ignore-nullability-error-on-ios.patch
@@ -1,0 +1,12 @@
+diff --git a/cmd/gomobile/env.go b/cmd/gomobile/env.go
+index dbf9c8c..538cf35 100644
+--- a/cmd/gomobile/env.go
++++ b/cmd/gomobile/env.go
+@@ -138,6 +138,7 @@ func envInit() (err error) {
+ 			panic(fmt.Errorf("unknown GOARCH: %q", arch))
+ 		}
+ 		cflags += " -fembed-bitcode"
++		cflags += " -Wno-nullability-completeness"
+ 		if err != nil {
+ 			return err
+ 		}

--- a/pkgs/development/tools/gomobile/ndk-search-path.patch
+++ b/pkgs/development/tools/gomobile/ndk-search-path.patch
@@ -1,0 +1,20 @@
+diff --git a/cmd/gomobile/env.go b/cmd/gomobile/env.go
+index dbf9c8c..a1c835a 100644
+--- a/cmd/gomobile/env.go
++++ b/cmd/gomobile/env.go
+@@ -165,10 +165,13 @@ func ndkRoot() (string, error) {
+ 	if androidHome == "" {
+ 		return "", errors.New("The Android SDK was not found. Please set ANDROID_HOME to the root of the Android SDK.")
+ 	}
+-	ndkRoot := filepath.Join(androidHome, "ndk-bundle")
++	ndkRoot := os.Getenv("ANDROID_NDK_HOME")
++	if ndkRoot == "" {
++		ndkRoot = filepath.Join(androidHome, "ndk-bundle")
++	}
+ 	_, err := os.Stat(ndkRoot)
+ 	if err != nil {
+-		return "", fmt.Errorf("The NDK was not found in $ANDROID_HOME/ndk-bundle (%q). Install the NDK with `sdkmanager 'ndk-bundle'`", ndkRoot)
++		return "", fmt.Errorf("The NDK was not found in $ANDROID_HOME/ndk-bundle (%q) nor in ANDROID_NDK_HOME. Install the NDK with `sdkmanager 'ndk-bundle'`", ndkRoot)
+ 	}
+ 	return ndkRoot, nil
+ }

--- a/pkgs/development/tools/gomobile/resolve-nix-android-sdk.patch
+++ b/pkgs/development/tools/gomobile/resolve-nix-android-sdk.patch
@@ -1,0 +1,15 @@
+diff --git a/cmd/gomobile/bind_androidapp.go b/cmd/gomobile/bind_androidapp.go
+index 3b01adc..76216fa 100644
+--- a/cmd/gomobile/bind_androidapp.go
++++ b/cmd/gomobile/bind_androidapp.go
+@@ -372,6 +372,10 @@ func androidAPIPath() (string, error) {
+ 	var apiVer int
+ 	for _, fi := range fis {
+ 		name := fi.Name()
++		// Resolve symlinked directories (this is how the Nix Android SDK package is built)
++		if fi2, err := os.Stat(filepath.Join(sdkDir.Name(), name)); err == nil {
++			fi = fi2
++		}
+ 		if !fi.IsDir() || !strings.HasPrefix(name, "android-") {
+ 			continue
+ 		}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16707,6 +16707,8 @@ in
     buildGoModule = buildGo112Module;
   };
 
+  gomobile = callPackage ../development/tools/gomobile { xcodeWrapper = xcodeenv.composeXcodeWrapper; inherit (androidenv.androidPkgs_9_0) platform-tools; };
+
   impl = callPackage ../development/tools/impl { };
 
   quicktemplate = callPackage ../development/tools/quicktemplate { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add the gomobile tool which allows targetting mobile devices with Go.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
