### PR TITLE
rustc: 1.33.0 -> 1.34.0

### DIFF
--- a/pkgs/development/compilers/rust/bootstrap.nix
+++ b/pkgs/development/compilers/rust/bootstrap.nix
@@ -3,16 +3,16 @@
 let
   # Note: the version MUST be one version prior to the version we're
   # building
-  version = "1.32.0";
+  version = "1.33.0";
 
-  # fetch hashes by running `print-hashes.sh 1.32.0`
+  # fetch hashes by running `print-hashes.sh 1.33.0`
   hashes = {
-    i686-unknown-linux-gnu = "4ce3a6a656669fa86606074b43fadeac7465ef48394249407e21106ed714c8db";
-    x86_64-unknown-linux-gnu = "e024698320d76b74daf0e6e71be3681a1e7923122e3ebd03673fcac3ecc23810";
-    armv7-unknown-linux-gnueabihf = "d7b69f60689d2905d8d3c2829b0f1cd0f86265a255ff88ea0deb601aebac6428";
-    aarch64-unknown-linux-gnu = "60def40961728212da4b3a9767d5a2ddb748400e150a5f8a6d5aa0e1b8ba1cee";
-    i686-apple-darwin = "76cc1280f6b61bf7cf1fddd5202cc236db7573ee05f39fc8cd12ddda8f39a7c3";
-    x86_64-apple-darwin = "f0dfba507192f9b5c330b5984ba71d57d434475f3d62bd44a39201e36fa76304";
+    i686-unknown-linux-gnu = "c379203687d98e60623aa88c4df4992dd5a9548bc30674b9fc8e671a979e9f3a";
+    x86_64-unknown-linux-gnu = "6623168b9ee9de79deb0d9274c577d741ea92003768660aca184e04fe774393f";
+    armv7-unknown-linux-gnueabihf = "f6f0ec0a98d922c4bfd79703bc9e9eef439ba347453f33608a87cd63c47e7245";
+    aarch64-unknown-linux-gnu = "a308044e4076b62f637313ea803fa0a8f340b0f1b53136856f2c43afcabe5387";
+    i686-apple-darwin = "ed20809d56bbaea041721ce6fc9f10f7ae7a720c5821587f01a537d07a5454b1";
+    x86_64-apple-darwin = "864e7c074a0b88e38883c87c169513d072300bb52e1d320a067bd34cf14f66bd";
   };
 
   platform =

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -17,11 +17,11 @@ let
   llvmShared = llvm_7.override { enableSharedLibraries = true; };
 in stdenv.mkDerivation rec {
   pname = "rustc";
-  version = "1.33.0";
+  version = "1.34.0";
 
   src = fetchurl {
     url = "https://static.rust-lang.org/dist/rustc-${version}-src.tar.gz";
-    sha256 = "152x91mg7bz4ygligwjb05fgm1blwy2i70s2j03zc9jiwvbsh0as";
+    sha256 = "0n8z1wngkxab1rvixqg6w8b727hzpnm9wp9h8iy3mpbrzp7mmj3s";
   };
 
   __darwinAllowLocalNetworking = true;


### PR DESCRIPTION
###### Motivation for this change

https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1340-2019-04-11

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
