### PR TITLE
[19.03] Static proot, wafHook cross compilation

### DIFF
--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -2740,9 +2740,9 @@ addEnvHooks "$hostOffset" myBashFunction
      <listitem>
        <para>
 	 Overrides the configure, build, and install phases. This will run the
-	 "waf" script used by many projects. If waf doesn’t exist, it will copy
-	 the version of waf available in Nixpkgs wafFlags can be used to pass
-	 flags to the waf script.
+	 "waf" script used by many projects.  If wafPath (default ./waf)
+	 doesn’t exist, it will copy the version of waf available in Nixpkgs.
+	 wafFlags can be used to pass flags to the waf script.
       </para>
      </listitem>
     </varlistentry>

--- a/pkgs/applications/audio/ardour/default.nix
+++ b/pkgs/applications/audio/ardour/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     patchShebangs ./tools/
   '';
 
-  configureFlags = [
+  wafConfigureFlags = [
     "--optimize"
     "--docs"
     "--with-backends=jack,alsa,dummy"

--- a/pkgs/applications/audio/guitarix/default.nix
+++ b/pkgs/applications/audio/guitarix/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     zita-resampler curl
   ];
 
-  configureFlags = [
+  wafConfigureFlags = [
     "--shared-lib"
     "--no-desktop-update"
     "--enable-nls"

--- a/pkgs/applications/misc/xiphos/default.nix
+++ b/pkgs/applications/misc/xiphos/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     export SWORD_HOME=${sword};
   '';
 
-  configureFlags= [ "--enable-webkit2" ];
+  wafConfigureFlags = [ "--enable-webkit2" ];
 
   meta = with stdenv.lib; {
     description = "A GTK Bible study tool";

--- a/pkgs/development/libraries/audio/lvtk/default.nix
+++ b/pkgs/development/libraries/audio/lvtk/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     sed -i '/target[ ]*= "ttl2c"/ ilib=["boost_system"],' tools/wscript_build
   '';
 
-  configureFlags = [
+  wafConfigureFlags = [
     "--boost-includes=${boost.dev}/include"
     "--boost-libs=${boost.out}/lib"
   ];

--- a/pkgs/development/libraries/ndn-cxx/default.nix
+++ b/pkgs/development/libraries/ndn-cxx/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
   };
   nativeBuildInputs = [ pkgconfig wafHook ];
   buildInputs = [ openssl doxygen boost sqlite python pythonPackages.sphinx];
-  configureFlags = [
+  wafConfigureFlags = [
     "--with-openssl=${openssl.dev}"
     "--boost-includes=${boost.dev}/include"
     "--boost-libs=${boost.out}/lib"

--- a/pkgs/development/libraries/science/networking/ns3/default.nix
+++ b/pkgs/development/libraries/science/networking/ns3/default.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
     patchShebangs doc/ns3_html_theme/get_version.sh
   '';
 
-  configureFlags = with stdenv.lib; [
+  wafConfigureFlags = with stdenv.lib; [
       "--enable-modules=${stdenv.lib.concatStringsSep "," modules}"
       "--with-python=${pythonEnv.interpreter}"
   ]

--- a/pkgs/development/libraries/talloc/default.nix
+++ b/pkgs/development/libraries/talloc/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, python, pkgconfig, readline, libxslt
 , docbook_xsl, docbook_xml_dtd_42, fixDarwinDylibNames
-, buildPackages
+, wafHook
 }:
 
 stdenv.mkDerivation rec {
@@ -11,23 +11,22 @@ stdenv.mkDerivation rec {
     sha256 = "1kk76dyav41ip7ddbbf04yfydb4jvywzi2ps0z2vla56aqkn11di";
   };
 
-  nativeBuildInputs = [ pkgconfig fixDarwinDylibNames python
+  nativeBuildInputs = [ pkgconfig fixDarwinDylibNames python wafHook
                         docbook_xsl docbook_xml_dtd_42 ];
   buildInputs = [ readline libxslt ];
 
-  prePatch = ''
-    patchShebangs buildtools/bin/waf
-  '';
+  wafPath = "buildtools/bin/waf";
 
   configureFlags = [
     "--enable-talloc-compat1"
     "--bundled-libraries=NONE"
     "--builtin-libraries=replace"
-  ] ++ stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
-    "--cross-compile"
-    "--cross-execute=${stdenv.hostPlatform.emulator buildPackages}"
   ];
-  configurePlatforms = [];
+
+  # this must not be exported before the ConfigurePhase otherwise waf whines
+  preBuild = stdenv.lib.optionalString stdenv.hostPlatform.isMusl ''
+    export NIX_CFLAGS_LINK="-no-pie -shared";
+  '';
 
   postInstall = ''
     ${stdenv.cc.targetPrefix}ar q $out/lib/libtalloc.a bin/default/talloc_[0-9]*.o

--- a/pkgs/development/libraries/talloc/default.nix
+++ b/pkgs/development/libraries/talloc/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   wafPath = "buildtools/bin/waf";
 
-  configureFlags = [
+  wafConfigureFlags = [
     "--enable-talloc-compat1"
     "--bundled-libraries=NONE"
     "--builtin-libraries=replace"

--- a/pkgs/development/libraries/tdb/default.nix
+++ b/pkgs/development/libraries/tdb/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, python2, pkgconfig, readline, libxslt
-, docbook_xsl, docbook_xml_dtd_42, buildPackages
+{ stdenv, fetchurl, wafHook, pkgconfig, readline, libxslt
+, docbook_xsl, docbook_xml_dtd_42
 }:
 
 stdenv.mkDerivation rec {
@@ -10,23 +10,17 @@ stdenv.mkDerivation rec {
     sha256 = "1ibcz466xwk1x6xvzlgzd5va4lyrjzm3rnjak29kkwk7cmhw4gva";
   };
 
-  nativeBuildInputs = [ pkgconfig python2 ];
+  nativeBuildInputs = [ pkgconfig wafHook ];
   buildInputs = [
     readline libxslt docbook_xsl docbook_xml_dtd_42
   ];
 
-  preConfigure = ''
-    patchShebangs buildtools/bin/waf
-  '';
+  wafPath = "buildtools/bin/waf";
 
   configureFlags = [
     "--bundled-libraries=NONE"
     "--builtin-libraries=replace"
-  ] ++ stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
-    "--cross-compile"
-    "--cross-execute=${stdenv.hostPlatform.emulator buildPackages}"
   ];
-  configurePlatforms = [ ];
 
   meta = with stdenv.lib; {
     description = "The trivial database";

--- a/pkgs/development/libraries/tdb/default.nix
+++ b/pkgs/development/libraries/tdb/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   wafPath = "buildtools/bin/waf";
 
-  configureFlags = [
+  wafConfigureFlags = [
     "--bundled-libraries=NONE"
     "--builtin-libraries=replace"
   ];

--- a/pkgs/development/tools/build-managers/waf/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/waf/setup-hook.sh
@@ -10,7 +10,7 @@ wafConfigurePhase() {
         configureFlags="${prefixKey:---prefix=}$prefix $configureFlags"
     fi
 
-    local flagsArray=();
+    local flagsArray=(@crossFlags@);
     for flag in $configureFlags "${configureFlagsArray[@]}";
     do
         if [[

--- a/pkgs/development/tools/build-managers/waf/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/waf/setup-hook.sh
@@ -1,8 +1,9 @@
 wafConfigurePhase() {
     runHook preConfigure
 
-    if ! [ -f ./waf ]; then
-        cp @waf@ waf
+    if ! [ -f "${wafPath:=./waf}" ]; then
+        echo "copying waf to $wafPath..."
+        cp @waf@ "$wafPath"
     fi
 
     if [[ -z "${dontAddPrefix:-}" && -n "$prefix" ]]; then
@@ -14,7 +15,7 @@ wafConfigurePhase() {
         ${configureTargets:-configure}
     )
     echoCmd 'configure flags' "${flagsArray[@]}"
-    python waf "${flagsArray[@]}"
+    python "$wafPath" "${flagsArray[@]}"
 
     runHook postConfigure
 }
@@ -33,7 +34,7 @@ wafBuildPhase () {
     )
 
     echoCmd 'build flags' "${flagsArray[@]}"
-    python waf "${flagsArray[@]}"
+    python "$wafPath" "${flagsArray[@]}"
 
     runHook postBuild
 }
@@ -52,7 +53,7 @@ wafInstallPhase() {
     )
 
     echoCmd 'install flags' "${flagsArray[@]}"
-    python waf "${flagsArray[@]}"
+    python "$wafPath" "${flagsArray[@]}"
 
     runHook postInstall
 }

--- a/pkgs/development/tools/build-managers/waf/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/waf/setup-hook.sh
@@ -10,8 +10,21 @@ wafConfigurePhase() {
         configureFlags="${prefixKey:---prefix=}$prefix $configureFlags"
     fi
 
-    local flagsArray=(
-        $configureFlags ${configureFlagsArray[@]}
+    local flagsArray=();
+    for flag in $configureFlags "${configureFlagsArray[@]}";
+    do
+        # waf does not support these flags, but they are "blindly" added by the
+        # pkgsStatic overlay, for example.
+        if [[ $flag != "--enable-static"
+           && $flag != "--disable-static"
+           && $flag != "--enable-shared"
+           && $flag != "--disable-shared" ]];
+        then
+            flagsArray=("${flagsArray[@]}" "$flag");
+        fi;
+    done
+    flagsArray=(
+        "${flagsArray[@]}"
         ${configureTargets:-configure}
     )
     echoCmd 'configure flags' "${flagsArray[@]}"

--- a/pkgs/development/tools/build-managers/waf/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/waf/setup-hook.sh
@@ -13,12 +13,18 @@ wafConfigurePhase() {
     local flagsArray=();
     for flag in $configureFlags "${configureFlagsArray[@]}";
     do
+        if [[
         # waf does not support these flags, but they are "blindly" added by the
         # pkgsStatic overlay, for example.
-        if [[ $flag != "--enable-static"
+              $flag != "--enable-static"
            && $flag != "--disable-static"
            && $flag != "--enable-shared"
-           && $flag != "--disable-shared" ]];
+           && $flag != "--disable-shared"
+        # these flags are added by configurePlatforms but waf just uses them
+        # to bail out in cross compilation cases
+           && $flag != --build=* 
+           && $flag != --host=* 
+           ]];
         then
             flagsArray=("${flagsArray[@]}" "$flag");
         fi;

--- a/pkgs/development/tools/build-managers/waf/setup-hook.sh
+++ b/pkgs/development/tools/build-managers/waf/setup-hook.sh
@@ -6,31 +6,14 @@ wafConfigurePhase() {
         cp @waf@ "$wafPath"
     fi
 
-    if [[ -z "${dontAddPrefix:-}" && -n "$prefix" ]]; then
-        configureFlags="${prefixKey:---prefix=}$prefix $configureFlags"
+    if [ -z "${dontAddPrefix:-}" ] && [ -n "$prefix" ]; then
+        wafConfigureFlags="${prefixKey:---prefix=}$prefix $wafConfigureFlags"
     fi
 
-    local flagsArray=(@crossFlags@);
-    for flag in $configureFlags "${configureFlagsArray[@]}";
-    do
-        if [[
-        # waf does not support these flags, but they are "blindly" added by the
-        # pkgsStatic overlay, for example.
-              $flag != "--enable-static"
-           && $flag != "--disable-static"
-           && $flag != "--enable-shared"
-           && $flag != "--disable-shared"
-        # these flags are added by configurePlatforms but waf just uses them
-        # to bail out in cross compilation cases
-           && $flag != --build=* 
-           && $flag != --host=* 
-           ]];
-        then
-            flagsArray=("${flagsArray[@]}" "$flag");
-        fi;
-    done
-    flagsArray=(
+    local flagsArray=(
+        @crossFlags@
         "${flagsArray[@]}"
+        $wafConfigureFlags "${wafConfigureFlagsArray[@]}"
         ${configureTargets:-configure}
     )
     echoCmd 'configure flags' "${flagsArray[@]}"

--- a/pkgs/misc/emulators/wxmupen64plus/default.nix
+++ b/pkgs/misc/emulators/wxmupen64plus/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
     export CXXFLAGS="-I${libX11.dev}/include/X11 -DLIBDIR=\\\"${mupen64plus}/lib/\\\""
     export LDFLAGS="-lwx_gtk2u_adv-2.9"
 
-    configureFlagsArray+=("--mupenapi=$APIDIR" "--wxconfig=`type -P wx-config`")
+    wafConfigureFlagsArray+=("--mupenapi=$APIDIR" "--wxconfig=`type -P wx-config`")
   '';
 
   NIX_CFLAGS_COMPILE = "-fpermissive";

--- a/pkgs/misc/jackaudio/default.nix
+++ b/pkgs/misc/jackaudio/default.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
     export NIX_CFLAGS_COMPILE="-F${CoreFoundation}/Library/Frameworks $NIX_CFLAGS_COMPILE"
   '';
 
-  configureFlags = [
+  wafConfigureFlags = [
     "--classic"
     "--autostart=${if (optDbus != null) then "dbus" else "classic"}"
   ] ++ optional (optDbus != null) "--dbus"

--- a/pkgs/tools/graphics/glmark2/default.nix
+++ b/pkgs/tools/graphics/glmark2/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     libjpeg libpng xorg.libxcb libX11 libGL libdrm python27 wayland udev mesa_noglu
   ];
 
-  configureFlags = ["--with-flavors=x11-gl,x11-glesv2,drm-gl,drm-glesv2,wayland-gl,wayland-glesv2"];
+  wafConfigureFlags = ["--with-flavors=x11-gl,x11-glesv2,drm-gl,drm-glesv2,wayland-gl,wayland-glesv2"];
 
   meta = with stdenv.lib; {
     description = "OpenGL (ES) 2.0 benchmark";

--- a/pkgs/tools/system/proot/default.nix
+++ b/pkgs/tools/system/proot/default.nix
@@ -11,6 +11,11 @@
     owner = "proot-me";
   };
 
+  postPatch = ''
+    # our cross machinery defines $CC and co just right
+    sed -i /CROSS_COMPILE/d src/GNUmakefile
+  '';
+
   buildInputs = [ talloc ];
   nativeBuildInputs = [ docutils ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6321,7 +6321,11 @@ in
   waf = callPackage ../development/tools/build-managers/waf { python = python3; };
   wafHook = makeSetupHook {
     deps = [ python ];
-    substitutions = { inherit waf; };
+    substitutions = {
+      inherit waf;
+      crossFlags = lib.optionalString (stdenv.hostPlatform != stdenv.targetPlatform)
+        ''--cross-compile "--cross-execute=${stdenv.targetPlatform.emulator pkgs}"'';
+    };
   } ../development/tools/build-managers/waf/setup-hook.sh;
 
   wakelan = callPackage ../tools/networking/wakelan { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The main purpose is to quickly backport breaking changes to recently released wafHook. proot changes are just picked up along.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---