### PR TITLE
deepin.qcef: init at 1.1.4.6

### DIFF
--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -44,6 +44,7 @@ let
     go-dbus-generator = callPackage ./go-dbus-generator { };
     go-gir-generator = callPackage ./go-gir-generator { };
     go-lib = callPackage ./go-lib { };
+    qcef = callPackage ./qcef { };
     qt5dxcb-plugin = callPackage ./qt5dxcb-plugin { };
     qt5integration = callPackage ./qt5integration { };
 

--- a/pkgs/desktops/deepin/qcef/default.nix
+++ b/pkgs/desktops/deepin/qcef/default.nix
@@ -1,0 +1,104 @@
+{ stdenv, fetchFromGitHub, pkgconfig, cmake, qtbase, qttools,
+  qtwebchannel, qtx11extras, dtkcore, dtkwidget, qt5integration,
+  libXScrnSaver, gnome2, nss, nspr, alsaLib, atk, cairo, cups, dbus,
+  expat, fontconfig, gdk_pixbuf, glib, gtk2, libX11, libXcomposite,
+  libXcursor, libXdamage, libXext, libXfixes, libXi, libXrandr,
+  libXrender, libXtst, libxcb, pango, pulseaudio, xorg, deepin }:
+
+let
+  rpahtLibraries = [
+    stdenv.cc.cc.lib  # libstdc++.so.6
+    alsaLib
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    fontconfig
+    gdk_pixbuf
+    glib
+    gnome2.GConf
+    gtk2
+    libxcb
+    nspr
+    nss
+    pango
+    pulseaudio
+    xorg.libX11
+    xorg.libXScrnSaver
+    xorg.libXcomposite
+    xorg.libXcursor
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXi
+    xorg.libXrandr
+    xorg.libXrender
+    xorg.libXtst
+  ];
+  libPath = stdenv.lib.makeLibraryPath rpahtLibraries;
+in
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "qcef";
+  version = "1.1.4.6";
+
+  srcs = [
+    (fetchFromGitHub {
+      owner = "linuxdeepin";
+      repo = pname;
+      rev = version;
+      sha256 = "06909sd0gf7n4hw6p4j96apjym219zabflgpwjafm7v00bgnwxxs";
+      name = pname;
+    })
+    (fetchFromGitHub {
+      owner = "linuxdeepin";
+      repo = "cef-binary";
+      rev = "059a0c9cef4e289a50dc7a2f4c91fe69db95035e";
+      sha256 = "1h7cq63n94y2a6fprq4g63admh49rcci7avl5z9kdimkhqb2jb84";
+      name = "cef-binary";
+    })
+  ];
+
+  sourceRoot = pname;
+
+  nativeBuildInputs = [
+    pkgconfig
+    cmake
+    qttools
+    deepin.setupHook
+  ];
+
+  buildInputs = [
+    qtbase
+    qtwebchannel
+    qtx11extras
+  ] ++ rpahtLibraries;
+
+  postUnpack = ''
+    rmdir ${pname}/cef
+    ln -s ../cef-binary ${pname}/cef
+  '';
+
+  postPatch = ''
+    searchHardCodedPaths
+    fixPath $out /usr src/core/qcef_global_settings.{h,cpp}
+    sed '/COMMAND rm -rf Release Resources/a COMMAND ldd qcef/libcef.so' -i src/CMakeLists.txt
+    sed '/COMMAND rm -rf Release Resources/a COMMAND patchelf --set-rpath ${libPath} qcef/libcef.so' -i src/CMakeLists.txt
+  '';
+
+  postFixup = ''
+    searchHardCodedPaths $out
+  '';
+
+  passthru.updateScript = deepin.updateScript { inherit name; };
+
+  meta = with stdenv.lib; {
+    description = "Qt5 binding of Chromium Embedded Framework";
+    homepage = https://github.com/linuxdeepin/qcef;
+    license = licenses.lgpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add [qcef](https://github.com/linuxdeepin/qcef) (Qt5 binding of Chromium Embedded Framework) to nixpkgs. It is a dependency for the forthcoming deepin-manual package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).