### PR TITLE
libpst: Fix build

### DIFF
--- a/pkgs/development/libraries/libpst/default.nix
+++ b/pkgs/development/libraries/libpst/default.nix
@@ -1,17 +1,22 @@
-{ stdenv, fetchurl, autoreconfHook, boost, python2, libgsf,
+{ stdenv, fetchurl, autoreconfHook, boost, libgsf,
   pkgconfig, bzip2, xmlto, gettext, imagemagick, doxygen }:
 
 stdenv.mkDerivation rec {
   name = "libpst-0.6.71";
 
   src = fetchurl {
-      url = "http://www.five-ten-sg.com/libpst/packages/${name}.tar.gz";
-      sha256 = "130nksrwgi3ih32si5alvxwzd5kmlg8yi7p03w0h7w9r3b90i4pv";
-    };
+    url = "http://www.five-ten-sg.com/libpst/packages/${name}.tar.gz";
+    sha256 = "130nksrwgi3ih32si5alvxwzd5kmlg8yi7p03w0h7w9r3b90i4pv";
+  };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
-  buildInputs = [ boost python2 libgsf bzip2
+  buildInputs = [
+    boost libgsf bzip2
     xmlto gettext imagemagick doxygen
+  ];
+
+  configureFlags = [
+    "--enable-python=no"
   ];
 
   doCheck = true;


### PR DESCRIPTION
Disable Python integration because it can't find `-lboost_python`.
I can't seem to get it to find the library so I just decided to disable Python.

Build has been broken for almost a year: https://hydra.nixos.org/build/92480675

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
