### PR TITLE
openscad: 2018.04-git -> 2019.05

### DIFF
--- a/pkgs/applications/graphics/openscad/default.nix
+++ b/pkgs/applications/graphics/openscad/default.nix
@@ -1,30 +1,27 @@
 { stdenv, fetchFromGitHub, qt5, libsForQt5
 , bison, flex, eigen, boost, libGLU_combined, glew, opencsg, cgal
 , mpfr, gmp, glib, pkgconfig, harfbuzz, gettext, freetype, fontconfig
+, double-conversion, lib3mf, libzip
 }:
 
 stdenv.mkDerivation rec {
-  version = "2018.04-git";
-  name = "openscad-${version}";
+  pname = "openscad";
+  version = "2019.05";
 
-#  src = fetchurl {
-#    url = "http://files.openscad.org/${name}.src.tar.gz";
-#    sha256 = "0djsgi9yx1nxr2gh1kgsqw5vrbncp8v5li0p1pp02higqf1psajx";
-#  };
   src = fetchFromGitHub {
     owner = "openscad";
     repo = "openscad";
-    rev = "179074dff8c23cbc0e651ce8463737df0006f4ca";
-    sha256 = "1y63yqyd0v255liik4ff5ak6mj86d8d76w436x76hs5dk6jgpmfb";
+    rev = "${pname}-${version}";
+    sha256 = "1qz384jqgk75zxk7sqd22ma9pyd94kh4h6a207ldx7p9rny6vc5l";
   };
 
-  nativeBuildInputs = [ bison flex pkgconfig ];
+  nativeBuildInputs = [ bison flex pkgconfig gettext qt5.qmake ];
 
   buildInputs = [
     eigen boost glew opencsg cgal mpfr gmp glib
-    harfbuzz gettext freetype fontconfig
+    harfbuzz lib3mf libzip double-conversion freetype fontconfig
   ] ++ stdenv.lib.optional stdenv.isLinux libGLU_combined
-    ++ (with qt5; [qtbase qmake] ++ stdenv.lib.optional stdenv.isDarwin qtmacextras)
+    ++ (with qt5; [qtbase qtmultimedia] ++ stdenv.lib.optional stdenv.isDarwin qtmacextras)
     ++ (with libsForQt5; [qscintilla])
   ;
 
@@ -32,8 +29,6 @@ stdenv.mkDerivation rec {
 
   # src/lexer.l:36:10: fatal error: parser.hxx: No such file or directory
   enableParallelBuilding = false; # true by default due to qmake
-
-  doCheck = false;
 
   postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
     mkdir $out/Applications
@@ -63,6 +58,6 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.gpl2;
     platforms = stdenv.lib.platforms.unix;
     maintainers = with stdenv.lib.maintainers;
-      [ bjornfor raskin the-kenny ];
+      [ bjornfor raskin the-kenny gebner ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

[OpenSCAD 2019.01 is going be released any day now.](https://github.com/openscad/openscad/issues/2905)

I'll update and merge this PR when the final 2019.01 version is released.

cc maintainers @the-kenny @raskin @bjornfor 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
