### PR TITLE
phpPackages: update php packages

### DIFF
--- a/pkgs/build-support/build-pecl.nix
+++ b/pkgs/build-support/build-pecl.nix
@@ -1,18 +1,19 @@
 { stdenv, php, autoreconfHook, fetchurl }:
 
-{ name
+{ pname
+, version
 , buildInputs ? []
 , nativeBuildInputs ? []
 , makeFlags ? []
 , src ? fetchurl {
-    url = "http://pecl.php.net/get/${name}.tgz";
+    url = "http://pecl.php.net/get/${pname}-${version}.tgz";
     inherit (args) sha256;
   }
 , ...
 }@args:
 
 stdenv.mkDerivation (args // {
-  name = "php-${name}";
+  name = "php-${pname}-${version}";
 
   inherit src;
 

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -444,6 +444,7 @@ let
 
     buildInputs = [ pkgs.v8_6_x ];
     configureFlags = [ "--with-v8js=${pkgs.v8_6_x}" ];
+    meta.broken = true;
   };
 
   xdebug = buildPecl rec {

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -32,6 +32,62 @@ let
     sha256 = "0abccvwif1pih222lbj2z4cf9ibciz48xj35lfixyry163vabkck";
   };
 
+  box = pkgs.stdenv.mkDerivation rec {
+    name = "box-${version}";
+    version = "2.7.5";
+
+    src = pkgs.fetchurl {
+      url = "https://github.com/box-project/box2/releases/download/${version}/box-${version}.phar";
+      sha256 = "1zmxdadrv0i2l8cz7xb38gnfmfyljpsaz2nnkjzqzksdmncbgd18";
+    };
+
+    phases = [ "installPhase" ];
+    buildInputs = [ pkgs.makeWrapper ];
+
+    installPhase = ''
+      mkdir -p $out/bin
+      install -D $src $out/libexec/box/box.phar
+      makeWrapper ${php}/bin/php $out/bin/box \
+        --add-flags "-d phar.readonly=0 $out/libexec/box/box.phar"
+    '';
+
+    meta = with pkgs.lib; {
+      description = "An application for building and managing Phars";
+      license = licenses.mit;
+      homepage = https://box-project.github.io/box2/;
+      maintainers = with maintainers; [ jtojnar ];
+    };
+  };
+
+  composer = pkgs.stdenv.mkDerivation rec {
+    pname = "composer";
+    version = "1.8.4";
+
+    src = pkgs.fetchurl {
+      url = "https://getcomposer.org/download/${version}/composer.phar";
+      sha256 = "12h5vqwhklxvwrplggzjl21n6kb972pwkj9ivmn2vbxyixn848hp";
+    };
+
+    unpackPhase = ":";
+
+    nativeBuildInputs = [ pkgs.makeWrapper ];
+
+    installPhase = ''
+      mkdir -p $out/bin
+      install -D $src $out/libexec/composer/composer.phar
+      makeWrapper ${php}/bin/php $out/bin/composer \
+        --add-flags "$out/libexec/composer/composer.phar" \
+        --prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.unzip ]}
+    '';
+
+    meta = with pkgs.lib; {
+      description = "Dependency Manager for PHP";
+      license = licenses.mit;
+      homepage = https://getcomposer.org/;
+      maintainers = with maintainers; [ globin offline ];
+    };
+  };
+
   couchbase = buildPecl rec {
     name = "couchbase-${version}";
     version = "2.6.0";
@@ -73,21 +129,6 @@ let
     ];
   };
 
-  php_excel = buildPecl rec {
-    name = "php_excel-${version}";
-    version = "1.0.2";
-    phpVersion = "php7";
-
-    buildInputs = [ pkgs.libxl ];
-
-    src = pkgs.fetchurl {
-      url = "https://github.com/iliaal/php_excel/releases/download/Excel-1.0.2-PHP7/excel-${version}-${phpVersion}.tgz";
-      sha256 = "0dpvih9gpiyh1ml22zi7hi6kslkilzby00z1p8x248idylldzs2n";
-    };
-
-    configureFlags = [ "--with-excel" "--with-libxl-incdir=${pkgs.libxl}/include_c" "--with-libxl-libdir=${pkgs.libxl}/lib" ];
-  };
-
   igbinary = buildPecl {
     name = "igbinary-2.0.8";
 
@@ -100,18 +141,18 @@ let
     sha256 = "105nyn703k9p9c7wwy6npq7xd9mczmmlhyn0gn2v2wz0f88spjxs";
   };
 
