### PR TITLE
nixos/bumblebee: allow legacy nvidia drivers

### DIFF
--- a/nixos/modules/hardware/video/bumblebee.nix
+++ b/nixos/modules/hardware/video/bumblebee.nix
@@ -63,6 +63,16 @@ in
         '';
       };
 
+      nvidiaDriver = mkOption {
+        default = "nvidia_x11";
+        example = "nvidia_x11_legacy390";
+        type = types.str;
+        description = ''
+          Set which nvidia driver to use. Change this if you have a legacy GPU.
+          Has no effect when using nouveau.
+        '';
+      };
+
       pmMethod = mkOption {
         default = "auto";
         type = types.enum [ "auto" "bbswitch" "switcheroo" "none" ];
@@ -77,7 +87,7 @@ in
   config = mkIf cfg.enable {
     boot.blacklistedKernelModules = [ "nvidia-drm" "nvidia" "nouveau" ];
     boot.kernelModules = optional useBbswitch "bbswitch";
-    boot.extraModulePackages = optional useBbswitch kernel.bbswitch ++ optional useNvidia kernel.nvidia_x11.bin;
+    boot.extraModulePackages = optional useBbswitch kernel.bbswitch ++ optional useNvidia kernel."${cfg.nvidiaDriver}".bin;
 
     environment.systemPackages = [ bumblebee primus ];
 


### PR DESCRIPTION
###### Motivation for this change

I have an old GPU that requires a legacy driver. Without this patch using bumblebee with it is impossible. While this didn't fix my problem and I ended up using nouveau (so I can't properly test this), I think it's a nice addition to the module

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
