### PR TITLE
purescript: upgrade to 0.12.4

### DIFF
--- a/pkgs/development/compilers/purescript/purescript/default.nix
+++ b/pkgs/development/compilers/purescript/purescript/default.nix
@@ -18,19 +18,19 @@ let
 
 in stdenv.mkDerivation rec {
   name = "purs-simple";
-  version = "v0.12.3";
+  version = "v0.12.4";
 
   src =
     if stdenv.isDarwin
     then
     fetchurl {
-      url = "https://github.com/purescript/purescript/releases/download/v0.12.3/macos.tar.gz";
-      sha256 = "1f916gv4fz571l4jvr15xjnsvjyy4nljv2ii9njwlm7k6yr5m0qn";
+      url = "https://github.com/purescript/purescript/releases/download/v0.12.4/macos.tar.gz";
+      sha256 = "046b18plakwvqr77x1hybhfiyzrhnnq0q5ixcmypri1mkkdsmczx";
     }
     else
     fetchurl {
-      url = "https://github.com/purescript/purescript/releases/download/v0.12.3/linux64.tar.gz";
-      sha256 = "1fad862a2sv4njxbbcfzibbi585m6is3ywb94nmjl8ax254baj3i";
+      url = "https://github.com/purescript/purescript/releases/download/v0.12.4/linux64.tar.gz";
+      sha256 = "18yny533sjfgacxqx1ki306nhznj4q6nv52c83l82gqj8amyj7k0";
     };
 
 


### PR DESCRIPTION
###### Motivation for this change

New release of PureScript https://github.com/purescript/purescript/releases/tag/v0.12.4

Mirrors changes in easy-purescript-nix: https://github.com/justinwoo/easy-purescript-nix/pull/37

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
