### PR TITLE
treewide: update homepages to https where available

### DIFF
--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio1.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio1.nix
@@ -90,7 +90,7 @@ stdenv.mkDerivation rec {
       production, performance and DJing, with a focus on flexible
       editing tools and a super-fast workflow.
     '';
-    homepage = http://www.bitwig.com/;
+    homepage = https://www.bitwig.com/;
     license = licenses.unfree;
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ michalrus mrVanDalo ];

--- a/pkgs/applications/audio/lsp-plugins/default.nix
+++ b/pkgs/applications/audio/lsp-plugins/default.nix
@@ -152,7 +152,7 @@ stdenv.mkDerivation rec {
         - Delay Compensator Stereo - Verzögerungsausgleicher Stereo
         - Delay Compensator x2 Stereo - Verzögerungsausgleicher x2 Stereo
       '';
-      homepage = http://lsp-plug.in;
+      homepage = https://lsp-plug.in;
       maintainers = with maintainers; [ magnetophon ];
       license = licenses.gpl2;
       platforms = platforms.linux;

--- a/pkgs/applications/graphics/jbrout/default.nix
+++ b/pkgs/applications/graphics/jbrout/default.nix
@@ -34,7 +34,7 @@ in pythonPackages.buildPythonApplication rec {
   propagatedBuildInputs = with pythonPackages; [ pillow lxml pyGtkGlade pyexiv2 fbida ];
 
   meta = {
-    homepage = http://manatlan.com/jbrout/;
+    homepage = https://manatlan.com/jbrout/;
     description = "Photo manager";
     platforms = stdenv.lib.platforms.linux;
     license = stdenv.lib.licenses.gpl2Plus;

--- a/pkgs/applications/graphics/jpegoptim/default.nix
+++ b/pkgs/applications/graphics/jpegoptim/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Optimize JPEG files";
-    homepage = http://www.kokkonen.net/tjko/projects.html ;
+    homepage = https://www.kokkonen.net/tjko/projects.html ;
     license = licenses.gpl2;
     maintainers = [ maintainers.aristid ];
     platforms = platforms.all;

--- a/pkgs/applications/misc/asciiquarium/default.nix
+++ b/pkgs/applications/misc/asciiquarium/default.nix
@@ -21,7 +21,7 @@ in stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "Enjoy the mysteries of the sea from the safety of your own terminal!";
-    homepage = https://robobunny.com/projects/asciiquarium/html;
+    homepage = https://robobunny.com/projects/asciiquarium/html/;
     license = licenses.gpl2;
     platforms = platforms.unix;
     maintainers = [ maintainers.utdemir ];

--- a/pkgs/applications/misc/kiwix/default.nix
+++ b/pkgs/applications/misc/kiwix/default.nix
@@ -99,7 +99,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "An offline reader for Web content";
-    homepage = http://kiwix.org;
+    homepage = https://kiwix.org;
     license = licenses.gpl3;
     platforms = platforms.linux;
     maintainers = with maintainers; [ robbinch ];

--- a/pkgs/applications/misc/navit/default.nix
+++ b/pkgs/applications/misc/navit/default.nix
@@ -81,7 +81,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://www.navit-project.org;
+    homepage = https://www.navit-project.org;
     description = "Car navigation system with routing engine using OSM maps";
     license = licenses.gpl2;
     maintainers = [ maintainers.genesis ];

--- a/pkgs/applications/networking/browsers/opera/default.nix
+++ b/pkgs/applications/networking/browsers/opera/default.nix
@@ -117,7 +117,7 @@ in stdenv.mkDerivation {
   '';
 
   meta = {
-    homepage = http://www.opera.com;
+    homepage = https://www.opera.com;
     description = "Web browser";
     platforms = [ "x86_64-linux" ];
     license = stdenv.lib.licenses.unfree;

--- a/pkgs/applications/networking/remote/anydesk/default.nix
+++ b/pkgs/applications/networking/remote/anydesk/default.nix
@@ -72,7 +72,7 @@ in stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     inherit description;
-    homepage = http://www.anydesk.com;
+    homepage = https://www.anydesk.com;
     license = licenses.unfree;
     platforms = platforms.linux;
     maintainers = with maintainers; [ peterhoeg ];

--- a/pkgs/applications/office/ledger/2.6.3.nix
+++ b/pkgs/applications/office/ledger/2.6.3.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   dontPatchELF = true;
 
   meta = {
-    homepage = http://ledger-cli.org/;
+    homepage = https://ledger-cli.org/;
     description = "A double-entry accounting system with a command-line reporting interface";
     license = "BSD";
 

--- a/pkgs/applications/office/mendeley/default.nix
+++ b/pkgs/applications/office/mendeley/default.nix
@@ -134,7 +134,7 @@ stdenv.mkDerivation {
   updateScript = import ./update.nix { inherit stdenv writeScript runtimeShell; };
 
   meta = with stdenv.lib; {
-    homepage = http://www.mendeley.com;
+    homepage = https://www.mendeley.com;
     description = "A reference manager and academic social network";
     license = licenses.unfree;
     platforms = [ "x86_64-linux" "i686-linux" ];

--- a/pkgs/applications/science/electronics/librepcb/default.nix
+++ b/pkgs/applications/science/electronics/librepcb/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A free EDA software to develop printed circuit boards";
-    homepage = http://librepcb.org/;
+    homepage = https://librepcb.org/;
     maintainers = with maintainers; [ luz ];
     license = licenses.gpl3;
     platforms = platforms.linux;

--- a/pkgs/applications/science/misc/boinc/default.nix
+++ b/pkgs/applications/science/misc/boinc/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Free software for distributed and grid computing";
-    homepage = http://boinc.berkeley.edu/;
+    homepage = https://boinc.berkeley.edu/;
     license = stdenv.lib.licenses.lgpl2Plus;
     platforms = stdenv.lib.platforms.linux;  # arbitrary choice
   };

--- a/pkgs/data/fonts/ankacoder/default.nix
+++ b/pkgs/data/fonts/ankacoder/default.nix
@@ -21,4 +21,3 @@ fetchzip rec {
     platforms = platforms.all;
   };
 }
-

--- a/pkgs/data/misc/ddccontrol-db/default.nix
+++ b/pkgs/data/misc/ddccontrol-db/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "Monitor database for DDCcontrol";
-    homepage = http://github.com/ddccontrol/ddccontrol-db;
+    homepage = https://github.com/ddccontrol/ddccontrol-db;
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = [ stdenv.lib.maintainers.pakhfn ];

--- a/pkgs/desktops/mate/atril/default.nix
+++ b/pkgs/desktops/mate/atril/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A simple multi-page document viewer for the MATE desktop";
-    homepage = http://mate-desktop.org;
+    homepage = https://mate-desktop.org;
     license = stdenv.lib.licenses.gpl2;
     platforms = stdenv.lib.platforms.unix;
   };

--- a/pkgs/desktops/mate/caja-extensions/default.nix
+++ b/pkgs/desktops/mate/caja-extensions/default.nix
@@ -29,12 +29,12 @@ stdenv.mkDerivation rec {
       substituteInPlace $f --replace "/usr/bin/convert" "${imagemagick}/bin/convert"
     done
   '';
-  
+
   configureFlags = [ "--with-cajadir=$$out/lib/caja/extensions-2.0" ];
 
   meta = with stdenv.lib; {
     description = "Set of extensions for Caja file manager";
-    homepage = http://mate-desktop.org;
+    homepage = https://mate-desktop.org;
     license = licenses.gpl2;
     platforms = platforms.unix;
     maintainers = [ maintainers.romildo ];

--- a/pkgs/desktops/mate/caja/default.nix
+++ b/pkgs/desktops/mate/caja/default.nix
@@ -28,12 +28,12 @@ stdenv.mkDerivation rec {
   patches = [
     ./caja-extension-dirs.patch
   ];
-  
+
   configureFlags = [ "--disable-update-mimedb" ];
-  
+
   meta = {
     description = "File manager for the MATE desktop";
-    homepage = http://mate-desktop.org;
+    homepage = https://mate-desktop.org;
     license = with stdenv.lib.licenses; [ gpl2 lgpl2 ];
     platforms = stdenv.lib.platforms.unix;
     maintainers = [ stdenv.lib.maintainers.romildo ];

--- a/pkgs/desktops/mate/engrampa/default.nix
+++ b/pkgs/desktops/mate/engrampa/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Archive Manager for MATE";
-    homepage = http://mate-desktop.org;
+    homepage = https://mate-desktop.org;
     license = stdenv.lib.licenses.gpl2;
     platforms = stdenv.lib.platforms.unix;
     maintainers = [ stdenv.lib.maintainers.romildo ];

--- a/pkgs/desktops/mate/eom/default.nix
+++ b/pkgs/desktops/mate/eom/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "An image viewing and cataloging program for the MATE desktop";
-    homepage = http://mate-desktop.org;
+    homepage = https://mate-desktop.org;
     license = stdenv.lib.licenses.gpl2;
     platforms = stdenv.lib.platforms.unix;
     maintainers = [ stdenv.lib.maintainers.romildo ];

--- a/pkgs/desktops/mate/mate-applets/default.nix
+++ b/pkgs/desktops/mate/mate-applets/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Applets for use with the MATE panel";
-    homepage = http://mate-desktop.org;
+    homepage = https://mate-desktop.org;
     license = with licenses; [ gpl2Plus lgpl2Plus ];
     platforms = platforms.linux;
     maintainers = [ maintainers.romildo ];

--- a/pkgs/desktops/mate/mate-backgrounds/default.nix
+++ b/pkgs/desktops/mate/mate-backgrounds/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Background images and data for MATE";
-    homepage = http://mate-desktop.org;
+    homepage = https://mate-desktop.org;
     license = licenses.gpl2;
     platforms = platforms.unix;
     maintainers = [ maintainers.romildo ];

--- a/pkgs/desktops/mate/mate-calc/default.nix
+++ b/pkgs/desktops/mate/mate-calc/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Calculator for the MATE desktop";
-    homepage = http://mate-desktop.org;
+    homepage = https://mate-desktop.org;
     license = [ licenses.gpl2Plus ];
     platforms = platforms.linux;
     maintainers = [ maintainers.romildo ];

--- a/pkgs/desktops/mate/mate-common/default.nix
+++ b/pkgs/desktops/mate/mate-common/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Common files for development of MATE packages";
-    homepage = http://mate-desktop.org;
+    homepage = https://mate-desktop.org;
     license = stdenv.lib.licenses.gpl3;
     platforms = stdenv.lib.platforms.unix;
     maintainers = [ stdenv.lib.maintainers.romildo ];

--- a/pkgs/desktops/mate/mate-desktop/default.nix
+++ b/pkgs/desktops/mate/mate-desktop/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Library with common API for various MATE modules";
-    homepage = http://mate-desktop.org;
+    homepage = https://mate-desktop.org;
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = [ maintainers.romildo ];

--- a/pkgs/desktops/mate/mate-icon-theme-faenza/default.nix
+++ b/pkgs/desktops/mate/mate-icon-theme-faenza/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Faenza icon theme from MATE";
-    homepage = http://mate-desktop.org;
+    homepage = https://mate-desktop.org;
     license = stdenv.lib.licenses.gpl2;
     platforms = stdenv.lib.platforms.unix;
     maintainers = [ stdenv.lib.maintainers.romildo ];

--- a/pkgs/desktops/mate/mate-icon-theme/default.nix
+++ b/pkgs/desktops/mate/mate-icon-theme/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Icon themes from MATE";
-    homepage = http://mate-desktop.org;
+    homepage = https://mate-desktop.org;
     license = stdenv.lib.licenses.lgpl3;
     platforms = stdenv.lib.platforms.linux;
     maintainers = [ stdenv.lib.maintainers.romildo ];

--- a/pkgs/desktops/mate/mate-media/default.nix
+++ b/pkgs/desktops/mate/mate-media/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Media tools for MATE";
-    homepage = http://mate-desktop.org;
+    homepage = https://mate-desktop.org;
     license = licenses.gpl3;
     platforms = platforms.unix;
     maintainers = [ maintainers.romildo maintainers.chpatrick ];

--- a/pkgs/desktops/mate/mate-netbook/default.nix
+++ b/pkgs/desktops/mate/mate-netbook/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
       Installing these utilities is recommended for netbooks and similar
       devices with low resolution displays.
     '';
-    homepage = http://mate-desktop.org;
+    homepage = https://mate-desktop.org;
     license = with licenses; [ gpl3 lgpl2Plus ];
     platforms = platforms.unix;
     maintainers = [ maintainers.romildo ];

--- a/pkgs/desktops/mate/mate-polkit/default.nix
+++ b/pkgs/desktops/mate/mate-polkit/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Integrates polkit authentication for MATE desktop";
-    homepage = http://mate-desktop.org;
+    homepage = https://mate-desktop.org;
     license = [ licenses.gpl2Plus ];
     platforms = platforms.unix;
     maintainers = [ maintainers.romildo ];

--- a/pkgs/desktops/mate/mate-power-manager/default.nix
+++ b/pkgs/desktops/mate/mate-power-manager/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "The MATE Power Manager";
-    homepage = http://mate-desktop.org;
+    homepage = https://mate-desktop.org;
     license = licenses.gpl3;
     platforms = platforms.unix;
     maintainers = [ maintainers.romildo maintainers.chpatrick ];

--- a/pkgs/desktops/mate/mate-screensaver/default.nix
+++ b/pkgs/desktops/mate/mate-screensaver/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Screen saver and locker for the MATE desktop";
-    homepage = http://mate-desktop.org;
+    homepage = https://mate-desktop.org;
     license = with licenses; [ gpl2Plus lgpl2Plus ];
     platforms = platforms.unix;
     maintainers = [ maintainers.romildo ];

--- a/pkgs/desktops/mate/mate-system-monitor/default.nix
+++ b/pkgs/desktops/mate/mate-system-monitor/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "System monitor for the MATE desktop";
-    homepage = http://mate-desktop.org;
+    homepage = https://mate-desktop.org;
     license = [ licenses.gpl2Plus ];
     platforms = platforms.unix;
     maintainers = [ maintainers.romildo ];

--- a/pkgs/desktops/mate/mate-terminal/default.nix
+++ b/pkgs/desktops/mate/mate-terminal/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "The MATE Terminal Emulator";
-    homepage = http://mate-desktop.org;
+    homepage = https://mate-desktop.org;
     license = licenses.gpl3;
     platforms = platforms.unix;
   };

--- a/pkgs/desktops/mate/mate-themes/default.nix
+++ b/pkgs/desktops/mate/mate-themes/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A set of themes from MATE";
-    homepage = http://mate-desktop.org;
+    homepage = https://mate-desktop.org;
     license = stdenv.lib.licenses.lgpl21;
     platforms = stdenv.lib.platforms.unix;
     maintainers = [ stdenv.lib.maintainers.romildo ];

--- a/pkgs/desktops/mate/mate-user-guide/default.nix
+++ b/pkgs/desktops/mate/mate-user-guide/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "MATE User Guide";
-    homepage = http://mate-desktop.org;
+    homepage = https://mate-desktop.org;
     license = with licenses; [ gpl2Plus fdl12 ];
     platforms = platforms.unix;
     maintainers = [ maintainers.romildo ];

--- a/pkgs/desktops/mate/mate-utils/default.nix
+++ b/pkgs/desktops/mate/mate-utils/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Utilities for the MATE desktop";
-    homepage = http://mate-desktop.org;
+    homepage = https://mate-desktop.org;
     license = with licenses; [ gpl2Plus lgpl2Plus ];
     platforms = platforms.unix;
     maintainers = [ maintainers.romildo ];

--- a/pkgs/desktops/mate/pluma/default.nix
+++ b/pkgs/desktops/mate/pluma/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Powerful text editor for the MATE desktop";
-    homepage = http://mate-desktop.org;
+    homepage = https://mate-desktop.org;
     license = stdenv.lib.licenses.gpl2;
     platforms = stdenv.lib.platforms.unix;
     maintainers = [ stdenv.lib.maintainers.romildo ];

--- a/pkgs/desktops/xfce/applications/mousepad.nix
+++ b/pkgs/desktops/xfce/applications/mousepad.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://www.xfce.org/;
+    homepage = https://www.xfce.org/;
     description = "A simple text editor for Xfce";
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/desktops/xfce/applications/orage.nix
+++ b/pkgs/desktops/xfce/applications/orage.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     xfce.xfce4-panel ];
 
   meta = {
-    homepage = http://www.xfce.org/projects/;
+    homepage = https://www.xfce.org/projects/;
     description = "A simple calendar application with reminders";
     license = stdenv.lib.licenses.gpl2;
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/desktops/xfce/applications/terminal.nix
+++ b/pkgs/desktops/xfce/applications/terminal.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ intltool exo gtk vte libxfce4util ncurses dbus-glib libxfce4ui ];
 
   meta = {
-    homepage = http://www.xfce.org/projects/terminal;
+    homepage = https://www.xfce.org/projects/terminal;
     description = "A modern terminal emulator primarily for the Xfce desktop environment";
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/desktops/xfce/applications/xfce4-mixer.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-mixer.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
   passthru = { inherit gst_plugins; };
 
   meta = {
-    homepage = http://www.xfce.org/projects/xfce4-mixer; # referenced but inactive
+    homepage = https://www.xfce.org/projects/xfce4-mixer; # referenced but inactive
     description = "A volume control application for the Xfce desktop environment";
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/desktops/xfce/applications/xfce4-screenshooter.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-screenshooter.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = {
-    homepage = http://goodies.xfce.org/projects/applications/xfce4-screenshooter;
+    homepage = https://goodies.xfce.org/projects/applications/xfce4-screenshooter;
     description = "Xfce screenshooter";
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/desktops/xfce/applications/xfce4-volumed.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-volumed.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     '';
 
   meta = with stdenv.lib; {
-    homepage = http://www.xfce.org/projects/xfce4-volumed; # referenced but inactive
+    homepage = https://www.xfce.org/projects/xfce4-volumed; # referenced but inactive
     description = "A volume keys control daemon for the Xfce desktop environment";
     license = licenses.gpl3;
     platforms = platforms.linux;

--- a/pkgs/desktops/xfce/art/xfce4-icon-theme.nix
+++ b/pkgs/desktops/xfce/art/xfce4-icon-theme.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ intltool gtk2 ];
 
   meta = {
-    homepage = http://www.xfce.org/;
+    homepage = https://www.xfce.org/;
     description = "Icons for Xfce";
     platforms = stdenv.lib.platforms.linux;
     maintainers = [ stdenv.lib.maintainers.eelco ];

--- a/pkgs/desktops/xfce/art/xfwm4-themes.nix
+++ b/pkgs/desktops/xfce/art/xfwm4-themes.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   name = "${p_name}-${ver_maj}.${ver_min}";
 
   meta = with stdenv.lib; {
-    homepage = http://www.xfce.org/;
+    homepage = https://www.xfce.org/;
     description = "Themes for Xfce";
     license = licenses.gpl3;
     platforms = platforms.linux;

--- a/pkgs/desktops/xfce/core/garcon.nix
+++ b/pkgs/desktops/xfce/core/garcon.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ intltool glib libxfce4util gtk libxfce4ui ];
 
   meta = with stdenv.lib; {
-    homepage = http://www.xfce.org/;
+    homepage = https://www.xfce.org/;
     description = "Xfce menu support library";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/desktops/xfce/core/gtk-xfce-engine.nix
+++ b/pkgs/desktops/xfce/core/gtk-xfce-engine.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   configureFlags = stdenv.lib.optional withGtk3 "--enable-gtk3";
 
   meta = {
-    homepage = http://www.xfce.org/;
+    homepage = https://www.xfce.org/;
     description = "GTK+ theme engine for Xfce";
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/desktops/xfce/core/libxfce4ui.nix
+++ b/pkgs/desktops/xfce/core/libxfce4ui.nix
@@ -33,10 +33,9 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
-    homepage = http://www.xfce.org/;
+    homepage = https://www.xfce.org/;
     description = "Basic GUI library for Xfce";
     license = licenses.lgpl2Plus;
     platforms = platforms.linux;
   };
 }
-

--- a/pkgs/desktops/xfce/core/libxfce4util.nix
+++ b/pkgs/desktops/xfce/core/libxfce4util.nix
@@ -18,10 +18,9 @@ stdenv.mkDerivation rec {
   buildInputs = [ glib intltool ];
 
   meta = {
-    homepage = http://www.xfce.org/;
+    homepage = https://www.xfce.org/;
     description = "Basic utility non-GUI functions for Xfce";
     license = "bsd";
     platforms = stdenv.lib.platforms.linux;
   };
 }
-

--- a/pkgs/desktops/xfce/core/libxfcegui4.nix
+++ b/pkgs/desktops/xfce/core/libxfcegui4.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     ];
 
   meta = {
-    homepage = http://www.xfce.org/;
+    homepage = https://www.xfce.org/;
     description = "Basic GUI library for Xfce";
     license = stdenv.lib.licenses.lgpl2Plus;
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/desktops/xfce/core/thunar-volman.nix
+++ b/pkgs/desktops/xfce/core/thunar-volman.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = {
-    homepage = http://goodies.xfce.org/projects/thunar-plugins/thunar-volman;
+    homepage = https://goodies.xfce.org/projects/thunar-plugins/thunar-volman;
     description = "Thunar extension for automatic management of removable drives and media";
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/desktops/xfce/core/xfce4-panel.nix
+++ b/pkgs/desktops/xfce/core/xfce4-panel.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
-    homepage = http://www.xfce.org/projects/xfce4-panel;
+    homepage = https://www.xfce.org/projects/xfce4-panel;
     description = "Xfce panel";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/desktops/xfce/core/xfce4-power-manager.nix
+++ b/pkgs/desktops/xfce/core/xfce4-power-manager.nix
@@ -35,11 +35,10 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://goodies.xfce.org/projects/applications/xfce4-power-manager;
+    homepage = https://goodies.xfce.org/projects/applications/xfce4-power-manager;
     description = "A power manager for the Xfce Desktop Environment";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = [ maintainers.eelco ];
   };
 }
-

--- a/pkgs/desktops/xfce/core/xfce4-session.nix
+++ b/pkgs/desktops/xfce/core/xfce4-session.nix
@@ -35,11 +35,10 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--with-xsession-prefix=$(out)" ];
 
   meta = with stdenv.lib; {
-    homepage = http://www.xfce.org/projects/xfce4-session;
+    homepage = https://www.xfce.org/projects/xfce4-session;
     description = "Session manager for Xfce";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = [ maintainers.eelco ];
   };
 }
-

--- a/pkgs/desktops/xfce/core/xfce4-settings.nix
+++ b/pkgs/desktops/xfce/core/xfce4-settings.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
-    homepage = http://www.xfce.org/projects/xfce4-settings;
+    homepage = https://www.xfce.org/projects/xfce4-settings;
     description = "Settings manager for Xfce";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/desktops/xfce/core/xfdesktop.nix
+++ b/pkgs/desktops/xfce/core/xfdesktop.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
-    homepage = http://www.xfce.org/projects/xfdesktop;
+    homepage = https://www.xfce.org/projects/xfdesktop;
     description = "Xfce desktop manager";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/desktops/xfce/core/xfwm4.nix
+++ b/pkgs/desktops/xfce/core/xfwm4.nix
@@ -22,11 +22,10 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
-    homepage = http://www.xfce.org/projects/xfwm4;
+    homepage = https://www.xfce.org/projects/xfwm4;
     description = "Window manager for Xfce";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = [ maintainers.eelco ];
   };
 }
-

--- a/pkgs/development/compilers/bupc/default.nix
+++ b/pkgs/development/compilers/bupc/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
       parallelism is fixed at program startup time, typically with a single
       thread of execution per processor.
     '';
-    homepage = http://upc.lbl.gov/;
+    homepage = https://upc.lbl.gov/;
     license = licenses.mit;
     platforms = with platforms; [ linux ];
     maintainers = with maintainers; [ zimbatm ];

--- a/pkgs/development/compilers/cmdstan/default.nix
+++ b/pkgs/development/compilers/cmdstan/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
       inference with Variational inference (ADVI) and penalized maximum
       likelihood estimation with Optimization (L-BFGS).
     '';
-    homepage = http://mc-stan.org/interfaces/cmdstan.html;
+    homepage = https://mc-stan.org/interfaces/cmdstan.html;
     license = stdenv.lib.licenses.bsd3;
     platforms = stdenv.lib.platforms.all;
   };

--- a/pkgs/development/compilers/ghcjs-ng/8.4/stage0.nix
+++ b/pkgs/development/compilers/ghcjs-ng/8.4/stage0.nix
@@ -107,7 +107,7 @@
         base binary bytestring containers ghc-prim ghci-ghcjs
         template-haskell-ghcjs
       ];
-      homepage = "http://github.com/ghcjs";
+      homepage = "https://github.com/ghcjs";
       license = stdenv.lib.licenses.mit;
     }) {};
 

--- a/pkgs/development/compilers/ghcjs-ng/8.6/stage0.nix
+++ b/pkgs/development/compilers/ghcjs-ng/8.6/stage0.nix
@@ -107,7 +107,7 @@
         base binary bytestring containers ghc-prim ghci-ghcjs
         template-haskell-ghcjs
       ];
-      homepage = "http://github.com/ghcjs";
+      homepage = "https://github.com/ghcjs";
       license = stdenv.lib.licenses.mit;
     }) {};
 

