### PR TITLE
hyperscan: 5.1.0 -> 5.1.1

### DIFF
--- a/pkgs/development/libraries/hyperscan/default.nix
+++ b/pkgs/development/libraries/hyperscan/default.nix
@@ -27,8 +27,8 @@ stdenv.mkDerivation rec {
     cmake ragel python3
     # Consider simply using busybox for these
     # Need at least: rev, sed, cut, nm
-    coreutils gnused
-  ] ++ stdenv.lib.optional stdenv.isLinux utillinux;
+    coreutils gnused utillinux
+  ];
 
   cmakeFlags = [
     "-DFAT_RUNTIME=ON"
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
 
     homepage = "https://www.hyperscan.io/";
     maintainers = with maintainers; [ avnik ];
-    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+    platforms = [ "x86_64-linux" ]; # can't find nm on darwin ; might build on aarch64 but untested
     license = licenses.bsd3;
   };
 }

--- a/pkgs/development/libraries/hyperscan/default.nix
+++ b/pkgs/development/libraries/hyperscan/default.nix
@@ -1,4 +1,5 @@
 { lib, stdenv, fetchFromGitHub, cmake, ragel, python27
+, coreutils, gnused, utillinux
 , boost
 }:
 
@@ -8,21 +9,25 @@
 #         I not see any reason (for now) to backport 8.41.
 
 stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
   pname = "hyperscan";
-  version = "5.1.0";
+  version = "5.1.1";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "hyperscan";
-    sha256 = "0r2c7s7alnq14yhbfhpkq6m28a3pyfqd427115k0754afxi82vbq";
+    sha256 = "11adkz5ln2d2jywwlmixfnwqp5wxskq1104hmmcpws590lhkjv6j";
     rev = "v${version}";
   };
 
   outputs = [ "out" "dev" ];
 
   buildInputs = [ boost ];
-  nativeBuildInputs = [ cmake ragel python27 ];
+  nativeBuildInputs = [
+    cmake ragel python27
+    # Consider simply using busybox for these
+    # Need at least: rev, sed, cut
+    coreutils gnused utillinux
+  ];
 
   cmakeFlags = [
     "-DFAT_RUNTIME=ON"


### PR DESCRIPTION
* provide misc utils needed by build


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

https://github.com/intel/hyperscan/releases/tag/v5.1.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---