### PR TITLE
pythonPackages.cntk: mark as broken with python 3.7

### DIFF
--- a/pkgs/development/python-modules/cntk/default.nix
+++ b/pkgs/development/python-modules/cntk/default.nix
@@ -10,7 +10,7 @@
 }:
 
 buildPythonPackage rec {
-  inherit (pkgs.cntk) name version src meta;
+  inherit (pkgs.cntk) name version src;
 
   buildInputs = [ pkgs.cntk pkgs.swig pkgs.openmpi ];
   propagatedBuildInputs = [ numpy scipy enum34 protobuf pip ];
@@ -35,4 +35,12 @@ buildPythonPackage rec {
     cd $NIX_BUILD_TOP
     ${python.interpreter} -c "import cntk"
   '';
+
+  meta = {
+    inherit (pkgs.cntk.meta) homepage description license maintainers;
+    # broken in CNTK 2.4 starting with python-3.7
+    # ("ImportError: cannot import name 'GenericMeta' from 'typing'")
+    broken = stdenv.lib.versionAtLeast python.version "3.7";
+
+  };
 }

--- a/pkgs/development/python-modules/cntk/default.nix
+++ b/pkgs/development/python-modules/cntk/default.nix
@@ -12,7 +12,8 @@
 buildPythonPackage rec {
   inherit (pkgs.cntk) name version src;
 
-  buildInputs = [ pkgs.cntk pkgs.swig pkgs.openmpi ];
+  nativeBuildInputs = [ pkgs.swig pkgs.openmpi ];
+  buildInputs = [ pkgs.cntk pkgs.openmpi ];
   propagatedBuildInputs = [ numpy scipy enum34 protobuf pip ];
 
   CNTK_LIB_PATH = "${pkgs.cntk}/lib";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
The CNTK python module seems to be broken since November 2018 (does not recognize swig).
Mark it as broken.

Needs back port to 19.03 (https://github.com/NixOS/nixpkgs/issues/56826)

CC @costrouc @abbradar 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
