### PR TITLE
tk: use aqua backend on darwin

### DIFF
--- a/pkgs/development/libraries/tk/generic.nix
+++ b/pkgs/development/libraries/tk/generic.nix
@@ -1,4 +1,6 @@
-{ stdenv, src, pkgconfig, tcl, libXft, fontconfig, patches ? [], ... }:
+{ stdenv, lib, src, pkgconfig, tcl, libXft, fontconfig, patches ? []
+, enableAqua ? stdenv.isDarwin, darwin
+, ... }:
 
 stdenv.mkDerivation {
   name = "tk-${tcl.version}";
@@ -21,15 +23,14 @@ stdenv.mkDerivation {
 
   configureFlags = [
     "--with-tcl=${tcl}/lib"
-  ];
+  ] ++ stdenv.lib.optional enableAqua "--enable-aqua";
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ ]
-    ++ stdenv.lib.optional stdenv.isDarwin fontconfig;
 
   propagatedBuildInputs = [ tcl libXft ];
-
-  NIX_CFLAGS_LINK = if stdenv.isDarwin then "-lfontconfig" else null;
+  buildInputs = lib.optional enableAqua (with darwin; with apple_sdk.frameworks; [
+      Cocoa cf-private
+    ]);
 
   doCheck = false; # fails. can't find itself
 


### PR DESCRIPTION
Most users don’t have xquartz, so let’s use the default window system
for macOS.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
