### PR TITLE
coqPackages.mathcomp: 1.7.0 -> 1.8.0

### DIFF
--- a/pkgs/development/coq-modules/mathcomp-analysis/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-analysis/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, coq, mathcomp-bigenough, mathcomp-finmap }:
 
 stdenv.mkDerivation rec {
-  version = "0.1.0";
+  version = "0.2.0";
   name = "coq${coq.coq-version}-mathcomp-analysis-${version}";
 
   src = fetchFromGitHub {
     owner = "math-comp";
     repo = "analysis";
     rev = version;
-    sha256 = "0hwkr2wzy710pcyh274fcarzdx8sv8myp16pv0vq5978nmih46al";
+    sha256 = "1186xjxgns4ns1szyi931964bjm0mp126qzlv10mkqqgfw07nhrd";
   };
 
   buildInputs = [ coq ];

--- a/pkgs/development/coq-modules/mathcomp-finmap/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-finmap/default.nix
@@ -1,14 +1,25 @@
 { stdenv, fetchFromGitHub, coq, mathcomp }:
 
+let param =
+  if stdenv.lib.versionAtLeast mathcomp.version "1.8.0"
+  then {
+    version = "1.2.0";
+    sha256 = "0b6wrdr0d7rcnv86s37zm80540jl2wmiyf39ih7mw3dlwli2cyj4";
+  } else {
+    version = "1.1.0";
+    sha256 = "05df59v3na8jhpsfp7hq3niam6asgcaipg2wngnzxzqnl86srp2a";
+  }
+; in
+
 stdenv.mkDerivation rec {
-  version = "1.1.0";
+  inherit (param) version;
   name = "coq${coq.coq-version}-mathcomp-finmap-${version}";
 
   src = fetchFromGitHub {
     owner = "math-comp";
     repo = "finmap";
     rev = version;
-    sha256 = "05df59v3na8jhpsfp7hq3niam6asgcaipg2wngnzxzqnl86srp2a";
+    inherit (param) sha256;
   };
 
   buildInputs = [ coq ];

--- a/pkgs/development/coq-modules/mathcomp/default.nix
+++ b/pkgs/development/coq-modules/mathcomp/default.nix
@@ -4,7 +4,12 @@
 
 let param =
 
-  if stdenv.lib.versionAtLeast coq.coq-version "8.6" then
+  if stdenv.lib.versionAtLeast coq.coq-version "8.7" then
+  {
+    version = "1.8.0";
+    sha256 = "07l40is389ih8bi525gpqs3qp4yb2kl11r9c8ynk1ifpjzpnabwp";
+  }
+  else if stdenv.lib.versionAtLeast coq.coq-version "8.6" then
   {
     version = "1.7.0";
     sha256 = "0wnhj9nqpx2bw6n1l4i8jgrw3pjajvckvj3lr4vzjb3my2lbxdd1";


### PR DESCRIPTION
coqPackages.mathcomp-finmap: 1.1.0 -> 1.2.0
coqPackages.mathcomp-analysis: 0.1.0 -> 0.2.0

###### Motivation for this change

Major update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