-  mailparse = assert !isPhp73; buildPecl {
-    name = "mailparse-3.0.2";
-
-    sha256 = "0fw447ralqihsjnn0fm2hkaj8343cvb90v0d1wfclgz49256y6nq";
-  };
-
   imagick = buildPecl {
     name = "imagick-3.4.3";
     sha256 = "0z2nc92xfc5axa9f2dy95rmsd2c81q8cs1pm4anh0a50x9g5ng0z";
     configureFlags = [ "--with-imagick=${pkgs.imagemagick.dev}" ];
     nativeBuildInputs = [ pkgs.pkgconfig ];
     buildInputs = [ (if isPhp73 then pkgs.pcre2 else pkgs.pcre) ];
+  };
+
+  mailparse = assert !isPhp73; buildPecl {
+    name = "mailparse-3.0.2";
+
+    sha256 = "0fw447ralqihsjnn0fm2hkaj8343cvb90v0d1wfclgz49256y6nq";
   };
 
   memcached = buildPecl rec {
@@ -146,137 +187,10 @@ let
     sha256 = "0d4p1gpl8gkzdiv860qzxfz250ryf0wmjgyc8qcaaqgkdyh5jy5p";
   };
 
-  sqlsrv = buildPecl rec {
-    name = "sqlsrv-5.6.1";
-    sha256 = "0ial621zxn9zvjh7k1h755sm2lc9aafc389yxksqcxcmm7kqmd0a";
-    buildInputs = [ pkgs.unixODBC ];
-  };
-
   pdo_sqlsrv = buildPecl rec {
     name = "pdo_sqlsrv-5.6.1";
     sha256 = "02ill1iqffa5fha9iz4y91823scml24ikfk8pn90jyycfwv07x6a";
     buildInputs = [ pkgs.unixODBC ];
-  };
-
-  xdebug = buildPecl rec {
-    version = "2.7.1";
-    name = "xdebug-${version}";
-
-    sha256 = "1hr4gy87a3gp682ggwp831xk1fxasil9wan8cxv23q3m752x3sdp";
-
-    doCheck = true;
-    checkTarget = "test";
-  };
-
-  yaml = buildPecl {
-    name = "yaml-2.0.4";
-
-    sha256 = "1036zhc5yskdfymyk8jhwc34kvkvsn5kaf50336153v4dqwb11lp";
-
-    configureFlags = [
-      "--with-yaml=${pkgs.libyaml}"
-    ];
-
-    nativeBuildInputs = [ pkgs.pkgconfig ];
-  };
-
-  zmq = assert !isPhp73; buildPecl {
-    name = "zmq-1.1.3";
-
-    sha256 = "1kj487vllqj9720vlhfsmv32hs2dy2agp6176mav6ldx31c3g4n4";
-
-    configureFlags = [
-      "--with-zmq=${pkgs.zeromq}"
-    ];
-
-    nativeBuildInputs = [ pkgs.pkgconfig ];
-  };
-
-  pthreads = assert (pkgs.config.php.zts or false); buildPecl {
-    name = "pthreads-3.1.5";
-    sha256 = "1ziap0py3zrc7qj9lw4nzq6wx1viyj8v9y1babchizzan014x6p5";
-    meta.broken = true;
-  };
-
-  redis = buildPecl {
-    name = "redis-4.2.0";
-    sha256 = "105k2rfz97svrqzdhd0a0668mn71c8v0j7hks95832fsvn5dhmbn";
-  };
-
-  v8 = buildPecl rec {
-    version = "0.2.2";
-    name = "v8-${version}";
-
-    sha256 = "103nys7zkpi1hifqp9miyl0m1mn07xqshw3sapyz365nb35g5q71";
-
-    buildInputs = [ pkgs.v8_6_x ];
-    configureFlags = [ "--with-v8=${pkgs.v8_6_x}" ];
-  };
-
-  v8js = assert !isPhp73; buildPecl rec {
-    version = "2.1.0";
-    name = "v8js-${version}";
-
-    sha256 = "0g63dyhhicngbgqg34wl91nm3556vzdgkq19gy52gvmqj47rj6rg";
-
-    buildInputs = [ pkgs.v8_6_x ];
-    configureFlags = [ "--with-v8js=${pkgs.v8_6_x}" ];
-  };
-
-  composer = pkgs.stdenv.mkDerivation rec {
-    pname = "composer";
-    version = "1.8.4";
-
-    src = pkgs.fetchurl {
-      url = "https://getcomposer.org/download/${version}/composer.phar";
-      sha256 = "12h5vqwhklxvwrplggzjl21n6kb972pwkj9ivmn2vbxyixn848hp";
-    };
-
-    unpackPhase = ":";
-
-    nativeBuildInputs = [ pkgs.makeWrapper ];
-
-    installPhase = ''
-      mkdir -p $out/bin
-      install -D $src $out/libexec/composer/composer.phar
-      makeWrapper ${php}/bin/php $out/bin/composer \
-        --add-flags "$out/libexec/composer/composer.phar" \
-        --prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.unzip ]}
-    '';
-
-    meta = with pkgs.lib; {
-      description = "Dependency Manager for PHP";
-      license = licenses.mit;
-      homepage = https://getcomposer.org/;
-      maintainers = with maintainers; [ globin offline ];
-    };
-  };
-
-  box = pkgs.stdenv.mkDerivation rec {
-    name = "box-${version}";
-    version = "2.7.5";
-
-    src = pkgs.fetchurl {
-      url = "https://github.com/box-project/box2/releases/download/${version}/box-${version}.phar";
-      sha256 = "1zmxdadrv0i2l8cz7xb38gnfmfyljpsaz2nnkjzqzksdmncbgd18";
-    };
-
-    phases = [ "installPhase" ];
-    buildInputs = [ pkgs.makeWrapper ];
-
-    installPhase = ''
-      mkdir -p $out/bin
-      install -D $src $out/libexec/box/box.phar
-      makeWrapper ${php}/bin/php $out/bin/box \
-        --add-flags "-d phar.readonly=0 $out/libexec/box/box.phar"
-    '';
-
-    meta = with pkgs.lib; {
-      description = "An application for building and managing Phars";
-      license = licenses.mit;
-      homepage = https://box-project.github.io/box2/;
-      maintainers = with maintainers; [ jtojnar ];
-    };
   };
 
   php-cs-fixer = pkgs.stdenv.mkDerivation rec {
@@ -339,31 +253,19 @@ let
     };
   };
 
