### PR TITLE
python.pkgs.{tensorflow-probability,dm-sonnet,graph_nets}: init

### DIFF
--- a/pkgs/development/python-modules/dm-sonnet/default.nix
+++ b/pkgs/development/python-modules/dm-sonnet/default.nix
@@ -1,0 +1,85 @@
+{ lib
+, fetchFromGitHub
+, buildBazelPackage
+, buildPythonPackage
+, git
+, python
+, six
+, absl-py
+, semantic-version
+, contextlib2
+, wrapt
+, tensorflow
+, tensorflow-probability
+}:
+
+let
+  version = "1.30";
+
+  # first build all binaries and generate setup.py using bazel
+  bazel-build = buildBazelPackage rec {
+    name = "dm-sonnet-bazel-${version}";
+
+    src = fetchFromGitHub {
+      owner = "deepmind";
+      repo = "sonnet";
+      rev = "v${version}";
+      sha256 = "1dli4a4arx2gmb4p676pfibvnpag9f13znisrk9381g7xpqqmaw6";
+    };
+
+    nativeBuildInputs = [
+      git # needed to fetch the bazel deps (protobuf in particular)
+    ];
+
+    # see https://github.com/deepmind/sonnet/blob/master/docs/INSTALL.md
+    bazelTarget = ":install";
+
+    fetchAttrs = {
+      sha256 = "1qwq6xp6gdmy8f0k96q3nsgqs56adrbgq39g5smwik6griwfx9mr";
+    };
+
+    buildAttrs = {
+      preBuild = ''
+        patchShebangs .
+      '';
+
+      installPhase = ''
+        # do not generate a wheel, instead just copy the generated files to $out to be installed by buildPythonPackage
+        sed -i 's,.*bdist_wheel.*,cp -rL . "$out"; exit 0,' bazel-bin/install
+
+        # the target directory "dist" does not actually matter since we're not generating a wheel
+        bazel-bin/install dist
+      '';
+    };
+  };
+
+# now use pip to install the package prepared by bazel
+in buildPythonPackage rec {
+  pname = "dm-sonnet";
+  inherit version;
+
+  src = bazel-build;
+
+  propagatedBuildInputs = [
+    six
+    absl-py
+    semantic-version
+    contextlib2
+    wrapt
+    tensorflow
+    tensorflow-probability
+  ];
+
+  # not sure how to properly run the real test suite -- through bazel?
+  checkPhase = ''
+    ${python.interpreter} -c "import sonnet"
+  '';
+
+  meta = with lib; {
+    description = "TensorFlow-based neural network library";
+    homepage = https://sonnet.dev;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ timokau ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/graph_nets/default.nix
+++ b/pkgs/development/python-modules/graph_nets/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, tensorflow
+, absl-py
+, dm-sonnet
+, networkx
+, numpy
+, setuptools
+, six
+, future
+}:
+
+buildPythonPackage rec {
+  pname = "graph_nets";
+  version = "1.0.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "15cbs9smmgqz2n9mnlzdbqj3iv9iw179d2g0f9lnimdy7xl4jqdf";
+  };
+
+  buildInputs = [];
+
+  postPatch = ''
+    # https://github.com/deepmind/graph_nets/issues/63
+    sed -i 's/dm-sonnet==1.23/dm-sonnet/' setup.py
+  '';
+
+  propagatedBuildInputs = [
+    tensorflow
+    absl-py
+    dm-sonnet
+    networkx
+    numpy
+    setuptools
+    six
+    future
+  ];
+
+  meta = with lib; {
+    description = "Build Graph Nets in Tensorflow";
+    homepage = https://github.com/deepmind/graph_nets;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ timokau ];
+  };
+}

--- a/pkgs/development/python-modules/tensorflow-probability/default.nix
+++ b/pkgs/development/python-modules/tensorflow-probability/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, tensorflow
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "tensorflow-probability";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "tensorflow";
+    repo = "probability";
+    rev = "v${version}";
+    sha256 = "1y210n4asv8j39pk68bdfrz01gddflvzhxbcvj5jw6rjgaagnhvx";
+  };
+
+  propagatedBuildInputs = [
+    tensorflow
+  ];
+
+  checkInputs = [
+    pytest
+  ];
+
+  # Tests have an invalid import (`tensorflow_probability.opensource`), should
+  # be resolved in the next version with
+  # https://github.com/tensorflow/probability/commit/77d5957f2f0bdddcb46582799cd9c5c5167a1a40
+  doCheck = false;
+  checkPhase = ''
+    py.test
+  '';
+
+  meta = with lib; {
+    description = "Library for probabilistic reasoning and statistical analysis";
+    homepage = https://www.tensorflow.org/probability/;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ timokau ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4877,6 +4877,8 @@ in {
 
   graphite_beacon = callPackage ../development/python-modules/graphite_beacon { };
 
+  graph_nets = callPackage ../development/python-modules/graph_nets { };
+
   influxgraph = callPackage ../development/python-modules/influxgraph { };
 
   graphitepager = callPackage ../development/python-modules/graphitepager { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5143,6 +5143,8 @@ in {
 
   tensorflow-estimator = callPackage ../development/python-modules/tensorflow-estimator { };
 
+  tensorflow-probability = callPackage ../development/python-modules/tensorflow-probability { };
+
   tensorflow-tensorboard = callPackage ../development/python-modules/tensorflow-tensorboard { };
 
   tensorflow =

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4927,6 +4927,8 @@ in {
 
   snapperGUI = callPackage ../development/python-modules/snappergui { };
 
+  dm-sonnet = callPackage ../development/python-modules/dm-sonnet { };
+
   uncertainties = callPackage ../development/python-modules/uncertainties { };
 
   funcy = callPackage ../development/python-modules/funcy { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I want to work with graph networks in tensorflow. The canonical library depends on `dm-sonnet`, which in turn depends on `tensorflow-probability`.

The `dm-sonnet` build is based on the `tensorflow` build (though greatly simplified), since I couldn't find any documentation for bazel builds.

I tested this by building a model to predict the shortest path on graphs, as in the [example](https://colab.research.google.com/github/deepmind/graph_nets/blob/master/graph_nets/demos/shortest_path.ipynb).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
