### PR TITLE
perl: add .withPackages

### DIFF
--- a/pkgs/development/interpreters/perl/wrapper.nix
+++ b/pkgs/development/interpreters/perl/wrapper.nix
@@ -1,0 +1,55 @@
+{ stdenv, perl, buildEnv, makeWrapper
+, extraLibs ? []
+, extraOutputsToInstall ? []
+, postBuild ? ""
+, ignoreCollisions ? false
+, lib
+, requiredPerlModules
+, makeWrapperArgs ? []
+}:
+
+# Create a perl executable that knows about additional packages.
+let
+  env = let
+    paths = requiredPerlModules (extraLibs ++ [ perl ] );
+  in buildEnv {
+    name = "${perl.name}-env";
+
+    inherit paths;
+    inherit ignoreCollisions;
+    extraOutputsToInstall = [ "out" ] ++ extraOutputsToInstall;
+
+    # we create wrapper for the binaries in the different packages
+    postBuild = ''
+
+      . "${makeWrapper}/nix-support/setup-hook"
+
+      if [ -L "$out/bin" ]; then
+          unlink "$out/bin"
+      fi
+      mkdir -p "$out/bin"
+
+      # take every binary from perl packages and put them into the env
+      for path in ${stdenv.lib.concatStringsSep " " paths}; do
+        if [ -d "$path/bin" ]; then
+          cd "$path/bin"
+          for prg in *; do
+            if [ -f "$prg" ]; then
+              rm -f "$out/bin/$prg"
+              if [ -x "$prg" ]; then
+                makeWrapper "$path/bin/$prg" "$out/bin/$prg" --set PERL5LIB "$out/${perl.libPrefix}"
+              fi
+            fi
+          done
+        fi
+      done
+    '' + postBuild;
+
+    meta = perl.meta // { outputsToInstall = ["out"]; }; # remove "man" from meta.outputsToInstall. pkgs.buildEnv produces no "man", it puts everything to "out"
+
+    passthru = perl.passthru // {
+      interpreter = "${env}/bin/perl";
+      inherit perl;
+    };
+  };
+in env

--- a/pkgs/development/perl-modules/generic/default.nix
+++ b/pkgs/development/perl-modules/generic/default.nix
@@ -1,8 +1,8 @@
-{ lib, stdenv, perl, buildPackages }:
+{ lib, stdenv, perl, buildPackages, toPerlModule }:
 
 { nativeBuildInputs ? [], name, ... } @ attrs:
 
-stdenv.mkDerivation (
+toPerlModule(stdenv.mkDerivation (
   (
   lib.recursiveUpdate
   {
@@ -39,4 +39,4 @@ stdenv.mkDerivation (
     nativeBuildInputs = nativeBuildInputs ++ [ (perl.dev or perl) ];
     perl = buildPackages.perl;
   }
-)
+))

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8107,8 +8107,6 @@ in
 
   ocropus = callPackage ../applications/misc/ocropus { };
 
-  inherit (callPackages ../development/interpreters/perl {}) perl528 perldevel;
-
   pachyderm = callPackage ../applications/networking/cluster/pachyderm { };
 
   php = php72;
@@ -13624,19 +13622,14 @@ in
 
   ### DEVELOPMENT / PERL MODULES
 
-  # the latest Maint version
-  perl528Packages = recurseIntoAttrs (callPackage ./perl-packages.nix {
-    perl = perl528;
-    overrides = (config.perlPackageOverrides or (p: {})) pkgs;
-  });
-  # the latest Devel version
-  perldevelPackages = recurseIntoAttrs (callPackage ./perl-packages.nix {
-    perl = perldevel;
-    overrides = (config.perlPackageOverrides or (p: {})) pkgs;
-  });
+  perlInterpreters = callPackages ../development/interpreters/perl {};
+  inherit (perlInterpreters) perl528 perldevel;
 
+  perl528Packages = recurseIntoAttrs perl528.pkgs;
+  perldevelPackages = perldevel.pkgs;
+
+  perl = perl528;
   perlPackages = perl528Packages;
-  inherit (perlPackages) perl;
 
   ack = perlPackages.ack;
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -5105,7 +5105,7 @@ let
       url = "mirror://cpan/authors/id/D/DA/DANKOGAI/${name}.tar.gz";
       sha256 = "4b538b47459cf5747b7395ccc8c8c9b3b661cc016c50b8a67e10fe19590fea5e";
     };
-    postInstall = ''rm $out/bin/{enc2xs,encguess,piconv} $out/share/man/man1/{enc2xs,encguess,piconv}.1''; # remote the files perl-5.28 already has
+    postInstall = "rm $out/bin/{enc2xs,encguess,piconv} $out/share/man/man1/{enc2xs,encguess,piconv}.1"; # remove the files perl-5.28 already has
     meta = {
       description = "Character encodings in Perl";
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -5105,6 +5105,7 @@ let
       url = "mirror://cpan/authors/id/D/DA/DANKOGAI/${name}.tar.gz";
       sha256 = "4b538b47459cf5747b7395ccc8c8c9b3b661cc016c50b8a67e10fe19590fea5e";
     };
+    postInstall = ''rm $out/bin/{enc2xs,encguess,piconv} $out/share/man/man1/{enc2xs,encguess,piconv}.1''; # remote the files perl-5.28 already has
     meta = {
       description = "Character encodings in Perl";
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -12,14 +12,33 @@
 assert stdenv.lib.versionAtLeast perl.version "5.28.1";
 let
   inherit (stdenv.lib) maintainers;
-  self = _self // overrides;
+  self = _self // (overrides pkgs);
   _self = with self; {
 
   inherit perl;
 
   callPackage = pkgs.newScope self;
 
-  buildPerlPackage = callPackage ../development/perl-modules/generic { };
+  # Check whether a derivation provides a perl module.
+  hasPerlModule = drv: drv ? perlModule ;
+
+  requiredPerlModules = drvs: let
+    modules = stdenv.lib.filter hasPerlModule drvs;
+  in stdenv.lib.unique ([perl] ++ modules ++ stdenv.lib.concatLists (stdenv.lib.catAttrs "requiredPerlModules" modules));
+
+  # Convert derivation to a perl module.
+  toPerlModule = drv:
+    drv.overrideAttrs( oldAttrs: {
+      # Use passthru in order to prevent rebuilds when possible.
+      passthru = (oldAttrs.passthru or {}) // {
+        perlModule = perl;
+        requiredPerlModules = requiredPerlModules drv.propagatedBuildInputs;
+      };
+    });
+
+  buildPerlPackage = callPackage ../development/perl-modules/generic {
+    inherit toPerlModule;
+  };
 
   # Helper functions for packages that use Module::Build to build.
   buildPerlModule = { buildInputs ? [], ... } @ args:


### PR DESCRIPTION

implement ```perl.withPackages``` after ```python``` and ```lua```

---
Tested on simple cases but might need review and more testing
```
$(nix-build -E "(import <nixpkgs> {}).perl.withPackages(p: [p.XMLParser])")/bin/perl \
  -MXML::Parser -e 'print $XML::Parser::VERSION' 
```
---
test-driver with 
```
      environment.systemPackages = with pkgs; [
        (perl.withPackages(p: [p.XMLParser]))
      ];
```
![](http://i.imgur.com/Tdu0DDM.png)

---
Fixes https://github.com/NixOS/nixpkgs/issues/59042