### PR TITLE
busybox: add patch to allow cross in llvm

### DIFF
--- a/pkgs/os-specific/linux/busybox/clang-cross.patch
+++ b/pkgs/os-specific/linux/busybox/clang-cross.patch
@@ -1,0 +1,37 @@
+diff --git a/Makefile b/Makefile
+index 6fedcffba..3385836c4 100644
+--- a/Makefile
++++ b/Makefile
+@@ -271,8 +271,8 @@ export quiet Q KBUILD_VERBOSE
+ # Look for make include files relative to root of kernel src
+ MAKEFLAGS += --include-dir=$(srctree)
+ 
+-HOSTCC  	= gcc
+-HOSTCXX  	= g++
++HOSTCC		= cc
++HOSTCXX	= c++
+ HOSTCFLAGS	:=
+ HOSTCXXFLAGS	:=
+ # We need some generic definitions
+@@ -289,7 +289,7 @@ MAKEFLAGS += -rR
+ # Make variables (CC, etc...)
+ 
+ AS		= $(CROSS_COMPILE)as
+-CC		= $(CROSS_COMPILE)gcc
++CC		= $(CROSS_COMPILE)cc
+ LD		= $(CC) -nostdlib
+ CPP		= $(CC) -E
+ AR		= $(CROSS_COMPILE)ar
+diff --git a/scripts/Makefile.IMA b/scripts/Makefile.IMA
+index f155108d7..185257064 100644
+--- a/scripts/Makefile.IMA
++++ b/scripts/Makefile.IMA
+@@ -39,7 +39,7 @@ ifndef HOSTCC
+ HOSTCC = cc
+ endif
+ AS              = $(CROSS_COMPILE)as
+-CC              = $(CROSS_COMPILE)gcc
++CC              = $(CROSS_COMPILE)cc
+ LD              = $(CC) -nostdlib
+ CPP             = $(CC) -E
+ AR              = $(CROSS_COMPILE)ar

--- a/pkgs/os-specific/linux/busybox/default.nix
+++ b/pkgs/os-specific/linux/busybox/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./busybox-in-store.patch
-  ];
+  ] ++ stdenv.lib.optional (stdenv.hostPlatform != stdenv.targetPlatform) ./clang-cross.patch;
 
   postPatch = "patchShebangs .";
 


### PR DESCRIPTION
Fixes #57670

$ nix build -f. --arg crossSystem '{ config = "aarch64-unknown-linux-musl"; useLLVM = true; }' busybox

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
