### PR TITLE
dedup: init at 1.0

### DIFF
--- a/pkgs/tools/backup/dedup/default.nix
+++ b/pkgs/tools/backup/dedup/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, lz4, snappy, openmp ? null }:
+
+stdenv.mkDerivation rec {
+  pname = "dedup";
+  version = "1.0";
+
+  src = fetchurl {
+    url = "https://dl.2f30.org/releases/${pname}-${version}.tar.gz";
+    sha256 = "0wd4cnzhqk8l7byp1y16slma6r3i1qglwicwmxirhwdy1m7j5ijy";
+  };
+
+  makeFlags = [
+    "CC:=$(CC)"
+    "PREFIX=${placeholder "out"}"
+    "MANPREFIX=${placeholder "out"}/share/man"
+  ] ++ stdenv.lib.optional (openmp != null) [
+    "OPENMPCFLAGS=-fopenmp"
+    "OPENMPLDLIBS=-lgomp"
+  ];
+
+  buildInputs = [ lz4 snappy openmp ];
+
+  meta = with stdenv.lib; {
+    description = "data deduplication program";
+    homepage = https://git.2f30.org/dedup/file/README.html;
+    license = with licenses; [ bsd0 isc ];
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/tools/backup/dedup/default.nix
+++ b/pkgs/tools/backup/dedup/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, lz4, snappy, openmp ? null }:
+{ stdenv, fetchurl, lz4, snappy, openmp }:
 
 stdenv.mkDerivation rec {
   pname = "dedup";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     "CC:=$(CC)"
     "PREFIX=${placeholder "out"}"
     "MANPREFIX=${placeholder "out"}/share/man"
-  ] ++ stdenv.lib.optional (openmp != null) [
+    # These are likely wrong on some platforms, please report!
     "OPENMPCFLAGS=-fopenmp"
     "OPENMPLDLIBS=-lgomp"
   ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1316,6 +1316,10 @@ in
 
   ddate = callPackage ../tools/misc/ddate { };
 
+  dedup = callPackage ../tools/backup/dedup {
+    inherit (llvmPackages) openmp;
+  };
+
   dehydrated = callPackage ../tools/admin/dehydrated { };
 
   deis = callPackage ../development/tools/deis {};


### PR DESCRIPTION
###### Motivation for this change

Neat utility, 1.0 release.o

https://git.2f30.org/dedup/file/README.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---