### PR TITLE
aws-okta: 0.19.0 -> 0.20.1

### DIFF
--- a/pkgs/tools/security/aws-okta/default.nix
+++ b/pkgs/tools/security/aws-okta/default.nix
@@ -1,8 +1,8 @@
-{ buildGoPackage, fetchFromGitHub, stdenv }:
+{ buildGoPackage, fetchFromGitHub, libusb1, pkgconfig, stdenv }:
 
 buildGoPackage rec {
   name = "aws-okta-${version}";
-  version = "0.19.0";
+  version = "0.20.1";
 
   goPackagePath = "github.com/segmentio/aws-okta";
 
@@ -10,10 +10,15 @@ buildGoPackage rec {
     owner = "segmentio";
     repo = "aws-okta";
     rev = "v${version}";
-    sha256 = "1c9mn492yva7cdsx2b0n8g2fdl9660v3xma0v82jzb0c9y9rq0ms";
+    sha256 = "084lb9rp04vbpzmvsb2l92a4gp7c8g28x4xsagzwkqqpwi3fd15d";
   };
 
+  goDeps = ./deps.nix;
+
   buildFlags = "--tags release";
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ libusb1 ];
 
   meta = with stdenv.lib; {
     inherit version;

--- a/pkgs/tools/security/aws-okta/deps.nix
+++ b/pkgs/tools/security/aws-okta/deps.nix
@@ -1,0 +1,29 @@
+[
+  {
+    goPackagePath = "github.com/sirupsen/logrus";
+    fetch = {
+      type = "git";
+      url = "https://github.com/sirupsen/logrus.git";
+      rev = "a437dfd2463eaedbec3dfe443e477d3b0a810b3f";
+      sha256 = "1904s2bbc7p88anzjp6fyj3jrbm5p6wbb8j4490674dq10kkcfbj";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sys/unix";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/sys.git";
+      rev = "b699b7032584f0953262cb2788a0ca19bb494703";
+      sha256 = "172sw1bm581qwal9pbf9qj1sgivr74nabbj8qq4q4fhgpzams9ix";
+    };
+  }
+  {
+    goPackagePath = "github.com/marshallbrekka/go-u2fhost";
+    fetch = {
+      type = "git";
+      url = "https://github.com/marshallbrekka/go-u2fhost";
+      rev = "72b0e7a3f583583996b3b382d2dfaa81fdc4b82c";
+      sha256 = "0apzmf0bjpr58ynw55agyjsl74zyg5qjk19nyyy4zhip3s9b1d0h";
+    };
+  }
+]


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
