### PR TITLE
perlPackages.DBDOracle: init at 1.76 (19.03 backport)

### DIFF
--- a/pkgs/development/perl-modules/DBD-Oracle/default.nix
+++ b/pkgs/development/perl-modules/DBD-Oracle/default.nix
@@ -1,0 +1,15 @@
+{ fetchurl, buildPerlPackage, DBI, TestNoWarnings, oracle-instantclient }:
+
+buildPerlPackage rec {
+  name = "DBD-Oracle-1.76";
+
+  src = fetchurl {
+    url = "mirror://cpan/authors/id/Z/ZA/ZARQUON/${name}.tar.gz";
+    sha256 = "b6db7f43c6252179274cfe99c1950b93e248f8f0fe35b07e50388c85d814d5f3";
+  };
+
+  ORACLE_HOME = "${oracle-instantclient}/lib";
+
+  buildInputs = [ TestNoWarnings oracle-instantclient ] ;
+  propagatedBuildInputs = [ DBI ];
+}

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -4002,6 +4002,8 @@ let
 
   DBDmysql = callPackage ../development/perl-modules/DBD-mysql { };
 
+  DBDOracle = callPackage ../development/perl-modules/DBD-Oracle { };
+
   DBDPg = callPackage ../development/perl-modules/DBD-Pg { };
 
   DBDsybase = callPackage ../development/perl-modules/DBD-sybase { };


### PR DESCRIPTION
(cherry picked from commit 73d45ab1b0618c273e0d9212ad9568f42247ea14)

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
#58726

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
