### PR TITLE
HylaFAX: fix ModemGroup, also minor metadata updates (backport to release-19.03)

### DIFF
--- a/nixos/modules/services/networking/hylafax/default.nix
+++ b/nixos/modules/services/networking/hylafax/default.nix
@@ -26,4 +26,6 @@
     }];
   };
 
+  meta.maintainers = [ lib.maintainers.yarny ];
+
 }

--- a/nixos/modules/services/networking/hylafax/faxq-default.nix
+++ b/nixos/modules/services/networking/hylafax/faxq-default.nix
@@ -4,7 +4,7 @@
 
 {
 
-  ModemGroup = [ ''"any:.*"'' ];
+  ModemGroup = [ ''"any:0:.*"'' ];
   ServerTracing = "0x78701";
   SessionTracing = "0x78701";
   UUCPLockDir = "/var/lock";

--- a/pkgs/servers/hylafaxplus/default.nix
+++ b/pkgs/servers/hylafaxplus/default.nix
@@ -87,9 +87,28 @@ stdenv.mkDerivation {
   dontAddPrefix = true;
   postInstall = ''. ${postInstall}'';
   postInstallCheck = ''. ${./post-install-check.sh}'';
-  meta.description = "enterprise-class system for sending and receiving facsimiles";
-  meta.homepage = http://hylafax.sourceforge.net;
-  meta.license = lib.licenses.bsd3;
-  meta.maintainers = [ lib.maintainers.yarny ];
-  meta.platforms = lib.platforms.linux;
+  meta = {
+    description = "enterprise-class system for sending and receiving facsimiles";
+    downloadPage = https://hylafax.sourceforge.io/download.php;
+    homepage = https://hylafax.sourceforge.io;
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.yarny ];
+    platforms = lib.platforms.linux;
+    longDescription = ''
+      HylaFAX is a scalable and time-proven solution
+      for sending and receiving facsimiles via modem(s).
+      It is based on a client-server architecture,
+      loosely comparable to CUPS:
+      A client connects to a server to issue outbound jobs,
+      the server then chooses a modem to
+      connect to the receiving fax machine.
+      The server notifies users about their
+      outbound jobs as well as about inbound jobs.
+      HylaFAX+ is a fork of HylaFAX that -- in general --
+      contains a superset of the features of
+      HylaFAX and produces releases more often.
+      This package contains the client
+      and the server parts of HylaFAX+.
+    '';
+  };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This is a backport of https://github.com/NixOS/nixpkgs/pull/59081 .

HylaFAX+ handles the ModemGroup parameter differently from the way the relevant manpage claims it is handled. This can lead to stuck jobs.
I'm using this opportunity to update/improve further minor aspects of the HylaFAX package and module.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS ( *note: no change to the package itself, only hylafax configuration in nixos module and package metadata* )
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
