### PR TITLE
i3blocks: 1.4 -> unstable-2019-02-07

### DIFF
--- a/pkgs/applications/window-managers/i3/blocks.nix
+++ b/pkgs/applications/window-managers/i3/blocks.nix
@@ -1,54 +1,19 @@
-{ fetchurl, stdenv, perl, makeWrapper
-, iproute, acpi, sysstat, xset, playerctl
-, cmus, openvpn, lm_sensors, alsaUtils
-, scripts ? [ "bandwidth" "battery" "cpu_usage" "disk" "iface"
-              "keyindicator" "load_average" "mediaplayer" "memory"
-	            "openvpn" "temperature" "volume" "wifi" ]
-}:
+{ fetchFromGitHub, stdenv, autoreconfHook }:
 
 with stdenv.lib;
 
-let
-  perlscripts = [ "battery" "cpu_usage" "keyindicator"
-                  "mediaplayer" "openvpn" "temperature" ];
-  contains_any = l1: l2: 0 < length( intersectLists l1 l2 );
-
-in
 stdenv.mkDerivation rec {
   name = "i3blocks-${version}";
-  version = "1.4";
+  version = "unstable-2019-02-07";
 
-  src = fetchurl {
-    url = "https://github.com/vivien/i3blocks/releases/download/${version}/${name}.tar.gz";
-    sha256 = "c64720057e22cc7cac5e8fcd58fd37e75be3a7d5a3cb8995841a7f18d30c0536";
+  src = fetchFromGitHub {
+    owner = "vivien";
+    repo = "i3blocks";
+    rev = "ec050e79ad8489a6f8deb37d4c20ab10729c25c3";
+    sha256 = "1fx4230lmqa5rpzph68dwnpcjfaaqv5gfkradcr85hd1z8d1qp1b";
   };
 
-  buildFlags = "SYSCONFDIR=/etc all";
-  installFlags = "PREFIX=\${out} VERSION=${version}";
-
-  buildInputs = optional (contains_any scripts perlscripts) perl;
-  nativeBuildInputs = [ makeWrapper ];
-
-  postFixup = ''
-    wrapProgram $out/libexec/i3blocks/bandwidth \
-      --prefix PATH : ${makeBinPath (optional (elem "bandwidth" scripts) iproute)}
-    wrapProgram $out/libexec/i3blocks/battery \
-      --prefix PATH : ${makeBinPath (optional (elem "battery" scripts) acpi)}
-    wrapProgram $out/libexec/i3blocks/cpu_usage \
-      --prefix PATH : ${makeBinPath (optional (elem "cpu_usage" scripts) sysstat)}
-    wrapProgram $out/libexec/i3blocks/iface \
-      --prefix PATH : ${makeBinPath (optional (elem "iface" scripts) iproute)}
-    wrapProgram $out/libexec/i3blocks/keyindicator \
-      --prefix PATH : ${makeBinPath (optional (elem "keyindicator" scripts) xset)}
-    wrapProgram $out/libexec/i3blocks/mediaplayer \
-      --prefix PATH : ${makeBinPath (optionals (elem "mediaplayer" scripts) [playerctl cmus])}
-    wrapProgram $out/libexec/i3blocks/openvpn \
-      --prefix PATH : ${makeBinPath (optional (elem "openvpn" scripts) openvpn)}
-    wrapProgram $out/libexec/i3blocks/temperature \
-      --prefix PATH : ${makeBinPath (optional (elem "temperature" scripts) lm_sensors)}
-    wrapProgram $out/libexec/i3blocks/volume \
-      --prefix PATH : ${makeBinPath (optional (elem "volume" scripts) alsaUtils)}
-  '';
+  nativeBuildInputs = [ autoreconfHook ];
 
   meta = {
     description = "A flexible scheduler for your i3bar blocks";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Updated i3blocks. The maintainer has stopped publishing releases (last one was 4 years ago), but develops the project actively. Since I'm updating to a commit in the master branch of the project, rather than  a new version number, what should I put as the commit message and version for the package?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
