### PR TITLE
Backport "Prometheus pushgateway 0.4.0 -> 0.8.0 & module" to release 19.03

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -479,6 +479,7 @@
   ./services/monitoring/prometheus/default.nix
   ./services/monitoring/prometheus/alertmanager.nix
   ./services/monitoring/prometheus/exporters.nix
+  ./services/monitoring/prometheus/pushgateway.nix
   ./services/monitoring/riemann.nix
   ./services/monitoring/riemann-dash.nix
   ./services/monitoring/riemann-tools.nix

--- a/nixos/modules/services/monitoring/prometheus/pushgateway.nix
+++ b/nixos/modules/services/monitoring/prometheus/pushgateway.nix
@@ -1,0 +1,166 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.services.prometheus.pushgateway;
+
+  cmdlineArgs =
+       opt "web.listen-address" cfg.web.listen-address
+    ++ opt "web.telemetry-path" cfg.web.telemetry-path
+    ++ opt "web.external-url" cfg.web.external-url
+    ++ opt "web.route-prefix" cfg.web.route-prefix
+    ++ optional cfg.persistMetrics ''--persistence.file="/var/lib/${cfg.stateDir}/metrics"''
+    ++ opt "persistence.interval" cfg.persistence.interval
+    ++ opt "log.level" cfg.log.level
+    ++ opt "log.format" cfg.log.format
+    ++ cfg.extraFlags;
+
+  opt = k : v : optional (v != null) ''--${k}="${v}"'';
+
+in {
+  options = {
+    services.prometheus.pushgateway = {
+      enable = mkEnableOption "Prometheus Pushgateway";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.prometheus-pushgateway;
+        defaultText = "pkgs.prometheus-pushgateway";
+        description = ''
+          Package that should be used for the prometheus pushgateway.
+        '';
+      };
+
+      web.listen-address = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Address to listen on for the web interface, API and telemetry.
+
+          <literal>null</literal> will default to <literal>:9091</literal>.
+        '';
+      };
+
+      web.telemetry-path = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Path under which to expose metrics.
+
+          <literal>null</literal> will default to <literal>/metrics</literal>.
+        '';
+      };
+
+      web.external-url = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          The URL under which Pushgateway is externally reachable.
+        '';
+      };
+
+      web.route-prefix = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Prefix for the internal routes of web endpoints.
+
+          Defaults to the path of
+          <option>services.prometheus.pushgateway.web.external-url</option>.
+        '';
+      };
+
+      persistence.interval = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "10m";
+        description = ''
+          The minimum interval at which to write out the persistence file.
+
+          <literal>null</literal> will default to <literal>5m</literal>.
+        '';
+      };
+
+      log.level = mkOption {
+        type = types.nullOr (types.enum ["debug" "info" "warn" "error" "fatal"]);
+        default = null;
+        description = ''
+          Only log messages with the given severity or above.
+
+          <literal>null</literal> will default to <literal>info</literal>.
+        '';
+      };
+
+      log.format = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "logger:syslog?appname=bob&local=7";
+        description = ''
+          Set the log target and format.
+
+          <literal>null</literal> will default to <literal>logger:stderr</literal>.
+        '';
+      };
+
+      extraFlags = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = ''
+          Extra commandline options when launching the Pushgateway.
+        '';
+      };
+
+      persistMetrics = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to persist metrics to a file.
+
+          When enabled metrics will be saved to a file called
+          <literal>metrics</literal> in the directory
+          <literal>/var/lib/pushgateway</literal>. The directory below
+          <literal>/var/lib</literal> can be set using
+          <option>services.prometheus.pushgateway.stateDir</option>.
+        '';
+      };
+
+      stateDir = mkOption {
+        type = types.str;
+        default = "pushgateway";
+        description = ''
+          Directory below <literal>/var/lib</literal> to store metrics.
+
+          This directory will be created automatically using systemd's
+          StateDirectory mechanism when
+          <option>services.prometheus.pushgateway.persistMetrics</option>
+          is enabled.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !hasPrefix "/" cfg.stateDir;
+        message =
+          "The option services.prometheus.pushgateway.stateDir" +
+          " shouldn't be an absolute directory." +
+          " It should be a directory relative to /var/lib.";
+      }
+    ];
+    systemd.services.pushgateway = {
+      wantedBy = [ "multi-user.target" ];
+      after    = [ "network.target" ];
+      serviceConfig = {
+        Restart  = "always";
+        DynamicUser = true;
+        ExecStart = "${cfg.package}/bin/pushgateway" +
+          optionalString (length cmdlineArgs != 0) (" \\\n  " +
+            concatStringsSep " \\\n  " cmdlineArgs);
+        StateDirectory = if cfg.persistMetrics then cfg.stateDir else null;
+      };
+    };
+  };
+}

