### PR TITLE
pythonPackages.pyomo: init at 5.6.5

### DIFF
--- a/pkgs/development/python-modules/pyomo/default.nix
+++ b/pkgs/development/python-modules/pyomo/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pyutilib
+, appdirs
+, ply
+, six
+, nose
+}:
+
+buildPythonPackage rec {
+  pname = "pyomo";
+  version = "5.6.1";
+
+  src = fetchPypi {
+    pname = "Pyomo";
+    inherit version;
+    sha256 = "449be9a4c9b3caee7c89dbe5f0e4e5ad0eaeef8be110a860641cd249986e362c";
+  };
+
+  checkInputs = [ nose ];
+  propagatedBuildInputs = [
+    pyutilib
+    appdirs
+    ply
+    six
+  ];
+
+  checkPhase = ''
+    rm pyomo/bilevel/tests/test_blp.py \
+       pyomo/version/tests/test_installer.py
+    nosetests
+  '';
+
+  meta = with lib; {
+    description = "Pyomo: Python Optimization Modeling Objects";
+    homepage = http://pyomo.org;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/pyutilib/default.nix
+++ b/pkgs/development/python-modules/pyutilib/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, nose
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "pyutilib";
+  version = "5.6.5";
+
+  src = fetchPypi {
+    pname = "PyUtilib";
+    inherit version;
+    sha256 = "4730084624be98f2c326da88f3852831c6aa919e11babab2c34b0299c8f5ce2a";
+  };
+
+  propagatedBuildInputs = [
+    nose
+    six
+  ];
+
+  # tests require text files that are not included in the pypi package
+  doCheck = false;
+
+  meta = with lib; {
+    description = "PyUtilib: A collection of Python utilities";
+    homepage = https://github.com/PyUtilib/pyutilib;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3819,6 +3819,8 @@ in {
   pylint = if isPy3k then callPackage ../development/python-modules/pylint { }
            else callPackage ../development/python-modules/pylint/1.9.nix { };
 
+  pyomo = callPackage ../development/python-modules/pyomo { };
+
   pyopencl = callPackage ../development/python-modules/pyopencl { };
 
   pyotp = callPackage ../development/python-modules/pyotp { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4007,6 +4007,8 @@ in {
 
   pyutil = callPackage ../development/python-modules/pyutil { };
 
+  pyutilib = callPackage ../development/python-modules/pyutilib { };
+
   pywal = callPackage ../development/python-modules/pywal { };
 
   pywebkitgtk = callPackage ../development/python-modules/pywebkitgtk { };


### PR DESCRIPTION
Closes #37372. PR was not being fixed.


###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
