### PR TITLE
kdeFrameworks: 5.56 -> 5.57

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/kservice/qdiriterator-follow-symlinks.patch
+++ b/pkgs/development/libraries/kde-frameworks/kservice/qdiriterator-follow-symlinks.patch
@@ -1,11 +1,11 @@
-Index: kservice-5.21.0/src/sycoca/kbuildsycoca.cpp
-===================================================================
---- kservice-5.21.0.orig/src/sycoca/kbuildsycoca.cpp
-+++ kservice-5.21.0/src/sycoca/kbuildsycoca.cpp
-@@ -203,7 +203,7 @@ bool KBuildSycoca::build()
-         QSet<QString> relFiles;
+diff --git a/src/sycoca/kbuildsycoca.cpp b/src/sycoca/kbuildsycoca.cpp
+index b125299..0682b90 100644
+--- a/src/sycoca/kbuildsycoca.cpp
++++ b/src/sycoca/kbuildsycoca.cpp
+@@ -207,7 +207,7 @@ bool KBuildSycoca::build()
          const QStringList dirs = QStandardPaths::locateAll(QStandardPaths::GenericDataLocation, m_resourceSubdir, QStandardPaths::LocateDirectory);
-         Q_FOREACH (const QString &dir, dirs) {
+         qCDebug(SYCOCA) << "Looking for subdir" << m_resourceSubdir << "=>" << dirs;
+         for (const QString &dir : dirs) {
 -            QDirIterator it(dir, QDirIterator::Subdirectories);
 +            QDirIterator it(dir, QDirIterator::Subdirectories | QDirIterator::FollowSymlinks);
              while (it.hasNext()) {

--- a/pkgs/development/libraries/kde-frameworks/srcs.nix
+++ b/pkgs/development/libraries/kde-frameworks/srcs.nix
@@ -3,635 +3,635 @@
 
 {
   attica = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/attica-5.56.0.tar.xz";
-      sha256 = "1ib68yg7dgfyh2kq72abw5bh8h0m85z3hcada3b3axq2xkcfxfmb";
-      name = "attica-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/attica-5.57.0.tar.xz";
+      sha256 = "a13682bccaca3529df6e3b54e1d4e48fb3d1654fe1b142701e73ce9fe0b87655";
+      name = "attica-5.57.0.tar.xz";
     };
   };
   baloo = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/baloo-5.56.0.tar.xz";
-      sha256 = "04hjlhlgw26l2pl4b5jk76xfs7366my71zp1xgiws5aq620bmmcy";
-      name = "baloo-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/baloo-5.57.0.tar.xz";
+      sha256 = "32ab4ed2d295fe734a4a475403dea72e2feef27f662ae64c841c410eb7bb3dd3";
+      name = "baloo-5.57.0.tar.xz";
     };
   };
   bluez-qt = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/bluez-qt-5.56.0.tar.xz";
-      sha256 = "1phph0rjms8n2qpkh9bk1n1n1cd75znsqj9r8njs1siasm6vi4nm";
-      name = "bluez-qt-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/bluez-qt-5.57.0.tar.xz";
+      sha256 = "43e1be1882832cef88186255a6b692d9fd1366bad09db0c2075a126b0fc0df65";
+      name = "bluez-qt-5.57.0.tar.xz";
     };
   };
   breeze-icons = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/breeze-icons-5.56.0.tar.xz";
-      sha256 = "0n6gizmzay98q1vi9ac60p0xq9hpaj9q0gcf8vbmvk4m0yzdd63x";
-      name = "breeze-icons-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/breeze-icons-5.57.0.tar.xz";
+      sha256 = "c3ba92acb5bfcff66f41232ebc6e8c893dab78ac59a713fa4bfa2a0e097f4ed2";
+      name = "breeze-icons-5.57.0.tar.xz";
     };
   };
   extra-cmake-modules = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/extra-cmake-modules-5.56.0.tar.xz";
-      sha256 = "0a5mxk805rlmpgbxwa9qkn515jqpcifsrk8ydxc3anjcsq6ffg4i";
-      name = "extra-cmake-modules-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/extra-cmake-modules-5.57.0.tar.xz";
+      sha256 = "aa53f8953792b452672f275c2ea9b96ab2adf3e13d9645c3451b06dbc8055b18";
+      name = "extra-cmake-modules-5.57.0.tar.xz";
     };
   };
   frameworkintegration = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/frameworkintegration-5.56.0.tar.xz";
-      sha256 = "1xc0vdvpjzhb6y1pz27c7x36qjjhcf4bll0fm3yljpm956v4d3gf";
-      name = "frameworkintegration-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/frameworkintegration-5.57.0.tar.xz";
+      sha256 = "9c5850c1d41900bcb81e7929d54856d0cdd2565a276e5e262f624eb1217cbb78";
+      name = "frameworkintegration-5.57.0.tar.xz";
     };
   };
   kactivities = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kactivities-5.56.0.tar.xz";
