### PR TITLE
freecad: 0.17 -> 0.18.1

### DIFF
--- a/pkgs/applications/graphics/freecad/default.nix
+++ b/pkgs/applications/graphics/freecad/default.nix
@@ -9,11 +9,11 @@ let
   pythonPackages = python27Packages;
 in stdenv.mkDerivation rec {
   name = "freecad-${version}";
-  version = "0.17";
+  version = "0.18.1";
 
   src = fetchurl {
     url = "https://github.com/FreeCAD/FreeCAD/archive/${version}.tar.gz";
-    sha256 = "1yv6abdzlpn4wxy315943xwrnbywxqfgkjib37qwfvbb8y9p60df";
+    sha256 = "0lamrs84zv99v4z7yi6d9amjmnh7r6frairc2aajgfic380720bc";
   };
 
   buildInputs = [ cmake coin3d xercesc ode eigen qt4 opencascade gts
@@ -21,14 +21,6 @@ in stdenv.mkDerivation rec {
   ] ++ (with pythonPackages; [
     matplotlib pycollada pyside pysideShiboken pysideTools pivy python boost
   ]);
-
-  patches = [
-    # Fix for finding boost_python. Boost >= 1.67.0 appends the Python version.
-    (fetchpatch {
-      url = https://github.com/FreeCAD/FreeCAD/commit/3c9e6b038ed544e446c61695dab62f83e781a28a.patch;
-      sha256 = "0f09qywzn0y41hylizb5g8jy74fi53iqmvqr5zznaz16wpw4hqbp";
-    })
-  ];
 
   enableParallelBuilding = true;
 
@@ -45,40 +37,8 @@ in stdenv.mkDerivation rec {
   postInstall = ''
     wrapProgram $out/bin/FreeCAD --prefix PYTHONPATH : $PYTHONPATH \
       --set COIN_GL_NO_CURRENT_CONTEXT_CHECK 1
-
-    mkdir -p $out/share/mime/packages
-    cat << EOF > $out/share/mime/packages/freecad.xml
-    <?xml version="1.0" encoding="UTF-8"?>
-    <mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
-      <mime-type type="application/x-extension-fcstd">
-        <sub-class-of type="application/zip"/>
-        <comment>FreeCAD Document</comment>
-        <glob pattern="*.fcstd"/>
-      </mime-type>
-    </mime-info>
-    EOF
-
-    mkdir -p $out/share/applications
-    cp $desktopItem/share/applications/* $out/share/applications/
-    for entry in $out/share/applications/*.desktop; do
-      substituteAllInPlace $entry
-    done
   '';
-
-  desktopItem = makeDesktopItem {
-    name = "freecad";
-    desktopName = "FreeCAD";
-    genericName = "CAD Application";
-    comment = meta.description;
-    exec = "@out@/bin/FreeCAD %F";
-    categories = "Science;Education;Engineering;";
-    startupNotify = "true";
-    mimeType = "application/x-extension-fcstd;";
-    extraEntries = ''
-      Path=@out@/share/freecad
-    '';
-  };
-
+    
   meta = with stdenv.lib; {
     description = "General purpose Open Source 3D CAD/MCAD/CAx/CAE/PLM modeler";
     homepage = https://www.freecadweb.org/;


### PR DESCRIPTION
###### Motivation for this change

Updating to the latest version. Some simplification has been possible as FreeCAD now includes XDG config files in its release.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
