### PR TITLE
graphene-hardened-malloc: init at 190405.003.2019.04.01.19

### DIFF
--- a/pkgs/development/libraries/graphene-hardened-malloc/default.nix
+++ b/pkgs/development/libraries/graphene-hardened-malloc/default.nix
@@ -1,0 +1,55 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "graphene-hardened-malloc-${version}";
+  version = "190405.003.2019.04.01.19";
+
+  src = fetchurl {
+    url = "https://github.com/GrapheneOS/hardened_malloc/archive/PQ2A.${version}.tar.gz";
+    sha256 = "1qczmajy3q07jd236dmal4iq5xxcsrkyw26gc9r4vs4wj4m42d11";
+  };
+
+  installPhase = ''
+    install -Dm444 -t $out/lib libhardened_malloc.so
+
+    mkdir -p $out/bin
+    substitute preload.sh $out/bin/preload-hardened-malloc --replace "\$dir" $out/lib
+    chmod 0555 $out/bin/preload-hardened-malloc
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    pushd test
+    make
+    $out/bin/preload-hardened-malloc ./offset
+
+    pushd simple-memory-corruption
+    make
+
+    # these tests don't actually appear to generate overflows currently
+    rm read_after_free_small string_overflow
+
+    for t in `find . -regex ".*/[a-z_]+"` ; do
+      echo "Running $t..."
+      # the program being aborted (as it should be) would result in an exit code > 128
+      (($out/bin/preload-hardened-malloc $t) && false) \
+        || (test $? -gt 128 || (echo "$t was not aborted" && false))
+    done
+    popd
+
+    popd
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/GrapheneOS/hardened_malloc;
+    description = "Hardened allocator designed for modern systems";
+    longDescription = ''
+      This is a security-focused general purpose memory allocator providing the malloc API
+      along with various extensions. It provides substantial hardening against heap
+      corruption vulnerabilities yet aims to provide decent overall performance.
+    '';
+    license = licenses.mit;
+    maintainers = with maintainers; [ ris ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9003,6 +9003,8 @@ in
 
   grail = callPackage ../development/libraries/grail { };
 
+  graphene-hardened-malloc = callPackage ../development/libraries/graphene-hardened-malloc { };
+
   gtk-doc = callPackage ../development/tools/documentation/gtk-doc { };
 
   gtkdialog = callPackage ../development/tools/misc/gtkdialog { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This is an interesting new hardened malloc implementation by the GrapheneOS people.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
