### PR TITLE
gitAndTools.git-remote-hg: 0.2 -> 1.0.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-remote-hg/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-remote-hg/default.nix
@@ -1,16 +1,16 @@
-{ stdenv, fetchgit, mercurial, makeWrapper,
+{ stdenv, fetchFromGitHub, mercurial, makeWrapper,
   asciidoc, xmlto, docbook_xsl, docbook_xml_dtd_45, libxslt, libxml2
 }:
 
 stdenv.mkDerivation rec {
-  rev = "e716a9e1a9e460a45663694ba4e9e8894a8452b2";
-  version = "0.2-${rev}";
-  name = "git-remote-hg-${version}";
+  version = "1.0.0";
+  pname = "git-remote-hg";
 
-  src = fetchgit {
-    inherit rev;
-    url = "git://github.com/fingolfin/git-remote-hg.git";
-    sha256 = "0cmlfdxfabrs3x10mfjfap8wz67s8xk2pjn2wlcj9k2v84gji60m";
+  src = fetchFromGitHub {
+    owner = "mnauw";
+    repo = "git-remote-hg";
+    rev = "v${version}";
+    sha256 = "0anl054zdi5rg5m4bm1n763kbdjkpdws3c89c8w8m5gq1ifsbd4d";
   };
 
   buildInputs = [ mercurial.python mercurial makeWrapper
@@ -27,8 +27,8 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = https://github.com/felipec/git-remote-hg;
-    description = "Semi-official Mercurial bridge from Git project, once installed, it allows you to clone, fetch and push to and from Mercurial repositories as if they were Git ones";
+    homepage = https://github.com/mnauw/git-remote-hg;
+    description = "Git remote helper for Mercurial repositories";
     license = licenses.gpl2;
     maintainers = [ maintainers.garbas ];
     platforms = platforms.unix;

--- a/pkgs/applications/version-management/git-and-tools/git-remote-hg/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-remote-hg/default.nix
@@ -1,11 +1,12 @@
-{ stdenv, fetchFromGitHub, mercurial, makeWrapper,
+{ stdenv, fetchFromGitHub, mercurial, python2Packages,
   asciidoc, xmlto, docbook_xsl, docbook_xml_dtd_45, libxslt, libxml2
 }:
 
-stdenv.mkDerivation rec {
+python2Packages.buildPythonApplication rec {
   version = "1.0.0";
   pname = "git-remote-hg";
 
+  # not using fetchPypi - the PyPI tarball does not include the manpage
   src = fetchFromGitHub {
     owner = "mnauw";
     repo = "git-remote-hg";
@@ -13,17 +14,17 @@ stdenv.mkDerivation rec {
     sha256 = "0anl054zdi5rg5m4bm1n763kbdjkpdws3c89c8w8m5gq1ifsbd4d";
   };
 
-  buildInputs = [ mercurial.python mercurial makeWrapper
-    asciidoc xmlto docbook_xsl docbook_xml_dtd_45 libxslt libxml2
-  ];
+  nativeBuildInputs = [ asciidoc xmlto docbook_xsl docbook_xml_dtd_45 libxslt libxml2 ];
+  propagatedBuildInputs = [ mercurial ];
 
   doCheck = false;
 
-  installFlags = "HOME=\${out} install-doc";
+  patches = [
+    ./patches/no-dynamic-git-version.patch
+  ];
 
   postInstall = ''
-    wrapProgram $out/bin/git-remote-hg \
-      --prefix PYTHONPATH : "$(echo ${mercurial}/lib/python*/site-packages):$(echo ${mercurial.python}/lib/python*/site-packages)${stdenv.lib.concatMapStrings (x: ":$(echo ${x}/lib/python*/site-packages)") mercurial.pythonPackages or []}"
+    make "HOME=${placeholder "out"}" install-doc;
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/version-management/git-and-tools/git-remote-hg/patches/no-dynamic-git-version.patch
+++ b/pkgs/applications/version-management/git-and-tools/git-remote-hg/patches/no-dynamic-git-version.patch
@@ -1,0 +1,21 @@
+diff --git a/setup.py b/setup.py
+index 26afd17..2410636 100644
+--- a/setup.py
++++ b/setup.py
+@@ -5,15 +5,7 @@ import subprocess
+ import sys
+ import os
+ 
+-# derive version from git repo
+-cmd = ["git", "describe", "--tags"]
+-commit = os.environ.get('REV', None)
+-if commit:
+-  cmd.append(commit)
+-process = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+-version = process.communicate()[0].strip()
+-# strip leading v
+-version = version[1:]
++version = "1.0.0"
+ 
+ # check for released version
+ assert (len(version) > 0)


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

git-remote-hg-0.2 is broken with recent versions of Mercurial:

```
$ hg init test-hg
$ cd test-hg
$ touch README
$ hg add
$ hg commit -m 'Add readme'
$ cd ..
$ git clone hg::test-hg test-git
Cloning into 'test-git'...
Traceback (most recent call last):
  File "/nix/store/5m6xvmcqq5j248i90hnrga7pal6wm3yr-git-remote-hg-0.2-e716a9e1a9e460a45663694ba4e9e8894a8452b2/bin/.git-remote-hg-wrapped", line 1333, in <module>
    sys.exit(main(sys.argv))
  File "/nix/store/5m6xvmcqq5j248i90hnrga7pal6wm3yr-git-remote-hg-0.2-e716a9e1a9e460a45663694ba4e9e8894a8452b2/bin/.git-remote-hg-wrapped", line 1317, in main
    do_import(parser)
  File "/nix/store/5m6xvmcqq5j248i90hnrga7pal6wm3yr-git-remote-hg-0.2-e716a9e1a9e460a45663694ba4e9e8894a8452b2/bin/.git-remote-hg-wrapped", line 729, in do_import
    export_bookmark(repo, bmark)
  File "/nix/store/5m6xvmcqq5j248i90hnrga7pal6wm3yr-git-remote-hg-0.2-e716a9e1a9e460a45663694ba4e9e8894a8452b2/bin/.git-remote-hg-wrapped", line 613, in export_bookmark
    export_ref(repo, bmark, 'bookmarks', head)
  File "/nix/store/5m6xvmcqq5j248i90hnrga7pal6wm3yr-git-remote-hg-0.2-e716a9e1a9e460a45663694ba4e9e8894a8452b2/bin/.git-remote-hg-wrapped", line 486, in export_ref
    revs = gitrange(repo, tip, head)
  File "/nix/store/5m6xvmcqq5j248i90hnrga7pal6wm3yr-git-remote-hg-0.2-e716a9e1a9e460a45663694ba4e9e8894a8452b2/bin/.git-remote-hg-wrapped", line 453, in gitrange
    pending = set([int(b)])
TypeError: int() argument must be a string or a number, not 'changectx'
fatal: stream ends early
fast-import: dumping crash report to /tmp/test-git/.git/fast_import_crash_16959
fatal: error while running fast-import
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
