### PR TITLE
openjpeg: 2.3.0 -> 2.3.1

### DIFF
--- a/pkgs/development/libraries/openjpeg/2.x.nix
+++ b/pkgs/development/libraries/openjpeg/2.x.nix
@@ -1,10 +1,10 @@
 { callPackage, fetchpatch, ... } @ args:
 
 callPackage ./generic.nix (args // rec {
-  version = "2.3.0";
+  version = "2.3.1";
   branch = "2.3";
   revision = "v${version}";
-  sha256 = "08plxrnfl33sn2vh5nwbsngyv6b1sfpplvx881crm1v1ai10m2lz";
+  sha256 = "1dn98d2dfa1lqyxxmab6rrcv52dyhjr4g7i4xf2w54fqsx14ynrb";
 
   extraFlags = [
     "-DOPENJPEG_INSTALL_INCLUDE_DIR=${placeholder "dev"}/include/openjpeg-${branch}"
@@ -12,20 +12,6 @@ callPackage ./generic.nix (args // rec {
   ];
 
   patches = [
-    (fetchpatch {
-      name = "CVE-2018-7648.patch";
-      url = "https://github.com/uclouvain/openjpeg/commit/cc3824767bde397fedb8a1ae4786a222ba860c8d.patch";
-      sha256 = "1j5nxmlgyfkxldk2f1ij6h850xw45q3b5brxqa04dxsfsv8cdj5j";
-    })
-    (fetchpatch {
-      name = "CVE-2017-17480+CVE-2018-18088.patch";
-      url = "https://github.com/uclouvain/openjpeg/commit/92023cd6c377e0384a7725949b25655d4d94dced.patch";
-      sha256 = "0rrxxqcp3vjkmvywxj9ac766m3fppy0x0nszrkf8irrqy1gnp38k";
-    })
-    (fetchpatch {
-      url = https://github.com/uclouvain/openjpeg/commit/24fd3ce777a64b8b315cfe1ee642ec7b1cc6aa97.patch;
-      sha256 = "1sl5wplgdfiqw8qbd8s5j5hq3ynbwgsnv8nxqfrk5s7vyrzx9pxv";
-    })
     ./fix-cmake-config-includedir.patch
   ];
 })


### PR DESCRIPTION
bug fixes, security fixes*

I /think/ we had patches for the mentioned CVE's,
but another pair of eyes is appreciated.


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---