### PR TITLE
dmd, gtk: Remove dontStrip because with binutils 2.31 everything is working again

### DIFF
--- a/pkgs/development/compilers/dmd/default.nix
+++ b/pkgs/development/compilers/dmd/default.nix
@@ -120,8 +120,6 @@ stdenv.mkDerivation rec {
     cd ..
   '';
 
-  dontStrip = true;
-
   installPhase = ''
       cd dmd
       mkdir $out

--- a/pkgs/development/libraries/gtkd/default.nix
+++ b/pkgs/development/libraries/gtkd/default.nix
@@ -84,10 +84,6 @@ stdenv.mkDerivation rec {
 
   installFlags = "prefix=$(out)";
 
-  # Workaround for https://github.com/NixOS/nixpkgs/issues/40397
-  # Remove after update to binutils 2.31
-  dontStrip = true;
-
   inherit atk cairo gdk_pixbuf librsvg pango;
   inherit (gnome3) glib gtk3 gtksourceview libgda libpeas;
   inherit (gst_all_1) gstreamer;


### PR DESCRIPTION
Because binutils 2.31 is merged now https://github.com/NixOS/nixpkgs/issues/40397 is fixed and the workaround (dontStrip=true) can be removed.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
