### PR TITLE
pythonPackages.loo-py: init at 2017.2

### DIFF
--- a/pkgs/development/libraries/symengine/default.nix
+++ b/pkgs/development/libraries/symengine/default.nix
@@ -3,26 +3,35 @@
 , cmake
 , gmp
 , flint
+, mpfr
+, libmpc
 }:
 
 stdenv.mkDerivation rec {
   name = "symengine-${version}";
-  version = "0.3.0";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "symengine";
     repo = "symengine";
     rev = "v${version}";
-    sha256 = "1p7hk163rgn1zzvjlq4vskblry3s2rg5bc7xlr08wfqckfr47bqc";
+    sha256 = "1kz893p3pmsw3gfwickk2nliw8p63yp89xriad7kpw4kmhvgr8gb";
   };
 
-  buildInputs = [ cmake gmp flint ];
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ gmp flint mpfr libmpc ];
 
   cmakeFlags = [
     "-DWITH_FLINT=ON"
+    "-DINTEGER_CLASS=flint"
+    "-DWITH_SYMENGINE_THREAD_SAFE=yes"
+    "-DWITH_MPC=yes"
+    "-DBUILD_FOR_DISTRIBUTION=yes"
   ];
 
   doCheck = true;
+
   checkPhase = ''
     ctest
   '';

--- a/pkgs/development/libraries/symengine/default.nix
+++ b/pkgs/development/libraries/symengine/default.nix
@@ -1,0 +1,38 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, gmp
+, flint
+}:
+
+stdenv.mkDerivation rec {
+  name = "symengine-${version}";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "symengine";
+    repo = "symengine";
+    rev = "v${version}";
+    sha256 = "1p7hk163rgn1zzvjlq4vskblry3s2rg5bc7xlr08wfqckfr47bqc";
+  };
+
+  buildInputs = [ cmake gmp flint ];
+
+  cmakeFlags = [
+    "-DWITH_FLINT=ON"
+  ];
+
+  doCheck = true;
+  checkPhase = ''
+    ctest
+  '';
+
+  meta = with stdenv.lib; {
+    description = "SymEngine is a fast symbolic manipulation library";
+    homepage = https://github.com/symengine/symengine;
+    platforms = platforms.unix ++ platforms.windows;
+    license = licenses.bsd3;
+    maintainers = [ maintainers.costrouc ];
+  };
+
+}

