### PR TITLE
python3Packages.nixpkgs: 0.2.2 -> 0.2.3

### DIFF
--- a/pkgs/development/python-modules/nixpkgs/default.nix
+++ b/pkgs/development/python-modules/nixpkgs/default.nix
@@ -9,22 +9,13 @@
 
 buildPythonPackage rec {
   pname = "nixpkgs";
-  version = "0.2.2";
+  version = "0.2.3";
   disabled = ! pythonAtLeast "3.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0gsrd99kkv99jsrh3hckz7ns1zwndi9vvh4465v4gnpz723dd6fj";
+    sha256 = "12ycbv31g4qv14aq6hfb85hhx026lgvzqfsrkpzb64na0c1yjcvn";
   };
-
-  patches = [
-    # Patch should be dropped once https://github.com/t184256/nixpkgs-python-importer/pull/7
-    # is merged and in a release
-    (fetchpatch {
-      url = "https://github.com/adisbladis/nixpkgs-python-importer/commit/749e05f1.patch";
-      sha256 = "1a72phazpqf6vf3hl3m84z9i5n6h1xpa53bqxnpsff6agxxhd21b";
-    })
-  ];
 
   buildInputs = [ pbr ];
   propagatedBuildInputs = [ pythonix ];


### PR DESCRIPTION
###### Motivation for this change

I've upstreamed a patch for nixpkgs-python-importer by @adisbladis that dealt with `pythonix` renaming `NixRef` to `NixError`.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
