### PR TITLE
cracklib: fix cross build

### DIFF
--- a/pkgs/development/libraries/cracklib/default.nix
+++ b/pkgs/development/libraries/cracklib/default.nix
@@ -1,5 +1,5 @@
 let version = "2.9.7"; in
-{ stdenv, fetchurl, zlib, gettext
+{ stdenv, lib, buildPackages, fetchurl, zlib, gettext
 , wordlists ? [ (fetchurl {
   url = "https://github.com/cracklib/cracklib/releases/download/v${version}/cracklib-words-${version}.gz";
   sha256 = "12fk8w06q628v754l357cf8kfjna98wj09qybpqr892az3x4a33z";
@@ -15,6 +15,7 @@ stdenv.mkDerivation rec {
     sha256 = "1rimpjsdnmw8f5b7k558cic41p2qy2n2yrlqp5vh7mp4162hk0py";
   };
 
+  nativeBuildInputs = lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) buildPackages.cracklib;
   buildInputs = [ zlib gettext ];
 
   postPatch = ''
@@ -25,12 +26,12 @@ stdenv.mkDerivation rec {
   '';
 
   postInstall = ''
-    make dict
+    make dict-local
   '';
   doInstallCheck = true;
   installCheckTarget = "test";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage    = https://github.com/cracklib/cracklib;
     description = "A library for checking the strength of passwords";
     license = licenses.lgpl21; # Different license for the wordlist: http://www.openwall.com/wordlists


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

#56805 broke cross compilation of cracklib (which breaks tons of other things). 

###### Things done

Adding `buildPackages.cracklib` to `nativeBuildInputs` adds the necessary tools to `PATH` to build the dictionary. The `dict-local` target does the same thing as `dict` except it explicitly specifies the output file. This prevents native `cracklib-packer` from trying to write to its own output directory.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
