### PR TITLE
trellis, yosys, nextpnr: update

### DIFF
--- a/pkgs/development/compilers/nextpnr/default.nix
+++ b/pkgs/development/compilers/nextpnr/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, cmake, makeWrapper
-, boost, python3
+, boost, python3, eigen
 , icestorm, trellis
 
 # TODO(thoughtpolice) Currently the GUI build seems broken at runtime on my
@@ -27,18 +27,18 @@ let
 in
 stdenv.mkDerivation rec {
   name = "nextpnr-${version}";
-  version = "2019.02.20";
+  version = "2019.04.02";
 
   src = fetchFromGitHub {
     owner  = "yosyshq";
     repo   = "nextpnr";
-    rev    = "e8d3aaaf34895a073e4023192d97fc936d090990";
-    sha256 = "0ijqpjnn7x16crd6cmd4nmgay320flizmjb7bbvg9hv464z3p4x7";
+    rev    = "6adf37e3c1d4301e087d89c9e9c37563fe8d78df";
+    sha256 = "0qqb2yd2s39hahh5qigvllgyzj7rp3r1k9jp2n9z2jrfpiaz68c6";
   };
 
   nativeBuildInputs = [ cmake makeWrapper ];
   buildInputs
-     = [ boostPython python3 ]
+     = [ boostPython python3 eigen ]
     ++ (stdenv.lib.optional enableGui qtbase);
 
   enableParallelBuilding = true;
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
   postInstall = stdenv.lib.optionalString enableGui ''
     for x in generic ice40 ecp5; do
       wrapProgram $out/bin/nextpnr-$x \
-        --prefix QT_PLUGIN_PATH : ${qtbase}/lib/qt-${qtbase.qtCompatVersion}/plugins
+        --prefix QT_PLUGIN_PATH : "${qtbase}/${qtbase.qtPluginPrefix}"
     done
   '';
 

--- a/pkgs/development/compilers/yosys/default.nix
+++ b/pkgs/development/compilers/yosys/default.nix
@@ -8,14 +8,14 @@ with builtins;
 
 stdenv.mkDerivation rec {
   name = "yosys-${version}";
-  version = "2019.02.22";
+  version = "2019.04.08";
 
   srcs = [
     (fetchFromGitHub {
       owner  = "yosyshq";
       repo   = "yosys";
-      rev    = "c521f4632f1c82b48a5538c832980668044e8fd9";
-      sha256 = "18pg1ry5qhhx8c49n2gqwlf55sd9bfsfk3khfyh1a1vjh1qpfgdf";
+      rev    = "0deaccbaae436bc94ad5b2913fa39a9368c09ace";
+      sha256 = "13kil8z1f35lr9436njn2y60458wnjxldz0bsjcr9mpx8if0zp84";
       name   = "yosys";
     })
 

--- a/pkgs/development/tools/trellis/default.nix
+++ b/pkgs/development/tools/trellis/default.nix
@@ -8,14 +8,14 @@ let
 in
 stdenv.mkDerivation rec {
   name = "trellis-${version}";
-  version = "2019.02.21";
+  version = "2019.04.02";
 
   srcs = [
     (fetchFromGitHub {
        owner  = "symbiflow";
        repo   = "prjtrellis";
-       rev    = "90910577671cdd950e56df6cb29d848dadea9467";
-       sha256 = "0j5gnkqfkp8k01wmzsplg713dmw1zvg04hsy33bzbyxaqviybdip";
+       rev    = "7848ab8db85194cb822bc27af5b50a6fe2db55c6";
+       sha256 = "1c9085idsnpw279ddshh58yv920vpcnymzznzj2n5z5vcnkbrr3v";
        name   = "trellis";
      })
     (fetchFromGitHub {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Updates trellis, yosys and nextpnr to their latest commits. This fixes some bugs with the ECP5 and adds new features such as LPF frequency constraints and the HeAP placer.

I also enabled the nextpnr GUI by default, as it works fine for me if I run it with nixGL (like any Nix package that uses OpenGL).

###### Things done

Tested building and running a VexRiscv based design on an ECP5 85k-5G.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
