### PR TITLE
i3easyfocus: 20180622 -> 20190411

### DIFF
--- a/pkgs/applications/window-managers/i3/easyfocus.nix
+++ b/pkgs/applications/window-managers/i3/easyfocus.nix
@@ -2,15 +2,15 @@
 , xorg , i3ipc-glib , glib
 }:
 
-stdenv.mkDerivation rec {
-  name = "i3easyfocus-${version}";
-  version = "20180622";
+stdenv.mkDerivation {
+  pname = "i3easyfocus";
+  version = "20190411";
 
   src = fetchFromGitHub {
     owner = "cornerman";
     repo = "i3-easyfocus";
-    rev = "3631d5af612d58c3d027f59c86b185590bd78ae1";
-    sha256 = "1wgknmmm7iz0wxsdh29gmx4arizva9101pzhnmac30bmixf3nzhr";
+    rev = "fffb468f7274f9d7c9b92867c8cb9314ec6cf81a";
+    sha256 = "1db23vzzmp0hnfss1fkd80za6d2pajx7hdwikw50pk95jq0w8wfm";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
introduced a new scheme to annotate windows.
https://github.com/cornerman/i3-easyfocus

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
