### PR TITLE
pythonPackages.serversyncstorage: disable if cornice.version != 0.17

### DIFF
--- a/pkgs/development/python-modules/serversyncstorage/default.nix
+++ b/pkgs/development/python-modules/serversyncstorage/default.nix
@@ -38,6 +38,7 @@ buildPythonPackage rec {
   ];
 
   meta = with stdenv.lib; {
+    broken = cornice.version != "0.17";
     description = "The SyncServer server software, as used by Firefox Sync";
     homepage = https://github.com/mozilla-services/server-syncstorage;
     license = licenses.mpl20;


### PR DESCRIPTION
###### Motivation for this change

This package doesn't build if accessed directly from the top level without a specially overridden cornice package supplied - as done by `syncserver`. See https://github.com/NixOS/nixpkgs/pull/54739#issuecomment-484850316


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