--- a/pkgs/development/compilers/javacard-devkit/default.nix
+++ b/pkgs/development/compilers/javacard-devkit/default.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
           converter -applet [AppletAID] [MyApplet] [myPackage] [PackageAID] [Version]
       For more details, please refer to the documentation by Oracle
     '';
-    homepage = http://www.oracle.com/technetwork/java/embedded/javacard/overview/index.html;
+    homepage = https://www.oracle.com/technetwork/java/embedded/javacard/overview/index.html;
     license = stdenv.lib.licenses.unfree;
     maintainers = [ stdenv.lib.maintainers.ekleog ];
     platforms = [ "i686-linux" "x86_64-linux" ];

--- a/pkgs/development/compilers/kotlin/default.nix
+++ b/pkgs/development/compilers/kotlin/default.nix
@@ -37,7 +37,7 @@ in stdenv.mkDerivation rec {
       It is developed by a team at JetBrains although it is an OSS language
       and has external contributors.
     '';
-    homepage = http://kotlinlang.org/;
+    homepage = https://kotlinlang.org/;
     license = stdenv.lib.licenses.asl20;
     maintainers = with stdenv.lib.maintainers;
       [ nequissimus ];

--- a/pkgs/development/compilers/mono/generic.nix
+++ b/pkgs/development/compilers/mono/generic.nix
@@ -80,7 +80,7 @@ stdenv.mkDerivation rec {
   inherit enableParallelBuilding;
 
   meta = with stdenv.lib; {
-    homepage = http://mono-project.com/;
+    homepage = https://mono-project.com/;
     description = "Cross platform, open source .NET development framework";
     platforms = with platforms; darwin ++ linux;
     maintainers = with maintainers; [ thoughtpolice obadz vrthra ];

--- a/pkgs/development/compilers/mosml/default.nix
+++ b/pkgs/development/compilers/mosml/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
       Moscow ML is a light-weight implementation of Standard ML (SML), a strict
       functional language used in teaching and research.
     '';
-    homepage = http://mosml.org/;
+    homepage = https://mosml.org/;
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = with maintainers; [ vaibhavsagar ];

--- a/pkgs/development/interpreters/jython/default.nix
+++ b/pkgs/development/interpreters/jython/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Python interpreter written in Java";
-    homepage = http://jython.org/;
+    homepage = https://jython.org/;
     license = stdenv.lib.licenses.psfl;
     platforms = jre.meta.platforms;
   };

--- a/pkgs/development/interpreters/mujs/default.nix
+++ b/pkgs/development/interpreters/mujs/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   makeFlags = [ "prefix=$(out)" ];
 
   meta = with stdenv.lib; {
-    homepage = http://mujs.com/;
+    homepage = https://mujs.com/;
     description = "A lightweight, embeddable Javascript interpreter";
     platforms = platforms.unix;
     maintainers = with maintainers; [ pSub ];

--- a/pkgs/development/libraries/alure/default.nix
+++ b/pkgs/development/libraries/alure/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A utility library to help manage common tasks with OpenAL applications";
-    homepage = http://kcat.strangesoft.net/alure.html;
+    homepage = https://kcat.strangesoft.net/alure.html;
     license = licenses.mit;
     platforms = platforms.linux;
   };

--- a/pkgs/development/libraries/igraph/default.nix
+++ b/pkgs/development/libraries/igraph/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "The network analysis package";
-    homepage = http://igraph.org/;
+    homepage = https://igraph.org/;
     license = lib.licenses.gpl2;
     maintainers = [ lib.maintainers.MostAwesomeDude ];
   };

--- a/pkgs/development/libraries/indilib/default.nix
+++ b/pkgs/development/libraries/indilib/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
                             libnova libjpeg gsl ];
 
   meta = {
-    homepage = http://www.indilib.org/;
+    homepage = https://www.indilib.org/;
     license = stdenv.lib.licenses.lgpl2Plus;
     description = "Implementaion of the INDI protocol for POSIX operating systems";
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/development/libraries/java/jflex/default.nix
+++ b/pkgs/development/libraries/java/jflex/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://www.jflex.de/;
+    homepage = https://www.jflex.de/;
     description = "Lexical analyzer generator for Java, written in Java";
     license = stdenv.lib.licenses.bsd3;
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/development/libraries/lasso/default.nix
+++ b/pkgs/development/libraries/lasso/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://lasso.entrouvert.org/;
+    homepage = https://lasso.entrouvert.org/;
     description = "Liberty Alliance Single Sign-On library";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;

--- a/pkgs/development/libraries/libast/default.nix
+++ b/pkgs/development/libraries/libast/default.nix
@@ -14,10 +14,9 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Library of Assorted Spiffy Things";
-    homepage = http://www.eterm.org;
+    homepage = https://www.eterm.org;
     license = licenses.bsd2;
     maintainers = [ maintainers.AndersonTorres ];
     platforms = platforms.unix;
   };
 }
