### PR TITLE
alacritty: 0.2.9 -> 0.3.0

### DIFF
--- a/pkgs/applications/misc/alacritty/default.nix
+++ b/pkgs/applications/misc/alacritty/default.nix
@@ -47,17 +47,17 @@ let
     libxkbcommon
   ];
 in buildRustPackage rec {
-  name = "alacritty-${version}";
-  version = "0.2.9";
+  pname = "alacritty";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "jwilm";
-    repo = "alacritty";
+    repo = pname;
     rev = "v${version}";
-    sha256 = "01wzkpbz6jjmpmnkqswilnn069ir3cx3jvd3j7zsvqdxqpwncz39";
+    sha256 = "0d9qnymi8v4aqm2p300ccdsgavrnd64sv7v0cz5dp0sp5c0vd7jl";
   };
 
-  cargoSha256 = "0h9wczgpjh52lhrqg0r2dkrh5svmyvrvh4yj7p0nz45skgrnl8w9";
+  cargoSha256 = "11gpv0h15n12f97mcwjymlzcmkldbakkkb5h931qgm3mvhhq5ay5";
 
   nativeBuildInputs = [
     cmake
@@ -92,19 +92,20 @@ in buildRustPackage rec {
     mkdir $out/Applications
     cp -r target/release/osx/Alacritty.app $out/Applications/Alacritty.app
   '' else ''
-    install -D alacritty.desktop $out/share/applications/alacritty.desktop
+    install -D extra/linux/alacritty.desktop -t $out/share/applications/
+    install -D extra/logo/alacritty-term.svg $out/share/icons/hicolor/scalable/apps/Alacritty.svg
     patchelf --set-rpath "${stdenv.lib.makeLibraryPath rpathLibs}" $out/bin/alacritty
   '') + ''
 
-    install -D alacritty-completions.zsh "$out/share/zsh/site-functions/_alacritty"
-    install -D alacritty-completions.bash "$out/etc/bash_completion.d/alacritty-completions.bash"
-    install -D alacritty-completions.fish "$out/share/fish/vendor_completions.d/alacritty.fish"
+    install -D extra/completions/_alacritty -t "$out/share/zsh/site-functions/"
+    install -D extra/completions/alacritty.bash -t "$out/etc/bash_completion.d/"
+    install -D extra/completions/alacritty.fish -t "$out/share/fish/vendor_completions.d/"
 
     install -dm 755 "$out/share/man/man1"
-    gzip -c alacritty.man > "$out/share/man/man1/alacritty.1.gz"
+    gzip -c extra/alacritty.man > "$out/share/man/man1/alacritty.1.gz"
 
     install -dm 755 "$terminfo/share/terminfo/a/"
-    tic -x -o "$terminfo/share/terminfo" alacritty.info
+    tic -x -o "$terminfo/share/terminfo" extra/alacritty.info
     mkdir -p $out/nix-support
     echo "$terminfo" >> $out/nix-support/propagated-user-env-packages
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

[Alacritty Version 0.3.0 Release](https://blog.christianduerr.com/alacritty_030_announcement)
[changelog](https://github.com/jwilm/alacritty/blob/master/CHANGELOG.md#version-030)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
