### PR TITLE
pythonPackages.pyschedule: init at 0.2.34

### DIFF
--- a/pkgs/development/python-modules/pyschedule/default.nix
+++ b/pkgs/development/python-modules/pyschedule/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pulp
+}:
+
+buildPythonPackage rec {
+  pname = "pyschedule";
+  version = "0.2.34";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "6bba9e9ea07906ce2dfe3cd847c1822b137f6b13e9f975c50b347312fd98e110";
+  };
+
+  propagatedBuildInputs = [
+    pulp
+  ];
+
+  # tests not included with pypi release (in examples)
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Formulate and solve resource-constrained scheduling problems";
+    homepage = https://github.com/timnon/pyschedule;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -730,6 +730,8 @@ in {
 
   pyscard = callPackage ../development/python-modules/pyscard { inherit (pkgs.darwin.apple_sdk.frameworks) PCSC; };
 
+  pyschedule = callPackage ../development/python-modules/pyschedule { };
+
   pyside = callPackage ../development/python-modules/pyside { };
 
   pysideShiboken = callPackage ../development/python-modules/pyside/shiboken.nix {


### PR DESCRIPTION
closes PR #37371. That PR was inactive

###### Motivation for this change



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
