### PR TITLE
modd: init at 0.8

### DIFF
--- a/pkgs/development/tools/modd/default.nix
+++ b/pkgs/development/tools/modd/default.nix
@@ -1,0 +1,22 @@
+{ buildGoPackage, fetchFromGitHub, stdenv }:
+
+buildGoPackage rec {
+  pname = "modd";
+  version = "0.8";
+  src = fetchFromGitHub {
+    owner = "cortesi";
+    repo = "modd";
+    rev = "v${version}";
+    sha256 = "1dmfpbpcvbx4sl4q1hwbfpalq1ml03w1cca7x40y18g570qk7aq5";
+  };
+  goPackagePath = "github.com/cortesi/modd";
+  subPackages = [ "cmd/modd" ];
+  goDeps = ./deps.nix;
+  meta = with stdenv.lib; {
+    description = "A flexible developer tool that runs processes and responds to filesystem changes";
+    homepage = https://github.com/cortesi/modd;
+    license = licenses.mit;
+    maintainers = with maintainers; [ kierdavis ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/tools/modd/deps.nix
+++ b/pkgs/development/tools/modd/deps.nix
@@ -1,0 +1,138 @@
+# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
+[
+  {
+    goPackagePath  = "github.com/alecthomas/template";
+    fetch = {
+      type = "git";
+      url = "https://github.com/alecthomas/template";
+      rev =  "a0175ee3bccc567396460bf5acd36800cb10c49c";
+      sha256 = "0qjgvvh26vk1cyfq9fadyhfgdj36f1iapbmr5xp6zqipldz8ffxj";
+    };
+  }
+  {
+    goPackagePath  = "github.com/alecthomas/units";
+    fetch = {
+      type = "git";
+      url = "https://github.com/alecthomas/units";
+      rev =  "2efee857e7cfd4f3d0138cc3cbb1b4966962b93a";
+      sha256 = "1j65b91qb9sbrml9cpabfrcf07wmgzzghrl7809hjjhrmbzri5bl";
+    };
+  }
+  {
+    goPackagePath  = "github.com/bmatcuk/doublestar";
+    fetch = {
+      type = "git";
+      url = "https://github.com/bmatcuk/doublestar";
+      rev =  "85a78806aa1b4707d1dbace9be592cf1ece91ab3";
+      sha256 = "01fd5j142pgsj5gfba43646aa6vd09fzvjhhik2r30nj4lsyy3z8";
+    };
+  }
+  {
+    goPackagePath  = "github.com/cortesi/moddwatch";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cortesi/moddwatch";
+      rev =  "d27f53de245eb09b9e475d498cc01c91ba8e89c8";
+      sha256 = "1ivxk6zxrc5rhd0p5kqi8jg58ql2mwdvrxvfzz8fkj1lxz975p9p";
+    };
+  }
+  {
+    goPackagePath  = "github.com/cortesi/termlog";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cortesi/termlog";
+      rev =  "87cefd5ac843f65364f70a1fd2477bb6437690e8";
+      sha256 = "1mygv1bv6dkm5p1wsvzrsyq771k6apdcxlyfqdp5ay8vl75jxvmb";
+    };
+  }
+  {
+    goPackagePath  = "github.com/fatih/color";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fatih/color";
+      rev =  "3f9d52f7176a6927daacff70a3e8d1dc2025c53e";
+      sha256 = "165ww24x6ba47ji4j14mp3f006ksnmi53ws9280pgd2zcw91nbn8";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mattn/go-colorable";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-colorable";
+      rev =  "167de6bfdfba052fa6b2d3664c8f5272e23c9072";
+      sha256 = "1nwjmsppsjicr7anq8na6md7b1z84l9ppnlr045hhxjvbkqwalvx";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mattn/go-isatty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-isatty";
+      rev =  "6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c";
+      sha256 = "0zs92j2cqaw9j8qx1sdxpv3ap0rgbs0vrvi72m40mg8aa36gd39w";
+    };
+  }
+  {
+    goPackagePath  = "github.com/rjeczalik/notify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/rjeczalik/notify";
+      rev =  "629144ba06a1c6af28c1e42c228e3d42594ce081";
+      sha256 = "0745w0mdr9xfr4rxw4pfr1sl8apc7wr7mvfykdl4wslq3mdj8a91";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev =  "505ab145d0a99da450461ae2c1a9f6cd10d1f447";
+      sha256 = "1vbsvcvmjz6c00p5vf8ls533p52fx2y3gy6v4k5qrdlzl4wf0i5s";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev =  "927f97764cc334a6575f4b7a1584a147864d5723";
+      sha256 = "0np7b766gb92vbm514yhdl7cjmqvn0dxdxskd84aas2ri1fkpgw5";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/sync";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sync";
+      rev =  "37e7f081c4d4c64e13b10787722085407fe5d15f";
+      sha256 = "1bb0mw6ckb1k7z8v3iil2qlqwfj408fvvp8m1cik2b46p7snyjhm";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev =  "b4a75ba826a64a70990f11a225237acd6ef35c9f";
+      sha256 = "0kzrd2wywkcq35iakbzplqyma4bvf2ng3mzi7917kxcbdq3fflrj";
+    };
+  }
+  {
+    goPackagePath  = "gopkg.in/alecthomas/kingpin.v2";
+    fetch = {
+      type = "git";
+      url = "https://github.com/alecthomas/kingpin";
+      rev =  "947dcec5ba9c011838740e680966fd7087a71d0d";
+      sha256 = "0mndnv3hdngr3bxp7yxfd47cas4prv98sqw534mx7vp38gd88n5r";
+    };
+  }
+  {
+    goPackagePath  = "mvdan.cc/sh";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mvdan/sh";
+      rev =  "8aeb0734cd0f08b7a473c9ac816be8687ca909cc";
+      sha256 = "1mj8qfkyb6k490qjy3riq6pm440qajf5lc8m74x7xhq5059qkgxx";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9188,6 +9188,8 @@ in
 
   moby = callPackage ../development/tools/misc/moby { };
 
+  modd = callPackage ../development/tools/modd { };
+
   msgpack-tools = callPackage ../development/tools/msgpack-tools { };
 
   msgpuck = callPackage ../development/libraries/msgpuck { };


### PR DESCRIPTION
###### Motivation for this change

Neat tool that watches files in a project directory and re-runs linters/tests or restarts daemons when a file is modified. More info at [project homepage](https://github.com/cortesi/modd).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
