### PR TITLE
ocamlPackages.re: seq is not needed when OCaml >= 4.07

### DIFF
--- a/pkgs/development/ocaml-modules/seq/default.nix
+++ b/pkgs/development/ocaml-modules/seq/default.nix
@@ -1,13 +1,22 @@
 { stdenv, fetchFromGitHub, ocaml, findlib, ocamlbuild }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation ({
   version = "0.1";
-  name = "ocaml${ocaml.version}-seq-${version}";
+  name = "ocaml${ocaml.version}-seq-0.1";
+
+  meta = {
+    license = stdenv.lib.licenses.lgpl21;
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    homepage = "https://github.com/c-cube/seq";
+    inherit (ocaml.meta) platforms;
+  };
+
+} // (if stdenv.lib.versionOlder ocaml.version "4.07" then {
 
   src = fetchFromGitHub {
     owner = "c-cube";
     repo = "seq";
-    rev = version;
+    rev = "0.1";
     sha256 = "1cjpsc7q76yfgq9iyvswxgic4kfq2vcqdlmxjdjgd4lx87zvcwrv";
   };
 
@@ -15,11 +24,19 @@ stdenv.mkDerivation rec {
 
   createFindlibDestdir = true;
 
-  meta = {
-    description = "Compatibility package for OCaml’s standard iterator type starting from 4.07";
-    license = stdenv.lib.licenses.lgpl21;
-    maintainers = [ stdenv.lib.maintainers.vbgl ];
-    inherit (src.meta) homepage;
-    inherit (ocaml.meta) platforms;
-  };
-}
+  meta.description = "Compatibility package for OCaml’s standard iterator type starting from 4.07";
+
+} else {
+
+  src = ./src-base;
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib/seq
+    cp META $out/lib/ocaml/${ocaml.version}/site-lib/seq
+  '';
+
+  meta.description = "dummy backward-compatibility package for iterators";
+
+}))

--- a/pkgs/development/ocaml-modules/seq/src-base/META
+++ b/pkgs/development/ocaml-modules/seq/src-base/META
@@ -1,0 +1,4 @@
+name="seq"
+version="[distributed with OCaml 4.07 or above]"
+description="dummy backward-compatibility package for iterators"
+requires=""


### PR DESCRIPTION
###### Motivation for this change

Imitate opam which installs the real seq package only for OCaml < 4.07 and only a META file for OCaml >= 4.07.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I am not sure how to test the depending packages from the `ocaml-ng.ocamlPackages_4_07` package set. The ones from the default set (4.06) are unchanged and thus not rebuilt by `nix-review`.
I have tested a few depending packages though, including odoc.