-      sha256 = "0l0p966b5rs6xjc61mpzmrkj7qqjvlzi6fwc7lky4z3fr924ssp7";
-      name = "kactivities-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kactivities-5.57.0.tar.xz";
+      sha256 = "442527db8710b9045dc574816bc9c32cad5f8a404e681fb030d7e9c2f3d77761";
+      name = "kactivities-5.57.0.tar.xz";
     };
   };
   kactivities-stats = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kactivities-stats-5.56.0.tar.xz";
-      sha256 = "1v3pf9drb22qv7039grx4k7q3a1jxd2a7sf818mxpqyys4fzkl3f";
-      name = "kactivities-stats-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kactivities-stats-5.57.0.tar.xz";
+      sha256 = "4c7a49905ec1b6e03831986b254d0fd091e44fe920fffa123c969765c6474ba3";
+      name = "kactivities-stats-5.57.0.tar.xz";
     };
   };
   kapidox = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kapidox-5.56.0.tar.xz";
-      sha256 = "0rhqqsv4zf13idk426x84jykw6lc74bz7pk606llbmyw4775c7wp";
-      name = "kapidox-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kapidox-5.57.0.tar.xz";
+      sha256 = "16f53e4722adddaa8729b4cccc374d16bdbfdd987f8655d2b431a91b046fe2b2";
+      name = "kapidox-5.57.0.tar.xz";
     };
   };
   karchive = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/karchive-5.56.0.tar.xz";
-      sha256 = "1mnavc5baa4qw90baw5b95760lk61m2rx0vfa3w5d7fid3m6q6i8";
-      name = "karchive-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/karchive-5.57.0.tar.xz";
+      sha256 = "e0e64e7e88c8df96f894de20aff4d12925e0d362c5134df83473ea48c0432783";
+      name = "karchive-5.57.0.tar.xz";
     };
   };
   kauth = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kauth-5.56.0.tar.xz";
-      sha256 = "0gb1yh2na2kfphln7arscv5n7llagkkv2y0zdprdy4michqa3k6b";
-      name = "kauth-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kauth-5.57.0.tar.xz";
+      sha256 = "9d6b9135cc47710b28e2a7731c4c5c1f6dba2b0e5fe982b9d2a82a11d7d497c2";
+      name = "kauth-5.57.0.tar.xz";
     };
   };
   kbookmarks = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kbookmarks-5.56.0.tar.xz";
-      sha256 = "0fwmq70ajyjqcva1n2vnf522gwl44aqsi6s9vf8zxsar14vil082";
-      name = "kbookmarks-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kbookmarks-5.57.0.tar.xz";
+      sha256 = "bf57f111e176ab2ecb79646b1f93cf5d84a8d3fcfb13b805b5140e75b42eb085";
+      name = "kbookmarks-5.57.0.tar.xz";
     };
   };
   kcmutils = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kcmutils-5.56.0.tar.xz";
-      sha256 = "1f1sccwyk6fzqd9ywnhkrsyaklmxi0w0w5jqhp1m4n3l30caixkw";
-      name = "kcmutils-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kcmutils-5.57.0.tar.xz";
+      sha256 = "f3ee63a356e18be95a15141346356f3f43bb067d0326021d99f4b73ee4716fbb";
+      name = "kcmutils-5.57.0.tar.xz";
     };
   };
   kcodecs = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kcodecs-5.56.0.tar.xz";
-      sha256 = "10lw85im4rd3nfdnw2p48cjwq0d47pa2s9v6vmhzmm3hxbflq8z7";
-      name = "kcodecs-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kcodecs-5.57.0.tar.xz";
+      sha256 = "c98b98cf7258c03fa5131a987e278f348d52f792dcb9f2a5664fe35aadea6995";
+      name = "kcodecs-5.57.0.tar.xz";
     };
   };
   kcompletion = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kcompletion-5.56.0.tar.xz";
-      sha256 = "1yxsrl0f24ps8xsilh2iqnl88yvw39iw2ch0yk7lwwk47jkgvns9";
-      name = "kcompletion-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kcompletion-5.57.0.tar.xz";
+      sha256 = "5ad8746a57cef2b12da5a97e296cbb0b708e8ecfb4253786a899fa86951395ec";
+      name = "kcompletion-5.57.0.tar.xz";
     };
   };
   kconfig = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kconfig-5.56.0.tar.xz";
-      sha256 = "0wii6pn5dq899s1r7p4q5vmm01jk11zwg2ky6760xf8nv8rhg5ra";
-      name = "kconfig-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kconfig-5.57.0.tar.xz";
+      sha256 = "155b0dbba8772aa8ea3e75217029daa00ada8699e5a807154214f66b2462c010";
+      name = "kconfig-5.57.0.tar.xz";
     };
   };
   kconfigwidgets = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kconfigwidgets-5.56.0.tar.xz";
-      sha256 = "00x5cxgxqza81znzm5rzxzr6scv3s5wbwbhsq61ksmjnlf5wvky5";
-      name = "kconfigwidgets-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kconfigwidgets-5.57.0.tar.xz";
+      sha256 = "771c5641a9ae465feaf00ffbb3f3c0433ad8d4a90355dc50d5b6b1b472912eb0";
+      name = "kconfigwidgets-5.57.0.tar.xz";
     };
   };
   kcoreaddons = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kcoreaddons-5.56.0.tar.xz";
