### PR TITLE
pythonPackages.azure-mgmt-storage: remove patch.

### DIFF
--- a/pkgs/development/python-modules/azure-mgmt-storage/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-storage/default.nix
@@ -15,12 +15,6 @@ buildPythonPackage rec {
     sha256 = "16iw7hqhq97vlzfwixarfnirc60l5mz951p57brpcwyylphl3yim";
   };
 
-  preConfigure = ''
-    # Patch to make this package work on requests >= 2.11.x
-    # CAN BE REMOVED ON NEXT PACKAGE UPDATE
-    sed -i 's|len(request_content)|str(len(request_content))|' azure/mgmt/storage/storagemanagement.py
-  '';
-
   postInstall = ''
     echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/__init__.py
     echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/mgmt/__init__.py


### PR DESCRIPTION
Can this be backported to 19.03 once merged. Will be needed to release Nixops.