### PR TITLE
vips: 8.7.0 -> 8.7.4

### DIFF
--- a/pkgs/tools/graphics/vips/default.nix
+++ b/pkgs/tools/graphics/vips/default.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation rec {
   name = "vips-${version}";
-  version = "8.7.0";
+  version = "8.7.4";
 
   src = fetchFromGitHub {
     owner = "libvips";
     repo = "libvips";
     rev = "v${version}";
-    sha256 = "1dwcpmpqbgb9lkajnqv50mrsn97mxbxpq6b5aya7fgfkgdnrs9sw";
+    sha256 = "0mcax1qg5i4iqlvgkz3s0c938d7ymx24pv3q2n3w2pjylnnd489s";
   };
 
   nativeBuildInputs = [ pkgconfig autoreconfHook gtk-doc gobject-introspection ];


### PR DESCRIPTION
###### Motivation for this change

https://github.com/libvips/libvips/blob/v8.7.4/ChangeLog

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---