### PR TITLE
keepassxc: 2.3.4 -> 2.4.0

### DIFF
--- a/pkgs/applications/misc/keepassx/community.nix
+++ b/pkgs/applications/misc/keepassx/community.nix
@@ -69,8 +69,9 @@ stdenv.mkDerivation rec {
   doCheck = true;
   checkPhase = ''
     export LC_ALL="en_US.UTF-8"
+	export QT_PLUGIN_PATH="${qtbase.bin}/${qtbase.qtPluginPrefix}"
+    make test ARGS+="-E testgui --output-on-failure"
   '';
-    # make test ARGS+="-E testgui --output-on-failure"
 
   nativeBuildInputs = [ cmake makeWrapper qttools ];
 

--- a/pkgs/applications/misc/keepassx/community.nix
+++ b/pkgs/applications/misc/keepassx/community.nix
@@ -15,6 +15,8 @@
 , libXi
 , qtx11extras
 , qtmacextras
+, qtsvg
+, qrencode
 
 , withKeePassBrowser ? true
 , withKeePassSSHAgent ? true
@@ -26,13 +28,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "keepassxc-${version}";
-  version = "2.3.4";
+  version = "2.4.0";
 
   src = fetchFromGitHub {
     owner = "keepassxreboot";
     repo = "keepassxc";
     rev = "${version}";
-    sha256 = "1gja402dsbws4z8ybnhqbw7rc9svgqnshqjgf7158d6x0ni386m3";
+    sha256 = "1k8s56003gym2dv6c54gxwzs20i7lf6w5g5qnr449jfmf6wvbivr";
   };
 
   NIX_CFLAGS_COMPILE = stdenv.lib.optionalString stdenv.cc.isClang [
@@ -50,7 +52,6 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./darwin.patch
-    ./qt511.patch
   ];
 
   cmakeFlags = [
@@ -58,6 +59,7 @@ stdenv.mkDerivation rec {
     "-DWITH_GUI_TESTS=ON"
     "-DWITH_XC_AUTOTYPE=ON"
     "-DWITH_XC_YUBIKEY=ON"
+    "-DWITH_XC_KEESHARE=ON"
   ]
   ++ (optional withKeePassBrowser "-DWITH_XC_BROWSER=ON")
   ++ (optional withKeePassHTTP "-DWITH_XC_HTTP=ON")
@@ -67,8 +69,8 @@ stdenv.mkDerivation rec {
   doCheck = true;
   checkPhase = ''
     export LC_ALL="en_US.UTF-8"
-    make test ARGS+="-E testgui --output-on-failure"
   '';
+    # make test ARGS+="-E testgui --output-on-failure"
 
   nativeBuildInputs = [ cmake makeWrapper qttools ];
 
@@ -85,8 +87,10 @@ stdenv.mkDerivation rec {
     libyubikey
     qtbase
     qtx11extras
+    qtsvg
     yubikey-personalization
     zlib
+    qrencode
   ] ++ stdenv.lib.optional stdenv.isDarwin qtmacextras;
 
   postInstall = optionalString stdenv.isDarwin ''

--- a/pkgs/applications/misc/keepassx/community.nix
+++ b/pkgs/applications/misc/keepassx/community.nix
@@ -69,7 +69,8 @@ stdenv.mkDerivation rec {
   doCheck = true;
   checkPhase = ''
     export LC_ALL="en_US.UTF-8"
-	export QT_PLUGIN_PATH="${qtbase.bin}/${qtbase.qtPluginPrefix}"
+    export QT_PLUGIN_PATH="${qtbase.bin}/${qtbase.qtPluginPrefix}"
+    export QT_QPA_PLATFORM=offscreen
     make test ARGS+="-E testgui --output-on-failure"
   '';
 

--- a/pkgs/applications/misc/keepassx/darwin.patch
+++ b/pkgs/applications/misc/keepassx/darwin.patch
@@ -1,52 +1,53 @@
-Remove the use of macdeployqt to avoid copying dependencies and
-reduce installation size from 90 MB to 9 MB.
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 658548f7..f8f10bdb 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -250,8 +250,8 @@ else()
-   set(PROGNAME keepassxc)
- endif()
- 
--if(APPLE AND WITH_APP_BUNDLE AND "${CMAKE_INSTALL_PREFIX}" STREQUAL "/usr/local")
--  set(CMAKE_INSTALL_PREFIX "/Applications")
-+if(APPLE AND WITH_APP_BUNDLE)
-+  set(CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}/Applications")
-   set(CMAKE_INSTALL_MANDIR "/usr/local/share/man")
- endif()
- 
-@@ -262,7 +262,7 @@ if(MINGW)
-   set(PLUGIN_INSTALL_DIR ".")
-   set(DATA_INSTALL_DIR   "share")
+@@ -288,6 +288,7 @@ if(MINGW)
+     set(PLUGIN_INSTALL_DIR ".")
+     set(DATA_INSTALL_DIR "share")
  elseif(APPLE AND WITH_APP_BUNDLE)
--  set(CLI_INSTALL_DIR    "/usr/local/bin")
-+  set(CLI_INSTALL_DIR    "../bin")
-   set(PROXY_INSTALL_DIR  "/usr/local/bin")
-   set(BIN_INSTALL_DIR    ".")
-   set(PLUGIN_INSTALL_DIR "${PROGNAME}.app/Contents/PlugIns")
++	set(CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}/Applications")
+     set(CMAKE_INSTALL_MANDIR "${PROGNAME}.app/Contents/Resources/man")
+     set(CLI_INSTALL_DIR "${PROGNAME}.app/Contents/MacOS")
+     set(PROXY_INSTALL_DIR "${PROGNAME}.app/Contents/MacOS")
+@@ -350,12 +351,6 @@ set(CMAKE_AUTORCC ON)
+ 
+ if(APPLE)
+     set(CMAKE_MACOSX_RPATH TRUE)
+-    find_program(MACDEPLOYQT_EXE macdeployqt HINTS ${Qt5_PREFIX}/bin ENV PATH)
+-    if(NOT MACDEPLOYQT_EXE)
+-        message(FATAL_ERROR "macdeployqt is required to build in macOS")
+-    else()
+-        message(STATUS "Using macdeployqt: ${MACDEPLOYQT_EXE}")
+-    endif()
+ endif()
+ 
+ # Debian sets the the build type to None for package builds.
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 69526967..38f7c5d4 100644
+index 110dc606..f9b58818 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -319,11 +319,6 @@ if(APPLE AND WITH_APP_BUNDLE)
-   set(CPACK_PACKAGE_FILE_NAME "${PROGNAME}-${KEEPASSXC_VERSION}")
-   include(CPack)
+@@ -343,11 +343,6 @@ if(APPLE AND WITH_APP_BUNDLE)
+     set(CPACK_PACKAGE_FILE_NAME "${PROGNAME}-${KEEPASSXC_VERSION}")
+     include(CPack)
  
--  add_custom_command(TARGET ${PROGNAME}
--                     POST_BUILD
--                     COMMAND ${MACDEPLOYQT_EXE} ${PROGNAME}.app
--                     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src
--                     COMMENT "Deploying app bundle")
+-    add_custom_command(TARGET ${PROGNAME}
+-            POST_BUILD
+-            COMMAND ${MACDEPLOYQT_EXE} ${PROGNAME}.app
+-            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src
+-            COMMENT "Deploying app bundle")
  endif()
  
  install(TARGETS ${PROGNAME}
 diff --git a/src/autotype/mac/CMakeLists.txt b/src/autotype/mac/CMakeLists.txt
-index 08c53278..b833b692 100644
+index f1c5387f..abf70b48 100644
 --- a/src/autotype/mac/CMakeLists.txt
 +++ b/src/autotype/mac/CMakeLists.txt
-@@ -14,7 +14,6 @@ if(WITH_APP_BUNDLE)
-   add_custom_command(TARGET keepassx-autotype-cocoa
-                      POST_BUILD
-                      COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/libkeepassx-autotype-cocoa.so ${PLUGIN_INSTALL_DIR}
--                     COMMAND ${MACDEPLOYQT_EXE} ${PROGNAME}.app -executable=${PLUGIN_INSTALL_DIR}/libkeepassx-autotype-cocoa.so -no-plugins
-                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src
-   COMMENT "Deploying autotype plugin")
+@@ -12,7 +12,6 @@ if(WITH_APP_BUNDLE)
+     add_custom_command(TARGET keepassx-autotype-cocoa
+             POST_BUILD
+             COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/libkeepassx-autotype-cocoa.so ${PLUGIN_INSTALL_DIR}
+-            COMMAND ${MACDEPLOYQT_EXE} ${PROGNAME}.app -executable=${PLUGIN_INSTALL_DIR}/libkeepassx-autotype-cocoa.so -no-plugins
+             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/src
+             COMMENT "Deploying autotype plugin")
  else()


### PR DESCRIPTION

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
