### PR TITLE
flatpak: clear GDK_PIXBUF_MODULE_FILE

### DIFF
--- a/pkgs/development/libraries/flatpak/default.nix
+++ b/pkgs/development/libraries/flatpak/default.nix
@@ -32,6 +32,7 @@ stdenv.mkDerivation rec {
     # patch taken from gtk_doc
     ./respect-xml-catalog-files-var.patch
     ./use-flatpak-from-path.patch
+    ./unset-env-vars.patch
   ];
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/flatpak/unset-env-vars.patch
+++ b/pkgs/development/libraries/flatpak/unset-env-vars.patch
@@ -1,0 +1,10 @@
+--- a/common/flatpak-run.c
++++ b/common/flatpak-run.c
+@@ -1192,6 +1192,7 @@ static const ExportData default_exports[] = {
+   {"PERLLIB", NULL},
+   {"PERL5LIB", NULL},
+   {"XCURSOR_PATH", NULL},
++  {"GDK_PIXBUF_MODULE_FILE", NULL},
+ };
+ 
+ static const ExportData no_ld_so_cache_exports[] = {


### PR DESCRIPTION
###### Motivation for this change

GDK_PIXBUF_MODULE_FILE is often set to a nix store path not available in a app
sandbox. This can cause some apps to fail launching, simply reset this env var
when running applications.

fixes https://github.com/NixOS/nixpkgs/issues/53441

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committehttps://github.com/NixOS/nixpkgs/issues/53441r, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
