### PR TITLE
pythonPackages.tinycss2: 0.6.1 -> 1.0.2

### DIFF
--- a/pkgs/development/python-modules/tinycss2/default.nix
+++ b/pkgs/development/python-modules/tinycss2/default.nix
@@ -1,19 +1,22 @@
-{ lib, buildPythonPackage, fetchPypi, webencodings, pytest, pytestrunner, pytestcov, pytest-flake8, pytest-isort, glibcLocales }:
+{ lib, buildPythonPackage, pythonOlder, fetchPypi
+, webencodings
+, pytest, pytestrunner, pytestcov, pytest-flake8, pytest-isort }:
 
 buildPythonPackage rec {
   pname = "tinycss2";
-  version = "0.6.1";
+  version = "1.0.2";
+  disabled = pythonOlder "3.5";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "7c53c2c0e914c7711c295b3101bcc78e0b7eda23ff20228a936efe11cdcc7136";
+    sha256 = "1kw84y09lggji4krkc58jyhsfj31w8npwhznr7lf19d0zbix09v4";
   };
+
+  patches = [ ./remove-redundant-dependency.patch ];
 
   propagatedBuildInputs = [ webencodings ];
 
-  checkInputs = [ pytest pytestrunner pytestcov pytest-flake8 pytest-isort glibcLocales ];
-
-  LC_ALL = "en_US.UTF-8";
+  checkInputs = [ pytest pytestrunner pytestcov pytest-flake8 pytest-isort ];
 
   meta = with lib; {
     description = "Low-level CSS parser for Python";

--- a/pkgs/development/python-modules/tinycss2/remove-redundant-dependency.patch
+++ b/pkgs/development/python-modules/tinycss2/remove-redundant-dependency.patch
@@ -1,0 +1,12 @@
+diff --git a/setup.cfg b/setup.cfg
+index b3b3c2d..480f3e6 100644
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -33,7 +33,6 @@ project_urls =
+ 
+ [options]
+ packages = find:
+-setup_requires = pytest-runner
+ install_requires = 
+ 	setuptools >= 39.2.0
+ 	webencodings >= 0.4


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
