### PR TITLE
When packaging rubygems, prune git repos from the bundler cache

### DIFF
--- a/pkgs/development/ruby-modules/gem/default.nix
+++ b/pkgs/development/ruby-modules/gem/default.nix
@@ -202,6 +202,8 @@ stdenv.mkDerivation ((builtins.removeAttrs attrs ["source"]) // {
     rm -fv $out/${ruby.gemPath}/doc/*/*/created.rid || true
     rm -fv $out/${ruby.gemPath}/gems/*/ext/*/mkmf.log || true
 
+    rm -rf $out/${ruby.gemPath}/cache/bundler/git
+
     # write out metadata and binstubs
     spec=$(echo $out/${ruby.gemPath}/specifications/*.gemspec)
     ruby ${./gem-post-build.rb} "$spec"


### PR DESCRIPTION
When packaging rubygems, prune git repos from the bundler cache:

There's [a comment](https://github.com/NixOS/nixpkgs/blob/aa004a564954be600b16dd02d05dcb0330b6513c/pkgs/development/ruby-modules/gem/default.nix#L150-L153) not far above this change indicating that it's important to *not* purge the cache, but consider this case:

    gem 'rails', git: 'https://github.com/rails/rails.git'

Since rails depends on several other gems from its own repository, this results in the Gemfile.lock stanza:

    GIT
      remote: https://github.com/rails/rails.git
      revision: c2093cdf8e48ccc4211195c3523319a1767a205a
      specs:
        actioncable (6.0.0.beta3)
          ...(some dependents)...
        actionmailbox (6.0.0.beta3)
          ...(some dependents)...
        actionmailer (6.0.0.beta3)
          ...(some dependents)...
        ...(and 10 more)...

Rails is a 200MB+ repo, so when building this, it results in 2.6GB+ of space usage. But even more importantly, nixpkgs will link everything under `lib/` currently, which includes, in this case, the redundant copies of `$out/${ruby.gemPath}/cache/bundler/git/rails-<sha>`:

    these derivations will be built:
      /nix/store/rxsi3i9bkmyw93h5xn99mhw5il59w7sx-your-package.drv
    building '/nix/store/rxsi3i9bkmyw93h5xn99mhw5il59w7sx-your-package.drv'...
    collision between `/nix/store/5qvwx0qyhx19vswg0cv3zdzn18qc8fn7-ruby2.5.5-actiontext-6.0.0.beta3/lib/ruby/gems/2.5.0/cache/bundler/git/rails-fcf0202857b07db1a0f6220dae5ca99319ca0f32/objects/info/packs' and `/nix/store/hybin7vdghvb81sb3j9g4yyym6j2wkh3-ruby2.5.5-actioncable-6.0.0.beta3/lib/ruby/gems/2.5.0/cache/bundler/git/rails-fcf0202857b07db1a0f6220dae5ca99319ca0f32/objects/info/packs'
    builder for '/nix/store/rxsi3i9bkmyw93h5xn99mhw5il59w7sx-your-package.drv' failed with exit code 255
    error: build of '/nix/store/rxsi3i9bkmyw93h5xn99mhw5il59w7sx-your-package.drv' failed

Long story short, keeping the whole git repo around feels pathological from the get-go, but I'm not sure how to resolve this conflict at all without pruning it. This is distinctly different from a gem cache where a `*.gem` can only ever correspond to one installed gem.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

I haven't actually even figured out how to try this yet to make sure it does what I think it does: I'm interested in discussing whether this is a reasonable change to do at a conceptual level.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Related: https://github.com/bundler/bundler/issues/3327