-

--- a/pkgs/development/libraries/libestr/default.nix
+++ b/pkgs/development/libraries/libestr/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with stdenv.lib; {
-    homepage = http://libestr.adiscon.com/;
+    homepage = https://libestr.adiscon.com/;
     description = "Some essentials for string handling";
     license = licenses.lgpl21;
     platforms = platforms.all;

--- a/pkgs/development/libraries/libgda/default.nix
+++ b/pkgs/development/libraries/libgda/default.nix
@@ -36,7 +36,7 @@ assert postgresSupport -> postgresql != null;
 
   meta = with stdenv.lib; {
     description = "Database access library";
-    homepage = http://www.gnome-db.org/;
+    homepage = https://www.gnome-db.org/;
     license = [ licenses.lgpl2 licenses.gpl2 ];
     maintainers = gnome3.maintainers;
     platforms = platforms.linux;

--- a/pkgs/development/libraries/libgdamm/default.nix
+++ b/pkgs/development/libraries/libgdamm/default.nix
@@ -31,7 +31,7 @@ in stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "C++ bindings for libgda";
-    homepage = http://www.gnome-db.org/;
+    homepage = https://www.gnome-db.org/;
     license = licenses.lgpl21Plus;
     maintainers = gnome3.maintainers;
     platforms = platforms.linux;

--- a/pkgs/development/libraries/libgpod/default.nix
+++ b/pkgs/development/libraries/libgpod/default.nix
@@ -30,7 +30,7 @@ in stdenv.mkDerivation rec {
     ++ lib.optionals monoSupport [ mono gtk-sharp-2_0 ];
 
   meta = {
-    homepage = http://gtkpod.sourceforge.net/;
+    homepage = https://gtkpod.sourceforge.net/;
     description = "Library used by gtkpod to access the contents of an ipod";
     license = "LGPL";
     platforms = stdenv.lib.platforms.gnu ++ stdenv.lib.platforms.linux;

--- a/pkgs/development/libraries/libiec61883/default.nix
+++ b/pkgs/development/libraries/libiec61883/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ libraw1394 ];
 
   meta = with stdenv.lib; {
-    homepage = http://www.linux1394.org;
+    homepage = https://www.linux1394.org;
     license = licenses.lgpl21Plus;
     platforms = platforms.linux;
   };

--- a/pkgs/development/libraries/liblognorm/default.nix
+++ b/pkgs/development/libraries/liblognorm/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--enable-regexp" ];
 
   meta = with stdenv.lib; {
-    homepage = http://www.liblognorm.com/;
+    homepage = https://www.liblognorm.com/;
     description = "Help to make sense out of syslog data, or, actually, any event data that is present in text form";
     license = licenses.lgpl21;
     platforms = platforms.all;

--- a/pkgs/development/libraries/libmemcached/default.nix
+++ b/pkgs/development/libraries/libmemcached/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   NIX_CFLAGS_COMPILE = [ "-fpermissive"/*gcc7*/ ];
 
   meta = with stdenv.lib; {
-    homepage = http://libmemcached.org;
+    homepage = https://libmemcached.org;
     description = "Open source C/C++ client library and tools for the memcached server";
     license = licenses.bsd3;
     platforms = platforms.linux ++ platforms.darwin;

--- a/pkgs/development/libraries/libmodbus/default.nix
+++ b/pkgs/development/libraries/libmodbus/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Library to send/receive data according to the Modbus protocol";
-    homepage = http://libmodbus.org/;
+    homepage = https://libmodbus.org/;
     license = licenses.lgpl21Plus;
     platforms = platforms.linux;
     maintainers = [ maintainers.bjornfor ];

--- a/pkgs/development/libraries/libpst/default.nix
+++ b/pkgs/development/libraries/libpst/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = with stdenv.lib; {
-    homepage = http://www.five-ten-sg.com/libpst/;
+    homepage = https://www.five-ten-sg.com/libpst/;
     description = "A library to read PST (MS Outlook Personal Folders) files";
     license = licenses.gpl2;
     maintainers = [maintainers.tohl];

--- a/pkgs/development/libraries/librelp/default.nix
+++ b/pkgs/development/libraries/librelp/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ gnutls zlib ];
 
   meta = with stdenv.lib; {
-    homepage = http://www.librelp.com/;
+    homepage = https://www.librelp.com/;
     description = "A reliable logging library";
     license = licenses.gpl2;
     platforms = platforms.linux;

--- a/pkgs/development/libraries/libxc/default.nix
+++ b/pkgs/development/libraries/libxc/default.nix
@@ -24,7 +24,7 @@ in stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "Library of exchange-correlation functionals for density-functional theory";
-    homepage = http://octopus-code.org/wiki/Libxc;
+    homepage = https://octopus-code.org/wiki/Libxc;
     license = licenses.lgpl3;
     platforms = [ "x86_64-linux" ];
     maintainers = with maintainers; [ markuskowa ];

--- a/pkgs/development/libraries/libxkbcommon/libxkbcommon_7.nix
+++ b/pkgs/development/libraries/libxkbcommon/libxkbcommon_7.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "A library to handle keyboard descriptions";
-    homepage = http://xkbcommon.org;
+    homepage = https://xkbcommon.org;
     license = licenses.mit;
     maintainers = with maintainers; [ garbas ttuegel ];
     platforms = with platforms; unix;

--- a/pkgs/development/libraries/mm-common/default.nix
+++ b/pkgs/development/libraries/mm-common/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
       control repository. An installation of mm-common is not required for
       building tarball releases, unless configured to use maintainer-mode.
     '';
-    homepage = http://www.gtkmm.org;
+    homepage = https://www.gtkmm.org;
     license = licenses.gpl2Plus;
     maintainers = gnome3.maintainers;
     platforms = platforms.linux;

--- a/pkgs/development/libraries/motif/default.nix
+++ b/pkgs/development/libraries/motif/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
             ];
 
   meta = with stdenv.lib; {
-    homepage = http://motif.ics.com;
+    homepage = https://motif.ics.com;
     description = "Unix standard widget-toolkit and window-manager";
     platforms = with platforms; linux ++ darwin;
     license = with licenses; [ lgpl21 ];

--- a/pkgs/development/libraries/opentracing-cpp/default.nix
+++ b/pkgs/development/libraries/opentracing-cpp/default.nix
@@ -12,10 +12,9 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "C++ implementation of the OpenTracing API";
-    homepage = http://opentracing.io;
+    homepage = https://opentracing.io;
     license = stdenv.lib.licenses.asl20;
     maintainers = with stdenv.lib.maintainers; [ rob ];
   };
 
 }
-

--- a/pkgs/development/libraries/physics/apfel/default.nix
+++ b/pkgs/development/libraries/physics/apfel/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "A PDF Evolution Library";
     license     = licenses.gpl3;
-    homepage    = http://apfel.mi.infn.it/;
+    homepage    = https://apfel.mi.infn.it/;
     platforms   = platforms.unix;
     maintainers = with maintainers; [ veprbl ];
   };

--- a/pkgs/development/libraries/science/math/openlibm/default.nix
+++ b/pkgs/development/libraries/science/math/openlibm/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "High quality system independent, portable, open source libm implementation";
-    homepage = http://www.openlibm.org/;
+    homepage = https://www.openlibm.org/;
     license = stdenv.lib.licenses.mit;
     maintainers = [ stdenv.lib.maintainers.ttuegel ];
     platforms = stdenv.lib.platforms.all;

--- a/pkgs/development/ocaml-modules/astring/default.nix
+++ b/pkgs/development/ocaml-modules/astring/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   inherit (topkg) buildPhase installPhase;
 
   meta = {
-    homepage = http://erratique.ch/software/astring;
+    homepage = https://erratique.ch/software/astring;
     description = "Alternative String module for OCaml";
     longDescription = ''
       Astring exposes an alternative String module for OCaml. This module tries

--- a/pkgs/development/ocaml-modules/bos/default.nix
+++ b/pkgs/development/ocaml-modules/bos/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
 	meta = {
 		description = "Basic OS interaction for OCaml";
-		homepage = http://erratique.ch/software/bos;
+		homepage = https://erratique.ch/software/bos;
 		license = stdenv.lib.licenses.isc;
 		maintainers = [ stdenv.lib.maintainers.vbgl ];
 		inherit (ocaml.meta) platforms;

--- a/pkgs/development/ocaml-modules/cmdliner/default.nix
+++ b/pkgs/development/ocaml-modules/cmdliner/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   inherit (topkg) buildPhase installPhase;
 
   meta = with stdenv.lib; {
-    homepage = http://erratique.ch/software/cmdliner;
+    homepage = https://erratique.ch/software/cmdliner;
     description = "An OCaml module for the declarative definition of command line interfaces";
     license = licenses.bsd3;
     platforms = ocaml.meta.platforms or [];

--- a/pkgs/development/ocaml-modules/fmt/default.nix
+++ b/pkgs/development/ocaml-modules/fmt/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   inherit (topkg) buildPhase installPhase;
 
   meta = {
-    homepage = http://erratique.ch/software/fmt;
+    homepage = https://erratique.ch/software/fmt;
     license = stdenv.lib.licenses.isc;
     description = "OCaml Format pretty-printer combinators";
     inherit (ocaml.meta) platforms;

--- a/pkgs/development/ocaml-modules/fpath/default.nix
+++ b/pkgs/development/ocaml-modules/fpath/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "An OCaml module for handling file system paths with POSIX and Windows conventions";
-    homepage = http://erratique.ch/software/fpath;
+    homepage = https://erratique.ch/software/fpath;
     license = stdenv.lib.licenses.isc;
     maintainers = [ stdenv.lib.maintainers.vbgl ];
     inherit (ocaml.meta) platforms;

--- a/pkgs/development/ocaml-modules/jsonm/default.nix
+++ b/pkgs/development/ocaml-modules/jsonm/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "An OCaml non-blocking streaming codec to decode and encode the JSON data format";
-    homepage = http://erratique.ch/software/jsonm;
+    homepage = https://erratique.ch/software/jsonm;
     license = stdenv.lib.licenses.bsd3;
     maintainers = with stdenv.lib.maintainers; [ vbgl ];
     platforms = ocaml.meta.platforms or [];

--- a/pkgs/development/ocaml-modules/mtime/default.nix
+++ b/pkgs/development/ocaml-modules/mtime/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Monotonic wall-clock time for OCaml";
-    homepage = http://erratique.ch/software/mtime;
+    homepage = https://erratique.ch/software/mtime;
     inherit (ocaml.meta) platforms;
     maintainers = [ maintainers.vbgl ];
     license = licenses.bsd3;

--- a/pkgs/development/ocaml-modules/ptime/default.nix
+++ b/pkgs/development/ocaml-modules/ptime/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   inherit (topkg) installPhase;
 
   meta = {
-    homepage = http://erratique.ch/software/ptime;
+    homepage = https://erratique.ch/software/ptime;
     description = "POSIX time for OCaml";
     longDescription = ''
       Ptime has platform independent POSIX time support in pure OCaml.

--- a/pkgs/development/ocaml-modules/react/default.nix
+++ b/pkgs/development/ocaml-modules/react/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
   inherit (topkg) buildPhase installPhase;
 
   meta = with stdenv.lib; {
-    homepage = http://erratique.ch/software/react;
+    homepage = https://erratique.ch/software/react;
     description = "Applicative events and signals for OCaml";
     license = licenses.bsd3;
     platforms = ocaml.meta.platforms or [];

--- a/pkgs/development/ocaml-modules/rresult/default.nix
+++ b/pkgs/development/ocaml-modules/rresult/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
 	meta = {
 		license = stdenv.lib.licenses.isc;
-		homepage = http://erratique.ch/software/rresult;
+		homepage = https://erratique.ch/software/rresult;
 		description = "Result value combinators for OCaml";
 		maintainers = [ stdenv.lib.maintainers.vbgl ];
 		inherit (ocaml.meta) platforms;

--- a/pkgs/development/ocaml-modules/topkg/default.nix
+++ b/pkgs/development/ocaml-modules/topkg/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
   passthru = { inherit run; };
 
   meta = {
-    homepage = http://erratique.ch/software/topkg;
+    homepage = https://erratique.ch/software/topkg;
     license = stdenv.lib.licenses.isc;
     maintainers = [ stdenv.lib.maintainers.vbgl ];
     description = "A packager for distributing OCaml software";

--- a/pkgs/development/ocaml-modules/uuidm/default.nix
+++ b/pkgs/development/ocaml-modules/uuidm/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "An OCaml module implementing 128 bits universally unique identifiers version 3, 5 (name based with MD5, SHA-1 hashing) and 4 (random based) according to RFC 4122";
-    homepage = http://erratique.ch/software/uuidm;
+    homepage = https://erratique.ch/software/uuidm;
     license = licenses.bsd3;
     platforms = ocaml.meta.platforms or [];
     maintainers = [ maintainers.maurer ];

--- a/pkgs/development/python-modules/aiolifx/default.nix
+++ b/pkgs/development/python-modules/aiolifx/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ bitstring ifaddr ];
 
   meta = with lib; {
-    homepage = http://github.com/frawau/aiolifx;
+    homepage = https://github.com/frawau/aiolifx;
     license = licenses.mit;
     description = "API for local communication with LIFX devices over a LAN with asyncio";
     maintainers = with maintainers; [ netixx ];

--- a/pkgs/development/python-modules/argh/default.nix
+++ b/pkgs/development/python-modules/argh/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://github.com/neithere/argh/;
+    homepage = https://github.com/neithere/argh/;
     description = "An unobtrusive argparse wrapper with natural syntax";
     license = licenses.lgpl2;
     maintainers = with maintainers; [ domenkozar ];

--- a/pkgs/development/python-modules/casttube/default.nix
+++ b/pkgs/development/python-modules/casttube/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "Interact with the Youtube Chromecast api";
-    homepage = http://github.com/ur1katz/casttube;
+    homepage = https://github.com/ur1katz/casttube;
     license = licenses.mit;
     maintainers = with maintainers; [ fpletz ];
   };

--- a/pkgs/development/python-modules/dask-glm/default.nix
+++ b/pkgs/development/python-modules/dask-glm/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://github.com/dask/dask-glm/;
+    homepage = https://github.com/dask/dask-glm/;
     description = "Generalized Linear Models with Dask";
     license = licenses.bsd3;
     maintainers = [ maintainers.costrouc ];

--- a/pkgs/development/python-modules/django-cache-url/default.nix
+++ b/pkgs/development/python-modules/django-cache-url/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with stdenv.lib; {
-    homepage = http://github.com/ghickman/django-cache-url;
+    homepage = https://github.com/ghickman/django-cache-url;
     description = "Use Cache URLs in your Django application";
     license = licenses.mit;
     maintainers = [ maintainers.costrouc ];

--- a/pkgs/development/python-modules/django-discover-runner/default.nix
+++ b/pkgs/development/python-modules/django-discover-runner/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with stdenv.lib; {
-    homepage = http://github.com/jezdez/django-discover-runner;
+    homepage = https://github.com/jezdez/django-discover-runner;
     description = "A Django test runner based on unittest2's test discovery";
     license = licenses.bsd0;
     maintainers = [ maintainers.costrouc ];

--- a/pkgs/development/python-modules/django-sesame/default.nix
+++ b/pkgs/development/python-modules/django-sesame/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "URLs with authentication tokens for automatic login";
-    homepage = http://github.com/aaugustin/django-sesame;
+    homepage = https://github.com/aaugustin/django-sesame;
     license = licenses.bsd3;
     maintainers = with maintainers; [ elohmeier ];
   };

--- a/pkgs/development/python-modules/favicon/default.nix
+++ b/pkgs/development/python-modules/favicon/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Find a website's favicon";
-    homepage = http://github.com/scottwernervt/favicon;
+    homepage = https://github.com/scottwernervt/favicon;
     license = licenses.mit;
     maintainers = with maintainers; [ elohmeier ];
   };

--- a/pkgs/development/python-modules/flask-socketio/default.nix
+++ b/pkgs/development/python-modules/flask-socketio/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Socket.IO integration for Flask applications";
-    homepage = http://github.com/miguelgrinberg/Flask-SocketIO/;
+    homepage = https://github.com/miguelgrinberg/Flask-SocketIO/;
     license = licenses.mit;
     maintainers = [ maintainers.mic92 ];
   };

--- a/pkgs/development/python-modules/genanki/default.nix
+++ b/pkgs/development/python-modules/genanki/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://github.com/kerrickstaley/genanki;
+    homepage = https://github.com/kerrickstaley/genanki;
     description = "Generate Anki decks programmatically";
     license = licenses.mit;
     maintainers = with maintainers; [ teto ];

--- a/pkgs/development/python-modules/gnureadline/default.nix
+++ b/pkgs/development/python-modules/gnureadline/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "The standard Python readline extension statically linked against the GNU readline library";
-    homepage = http://github.com/ludwigschwardt/python-gnureadline;
+    homepage = https://github.com/ludwigschwardt/python-gnureadline;
     license = licenses.gpl3;
   };
 

--- a/pkgs/development/python-modules/hdmedians/default.nix
+++ b/pkgs/development/python-modules/hdmedians/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://github.com/daleroberts/hdmedians;
+    homepage = https://github.com/daleroberts/hdmedians;
     description = "High-dimensional medians";
     license = licenses.gpl3;
     maintainers = [ maintainers.costrouc ];

--- a/pkgs/development/python-modules/ipdbplugin/default.nix
+++ b/pkgs/development/python-modules/ipdbplugin/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ nose ipython ];
 
   meta = with stdenv.lib; {
-    homepage = http://github.com/flavioamieiro/nose-ipdb/tree/master;
+    homepage = https://github.com/flavioamieiro/nose-ipdb/tree/master;
     description = "Nose plugin to use iPdb instead of Pdb when tests fail";
     license = licenses.lgpl2;
     maintainers = [ maintainers.costrouc ];

--- a/pkgs/development/python-modules/nixpkgs/default.nix
+++ b/pkgs/development/python-modules/nixpkgs/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "Allows to `from nixpkgs import` stuff in interactive Python sessions";
-    homepage = http://github.com/t184256/nixpkgs-python-importer;
+    homepage = https://github.com/t184256/nixpkgs-python-importer;
     license = licenses.mit;
     maintainers = with maintainers; [ t184256 ];
   };

--- a/pkgs/development/python-modules/pagerduty/default.nix
+++ b/pkgs/development/python-modules/pagerduty/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   };
 
   meta = with stdenv.lib; {
-    homepage = http://github.com/samuel/python-pagerduty;
+    homepage = https://github.com/samuel/python-pagerduty;
     description = "Library for the PagerDuty service API";
     license = licenses.bsd0;
   };

--- a/pkgs/development/python-modules/pilkit/default.nix
+++ b/pkgs/development/python-modules/pilkit/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   buildInputs = [ pillow nose_progressive nose mock blessings ];
 
   meta = with stdenv.lib; {
-    homepage = http://github.com/matthewwithanm/pilkit/;
+    homepage = https://github.com/matthewwithanm/pilkit/;
     description = "A collection of utilities and processors for the Python Imaging Libary";
     license = licenses.bsd0;
     maintainers = with maintainers; [ domenkozar ];

--- a/pkgs/development/python-modules/pychef/default.nix
+++ b/pkgs/development/python-modules/pychef/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with stdenv.lib; {
-    homepage = http://github.com/coderanger/pychef;
+    homepage = https://github.com/coderanger/pychef;
     description = "Python implementation of a Chef API client";
     license = licenses.bsd0;
   };

--- a/pkgs/development/python-modules/pytest-ansible/default.nix
+++ b/pkgs/development/python-modules/pytest-ansible/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://github.com/jlaska/pytest-ansible;
+    homepage = https://github.com/jlaska/pytest-ansible;
     description = "Plugin for py.test to simplify calling ansible modules from tests or fixtures";
     license = licenses.mit;
     maintainers = [ maintainers.costrouc ];

--- a/pkgs/development/python-modules/python-engineio/default.nix
+++ b/pkgs/development/python-modules/python-engineio/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
 
   meta = with stdenv.lib; {
     description = "Engine.IO server";
-    homepage = http://github.com/miguelgrinberg/python-engineio/;
+    homepage = https://github.com/miguelgrinberg/python-engineio/;
     license = licenses.mit;
     platforms = platforms.linux;
     maintainers = [ maintainers.mic92 ];

--- a/pkgs/development/python-modules/python-json-logger/default.nix
+++ b/pkgs/development/python-modules/python-json-logger/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   checkInputs = [ nose ];
 
   meta = with stdenv.lib; {
-    homepage = http://github.com/madzak/python-json-logger;
+    homepage = https://github.com/madzak/python-json-logger;
     description = "A python library adding a json log formatter";
     license = licenses.bsdOriginal;
     maintainers = [ maintainers.costrouc ];

--- a/pkgs/development/python-modules/python-snappy/default.nix
+++ b/pkgs/development/python-modules/python-snappy/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Python library for the snappy compression library from Google";
-    homepage = http://github.com/andrix/python-snappy;
+    homepage = https://github.com/andrix/python-snappy;
     license = licenses.bsd3;
     maintainers = [ maintainers.costrouc ];
   };

--- a/pkgs/development/python-modules/python-socketio/default.nix
+++ b/pkgs/development/python-modules/python-socketio/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Socket.IO server";
-    homepage = http://github.com/miguelgrinberg/python-socketio/;
+    homepage = https://github.com/miguelgrinberg/python-socketio/;
     license = licenses.mit;
     maintainers = [ maintainers.mic92 ];
   };

--- a/pkgs/development/python-modules/readthedocs-sphinx-ext/default.nix
+++ b/pkgs/development/python-modules/readthedocs-sphinx-ext/default.nix
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Sphinx extension for Read the Docs overrides";
-    homepage = http://github.com/rtfd/readthedocs-sphinx-ext;
+    homepage = https://github.com/rtfd/readthedocs-sphinx-ext;
     license = licenses.mit;
   };
 }

--- a/pkgs/development/python-modules/slicerator/default.nix
+++ b/pkgs/development/python-modules/slicerator/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with stdenv.lib; {
-    homepage = http://github.com/soft-matter/slicerator;
+    homepage = https://github.com/soft-matter/slicerator;
     description = "A lazy-loading, fancy-sliceable iterable";
     license = licenses.bsdOriginal;
     maintainers = [ maintainers.costrouc ];

--- a/pkgs/development/python-modules/ssdeep/default.nix
+++ b/pkgs/development/python-modules/ssdeep/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with stdenv.lib; {
-    homepage = http://github.com/DinoTools/python-ssdeep;
+    homepage = https://github.com/DinoTools/python-ssdeep;
     description = "Python wrapper for the ssdeep library";
     license = licenses.lgpl3;
   };

--- a/pkgs/development/python-modules/streamz/default.nix
+++ b/pkgs/development/python-modules/streamz/default.nix
@@ -35,7 +35,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Pipelines to manage continuous streams of data";
-    homepage = http://github.com/mrocklin/streamz/;
+    homepage = https://github.com/mrocklin/streamz/;
     license = licenses.bsd3;
     maintainers = [ maintainers.costrouc ];
   };

--- a/pkgs/development/python-modules/xattr/default.nix
+++ b/pkgs/development/python-modules/xattr/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://github.com/xattr/xattr;
+    homepage = https://github.com/xattr/xattr;
     description = "Python wrapper for extended filesystem attributes";
     license = licenses.mit;
   };

--- a/pkgs/development/python-modules/zope-deferredimport/default.nix
+++ b/pkgs/development/python-modules/zope-deferredimport/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Allows you to perform imports names that will only be resolved when used in the code";
-    homepage = http://github.com/zopefoundation/zope.deferredimport;
+    homepage = https://github.com/zopefoundation/zope.deferredimport;
     license = licenses.zpl21;
   };
 }

--- a/pkgs/development/python-modules/zope-hookable/default.nix
+++ b/pkgs/development/python-modules/zope-hookable/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Supports the efficient creation of “hookable” objects";
-    homepage = http://github.com/zopefoundation/zope.hookable;
+    homepage = https://github.com/zopefoundation/zope.hookable;
     license = licenses.zpl21;
   };
 }

