### PR TITLE
netbsd.mkDerivation: fix darwin build

### DIFF
--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -65,6 +65,8 @@ let
       platforms = platforms.unix;
       license = licenses.bsd2;
     };
+  } // lib.optionalAttrs stdenv'.isDarwin {
+    MKRELRO = "no";
   } // lib.optionalAttrs (stdenv'.cc.isClang or false) {
     HAVE_LLVM = lib.head (lib.splitString "." (lib.getVersion stdenv'.cc.cc));
   } // lib.optionalAttrs (stdenv'.cc.isGNU or false) {

--- a/pkgs/os-specific/bsd/netbsd/default.nix
+++ b/pkgs/os-specific/bsd/netbsd/default.nix
@@ -51,7 +51,7 @@ let
 
     AR = "${stdenv'.cc.targetPrefix or ""}ar";
     CC = "${stdenv'.cc.targetPrefix or ""}cc";
-    CPP = if (stdenv'.cc.isClang or false) then "clang-cpp" else "cpp";
+    CPP = "${stdenv'.cc.targetPrefix or ""}cpp";
     CXX = "${stdenv'.cc.targetPrefix or ""}c++";
     LD = "${stdenv'.cc.targetPrefix or ""}ld";
     STRIP = "${stdenv'.cc.targetPrefix or ""}strip";


### PR DESCRIPTION
Fixes build of netbsd.make on darwin

Fixes: aab8c7ba437d ('netbsd: add cross target')
Resolves: #59141

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---