### PR TITLE
Update libimobiledevice packages, fix usbmuxd

### DIFF
--- a/pkgs/development/libraries/libimobiledevice/default.nix
+++ b/pkgs/development/libraries/libimobiledevice/default.nix
@@ -3,15 +3,15 @@
 
 stdenv.mkDerivation rec {
   pname = "libimobiledevice";
-  version = "2018-07-24";
+  version = "2019-04-04";
 
   name = "${pname}-${version}";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
-    rev = "d7a2e04d2e7880c56116fd35489a7f98755501b7";
-    sha256 = "0cj0j10lmfr28c7nh79n2mcmy31xx50g93h0bqs0l7y76ph4dqkc";
+    rev = "eea4f1be9107c8ab621fd71460e47d0d38e55d71";
+    sha256 = "0wh6z5f5znlqs0grh7c8jj1s411azgyy45klmql5kj3p8qqybqrs";
   };
 
   outputs = [ "out" "dev" ];
@@ -56,6 +56,6 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.lgpl21Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ infinisil ];
   };
 }

--- a/pkgs/development/libraries/libplist/default.nix
+++ b/pkgs/development/libraries/libplist/default.nix
@@ -5,15 +5,15 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "libplist";
-  version = "2019-01-20";
+  version = "2019-04-04";
 
   name = "${pname}-${version}";
 
   src = fetchFromGitHub {
     owner = "libimobiledevice";
     repo = pname;
-    rev = "bec850fe399639f3b8582a39386216970dea15ed";
-    sha256 = "197yw8xz8x2xld8b6975scgnl30j4ibm9llmzljyqngs0zsdwnin";
+    rev = "42bb64ba966082b440cb68cbdadf317f44710017";
+    sha256 = "19yw80yblq29i2jx9yb7bx0lfychy9dncri3fk4as35kq5bf26i8";
   };
 
   outputs = ["bin" "dev" "out" "py"];
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     description = "A library to handle Apple Property List format in binary or XML";
     homepage = https://github.com/libimobiledevice/libplist;
     license = licenses.lgpl21Plus;
-    maintainers = [ ];
+    maintainers = with maintainers; [ infinisil ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/libusbmuxd/default.nix
+++ b/pkgs/development/libraries/libusbmuxd/default.nix
@@ -2,15 +2,15 @@
 
 stdenv.mkDerivation rec {
   pname = "libusbmuxd";
-  version = "2019-01-18";
+  version = "2019-03-23";
 
   name = "${pname}-${version}";
 
   src = fetchFromGitHub {
     owner = "libimobiledevice";
     repo = pname;
-    rev = "c75605d862cd1c312494f6c715246febc26b2e05";
-    sha256 = "0467a045k4znmaz61i7a2s7yywj67q830ja6zn7z39k5pqcl2z4p";
+    rev = "873252dc8b4e469c7dc692064ac616104fca5f65";
+    sha256 = "0qx3q0n1f2ajfm3vnairikayzln6iyb2y0i7sqfl8mj45ahl6wyj";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
@@ -21,6 +21,6 @@ stdenv.mkDerivation rec {
     homepage    = https://github.com/libimobiledevice/libusbmuxd;
     license     = licenses.lgpl21Plus;
     platforms   = platforms.linux;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ infinisil ];
   };
 }

--- a/pkgs/tools/filesystems/ifuse/default.nix
+++ b/pkgs/tools/filesystems/ifuse/default.nix
@@ -2,15 +2,15 @@
 
 stdenv.mkDerivation rec {
   pname = "ifuse";
-  version = "1.1.3";
+  version = "2018-10-08";
 
   name = "${pname}-${version}";
 
   src = fetchFromGitHub {
     owner = "libimobiledevice";
     repo = pname;
-    rev = version;
-    sha256 = "0p01rds3vc5864v48swgqw5dv0h937nqnxggryixg9pkvzhc6cx5";
+    rev = "e75d32c34d0e8b80320f0a007d5ecbb3f55ef7f0";
+    sha256 = "1b9w2i0sliswlkkb890l9i0rxrf631xywxf8ihygfmjdsfw47h1m";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig fuse usbmuxd libimobiledevice ];
@@ -26,6 +26,6 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.lgpl21Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ infinisil ];
   };
 }

--- a/pkgs/tools/misc/ideviceinstaller/default.nix
+++ b/pkgs/tools/misc/ideviceinstaller/default.nix
@@ -2,15 +2,15 @@
 
 stdenv.mkDerivation rec {
   pname = "ideviceinstaller";
-  version = "2018-06-01";
+  version = "2018-10-01";
 
   name = "${pname}-${version}";
 
   src = fetchFromGitHub {
     owner = "libimobiledevice";
     repo = pname;
-    rev = "f7988de8279051f3d2d7973b8d7f2116aa5d9317";
-    sha256 = "1vmdvbwnjz3f90b9bqq7jg04q7awsbi9pmkvgwal8xdpp6jcwkwx";
+    rev = "f14def7cd9303a0fe622732fae9830ae702fdd7c";
+    sha256 = "1biwhbldvgdhn8ygp7w79ca0rivzdjpykr76pyhy7r2fa56mrwq8";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig usbmuxd libimobiledevice libzip ];
@@ -19,12 +19,12 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/libimobiledevice/ideviceinstaller;
     description = "List/modify installed apps of iOS devices";
     longDescription = ''
-      ideviceinstaller is a tool to interact with the installation_proxy 
+      ideviceinstaller is a tool to interact with the installation_proxy
       of an iOS device allowing to install, upgrade, uninstall, archive, restore
       and enumerate installed or archived apps.
     '';
     license = licenses.gpl2;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ aristid ];
+    maintainers = with maintainers; [ aristid infinisil ];
   };
 }

--- a/pkgs/tools/misc/usbmuxd/default.nix
+++ b/pkgs/tools/misc/usbmuxd/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "usbmuxd";
-  version = "2018-10-10";
+  version = "2019-03-05";
 
   src = fetchFromGitHub {
     owner = "libimobiledevice";
     repo = pname;
-    rev = "96e4aabe0b9a46ea9da4955a10c774a8e58fe677";
-    sha256 = "03xnj4y606adbhl829vv46qa78f6w2ik4mjz19a34x9lhkcrqxqi";
+    rev = "b1b0bf390363fa36aff1bc09443ff751943b9c34";
+    sha256 = "176hapckx98h4x0ni947qpkv2s95f8xfwz00wi2w7rgbr6cviwjq";
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
@@ -33,6 +33,6 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ infinisil ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/54953 updated usbmuxd only, seemingly without testing, because when I updated my system today it didn't work anymore, the issue being https://github.com/libimobiledevice/usbmuxd/issues/95. All these libimobiledevice packages should be updated together such that such things don't happen. This PR updates all of them to their latest master version. I also changed ifuse to use the master version instead of its releases, because there hasn't been a release in a while (see https://github.com/libimobiledevice/ifuse/issues/34).

Ping @worldofpeace @arilotter 

This is currently also broken for 19.03 too, <s>PR for a partial backport is incoming</s> after discussions with @grahamc and @samueldr on IRC I decided to instead backport all of these updates, because libimobiledevice doesn't have any stable versions anyways, and not updating all those packages roughly at the same time might lead to more such issues.

###### Things done

I have verified that this fixes above issue, allowing me to use my iPhone for tethering again. I also checked that ifuse can mount the filesystem and that ideviceinstaller can list installed apps.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
