### PR TITLE
deepin.dde-polkit-agent: set plugins dir from environment variable

### DIFF
--- a/pkgs/desktops/deepin/dde-polkit-agent/dde-polkit-agent.plugins-dir.patch
+++ b/pkgs/desktops/deepin/dde-polkit-agent/dde-polkit-agent.plugins-dir.patch
@@ -1,0 +1,42 @@
+From 4f457d38e9e75bc97ee7dba633bf0cdd61b8cd5b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jos=C3=A9=20Romildo=20Malaquias?= <malaquias@gmail.com>
+Date: Fri, 19 Apr 2019 22:01:16 -0300
+Subject: [PATCH] Use an environment variable to find plugins
+
+---
+ pluginmanager.cpp | 18 ++++++++++++------
+ 1 file changed, 12 insertions(+), 6 deletions(-)
+
+diff --git a/pluginmanager.cpp b/pluginmanager.cpp
+index 0c03237..79bdf86 100644
+--- a/pluginmanager.cpp
++++ b/pluginmanager.cpp
+@@ -34,13 +34,19 @@ QList<QButtonGroup*> PluginManager::reduceGetOptions(const QString &actionID)
+ void PluginManager::load()
+ {
+ 
+-    QDir dir("/usr/lib/polkit-1-dde/plugins/");
+-    QFileInfoList pluginFiles = dir.entryInfoList((QStringList("*.so")));
++    QStringList pluginsDirs = QProcessEnvironment::systemEnvironment().value("DDE_POLKIT_PLUGINS_DIRS").split(QDir::listSeparator(), QString::SkipEmptyParts);
++    pluginsDirs.append("/usr/lib/polkit-1-dde/plugins/");
+ 
+-    for (const QFileInfo &pluginFile : pluginFiles) {
+-       AgentExtension *plugin = loadFile(pluginFile.absoluteFilePath());
+-       if (plugin)
+-           m_plugins << plugin;
++    for (const QString &dirName : pluginsDirs) {
++        QDir dir(dirName);
++
++        QFileInfoList pluginFiles = dir.entryInfoList((QStringList("*.so")));
++
++        for (const QFileInfo &pluginFile : pluginFiles) {
++            AgentExtension *plugin = loadFile(pluginFile.absoluteFilePath());
++            if (plugin)
++                m_plugins << plugin;
++        }
+     }
+ }
+ 
+-- 
+2.21.0
+

--- a/pkgs/desktops/deepin/dde-polkit-agent/default.nix
+++ b/pkgs/desktops/deepin/dde-polkit-agent/default.nix
@@ -27,6 +27,10 @@ stdenv.mkDerivation rec {
     polkit-qt
   ];
 
+  patches = [
+    ./dde-polkit-agent.plugins-dir.patch
+  ];
+
   postPatch = ''
     searchHardCodedPaths
     patchShebangs translate_generation.sh


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

deepin.dde-polkit-agent: set plugins dir from environment variable

About packaging deepin for NixOS: https://github.com/NixOS/nixpkgs/issues/59023

See also https://github.com/NixOS/nixpkgs/pull/59244#issuecomment-485097016


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).