### PR TITLE
[WIP] binutils, build-fhs-userenv: make use of ld fallback

### DIFF
--- a/pkgs/build-support/build-fhs-userenv/env.nix
+++ b/pkgs/build-support/build-fhs-userenv/env.nix
@@ -50,7 +50,7 @@ let
   etcProfile = writeText "profile" ''
     export PS1='${name}-chrootenv:\u@\h:\w\$ '
     export LOCALE_ARCHIVE='/usr/lib/locale/locale-archive'
-    export LD_LIBRARY_PATH='/run/opengl-driver/lib:/run/opengl-driver-32/lib:/usr/lib:/usr/lib32'
+    export LD_LIBRARY_PATH='/run/opengl-driver/lib:/run/opengl-driver-32/lib'
     export PATH='/run/wrappers/bin:/usr/bin:/usr/sbin'
     export TZDIR='/etc/zoneinfo'
 
@@ -182,6 +182,13 @@ let
         ln -s "$i"
       fi
     done
+
+    # Configure the dynamic linker to look at the default locations (which
+    # it normally doesn't do on nix).
+    cat > etc/nix-ld.so.conf << "EOF
+    /lib
+    /usr/lib
+    EOF
   '';
 
 in stdenv.mkDerivation {

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -58,8 +58,15 @@ stdenv.mkDerivation ({
       /* Allow NixOS and Nix to handle the locale-archive. */
       ./nix-locale-archive.patch
 
-      /* Don't use /etc/ld.so.cache, for non-NixOS systems.  */
-      ./dont-use-system-ld-so-cache.patch
+      /* Don't use /etc/ld.so.cache or /etc/ld.so.conf, for non-NixOS systems.
+       * This is done to prevent the dynamic linker from picking up non-nix
+       * libraries at runtime. If that were the case, it could happen that some
+       * package works for one user on a non-nixos system, while it doesn't
+       * work for another. /etc/nix-ld.so.conf is checked instead of the regular
+       * /etc/ld.so.conf in order to provide an opt-in mechanism for users who
+       * do want to consider libraries outside the nix store for dynamic
+       * linking. */
+      ./dont-use-system-ld-so-cache-and-conf.patch
 
       /* Don't use /etc/ld.so.preload, but /etc/ld-nix.so.preload.  */
       ./dont-use-system-ld-so-preload.patch

--- a/pkgs/development/libraries/glibc/dont-use-system-ld-so-cache-and-conf.patch
+++ b/pkgs/development/libraries/glibc/dont-use-system-ld-so-cache-and-conf.patch
@@ -6,7 +6,7 @@ diff -Naur glibc-2.27-orig/elf/ldconfig.c glibc-2.27/elf/ldconfig.c
  
  #ifndef LD_SO_CONF
 -# define LD_SO_CONF SYSCONFDIR "/ld.so.conf"
-+# define LD_SO_CONF PREFIX "/etc/ld.so.conf"
++# define LD_SO_CONF "/etc/nix-ld.so.conf"
  #endif
  
  /* Get libc version number.  */


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Currently build-fhs-userenv uses `LD_LIBRARY_PATH` to instruct the dynamic linker to look at `/usr/lib`. This is necessary since nix explicitly forbids its dynamic linker to look in that default location.

This doesn't perfectly emulate the "normal" behaviour however, since `LD_LIBRARY_PATH` has precedence over a binaries own `runpath`. In contrast, the default directories (`/usr/lib`) are normally checked *after* the `runpath`.

This can lead to confusing bugs when system libraries are preferred over `runpath` in self compiled binaries.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
