### PR TITLE
petrinizer: init at 0.9.1.1

### DIFF
--- a/pkgs/applications/science/logic/petrinizer/default.nix
+++ b/pkgs/applications/science/logic/petrinizer/default.nix
@@ -1,0 +1,25 @@
+{ mkDerivation, async, base, bytestring, containers, fetchFromGitLab, mtl
+, parallel-io, parsec, sbv, stdenv, stm, transformers
+}:
+mkDerivation rec {
+  pname = "petrinizer";
+  version = "0.9.1.1";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.lrz.de";
+    owner = "i7";
+    repo = pname;
+    rev = version;
+    sha256 = "1n7fzm96gq5rxm2f8w8sr1yzm1zcxpf0b473c6xnhsgqsis5j4xw";
+  };
+
+  isLibrary = false;
+  isExecutable = true;
+  executableHaskellDepends = [
+    async base bytestring containers mtl parallel-io parsec sbv stm
+    transformers
+  ];
+  description = "Safety and Liveness Analysis of Petri Nets with SMT solvers";
+  license = stdenv.lib.licenses.gpl3;
+  maintainers = with stdenv.lib.maintainers; [ raskin ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19755,6 +19755,8 @@ in
 
   peru = callPackage ../applications/version-management/peru {};
 
+  petrinizer = haskellPackages.callPackage ../applications/science/logic/petrinizer {};
+
   pmidi = callPackage ../applications/audio/pmidi { };
 
   printrun = callPackage ../applications/misc/printrun { };


### PR DESCRIPTION
###### Motivation for this change

Adding a Petrinizer tool used both in previous and ongoing research…

Will merge my self if the checks pass.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
