### PR TITLE
hyperrogue: add .desktop file and icon

### DIFF
--- a/pkgs/games/hyperrogue/default.nix
+++ b/pkgs/games/hyperrogue/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, SDL, SDL_ttf, SDL_gfx, SDL_mixer, autoreconfHook,
-  libpng, glew }:
+  libpng, glew, makeDesktopItem }:
 
 stdenv.mkDerivation rec {
   name = "hyperrogue-${version}";
@@ -15,6 +15,33 @@ stdenv.mkDerivation rec {
   CPPFLAGS = "-I${SDL.dev}/include/SDL";
 
   buildInputs = [ autoreconfHook SDL SDL_ttf SDL_gfx SDL_mixer libpng glew ];
+
+  desktopItem = makeDesktopItem {
+    name = "hyperrogue";
+    desktopName = "HyperRogue";
+    genericName = "HyperRogue";
+    comment = meta.description;
+    icon = "hyperrogue";
+    exec = "hyperrogue";
+    categories = "Game;AdventureGame;";
+  };
+
+  postInstall = ''
+    install -m 444 -D ${desktopItem}/share/applications/hyperrogue.desktop \
+      $out/share/applications/hyperrogue.desktop
+    install -m 444 -D hyperroid/app/src/main/res/drawable-ldpi/icon.png \
+      $out/share/icons/hicolor/36x36/apps/hyperrogue.png
+    install -m 444 -D hyperroid/app/src/main/res/drawable-mdpi/icon.png \
+      $out/share/icons/hicolor/48x48/apps/hyperrogue.png
+    install -m 444 -D hyperroid/app/src/main/res/drawable-hdpi/icon.png \
+      $out/share/icons/hicolor/72x72/apps/hyperrogue.png
+    install -m 444 -D hyperroid/app/src/main/res/drawable-xhdpi/icon.png \
+      $out/share/icons/hicolor/96x96/apps/hyperrogue.png
+    install -m 444 -D hyperroid/app/src/main/res/drawable-xxhdpi/icon.png \
+      $out/share/icons/hicolor/144x144/apps/hyperrogue.png
+    install -m 444 -D hyperroid/app/src/main/res/drawable-xxxhdpi/icon.png \
+      $out/share/icons/hicolor/192x192/apps/hyperrogue.png
+  '';
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change

Add .desktop file and icons.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
