### PR TITLE
sarasa-gothic: 0.6.0 -> 0.8.0

### DIFF
--- a/pkgs/data/fonts/sarasa-gothic/default.nix
+++ b/pkgs/data/fonts/sarasa-gothic/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchurl, p7zip }:
 
 let
-  version = "0.6.0";
-  sha256 = "08g3kzplp3v8kvni1vzl73fgh03xgfl8pwqyj7vwjihjdr1xfjyz";
+  version = "0.8.0";
+  sha256 = "0zafvzrh4180hmz351f1rvs29n8mfxf0qv6mdl7psf1f066dizs6";
 in fetchurl rec {
   inherit sha256;
 


### PR DESCRIPTION
###### Motivation for this change

https://github.com/be5invis/Sarasa-Gothic/releases/tag/v0.8.0
https://github.com/be5invis/Sarasa-Gothic/releases/tag/v0.7.2
https://github.com/be5invis/Sarasa-Gothic/releases/tag/v0.7.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---