### PR TITLE
cassandra: Wrap new binaries

### DIFF
--- a/pkgs/servers/nosql/cassandra/generic.nix
+++ b/pkgs/servers/nosql/cassandra/generic.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, python, makeWrapper, gawk, bash, getopt, procps
-, which, jre, version, sha256, ...
+, which, jre, version, sha256, coreutils, ...
 }:
 
 let
@@ -43,16 +43,30 @@ stdenv.mkDerivation rec {
       rmdir $out/doc
     fi
 
-    for cmd in bin/cassandra bin/nodetool bin/sstablekeys \
-      bin/sstableloader bin/sstableupgrade \
-      tools/bin/cassandra-stress tools/bin/cassandra-stressd \
-      tools/bin/sstablemetadata tools/bin/sstableofflinerelevel \
-      tools/bin/token-generator tools/bin/sstablelevelreset; do
+
+    for cmd in bin/cassandra \
+               bin/nodetool \
+               bin/sstablekeys \
+               bin/sstableloader \
+               bin/sstablescrub \
+               bin/sstableupgrade \
+               bin/sstableutil \
+               bin/sstableverify \
+               tools/bin/cassandra-stress \
+               tools/bin/cassandra-stressd \
+               tools/bin/sstabledump \
+               tools/bin/sstableexpiredblockers \
+               tools/bin/sstablelevelreset \
+               tools/bin/sstablemetadata \
+               tools/bin/sstableofflinerelevel \
+               tools/bin/sstablerepairedset \
+               tools/bin/sstablesplit \
+               tools/bin/token-generator; do
 
       # check if file exists because some bin tools don't exist across all
       # cassandra versions
       if [ -f $out/$cmd ]; then
-        wrapProgram $out/$cmd \
+        makeWrapper $out/$cmd $out/bin/$(${coreutils}/bin/basename "$cmd") \
           --suffix-each LD_LIBRARY_PATH : ${libPath} \
           --prefix PATH : ${binPath} \
           --set JAVA_HOME ${jre}


### PR DESCRIPTION
###### Motivation for this change

The new releases of Cassandra added some binaries that the install
script didn't wrap and thus were unusable.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).