### PR TITLE
[19.03] emacs: Link subdirs.el into emacs-packages-deps

### DIFF
--- a/pkgs/build-support/emacs/wrapper.nix
+++ b/pkgs/build-support/emacs/wrapper.nix
@@ -121,21 +121,25 @@ stdenv.mkDerivation {
 
      siteStart="$out/share/emacs/site-lisp/site-start.el"
      siteStartByteCompiled="$siteStart"c
+     subdirs="$out/share/emacs/site-lisp/subdirs.el"
+     subdirsByteCompiled="$subdirs"c
 
-     # A dependency may have brought the original siteStart, delete it and
-     # create our own
+     # A dependency may have brought the original siteStart or subdirs, delete
+     # it and create our own
      # Begin the new site-start.el by loading the original, which sets some
      # NixOS-specific paths. Paths are searched in the reverse of the order
      # they are specified in, so user and system profile paths are searched last.
-     rm -f $siteStart $siteStartByteCompiled
+     rm -f $siteStart $siteStartByteCompiled $subdirs $subdirsByteCompiled
      cat >"$siteStart" <<EOF
 (load-file "$emacs/share/emacs/site-lisp/site-start.el")
 (add-to-list 'load-path "$out/share/emacs/site-lisp")
 (add-to-list 'exec-path "$out/bin")
 EOF
+      # Link subdirs.el from the emacs distribution
+      ln -s $emacs/share/emacs/site-lisp/subdirs.el -T $subdirs
 
      # Byte-compiling improves start-up time only slightly, but costs nothing.
-     $emacs/bin/emacs --batch -f batch-byte-compile "$siteStart"
+     $emacs/bin/emacs --batch -f batch-byte-compile "$siteStart" "$subdirs"
   '';
 
   phases = [ "installPhase" ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Ports  #55081 from unstable to 19.03.

cc @matthewbauer 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
