### PR TITLE
siji: Also package bdf font

### DIFF
--- a/pkgs/data/fonts/siji/default.nix
+++ b/pkgs/data/fonts/siji/default.nix
@@ -8,11 +8,13 @@ in fetchzip {
   url = https://github.com/stark/siji/archive/95369afac3e661cb6d3329ade5219992c88688c1.zip;
 
   postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.pcf -d $out/share/fonts/pcf
+    unzip -j $downloadedFile
+
+    install -D *.pcf -t $out/share/fonts/pcf
+    install -D *.bdf -t $out/share/fonts/bdf
   '';
 
-  sha256 = "1799hs7zd8w7qyja4mii9ggmrm786az7ldsqwx9mbi51b56ym640";
+  sha256 = "1ymcbirdbkqaf0xs2y00l0wachb4yxh1fgqm5avqwvccs0lsfj1d";
 
   meta = {
     homepage = https://github.com/stark/siji;


### PR DESCRIPTION
###### Motivation for this change

The pcf version seems to be incompatible with newer FreeType versions
and hence doesn't show up in `fc-list`. A bdf file format is also
available. After packaging that the font shows up in `fc-list`.

See: https://github.com/stark/siji/issues/28

Fixes #59847 

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
