### PR TITLE
deepin.udisks2-qt5: init at 0.0.1

### DIFF
--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -49,6 +49,7 @@ let
     qcef = callPackage ./qcef { };
     qt5dxcb-plugin = callPackage ./qt5dxcb-plugin { };
     qt5integration = callPackage ./qt5integration { };
+    udisks2-qt5 = callPackage ./udisks2-qt5 { };
 
   };
 

--- a/pkgs/desktops/deepin/udisks2-qt5/default.nix
+++ b/pkgs/desktops/deepin/udisks2-qt5/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, fetchFromGitHub, qmake, deepin }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "udisks2-qt5";
+  version = "0.0.1";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "1gk4jmq7mrzk181r6man2rz1iyzkfasz7053a30h4nn24mq8ikig";
+  };
+
+  nativeBuildInputs = [
+    qmake
+    deepin.setupHook
+  ];
+
+  postPatch = ''
+    searchHardCodedPaths
+  '';
+
+  postFixup = ''
+    searchHardCodedPaths $out
+  '';
+
+  passthru.updateScript = deepin.updateScript { inherit name; };
+
+  meta = with stdenv.lib; {
+    description = "UDisks2 D-Bus interfaces binding for Qt5";
+    homepage = https://github.com/linuxdeepin/udisks2-qt5;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/desktops/deepin/udisks2-qt5/default.nix
+++ b/pkgs/desktops/deepin/udisks2-qt5/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, qmake, deepin }:
+{ stdenv, fetchFromGitHub, qmake, qtbase, pkgconfig, deepin }:
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
@@ -13,8 +13,12 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    qmake
     deepin.setupHook
+    qmake
+  ];
+
+  buildInputs = [
+    qtbase
   ];
 
   postPatch = ''


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add [udisks2-qt5](https://github.com/linuxdeepin/udisks2-qt5), UDisks2 D-Bus interfaces binding for Qt5.

About packaging deepin for NixOS: https://github.com/NixOS/nixpkgs/issues/59023

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).