### PR TITLE
mxu11x0: 1.3 -> 1.4

### DIFF
--- a/pkgs/os-specific/linux/mxu11x0/default.nix
+++ b/pkgs/os-specific/linux/mxu11x0/default.nix
@@ -1,13 +1,11 @@
-{ stdenv, fetchFromGitHub, kernel }:
+{ stdenv, pkgs, fetchurl, kernel }:
 
 stdenv.mkDerivation {
-  name = "mxu11x0-1.3.11+git2017-07-13-${kernel.version}";
+  name = "mxu11x0-1.4-${kernel.version}";
 
-  src = fetchFromGitHub {
-    owner = "ellysh";
-    repo = "mxu11x0";
-    rev = "cbbb5ec2045939209117cb5fcd6c7c23bcc109ef";
-    sha256 = "0wf44pnz5aclvg2k1f8ljnwws8hh6191i5h06nz95ijbxhwz63w4";
+  src = fetchurl {
+    url = "https://www.moxa.com/Moxa/media/PDIM/S100000385/moxa-uport-1000-series-linux-3.x-and-4.x-for-uport-11x0-series-driver-v1.4.tgz";
+    sha256 = "1hz9ygabbp8pv49k1j4qcsr0v3zw9xy0bh1akqgxp5v29gbdgxjl";
   };
 
   preBuild = ''
@@ -34,6 +32,5 @@ stdenv.mkDerivation {
     license = licenses.gpl1;
     maintainers = with maintainers; [ uralbash ];
     platforms = platforms.linux;
-    broken = versionOlder kernel.version "4.9" || !versionOlder kernel.version "4.13";
   };
 }

--- a/pkgs/os-specific/linux/mxu11x0/default.nix
+++ b/pkgs/os-specific/linux/mxu11x0/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, pkgs, fetchurl, kernel }:
+{ stdenv, fetchurl, kernel }:
 
 stdenv.mkDerivation {
   name = "mxu11x0-1.4-${kernel.version}";

--- a/pkgs/os-specific/linux/mxu11x0/default.nix
+++ b/pkgs/os-specific/linux/mxu11x0/default.nix
@@ -28,8 +28,8 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "MOXA UPort 11x0 USB to Serial Hub driver";
-    homepage = https://github.com/ellysh/mxu11x0;
-    license = licenses.gpl1;
+    homepage = https://www.moxa.com/en/products/industrial-edge-connectivity/usb-to-serial-converters-usb-hubs/usb-to-serial-converters/uport-1000-series;
+    license = licenses.gpl2Plus;
     maintainers = with maintainers; [ uralbash ];
     platforms = platforms.linux;
   };


### PR DESCRIPTION
###### Motivation for this change

The new version fixes a bug with the latest versions of linux kernel

###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
