### PR TITLE
packr: init at 2.1.0

### DIFF
--- a/pkgs/development/tools/misc/packr/default.nix
+++ b/pkgs/development/tools/misc/packr/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchFromGitHub, buildGoModule }:
+
+let
+  owner = "gobuffalo";
+  pname = "packr";
+  version = "2.1.0";
+in
+buildGoModule rec {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    inherit owner;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0i95hqwc2r7h8f2d9jyriryrlwb4s93mbr84r1a76dg7y1phadll";
+  };
+
+  sourceRoot = "source/v2";
+  modSha256 = "11dpcms3pjcfsy40f1l5hhva3qanc3h4s9wkwmwgp2r79i7f1gyj";
+
+  # Requires a valid GOROOT at runtime, and silently fails without
+  # one.
+  allowGoReference = true;
+
+  modAttrs = {
+    # `go mod download` consistently misses this one
+    postBuild = ''
+      go mod download 'github.com/spf13/pflag@v1.0.3'
+    '';
+  };
+
+  meta = with stdenv.lib; {
+    description = ''
+      The simple and easy way to embed static files into Go binaries.
+    '';
+    platforms = platforms.unix;
+    license = licenses.mit;
+    homepage = https://github.com/gobuffalo/packr;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8433,6 +8433,8 @@ in
 
   mspdebug = callPackage ../development/misc/msp430/mspdebug.nix { };
 
+  packr = callPackage ../development/tools/misc/packr { };
+
   pharo-vms = callPackage ../development/pharo/vm { };
   pharo = pharo-vms.multi-vm-wrapper;
   pharo-cog32 = pharo-vms.cog32;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

New package, and a build dependency for the current version of the Circle CI command line package `circleci-cli`.

This requires some changes to `buildGoModule`, but I don't think what I have here is a very nice expression of that (help wanted).

I also could not make `go mod download` actually download all required modules.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---