### PR TITLE
pantheon updates, etc.

### DIFF
--- a/pkgs/desktops/pantheon/apps/elementary-music/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-music/default.nix
@@ -7,7 +7,7 @@
 
 stdenv.mkDerivation rec {
   pname = "music";
-  version = "5.0.3";
+  version = "5.0.4";
 
   name = "elementary-${pname}-${version}";
 
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "0qbny4484kr7lihg54rbhfwah9k43iivk3rivfvn7i5w66vn5spl";
+    sha256 = "02qjsf9xnfh043xbls9mll2r1wcdvclw60x8wysv12rhbm90gwvp";
   };
 
   passthru = {

--- a/pkgs/desktops/pantheon/apps/elementary-photos/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-photos/default.nix
@@ -5,7 +5,7 @@
 
 stdenv.mkDerivation rec {
   pname = "photos";
-  version = "2.6.2";
+  version = "2.6.3";
 
   name = "elementary-${pname}-${version}";
 
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "166a1jb85n67z6ffm5i0xzap407rv0r511lzh0gidkap1qy6pnmi";
+    sha256 = "1s0ww5g26wj0gd1drj8gxs74gvg2c9fdj4ixpifj8jh8yafdmrvg";
   };
 
   passthru = {
@@ -64,14 +64,6 @@ stdenv.mkDerivation rec {
 
   mesonFlags = [
     "-Dplugins=false"
-  ];
-
-  patches = [
-    # Fix build against gexiv2 0.12
-    (fetchpatch {
-      url = "https://github.com/elementary/photos/commit/86df00ced674abb2ee430ea24422079cfabb314c.patch";
-      sha256 = "0836fzja93w36jf7ldqypsmnqn46mwsl93q41m104zn8qm0wrkmy";
-    })
   ];
 
   postPatch = ''

--- a/pkgs/desktops/pantheon/apps/elementary-photos/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-photos/default.nix
@@ -66,6 +66,12 @@ stdenv.mkDerivation rec {
     "-Dplugins=false"
   ];
 
+  patches = [
+    # https://github.com/elementary/photos/pull/505
+    # Unrelated line got dropped in https://github.com/elementary/photos/pull/498
+    ./fix-missing-line.patch
+  ];
+
   postPatch = ''
     chmod +x meson/post_install.py
     patchShebangs meson/post_install.py

--- a/pkgs/desktops/pantheon/apps/elementary-photos/fix-missing-line.patch
+++ b/pkgs/desktops/pantheon/apps/elementary-photos/fix-missing-line.patch
@@ -1,0 +1,21 @@
+From 88ee69b57f94efa2779595d1544109fed6a3211c Mon Sep 17 00:00:00 2001
+From: Fabio Valentini <decathorpe@gmail.com>
+Date: Tue, 16 Apr 2019 16:12:47 +0200
+Subject: [PATCH] photos/PhotoMetadata: fix issue introduced with PR #498
+
+---
+ src/photos/PhotoMetadata.vala | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/photos/PhotoMetadata.vala b/src/photos/PhotoMetadata.vala
+index f0a4a73b..34dcbb55 100644
+--- a/src/photos/PhotoMetadata.vala
++++ b/src/photos/PhotoMetadata.vala
+@@ -197,6 +197,7 @@ public class PhotoMetadata : MediaMetadata {
+ #else
+         exiv2.from_app1_segment (buffer, length);
+ #endif
++        exif = Exif.Data.new_from_data (buffer, length);
+         source_name = "<app1 segment %d bytes>".printf (length);
+     }
+ 

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/a11y/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/a11y/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     switchboard
   ];
 
-  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "lib/switchboard";
+  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder ''out''}/lib/switchboard";
 
   meta = with stdenv.lib; {
     description = "Switchboard Universal Access Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/about/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/about/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     ./remove-update-button.patch
   ];
 
-  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "lib/switchboard";
+  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder ''out''}/lib/switchboard";
 
   meta = with stdenv.lib; {
     description = "Switchboard About Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/applications/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/applications/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     switchboard
   ];
 
-  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "lib/switchboard";
+  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder ''out''}/lib/switchboard";
 
   meta = with stdenv.lib; {
     description = "Switchboard Applications Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/bluetooth/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/bluetooth/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     switchboard
   ];
 
-  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "lib/switchboard";
+  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder ''out''}/lib/switchboard";
 
   meta = with stdenv.lib; {
     description = "Switchboard Bluetooth Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/datetime/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/datetime/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
     ./clock-format.patch
   ];
 
