### PR TITLE
neopg: 0.0.4 -> 0.0.6

### DIFF
--- a/pkgs/tools/security/neopg/default.nix
+++ b/pkgs/tools/security/neopg/default.nix
@@ -3,7 +3,7 @@
 , cmake
 , sqlite
 , botan2
-, boost164
+, boost
 , curl
 , gettext
 , pkgconfig
@@ -12,26 +12,26 @@
 
 stdenv.mkDerivation rec {
   name = "neopg-${version}";
-  version = "0.0.4";
+  version = "0.0.6";
 
   src = fetchFromGitHub {
     owner = "das-labor";
     repo = "neopg";
     rev = "v${version}";
-    sha256 = "0hhkl326ff6f76k8pwggpzmivbm13fz497nlyy6ybn5bmi9xfblm";
+    sha256 = "15xp5w046ix59cfrhh8ka4camr0d8qqw643g184sqrcqwpk7nbrx";
     fetchSubmodules = true;
   };
 
   nativeBuildInputs = [ pkgconfig ];
 
-  buildInputs = [ cmake sqlite botan2 boost164 curl gettext libusb gnutls ];
+  buildInputs = [ cmake sqlite botan2 boost curl gettext libusb gnutls ];
 
   doCheck = true;
   checkTarget = "test";
+  dontUseCmakeBuildDir = true;
 
-  postInstall = ''
-    mkdir -p $out/bin
-    cp src/neopg $out/bin/neopg
+  preCheck = ''
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(pwd)/3rdparty/googletest/googletest:$(pwd)/neopg
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
