### PR TITLE
calibre: 3.40.1 -> 3.41.3

### DIFF
--- a/pkgs/applications/misc/calibre/default.nix
+++ b/pkgs/applications/misc/calibre/default.nix
@@ -5,12 +5,12 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "3.40.1";
+  version = "3.41.3";
   name = "calibre-${version}";
 
   src = fetchurl {
     url = "https://download.calibre-ebook.com/${version}/${name}.tar.xz";
-    sha256 = "1s1kq8axfymr7agg7dqw47kanlrkzzhsy8pcj1fs5644zjp5n0bq";
+    sha256 = "167hhv4wimkjnyfgqkyqmaiixhicbxacy6190gps98jyj4csi8ra";
   };
 
   patches = [
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
   ] ++ (with python2Packages; [
     apsw cssselect css-parser dateutil dnspython html5-parser lxml mechanize netifaces pillow
     python pyqt5_with_qtwebkit sip
-    regex msgpack
+    regex msgpack beautifulsoup4
     # the following are distributed with calibre, but we use upstream instead
     odfpy
   ]);


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

New features

    Kobo driver: Support for new firmware
    Content server: Add an option to control which book list mode is used by default for new users (Preferences->Sharing over the net->Choose book list mode)
    Content server: Allow clicking on book cover in details page to read the book.

    Closes tickets: 1819058
    Amazon metadata plugin: Add a option to use the mobi-asin to find books.

    Closes tickets: 1823520
    E-book viewer: Allow specifying ToC hrefs via the --open-at command line parameter.

    Closes tickets: 1656573
    Tag Mapper: Allow Title-casing of tags.

    Closes tickets: 1823097
    Manage authors dialog: Add an entry to the right click menu to show books by the current author in the main book list.

    Closes tickets: 1821992
    Lots of internal changes to calibre's codebase to prepare it for python 3 support.

Bug fixes

    Content server: Fix links to external resources in book details and the viewer not working
    Content server: Fix using a bookmark to load the book list not working if server is password protected.

    Closes tickets: 1819025
    Content server: Book details page: Fix close button not going back to book list after using Next/previous buttons.

    Closes tickets: 1819060
    Kobo driver: Fix update device metadata setting not being saved. Also fix book language not being set correctly on newer firmware.
    PDF Output: Fix 'stroke-dasharray' lines in SVG images in the input document not being rendered correctly.

    Closes tickets: 1821923
    Fix searching for authors on amazon not working because of a change in the amazon URL structure.

    Closes tickets: 1822532
    Cover grid: Check for cover size change due to screen scale change on every paint event and invalidate cache if there is a change.

    Closes tickets: 1723972
    Edit book: Fix Option key + ; not working in the editor.

    Closes tickets: 1823040
    Edit book: Fix pasting images into a book with no Images folder not working correctly.

    Closes tickets: 1817405
    Confirm cancel on library restore dialog

    Closes tickets: 1823204
    EPUB/MOBI Catalogs: Fix presets not being applied for some options.

    Closes tickets: 1821968
    Fix using --insert-metadata with ebook-convert not inserting the title and author metadata from the source document
    Adding books: When adding with auto-merge and auto-convert enabled, also run conversions for books into which the added files are merged.

    Closes tickets: 1822018

New news sources

    The New Criterion by Darko Miletic

Improved news sources

    Il Post
    Le Monde Edition Abonnes Papier
    Le Temps
    NASA
    1843
    derStandard
    LA Times



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
