### PR TITLE
bookworm: unstabled-2018-11-19 -> 1.1.1

### DIFF
--- a/pkgs/applications/office/bookworm/default.nix
+++ b/pkgs/applications/office/bookworm/default.nix
@@ -1,22 +1,25 @@
-{ stdenv, fetchFromGitHub, fetchpatch, pantheon, python3, python2, pkgconfig, libxml2, meson, ninja, gtk3, gnome3, glib, webkitgtk
-, gobject-introspection, sqlite, poppler, poppler_utils, html2text, curl, gnugrep, coreutils, bash, unzip, unar, wrapGAppsHook }:
+{ stdenv, fetchFromGitHub, fetchpatch, pantheon, python3, python2, pkgconfig,
+libxml2, cmake, ninja, gtk3, gnome3, glib, webkitgtk , gobject-introspection,
+sqlite, poppler, poppler_utils, html2text, curl, gnugrep, coreutils, bash,
+unzip, unar, wrapGAppsHook, pcre, libpthreadstubs, libXdmcp, utillinux,
+libselinux, libsepol, libxkbcommon, epoxy, at-spi2-core, dbus }:
 
 stdenv.mkDerivation rec {
   pname = "bookworm";
-  version = "unstable-2018-11-19";
+  version = "1.1.1";
 
   src = fetchFromGitHub {
     owner = "babluboy";
     repo = pname;
-    rev = "4c3061784ff42151cac77d12bf2a28bf831fdfc5";
-    sha256 = "0yrqxa60xlvz249kx966z5krx8i7h17ac0hjgq9p8f0irzy5yp0n";
+    rev = version;
+    sha256 = "0qzwvlwv3nbgzqxxd7kd4rlvld7k03ivmyh099rzm6z00mm4y031";
   };
 
   nativeBuildInputs = [
     bash
     gobject-introspection
     libxml2
-    meson
+    cmake
     ninja
     pkgconfig
     python3
@@ -25,26 +28,32 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    pantheon.elementary-icon-theme
-    pantheon.granite
+    at-spi2-core
+    dbus
+    epoxy
     glib
     gnome3.libgee
     gtk3
     html2text
+    libpthreadstubs
+    libselinux
+    libsepol
+    libXdmcp
+    libxkbcommon
+    pantheon.elementary-icon-theme
+    pantheon.granite
+    pcre
     poppler
     python2
     sqlite
+    utillinux
     webkitgtk
   ];
-
-  postPatch = ''
-    chmod +x meson/post_install.py
-    patchShebangs meson/post_install.py
-  '';
 
   # These programs are expected in PATH from the source code and scripts
   preFixup = ''
     gappsWrapperArgs+=(
+      --argv0 "$out/bin/com.github.babluboy.bookworm"
       --prefix PATH : "${stdenv.lib.makeBinPath [ unzip unar poppler_utils html2text coreutils curl gnugrep ]}"
       --prefix PATH : $out/bin
     )


### PR DESCRIPTION
This bumps bookworm to the latest release, now using meson as build
system.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
