### PR TITLE
Persistent Memory Development Kit

### DIFF
--- a/pkgs/development/libraries/libndctl/default.nix
+++ b/pkgs/development/libraries/libndctl/default.nix
@@ -1,17 +1,17 @@
 { stdenv, fetchFromGitHub, autoreconfHook
 , asciidoctor, pkgconfig, xmlto, docbook_xsl, docbook_xml_dtd_45, libxslt
-, json_c, kmod, which, file, utillinux, systemd
+, json_c, kmod, which, file, utillinux, systemd, keyutils
 }:
 
 stdenv.mkDerivation rec {
   name = "libndctl-${version}";
-  version = "63";
+  version = "64.1";
 
   src = fetchFromGitHub {
     owner  = "pmem";
     repo   = "ndctl";
     rev    = "v${version}";
-    sha256 = "060nsza8xic769bxj3pvl70a9885bwrc0myw16l095i3z6w7yzwq";
+    sha256 = "1la82fqbdwjkw6il498nkdfgqc4aszv481xf2p9p07jfvankx24v";
   };
 
   outputs = [ "out" "lib" "man" "dev" ];
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     ];
 
   buildInputs =
-    [ json_c kmod utillinux systemd
+    [ json_c kmod utillinux systemd keyutils
     ];
 
   configureFlags =

--- a/pkgs/development/libraries/pmdk/default.nix
+++ b/pkgs/development/libraries/pmdk/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchFromGitHub
+, autoconf, libndctl, pkgconfig
+}:
+
+stdenv.mkDerivation rec {
+  name = "pmdk-${version}";
+  version = "1.6";
+
+  src = fetchFromGitHub {
+    owner  = "pmem";
+    repo   = "pmdk";
+    rev    = "refs/tags/${version}";
+    sha256 = "11h9h5ifgaa5f6v9y77s5lmsj7k61qg52992s1361cmvl0ndgl9k";
+  };
+
+  nativeBuildInputs = [ autoconf pkgconfig ];
+  buildInputs = [ libndctl ];
+  enableParallelBuilding = true;
+
+  outputs = [ "out" "lib" "dev" "man" ];
+
+  patchPhase = "patchShebangs utils";
+
+  installPhase = ''
+    make install prefix=$out
+
+    mkdir -p $lib $dev $man/share
+    mv $out/share/man $man/share/man
+    mv $out/include $dev/include
+    mv $out/lib     $lib/lib
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Persistent Memory Development Kit";
+    homepage    = https://github.com/pmem/pmdk;
+    license     = licenses.lgpl21;
+    maintainers = with maintainers; [ thoughtpolice ];
+    platforms   = [ "x86_64-linux" ]; # aarch64 is experimental
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8892,6 +8892,8 @@ in
 
   pmd = callPackage ../development/tools/analysis/pmd { };
 
+  pmdk = callPackage ../development/libraries/pmdk { };
+
   jdepend = callPackage ../development/tools/analysis/jdepend { };
 
   fedpkg = pythonPackages.callPackage ../development/tools/fedpkg { };


### PR DESCRIPTION
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
