### PR TITLE
hpl: init at 2.3

### DIFF
--- a/pkgs/tools/misc/hpl/default.nix
+++ b/pkgs/tools/misc/hpl/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchurl, openblasCompat, mpi } :
+
+stdenv.mkDerivation rec {
+  name = "hpl-${version}";
+  version = "2.3";
+
+  src = fetchurl {
+    url = "http://www.netlib.org/benchmark/hpl/${name}.tar.gz";
+    sha256 = "0c18c7fzlqxifz1bf3izil0bczv3a7nsv0dn6winy3ik49yw3i9j";
+  };
+
+  enableParallelBuilding = true;
+
+  postInstall = ''
+    # only contains the static lib
+    rm -r $out/lib
+
+    install -D testing/ptest/HPL.dat $out/share/hpl/HPL.dat
+  '';
+
+  buildInputs = [ openblasCompat mpi ];
+
+  meta = with stdenv.lib; {
+    description = "Portable Implementation of the Linpack Benchmark for Distributed-Memory Computers";
+    homepage = http://www.netlib.org/benchmark/hpl/;
+    platforms = platforms.unix;
+    license = licenses.bsdOriginal;
+    maintainers = [ maintainers.markuskowa ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17872,6 +17872,8 @@ in
 
   howl = callPackage ../applications/editors/howl { };
 
+  hpl = callPackage ../tools/misc/hpl { mpi = openmpi; };
+
   ht = callPackage ../applications/editors/ht { };
 
   hubstaff = callPackage ../applications/misc/hubstaff { };


### PR DESCRIPTION
###### Motivation for this change
Add the linpack benchmark package (linear algebra benchmark for distributed parallel computers)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
