### PR TITLE
boost: fix 1.55 build on macOS

### DIFF
--- a/pkgs/development/libraries/boost/darwin-1.55-no-system-python.patch
+++ b/pkgs/development/libraries/boost/darwin-1.55-no-system-python.patch
@@ -1,0 +1,45 @@
+diff --git a/tools/build/src/tools/python.jam b/tools/build/src/tools/python.jam
+index 273b28a..2d2031e 100644
+--- a/tools/build/v2/tools/python.jam
++++ b/tools/build/v2/tools/python.jam
+@@ -428,13 +428,7 @@ local rule windows-installed-pythons ( version ? )
+ 
+ local rule darwin-installed-pythons ( version ? )
+ {
+-    version ?= $(.version-countdown) ;
+-
+-    local prefix
+-      = [ GLOB /System/Library/Frameworks /Library/Frameworks
+-          : Python.framework ] ;
+-
+-    return $(prefix)/Versions/$(version)/bin/python ;
++    return ;
+ }
+ 
+ 
+@@ -890,25 +884,6 @@ local rule configure ( version ? : cmd-or-prefix ? : includes * : libraries ? :
+ 
+     # See if we can find a framework directory on darwin.
+     local framework-directory ;
+-    if $(target-os) = darwin
+-    {
+-        # Search upward for the framework directory.
+-        local framework-directory = $(libraries[-1]) ;
+-        while $(framework-directory:D=) && $(framework-directory:D=) != Python.framework
+-        {
+-            framework-directory = $(framework-directory:D) ;
+-        }
+-
+-        if $(framework-directory:D=) = Python.framework
+-        {
+-            debug-message framework directory is \"$(framework-directory)\" ;
+-        }
+-        else
+-        {
+-            debug-message "no framework directory found; using library path" ;
+-            framework-directory = ;
+-        }
+-    }
+ 
+     local dll-path = $(libraries) ;
+ 

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -104,7 +104,10 @@ stdenv.mkDerivation {
   patchFlags = "";
 
   patches = patches
-    ++ optional stdenv.isDarwin ./darwin-no-system-python.patch;
+  ++ optional stdenv.isDarwin (
+    if version == "1.55.0"
+    then ./darwin-1.55-no-system-python.patch
+    else ./darwin-no-system-python.patch);
 
   meta = {
     homepage = http://boost.org/;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Motivation for this change

darwin-no-system-python.patch does not apply cleany on Boost 1.55's sources. Fix this patch file for Boost 1.55, making it build on Darwin.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
