### PR TITLE
gimp: 2.10.8 → 2.10.10

### DIFF
--- a/pkgs/applications/graphics/gimp/default.nix
+++ b/pkgs/applications/graphics/gimp/default.nix
@@ -8,12 +8,12 @@
 let
   inherit (python2Packages) pygtk wrapPython python;
 in stdenv.mkDerivation rec {
-  name = "gimp-${version}";
-  version = "2.10.8";
+  pname = "gimp";
+  version = "2.10.10";
 
   src = fetchurl {
-    url = "http://download.gimp.org/pub/gimp/v${stdenv.lib.versions.majorMinor version}/${name}.tar.bz2";
-    sha256 = "16sb4kslwin2jbgdb4nhks78pd0af8mvj8g5hap3hj946p7w2jfq";
+    url = "http://download.gimp.org/pub/gimp/v${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.bz2";
+    sha256 = "0xwck5nbpb945s1cyij3kfqw1pchbhx8i5vf5hgywyjw4r1z5l8j";
   };
 
   nativeBuildInputs = [ pkgconfig intltool gettext wrapPython ];

--- a/pkgs/development/libraries/gegl/4.0.nix
+++ b/pkgs/development/libraries/gegl/4.0.nix
@@ -1,19 +1,44 @@
-{ stdenv, fetchurl, pkgconfig, glib, babl, libpng, cairo, libjpeg, which
-, librsvg, pango, gtk, bzip2, json-glib, intltool, autoreconfHook, libraw
+{ stdenv, fetchurl, fetchpatch, pkgconfig, glib, babl, libpng, cairo, libjpeg, which
+, librsvg, pango, gtk, bzip2, json-glib, gettext, autoreconfHook, libraw
 , gexiv2, libwebp, gnome3, libintl }:
 
-let
-  version = "0.4.12";
-in stdenv.mkDerivation rec {
-  name = "gegl-${version}";
+stdenv.mkDerivation rec {
+  pname = "gegl";
+  version = "0.4.14";
 
   outputs = [ "out" "dev" "devdoc" ];
   outputBin = "dev";
 
   src = fetchurl {
-    url = "https://download.gimp.org/pub/gegl/${stdenv.lib.versions.majorMinor version}/${name}.tar.bz2";
-    sha256 = "0ljqxc4iyy2hrj31pxcy1xp4xm5zbx1nigqisphmg4p8mcz2jrz9";
+    url = "https://download.gimp.org/pub/gegl/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.bz2";
+    sha256 = "00crhngwi07f5b9x77kx5p7p4cl6l5g6glpz9rqv7pfqk62xa0ac";
   };
+
+  patches = stdenv.lib.optionals stdenv.isDarwin [
+    # Make the Darwin patches below apply cleanly
+    (fetchpatch {
+      url = https://gitlab.gnome.org/GNOME/gegl/commit/141a7aa76cd36143f624f06b1c43d2483945653c.patch;
+      sha256 = "0ijv9ra6723jn60krjwzbc6l9qr08h76bsz9xgddvfgsgr1nnpbi";
+    })
+    (fetchpatch {
+      url = https://gitlab.gnome.org/GNOME/gegl/commit/b3ff0df080d133bbdb394c3db40d4f9d2980a8a6.patch;
+      sha256 = "0im0rqk8mz9vi7qqx06vj4wm5hjwv1544jwdaaywlcrs9g266hl0";
+    })
+    (fetchpatch {
+      url = https://gitlab.gnome.org/GNOME/gegl/commit/fe756be6f0c776a45201a61f67d3e5e42f6398de.patch;
+      sha256 = "0h3rqwfsph2gisbwvc2v5a9r5b0djcxlm790xpi6yfndj42b0v2b";
+    })
+    # Fix build on Darwin
+    # https://gitlab.gnome.org/GNOME/gegl/merge_requests/28
+    (fetchpatch {
+      url = https://gitlab.gnome.org/GNOME/gegl/commit/ac331b5c0e3d940b64bb811b0f54e86c7d312917.patch;
+      sha256 = "1yj9jh8q9cbr1szrxhdapknk4nfhbkbc1njv50ifrj7vyfislj34";
+    })
+    (fetchpatch {
+      url = https://gitlab.gnome.org/GNOME/gegl/commit/d05eb01170728f45f561ca937708a293e29e02d9.patch;
+      sha256 = "0gwz12sm8kkmzyxsiq0sl30cabs5q0ckj743yrzimspkhrvc1ya2";
+    })
+  ];
 
   enableParallelBuilding = true;
 
@@ -26,7 +51,7 @@ in stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ glib json-glib babl ]; # for gegl-4.0.pc
 
-  nativeBuildInputs = [ pkgconfig intltool which autoreconfHook libintl ];
+  nativeBuildInputs = [ pkgconfig gettext which autoreconfHook libintl ];
 
   meta = with stdenv.lib; {
     description = "Graph-based image processing framework";


### PR DESCRIPTION
###### Motivation for this change
Announcement: https://www.gimp.org/news/2019/04/07/gimp-2-10-10-released/
GIMP Changes: https://gitlab.gnome.org/GNOME/gimp/blob/GIMP_2_10_10/NEWS
GEGL Changes: https://gitlab.gnome.org/GNOME/gegl/blob/GEGL_0_4_14/docs/NEWS.txt

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
