### PR TITLE
Merge simple updates

### DIFF
--- a/pkgs/applications/altcoins/ethabi.nix
+++ b/pkgs/applications/altcoins/ethabi.nix
@@ -4,16 +4,16 @@ with rustPlatform;
 
 buildRustPackage rec {
   name = "ethabi-${version}";
-  version = "4.1.0";
+  version = "7.0.0";
 
   src = fetchFromGitHub {
     owner = "paritytech";
     repo = "ethabi";
     rev = "v${version}";
-    sha256 = "0kxflixmgycdh7sv73zf2mrkbcfzzw7f5sjbsjks9crc9cvjqi6p";
+    sha256 = "1gqd3vwsvv1wvi659qcdywgmh41swblpwmmxb033k8irw581dwq4";
   };
 
-  cargoSha256 = "18rigpsmfiv6im2sspnxadgqrlfdp9dd75ji8s56ksc9g7hrc3wz";
+  cargoSha256 = "0ckj5s5fr7xdqpnn4m9zwa1w71g6wwqqvax6f4xkijxdcx83n6c2";
 
   cargoBuildFlags = ["--features cli"];
 

--- a/pkgs/applications/altcoins/go-ethereum.nix
+++ b/pkgs/applications/altcoins/go-ethereum.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "go-ethereum-${version}";
-  version = "1.8.22";
+  version = "1.8.25";
   goPackagePath = "github.com/ethereum/go-ethereum";
 
   # Fix for usb-related segmentation faults on darwin
@@ -16,7 +16,7 @@ buildGoPackage rec {
     owner = "ethereum";
     repo = "go-ethereum";
     rev = "v${version}";
-    sha256 = "0ag9qxrf7n0qkccaf6v4jaysivpxvsy5zfzar3mcm65223pqy375";
+    sha256 = "0kjmr4brw6vszmqqyx8q330nfav8sy4ggn010n254gbi461zy5j7";
   };
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/libsodium/default.nix
+++ b/pkgs/development/libraries/libsodium/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "libsodium-1.0.16";
+  name = "libsodium-1.0.17";
 
   src = fetchurl {
     url = "https://download.libsodium.org/libsodium/releases/${name}.tar.gz";
-    sha256 = "0cq5pn7qcib7q70mm1lgjwj75xdxix27v0xl1xl0kvxww7hwgbgf";
+    sha256 = "1cf2d9v1gylz1qcy2zappbf526qfmph6gd6fnn3w2b347vixmhqc";
   };
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/python-modules/sqlparse/default.nix
+++ b/pkgs/development/python-modules/sqlparse/default.nix
@@ -2,25 +2,21 @@
 , buildPythonPackage
 , fetchPypi
 , pytest
-, isPy3k
 }:
 
 buildPythonPackage rec {
   pname = "sqlparse";
-  version = "0.2.4";
+  version = "0.3.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "ce028444cfab83be538752a2ffdb56bc417b7784ff35bb9a3062413717807dec";
+    sha256 = "7c3dca29c022744e95b547e867cee89f4fce4373f3549ccd8797d8eb52cdb873";
   };
 
   checkInputs = [ pytest ];
   checkPhase = ''
     py.test
   '';
-
-  # Package supports 3.x, but tests are clearly 2.x only.
-  doCheck = !isPy3k;
 
   meta = with stdenv.lib; {
     description = "Non-validating SQL parser for Python";

--- a/pkgs/development/web/now-cli/default.nix
+++ b/pkgs/development/web/now-cli/default.nix
@@ -1,12 +1,12 @@
 { stdenv, lib, fetchurl }:
 stdenv.mkDerivation rec {
   name = "now-cli-${version}";
-  version = "14.0.3";
+  version = "15.0.3";
 
   # TODO: switch to building from source, if possible
   src = fetchurl {
     url = "https://github.com/zeit/now-cli/releases/download/${version}/now-linux.gz";
-    sha256 = "0nnwaj3iik8anx7xd5mzbrgq5g5ng8gqmhxyyfgkmawsg34bk6nj";
+    sha256 = "db9e0ca18513bc407c59945deaa64006acf03dd6007879f0594a38b56153a7c2";
   };
 
   sourceRoot = ".";

--- a/pkgs/games/flightgear/default.nix
+++ b/pkgs/games/flightgear/default.nix
@@ -6,14 +6,14 @@
 }:
 
 let
-  version = "2018.2.2";
-  shortVersion = "2018.2";
+  version = "2018.3.1";
+  shortVersion = "2018.3";
   data = stdenv.mkDerivation rec {
     name = "flightgear-base-${version}";
 
     src = fetchurl {
       url = "mirror://sourceforge/flightgear/release-${shortVersion}/FlightGear-${version}-data.tar.bz2";
-      sha256 = "c89b94e4cf3cb7eda728daf6cca6dd051f7a47863776c99fd2f3fe0054400ac4";
+      sha256 = "1h69ifj84l4k0f497ybk51xj3bprzw4xvwrwzzj708zhkjk78fmh";
     };
 
     phases = [ "installPhase" ];
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://sourceforge/flightgear/release-${shortVersion}/${name}.tar.bz2";
-    sha256 = "61f809ef0a3f6908d156f0c483ed5313d31b5a6ac74761955d0b266751718147";
+    sha256 = "0h56npn00b6fd38cf5cha82nnglxmhd12b7h2rn3gjymwhviyjix";
   };
 
   # Of all the files in the source and data archives, there doesn't seem to be


### PR DESCRIPTION
Merges multiple PRs into one. I reviewed all of them. All of them are simple updates (as in "hash and sha update", modulo one "doCheck = false" removal).

###### Motivation for this change

* Closes #59236
* Closes #59233
* Closes #59220
* Closes #59218
* Closes #59248
* Closes #59221

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