-      sha256 = "17kvndaab9l6r79rh0pyjgw4yqh99xfyksc4yxzhhlyl3fgh6hcz";
-      name = "kcoreaddons-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kcoreaddons-5.57.0.tar.xz";
+      sha256 = "7c2573de9b745e55fe61cff26941839cff0d2e40b6c5d791c24c9d6cc8cf7485";
+      name = "kcoreaddons-5.57.0.tar.xz";
     };
   };
   kcrash = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kcrash-5.56.0.tar.xz";
-      sha256 = "1q5iyqi1qgk5ngc9fdilrc5mjxy2mb0xbdnlx234hn1a44aq47jq";
-      name = "kcrash-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kcrash-5.57.0.tar.xz";
+      sha256 = "4b12719a20f2ff0fe0a2656609d0aa277245cd2a9f764a7b6cfaa6da9d928dc0";
+      name = "kcrash-5.57.0.tar.xz";
     };
   };
   kdbusaddons = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kdbusaddons-5.56.0.tar.xz";
-      sha256 = "0wmrcz92k27j0s2iyzd9ldynv4p52x70sxzby2m807ffrs692c5r";
-      name = "kdbusaddons-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kdbusaddons-5.57.0.tar.xz";
+      sha256 = "86946d97e74420637f59ea0fff93e303bcbdc5b1d5e1c6361e2d9a3ceb0e1259";
+      name = "kdbusaddons-5.57.0.tar.xz";
     };
   };
   kdeclarative = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kdeclarative-5.56.0.tar.xz";
-      sha256 = "0slhxqzbrj23vw7f017cx3brpqkw3933jj7z8kc2bgfzjypj373r";
-      name = "kdeclarative-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kdeclarative-5.57.0.tar.xz";
+      sha256 = "5335b39ac1cca34209c0420dab867b67ddb0e9ee483bdd6d4192269a1d5f654f";
+      name = "kdeclarative-5.57.0.tar.xz";
     };
   };
   kded = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kded-5.56.0.tar.xz";
-      sha256 = "0fdzpsrigjqssqw25gxz5d1i0j8g3hc8xpv4v74mp0pcv9g10apz";
-      name = "kded-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kded-5.57.0.tar.xz";
+      sha256 = "04327dda12fa547bebb8e1b1bc26373e8f4174007dd629231403d59ce004201f";
+      name = "kded-5.57.0.tar.xz";
     };
   };
   kdelibs4support = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/portingAids/kdelibs4support-5.56.0.tar.xz";
-      sha256 = "1yhfnvzgwmnivm99gkq67gnx0ar02j043mq3fg2lgwlrarqi9k7d";
-      name = "kdelibs4support-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/portingAids/kdelibs4support-5.57.0.tar.xz";
+      sha256 = "e9d1c06191031b482ea01d891756d125ff32927239c36a3011fc7b8f17aca1b0";
+      name = "kdelibs4support-5.57.0.tar.xz";
     };
   };
   kdesignerplugin = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kdesignerplugin-5.56.0.tar.xz";
-      sha256 = "05nqayzafn2zz74lx8zj7hi7knclcip7zbqmpk1g3nriysc39x4v";
-      name = "kdesignerplugin-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kdesignerplugin-5.57.0.tar.xz";
+      sha256 = "9e85a4ac798122b459722773a6e81f639be6dfe9c9714a16704f555c88334393";
+      name = "kdesignerplugin-5.57.0.tar.xz";
     };
   };
   kdesu = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kdesu-5.56.0.tar.xz";
-      sha256 = "0fc77rbkd1m7rv4rq56g0fg4vg0siamdm5g788816ig9gn1j76ll";
-      name = "kdesu-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kdesu-5.57.0.tar.xz";
+      sha256 = "76d98db52f7f375991cd7ccbbf1dc100716f99a5792b71ef31a75cc33cf45b19";
+      name = "kdesu-5.57.0.tar.xz";
     };
   };
   kdewebkit = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kdewebkit-5.56.0.tar.xz";
-      sha256 = "1c1mxs30182ilxybp0xwaljrjg5y9j1ri79169hn8664xs3wcbc2";
-      name = "kdewebkit-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kdewebkit-5.57.0.tar.xz";
+      sha256 = "809e9df4ac3ca8b59799c8781694092cb1793f03af0b87a347a1c6019f96a592";
+      name = "kdewebkit-5.57.0.tar.xz";
     };
   };
   kdnssd = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kdnssd-5.56.0.tar.xz";
-      sha256 = "1gskwc8sbj6cicblmrxh7qnh1gap0qivs8k5zf5qs94p1xc864vy";
-      name = "kdnssd-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kdnssd-5.57.0.tar.xz";
+      sha256 = "5a61b942fd14c9d96370e19fd7a29594bfcbd3074e12625caac083206fce2789";
+      name = "kdnssd-5.57.0.tar.xz";
     };
   };
   kdoctools = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kdoctools-5.56.0.tar.xz";
