### PR TITLE
deepin.deepin-anything: init at 0.0.7

### DIFF
--- a/pkgs/desktops/deepin/deepin-anything/default.nix
+++ b/pkgs/desktops/deepin/deepin-anything/default.nix
@@ -1,0 +1,64 @@
+{ stdenv, fetchFromGitHub, pkgconfig, qtbase, udisks2-qt5, utillinux,
+  dtkcore, deepin }:
+
+stdenv.mkDerivation rec {
+  name = "${pname}-${version}";
+  pname = "deepin-anything";
+  version = "0.0.7";
+
+  src = fetchFromGitHub {
+    owner = "linuxdeepin";
+    repo = pname;
+    rev = version;
+    sha256 = "1qggqjjqz2y51pag0v5qniv6763mgrmzjmr7248xx2paw3a923vk";
+  };
+
+  outputs = [ "out" "modsrc" ];
+
+  nativeBuildInputs = [
+    pkgconfig
+    deepin.setupHook
+  ];
+
+  buildInputs = [
+    dtkcore
+    qtbase
+    udisks2-qt5
+    utillinux
+  ];
+
+  enableParallelBuilding = true;
+
+  makeFlags = [
+    "DEB_HOST_MULTIARCH="
+    "PREFIX=${placeholder ''out''}"
+  ];
+
+  postPatch = ''
+    searchHardCodedPaths  # for debugging
+    fixPath $modsrc /usr/src Makefile
+    fixPath $out /usr Makefile
+    fixPath $out /usr server/tool/tool.pro
+    fixPath $out /etc server/tool/tool.pro
+    fixPath $out /usr/bin \
+      server/tool/deepin-anything-tool.service \
+      server/tool/com.deepin.anything.service \
+      server/monitor/deepin-anything-monitor.service
+    sed -e 's,/lib/systemd,$$PREFIX/lib/systemd,' -i server/monitor/src/src.pro server/tool/tool.pro
+  '';
+
+  postFixup = ''
+    searchHardCodedPaths $out  # for debugging
+    searchHardCodedPaths $modsrc  # for debugging
+  '';
+
+  passthru.updateScript = deepin.updateScript { inherit name; };
+
+  meta = with stdenv.lib; {
+    description = "Deepin file search tool";
+    homepage = https://github.com/linuxdeepin/deepin-anything;
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ romildo ];
+  };
+}

--- a/pkgs/desktops/deepin/default.nix
+++ b/pkgs/desktops/deepin/default.nix
@@ -15,6 +15,7 @@ let
     dde-polkit-agent = callPackage ./dde-polkit-agent { };
     dde-qt-dbus-factory = callPackage ./dde-qt-dbus-factory { };
     dde-session-ui = callPackage ./dde-session-ui { };
+    deepin-anything = callPackage ./deepin-anything { };
     deepin-desktop-base = callPackage ./deepin-desktop-base { };
     deepin-desktop-schemas = callPackage ./deepin-desktop-schemas { };
     deepin-gettext-tools = callPackage ./deepin-gettext-tools { };

--- a/pkgs/os-specific/linux/deepin-anything/default.nix
+++ b/pkgs/os-specific/linux/deepin-anything/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, deepin, kernel }:
+
+stdenv.mkDerivation {
+  pname = "deepin-anything-module";
+  version = "${deepin.deepin-anything.version}-${kernel.version}";
+  src = deepin.deepin-anything.modsrc;
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  buildPhase = ''
+    make -C src/deepin-anything-0.0 kdir=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build
+  '';
+
+  installPhase = ''
+     install -m 644 -D -t $out/lib/modules/${kernel.modDirVersion}/extra src/deepin-anything-0.0/*.ko
+  '';
+
+  meta = deepin.deepin-anything.meta // {
+    description = deepin.deepin-anything.meta.description + " (kernel modules)";
+    badPlatforms = [ "aarch64-linux" ];  # the kernel module is not building
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15131,6 +15131,8 @@ in
 
     cpupower = callPackage ../os-specific/linux/cpupower { };
 
+    deepin-anything = callPackage ../os-specific/linux/deepin-anything { };
+
     dpdk = callPackage ../os-specific/linux/dpdk { };
 
     exfat-nofuse = callPackage ../os-specific/linux/exfat { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add [deepin-anything](https://github.com/linuxdeepin/deepin-anything), the Deepin file search tool.

> It is dedicated to providing Linux users with a lightning-fast file name search function and offline search.

About packaging deepin for NixOS: https://github.com/NixOS/nixpkgs/issues/59023

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).