### PR TITLE
nordic: 1.5.4 -> 1.6.5

### DIFF
--- a/pkgs/data/themes/nordic/default.nix
+++ b/pkgs/data/themes/nordic/default.nix
@@ -2,24 +2,24 @@
 
 stdenv.mkDerivation rec {
   name = "nordic-${version}";
-  version = "1.5.4";
+  version = "1.6.5";
 
   srcs = [
     (fetchurl {
       url = "https://github.com/EliverLara/Nordic/releases/download/v${version}/Nordic.tar.xz";
-      sha256 = "0m00hwr6ms9fzlpl97d972wvgq5l0m11mpn213248a8sqbh2zz9g";
+      sha256 = "163g1kh92fhgbwi91053xs39bpdd032w2v67c3jf8lf4cgvkwggp";
     })
     (fetchurl {
       url = "https://github.com/EliverLara/Nordic/releases/download/v${version}/Nordic-blue.tar.xz";
-      sha256 = "05k1m9f0q4mfaqp2as3ymjsqmyz0bs5cd576srd5v952dzxmmbm2";
+      sha256 = "05qq1v8sil8s51aa78q2najcqdnkpgdzc8dckrx47wy36cfxbxwz";
     })
     (fetchurl {
       url = "https://github.com/EliverLara/Nordic/releases/download/v${version}/Nordic-standard-buttons.tar.xz";
-      sha256 = "1qps13fpp8y83c25c51w7kyds266gmks8c7kjp23iybij2lkny1m";
+      sha256 = "17r450xxd8v8125a4bwd0yj3f3vnwcad2f19a0vgmk63s9grvkg0";
     })
     (fetchurl {
       url = "https://github.com/EliverLara/Nordic/releases/download/v${version}/Nordic-blue-standard-buttons.tar.xz";
-      sha256 = "1c0j6qsxa6zahrl9ad0q6pczgbmm8qn9qsd7k41yk2ndh9iqzr5y";
+      sha256 = "0894naw0wkl2h9l27qz9h1k02dfgfqyb02icmgadg0cb44j3zlpb";
     })
   ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update to version [1.6.5](https://github.com/EliverLara/Nordic/releases/tag/v1.6.5)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).