### PR TITLE
joplin-desktop: 1.0.140 -> 1.0.142

### DIFF
--- a/pkgs/applications/misc/joplin-desktop/default.nix
+++ b/pkgs/applications/misc/joplin-desktop/default.nix
@@ -1,8 +1,8 @@
 { stdenv, appimage-run, fetchurl }:
 
 let
-  version = "1.0.140";
-  sha256 = "1114v141jayqhvkkxf7dr864j09nf5nz002c7z0pprzr00fifqzx";
+  version = "1.0.142";
+  sha256 = "0k7lnv3qqz17a2a2d431sic3ggi3373r5k0kwxm4017ama7d72m1";
 in
   stdenv.mkDerivation rec {
   name = "joplin-${version}";

--- a/pkgs/applications/misc/joplin-desktop/default.nix
+++ b/pkgs/applications/misc/joplin-desktop/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, appimage-run, fetchurl }:
+{ stdenv, appimage-run, fetchurl, gsettings-desktop-schemas, gtk3, gobject-introspection, wrapGAppsHook }:
 
 let
   version = "1.0.142";
@@ -12,7 +12,8 @@ in
     inherit sha256;
   };
 
-  buildInputs = [ appimage-run ];
+  nativeBuildInputs = [ wrapGAppsHook ];
+  buildInputs = [ appimage-run gtk3 gsettings-desktop-schemas gobject-introspection ];
 
   unpackPhase = ":";
 


### PR DESCRIPTION
https://discourse.joplin.cozic.net/t/joplin-version-1-0-142/2024


###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---