### PR TITLE
nixos/less: add configuration assertions

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1909.xml
+++ b/nixos/doc/manual/release-notes/rl-1909.xml
@@ -117,6 +117,17 @@
       The same applies to ModemManager where modem-manager.service is now called ModemManager.service again.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     If <xref linkend="opt-programs.less.configFile" /> is not <literal>null</literal>, and at
+     least one of <xref linkend="opt-programs.less.commands" />,
+     <xref linkend="opt-programs.less.clearDefaultCommands" />,
+     <xref linkend="opt-programs.less.lineEditingKeys" /> or
+     <xref linkend="opt-programs.less.envVariables" />
+     is set, an assertion error will be thrown. Previously
+     <xref linkend="opt-programs.less.configFile" /> took silently precedence over the four options.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/nixos/modules/programs/less.nix
+++ b/nixos/modules/programs/less.nix
@@ -43,10 +43,6 @@ in
         example = literalExample "$${pkgs.my-configs}/lesskey";
         description = ''
           Path to lesskey configuration file.
-
-          <option>configFile</option> takes precedence over <option>commands</option>,
-          <option>clearDefaultCommands</option>, <option>lineEditingKeys</option>, and
-          <option>envVariables</option>.
         '';
       };
 
@@ -107,6 +103,37 @@ in
   };
 
   config = mkIf cfg.enable {
+
+    assertions = [
+      { assertion = cfg.configFile != null -> cfg.commands == {};
+        message = ''
+          config.programs.less.configFile is assigned and
+          config.programs.less.commands is not empty.
+          Only one of these options should be configured.
+        '';
+      }
+      { assertion = cfg.configFile != null -> !cfg.clearDefaultCommands;
+        message = ''
+          config.programs.less.configFile is assigned and
+          config.programs.less.clearDefaultCommands is true.
+          Only one of these options should be configured.
+        '';
+      }
+      { assertion = cfg.configFile != null -> cfg.lineEditingKeys == {};
+        message = ''
+          config.programs.less.configFile is assigned and
+          config.programs.less.lineEditingKeys is not empty.
+          Only one of these options should be configured.
+        '';
+      }
+      { assertion = cfg.configFile != null -> cfg.envVariables == {};
+        message = ''
+          config.programs.less.configFile is assigned and
+          config.programs.less.envVariables is not empty.
+          Only one of these options should be configured.
+        '';
+      }
+    ];
 
     environment.systemPackages = [ pkgs.less ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Instead of silently overriding values the user has configured for `commands`, `clearDefaultCommands`, `lineEditingKeys`, or `envVariables`, prevent the system from building a conflicted configuration and tell the user what's causing the conflict.

Addresses https://github.com/NixOS/nixpkgs/pull/38629#commitcomment-33066989

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
