### PR TITLE
glibc: re-enable stripping in cross builds

### DIFF
--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -214,10 +214,6 @@ stdenv.mkDerivation ({
 // lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform) {
   preInstall = null; # clobber the native hook
 
-  dontStrip = true;
-
-  separateDebugInfo = false; # this is currently broken for crossDrv
-
   # To avoid a dependency on the build system 'bash'.
   preFixup = ''
     rm -f $bin/bin/{ldd,tzselect,catchsegv,xtrace}


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

References to the host toolchain are leaking through debug symbols in glibc, causing gnu cross-builds to always depend on the host toolchain. The decision to not strip was made in 2009 (c6b526495bc37e63b43c3fc17705cefac81fa904), and I suspect the reasons that justified it back then do not apply anymore in 2019.

Closure size before:
/nix/store/v5pxj0bgg627hic2khk4d43z6cjp5v7d-hello-2.10-armv7l-unknown-linux-gnueabihf                            596.8M

After:
/nix/store/llp1ncmpar406rc2vhj7g5ix4yqwna3n-hello-2.10-armv7l-unknown-linux-gnueabihf     23.6M

Fixes #58501 (as far as I can tell). @illegalprime @Thra11 @matthewbauer 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
