### PR TITLE
lib/optionalString: ensure it returns string

### DIFF
--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -177,7 +177,7 @@ rec {
     # Condition
     cond:
     # String to return if condition is true
-    string: if cond then string else "";
+    string: if cond then assert isString string; string else "";
 
   /* Determine whether a string has given prefix.
 


### PR DESCRIPTION
###### Motivation for this change

Enforce type safety a little bit.
Many evaluation errors expected