### PR TITLE
brackets: add missing dependencies.

### DIFF
--- a/pkgs/applications/editors/brackets/default.nix
+++ b/pkgs/applications/editors/brackets/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchurl, gtk2, glib, gdk_pixbuf, alsaLib, nss, nspr, gconf
-, cups, libgcrypt_1_5, systemd, dbus }:
+, cups, libgcrypt_1_5, systemd, dbus, libXdamage, expat }:
 with stdenv.lib;
 
 let
   bracketsLibs = makeLibraryPath [
-    gtk2 glib gdk_pixbuf stdenv.cc.cc.lib alsaLib nss nspr gconf cups libgcrypt_1_5 dbus systemd
+    gtk2 glib gdk_pixbuf stdenv.cc.cc.lib alsaLib nss nspr gconf cups libgcrypt_1_5 dbus systemd libXdamage expat
   ];
 in
 stdenv.mkDerivation rec {


### PR DESCRIPTION
`libexpat` and `libXdamage` seems to be required for brackets to run. Fixes #55810.

I'm sorry that's my first contribution and despite NixOS being my daily driver I'm really not familiar with packaging process and builds.

So I tested my changes using  `nix-env -f /home/damien/Repositories/fork-nixpkgs -i brackets` and it runs.

I'm at work so i didn't take time to run in a sandbox mode :(


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Motivation for this change
Make brackets run again.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
