### PR TITLE
unigine-valley: fix loading libGL.so 

### DIFF
--- a/pkgs/applications/graphics/unigine-valley/default.nix
+++ b/pkgs/applications/graphics/unigine-valley/default.nix
@@ -12,6 +12,7 @@
 , libXinerama
 , libXrandr
 , libXrender
+, libGL
 , openal}:
 
 let
@@ -47,6 +48,7 @@ in
       libXinerama
       libXrandr
       libXrender
+      libGL
       openal
     ];
 


### PR DESCRIPTION
Reflect changes introduced in #37369

```valley``` failed to find ```libGL.so```
