### PR TITLE
qbittorrent: add python as a runtime dependency for tracker search

### DIFF
--- a/pkgs/applications/networking/p2p/qbittorrent/default.nix
+++ b/pkgs/applications/networking/p2p/qbittorrent/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchFromGitHub, pkgconfig
-, boost, libtorrentRasterbar, qtbase, qttools, qtsvg
+{ stdenv, fetchFromGitHub, makeWrapper, pkgconfig
+, boost, libtorrentRasterbar, python, qtbase, qttools, qtsvg
 , debugSupport ? false # Debugging
 , guiSupport ? true, dbus ? null # GUI (disable to run headless)
 , webuiSupport ? true # WebUI
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   };
 
   # NOTE: 2018-05-31: CMake is working but it is not officially supported
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ makeWrapper pkgconfig ];
 
   buildInputs = [ boost libtorrentRasterbar qtbase qttools qtsvg ]
     ++ optional guiSupport dbus; # D(esktop)-Bus depends on GUI support
@@ -36,6 +36,13 @@ stdenv.mkDerivation rec {
     ++ optional debugSupport "--enable-debug";
 
   enableParallelBuilding = true;
+
+  # NOTE: 2019-08-06: Python is needed at runtime for tracker search
+  postInstall = "wrapProgram $out/bin/${
+    if guiSupport
+    then "qbittorrent"
+    else "qbittorrent-nox"
+  } --prefix PATH ${makeBinPath [ python ]}";
 
   meta = {
     description = "Featureful free software BitTorrent client";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20036,7 +20036,9 @@ in
 
   pythonmagick = callPackage ../applications/graphics/PythonMagick { };
 
-  qbittorrent = libsForQt5.callPackage ../applications/networking/p2p/qbittorrent { };
+  qbittorrent = libsForQt5.callPackage ../applications/networking/p2p/qbittorrent {
+    python = python3;
+  };
 
   qcomicbook = libsForQt5.callPackage ../applications/graphics/qcomicbook { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This change wraps qbittorrent with python as a run-time dependency. This ensures that python is included in the resulting closure for tracker search support.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS (aarch64_linux, built with guiSupport = false)
   - [x] Arch Linux (x86_64-linux)
   - [ ] macOS
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
   - [x] qbittorrent-nox (requires building with guiSupport = false)
   - [x] qbittorrent
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
   - 387 224 920  bytes &rarr; 451 423 776 bytes
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
