### PR TITLE
[staging-19.03] runc: 1.0.0-rc6 -> 1.0.0-rc7

### DIFF
--- a/pkgs/applications/virtualization/runc/default.nix
+++ b/pkgs/applications/virtualization/runc/default.nix
@@ -5,13 +5,13 @@ with lib;
 
 buildGoPackage rec {
   name = "runc-${version}";
-  version = "1.0.0-rc6";
+  version = "1.0.0-rc7";
 
   src = fetchFromGitHub {
     owner = "opencontainers";
     repo = "runc";
     rev = "v${version}";
-    sha256 = "1jwacb8xnmx5fr86gximhbl9dlbdwj3rpf27hav9q1si86w5pb1j";
+    sha256 = "1baryjpka8wmzc6c66bir12i390ix3641a06j33shpsb683ws3fj";
   };
 
   goPackagePath = "github.com/opencontainers/runc";


### PR DESCRIPTION
###### Motivation for this change

Bump to latest rc release with security fixes, see [release notes](https://github.com/opencontainers/runc/releases/tag/v1.0.0-rc7) (mainly CVE-2019-5736)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
