### PR TITLE
coqPackages: refactor

### DIFF
--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -2,8 +2,9 @@
 
 let
   mkCoqPackages' = self: coq:
-    let callPackage = newScope self ; in rec {
-      inherit callPackage coq;
+    let newScope = self.newScope;
+        callPackage = self.callPackage; in {
+      inherit coq;
       coqPackages = self;
 
       contribs = recurseIntoAttrs
@@ -75,7 +76,7 @@ in rec {
    * a `dontFilter` attribute into the Coq derivation.
    */
   mkCoqPackages = coq:
-    let self = mkCoqPackages' self coq; in
+    let self = lib.makeScope newScope (lib.flip mkCoqPackages' coq); in
     if coq.dontFilter or false then self
     else filterCoqPackages coq self;
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Coq packages that depend on other need to be recompiled when the dependencies are updated,
so we make the whole `coqPackage` overridable by `overrideScope'`, using `lib.makeScope`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
