### PR TITLE
lambda-mod-zsh-theme: 2017-10-08 -> 2019-04-17

### DIFF
--- a/pkgs/shells/zsh/lambda-mod-zsh-theme/default.nix
+++ b/pkgs/shells/zsh/lambda-mod-zsh-theme/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchFromGitHub, zsh }:
 
 stdenv.mkDerivation {
-  name = "lambda-mod-zsh-theme-unstable-2017-10-08";
+  name = "lambda-mod-zsh-theme-unstable-2019-04-17";
 
   src = fetchFromGitHub {
     owner = "halfo";
     repo = "lambda-mod-zsh-theme";
-    sha256 = "13yis07zyr192s0x2h04k5bm1yzbk5m3js83aa17xh5573w4b786";
-    rev = "61c373c8aa5556d51522290b82ad44e7166bced1";
+    rev = "6b83aedf9de41ea4e226cdbc78af1b7b92beb6ac";
+    sha256 = "1xf451c349fxnqbvsb07y9r1iqrwslx6x4b6drmnqqqy4yx1r5dj";
   };
 
   buildInputs = [ zsh ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

See https://github.com/halfo/lambda-mod-zsh-theme/compare/61c373c...6b83aed

The newly introduced commit (87e7cd7) adds support for LAMBDA_MOD_N_DIR_LEVELS
to control the amount of dir levels shown in the prompt.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