-  phpcs = pkgs.stdenv.mkDerivation rec {
-    pname = "phpcs";
-    version = "3.4.1";
+  php_excel = buildPecl rec {
+    name = "php_excel-${version}";
+    version = "1.0.2";
+    phpVersion = "php7";
+
+    buildInputs = [ pkgs.libxl ];
 
     src = pkgs.fetchurl {
-      url = "https://github.com/squizlabs/PHP_CodeSniffer/releases/download/${version}/phpcs.phar";
-      sha256 = "07zwj8msy0awnrwmv3gcilbsj9jyrvxw0q523yf16ydv55422pl0";
+      url = "https://github.com/iliaal/php_excel/releases/download/Excel-1.0.2-PHP7/excel-${version}-${phpVersion}.tgz";
+      sha256 = "0dpvih9gpiyh1ml22zi7hi6kslkilzby00z1p8x248idylldzs2n";
     };
 
-    phases = [ "installPhase" ];
-    buildInputs = [ pkgs.makeWrapper ];
-
-    installPhase = ''
-      mkdir -p $out/bin
-      install -D $src $out/libexec/phpcs/phpcs.phar
-      makeWrapper ${php}/bin/php $out/bin/phpcs \
-        --add-flags "$out/libexec/phpcs/phpcs.phar"
-    '';
-
-    meta = with pkgs.lib; {
-      description = "PHP coding standard tool";
-      license = licenses.bsd3;
-      homepage = https://squizlabs.github.io/PHP_CodeSniffer/;
-      maintainers = with maintainers; [ javaguirre etu ];
-    };
+    configureFlags = [ "--with-excel" "--with-libxl-incdir=${pkgs.libxl}/include_c" "--with-libxl-libdir=${pkgs.libxl}/lib" ];
   };
 
   phpcbf = pkgs.stdenv.mkDerivation rec {
@@ -390,6 +292,33 @@ let
       license = licenses.bsd3;
       homepage = https://squizlabs.github.io/PHP_CodeSniffer/;
       maintainers = with maintainers; [ cmcdragonkai etu ];
+    };
+  };
+
+  phpcs = pkgs.stdenv.mkDerivation rec {
+    pname = "phpcs";
+    version = "3.4.1";
+
+    src = pkgs.fetchurl {
+      url = "https://github.com/squizlabs/PHP_CodeSniffer/releases/download/${version}/phpcs.phar";
+      sha256 = "07zwj8msy0awnrwmv3gcilbsj9jyrvxw0q523yf16ydv55422pl0";
+    };
+
+    phases = [ "installPhase" ];
+    buildInputs = [ pkgs.makeWrapper ];
+
+    installPhase = ''
+      mkdir -p $out/bin
+      install -D $src $out/libexec/phpcs/phpcs.phar
+      makeWrapper ${php}/bin/php $out/bin/phpcs \
+        --add-flags "$out/libexec/phpcs/phpcs.phar"
+    '';
+
+    meta = with pkgs.lib; {
+      description = "PHP coding standard tool";
+      license = licenses.bsd3;
+      homepage = https://squizlabs.github.io/PHP_CodeSniffer/;
+      maintainers = with maintainers; [ javaguirre etu ];
     };
   };
 
