### PR TITLE
dosbox: add XDG icon

### DIFF
--- a/pkgs/misc/emulators/dosbox/default.nix
+++ b/pkgs/misc/emulators/dosbox/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, makeDesktopItem, SDL, SDL_net, SDL_sound, libGLU_combined, libpng }:
+{ stdenv, lib, fetchurl, makeDesktopItem, SDL, SDL_net, SDL_sound, libGLU_combined, libpng, graphicsmagick }:
 
 stdenv.mkDerivation rec {
   name = "dosbox-0.74-2";
@@ -12,11 +12,14 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ SDL SDL_net SDL_sound libGLU_combined libpng ];
 
+  nativeBuildInputs = [ graphicsmagick ];
+
   configureFlags = lib.optional stdenv.isDarwin "--disable-sdltest";
 
   desktopItem = makeDesktopItem {
     name = "dosbox";
     exec = "dosbox";
+    icon = "dosbox";
     comment = "x86 emulator with internal DOS";
     desktopName = "DOSBox";
     genericName = "DOS emulator";
@@ -26,6 +29,9 @@ stdenv.mkDerivation rec {
   postInstall = ''
      mkdir -p $out/share/applications
      cp ${desktopItem}/share/applications/* $out/share/applications
+
+     mkdir -p $out/share/icons/hicolor/256x256/apps
+     gm convert src/dosbox.ico $out/share/icons/hicolor/256x256/apps/dosbox.png
   '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change

Add an XDG icon for dosbox. The official icon is in .ico format, which
is not compatible with the freedesktop.org spec, so graphicsmagick is
included as a build time dependency and used to convert it to a PNG.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
