### PR TITLE
nixos/doc: remove prometheus2 notes from the 19.09 release notes

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1909.xml
+++ b/nixos/doc/manual/release-notes/rl-1909.xml
@@ -35,26 +35,6 @@
    The following new services were added since the last release:
   </para>
 
-  <itemizedlist>
-   <listitem>
-    <para>
-       Besides the existing <option>services.prometheus</option> module which
-       targets Prometheus-1 a new <option>services.prometheus2</option> module
-       has been added which targets Prometheus-2.
-    </para>
-    <para>
-       Both modules can be enabled at the same time. In fact
-       <link xlink:href="https://prometheus.io/docs/prometheus/latest/migration/#storage">
-       this is needed for upgrading existing Prometheus-1 data to Prometheus-2
-       </link>.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-      There is a new <option>services.tox-node</option> module for running tox bootstrap nodes.
-    </para>
-   </listitem>
-  </itemizedlist>
  </section>
 
  <section xmlns="http://docbook.org/ns/docbook"
@@ -85,25 +65,6 @@
      if you run an application like eg. Nextcloud, where you need to use
      the Unix socket path as the database host name, you need to change it
      accordingly.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-      The directory where Prometheus will store its metric data is now
-      managed by systemd's StateDirectory mechanism. It still defaults
-      to <literal>/var/lib/prometheus</literal>.
-    </para>
-    <para>
-      Its location can be specified by the new
-      <option>services.prometheus.stateDir</option> option which
-      defaults to <literal>prometheus</literal>. Note that this should
-      be a directory relative to <literal>/var/lib/</literal>.
-    </para>
-    <para>
-      The option <option>services.prometheus.dataDir</option> has been
-      deprecated. You can still set it but it's now required to have
-      <literal>/var/lib/</literal> as a prefix and you can't set
-      <option>services.prometheus.stateDir</option> at the same time.
     </para>
    </listitem>
    <listitem>


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Since [prometheus2 has been backported to 19.03](https://github.com/NixOS/nixpkgs/pull/59262) it won't be new anymore for 19.09.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
