### PR TITLE
pythonPackages.lektor: 2.3 -> 3.1.3

### DIFF
--- a/pkgs/development/python-modules/lektor/default.nix
+++ b/pkgs/development/python-modules/lektor/default.nix
@@ -1,6 +1,6 @@
-{ stdenv
+{ lib
 , buildPythonPackage
-, fetchgit
+, fetchFromGitHub
 , click
 , watchdog
 , exifread
@@ -12,35 +12,47 @@
 , flask
 , pyopenssl
 , ndg-httpsclient
-, pkgs
+, pytest
+, pytestcov
+, pytest-mock
+, pytest-pylint
+, pytest-click
+, isPy27
+, functools32
 }:
 
 buildPythonPackage rec {
   pname = "lektor";
-  version = "2.3";
+  version = "3.1.3";
 
-  src = fetchgit {
-    url = "https://github.com/lektor/lektor";
-    rev = "refs/tags/${version}";
-    sha256 = "1n0ylh1sbpvi9li3g6a7j7m28njfibn10y6s2gayjxwm6fpphqxy";
+  src = fetchFromGitHub {
+    owner = "lektor";
+    repo = "lektor";
+    rev = version;
+    sha256 = "16qw68rz5q77w84lwyhjpfd3bm4mfrhcjrnxwwnz3vmi610h68hx";
   };
 
-  buildInputs = [ pkgs.glibcLocales ];
   propagatedBuildInputs = [
     click watchdog exifread requests mistune inifile Babel jinja2
     flask pyopenssl ndg-httpsclient
+  ] ++ lib.optionals isPy27 [ functools32 ];
+
+  checkInputs = [
+    pytest pytestcov pytest-mock pytest-pylint pytest-click
   ];
 
-  LC_ALL="en_US.UTF-8";
+  checkPhase = ''
+    pytest
+  '';
 
-  # No tests included in archive
+  # many errors -- tests assume inside of git repo, linting errors 13/317 fail
   doCheck = false;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A static content management system";
     homepage    = "https://www.getlektor.com/";
     license     = licenses.bsd0;
-    maintainers = with maintainers; [ vozz ];
+    maintainers = with maintainers; [ vozz costrouc ];
   };
 
 }

--- a/pkgs/development/python-modules/pytest-click/default.nix
+++ b/pkgs/development/python-modules/pytest-click/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytest
+, click
+, pytestcov
+, isPy27
+, mock
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-click";
+  version = "0.3";
+
+  src = fetchFromGitHub {
+    owner = "Stranger6667";
+    repo = "pytest-click";
+    rev = version;
+    sha256 = "1cd15anw8d4rq6qs03j6ag38199rqw7vp0w0w0fm41mvdzr0lwvz";
+  };
+
+  postConfigure = ''
+    substituteInPlace setup.py \
+      --replace "mock==1.0.1" "mock"
+  '';
+
+  propagatedBuildInputs = [
+    pytest
+    click
+  ];
+
+  checkInputs = [ pytestcov ] ++ lib.optionals isPy27 [ mock ];
+
+  meta = with lib; {
+    description = "pytest plugin for click";
+    homepage = https://github.com/Stranger6667/pytest-click;
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-pylint/default.nix
+++ b/pkgs/development/python-modules/pytest-pylint/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytest
+, pylint
+, six
+, pytestrunner
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-pylint";
+  version = "0.14.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "7bfbb66fc6dc160193a9e813a7c55e5ae32028f18660deeb90e1cb7e980cbbac";
+  };
+
+  buildInputs = [ pytestrunner ];
+
+  propagatedBuildInputs = [
+    pytest
+    pylint
+    six
+  ];
+
+  # tests not included with release
+  doCheck = false;
+
+  meta = with lib; {
+    description = "pytest plugin to check source code with pylint";
+    homepage = https://github.com/carsongee/pytest-pylint;
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -738,6 +738,8 @@ in {
 
   pytest-mypy = callPackage ../development/python-modules/pytest-mypy { };
 
+  pytest-pylint = callPackage ../development/python-modules/pytest-pylint { };
+
   pytest-tornado = callPackage ../development/python-modules/pytest-tornado { };
 
   python-binance = callPackage ../development/python-modules/python-binance { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -736,6 +736,8 @@ in {
 
   pytesseract = callPackage ../development/python-modules/pytesseract { };
 
+  pytest-click = callPackage ../development/python-modules/pytest-click { };
+
   pytest-mypy = callPackage ../development/python-modules/pytest-mypy { };
 
   pytest-pylint = callPackage ../development/python-modules/pytest-pylint { };


### PR DESCRIPTION
###### Motivation for this change

Company is deploying a lektor based blog wanted to have the latest lektor version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
