### PR TITLE
knotes: init

### DIFF
--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -126,6 +126,7 @@ let
       kmime = callPackage ./kmime.nix {};
       kmix = callPackage ./kmix.nix {};
       kmplot = callPackage ./kmplot.nix {};
+      knotes = callPackage ./knotes.nix {};
       kolourpaint = callPackage ./kolourpaint.nix {};
       kompare = callPackage ./kompare.nix {};
       konsole = callPackage ./konsole.nix {};

--- a/pkgs/applications/kde/knotes.nix
+++ b/pkgs/applications/kde/knotes.nix
@@ -1,0 +1,29 @@
+{
+  mkDerivation, lib,
+  extra-cmake-modules, kdoctools,
+  kcompletion, kconfig, kconfigwidgets, kcoreaddons, kcrash,
+  kdbusaddons, kdnssd, kglobalaccel, kiconthemes, kitemmodels,
+  kitemviews, kcmutils, knewstuff, knotifications, knotifyconfig,
+  kparts, ktextwidgets, kwidgetsaddons, kwindowsystem,
+  kdelibs4support,
+  grantlee, grantleetheme, qtx11extras,
+  akonadi, akonadi-notes, akonadi-search, kcalutils,
+  kontactinterface, libkdepim, kmime, pimcommon, kpimtextedit,
+  kcalcore
+}:
+
+mkDerivation {
+  name = "knotes";
+  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  buildInputs = [
+    kcompletion kconfig kconfigwidgets kcoreaddons kcrash
+    kdbusaddons kdnssd kglobalaccel kiconthemes kitemmodels kitemviews
+    kcmutils knewstuff knotifications knotifyconfig kparts ktextwidgets
+    kwidgetsaddons kwindowsystem kdelibs4support
+    grantlee grantleetheme qtx11extras
+    akonadi akonadi-notes kcalutils kontactinterface
+    libkdepim kmime pimcommon kpimtextedit
+    akonadi-search
+    kcalcore
+  ];
+}


### PR DESCRIPTION
###### Motivation for this change

Seems to work properly for basic desktop sticky-notes :).


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---