### PR TITLE
Prodigal: init at 2.6.3

### DIFF
--- a/pkgs/applications/science/biology/prodigal/default.nix
+++ b/pkgs/applications/science/biology/prodigal/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "prodigal";
+  version = "2.6.3";
+
+  src = fetchFromGitHub {
+    repo = "Prodigal";
+    owner = "hyattpd";
+    rev = "v${version}";
+    sha256 = "1fs1hqk83qjbjhrvhw6ni75zakx5ki1ayy3v6wwkn3xvahc9hi5s";
+  };
+
+  makeFlags = [
+    "CC=cc"
+    "INSTALLDIR=$(out)/bin"
+  ];
+  
+  meta = with stdenv.lib; {
+    description = "Fast, reliable protein-coding gene prediction for prokaryotic genomes";
+    homepage = https://github.com/hyattpd/Prodigal;
+    license = licenses.gpl3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ luispedro ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21948,6 +21948,8 @@ in
 
   plink-ng = callPackage ../applications/science/biology/plink-ng { };
 
+  prodigal = callPackage ../applications/science/biology/prodigal { };
+
   raxml = callPackage ../applications/science/biology/raxml { };
 
   raxml-mpi = appendToName "mpi" (raxml.override {


### PR DESCRIPTION
###### Motivation for this change

Prodigal is widely used in bioinformatics.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
