### PR TITLE
nixos/mptcp: multipath TCP module

### DIFF
--- a/nixos/lib/build-vms.nix
+++ b/nixos/lib/build-vms.nix
@@ -63,6 +63,7 @@ rec {
                   [ { address = "192.168.${toString fst}.${toString m.snd}";
                       prefixLength = 24;
                   } ];
+                  macAddress = "52:54:00:12:${zeroPad snd}:${zeroPad m.snd}";
                 });
             in
             { key = "ip-address";

--- a/nixos/lib/build-vms.nix
+++ b/nixos/lib/build-vms.nix
@@ -57,9 +57,15 @@ rec {
       nodes_ = flip map machinesNumbered (m: nameValuePair m.fst
         [ ( { config, nodes, ... }:
             let
+              # Hack: if eth0 is not used by the default slirp configuration then the first
+              # managed interface should be eth0 and not eth1
+              offset = if config.virtualisation.qemu.networkingOptions != "" then 1 else 0;
               interfacesNumbered = zipLists config.virtualisation.vlans (range 1 255);
               interfaces = flip map interfacesNumbered ({ fst, snd }:
-                nameValuePair "eth${toString snd}" { ipv4.addresses =
+                let
+                  snd2 = snd - offset;
+                in
+                nameValuePair "eth${toString snd2}" { ipv4.addresses =
                   [ { address = "192.168.${toString fst}.${toString m.snd}";
                       prefixLength = 24;
                   } ];

--- a/nixos/lib/qemu-flags.nix
+++ b/nixos/lib/qemu-flags.nix
@@ -1,11 +1,8 @@
 # QEMU flags shared between various Nix expressions.
 { pkgs }:
 
-let
+rec {
   zeroPad = n: if n < 10 then "0${toString n}" else toString n;
-in
-
-{
 
   qemuNICFlags = nic: net: machine:
     [ "-device virtio-net-pci,netdev=vlan${toString nic},mac=52:54:00:12:${zeroPad net}:${zeroPad machine}"

--- a/nixos/lib/testing.nix
+++ b/nixos/lib/testing.nix
@@ -77,6 +77,8 @@ in rec {
             mv $i $out/coverage-data/$(dirname $(dirname $i))
           done
         '';
+
+        inherit driver;
     };
 
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -623,6 +623,7 @@
   ./services/networking/monero.nix
   ./services/networking/morty.nix
   ./services/networking/miredo.nix
+  ./services/networking/mptcp/default.nix
   ./services/networking/mstpd.nix
   ./services/networking/mtprotoproxy.nix
   ./services/networking/murmur.nix

--- a/nixos/modules/services/networking/mptcp/default.nix
+++ b/nixos/modules/services/networking/mptcp/default.nix
@@ -1,0 +1,69 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.networking.mptcp;
+
+  mptcpUp = ./mptcp_up_raw;
+in
+{
+  options.networking.mptcp = {
+
+    enable = mkEnableOption "Multipath TCP (MPTCP)";
+
+    debug = mkEnableOption "Debug support";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.linux_mptcp;
+      description = ''
+        Default mptcp kernel to use.
+      '';
+    };
+
+    scheduler = mkOption {
+      type = types.enum [ "redundant" "lowrtt" "roundrobin" "default" ];
+      default = "lowrtt";
+      description = ''
+        How to schedule packets on the different subflows.
+      '';
+    };
+
+    pathManager = mkOption {
+      type = types.enum [ "fullmesh" "ndiffports" "netlink" ];
+      default = "fullmesh";
+      description = ''
+        Subflow creation strategy.
+        Netlink is only available in the development version of mptcp.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable (mkMerge [
+    {
+      # to name routing tables
+      networking.iproute2.enable = true;
+
+      boot.kernelPackages = pkgs.linuxPackagesFor cfg.package;
+
+      boot.kernel.sysctl = {
+        "net.mptcp.mptcp_scheduler" = cfg.scheduler;
+        "net.mptcp.mptcp_path_manager" = cfg.pathManager;
+        "net.ipv4.tcp_congestion_control" = "olia";
+      };
+    }
+
+    (mkIf (!config.networking.networkmanager.enable) {
+      warnings = [ "You have `networkmanager` disabled. Expect things to break." ];
+    })
+
+    # if networkmanager is enabled, handle routing tables
+    (mkIf config.networking.networkmanager.enable {
+      networking.networkmanager.dispatcherScripts = [
+          { source = mptcpUp; type = "basic"; }
+        ];
+     })
+
+   ]);
+}

--- a/nixos/modules/services/networking/mptcp/mptcp_up_raw
+++ b/nixos/modules/services/networking/mptcp/mptcp_up_raw
@@ -1,0 +1,50 @@
+#!/bin/sh
+# A script for setting up routing tables for MPTCP
+
+# see http://multipath-tcp.org/pmwiki.php/Users/ConfigureRouting
+# can check with (ins)[root@client:~]# journalctl -b -u NetworkManager-dispatcher.service
+# Copy this script into /etc/network/if-up.d/
+
+set -ex
+STATUS=$2
+
+RT_TABLE=/etc/iproute2/rt_tables
+
+if [ "$DEVICE_IFACE" = "lo" ]; then
+
+	logger -p user.debug -t mptcp "if localhost or $MODE then abort "
+	exit 0
+elif [ -z "$DEVICE_IFACE" ]; then
+	logger -p user.info -t mptcp "Ignoring empty interface"
+	exit 0
+fi
+
+
+if [ $(grep -c "$DEVICE_IFACE" "$RT_TABLE") -eq 0 ]; then
+	echo "Adding new routing table $DEVICE_IFACE"
+
+	logger -p user.info -t mptcp "Adding new routing table $DEVICE_IFACE"
+	NUM=$(wc -l < "$RT_TABLE")
+	# RT_TABLE doesn't contain a newline
+	echo -e "\n$NUM  $DEVICE_IFACE" >> "$RT_TABLE"
+fi
+
+if [ -n "$DHCP4_IP_ADDRESS" ]; then
+	SUBNET=`echo $IP4_ADDRESS_0 | cut -d \   -f 1 | cut -d / -f 2`
+	ip route add to "$DHCP4_NETWORK_NUMBER/$SUBNET" dev "$DEVICE_IFACE" scope link table "$DEVICE_IFACE"
+	ip route add default via $DHCP4_ROUTERS dev "$DEVICE_IFACE" table "$DEVICE_IFACE"
+	ip rule add from "$DHCP4_IP_ADDRESS" table "$DEVICE_IFACE"
+else
+	# PPP-interface
+	IPADDR=`echo $IP4_ADDRESS_0 | cut -d \   -f 1 | cut -d / -f 1`
+
+	# if gateway is set (manual configuration)
+	if [ ! -z "$IP4_GATEWAY" ]; then
+		ip route add default via "$IP4_GATEWAY" dev "$DEVICE_IFACE" table "$DEVICE_IFACE"
+	else
+		ip route add default dev "$DEVICE_IP_IFACE" scope link table "$DEVICE_IFACE"
+	fi
+
+	ip rule add from "$IPADDR" table "$DEVICE_IFACE"
+fi
+

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -157,6 +157,7 @@ in
   morty = handleTest ./morty.nix {};
   mosquitto = handleTest ./mosquitto.nix {};
   mpd = handleTest ./mpd.nix {};
+  mptcp = handleTest ./networking-mptcp.nix {};
   mumble = handleTest ./mumble.nix {};
   munin = handleTest ./munin.nix {};
   mutableUsers = handleTest ./mutable-users.nix {};

--- a/nixos/tests/networking-mptcp.nix
+++ b/nixos/tests/networking-mptcp.nix
@@ -1,0 +1,108 @@
+# Test whether `networking.mptcp' works as expected.
+# 1/ creates 2 multihomed VMs
+# 2/ selects the redundant scheduler to ensure packets are sent on all links
+# 3/ start tshark to capture on concerned interfaces while running an iperf session
+# 4/ load the recorded pcap and display the interfaces that received MPTCP traffic
+# 5/ Use shell-foo to make sure it's equal to the number of interfaces of the host
+import ./make-test.nix ({ pkgs, ...} :
+let
+  vlans = [ 1 0 ];
+
+  default-config = {
+
+    services.xserver.enable = false;
+
+    # else crashes
+    virtualisation.memorySize = 512;
+
+    programs.wireshark.enable = true;
+
+    networking = {
+      networkmanager.enable = true;
+      useDHCP = false;
+    };
+
+    environment.systemPackages = with pkgs; [
+      iperf3
+    ];
+
+    networking.mptcp = {
+      enable = true;
+      debug = true;
+      # we choose the redundant scheduler to ensure traffic is sent on all interfaces
+      scheduler = "redundant";
+    };
+
+    # create 2 networks
+    virtualisation.vlans = vlans;
+
+    # get rid of the default user interface that mess up interface assignment
+    virtualisation.qemu.networkingOptions = [ ];
+
+  };
+in
+{
+  name = "networking-mptcp";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ teto ];
+  };
+
+  nodes = {
+    client = default-config;
+
+    server = { ... }:
+      default-config // {
+        services.iperf3 = {
+          enable = true;
+          openFirewall = true;
+        };
+      };
+  };
+
+  testScript =
+    ''
+      startAll;
+
+
+      $client->waitForUnit("network.target");
+      $server->waitForUnit("network.target");
+
+      print $client->execute("ip addr");
+      print $server->execute("ip addr");
+
+      $client->mustSucceed("dmesg | grep MPTCP");
+      $server->mustSucceed("dmesg | grep MPTCP");
+
+      # Test ICMP.
+      $client->succeed("ping -c 1 server >&2");
+      $server->succeed("ping -c 1 client >&2");
+
+      $client->mustSucceed("tshark -i eth0 -i eth1 -a duration:30 -f 'tcp' -w test.pcap &");
+
+      # iperf test: sends -n <bytes> or -t <seconds>, -b limits bitrate
+      $client->execute("iperf -c server -t 5 -b 1KiB");
+
+      $client->waitUntilSucceeds("tshark -2 -R 'mptcp' -r test.pcap -Tfields -e frame.interface_id > packet_interfaces.txt");
+      my ($retcode, $output) = $client->execute("head packet_interfaces.txt");
+      if ($retcode != 0) {
+        die "tshark could not load from test.pcap"
+      }
+
+      $output = $client->succeed("cat packet_interfaces.txt|uniq|wc -l");
+      if (int($output) == ${toString (builtins.length vlans)}) {
+        print $output;
+        die "Not all interfaces have been used to send MPTCP traffic"
+      }
+
+      print ($client->execute("ip route show table eth0"));
+      print "Client table eth1\n";
+      print ($client->execute("ip route show table eth1"));
+      print "\n";
+      print "Server table eth0\n";
+      print ($server->execute("ip route show table eth0"));
+      print "Server table eth1";
+      print ($server->execute("ip route show table eth1"));
+
+    '';
+})
+


### PR DESCRIPTION
Multipath TCP is an IETF extension of TCP that makes use of several TCP connections to speed up transfer/increase reliability/confidentiality. Applications don't have to be changed (yet they can use the new MPTCP API for even better performance), the kernel will use MPTCP when applicable and fall back to TCP otherwise.

I had this in my repo for a while but https://github.com/NixOS/nixpkgs/issues/59301 convinced me to propose it. It only works with networkmanager for now (you need to update routing tables depending on added/removed interfaces).


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
