### PR TITLE
mxisd: 1.2.0 -> 1.4.3

### DIFF
--- a/nixos/modules/services/networking/mxisd.nix
+++ b/nixos/modules/services/networking/mxisd.nix
@@ -103,20 +103,12 @@ in {
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
 
-      # mxisd / spring.boot needs the configuration to be named "application.yaml"
-      preStart = ''
-        config=${cfg.dataDir}/application.yaml
-        cp ${configFile} $config
-        chmod 444 $config
-      '';
-
       serviceConfig = {
         Type = "simple";
         User = "mxisd";
         Group = "mxisd";
-        ExecStart = "${cfg.package}/bin/mxisd --spring.config.location=${cfg.dataDir}/ --spring.profiles.active=systemd --java.security.egd=file:/dev/./urandom";
+        ExecStart = "${cfg.package}/bin/mxisd -c ${configFile}";
         WorkingDirectory = cfg.dataDir;
-        SuccessExitStatus = 143;
         Restart = "on-failure";
       };
     };

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -151,6 +151,7 @@ in
   mumble = handleTest ./mumble.nix {};
   munin = handleTest ./munin.nix {};
   mutableUsers = handleTest ./mutable-users.nix {};
+  mxisd = handleTest ./mxisd.nix {};
   mysql = handleTest ./mysql.nix {};
   mysqlBackup = handleTest ./mysql-backup.nix {};
   mysqlReplication = handleTest ./mysql-replication.nix {};

--- a/pkgs/servers/mxisd/0001-gradle.patch
+++ b/pkgs/servers/mxisd/0001-gradle.patch
@@ -1,19 +1,19 @@
---- a/build.gradle	2018-11-16 15:15:29.021469758 +0100
-+++ b/build.gradle	2018-11-16 15:16:50.982289782 +0100
-@@ -64,7 +64,7 @@
+--- a/build.gradle	2019-05-16 21:09:08.373112953 +0200
++++ b/build.gradle	2019-05-16 21:09:37.093114427 +0200
+@@ -72,7 +72,7 @@
  
  buildscript {
      repositories {
--        mavenCentral()
-+    REPLACE
+-        jcenter()
++REPLACE
      }
  
      dependencies {
-@@ -73,9 +73,7 @@
+@@ -81,9 +81,7 @@
  }
  
  repositories {
--    mavenCentral()
+-    jcenter()
 -    maven { url "https://kamax.io/maven/releases/" }
 -    maven { url "https://kamax.io/maven/snapshots/" }
 +REPLACE

--- a/pkgs/servers/mxisd/default.nix
+++ b/pkgs/servers/mxisd/default.nix
@@ -1,22 +1,22 @@
-{ stdenv, fetchFromGitHub, jdk, jre, git, gradle_2_5, perl, makeWrapper, writeText }:
+{ stdenv, fetchFromGitHub, jdk, jre, git, gradle_4_10, perl, makeWrapper, writeText }:
 
 let
   name = "mxisd-${version}";
-  version = "1.2.0";
-  rev = "8c4ddd2e6526c1d2b284ba88cce3c2b926d99c62";
+  version = "1.4.3";
+  rev = "cd890d114a46e4a3792c57cc7a35b95b2c466a16";
 
   src = fetchFromGitHub {
     inherit rev;
     owner = "kamax-matrix";
     repo = "mxisd";
-    sha256 = "083plqg0rxsqwzyskin78wkmylhb7cqz37lpsa1zy56sxpdw1a3l";
+    sha256 = "05plcf6bq19fmx528fgnib4bw9gz36irwlnfsykys1bpmi60wj69";
   };
 
 
   deps = stdenv.mkDerivation {
     name = "${name}-deps";
     inherit src;
-    nativeBuildInputs = [ gradle_2_5 perl git ];
+    nativeBuildInputs = [ gradle_4_10 perl git ];
 
     buildPhase = ''
       export MXISD_BUILD_VERSION=${rev}
@@ -35,13 +35,13 @@ let
 
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = "0shshn05nzv23shry1xpcgvqg59gx929n0qngpfjhbq0kp7px68m";
+    outputHash = "0z9f3w7lfdvbk26kyckpbgas7mi98rjghck9w0kvx3r7k48p5vnv";
   };
 
 in
 stdenv.mkDerivation {
   inherit name src version;
-  nativeBuildInputs = [ gradle_2_5 perl makeWrapper ];
+  nativeBuildInputs = [ gradle_4_10 perl makeWrapper ];
   buildInputs = [ jre ];
 
   patches = [ ./0001-gradle.patch ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @fpletz @hschaeidt :spider_web: 
I suggest to backport to 19.03