### PR TITLE
sl: add missing man pages

### DIFF
--- a/pkgs/tools/misc/sl/default.nix
+++ b/pkgs/tools/misc/sl/default.nix
@@ -7,29 +7,30 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "eyJhb";
     repo = "sl";
-    rev = "${version}";
+    rev = version;
     sha256 = "029lv6vw39c7gj8bkfyqs8q4g32174vbmghhhgfk8wrhnxq60qn7";
   };
 
   buildInputs = [ ncurses ];
 
-  buildFlags = [ "CC=cc" ];
-
   installPhase = ''
-    mkdir -p $out/bin $out/share/man/man1
-    cp sl $out/bin
-    cp sl.1 $outputMan
+    runHook preInstall
+
+    install -Dm755 -t $out/bin sl
+    install -Dm644 -t $out/share/man/man1 sl.1{,.ja}
+
+    runHook postInstall
   '';
 
   meta = with stdenv.lib; {
+    description = "Steam Locomotive runs across your terminal when you type 'sl'";
     homepage = http://www.tkl.iis.u-tokyo.ac.jp/~toyoda/index_e.html;
     license = rec {
       shortName = "Toyoda Masashi's free software license";
       fullName = shortName;
       url = https://github.com/eyJhb/sl/blob/master/LICENSE;
     };
-    maintainers = [ maintainers.eyjhb ];
-    description = "Steam Locomotive runs across your terminal when you type 'sl'";
+    maintainers = with maintainers; [ eyjhb ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Man pages were missing.

Cc: @eyJhb 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
