### PR TITLE
zsh-prezto: 2017-12-03 -> 2019-03-18

### DIFF
--- a/pkgs/shells/zsh/zsh-prezto/default.nix
+++ b/pkgs/shells/zsh/zsh-prezto/default.nix
@@ -1,20 +1,22 @@
 { stdenv, fetchgit }:
 
 stdenv.mkDerivation rec {
-  name = "zsh-prezto-2017-12-03";
+  name = "zsh-prezto-2019-03-18";
   src = fetchgit {
     url = "https://github.com/sorin-ionescu/prezto";
-    rev = "029414581e54f5b63156f81acd0d377e8eb78883";
-    sha256 = "0crrj2nq0wcv5in8qimnkca2an760aqald13vq09s5kbwwc9rs1f";
+    rev = "1f4601e44c989b90dc7314b151891fa60a101251";
+    sha256 = "1dcd5r7pc4biiplm0lh7yca0h6hs0xpaq9dwaarmfsh9wrd68350";
     fetchSubmodules = true;
   };
   buildPhase = ''
-    sed -i -e "s|\''${ZDOTDIR:\-\$HOME}/.zpreztorc|/etc/zpreztorc|g" init.zsh
+    sed -i '/\''${ZDOTDIR:\-\$HOME}\/.zpreztorc" ]]/i\
+    if [[ -s "/etc/zpreztorc" ]]; then\
+      source "/etc/zpreztorc"\
+    fi' init.zsh
     sed -i -e "s|\''${ZDOTDIR:\-\$HOME}/.zprezto/|$out/|g" init.zsh
     for i in runcoms/*; do
       sed -i -e "s|\''${ZDOTDIR:\-\$HOME}/.zprezto/|$out/|g" $i
     done
-    sed -i -e "s|\''${0:h}/cache.zsh|\''${ZDOTDIR:\-\$HOME}/.zfasd_cache|g" modules/fasd/init.zsh
   '';
   installPhase = ''
     mkdir -p $out


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Updated zsh-prezto to the latest version. Also removed some redundant `sed`s in the install script, and made it so that `$HOME/.zpreztorc` is sourced after `/etc/zpreztorc` which better reflects upstream (previously, only `/etc/zpreztorc` was sourced).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---