### PR TITLE
Barco clickshare

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -94,6 +94,7 @@
   ./programs/ccache.nix
   ./programs/cdemu.nix
   ./programs/chromium.nix
+  ./programs/clickshare.nix
   ./programs/command-not-found/command-not-found.nix
   ./programs/criu.nix
   ./programs/dconf.nix

--- a/nixos/modules/programs/clickshare.nix
+++ b/nixos/modules/programs/clickshare.nix
@@ -1,0 +1,21 @@
+{ config, lib, pkgs, ... }:
+
+{
+
+  options.programs.clickshare-csc1.enable =
+    lib.options.mkEnableOption ''
+      Barco ClickShare CSC-1 driver/client.
+      This allows users in the <literal>clickshare</literal>
+      group to access and use a ClickShare USB dongle
+      that is connected to the machine
+    '';
+
+  config = lib.modules.mkIf config.programs.clickshare-csc1.enable {
+    environment.systemPackages = [ pkgs.clickshare-csc1 ];
+    services.udev.packages = [ pkgs.clickshare-csc1 ];
+    users.groups.clickshare = {};
+  };
+
+  meta.maintainers = [ lib.maintainers.yarny ];
+
+}

--- a/pkgs/applications/video/clickshare-csc1/default.nix
+++ b/pkgs/applications/video/clickshare-csc1/default.nix
@@ -1,0 +1,124 @@
+{ lib
+, stdenv
+, fetchurl
+, alsaLib
+, autoPatchelfHook
+, binutils-unwrapped
+, gnutar
+, libav_0_8
+, libnotify
+, libresample
+, libusb1
+, qt4
+, rpmextract
+, unzip
+, xorg
+, usersGroup ? "clickshare"  # for udev access rules
+}:
+
+
+# This fetches the latest firmware version that
+# contains a linux-compatible client binary.
+# Barco no longer supports linux, so updates are unlikely:
+# https://www.barco.com/de/support/clickshare-csc-1/knowledge-base/KB1191
+
+
+stdenv.mkDerivation rec {
+  name = "clickshare-csc1-${version}";
+  version = "01.07.00.033";
+  src = fetchurl {
+    name = "clickshare-csc1-${version}.zip";
+    url = https://www.barco.com/services/website/de/TdeFiles/Download?FileNumber=R33050020&TdeType=3&MajorVersion=01&MinorVersion=07&PatchVersion=00&BuildVersion=033;
+    sha256 = "0h4jqidqvk4xkaky5bizi7ilz4qzl2mh68401j21y3djnzx09br3";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    binutils-unwrapped
+    gnutar
+    rpmextract
+    unzip
+  ];
+  buildInputs = [
+    alsaLib
+    libav_0_8
+    libnotify
+    libresample
+    libusb1
+    qt4
+    xorg.libX11
+    xorg.libXdamage
+    xorg.libXfixes
+    xorg.libXinerama
+    xorg.libXtst
+  ];
+  sourceRoot = ".";
+
+  # The source consists of nested archives.
+  # We extract them archive by archive.
+  # If the filename contains version numbers,
+  # we use a wildcard and check that there
+  # is actually only one file matching.
+  postUnpack =
+    let
+      rpmArch =
+        if stdenv.hostPlatform.isx86_32 then "i386" else
+        if stdenv.hostPlatform.isx86_64 then "x86_64" else
+        throw "unsupported system: ${stdenv.hostPlatform.system}";
+    in
+      ''
+        ls clickshare_baseunit_*.*_all.signed_release.ipk | wc --lines | xargs test 1 =
+        tar --verbose --extract --one-top-level=dir1 < clickshare_baseunit_*.*_all.signed_release.ipk
+        mkdir dir2
+        ( cd dir2 ; ar xv ../dir1/firmware.ipk )
+        tar --verbose --gzip --extract --one-top-level=dir3 --exclude='dev/*' < dir2/data.tar.gz
+        ls dir3/clickshare/clickshare-*-*.${rpmArch}.rpm | wc --lines | xargs test 1 =
+        mkdir dir4
+        cd dir4
+        rpmextract ../dir3/clickshare/clickshare-*-*.${rpmArch}.rpm
+      '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir --verbose --parents $out
+    mv --verbose --target-directory=. usr/*
+    rmdir --verbose usr
+    cp --verbose --recursive --target-directory=$out *
+    runHook postInstall
+  '';
+
+  # Default udev rule restricts access to the
+  # clickshare USB dongle to the `wheel` group.
+  # We replace it with the group
+  # stated in the package arguments.
+  # Also, we patch executable and icon paths in .desktop files.
+  preFixup = ''
+    substituteInPlace \
+        $out/lib/udev/rules.d/99-clickshare.rules \
+        --replace wheel ${usersGroup}
+    substituteInPlace \
+        $out/share/applications/clickshare.desktop \
+        --replace Exec= Exec=$out/bin/ \
+        --replace =/usr =$out
+    substituteInPlace \
+        $out/etc/xdg/autostart/clickshare-launcher.desktop \
+        --replace =/usr =$out
+  '';
+
+  meta = {
+    homepage = https://www.barco.com/de/support/clickshare-csc-1/drivers;
+    downloadPage = https://www.barco.com/de/Support/software/R33050020;
+    platforms = [ "i686-linux" "x86_64-linux" ];
+    license = lib.licenses.unfree;
+    maintainers = [ lib.maintainers.yarny ];
+    description = "Linux driver/client for Barco ClickShare CSC-1";
+    longDescription = ''
+      Barco ClickShare is a wireless presentation system
+      where a USB dongle transmits to a base station
+      that is connected with a beamer.
+      The USB dongle requires proprietary software that
+      captures the screen and sends it to the dongle.
+      This package provides the necessary software for Linux.
+    '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17099,6 +17099,8 @@ in
 
   clfswm = callPackage ../applications/window-managers/clfswm { };
 
+  clickshare-csc1 = callPackage ../applications/video/clickshare-csc1 { };
+
   cligh = python3Packages.callPackage ../development/tools/github/cligh {};
 
   clipgrab = qt5.callPackage ../applications/video/clipgrab { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Let NixOS users share their desktops with Barco's ClickShare dongles during presentations etc. See the package's description and Barco's homepage for more information on the technology.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS: x86_64-linux, x86_32-linux
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) ( *does not apply* )
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"` ( *does not apply* )
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after): *the package requires 5.9 MiB*
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
