### PR TITLE
Dlang update (ldc: 1.14.0 -> 1.15.0, dmd: 2.084.1 -> 2.085.1, dtools: 2.084.1 -> 2.085.1, dub: 1.13.0 -> 1.14.0)

### DIFF
--- a/pkgs/development/compilers/dmd/default.nix
+++ b/pkgs/development/compilers/dmd/default.nix
@@ -2,10 +2,10 @@
 , makeWrapper, unzip, which, writeTextFile
 , curl, tzdata, gdb, darwin, git
 , callPackage, targetPackages, ldc
-, version ? "2.084.1"
-, dmdSha256 ? "10ll5072rkv3ln7i5l88h2f9mzda567kw2jwh6466vm6ylzl4jms"
-, druntimeSha256 ? "0i0g2cnzh097pmvb86gvyj79canaxppw33hp7ylqnd11q4kqc8pb"
-, phobosSha256 ? "1hxpismj9gy5n1bc9kl9ykgd4lfmkq9i8xgrq09j0fybfwn9j1gc"
+, version ? "2.085.1"
+, dmdSha256 ? "0ccidfcawrcwdpfjwjiln5xwr4ffp8i2hwx52p8zn3xmc5yxm660"
+, druntimeSha256 ? "109f2glsqrlshk06761xlw4r5v22mivp873cq9g5gcax3g00k617"
+, phobosSha256 ? "0giispqqx8j8xg6c0hm7nx77bcahiwic8rvf12sws3sv5pizv8pr"
 }:
 
 let
@@ -49,14 +49,6 @@ stdenv.mkDerivation rec {
     sha256 = phobosSha256;
     name = "phobos";
   })
-  ];
-
-  patches = [
-    (fetchpatch {
-      name = "fix-loader-import.patch";
-      url = "https://github.com/dlang/dmd/commit/e7790436c4af1910b8c079dac9bb69627d7dea4b.patch";
-      sha256 = "0w69hajx8agywc7m2hph5m27g2yclz8ml0gjjyjk9k6ii3jv45kx";
-    })
   ];
 
   patchFlags = [ "--directory=dmd" "-p1" ];

--- a/pkgs/development/tools/build-managers/dub/default.nix
+++ b/pkgs/development/tools/build-managers/dub/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   name = "dub-${version}";
-  version = "1.13.0";
+  version = "1.14.0";
 
   enableParallelBuilding = true;
 
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner = "dlang";
     repo = "dub";
     rev = "v${version}";
-    sha256 = "1wd5pdnbaafj33bbg188w0iz28ps4cyjangb12g2s9dyic29zjqv";
+    sha256 = "070kfkyrkr98y1hbhcf85842c0x7l95w1ambrkdgajpb6kcmpf84";
   };
 
   postUnpack = ''

--- a/pkgs/development/tools/dtools/default.nix
+++ b/pkgs/development/tools/dtools/default.nix
@@ -2,21 +2,21 @@
 
 stdenv.mkDerivation rec {
   name = "dtools-${version}";
-  version = "2.084.1";
+  version = "2.085.1";
 
   srcs = [
     (fetchFromGitHub {
       owner = "dlang";
       repo = "dmd";
       rev = "v${version}";
-      sha256 = "10ll5072rkv3ln7i5l88h2f9mzda567kw2jwh6466vm6ylzl4jms";
+      sha256 = "0ccidfcawrcwdpfjwjiln5xwr4ffp8i2hwx52p8zn3xmc5yxm660";
       name = "dmd";
     })
     (fetchFromGitHub {
       owner = "dlang";
       repo = "tools";
       rev = "v${version}";
-      sha256 = "0z3xkv9s1pdx8zdhsb92mwax2q5xhwjgh6g3iv53xip1nsxygn48";
+      sha256 = "1x85w4k2zqgv2bjbvhschxdc6kq8ygp89h499cy8rfqm6q23g0ws";
       name = "dtools";
     })
   ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update to new versions.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
