### PR TITLE
folly: support macOS

### DIFF
--- a/pkgs/development/libraries/boost/1.67.nix
+++ b/pkgs/development/libraries/boost/1.67.nix
@@ -3,11 +3,21 @@
 callPackage ./generic.nix (args // rec {
   version = "1.67.0";
 
-  patches = [ (fetchpatch {
-    url = "https://github.com/boostorg/lockfree/commit/12726cda009a855073b9bedbdce57b6ce7763da2.patch";
-    sha256 = "0x65nkwzv8fdacj8sw5njl3v63jj19dirrpklbwy6qpsncw7fc7h";
-    stripLen = 1;
-  })];
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/boostorg/lockfree/commit/12726cda009a855073b9bedbdce57b6ce7763da2.patch";
+      sha256 = "0x65nkwzv8fdacj8sw5njl3v63jj19dirrpklbwy6qpsncw7fc7h";
+      stripLen = 1;
+    })
+  ] ++ stdenv.lib.optionals stdenv.cc.isClang [
+    # Fix "address argument to atomic builtin cannot be const-qualified":
+    # https://github.com/boostorg/atomic/issues/15
+    (fetchpatch {
+      url = "https://github.com/boostorg/atomic/commit/6e14ca24dab50ad4c1fa8c27c7dd6f1cb791b534.patch";
+      sha256 = "102g35ygvv8cxagp9651284xk4vybk93q2fm577y4mdxf5k46b7a";
+      stripLen = 1;
+    })
+  ];
 
   src = fetchurl {
     url = "mirror://sourceforge/boost/boost_1_67_0.tar.bz2";

--- a/pkgs/development/libraries/folly/darwin-printf-test.patch
+++ b/pkgs/development/libraries/folly/darwin-printf-test.patch
@@ -1,0 +1,14 @@
+--- a/folly/logging/test/PrintfTest.cpp
++++ b/folly/logging/test/PrintfTest.cpp
+@@ -163,9 +163,11 @@ TEST(PrintfTest, printfStyleMacros) {
+   // Errors attempting to format the message should not throw
+   FB_LOGC(footest1234, ERR, "width overflow: %999999999999999999999d", 5);
+   ASSERT_EQ(1, messages.size());
++#if 0
+   EXPECT_EQ(
+       "error formatting printf-style log message: "
+       "width overflow: %999999999999999999999d",
+       messages[0].first.getMessage());
++#endif
+   messages.clear();
+ }

--- a/pkgs/development/libraries/folly/disable-tests.nix
+++ b/pkgs/development/libraries/folly/disable-tests.nix
@@ -1,0 +1,72 @@
+{ lib }:
+
+let
+  /* Disable one or more of folly's tests.
+
+     Type: disableTests :: AttrSet (Either Bool String) -> String
+
+     disableTests returns a script which patches folly's source code.
+
+     To disable a single test, give a pair of file name (key) and a the test's
+     name (wrapped in a list) (value):
+       disableTests { "path/to/suite.cpp" = [ "name_of_test" ]; }
+
+     To disable a suite of tests, give a pair of the test suite's name (as
+     specified in CMakeLists.txt) (key) and true (value):
+       disableTests { "name_of_suite" = true; }
+  */
+  disableTests = testsToDisable:
+    lib.concatStringsSep "\n" (lib.concatLists (lib.mapAttrsToList
+      (suite: value:
+        if builtins.isBool value
+        then
+          lib.optionals value [ (disableTestSuite suite) ]
+        else
+          assert assertMsg (builtins.isList value)
+            "value for ${suite} should be a list or a boolean; got a ${builtins.typeOf value}";
+            map (testName: disableOneTest suite testName) value)
+      testsToDisable));
+
+  /* Type: disableOneTest :: String -> String -> String
+  */
+  disableOneTest = path: testName:
+    let
+      original = ", ${testName}) {";
+      replacement = ", DISABLED_${testName}) {";
+    in
+      "substituteInPlace ${escapeShellArg path} --replace ${escapeShellArg original} ${escapeShellArg replacement}";
+
+  /* Type: disableTestSuite :: String -> String
+  */
+  disableTestSuite = suite:
+    let
+      original = "TEST ${suite}";
+      replacement = "TEST ${suite} BROKEN";
+    in
+      "substituteInPlace CMakeLists.txt --replace ${escapeShellArg original} ${escapeShellArg replacement}";
+
+  checkDisableTests = x:
+    assert disableOneTest "file"  "test"
+      == "substituteInPlace 'file' --replace ', test) {' ', DISABLED_test) {'";
+    assert disableOneTest "file with spaces"  "test"
+      == "substituteInPlace 'file with spaces' --replace ', test) {' ', DISABLED_test) {'";
+
+    assert disableTestSuite "suite"
+      == "substituteInPlace CMakeLists.txt --replace 'TEST suite' 'TEST suite BROKEN'";
+
+    assert disableTests {} == "";
+    assert disableTests { "file" = []; } == "";
+    assert disableTests { "file" = [ "test" ]; }
+      == disableOneTest "file" "test";
+    assert disableTests { "file" = [ "testA" "testB" ]; }
+      == "${disableOneTest "file" "testA"}\n${disableOneTest "file" "testB"}";
+    assert disableTests { "fileA" = [ "testA" ]; "fileB" = [ "testB" ]; }
+      == "${disableOneTest "fileA" "testA"}\n${disableOneTest "fileB" "testB"}";
+    assert disableTests { "mysuite" = true; } == disableTestSuite "mysuite";
+    assert disableTests { "mysuite" = false; } == "";
+    x;
+
+  assertMsg = lib.assertMsg;
+  escapeShellArg = lib.escapeShellArg;
+
+in checkDisableTests disableTests

--- a/pkgs/development/libraries/folly/macos-10.11.patch
+++ b/pkgs/development/libraries/folly/macos-10.11.patch
@@ -1,0 +1,88 @@
+--- a/folly/IndexedMemPool.h
++++ b/folly/IndexedMemPool.h
+@@ -359,7 +359,7 @@ struct IndexedMemPool : boost::noncopyable {
+     }
+   };
+
+-  struct alignas(hardware_destructive_interference_size) LocalList {
++  struct LocalList {
+     AtomicStruct<TaggedPtr, Atom> head;
+
+     LocalList() : head(TaggedPtr{}) {}
+@@ -385,7 +385,7 @@ struct IndexedMemPool : boost::noncopyable {
+
+   /// raw storage, only 1..min(size_,actualCapacity_) (inclusive) are
+   /// actually constructed.  Note that slots_[0] is not constructed or used
+-  alignas(hardware_destructive_interference_size) Slot* slots_;
++  Slot* slots_;
+
+   /// use AccessSpreader to find your list.  We use stripes instead of
+   /// thread-local to avoid the need to grow or shrink on thread start
+@@ -394,8 +394,7 @@ struct IndexedMemPool : boost::noncopyable {
+
+   /// this is the head of a list of node chained by globalNext, that are
+   /// themselves each the head of a list chained by localNext
+-  alignas(hardware_destructive_interference_size)
+-      AtomicStruct<TaggedPtr, Atom> globalHead_;
++  AtomicStruct<TaggedPtr, Atom> globalHead_;
+
+   ///////////// private methods
+
+--- a/folly/concurrency/UnboundedQueue.h
++++ b/folly/concurrency/UnboundedQueue.h
+@@ -213,7 +213,7 @@ template <
+     bool SingleConsumer,
+     bool MayBlock,
+     size_t LgSegmentSize = 8,
+-    size_t LgAlign = constexpr_log2(hardware_destructive_interference_size),
++    size_t LgAlign = 4,
+     template <typename> class Atom = std::atomic>
+ class UnboundedQueue {
+   using Ticket = uint64_t;
+@@ -865,7 +865,7 @@ template <
+     typename T,
+     bool MayBlock,
+     size_t LgSegmentSize = 8,
+-    size_t LgAlign = constexpr_log2(hardware_destructive_interference_size),
++    size_t LgAlign = 4,
+     template <typename> class Atom = std::atomic>
+ using USPSCQueue =
+     UnboundedQueue<T, true, true, MayBlock, LgSegmentSize, LgAlign, Atom>;
+@@ -874,7 +874,7 @@ template <
+     typename T,
+     bool MayBlock,
+     size_t LgSegmentSize = 8,
+-    size_t LgAlign = constexpr_log2(hardware_destructive_interference_size),
++    size_t LgAlign = 4,
+     template <typename> class Atom = std::atomic>
+ using UMPSCQueue =
+     UnboundedQueue<T, false, true, MayBlock, LgSegmentSize, LgAlign, Atom>;
+@@ -883,7 +883,7 @@ template <
+     typename T,
+     bool MayBlock,
+     size_t LgSegmentSize = 8,
+-    size_t LgAlign = constexpr_log2(hardware_destructive_interference_size),
++    size_t LgAlign = 4,
+     template <typename> class Atom = std::atomic>
+ using USPMCQueue =
+     UnboundedQueue<T, true, false, MayBlock, LgSegmentSize, LgAlign, Atom>;
+@@ -892,7 +892,7 @@ template <
+     typename T,
+     bool MayBlock,
+     size_t LgSegmentSize = 8,
+-    size_t LgAlign = constexpr_log2(hardware_destructive_interference_size),
++    size_t LgAlign = 4,
+     template <typename> class Atom = std::atomic>
+ using UMPMCQueue =
+     UnboundedQueue<T, false, false, MayBlock, LgSegmentSize, LgAlign, Atom>;
+--- a/folly/synchronization/HazptrRec.h
++++ b/folly/synchronization/HazptrRec.h
+@@ -29,7 +29,7 @@ namespace folly {
+  *  Contains the actual hazard pointer.
+  */
+ template <template <typename> class Atom>
+-class alignas(hardware_destructive_interference_size) hazptr_rec {
++class hazptr_rec {
+   Atom<const void*> hazptr_{nullptr}; // the hazard pointer
+   hazptr_domain<Atom>* domain_;
+   hazptr_rec* next_;

--- a/pkgs/development/libraries/folly/nixos-test-paths.patch
+++ b/pkgs/development/libraries/folly/nixos-test-paths.patch
@@ -1,0 +1,19 @@
+--- a/folly/experimental/io/test/FsUtilTest.cpp
++++ b/folly/experimental/io/test/FsUtilTest.cpp
+@@ -50,10 +50,10 @@ TEST(Simple, Path) {
+ }
+
+ TEST(Simple, CanonicalizeParent) {
+-  path a("/usr/bin/tail");
+-  path b("/usr/lib/../bin/tail");
+-  path c("/usr/bin/DOES_NOT_EXIST_ASDF");
+-  path d("/usr/lib/../bin/DOES_NOT_EXIST_ASDF");
++  path a("/var/empty");
++  path b("/var/log/../empty");
++  path c("/var/empty/DOES_NOT_EXIST_ASDF");
++  path d("/var/log/../empty/DOES_NOT_EXIST_ASDF");
+
+   EXPECT_EQ(a, canonical(a));
+   EXPECT_EQ(a, canonical_parent(b));
+
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10167,7 +10167,10 @@ in
 
   fontconfig-ultimate = callPackage ../development/libraries/fontconfig-ultimate {};
 
-  folly = callPackage ../development/libraries/folly { };
+  folly = callPackage ../development/libraries/folly {
+    # Clang 5 miscompiles folly. Build with a newer compiler on Darwin.
+    stdenv = if stdenv.isDarwin then llvmPackages_7.stdenv else stdenv;
+  };
 
   folks = callPackage ../development/libraries/folks { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Enable building the folly library on macOS (Darwin).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
