### PR TITLE
nixos/dde-api: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -255,6 +255,7 @@
   ./services/databases/virtuoso.nix
   ./services/desktops/accountsservice.nix
   ./services/desktops/bamf.nix
+  ./services/desktops/deepin/dde-api.nix
   ./services/desktops/deepin/deepin-menu.nix
   ./services/desktops/dleyna-renderer.nix
   ./services/desktops/dleyna-server.nix

--- a/nixos/modules/services/desktops/deepin/dde-api.nix
+++ b/nixos/modules/services/desktops/deepin/dde-api.nix
@@ -1,0 +1,41 @@
+# dde-api
+
+{ config, pkgs, lib, ... }:
+
+{
+
+  ###### interface
+
+  options = {
+
+    services.deepin.dde-api = {
+
+      enable = lib.mkEnableOption
+        "Services provided by the Deepin Desktop Environment API";
+
+    };
+
+  };
+
+
+  ###### implementation
+
+  config = lib.mkIf config.services.deepin.dde-api.enable {
+
+    environment.systemPackages = [ pkgs.deepin.dde-api ];
+
+    services.dbus.packages = [ pkgs.deepin.dde-api ];
+
+    systemd.packages = [ pkgs.deepin.dde-api ];
+
+    users.groups.deepin-sound-player = { };
+
+    users.users.deepin-sound-player = {
+      description = "Deepin sound player";
+      group = "deepin-sound-player";
+      isSystemUser = true;
+    };
+
+  };
+
+}


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add a NixOS module for the services provided by the package [dde-api](https://github.com/linuxdeepin/dde-api).

About packaging deepin for NixOS: #59023

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).