### PR TITLE
brook: init at 20190401

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5252,6 +5252,11 @@
     github = "xnwdd";
     name = "Guillermo NWDD";
   };
+  xrelkd = {
+    email = "46590321+xrelkd@users.noreply.github.com";
+    github = "xrelkd";
+    name = "xrelkd";
+  };
   xurei = {
     email = "olivier.bourdoux@gmail.com";
     github = "xurei";

--- a/pkgs/tools/networking/brook/default.nix
+++ b/pkgs/tools/networking/brook/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  pname = "brook";
+  version = "20190401";
+
+  goPackagePath = "github.com/txthinking/brook";
+
+  src = fetchFromGitHub {
+    owner = "txthinking";
+    repo = "${pname}";
+    rev = "v${version}";
+    sha256 = "0kx0dpvr3llpdzmw5bvzhdvwkmzrv6kqbsilx6rgrvyl61y9pyry";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/txthinking/brook;
+    description = "A cross-platform Proxy/VPN software";
+    license = with licenses; [ gpl3 ];
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ xrelkd ];
+  };
+}
+

--- a/pkgs/tools/networking/brook/deps.nix
+++ b/pkgs/tools/networking/brook/deps.nix
@@ -1,0 +1,173 @@
+[
+  {
+    goPackagePath = "github.com/urfave/cli";
+    fetch = {
+      type = "git";
+      url = "https://github.com/urfave/cli";
+      rev = "a1c7408de3f632d86eee604a3bb755f1ffb68226";
+      sha256 = "1fq0amfgpccf35nll7xw0k6smwrb7h0wy62n70kfd9kvh64n8hbn";
+    };
+  }
+  {
+    goPackagePath = "github.com/bitly/go-simplejson";
+    fetch = {
+      type = "git";
+      url = "https://github.com/bitly/go-simplejson";
+      rev = "9db4a59bd4d803ae0c173a7d8a538e056cd59d57";
+      sha256 = "0cbnjzjq55jnzk07zdk7nb96yzgpyawm1r6km3xignn8ih4bnn6g";
+    };
+  }
+  {
+    goPackagePath = "github.com/fatih/structs";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fatih/structs";
+      rev = "878a968ab22548362a09bdb3322f98b00f470d46";
+      sha256 = "15nkffa8ylr5kkv52gyry675l8bzv3c0xx39j0fzz0vp2kcjyy8x";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-sql-driver/mysql";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-sql-driver/mysql";
+      rev = "93c3765e9bb2e29c6a63277c9f829dae34ec24eb";
+      sha256 = "043yalxp97vc9xsd5npms0h6slxrlzf8dzvd9l0wcxa8v0cl9lp6";
+    };
+  }
+  {
+    goPackagePath = "github.com/jinzhu/inflection";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jinzhu/inflection";
+      rev = "04140366298a54a039076d798123ffa108fff46c";
+      sha256 = "1s4qcnwaajp3c5ykwx4dfy32hykwsm0ki7kx8lcw8b0z0grkz6qh";
+    };
+  }
+  {
+    goPackagePath = "github.com/jmoiron/sqlx";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jmoiron/sqlx";
+      rev = "1d3423c595d749e4613fce663591b44ae539d377";
+      sha256 = "0947211fqibv9sqsk22lfnk080vqnsxmsan9fff5phygbmzbhzzb";
+    };
+  }
+  {
+    goPackagePath = "github.com/mdp/qrterminal";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mdp/qrterminal";
+      rev = "28b49810f53911623d0a538d8edc01b8cbe2bd0e";
+      sha256 = "17dq5niw57r1iq1rn1crpgbq1ydrcxqpzc9gj7dd1snc0p9n1rv1";
+    };
+  }
+  {
+    goPackagePath = "github.com/miekg/dns";
+    fetch = {
+      type = "git";
+      url = "https://github.com/miekg/dns";
+      rev = "73601d4aed9d844322611759d7f3619110b7c88e";
+      sha256 = "1frnj97bbch1qhg55fx2yz6mdjsz8fw94sj7pkrjms239j7vqcvm";
+    };
+  }
+  {
+    goPackagePath = "github.com/patrickmn/go-cache";
+    fetch = {
+      type = "git";
+      url = "https://github.com/patrickmn/go-cache";
+      rev = "5633e0862627c011927fa39556acae8b1f1df58a";
+      sha256 = "1zjk6yvig68zcbipa85dxz9xa82fk4zp4q33hwzxdv6h68wga5bs";
+    };
+  }
+  {
+    goPackagePath = "github.com/shurcooL/sanitized_anchor_name";
+    fetch = {
+      type = "git";
+      url = "https://github.com/shurcooL/sanitized_anchor_name";
+      rev = "7bfe4c7ecddb3666a94b053b422cdd8f5aaa3615";
+      sha256 = "1gv9p2nr46z80dnfjsklc6zxbgk96349sdsxjz05f3z6wb6m5l8f";
+    };
+  }
+  {
+    goPackagePath = "github.com/txthinking/gotun2socks";
+    fetch = {
+      type = "git";
+      url = "https://github.com/txthinking/gotun2socks";
+      rev = "35016fdae05e78db993d43f55eb96ddbe3958252";
+      sha256 = "11rl8pqyd6jzi5alpymzi0i5q7pk2492di44v85g7r24y6livrjg";
+    };
+  }
+  {
+    goPackagePath = "github.com/txthinking/mailx";
+    fetch = {
+      type = "git";
+      url = "https://github.com/txthinking/mailx";
+      rev = "ebc2af2e1aa8d2178c30786c18eb138fbe40010d";
+      sha256 = "02h5b922savsljcgjz3gxkydk52zd2gbs51prz88l60n6miv9k70";
+    };
+  }
+  {
+    goPackagePath = "github.com/txthinking/socks5";
+    fetch = {
+      type = "git";
+      url = "https://github.com/txthinking/socks5";
+      rev = "254e122c4eaf8657900905ed5bed5777870b9df8";
+      sha256 = "1q43sxzacj216mdzl44khhx51w1z78jpraw955dnjv9va0zqbhmi";
+    };
+  }
+  {
+    goPackagePath = "github.com/txthinking/x";
+    fetch = {
+      type = "git";
+      url = "https://github.com/txthinking/x";
+      rev = "e13a838cdc21596c45b4e6b6fd15c822597c9ae3";
+      sha256 = "0l5gzhy3h3qynfkgd789hxkv433yqdn1mmk945bwjha7vrm4rx2z";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev = "38d8ce5564a5b71b2e3a00553993f1b9a7ae852f";
+      sha256 = "1x52liy2540pw75sqsw4vpg41vq2dnmqpc0j5r7k6jxv6xmbr5mb";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev = "eb5bcb51f2a31c7d5141d810b70815c05d9c9146";
+      sha256 = "17k4g8krxbl84gzcs275b7gsh66dzm15fdxivjnx9xz8q84l4kby";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev = "31e7599a6c37728c25ca34167be099d072ad335d";
+      sha256 = "18i17j7nkkc5dl9rpzm8l345r409hfj4knfnldar684337x1irrf";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/russross/blackfriday.v2";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/russross/blackfriday.v2";
+      rev = "d3b5b032dc8e8927d31a5071b56e14c89f045135";
+      sha256 = "0nlz7isdd4rgnwzs68499hlwicxz34j2k2a0b8jy0y7ycd2bcr5j";
+    };
+  }
+  {
+    goPackagePath = "rsc.io/qr";
+    fetch = {
+      type = "git";
+      url = "https://github.com/rsc/qr";
+      rev = "ca9a01fc2f9505024045632c50e5e8cd6142fafe";
+      sha256 = "04yx493g0fqp8i59zjxnl4k3s0cl0kr5m8xh0ph8m10r1hkw0xr3";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1053,6 +1053,8 @@ in
 
   bro = callPackage ../applications/networking/ids/bro { };
 
+  brook = callPackage ../tools/networking/brook { };
+
   broot = callPackage ../tools/misc/broot { };
 
   bruteforce-luks = callPackage ../tools/security/bruteforce-luks { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Brook is a cross-platform(Linux/MacOS/Windows/Android/iOS) proxy/vpn software

[https://github.com/txthinking/brook](https://github.com/txthinking/brook)
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
