### PR TITLE
python.pkgs.pytest-watch: init at 4.2.0

### DIFF
--- a/pkgs/development/python-modules/pytest-watch/default.nix
+++ b/pkgs/development/python-modules/pytest-watch/default.nix
@@ -1,0 +1,28 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, colorama
+, docopt
+, pytest
+, watchdog
+}:
+
+buildPythonPackage rec {
+
+  pname = "pytest-watch";
+  version = "4.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1fflnd3varpqy8yzcs451n8h7wmjyx1408qdin5p2qdksl1ny4q6";
+  };
+
+  propagatedBuildInputs = [ colorama docopt watchdog pytest ];
+
+  meta = with stdenv.lib; {
+    description = "A zero-config CLI tool that runs pytest on file change";
+    homepage    = https://github.com/joeyespo/pytest-watch;
+    license     = licenses.mit;
+    maintainers = with maintainers; [ sveitser ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-watch/default.nix
+++ b/pkgs/development/python-modules/pytest-watch/default.nix
@@ -17,7 +17,8 @@ buildPythonPackage rec {
     sha256 = "1fflnd3varpqy8yzcs451n8h7wmjyx1408qdin5p2qdksl1ny4q6";
   };
 
-  propagatedBuildInputs = [ colorama docopt watchdog pytest ];
+  buildInputs = [ pytest ];
+  propagatedBuildInputs = [ colorama docopt watchdog ];
 
   meta = with lib; {
     description = "A zero-config CLI tool that runs pytest on file change";

--- a/pkgs/development/python-modules/pytest-watch/default.nix
+++ b/pkgs/development/python-modules/pytest-watch/default.nix
@@ -1,4 +1,4 @@
-{ stdenv
+{ lib
 , buildPythonPackage
 , fetchPypi
 , colorama
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ colorama docopt watchdog pytest ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A zero-config CLI tool that runs pytest on file change";
     homepage    = https://github.com/joeyespo/pytest-watch;
     license     = licenses.mit;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1627,6 +1627,8 @@ in {
 
   pytest-warnings = callPackage ../development/python-modules/pytest-warnings { };
 
+  pytest-watch = callPackage ../development/python-modules/pytest-watch { };
+
   pytestpep8 = callPackage ../development/python-modules/pytest-pep8 { };
 
   pytest-pep257 = callPackage ../development/python-modules/pytest-pep257 { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add [pytest-watch](https://github.com/joeyespo/pytest-watch).

Tested commands `ptw` and `pytest-watch` successfully with python2 and 3.7 on a small test project.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
