### PR TITLE
mautrix-telegram: patch away alembic dependency

### DIFF
--- a/pkgs/servers/mautrix-telegram/default.nix
+++ b/pkgs/servers/mautrix-telegram/default.nix
@@ -1,4 +1,4 @@
-{ lib, python3 }:
+{ lib, python3, mautrix-telegram }:
 
 with python3.pkgs;
 
@@ -11,11 +11,15 @@ buildPythonPackage rec {
     sha256 = "51951845e52c4ca5410e0f4a51d99014dd6df2fcedfca8b7241e045359cbf112";
   };
 
+  postPatch = ''
+    sed -i -e '/alembic>/d' setup.py
+  '';
+
   propagatedBuildInputs = [
+    Mako
     aiohttp
     mautrix-appservice
     sqlalchemy
-    alembic
     CommonMark
     ruamel_yaml
     future-fstrings
@@ -25,6 +29,18 @@ buildPythonPackage rec {
     pillow
     lxml
   ];
+
+  # `alembic` (a database migration tool) is only needed for the initial setup,
+  # and not needed during the actual runtime. However `alembic` requires `mautrix-telegram`
+  # in its environment to create a database schema from all models.
+  #
+  # Hence we need to patch away `alembic` from `mautrix-telegram` and create an `alembic`
+  # which has `mautrix-telegram` in its environment.
+  passthru.alembic = alembic.overrideAttrs (old: {
+    propagatedBuildInputs = old.propagatedBuildInputs ++ [
+      mautrix-telegram
+    ];
+  });
 
   checkInputs = [
     pytest
@@ -37,6 +53,6 @@ buildPythonPackage rec {
     homepage = https://github.com/tulir/mautrix-telegram;
     description = "A Matrix-Telegram hybrid puppeting/relaybot bridge";
     license = licenses.agpl3Plus;
-    maintainers = with maintainers; [ nyanloutre ];
+    maintainers = with maintainers; [ nyanloutre ma27 ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3908,7 +3908,7 @@ in
 
   matrix-synapse = callPackage ../servers/matrix-synapse { };
 
-  mautrix-telegram = callPackage ../servers/mautrix-telegram { };
+  mautrix-telegram = recurseIntoAttrs (callPackage ../servers/mautrix-telegram { });
 
   mautrix-whatsapp = callPackage ../servers/mautrix-whatsapp { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

`alembic`[1] is a database migration tool which is invoked from the CLI
when installing the telegram bridge, but never needed during the
runtime.

The reason why `alembic` is required here is to ensure that it
exists in the Python environment when deploying the bridge. However
`alembic` requires `mautrix-telegram` in its environment to create a
database schema from the Python models.

Such a dependency relation may be possible with tools like virtualenv,
however it'll result in an infinite recursion at evaluation time in Nix.

With this patch, `mautrix-telegram` doesn't depend on `alembic` anymore
and provides a patched alembic (`pkgs.mautrix-telegram.alembic`) which
has `mautrix-telegram` in its path.

[1] https://alembic.sqlalchemy.org/en/latest/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
