### PR TITLE
libpam: fix w/musl after update to 1.3.1

### DIFF
--- a/pkgs/os-specific/linux/pam/default.nix
+++ b/pkgs/os-specific/linux/pam/default.nix
@@ -18,10 +18,9 @@ stdenv.mkDerivation rec {
       url = "https://git.alpinelinux.org/cgit/aports/plain/main/linux-pam/libpam-fix-build-with-eglibc-2.16.patch?id=05a62bda8ec255d7049a2bd4cf0fdc4b32bdb2cc";
       sha256 = "1ib6shhvgzinjsc603k2x1lxh9dic6qq449fnk110gc359m23j81";
     })
-    (fetchpatch {
-      url = "https://git.alpinelinux.org/cgit/aports/plain/main/linux-pam/musl-fix-pam_exec.patch?id=05a62bda8ec255d7049a2bd4cf0fdc4b32bdb2cc";
-      sha256 = "04dx6s9d8cxl40r7m7dc4si47ds4niaqm7902y1d6wcjvs11vrf0";
-    })
+    # From adelie's package repo, using local copy since it seems to be currently offline.
+    # (we previously used similar patch from void, but stopped working with update to 1.3.1)
+    ./musl-fix-pam_exec.patch
   ];
 
   outputs = [ "out" "doc" "man" /* "modules" */ ];

--- a/pkgs/os-specific/linux/pam/musl-fix-pam_exec.patch
+++ b/pkgs/os-specific/linux/pam/musl-fix-pam_exec.patch
@@ -1,0 +1,33 @@
+--- ./modules/pam_exec/pam_exec.c.orig
++++ ./modules/pam_exec/pam_exec.c
+@@ -103,11 +103,14 @@
+   int optargc;
+   const char *logfile = NULL;
+   const char *authtok = NULL;
++  char authtok_buf[PAM_MAX_RESP_SIZE+1];
++
+   pid_t pid;
+   int fds[2];
+   int stdout_fds[2];
+   FILE *stdout_file = NULL;
+ 
++  memset(authtok_buf, 0, sizeof(authtok_buf));
+   if (argc < 1) {
+     pam_syslog (pamh, LOG_ERR,
+ 		"This module needs at least one argument");
+@@ -180,12 +183,12 @@
+ 	      if (resp)
+ 		{
+ 		  pam_set_item (pamh, PAM_AUTHTOK, resp);
+-		  authtok = strndupa (resp, PAM_MAX_RESP_SIZE);
++		  authtok = strncpy(authtok_buf, resp, sizeof(authtok_buf));
+ 		  _pam_drop (resp);
+ 		}
+ 	    }
+ 	  else
+-	    authtok = strndupa (void_pass, PAM_MAX_RESP_SIZE);
++	    authtok = strncpy(authtok_buf, void_pass, sizeof(authtok_buf));
+ 
+ 	  if (pipe(fds) != 0)
+ 	    {
+


### PR DESCRIPTION
###### Motivation for this change

Basically this moves to a similar patch to what we were using before the update.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---