### PR TITLE
startx: fix typos for startx option description

### DIFF
--- a/nixos/modules/services/x11/display-managers/startx.nix
+++ b/nixos/modules/services/x11/display-managers/startx.nix
@@ -20,8 +20,8 @@ in
           Whether to enable the dummy "startx" pseudo-display manager,
           which allows users to start X manually via the "startx" command
           from a vt shell. The X server runs under the user's id, not as root.
-          The user must provide a ~/.xinintrc file containing session startup
-          commands, see startx(1). This is not autmatically generated
+          The user must provide a ~/.xinitrc file containing session startup
+          commands, see startx(1). This is not automatically generated
           from the desktopManager and windowManager settings.
         '';
       };


### PR DESCRIPTION
###### Motivation for this change

Fix typos in services.xserver.displayManager.startx.enable.description

###### Things done

`~/.xinintrc` => `~/.xinitrc`
`autmatically` => `automatically`