### PR TITLE
 snakemake: 5.2.2 -> 5.4.4

### DIFF
--- a/pkgs/applications/science/misc/snakemake/default.nix
+++ b/pkgs/applications/science/misc/snakemake/default.nix
@@ -5,13 +5,14 @@
 
 python.buildPythonPackage rec {
   pname = "snakemake";
-  version = "5.2.2";
+  version = "5.4.4";
 
   propagatedBuildInputs = with python; [
     appdirs
     ConfigArgParse
     datrie
     docutils
+    GitPython
     jsonschema
     pyyaml
     ratelimiter
@@ -21,7 +22,7 @@ python.buildPythonPackage rec {
 
   src = python.fetchPypi {
     inherit pname version;
-    sha256 = "adffe7e24b4a613a9e8bf0a2a320b3cea236d86afb9132bb0bbbc08b8e35a3a3";
+    sha256 = "157323e0e1be34302edbbf399b2acbe25a4291bceffd47a0469963a970c9375f";
   };
 
   doCheck = false; # Tests depend on Google Cloud credentials at ${HOME}/gcloud-service-key.json

--- a/pkgs/development/python-modules/datrie/default.nix
+++ b/pkgs/development/python-modules/datrie/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi
+{ stdenv, buildPythonPackage, fetchPypi, fetchpatch
 , cython, pytest, pytestrunner, hypothesis }:
 
 buildPythonPackage rec {
@@ -9,6 +9,14 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "08r0if7dry2q7p34gf7ffyrlnf4bdvnprxgydlfxgfnvq8f3f4bs";
   };
+
+  patches = [
+    # fix tests against recent hypothesis
+    (fetchpatch {
+      url = "https://github.com/pytries/datrie/commit/9b24b4c02783cdb703ac3f6c6d7d881db93166e0.diff";
+      sha256 = "1ql7jcf57q3x3fcbddl26y9kmnbnj2dv6ga8mwq94l4a3213j2iy";
+    })
+  ];
 
   nativeBuildInputs = [ cython ];
   buildInputs = [ pytest pytestrunner hypothesis ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
cc @renatoGarcia @Helkafen