### PR TITLE
Fix pythonPackages.sounddevice and upgrade 0.3.12 -> 0.3.13

### DIFF
--- a/pkgs/development/python-modules/sounddevice/default.nix
+++ b/pkgs/development/python-modules/sounddevice/default.nix
@@ -9,11 +9,11 @@
 
 buildPythonPackage rec {
   pname = "sounddevice";
-  version = "0.3.12";
+  version = "0.3.13";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "f59ae4e2ec12cb1e5940f06f08804ecca855d959de25ca45a3938de45d0f81a2";
+    sha256 = "01x2hm3xxzhxrjcj21si4ggmvkwmy5hag7f6yabqlhwskws721cd";
   };
 
   propagatedBuildInputs = [ cffi numpy portaudio ];

--- a/pkgs/development/python-modules/sounddevice/fix-portaudio-library-path.patch
+++ b/pkgs/development/python-modules/sounddevice/fix-portaudio-library-path.patch
@@ -1,8 +1,8 @@
-diff --git a/sounddevice.py b/sounddevice.py
-index f03476c..5745b6e 100644
---- a/sounddevice.py
-+++ b/sounddevice.py
-@@ -58,28 +58,7 @@ from ctypes.util import find_library as _find_library
+diff --git i/sounddevice.py w/sounddevice.py
+index c7c1d62..aabcb12 100644
+--- i/sounddevice.py
++++ w/sounddevice.py
+@@ -58,29 +58,7 @@ from ctypes.util import find_library as _find_library
  from _sounddevice import ffi as _ffi
 
 
@@ -10,6 +10,7 @@ index f03476c..5745b6e 100644
 -    for _libname in (
 -            'portaudio',  # Default name on POSIX systems
 -            'bin\\libportaudio-2.dll',  # DLL from conda-forge
+-            'lib/libportaudio.dylib',  # dylib from anaconda
 -            ):
 -        _libname = _find_library(_libname)
 -        if _libname is not None:


### PR DESCRIPTION
###### Motivation for this change
v0.3.12 was broken because the outdated patch didn't apply anymore.
I upgraded it to 0.3.13 and updated the patch.

Fixes #59909

Should probably be backported to 19.03.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
