### PR TITLE
gtranslator: init at 3.32.0

### DIFF
--- a/pkgs/tools/text/gtranslator/default.nix
+++ b/pkgs/tools/text/gtranslator/default.nix
@@ -1,0 +1,68 @@
+{ stdenv
+, fetchurl
+, meson
+, ninja
+, pkgconfig
+, itstool
+, gettext
+, python3
+, wrapGAppsHook
+, libxml2
+, libgda
+, gspell
+, glib
+, gtk3
+, gtksourceview4
+, gnome3
+, gsettings-desktop-schemas
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gtranslator";
+  version = "3.32.0";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "1dqigah7x6h3afw5jcs3lw3h9y0acj72arcgxr89l6galvknr2xa";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkgconfig
+    itstool
+    gettext
+    python3
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    libxml2
+    glib
+    gtk3
+    gtksourceview4
+    libgda
+    gettext
+    gspell
+    gsettings-desktop-schemas
+  ];
+
+  postPatch = ''
+    chmod +x build-aux/meson/meson_post_install.py
+    patchShebangs build-aux/meson/meson_post_install.py
+  '';
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+    };
+  };
+
+  meta = with stdenv.lib; {
+    description = "GNOME translation making program";
+    homepage = https://wiki.gnome.org/Apps/Gtranslator;
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ jtojnar ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9006,6 +9006,8 @@ in
 
   gtkdialog = callPackage ../development/tools/misc/gtkdialog { };
 
+  gtranslator = callPackage ../tools/text/gtranslator { };
+
   guff = callPackage ../tools/graphics/guff { };
 
   guile-lint = callPackage ../development/tools/guile/guile-lint {


### PR DESCRIPTION
Tool for translating Gettext files: https://gitlab.gnome.org/GNOME/gtranslator

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
