### PR TITLE
pandoc-imagine: init at unstable-2018-11-19

### DIFF
--- a/pkgs/tools/misc/pandoc-imagine/default.nix
+++ b/pkgs/tools/misc/pandoc-imagine/default.nix
@@ -1,0 +1,28 @@
+{ fetchFromGitHub, buildPythonApplication, lib, pandocfilters, six }:
+
+buildPythonApplication rec {
+  pname = "pandoc-imagine";
+  version = "unstable-2018-11-19";
+
+  src = fetchFromGitHub {
+    repo = "imagine";
+    owner = "hertogp";
+    rev = "cc9be85";
+    sha256 = "0iksh9081g488yfjzd24bz4lm1nrrjamph1vynx3imrcfgyq7nsb";
+  };
+
+  propagatedBuildInputs = [ pandocfilters six ];
+
+  # No tests in archive
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = src.meta.homepage;
+    description = ''
+      A pandoc filter that will turn code blocks tagged with certain classes
+      into images or ASCII art
+    '';
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ synthetica ];
+  };
+}

--- a/pkgs/tools/misc/pandoc-imagine/default.nix
+++ b/pkgs/tools/misc/pandoc-imagine/default.nix
@@ -7,7 +7,7 @@ buildPythonApplication rec {
   src = fetchFromGitHub {
     repo = "imagine";
     owner = "hertogp";
-    rev = "cc9be85";
+    rev = "cc9be85155666c2d12d47a71690ba618cea1fac2";
     sha256 = "0iksh9081g488yfjzd24bz4lm1nrrjamph1vynx3imrcfgyq7nsb";
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4628,6 +4628,8 @@ in
 
   pa_applet = callPackage ../tools/audio/pa-applet { };
 
+  pandoc-imagine = python3Packages.callPackage ../tools/misc/pandoc-imagine { };
+
   pasystray = callPackage ../tools/audio/pasystray { };
 
   phash = callPackage ../development/libraries/phash { };


### PR DESCRIPTION
There exists a released version, but it's more than a year behind the latest master. 

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
