### PR TITLE
bluej-bin: init at 414

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1989,6 +1989,10 @@
     github = "Hodapp87";
     name = "Chris Hodapp";
   };
+  hochi = {
+    github = "h0chi";
+    name = "hochi";
+  };
   hrdinka = {
     email = "c.nix@hrdinka.at";
     github = "hrdinka";

--- a/pkgs/applications/editors/bluej-bin/default.nix
+++ b/pkgs/applications/editors/bluej-bin/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchurl, makeWrapper, unzip, jetbrains
+}:
+let
+  version = "414";
+in
+stdenv.mkDerivation {
+  name = "bluej-bin-${version}";
+  src = fetchurl {
+    url = "https://www.bluej.org/download/files/BlueJ-linux-${version}.deb";
+    sha512 = "c9c5c905d6dcf4388fe1423179be836ad8d35a4d197e53706a5764d9192c439aa60b80a28b87222b9f16ed1534d7a7768d924fc06ddd95107aea3cb00570c22a";
+  };
+
+  buildCommand = ''
+    # Unpack the original deb package and perform some path patching.
+    ar p $src data.tar.xz | tar xJ
+    patchShebangs .
+
+    # Copy to installation directory and create a wrapper capable of starting
+    # it.
+    mkdir -pv $out/
+    mv usr/* $out
+    cp -a usr $out
+    makeWrapper ${jetbrains.jdk}/bin/java $out/bin/bluej \
+      --add-flags "-Djavafx.embed.singleThread=true -Dawt.useSystemAAFontSettings=on -Xmx512M -cp \"$out/share/bluej/bluej.jar:${jetbrains.jdk}/lib/tools.jar\" bluej.Boot"
+  '';
+
+  buildInputs = [ makeWrapper unzip ];
+
+  meta = {
+    description = "A simple integrated development environment for Java";
+    homepage = "https://www.bluej.org/";
+    license = stdenv.lib.licenses.gpl2;
+    maintainers = with stdenv.lib.maintainers; [ hochi ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16617,8 +16617,10 @@ in
   bluefish = callPackage ../applications/editors/bluefish {
     gtk = gtk3;
   };
-
+  
   bluejeans = callPackage ../applications/networking/browsers/mozilla-plugins/bluejeans { };
+
+  bluej-bin = callPackage ../applications/editors/bluej-bin { };
 
   bluejeans-gui = callPackage ../applications/networking/instant-messengers/bluejeans {
     gconf = pkgs.gnome2.GConf;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
BlueJ is used in my programming lecture. Disclaimer: This is my first package submission to nixpkgs.

###### Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
