### PR TITLE
networkmanager: port to Meson

### DIFF
--- a/pkgs/build-support/libredirect/libredirect.c
+++ b/pkgs/build-support/libredirect/libredirect.c
@@ -91,6 +91,20 @@ int open64(const char * path, int flags, ...)
     return open64_real(rewrite(path, buf), flags, mode);
 }
 
+int openat(int dirfd, const char * path, int flags, ...)
+{
+    int (*openat_real) (int, const char *, int, mode_t) = dlsym(RTLD_NEXT, "openat");
+    mode_t mode = 0;
+    if (flags & O_CREAT) {
+        va_list ap;
+        va_start(ap, flags);
+        mode = va_arg(ap, mode_t);
+        va_end(ap);
+    }
+    char buf[PATH_MAX];
+    return openat_real(dirfd, rewrite(path, buf), flags, mode);
+}
+
 FILE * fopen(const char * path, const char * mode)
 {
     FILE * (*fopen_real) (const char *, const char *) = dlsym(RTLD_NEXT, "fopen");
@@ -151,4 +165,11 @@ int execv(const char *path, char *const argv[])
     int (*execv_real) (const char *path, char *const argv[]) = dlsym(RTLD_NEXT, "execv");
     char buf[PATH_MAX];
     return execv_real(rewrite(path, buf), argv);
+}
+
+void *dlopen(const char *filename, int flag)
+{
+    void * (*__dlopen_real) (const char *, int) = dlsym(RTLD_NEXT, "dlopen");
+    char buf[PATH_MAX];
+    return __dlopen_real(rewrite(filename, buf), flag);
 }

--- a/pkgs/tools/networking/network-manager/fix-docs-build.patch
+++ b/pkgs/tools/networking/network-manager/fix-docs-build.patch
@@ -1,0 +1,11 @@
+--- a/libnm/meson.build
++++ b/libnm/meson.build
+@@ -262,6 +262,8 @@
+     'env', '-i',
+     'GI_TYPELIB_PATH=' + gi_typelib_path,
+     'LD_LIBRARY_PATH=' + ld_library_path,
++    'LD_PRELOAD=' + '@DOCS_LD_PRELOAD@',
++    'NIX_REDIRECTS=' + '@DOCS_NIX_REDIRECTS@',
+   ]
+ 
+   name = 'nm-property-docs.xml'

--- a/pkgs/tools/networking/network-manager/fix-install-paths.patch
+++ b/pkgs/tools/networking/network-manager/fix-install-paths.patch
@@ -1,0 +1,25 @@
+--- a/meson.build
++++ b/meson.build
+@@ -925,9 +925,9 @@
+   join_paths('tools', 'meson-post-install.sh'),
+   nm_datadir,
+   nm_bindir,
+-  nm_pkgconfdir,
++  nm_prefix + nm_pkgconfdir,
+   nm_pkglibdir,
+-  nm_pkgstatedir,
++  nm_prefix + nm_pkgstatedir,
+   enable_docs ? 'install_docs' : '',
+   nm_mandir,
+ )
+--- a/src/settings/plugins/ifcfg-rh/meson.build
++++ b/src/settings/plugins/ifcfg-rh/meson.build
+@@ -70,7 +70,7 @@
+ )
+ 
+ meson.add_install_script('sh', '-c',
+-                         'mkdir -p $DESTDIR/@0@/sysconfig/network-scripts'.format(nm_sysconfdir))
++                         'mkdir -p $DESTDIR/@0@/sysconfig/network-scripts'.format(nm_prefix + nm_sysconfdir))
+ 
+ if enable_tests
+   subdir('tests')


### PR DESCRIPTION
###### Motivation for this change
All hail Meson!

See the commit messages for details.

###### Things done

I checked that the outputs still match: The `man` and `doc` were moved to separate outputs, Vapi was added to `dev` output, `devdoc` were added, libtool files were removed from `out`.

I also opened the docs in Devhelp but they suffer from the common `about:blank` bug: `env XDG_DATA_DIRS=$(nix-build -A networkmanager.devdoc --no-link)/share GTK3_MODULES= devhelp`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


---
