### PR TITLE
Expose prometheus generic builder.

### DIFF
--- a/pkgs/servers/monitoring/prometheus/default.nix
+++ b/pkgs/servers/monitoring/prometheus/default.nix
@@ -3,7 +3,7 @@
 let
   goPackagePath = "github.com/prometheus/prometheus";
 in rec {
-  generic = { version, sha256, doCheck ? true, ... }@attrs:
+  buildPrometheus = { version, sha256, doCheck ? true, ... }@attrs:
     let attrs' = builtins.removeAttrs attrs ["version" "sha256"]; in
       buildGoPackage ({
         name = "prometheus-${version}";
@@ -42,12 +42,12 @@ in rec {
         };
     } // attrs');
 
-  prometheus_1 = generic {
+  prometheus_1 = buildPrometheus {
     version = "1.8.2";
     sha256 = "088flpg3qgnj9afl9vbaa19v2s1d21yxy38nrlv5m7cxwy2pi5pv";
   };
 
-  prometheus_2 = generic {
+  prometheus_2 = buildPrometheus {
     version = "2.6.0";
     sha256 = "1d9zwzs280pw9zspqwp7xx3ji04lfg2v9l5qhrfy3y633ghcmpxz";
   };

--- a/pkgs/servers/monitoring/prometheus/default.nix
+++ b/pkgs/servers/monitoring/prometheus/default.nix
@@ -2,8 +2,8 @@
 
 let
   goPackagePath = "github.com/prometheus/prometheus";
-
-  generic = { version, sha256, ... }@attrs:
+in rec {
+  generic = { version, sha256, doCheck ? true, ... }@attrs:
     let attrs' = builtins.removeAttrs attrs ["version" "sha256"]; in
       buildGoPackage ({
         name = "prometheus-${version}";
@@ -16,8 +16,6 @@ let
           repo = "prometheus";
           inherit sha256;
         };
-
-        doCheck = true;
 
         buildFlagsArray = let t = "${goPackagePath}/vendor/github.com/prometheus/common/version"; in ''
           -ldflags=
@@ -43,7 +41,7 @@ let
           platforms = platforms.unix;
         };
     } // attrs');
-in rec {
+
   prometheus_1 = generic {
     version = "1.8.2";
     sha256 = "088flpg3qgnj9afl9vbaa19v2s1d21yxy38nrlv5m7cxwy2pi5pv";


### PR DESCRIPTION
###### Motivation for this change
 So that people can easily try newer prometheus versions in overlays:
```nix
 self: super: {
   prometheus_2 = (super.callPackage <nixpkgs/pkgs/servers/monitoring/prometheus> {}).generic {
     version = "2.8.1";
     sha256 = "0x8w0qdh4lcf19nmdlhvgzpy08c2a932d3k49cjwhi5npcsf858n";
     doCheck = false;
   };
 }
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