-      sha256 = "01y06rf1nhw2p8s0j60anr2qvssrqfimddvp2mqqkvx9xkx3py74";
-      name = "kdoctools-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kdoctools-5.57.0.tar.xz";
+      sha256 = "649dbaff4f1559302e7da07f423a0bc9e3faa1c7a93dfeb170e50bf452d8def2";
+      name = "kdoctools-5.57.0.tar.xz";
     };
   };
   kemoticons = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kemoticons-5.56.0.tar.xz";
-      sha256 = "00hbd09gnwyfszdwa9yf5m8wpbbapc4kwhs3qxhbvvmll0jv9vl2";
-      name = "kemoticons-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kemoticons-5.57.0.tar.xz";
+      sha256 = "c07b69c9275c117507166622e185c2bf0f36e1e4e8ad7b25fa3e1d793da4711b";
+      name = "kemoticons-5.57.0.tar.xz";
     };
   };
   kfilemetadata = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kfilemetadata-5.56.0.tar.xz";
-      sha256 = "04pmd2f77zxi14l3rhw4dyrh9dafchxqw1xjyv60j97gmm1b9796";
-      name = "kfilemetadata-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kfilemetadata-5.57.0.tar.xz";
+      sha256 = "49e6c281fdffd4f5fe363c6cefdb6c3022ef57c935d7d6b135607cdde9b2d116";
+      name = "kfilemetadata-5.57.0.tar.xz";
     };
   };
   kglobalaccel = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kglobalaccel-5.56.0.tar.xz";
-      sha256 = "0pmgvizc2dwrwr7m49125ybcpsc95r9riwxnihf37napyaacd9y3";
-      name = "kglobalaccel-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kglobalaccel-5.57.0.tar.xz";
+      sha256 = "46370dcd4f110e6ccde3b3bf9c075deb1f22ad54016137925e4aea97b03cc2fe";
+      name = "kglobalaccel-5.57.0.tar.xz";
     };
   };
   kguiaddons = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kguiaddons-5.56.0.tar.xz";
-      sha256 = "0gp2i29y1vws8i3q8s1bhyxksa42l6q55m459yczddcvcw0vd45i";
-      name = "kguiaddons-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kguiaddons-5.57.0.tar.xz";
+      sha256 = "744eb0ec35c936c17c3d11a08d19014e2166c4a307370207e0f5a38f01a91ebd";
+      name = "kguiaddons-5.57.0.tar.xz";
     };
   };
   kholidays = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kholidays-5.56.0.tar.xz";
-      sha256 = "0lm2ls3a15qbsfhamh2ldzvr62wi9nrhxd83rhyk3ifsgac4mg18";
-      name = "kholidays-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kholidays-5.57.0.tar.xz";
+      sha256 = "f7db45906623c33dfbb297810082f8ff30c949e6a7d477f3b72de0521b0c9452";
+      name = "kholidays-5.57.0.tar.xz";
     };
   };
   khtml = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/portingAids/khtml-5.56.0.tar.xz";
-      sha256 = "1wmcqc4546mqagqpgb97h3yd7nxaq4si2484li5hnw8mglm1qf3x";
-      name = "khtml-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/portingAids/khtml-5.57.0.tar.xz";
+      sha256 = "63d22fbc8cad3075a0b7ef195291c4b79ebc65da5de81b4885cac1063d783da3";
+      name = "khtml-5.57.0.tar.xz";
     };
   };
   ki18n = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/ki18n-5.56.0.tar.xz";
-      sha256 = "0hdfad9vmyzfni9ln0dc9p26gpjksk754z28v35hww6z9kgbr1dq";
-      name = "ki18n-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/ki18n-5.57.0.tar.xz";
+      sha256 = "bbd60981c9a0c1f9d9a52c8dd86adef7c4c30caf603f806d8730febaa36f0dd9";
+      name = "ki18n-5.57.0.tar.xz";
     };
   };
   kiconthemes = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kiconthemes-5.56.0.tar.xz";
-      sha256 = "0rdpvbqsb2wqi3glmggilm1mhpy6nc80am5hl4c34269mxd55q8a";
-      name = "kiconthemes-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kiconthemes-5.57.0.tar.xz";
+      sha256 = "09abb03a97027948a1116bfb2ca9842d3f8fb2def83b0b02aaed194dd5bd16f3";
+      name = "kiconthemes-5.57.0.tar.xz";
     };
   };
   kidletime = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kidletime-5.56.0.tar.xz";
-      sha256 = "09184bi8fvq34hwkldyibji7r79wd2wvhxk1i4kzkjg177dnaa95";
-      name = "kidletime-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kidletime-5.57.0.tar.xz";
+      sha256 = "e99a07f814573526ed5141fc9e4bc2df12298df53a0d2787c3b7a4c3af915665";
+      name = "kidletime-5.57.0.tar.xz";
     };
   };
   kimageformats = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kimageformats-5.56.0.tar.xz";
-      sha256 = "1cgh32jkg0ybfp8z6qwn7y6yr9mb0fiqly4pb0qc1lcm6awdx3d5";
-      name = "kimageformats-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kimageformats-5.57.0.tar.xz";
+      sha256 = "d7ce6c4737ae2846f015633e7479b60460d960a3a578777c2a884d499bd6cc14";
+      name = "kimageformats-5.57.0.tar.xz";
     };
   };
   kinit = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kinit-5.56.0.tar.xz";
