### PR TITLE
Datadog: update packages

### DIFF
--- a/pkgs/tools/networking/dd-agent/README.md
+++ b/pkgs/tools/networking/dd-agent/README.md
@@ -6,3 +6,12 @@ To update datadog-agent v6 (v5 is deprecated and should be removed):
 4. `nix-env -i -f https://github.com/nixcloud/dep2nix/archive/master.tar.gz`
 5. `dep2nix`
 6. `cp deps.nix $NIXPKGS/pkgs/tools/networking/dd-agent/datadog-agent-deps.nix`
+
+To update datadog-process-agent:
+
+1. Bump `version`, `rev` and `sha256` in `datadog-process-agent.nix`
+2. `git clone https://github.com/DataDog/datadog-process-agent.git && cd datadog-process-agent`
+3. `git checkout <tag>`
+4. `nix-env -i -f https://github.com/nixcloud/dep2nix/archive/master.tar.gz`
+5. `dep2nix`
+6. `cp deps.nix $NIXPKGS/pkgs/tools/networking/dd-agent/datadog-process-agent-deps.nix`

--- a/pkgs/tools/networking/dd-agent/README.md
+++ b/pkgs/tools/networking/dd-agent/README.md
@@ -1,8 +1,8 @@
-To update v6 (v5 is deprecated and should be removed):
+To update datadog-agent v6 (v5 is deprecated and should be removed):
 
-1. Bump `version`, `rev`, `sha256` and `payloadVersion` in `6.nix`
+1. Bump `version`, `rev`, `sha256` and `payloadVersion` in `datadog-agent.nix`
 2. `git clone https://github.com/DataDog/datadog-agent.git && cd datadog-agent`
 3. `git checkout <tag>`
 4. `nix-env -i -f https://github.com/nixcloud/dep2nix/archive/master.tar.gz`
-5. `deps2nix`
-6. `cp deps.nix $NIXPKGS/pkgs/tools/networking/dd-agent/deps.nix`
+5. `dep2nix`
+6. `cp deps.nix $NIXPKGS/pkgs/tools/networking/dd-agent/datadog-agent-deps.nix`

