### PR TITLE
wallutils: init at 5.7.2

### DIFF
--- a/pkgs/tools/graphics/wallutils/default.nix
+++ b/pkgs/tools/graphics/wallutils/default.nix
@@ -1,0 +1,34 @@
+{ buildGoModule, fetchFromGitHub, lib
+, wayland, libX11, xbitmaps, libXcursor, libXmu
+}:
+
+buildGoModule rec {
+  name = "wallutils-${version}";
+  version = "5.7.2";
+
+  src = fetchFromGitHub {
+    owner = "xyproto";
+    repo = "wallutils";
+    rev = version;
+    sha256 = "1q4487s83iwwgd40hkihpns84ya8mg54zp63ag519cdjizz38xyi";
+  };
+
+  modSha256 = "0kj9s9ymd99a5w9r1d997qysnzlgpnmh5dnki33h1jlwz47nwkld";
+
+  patches = [ ./lscollection-Add-NixOS-paths-to-DefaultWallpaperDirectories.patch ];
+
+  postPatch = ''
+    # VersionString is sometimes not up-to-date:
+    sed -iE 's/VersionString = "[0-9].[0-9].[0-9]"/VersionString = "${version}"/' wallutils.go
+  '';
+
+  buildInputs = [ wayland libX11 xbitmaps libXcursor libXmu ];
+
+  meta = with lib; {
+    description = "Utilities for handling monitors, resolutions, and (timed) wallpapers";
+    inherit (src.meta) homepage;
+    license = licenses.mit;
+    maintainers = with maintainers; [ primeos ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/graphics/wallutils/lscollection-Add-NixOS-paths-to-DefaultWallpaperDirectories.patch
+++ b/pkgs/tools/graphics/wallutils/lscollection-Add-NixOS-paths-to-DefaultWallpaperDirectories.patch
@@ -1,0 +1,25 @@
+From 9d064428cec970ced9be6753d6250b20a45a9fe2 Mon Sep 17 00:00:00 2001
+From: Michael Weiss <dev.primeos@gmail.com>
+Date: Fri, 19 Apr 2019 11:56:50 +0200
+Subject: [PATCH] lscollection: Add NixOS paths to DefaultWallpaperDirectories
+
+---
+ collections.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/collections.go b/collections.go
+index ef74ea6..9f9a608 100644
+--- a/collections.go
++++ b/collections.go
+@@ -21,7 +21,7 @@ const (
+ )
+ 
+ var (
+-	DefaultWallpaperDirectories = []string{"/usr/share/pixmaps", "/usr/share/wallpapers", "/usr/share/backgrounds", "/usr/local/share/pixmaps", "/usr/local/share/wallpapers", "/usr/local/share/backgrounds", "/usr/share/archlinux"}
++	DefaultWallpaperDirectories = []string{"/run/current-system/sw/share/pixmaps", "/run/current-system/sw/share/wallpapers", "/run/current-system/sw/share/backgrounds", "/usr/share/pixmaps", "/usr/share/wallpapers", "/usr/share/backgrounds", "/usr/local/share/pixmaps", "/usr/local/share/wallpapers", "/usr/local/share/backgrounds", "/usr/share/archlinux"}
+ )
+ 
+ type SearchResults struct {
+-- 
+2.19.2
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2557,6 +2557,8 @@ in
     inherit (pythonPackages) sphinx;
   };
 
+  wallutils = callPackage ../tools/graphics/wallutils { };
+
   wl-clipboard = callPackage ../tools/misc/wl-clipboard { };
 
   zabbix-cli = callPackage ../tools/misc/zabbix-cli { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
