### PR TITLE
zig: 0.3.0 -> 0.4.0

### DIFF
--- a/pkgs/development/compilers/zig/default.nix
+++ b/pkgs/development/compilers/zig/default.nix
@@ -1,22 +1,18 @@
 { stdenv, fetchFromGitHub, cmake, llvmPackages, libxml2, zlib }:
 
 stdenv.mkDerivation rec {
-  version = "0.3.0";
-  name = "zig-${version}";
+  version = "0.4.0";
+  pname = "zig";
 
   src = fetchFromGitHub {
     owner = "ziglang";
-    repo = "zig";
-    rev = "${version}";
-    sha256 = "089ywagxjjh7gxv8h8yg7jpmryzjf7n4m5irhdkhp2966d03kyxm";
+    repo = pname;
+    rev = version;
+    sha256 = "1cq6cc5pvybz9kn3y0j5gskkjq88hkmmcsva54mfzpcc65l3pv6p";
   };
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ llvmPackages.clang-unwrapped llvmPackages.llvm libxml2 zlib ];
-
-  cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=Release"
-  ];
 
   meta = with stdenv.lib; {
     description = "Programming languaged designed for robustness, optimality, and clarity";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13391,7 +13391,7 @@ in
   zmqpp = callPackage ../development/libraries/zmqpp { };
 
   zig = callPackage ../development/compilers/zig {
-    llvmPackages = llvmPackages_7;
+    llvmPackages = llvmPackages_8;
   };
 
   zimlib = callPackage ../development/libraries/zimlib { };


### PR DESCRIPTION
Bump to use LLVM8, but just guessing ;).

Update: of course it does, here's
the release notes:

https://ziglang.org/download/0.4.0/release-notes.html

Built (updated) tetris example, LGTM!
(rem to grab its deps via nix-shell or so)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @andrewrk