### PR TITLE
ubootRock64, ubootRockPro64: make compatible with latest dtc

### DIFF
--- a/pkgs/misc/uboot/rock64-fdt-dtc-compatibility.patch
+++ b/pkgs/misc/uboot/rock64-fdt-dtc-compatibility.patch
@@ -1,0 +1,105 @@
+From fbee2adffd39b03e10262b09779faef94c4d5a9d Mon Sep 17 00:00:00 2001
+From: Ben Wolsieffer <benwolsieffer@gmail.com>
+Date: Thu, 18 Apr 2019 15:50:24 -0400
+Subject: [PATCH] fdt: make compatible with dtc >=1.4.6
+
+Signed-off-by: Ben Wolsieffer <benwolsieffer@gmail.com>
+---
+ include/libfdt_env.h         | 6 +++---
+ lib/libfdt/fdt.h             | 6 +++---
+ lib/libfdt/libfdt.h          | 6 +++---
+ lib/libfdt/libfdt_internal.h | 6 +++---
+ tools/dtoc/fdt.py            | 2 +-
+ 5 files changed, 13 insertions(+), 13 deletions(-)
+
+diff --git a/include/libfdt_env.h b/include/libfdt_env.h
+index 6c6845f76c..1fbcd0ef83 100644
+--- a/include/libfdt_env.h
++++ b/include/libfdt_env.h
+@@ -6,8 +6,8 @@
+  * SPDX-License-Identifier:	LGPL-2.1+
+  */
+ 
+-#ifndef _LIBFDT_ENV_H
+-#define _LIBFDT_ENV_H
++#ifndef LIBFDT_ENV_H
++#define LIBFDT_ENV_H
+ 
+ #include "compiler.h"
+ #include "linux/types.h"
+@@ -32,4 +32,4 @@ typedef __be64 fdt64_t;
+ /* adding a ramdisk needs 0x44 bytes in version 2008.10 */
+ #define FDT_RAMDISK_OVERHEAD	0x80
+ 
+-#endif /* _LIBFDT_ENV_H */
++#endif /* LIBFDT_ENV_H */
+diff --git a/lib/libfdt/fdt.h b/lib/libfdt/fdt.h
+index 3134d78332..38cc182739 100644
+--- a/lib/libfdt/fdt.h
++++ b/lib/libfdt/fdt.h
+@@ -1,5 +1,5 @@
+-#ifndef _FDT_H
+-#define _FDT_H
++#ifndef FDT_H
++#define FDT_H
+ /*
+  * libfdt - Flat Device Tree manipulation
+  * Copyright (C) 2006 David Gibson, IBM Corporation.
+@@ -64,4 +64,4 @@ struct fdt_property {
+ #define FDT_V16_SIZE	FDT_V3_SIZE
+ #define FDT_V17_SIZE	(FDT_V16_SIZE + sizeof(fdt32_t))
+ 
+-#endif /* _FDT_H */
++#endif /* FDT_H */
+diff --git a/lib/libfdt/libfdt.h b/lib/libfdt/libfdt.h
+index cb533f4275..9345a59f05 100644
+--- a/lib/libfdt/libfdt.h
++++ b/lib/libfdt/libfdt.h
+@@ -1,5 +1,5 @@
+-#ifndef _LIBFDT_H
+-#define _LIBFDT_H
++#ifndef LIBFDT_H
++#define LIBFDT_H
+ /*
+  * libfdt - Flat Device Tree manipulation
+  * Copyright (C) 2006 David Gibson, IBM Corporation.
+@@ -2189,4 +2189,4 @@ int fdt_device_is_available(const void *blob, int node);
+ int fdt_node_offset_by_phandle_node(const void *fdt, int node, uint32_t phandle);
+ #endif /* SWIG */
+ 
+-#endif /* _LIBFDT_H */
++#endif /* LIBFDT_H */
+diff --git a/lib/libfdt/libfdt_internal.h b/lib/libfdt/libfdt_internal.h
+index 9a79fe85dd..8fdda7ee79 100644
+--- a/lib/libfdt/libfdt_internal.h
++++ b/lib/libfdt/libfdt_internal.h
+@@ -1,5 +1,5 @@
+-#ifndef _LIBFDT_INTERNAL_H
+-#define _LIBFDT_INTERNAL_H
++#ifndef LIBFDT_INTERNAL_H
++#define LIBFDT_INTERNAL_H
+ /*
+  * libfdt - Flat Device Tree manipulation
+  * Copyright (C) 2006 David Gibson, IBM Corporation.
+@@ -47,4 +47,4 @@ static inline struct fdt_reserve_entry *_fdt_mem_rsv_w(void *fdt, int n)
+ 
+ #define FDT_SW_MAGIC		(~FDT_MAGIC)
+ 
+-#endif /* _LIBFDT_INTERNAL_H */
++#endif /* LIBFDT_INTERNAL_H */
+diff --git a/tools/dtoc/fdt.py b/tools/dtoc/fdt.py
+index dbc338653b..ac2191fb37 100644
+--- a/tools/dtoc/fdt.py
++++ b/tools/dtoc/fdt.py
+@@ -360,7 +360,7 @@ class Fdt:
+         poffset = libfdt.fdt_first_property_offset(self._fdt, node._offset)
+         while poffset >= 0:
+             p = self._fdt_obj.get_property_by_offset(poffset)
+-            prop = Prop(node, poffset, p.name, p.value)
++            prop = Prop(node, poffset, p.name, p)
+             props_dict[prop.name] = prop
+ 
+             poffset = libfdt.fdt_next_property_offset(self._fdt, poffset)
+-- 
+2.21.0
+

