### PR TITLE
networkmanager-l2tp: 1.2.12 -> 1.7.0-dev

### DIFF
--- a/pkgs/tools/networking/network-manager/l2tp/default.nix
+++ b/pkgs/tools/networking/network-manager/l2tp/default.nix
@@ -1,18 +1,18 @@
 { stdenv, substituteAll, fetchFromGitHub, autoreconfHook, libtool, intltool, pkgconfig
 , file, findutils
-, gtk3, networkmanager, ppp, xl2tpd, strongswan, libsecret
+, gtk3, networkmanager, ppp, xl2tpd, strongswan, libsecret, openssl, nss
 , withGnome ? true, gnome3, networkmanagerapplet }:
 
 stdenv.mkDerivation rec {
   name = "${pname}${if withGnome then "-gnome" else ""}-${version}";
   pname = "NetworkManager-l2tp";
-  version = "1.2.12";
+  version = "1.7.0-dev";
 
   src = fetchFromGitHub {
     owner = "nm-l2tp";
     repo = "network-manager-l2tp";
-    rev = "${version}";
-    sha256 = "0cq07kvlm98s8a7l4a3zmqnif8x3307kv7n645zx3f1r7x72b8m4";
+    rev = "8a72e8f57f61083a8e0663103bb8c1394d93439a";
+    sha256 = "1d2q041n9sbcnnvkdwngkr0mwj99qdjarn14n3zh6i4jzpmmqy5a";
   };
 
   patches = [
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  buildInputs = [ networkmanager ppp ]
+  buildInputs = [ networkmanager ppp openssl nss ]
     ++ stdenv.lib.optionals withGnome [ gtk3 libsecret networkmanagerapplet ];
 
   nativeBuildInputs = [ autoreconfHook libtool intltool pkgconfig file findutils ];

--- a/pkgs/tools/networking/network-manager/l2tp/fix-paths.patch
+++ b/pkgs/tools/networking/network-manager/l2tp/fix-paths.patch
@@ -1,5 +1,5 @@
 diff --git a/shared/utils.c b/shared/utils.c
-index c978a1f..d2c36cd 100644
+index c978a1f..25673cb 100644
 --- a/shared/utils.c
 +++ b/shared/utils.c
 @@ -52,7 +52,7 @@ nm_find_ipsec (void)
@@ -7,7 +7,7 @@ index c978a1f..d2c36cd 100644
  	static const char *ipsec_binary_paths[] =
  		{
 -			"/sbin/ipsec",
-+			"@strongswan@/bin/ipsec",
++			"@strongswan@/sbin/ipsec",
  			"/usr/sbin/ipsec",
  			"/usr/local/sbin/ipsec",
  			"/sbin/strongswan",
@@ -16,7 +16,7 @@ index c978a1f..d2c36cd 100644
  	static const char *l2tp_binary_paths[] =
  		{
 -			"/sbin/xl2tpd",
-+			"@xl2tpd@/bin/xl2tpd",
++			"@xl2tpd@/sbin/xl2tpd",
  			"/usr/sbin/xl2tpd",
  			"/usr/local/sbin/xl2tpd",
  			NULL

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4523,7 +4523,9 @@ in
 
   networkmanager-openvpn = callPackage ../tools/networking/network-manager/openvpn { };
 
-  networkmanager-l2tp = callPackage ../tools/networking/network-manager/l2tp { };
+  networkmanager-l2tp = callPackage ../tools/networking/network-manager/l2tp {
+    openssl = openssl_1_1;
+  };
 
   networkmanager-vpnc = callPackage ../tools/networking/network-manager/vpnc { };
 


### PR DESCRIPTION
I don't know what's the nixos policy regarding this release: it follows gnome rules and thus the odd version number indicates an unstable release.
Also the homepage contains a license warning https://github.com/nm-l2tp/NetworkManager-l2tp so it might be best to wait for an openssl 3 release before actually merging.
Meanwhile this is here for those who want to try and to prevent duplicate work. It works for me.
The closure size should increase as the package now requires openssl and nss.

Among the new features:
Adds user or machine TLS certificate support with L2TP/IPsec VPN servers cf:
https://github.com/nm-l2tp/NetworkManager-l2tp/blob/master/NEWS

This check has been added in https://github.com/nm-l2tp/NetworkManager-l2tp/commit/56e82afe1fa4193ac60a93b7724cd9cc65797af1,
    i.e. l2tp version 1.7.0.

The source is not the exact 1.7.0 since a commit was added afterwards to work around nixos limitations.:
https://github.com/nm-l2tp/NetworkManager-l2tp/commit/8a72e8f57f61083a8e0663103bb8c1394d93439a

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
