### PR TITLE
samba: 4.7.10 -> 4.10.2

### DIFF
--- a/pkgs/servers/samba/4.x-fix-makeflags-parsing.patch
+++ b/pkgs/servers/samba/4.x-fix-makeflags-parsing.patch
@@ -1,0 +1,11 @@
+--- a/buildtools/wafsamba/samba_utils.py	2019-04-08 01:13:47.525306574 +0000
++++ b/buildtools/wafsamba/samba_utils.py	2019-04-08 01:14:34.805245676 +0000
+@@ -495,7 +495,7 @@
+                 Logs.zones = ['runner']
+             if Logs.verbose > 2:
+                 Logs.zones = ['*']
+-        elif opt[0].isupper() and opt.find('=') != -1:
++        elif opt[0] and opt.find('=') != -1:
+             # this allows us to set waf options on the make command line
+             # for example, if you do "make FOO=blah", then we set the
+             # option 'FOO' in Options.options, to blah. If you look in wafsamba/wscript

--- a/pkgs/servers/samba/4.x-no-persistent-install-dynconfig.patch
+++ b/pkgs/servers/samba/4.x-no-persistent-install-dynconfig.patch
@@ -1,15 +1,18 @@
-diff -ru3 samba-4.4.6/dynconfig/wscript samba-4.4.6-new/dynconfig/wscript
---- samba-4.4.6/dynconfig/wscript	2016-01-26 14:45:46.000000000 +0300
-+++ samba-4.4.6-new/dynconfig/wscript	2016-10-15 22:21:18.159705132 +0300
-@@ -416,11 +416,3 @@
+--- a/dynconfig/wscript	2018-12-23 20:28:42.908832206 -0800
++++ b/dynconfig/wscript	2018-12-23 20:31:55.568835627 -0800
+@@ -419,15 +419,3 @@
                          public_headers=os_path_relpath(os.path.join(Options.launch_dir, version_header), bld.curdir),
                          header_path='samba',
                          cflags=cflags)
 -
 -    # install some extra empty directories
--    bld.INSTALL_DIRS("", "${CONFIGDIR} ${PRIVATE_DIR} ${LOGFILEBASE}");
--    bld.INSTALL_DIRS("", "${PRIVATE_DIR} ${PRIVILEGED_SOCKET_DIR}")
--    bld.INSTALL_DIRS("", "${STATEDIR} ${CACHEDIR}");
+-    bld.INSTALL_DIR("${CONFIGDIR}")
+-    bld.INSTALL_DIR("${LOGFILEBASE}")
+-    bld.INSTALL_DIR("${PRIVILEGED_SOCKET_DIR}")
+-    bld.INSTALL_DIR("${PRIVATE_DIR}", 0o700)
+-    bld.INSTALL_DIR("${BINDDNS_DIR}", 0o770)
+-    bld.INSTALL_DIR("${STATEDIR}")
+-    bld.INSTALL_DIR("${CACHEDIR}")
 -
 -    # these might be on non persistent storage
 -    bld.INSTALL_DIRS("", "${LOCKDIR} ${PIDDIR} ${SOCKET_DIR}")

--- a/pkgs/servers/samba/4.x-no-persistent-install.patch
+++ b/pkgs/servers/samba/4.x-no-persistent-install.patch
@@ -1,7 +1,6 @@
-diff -ru3 samba-4.4.6/ctdb/wscript samba-4.4.6-new/ctdb/wscript
---- samba-4.4.6/ctdb/wscript	2016-09-22 09:42:48.000000000 +0300
-+++ samba-4.4.6-new/ctdb/wscript	2016-10-15 23:31:13.932088237 +0300
-@@ -581,7 +581,7 @@
+--- a/ctdb/wscript	2019-01-15 02:07:00.000000000 -0800
++++ b/ctdb/wscript	2019-01-20 20:21:08.800187459 -0800
+@@ -814,7 +814,7 @@
      for t in etc_subdirs:
          files = SUBDIR_MODE('%s/%s' % (configdir, t), trim_path=configdir)
          for fmode in files:
