### PR TITLE
oraclejdk: use working mirror for download

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk-linux-base.nix
@@ -89,8 +89,9 @@ let result = stdenv.mkDerivation rec {
       armv7l-linux  = "linux-arm32-vfp-hflt";
       aarch64-linux = "linux-arm64-vfp-hflt";
     }.${stdenv.hostPlatform.system};
+    javadlPlatformName = "linux-i586";
   in fetchurl {
-   url = "http://download.oracle.com/otn-pub/java/jdk/${productVersion}u${patchVersion}-b${buildVersion}/${releaseToken}/jdk-${productVersion}u${patchVersion}-${platformName}.tar.gz";
+   url = "http://javadl.oracle.com/webapps/download/GetFile/1.${productVersion}.0_${patchVersion}-b${buildVersion}/${releaseToken}/${javadlPlatformName}/jdk-${productVersion}u${patchVersion}-${platformName}.tar.gz";
    curlOpts = "-b oraclelicense=a";
    sha256 = sha256.${stdenv.hostPlatform.system};
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

http://download.oracle.com/otn-pub/ was recently renamed to http://download.oracle.com/otn/ and now requires authentication with an Oracle account. http://download.oracle.com/otn-pub/ links don't work anymore, so installing oraclejdk fails.

Switch to http://javadl.oracle.com/webapps/download/GetFile/, which does not require authentication. This fixes installing oraclejdk.

Note: The URL for JCE is still broken; this commit only fixes the URL for the JDK.

This commit fixes nixpkgs issue #59761.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
