### PR TITLE
python3Packages.django_2_2: init at 2.2

### DIFF
--- a/pkgs/development/python-modules/django/2_2.nix
+++ b/pkgs/development/python-modules/django/2_2.nix
@@ -1,0 +1,38 @@
+{ stdenv, buildPythonPackage, fetchPypi, substituteAll,
+  isPy3k,
+  geos, gdal, pytz, sqlparse,
+  withGdal ? false
+}:
+
+buildPythonPackage rec {
+  pname = "Django";
+  version = "2.2.1";
+
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1spa701phl8ha7qmfr89hwpa43kf52zbrs3xyc0rlvxianykrk3g";
+  };
+
+  patches = stdenv.lib.optional withGdal
+    (substituteAll {
+      src = ./1.10-gis-libs.template.patch;
+      geos = geos;
+      gdal = gdal;
+      extension = stdenv.hostPlatform.extensions.sharedLibrary;
+    })
+  ;
+
+  propagatedBuildInputs = [ pytz sqlparse ];
+
+  # too complicated to setup
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "A high-level Python Web framework";
+    homepage = https://www.djangoproject.com/;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ georgewhewell lsix ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2433,6 +2433,8 @@ in {
     gdal = self.gdal;
   };
 
+  django_2_2 = callPackage ../development/python-modules/django/2_2.nix { };
+
   django_1_8 = callPackage ../development/python-modules/django/1_8.nix { };
 
   django-allauth = callPackage ../development/python-modules/django-allauth { };


### PR DESCRIPTION


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This introduces Django-2.2, the new LTR version of django. As it only
supports python3, python2 will continue to use django_1_11 as LTR
version as it is still supported until 2020.

We can decide to continue with 1.11 as main version of django for some time, but I prefer to pick the last stable one.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
