### PR TITLE
nginxModules: update and add nginx modules

### DIFF
--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -114,6 +114,15 @@ in
     inputs = [ pkgs.libbsd ];
   };
 
+  limit-speed = {
+    src = fetchFromGitHub {
+      owner = "yaoweibin";
+      repo = "nginx_limit_speed_module";
+      rev = "f77ad4a56fbb134878e75827b40cf801990ed936";
+      sha256 = "0kkrd08zpcwx938i2is07vq6pgjkvn97xzjab0g4zaz8bivgmjp8";
+    };
+  };
+
   live ={
     src = fetchFromGitHub {
       owner = "arut";

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -165,6 +165,15 @@ in
     };
   };
 
+  mpeg-ts ={
+    src = fetchFromGitHub {
+      owner = "arut";
+      repo = "nginx-ts-module";
+      rev = "v0.1.1";
+      sha256 = "12dxcyy6wna1fccl3a9lnsbymd6p4apnwz6c24w74v97qvpfdxqd";
+    };
+  };
+
   ngx_aws_auth = {
     src = fetchFromGitHub {
       owner = "anomalizer";

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -389,6 +389,16 @@ in
     };
   };
 
+  video-thumbextractor = {
+    src = fetchFromGitHub {
+      owner = "wandenberg";
+      repo = "nginx-video-thumbextractor-module";
+      rev = "0.9.0";
+      sha256 = "1b0v471mzbcys73pzr7gpvzzhff0cva0l5ff32cv7z1v9c0ypji7";
+    };
+    inputs = [ pkgs.ffmpeg ];
+  };
+
   vts = {
     src = fetchFromGitHub {
       owner = "vozlt";

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -105,6 +105,15 @@ in
     inputs = [ pkgs.libbsd ];
   };
 
+  live ={
+    src = fetchFromGitHub {
+      owner = "arut";
+      repo = "nginx-live-module";
+      rev = "5e4a1e3a718e65e5206c24eba00d42b0d1c4b7dd";
+      sha256 = "1kpnhl4b50zim84z22ahqxyxfq4jv8ab85kzsy2n5ciqbyg491lz";
+    };
+  };
+
   lua = {
     src = fetchFromGitHub {
       owner = "openresty";

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -307,6 +307,15 @@ in
     };
   };
 
+  sorted-querystring = {
+    src = fetchFromGitHub {
+      owner = "wandenberg";
+      repo = "nginx-sorted-querystring-module";
+      rev = "0.3";
+      sha256 = "0p6b0hcws39n27fx4xp9k4hb3pcv7b6kah4qqaj0pzjy3nbp4gj7";
+    };
+  };
+
   statsd = {
     src = fetchFromGitHub {
       owner = "apcera";

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -192,6 +192,15 @@ in
     };
   };
 
+  naxsi ={
+    src = fetchFromGitHub {
+      owner = "nbs-system";
+      repo = "naxsi";
+      rev = "0.56";
+      sha256 = "12kn6wbl8xqc19fi05ffprqps4pplg4a6i1cf01xc0d6brx1fg8v";
+    } + "/naxsi_src";
+  };
+
   ngx_aws_auth = {
     src = fetchFromGitHub {
       owner = "anomalizer";

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -36,8 +36,8 @@ in
     src = fetchFromGitHub {
       owner = "arut";
       repo = "nginx-dav-ext-module";
-      rev = "v0.1.0";
-      sha256 = "1ifahd69vz715g3zim618jbmxb7kcmzykc696grskxm0svpy294k";
+      rev = "v3.0.0";
+      sha256 = "000dm5zk0m1hm1iq60aff5r6y8xmqd7djrwhgnz9ig01xyhnjv9w";
     };
     inputs = [ pkgs.expat ];
   };

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -347,8 +347,8 @@ in
     src = fetchFromGitHub {
       owner = "yaoweibin";
       repo = "nginx_upstream_check_module";
-      rev = "9aecf15ec379fe98f62355c57b60c0bc83296f04";
-      sha256 = "1cjisxw1wykll683nw09k0i1nvzslp4dr59x58cvarpk43paim2y";
+      rev = "007f76f7adbcbd6abd9352502af1a4ae463def85";
+      sha256 = "1qcg7c9rcl70wr1qf188shnn9s2f7cxnlw05s6scbvlgnf6ik6in";
     };
   };
 

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -6,8 +6,8 @@ let
     src = fetchFromGitHub {
       owner = "chobits";
       repo = "ngx_http_proxy_connect_module";
-      rev = "8201639082cba702211585b03d4cc7bc51c65167";
-      sha256 = "0z71x3xnlczrr2kq43w3drxj9g14fkk4jz66x921v0yb8r9mnn5a";
+      rev = "18e2520b361ffebde6c08c8119ecfba113a3b53c";
+      sha256 = "1nyil5n2a97nqsqarvnp4bazw4vnxifqizzw5aank4vi9xlq90b2";
     };
 
     patches = [
@@ -85,6 +85,14 @@ in
       rev = "8af234043059c857be27879bc547c141eafd5c13";
       sha256 = "1ycb5zd9sw60ra53jpak1m73zwrjikwhrrh9q6266h1mlyns7zxm";
     };
+  };
+
+  http_proxy_connect_module_v15 = http_proxy_connect_module_generic "proxy_connect_rewrite_1015" // {
+    supports = with lib.versions; version: major version == "1" && minor version == "15";
+  };
+
+  http_proxy_connect_module_v14 = http_proxy_connect_module_generic "proxy_connect_rewrite_1014" // {
+    supports = with lib.versions; version: major version == "1" && minor version == "14";
   };
 
   ipscrub = {
@@ -334,13 +342,5 @@ in
       rev = "v0.1.18";
       sha256 = "1jq2s9k7hah3b317hfn9y3g1q4g4x58k209psrfsqs718a9sw8c7";
     };
