### PR TITLE
pythonPackages.pyramid_chameleon: fix build by patching tests

### DIFF
--- a/pkgs/development/python-modules/pyramid_chameleon/default.nix
+++ b/pkgs/development/python-modules/pyramid_chameleon/default.nix
@@ -16,6 +16,11 @@ buildPythonPackage rec {
     sha256 = "d176792a50eb015d7865b44bd9b24a7bd0489fa9a5cebbd17b9e05048cef9017";
   };
 
+  patches = [
+    # https://github.com/Pylons/pyramid_chameleon/pull/25
+    ./test-renderers-pyramid-import.patch
+  ];
+
   propagatedBuildInputs = [ chameleon pyramid zope_interface setuptools ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/python-modules/pyramid_chameleon/test-renderers-pyramid-import.patch
+++ b/pkgs/development/python-modules/pyramid_chameleon/test-renderers-pyramid-import.patch
@@ -1,0 +1,11 @@
+--- a/pyramid_chameleon/tests/test_renderers.py
++++ b/pyramid_chameleon/tests/test_renderers.py
+@@ -258,7 +258,7 @@ class TestChameleonRendererLookup(unittest.TestCase):
+         self.assertRaises(ValueError, lookup.__call__, info)
+ 
+     def test___call__spec_alreadyregistered(self):
+-        from pyramid import tests
++        from pyramid_chameleon import tests
+         module_name = tests.__name__
+         relpath = 'test_renderers.py'
+         spec = '%s:%s' % (module_name, relpath)


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Seems to have been broken for a while.

Test suite was failing on a seemingly nonsensical test. Looking into this part of the test suite it appears it started as a modified copy of part of the main pyramid test suite. Presumably this line simply never got converted - change it to match the similar imports.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
