### PR TITLE
opam: fix sandboxing in release-19.03

### DIFF
--- a/pkgs/development/tools/ocaml/opam/default.nix
+++ b/pkgs/development/tools/ocaml/opam/default.nix
@@ -104,7 +104,7 @@ in stdenv.mkDerivation rec {
     makeWrapper $out/bin/.opam-wrapped $out/bin/opam \
       --argv0 "opam" \
       --suffix PATH : ${aspcud}/bin:${unzip}/bin:${curl}/bin:${lib.optionalString stdenv.isLinux "${bubblewrap}/bin:"}${getconf}/bin \
-      --set OPAM_USER_PATH_RO /run/current-system/sw/bin:/nix/store
+      --set OPAM_USER_PATH_RO /run/current-system/sw/bin:/nix/
     $out/bin/opam-installer --prefix=$installer opam-installer.install
   '';
 

--- a/pkgs/development/tools/ocaml/opam/opam.nix.pl
+++ b/pkgs/development/tools/ocaml/opam/opam.nix.pl
@@ -114,7 +114,7 @@ print <<'EOF';
     makeWrapper $out/bin/.opam-wrapped $out/bin/opam \
       --argv0 "opam" \
       --suffix PATH : ${aspcud}/bin:${unzip}/bin:${curl}/bin:${lib.optionalString stdenv.isLinux "${bubblewrap}/bin:"}${getconf}/bin \
-      --set OPAM_USER_PATH_RO /run/current-system/sw/bin:/nix/store
+      --set OPAM_USER_PATH_RO /run/current-system/sw/bin:/nix/
     $out/bin/opam-installer --prefix=$installer opam-installer.install
   '';
 


### PR DESCRIPTION
Cherry-pick 83e6a1c99667dc7e0839b8b36e213d7e238511d7 from master to release branch.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

opam is working fine on master, but not in the release version 19.03, where it complains that it cannot find `ocamlc` whenever building a package.
opam runs these build commands in a sandbox, and this commit is needed so that the sandbox can see the entire `/nix` tree as RO, otherwise it won't be able to resolve the `ocamlc` symlink from the user's profile.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review rev HEAD -p release-19.03"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
