### PR TITLE
crawl: 0.22.1 -> 0.23.2

### DIFF
--- a/pkgs/games/crawl/crawl_purify.patch
+++ b/pkgs/games/crawl/crawl_purify.patch
@@ -1,6 +1,6 @@
-diff -ru3 crawl-ref-0.20.1-src-old/crawl-ref/source/Makefile crawl-ref-0.20.1-src-new/crawl-ref/source/Makefile
---- crawl-ref-0.20.1-src-old/crawl-ref/source/Makefile	1970-01-01 03:00:01.000000000 +0300
-+++ crawl-ref-0.20.1-src-new/crawl-ref/source/Makefile	2017-07-27 14:45:34.611221571 +0300
+diff -ru3 crawl-ref-0.23.2-src-old/crawl-ref/source/Makefile crawl-ref-0.23.2-src-new/crawl-ref/source/Makefile
+--- crawl-ref-0.23.2-src-old/crawl-ref/source/Makefile	1970-01-01 03:00:01.000000000 +0300
++++ crawl-ref-0.23.2-src-new/crawl-ref/source/Makefile	2017-07-27 14:45:34.611221571 +0300
 @@ -286,13 +286,7 @@
  LIBZ := contrib/install/$(ARCH)/lib/libz.a
  
@@ -16,9 +16,9 @@ diff -ru3 crawl-ref-0.20.1-src-old/crawl-ref/source/Makefile crawl-ref-0.20.1-sr
  else
  	# This is totally wrong, works only with some old-style setups, and
  	# on some architectures of Debian/new FHS multiarch -- excluding, for
-diff -ru3 crawl-ref-0.20.1-src-old/crawl-ref/source/util/find_font crawl-ref-0.20.1-src-new/crawl-ref/source/util/find_font
---- crawl-ref-0.20.1-src-old/crawl-ref/source/util/find_font	1970-01-01 03:00:01.000000000 +0300
-+++ crawl-ref-0.20.1-src-new/crawl-ref/source/util/find_font	2017-07-27 14:44:29.784235540 +0300
+diff -ru3 crawl-ref-0.23.2-src-old/crawl-ref/source/util/find_font crawl-ref-0.23.2-src-new/crawl-ref/source/util/find_font
+--- crawl-ref-0.23.2-src-old/crawl-ref/source/util/find_font	1970-01-01 03:00:01.000000000 +0300
++++ crawl-ref-0.23.2-src-new/crawl-ref/source/util/find_font	2017-07-27 14:44:29.784235540 +0300
 @@ -1,6 +1,6 @@
  #! /bin/sh
  
@@ -35,3 +35,15 @@ diff -ru3 crawl-ref-0.20.1-src-old/crawl-ref/source/util/find_font crawl-ref-0.2
 +    } | xargs -I% find -L % \( -type f -o -type l \) -iname "$name" -print \
        | head -n1
  } 2>/dev/null
+diff --git a/crawl-ref/source/windowmanager-sdl.cc b/crawl-ref/source/windowmanager-sdl.cc
+--- a/crawl-ref/source/windowmanager-sdl.cc
++++ b/crawl-ref/source/windowmanager-sdl.cc
+@@ -20,7 +20,7 @@
+ # else
+ #  include <SDL2/SDL.h>
+ # endif
+-# include <SDL_image.h>
++# include <SDL2/SDL_image.h>
+ # if defined(USE_SOUND) && !defined(WINMM_PLAY_SOUNDS)
+ #  include <SDL2/SDL_mixer.h>
+ # endif

--- a/pkgs/games/crawl/default.nix
+++ b/pkgs/games/crawl/default.nix
@@ -1,17 +1,17 @@
-{ stdenv, lib, fetchFromGitHub, which, sqlite, lua5_1, perl, zlib, pkgconfig, ncurses
+{ stdenv, lib, fetchFromGitHub, which, sqlite, lua5_1, perl, python3, zlib, pkgconfig, ncurses
 , dejavu_fonts, libpng, SDL2, SDL2_image, SDL2_mixer, libGLU_combined, freetype, pngcrush, advancecomp
 , tileMode ? false, enableSound ? tileMode
 }:
 
 stdenv.mkDerivation rec {
   name = "crawl-${version}${lib.optionalString tileMode "-tiles"}";
-  version = "0.22.1";
+  version = "0.23.2";
 
   src = fetchFromGitHub {
     owner = "crawl";
     repo = "crawl";
     rev = version;
-    sha256 = "19yzl241glv2zazifgz59bw3jlh4hj59xx5w002hnh9rp1w15rnr";
+    sha256 = "1d6mip4rvp81839yf2xm63hf34aza5wg4g5z5hi5275j94szaacs";
   };
 
   # Patch hard-coded paths in the makefile
@@ -21,6 +21,7 @@ stdenv.mkDerivation rec {
 
   # Still unstable with luajit
   buildInputs = [ lua5_1 zlib sqlite ncurses ]
+                ++ (with python3.pkgs; [ pyyaml ])
                 ++ lib.optionals tileMode [ libpng SDL2 SDL2_image freetype libGLU_combined ]
                 ++ lib.optional enableSound SDL2_mixer;
 


### PR DESCRIPTION
###### Motivation for this change

Updating to latest version.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---