### PR TITLE
git-ignore: 0.2.0 -> 1.0.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/git-ignore/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-ignore/default.nix
@@ -3,23 +3,28 @@
 with rustPlatform;
 
 buildRustPackage rec {
-  name = "git-ignore-${version}";
-  version = "0.2.0";
-
-  cargoSha256 = "1fqfy8lnvpn5sd3l73x2p359zq4303vsrdgw3aphvy6580yjb84d";
+  pname = "git-ignore";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "sondr3";
-    repo = "git-ignore";
+    repo = pname;
     rev = "v${version}";
-    sha256 = "1nihh5inh46r8jg9z7d6g9gqfyhrznmkn15nmzpbnzf0653dl629";
+    sha256 = "0krz50pw9bkyzl78bvppk6skbpjp8ga7bd34jya4ha1xfmd8p89c";
   };
+
+  cargoSha256 = "0r6whz8vghhjyc5vrr0n172nghmi61zj96lk26qm0bgxqyzll1kj";
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ openssl ]
   ++ stdenv.lib.optionals stdenv.isDarwin [
     darwin.apple_sdk.frameworks.Security
   ];
+
+  preFixup = ''
+    mkdir -p "$out/man/man1"
+    cp target/release/build/git-ignore-*/out/git-ignore.1 "$out/man/man1/"
+  '';
 
   meta = with stdenv.lib; {
     description = "Quickly and easily fetch .gitignore templates from gitignore.io";

--- a/pkgs/applications/version-management/git-and-tools/git-ignore/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-ignore/default.nix
@@ -21,9 +21,10 @@ buildRustPackage rec {
     darwin.apple_sdk.frameworks.Security
   ];
 
+  outputs = [ "out" "man" ];
   preFixup = ''
-    mkdir -p "$out/man/man1"
-    cp target/release/build/git-ignore-*/out/git-ignore.1 "$out/man/man1/"
+    mkdir -p "$man/man/man1"
+    cp target/release/build/git-ignore-*/out/git-ignore.1 "$man/man/man1/"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update my own package to the latest release.

###### Things done
Tested by installing on my NixOS and macOS machine with `nix-env -f . -i git-ignore` in the `nixpkgs` directory.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