--- a/pkgs/misc/uboot/rock64.nix
+++ b/pkgs/misc/uboot/rock64.nix
@@ -15,6 +15,8 @@ in buildUBoot rec {
     sha256 = "0gclcd034qfhfbabrdqmky08i0hlwmn63n0zg6mndplms5qpcx75";
   };
 
+  patches = [ ./rock64-fdt-dtc-compatibility.patch ];
+
   extraMakeFlags = [ "BL31=${armTrustedFirmwareRK3328}/bl31.elf" "u-boot.itb" "all" ];
 
   # Close to being blob free, but the U-Boot TPL causes the kernel to hang after a few minutes

--- a/pkgs/misc/uboot/rockpro64.nix
+++ b/pkgs/misc/uboot/rockpro64.nix
@@ -15,6 +15,8 @@ in buildUBoot rec {
     sha256 = "0gclcd034qfhfbabrdqmky08i0hlwmn63n0zg6mndplms5qpcx75";
   };
 
+  patches = [ ./rock64-fdt-dtc-compatibility.patch ];
+
   # Upstream ATF hangs in SPL
   extraMakeFlags = [ "BL31=${rkbin}/rk33/rk3399_bl31_v1.17.elf" "u-boot.itb" "all" ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15644,35 +15644,9 @@ in
   # Non-upstream U-Boots:
   ubootNanonote = callPackage ../misc/uboot/nanonote.nix { };
 
-  inherit (let
-    dtc = buildPackages.dtc.overrideAttrs (old: rec {
-      version = "1.4.5";
-      src = fetchgit {
-        url = "https://git.kernel.org/pub/scm/utils/dtc/dtc.git";
-        rev = "refs/tags/v${version}";
-        sha256 = "10y5pbkcj5gkijcgnlvrh6q2prpnvsgihb9asz3zfp66mcjwzsy3";
-      };
-    });
-    # Newer dtc versions are incompatible with U-Boot 2017.09
-    inherit (callPackage ../misc/uboot {
-      inherit dtc;
-      buildPackages = buildPackages // {
-        python2 = buildPackages.python2.override (old: {
-          packageOverrides = pySelf: pySuper: {
-            libfdt = pySelf.toPythonModule dtc;
-          };
-        });
-      };
-    }) buildUBoot;
-  in {
-    ubootRock64 = callPackage ../misc/uboot/rock64.nix {
-      inherit buildUBoot;
-    };
+  ubootRock64 = callPackage ../misc/uboot/rock64.nix { };
 
-    ubootRockPro64 = callPackage ../misc/uboot/rockpro64.nix {
-      inherit buildUBoot;
-    };
-  }) ubootRock64 ubootRockPro64;
+  ubootRockPro64 = callPackage ../misc/uboot/rockpro64.nix { };
 
   uclibc = callPackage ../os-specific/linux/uclibc { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The update to U-Boot 1.5.0 dropped the setup.py patch, but it is still needed by dtc 1.4.5, used to build `ubootRock64`.

###### Things done

Add the patch to the dtc 1.4.5 override.

cc @dezgeg 
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
