### PR TITLE
Fix pythonPackages.moviepy

### DIFF
--- a/pkgs/development/python-modules/moviepy/default.nix
+++ b/pkgs/development/python-modules/moviepy/default.nix
@@ -4,7 +4,10 @@
 , numpy
 , decorator
 , imageio
+, imageio-ffmpeg
 , isPy3k
+, proglog
+, requests
 , tqdm
 }:
 
@@ -19,7 +22,7 @@ buildPythonPackage rec {
 
   # No tests
   doCheck = false;
-  propagatedBuildInputs = [ numpy decorator imageio tqdm ];
+  propagatedBuildInputs = [ numpy decorator imageio imageio-ffmpeg tqdm requests proglog ];
 
   meta = with stdenv.lib; {
     description = "Video editing with Python";

--- a/pkgs/development/python-modules/moviepy/default.nix
+++ b/pkgs/development/python-modules/moviepy/default.nix
@@ -10,7 +10,19 @@
 , proglog
 , requests
 , tqdm
+# Advanced image processing (triples size of output)
+, advancedProcessing ? false
+, opencv ? null
+, scikitimage ? null
+, scikitlearn ? null
+, scipy ? null
+, matplotlib ? null
+, youtube-dl ? null
 }:
+
+assert advancedProcessing -> (
+  opencv != null && scikitimage != null && scikitlearn != null
+  && scipy != null && matplotlib != null && youtube-dl != null);
 
 buildPythonPackage rec {
   pname = "moviepy";
@@ -23,9 +35,14 @@ buildPythonPackage rec {
     sha256 = "16c7ffca23d90c76dd7b163f648c8166dfd589b7c180b8ff75aa327ae0a2fc6d";
   };
 
-  # No tests
+  # No tests, require network connection
   doCheck = false;
-  propagatedBuildInputs = [ numpy decorator imageio imageio-ffmpeg tqdm requests proglog ];
+
+  propagatedBuildInputs = [
+    numpy decorator imageio imageio-ffmpeg tqdm requests proglog
+  ] ++ (stdenv.lib.optionals advancedProcessing [
+    opencv scikitimage scikitlearn scipy matplotlib youtube-dl
+  ]);
 
   meta = with stdenv.lib; {
     description = "Video editing with Python";

--- a/pkgs/development/python-modules/moviepy/default.nix
+++ b/pkgs/development/python-modules/moviepy/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , buildPythonPackage
 , fetchPypi
+, pythonAtLeast
 , numpy
 , decorator
 , imageio
@@ -14,6 +15,8 @@
 buildPythonPackage rec {
   pname = "moviepy";
   version = "1.0.0";
+
+  disabled = !(pythonAtLeast "3.4");
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/proglog/default.nix
+++ b/pkgs/development/python-modules/proglog/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, fetchPypi, buildPythonPackage, tqdm }:
+
+buildPythonPackage rec {
+  pname = "proglog";
+  version = "0.1.9";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "13diln950wk6nnn4rpmzx37rvrnpa7f803gwygiwbq1q46zwri6q";
+  };
+
+  propagatedBuildInputs = [ tqdm ];
+
+  meta = with stdenv.lib; {
+    description = "Logs and progress bars manager for Python";
+    homepage = https://github.com/Edinburgh-Genome-Foundry/Proglog;
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -589,6 +589,8 @@ in {
 
   progress = callPackage ../development/python-modules/progress { };
 
+  proglog = callPackage ../development/python-modules/proglog { };
+
   pure-python-adb-homeassistant = callPackage ../development/python-modules/pure-python-adb-homeassistant { };
 
   pymysql = callPackage ../development/python-modules/pymysql { };


### PR DESCRIPTION
###### Motivation for this change
The package was updated in #55757 but the list of dependencies was not.
Now it build again and I can import it in python3.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
