### PR TITLE
just: init at 0.4.0

### DIFF
--- a/pkgs/development/tools/just/default.nix
+++ b/pkgs/development/tools/just/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchFromGitHub, rustPlatform, coreutils, bash, dash }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "just";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "casey";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1v42y8lc1akpnzad0gf89jywbxa74mmzimfsbvkdi7101z5q5qlp";
+  };
+
+  cargoSha256 = "1kgkcl7qffh6vbjdpvrkw8ih1v8zrxs3f0a20mg6z97gdym6mm8g";
+
+  checkInputs = [ coreutils bash dash ];
+
+  preCheck = ''
+    # USER must not be empty
+    export USER=just-user
+    export USERNAME=just-user
+
+    sed -i tests/integration.rs \
+        -e "s@/bin/echo@${coreutils}/bin/echo@g" \
+        -e "s@#!/usr/bin/env sh@#!${bash}/bin/sh@g" \
+        -e "s@#!/usr/bin/env cat@#!${coreutils}/bin/cat@g"
+
+    sed -i tests/interrupts.rs \
+        -e "s@/bin/echo@${coreutils}/bin/echo@g" \
+        -e "s@#!/usr/bin/env sh@#!${bash}/bin/sh@g" \
+        -e "s@#!/usr/bin/env cat@#!${coreutils}/bin/cat@g"
+
+    sed -i src/justfile.rs \
+        -e "s@/bin/echo@${coreutils}/bin/echo@g" \
+        -e "s@#!/usr/bin/env sh@#!${bash}/bin/sh@g" \
+        -e "s@#!/usr/bin/env cat@#!${coreutils}/bin/cat@g"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A handy way to save and run project-specific commands";
+    homepage = https://github.com/casey/just;
+    license = licenses.cc0;
+    maintainers = with maintainers; [ xrelkd ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3689,6 +3689,8 @@ in
 
   junkie = callPackage ../tools/networking/junkie { };
 
+  just = callPackage ../development/tools/just { };
+
   go-jira = callPackage ../applications/misc/go-jira { };
 
   john = callPackage ../tools/security/john { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

`just` is a handy way to save and run project-specific commands.

[https://github.com/casey/just](https://github.com/casey/just)
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
