### PR TITLE
fsfe-reuse: Init at 0.3.4

### DIFF
--- a/pkgs/development/tools/fsfe-reuse/default.nix
+++ b/pkgs/development/tools/fsfe-reuse/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, python3Packages, fetchFromGitLab }:
+
+with python3Packages;
+
+python3Packages.buildPythonApplication rec {
+  name = "${pname}-${version}";
+  pname = "fsfe-reuse";
+  version = "0.3.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0qwwzlm2fnw88m0xs0v61l46vlfhwyih1s6bj7fg4ivhjcgz0hq7";
+  };
+
+  propagatedBuildInputs = with python3Packages; [ chardet debian pygit2 ];
+
+  checkInputs = with python3Packages; [ tox ];
+
+  # needs tox
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "reuse is a tool for compliance with the REUSE Initiative recommendations.";
+    homepage = "https://reuse.gitlab.io/";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ kirelagin ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2916,6 +2916,8 @@ in
 
   fsarchiver = callPackage ../tools/archivers/fsarchiver { };
 
+  fsfe-reuse = callPackage ../development/tools/fsfe-reuse { };
+
   fsfs = callPackage ../tools/filesystems/fsfs { };
 
   fstl = qt5.callPackage ../applications/graphics/fstl { };


### PR DESCRIPTION
###### Motivation for this change

Add new package, the lint tool for the [REUSE Initiative](https://reuse.software/).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
