### PR TITLE
nordic-polar: 1.4.0 -> 1.5.0

### DIFF
--- a/pkgs/data/themes/nordic-polar/default.nix
+++ b/pkgs/data/themes/nordic-polar/default.nix
@@ -2,16 +2,16 @@
 
 stdenv.mkDerivation rec {
   name = "nordic-polar-${version}";
-  version = "1.4.0";
+  version = "1.5.0";
 
   srcs = [
     (fetchurl {
-      url = "https://github.com/EliverLara/Nordic-Polar/releases/download/v${version}/Nordic-Polar.tar.xz";
-      sha256 = "0sw4m1njnxal1kkiipsvfg9ndzxsf9rxfba5vhwswyzk388264xa";
+      url = "https://github.com/EliverLara/Nordic-Polar/releases/download/v.${version}/Nordic-Polar.tar.xz";
+      sha256 = "0ddccxvyf929045x6fm8xyx6rvb0d6wh6pylycwgqqm4vxbdwnly";
     })
     (fetchurl {
-      url = "https://github.com/EliverLara/Nordic-Polar/releases/download/v${version}/Nordic-Polar-standard-buttons.tar.xz";
-      sha256 = "0ix0x0pnhfd1lrfj7a7n8xfg8vvzg7m0dzrsj8gzpav6wvwlypiy";
+      url = "https://github.com/EliverLara/Nordic-Polar/releases/download/v.${version}/Nordic-Polar-standard-buttons.tar.xz";
+      sha256 = "0q0qfy0aw80rds6isx3pjrqx4zrq2crxrm29nrmyzh4gr7n17li6";
     })
   ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update to version [1.5.0](https://github.com/EliverLara/Nordic-Polar/releases/tag/v.1.5.0)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).