### PR TITLE
Miscellaneous cross compilation fixes

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -103,7 +103,7 @@ rec {
       in
         if final.parsed.kernel.name == pkgs.stdenv.hostPlatform.parsed.kernel.name &&
            pkgs.stdenv.hostPlatform.isCompatible final
-        then "${pkgs.runtimeShell} -c"
+        then "${pkgs.runtimeShell} -c '\"$@\"' --"
         else if final.isWindows
         then "${wine}/bin/${wine-name}"
         else if final.isLinux && pkgs.stdenv.hostPlatform.isLinux

--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -78,10 +78,9 @@ rec {
         else if final.isx86 then "i386"
         else {
           "powerpc" = "ppc";
+          "powerpcle" = "ppc";
           "powerpc64" = "ppc64";
-          "powerpc64le" = "ppc64";
-          "mips64" = "mips";
-          "mipsel64" = "mipsel";
+          "powerpc64le" = "ppc64le";
         }.${final.parsed.cpu.name} or final.parsed.cpu.name;
 
       emulator = pkgs: let

--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -72,6 +72,13 @@ rec {
          release = null;
       };
 
+      kernelArch =
+        if final.isAarch32 then "arm"
+        else if final.isAarch64 then "arm64"
+        else if final.isx86_32 then "x86"
+        else if final.isx86_64 then "ia64"
+        else final.parsed.cpu.name;
+
       qemuArch =
         if final.isArm then "arm"
         else if final.isx86_64 then "x86_64"

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -127,22 +127,42 @@ rec {
     (b == i386 && isCompatible a i486)
     (b == i486 && isCompatible a i586)
     (b == i586 && isCompatible a i686)
-    # NOTE: Not true in some cases. Like in WSL mode.
+
+    # XXX: Not true in some cases. Like in WSL mode.
     (b == i686 && isCompatible a x86_64)
 
-    # ARM
+    # ARMv4
     (b == arm && isCompatible a armv5tel)
-    (b == armv5tel && isCompatible a armv6m)
-    (b == armv6m && isCompatible a armv6l)
-    (b == armv6l && isCompatible a armv7a)
-    (b == armv7a && isCompatible a armv7r)
-    (b == armv7r && isCompatible a armv7m)
-    (b == armv7m && isCompatible a armv7l)
-    (b == armv7l && isCompatible a armv8a)
-    (b == armv8a && isCompatible a armv8r)
-    (b == armv8r && isCompatible a armv8m)
-    # NOTE: not always true! Some arm64 cpus don’t support arm32 mode.
-    (b == armv8m && isCompatible a aarch64)
+
+    # ARMv5
+    (b == armv5tel && isCompatible a armv6l)
+
+    # ARMv6
+    (b == armv6l && isCompatible a armv6m)
+    (b == armv6m && isCompatible a armv7l)
+
+    # ARMv7
+    (b == armv7l && isCompatible a armv7a)
+    (b == armv7l && isCompatible a armv7r)
+    (b == armv7l && isCompatible a armv7m)
+    (b == armv7a && isCompatible a armv8a)
+    (b == armv7r && isCompatible a armv8a)
+    (b == armv7m && isCompatible a armv8a)
+    (b == armv7a && isCompatible a armv8r)
+    (b == armv7r && isCompatible a armv8r)
+    (b == armv7m && isCompatible a armv8r)
+    (b == armv7a && isCompatible a armv8m)
+    (b == armv7r && isCompatible a armv8m)
+    (b == armv7m && isCompatible a armv8m)
+
+    # ARMv8
+    (b == armv8r && isCompatible a armv8a)
+    (b == armv8m && isCompatible a armv8a)
+
+    # XXX: not always true! Some arm64 cpus don’t support arm32 mode.
+    (b == aarch64 && a == armv8a)
+    (b == armv8a && isCompatible a aarch64)
+
     (b == aarch64 && a == aarch64_be)
     (b == aarch64_be && isCompatible a aarch64)
 

--- a/pkgs/development/interpreters/spidermonkey/52.nix
+++ b/pkgs/development/interpreters/spidermonkey/52.nix
@@ -31,7 +31,7 @@ in stdenv.mkDerivation rec {
     })
   ];
 
-  configurePlatforms = [ "host" "target" ];
+  configurePlatforms = [ ];
 
   preConfigure = ''
     export CXXFLAGS="-fpermissive"
@@ -51,7 +51,11 @@ in stdenv.mkDerivation rec {
     "--with-intl-api"
     "--enable-readline"
     "--enable-shared-js"
-  ] ++ stdenv.lib.optional stdenv.hostPlatform.isMusl "--disable-jemalloc";
+  ] ++ stdenv.lib.optional stdenv.hostPlatform.isMusl "--disable-jemalloc"
+    ++ stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    "--host=${stdenv.buildPlatform.config}"
+    "--target=${stdenv.hostPlatform.config}"
+  ];
 
   makeFlags = [
     "HOST_CC=${buildPackages.stdenv.cc}/bin/cc"

--- a/pkgs/development/libraries/aws-c-common/default.nix
+++ b/pkgs/development/libraries/aws-c-common/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake }:
+{ lib, stdenv, fetchFromGitHub, cmake, libexecinfo }:
 
 stdenv.mkDerivation rec {
   pname = "aws-c-common";
@@ -12,6 +12,8 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
+
+  buildInputs = lib.optional stdenv.hostPlatform.isMusl libexecinfo;
 
   NIX_CFLAGS_COMPILE = lib.optionals stdenv.isDarwin [
     "-Wno-nullability-extension"

--- a/pkgs/os-specific/linux/kernel-headers/default.nix
+++ b/pkgs/os-specific/linux/kernel-headers/default.nix
@@ -12,7 +12,7 @@ let
       inherit sha256;
     };
 
-    ARCH = stdenvNoCC.hostPlatform.platform.kernelArch or (throw "missing kernelArch");
+    ARCH = stdenvNoCC.hostPlatform.platform.kernelArch or stdenvNoCC.hostPlatform.kernelArch;
 
     # It may look odd that we use `stdenvNoCC`, and yet explicit depend on a cc.
     # We do this so we have a build->build, not build->host, C compiler.

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -129,12 +129,12 @@ in stdenv.mkDerivation rec {
       test -e $i
       substituteInPlace $i \
         --replace /usr/bin/getent ${getent}/bin/getent \
-        --replace /sbin/swapon ${utillinux.bin}/sbin/swapon \
-        --replace /sbin/swapoff ${utillinux.bin}/sbin/swapoff \
-        --replace /sbin/fsck ${utillinux.bin}/sbin/fsck \
+        --replace /sbin/swapon ${lib.getBin utillinux}/sbin/swapon \
+        --replace /sbin/swapoff ${lib.getBin utillinux}/sbin/swapoff \
+        --replace /sbin/fsck ${lib.getBin utillinux}/sbin/fsck \
         --replace /bin/echo ${coreutils}/bin/echo \
         --replace /bin/cat ${coreutils}/bin/cat \
-        --replace /sbin/sulogin ${utillinux.bin}/sbin/sulogin \
+        --replace /sbin/sulogin ${lib.getBin utillinux}/sbin/sulogin \
         --replace /usr/lib/systemd/systemd-fsck $out/lib/systemd/systemd-fsck \
         --replace /bin/plymouth /run/current-system/sw/bin/plymouth # To avoid dependency
     done

--- a/pkgs/stdenv/default.nix
+++ b/pkgs/stdenv/default.nix
@@ -43,8 +43,14 @@ in
     "x86_64-linux" = stagesLinux;
     "armv5tel-linux" = stagesLinux;
     "armv6l-linux" = stagesLinux;
+    "armv6m-linux" = stagesLinux;
     "armv7a-linux" = stagesLinux;
     "armv7l-linux" = stagesLinux;
+    "armv7r-linux" = stagesLinux;
+    "armv7m-linux" = stagesLinux;
+    "armv8a-linux" = stagesLinux;
+    "armv8r-linux" = stagesLinux;
+    "armv8m-linux" = stagesLinux;
     "aarch64-linux" = stagesLinux;
     "mipsel-linux" = stagesLinux;
     "powerpc-linux" = /* stagesLinux */ stagesNative;

--- a/pkgs/top-level/impure.nix
+++ b/pkgs/top-level/impure.nix
@@ -72,6 +72,8 @@ in
         else overlays homeOverlaysDir
       else []
 
+, crossOverlays ? []
+
 , ...
 } @ args:
 
@@ -80,7 +82,7 @@ in
 assert args ? localSystem -> !(args ? system || args ? platform);
 
 import ./. (builtins.removeAttrs args [ "system" "platform" ] // {
-  inherit config overlays crossSystem;
+  inherit config overlays crossSystem crossOverlays;
   # Fallback: Assume we are building packages on the current (build, in GNU
   # Autotools parlance) system.
   localSystem = (if args ? localSystem then {}


### PR DESCRIPTION
This is a collection of fixes to the cross compilation infrastructures that I have collected. Mostly just stuff that I don't want to forget to merge. Summary:

- fix isCompatible identity
- add handling for musl when building aws-sdk-cpp
- fix the ARM isCompatible definitions
- use isCompatible as a backup for finding bootstrap tools
- fix spidermonkey compilation
- expose crossOverlays to Nix command line args

I can split these up into separate PRs if requested.

/cc @illegalprime 

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