--- a/nixos/tests/prometheus-2.nix
+++ b/nixos/tests/prometheus-2.nix
@@ -3,15 +3,29 @@ import ./make-test.nix {
 
   nodes = {
     one = { pkgs, ... }: {
+      environment.systemPackages = [ pkgs.jq ];
       services.prometheus2 = {
         enable = true;
-        scrapeConfigs = [{
-          job_name = "prometheus";
-          static_configs = [{
-            targets = [ "127.0.0.1:9090" ];
-            labels = { instance = "localhost"; };
-          }];
-        }];
+        scrapeConfigs = [
+          {
+            job_name = "prometheus";
+            static_configs = [
+              {
+                targets = [ "127.0.0.1:9090" ];
+                labels = { instance = "localhost"; };
+              }
+            ];
+          }
+          {
+            job_name = "pushgateway";
+            scrape_interval = "1s";
+            static_configs = [
+              {
+                targets = [ "127.0.0.1:9091" ];
+              }
+            ];
+          }
+        ];
         rules = [
           ''
             groups:
@@ -22,6 +36,12 @@ import ./make-test.nix {
           ''
         ];
       };
+      services.prometheus.pushgateway = {
+        enable = true;
+        persistMetrics = true;
+        persistence.interval = "1s";
+        stateDir = "prometheus-pushgateway";
+      };
     };
   };
 
@@ -30,5 +50,18 @@ import ./make-test.nix {
     $one->waitForUnit("prometheus2.service");
     $one->waitForOpenPort(9090);
     $one->succeed("curl -s http://127.0.0.1:9090/metrics");
+
+    # Let's test if pushing a metric to the pushgateway succeeds
+    # and whether that metric gets ingested by prometheus.
+    $one->waitForUnit("pushgateway.service");
+    $one->succeed(
+      "echo 'some_metric 3.14' | " .
+      "curl --data-binary \@- http://127.0.0.1:9091/metrics/job/some_job");
+    $one->waitUntilSucceeds(
+      "curl -sf 'http://127.0.0.1:9090/api/v1/query?query=some_metric' " .
+      "| jq '.data.result[0].value[1]' | grep '\"3.14\"'");
+
+    # Let's test if the pushgateway persists metrics to the configured location.
+    $one->waitUntilSucceeds("test -e /var/lib/prometheus-pushgateway/metrics");
   '';
 }

--- a/pkgs/servers/monitoring/prometheus/pushgateway.nix
+++ b/pkgs/servers/monitoring/prometheus/pushgateway.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "pushgateway-${version}";
-  version = "0.7.0";
+  version = "0.8.0";
   rev = "v${version}";
 
   goPackagePath = "github.com/prometheus/pushgateway";
@@ -11,7 +11,7 @@ buildGoPackage rec {
     inherit rev;
     owner = "prometheus";
     repo = "pushgateway";
-    sha256 = "1sczg6vrpxv0jlqhkif8443v7mhbp3lp40g71ndqkf1s669m1pl4";
+    sha256 = "1mzwkxnznv6wzy7dc8rksa8gr7z92plrzls8gb8rk432zfqcbv6a";
   };
 
   buildUser = "nix@nixpkgs";

--- a/pkgs/servers/monitoring/prometheus/pushgateway.nix
+++ b/pkgs/servers/monitoring/prometheus/pushgateway.nix
@@ -1,8 +1,8 @@
-{ stdenv, go, buildGoPackage, go-bindata, fetchFromGitHub }:
+{ stdenv, go, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
   name = "pushgateway-${version}";
-  version = "0.4.0";
+  version = "0.7.0";
   rev = "v${version}";
 
   goPackagePath = "github.com/prometheus/pushgateway";
@@ -11,33 +11,39 @@ buildGoPackage rec {
     inherit rev;
     owner = "prometheus";
     repo = "pushgateway";
-    sha256 = "19hsv42addcx4dsjdbh64y7ggjvaaay9gag0342gz7gyl9sr719f";
+    sha256 = "1sczg6vrpxv0jlqhkif8443v7mhbp3lp40g71ndqkf1s669m1pl4";
   };
 
-  buildInputs = [ go-bindata ];
-
-  preBuild = ''
-  (
-    cd "go/src/$goPackagePath"
-    go-bindata ./resources/
-  )
-  '';
+  buildUser = "nix@nixpkgs";
+  buildDate = "19700101-00:00:00";
 
   buildFlagsArray = ''
     -ldflags=
-        -X main.buildVersion=${version}
-        -X main.buildRev=${rev}
-        -X main.buildBranch=${rev}
-        -X main.buildUser=nix@nixpkgs
-        -X main.buildDate=19700101-00:00:00
+        -X github.com/prometheus/pushgateway/vendor/github.com/prometheus/common/version.Version=${version}
+        -X github.com/prometheus/pushgateway/vendor/github.com/prometheus/common/version.Revision=${rev}
+        -X github.com/prometheus/pushgateway/vendor/github.com/prometheus/common/version.Branch=${rev}
+        -X github.com/prometheus/pushgateway/vendor/github.com/prometheus/common/version.BuildUser=${buildUser}
+        -X github.com/prometheus/pushgateway/vendor/github.com/prometheus/common/version.BuildDate=${buildDate}
         -X main.goVersion=${stdenv.lib.getVersion go}
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    export PATH=$PATH:$bin/bin
+
+    pushgateway --help
+
+    # Make sure our -X options were included in the build
+    for s in ${version} ${rev} ${buildUser} ${buildDate}; do
+      pushgateway --version 2>&1 | fgrep -q -- "$s" || { echo "pushgateway --version output missing $s"; exit 1; }
+    done
   '';
 
   meta = with stdenv.lib; {
     description = "Allows ephemeral and batch jobs to expose metrics to Prometheus";
     homepage = https://github.com/prometheus/pushgateway;
     license = licenses.asl20;
-    maintainers = with maintainers; [ benley fpletz ];
+    maintainers = with maintainers; [ benley fpletz ivan ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I would like to use the latest prometheus pushgateway on NixOS. So this backports the following PRs to `release-19.03`:
* https://github.com/NixOS/nixpkgs/pull/55982  `prometheus-pushgateway`: 0.4.0 -> 0.7.0
* https://github.com/NixOS/nixpkgs/pull/59608: `prometheus-pushgateway`: 0.7.0 -> 0.8.0
* https://github.com/NixOS/nixpkgs/pull/59676: adds the `services.prometheus.pushgateway` module.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
