### PR TITLE
gnome3.tracker: correct gdbus path

### DIFF
--- a/pkgs/desktops/gnome-3/core/tracker/default.nix
+++ b/pkgs/desktops/gnome-3/core/tracker/default.nix
@@ -30,8 +30,8 @@ in stdenv.mkDerivation rec {
   LC_ALL = "en_US.UTF-8";
 
   mesonFlags = [
-    "-Ddbus_services=share/dbus-1/services"
-    "-Dsystemd_user_services=lib/systemd/user"
+    "-Ddbus_services=${placeholder ''out''}/share/dbus-1/services"
+    "-Dsystemd_user_services=${placeholder ''out''}/lib/systemd/user"
     # TODO: figure out wrapping unit tests, some of them fail on missing gsettings-desktop-schemas
     "-Dfunctional_tests=false"
     "-Ddocs=true"
@@ -40,7 +40,7 @@ in stdenv.mkDerivation rec {
   patches = [
     (substituteAll {
       src = ./fix-paths.patch;
-      glib_dev = glib.dev;
+      gdbus = "${glib.bin}/bin/gdbus";
     })
   ];
 

--- a/pkgs/desktops/gnome-3/core/tracker/fix-paths.patch
+++ b/pkgs/desktops/gnome-3/core/tracker/fix-paths.patch
@@ -5,7 +5,7 @@
  Name=Tracker Store
  Comment=Metadata database store and lookup manager
 -Exec=gdbus call -e -d org.freedesktop.DBus -o /org/freedesktop/DBus -m org.freedesktop.DBus.StartServiceByName org.freedesktop.Tracker1 0
-+Exec=@glib_dev@/bin/gdbus call -e -d org.freedesktop.DBus -o /org/freedesktop/DBus -m org.freedesktop.DBus.StartServiceByName org.freedesktop.Tracker1 0
++Exec=@gdbus@ call -e -d org.freedesktop.DBus -o /org/freedesktop/DBus -m org.freedesktop.DBus.StartServiceByName org.freedesktop.Tracker1 0
  Terminal=false
  Type=Application
  Categories=Utility;


### PR DESCRIPTION
It's in glib.bin

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
