### PR TITLE
ocamlPackages.base64: 2.0.0 -> 3.2.0

### DIFF
--- a/pkgs/development/ocaml-modules/base64/2.0.nix
+++ b/pkgs/development/ocaml-modules/base64/2.0.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchzip, ocaml, findlib, ocamlbuild }:
+
+let version = "2.0.0"; in
+
+stdenv.mkDerivation {
+  name = "ocaml-base64-${version}";
+
+  src = fetchzip {
+    url = "https://github.com/mirage/ocaml-base64/archive/v${version}.tar.gz";
+    sha256 = "1nv55gwq5vaxmrcz9ja2s165b1p9fhcxszc1l76043gpa56qm4fs";
+  };
+
+  buildInputs = [ ocaml findlib ocamlbuild ];
+
+  createFindlibDestdir = true;
+
+  meta = {
+    homepage = https://github.com/mirage/ocaml-base64;
+    platforms = ocaml.meta.platforms or [];
+    description = "Base64 encoding and decoding in OCaml";
+    license = stdenv.lib.licenses.isc;
+    maintainers = with stdenv.lib.maintainers; [ vbgl ];
+  };
+}

--- a/pkgs/development/ocaml-modules/base64/default.nix
+++ b/pkgs/development/ocaml-modules/base64/default.nix
@@ -1,24 +1,26 @@
-{ stdenv, fetchzip, ocaml, findlib, ocamlbuild }:
+{ lib, fetchzip, buildDunePackage, alcotest, bos }:
 
-let version = "2.0.0"; in
+let version = "3.2.0"; in
 
-stdenv.mkDerivation {
-  name = "ocaml-base64-${version}";
+buildDunePackage {
+  pname = "base64";
+  inherit version;
 
   src = fetchzip {
     url = "https://github.com/mirage/ocaml-base64/archive/v${version}.tar.gz";
-    sha256 = "1nv55gwq5vaxmrcz9ja2s165b1p9fhcxszc1l76043gpa56qm4fs";
+    sha256 = "1ilw3zj0w6cq7i4pvr8m2kv5l5f2y9aldmv72drlwwns013b1gwy";
   };
 
-  buildInputs = [ ocaml findlib ocamlbuild ];
+  minimumOCamlVersion = "4.03";
 
-  createFindlibDestdir = true;
+  buildInputs = [ alcotest bos ];
+
+  doCheck = true;
 
   meta = {
     homepage = https://github.com/mirage/ocaml-base64;
-    platforms = ocaml.meta.platforms or [];
     description = "Base64 encoding and decoding in OCaml";
-    license = stdenv.lib.licenses.isc;
-    maintainers = with stdenv.lib.maintainers; [ vbgl ];
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ vbgl ];
   };
 }

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -53,6 +53,8 @@ let
 
     atdgen = callPackage ../development/ocaml-modules/atdgen { };
 
+    base64_2 = callPackage ../development/ocaml-modules/base64/2.0.nix { };
+
     base64 = callPackage ../development/ocaml-modules/base64 { };
 
     bap = callPackage ../development/ocaml-modules/bap {
@@ -144,12 +146,15 @@ let
     cmdliner = callPackage ../development/ocaml-modules/cmdliner { };
 
     cohttp_p4 = callPackage ../development/ocaml-modules/cohttp/0.19.3.nix {
+      base64 = base64_2;
       lwt = lwt2;
     };
 
     cohttp =
       if lib.versionOlder "4.03" ocaml.version
-      then callPackage ../development/ocaml-modules/cohttp { }
+      then callPackage ../development/ocaml-modules/cohttp {
+        base64 = base64_2;
+      }
       else cohttp_p4;
 
     cohttp-lwt = callPackage ../development/ocaml-modules/cohttp/lwt.nix { };
@@ -337,7 +342,10 @@ let
     then callPackage ../development/tools/ocaml/js_of_ocaml/3.0.nix { }
     else js_of_ocaml_2;
 
-    js_of_ocaml_2 = callPackage ../development/tools/ocaml/js_of_ocaml { lwt = lwt2; };
+    js_of_ocaml_2 = callPackage ../development/tools/ocaml/js_of_ocaml {
+      base64 = base64_2;
+      lwt = lwt2;
+    };
 
     js_of_ocaml-camlp4 = callPackage ../development/tools/ocaml/js_of_ocaml/camlp4.nix {};
 
@@ -574,7 +582,10 @@ let
 
     ounit = callPackage ../development/ocaml-modules/ounit { };
 
-    piqi = callPackage ../development/ocaml-modules/piqi { };
+    piqi = callPackage ../development/ocaml-modules/piqi {
+      base64 = base64_2;
+    };
+
     piqi-ocaml = callPackage ../development/ocaml-modules/piqi-ocaml { };
 
     ppxfind = callPackage ../development/ocaml-modules/ppxfind { };


### PR DESCRIPTION
###### Motivation for this change

Needed to update `pyre`. See #58618.

Since the API changes a lot between versions 2 and 3, the legacy version 2 is kept around.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
