### PR TITLE
runInLinuxVM, test-driver: pass host's cpu type to guest vm

### DIFF
--- a/nixos/lib/qemu-flags.nix
+++ b/nixos/lib/qemu-flags.nix
@@ -17,9 +17,9 @@ in
         else throw "Unknown QEMU serial device for system '${pkgs.stdenv.hostPlatform.system}'";
 
   qemuBinary = qemuPkg: {
-    x86_64-linux = "${qemuPkg}/bin/qemu-kvm -cpu kvm64";
+    x86_64-linux = "${qemuPkg}/bin/qemu-kvm -cpu host";
     armv7l-linux = "${qemuPkg}/bin/qemu-system-arm -enable-kvm -machine virt -cpu host";
     aarch64-linux = "${qemuPkg}/bin/qemu-system-aarch64 -enable-kvm -machine virt,gic-version=host -cpu host";
-    x86_64-darwin = "${qemuPkg}/bin/qemu-kvm -cpu kvm64";
+    x86_64-darwin = "${qemuPkg}/bin/qemu-kvm -cpu host";
   }.${pkgs.stdenv.hostPlatform.system} or "${qemuPkg}/bin/qemu-kvm";
 }

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -74,7 +74,7 @@ let
       # FIXME don't duplicate the -enable-kvm etc. flags here yet again!
       qemuFlags =
         (if system == "x86_64-linux" then "-m 768 " else "-m 512 ") +
-        (optionalString (system == "x86_64-linux") "-cpu kvm64 ") +
+        (optionalString (system == "x86_64-linux") "-cpu host ") +
         (optionalString (system == "aarch64-linux") "-enable-kvm -machine virt,gic-version=host -cpu host ");
 
       hdFlags = ''hda => "vm-state-machine/machine.qcow2", hdaInterface => "${iface}", ''


### PR DESCRIPTION
`kvm64` is the most generic CPU, which does not support SSE4.2, AVX and other ISA extentions.

There are already some packages which use extended opcodes. They cannot be run in VM.

With the acceptance of https://github.com/NixOS/nixpkgs/pull/59225 and https://github.com/NixOS/nixpkgs/pull/59148 even ```glibc``` would have AVX instructions in ```memcpy()``` code (if ```platform.gcc.arch``` is at least ```sandybridge```) so almost all the packages from host's nix store shared with the VM via 9p won't run in the VM if the the VM does not have the same CPU as the host.