-      sha256 = "1ihrannyaj33wsir20qy363vdjafhlsmj45qzl3xkl4rbyl6ngs7";
-      name = "kinit-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kinit-5.57.0.tar.xz";
+      sha256 = "7d5ca84d7bd554531aa6d720d3dc41ac091cf047a52d097a23e5c8fad08b684c";
+      name = "kinit-5.57.0.tar.xz";
     };
   };
   kio = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kio-5.56.0.tar.xz";
-      sha256 = "1m2c3a5isj966snmzs97i9kyhwnbzlwf61lqw5yxck25x7d0pyyn";
-      name = "kio-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kio-5.57.0.tar.xz";
+      sha256 = "d68151d58f1ed2e0724074c6bca42510dd3e19617baa4b4130198ad3a36a64ab";
+      name = "kio-5.57.0.tar.xz";
     };
   };
   kirigami2 = {
-    version = "5.56.1";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kirigami2-5.56.1.tar.xz";
-      sha256 = "0npq65kslwkdsylmv5hgcqsa5i9386dmnx8ig79rlf3409awn2f8";
-      name = "kirigami2-5.56.1.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kirigami2-5.57.0.tar.xz";
+      sha256 = "3cdbea0e472293e85e625820f6b9e2d20f59cff263ed150904b6b2acad81062b";
+      name = "kirigami2-5.57.0.tar.xz";
     };
   };
   kitemmodels = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kitemmodels-5.56.0.tar.xz";
-      sha256 = "13m1bvhljyc1jb9hdlz5v009kmkz7q0qf06l5zkck5k0fq41rkrg";
-      name = "kitemmodels-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kitemmodels-5.57.0.tar.xz";
+      sha256 = "b0eef30ce3e5f2fe9afb60d589bea16a0d0e4a57ffffb37ae0e14a54f1681464";
+      name = "kitemmodels-5.57.0.tar.xz";
     };
   };
   kitemviews = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kitemviews-5.56.0.tar.xz";
-      sha256 = "1ar492jpyprxvzcgnq0gnbyxlndb3rd0z32drk7xsx19vpk3ch58";
-      name = "kitemviews-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kitemviews-5.57.0.tar.xz";
+      sha256 = "6b499a21c88d5998c903e8e4dd480c612b96e5e31d17430a507c07566febdd30";
+      name = "kitemviews-5.57.0.tar.xz";
     };
   };
   kjobwidgets = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kjobwidgets-5.56.0.tar.xz";
-      sha256 = "1dh4ilry575k6z0glqb60ldjfkwpnkvijdzfyrc22bn84hbh19iy";
-      name = "kjobwidgets-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kjobwidgets-5.57.0.tar.xz";
+      sha256 = "4b98e7cd9b8d877326854addcee300071afc92f4378d3a94734e470271638002";
+      name = "kjobwidgets-5.57.0.tar.xz";
     };
   };
   kjs = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/portingAids/kjs-5.56.0.tar.xz";
-      sha256 = "1b3l76ipf0fr8bvp3f4njimmg5yw9ciwzzgvb34ds65aycplagln";
-      name = "kjs-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/portingAids/kjs-5.57.0.tar.xz";
+      sha256 = "865fb86566a0ea904ab0a3bd6a63787161b28578660d475fc316c50c8a7b1e90";
+      name = "kjs-5.57.0.tar.xz";
     };
   };
   kjsembed = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/portingAids/kjsembed-5.56.0.tar.xz";
-      sha256 = "0lkfq7099yiwvlycrix3s0dbk860rqfnix5fiw5vmi855is7mpkv";
-      name = "kjsembed-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/portingAids/kjsembed-5.57.0.tar.xz";
+      sha256 = "741aae8db274febe7e5d0d10dc99271efc590b2465d2c4d4e4a9162d2b36e3b4";
+      name = "kjsembed-5.57.0.tar.xz";
     };
   };
   kmediaplayer = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/portingAids/kmediaplayer-5.56.0.tar.xz";
-      sha256 = "0blqbi40l1pk8qf9054ha4a8r7cb4pddbqydsqlsscl4gm8530jh";
-      name = "kmediaplayer-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/portingAids/kmediaplayer-5.57.0.tar.xz";
+      sha256 = "521dcb4b3f9a67203e9eac27b8d777cb22557861b9fae0006c2aecda96d9bad4";
+      name = "kmediaplayer-5.57.0.tar.xz";
     };
   };
   knewstuff = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/knewstuff-5.56.0.tar.xz";
-      sha256 = "0r0ia0521vfri7mc6wpg3ihryqj48s3krgmliwbh635rfd3lcj9j";
-      name = "knewstuff-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/knewstuff-5.57.0.tar.xz";
+      sha256 = "6a9d77a62b036b4ed0f32ffaa9f204db1403030d01dbe8fb055d02361db2f981";
+      name = "knewstuff-5.57.0.tar.xz";
     };
   };
   knotifications = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/knotifications-5.56.0.tar.xz";
