### PR TITLE
macdylibbundler: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3441,6 +3441,11 @@
     github = "nocoolnametom";
     name = "Tom Doggett";
   };
+  nomeata = {
+    email = "mail@joachim-breitner.de";
+    github = "nomeata";
+    name = "Joachim Breitner";
+  };
   noneucat = {
     email = "andy@lolc.at";
     github = "noneucat";

--- a/pkgs/development/tools/misc/macdylibbundler/default.nix
+++ b/pkgs/development/tools/misc/macdylibbundler/default.nix
@@ -1,7 +1,8 @@
 { stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  name = "macdylibbundler";
+  name = "macdylibbundler-${version}";
+  version = "20180825";
 
   src = fetchFromGitHub {
     owner = "auriamg";

--- a/pkgs/development/tools/misc/macdylibbundler/default.nix
+++ b/pkgs/development/tools/misc/macdylibbundler/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "macdylibbundler";
+
+  src = fetchFromGitHub {
+    owner = "auriamg";
+    repo = "macdylibbundler";
+    rev = "ce13cb585ead5237813b85e68fe530f085fc0a9e";
+    sha256 = "149p3dcnap4hs3nhq5rfvr3m70rrb5hbr5xkj1h0gsfp0d7gvxnj";
+  };
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  meta = with stdenv.lib; {
+    description = "Utility to ease bundling libraries into executables for OSX";
+    longDescription = ''
+      dylibbundler is a small command-line programs that aims to make bundling
+      .dylibs as easy as possible. It automatically determines which dylibs are
+      needed by your program, copies these libraries inside the app bundle, and
+      fixes both them and the executable to be ready for distribution... all
+      this with a single command on the teminal! It will also work if your
+      program uses plug-ins that have dependencies too.
+    '';
+    homepage = https://github.com/auriamg/macdylibbundler;
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = [ maintainers.nomeata ];
+
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18432,6 +18432,8 @@ in
 
   mac = callPackage ../development/libraries/mac { };
 
+  macdylibbundler = callPackage ../development/tools/misc/macdylibbundler { };
+
   magic-wormhole = with python3Packages; toPythonApplication magic-wormhole;
 
   mail-notification = callPackage ../desktops/gnome-2/desktop/mail-notification {};


### PR DESCRIPTION
###### Motivation for this change

which I found useful to make self-contained releases of binaries built
on osx.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).