### PR TITLE
rund: init at version 1.0.0

### DIFF
--- a/pkgs/development/tools/rund/default.nix
+++ b/pkgs/development/tools/rund/default.nix
@@ -1,0 +1,49 @@
+{stdenv, lib, fetchFromGitHub, ldc ? null, dcompiler ? ldc }:
+
+assert dcompiler != null;
+
+stdenv.mkDerivation rec {
+  pname = "rund";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "dragon-lang";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "10x6f1nn294r5qnpacrpcbp348dndz5fv4nz6ih55c61ckpkvgcf";
+  };
+
+  buildInputs = [ dcompiler ];
+  buildPhase = ''
+    for candidate in dmd ldmd2 gdmd; do
+      echo Checking for DCompiler $candidate ...
+      dc=$(type -P $candidate || echo "")
+      if [ ! "$dc" == "" ]; then
+        break
+      fi
+    done
+    if [ "$dc" == "" ]; then
+      exit "Error: could not find a D compiler"
+    fi
+    echo Using DCompiler $candidate
+    $dc -I=$src/src -i -run $src/make.d build --out $NIX_BUILD_TOP
+  '';
+
+  doCheck = true;
+  checkPhase = ''
+    $NIX_BUILD_TOP/rund make.d test
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv $NIX_BUILD_TOP/rund $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A compiler-wrapper that runs and caches D programs";
+    homepage = https://github.com/dragon-lang/rund;
+    license = lib.licenses.boost;
+    maintainers = with maintainers; [ jonathanmarler ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5943,6 +5943,8 @@ in
 
   runningx = callPackage ../tools/X11/runningx { };
 
+  rund = callPackage ../development/tools/rund { };
+
   runzip = callPackage ../tools/archivers/runzip { };
 
   rw = callPackage ../tools/misc/rw { };


### PR DESCRIPTION
###### Motivation for this change

Adding a D Programming Language Compiler Wrapper tool that runs and caches D programs.

This is an alternative to the existing `rdmd` tool.  It's a rewrite that leverages a new compiler feature that allows it to run the compiler once instead of having to run it twice like `rdmd` does.  This is a big change to how the cache logic works so I decided to fork the tool rather than trying to update `rdmd` to support both the old and new logic in the same tool.

It also introduces new features like "Source Compiler Directives" which allow D Language source files to contain compiler configuration. It addresses the same problem described here:

http://chriswarbo.net/projects/nixos/nix_shell_shebangs.html
> By using /usr/bin/env, we lose the ability to pass arguments to the nix-shell command. To work around this, nix-shell will look at that second line to get its options.

D programs can use this tool by adding the shebang line `#!/usr/bin/env rund` to the top of their main source file allowing them to be executed with `./myprogram.d`.

i.e.
```D
#!/usr/bin/env rund
//!debugSymbols
//     ^ this is an example of a source compiler directive
import std.stdio;void main() { writeln("Hello World!"); }
```

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [N/A] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [N/A] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
