### PR TITLE
cargo-outdated: init at unstable-2019-04-13

### DIFF
--- a/pkgs/tools/package-management/cargo-outdated/default.nix
+++ b/pkgs/tools/package-management/cargo-outdated/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, rustPlatform, pkgconfig, openssl, darwin }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-outdated";
+  version = "unstable-2019-04-13";
+
+  src = fetchFromGitHub {
+    owner = "kbknapp";
+    repo = pname;
+    rev = "ce4b6baddc94b77a155abbb5a4fa4d3b31a45598";
+    sha256 = "0x00vn0ldnm2hvndfmq4g4q5w6axyg9vsri3i5zxhmir7423xabp";
+  };
+
+  cargoSha256 = "1xqii2z0asgkwn1ny9n19w7d4sjz12a6i55x2pf4cfrciapdpvdl";
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ openssl ]
+  ++ stdenv.lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.Security
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A cargo subcommand for displaying when Rust dependencies are out of date";
+    homepage = https://github.com/kbknapp/cargo-outdated;
+    license = with licenses; [ asl20 /* or */ mit ];
+    platforms = platforms.all;
+    maintainers = [ maintainers.sondr3 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7762,6 +7762,7 @@ in
 
   cargo-download = callPackage ../tools/package-management/cargo-download { };
   cargo-edit = callPackage ../tools/package-management/cargo-edit { };
+  cargo-outdated = callPackage ../tools/package-management/cargo-outdated {};
   cargo-release = callPackage ../tools/package-management/cargo-release {
     inherit (darwin.apple_sdk.frameworks) Security;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This is a pretty useful package for seeing what you can/should update with Cargo that currently can't be straight up installed unless you have `openssl` and `pkgconfig` available (and working, doesn't work on my machine).

**NOTE:** I have to install this from the latest commit on master right now as there is an issue with `Cargo.lock` not being correct, see [this PR](https://github.com/kbknapp/cargo-outdated/pull/159).

###### Things done
~~However, this package depends on #57017 as the generated `Cargo.lock` cannot be parsed by the old version of `cargo-vendor` in our repo. I'll update this once/if that is merged.~~ It's been merged and it builds fine.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
