### PR TITLE
wmctrl: upd upstream links, clean-up, adopt package

### DIFF
--- a/pkgs/tools/X11/wmctrl/default.nix
+++ b/pkgs/tools/X11/wmctrl/default.nix
@@ -1,14 +1,20 @@
-{stdenv, fetchurl, libX11, glib, pkgconfig, libXmu }:
+{ stdenv
+, fetchurl
+, libX11
+, glib
+, pkgconfig
+, libXmu
+}:
 
 stdenv.mkDerivation rec {
-  
+
   name = "wmctrl-1.07";
- 
+
   src = fetchurl {
     url = "http://tomas.styblo.name/wmctrl/dist/${name}.tar.gz";
     sha256 = "1afclc57b9017a73mfs9w7lbdvdipmf9q0xdk116f61gnvyix2np";
   };
- 
+
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ libX11 libXmu glib ];
 
@@ -19,5 +25,7 @@ stdenv.mkDerivation rec {
     description = "Command line tool to interact with an EWMH/NetWM compatible X Window Manager";
     license = stdenv.lib.licenses.gpl2;
     platforms = with stdenv.lib.platforms; all;
+    maintainers = [ stdenv.lib.maintainers.Anton-Latukha ];
   };
+
 }

--- a/pkgs/tools/X11/wmctrl/default.nix
+++ b/pkgs/tools/X11/wmctrl/default.nix
@@ -8,10 +8,12 @@
 
 stdenv.mkDerivation rec {
 
-  name = "wmctrl-1.07";
+  pname = "wmctrl";
+  version = "1.07";
 
   src = fetchurl {
-    url = "http://tomas.styblo.name/wmctrl/dist/${name}.tar.gz";
+    # NOTE: 2019-04-11: There is also a semi-official mirror: http://tripie.sweb.cz/utils/wmctrl/
+    url = "https://sites.google.com/site/tstyblo/wmctrl/${pname}-${version}.tar.gz";
     sha256 = "1afclc57b9017a73mfs9w7lbdvdipmf9q0xdk116f61gnvyix2np";
   };
 
@@ -21,8 +23,8 @@ stdenv.mkDerivation rec {
   patches = [ ./64-bit-data.patch ];
 
   meta = {
-    homepage = http://tomas.styblo.name/wmctrl/;
-    description = "Command line tool to interact with an EWMH/NetWM compatible X Window Manager";
+    homepage = https://sites.google.com/site/tstyblo/wmctrl;
+    description = "CLI tool to interact with EWMH/NetWM compatible X Window Managers";
     license = stdenv.lib.licenses.gpl2;
     platforms = with stdenv.lib.platforms; all;
     maintainers = [ stdenv.lib.maintainers.Anton-Latukha ];


### PR DESCRIPTION
###### Motivation for this change

1. Official page and upstream links do not exist anymore, they were redirects to Google+.
  Found his official webpage now & `sha256` matches.
2. Clean-up.
3. Adopted the package.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
