### PR TITLE
knot-resolver: 3.2.1 -> 4.0.0 -> 4.1.0

### DIFF
--- a/nixos/modules/services/networking/kresd.nix
+++ b/nixos/modules/services/networking/kresd.nix
@@ -80,8 +80,11 @@ in
         # Syntax depends on being IPv6 or IPv4.
         (iface: if elem ":" (stringToCharacters iface) then "[${iface}]:53" else "${iface}:53")
         cfg.interfaces;
-      socketConfig.ListenDatagram = listenStreams;
-      socketConfig.FreeBind = true;
+      socketConfig = {
+        ListenDatagram = listenStreams;
+        FreeBind = true;
+        FileDescriptorName = "dns";
+      };
     };
 
     systemd.sockets.kresd-tls = mkIf (cfg.listenTLS != []) rec {

--- a/pkgs/servers/dns/knot-resolver/default.nix
+++ b/pkgs/servers/dns/knot-resolver/default.nix
@@ -51,11 +51,10 @@ unwrapped = stdenv.mkDerivation rec {
     "-Dinstall_kresd_conf=disabled" # not really useful; examples are inside share/doc/
     "--default-library=static" # not used by anyone
   ]
-  ++ optionals doInstallCheck [
-    "-Dunit_tests=enabled"
-    "-Dconfig_tests=enabled"
+  ++ optional doInstallCheck "-Dunit_tests=enabled"
+  ++ optional (doInstallCheck && !stdenv.isDarwin) "-Dconfig_tests=enabled"
     #"-Dextra_tests=enabled" # not suitable as in-distro tests; many deps, too.
-  ];
+  ;
 
   postInstall = ''
     rm "$out"/lib/libkres.a

--- a/pkgs/servers/dns/knot-resolver/default.nix
+++ b/pkgs/servers/dns/knot-resolver/default.nix
@@ -1,68 +1,70 @@
-{ stdenv, fetchurl, fetchpatch, runCommand, pkgconfig, hexdump, which
-, knot-dns, luajit, libuv, lmdb, gnutls, nettle
-, cmocka, systemd, dns-root-data, makeWrapper
+{ stdenv, fetchurl
+# native deps.
+, runCommand, pkgconfig, meson, ninja, makeWrapper
+# build+runtime deps.
+, knot-dns, luajitPackages, libuv, gnutls, lmdb, systemd, dns-root-data
+# test-only deps.
+, cmocka, which, cacert
 , extraFeatures ? false /* catch-all if defaults aren't enough */
-, luajitPackages
 }:
 let # un-indented, over the whole file
 
 result = if extraFeatures then wrapped-full else unwrapped;
 
-inherit (stdenv.lib) optional;
+inherit (stdenv.lib) optional optionals concatStringsSep;
+lua = luajitPackages;
+
+# FIXME: remove these usages once resolving
+# https://github.com/NixOS/nixpkgs/pull/63108#issuecomment-508670438
+exportLuaPathsFor = luaPkgs: ''
+  export LUA_PATH='${ concatStringsSep ";" (map lua.getLuaPath  luaPkgs)}'
+  export LUA_CPATH='${concatStringsSep ";" (map lua.getLuaCPath luaPkgs)}'
+'';
 
 unwrapped = stdenv.mkDerivation rec {
   name = "knot-resolver-${version}";
-  version = "3.2.1";
+  version = "4.0.0";
 
   src = fetchurl {
     url = "https://secure.nic.cz/files/knot-resolver/${name}.tar.xz";
-    sha256 = "d1396888ec3a63f19dccdf2b7dbcb0d16a5d8642766824b47f4c21be90ce362b";
+    sha256 = "37161d931e64535ce38c33b9635f06a43cd1541945bf2c79a55e37f230de1631";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "support-libzscanner-2.8.diff";
-      url = "https://gitlab.labs.nic.cz/knot/knot-resolver/commit/186f263.diff";
-      sha256 = "19zqigvc7m2a4j6bk9whx7gj0v009568rz5qwk052z7pzfikr8mk";
-    })
-  ];
-
-  # Short-lived cross fix, as upstream is migrating to meson anyway.
-  postPatch = ''
-    substituteInPlace platform.mk --replace "objdump" "$OBJDUMP"
-  '';
 
   outputs = [ "out" "dev" ];
 
-  configurePhase = "patchShebangs scripts/";
+  preConfigure = ''
+    patchShebangs scripts/
+  ''
+    + stdenv.lib.optionalString doInstallCheck (exportLuaPathsFor [ lua.cqueues lua.basexx ]);
 
-  nativeBuildInputs = [ pkgconfig which hexdump ];
+  nativeBuildInputs = [ pkgconfig meson ninja ];
 
   # http://knot-resolver.readthedocs.io/en/latest/build.html#requirements
-  buildInputs = [ knot-dns luajit libuv gnutls nettle lmdb ]
-    ++ optional stdenv.isLinux systemd # sd_notify
+  buildInputs = [ knot-dns lua.lua libuv gnutls lmdb ]
+    ++ optional stdenv.isLinux systemd # passing sockets, sd_notify
     ## optional dependencies; TODO: libedit, dnstap
     ;
 
-  checkInputs = [ cmocka ];
-
-  makeFlags = [
-    "PREFIX=$(out)"
-    "ROOTHINTS=${dns-root-data}/root.hints"
-    "KEYFILE_DEFAULT=${dns-root-data}/root.ds"
+  mesonFlags = [
+    "-Dkeyfile_default=${dns-root-data}/root.ds"
+    "-Droot_hints=${dns-root-data}/root.hints"
+    "-Dinstall_kresd_conf=disabled" # not really useful; examples are inside share/doc/
+    "--default-library=static" # not used by anyone
+  ]
+  ++ optionals doInstallCheck [
+    "-Dunit_tests=enabled"
+    "-Dconfig_tests=enabled"
+    #"-Dextra_tests=enabled" # not suitable as in-distro tests; many deps, too.
   ];
-  CFLAGS = [ "-O2" "-DNDEBUG" ];
-
-  enableParallelBuilding = true;
-
-  doCheck = true;
-  doInstallCheck = false; # FIXME
-  preInstallCheck = ''
-    patchShebangs tests/config/runtest.sh
-  '';
 
   postInstall = ''
-    rm "$out"/etc/knot-resolver/root.hints # using system-wide instead
+    rm "$out"/lib/libkres.a
+  '';
+
+  doInstallCheck = stdenv.hostPlatform == stdenv.buildPlatform;
+  installCheckInputs = [ cmocka which cacert ];
+  installCheckPhase = ''
+    meson test --print-errorlogs
   '';
 
   meta = with stdenv.lib; {
@@ -93,11 +95,12 @@ wrapped-full =
     preferLocalBuild = true;
     allowSubstitutes = false;
   }
-  ''
+  (exportLuaPathsFor luaPkgs
+  + ''
     mkdir -p "$out"/{bin,share}
     makeWrapper '${unwrapped}/bin/kresd' "$out"/bin/kresd \
-      --set LUA_PATH  '${concatStringsSep ";" (map getLuaPath  luaPkgs)}' \
-      --set LUA_CPATH '${concatStringsSep ";" (map getLuaCPath luaPkgs)}'
+      --set LUA_PATH  "$LUA_PATH" \
+      --set LUA_CPATH "$LUA_CPATH"
 
     ln -sr '${unwrapped}/share/man' "$out"/share/
     ln -sr "$out"/{bin,sbin}
@@ -105,6 +108,6 @@ wrapped-full =
     echo "Checking that 'http' module loads, i.e. lua search paths work:"
     echo "modules.load('http')" > test-http.lua
     echo -e 'quit()' | env -i "$out"/bin/kresd -a 127.0.0.1#53535 -c test-http.lua
-  '';
+  '');
 
 in result

--- a/pkgs/servers/dns/knot-resolver/default.nix
+++ b/pkgs/servers/dns/knot-resolver/default.nix
@@ -23,11 +23,11 @@ exportLuaPathsFor = luaPkgs: ''
 
 unwrapped = stdenv.mkDerivation rec {
   name = "knot-resolver-${version}";
-  version = "4.0.0";
+  version = "4.1.0";
 
   src = fetchurl {
     url = "https://secure.nic.cz/files/knot-resolver/${name}.tar.xz";
-    sha256 = "37161d931e64535ce38c33b9635f06a43cd1541945bf2c79a55e37f230de1631";
+    sha256 = "2fe470f9bb1007667cdd448f758087244b7195a0234c2b100a9beeed0a2d3e68";
   };
 
   outputs = [ "out" "dev" ];
@@ -61,7 +61,8 @@ unwrapped = stdenv.mkDerivation rec {
     rm "$out"/lib/libkres.a
   '';
 
-  doInstallCheck = stdenv.hostPlatform == stdenv.buildPlatform;
+  # aarch64: see https://github.com/wahern/cqueues/issues/223
+  doInstallCheck = with stdenv; hostPlatform == buildPlatform && !hostPlatform.isAarch64;
   installCheckInputs = [ cmocka which cacert ];
   installCheckPhase = ''
     meson test --print-errorlogs
@@ -71,8 +72,7 @@ unwrapped = stdenv.mkDerivation rec {
     description = "Caching validating DNS resolver, from .cz domain registry";
     homepage = https://knot-resolver.cz;
     license = licenses.gpl3Plus;
-    # Platforms using negative pointers for stack won't work ATM due to LuaJIT impl.
-    platforms = filter (p: p != "aarch64-linux") platforms.unix;
+    platforms = platforms.unix;
     maintainers = [ maintainers.vcunat /* upstream developer */ ];
   };
 };


### PR DESCRIPTION
https://lists.nic.cz/pipermail/knot-resolver-users/2019/000136.html

Works fine for me (as of the 4.0.0 commit), including the nixos service.  Still, I'd like to improve the service to support easy passing of sockets to http module.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] N/A Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] N/A Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after):
    * no changes in runtime dependencies
    * a few KiB changes in the package itself
- [x] N/A Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