-  };
-
-  http_proxy_connect_module_v15 = http_proxy_connect_module_generic "proxy_connect_rewrite_1015" // {
-    supports = with lib.versions; version: major version == "1" && minor version == "15";
-  };
-
-  http_proxy_connect_module_v14 = http_proxy_connect_module_generic "proxy_connect_rewrite_1014" // {
-    supports = with lib.versions; version: major version == "1" && minor version == "14";
   };
 }

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -329,8 +329,8 @@ in
     src = fetchFromGitHub {
       owner = "yaoweibin";
       repo = "ngx_http_substitutions_filter_module";
-      rev = "v0.6.4";
-      sha256 = "0q86cv0mfffh43id5xanywyhpd7b0jijrmk8y311c13l9ajrd2rx";
+      rev = "bc58cb11844bc42735bbaef7085ea86ace46d05b";
+      sha256 = "1q5hr3sqys4f365gzjci549rn9ylhgj4xb29ril04zr5vkhzlnar";
     };
   };
 

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -118,8 +118,8 @@ in
     src = fetchFromGitHub {
       owner = "openresty";
       repo = "lua-nginx-module";
-      rev = "v0.10.13";
-      sha256 = "19mpc76lfhyyvkfs2n08b4rc9cf2v7rm8fskkf60hsdcf6qna822";
+      rev = "v0.10.14";
+      sha256 = "1vg6pp9n8z42p6f3jqk15gvdyy7mfvs5ssfbiy83bydjx42fq7g0";
     };
     inputs = [ pkgs.luajit ];
     preConfigure = ''

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -280,6 +280,15 @@ in
     };
   };
 
+  slowfs-cache = {
+    src = fetchFromGitHub {
+      owner  = "FRiCKLE";
+      repo   = "ngx_slowfs_cache";
+      rev    = "1.10";
+      sha256 = "1gyza02pcws3zqm1phv3ag50db5gnapxyjwy8skjmvawz7p5bmxr";
+    };
+  };
+
   statsd = {
     src = fetchFromGitHub {
       owner = "apcera";

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -356,8 +356,8 @@ in
     src = fetchFromGitHub {
       owner = "tarantool";
       repo = "nginx_upstream_module";
-      rev = "v2.7";
-      sha256 = "05dwj0caj910p7kan2qjvm6x2x601igryhny2xzr47hhsk5q1cnx";
+      rev = "v2.7.1";
+      sha256 = "0ya4330in7zjzqw57djv4icpk0n1j98nvf0f8v296yi9rjy054br";
     };
     inputs = [ pkgs.msgpuck.dev pkgs.yajl ];
   };

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -32,6 +32,15 @@ in
     inputs = [ pkgs.brotli ];
   };
 
+  coolkit = {
+    src = fetchFromGitHub {
+      owner  = "FRiCKLE";
+      repo   = "ngx_coolkit";
+      rev    = "0.2";
+      sha256 = "1idj0cqmfsdqawjcqpr1fsq670fdki51ksqk2lslfpcs3yrfjpqh";
+    };
+  };
+
   dav = {
     src = fetchFromGitHub {
       owner = "arut";


### PR DESCRIPTION
Update nginx modules:
- http_proxy_connect_module to 16.04.2019
- dav to 3.0.0
- lua to 0.10.14
- upstream-check to 12.08.2018
- upstream-tarantool to 2.7.1
- subsFilter to 13.04.2016

Added nginx modules:
- live 18.11.2018
- mpeg-ts 0.1.1
- coolkit 0.2
- slowfs-cache 1.10
- limit-speed 21.05.2014
- sorted-querystring 0.3
- video-thumbextractor 0.9.0
- naxsi 0.56

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
