### PR TITLE
Fix Cassandra, improve config and tests

### DIFF
--- a/nixos/modules/services/databases/cassandra.nix
+++ b/nixos/modules/services/databases/cassandra.nix
@@ -229,11 +229,11 @@ in {
       example = literalExample "null";
       description = ''
           Set the interval how often full repairs are run, i.e.
-          `nodetool repair --full` is executed. See
+          <literal>nodetool repair --full</literal> is executed. See
           https://cassandra.apache.org/doc/latest/operating/repair.html
           for more information.
 
-          Set to `null` to disable full repairs.
+          Set to <literal>null</literal> to disable full repairs.
         '';
     };
     fullRepairOptions = mkOption {
@@ -250,11 +250,11 @@ in {
       example = literalExample "null";
       description = ''
           Set the interval how often incremental repairs are run, i.e.
-          `nodetool repair` is executed. See
+          <literal>nodetool repair<literal> is executed. See
           https://cassandra.apache.org/doc/latest/operating/repair.html
           for more information.
 
-          Set to `null` to disable incremental repairs.
+          Set to <literal>null</literal> to disable incremental repairs.
         '';
     };
     incrementalRepairOptions = mkOption {
@@ -342,6 +342,8 @@ in {
       description = ''
         Roles that are allowed to access the JMX (e.g. nodetool)
         BEWARE: The passwords will be stored world readable in the nix-store.
+                It's recommended to use your own protected file using
+                <literal>jmxRolesFile</literal>
 
         Doesn't work in versions older than 3.11 because they don't like that
         it's world readable.
@@ -388,7 +390,8 @@ in {
         { assertion = cfg.remoteJmx -> cfg.jmxRolesFile != null;
           message = ''
             If you want JMX available remotely you need to set a password using
-            `jmxRoles` or `jmxRolesFile` if using Cassandra older than v3.11.
+            <literal>jmxRoles</literal> or <literal>jmxRolesFile</literal> if
+            using Cassandra older than v3.11.
           '';
         }
       ];

--- a/nixos/modules/services/databases/cassandra.nix
+++ b/nixos/modules/services/databases/cassandra.nix
@@ -12,16 +12,17 @@ let
        cluster_name = cfg.clusterName;
        partitioner = "org.apache.cassandra.dht.Murmur3Partitioner";
        endpoint_snitch = "SimpleSnitch";
-       seed_provider =
-         [{ class_name = "org.apache.cassandra.locator.SimpleSeedProvider";
-            parameters = [ { seeds = concatStringsSep "," cfg.seedAddresses; } ];
-         }];
        data_file_directories = [ "${cfg.homeDir}/data" ];
        commitlog_directory = "${cfg.homeDir}/commitlog";
        saved_caches_directory = "${cfg.homeDir}/saved_caches";
-     } // (if lib.versionAtLeast cfg.package.version "3"
-             then { hints_directory = "${cfg.homeDir}/hints"; }
-             else {})
+     } // (lib.optionalAttrs (cfg.seedAddresses != []) {
+       seed_provider = [{
+         class_name = "org.apache.cassandra.locator.SimpleSeedProvider";
+         parameters = [ { seeds = concatStringsSep "," cfg.seedAddresses; } ];
+       }];
+     }) // (lib.optionalAttrs (lib.versionAtLeast cfg.package.version "3") {
+       hints_directory = "${cfg.homeDir}/hints";
+     })
     );
   cassandraConfigWithAddresses = cassandraConfig //
     ( if cfg.listenAddress == null

--- a/nixos/modules/services/databases/cassandra.nix
+++ b/nixos/modules/services/databases/cassandra.nix
@@ -13,7 +13,7 @@ let
        endpoint_snitch = "SimpleSnitch";
        seed_provider =
          [{ class_name = "org.apache.cassandra.locator.SimpleSeedProvider";
-            parameters = [ { seeds = "127.0.0.1"; } ];
+            parameters = [ { seeds = concatStringsSep "," cfg.seedAddresses; } ];
          }];
        data_file_directories = [ "${cfg.homeDir}/data" ];
        commitlog_directory = "${cfg.homeDir}/commitlog";
@@ -161,6 +161,16 @@ in {
       '';
       description = ''
         XML logback configuration for cassandra
+      '';
+    };
+    seedAddresses = mkOption {
+      type = types.listOf types.str;
+      default = [ "127.0.0.1" ];
+      description = ''
+        The addresses of hosts designated as contact points in the cluster. A
+        joining node contacts one of the nodes in the seeds list to learn the
+        topology of the ring.
+        Set to 127.0.0.1 for a single node cluster.
       '';
     };
     allowClients = mkOption {

--- a/nixos/modules/services/databases/cassandra.nix
+++ b/nixos/modules/services/databases/cassandra.nix
@@ -8,6 +8,7 @@ let
   cassandraConfig = flip recursiveUpdate cfg.extraConfig
     ({ commitlog_sync = "batch";
        commitlog_sync_batch_window_in_ms = 2;
+       start_native_transport = cfg.allowClients;
        partitioner = "org.apache.cassandra.dht.Murmur3Partitioner";
        endpoint_snitch = "SimpleSnitch";
        seed_provider =
@@ -160,6 +161,18 @@ in {
       '';
       description = ''
         XML logback configuration for cassandra
+      '';
+    };
+    allowClients = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Enables or disables the native transport server (CQL binary protocol).
+        This server uses the same address as the <literal>rpcAddress</literal>,
+        but the port it uses is not <literal>rpc_port</literal> but
+        <literal>native_transport_port</literal>. See the official Cassandra
+        docs for more information on these variables and set them using
+        <literal>extraConfig</literal>.
       '';
     };
     extraConfig = mkOption {

--- a/nixos/modules/services/databases/cassandra.nix
+++ b/nixos/modules/services/databases/cassandra.nix
@@ -9,6 +9,7 @@ let
     ({ commitlog_sync = "batch";
        commitlog_sync_batch_window_in_ms = 2;
        start_native_transport = cfg.allowClients;
+       cluster_name = cfg.clusterName;
        partitioner = "org.apache.cassandra.dht.Murmur3Partitioner";
        endpoint_snitch = "SimpleSnitch";
        seed_provider =
@@ -52,6 +53,15 @@ in {
     enable = mkEnableOption ''
       Apache Cassandra – Scalable and highly available database.
     '';
+    clusterName = mkOption {
+      type = types.str;
+      default = "NixOS Test Cluster";
+      description = ''
+        The name of the cluster.
+        This setting prevents nodes in one logical cluster from joining
+        another. All nodes in a cluster must have the same value.
+      '';
+    };
     user = mkOption {
       type = types.str;
       default = defaultUser;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -36,6 +36,7 @@ in
   borgbackup = handleTest ./borgbackup.nix {};
   buildbot = handleTest ./buildbot.nix {};
   cadvisor = handleTestOn ["x86_64-linux"] ./cadvisor.nix {};
+  cassandra = handleTest ./cassandra.nix {};
   ceph = handleTestOn ["x86_64-linux"] ./ceph.nix {};
   certmgr = handleTest ./certmgr.nix {};
   cfssl = handleTestOn ["x86_64-linux"] ./cfssl.nix {};

--- a/nixos/tests/cassandra.nix
+++ b/nixos/tests/cassandra.nix
@@ -2,9 +2,11 @@ import ./make-test.nix ({ pkgs, ...}:
 let
   # Change this to test a different version of Cassandra:
   testPackage = pkgs.cassandra;
+  clusterName = "NixOS Automated-Test Cluster";
 
   cassandraCfg = ipAddress:
     { enable = true;
+      inherit clusterName;
       listenAddress = ipAddress;
       rpcAddress = ipAddress;
       extraConfig =
@@ -47,6 +49,11 @@ in
       $cass0->waitForUnit("cassandra.service");
       $cass0->waitUntilSucceeds("nc -z localhost 7199");
       $cass0->succeed("nodetool status --resolve-ip | egrep '^UN[[:space:]]+cass0'");
+    };
+    subtest "Cluster name was set", sub {
+      $cass0->waitForUnit("cassandra.service");
+      $cass0->waitUntilSucceeds("nc -z localhost 7199");
+      $cass0->waitUntilSucceeds("nodetool describecluster | grep 'Name: ${clusterName}'");
     };
 
     # Check cluster interaction

--- a/nixos/tests/cassandra.nix
+++ b/nixos/tests/cassandra.nix
@@ -9,13 +9,7 @@ let
       inherit clusterName;
       listenAddress = ipAddress;
       rpcAddress = ipAddress;
-      extraConfig =
-        { start_native_transport = true;
-          seed_provider =
-            [{ class_name = "org.apache.cassandra.locator.SimpleSeedProvider";
-               parameters = [ { seeds = "192.168.1.1"; } ];
-            }];
-        };
+      seedAddresses = [ "192.168.1.1" ];
       package = testPackage;
     };
   nodeCfg = ipAddress: extra: {pkgs, config, ...}:

--- a/nixos/tests/cassandra.nix
+++ b/nixos/tests/cassandra.nix
@@ -14,7 +14,13 @@ let
     };
   nodeCfg = ipAddress: extra: {pkgs, config, ...}:
     { environment.systemPackages = [ testPackage ];
-      networking.firewall.enable = false;
+      networking = {
+        firewall.allowedTCPPorts = [ 7000 7199 9042 ];
+        useDHCP = false;
+        interfaces.eth1.ipv4.addresses = pkgs.lib.mkOverride 0 [
+          { address = ipAddress; prefixLength = 24; }
+        ];
+      };
       services.cassandra = cassandraCfg ipAddress // extra;
       virtualisation.memorySize = 1024;
     };


### PR DESCRIPTION
###### Motivation for this change
- It's more intuitive and discoverable when you can configure set some options using Nix attributes - plus we can check it using some assertions.
- Make it possible to set the variables in `cassandra-env.sh`.
- Allow client connections by default because that's what users expect.
- Fix tests and test more things
- Make binaries work again (properly wrap them)

The test doesn't work - it doesn't work without this PR. I'll figure out why, when I have time. Seems like a race condition of the VMs starting, it's not a problem with the module itself, rather the tests.
[EDIT]: I think I fixed the tests, please have ofborg run them.

I tested manually on my system that the different configuration options actually have the desired effect.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).