### PR TITLE
tahoe-lafs: clean up inputs

### DIFF
--- a/pkgs/tools/networking/p2p/tahoe-lafs/default.nix
+++ b/pkgs/tools/networking/p2p/tahoe-lafs/default.nix
@@ -50,7 +50,7 @@ pythonPackages.buildPythonApplication rec {
 
   nativeBuildInputs = with pythonPackages; [ sphinx texinfo wheel ];
 
-  buildInputs = with pythonPackages; [ unzip mock ];
+  buildInputs = with pythonPackages; [ unzip ];
 
   # The `backup' command requires `sqlite3'.
   propagatedBuildInputs = with pythonPackages; [
@@ -59,7 +59,7 @@ pythonPackages.buildPythonApplication rec {
     service-identity pyyaml magic-wormhole treq
   ];
 
-  checkInputs = with pythonPackages; [ hypothesis twisted ];
+  checkInputs = with pythonPackages; [ mock hypothesis twisted ];
 
   # Install the documentation.
   postInstall = ''

--- a/pkgs/tools/networking/p2p/tahoe-lafs/default.nix
+++ b/pkgs/tools/networking/p2p/tahoe-lafs/default.nix
@@ -50,8 +50,6 @@ pythonPackages.buildPythonApplication rec {
 
   nativeBuildInputs = with pythonPackages; [ sphinx texinfo wheel ];
 
-  buildInputs = with pythonPackages; [ unzip ];
-
   # The `backup' command requires `sqlite3'.
   propagatedBuildInputs = with pythonPackages; [
     twisted foolscap nevow simplejson zfec pycryptopp darcsver

--- a/pkgs/tools/networking/p2p/tahoe-lafs/default.nix
+++ b/pkgs/tools/networking/p2p/tahoe-lafs/default.nix
@@ -48,7 +48,7 @@ pythonPackages.buildPythonApplication rec {
     )
   '';
 
-  nativeBuildInputs = with pythonPackages; [ sphinx texinfo wheel ];
+  nativeBuildInputs = with pythonPackages; [ sphinx texinfo ];
 
   # The `backup' command requires `sqlite3'.
   propagatedBuildInputs = with pythonPackages; [

--- a/pkgs/tools/networking/p2p/tahoe-lafs/default.nix
+++ b/pkgs/tools/networking/p2p/tahoe-lafs/default.nix
@@ -50,7 +50,7 @@ pythonPackages.buildPythonApplication rec {
 
   nativeBuildInputs = with pythonPackages; [ sphinx texinfo ];
 
-  buildInputs = with pythonPackages; [ unzip numpy mock ];
+  buildInputs = with pythonPackages; [ unzip mock wheel ];
 
   # The `backup' command requires `sqlite3'.
   propagatedBuildInputs = with pythonPackages; [

--- a/pkgs/tools/networking/p2p/tahoe-lafs/default.nix
+++ b/pkgs/tools/networking/p2p/tahoe-lafs/default.nix
@@ -48,9 +48,9 @@ pythonPackages.buildPythonApplication rec {
     )
   '';
 
-  nativeBuildInputs = with pythonPackages; [ sphinx texinfo ];
+  nativeBuildInputs = with pythonPackages; [ sphinx texinfo wheel ];
 
-  buildInputs = with pythonPackages; [ unzip mock wheel ];
+  buildInputs = with pythonPackages; [ unzip mock ];
 
   # The `backup' command requires `sqlite3'.
   propagatedBuildInputs = with pythonPackages; [


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

make tahoe-lafs build on aarch64

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
