### PR TITLE
nixos/manual: update 17.03 -> 19.03 in upgrading section

### DIFF
--- a/nixos/doc/manual/development/releases.xml
+++ b/nixos/doc/manual/development/releases.xml
@@ -177,6 +177,12 @@
     </listitem>
     <listitem>
      <para>
+      Update "Chapter 4. Upgrading NixOS" section of the manual to match 
+      new stable release version.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
       Update http://nixos.org/nixos/download.html and
       http://nixos.org/nixos/manual in
       https://github.com/NixOS/nixos-org-configurations

--- a/nixos/doc/manual/installation/upgrading.xml
+++ b/nixos/doc/manual/installation/upgrading.xml
@@ -14,11 +14,11 @@
     <para>
      <emphasis>Stable channels</emphasis>, such as
      <literal
-    xlink:href="https://nixos.org/channels/nixos-17.03">nixos-17.03</literal>.
+    xlink:href="https://nixos.org/channels/nixos-19.03">nixos-19.03</literal>.
      These only get conservative bug fixes and package upgrades. For instance,
      a channel update may cause the Linux kernel on your system to be upgraded
-     from 4.9.16 to 4.9.17 (a minor bug fix), but not from
-     4.9.<replaceable>x</replaceable> to 4.11.<replaceable>x</replaceable> (a
+     from 4.19.34 to 4.19.38 (a minor bug fix), but not from
+     4.19.<replaceable>x</replaceable> to 4.20.<replaceable>x</replaceable> (a
      major change that has the potential to break things). Stable channels are
      generally maintained until the next stable branch is created.
     </para>
@@ -38,7 +38,7 @@
     <para>
      <emphasis>Small channels</emphasis>, such as
      <literal
-    xlink:href="https://nixos.org/channels/nixos-17.03-small">nixos-17.03-small</literal>
+    xlink:href="https://nixos.org/channels/nixos-19.03-small">nixos-19.03-small</literal>
      or
      <literal
     xlink:href="https://nixos.org/channels/nixos-unstable-small">nixos-unstable-small</literal>.
@@ -63,8 +63,8 @@
  <para>
   When you first install NixOS, you’re automatically subscribed to the NixOS
   channel that corresponds to your installation source. For instance, if you
-  installed from a 17.03 ISO, you will be subscribed to the
-  <literal>nixos-17.03</literal> channel. To see which NixOS channel you’re
+  installed from a 19.03 ISO, you will be subscribed to the
+  <literal>nixos-19.03</literal> channel. To see which NixOS channel you’re
   subscribed to, run the following as root:
 <screen>
 # nix-channel --list | grep nixos
@@ -75,13 +75,13 @@ nixos https://nixos.org/channels/nixos-unstable
 # nix-channel --add https://nixos.org/channels/<replaceable>channel-name</replaceable> nixos
 </screen>
   (Be sure to include the <literal>nixos</literal> parameter at the end.) For
-  instance, to use the NixOS 17.03 stable channel:
+  instance, to use the NixOS 19.03 stable channel:
 <screen>
-# nix-channel --add https://nixos.org/channels/nixos-17.03 nixos
+# nix-channel --add https://nixos.org/channels/nixos-19.03 nixos
 </screen>
   If you have a server, you may want to use the “small” channel instead:
 <screen>
-# nix-channel --add https://nixos.org/channels/nixos-17.03-small nixos
+# nix-channel --add https://nixos.org/channels/nixos-19.03-small nixos
 </screen>
   And if you want to live on the bleeding edge:
 <screen>
@@ -127,7 +127,7 @@ nixos https://nixos.org/channels/nixos-unstable
    current channel. (To see when the service runs, see <command>systemctl
    list-timers</command>.) You can also specify a channel explicitly, e.g.
 <programlisting>
-<xref linkend="opt-system.autoUpgrade.channel"/> = https://nixos.org/channels/nixos-17.03;
+<xref linkend="opt-system.autoUpgrade.channel"/> = https://nixos.org/channels/nixos-19.03;
 </programlisting>
   </para>
  </section>


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
The manual references 17.03 in a few spots in the upgrading section of the manual. I think it makes sense to keep those references current as there are a lot of copy and paste warriors out there and it would be nice to make upgrading as easy as possible.

###### Things done
changed 17.03 -> 19.03 , and updated example to accurately cover this change as well
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
