### PR TITLE
Add libirecovery and idevicerestore

### DIFF
--- a/pkgs/development/libraries/libimobiledevice/default.nix
+++ b/pkgs/development/libraries/libimobiledevice/default.nix
@@ -34,7 +34,6 @@ stdenv.mkDerivation rec {
   preConfigure = "NOCONFIGURE=1 ./autogen.sh";
 
   configureFlags = [
-    "--disable-static"
     "--disable-openssl"
     "--without-cython"
   ];

--- a/pkgs/development/libraries/libirecovery/default.nix
+++ b/pkgs/development/libraries/libirecovery/default.nix
@@ -1,0 +1,54 @@
+{ stdenv, fetchFromGitHub, automake, autoconf, libtool, pkgconfig
+, libusb
+, readline
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libirecovery";
+  version = "2019-01-28";
+
+  src = fetchFromGitHub {
+    owner = "libimobiledevice";
+    repo = pname;
+    rev = "5da2a0d7d60f79d93c283964888c6fbbc17be1a3";
+    sha256 = "0fqmr1h4b3qn608dn606y7aqv3bsm949gx72b5d6433xlw9b23n8";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+    libtool
+    pkgconfig
+  ];
+
+  buildInputs = [
+    libusb
+    readline
+  ];
+
+  preConfigure = "NOCONFIGURE=1 ./autogen.sh";
+
+  # Packager note: Not clear whether this needs a NixOS configuration,
+  # as only the `idevicerestore` binary was tested so far (which worked
+  # without further configuration).
+  configureFlags = [
+    "--with-udevrulesdir=${placeholder ''out''}/lib/udev/rules.d"
+    ''--with-udevrule="OWNER=\"root\", GROUP=\"myusergroup\", MODE=\"0660\""''
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/libimobiledevice/libirecovery;
+    description = "Library and utility to talk to iBoot/iBSS via USB on Mac OS X, Windows, and Linux";
+    longDescription = ''
+      libirecovery is a cross-platform library which implements communication to
+      iBoot/iBSS found on Apple's iOS devices via USB. A command-line utility is also
+      provided.
+    '';
+    license = licenses.lgpl21;
+    # Upstream description says it works on more platforms, but packager hasn't tried that yet
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ nh2 ];
+  };
+}

--- a/pkgs/tools/misc/idevicerestore/default.nix
+++ b/pkgs/tools/misc/idevicerestore/default.nix
@@ -1,0 +1,58 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig
+, curl
+, libimobiledevice
+, libirecovery
+, libzip
+, libusbmuxd
+}:
+
+stdenv.mkDerivation rec {
+  pname = "idevicerestore";
+  version = "2019-02-14";
+
+  src = fetchFromGitHub {
+    owner = "libimobiledevice";
+    repo = pname;
+    rev = "8a882038b2b1e022fbd19eaf8bea51006a373c06";
+    sha256 = "17lisl7ll43ixl1zqwchn7jljrdyl2p9q99w30i6qaci71mas37m";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkgconfig
+  ];
+
+  buildInputs = [
+    curl
+    libimobiledevice
+    libirecovery
+    libzip
+    libusbmuxd
+    # Not listing other dependencies specified in
+    # https://github.com/libimobiledevice/idevicerestore/blob/8a882038b2b1e022fbd19eaf8bea51006a373c06/README#L20
+    # because they are inherited `libimobiledevice`.
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/libimobiledevice/idevicerestore;
+    description = "Restore/upgrade firmware of iOS devices";
+    longDescription = ''
+      The idevicerestore tool allows to restore firmware files to iOS devices.
+
+      It is a full reimplementation of all granular steps which are performed during
+      restore of a firmware to a device.
+
+      In general, upgrades and downgrades are possible, however subject to
+      availability of SHSH blobs from Apple for signing the firmare files.
+
+      To restore a device to some firmware, simply run the following:
+      $ sudo idevicerestore -l
+
+      This will download and restore a device to the latest firmware available.
+    '';
+    license = licenses.lgpl21Plus;
+    # configure.ac suggests it should work for darwin and mingw as well but not tried yet
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ nh2 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11834,6 +11834,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Carbon;
   };
 
+  libirecovery = callPackage ../development/libraries/libirecovery { };
+
   libivykis = callPackage ../development/libraries/libivykis { };
 
   liblastfmSF = callPackage ../development/libraries/liblastfmSF { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3839,6 +3839,7 @@ in
 
   ifuse = callPackage ../tools/filesystems/ifuse { };
   ideviceinstaller = callPackage ../tools/misc/ideviceinstaller { };
+  idevicerestore = callPackage ../tools/misc/idevicerestore { };
 
   inherit (callPackages ../tools/filesystems/irods rec {
             stdenv = llvmPackages_38.libcxxStdenv;


### PR DESCRIPTION
###### Motivation for this change

I want to restore an old iPad to factory settings.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
  - [x] not all but I tested that `idevicerestore -l -e` successfully erased an `iPad3,3` I tried it on to firmware `9.3.5 (build 13G36)` on Ubuntu 16.04 with the built binary
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

This PR also removes one unnecessary `--disable-static` configure flag from a dependency.