### PR TITLE
pythonPackages.humanfriendly: init at 4.18

### DIFF
--- a/pkgs/development/python-modules/humanfriendly/default.nix
+++ b/pkgs/development/python-modules/humanfriendly/default.nix
@@ -1,0 +1,26 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "humanfriendly";
+  version = "4.18";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "33ee8ceb63f1db61cce8b5c800c531e1a61023ac5488ccde2ba574a85be00a85";
+  };
+
+  # humanfriendly tests depends on coloredlogs which itself depends on
+  # humanfriendly. This lead to infinite recursion when trying to
+  # build this package so we have to disable the test suite :(
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Human friendly output for text interfaces using Python";
+    homepage = https://pypi.org/project/humanfriendly/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ montag451 ];
+  };
+}

--- a/pkgs/development/python-modules/humanfriendly/default.nix
+++ b/pkgs/development/python-modules/humanfriendly/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
     sha256 = "33ee8ceb63f1db61cce8b5c800c531e1a61023ac5488ccde2ba574a85be00a85";
   };
 
-  propagatedBuildInputs = [] ++ lib.optional (pythonOlder "3.3") monotonic;
+  propagatedBuildInputs = lib.optional (pythonOlder "3.3") monotonic;
 
   # humanfriendly tests depends on coloredlogs which itself depends on
   # humanfriendly. This lead to infinite recursion when trying to

--- a/pkgs/development/python-modules/humanfriendly/default.nix
+++ b/pkgs/development/python-modules/humanfriendly/default.nix
@@ -1,6 +1,8 @@
 { stdenv
+, pythonOlder
 , buildPythonPackage
 , fetchPypi
+, monotonic
 }:
 
 buildPythonPackage rec {
@@ -11,6 +13,8 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "33ee8ceb63f1db61cce8b5c800c531e1a61023ac5488ccde2ba574a85be00a85";
   };
+
+  propagatedBuildInputs = [] ++ lib.optional (pythonOlder "3.3") monotonic;
 
   # humanfriendly tests depends on coloredlogs which itself depends on
   # humanfriendly. This lead to infinite recursion when trying to

--- a/pkgs/development/python-modules/humanfriendly/default.nix
+++ b/pkgs/development/python-modules/humanfriendly/default.nix
@@ -1,4 +1,4 @@
-{ stdenv
+{ lib
 , pythonOlder
 , buildPythonPackage
 , fetchPypi
@@ -21,9 +21,9 @@ buildPythonPackage rec {
   # build this package so we have to disable the test suite :(
   doCheck = false;
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Human friendly output for text interfaces using Python";
-    homepage = https://pypi.org/project/humanfriendly/;
+    homepage = https://humanfriendly.readthedocs.io/;
     license = licenses.mit;
     maintainers = with maintainers; [ montag451 ];
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1975,6 +1975,8 @@ in {
 
   humanize = callPackage ../development/python-modules/humanize { };
 
+  humanfriendly = callPackage ../development/python-modules/humanfriendly { };
+
   hupper = callPackage ../development/python-modules/hupper {};
 
   hsaudiotag = callPackage ../development/python-modules/hsaudiotag { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
