### PR TITLE
brogue: add .desktop file and icon

### DIFF
--- a/pkgs/games/brogue/default.nix
+++ b/pkgs/games/brogue/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, SDL, ncurses, libtcod }:
+{ stdenv, fetchurl, SDL, ncurses, libtcod, makeDesktopItem }:
 
 stdenv.mkDerivation rec {
   name = "brogue-${version}";
@@ -19,8 +19,21 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ SDL ncurses libtcod ];
 
+  desktopItem = makeDesktopItem {
+    name = "brogue";
+    desktopName = "Brogue";
+    genericName = "Roguelike";
+    comment = "Brave the Dungeons of Doom!";
+    icon = "brogue";
+    exec = "brogue";
+    categories = "Game;AdventureGame;";
+    terminal = "false";
+  };
+
   installPhase = ''
     install -m 555 -D bin/brogue $out/bin/brogue
+    install -m 444 -D ${desktopItem}/share/applications/brogue.desktop $out/share/applications/brogue.desktop
+    install -m 444 -D bin/brogue-icon.png $out/share/icons/hicolor/256x256/apps/brogue.png
     mkdir -p $out/share/brogue
     cp -r bin/fonts $out/share/brogue/
   '';


### PR DESCRIPTION
###### Motivation for this change

Add XDG .desktop file and icon. Note that the .desktop file included in
the source archive is not used because it uses unsuitable paths and
refers to an old version of the game.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
