### PR TITLE
haskell: add fpcomplete mirror, use hackage mirrors in more places

### DIFF
--- a/pkgs/applications/editors/emacs-modes/hsc3/default.nix
+++ b/pkgs/applications/editors/emacs-modes/hsc3/default.nix
@@ -8,9 +8,9 @@ let version = "0.15";
 in stdenv.mkDerivation {
   name = "hsc3-mode-${version}";
   src = fetchurl {
-    url = http://hackage.haskell.org/package/hsc3-0.15/hsc3-0.15.tar.gz;
+    url = mirror://hackage/hsc3-0.15/hsc3-0.15.tar.gz;
     sha256 = "2f3b15655419cf8ebe25ab1c6ec22993b2589b4ffca7c3a75ce478ca78a0bde6";
-  }; 
+  };
 
   buildInputs = [ emacs ];
 

--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -308,6 +308,8 @@ rec {
   hackage = [
     http://hackage.haskell.org/package/
     http://hdiff.luite.com/packages/archive/package/
+    http://hackage.fpcomplete.com/package/
+    http://objects-us-east-1.dream.io/hackage-mirror/package/
   ];
 
   # Roy marples mirrors

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -118,7 +118,7 @@ let
 
   binDir = if enableSeparateBinOutput then "$bin/bin" else "$out/bin";
 
-  newCabalFileUrl = "http://hackage.haskell.org/package/${pname}-${version}/revision/${revision}.cabal";
+  newCabalFileUrl = "mirror://hackage/${pname}-${version}/revision/${revision}.cabal";
   newCabalFile = fetchurl {
     url = newCabalFileUrl;
     sha256 = editedCabalFile;

--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -183,7 +183,7 @@ in package-set { inherit pkgs stdenv callPackage; } self // {
     callHackageDirect = {pkg, ver, sha256}@args:
       let pkgver = "${pkg}-${ver}";
       in self.callCabal2nix pkg (pkgs.fetchzip {
-           url = "http://hackage.haskell.org/package/${pkgver}/${pkgver}.tar.gz";
+           url = "mirror://hackage/${pkgver}/${pkgver}.tar.gz";
            inherit sha256;
          });
 


### PR DESCRIPTION
Fixes #58971

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
