### PR TITLE
nixops: 1.6.1 -> 1.7

### DIFF
--- a/pkgs/tools/package-management/nixops/default.nix
+++ b/pkgs/tools/package-management/nixops/default.nix
@@ -3,7 +3,7 @@
 callPackage ./generic.nix (rec {
   version = "1.7";
   src = fetchurl {
-    url = "https://hydra.nixos.org/build/92372310/download/2/nixops-1.7.tar.bz2";
+    url = "https://nixos.org/releases/nixops/nixops-${version}/nixops-${version}.tar.bz2";
     sha256 = "091c0b5bca57d4aa20be20e826ec161efe3aec9c788fbbcf3806a734a517f0f3";
   };
 })

--- a/pkgs/tools/package-management/nixops/default.nix
+++ b/pkgs/tools/package-management/nixops/default.nix
@@ -1,24 +1,9 @@
 { callPackage, newScope, pkgs, fetchurl }:
 
 callPackage ./generic.nix (rec {
-  version = "1.6.1";
+  version = "1.7";
   src = fetchurl {
-    url = "http://nixos.org/releases/nixops/nixops-${version}/nixops-${version}.tar.bz2";
-    sha256 = "0lfx5fhyg3z6725ydsk0ibg5qqzp5s0x9nbdww02k8s307axiah3";
-  };
-# nixops is incompatible with the most recent versions of listed
-# azure-mgmt-* packages, therefore we are pinning them to
-# package-private versions, so that they don't get trampled by
-# updates.
-# see
-# https://github.com/NixOS/nixops/issues/1065
-  python2Packages = pkgs.python2Packages.override {
-    overrides = (self: super: let callPackage = newScope self; in {
-      azure-mgmt-compute = callPackage ./azure-mgmt-compute { };
-      azure-mgmt-network = callPackage ./azure-mgmt-network { };
-      azure-mgmt-nspkg = callPackage ./azure-mgmt-nspkg { };
-      azure-mgmt-resource = callPackage ./azure-mgmt-resource { };
-      azure-mgmt-storage = callPackage ./azure-mgmt-storage { };
-    });
+    url = "https://hydra.nixos.org/build/92372310/download/2/nixops-1.7.tar.bz2";
+    sha256 = "091c0b5bca57d4aa20be20e826ec161efe3aec9c788fbbcf3806a734a517f0f3";
   };
 })

