### PR TITLE
jool: unstable-20180706 -> 4.0.0

### DIFF
--- a/pkgs/os-specific/linux/jool/cli.nix
+++ b/pkgs/os-specific/linux/jool/cli.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, libnl }:
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, libnl, iptables }:
 
 let
   sourceAttrs = (import ./source.nix) { inherit fetchFromGitHub; };
@@ -9,15 +9,13 @@ stdenv.mkDerivation {
 
   src = sourceAttrs.src;
 
-  setSourceRoot = ''
-    sourceRoot=$(echo */usr)
-  '';
-
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
-  buildInputs = [ libnl ];
+  buildInputs = [ libnl iptables ];
 
-  postPatch = ''
-    chmod u+w -R ../common
+  makeFlags = "-C src/usr";
+
+  prePatch = ''
+    sed -e 's%^XTABLES_SO_DIR = .*%XTABLES_SO_DIR = '"$out"'/lib/xtables%g' -i src/usr/iptables/Makefile
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/os-specific/linux/jool/default.nix
+++ b/pkgs/os-specific/linux/jool/default.nix
@@ -1,7 +1,5 @@
 { stdenv, fetchFromGitHub, kernel }:
 
-assert stdenv.lib.versionOlder kernel.version "4.20";
-
 let
   sourceAttrs = (import ./source.nix) { inherit fetchFromGitHub; };
 in

--- a/pkgs/os-specific/linux/jool/default.nix
+++ b/pkgs/os-specific/linux/jool/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, kernel }:
 
-assert stdenv.lib.versionOlder kernel.version "4.18";
+assert stdenv.lib.versionOlder kernel.version "4.20";
 
 let
   sourceAttrs = (import ./source.nix) { inherit fetchFromGitHub; };
@@ -15,15 +15,15 @@ stdenv.mkDerivation {
   hardeningDisable = [ "pic" ];
 
   prePatch = ''
-    sed -e 's@/lib/modules/\$(.*)@${kernel.dev}/lib/modules/${kernel.modDirVersion}@' -i mod/*/Makefile
+    sed -e 's@/lib/modules/\$(.*)@${kernel.dev}/lib/modules/${kernel.modDirVersion}@' -i src/mod/*/Makefile
   '';
 
   buildPhase = ''
-    make -C mod
+    make -C src/mod
   '';
 
   installPhase = ''
-    make -C mod modules_install INSTALL_MOD_PATH=$out
+    make -C src/mod modules_install INSTALL_MOD_PATH=$out
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/os-specific/linux/jool/source.nix
+++ b/pkgs/os-specific/linux/jool/source.nix
@@ -1,11 +1,11 @@
 { fetchFromGitHub }:
 
 rec {
-  version = "unstable-20180706";
+  version = "4.0.0";
   src = fetchFromGitHub {
     owner = "NICMx";
     repo = "Jool";
-    rev = "de791931d94e972c36bb3c102a9cadab5230c285";
-    sha256 = "09mr7lc9k17znpslsfmndx4vgl240llcgblxm92fizmwz23y1d6c";
+    rev = "v${version}";
+    sha256 = "1ivnx7ijqf41kxmi2bmsf9qfcv6b1rvag35754ddlndry3sgvimr";
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Updated `jool` to version 4.0, and fixed it so that it builds on up-to-date kernels.

Also removed the assertion on the kernel version; upstream doesn't list any constraints on supported kernels anywhere I can see, and if the kernel API makes an incompatible change, we'll notice when it fails to build normally.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
