### PR TITLE
hexyl: 0.4.0 -> 0.5.0

### DIFF
--- a/pkgs/tools/misc/hexyl/default.nix
+++ b/pkgs/tools/misc/hexyl/default.nix
@@ -1,17 +1,17 @@
 { stdenv, fetchFromGitHub, rustPlatform }:
 
 rustPlatform.buildRustPackage rec {
-  name    = "hexyl-${version}";
-  version = "0.4.0";
+  pname   = "hexyl";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner  = "sharkdp";
-    repo   = "hexyl";
+    repo   = pname;
     rev    = "v${version}";
-    sha256 = "09h01y0r7km0vgljgc8bgiswbrq47id408vpya2da4mijbg4h82r";
+    sha256 = "1b5y2lwcv802hjp105h35vda1d6rgysm9qvrm0v96srm0qqh8rq3";
   };
 
-  cargoSha256 = "1zy2jvzx62yjaiq25560krz1648vqwfr5kjbq3wz7nlmf1cs7s2c";
+  cargoSha256 = "0lnwkp9jxz7c0jp7w8z2kpl2qkpd1np3s83nim8s6srl6aapc94c";
 
   meta = with stdenv.lib; {
     description = "A command-line hex viewer";


### PR DESCRIPTION
[changelog](https://github.com/sharkdp/hexyl/releases/tag/v0.5.0)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @lilyball