### PR TITLE
libuv: fix darwin sandbox build

### DIFF
--- a/pkgs/development/libraries/libuv/default.nix
+++ b/pkgs/development/libraries/libuv/default.nix
@@ -17,11 +17,10 @@ stdenv.mkDerivation rec {
       "spawn_setuid_fails" "spawn_setgid_fails" "fs_chown" # user namespaces
       "getaddrinfo_fail" "getaddrinfo_fail_sync"
       "threadpool_multiple_event_loops" # times out on slow machines
-    ]
-      # Sometimes: timeout (no output), failed uv_listen. Someone
-      # should report these failures to libuv team. There tests should
-      # be much more robust.
-      ++ stdenv.lib.optionals stdenv.isDarwin [
+    ] ++ stdenv.lib.optionals stdenv.isDarwin [
+        # Sometimes: timeout (no output), failed uv_listen. Someone
+        # should report these failures to libuv team. There tests should
+        # be much more robust.
         "process_title" "emfile" "poll_duplex" "poll_unidirectional"
         "ipc_listen_before_write" "ipc_listen_after_write" "ipc_tcp_connection"
         "tcp_alloc_cb_fail" "tcp_ping_pong" "tcp_ref3" "tcp_ref4"
@@ -34,11 +33,16 @@ stdenv.mkDerivation rec {
         "multiple_listen" "delayed_accept"
         "shutdown_close_tcp" "shutdown_eof" "shutdown_twice" "callback_stack"
         "tty_pty" "condvar_5"
-      ] ++ stdenv.lib.optionals stdenv.isAarch32 [
-        # I observe this test failing with some regularity on ARMv7:
-        # https://github.com/libuv/libuv/issues/1871
-        "shutdown_close_pipe"
-      ];
+        # Tests that fail when sandboxing is enabled.
+        "fs_event_close_in_callback" "fs_event_watch_dir"
+        "fs_event_watch_dir_recursive" "fs_event_watch_file"
+        "fs_event_watch_file_current_dir" "fs_event_watch_file_exact_path"
+        "process_priority" "udp_create_early_bad_bind"
+    ] ++ stdenv.lib.optionals stdenv.isAarch32 [
+      # I observe this test failing with some regularity on ARMv7:
+      # https://github.com/libuv/libuv/issues/1871
+      "shutdown_close_pipe"
+    ];
     tdRegexp = lib.concatStringsSep "\\|" toDisable;
     in lib.optionalString doCheck ''
       sed '/${tdRegexp}/d' -i test/test-list.h
@@ -54,6 +58,9 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   doCheck = true;
+
+  # Some of the tests use localhost networking.
+  __darwinAllowLocalNetworking = true;
 
   meta = with lib; {
     description = "A multi-platform support library with a focus on asynchronous I/O";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
