### PR TITLE
xtris: init at 1.15

### DIFF
--- a/pkgs/games/xtris/default.nix
+++ b/pkgs/games/xtris/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchzip, xorg }:
+stdenv.mkDerivation rec {
+  name = "xtris-${version}";
+  version = "1.15";
+
+  src = fetchzip {
+    url = "https://web.archive.org/web/20120315061213/http://www.iagora.com/~espel/xtris/xtris-${version}.tar.gz";
+    sha256 = "1vqva99lyv7r6f9c7yikk8ahcfh9aq3clvwm4pz964wlbr9mj1v6";
+  };
+
+  patchPhase = ''
+    sed -i '
+      s:/usr/local/bin:'$out'/bin:
+      s:/usr/local/man:'$out'/share/man:
+      s:mkdir:mkdir -p:g
+      s:^CFLAGS:#CFLAGS:
+    ' Makefile
+  '';
+  buildInputs = [ xorg.libX11 ];
+
+  meta = with stdenv.lib; {
+    description = "A multi-player version of the classical game of Tetris, for the X Window system";
+    homepage = https://web.archive.org/web/20120315061213/http://www.iagora.com/~espel/xtris/xtris.html;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21530,6 +21530,8 @@ in
 
   xsokoban = callPackage ../games/xsokoban { };
 
+  xtris = callPackage ../games/xtris { };
+
   inherit (callPackage ../games/quake2/yquake2 { })
     yquake2
     yquake2-ctf


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This has always been one of my favorite, if not my favorite implementation of Tetris™.

It features:
1. multiplayer
2. bots
3. a chat!

Now, the last upstream release of this software was over 21 years ago and the website and source used in this derivation are on archive.org.
However, it uses the X11 core protocol to draw its UI and still works after more than two decades, so I assume it will keep on working at least two decades more.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