-      sha256 = "05nf2870fq9cwacgyy8iky5v37fq4jrsh4hl9xy9928d19qnmb24";
-      name = "knotifications-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/knotifications-5.57.0.tar.xz";
+      sha256 = "7de068f4cf9bcefef54ae1cb180e2c0af9be951afbcaa960245507259620cf15";
+      name = "knotifications-5.57.0.tar.xz";
     };
   };
   knotifyconfig = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/knotifyconfig-5.56.0.tar.xz";
-      sha256 = "0zwq0p779482sxxjg62z1rkpiiyn6b3r47l450dm6hm56vkf7vxl";
-      name = "knotifyconfig-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/knotifyconfig-5.57.0.tar.xz";
+      sha256 = "e7fe39ed72b7f79d8cafe6c30d5c62ade0f33be37a62d9e5b929064dd1750ac1";
+      name = "knotifyconfig-5.57.0.tar.xz";
     };
   };
   kpackage = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kpackage-5.56.0.tar.xz";
-      sha256 = "037r0ldp70q0yafld1ddff1d4wipb5ras88r72qazjcfqfg9rzjr";
-      name = "kpackage-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kpackage-5.57.0.tar.xz";
+      sha256 = "2d2d497d50e8ce986d6de4462391122963d9b7605889fd20cd3ceb4dd6910814";
+      name = "kpackage-5.57.0.tar.xz";
     };
   };
   kparts = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kparts-5.56.0.tar.xz";
-      sha256 = "1vj5ard5ff0wzpjqzrkd2kb31dkjly1cf4ww1ljrrwi7qgzxgw0z";
-      name = "kparts-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kparts-5.57.0.tar.xz";
+      sha256 = "5a079986963d186e98a1174e19e490731012732ad5ad31a431a8f7a31c6b6ed2";
+      name = "kparts-5.57.0.tar.xz";
     };
   };
   kpeople = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kpeople-5.56.0.tar.xz";
-      sha256 = "0h456kjhx4ylbkiv3706g8ccdq55aamrhj5rgiql2gaw3d5dbrkr";
-      name = "kpeople-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kpeople-5.57.0.tar.xz";
+      sha256 = "7c239b80b7976e3bfa46338e05a048aecb9c1972548dc33cc8a17e66eb08a85c";
+      name = "kpeople-5.57.0.tar.xz";
     };
   };
   kplotting = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kplotting-5.56.0.tar.xz";
-      sha256 = "1hrk3iv77s46lcs6c5mfiyzr80vpg9261mlixc3qwps0mww43r1r";
-      name = "kplotting-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kplotting-5.57.0.tar.xz";
+      sha256 = "c2c35030b1a2ca25f503c1a2df7ca225d156a9ea80f52883e136679aea6efc8e";
+      name = "kplotting-5.57.0.tar.xz";
     };
   };
   kpty = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kpty-5.56.0.tar.xz";
-      sha256 = "1dzp4a6rz6hsp1y8m5l73i8v2a3bpwkv4rrypkd00051ajcch47k";
-      name = "kpty-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kpty-5.57.0.tar.xz";
+      sha256 = "14a0f9d5ecc387c88d24270dbf4c128deb8ad18ab64b39766b335ad03a47c3b6";
+      name = "kpty-5.57.0.tar.xz";
     };
   };
   kross = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/portingAids/kross-5.56.0.tar.xz";
-      sha256 = "0ry6fpl0rb8z5r08bzh6kj14mp7l94calvdk3vrnc89cpm5gxymv";
-      name = "kross-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/portingAids/kross-5.57.0.tar.xz";
+      sha256 = "3b0f92751bb70c64b2ac25b466f886cc8b02babf02c744bcc909aa3ce6915a66";
+      name = "kross-5.57.0.tar.xz";
     };
   };
   krunner = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/krunner-5.56.0.tar.xz";
-      sha256 = "1gs0fr78zbhxl8c08zj4s98zshc42zxzwv7p9l7rmq8h21spc8ga";
-      name = "krunner-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/krunner-5.57.0.tar.xz";
+      sha256 = "40f52d4d883748f5b9a78b5bd7dd6aaa52eae88b89d7a33eafbcbb9ccf6f4805";
+      name = "krunner-5.57.0.tar.xz";
     };
   };
   kservice = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kservice-5.56.0.tar.xz";
-      sha256 = "1hsc8pagigwspyv9ipl3l2b9mf8amfksk8a2k3iic9nw1hmpxinv";
-      name = "kservice-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kservice-5.57.0.tar.xz";
+      sha256 = "531940baa47273714fbc35941f2ef5fbdb801b7a5ed5fef5a8ff1d86bf1dae14";
+      name = "kservice-5.57.0.tar.xz";
     };
   };
   ktexteditor = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/ktexteditor-5.56.0.tar.xz";
-      sha256 = "1a2r97v3xwh61q688jvwkk99bphfd0v0ldqms5d73q3m6w1x122c";
-      name = "ktexteditor-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/ktexteditor-5.57.0.tar.xz";
+      sha256 = "aa510656f632ef09c18af4263386265c293cb929f139786acd102881250314c3";
+      name = "ktexteditor-5.57.0.tar.xz";
     };
   };
   ktextwidgets = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/ktextwidgets-5.56.0.tar.xz";