--- a/pkgs/tools/package-management/nixops/generic.nix
+++ b/pkgs/tools/package-management/nixops/generic.nix
@@ -1,4 +1,4 @@
-{ lib, python2Packages, libxslt, docbook_xsl_ns, openssh, cacert
+{ lib, python2Packages, libxslt, docbook_xsl_ns, openssh, cacert, nixopsAzurePackages ? []
 # version args
 , src, version
 , meta ? {}
@@ -16,11 +16,6 @@ python2Packages.buildPythonApplication {
       boto3
       hetzner
       libcloud
-      azure-storage
-      azure-mgmt-compute
-      azure-mgmt-network
-      azure-mgmt-resource
-      azure-mgmt-storage
       adal
       # Go back to sqlite once Python 2.7.13 is released
       pysqlite
@@ -28,7 +23,7 @@ python2Packages.buildPythonApplication {
       digital-ocean
       libvirt
       typing
-    ];
+    ] ++ nixopsAzurePackages;
 
   checkPhase =
   # Ensure, that there are no (python) import errors
@@ -53,7 +48,7 @@ python2Packages.buildPythonApplication {
   meta = {
     homepage = https://github.com/NixOS/nixops;
     description = "NixOS cloud provisioning and deployment tool";
-    maintainers = with lib.maintainers; [ eelco rob domenkozar ];
+    maintainers = with lib.maintainers; [ aminechikhaoui eelco rob domenkozar ];
     platforms = lib.platforms.unix;
     license = lib.licenses.lgpl3;
   } // meta;

--- a/pkgs/tools/package-management/nixops/nixops-v1_6_1.nix
+++ b/pkgs/tools/package-management/nixops/nixops-v1_6_1.nix
@@ -1,0 +1,31 @@
+{ callPackage, newScope, pkgs, fetchurl }:
+
+callPackage ./generic.nix (rec {
+  version = "1.6.1";
+  src = fetchurl {
+    url = "http://nixos.org/releases/nixops/nixops-${version}/nixops-${version}.tar.bz2";
+    sha256 = "0lfx5fhyg3z6725ydsk0ibg5qqzp5s0x9nbdww02k8s307axiah3";
+  };
+  nixopsAzurePackages = with python2Packages; [
+    azure-storage
+    azure-mgmt-compute
+    azure-mgmt-network
+    azure-mgmt-resource
+    azure-mgmt-storage
+  ];
+  # nixops is incompatible with the most recent versions of listed
+  # azure-mgmt-* packages, therefore we are pinning them to
+  # package-private versions, so that they don't get trampled by
+  # updates.
+  # see
+  # https://github.com/NixOS/nixops/issues/1065
+  python2Packages = pkgs.python2Packages.override {
+    overrides = (self: super: let callPackage = newScope self; in {
+      azure-mgmt-compute = callPackage ./azure-mgmt-compute { };
+      azure-mgmt-network = callPackage ./azure-mgmt-network { };
+      azure-mgmt-nspkg = callPackage ./azure-mgmt-nspkg { };
+      azure-mgmt-resource = callPackage ./azure-mgmt-resource { };
+      azure-mgmt-storage = callPackage ./azure-mgmt-storage { };
+    });
+  };
+})

--- a/pkgs/tools/package-management/nixops/unstable.nix
+++ b/pkgs/tools/package-management/nixops/unstable.nix
@@ -5,26 +5,9 @@
 # Then copy the URL to the tarball.
 
 callPackage ./generic.nix (rec {
-  version = "1.6.1pre2728_8ed39f9";
+  version = "1.7pre2764_932bf43";
   src = fetchurl {
-    url = "https://hydra.nixos.org/build/88329589/download/2/nixops-${version}.tar.bz2";
-    sha256 = "1ppnhqmsbiijm6r77h86abv3fjny5iq35yvj207s520kjwzaj7kc";
+    url = "https://hydra.nixos.org/build/92372343/download/2/nixops-${version}.tar.bz2";
+    sha256 = "f35bf81bf2805473ea54248d0ee92d163d00a1992f3f75d17e8cf430db1f9919";
   };
-  # # Marking unstable as broken, instead of using the pinned version,
-  # # like stable does You might be able to use the following code (as
-  # # in stable), to run unstable against the pinned packages
-  # python2Packages = pkgs.python2Packages.override {
-  #   overrides = (self: super: let callPackage = newScope self; in {
-  #     azure-mgmt-compute = callPackage ./azure-mgmt-compute { };
-  #     azure-mgmt-network = callPackage ./azure-mgmt-network { };
-  #     azure-mgmt-nspkg = callPackage ./azure-mgmt-nspkg { };
-  #     azure-mgmt-resource = callPackage ./azure-mgmt-resource { };
-  #     azure-mgmt-storage = callPackage ./azure-mgmt-storage { };
-  #   });
-  # };
-  # # otherwise
-  # # see https://github.com/NixOS/nixpkgs/pull/52550
-  # # see https://github.com/NixOS/nixops/issues/1065
-  # # see https://github.com/NixOS/nixpkgs/issues/52547
-  meta.broken = true;
 })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22907,6 +22907,8 @@ in
 
   nixops = callPackage ../tools/package-management/nixops { };
 
+  nixops_1_6_1 = callPackage ../tools/package-management/nixops/nixops-v1_6_1.nix {};
+
   nixopsUnstable = lowPrio (callPackage ../tools/package-management/nixops/unstable.nix { });
 
   nixops-dns = callPackage ../tools/package-management/nixops/nixops-dns.nix { };


### PR DESCRIPTION
Add release 1.7, also keep version 1.6.1 available for Azure
backend users. Azure backend was disabled in v1.7 due to the
python API changes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
