### PR TITLE
nixos/hardened: option to use hardened-malloc systemwide

### DIFF
--- a/nixos/tests/hardened.nix
+++ b/nixos/tests/hardened.nix
@@ -24,9 +24,24 @@ import ./make-test.nix ({ pkgs, ...} : {
       };
       boot.extraModulePackages = [ config.boot.kernelPackages.wireguard ];
       boot.kernelModules = [ "wireguard" ];
+      security.hardenMemoryAllocation = true;
     };
 
   testScript =
+    let
+      hardened-malloc-tests = pkgs.stdenv.mkDerivation rec {
+        name = "hardened-malloc-tests-${pkgs.graphene-hardened-malloc.version}";
+        src = pkgs.graphene-hardened-malloc.src;
+        buildPhase = ''
+          cd test/simple-memory-corruption
+          make -j4
+        '';
+
+        installPhase = ''
+          find . -type f -executable -exec install -Dt $out/bin '{}' +
+        '';
+      };
+    in
     ''
       $machine->waitForUnit("multi-user.target");
 
@@ -82,6 +97,19 @@ import ./make-test.nix ({ pkgs, ...} : {
       subtest "kernelimage", sub {
         $machine->fail("systemctl hibernate");
         $machine->fail("systemctl kexec");
+      };
+
+      # Test hardened memory allocator
+      sub runMallocTestProg {
+          my ($progName, $errorText) = @_;
+          my $text = "fatal allocator error: " . $errorText;
+          $machine->fail("${hardened-malloc-tests}/bin/" . $progName) =~ $text;
+      };
+
+      subtest "hardenedmalloc", sub {
+        runMallocTestProg("double_free_large", "invalid free");
+        runMallocTestProg("unaligned_free_small", "invalid unaligned free");
+        runMallocTestProg("write_after_free_small", "detected write after free");
       };
     '';
 })


### PR DESCRIPTION
Not sure if this is the best way to go about this, but seems to "work", in that e.g., double free is detected & killed.

Not enabled by the hardened profile for now, needs a bit of testing.
