### PR TITLE
coqPackages.tlc: 20180316 -> 20181116

### DIFF
--- a/pkgs/development/coq-modules/tlc/default.nix
+++ b/pkgs/development/coq-modules/tlc/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, coq }:
 
 stdenv.mkDerivation rec {
-  version = "20180316";
+  version = "20181116";
   name = "coq${coq.coq-version}-tlc-${version}";
 
   src = fetchurl {
     url = "http://tlc.gforge.inria.fr/releases/tlc-${version}.tar.gz";
-    sha256 = "0y8h0x9dfn9dm60j1jkxr9i8lbfqd3ff626wrc9v49qxhi50szqq";
+    sha256 = "0iv6f6zmrv2lhq3xq57ipmw856ahsql754776ymv5wjm88ld63nm";
   };
 
   buildInputs = [ coq ];


### PR DESCRIPTION
###### Motivation for this change

Compatibility with Coq 8.10.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
