### PR TITLE
hpack-convert: 1.0.1 -> 1.0.2

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1267,4 +1267,16 @@ self: super: {
   # Haddock failure: https://github.com/haskell/haddock/issues/979
   esqueleto = dontHaddock (dontCheck super.esqueleto);
 
+  # Get hpack-convert to compile with the versions of its dependencies in nixpkgs.
+  # The tests are still broken
+  hpack-convert = dontCheck (overrideSrc super.hpack-convert {
+    version = "1.0.2";
+    src = pkgs.fetchFromGitHub {
+      owner = "yamadapc";
+      repo = "hpack-convert";
+      rev = "8695b5666c8ee66785c43074b9ae8b3a5d445192";
+      sha256 = "0aha6jspn7a6vfhkxsp2674valjlmmsssgkp5z7g143xmiq4h8pj";
+    };
+  });
+
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super


### PR DESCRIPTION
1.0.1 does not compile with the current package set


###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---