### PR TITLE
openssh: 7.9p1 -> 8.1p1

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2003.xml
+++ b/nixos/doc/manual/release-notes/rl-2003.xml
@@ -88,6 +88,14 @@
    <listitem>
      <para>SD images are now compressed by default using <literal>bzip2</literal>.</para>
    </listitem>
+   <listitem>
+    <para>
+     OpenSSH has been upgraded from 7.9 to 8.1, improving security and adding features
+     but with potential incompatibilities.  Consult the
+     <link xlink:href="https://www.openssh.com/txt/release-8.1">
+     release announcement</link> for more information.
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 </section>

--- a/pkgs/tools/networking/openssh/default.nix
+++ b/pkgs/tools/networking/openssh/default.nix
@@ -13,16 +13,16 @@ let
   gssapiPatch = fetchpatch {
     name = "openssh-gssapi.patch";
     url = "https://salsa.debian.org/ssh-team/openssh/raw/"
-      + "d80ebbf028196b2478beebf5a290b97f35e1eed9"
+      + "e50a98bda787a3b9f53ed67bdccbbac0bde1f9ae"
       + "/debian/patches/gssapi.patch";
-    sha256 = "14j9cabb3gkhkjc641zbiv29mbvsmgsvis3fbj8ywsd21zc7m2wv";
+    sha256 = "14j9cabb3gkhkjc641zbiv29mbvsmgsvis3fbj8ywsd21zc7m2hv";
   };
 
 in
 with stdenv.lib;
 stdenv.mkDerivation rec {
   pname = "openssh";
-  version = if hpnSupport then "7.8p1" else "7.9p1";
+  version = if hpnSupport then "7.8p1" else "8.1p1";
 
   src = if hpnSupport then
       fetchurl {
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     else
       fetchurl {
         url = "mirror://openbsd/OpenSSH/portable/${pname}-${version}.tar.gz";
-        sha256 = "1b8sy6v0b8v4ggmknwcqx3y1rjcpsll0f1f8f4vyv11x4ni3njvb";
+        sha256 = "1zwk3g57gb13br206k6jdhgnp6y1nibwswzraqspbl1m73pxpx82";
       };
 
   patches =
@@ -42,6 +42,8 @@ stdenv.mkDerivation rec {
       # See discussion in https://github.com/NixOS/nixpkgs/pull/16966
       ./dont_create_privsep_path.patch
 
+      ./ssh-keysign.patch
+    ] ++ optional hpnSupport
       # CVE-2018-20685, can probably be dropped with next version bump
       # See https://sintonen.fi/advisories/scp-client-multiple-vulnerabilities.txt
       # for details
@@ -50,9 +52,6 @@ stdenv.mkDerivation rec {
         url = https://github.com/openssh/openssh-portable/commit/6010c0303a422a9c5fa8860c061bf7105eb7f8b2.patch;
         sha256 = "0q27i9ymr97yb628y44qi4m11hk5qikb1ji1vhvax8hp18lwskds";
       })
-
-      ./ssh-keysign.patch
-    ]
     ++ optional withGssapiPatches (assert withKerberos; gssapiPatch);
 
   postPatch =

--- a/pkgs/tools/networking/openssh/default.nix
+++ b/pkgs/tools/networking/openssh/default.nix
@@ -110,5 +110,6 @@ stdenv.mkDerivation rec {
     license = stdenv.lib.licenses.bsd2;
     platforms = platforms.unix ++ platforms.windows;
     maintainers = with maintainers; [ eelco aneeshusa ];
+    broken = hpnSupport;
   };
 }

--- a/pkgs/tools/networking/openssh/default.nix
+++ b/pkgs/tools/networking/openssh/default.nix
@@ -88,6 +88,8 @@ stdenv.mkDerivation rec {
     ++ optional stdenv.isDarwin "--disable-libutil"
     ++ optional (!linkOpenssl) "--without-openssl";
 
+  buildFlags = [ "SSH_KEYSIGN=ssh-keysign" ];
+
   enableParallelBuilding = true;
 
   hardeningEnable = [ "pie" ];


### PR DESCRIPTION
###### Motivation for this change

https://www.openwall.com/lists/oss-security/2019/04/18/1

Sending to staging for anticipated build impact,
please promote to master as needed for security implications.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---