### PR TITLE
tox-node: init at 0.0.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4584,6 +4584,11 @@
     github = "stumoss";
     name = "Stuart Moss";
   };
+  suhr = {
+    email = "suhr@i2pmail.org";
+    github = "suhr";
+    name = "Сухарик";
+  };
   SuprDewd = {
     email = "suprdewd@gmail.com";
     github = "SuprDewd";

--- a/pkgs/tools/networking/tox-node/default.nix
+++ b/pkgs/tools/networking/tox-node/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, rustPlatform, fetchFromGitHub
+, libsodium, openssl
+, pkgconfig
+}:
+
+with rustPlatform;
+
+buildRustPackage rec {
+  name = "tox-node-${version}";
+  version = "0.0.7";
+
+  src = fetchFromGitHub {
+    owner = "tox-rs";
+    repo = "tox-node";
+    rev = "v${version}";
+    sha256 = "0p1k4glqm3xasck66fywkyg42lbccad9rc6biyvi24rn76qip4jm";
+  };
+
+  buildInputs = [ libsodium openssl ];
+  nativeBuildInputs = [ pkgconfig ];
+
+  SODIUM_USE_PKG_CONFIG = "yes";
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D target/release/tox-node $out/bin/tox-node
+
+    runHook postInstall
+  '';
+
+  doCheck = false;
+
+  cargoSha256 = "18w1ycvj2q4q8lj81wn5lfljh5wa7b230ahqdz30w20pv1cazsv2";
+
+  meta = with stdenv.lib; {
+    description = "A server application to run tox node written in pure Rust";
+    homepage = https://github.com/tox-rs/tox-node;
+    license = [ licenses.mit ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ suhr ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5967,6 +5967,8 @@ in
 
   torsocks = callPackage ../tools/security/tor/torsocks.nix { };
 
+  tox-node = callPackage ../tools/networking/tox-node { };
+
   toxvpn = callPackage ../tools/networking/toxvpn { };
 
   toybox = callPackage ../tools/misc/toybox { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
