### PR TITLE
pythonPackages.pikepdf: init at 1.2.0

### DIFF
--- a/pkgs/development/python-modules/pikepdf/default.nix
+++ b/pkgs/development/python-modules/pikepdf/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, buildPythonPackage, python3Packages, fetchPypi, qpdf, pythonOlder }:
+
+
+buildPythonPackage rec {
+  pname = "pikepdf";
+  version = "1.2.0";
+  disabled = pythonOlder "3.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1rhp66j091px0jvlx817h8csadkmvg26l3y98ccs5cd06xh6ly2p";
+  };
+
+  buildInputs = with python3Packages; [ defusedxml lxml qpdf pybind11
+                                        setuptools setuptools_scm
+                                      ];
+  checkInputs = with python3Packages; [ nose pytest hypothesis pillow ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "setuptools_scm_git_archive" ""
+  '';
+
+  preConfigure = ''
+    mkdir tmp
+    export HOME=tmp
+  '';
+
+  checkPhase = ''
+    ${python3Packages.python.interpreter} -m pytest
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Read and write PDFs with Python, powered by qpdf";
+    homepage = https://github.com/pikepdf/pikepdf;
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ leenaars ];
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -579,6 +579,8 @@ in {
 
   phonopy = callPackage ../development/python-modules/phonopy { };
 
+  pikepdf = callPackage ../development/python-modules/pikepdf { };
+
   pims = callPackage ../development/python-modules/pims { };
 
   plantuml = callPackage ../tools/misc/plantuml { };


### PR DESCRIPTION
###### Motivation for this change

Dependency for e.g. ocrmypdf

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
