### PR TITLE
ocamlPackages.uri: 1.9.6 -> 2.2.0; ocamlPackages.cohttp: 1.1.1 -> 2.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/cohttp/default.nix
+++ b/pkgs/development/ocaml-modules/cohttp/default.nix
@@ -1,27 +1,27 @@
-{ stdenv, fetchFromGitHub, buildDunePackage
+{ lib, fetchFromGitHub, buildDunePackage
 , ppx_fields_conv, ppx_sexp_conv, ppx_deriving
 , base64, fieldslib, jsonm, re, stringext, uri
 }:
 
 buildDunePackage rec {
   pname = "cohttp";
-	version = "1.1.1";
+	version = "2.0.0";
 
 	src = fetchFromGitHub {
 		owner = "mirage";
 		repo = "ocaml-cohttp";
 		rev = "v${version}";
-		sha256 = "1dzd6vy43b7p9xplzg2whylz5br59zxaqywa14b4l377f31gnwq1";
+		sha256 = "0nz9y7l5s9a2rq5sb1m5705h99wvf4dk3fhcgragwhy5nwwzcya8";
 	};
 
 	buildInputs = [ jsonm ppx_fields_conv ppx_sexp_conv ];
 
-	propagatedBuildInputs = [ ppx_deriving base64 fieldslib re stringext uri ];
+	propagatedBuildInputs = [ base64 fieldslib re stringext uri ];
 
 	meta = {
 		description = "HTTP(S) library for Lwt, Async and Mirage";
-		license = stdenv.lib.licenses.isc;
-		maintainers = [ stdenv.lib.maintainers.vbgl ];
+		license = lib.licenses.isc;
+		maintainers = [ lib.maintainers.vbgl ];
 		inherit (src.meta) homepage;
 	};
 }

--- a/pkgs/development/ocaml-modules/cohttp/lwt.nix
+++ b/pkgs/development/ocaml-modules/cohttp/lwt.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildDunePackage, cohttp, ocaml_lwt, uri, ppx_sexp_conv }:
+{ stdenv, buildDunePackage, cohttp, ocaml_lwt, uri, ppx_sexp_conv, logs }:
 
 if !stdenv.lib.versionAtLeast cohttp.version "0.99"
 then cohttp
@@ -10,5 +10,5 @@ buildDunePackage rec {
 
 	buildInputs = [ uri ppx_sexp_conv ];
 
-	propagatedBuildInputs = [ cohttp ocaml_lwt ];
+	propagatedBuildInputs = [ cohttp ocaml_lwt logs ];
 }

--- a/pkgs/development/ocaml-modules/uri/default.nix
+++ b/pkgs/development/ocaml-modules/uri/default.nix
@@ -1,24 +1,39 @@
-{ stdenv, fetchurl, buildDunePackage, ppx_sexp_conv, ounit
-, re, sexplib, stringext
+{ lib, fetchurl, buildDunePackage, ppx_sexp_conv, ounit
+, re, sexplib0, sexplib, stringext
+, legacy ? false
 }:
+
+let params =
+  if legacy then rec {
+    version = "1.9.6";
+    archive = version;
+    sha256 = "1m845rwd70wi4iijkrigyz939m1x84ba70hvv0d9sgk6971w4kz0";
+    inherit sexplib;
+  } else rec {
+    version = "2.2.0";
+    archive = "v${version}";
+    sha256 = "1q0xmc93l46dilxclkmai7w952bdi745rhvsx5vissaigcj9wbwi";
+    sexplib = sexplib0;
+  }
+; in
 
 buildDunePackage rec {
   pname = "uri";
-  version = "1.9.6";
+  inherit (params) version;
 
   src = fetchurl {
-    url = "https://github.com/mirage/ocaml-${pname}/releases/download/v${version}/${pname}-${version}.tbz";
-    sha256 = "1m845rwd70wi4iijkrigyz939m1x84ba70hvv0d9sgk6971w4kz0";
+    url = "https://github.com/mirage/ocaml-${pname}/releases/download/v${version}/${pname}-${params.archive}.tbz";
+    inherit (params) sha256;
   };
 
   buildInputs = [ ounit ];
-  propagatedBuildInputs = [ ppx_sexp_conv re sexplib stringext ];
+  propagatedBuildInputs = [ ppx_sexp_conv re params.sexplib stringext ];
   doCheck = true;
 
   meta = {
     homepage = "https://github.com/mirage/ocaml-uri";
     description = "RFC3986 URI parsing library for OCaml";
-    license = stdenv.lib.licenses.isc;
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.vbgl ];
   };
 }

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -68,6 +68,7 @@ let
         };
       };
       uri = uri.override {
+        legacy = true;
         inherit (janeStreet_0_9_0) ppx_sexp_conv sexplib;
       };
     };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -67,8 +67,7 @@ let
           };
         };
       };
-      uri = uri.override {
-        legacy = true;
+      uri = uri_1_9.override {
         inherit (janeStreet_0_9_0) ppx_sexp_conv sexplib;
       };
     };
@@ -755,6 +754,10 @@ let
       if lib.versionAtLeast ocaml.version "4.3"
       then callPackage ../development/ocaml-modules/uri { }
       else callPackage ../development/ocaml-modules/uri/legacy.nix { };
+
+    uri_1_9 = callPackage ../development/ocaml-modules/uri {
+      legacy = true;
+    };
 
     uri_p4 = callPackage ../development/ocaml-modules/uri/legacy.nix {
       legacyVersion = true;

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -153,9 +153,7 @@ let
 
     cohttp =
       if lib.versionOlder "4.03" ocaml.version
-      then callPackage ../development/ocaml-modules/cohttp {
-        base64 = base64_2;
-      }
+      then callPackage ../development/ocaml-modules/cohttp { }
       else cohttp_p4;
 
     cohttp-lwt = callPackage ../development/ocaml-modules/cohttp/lwt.nix { };


### PR DESCRIPTION
###### Motivation for this change

Major updates.

Keep the legacy version `uri`, still required by `bap`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
