### PR TITLE
roccat-tools fix wrong -DLIBDIR

### DIFF
--- a/pkgs/os-specific/linux/roccat-tools/default.nix
+++ b/pkgs/os-specific/linux/roccat-tools/default.nix
@@ -26,10 +26,10 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   cmakeFlags = [
-    "-DUDEVDIR=\${out}/lib/udev/rules.d"
+    "-DUDEVDIR=${placeholder "out"}/lib/udev/rules.d"
     "-DCMAKE_MODULE_PATH=${libgaminggear.dev}/lib/cmake"
     "-DWITH_LUA=${lua.luaversion}"
-    "-DLIBDIR=lib"
+    "-DLIBDIR=${placeholder "out"}/lib"
   ];
 
   meta = {


### PR DESCRIPTION
fix wrong -DLIBDIR to include nix store path, and find the missing libs. without this, roccateventhandler doesn't detect devices properly ( and doesn't create device dbus methods ).
also replace \${out} on -DUDEVDIR with proper ${placeholder "out"}

tested these changes locally and fixed roccat-tools that weren't working with my roccat keyboard and mouse

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
