### PR TITLE
Qsynth backport

### DIFF
--- a/pkgs/applications/audio/qsynth/default.nix
+++ b/pkgs/applications/audio/qsynth/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation  rec {
   name = "qsynth-${version}";
-  version = "0.5.5";
+  version = "0.5.6";
 
   src = fetchurl {
     url = "mirror://sourceforge/qsynth/${name}.tar.gz";
-    sha256 = "08x7znvbwi9miavcarymi7dsv8njmxzwzma20dbmz8j2aswm53w5";
+    sha256 = "0h4hhja8qbyzd6v24flw9wr4mwl03nplryx1gyrppn7sg13l1sx6";
   };
 
   nativeBuildInputs = [ autoconf pkgconfig ];

--- a/pkgs/applications/audio/qsynth/default.nix
+++ b/pkgs/applications/audio/qsynth/default.nix
@@ -1,23 +1,17 @@
-{ stdenv, fetchurl, alsaLib, fluidsynth, libjack2, qtbase, qttools, qtx11extras, cmake, pkgconfig }:
+{ stdenv, fetchurl, alsaLib, fluidsynth, libjack2, qt5, autoconf, pkgconfig }:
 
 stdenv.mkDerivation  rec {
   name = "qsynth-${version}";
-  version = "0.5.2";
+  version = "0.5.5";
 
   src = fetchurl {
     url = "mirror://sourceforge/qsynth/${name}.tar.gz";
-    sha256 = "1rfkaxq1pyc4hv3l0i6wicianbcbm1wp53kh9i5d4jsljgisd1dv";
+    sha256 = "08x7znvbwi9miavcarymi7dsv8njmxzwzma20dbmz8j2aswm53w5";
   };
 
-  # cmake is looking for qsynth.desktop.in and fails if it doesn't find it
-  # seems like a bug and can presumable go in the next version after 0.5.2
-  postPatch = ''
-    mv src/qsynth.desktop src/qsynth.desktop.in
-  '';
+  nativeBuildInputs = [ autoconf pkgconfig ];
 
-  nativeBuildInputs = [ cmake pkgconfig ];
-
-  buildInputs = [ alsaLib fluidsynth libjack2 qtbase qttools qtx11extras ];
+  buildInputs = [ alsaLib fluidsynth libjack2 qt5.qtbase qt5.qttools qt5.qtx11extras ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change
Fixes #59672

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
