### PR TITLE
emacs: 26.1 -> 26.2

### DIFF
--- a/pkgs/applications/editors/emacs/clean-env-macport.patch
+++ b/pkgs/applications/editors/emacs/clean-env-macport.patch
@@ -1,13 +1,13 @@
 Dump temacs in an empty environment to prevent -dev paths from ending
 up in the dumped image.
 
-diff --git a/src/Makefile.in b/src/Makefile.in
---- a/src/Makefile.in
-+++ b/src/Makefile.in
-@@ -535,7 +535,7 @@ ifeq ($(CANNOT_DUMP),yes)
+diff -ru -x '*~' emacs-25.3/src/Makefile.in emacs-25.3-new/src/Makefile.in
+--- emacs-25.3/src/Makefile.in	2017-04-14 17:02:47.000000000 +0200
++++ emacs-25.3-new/src/Makefile.in	2017-09-25 19:03:02.173861038 +0200
+@@ -532,7 +532,7 @@
+ ifeq ($(CANNOT_DUMP),yes)
  	ln -f temacs$(EXEEXT) $@
  else
- 	unset EMACS_HEAP_EXEC; \
 -	LC_ALL=C $(RUN_TEMACS) -batch $(BUILD_DETAILS) -l loadup dump
 +	env -i LC_ALL=C $(RUN_TEMACS) -batch $(BUILD_DETAILS) -l loadup dump
    ifneq ($(PAXCTL_dumped),)

--- a/pkgs/applications/editors/emacs/default.nix
+++ b/pkgs/applications/editors/emacs/default.nix
@@ -31,12 +31,12 @@ let
 in
 stdenv.mkDerivation rec {
   name = "emacs-${version}${versionModifier}";
-  version = "26.1";
+  version = "26.2";
   versionModifier = "";
 
   src = fetchurl {
     url = "mirror://gnu/emacs/${name}.tar.xz";
-    sha256 = "0b6k1wq44rc8gkvxhi1bbjxbz3cwg29qbq8mklq2az6p1hjgrx0w";
+    sha256 = "13n5m60i47k96mpv5pp6km2ph9rv2m5lmbpzj929v02vpsfyc70m";
   };
 
   enableParallelBuilding = true;
@@ -44,13 +44,6 @@ stdenv.mkDerivation rec {
   patches = [
     ./clean-env.patch
     ./tramp-detect-wrapped-gvfsd.patch
-
-    # should drop this at next package update
-    (fetchpatch {
-      name = "support-hunspell-1.7.0-in-ispell.el.patch";
-      url = "https://git.savannah.gnu.org/cgit/emacs.git/patch/?id=2925ce5a7ec1424cfaea9f2f86bd3cab27832584";
-      sha256 = "0w7cgw6zgr7phbivb98innps1rlqf5q2lhwkrwdmai8sbca5bd11";
-    })
   ];
 
   postPatch = lib.optionalString srcRepo ''

--- a/pkgs/applications/editors/emacs/macport.nix
+++ b/pkgs/applications/editors/emacs/macport.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     sha256 = "0f2wzdw2a3ac581322b2y79rlj3c9f33ddrq9allj97r1si6v5xk";
   };
 
-  patches = [ ./clean-env.patch ];
+  patches = [ ./clean-env-macport.patch ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