--- a/pkgs/development/python-modules/zope_contenttype/default.nix
+++ b/pkgs/development/python-modules/zope_contenttype/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   };
 
   meta = with stdenv.lib; {
-    homepage = http://github.com/zopefoundation/zope.contenttype;
+    homepage = https://github.com/zopefoundation/zope.contenttype;
     description = "A utility module for content-type (MIME type) handling";
     license = licenses.zpl20;
     maintainers = with maintainers; [ goibhniu ];

--- a/pkgs/development/python-modules/zope_deprecation/default.nix
+++ b/pkgs/development/python-modules/zope_deprecation/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   buildInputs = [ zope_testing ];
 
   meta = with stdenv.lib; {
-    homepage = http://github.com/zopefoundation/zope.deprecation;
+    homepage = https://github.com/zopefoundation/zope.deprecation;
     description = "Zope Deprecation Infrastructure";
     license = licenses.zpl20;
     maintainers = with maintainers; [ garbas domenkozar ];

--- a/pkgs/development/python-modules/zope_lifecycleevent/default.nix
+++ b/pkgs/development/python-modules/zope_lifecycleevent/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ zope_event zope_component ];
 
   meta = with stdenv.lib; {
-    homepage = http://github.com/zopefoundation/zope.lifecycleevent;
+    homepage = https://github.com/zopefoundation/zope.lifecycleevent;
     description = "Object life-cycle events";
     license = licenses.zpl20;
     maintainers = with maintainers; [ goibhniu ];

--- a/pkgs/development/python-modules/zope_location/default.nix
+++ b/pkgs/development/python-modules/zope_location/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with stdenv.lib; {
-    homepage = http://github.com/zopefoundation/zope.location/;
+    homepage = https://github.com/zopefoundation/zope.location/;
     description = "Zope Location";
     license = licenses.zpl20;
     maintainers = with maintainers; [ goibhniu ];

--- a/pkgs/development/python-modules/zope_proxy/default.nix
+++ b/pkgs/development/python-modules/zope_proxy/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = with stdenv.lib; {
-    homepage = http://github.com/zopefoundation/zope.proxy;
+    homepage = https://github.com/zopefoundation/zope.proxy;
     description = "Generic Transparent Proxies";
     license = licenses.zpl20;
     maintainers = with maintainers; [ goibhniu ];

--- a/pkgs/development/python-modules/zope_size/default.nix
+++ b/pkgs/development/python-modules/zope_size/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ zope_i18nmessageid zope_interface ];
 
   meta = with stdenv.lib; {
-    homepage = http://github.com/zopefoundation/zope.size;
+    homepage = https://github.com/zopefoundation/zope.size;
     description = "Interfaces and simple adapter that give the size of an object";
     license = licenses.zpl20;
     maintainers = with maintainers; [ goibhniu ];

--- a/pkgs/development/tools/build-managers/boot/default.nix
+++ b/pkgs/development/tools/build-managers/boot/default.nix
@@ -10,14 +10,14 @@ stdenv.mkDerivation rec {
   };
 
   inherit jdk;
-  
+
   builder = ./builder.sh;
 
   propagatedBuildInputs = [ jdk ];
 
   meta = with stdenv.lib; {
     description = "Build tooling for Clojure";
-    homepage = http://boot-clj.com/;
+    homepage = https://boot-clj.com/;
     license = licenses.epl10;
     platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ ragge ];

--- a/pkgs/development/tools/database/timescaledb-parallel-copy/default.nix
+++ b/pkgs/development/tools/database/timescaledb-parallel-copy/default.nix
@@ -18,7 +18,7 @@ buildGoPackage rec {
 
   meta = with stdenv.lib; {
     description = "Bulk, parallel insert of CSV records into PostgreSQL";
-    homepage    = http://github.com/timescale/timescaledb-parallel-copy;
+    homepage    = https://github.com/timescale/timescaledb-parallel-copy;
     license     = licenses.asl20;
     platforms   = platforms.unix;
     maintainers = with maintainers; [ thoughtpolice ];

--- a/pkgs/development/tools/minizinc/default.nix
+++ b/pkgs/development/tools/minizinc/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
   };
 
   meta = with stdenv.lib; {
-    homepage = http://www.minizinc.org/;
+    homepage = https://www.minizinc.org/;
     description = "MiniZinc is a medium-level constraint modelling language.";
 
     longDescription = ''
@@ -31,4 +31,3 @@ stdenv.mkDerivation {
     maintainers = [ maintainers.sheenobu ];
   };
 }
-

--- a/pkgs/development/tools/misc/autobuild/default.nix
+++ b/pkgs/development/tools/misc/autobuild/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
       summary of the build status, after reading the manual.
     '';
 
-    homepage = http://josefsson.org/autobuild/;
+    homepage = https://josefsson.org/autobuild/;
     license = stdenv.lib.licenses.gpl2Plus;
   };
 }

--- a/pkgs/development/tools/misc/objconv/default.nix
+++ b/pkgs/development/tools/misc/objconv/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Object and executable file converter, modifier and disassembler";
-    homepage = http://www.agner.org/optimize/;
+    homepage = https://www.agner.org/optimize/;
     license = licenses.gpl2;
     maintainers = with maintainers; [ orivej vrthra ];
     platforms = platforms.unix;

--- a/pkgs/development/tools/parsing/antlr/2.7.7.nix
+++ b/pkgs/development/tools/parsing/antlr/2.7.7.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
       frameworks. From a grammar, ANTLR generates a parser that can build and
       walk parse trees.
     '';
-    homepage = http://www.antlr.org/;
+    homepage = https://www.antlr.org/;
     license = licenses.bsd3;
     platforms = platforms.unix;
   };

--- a/pkgs/development/tools/parsing/antlr/3.4.nix
+++ b/pkgs/development/tools/parsing/antlr/3.4.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
       frameworks. From a grammar, ANTLR generates a parser that can build and
       walk parse trees.
     '';
-    homepage = http://www.antlr.org/;
+    homepage = https://www.antlr.org/;
     license = licenses.bsd3;
     platforms = platforms.linux ++ platforms.darwin;
   };

--- a/pkgs/development/tools/parsing/antlr/3.5.nix
+++ b/pkgs/development/tools/parsing/antlr/3.5.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
       frameworks. From a grammar, ANTLR generates a parser that can build and
       walk parse trees.
     '';
-    homepage = http://www.antlr.org/;
+    homepage = https://www.antlr.org/;
     license = licenses.bsd3;
     platforms = platforms.linux;
   };

