### PR TITLE
libnotify: 0.7.7 -> 0.7.8

### DIFF
--- a/pkgs/development/libraries/libnotify/default.nix
+++ b/pkgs/development/libraries/libnotify/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, meson, ninja, pkgconfig
+{ stdenv, fetchurl, meson, ninja, pkgconfig, fetchpatch
 , glib, gdk_pixbuf, gobject-introspection, gnome3 }:
 
 stdenv.mkDerivation rec {
@@ -9,6 +9,15 @@ stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "1371csx0n92g60b5dmai4mmzdnx8081mc3kcgc6a0xipcq5rw839";
   };
+
+  patches = [
+    # Fix darwin build
+    # https://gitlab.gnome.org/GNOME/libnotify/merge_requests/9
+    (fetchpatch {
+      url = "https://gitlab.gnome.org/GNOME/libnotify/commit/55eb69247fe2b479ea43311503042fc03bf4e67d.patch";
+      sha256 = "1hlb5b7c5axiyir1i5j2pi94bm2gyr1ybkp6yaqy7yk6iiqlvv50";
+    })
+  ];
 
   mesonFlags = [
     # disable tests as we don't need to depend on gtk+(2/3)

--- a/pkgs/development/libraries/libnotify/default.nix
+++ b/pkgs/development/libraries/libnotify/default.nix
@@ -1,21 +1,31 @@
-{ stdenv, fetchurl, pkgconfig, autoreconfHook
-, glib, gdk_pixbuf, gobject-introspection }:
+{ stdenv, fetchurl, meson, ninja, pkgconfig
+, glib, gdk_pixbuf, gobject-introspection, gnome3 }:
 
 stdenv.mkDerivation rec {
-  ver_maj = "0.7";
-  ver_min = "7";
-  name = "libnotify-${ver_maj}.${ver_min}";
+  pname = "libnotify";
+  version = "0.7.8";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/libnotify/${ver_maj}/${name}.tar.xz";
-    sha256 = "017wgq9n00hx39n0hm784zn18hl721hbaijda868cm96bcqwxd4w";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "1371csx0n92g60b5dmai4mmzdnx8081mc3kcgc6a0xipcq5rw839";
   };
 
-  # disable tests as we don't need to depend on gtk+(2/3)
-  configureFlags = [ "--disable-tests" ];
+  mesonFlags = [
+    # disable tests as we don't need to depend on gtk+(2/3)
+    "-Dtests=false"
+    "-Ddocbook_docs=disabled"
+    "-Dgtk_doc=false"
+  ];
 
-  nativeBuildInputs = [ pkgconfig autoreconfHook gobject-introspection ];
+  nativeBuildInputs = [ meson ninja pkgconfig gobject-introspection ];
   buildInputs = [ glib gdk_pixbuf ];
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+      versionPolicy = "none";
+    };
+  };
 
   meta = with stdenv.lib; {
     homepage = https://developer.gnome.org/notification-spec/;


### PR DESCRIPTION
* cleanup a bit using new helpers
* move to meson to avoid need for gtk_doc and such
* NEWS: https://gitlab.gnome.org/GNOME/libnotify/blob/0.7.8/NEWS
* tag: https://gitlab.gnome.org/GNOME/libnotify/tags/0.7.8


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---