### PR TITLE
haskell-generic-builder: disable library-for-ghci by default

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -81,10 +81,10 @@ in
   # built. Will delay failures, if any, to compile time.
   allowInconsistentDependencies ? false
 , maxBuildCores ? 4 # GHC usually suffers beyond -j4. https://ghc.haskell.org/trac/ghc/ticket/9221
-, # Build a pre-linked .o file for this Haskell library.  This can make it
-  # slightly faster to load this library into GHCi, but takes extra disk space
-  # and compile time.
-  enableLibraryForGhci ? true
+, # If set to true, this builds a pre-linked .o file for this Haskell library.
+  # This can make it slightly faster to load this library into GHCi, but takes
+  # extra disk space and compile time.
+  enableLibraryForGhci ? false
 } @ args:
 
 assert editedCabalFile != null -> revision != null;


### PR DESCRIPTION
This commit disables the library-for-ghci flag passed to `Setup configure` in the Haskell generic-builder.nix file.

This stops HSfoo.o files from being built.  Building HSfoo.o files cause doctest to take an extremely long time to load dependencies when running.

This is a follow-up from https://github.com/NixOS/nixpkgs/pull/58743.  There is more explanation on that PR.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

It is debatable as to whether or not we should make this change.

The reasons in favor of making this change:

- Doctest now works for large packages with many dependencies without taking a lot of time to run.  This has been a problem for us at work.  I've also run into this personally with the Haskell package Termonad: https://github.com/cdepillabout/termonad/issues/15
- It appears that both `stack` and `cabal` use `--disable-library-for-ghci` by default.  It makes sense that nixpkgs would follow this.
- Disabling `library-for-ghci` reduces the build times very slightly.  The resulting output takes up slightly less disk space.  (I don't think this is a particularly compelling reason though.)

The reasons against making this change:

- Maybe someone is depending on `--enable-library-for-ghci` being used?  Maybe disabling it would break their build/workflow somehow?  I have done a bunch of searching around this issue trying to figure out what is going on here, and I haven't found any reference to anyone specifically enabling or disabling `library-for-ghci`, so I would doubt anyone is actively depending on it (although there is a possibility).
- The GHC documentation claims that enabling `library-for-ghci` causes packages to be loaded into GHCi slightly quicker than when it is disabled: https://github.com/NixOS/nixpkgs/pull/58743#issuecomment-478866824.  However, in the case of `doctest` (which loads packages uses the GHCi API), this seems to not be the case.  I don't know what is going on here.

My personal opinion is that we should merge this PR and disable `library-for-ghci` by default.  I think it is more important that commonly used tools like `doctest` work well, than having libraries (sometimes?) load slightly quicker in GHCi.

At some point in the future, I imagine it would be best if we could figure out what's going on with doctest, and whether the bug lies in our nix stuff, doctest, Cabal, GHC, etc.

Pinging @peti.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
