### PR TITLE
linux: kernel: Add kernels with rt patchset

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-rt.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rt.nix
@@ -1,0 +1,70 @@
+{ fetchurl
+, linux_4_4
+, linux_4_9
+, linux_4_14
+, linux_4_19
+, linux_5_0
+}:
+
+#
+# rt kernels
+# ==========
+#
+# Here are the linux kernels with the realtime patchset applied.
+# What we do here is overriding the "original" kernel by replacing the
+# sources with the sources of the realtime-kernel git tree .tar.gz exports.
+# Because of this, we also get the patches applied in the all-packages.nix
+# file automatically.
+#
+# Howto Update
+# ------------
+#
+# For updating an expression here, go to
+#
+#   https://git.kernel.org/pub/scm/linux/kernel/git/rt/linux-stable-rt.git/
+#
+# and find the latest kernel .tar.gz files, then update the version and sha256
+# in the expression below.
+#
+
+let
+  rtKernel = { origKernel, version,  sha256 } @ args:
+  origKernel.overrideAttrs (o: rec {
+    version = args.version;
+    src = fetchurl {
+      sha256 = args.sha256;
+      url = "https://git.kernel.org/pub/scm/linux/kernel/git/rt/linux-stable-rt.git/snapshot/linux-stable-rt-${args.version}.tar.gz";
+    };
+  });
+in
+{
+  linux_4_4_rt = rtKernel {
+    origKernel = linux_4_4;
+    version = "4.4.177-rt179";
+    sha256 = "16fmaww65n194pm9qd1ld17d4w84m10krbd1dyxjmlcn5cf9mq75";
+  };
+
+  linux_4_9_rt = rtKernel {
+    origKernel = linux_4_9;
+    version = "4.9.146-rt125";
+    sha256 = "1j2zsf4a72c1k98bhsiiw0fhg3sazaixgbrw076fn2fgwgqh1sjb";
+  };
+
+  linux_4_14_rt = rtKernel {
+    origKernel = linux_4_14;
+    version = "4.14.109-rt57";
+    sha256 = "17la2fb06swyvdm5x7005c7hk13n8s5hbvqfxb2dzlx3gzf1sj4q";
+  };
+
+  linux_4_19_rt = rtKernel {
+    origKernel = linux_4_19;
+    version = "4.19.31-rt18";
+    sha256 = "0a40bhrc803ngsr0qy4r9igk9sal2r2sqk47y68q8nhrf4z1nzbw";
+  };
+
+  linux_5_0_rt = rtKernel {
+    origKernel = linux_5_0;
+    version = "5.0.3-rt1";
+    sha256 = "0k21xqzhg1281661gqc0r35as1av8nf0f0f6zsvm1fw5lxgb0fkh";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14846,6 +14846,8 @@ in
       ];
   };
 
+  linux_rt = callPackage ../os-specific/linux/kernel/linux-rt.nix {};
+
   linux_4_9 = callPackage ../os-specific/linux/kernel/linux-4.9.nix {
     kernelPatches =
       [ kernelPatches.bridge_stp_helper


### PR DESCRIPTION
This patch adds kernels with the "realtime" patchset.

###### Motivation for this change

Having the realtime kernels in nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I did not test-build this because this may take a rather long time on my machine and I want some feedback first.

As this was inspired by the [musnix](https://github.com/musnix/musnix/) project, I ping them here:

@henrytill 
@magnetophon 

I imported the kernels into the `all-packages.nix` as an extra attribute to not spam the main namespace. I'm not sure whether this is wanted, but I guess people who do care find what they need and people who do not care are not bothered by that, right?