### PR TITLE
stretchly: init at 0.19.1 (backport to 19.03)

### DIFF
--- a/pkgs/applications/misc/stretchly/default.nix
+++ b/pkgs/applications/misc/stretchly/default.nix
@@ -1,0 +1,139 @@
+{ GConf
+, alsaLib
+, at-spi2-atk
+, atk
+, cairo
+, cups
+, dbus
+, expat
+, fetchurl
+, fontconfig
+, gdk_pixbuf
+, glib
+, gtk2
+, gtk3
+, lib
+, libX11
+, libXScrnSaver
+, libXcomposite
+, libXcursor
+, libXdamage
+, libXext
+, libXfixes
+, libXi
+, libXrandr
+, libXrender
+, libXtst
+, libappindicator
+, libdrm
+, libnotify
+, libpciaccess
+, libpng12
+, libxcb
+, nspr
+, nss
+, pango
+, pciutils
+, pulseaudio
+, stdenv
+, udev
+, wrapGAppsHook
+}:
+
+let
+  libs = [
+    GConf
+    alsaLib
+    at-spi2-atk
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    fontconfig
+    gdk_pixbuf
+    glib
+    gtk2
+    gtk3
+    libX11
+    libXScrnSaver
+    libXcomposite
+    libXcursor
+    libXdamage
+    libXext
+    libXfixes
+    libXi
+    libXrandr
+    libXrender
+    libXtst
+    libappindicator
+    libdrm
+    libnotify
+    libpciaccess
+    libpng12
+    libxcb
+    nspr
+    nss
+    pango
+    pciutils
+    pulseaudio
+    stdenv.cc.cc.lib
+    udev
+  ];
+
+  libPath = lib.makeLibraryPath libs;
+in
+
+stdenv.mkDerivation rec {
+  pname = "stretchly";
+  version = "0.19.1";
+
+  src = fetchurl {
+    url = "https://github.com/hovancik/stretchly/releases/download/v${version}/stretchly-${version}.tar.xz";
+    sha256 = "1q2wxfqs8qv9b1rfh5lhmyp3rrgdl05m6ihsgkxlgp0yzi07afz8";
+  };
+
+  nativeBuildInputs = [
+    wrapGAppsHook
+  ];
+
+  buildInputs = libs;
+
+  dontPatchELF = true;
+  dontBuild = true;
+  dontConfigure = true;
+
+  installPhase = ''
+    mkdir -p $out/bin $out/lib/stretchly
+    cp -r ./* $out/lib/stretchly/
+    ln -s $out/lib/stretchly/libffmpeg.so $out/lib/
+    ln -s $out/lib/stretchly/libnode.so $out/lib/
+    ln -s $out/lib/stretchly/stretchly $out/bin/
+  '';
+
+  preFixup = ''
+    patchelf --set-rpath "${libPath}" $out/lib/stretchly/libffmpeg.so
+    patchelf --set-rpath "${libPath}" $out/lib/stretchly/libnode.so
+
+    patchelf \
+      --set-rpath "$out/lib/stretchly:${libPath}" \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      $out/lib/stretchly/stretchly
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A break time reminder app";
+    longDescription = ''
+      stretchly is a cross-platform electron app that reminds you to take
+      breaks when working on your computer. By default, it runs in your tray
+      and displays a reminder window containing an idea for a microbreak for 20
+      seconds every 10 minutes. Every 30 minutes, it displays a window
+      containing an idea for a longer 5 minute break.
+    '';
+    homepage = https://hovancik.net/stretchly;
+    downloadPage = https://hovancik.net/stretchly/downloads/;
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ cdepillabout ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19529,6 +19529,10 @@ in
     bison = bison2;
   };
 
+  stretchly = callPackage ../applications/misc/stretchly {
+    inherit (gnome2) GConf;
+  };
+
   stumpish = callPackage ../applications/window-managers/stumpish {};
 
   stumpwm = callPackage ../applications/window-managers/stumpwm {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This backports the stretchly derivation from #59383 to 19.03.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
