### PR TITLE
[18.09] containerd: 1.1.2 -> 1.1.7

### DIFF
--- a/pkgs/applications/virtualization/containerd/default.nix
+++ b/pkgs/applications/virtualization/containerd/default.nix
@@ -5,13 +5,13 @@ with lib;
 
 stdenv.mkDerivation rec {
   name = "containerd-${version}";
-  version = "1.1.2";
+  version = "1.1.7";
 
   src = fetchFromGitHub {
     owner = "containerd";
     repo = "containerd";
     rev = "v${version}";
-    sha256 = "1rp015cm5fw9kfarcmfhfkr1sh0iz7kvqls6f8nfhwrrz5armd5v";
+    sha256 = "1qnfsp7wyrnz3q5bqfl0s34r85gki3j6w4x0ny3vpvhs30cz97yg";
   };
 
   hardeningDisable = [ "fortify" ];


### PR DESCRIPTION
###### Motivation for this change

Bump a few security fix version :sweat_smile: See release notes for all:
- [1.1.3 release notes](https://github.com/containerd/containerd/releases/tag/v1.1.3)
- [1.1.4 release notes](https://github.com/containerd/containerd/releases/tag/v1.1.4)
- [1.1.5 release notes](https://github.com/containerd/containerd/releases/tag/v1.1.5)
- [1.1.6 release notes](https://github.com/containerd/containerd/releases/tag/v1.1.6)
- [1.1.7 release notes](https://github.com/containerd/containerd/releases/tag/v1.1.7)

cc @offlinehacker @grahamc 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
