### PR TITLE
afl-qemu: remove unnecessary build dependencies

### DIFF
--- a/pkgs/tools/security/afl/default.nix
+++ b/pkgs/tools/security/afl/default.nix
@@ -69,7 +69,7 @@ let
       homepage    = "http://lcamtuf.coredump.cx/afl/";
       license     = stdenv.lib.licenses.asl20;
       platforms   = ["x86_64-linux" "i686-linux"];
-      maintainers = [ stdenv.lib.maintainers.thoughtpolice ];
+      maintainers = with stdenv.lib.maintainers; [ thoughtpolice ris ];
     };
   };
 in afl

--- a/pkgs/tools/security/afl/qemu.nix
+++ b/pkgs/tools/security/afl/qemu.nix
@@ -1,7 +1,5 @@
-{ stdenv, fetchurl, afl, python2, zlib, pkgconfig, glib, ncurses, perl
-, attr, libcap, vde2, texinfo, libuuid, flex, bison, lzo, snappy
-, libaio, libcap_ng, gnutls, pixman, autoconf
-, writeText
+{ stdenv, fetchurl, afl, python2, zlib, pkgconfig, glib, perl
+, texinfo, libuuid, flex, bison, pixman, autoconf
 }:
 
 with stdenv.lib;
@@ -41,9 +39,8 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    zlib glib pixman ncurses attr libcap
-    vde2 libuuid lzo snappy libcap_ng gnutls
-  ] ++ optionals (stdenv.isLinux) [ libaio ];
+    zlib glib pixman libuuid
+  ];
 
   enableParallelBuilding = true;
 
@@ -63,9 +60,9 @@ stdenv.mkDerivation rec {
       "--disable-gtk"
       "--disable-sdl"
       "--disable-vnc"
+      "--disable-kvm"
       "--target-list=${cpuTarget}"
       "--enable-pie"
-      "--enable-kvm"
       "--sysconfdir=/etc"
       "--localstatedir=/var"
     ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This simply removes all the unnecessary build dependencies for the afl-patched qemu. It looks like it was initially a copy of the regular qemu package, but afl only uses qemu in a very minimal manner (e.g. it doesn't even use system mode). So I trimmed this down to what seems to be the bare minimum with a process of trial and error.

Also added myself to the maintainers list for `afl` as I've tinkered with this package quite a bit now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
