### PR TITLE
boringtun: init at 20190407

### DIFF
--- a/pkgs/tools/networking/boringtun/default.nix
+++ b/pkgs/tools/networking/boringtun/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "boringtun";
+  # "boringtun" is still undergoing review for security concerns.
+  # The GitHub page does not show any release yet,
+  # use 20190407 as version number to indicate that it is an unstable version.
+  version = "20190407";
+
+  src = fetchFromGitHub {
+    owner = "cloudflare";
+    repo = pname;
+    rev = "b040eb4fd1591b1d5ceb07c6cbb0856553f50adc";
+    sha256 = "04i53dvxld2a0xzr0gfl895rcwfvisj1rfs7rl0444gml8s8xyb3";
+  };
+
+  cargoSha256 = "0mqgd5r3rdzaw3vkmz0rswn3cwq9b4im6g4rrq7wr7pgrzq96xwm";
+
+  # To prevent configuration phase error that is caused by
+  # lacking a new line in file ".cargo/config",
+  # we append a new line to the end of file.
+  preConfigure = "echo '' >> .cargo/config";
+
+  # Testing this project requires sudo, Docker and network access, etc.
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Userspace WireGuard® implementation in Rust";
+    homepage = https://github.com/cloudflare/boringtun;
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ xrelkd ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1042,6 +1042,8 @@ in
 
   borgbackup = callPackage ../tools/backup/borg { };
 
+  boringtun = callPackage ../tools/networking/boringtun { };
+
   boomerang = libsForQt5.callPackage ../development/tools/boomerang { };
 
   boost-build = callPackage ../development/tools/boost-build { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
BoringTun is an implementation of the WireGuard® protocol designed for portability and speed.
https://github.com/cloudflare/boringtun
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
