### PR TITLE
gnome3.mutter: 3.32.0 -> 3.32.1

### DIFF
--- a/pkgs/desktops/gnome-3/core/mutter/default.nix
+++ b/pkgs/desktops/gnome-3/core/mutter/default.nix
@@ -10,12 +10,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "mutter-${version}";
-  version = "3.32.0";
+  pname = "mutter";
+  version = "3.32.1";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/mutter/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "068zir5c1awmzb31gx94zjykv6c3xb1p5pch7860y3xlihha4s3n";
+    url = "mirror://gnome/sources/mutter/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    sha256 = "1q74lrb08vy0ynxbssqyxvbzf9252xgf9l6jxr9g4q0gmvpq402j";
   };
 
   mesonFlags = [


### PR DESCRIPTION
###### Motivation for this change

Version bump.

Fixes [a few crashes](https://gitlab.gnome.org/GNOME/mutter/merge_requests/506) associated with resume from suspend that were introduced in 3.32.0.

[NEWS for 3.32.1](https://gitlab.gnome.org/GNOME/mutter/blob/3.32.1/NEWS):

```
* Fix fallback app menu on wayland [Florian; #493]
* Fix elogind support [Tom; !491]
* Fix startup notifications not timing out [Carlos; #501]
* Fix keyboard accessibility toggle from keys
  [Olivier, Carlos; !501, #529, !531]
* Fix touchscreen input on rotated displays [Carlos; #514]
* Work around hangul text input bug [Carlos; #1365]
* Fix blurry wallpaper scaling [Daniel; !505]
* Fix placement of window menu when using fractional scaling [Jan; #527]
* Fix repaint issues of offscreen effects on secondary monitors [Daniel; !511]
* Fix windows not getting focus after launch [Daniel; #505]
* Properly advertise support for 'underscan' property [Jonas; !507]
* Improve power-saving handling [Jonas; !506]
* Fix moving windows by super+touch [Jonas D.; !495]
* Misc. bug fixes and cleanups [Benjamin, Florian, Adam, Marco, Pablo,
  Erik, Jonas, Heiher, Pekka, Daniel, Olivier, Carlos; !478, !475, !480,
  !482, #490, !488, #491, #480, !477, !496, !492, !485, !515, !519, !521,
  !216, !538, #541, #523]

Contributors:
  Jonas Ådahl, Pablo Barciela, Benjamin Berg, Tom Briden, Jonas Dreßler,
  Olivier Fourdan, Carlos Garnacho, Jan Alexander Steffens (heftig), Heiher,
  Adam Jackson, Erik Kurzinger, Florian Müllner, Pekka Paalanen,
  Marco Trevisan (Treviño), Daniel van Vugt

Translators:
  Khaled Hosny [ar], Goran Vidović [hr], Daniel Mustieles [es]
```

###### Things done

I'm successfully running this on my personal laptop.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
