### PR TITLE
cargo-bloat: init at 0.6.2

### DIFF
--- a/pkgs/development/tools/rust/cargo-bloat/default.nix
+++ b/pkgs/development/tools/rust/cargo-bloat/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, rustPlatform, fetchFromGitHub }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-bloat";
+  version = "0.6.2";
+
+  src = fetchFromGitHub {
+    owner = "RazrFalcon";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0wf86r1s9skv0m4gp66g388847309nw9z1h8gadfg2c5w5idh3fb";
+  };
+
+  cargoSha256 = "1mmfcvpwwi6fjb47fz1azrpdkg1x5p3qn5bx4p6dyjcs1fmpdbbq";
+
+  meta = with stdenv.lib; {
+    description = "A tool and Cargo subcommand that helps you find out what takes most of the space in your executable";
+    homepage = https://github.com/RazrFalcon/cargo-bloat;
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ xrelkd ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7751,6 +7751,7 @@ in
   cargo-asm = callPackage ../development/tools/rust/cargo-asm {
     inherit (darwin.apple_sdk.frameworks) Security;
   };
+  cargo-bloat = callPackage ../development/tools/rust/cargo-bloat { };
   cargo-expand = callPackage ../development/tools/rust/cargo-expand { };
   cargo-fuzz = callPackage ../development/tools/rust/cargo-fuzz { };
   cargo-xbuild = callPackage ../development/tools/rust/cargo-xbuild { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

A tool and Cargo subcommand that helps you find out what takes most of the space in your Rust executable.
https://github.com/RazrFalcon/cargo-bloat

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
