### PR TITLE
journalwatch: fix broken package, general maintenance

### DIFF
--- a/pkgs/tools/system/journalwatch/default.nix
+++ b/pkgs/tools/system/journalwatch/default.nix
@@ -20,14 +20,10 @@ buildPythonPackage rec {
 
 
   doCheck = true;
-
+  checkInputs = [ pytest ];
   checkPhase = ''
-    pytest test_journalwatch.py
-  '';
-
-  buildInputs = [
     pytest
-  ];
+  '';
 
   propagatedBuildInputs = [
     systemd

--- a/pkgs/tools/system/journalwatch/default.nix
+++ b/pkgs/tools/system/journalwatch/default.nix
@@ -1,15 +1,15 @@
-{ stdenv, buildPythonPackage, fetchurl, pythonOlder, systemd, pytest }:
+{ stdenv, buildPythonPackage, fetchFromGitHub, pythonOlder, systemd, pytest }:
 
 buildPythonPackage rec {
   pname = "journalwatch";
-  name = "${pname}-${version}";
   version = "1.1.0";
   disabled = pythonOlder "3.3";
 
-
-  src = fetchurl {
-    url = "https://github.com/The-Compiler/${pname}/archive/v${version}.tar.gz";
-    sha512 = "3hvbgx95hjfivz9iv0hbhj720wvm32z86vj4a60lji2zdfpbqgr2b428lvg2cpvf71l2xn6ca5v0hzyz57qylgwqzgfrx7hqhl5g38s";
+  src = fetchFromGitHub {
+    owner = "The-Compiler";
+    repo = pname;
+    rev = "v${version}";
+    sha512 = "11g2f1w9lfqw6zxxyg7qrqpb914s6w71j0gnpw7qr7cak2l5jlf2l39dlg30y55rw7jgmf0yg77wwzd0c430mq1n6q1v8w86g1rwkzb";
   };
 
   # can be removed post 1.1.0


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The `journalwatch` package is broken on 19.03, as the now more strict dependency handling of `buildPythonPackage` uncovered the error of having `pytest` as `buildInput` instead of `checkInput`. This PR fixes that, along with some general maintenance:

* Move from deprecated `permissionsStartOnly`: https://github.com/NixOS/nixpkgs/pull/56265
* Move to `fetchFromGitHub`: https://github.com/NixOS/nixpkgs/issues/32997
* ~~Add `service.journalwatch.package` option for easy change of used package~~

The ee20ba8 fix pytest checks commit requires a backport to 19.03 to unbreak the package, the other commits are nice to have and should be backwards-compatible, but are not required. I'm sorry I did not notice the breakage prior release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
