### PR TITLE
pythonPackages.zerorpc: init at 0.6.1

### DIFF
--- a/pkgs/development/python-modules/zerorpc/default.nix
+++ b/pkgs/development/python-modules/zerorpc/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchPypi, future, gevent, msgpack-python, pyzmq }:
+
+buildPythonPackage rec {
+  pname = "zerorpc";
+  version = "0.6.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "14d0nmprs0nm17d8kg2f7qalsi8x7c4damsccqgncylj7mpnk9hh";
+  };
+
+  propagatedBuildInputs = [ future gevent msgpack-python pyzmq ];
+
+  doCheck = false; # pypi version doesn't include tests
+
+  meta = with lib; {
+    description = "An easy to use, intuitive, and cross-language RPC";
+    homepage = "https://www.zerorpc.io";
+    license = licenses.mit;
+    maintainers = with maintainers; [ xeji ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4429,6 +4429,8 @@ in {
 
   zc_lockfile = callPackage ../development/python-modules/zc_lockfile { };
 
+  zerorpc = callPackage ../development/python-modules/zerorpc { };
+
   zipstream = callPackage ../development/python-modules/zipstream { };
 
   zodb = callPackage ../development/python-modules/zodb {};


### PR DESCRIPTION
###### Motivation for this change

A simple, easy-to-use RPC implementation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
