### PR TITLE
python3Packages.nixpkgs-pytools: init at 1.0.0

### DIFF
--- a/pkgs/development/python-modules/nixpkgs-pytools/default.nix
+++ b/pkgs/development/python-modules/nixpkgs-pytools/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, jinja2
+, setuptools
+, isPy27
+}:
+
+buildPythonPackage rec {
+  pname = "nixpkgs-pytools";
+  version = "1.0.0";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "6aaf1e990be639a0d01afb454756606f3111dd8c596b6e848d4a0cec019168d0";
+  };
+
+  propagatedBuildInputs = [
+    jinja2
+    setuptools
+  ];
+
+  # tests require network ..
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Tools for removing the tedious nature of creating nixpkgs derivations";
+    homepage = https://github.com/nix-community/nixpkgs-pytools;
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1595,6 +1595,8 @@ in
 
   nfdump = callPackage ../tools/networking/nfdump { };
 
+  nixpkgs-pytools = with python3.pkgs; toPythonApplication nixpkgs-pytools;
+
   noteshrink = callPackage ../tools/misc/noteshrink { };
 
   noti = callPackage ../tools/misc/noti {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3324,6 +3324,8 @@ in {
 
   nixpkgs = callPackage ../development/python-modules/nixpkgs { };
 
+  nixpkgs-pytools = callPackage ../development/python-modules/nixpkgs-pytools { };
+
   nodeenv = callPackage ../development/python-modules/nodeenv { };
 
   nose = callPackage ../development/python-modules/nose { };


### PR DESCRIPTION
###### Motivation for this change

nixpkgs-pytools has been added to the nix-community! https://github.com/nix-community/nixpkgs-pytools

Adding a release to nixpkgs to make it easier to use.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc: @makefu 