### PR TITLE
nixos/printing: fix CUPS `SetEnv` directive placement

### DIFF
--- a/nixos/modules/services/printing/cupsd.nix
+++ b/nixos/modules/services/printing/cupsd.nix
@@ -60,6 +60,8 @@ let
 
     TempDir ${cfg.tempDir}
 
+    SetEnv PATH /var/lib/cups/path/lib/cups/filter:/var/lib/cups/path/bin
+
     # User and group used to run external programs, including
     # those that actually send the job to the printer.  Note that
     # Udev sets the group of printer devices to `lp', so we want
@@ -75,8 +77,6 @@ let
       Listen ${addr}
     '') cfg.listenAddresses}
     Listen /var/run/cups/cups.sock
-
-    SetEnv PATH /var/lib/cups/path/lib/cups/filter:/var/lib/cups/path/bin
 
     DefaultShared ${if cfg.defaultShared then "Yes" else "No"}
 


### PR DESCRIPTION
With CUPS v2.3b5, the configuration directive `SetEnv`
moved from `cupsd.conf` to `cups-files.conf`.  See also
https://github.com/apple/cups/commit/d47f6aec436e0e9df6554436e391471097686ecc .

We have to follow up as `SetEnv` is now ignored in `cupsd.conf`.
Without this, executables called by cups
can't find other executables they depend on,
like `gs` or `perl`.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Executables called by CUPS can't find their fellow executables. Here is an example problem: 
> Apr 06 16:50:45 nixosc cupsd[1861]: sh: gs: command not found
> [ ... ]
> Apr 06 16:50:45 nixosc cupsd[1861]: PID 2268 (/nix/store/5rnrjs5340dp1njgla68b7ajyc2r95vs-cups-progs/lib/cups/filter/foomatic-rip) stopped with status 3.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This commit should also go into release-19.03 (but not in release-18.09 which uses an older CUPS release). Should I open a separate pull request for this?