### PR TITLE
google-cloud-sdk: 222.0.0 -> 241.0.0

### DIFF
--- a/pkgs/tools/admin/google-cloud-sdk/default.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/default.nix
@@ -19,18 +19,18 @@ let
   sources = name: system: {
     x86_64-darwin = {
       url = "${baseUrl}/${name}-darwin-x86_64.tar.gz";
-      sha256 = "03ymvfhk8azyvdm6j4pbqx2fsh178kw81yqwkycbhmm6mnyc8yv1";
+      sha256 = "1w94c1p8vnp3kf802zpr3i0932f5b5irnfqmxj2p44gfyfmkym1j";
     };
 
     x86_64-linux = {
       url = "${baseUrl}/${name}-linux-x86_64.tar.gz";
-      sha256 = "1pw4w3v81mp8alm6vxq10242xxwv8rfs59bjxrmy0pfkjgsr4x4v";
+      sha256 = "0pps7csf8d3rxqgd0bv06ga6cgkqhlbsys0k0sy1ipl3i6h5hmpf";
     };
   }.${system};
 
 in stdenv.mkDerivation rec {
   name = "google-cloud-sdk-${version}";
-  version = "222.0.0";
+  version = "241.0.0";
 
   src = fetchurl (sources name stdenv.hostPlatform.system);
 


### PR DESCRIPTION
Switch to latest Google Cloud SDK, including support for new Alpha services.