### PR TITLE
pipenv: Ignore Python site-packages

### DIFF
--- a/pkgs/development/tools/pipenv/default.nix
+++ b/pkgs/development/tools/pipenv/default.nix
@@ -24,6 +24,7 @@ buildPythonApplication rec {
 
   makeWrapperArgs = [
     "--set PYTHONPATH \"$PYTHONPATH\""
+    "--set PIP_IGNORE_INSTALLED 1"
   ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
pipenv nix wrapper contains a PYTHONPATH which has some dependencies
for pipenv installed. pipenv by default uses site-packages when
resolving packages, which means that any package that is included in
the nix wrapper is satisfied when running `pipenv install`.

But when the actual virtualenv created by pipenv is activated, it
doesn't contain those packages anymore and fails to import them.

pipenv has a flag PIP_IGNORE_INSTALLED which can be used to ignore
site-packages. Which fixes the problem of having different resolved
packages when running pipenv and when running the virtualenv.

###### Motivation for this change

See issue #59049

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
