### PR TITLE
mkchromecast: init at 5872a246

### DIFF
--- a/pkgs/applications/misc/mkchromecast/default.nix
+++ b/pkgs/applications/misc/mkchromecast/default.nix
@@ -1,7 +1,6 @@
-{ lib, fetchFromGitHub, buildPythonApplication, pulseaudio
-, PyChromecast, psutil, mutagen, flask, pyqt5, netifaces, requests, soco
+{ lib, fetchFromGitHub, pulseaudio, python3Packages
 , vorbis-tools, sox, lame, flac, faac, ffmpeg }:
-buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "mkchromecast";
   version = "unstable-2019-04-07";
   src = fetchFromGitHub {
@@ -11,8 +10,9 @@ buildPythonApplication rec {
     sha256 = "05ldgx583s4b3qqn2r3sj7wjmfdqndkm59g2bwdkpz7pbcahkfmr";
   };
 
-  propagatedBuildInputs = [
+  propagatedBuildInputs = with python3Packages; [
     PyChromecast psutil mutagen flask pyqt5 netifaces requests soco
+  ] ++ [
     pulseaudio vorbis-tools sox lame flac faac ffmpeg
   ];
 

--- a/pkgs/applications/misc/mkchromecast/default.nix
+++ b/pkgs/applications/misc/mkchromecast/default.nix
@@ -1,0 +1,27 @@
+{ lib, fetchFromGitHub, buildPythonApplication, pulseaudio
+, PyChromecast, psutil, mutagen, flask, pyqt5, netifaces, requests, soco
+, vorbis-tools, sox, lame, flac, faac, ffmpeg }:
+buildPythonApplication rec {
+  pname = "mkchromecast";
+  version = "5872a246f0610b74fc2b197eb02dc91b96fb68cc";
+  src = fetchFromGitHub {
+    owner  = "muammar";
+    repo   = "mkchromecast";
+    rev    = version;
+    sha256 = "05ldgx583s4b3qqn2r3sj7wjmfdqndkm59g2bwdkpz7pbcahkfmr";
+  };
+
+  propagatedBuildInputs = [
+    PyChromecast psutil mutagen flask pyqt5 netifaces requests soco
+    pulseaudio vorbis-tools sox lame flac faac ffmpeg
+  ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = https://mkchromecast.com/;
+    description = "Cast macOS and Linux Audio/Video to your Google Cast and Sonos Devices";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bobvanderlinden ];
+  };
+}

--- a/pkgs/applications/misc/mkchromecast/default.nix
+++ b/pkgs/applications/misc/mkchromecast/default.nix
@@ -3,11 +3,11 @@
 , vorbis-tools, sox, lame, flac, faac, ffmpeg }:
 buildPythonApplication rec {
   pname = "mkchromecast";
-  version = "5872a246f0610b74fc2b197eb02dc91b96fb68cc";
+  version = "unstable-2019-04-07";
   src = fetchFromGitHub {
     owner  = "muammar";
     repo   = "mkchromecast";
-    rev    = version;
+    rev    = "5872a246f0610b74fc2b197eb02dc91b96fb68cc";
     sha256 = "05ldgx583s4b3qqn2r3sj7wjmfdqndkm59g2bwdkpz7pbcahkfmr";
   };
 

--- a/pkgs/applications/misc/mkchromecast/default.nix
+++ b/pkgs/applications/misc/mkchromecast/default.nix
@@ -16,6 +16,7 @@ python3Packages.buildPythonApplication rec {
     pulseaudio vorbis-tools sox lame flac faac ffmpeg
   ];
 
+  # mkchromecast does not include tests.
   doCheck = false;
 
   meta = with lib; {

--- a/pkgs/development/python-modules/pychromecast/default.nix
+++ b/pkgs/development/python-modules/pychromecast/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "PyChromecast";
-  version = "3.0.0";
+  version = "3.2.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "15zaka9zjyx5lb78f0qs6w8g1rgz94gjgrgxm6iwih0a2l0pv5h9";
+    sha256 = "0jksh7rb4880kni8iw3hb5q9dm5gi40zmx4r2fwydnpfhadhq5af";
   };
 
   disabled = !isPy3k;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21930,6 +21930,10 @@ in
 
   m4rie = callPackage ../development/libraries/science/math/m4rie { };
 
+  mkchromecast = callPackage ../applications/misc/mkchromecast {
+    inherit (python3Packages) buildPythonApplication PyChromecast psutil mutagen flask pyqt5 netifaces requests soco;
+  };
+
   mkl = callPackage ../development/libraries/science/math/mkl { };
 
   nasc = callPackage ../applications/science/math/nasc { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21930,9 +21930,7 @@ in
 
   m4rie = callPackage ../development/libraries/science/math/m4rie { };
 
-  mkchromecast = callPackage ../applications/misc/mkchromecast {
-    inherit (python3Packages) buildPythonApplication PyChromecast psutil mutagen flask pyqt5 netifaces requests soco;
-  };
+  mkchromecast = callPackage ../applications/misc/mkchromecast { };
 
   mkl = callPackage ../development/libraries/science/math/mkl { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This adds the mkchromecast package. i have tested this using:

```
nix-build -A pkgs.mkchromecast .
result/bin/mkchromecast --port 8080 --video --screencast --resolution 720p
```

And it would show my screen on my TV after a few moments.

The upgrade of pychromecast was not needed strictly speaking, but it seemed appropriate to enable all functionality of mkchromecast.

There wasn't a recent release, but that's something that hopefully will come (https://github.com/muammar/mkchromecast/issues/244).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
