### PR TITLE
linux: kernel: Add linux-ck for 4.14, 4.19 and 5.0

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-4.14-ck.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.14-ck.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPackages, fetchurl, perl, buildLinux, modDirVersionArg ? null, ... } @ args:
+
+with stdenv.lib;
+
+buildLinux (args // rec {
+  version = "4.14.0-ck1";
+
+  # modDirVersion needs to be x.y.z, will automatically add .0 if needed
+
+  # branchVersion needs to be x.y
+  extraMeta.branch = concatStrings (intersperse "." (take 2 (splitString "." version)));
+
+  src = args.fetchFromGitHub {
+    owner  = "ckolivas";
+    repo   = "linux";
+    rev    = "4.14-ck";
+    sha256 = "12v1y4rld79pwc7nfg1sq2sh0xphsl5bd54iklj2qhk4h19z46iy";
+  };
+} // (args.argsOverride or {}))
+

--- a/pkgs/os-specific/linux/kernel/linux-4.19-ck.nix
+++ b/pkgs/os-specific/linux/kernel/linux-4.19-ck.nix
@@ -1,0 +1,19 @@
+{ stdenv, buildPackages, fetchFromGitHub, perl, buildLinux, modDirVersionArg ? null, ... } @ args:
+
+with stdenv.lib;
+
+buildLinux (args // rec {
+  version = "4.19.0-ck1";
+
+  # modDirVersion needs to be x.y.z, will automatically add .0 if needed
+
+  # branchVersion needs to be x.y
+  extraMeta.branch = concatStrings (intersperse "." (take 2 (splitString "." version)));
+
+  src = args.fetchFromGitHub {
+    owner  = "ckolivas";
+    repo   = "linux";
+    rev    = "4.19-ck";
+    sha256 = "12vmy4rld79pwc7nfg1sq2sh0xphsl5bd54iklj2qhk4h19z46iy";
+  };
+} // (args.argsOverride or {}))

--- a/pkgs/os-specific/linux/kernel/linux-5.0-ck.nix
+++ b/pkgs/os-specific/linux/kernel/linux-5.0-ck.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPackages, fetchFromGitHub, perl, buildLinux, modDirVersionArg ? null, ... } @ args:
+
+with stdenv.lib;
+
+buildLinux (args // rec {
+  version = "5.0.0-ck1";
+
+  # modDirVersion needs to be x.y.z, will automatically add .0 if needed
+
+  # branchVersion needs to be x.y
+  extraMeta.branch = concatStrings (intersperse "." (take 2 (splitString "." version)));
+
+  src = args.fetchFromGitHub {
+    owner  = "ckolivas";
+    repo   = "linux";
+    rev    = "5.0-ck";
+    sha256 = "121my4r1d79pwc7nfg1sq2sh0xphsl5bd54iklj2qhk4h19z46iy";
+  };
+} // (args.argsOverride or {}))
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15209,6 +15209,13 @@ in
       ];
   };
 
+  linux_5_0_ck = callPackage ../os-specific/linux/kernel/linux-5.0-ck.nix {
+    kernelPatches =
+      [ kernelPatches.bridge_stp_helper
+        kernelPatches.modinst_arg_list_too_long
+      ];
+  };
+
   linux_testing = callPackage ../os-specific/linux/kernel/linux-testing.nix {
     kernelPatches = [
       kernelPatches.bridge_stp_helper

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15186,6 +15186,13 @@ in
       ];
   };
 
+  linux_4_19_ck = callPackage ../os-specific/linux/kernel/linux-4.19-ck.nix {
+    kernelPatches =
+      [ kernelPatches.bridge_stp_helper
+        kernelPatches.modinst_arg_list_too_long
+      ];
+  };
+
   linux_5_0 = callPackage ../os-specific/linux/kernel/linux-5.0.nix {
     kernelPatches =
       [ kernelPatches.bridge_stp_helper

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15172,6 +15172,13 @@ in
       ];
   };
 
+  linux_4_14_ck = callPackage ../os-specific/linux/kernel/linux-4.14-ck.nix {
+    kernelPatches =
+      [ kernelPatches.bridge_stp_helper
+        kernelPatches.modinst_arg_list_too_long
+      ];
+  };
+
   linux_4_19 = callPackage ../os-specific/linux/kernel/linux-4.19.nix {
     kernelPatches =
       [ kernelPatches.bridge_stp_helper


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Having linux-ck kernels in nixpkgs.

Stolen from https://github.com/kisonecat/nixos-linux-ck/blob/master/kernel.nix

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Evaluation will fail because of `pkgs/os-specific/linux/tbs/default.nix` being broken.