### PR TITLE
cargo-xbuild: init at 0.5.7

### DIFF
--- a/pkgs/development/tools/rust/cargo-xbuild/default.nix
+++ b/pkgs/development/tools/rust/cargo-xbuild/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  name = "cargo-xbuild-${version}";
+  version = "0.5.7";
+
+  src = fetchFromGitHub {
+    owner = "rust-osdev";
+    repo = "cargo-xbuild";
+    rev = "v${version}";
+    sha256 = "11hjyf16m4ri4c912jsdmqq88xcrys119135nz48y5p7b4yp0s7a";
+  };
+
+  cargoSha256 = "077qiqm470iqcgxqjzbmzxikxd5862vyg788hacli4yzpvyaq9r9";
+
+  meta = with stdenv.lib; {
+    description = "Automatically cross-compiles the sysroot crates core, compiler_builtins, and alloc";
+    homepage = https://github.com/rust-osdev/cargo-xbuild;
+    license = with licenses; [ mit asl20 ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7695,6 +7695,7 @@ in
     inherit (darwin.apple_sdk.frameworks) Security;
   };
   cargo-fuzz = callPackage ../development/tools/rust/cargo-fuzz { };
+  cargo-xbuild = callPackage ../development/tools/rust/cargo-xbuild { };
 
   pyo3-pack = callPackage ../development/tools/rust/pyo3-pack { };
   rainicorn = callPackage ../development/tools/rust/rainicorn { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

A tool helps people to automatically cross-compile the sysroot crates core, compiler_builtins, and alloc.

[https://crates.io/crates/cargo-xbuild](https://crates.io/crates/cargo-xbuild)
[https://github.com/rust-osdev/cargo-xbuild](https://github.com/rust-osdev/cargo-xbuild)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
