### PR TITLE
pythonPackages.chevron: init at 0.13.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1219,6 +1219,11 @@
     github = "dgonyeo";
     name = "Derek Gonyeo";
   };
+  dhkl = {
+    email = "david@davidslab.com";
+    github = "dhl";
+    name = "David Leung";
+  };
   dipinhora = {
     email = "dipinhora+github@gmail.com";
     github = "dipinhora";

--- a/pkgs/development/python-modules/chevron/default.nix
+++ b/pkgs/development/python-modules/chevron/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "chevron";
+  version = "0.13.1";
+
+  # No tests available in the PyPI tarball
+  src = fetchFromGitHub {
+    owner = "noahmorrison";
+    repo = "chevron";
+    rev = "0.13.1";
+    sha256 = "0l1ik8dvi6bgyb3ym0w4ii9dh25nzy0x4yawf4zbcyvvcb6af470";
+  };
+
+  checkPhase = ''
+    ${python.interpreter} test_spec.py
+  '';
+
+  meta = with lib; {
+    homepage = https://github.com/noahmorrison/chevron;
+    description = "A python implementation of the mustache templating language";
+    license = licenses.mit;
+    maintainers = with maintainers; [ dhkl ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1177,6 +1177,8 @@ in {
 
   cheroot = callPackage ../development/python-modules/cheroot {};
 
+  chevron = callPackage ../development/python-modules/chevron {};
+
   cli-helpers = callPackage ../development/python-modules/cli-helpers {};
 
   cmarkgfm = callPackage ../development/python-modules/cmarkgfm { };


### PR DESCRIPTION
A Python implementation of mustache

This is being packaged as part of the effort to update `aws-sam-cli` to the latest version

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
