### PR TITLE
deepin.deepin-screenshot: init at 4.1.8

### DIFF
--- a/pkgs/desktops/deepin/deepin-screenshot/default.nix
+++ b/pkgs/desktops/deepin/deepin-screenshot/default.nix
@@ -1,0 +1,56 @@
+{ stdenv, fetchFromGitHub, fetchpatch, cmake, pkgconfig, xdg_utils, qttools, qtx11extras,
+  dtkcore, dtkwidget, dtkwm, deepin-turbo, deepin-shortcut-viewer,
+  deepin }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "deepin-screenshot";
+  version = "4.1.8";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "1zhjchflgws2q74b9fgdjy2wzifjhimnrrq1sxlv395793xv8lrr";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkgconfig
+    qttools
+    deepin.setupHook
+  ];
+
+  buildInputs = [
+    deepin-shortcut-viewer
+    deepin-turbo
+    dtkcore
+    dtkwidget
+    dtkwm
+    qtx11extras
+  ];
+
+  patches = [
+    (fetchpatch {
+      url = https://github.com/linuxdeepin/deepin-screenshot/pull/52/commits/e14508b223fd9965854ed41c944cea2ea19e6e0c.patch;
+      sha256 = "18zvz98z3hr8pcdyb706za6h2nwx23zsjb1hgyp21ycinhzr9j9h";
+    })
+  ];
+
+  postPatch = ''
+    patchShebangs generate_translations.sh
+    fixPath ${deepin-turbo} /usr/bin/deepin-turbo-invoker src/dbusservice/com.deepin.Screenshot.service
+    fixPath $out/bin/deepin-screenshot /usr/bin/deepin-screenshot src/dbusservice/com.deepin.Screenshot.service
+    substituteInPlace src/mainwindow.cpp --replace '"xdg-open,%1"' '"${xdg_utils}/bin/xdg-open,%1"'
+  '';
+
+  passthru.updateScript = deepin.updateScript { inherit name; };
+
+  meta = with stdenv.lib; {
+    description = "Easy-to-use screenshot tool for Deepin Desktop Environment";
+    homepage = https://github.com/linuxdeepin/deepin-screenshot;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo flokli ];
+  };
+}

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -30,6 +30,7 @@ let
     deepin-metacity = callPackage ./deepin-metacity { };
     deepin-movie-reborn = callPackage ./deepin-movie-reborn { };
     deepin-mutter = callPackage ./deepin-mutter { };
+    deepin-screenshot = callPackage ./deepin-screenshot { };
     deepin-shortcut-viewer = callPackage ./deepin-shortcut-viewer { };
     deepin-sound-theme = callPackage ./deepin-sound-theme { };
     deepin-terminal = callPackage ./deepin-terminal {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add [deepin-screenshot](https://github.com/linuxdeepin/deepin-screenshot), a easy-to-use screenshot tool for Deepin Desktop Environment.

About packaging deepin for NixOS: https://github.com/NixOS/nixpkgs/issues/59023

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).