### PR TITLE
pythonPackages.aws-lambda-builders: init at 0.2.1

### DIFF
--- a/pkgs/development/python-modules/aws-lambda-builders/default.nix
+++ b/pkgs/development/python-modules/aws-lambda-builders/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, six
+, pytest
+, mock
+, parameterized
+, isPy35
+}:
+
+buildPythonPackage rec {
+  pname = "aws-lambda-builders";
+  version = "0.2.1";
+
+  # No tests available in PyPI tarball
+  src = fetchFromGitHub {
+    owner = "awslabs";
+    repo = "aws-lambda-builders";
+    rev = "v${version}";
+    sha256 = "1pbi6572q1nqs2wd7jx9d5vgf3rqdsqlaz4v8fqvl23wfb2c4vpd";
+  };
+
+  # Package is not compatible with Python 3.5
+  disabled = isPy35;
+
+  propagatedBuildInputs = [
+    six
+  ];
+
+  checkInputs = [
+    pytest
+    mock
+    parameterized
+  ];
+
+  checkPhase = ''
+    export PATH=$out/bin:$PATH
+    pytest tests/functional
+  '';
+
+  meta = with lib; {
+    homepage = https://github.com/awslabs/aws-lambda-builders;
+    description = "A tool to compile, build and package AWS Lambda functions";
+    longDescription = ''
+      Lambda Builders is a Python library to compile, build and package
+      AWS Lambda functions for several runtimes & frameworks.
+    '';
+    license = licenses.asl20;
+    maintainers = with maintainers; [ dhkl ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1072,6 +1072,8 @@ in {
 
   avro3k = callPackage ../development/python-modules/avro3k {};
 
+  aws-lambda-builders = callPackage ../development/python-modules/aws-lambda-builders { };
+
   python-slugify = callPackage ../development/python-modules/python-slugify { };
 
   awesome-slugify = callPackage ../development/python-modules/awesome-slugify {};


### PR DESCRIPTION
A tool to compile, build and package AWS Lambda functions.

This is being packaged as part of the effort to update `aws-sam-cli`.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