-      sha256 = "1km19z577y29di8zp6amlccqdavxk4f4sg1dblj6gp64zkw9dbqp";
-      name = "ktextwidgets-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/ktextwidgets-5.57.0.tar.xz";
+      sha256 = "b74036eea1ec19a22aa0e76cd1a8338f55e5c32a30dc47d602783c6bc5ba54bf";
+      name = "ktextwidgets-5.57.0.tar.xz";
     };
   };
   kunitconversion = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kunitconversion-5.56.0.tar.xz";
-      sha256 = "1kf5dc6p77mkx2i23ppfs0k3laybmx5vqq7aq1bxnkxj1ws75144";
-      name = "kunitconversion-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kunitconversion-5.57.0.tar.xz";
+      sha256 = "157f4d21e83a6e92e30894f472b65452ecd2183ac2e25e24f740e971befed383";
+      name = "kunitconversion-5.57.0.tar.xz";
     };
   };
   kwallet = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kwallet-5.56.0.tar.xz";
-      sha256 = "02i6xkq9ki6sybjvcxkznf5v8b34pqxysg9pi5v4z6jkw2jpr5fj";
-      name = "kwallet-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kwallet-5.57.0.tar.xz";
+      sha256 = "ad089026f4d5b10d567d0fd56f8b63749acd214fb8029d43187ba42afaf36975";
+      name = "kwallet-5.57.0.tar.xz";
     };
   };
   kwayland = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kwayland-5.56.0.tar.xz";
-      sha256 = "1779in51z63sv6607xd7y30wprs9vs8nnqa28fxg1q4nicwnvrxv";
-      name = "kwayland-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kwayland-5.57.0.tar.xz";
+      sha256 = "f00d2997163f559cecf30f5e945d5456628a0d120acafba49fa14af28c22b1d6";
+      name = "kwayland-5.57.0.tar.xz";
     };
   };
   kwidgetsaddons = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kwidgetsaddons-5.56.0.tar.xz";
-      sha256 = "0flmw1wfzs49dmmlbbimizjwj09wp4qwr9znxn3h5yfn0mxfc1lv";
-      name = "kwidgetsaddons-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kwidgetsaddons-5.57.0.tar.xz";
+      sha256 = "abd80a566e1003bca7c72d3a0dc1ee470bc9935d11371cfff0d960f11e1ef5c2";
+      name = "kwidgetsaddons-5.57.0.tar.xz";
     };
   };
   kwindowsystem = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kwindowsystem-5.56.0.tar.xz";
-      sha256 = "0dk9ymlpdpvra2zm1f2rcx2dwnn9qc49n2y7p6iw094fwk5rzczc";
-      name = "kwindowsystem-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kwindowsystem-5.57.0.tar.xz";
+      sha256 = "0c8a009dde7ca1722810777b99aa4e1a3471687460c25e0f41645c9e11daf274";
+      name = "kwindowsystem-5.57.0.tar.xz";
     };
   };
   kxmlgui = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kxmlgui-5.56.0.tar.xz";
-      sha256 = "1ipa0qnkh6gs3f6ygvb7cf0yv1m89m3cdl1z23br4fn14d5mxbrl";
-      name = "kxmlgui-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kxmlgui-5.57.0.tar.xz";
+      sha256 = "325124518e8fa4847c898dee193d96b76a7ba27d7c79d875f34c632f46fe1f90";
+      name = "kxmlgui-5.57.0.tar.xz";
     };
   };
   kxmlrpcclient = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kxmlrpcclient-5.56.0.tar.xz";
-      sha256 = "1bjnpl4521gv35zghaanz6v5bap2b9n2kz7b0rif1bf6iak018ql";
-      name = "kxmlrpcclient-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kxmlrpcclient-5.57.0.tar.xz";
+      sha256 = "d47d5cc49f050dda3a26f7654226c0d124ca5ba5503a60e606307426bbe43b9d";
+      name = "kxmlrpcclient-5.57.0.tar.xz";
     };
   };
   modemmanager-qt = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/modemmanager-qt-5.56.0.tar.xz";
-      sha256 = "1xwx6yybij8nlaqfpz76pindfxshcyg9p21nqm6ddpgyzh74klbc";
-      name = "modemmanager-qt-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/modemmanager-qt-5.57.0.tar.xz";
+      sha256 = "030bfcfafd5079f25a165aaa5f52693a8fe4b3c15c1345a641716c4329e0929d";
+      name = "modemmanager-qt-5.57.0.tar.xz";
     };
   };
   networkmanager-qt = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/networkmanager-qt-5.56.0.tar.xz";
-      sha256 = "0p0b3rq7s1yzy6zspd6xnzjc0hza9d7fixm8pw369kn5k3pi5lk1";
-      name = "networkmanager-qt-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/networkmanager-qt-5.57.0.tar.xz";
+      sha256 = "4d2da2556bfeef4be03833d707284573b469a1f6ad66ba73eae80835bd2e1982";
+      name = "networkmanager-qt-5.57.0.tar.xz";
     };
   };
   oxygen-icons5 = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/oxygen-icons5-5.56.0.tar.xz";
