### PR TITLE
Revert "gtksourceview: 3.24.9 -> 3.24.10"

### DIFF
--- a/pkgs/development/libraries/gtksourceview/3.x.nix
+++ b/pkgs/development/libraries/gtksourceview/3.x.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "gtksourceview-${version}";
-  version = "3.24.10";
+  version = "3.24.9";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gtksourceview/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "16ym7jwiki4s1pilwr4incx0yg7ll94f1cajrnpndkxxs36hcm5b";
+    sha256 = "1hh7brcvpip96mkf9460ksy2qpx2pwynwd0634rx78z6afj7d7b9";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
Reverts NixOS/nixpkgs#58175

This doesn't cause a conflict, but I think it would make more sense to just put this in staging-next.

cc @jtojnar 