### PR TITLE
clang8: apply patch to disable xpc

### DIFF
--- a/pkgs/development/compilers/llvm/8/clang/clang-xpc.patch
+++ b/pkgs/development/compilers/llvm/8/clang/clang-xpc.patch
@@ -1,0 +1,41 @@
+From 61c9b97d7b81cc2c013b423bf1763a92b14fcae3 Mon Sep 17 00:00:00 2001
+From: Jan Korous <jkorous@apple.com>
+Date: Tue, 26 Mar 2019 03:48:25 +0000
+Subject: [PATCH] [clangd][xpc][cmake] Respect explicit value of
+ CLANGD_BUILD_XPC
+
+We shouldn't prevent user from disabling XPC framework build on Darwin.
+However, by keeping it on by default our CI systems also test
+it by default on macOS.
+
+Based on user request:
+http://lists.llvm.org/pipermail/cfe-dev/2019-March/061778.html
+
+Differential Revision: https://reviews.llvm.org/D59808
+
+git-svn-id: https://llvm.org/svn/llvm-project/clang-tools-extra/trunk@356974 91177308-0d34-0410-b5e6-96231b3b80d8
+---
+ CMakeLists.txt | 13 ++++++++++---
+ 1 file changed, 10 insertions(+), 3 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 66ebeaeeaa..514b17fb3c 100644
+--- a/tools/extra/CMakeLists.txt
++++ b/tools/extra/CMakeLists.txt
+@@ -1,6 +1,13 @@
+-option(CLANGD_BUILD_XPC "Build XPC Support For Clangd." OFF)
+-if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+-  set(CLANGD_BUILD_XPC ON CACHE BOOL "" FORCE)
++if (NOT DEFINED CLANGD_BUILD_XPC)
++  if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
++    set(CLANGD_BUILD_XPC_DEFAULT ON)
++  else ()
++    set(CLANGD_BUILD_XPC_DEFAULT OFF)
++  endif ()
++
++  set(CLANGD_BUILD_XPC ${CLANGD_BUILD_XPC_DEFAULT} CACHE BOOL "Build XPC Support For Clangd." FORCE)
++
++  unset(CLANGD_BUILD_XPC_DEFAULT)
+ endif ()
+ 
+ add_subdirectory(clang-apply-replacements)

--- a/pkgs/development/compilers/llvm/8/clang/default.nix
+++ b/pkgs/development/compilers/llvm/8/clang/default.nix
@@ -24,6 +24,7 @@ let
 
     cmakeFlags = [
       "-DCMAKE_CXX_FLAGS=-std=c++11"
+      "-DCLANGD_BUILD_XPC=OFF"
     ] ++ stdenv.lib.optionals enableManpages [
       "-DCLANG_INCLUDE_DOCS=ON"
       "-DLLVM_ENABLE_SPHINX=ON"
@@ -35,7 +36,10 @@ let
       "-DLINK_POLLY_INTO_TOOLS=ON"
     ];
 
-    patches = [ ./purity.patch ];
+    patches = [
+      ./purity.patch
+      ./clang-xpc.patch
+    ];
 
     postPatch = ''
       sed -i -e 's/DriverArgs.hasArg(options::OPT_nostdlibinc)/true/' \


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
