### PR TITLE
quazip: 0.7.3 -> 0.7.6

### DIFF
--- a/pkgs/development/libraries/quazip/default.nix
+++ b/pkgs/development/libraries/quazip/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Provides access to ZIP archives from Qt programs";
     license = stdenv.lib.licenses.gpl2Plus;
-    homepage = http://quazip.sourceforge.net/;
+    homepage = https://stachenov.github.io/quazip/; # Migrated from http://quazip.sourceforge.net/
     platforms = stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/development/libraries/quazip/default.nix
+++ b/pkgs/development/libraries/quazip/default.nix
@@ -1,14 +1,15 @@
-{ fetchurl, stdenv, zlib, qtbase, qmake }:
+{ fetchFromGitHub, stdenv, zlib, qtbase, qmake }:
 
 stdenv.mkDerivation rec {
-  name = "quazip-0.7.3";
+  pname = "quazip";
+  version = "0.7.6";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/quazip/${name}.tar.gz";
-    sha256 = "1db9w8ax1ki0p67a47h4cnbwfgi2di4y3k9nc3a610kffiag7m1a";
+  src = fetchFromGitHub {
+    owner = "stachenov";
+    repo = pname;
+    rev = version;
+    sha256 = "1p6khy8fn9bwp14l6wd3sniwwm5v216l8xncfb7a6psjzvq5ypy6";
   };
-
-  preConfigure = "cd quazip";
 
   buildInputs = [ zlib qtbase ];
   nativeBuildInputs = [ qmake ];


### PR DESCRIPTION
###### Motivation for this change

quazip has been moved from sourceforge to GitHub. This is why quazip wasn't picked up by automatic packages updates. See:

http://quazip.sourceforge.net/



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [-] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
