### PR TITLE
WIP: pkgsEmscripten: emscripten package set using cross toolchain

### DIFF
--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -195,4 +195,6 @@ rec {
         allowSubstitutes = false;
       });
     };
+
+  emscriptenAdapter = import ./emscripten-adapter.nix { inherit (pkgs) lib emscripten python; };
 }

--- a/pkgs/stdenv/emscripten-adapter.nix
+++ b/pkgs/stdenv/emscripten-adapter.nix
@@ -1,18 +1,14 @@
-{ pkgs, lib, emscripten, python }:
+{ lib, emscripten, python }:
 
-{ buildInputs ? [], nativeBuildInputs ? []
+stdenv: (stdenv // {
 
-, enableParallelBuilding ? true
+mkDerivation = args: stdenv.mkDerivation ( args // {
 
-, meta ? {}, ... } @ args:
+  name = "emscripten-${args.name or args.pname}";
 
-pkgs.stdenv.mkDerivation (
-  args // 
-  {
-
-  name = "emscripten-${args.name}";
-  buildInputs = [ emscripten python ] ++ buildInputs;
-  nativeBuildInputs = [ emscripten python ] ++ nativeBuildInputs;
+#   name = "emscripten-${args.name}";
+  buildInputs = (args.buildInputs or []) ++ [ emscripten python ];
+  nativeBuildInputs = (args.nativeBuildInputs or []) ++ [ emscripten python ];
 
   # fake conftest results with emscripten's python magic
   EMCONFIGURE_JS=2;
@@ -53,14 +49,18 @@ pkgs.stdenv.mkDerivation (
 
   enableParallelBuilding = args.enableParallelBuilding or true;
 
-  meta = {
+  meta = let
+    meta' = args.meta or {};
+  in {
     # Add default meta information
     platforms = lib.platforms.all;
     # Do not build this automatically
     hydraPlatforms = [];
-  } // meta // {
+  } // meta' // {
     # add an extra maintainer to every package
-    maintainers = (meta.maintainers or []) ++
+    maintainers = (meta'.maintainers or []) ++
                   [ lib.maintainers.qknight ];
   };
+});
+
 })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2561,7 +2561,7 @@ in
 
   ### DEVELOPMENT / EMSCRIPTEN
 
-  buildEmscriptenPackage = callPackage ../development/em-modules/generic { };
+#   buildEmscriptenPackage = callPackage ../development/em-modules/generic { };
 
   carp = callPackage ../development/compilers/carp { };
 
@@ -2575,9 +2575,9 @@ in
 
   emscriptenfastcomp = emscriptenfastcompPackages.emscriptenfastcomp;
 
-  emscriptenPackages = recurseIntoAttrs (callPackage ./emscripten-packages.nix { });
+#   emscriptenPackages = recurseIntoAttrs (callPackage ./emscripten-packages.nix { });
 
-  emscriptenStdenv = stdenv // { mkDerivation = buildEmscriptenPackage; };
+#   emscriptenStdenv = stdenv // { mkDerivation = buildEmscriptenPackage; };
 
   efibootmgr = callPackage ../tools/system/efibootmgr { };
 

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -225,6 +225,18 @@ let
         };
       };
     });
+
+    # Emscripten packages.
+    pkgsEmscripten = nixpkgsFun ({
+      overlays = [ (self': super': {
+        pkgsEmscripten = super';
+      })] ++ overlays;
+      crossOverlays = [ (import ./emscripten-packages.nix) ];
+      crossSystem = {
+        parsed = stdenv.hostPlatform.parsed;
+      };
+    });
+
   };
 
   # The complete chain of package set builders, applied from top to bottom.


### PR DESCRIPTION
Implement the emscripten package set using the cross toolchain in a similar
way as `pkgsMusl`.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
