### PR TITLE
vscode: use absolute predetermined path instead of heuristic

### DIFF
--- a/pkgs/applications/editors/vscode/default.nix
+++ b/pkgs/applications/editors/vscode/default.nix
@@ -132,7 +132,7 @@ in
       homepage = https://code.visualstudio.com/;
       downloadPage = https://code.visualstudio.com/Updates;
       license = licenses.unfree;
-      maintainers = with maintainers; [ eadwu ];
+      maintainers = with maintainers; [ eadwu synthetica ];
       platforms = [ "i686-linux" "x86_64-linux" "x86_64-darwin" ];
     };
   }

--- a/pkgs/applications/editors/vscode/default.nix
+++ b/pkgs/applications/editors/vscode/default.nix
@@ -111,6 +111,7 @@ in
 
         # Override the previously determined VSCODE_PATH with the one we know to be correct
         sed -i "/ELECTRON=/iVSCODE_PATH='$out/lib/vscode'" $out/bin/code
+        grep -q "VSCODE_PATH='$out/lib/vscode'" $out/bin/code # check if sed succeeded
       '';
 
     preFixup = lib.optionalString (system == "i686-linux" || system == "x86_64-linux") ''

--- a/pkgs/applications/editors/vscode/default.nix
+++ b/pkgs/applications/editors/vscode/default.nix
@@ -108,6 +108,9 @@ in
 
         mkdir -p $out/share/pixmaps
         cp $out/lib/vscode/resources/app/resources/linux/code.png $out/share/pixmaps/code.png
+
+        # Override the previously determined VSCODE_PATH with the one we know to be correct
+        sed -i "/ELECTRON=/iVSCODE_PATH='$out/lib/vscode'" $out/bin/code
       '';
 
     preFixup = lib.optionalString (system == "i686-linux" || system == "x86_64-linux") ''


### PR DESCRIPTION
Fixes #59725

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

#59725

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
