### PR TITLE
nixos/netboot: import -> callPackage

### DIFF
--- a/nixos/modules/installer/netboot/netboot.nix
+++ b/nixos/modules/installer/netboot/netboot.nix
@@ -65,8 +65,7 @@ with lib;
       [ config.system.build.toplevel ];
 
     # Create the squashfs image that contains the Nix store.
-    system.build.squashfsStore = import ../../../lib/make-squashfs.nix {
-      inherit (pkgs) stdenv squashfsTools closureInfo;
+    system.build.squashfsStore = pkgs.callPackage ../../../lib/make-squashfs.nix {
       storeContents = config.netboot.storeContents;
     };
 


### PR DESCRIPTION
Copy-paste from iso-image.nix
https://github.com/NixOS/nixpkgs/blob/ca7a18a24b4e54fb8ed2d756cd1c017e1aa67774/nixos/modules/installer/cd-dvd/iso-image.nix#L577-L579

Besides the simplification, it should use ```pkgs.buildPackages.squashfsTools``` because it is used in ```nativeBuildInputs``` instead of incorrect ```pkgs.squashfsTools``` which was forced by ```import```
