### PR TITLE
[WIP] xSDK initialize libraries for the exascale computing project

### DIFF
--- a/pkgs/development/libraries/science/math/amrex/default.nix
+++ b/pkgs/development/libraries/science/math/amrex/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, fetchFromGitHub
+, python
+, mpi
+, gfortran
+}:
+
+stdenv.mkDerivation rec {
+  name = "amrex-${version}";
+  version = "19.04.2";
+
+  src = fetchFromGitHub {
+    owner = "AMReX-Codes";
+    repo = "amrex";
+    rev = version;
+    sha256 = "0h22l4kmmblqvsy3rny5yp35fa13lhg3wn4b5fky0cqqwqwafzfd";
+  };
+
+  preConfigure = ''
+    patchShebangs .
+  '';
+
+  buildInputs = [ python mpi gfortran ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/AMReX-Codes/amrex;
+    description = "AMReX: Software Framework for Block Structured AMR";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ costrouc ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/science/math/dealii/default.nix
+++ b/pkgs/development/libraries/science/math/dealii/default.nix
@@ -1,0 +1,27 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, mpi
+}:
+
+stdenv.mkDerivation rec {
+  name = "dealii-${version}";
+  version = "9.0.1";
+
+  src = fetchFromGitHub {
+    owner = "dealii";
+    repo = "dealii";
+    rev = "v${version}";
+    sha256 = "01vz85fcm092bkbk4ib356j80b2hdwcxykkrhyrkw2pbas2npvnf";
+  };
+
+  buildInputs = [ cmake mpi ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/dealii/dealii;
+    description = "Computational solution of partial differential equations using adaptive finite elements";
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ costrouc ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/science/math/hypre/default.nix
+++ b/pkgs/development/libraries/science/math/hypre/default.nix
@@ -1,0 +1,33 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, mpi
+, gfortran
+}:
+
+stdenv.mkDerivation rec {
+  name = "hypre-${version}";
+  version = "2.15.1";
+
+  src = fetchFromGitHub {
+    owner = "hypre-space";
+    repo = "hypre";
+    rev = "v${version}";
+    sha256 = "1gha571flc6q513137q4416hzpzb6qn2b9hlp3swik5150m91bbb";
+  };
+
+  preConfigure = ''
+    cd src
+    asdfasdfasdfasdf # intentionally fail build
+  '';
+
+  buildInputs = [ mpi gfortran cmake ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/hypre-space/hypre;
+    description = "Library for preconditioners and solvers featuring multigrid methods for the solution of large, sparse linear systems of equations";
+    license = licenses.lgpl2;
+    maintainers = with maintainers; [ costrouc ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21991,6 +21991,10 @@ in
 
   cliquer = callPackage ../development/libraries/science/math/cliquer { };
 
+  dealii = callPackage ../development/libraries/science/math/dealii {
+    mpi = openmpi;
+  };
+
   ecos = callPackage ../development/libraries/science/math/ecos { };
 
   flintqs = callPackage ../development/libraries/science/math/flintqs { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22003,6 +22003,10 @@ in
 
   gurobi = callPackage ../applications/science/math/gurobi { };
 
+  hypre = callPackage ../development/libraries/science/math/hypre {
+    mpi = openmpi;
+  };
+
   jags = callPackage ../applications/science/math/jags { };
 
   libbraiding = callPackage ../development/libraries/science/math/libbraiding { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21977,6 +21977,10 @@ in
 
   arpack = callPackage ../development/libraries/science/math/arpack { };
 
+  amrex = callPackage ../development/libraries/science/math/amrex {
+    mpi = openmpi;
+  };
+
   blas = callPackage ../development/libraries/science/math/blas { };
 
   brial = callPackage ../development/libraries/science/math/brial { };


### PR DESCRIPTION
###### Motivation for this change

I want to make nixos/nixpkgs the place to go for hpc. Currently many scientists with these libraries use https://spack.readthedocs.io/en/latest/ and these are the important core libraries. More to come listed in https://xsdk.info/packages/.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
