### PR TITLE
go-ethereum: 1.8.26 -> 1.8.27

### DIFF
--- a/pkgs/applications/altcoins/go-ethereum.nix
+++ b/pkgs/applications/altcoins/go-ethereum.nix
@@ -1,8 +1,9 @@
-{ stdenv, buildGoPackage, fetchFromGitHub, libobjc, IOKit }:
+{ stdenv, buildGoPackage, fetchFromGitHub, libobjc, IOKit, fetchpatch }:
 
 buildGoPackage rec {
-  name = "go-ethereum-${version}";
-  version = "1.8.26";
+  pname = "go-ethereum";
+  version = "1.8.27";
+
   goPackagePath = "github.com/ethereum/go-ethereum";
 
   # Fix for usb-related segmentation faults on darwin
@@ -12,11 +13,22 @@ buildGoPackage rec {
   # Fixes Cgo related build failures (see https://github.com/NixOS/nixpkgs/issues/25959 )
   hardeningDisable = [ "fortify" ];
 
+  # Apply ethereum/go-ethereum#19183 to fix the aarch64 build failure.
+  #
+  # TODO Remove this patch when upstream (https://github.com/ethereum/go-ethereum)
+  # fix this problem in the future release.
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/ethereum/go-ethereum/commit/39bd2609.patch";
+      sha256 = "1a362hzvcjk505hicv25kziy3c6s5an4j7rk4jibcxwgvygb3mz5";
+    })
+ ];
+
   src = fetchFromGitHub {
     owner = "ethereum";
-    repo = "go-ethereum";
+    repo = pname;
     rev = "v${version}";
-    sha256 = "0i7shrwix5j8l5i0ap5pzhninwyk2kvm1pax27pnnjlpam8577i4";
+    sha256 = "1640y7lqy7bvjjgx6wp0cnbw632ls5fj4ixclr819lfz4p5dfhx1";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update `go-ethereum` to the latest release.

https://github.com/ethereum/go-ethereum/releases/tag/v1.8.27

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