--- a/pkgs/development/tools/parsing/antlr/4.7.nix
+++ b/pkgs/development/tools/parsing/antlr/4.7.nix
@@ -73,7 +73,7 @@ let
         frameworks. From a grammar, ANTLR generates a parser that can build and
         walk parse trees.
       '';
-      homepage = http://www.antlr.org/;
+      homepage = https://www.antlr.org/;
       license = licenses.bsd3;
       platforms = platforms.unix;
     };

--- a/pkgs/development/tools/parsing/byacc/default.nix
+++ b/pkgs/development/tools/parsing/byacc/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Berkeley YACC";
-    homepage = http://invisible-island.net/byacc/byacc.html;
+    homepage = https://invisible-island.net/byacc/byacc.html;
     license = licenses.publicDomain;
     platforms = platforms.unix;
   };

--- a/pkgs/development/web/twitter-bootstrap/default.nix
+++ b/pkgs/development/web/twitter-bootstrap/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Front-end framework for faster and easier web development";
-    homepage = http://getbootstrap.com/;
+    homepage = https://getbootstrap.com/;
     license = stdenv.lib.licenses.mit;
   };
 

--- a/pkgs/misc/emulators/kega-fusion/default.nix
+++ b/pkgs/misc/emulators/kega-fusion/default.nix
@@ -70,7 +70,7 @@ in stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Sega SG1000, SC3000, SF7000, Master System, Game Gear, Genesis/Megadrive, SVP, Pico, SegaCD/MegaCD and 32X emulator";
-    homepage = http://www.carpeludum.com/kega-fusion/;
+    homepage = https://www.carpeludum.com/kega-fusion/;
     maintainers = with maintainers; [ abbradar ];
     license = licenses.unfreeRedistributable;
     platforms = [ "i686-linux" ];