-      sha256 = "17cjcfmc8vywh8n2ck0s3b0i88ilamdah0gipicn7vj65l4wc1qb";
-      name = "oxygen-icons5-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/oxygen-icons5-5.57.0.tar.xz";
+      sha256 = "2b12a9de3767d233b4b01bc97e23899d94c02b13fee4d20483d3f5d2baaaa1e5";
+      name = "oxygen-icons5-5.57.0.tar.xz";
     };
   };
   plasma-framework = {
-    version = "5.56.1";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/plasma-framework-5.56.1.tar.xz";
-      sha256 = "0wn7q2cfrgzcprzgqj1d4calc0mmrrn615698fish7x9s1n7ag6w";
-      name = "plasma-framework-5.56.1.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/plasma-framework-5.57.0.tar.xz";
+      sha256 = "b886aeee6691911ead25e6fd5631fa41ce2330b0fbbdc040717fa576bacae2ca";
+      name = "plasma-framework-5.57.0.tar.xz";
     };
   };
   prison = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/prison-5.56.0.tar.xz";
-      sha256 = "05hy6fz05snpgjz6bnm3qcr7smg65a0m6rdmyv7avrpbs4qpbghx";
-      name = "prison-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/prison-5.57.0.tar.xz";
+      sha256 = "6613decb2e0b61af5af3a3a9995970c2fdaa72f36bcfd7e9db547017ee4ca235";
+      name = "prison-5.57.0.tar.xz";
     };
   };
   purpose = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/purpose-5.56.0.tar.xz";
-      sha256 = "0rvywfkhqbmd39g950mpnn35i3kg7j63ylvdy2px2d71am6acal8";
-      name = "purpose-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/purpose-5.57.0.tar.xz";
+      sha256 = "4b38f1b88e6e621bc20c04a5f7bc7293fba6c851209167c5e794b6becaea244e";
+      name = "purpose-5.57.0.tar.xz";
     };
   };
   qqc2-desktop-style = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/qqc2-desktop-style-5.56.0.tar.xz";
-      sha256 = "08afy1gsy0lvpzqmv5azzfiy5x9lvffsf6qvzxxab4v5ch8fn00b";
-      name = "qqc2-desktop-style-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/qqc2-desktop-style-5.57.0.tar.xz";
+      sha256 = "ff40fd6d48815c39e46e19eadf4048f04e79f34f7522a9ba655e6d4a1690546e";
+      name = "qqc2-desktop-style-5.57.0.tar.xz";
     };
   };
   solid = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/solid-5.56.0.tar.xz";
-      sha256 = "17kfwj0y41pkd0kxj2fj9m9qs7bq05vka9ngfr022lfwdhs907c4";
-      name = "solid-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/solid-5.57.0.tar.xz";
+      sha256 = "fbdb0678a5a1b9f902661b4823dbae4629a88708b729d827dd0598799f727209";
+      name = "solid-5.57.0.tar.xz";
     };
   };
   sonnet = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/sonnet-5.56.0.tar.xz";
-      sha256 = "0r8bsf7a9rjvv4jirycwf3xvkqa9iax23p93m301x82hdvmkjr9w";
-      name = "sonnet-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/sonnet-5.57.0.tar.xz";
+      sha256 = "08e13a707b64055f512bba982ec5e69a9e7c62c02d1ee8b6fdc67c67b1265334";
+      name = "sonnet-5.57.0.tar.xz";
     };
   };
   syndication = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/syndication-5.56.0.tar.xz";
-      sha256 = "0wnrhfp5b4wgmigqh39c0f2qfblgmc3x6018b4wcayfs8gb4m1q9";
-      name = "syndication-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/syndication-5.57.0.tar.xz";
+      sha256 = "251b2333bd3e49f833ef5ac12e0d2540a7640c84625090a85d99715927653728";
+      name = "syndication-5.57.0.tar.xz";
     };
   };
   syntax-highlighting = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/syntax-highlighting-5.56.0.tar.xz";
-      sha256 = "0gl0v1bscqd6xhl3644wix8ix04lax0h1zzr1v65704c4qp87h8l";
-      name = "syntax-highlighting-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/syntax-highlighting-5.57.0.tar.xz";
+      sha256 = "e82261e791005a55414fc81a396ca33ee8c061acd66c2c351492d866b3592e9f";
+      name = "syntax-highlighting-5.57.0.tar.xz";
     };
   };
   threadweaver = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/threadweaver-5.56.0.tar.xz";
-      sha256 = "1gyvj0v1zhfk8shi31pivvf5rwxkgv9bjmy2vippk2vxvkh0qc5x";
-      name = "threadweaver-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/threadweaver-5.57.0.tar.xz";
+      sha256 = "83969d0f6e4a337fba6b554708f867654af86368066ccef75a4fde85569d1ee0";
+      name = "threadweaver-5.57.0.tar.xz";
     };
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

https://kde.org/announcements/kde-frameworks-5.57.0.php

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---