### PR TITLE
lib3mf: init at 1.8.1

### DIFF
--- a/pkgs/development/libraries/lib3mf/default.nix
+++ b/pkgs/development/libraries/lib3mf/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub, cmake, ninja, libuuid, gtest }:
+
+stdenv.mkDerivation rec {
+  pname = "lib3mf";
+  version = "1.8.1";
+
+  src = fetchFromGitHub {
+    owner = "3MFConsortium";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "11wpk6n9ga2p57h1dcrp37w77mii0r7r6mlrgmykf7rvii1rzgqd";
+  };
+
+  nativeBuildInputs = [ cmake ninja ];
+
+  buildInputs = [ libuuid ];
+
+  postPatch = ''
+    rmdir UnitTests/googletest
+    ln -s ${gtest.src} UnitTests/googletest
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Reference implementation of the 3D Manufacturing Format file standard";
+    homepage = "https://3mf.io/";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ gebner ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10754,6 +10754,8 @@ in
 
   lib3ds = callPackage ../development/libraries/lib3ds { };
 
+  lib3mf = callPackage ../development/libraries/lib3mf { };
+
   libaacs = callPackage ../development/libraries/libaacs { };
 
   libaal = callPackage ../development/libraries/libaal { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

lib3mf will be a required dependency for the next OpenSCAD release, which [should be released any day now](https://github.com/openscad/openscad/issues/2905).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
