### PR TITLE
pgrouting: init at 2.6.2

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pgrouting.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgrouting.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, postgresql, perl, cmake, boost, gmp, cgal, mpfr }:
+
+stdenv.mkDerivation rec {
+  pname = "pgrouting";
+  version = "2.6.2";
+
+  nativeBuildInputs = [ cmake perl ];
+  buildInputs = [ postgresql boost gmp cgal mpfr ];
+
+  src = fetchFromGitHub {
+    owner  = "pgRouting";
+    repo   = pname;
+    rev    = "v${version}";
+    sha256 = "09xy5pmiwq0lxf2m8p4q5r892mfmn32vf8m75p84jnz4707z1l0j";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin # for buildEnv, see https://github.com/NixOS/nixpkgs/issues/22653
+    install -D lib/*.so                        -t $out/lib
+    install -D sql/pgrouting--${version}.sql   -t $out/share/extension
+    install -D sql/common/pgrouting.control    -t $out/share/extension
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A PostgreSQL/PostGIS extension that provides geospatial routing functionality";
+    homepage    = https://pgrouting.org/;
+    maintainers = [ maintainers.steve-chavez ];
+    platforms   = platforms.linux;
+    license     = licenses.gpl2;
+  };
+}

--- a/pkgs/servers/sql/postgresql/packages.nix
+++ b/pkgs/servers/sql/postgresql/packages.nix
@@ -36,4 +36,6 @@ self: super: {
     tsearch_extras = super.callPackage ./ext/tsearch_extras.nix { };
 
     tds_fdw = super.callPackage ./ext/tds_fdw.nix { };
+
+    pgrouting = super.callPackage ./ext/pgrouting.nix { };
 }


### PR DESCRIPTION
###### Motivation for this change
pgRouting extends the PostGIS / PostgreSQL geospatial database to provide geospatial routing functionality.

I mostly copied the equivalent archlinux package instructions https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=pgrouting. 

If there's a more idiomatic way to build the package in nix please let me know.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---