--- a/pkgs/misc/emulators/mess/default.nix
+++ b/pkgs/misc/emulators/mess/default.nix
@@ -18,7 +18,7 @@ let
 
 in
 
-stdenv.mkDerivation { 
+stdenv.mkDerivation {
   name = "mess-0.${version}";
 
   unpackPhase =
@@ -37,11 +37,11 @@ stdenv.mkDerivation {
   installPhase =
     ''
       mkdir -p $out/bin
-      cp mess* $out/bin/mess 
+      cp mess* $out/bin/mess
     '';
 
   meta = {
-    homepage = http://www.mess.org/;
+    homepage = https://www.mess.org/;
     license = "non-commercial";
     description = "Multi Emulator Super System, an emulator of many game consoles and computer systems";
     broken = true;

--- a/pkgs/os-specific/linux/nvidia-x11/generic.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/generic.nix
@@ -86,7 +86,7 @@ let
     };
 
     meta = with stdenv.lib; {
-      homepage = http://www.nvidia.com/object/unix.html;
+      homepage = https://www.nvidia.com/object/unix.html;
       description = "X.org driver and kernel module for NVIDIA graphics cards";
       license = licenses.unfreeRedistributable;
       platforms = [ "i686-linux" "x86_64-linux" ];

--- a/pkgs/os-specific/linux/nvidia-x11/persistenced.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/persistenced.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = http://www.nvidia.com/object/unix.html;
+    homepage = https://www.nvidia.com/object/unix.html;
     description = "Settings application for NVIDIA graphics cards";
     license = licenses.unfreeRedistributable;
     platforms = nvidia_x11.meta.platforms;

--- a/pkgs/os-specific/linux/nvidia-x11/settings.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/settings.nix
@@ -80,7 +80,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with stdenv.lib; {
-    homepage = http://www.nvidia.com/object/unix.html;
+    homepage = https://www.nvidia.com/object/unix.html;
     description = "Settings application for NVIDIA graphics cards";
     license = licenses.unfreeRedistributable;
     platforms = nvidia_x11.meta.platforms;

--- a/pkgs/servers/coturn/default.nix
+++ b/pkgs/servers/coturn/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   patches = [ ./pure-configure.patch ];
 
   meta = with stdenv.lib; {
-    homepage = http://coturn.net/;
+    homepage = https://coturn.net/;
     license = with licenses; [ bsd3 ];
     description = "A TURN server";
     platforms = platforms.all;

--- a/pkgs/servers/dns/bind/default.nix
+++ b/pkgs/servers/dns/bind/default.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation rec {
   doCheck = false; # requires root and the net
 
   meta = {
-    homepage = http://www.isc.org/software/bind;
+    homepage = https://www.isc.org/downloads/bind/;
     description = "Domain name server";
     license = stdenv.lib.licenses.mpl20;
 

--- a/pkgs/tools/admin/analog/default.nix
+++ b/pkgs/tools/admin/analog/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = http://www.c-amie.co.uk/software/analog/;
+    homepage = https://www.c-amie.co.uk/software/analog/;
     license = stdenv.lib.licenses.gpl2;
     description = "Powerful tool to generate web server statistics";
     maintainers = [ stdenv.lib.maintainers.peti ];

--- a/pkgs/tools/graphics/logstalgia/default.nix
+++ b/pkgs/tools/graphics/logstalgia/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
                   glm freetype ];
 
   meta = with stdenv.lib; {
-    homepage = http://logstalgia.io/;
+    homepage = https://logstalgia.io/;
     description = "Website traffic visualization tool";
     license = licenses.gpl3Plus;
 

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-anthy/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-anthy/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     isIbusEngine = true;
     description  = "IBus interface to the anthy input method";
-    homepage     = http://wiki.github.com/fujiwarat/ibus-anthy;
+    homepage     = https://github.com/fujiwarat/ibus-anthy;
     license      = licenses.gpl2Plus;
     platforms    = platforms.linux;
     maintainers  = with maintainers; [ gebner ericsagnes ];

--- a/pkgs/tools/misc/autojump/default.nix
+++ b/pkgs/tools/misc/autojump/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
 
       Autojump supports tab-completion.
     '';
-    homepage = http://wiki.github.com/wting/autojump;
+    homepage = https://github.com/wting/autojump;
     license = licenses.gpl3;
     platforms = platforms.all;
     maintainers = with maintainers; [ domenkozar yurrriq ];

--- a/pkgs/tools/networking/autossh/default.nix
+++ b/pkgs/tools/networking/autossh/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     '';
 
   meta = with stdenv.lib; {
-    homepage = http://www.harding.motd.ca/autossh/;
+    homepage = https://www.harding.motd.ca/autossh/;
     description = "Automatically restart SSH sessions and tunnels";
     platforms = platforms.unix;
     maintainers = with maintainers; [ pSub ];

--- a/pkgs/tools/networking/ip2location/default.nix
+++ b/pkgs/tools/networking/ip2location/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
       weather, MCC, MNC, mobile brand name, elevation and usage type of
       any IP address or host name in the IP2Location databases.
     '';
-    homepage = http://www.ip2location.com/free/applications;
+    homepage = https://www.ip2location.com/free/applications;
     license = with licenses; [ gpl3Plus lgpl3Plus ];
     platforms = platforms.linux;
   };

--- a/pkgs/tools/networking/keepalived/default.nix
+++ b/pkgs/tools/networking/keepalived/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
  ];
 
   meta = with stdenv.lib; {
-    homepage = http://keepalived.org;
+    homepage = https://keepalived.org;
     description = "Routing software written in C";
     license = licenses.gpl2;
     platforms = platforms.linux;

--- a/pkgs/tools/networking/ngrok-1/default.nix
+++ b/pkgs/tools/networking/ngrok-1/default.nix
@@ -28,4 +28,8 @@ buildGoPackage rec {
   '';
 
   buildFlags = [ "-tags release" ];
+
+  meta = {
+    homepage = https://ngrok.com/;
+  };
 }

--- a/pkgs/tools/networking/nzbget/default.nix
+++ b/pkgs/tools/networking/nzbget/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
-    homepage = http://nzbget.net;
+    homepage = https://nzbget.net;
     license = licenses.gpl2Plus;
     description = "A command line tool for downloading files from news servers";
     maintainers = with maintainers; [ pSub ];

--- a/pkgs/tools/system/ior/default.nix
+++ b/pkgs/tools/system/ior/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   preConfigure = "./bootstrap";
 
   meta = with stdenv.lib; {
-    homepage = http://www.nersc.gov/users/computational-systems/cori/nersc-8-procurement/trinity-nersc-8-rfp/nersc-8-trinity-benchmarks/ior/;
+    homepage = https://www.nersc.gov/users/computational-systems/cori/nersc-8-procurement/trinity-nersc-8-rfp/nersc-8-trinity-benchmarks/ior/;
     description = "Parallel file system I/O performance test";
     license = licenses.gpl2;
     platforms = platforms.linux;

--- a/pkgs/tools/text/xml/jing-trang/default.nix
+++ b/pkgs/tools/text/xml/jing-trang/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     description = "A RELAX NG validator in Java";
     # The homepage is www.thaiopensource.com, but it links to googlecode.com
     # for downloads and call it the "project site".
-    homepage = "http://www.thaiopensource.com/relaxng/trang.html";
+    homepage = https://www.thaiopensource.com/relaxng/trang.html;
     platforms = platforms.unix;
     maintainers = [ maintainers.bjornfor ];
   };

--- a/pkgs/tools/typesetting/asciidoctor/default.nix
+++ b/pkgs/tools/typesetting/asciidoctor/default.nix
@@ -47,7 +47,7 @@ bundlerApp {
 
   meta = with lib; {
     description = "A faster Asciidoc processor written in Ruby";
-    homepage = http://asciidoctor.org/;
+    homepage = https://asciidoctor.org/;
     license = licenses.mit;
     maintainers = with maintainers; [ gpyh ];
     platforms = platforms.unix;

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -61,7 +61,7 @@ let
     propagatedBuildInputs = [ FileNext ];
     meta = with stdenv.lib; {
       description = "A grep-like tool tailored to working with large trees of source code";
-      homepage    = http://betterthangrep.com/;
+      homepage    = https://beyondgrep.com;
       license     = licenses.artistic2;
       maintainers = with maintainers; [ lovek323 ];
     };
@@ -11015,7 +11015,7 @@ let
       sha256 = "5f5f1142185a67b87406a3fb31f221564f61838a70ef4c07284a66c55e82ad05";
     };
     meta = {
-      homepage = http://wiki.github.com/toddr/Net-Ident/;
+      homepage = https://github.com/toddr/Net-Ident;
       description = "Lookup the username on the remote end of a TCP/IP connection";
       license = stdenv.lib.licenses.mit;
     };
@@ -13197,7 +13197,7 @@ let
       sha256 = "d6d3c711657a380f1cb24d8b54a1cd20f725f7f54665189e9e67bb0b877109a3";
     };
     meta = {
-      homepage = http://wiki.github.com/toddr/Regexp-Parser;
+      homepage = https://github.com/toddr/Regexp-Parser;
       description = "Base class for parsing regexes";
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
     };


### PR DESCRIPTION
Based on "problems" from repology:

https://repology.org/repository/nix_unstable/problems

Mostly simple changes to reflect redirects.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
