### PR TITLE
tilt: init at 0.7.13

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -365,6 +365,11 @@
     github = "ankhers";
     name = "Justin Wood";
   };
+  anton-dessiatov = {
+    email = "anton.dessiatov@gmail.com";
+    github = "anton-dessiatov";
+    name = "Anton Desyatov";
+  };
   Anton-Latukha = {
     email = "anton.latuka+nixpkgs@gmail.com";
     github = "Anton-Latukha";

--- a/pkgs/applications/networking/cluster/tilt/default.nix
+++ b/pkgs/applications/networking/cluster/tilt/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  pname   = "tilt";
+  name    = "${pname}-${version}";
+  /* Do not use "dev" as a version. If you do, Tilt will consider itself
+     running in development environment and try to serve assets from the
+     source tree, which is not there once build completes.  */
+  version = "0.7.13";
+  rev = "67cd823b2a07c7bb2bcb919c0963e8f23e22d57e";
+
+  src = fetchFromGitHub {
+    owner  = "windmilleng";
+    repo   = "tilt";
+    rev    = "${rev}";
+    sha256 = "0cfmdd6wsczcmy6fkd418rvancx4qy1c3pzq9jbfsy4innhh51j7";
+  };
+
+  goPackagePath = "github.com/windmilleng/tilt";
+  subPackages = [ "cmd/tilt" ];
+
+  buildFlagsArray = ("-ldflags=-X main.version=${version} -X main.date=2019-04-18");
+
+  meta = with stdenv.lib; {
+    description = "Local development tool to manage your developer instance when your team deploys to Kubernetes in production";
+    homepage = https://tilt.dev/;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ anton-dessiatov ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23330,6 +23330,8 @@ in
 
   terragrunt = callPackage ../applications/networking/cluster/terragrunt {};
 
+  tilt = callPackage ../applications/networking/cluster/tilt {};
+
   tetex = callPackage ../tools/typesetting/tex/tetex { libpng = libpng12; };
 
   tetra-gtk-theme = callPackage ../misc/themes/tetra { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

[Tilt](https://tilt.dev/) is a convenient tool to help developers work on microservices locally at their dev machines. It automates edit-compile-deploy cycle against minikube.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
