### PR TITLE
gnome3.grilo-plugins: add dependencies

### DIFF
--- a/pkgs/desktops/gnome-3/core/grilo-plugins/default.nix
+++ b/pkgs/desktops/gnome-3/core/grilo-plugins/default.nix
@@ -4,11 +4,14 @@
 , ninja
 , pkgconfig
 , gettext
+, gperf
 , sqlite
 , librest
+, libarchive
+, libsoup
 , gnome3
 , libxml2
-, lua5
+, lua5_3
 , liboauth
 , libgdata
 , libmediaart
@@ -38,18 +41,21 @@ stdenv.mkDerivation rec {
     pkgconfig
     gettext
     itstool
+    gperf # for lua-factory
   ];
 
   buildInputs = [
     grilo
     libxml2
     libgdata
-    lua5
+    lua5_3
     liboauth
     sqlite
     gnome-online-accounts
     totem-pl-parser
     librest
+    libarchive
+    libsoup
     gmime
     json-glib
     avahi


### PR DESCRIPTION
###### Motivation for this change
Add libsoup dependency which is required by libgdata dependency of YouTube plug-in and also by Dleyna plug-in, and which was removed during previous clean-up.

Also add dependencies for lua-factory plug-in which is enabled by default by master.

Partially fixes: https://github.com/NixOS/nixpkgs/issues/59792

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
