### PR TITLE
[18.09] dovecot: fix CVE-2019-10691

### DIFF
--- a/pkgs/servers/mail/dovecot/default.nix
+++ b/pkgs/servers/mail/dovecot/default.nix
@@ -53,6 +53,11 @@ stdenv.mkDerivation rec {
       url = https://github.com/dovecot/core/compare/578cf77e84b3d25e2f95f08133a2b0b212aa77cc~1..696320b0f3644e928a9d0c71c063f603c3792dbb.patch;
       sha256 = "101d757gid0dn3mxqqpa59igkgkq7bwffsklh3nimaav0v2zb018";
     })
+    (fetchpatch {
+      name = "CVE-2019-10691.patch";
+      url = https://github.com/dovecot/core/commit/973769d74433de3c56c4ffdf4f343cb35d98e4f7.patch;
+      sha256 = "1rp0nfq2qkrx59l6rf8i0v3a8svijmkpnimcpa7vz3b93krk50bp";
+    })
   ];
 
   configureFlags = [


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
https://dovecot.org/pipermail/dovecot-news/2019-April/000406.html


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