@@ -451,5 +380,76 @@ let
       homepage = https://psysh.org/;
       maintainers = with maintainers; [ caugner ];
     };
+  };
+
+  pthreads = assert (pkgs.config.php.zts or false); buildPecl {
+    name = "pthreads-3.1.5";
+    sha256 = "1ziap0py3zrc7qj9lw4nzq6wx1viyj8v9y1babchizzan014x6p5";
+    meta.broken = true;
+  };
+
+  redis = buildPecl {
+    name = "redis-4.2.0";
+    sha256 = "105k2rfz97svrqzdhd0a0668mn71c8v0j7hks95832fsvn5dhmbn";
+  };
+
+  sqlsrv = buildPecl rec {
+    name = "sqlsrv-5.6.1";
+    sha256 = "0ial621zxn9zvjh7k1h755sm2lc9aafc389yxksqcxcmm7kqmd0a";
+    buildInputs = [ pkgs.unixODBC ];
+  };
+
+  v8 = buildPecl rec {
+    version = "0.2.2";
+    name = "v8-${version}";
+
+    sha256 = "103nys7zkpi1hifqp9miyl0m1mn07xqshw3sapyz365nb35g5q71";
+
+    buildInputs = [ pkgs.v8_6_x ];
+    configureFlags = [ "--with-v8=${pkgs.v8_6_x}" ];
+  };
+
+  v8js = assert !isPhp73; buildPecl rec {
+    version = "2.1.0";
+    name = "v8js-${version}";
+
+    sha256 = "0g63dyhhicngbgqg34wl91nm3556vzdgkq19gy52gvmqj47rj6rg";
+
+    buildInputs = [ pkgs.v8_6_x ];
+    configureFlags = [ "--with-v8js=${pkgs.v8_6_x}" ];
+  };
+
+  xdebug = buildPecl rec {
+    version = "2.7.1";
+    name = "xdebug-${version}";
+
+    sha256 = "1hr4gy87a3gp682ggwp831xk1fxasil9wan8cxv23q3m752x3sdp";
+
+    doCheck = true;
+    checkTarget = "test";
+  };
+
+  yaml = buildPecl {
+    name = "yaml-2.0.4";
+
+    sha256 = "1036zhc5yskdfymyk8jhwc34kvkvsn5kaf50336153v4dqwb11lp";
+
+    configureFlags = [
+      "--with-yaml=${pkgs.libyaml}"
+    ];
+
+    nativeBuildInputs = [ pkgs.pkgconfig ];
+  };
+
+  zmq = assert !isPhp73; buildPecl {
+    name = "zmq-1.1.3";
+
+    sha256 = "1kj487vllqj9720vlhfsmv32hs2dy2agp6176mav6ldx31c3g4n4";
+
+    configureFlags = [
+      "--with-zmq=${pkgs.zeromq}"
+    ];
+
+    nativeBuildInputs = [ pkgs.pkgconfig ];
   };
 }; in self

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -33,10 +33,10 @@ let
   };
 
   ast = buildPecl rec {
-    version = "1.0.0";
+    version = "1.0.1";
     pname = "ast";
 
-    sha256 = "0abccvwif1pih222lbj2z4cf9ibciz48xj35lfixyry163vabkck";
+    sha256 = "0ja74k2lmxwhhvp9y9kc7khijd7s2dqma5x8ghbhx9ajkn0wg8iq";
   };
 
   box = pkgs.stdenv.mkDerivation rec {

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -67,12 +67,12 @@ let
   };
 
   composer = pkgs.stdenv.mkDerivation rec {
-    version = "1.8.4";
+    version = "1.8.5";
     pname = "composer";
 
     src = pkgs.fetchurl {
       url = "https://getcomposer.org/download/${version}/composer.phar";
-      sha256 = "12h5vqwhklxvwrplggzjl21n6kb972pwkj9ivmn2vbxyixn848hp";
+      sha256 = "05qfgh2dz8pjf47ndyhkicqbnqzwypk90cczd4c6d8jl9gbiqk2f";
     };
 
     unpackPhase = ":";

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -9,9 +9,12 @@ let
 
   isPhp73 = pkgs.lib.versionAtLeast php.version "7.3";
 
-  apcu = buildPecl {
-    name = "apcu-5.1.17";
+  apcu = buildPecl rec {
+    version = "5.1.17";
+    pname = "apcu";
+
     sha256 = "14y7alvj5q17q1b544bxidavkn6i40cjbq2nv1m0k70ai5vv84bb";
+
     buildInputs = [ (if isPhp73 then pkgs.pcre2 else pkgs.pcre) ];
     doCheck = true;
     checkTarget = "test";
@@ -20,21 +23,25 @@ let
     outputs = [ "out" "dev" ];
   };
 
-  apcu_bc = buildPecl {
-    name = "apcu_bc-1.0.5";
+  apcu_bc = buildPecl rec {
+    version = "1.0.5";
+    pname = "apcu_bc";
+
     sha256 = "0ma00syhk2ps9k9p02jz7rii6x3i2p986il23703zz5npd6y9n20";
+
     buildInputs = [ apcu (if isPhp73 then pkgs.pcre2 else pkgs.pcre) ];
   };
 
-  ast = buildPecl {
-    name = "ast-1.0.0";
+  ast = buildPecl rec {
+    version = "1.0.0";
+    pname = "ast";
 
     sha256 = "0abccvwif1pih222lbj2z4cf9ibciz48xj35lfixyry163vabkck";
   };
 
   box = pkgs.stdenv.mkDerivation rec {
-    name = "box-${version}";
     version = "2.7.5";
+    pname = "box";
 
     src = pkgs.fetchurl {
       url = "https://github.com/box-project/box2/releases/download/${version}/box-${version}.phar";
@@ -60,8 +67,8 @@ let
   };
 
   composer = pkgs.stdenv.mkDerivation rec {
-    pname = "composer";
     version = "1.8.4";
+    pname = "composer";
 
     src = pkgs.fetchurl {
       url = "https://getcomposer.org/download/${version}/composer.phar";
@@ -89,8 +96,8 @@ let
   };
 
   couchbase = buildPecl rec {
-    name = "couchbase-${version}";
     version = "2.6.0";
+    pname = "couchbase";
 
     buildInputs = [ pkgs.libcouchbase pkgs.zlib igbinary pcs ];
 
@@ -129,35 +136,38 @@ let
     ];
   };
 
-  igbinary = buildPecl {
-    name = "igbinary-2.0.8";
-
-    configureFlags = [ "--enable-igbinary" ];
-
-    makeFlags = [ "phpincludedir=$(dev)/include" ];
-
-    outputs = [ "out" "dev" ];
+  igbinary = buildPecl rec {
+    version = "2.0.8";
+    pname = "igbinary";
 
     sha256 = "105nyn703k9p9c7wwy6npq7xd9mczmmlhyn0gn2v2wz0f88spjxs";
+
+    configureFlags = [ "--enable-igbinary" ];
+    makeFlags = [ "phpincludedir=$(dev)/include" ];
+    outputs = [ "out" "dev" ];
   };
 
-  imagick = buildPecl {
-    name = "imagick-3.4.3";
+  imagick = buildPecl rec {
+    version = "3.4.3";
+    pname = "imagick";
+
     sha256 = "0z2nc92xfc5axa9f2dy95rmsd2c81q8cs1pm4anh0a50x9g5ng0z";
+
     configureFlags = [ "--with-imagick=${pkgs.imagemagick.dev}" ];
     nativeBuildInputs = [ pkgs.pkgconfig ];
     buildInputs = [ (if isPhp73 then pkgs.pcre2 else pkgs.pcre) ];
   };
 
-  mailparse = assert !isPhp73; buildPecl {
-    name = "mailparse-3.0.2";
+  mailparse = assert !isPhp73; buildPecl rec {
+    version = "3.0.2";
+    pname = "mailparse";
 
     sha256 = "0fw447ralqihsjnn0fm2hkaj8343cvb90v0d1wfclgz49256y6nq";
   };
 
   memcached = buildPecl rec {
     version = "3.1.3";
-    name = "memcached-${version}";
+    pname = "memcached";
 
     src = fetchgit {
       url = "https://github.com/php-memcached-dev/php-memcached";
@@ -175,27 +185,34 @@ let
   };
 
   oci8 = buildPecl rec {
-    name = "oci8-2.1.8";
+    version = "2.1.8";
+    pname = "oci8";
+
     sha256 = "1bp6fss2f2qmd5bdk7x22j8vx5qivrdhz4x7csf29vjgj6gvchxy";
+
     buildInputs = [ pkgs.re2c pkgs.oracle-instantclient ];
     configureFlags = [ "--with-oci8=shared,instantclient,${pkgs.oracle-instantclient}/lib" ];
   };
 
   pcs = buildPecl rec {
-    name = "pcs-1.3.3";
+    version = "1.3.3";
+    pname = "pcs";
 
     sha256 = "0d4p1gpl8gkzdiv860qzxfz250ryf0wmjgyc8qcaaqgkdyh5jy5p";
   };
 
   pdo_sqlsrv = buildPecl rec {
-    name = "pdo_sqlsrv-5.6.1";
+    version = "5.6.1";
+    pname = "pdo_sqlsrv";
+
     sha256 = "02ill1iqffa5fha9iz4y91823scml24ikfk8pn90jyycfwv07x6a";
+
     buildInputs = [ pkgs.unixODBC ];
   };
 
   php-cs-fixer = pkgs.stdenv.mkDerivation rec {
-    name = "php-cs-fixer-${version}";
     version = "2.14.0";
+    pname = "php-cs-fixer";
 
     src = pkgs.fetchurl {
       url = "https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v${version}/php-cs-fixer.phar";
@@ -221,8 +238,8 @@ let
   };
 
   php-parallel-lint = pkgs.stdenv.mkDerivation rec {
-    name = "php-parallel-lint-${version}";
     version = "1.0.0";
+    pname = "php-parallel-lint";
 
     src = pkgs.fetchFromGitHub {
       owner = "JakubOnderka";
@@ -254,8 +271,8 @@ let
   };
 
   php_excel = buildPecl rec {
-    name = "php_excel-${version}";
     version = "1.0.2";
+    pname = "php_excel";
     phpVersion = "php7";
 
     buildInputs = [ pkgs.libxl ];
@@ -269,8 +286,8 @@ let
   };
 
   phpcbf = pkgs.stdenv.mkDerivation rec {
-    pname = "phpcbf";
     version = "3.4.1";
+    pname = "phpcbf";
 
     src = pkgs.fetchurl {
       url = "https://github.com/squizlabs/PHP_CodeSniffer/releases/download/${version}/phpcbf.phar";
@@ -296,8 +313,8 @@ let
   };
 
   phpcs = pkgs.stdenv.mkDerivation rec {
-    pname = "phpcs";
     version = "3.4.1";
+    pname = "phpcs";
 
     src = pkgs.fetchurl {
       url = "https://github.com/squizlabs/PHP_CodeSniffer/releases/download/${version}/phpcs.phar";
@@ -323,8 +340,8 @@ let
   };
 
   phpstan = pkgs.stdenv.mkDerivation rec {
-    pname = "phpstan";
     version = "0.11.5";
+    pname = "phpstan";
 
     src = pkgs.fetchurl {
       url = "https://github.com/phpstan/phpstan/releases/download/${version}/phpstan.phar";
@@ -357,8 +374,8 @@ let
   };
 
   psysh = pkgs.stdenv.mkDerivation rec {
-    name = "psysh-${version}";
     version = "0.9.8";
+    pname = "psysh";
 
     src = pkgs.fetchurl {
       url = "https://github.com/bobthecow/psysh/releases/download/v${version}/psysh-v${version}.tar.gz";
@@ -382,26 +399,34 @@ let
     };
   };
 
-  pthreads = assert (pkgs.config.php.zts or false); buildPecl {
-    name = "pthreads-3.1.5";
+  pthreads = assert (pkgs.config.php.zts or false); buildPecl rec {
+    version = "3.1.5";
+    pname = "pthreads";
+
     sha256 = "1ziap0py3zrc7qj9lw4nzq6wx1viyj8v9y1babchizzan014x6p5";
+
     meta.broken = true;
   };
 
-  redis = buildPecl {
-    name = "redis-4.2.0";
+  redis = buildPecl rec {
+    version = "4.2.0";
+    pname = "redis";
+
     sha256 = "105k2rfz97svrqzdhd0a0668mn71c8v0j7hks95832fsvn5dhmbn";
   };
 
   sqlsrv = buildPecl rec {
-    name = "sqlsrv-5.6.1";
+    version = "5.6.1";
+    pname = "sqlsrv";
+
     sha256 = "0ial621zxn9zvjh7k1h755sm2lc9aafc389yxksqcxcmm7kqmd0a";
+
     buildInputs = [ pkgs.unixODBC ];
   };
 
   v8 = buildPecl rec {
     version = "0.2.2";
-    name = "v8-${version}";
+    pname = "v8";
 
     sha256 = "103nys7zkpi1hifqp9miyl0m1mn07xqshw3sapyz365nb35g5q71";
 
@@ -411,7 +436,7 @@ let
 
   v8js = assert !isPhp73; buildPecl rec {
     version = "2.1.0";
-    name = "v8js-${version}";
+    pname = "v8js";
 
     sha256 = "0g63dyhhicngbgqg34wl91nm3556vzdgkq19gy52gvmqj47rj6rg";
 
@@ -421,7 +446,7 @@ let
 
   xdebug = buildPecl rec {
     version = "2.7.1";
-    name = "xdebug-${version}";
+    pname = "xdebug";
 
     sha256 = "1hr4gy87a3gp682ggwp831xk1fxasil9wan8cxv23q3m752x3sdp";
 
@@ -429,8 +454,9 @@ let
     checkTarget = "test";
   };
 
-  yaml = buildPecl {
-    name = "yaml-2.0.4";
+  yaml = buildPecl rec {
+    version = "2.0.4";
+    pname = "yaml";
 
     sha256 = "1036zhc5yskdfymyk8jhwc34kvkvsn5kaf50336153v4dqwb11lp";
 
@@ -441,8 +467,9 @@ let
     nativeBuildInputs = [ pkgs.pkgconfig ];
   };
 
-  zmq = assert !isPhp73; buildPecl {
-    name = "zmq-1.1.3";
+  zmq = assert !isPhp73; buildPecl rec {
+    version = "1.1.3";
+    pname = "zmq";
 
     sha256 = "1kj487vllqj9720vlhfsmv32hs2dy2agp6176mav6ldx31c3g4n4";
 

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -433,6 +433,7 @@ let
 
     buildInputs = [ pkgs.v8_6_x ];
     configureFlags = [ "--with-v8=${pkgs.v8_6_x}" ];
+    meta.broken = true;
   };
 
   v8js = assert !isPhp73; buildPecl rec {

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -287,12 +287,12 @@ let
   };
 
   phpcbf = pkgs.stdenv.mkDerivation rec {
-    version = "3.4.1";
+    version = "3.4.2";
     pname = "phpcbf";
 
     src = pkgs.fetchurl {
       url = "https://github.com/squizlabs/PHP_CodeSniffer/releases/download/${version}/phpcbf.phar";
-      sha256 = "052fsgzc39mfjy34mv1ip2qdghypsy218wfp8vh3a593pzkmzdcv";
+      sha256 = "08s47r8i5dyjivk1q3nhrz40n6fx3zghrn5irsxfnx5nj9pb7ffp";
     };
 
     phases = [ "installPhase" ];

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -185,10 +185,10 @@ let
   };
 
   oci8 = buildPecl rec {
-    version = "2.1.8";
+    version = "2.2.0";
     pname = "oci8";
 
-    sha256 = "1bp6fss2f2qmd5bdk7x22j8vx5qivrdhz4x7csf29vjgj6gvchxy";
+    sha256 = "0jhivxj1nkkza4h23z33y7xhffii60d7dr51h1czjk10qywl7pyd";
 
     buildInputs = [ pkgs.re2c pkgs.oracle-instantclient ];
     configureFlags = [ "--with-oci8=shared,instantclient,${pkgs.oracle-instantclient}/lib" ];

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -41,7 +41,7 @@ let
 
   box = pkgs.stdenv.mkDerivation rec {
     version = "2.7.5";
-    pname = "box";
+    pname = "php-box";
 
     src = pkgs.fetchurl {
       url = "https://github.com/box-project/box2/releases/download/${version}/box-${version}.phar";
@@ -68,7 +68,7 @@ let
 
   composer = pkgs.stdenv.mkDerivation rec {
     version = "1.8.5";
-    pname = "composer";
+    pname = "php-composer";
 
     src = pkgs.fetchurl {
       url = "https://getcomposer.org/download/${version}/composer.phar";
@@ -288,7 +288,7 @@ let
 
   phpcbf = pkgs.stdenv.mkDerivation rec {
     version = "3.4.2";
-    pname = "phpcbf";
+    pname = "php-phpcbf";
 
     src = pkgs.fetchurl {
       url = "https://github.com/squizlabs/PHP_CodeSniffer/releases/download/${version}/phpcbf.phar";
@@ -315,7 +315,7 @@ let
 
   phpcs = pkgs.stdenv.mkDerivation rec {
     version = "3.4.2";
-    pname = "phpcs";
+    pname = "php-phpcs";
 
     src = pkgs.fetchurl {
       url = "https://github.com/squizlabs/PHP_CodeSniffer/releases/download/${version}/phpcs.phar";

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -211,12 +211,12 @@ let
   };
 
   php-cs-fixer = pkgs.stdenv.mkDerivation rec {
-    version = "2.14.0";
+    version = "2.14.2";
     pname = "php-cs-fixer";
 
     src = pkgs.fetchurl {
       url = "https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v${version}/php-cs-fixer.phar";
-      sha256 = "0ap5bhm1h2ldyzlch7bz5n3jj2bpm4wd6bzw51g414pk9vksswc1";
+      sha256 = "1d5msgrkiim8iwkkrq3m1cnx7wfi96m1qs6rbh279kw5ysvzkaj9";
     };
 
     phases = [ "installPhase" ];

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -314,12 +314,12 @@ let
   };
 
   phpcs = pkgs.stdenv.mkDerivation rec {
-    version = "3.4.1";
+    version = "3.4.2";
     pname = "phpcs";
 
     src = pkgs.fetchurl {
       url = "https://github.com/squizlabs/PHP_CodeSniffer/releases/download/${version}/phpcs.phar";
-      sha256 = "07zwj8msy0awnrwmv3gcilbsj9jyrvxw0q523yf16ydv55422pl0";
+      sha256 = "0hk9w5kn72z9xhswfmxilb2wk96vy07z4a1pwrpspjlr23aajrk9";
     };
 
     phases = [ "installPhase" ];

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -411,10 +411,10 @@ let
   };
 
   redis = buildPecl rec {
-    version = "4.2.0";
+    version = "4.3.0";
     pname = "redis";
 
-    sha256 = "105k2rfz97svrqzdhd0a0668mn71c8v0j7hks95832fsvn5dhmbn";
+    sha256 = "18hvll173mlp6dk6xvgajkjf4min8f5gn809nr1ahq4r6kn4rw60";
   };
 
   sqlsrv = buildPecl rec {

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -375,12 +375,12 @@ let
   };
 
   psysh = pkgs.stdenv.mkDerivation rec {
-    version = "0.9.8";
+    version = "0.9.9";
     pname = "psysh";
 
     src = pkgs.fetchurl {
       url = "https://github.com/bobthecow/psysh/releases/download/v${version}/psysh-v${version}.tar.gz";
-      sha256 = "0xs9bl0hplkm2hajmm4qca65bm2x7wnx4vbmk0d2jxpvwrgqgnzd";
+      sha256 = "0knbib0afwq2z5fc639ns43x8pi3kmp85y13bkcl00dhvf46yinw";
     };
 
     phases = [ "installPhase" ];
@@ -389,6 +389,7 @@ let
     installPhase = ''
       mkdir -p $out/bin
       tar -xzf $src -C $out/bin
+      chmod +x $out/bin/psysh
       wrapProgram $out/bin/psysh
     '';
 

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -283,6 +283,7 @@ let
     };
 
     configureFlags = [ "--with-excel" "--with-libxl-incdir=${pkgs.libxl}/include_c" "--with-libxl-libdir=${pkgs.libxl}/lib" ];
+    meta.broken = true;
   };
 
   phpcbf = pkgs.stdenv.mkDerivation rec {

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -137,10 +137,10 @@ let
   };
 
   igbinary = buildPecl rec {
-    version = "2.0.8";
+    version = "3.0.1";
     pname = "igbinary";
 
-    sha256 = "105nyn703k9p9c7wwy6npq7xd9mczmmlhyn0gn2v2wz0f88spjxs";
+    sha256 = "1w8jmf1qpggdvq0ndfi86n7i7cqgh1s8q6hys2lijvi37rzn0nar";
 
     configureFlags = [ "--enable-igbinary" ];
     makeFlags = [ "phpincludedir=$(dev)/include" ];


### PR DESCRIPTION
Update php packages:
- ast to 1.0.1
- igbinary to 3.0.1
- redis to 4.3.0
- composer to 1.8.5
- php-cs-fixer to 2.14.2
- phpcs to 3.4.2
- phpcbf to 3.4.2
- psysh to 0.9.9
- oci8 to 2.2.0

Mark package php_excel broken.
Mark package v8 v8js broken - error build package pkgs.v8_6_x
Sort php packages alphabetically.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