--- a/pkgs/tools/networking/dd-agent/datadog-agent-deps.nix
+++ b/pkgs/tools/networking/dd-agent/datadog-agent-deps.nix
@@ -32,8 +32,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/DataDog/gohai";
-      rev =  "bc98f936c76570e79c1c7e739425ff22ab2ee4a3";
-      sha256 = "1r59b6qpjnv399hm6pqfklm47hapkjwy9cp92frb3mhfz0wf9djl";
+      rev =  "43b075bb9705588cd89c71363d6d72937e3020c7";
+      sha256 = "195z5g8gdxcx4cq51p2xqha3j8m7mk5d5lr6i3hbaxp948hgc8dh";
     };
   }
   {
@@ -50,8 +50,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/DataDog/viper";
-      rev =  "23ced3bc6b3751855704445e48da2c53075ade86";
-      sha256 = "1zzf4mqpmk47p3395k2v8q6wi7lnqxr0l55vv4zk9gpqqyifbm9m";
+      rev =  "v1.5.0";
+      sha256 = "1sv0xvmfaif7zpfwk0j6qf11hxnfdsb2zfj63b9zx7l0zzhjzh06";
     };
   }
   {
@@ -397,15 +397,6 @@
     };
   }
   {
-    goPackagePath  = "github.com/geoffgarside/ber";
-    fetch = {
-      type = "git";
-      url = "https://github.com/geoffgarside/ber";
-      rev =  "0b763e6b6fb1cb7422c29cd9195a3abf625651fb";
-      sha256 = "04k9k6805mvgp6gxs53frvlpp45hvkvrpj1jl1hc27ldwv5gpjrk";
-    };
-  }
-  {
     goPackagePath  = "github.com/ghodss/yaml";
     fetch = {
       type = "git";
@@ -682,15 +673,6 @@
       url = "https://github.com/json-iterator/go";
       rev =  "1624edc4454b8682399def8740d46db5e4362ba4";
       sha256 = "11wn4hpmrs8bmpvd93wqk49jfbbgylakhi35f9k5qd7jd479ci4s";
-    };
-  }
-  {
-    goPackagePath  = "github.com/k-sone/snmpgo";
-    fetch = {
-      type = "git";
-      url = "https://github.com/k-sone/snmpgo";
-      rev =  "de09377ff34857b08afdc16ea8c7c2929eb1fc6e";
-      sha256 = "0fia82msxviawcp5w4j4ll9n7z3gfjjvigqcq0d94cshj9ras10j";
     };
   }
   {
@@ -1057,9 +1039,9 @@
     goPackagePath  = "github.com/spf13/cast";
     fetch = {
       type = "git";
-      url = "https://github.com/spf13/cast";
-      rev =  "8965335b8c7107321228e3e3702cab9832751bac";
-      sha256 = "177bk7lq40jbgv9p9r80aydpaccfk8ja3a7jjhfwiwk9r1pa4rr2";
+      url = "https://github.com/DataDog/cast";
+      rev =  "1ee8c8bd14a3d768a7ff681617ed56bc6c204940";
+      sha256 = "0sgqmhicy672250cxgqd8zlni3qlj57r8liyiaq15g9spyhflhl0";
     };
   }
   {

--- a/pkgs/tools/networking/dd-agent/datadog-agent.nix
+++ b/pkgs/tools/networking/dd-agent/datadog-agent.nix
@@ -6,14 +6,14 @@ let
 
 in buildGoPackage rec {
   name = "datadog-agent-${version}";
-  version = "6.10.1";
+  version = "6.11.0";
   owner   = "DataDog";
   repo    = "datadog-agent";
 
   src = fetchFromGitHub {
     inherit owner repo;
     rev    = "${version}";
-    sha256 = "1yxwlf0kwjhadq6f1p9z100d363x1s1xzni3rw42m08mzx9fr469";
+    sha256 = "1gvawsrm3qlrciahnqa9793hwm586jiccmnz1pp0z889508wbg07";
   };
 
   subPackages = [
@@ -23,7 +23,7 @@ in buildGoPackage rec {
     "cmd/py-launcher"
     "cmd/trace-agent"
   ];
-  goDeps = ./deps.nix;
+  goDeps = ./datadog-agent-deps.nix;
   goPackagePath = "github.com/${owner}/${repo}";
 
   # Explicitly set this here to allow it to be overridden.

--- a/pkgs/tools/networking/dd-agent/datadog-process-agent-deps.nix
+++ b/pkgs/tools/networking/dd-agent/datadog-process-agent-deps.nix
@@ -23,8 +23,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/DataDog/datadog-agent";
-      rev =  "4aa90bd394b62b0d3e3f15703c6e459c1c477fbc";
-      sha256 = "13zvg8ykakq97bw0kd2gj4s9gfjpx23d3c51w1jpa1raqwhgqi8z";
+      rev =  "d7712d570b91f4f97af9f155ad1c676921d8325d";
+      sha256 = "1gi921z79la4hjhm8xhl4jz167200qljvhhsy4blj4vinkgfpm8w";
     };
   }
   {
@@ -41,8 +41,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/DataDog/gopsutil";
-      rev =  "c8f74f1344dd41bc49ec4d3c2377c526aaedfd20";
-      sha256 = "0r8al83apxrq1v6s2mq0p8h3c4z4n5g7ax8vcvs70pq0czy2fvgp";
+      rev =  "233cd0cf42c26d835ed6f0e46f2103432a88b526";
+      sha256 = "0rvxs1jjzv3j834dns28zr25bznarjmpgdy0z6gpimnq5nyicys5";
     };
   }
   {
@@ -50,8 +50,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/DataDog/viper";
-      rev =  "23ced3bc6b3751855704445e48da2c53075ade86";
-      sha256 = "1zzf4mqpmk47p3395k2v8q6wi7lnqxr0l55vv4zk9gpqqyifbm9m";
+      rev =  "v1.5.0";
+      sha256 = "1sv0xvmfaif7zpfwk0j6qf11hxnfdsb2zfj63b9zx7l0zzhjzh06";
     };
   }
   {

--- a/pkgs/tools/networking/dd-agent/datadog-process-agent.nix
+++ b/pkgs/tools/networking/dd-agent/datadog-process-agent.nix
@@ -2,14 +2,14 @@
 
 buildGoPackage rec {
   name = "datadog-process-agent-${version}";
-  version = "6.10.0";
+  version = "6.11.0";
   owner   = "DataDog";
   repo    = "datadog-process-agent";
 
   src = fetchFromGitHub {
     inherit owner repo;
     rev    = "${version}";
-    sha256 = "16lr1gp6n0aph8zikk5kmaib9i5b1jbndxlxfi84bd9f8lhvmkhk";
+    sha256 = "1max3gp1isb30fjy55bkp9dsd8al31a968pmnr1h8wg2pycvgyif";
   };
 
   goDeps = ./datadog-process-agent-deps.nix;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16904,7 +16904,7 @@ in
   dbvisualizer = callPackage ../applications/misc/dbvisualizer {};
 
   dd-agent = callPackage ../tools/networking/dd-agent/5.nix { };
-  datadog-agent = callPackage ../tools/networking/dd-agent/6.nix {
+  datadog-agent = callPackage ../tools/networking/dd-agent/datadog-agent.nix {
     pythonPackages = datadog-integrations-core {};
   };
   datadog-process-agent = callPackage ../tools/networking/dd-agent/datadog-process-agent.nix { };


### PR DESCRIPTION
Update datadog packages:
- datadog agent to 6.11.0;
- datadog process agent to 6.11.0;

cc @kalbasit 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
