### PR TITLE
cargo-expand: 0.4.10 -> 0.4.11

### DIFF
--- a/pkgs/development/tools/rust/cargo-expand/default.nix
+++ b/pkgs/development/tools/rust/cargo-expand/default.nix
@@ -2,19 +2,19 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-expand";
-  version = "0.4.10";
+  version = "0.4.11";
 
   src = fetchFromGitHub {
     owner = "dtolnay";
     repo = pname;
     rev = version;
-    sha256 = "1f90v67clmql2bb32sgs7c48q8nhyw2pfk4hpkiy8qll8fypjgik";
+    sha256 = "051hy2320mqdxvafhafwnk1n8q2sq2d7jyhx5bbxvqmjjm55lg8h";
   };
 
-  cargoSha256 = "042s28p68jz3my2q1crmq7xzcajwxmcprgg9z7r9ffhrybk4jvwz";
+  cargoSha256 = "0d1j01nrq5j0yrgd85lnvg1mzalcd8xadkza3yvwnqzf554idrcy";
 
   meta = with stdenv.lib; {
-    description = ''A utility and Cargo subcommand designed to let people expand macros in their Rust source code'';
+    description = "A utility and Cargo subcommand designed to let people expand macros in their Rust source code";
     homepage = https://github.com/dtolnay/cargo-expand;
     license = with licenses; [ mit asl20 ];
     platforms = platforms.all;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update `cargo-expand` to the latest release.

https://github.com/dtolnay/cargo-expand/releases/tag/0.4.11

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
