### PR TITLE
fuse3: use /etc/fuse.conf for configuration

### DIFF
--- a/pkgs/os-specific/linux/fuse/fuse3-install.patch
+++ b/pkgs/os-specific/linux/fuse/fuse3-install.patch
@@ -32,3 +32,13 @@
 -fi
 -
 -
+diff --git a/util/meson.build b/util/meson.build
+index aa0e734..06d4378 100644
+--- a/util/meson.build
++++ b/util/meson.build
+@@ -1,4 +1,4 @@
+-fuseconf_path = join_paths(get_option('prefix'), get_option('sysconfdir'), 'fuse.conf')
++fuseconf_path = join_paths('/', get_option('sysconfdir'), 'fuse.conf')
+ 
+ executable('fusermount3', ['fusermount.c', '../lib/mount_util.c'],
+            include_directories: include_dirs,


### PR DESCRIPTION
We don’t want the config file to be read only.

Fixes #59021

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
