### PR TITLE
torcs: add musicplayer.patch

### DIFF
--- a/pkgs/games/torcs/default.nix
+++ b/pkgs/games/torcs/default.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation rec {
       url = "https://salsa.debian.org/games-team/torcs/raw/master/debian/patches/glibc-default-source.patch";
       sha256 = "0k4hgpddnhv68mdc9ics7ah8q54j60g394d7zmcmzg6l3bjd9pyp";
     })
+    ./musicplayer.patch
   ];
 
   postPatch = ''

--- a/pkgs/games/torcs/musicplayer.patch
+++ b/pkgs/games/torcs/musicplayer.patch
@@ -1,0 +1,11 @@
+--- a/src/libs/musicplayer/OpenALMusicPlayer.cpp	2019-04-15 00:11:33.924726111 +0200
++++ b/src/libs/musicplayer/OpenALMusicPlayer.cpp	2019-04-15 00:11:28.165715604 +0200
+@@ -161,7 +161,7 @@
+ {
+ 	char pcm[BUFFERSIZE];
+ 	int size = 0;
+-	const char* error = '\0';
++	const char* error = "";
+ 	
+ 	if (!stream->read(pcm, BUFFERSIZE, &size, &error)) {
+ 		GfError("OpenALMusicPlayer: Stream read error: %s\n", error);


### PR DESCRIPTION
Unbreaks build of torcs.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
