### PR TITLE
aws-vault: 4.3.0 -> 4.5.1

### DIFF
--- a/pkgs/tools/admin/aws-vault/default.nix
+++ b/pkgs/tools/admin/aws-vault/default.nix
@@ -2,7 +2,7 @@
 buildGoPackage rec {
   name = "${pname}-${version}";
   pname = "aws-vault";
-  version = "4.3.0";
+  version = "4.5.1";
 
   goPackagePath = "github.com/99designs/${pname}";
 
@@ -10,7 +10,7 @@ buildGoPackage rec {
     owner = "99designs";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0cwzvw1rcvg7y3m8dahr9r05s4i9apnfw5xhiaf0rlkdh3vy33wp";
+    sha256 = "0y64fx15p9ls829lif7c0jaxyclzpnr8l5cyw25q545878dzmcs5";
   };
 
   # set the version. see: aws-vault's Makefile


### PR DESCRIPTION
###### Motivation for this change
aws-vault version 4.5.0 adds support for `pass` (a.k.a. password-store), which is a feature that I'd love to use on NixOS.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

r? @zimbatm (maintainer)