### PR TITLE
deepin.dde-network-utils: init at 0.1.2

### DIFF
--- a/pkgs/desktops/deepin/dde-network-utils/default.nix
+++ b/pkgs/desktops/deepin/dde-network-utils/default.nix
@@ -1,0 +1,54 @@
+{ stdenv, fetchFromGitHub, substituteAll, qmake, pkgconfig, qttools,
+  dde-qt-dbus-factory, proxychains, which, deepin }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "dde-network-utils";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "1m6njld06yphppyyhygz8mv4gvq2zw0676pbls9m3fs7b3dl56sv";
+  };
+
+  nativeBuildInputs = [
+    qmake
+    pkgconfig
+    qttools
+    deepin.setupHook
+  ];
+
+  buildInputs = [
+    dde-qt-dbus-factory
+    proxychains
+    which
+  ];
+
+  patches = [
+    (substituteAll {
+      src = ./fix-paths.patch;
+      inherit which proxychains;
+    })
+  ];
+
+  postPatch = ''
+    searchHardCodedPaths  # for debugging
+    patchShebangs translate_generation.sh
+  '';
+
+  postFixup = ''
+    searchHardCodedPaths $out  # for debugging
+  '';
+
+  passthru.updateScript = deepin.updateScript { inherit name; };
+
+  meta = with stdenv.lib; {
+    description = "Deepin network utils";
+    homepage = https://github.com/linuxdeepin/dde-network-utils;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/desktops/deepin/dde-network-utils/fix-paths.patch
+++ b/pkgs/desktops/deepin/dde-network-utils/fix-paths.patch
@@ -1,0 +1,23 @@
+diff -ur dde-network-utils-master.orig/dde-network-utils.pro dde-network-utils-master/dde-network-utils.pro
+--- dde-network-utils-master.orig/dde-network-utils.pro	2019-04-04 03:37:46.000000000 -0300
++++ dde-network-utils-master/dde-network-utils.pro	2019-04-07 05:56:28.283195087 -0300
+@@ -52,6 +52,7 @@
+ 
+ QMAKE_PKGCONFIG_NAME = libddenetworkutils
+ QMAKE_PKGCONFIG_DESCRIPTION = libddenetworkutils
++QMAKE_PKGCONFIG_PREFIX = $$PREFIX
+ QMAKE_PKGCONFIG_INCDIR = $$includes.path
+ QMAKE_PKGCONFIG_LIBDIR = $$target.path
+ QMAKE_PKGCONFIG_DESTDIR = pkgconfig
+diff -ur dde-network-utils-master.orig/networkworker.cpp dde-network-utils-master/networkworker.cpp
+--- dde-network-utils-master.orig/networkworker.cpp	2019-04-04 03:37:46.000000000 -0300
++++ dde-network-utils-master/networkworker.cpp	2019-04-07 05:54:28.656479216 -0300
+@@ -80,7 +80,7 @@
+         }
+     }
+ 
+-    const bool isAppProxyVaild = QProcess::execute("which", QStringList() << "/usr/bin/proxychains4") == 0;
++    const bool isAppProxyVaild = QProcess::execute("@which@/bin/which", QStringList() << "@proxychains@/bin/proxychains4") == 0;
+     m_networkModel->onAppProxyExistChanged(isAppProxyVaild);
+ }
+ 

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -17,6 +17,7 @@ let
       go = go_1_11;
     };
     dde-polkit-agent = callPackage ./dde-polkit-agent { };
+    dde-network-utils = callPackage ./dde-network-utils { };
     dde-qt-dbus-factory = callPackage ./dde-qt-dbus-factory { };
     dde-session-ui = callPackage ./dde-session-ui { };
     deepin-desktop-base = callPackage ./deepin-desktop-base { };
@@ -38,8 +39,8 @@ let
     deepin-wm = callPackage ./deepin-wm { };
     dpa-ext-gnomekeyring = callPackage ./dpa-ext-gnomekeyring { };
     dtkcore = callPackage ./dtkcore { };
-    dtkwm = callPackage ./dtkwm { };
     dtkwidget = callPackage ./dtkwidget { };
+    dtkwm = callPackage ./dtkwm { };
     go-dbus-factory = callPackage ./go-dbus-factory { };
     go-dbus-generator = callPackage ./go-dbus-generator { };
     go-gir-generator = callPackage ./go-gir-generator { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add `dde-network-utils` to nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).