### PR TITLE
codimd: js-sequence-diagrams: use git source rather than the NPM tarball

### DIFF
--- a/pkgs/servers/web-apps/codimd/js-sequence-diagrams/default.nix
+++ b/pkgs/servers/web-apps/codimd/js-sequence-diagrams/default.nix
@@ -11,9 +11,11 @@ in
     name = "js-sequence-diagrams";
     packageName = "js-sequence-diagrams";
     version = "1000000.0.6";
-    src = pkgs.fetchurl {
-      url = "https://registry.npmjs.org/js-sequence-diagrams/-/js-sequence-diagrams-1000000.0.6.tgz";
-      sha1 = "e95db01420479c5ccbc12046af1da42fde649e5c";
+    src = pkgs.fetchFromGitHub {
+      owner = "Moeditor";
+      repo = "js-sequence-diagrams";
+      rev = "4d46bc6229a3f93c9bcad561cab4924034f5456d";
+      sha256 = "09ri5cx5yq87p3nla06gs0xb2gifmsy0xhs0s5524xr4ya6pnivv";
     };
     dependencies = [ ];
     dontNpmInstall = true;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

It seems as NPM just removed the tarballs of the unpublished package,
hence `codimd` isn't buildable. The sources for the package are
available on github[1] and fix the build.

For further information about the `js-sequence-diagrams` workarounds,
please refer to 5feec424de6bb9596880a778bb608f0cb5d1c570.

[1] https://github.com/Moeditor/js-sequence-diagrams

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
