### PR TITLE
deepin.deepin-mutter: fix paths related to plugins and desktop files

### DIFF
--- a/pkgs/desktops/deepin/deepin-mutter/deepin-mutter.plugins-dir.patch
+++ b/pkgs/desktops/deepin/deepin-mutter/deepin-mutter.plugins-dir.patch
@@ -1,0 +1,41 @@
+From 8eeb4febcae517080d6638f8953e02335df79f01 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jos=C3=A9=20Romildo=20Malaquias?= <malaquias@gmail.com>
+Date: Sat, 20 Apr 2019 00:28:47 -0300
+Subject: [PATCH] Get plugins dir from environment variable
+
+---
+ src/compositor/meta-plugin-manager.c | 12 ++++++++++--
+ 1 file changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/src/compositor/meta-plugin-manager.c b/src/compositor/meta-plugin-manager.c
+index ac5716db..d000100b 100644
+--- a/src/compositor/meta-plugin-manager.c
++++ b/src/compositor/meta-plugin-manager.c
+@@ -56,14 +56,22 @@ meta_plugin_manager_set_plugin_type (GType gtype)
+ void
+ meta_plugin_manager_load (const gchar       *plugin_name)
+ {
+-  const gchar *dpath = MUTTER_PLUGIN_DIR "/";
++  const gchar *env_var;
++  const gchar *dpath;
+   gchar       *path;
+   MetaModule  *module;
+ 
++  env_var = g_getenv ("DEEPIN_MUTTER_PLUGINS_DIR");
++  g_debug ("$DEEPIN_MUTTER_PLUGINS_DIR: %s\n", env_var);
++
++  dpath = env_var == NULL || strlen (env_var) == 0 ? MUTTER_PLUGIN_DIR : env_var;
++  g_debug ("dpath: %s\n", dpath);
++
+   if (g_path_is_absolute (plugin_name))
+     path = g_strdup (plugin_name);
+   else
+-    path = g_strconcat (dpath, plugin_name, ".so", NULL);
++    path = g_strconcat (dpath, "/", plugin_name, ".so", NULL);
++  g_debug ("path: %s\n", path);
+ 
+   module = g_object_new (META_TYPE_MODULE, "path", path, NULL);
+   if (!module || !g_type_module_use (G_TYPE_MODULE (module)))
+-- 
+2.21.0
+

--- a/pkgs/desktops/deepin/deepin-mutter/default.nix
+++ b/pkgs/desktops/deepin/deepin-mutter/default.nix
@@ -50,6 +50,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     searchHardCodedPaths  # debugging
+    sed -i -e "s,Exec=deepin-mutter,Exec=$out/bin/deepin-mutter," data/mutter.desktop.in
   '';
 
   configureFlags = [

--- a/pkgs/desktops/deepin/deepin-mutter/default.nix
+++ b/pkgs/desktops/deepin/deepin-mutter/default.nix
@@ -44,8 +44,12 @@ stdenv.mkDerivation rec {
     xorg.libxkbfile
   ];
 
+  patches = [
+    ./deepin-mutter.plugins-dir.patch
+  ];
+
   postPatch = ''
-    searchHardCodedPaths
+    searchHardCodedPaths  # debugging
   '';
 
   configureFlags = [
@@ -55,6 +59,10 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     NOCONFIGURE=1 ./autogen.sh
+  '';
+
+  postFixup = ''
+    searchHardCodedPaths $out  # debugging
   '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

- deepin.deepin-mutter: set plugins dir from environment variable
- deepin.deepin-mutter: use absolute path in desktop file

About packaging deepin for NixOS: https://github.com/NixOS/nixpkgs/issues/59023

See also https://github.com/NixOS/nixpkgs/pull/59244#issuecomment-485097016

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).