### PR TITLE
Removes zfs from only the "new_kernel" installer variants

### DIFF
--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-kde-new-kernel.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-kde-new-kernel.nix
@@ -1,7 +1,6 @@
-{ pkgs, ... }:
-
 {
-  imports = [ ./installation-cd-graphical-kde.nix ];
-
-  boot.kernelPackages = pkgs.linuxPackages_latest;
+  imports = [
+    ./installation-cd-graphical-kde.nix
+    ../../profiles/latest-kernel.nix
+  ];
 }

--- a/nixos/modules/installer/cd-dvd/installation-cd-minimal-new-kernel.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-minimal-new-kernel.nix
@@ -1,7 +1,6 @@
-{ pkgs, ... }:
-
 {
-  imports = [ ./installation-cd-minimal.nix ];
-
-  boot.kernelPackages = pkgs.linuxPackages_latest;
+  imports = [
+    ./installation-cd-minimal.nix
+    ../../profiles/latest-kernel.nix
+  ];
 }

--- a/nixos/modules/installer/cd-dvd/sd-image-aarch64-new-kernel.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image-aarch64-new-kernel.nix
@@ -1,7 +1,6 @@
-{ pkgs, ... }:
-
 {
-  imports = [ ./sd-image-aarch64.nix ];
-
-  boot.kernelPackages = pkgs.linuxPackages_latest;
+  imports = [
+    ./sd-image-aarch64.nix
+    ../../profiles/latest-kernel.nix
+  ];
 }

--- a/nixos/modules/installer/cd-dvd/sd-image-armv7l-multiplatform.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image-armv7l-multiplatform.nix
@@ -20,6 +20,8 @@ in
 
   boot.consoleLogLevel = lib.mkDefault 7;
   boot.kernelPackages = pkgs.linuxPackages_latest;
+  # There is no zfs support (yet?) on armv7.
+  boot.supportedFilesystems = [ "btrfs" "reiserfs" "vfat" "f2fs" "xfs" "ntfs" "cifs" ];
   # The serial ports listed here are:
   # - ttyS0: for Tegra (Jetson TK1)
   # - ttymxc0: for i.MX6 (Wandboard)

--- a/nixos/modules/profiles/base.nix
+++ b/nixos/modules/profiles/base.nix
@@ -49,7 +49,7 @@
   ];
 
   # Include support for various filesystems.
-  boot.supportedFilesystems = [ "btrfs" "reiserfs" "vfat" "f2fs" "xfs" "zfs" "ntfs" "cifs" ];
+  boot.supportedFilesystems = lib.mkDefault [ "btrfs" "reiserfs" "vfat" "f2fs" "xfs" "zfs" "ntfs" "cifs" ];
 
   # Configure host id for ZFS to work
   networking.hostId = lib.mkDefault "8425e349";

--- a/nixos/modules/profiles/latest-kernel.nix
+++ b/nixos/modules/profiles/latest-kernel.nix
@@ -1,0 +1,6 @@
+{ pkgs, ... }:
+
+{
+  boot.kernelPackages = pkgs.linuxPackages_latest;
+  boot.supportedFilesystems = [ "btrfs" "reiserfs" "vfat" "f2fs" "xfs" "ntfs" "cifs" ];
+}


### PR DESCRIPTION
Fixes #58959.

This was tested using [this patch to neuter the zfs kernel module](https://gist.github.com/6df53f5e07776199e8e5a2daf4c83b83).

```
nix-build nixos/release-combined.nix -A nixos.iso_minimal_new_kernel.x86_64-linux
```

and on aarch64

```
nix-build nixos/release-combined.nix -A nixos.iso_minimal_new_kernel.aarch64-linux
```

* * *

I wasn't able to think of an elegant way to reduce the duplication of the list of supported filesystems. Referencing to a configured value within the module system is an infinite recursion.  The only way I thought of is a bit ugly, is through having the list in a `.nix` file which would be imported (and filtered as needed). This would have made one bizarro file which would live within the other module files, but couldn't be added to `imports`.

Any inputs on ways to remove the mostly duplicated list?