### PR TITLE
coqPackages.Verdi: 20181102 -> 20190202

### DIFF
--- a/pkgs/development/coq-modules/Verdi/default.nix
+++ b/pkgs/development/coq-modules/Verdi/default.nix
@@ -1,7 +1,12 @@
 { stdenv, fetchFromGitHub, coq, Cheerios, InfSeqExt, ssreflect }:
 
 let param =
+  if stdenv.lib.versionAtLeast coq.coq-version "8.7" then
   {
+      version = "20190202";
+      rev = "bc193be9ea8485add7646a0f72e2aa76a9c7e01f";
+      sha256 = "1adkwxnmc9qfah2bya0hpd2vzkmk1y212z4n7fcmvr1a85ykgd7z";
+  } else {
       version = "20181102";
       rev = "25b79cf1be5527ab8dc1b8314fcee93e76a2e564";
       sha256 = "1vw47c37k5vaa8vbr6ryqy8riagngwcrfmb3rai37yi9xhdqg55z";


### PR DESCRIPTION
###### Motivation for this change

Compatibility with Coq 8.10

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