-  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "lib/switchboard";
+  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder ''out''}/lib/switchboard";
 
   meta = with stdenv.lib; {
     description = "Switchboard Date & Time Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/display/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/display/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     switchboard
   ];
 
-  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "lib/switchboard";
+  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder ''out''}/lib/switchboard";
 
   meta = with stdenv.lib; {
     description = "Switchboard Displays Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/keyboard/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/keyboard/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "lib/switchboard";
+  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder ''out''}/lib/switchboard";
 
   meta = with stdenv.lib; {
     description = "Switchboard Keyboard Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/mouse-touchpad/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/mouse-touchpad/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     switchboard
   ];
 
-  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "lib/switchboard";
+  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder ''out''}/lib/switchboard";
 
   meta = with stdenv.lib; {
     description = "Switchboard Mouse & Touchpad Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/mouse-touchpad/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/mouse-touchpad/default.nix
@@ -1,16 +1,24 @@
-{ stdenv, fetchFromGitHub, pantheon, fetchpatch, meson, ninja
-, pkgconfig, vala, libgee, granite, gtk3, switchboard, gobject-introspection }:
+{ stdenv, fetchFromGitHub, pantheon, fetchpatch, meson, ninja, pkgconfig, vala
+, libgee, granite, gtk3, switchboard, elementary-settings-daemon, gobject-introspection }:
 
 stdenv.mkDerivation rec {
   pname = "switchboard-plug-mouse-touchpad";
-  version = "2.1.4";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = pname;
     rev = version;
-    sha256 = "1zh5472ab01bckrc1py5bqqsal9i9pbgx6i8ap2d4yzhc8sirjrf";
+    sha256 = "0mr25p7j5hl8zmvz5i3g30s4xbdhk6d22lw2akch3si40il9q5fv";
   };
+
+  patches = [
+    ./hardcode-settings-daemon-gsettings.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace src/Views/General.vala --subst-var-by GSD_GSETTINGS ${elementary-settings-daemon}/share/gsettings-schemas/${elementary-settings-daemon.name}/glib-2.0/schemas
+  '';
 
   passthru = {
     updateScript = pantheon.updateScript {

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/mouse-touchpad/hardcode-settings-daemon-gsettings.patch
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/mouse-touchpad/hardcode-settings-daemon-gsettings.patch
@@ -1,0 +1,63 @@
+diff --git a/src/Views/General.vala b/src/Views/General.vala
+index 4b19b73..dfa3d4d 100644
+--- a/src/Views/General.vala
++++ b/src/Views/General.vala
+@@ -138,32 +138,34 @@ public class MouseTouchpad.GeneralView : Gtk.Grid {
+         attach (pointer_speed_scale, 3, 8);
+         attach (pointer_speed_help, 1, 9, 3);
+ 
+-        var xsettings_schema = SettingsSchemaSource.get_default ().lookup ("org.gnome.settings-daemon.plugins.xsettings", false);
+-        if (xsettings_schema != null) {
+-            var primary_paste_switch = new Gtk.Switch ();
+-            primary_paste_switch.halign = Gtk.Align.START;
+-
+-            var primary_paste_help = new Gtk.Label (_("Middle or three-finger clicking on an input will paste any selected text"));
+-            primary_paste_help.margin_bottom = 18;
+-            primary_paste_help.wrap = true;
+-            primary_paste_help.xalign = 0;
+-            primary_paste_help.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
+-
+-            attach (new SettingLabel (_("Middle click paste:")), 0, 4);
+-            attach (primary_paste_switch, 1, 4);
+-            attach (primary_paste_help, 1, 5, 3);
+-
+-            var xsettings = new GLib.Settings ("org.gnome.settings-daemon.plugins.xsettings");
+-            primary_paste_switch.notify["active"].connect (() => on_primary_paste_switch_changed (primary_paste_switch, xsettings));
+-
+-            var current_value = xsettings.get_value ("overrides").lookup_value ("Gtk/EnablePrimaryPaste", VariantType.INT32);
+-            if (current_value != null) {
+-                primary_paste_switch.active = current_value.get_int32 () == 1;
+-            }
++        var primary_paste_switch = new Gtk.Switch ();
++        primary_paste_switch.halign = Gtk.Align.START;
++
++        var primary_paste_help = new Gtk.Label (_("Middle or three-finger clicking on an input will paste any selected text"));
++        primary_paste_help.margin_bottom = 18;
++        primary_paste_help.wrap = true;
++        primary_paste_help.xalign = 0;
++        primary_paste_help.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
++
++        attach (new SettingLabel (_("Middle click paste:")), 0, 4);
++        attach (primary_paste_switch, 1, 4);
++        attach (primary_paste_help, 1, 5, 3);
++
++        SettingsSchemaSource daemon_schema_source = new SettingsSchemaSource.from_directory ("@GSD_GSETTINGS@", null, true);
++        SettingsSchema xsettings_schema = daemon_schema_source.lookup ("org.gnome.settings-daemon.plugins.xsettings", false);
++
++        var xsettings = new GLib.Settings.full (xsettings_schema, null, null);
++        primary_paste_switch.notify["active"].connect (() => on_primary_paste_switch_changed (primary_paste_switch, xsettings));
++
++        var current_value = xsettings.get_value ("overrides").lookup_value ("Gtk/EnablePrimaryPaste", VariantType.INT32);
++        if (current_value != null) {
++            primary_paste_switch.active = current_value.get_int32 () == 1;
+         }
+ 
+-        var daemon_settings = new GLib.Settings ("org.gnome.settings-daemon.peripherals.mouse");
+-        daemon_settings.bind ("locate-pointer", reveal_pointer_switch, "active", GLib.SettingsBindFlags.DEFAULT);
++        SettingsSchema daemon_mouse_schema = daemon_schema_source.lookup ("org.gnome.settings-daemon.peripherals.mouse", false);
++
++        var daemon_mouse_settings = new GLib.Settings.full (daemon_mouse_schema, null, null);
++        daemon_mouse_settings.bind ("locate-pointer", reveal_pointer_switch, "active", GLib.SettingsBindFlags.DEFAULT);
+ 
+         var a11y_mouse_settings = new GLib.Settings ("org.gnome.desktop.a11y.mouse");
+         a11y_mouse_settings.bind ("secondary-click-enabled", hold_switch, "active", GLib.SettingsBindFlags.DEFAULT);

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/network/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/network/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
   ];
 
 
-  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "lib/switchboard";
+  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder ''out''}/lib/switchboard";
 
   meta = with stdenv.lib; {
     description = "Switchboard Networking Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/notifications/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/notifications/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     switchboard
   ];
 
-  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "lib/switchboard";
+  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder ''out''}/lib/switchboard";
 
   meta = with stdenv.lib; {
     description = "Switchboard Notifications Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/pantheon-shell/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/pantheon-shell/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
   '';
 
 
-  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "lib/switchboard";
+  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder ''out''}/lib/switchboard";
 
   meta = with stdenv.lib; {
     description = "Switchboard Desktop Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/power/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/power/default.nix
@@ -49,10 +49,10 @@ stdenv.mkDerivation rec {
     substituteInPlace src/MainView.vala --subst-var-by GSD_GSETTINGS_PATH ${elementary-settings-daemon}/share/gsettings-schemas/${elementary-settings-daemon.name}/glib-2.0/schemas
   '';
 
-  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "lib/switchboard";
-  PKG_CONFIG_DBUS_1_SYSTEM_BUS_SERVICES_DIR = "share/dbus-1/system-services";
-  PKG_CONFIG_DBUS_1_SYSCONFDIR = "etc";
-  PKG_CONFIG_POLKIT_GOBJECT_1_POLICYDIR = "share/polkit-1/actions";
+  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder ''out''}/lib/switchboard";
+  PKG_CONFIG_DBUS_1_SYSTEM_BUS_SERVICES_DIR = "${placeholder ''out''}/share/dbus-1/system-services";
+  PKG_CONFIG_DBUS_1_SYSCONFDIR = "${placeholder ''out''}/etc";
+  PKG_CONFIG_POLKIT_GOBJECT_1_POLICYDIR = "${placeholder ''out''}/share/polkit-1/actions";
 
   meta = with stdenv.lib; {
     description = "Switchboard Power Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/printers/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/printers/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     switchboard
   ];
 
-  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "lib/switchboard";
+  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder ''out''}/lib/switchboard";
 
   meta = with stdenv.lib; {
     description = "Switchboard Printers Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/security-privacy/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/security-privacy/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     zeitgeist
   ];
 
-  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "lib/switchboard";
+  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder ''out''}/lib/switchboard";
 
   patches = [
     ./hardcode-gsettings.patch

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/sharing/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/sharing/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     switchboard
   ];
 
-  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "lib/switchboard";
+  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder ''out''}/lib/switchboard";
 
   meta = with stdenv.lib; {
     description = "Switchboard Sharing Plug";

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/sound/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/sound/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     switchboard
   ];
 
-  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "lib/switchboard";
+  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder ''out''}/lib/switchboard";
 
   meta = with stdenv.lib; {
     description = "Switchboard Sound Plug";

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/applications-menu/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/applications-menu/default.nix
@@ -51,8 +51,8 @@ stdenv.mkDerivation rec {
     zeitgeist
    ];
 
-  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "lib/wingpanel";
-  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "lib/switchboard";
+  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "${placeholder ''out''}/lib/wingpanel";
+  PKG_CONFIG_SWITCHBOARD_2_0_PLUGSDIR = "${placeholder ''out''}/lib/switchboard";
 
   patches = [
     (substituteAll {

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/bluetooth/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/bluetooth/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     wingpanel
   ];
 
-  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "lib/wingpanel";
+  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "${placeholder ''out''}/lib/wingpanel";
 
   postPatch = ''
     chmod +x meson/post_install.py

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/datetime/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/datetime/default.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "lib/wingpanel";
+  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "${placeholder ''out''}/lib/wingpanel";
 
   postPatch = ''
     chmod +x meson/post_install.py

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/keyboard/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/keyboard/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "lib/wingpanel";
+  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "${placeholder ''out''}/lib/wingpanel";
 
   meta = with stdenv.lib; {
     description = "Keyboard Indicator for Wingpanel";

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/network/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/network/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     wingpanel
   ];
 
-  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "lib/wingpanel";
+  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "${placeholder ''out''}/lib/wingpanel";
 
   meta = with stdenv.lib; {
     description = "Network Indicator for Wingpanel";

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/nightlight/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/nightlight/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     wingpanel
   ];
 
-  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "lib/wingpanel";
+  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "${placeholder ''out''}/lib/wingpanel";
 
   meta = with stdenv.lib; {
     description = "Night Light Indicator for Wingpanel";

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/notifications/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/notifications/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     wingpanel
   ];
 
-  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "lib/wingpanel";
+  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "${placeholder ''out''}/lib/wingpanel";
 
   meta = with stdenv.lib; {
     description = "Notifications Indicator for Wingpanel";

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/power/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/power/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     wingpanel
   ];
 
-  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "lib/wingpanel";
+  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "${placeholder ''out''}/lib/wingpanel";
 
   postPatch = ''
     chmod +x meson/post_install.py

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/session/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/session/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     wingpanel
   ];
 
-  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "lib/wingpanel";
+  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "${placeholder ''out''}/lib/wingpanel";
 
   meta = with stdenv.lib; {
     description = "Session Indicator for Wingpanel";

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/sound/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/sound/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     wingpanel
   ];
 
-  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "lib/wingpanel";
+  PKG_CONFIG_WINGPANEL_2_0_INDICATORSDIR = "${placeholder ''out''}/lib/wingpanel";
 
   postPatch = ''
     chmod +x meson/post_install.py

--- a/pkgs/misc/screensavers/light-locker/default.nix
+++ b/pkgs/misc/screensavers/light-locker/default.nix
@@ -1,43 +1,64 @@
 { stdenv
 , fetchFromGitHub
-, which
-, xfce
-, glib
+, meson
+, ninja
 , pkgconfig
+, gtk3
+, glib
+, intltool
+, dbus-glib
 , libX11
 , libXScrnSaver
-, libXxf86misc
-, gtk3
-, dbus-glib
+, libXxf86vm
+, libXext
 , systemd
+, pantheon
 , wrapGAppsHook
 }:
 
 stdenv.mkDerivation rec {
-  name = "${basename}-${version}";
-  basename = "light-locker";
-  version = "1.8.0";
+  pname = "light-locker";
+  version = "1.9.0";
+
+  outputs = [ "out" "man" ];
 
   src = fetchFromGitHub {
     owner = "the-cavalry";
-    repo = basename;
+    repo = pname;
     rev = "v${version}";
-    sha256 = "1zsafc10bmliknf12h3mgy7f73lvgph0q0wkaqp42iagmw11yaj8";
+    sha256 = "1z5lcd02gqax65qc14hj5khifg7gr53zy3s5i6apba50lbdlfk46";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ which xfce.xfce4-dev-tools glib systemd
-                  libX11 libXScrnSaver libXxf86misc gtk3 dbus-glib wrapGAppsHook ];
+  nativeBuildInputs = [
+    intltool
+    meson
+    ninja
+    pkgconfig
+  ];
 
-  preConfigure = ''
-    ./autogen.sh
-  '';
+  buildInputs = [
+    dbus-glib
+    glib
+    gtk3
+    libX11
+    libXScrnSaver
+    libXext
+    libXxf86vm
+    systemd
+    wrapGAppsHook
+  ];
 
-  configureFlags = [ "--with-xf86gamma-ext" "--with-mit-ext"
-                     "--with-dpms-ext" "--with-systemd"
-                     # ConsoleKit and UPower were dropped in favor
-                     # of systemd replacements
-                     "--without-console-kit" "--without-upower" ];
+  mesonFlags = [
+    "-Dmit-ext=true"
+    "-Ddpms-ext=true"
+    "-Dxf86gamma-ext=true"
+    "-Dsystemd=true"
+    "-Dupower=true"
+    "-Dlate-locking=true"
+    "-Dlock-on-suspend=true"
+    "-Dlock-on-lid=true"
+    "-Dgsettings=true"
+  ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/the-cavalry/light-locker;
@@ -52,7 +73,7 @@ stdenv.mkDerivation rec {
       ConsoleKit/UPower or logind/systemd.
     '';
     license = licenses.gpl2;
-    maintainers = with maintainers; [ obadz ];
+    maintainers = with maintainers; [ obadz ] ++ pantheon.maintainers;
     platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/networking/network-manager/applet.nix
+++ b/pkgs/tools/networking/network-manager/applet.nix
@@ -33,9 +33,14 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ meson ninja intltool pkgconfig wrapGAppsHook gobject-introspection python3 gtk-doc docbook_xsl docbook_xml_dtd_43 libxml2 ];
 
+  # Needed for wingpanel-indicator-network and switchboard-plug-network
+  patches = [ ./hardcode-gsettings.patch ];
+
   postPatch = ''
     chmod +x meson_post_install.py # patchShebangs requires executable file
     patchShebangs meson_post_install.py
+
+    substituteInPlace src/wireless-security/eap-method.c --subst-var-by NM_APPLET_GSETTINGS $lib/share/gsettings-schemas/${name}/glib-2.0/schemas
   '';
 
   passthru = {

--- a/pkgs/tools/networking/network-manager/hardcode-gsettings.patch
+++ b/pkgs/tools/networking/network-manager/hardcode-gsettings.patch
@@ -1,0 +1,32 @@
+diff --git a/src/wireless-security/eap-method.c b/src/wireless-security/eap-method.c
+index 2e9daa23..6663b3ce 100644
+--- a/src/wireless-security/eap-method.c
++++ b/src/wireless-security/eap-method.c
+@@ -265,8 +265,11 @@ eap_method_ca_cert_ignore_get (EAPMethod *method, NMConnection *connection)
+ static GSettings *
+ _get_ca_ignore_settings (NMConnection *connection)
+ {
++	GSettingsSchemaSource *schema_source;
++	g_autoptr (GSettingsSchema) *schema;
+ 	GSettings *settings;
+-	char *path = NULL;
++
++	g_autofree char *path = NULL;
+ 	const char *uuid;
+ 
+ 	g_return_val_if_fail (connection, NULL);
+@@ -274,9 +277,12 @@ _get_ca_ignore_settings (NMConnection *connection)
+ 	uuid = nm_connection_get_uuid (connection);
+ 	g_return_val_if_fail (uuid && *uuid, NULL);
+ 
++	schema_source = g_settings_schema_source_new_from_directory ("@NM_APPLET_GSETTINGS@", g_settings_schema_source_get_default (), TRUE, NULL);
++	schema = g_settings_schema_source_lookup (schema_source, "org.gnome.nm-applet.eap", FALSE);
++	g_settings_schema_source_unref (schema_source);
++
+ 	path = g_strdup_printf ("/org/gnome/nm-applet/eap/%s/", uuid);
+-	settings = g_settings_new_with_path ("org.gnome.nm-applet.eap", path);
+-	g_free (path);
++	settings = g_settings_new_full (schema, NULL, path);
+ 
+ 	return settings;
+ }


### PR DESCRIPTION
###### Motivation for this change
The usual.

###### Summary of changes

* https://github.com/elementary/photos/releases/tag/2.6.3

The gexiv2 0.12 patch is included in this release.

* https://github.com/elementary/switchboard-plug-mouse-touchpad/releases/tag/2.2.0
> Use org.gnome.settings-daemon.plugins.xsettings for middle click paste

That has been hardcoded with a patch.

* Using placeholder in https://github.com/NixOS/nixpkgs/commit/b335d5640c04e7940ba1c00965933b9ad3767519 https://github.com/NixOS/nixpkgs/commit/4a690093b1def766576ae2c577a55c037f5c8d13.

Lastly there's a hardcode-gsettings patch for `networkmanagerapplet` `org.gnome.nm-applet.eap` 
that is needed for `wingpanel-indicator-network` and `switchboard-plug-network`.
##### Though mind the commit msg :smile: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