--- a/pkgs/development/python-modules/cgen/default.nix
+++ b/pkgs/development/python-modules/cgen/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytools
+, numpy
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "cgen";
+  version = "2017.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "a04525d51ee975d37d590d6d82bf80a46e77f75187cccfd2248a89616a778795";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [
+    pytools
+    numpy
+  ];
+
+  checkPhase = ''
+    pytest
+  '';
+
+  meta = with lib; {
+    description = "C/C++ source generation from an AST";
+    homepage = https://github.com/inducer/cgen;
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/genpy/default.nix
+++ b/pkgs/development/python-modules/genpy/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytools
+, numpy
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "genpy";
+  version = "2016.1.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1c11726f1e8ace8bbdfc87816403c9a59f53a8c3d45c99187ae17c9725d87a91";
+  };
+
+  propagatedBuildInputs = [
+    pytools
+    numpy
+  ];
+
+  meta = with lib; {
+    description = "C/C++ source generation from an AST";
+    homepage = https://github.com/inducer/genpy;
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/islpy/default.nix
+++ b/pkgs/development/python-modules/islpy/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, isl
+, pytest
+, cffi
+, six
+}:
+
+buildPythonPackage rec {
+  pname = "islpy";
+  version = "2018.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "be422a53b576210a0bb9775866abb6580b1e568222fc3e4e39d9e82f6d1d7253";
+  };
+
+  postConfigure = ''
+    substituteInPlace setup.py \
+      --replace "\"pytest>=2\"," ""
+  '';
+
+  buildInputs = [ isl ];
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [
+    cffi
+    six
+  ];
+
+  checkPhase = ''
+    pytest test
+  '';
+
+  meta = with lib; {
+    description = "Python wrapper around isl, an integer set library";
+    homepage = https://github.com/inducer/islpy;
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/loo-py/default.nix
+++ b/pkgs/development/python-modules/loo-py/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytools
+, pymbolic
+, genpy
+, cgen
+, islpy
+, six
+, colorama
+, mako
+, pyopencl
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "loo-py";
+  version = "2017.2";
+
+  src = fetchPypi {
+    pname = "loo.py";
+    inherit version;
+    sha256 = "c656992de48b328cdaccd7d1f14eb522b9dd5a1d0d15f54623f4ab18fd219abc";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [
+    pytools
+    pymbolic
+    genpy
+    cgen
+    islpy
+    six
+    colorama
+    mako
+    pyopencl
+  ];
+
+  # pyopencl._cl.LogicError: clGetPlatformIDs failed: PLATFORM_NOT_FOUND_KHR
+  doCheck = false;
+  checkPhase = ''
+    HOME=$(mktemp -d) pytest test
+  '';
+
+  meta = with lib; {
+    description = "A code generator for array-based code on CPUs and GPUs";
+    homepage = https://mathema.tician.de/software/loopy;
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/pymbolic/default.nix
+++ b/pkgs/development/python-modules/pymbolic/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytools
+, pytest
+, six
+, sympy
+, pexpect
+, symengine
+}:
+
+buildPythonPackage rec {
+  pname = "pymbolic";
+  version = "2018.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "a47d5524d6a3cdc8a028079ce632eeb45ceea7243272d234f250622087688207";
+  };
+
+  postConfigure = ''
+    substituteInPlace setup.py \
+      --replace "\"pytest>=2.3\"," ""
+  '';
+
+  checkInputs = [ sympy pexpect symengine pytest ];
+  propagatedBuildInputs = [
+    pytools
+    six
+  ];
+
+  # too many tests fail
+  doCheck = false;
+  checkPhase = ''
+    pytest test
+  '';
+
+  meta = with lib; {
+    description = "A package for symbolic computation";
+    homepage = https://mathema.tician.de/software/pymbolic;
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/symengine/default.nix
+++ b/pkgs/development/python-modules/symengine/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, cython
+, cmake
+, symengine
+, nose
+}:
+
+buildPythonPackage rec {
+  pname = "symengine";
+  version = "0.3.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "e86d13aadc9f765f2c5462da32950edd36d1a0a52dbfc96e766be3689957c04d";
+  };
+
+  postConfigure = ''
+    substituteInPlace setup.py \
+      --replace "\"cmake\"" "\"${cmake}/bin/cmake\""
+
+    substituteInPlace cmake/FindCython.cmake \
+      --replace "SET(CYTHON_BIN cython" "SET(CYTHON_BIN ${cython}/bin/cython"
+  '';
+
+  buildInputs = [ cython cmake ];
+
+  setupPyBuildFlags = [ "--symengine-dir=${symengine}/" ];
+
+  # tests fail due to trying to import local "symengine" directory
+  doCheck = false;
+  checkPhase = ''
+    nosetests symengine/tests -v
+  '';
+
+  meta = with lib; {
+    description = "Python library providing wrappers to SymEngine";
+    homepage = https://github.com/symengine/symengine.py;
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/symengine/default.nix
+++ b/pkgs/development/python-modules/symengine/default.nix
@@ -1,19 +1,23 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , cython
 , cmake
 , symengine
-, nose
+, pytest
+, sympy
+, python
 }:
 
 buildPythonPackage rec {
   pname = "symengine";
-  version = "0.3.0";
+  version = "0.4.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "e86d13aadc9f765f2c5462da32950edd36d1a0a52dbfc96e766be3689957c04d";
+  src = fetchFromGitHub {
+    owner = "symengine";
+    repo = "symengine.py";
+    rev = "v${version}";
+    sha256 = "07i9rwxphi4zgwc7y6f6qvq73iym2cx4k1bpd7rmd3wkpgrrfxqx";
   };
 
   postConfigure = ''
@@ -26,12 +30,17 @@ buildPythonPackage rec {
 
   buildInputs = [ cython cmake ];
 
-  setupPyBuildFlags = [ "--symengine-dir=${symengine}/" ];
+  checkInputs = [ pytest sympy ];
 
-  # tests fail due to trying to import local "symengine" directory
-  doCheck = false;
+  setupPyBuildFlags = [
+    "--symengine-dir=${symengine}/"
+    "--define=\"CYTHON_BIN=${cython}/bin/cython\""
+  ];
+
   checkPhase = ''
-    nosetests symengine/tests -v
+    mkdir empty
+    cd empty
+    ${python.interpreter} ../bin/test_python.py
   '';
 
   meta = with lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5937,6 +5937,8 @@ in
 
   svtplay-dl = callPackage ../tools/misc/svtplay-dl { };
 
+  symengine = callPackage ../development/libraries/symengine { };
+
   sysbench = callPackage ../development/tools/misc/sysbench {};
 
   system-config-printer = callPackage ../tools/misc/system-config-printer {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5380,6 +5380,8 @@ in {
 
   gensim = callPackage  ../development/python-modules/gensim { };
 
+  genpy = callPackage ../development/python-modules/genpy { };
+
   cymem = callPackage ../development/python-modules/cymem { };
 
   ftfy = callPackage ../development/python-modules/ftfy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2042,6 +2042,8 @@ in {
 
   isbnlib = callPackage ../development/python-modules/isbnlib { };
 
+  islpy = callPackage ../development/python-modules/islpy { };
+
   itsdangerous = callPackage ../development/python-modules/itsdangerous { };
 
   iniparse = callPackage ../development/python-modules/iniparse { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4607,6 +4607,10 @@ in {
 
   python-vagrant = callPackage ../development/python-modules/python-vagrant { };
 
+  symengine = callPackage ../development/python-modules/symengine {
+    symengine = pkgs.symengine;
+  };
+
   sympy = callPackage ../development/python-modules/sympy { };
 
   pilkit = callPackage ../development/python-modules/pilkit { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2244,6 +2244,8 @@ in {
 
   pylama = callPackage ../development/python-modules/pylama { };
 
+  pymbolic = callPackage ../development/python-modules/pymbolic { };
+
   pymediainfo = callPackage ../development/python-modules/pymediainfo { };
 
   pyphen = callPackage ../development/python-modules/pyphen {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1196,6 +1196,8 @@ in {
 
   cement = callPackage ../development/python-modules/cement {};
 
+  cgen = callPackage ../development/python-modules/cgen { };
+
   cgroup-utils = callPackage ../development/python-modules/cgroup-utils {};
 
   chainer = callPackage ../development/python-modules/chainer {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1740,6 +1740,8 @@ in {
 
   locket = callPackage ../development/python-modules/locket { };
 
+  loo-py = callPackage ../development/python-modules/loo-py { };
+
   tblib = callPackage ../development/python-modules/tblib { };
 
   s3fs = callPackage ../development/python-modules/s3fs { };


### PR DESCRIPTION
###### Motivation for this change

This is a PR motivated by wanting to use the package `loo.py`. I have enabled as many tests as possible in all the packages. Serveral packages had to be built. 

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
