### PR TITLE
appleseed: 1.9.0-beta -> 2.0.5-beta (fixes build)

### DIFF
--- a/pkgs/tools/graphics/appleseed/default.nix
+++ b/pkgs/tools/graphics/appleseed/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, cmake, boost165, pkgconfig, guile,
 eigen, libpng, python, libGLU, qt4, openexr, openimageio,
-opencolorio, xercesc, ilmbase, osl, seexpr
+opencolorio, xercesc, ilmbase, osl, seexpr, makeWrapper
 }:
 
 let boost_static = boost165.override {
@@ -10,21 +10,21 @@ let boost_static = boost165.override {
 in stdenv.mkDerivation rec {
 
   name = "appleseed-${version}";
-  version = "1.9.0-beta";
+  version = "2.0.5-beta";
 
   src = fetchFromGitHub {
     owner  = "appleseedhq";
     repo   = "appleseed";
-    rev    = "1.9.0-beta";
-    sha256 = "0m7zvfkdjfn48zzaxh2wa1bsaj4l876a05bzgmjlfq5dz3202anr";
+    rev    = version;
+    sha256 = "1sq9s0rzjksdn8ayp1g17gdqhp7fqks8v1ddd3i5rsl96b04fqx5";
   };
   buildInputs = [
     cmake pkgconfig boost_static guile eigen libpng python
     libGLU qt4 openexr openimageio opencolorio xercesc
-    osl seexpr
+    osl seexpr makeWrapper
   ];
 
-  NIX_CFLAGS_COMPILE = "-I${openexr.dev}/include/OpenEXR -I${ilmbase.dev}/include/OpenEXR -I${openimageio.dev}/include/OpenImageIO";
+  NIX_CFLAGS_COMPILE = "-I${openexr.dev}/include/OpenEXR -I${ilmbase.dev}/include/OpenEXR -I${openimageio.dev}/include/OpenImageIO -Wno-unused-but-set-variable";
 
   cmakeFlags = [
       "-DUSE_EXTERNAL_XERCES=ON" "-DUSE_EXTERNAL_OCIO=ON" "-DUSE_EXTERNAL_OIIO=ON"
@@ -49,6 +49,7 @@ in stdenv.mkDerivation rec {
   # Work around a bug in the CMake build:
   postInstall = ''
     chmod a+x $out/bin/*
+    wrapProgram $out/bin/appleseed.studio --set PYTHONHOME ${python}
   '';
 }
 


### PR DESCRIPTION

###### Motivation for this change

`appleseed`'s build looks like it was broken by a bump of `osl`. `1.9.0-beta` doesn't seem to build against this new version, but `2.0.5-beta` does, provided we set `-Wno-unused-but-set-variable`
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
