### PR TITLE
trivial-builders: Fix outdated comment on writeTextFile

### DIFF
--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -32,19 +32,23 @@ rec {
    *
    * Examples:
    * # Writes my-file to /nix/store/<store path>
-   * writeTextFile "my-file"
-   *   ''
-   *   Contents of File
+   * writeTextFile {
+   *   name = "my-file";
+   *   text = ''
+   *     Contents of File
    *   '';
+   * }
+   * # See also the `writeText` helper function below.
    *
    * # Writes executable my-file to /nix/store/<store path>/bin/my-file
-   * writeTextFile "my-file"
-   *   ''
-   *   Contents of File
-   *   ''
-   *   true
-   *   "/bin/my-file";
-   *   true
+   * writeTextFile {
+   *   name = "my-file";
+   *   text = ''
+   *     Contents of File
+   *   '';
+   *   executable = true;
+   *   destination = "/bin/my-file";
+   * }
    */
   writeTextFile =
     { name # the name of the derivation


### PR DESCRIPTION
###### Motivation for this change

Fix wrong comment.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
