### PR TITLE
repology: fix homepage for a few packages - nothing else

### DIFF
--- a/pkgs/applications/audio/puddletag/default.nix
+++ b/pkgs/applications/audio/puddletag/default.nix
@@ -28,8 +28,8 @@ python2Packages.buildPythonApplication rec {
   dontStrip = true;  # we are not generating any binaries
 
   meta = with stdenv.lib; {
-    homepage    = https://puddletag.net;
     description = "An audio tag editor similar to the Windows program, Mp3tag";
+    homepage    = https://docs.puddletag.net;
     license     = licenses.gpl3;
     maintainers = with maintainers; [ peterhoeg ];
     platforms   = platforms.linux;

--- a/pkgs/applications/misc/krename/default.nix
+++ b/pkgs/applications/misc/krename/default.nix
@@ -17,15 +17,17 @@ in mkDerivation rec {
     sha256 = "136j1dkqrhv458rjh5v3vzjhvq6dhz7k79zk6mmx8zvqacc7cq8a";
   };
 
-  meta = with lib; {
-    homepage = http://www.krename.net;
-    description = "A powerful batch renamer for KDE";
-    license = licenses.gpl2;
-    inherit (kconfig.meta) platforms;
-    maintainers = with maintainers; [ peterhoeg ];
-  };
-
   buildInputs = [ taglib exiv2 podofo ];
+
   nativeBuildInputs = [ extra-cmake-modules kdoctools wrapGAppsHook ];
+
   propagatedBuildInputs = [ kconfig kcrash kinit kjsembed ];
+
+  meta = with lib; {
+    description = "A powerful batch renamer for KDE";
+    homepage = https://kde.org/applications/utilities/krename/;
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ peterhoeg ];
+    inherit (kconfig.meta) platforms;
+  };
 }

--- a/pkgs/applications/networking/remote/anydesk/default.nix
+++ b/pkgs/applications/networking/remote/anydesk/default.nix
@@ -72,7 +72,7 @@ in stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     inherit description;
-    homepage = http://www.anydesk.com;
+    homepage = https://www.anydesk.com;
     license = licenses.unfree;
     platforms = platforms.linux;
     maintainers = with maintainers; [ peterhoeg ];

--- a/pkgs/development/python-modules/broadlink/default.nix
+++ b/pkgs/development/python-modules/broadlink/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Python API for controlling Broadlink IR controllers";
-    homepage =  http://github.com/mjg59/python-broadlink;
+    homepage =  https://github.com/mjg59/python-broadlink;
     license = licenses.mit;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

repology was showing a few errors for packages I maintain - think of it as spring cleaning.

No other changes.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
