### PR TITLE
python3{5,6}: Reintroduce bytecode determinism

### DIFF
--- a/pkgs/development/interpreters/python/cpython/3.5/force_bytecode_determinism.patch
+++ b/pkgs/development/interpreters/python/cpython/3.5/force_bytecode_determinism.patch
@@ -1,0 +1,17 @@
+--- a/Lib/py_compile.py
++++ b/Lib/py_compile.py
+@@ -139,3 +139,4 @@
+     source_stats = loader.path_stats(file)
++    source_mtime = 1 if 'DETERMINISTIC_BUILD' in os.environ else source_stats['mtime']
+     bytecode = importlib._bootstrap_external._code_to_bytecode(
+-            code, source_stats['mtime'], source_stats['size'])
++            code, source_mtime, source_stats['size'])
+--- a/Lib/importlib/_bootstrap_external.py
++++ b/Lib/importlib/_bootstrap_external.py
+@@ -485,5 +485,5 @@
+     if source_stats is not None:
+         try:
+-            source_mtime = int(source_stats['mtime'])
++            source_mtime = 1
+         except KeyError:
+             pass

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -87,6 +87,9 @@ in with passthru; stdenv.mkDerivation {
     # (since it will do a futile invocation of gcc (!) to find
     # libuuid, slowing down program startup a lot).
     (./. + "/${sourceVersion.major}.${sourceVersion.minor}/no-ldconfig.patch")
+  ] ++ optionals (isPy35 || isPy36) [
+    # Determinism: Write null timestamps when compiling python files.
+    ./3.5/force_bytecode_determinism.patch
   ] ++ optionals isPy35 [
     # Backports support for LD_LIBRARY_PATH from 3.6
     ./3.5/ld_library_path.patch
@@ -166,8 +169,8 @@ in with passthru; stdenv.mkDerivation {
     export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -msse2"
     export MACOSX_DEPLOYMENT_TARGET=10.6
   '' + optionalString (isPy3k && pythonOlder "3.7") ''
-    # Determinism: The interpreter is patched to write null timestamps when compiling python files.
-    # This way python does not try to update them when we freeze timestamps in nix store.
+    # Determinism: The interpreter is patched to write null timestamps when compiling Python files
+    #   so Python doesn't try to update the bytecode when seeing frozen timestamps in Nix's store.
     export DETERMINISTIC_BUILD=1;
   '' + optionalString stdenv.hostPlatform.isMusl ''
     export NIX_CFLAGS_COMPILE+=" -DTHREAD_STACK_SIZE=0x100000"


### PR DESCRIPTION
###### Motivation for this change

Originally introduced in #22585, patches to lock down CPython bytecode mtime timestamps were lost in #53123 when the CPython version files were merged, likely due to CPython 3.7 not needing them anymore. These patches should remain in-tree until CPython 3.5 and 3.6 support is dropped completely.

Found with the [diffoscope](https://diffoscope.org/).

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Due to the scope of this change, I've only tested it on [my NUR](https://github.com/bb010g/nur-packages) Python packages / applications, but tests passed and the `nix-build --check` came up clean on python3-3.6.8, python3.6-setuptools-40.8.0, python3.6-dnspython-1.16.0, python3.6-namedlist-1.7, python3.6-certifi-2018.11.29, python3.6-six-1.12.0, python3.6-webencodings-0.5.1, python3.6-html5lib-1.0.1, python3.6-SQLAlchemy-1.2.14, python3.6-Yapsy-1.12.0, python3.6-singledispatch-3.4.0.3, python3.6-backports_abc-0.5, python3.6-tornado-4.5.3, python3.6-chardet-3.0.4, and python3.6-wpull-2.0.3.

It's the same patch as before; I'm not sure how much more testing it needs. Applied to staging because I think that's where large rebuild PRs go?
