### PR TITLE
python3Packages.WazeRouteCalculator: 0.7.2 -> 0.9.0 and pyupdate: 1.3.5 -> 1.3.6

### DIFF
--- a/pkgs/development/python-modules/WazeRouteCalculator/default.nix
+++ b/pkgs/development/python-modules/WazeRouteCalculator/default.nix
@@ -3,11 +3,11 @@
 
 buildPythonPackage rec {
   pname = "WazeRouteCalculator";
-  version = "0.7.2";
+  version = "0.9";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "09fe1bfb32291a658ba9baffe3fe176693f41362d74caba60fb04be01b447fa1";
+    sha256 = "1kwr7r1cn9xxvf9asxqhsy4swx4v6hsgw5cr5wmn71qg11k1i5cx";
   };
 
   propagatedBuildInputs = [ requests ];

--- a/pkgs/development/python-modules/pyupdate/default.nix
+++ b/pkgs/development/python-modules/pyupdate/default.nix
@@ -3,11 +3,11 @@
 
 buildPythonPackage rec {
   pname = "pyupdate";
-  version = "1.3.5";
+  version = "1.3.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1qxbakhsgmdc5aakhkadr26dlhi0lma7170b245sragn170fqjxf";
+    sha256 = "151dxqvdpik4jy84sq6fhjyrq2qq5l70dccgxdbxxf9qyjxpywfl";
   };
 
   propagatedBuildInputs = [ requests ];


### PR DESCRIPTION
###### Motivation for this change

These 2 are lumped together as they are both only needed by home assistant.

Cc: @dotlambda 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
