### PR TITLE
simplenote: 1.1.3 -> 1.5.0

### DIFF
--- a/pkgs/applications/misc/simplenote/default.nix
+++ b/pkgs/applications/misc/simplenote/default.nix
@@ -1,25 +1,26 @@
-{ fetchurl, stdenv, lib, zlib, glib, alsaLib, dbus, gtk2, atk, pango, freetype, fontconfig
-, libgnome-keyring3, gdk-pixbuf, cairo, cups, expat, libgpgerror, nspr
-, nss, xorg, libcap, systemd, libnotify ,libXScrnSaver, gnome2 }:
+{ fetchurl, stdenv, lib, zlib, glib, alsaLib, dbus, gtk3, atk, pango, freetype, fontconfig
+, libgnome-keyring3, gdk_pixbuf, cairo, cups, expat, libgpgerror, nspr
+, nss, xorg, libcap, systemd, at_spi2_atk, libnotify, libuuid, libXScrnSaver, gnome2 }:
+
+let version = "1.5.0"; in
 
 stdenv.mkDerivation rec {
 
-  name = "simplenote-${pkgver}";
-  pkgver = "1.1.3";
+  name = "simplenote-${version}";
 
   src = fetchurl {
-    url = "https://github.com/Automattic/simplenote-electron/releases/download/v${pkgver}/Simplenote-linux-${pkgver}.tar.gz";
-    sha256 = "1z92yyjmg3bgfqfdpnysf98h9hhhnqzdqqigwlmdmn3d7fy49kcf";
+    url = "https://github.com/Automattic/simplenote-electron/releases/download/v${version}/Simplenote-linux-${version}-x64.tar.gz";
+    sha256 = "9993cd9fd6c9a015aa85219abbaebe611d403bce4beb0dd94d0c7d3c2e1b9140";
   };
 
   buildCommand = let
 
     packages = [
-      stdenv.cc.cc zlib glib dbus gtk2 atk pango freetype libgnome-keyring3
-      fontconfig gdk-pixbuf cairo cups expat libgpgerror alsaLib nspr nss
+      stdenv.cc.cc zlib glib dbus gtk3 atk pango freetype libgnome-keyring3
+      fontconfig gdk_pixbuf cairo cups expat libgpgerror alsaLib nspr nss
       xorg.libXrender xorg.libX11 xorg.libXext xorg.libXdamage xorg.libXtst
       xorg.libXcomposite xorg.libXi xorg.libXfixes xorg.libXrandr
-      xorg.libXcursor libcap systemd libnotify libXScrnSaver gnome2.GConf
+      xorg.libXcursor libcap systemd at_spi2_atk libnotify libuuid libXScrnSaver gnome2.GConf
       xorg.libxcb
     ];
 
@@ -31,8 +32,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/share/
     mkdir -p $out/bin
     tar xvzf $src -C $out/share/
-    mv $out/share/Simplenote-linux-x64 $out/share/simplenote
-    mv $out/share/simplenote/Simplenote $out/share/simplenote/simplenote
+    mv $out/share/Simplenote-linux-${version}-x64 $out/share/simplenote
     mkdir -p $out/share/applications
 
     cat > $out/share/applications/simplenote.desktop << EOF

--- a/pkgs/applications/misc/simplenote/default.nix
+++ b/pkgs/applications/misc/simplenote/default.nix
@@ -1,6 +1,6 @@
 { fetchurl, stdenv, lib, zlib, glib, alsaLib, dbus, gtk3, atk, pango, freetype, fontconfig
-, libgnome-keyring3, gdk_pixbuf, cairo, cups, expat, libgpgerror, nspr
-, nss, xorg, libcap, systemd, at_spi2_atk, libnotify, libuuid, libXScrnSaver, gnome2 }:
+, libgnome-keyring3, gdk-pixbuf, cairo, cups, expat, libgpgerror, nspr
+, nss, xorg, libcap, systemd, at-spi2-atk, libnotify, libuuid, libXScrnSaver, gnome2 }:
 
 let version = "1.5.0"; in
 
@@ -17,11 +17,11 @@ stdenv.mkDerivation rec {
 
     packages = [
       stdenv.cc.cc zlib glib dbus gtk3 atk pango freetype libgnome-keyring3
-      fontconfig gdk_pixbuf cairo cups expat libgpgerror alsaLib nspr nss
+      fontconfig gdk-pixbuf cairo cups expat libgpgerror alsaLib nspr nss
       xorg.libXrender xorg.libX11 xorg.libXext xorg.libXdamage xorg.libXtst
       xorg.libXcomposite xorg.libXi xorg.libXfixes xorg.libXrandr
-      xorg.libXcursor libcap systemd at_spi2_atk libnotify libuuid libXScrnSaver gnome2.GConf
-      xorg.libxcb
+      xorg.libXcursor libcap systemd at-spi2-atk libnotify libuuid libXScrnSaver
+      gnome2.GConf xorg.libxcb
     ];
 
     libPathNative = lib.makeLibraryPath packages;


### PR DESCRIPTION
###### Motivation for this change

Old version was opening a pop-up, offering an upgrade on each open.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
