### PR TITLE
vulnix: 1.8.0 -> 1.8.1

### DIFF
--- a/pkgs/tools/security/vulnix/default.nix
+++ b/pkgs/tools/security/vulnix/default.nix
@@ -2,11 +2,11 @@
 
 pythonPackages.buildPythonApplication rec {
   pname = "vulnix";
-  version = "1.8.0";
+  version = "1.8.1";
 
   src = pythonPackages.fetchPypi {
     inherit pname version;
-    sha256 = "15j8zz7qmf6c6vhim08yn1knn0qhwypmc7bxw608zg5nf50vghyb";
+    sha256 = "1kpwqsnz7jisi622halzl4s5q42d76nbq6ra800gscnfx48hqw9r";
   };
 
   outputs = [ "out" "doc" "man" ];


### PR DESCRIPTION
###### Motivation for this change

Minor change to ensure compatibility with PyYAML 5.x. See also #57688

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions (Ubuntu)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size -> negligible
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
