### PR TITLE
libow: init at 3.2p1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1229,6 +1229,11 @@
     github = "disassembler";
     name = "Samuel Leathers";
   };
+  disserman = {
+    email = "disserman@gmail.com";
+    github = "divi255";
+    name = "Sergei S.";
+  };
   dizfer = {
     email = "david@izquierdofernandez.com";
     github = "dizfer";

--- a/pkgs/development/libraries/libow/default.nix
+++ b/pkgs/development/libraries/libow/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchFromGitHub, autoconf, automake, pkgconfig, libtool }:
+
+stdenv.mkDerivation rec {
+  version = "3.2p1";
+  name = "libow-${version}";
+
+  src = fetchFromGitHub {
+    owner = "owfs";
+    repo = "owfs";
+    rev = "v${version}";
+    sha256 = "17jhhvlqzndf7q3xnb8bjf4j0j905c420cbxabwpz8xac3z62vb8";
+  };
+
+  nativeBuildInputs = [ autoconf automake pkgconfig ];
+
+  meta = with stdenv.lib; {
+    description = "1-Wire File System full library";
+    homepage = http://owfs.org/;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ disserman ];
+    platforms = platforms.unix;
+  };
+
+  buildInputs = [ libtool ];
+
+  preConfigure = "./bootstrap";
+
+  configureFlags = [
+      "--disable-owtcl"
+      "--disable-owphp"
+      "--disable-owpython"
+      "--disable-zero"
+      "--disable-owshell"
+      "--disable-owhttpd"
+      "--disable-owftpd"
+      "--disable-owserver"
+      "--disable-owperl"
+      "--disable-owtcl"
+      "--disable-owtap"
+      "--disable-owmon"
+      "--disable-owexternal"
+    ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11481,6 +11481,8 @@ in
 
   libotr = callPackage ../development/libraries/libotr { };
 
+  libow = callPackage ../development/libraries/libow { };
+
   libp11 = callPackage ../development/libraries/libp11 { };
 
   libpar2 = callPackage ../development/libraries/libpar2 { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

libow 1-wire file system library (owfs) package

includes libraries and headers only

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
