### PR TITLE
tahoe-lafs: 1.13.0 -> unstable-2019-04-08

### DIFF
--- a/pkgs/development/python-modules/eliot/default.nix
+++ b/pkgs/development/python-modules/eliot/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildPythonPackage, fetchPypi, zope_interface, pyrsistent, boltons
+, hypothesis, testtools, pytest }:
+
+buildPythonPackage rec {
+  pname = "eliot";
+  version = "1.7.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0ylyycf717s5qsrx8b9n6m38vyj2k8328lfhn8y6r31824991wv8";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "boltons >= 19.0.1" boltons
+
+    # depends on eliot.prettyprint._main which we don't have here.
+    rm eliot/tests/test_prettyprint.py
+  '';
+
+  checkInputs = [ testtools pytest hypothesis ];
+  propagatedBuildInputs = [ zope_interface pyrsistent boltons ];
+
+  meta = with lib; {
+    homepage = https://github.com/itamarst/eliot/;
+    description = "Logging library that tells you why it happened";
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/python-subunit/default.nix
+++ b/pkgs/development/python-modules/python-subunit/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchPypi, extras, testtools }:
+
+buildPythonPackage rec {
+  pname = "python-subunit";
+  version = "1.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1fsw8rsn1s3nklx06mayrg5rn2zbky6wwjc5z07s7rf1wjzfs1wn";
+  };
+
+  # tests require internet
+  doCheck = false;
+
+  propagatedBuildInputs = [ extras testtools ];
+
+  meta = with lib; {
+    homepage = http://launchpad.net/subunit;
+    description = "Python implementation of subunit test streaming protocol";
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/subunitreporter/default.nix
+++ b/pkgs/development/python-modules/subunitreporter/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchPypi, zope_interface, twisted, python-subunit }:
+
+buildPythonPackage rec {
+  pname = "subunitreporter";
+  version = "19.3.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0vdmpp5hln38npn173bfjnqhd9dapxv9r30mi3sfdgsdmy7f4ynn";
+  };
+
+  checkInputs = [ python-subunit ];
+  propagatedBuildInputs = [ twisted zope_interface ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/LeastAuthority/subunitreporter;
+    description = "A Twisted Trial reporter which emits Subunit v2 streams.";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/twisted/default.nix
+++ b/pkgs/development/python-modules/twisted/default.nix
@@ -12,6 +12,7 @@
 , pyopenssl
 , service-identity
 , idna
+, appdirs
 }:
 buildPythonPackage rec {
   pname = "Twisted";
@@ -26,6 +27,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ zope_interface incremental automat constantly hyperlink pyhamcrest attrs ];
 
   passthru.extras.tls = [ pyopenssl service-identity idna ];
+  passthru.extras.conch = [ appdirs ];
 
   # Patch t.p._inotify to point to libc. Without this,
   # twisted.python.runtime.platform.supportsINotify() == False

--- a/pkgs/development/python-modules/txaio/default.nix
+++ b/pkgs/development/python-modules/txaio/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, pytest_3, mock, six, twisted,isPy37 }:
+{ stdenv, buildPythonPackage, fetchPypi, pytest_3, mock, six, twisted, isPy3k }:
 
 buildPythonPackage rec {
   pname = "txaio";
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   '';
 
   # Needs some fixing for 3.7
-  doCheck = !isPy37;
+  doCheck = !isPy3k;
 
   meta = with stdenv.lib; {
     description = "Utilities to support code that runs unmodified on Twisted and asyncio.";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1824,6 +1824,8 @@ in {
 
   elasticsearch-curator = callPackage ../development/python-modules/elasticsearch-curator { };
 
+  eliot = callPackage ../development/python-modules/eliot { };
+
   entrypoints = callPackage ../development/python-modules/entrypoints { };
 
   enzyme = callPackage ../development/python-modules/enzyme {};
@@ -2258,6 +2260,8 @@ in {
   sarge = callPackage ../development/python-modules/sarge { };
 
   subliminal = callPackage ../development/python-modules/subliminal {};
+
+  subunitreporter = callPackage ../development/python-modules/subunitreporter { };
 
   hyperlink = callPackage ../development/python-modules/hyperlink {};
 
@@ -3038,6 +3042,8 @@ in {
   };
 
   python-Levenshtein = callPackage ../development/python-modules/python-levenshtein { };
+
+  python-subunit = callPackage ../development/python-modules/python-subunit { };
 
   fs = callPackage ../development/python-modules/fs { };
 


### PR DESCRIPTION
###### Motivation for this change

The new version has a lot of improvements and is required to get Gridsync to work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
