### PR TITLE
pinentry: fix libassuan and libgpg-error detection in cross builds

### DIFF
--- a/pkgs/tools/security/pinentry/default.nix
+++ b/pkgs/tools/security/pinentry/default.nix
@@ -11,6 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0w35ypl960pczg5kp6km3dyr000m1hf0vpwwlh72jjkjza36c1v8";
   };
 
+  nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ libgpgerror libassuan libcap libsecret gtk2 gcr ncurses qt ];
 
   prePatch = ''
@@ -33,9 +34,10 @@ stdenv.mkDerivation rec {
     (stdenv.lib.enableFeature (gtk2 != null)      "pinentry-gtk2")
     (stdenv.lib.enableFeature (gcr != null)       "pinentry-gnome3")
     (stdenv.lib.enableFeature (qt != null)        "pinentry-qt")
-  ];
 
-  nativeBuildInputs = [ pkgconfig ];
+    "--with-libassuan-prefix=${libassuan.dev}"
+    "--with-libgpg-error-prefix=${libgpgerror.dev}"
+  ];
 
   meta = with stdenv.lib; {
     homepage = http://gnupg.org/aegypten2/;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