@@ -9,14 +8,14 @@ diff -ru3 samba-4.4.6/ctdb/wscript samba-4.4.6-new/ctdb/wscript
 +            bld.INSTALL_FILES('${EXEC_PREFIX}${CTDB_ETCDIR}', 'config/%s' % fmode[0],
                                destname=fmode[0], chmod=fmode[1])
  
-     bld.SAMBA_GENERATOR('ctdb-functions',
-@@ -601,23 +601,19 @@
+     # If this is a direct install and there are no event scripts
+@@ -852,24 +852,20 @@
      ]
  
      for t in etc_scripts:
 -        bld.INSTALL_FILES(bld.env.CTDB_ETCDIR, 'config/%s' % t,
 +        bld.INSTALL_FILES('${EXEC_PREFIX}${CTDB_ETCDIR}', 'config/%s' % t,
-                           destname=t, chmod=0755)
+                           destname=t, chmod=MODE_755)
  
      bld.SAMBA_GENERATOR('ctdb-sudoers',
                          source='config/ctdb.sudoers',
@@ -26,14 +25,15 @@ diff -ru3 samba-4.4.6/ctdb/wscript samba-4.4.6-new/ctdb/wscript
 +    bld.INSTALL_FILES('${EXEC_PREFIX}${SYSCONFDIR}/sudoers.d', 'ctdb.sudoers',
                        destname='ctdb')
  
--    bld.INSTALL_FILES('${CTDB_ETCDIR}/notify.d', 'config/notify.d.README',
-+    bld.INSTALL_FILES('${EXEC_PREFIX}${CTDB_ETCDIR}/notify.d', 'config/notify.d.README',
+-    bld.INSTALL_FILES('${CTDB_ETCDIR}/events/notification',
++    bld.INSTALL_FILES('${EXEC_PREFIX}${CTDB_ETCDIR}/events/notification',
+                       'config/notification.README',
                        destname='README')
  
--    bld.install_dir(bld.env.CTDB_LOGDIR)
--    bld.install_dir(bld.env.CTDB_RUNDIR)
--    bld.install_dir(bld.env.CTDB_VARDIR)
+-    bld.INSTALL_DIR(bld.env.CTDB_LOGDIR)
+-    bld.INSTALL_DIR(bld.env.CTDB_RUNDIR)
+-    bld.INSTALL_DIR(bld.env.CTDB_VARDIR)
 -
-     # Unit tests
-     ctdb_unit_tests = [
-         'db_hash_test',
+     for d in ['volatile', 'persistent', 'state']:
+         bld.INSTALL_DIR(os.path.join(bld.env.CTDB_VARDIR, d))
+ 

--- a/pkgs/servers/samba/4.x.nix
+++ b/pkgs/servers/samba/4.x.nix
@@ -1,9 +1,9 @@
 { lib, stdenv, fetchurl, python, pkgconfig, perl, libxslt, docbook_xsl
 , fetchpatch
-, docbook_xml_dtd_42, readline, talloc
+, docbook_xml_dtd_42, readline
 , popt, iniparser, libbsd, libarchive, libiconv, gettext
 , krb5Full, zlib, openldap, cups, pam, avahi, acl, libaio, fam, libceph, glusterfs
-, gnutls, ncurses, libunwind, systemd
+, gnutls, ncurses, libunwind, systemd, jansson, lmdb, gpgme
 
 , enableLDAP ? false
 , enablePrinting ? false
@@ -20,11 +20,11 @@ with lib;
 
 stdenv.mkDerivation rec {
   name = "samba-${version}";
-  version = "4.7.12";
+  version = "4.10.2";
 
   src = fetchurl {
     url = "mirror://samba/pub/samba/stable/${name}.tar.gz";
-    sha256 = "0jmg39xigrh48j39r4f1390kmr1p3xbfxzfabln4b0r9qdmki70f";
+    sha256 = "112yizx9cpjhi8c7mh9znqg0c9dkj3383hwr8dhgpykl3g2zv347";
   };
 
   outputs = [ "out" "dev" "man" ];
@@ -33,30 +33,19 @@ stdenv.mkDerivation rec {
     [ ./4.x-no-persistent-install.patch
       ./patch-source3__libads__kerberos_keytab.c.patch
       ./4.x-no-persistent-install-dynconfig.patch
-
-      # conditionall disable MacOS incompatible tests
-      (fetchpatch {
-        url = "https://patch-diff.githubusercontent.com/raw/samba-team/samba/pull/107.patch";
-        sha256 = "0r6q34vjj0bdzmcbnrkad9rww58k4krbwicv4gs1g3dj49skpvd6";
-      })
-
-      (fetchpatch {
-        name = "CVE-2019-3824.patch";
-        url = "https://attachments.samba.org/attachment.cgi?id=14859";
-        sha256 = "02qf3zr55mzbimqdv01k3b22jjb084vfr5zabapyr5h1f588mw0q";
-      })
+      ./4.x-fix-makeflags-parsing.patch
     ];
 
   buildInputs =
     [ python pkgconfig perl libxslt docbook_xsl docbook_xml_dtd_42 /*
-      docbook_xml_dtd_45 */ readline talloc popt iniparser
+      docbook_xml_dtd_45 */ readline popt iniparser jansson
       libbsd libarchive zlib fam libiconv gettext libunwind krb5Full
     ]
     ++ optionals stdenv.isLinux [ libaio systemd ]
     ++ optional enableLDAP openldap
     ++ optional (enablePrinting && stdenv.isLinux) cups
     ++ optional enableMDNS avahi
-    ++ optional enableDomainController gnutls
+    ++ optionals enableDomainController [ gnutls gpgme lmdb ]
     ++ optional enableRegedit ncurses
     ++ optional (enableCephFS && stdenv.isLinux) libceph
     ++ optional (enableGlusterFS && stdenv.isLinux) glusterfs
@@ -69,6 +58,8 @@ stdenv.mkDerivation rec {
 
     # Fix the XML Catalog Paths
     sed -i "s,\(XML_CATALOG_FILES=\"\),\1$XML_CATALOG_FILES ,g" buildtools/wafsamba/wafsamba.py
+
+    patchShebangs ./buildtools/bin
   '';
 
   configureFlags =
@@ -87,8 +78,9 @@ stdenv.mkDerivation rec {
     ++ optional (!enableAcl) "--without-acl-support"
     ++ optional (!enablePam) "--without-pam";
 
-  # To build in parallel.
-  buildPhase = "python buildtools/bin/waf build -j $NIX_BUILD_CORES";
+  preBuild = ''
+      export MAKEFLAGS="-j $NIX_BUILD_CORES"
+  '';
 
   # Some libraries don't have /lib/samba in RPATH but need it.
   # Use find -type f -executable -exec echo {} \; -exec sh -c 'ldd {} | grep "not found"' \;
@@ -111,5 +103,6 @@ stdenv.mkDerivation rec {
     description = "The standard Windows interoperability suite of programs for Linux and Unix";
     license = licenses.gpl3;
     platforms = platforms.unix;
+    maintainers = with maintainers; [ aneeshusa ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14289,7 +14289,7 @@ in
   samba3 = callPackage ../servers/samba/3.x.nix { };
 
   samba4 = callPackage ../servers/samba/4.x.nix {
-    python = python2;
+    python = python3;
   };
 
   sambaMaster = callPackage ../servers/samba/master.nix { };


### PR DESCRIPTION
Release notes: https://www.samba.org/samba/history/samba-4.10.2.html
Notably, Samba 4.10.0 is the first with Python 3 support,
and the 4.10 line will be the last supporting Python 2,
so switch to Python 3.

Add myself as a maintainer.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I set up Samba and wanted to use an up-to-date version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [WIP] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [WIP] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).