### PR TITLE
rxvt_unicode: allow to specify dependencies for plugins

### DIFF
--- a/pkgs/applications/misc/rxvt_unicode/wrapper.nix
+++ b/pkgs/applications/misc/rxvt_unicode/wrapper.nix
@@ -1,4 +1,4 @@
-{ symlinkJoin, rxvt_unicode, makeWrapper, plugins }:
+{ symlinkJoin, rxvt_unicode, makeWrapper, plugins, perlPackages, perlDeps ? []}:
 
 let
   rxvt_name = builtins.parseDrvName rxvt_unicode.name;
@@ -12,8 +12,10 @@ in symlinkJoin {
 
   postBuild = ''
     wrapProgram $out/bin/urxvt \
+      --set PERL5LIB : "${perlPackages.makePerlPath perlDeps}" \
       --suffix-each URXVT_PERL_LIB ':' "$out/lib/urxvt/perl"
     wrapProgram $out/bin/urxvtd \
+      --set PERL5LIB : "${perlPackages.makePerlPath perlDeps}" \
       --suffix-each URXVT_PERL_LIB ':' "$out/lib/urxvt/perl"
   '';
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -8461,6 +8461,20 @@ let
     };
   };
 
+  LinuxFD = buildPerlModule rec {
+    name = "Linux-FD-0.011";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/L/LE/LEONT/${name}.tar.gz";
+      sha256 = "6bb579d47644cb0ed35626ff77e909ae69063073c6ac09aa0614fef00fa37356";
+    };
+    buildInputs = [ ModuleBuild TestException ];
+    propagatedBuildInputs = [ SubExporter ];
+    meta = {
+      description = "Linux specific special filehandles";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   LinuxInotify2 = buildPerlPackage rec {
     name = "Linux-Inotify2-2.1";
     src = fetchurl {


### PR DESCRIPTION
###### Motivation for this change
I needed to add some perl modules for a urxvt script.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change
- [x] Tested execu (usually in `./result/bin/`)tion of all binary files
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
