### PR TITLE
pythonPackages.annexremote: init at 1.3.1

### DIFF
--- a/pkgs/development/python-modules/annexremote/default.nix
+++ b/pkgs/development/python-modules/annexremote/default.nix
@@ -9,6 +9,8 @@ buildPythonPackage rec {
   pname = "annexremote";
   version = "1.3.1";
 
+  # use fetchFromGitHub instead of fetchPypi because the test suite of
+  # the package is not included into the PyPI tarball
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "Lykos153";

--- a/pkgs/development/python-modules/annexremote/default.nix
+++ b/pkgs/development/python-modules/annexremote/default.nix
@@ -1,0 +1,24 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, future
+}:
+
+buildPythonPackage rec {
+  pname = "annexremote";
+  version = "1.3.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "058d39fd59db165f0014601da1ba9ecde7614de87eef3061e9ea0b1dd096a9cd";
+  };
+
+  propagatedBuildInputs = [ future ];
+
+  meta = with stdenv.lib; {
+    description = "git annex special remotes made easy";
+    homepage = https://pypi.org/project/annexremote/;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ montag451 ];
+  };
+}

--- a/pkgs/development/python-modules/annexremote/default.nix
+++ b/pkgs/development/python-modules/annexremote/default.nix
@@ -1,23 +1,29 @@
-{ stdenv
+{ lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , future
+, nose
 }:
 
 buildPythonPackage rec {
   pname = "annexremote";
   version = "1.3.1";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "058d39fd59db165f0014601da1ba9ecde7614de87eef3061e9ea0b1dd096a9cd";
+  src = fetchFromGitHub {
+    rev = "v${version}";
+    owner = "Lykos153";
+    repo = "AnnexRemote";
+    sha256 = "13ny7h41430pi9393dw3qgwxvzcxacapjsw0d3vjm7lc4h566alq";
   };
 
   propagatedBuildInputs = [ future ];
 
-  meta = with stdenv.lib; {
-    description = "git annex special remotes made easy";
-    homepage = https://pypi.org/project/annexremote/;
+  checkInputs = [ nose ];
+  checkPhase = "nosetests -v";
+
+  meta = with lib; {
+    description = "Helper module to easily develop git-annex remotes";
+    homepage = https://github.com/Lykos153/AnnexRemote;
     license = licenses.gpl3;
     maintainers = with maintainers; [ montag451 ];
   };

--- a/pkgs/development/python-modules/annexremote/default.nix
+++ b/pkgs/development/python-modules/annexremote/default.nix
@@ -1,7 +1,9 @@
 { lib
+, isPy3k
 , buildPythonPackage
 , fetchFromGitHub
 , future
+, mock
 , nose
 }:
 
@@ -20,7 +22,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ future ];
 
-  checkInputs = [ nose ];
+  checkInputs = [ nose ] ++ lib.optional (!isPy3k) mock;
   checkPhase = "nosetests -v";
 
   meta = with lib; {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -954,6 +954,8 @@ in {
 
   allpairspy = callPackage ../development/python-modules/allpairspy { };
 
+  annexremote = callPackage ../development/python-modules/annexremote { };
+
   ansible = callPackage ../development/python-modules/ansible { };
 
   ansible-kernel = callPackage ../development/python-modules/ansible-kernel { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
