### PR TITLE
devpi-server: fix build by forcing use of pytest_3

### DIFF
--- a/pkgs/development/python-modules/routes/default.nix
+++ b/pkgs/development/python-modules/routes/default.nix
@@ -6,6 +6,7 @@
 , webob
 , coverage
 , webtest
+, nose
 }:
 
 buildPythonPackage rec {
@@ -18,7 +19,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ repoze_lru six webob ];
-  checkInputs = [ coverage webtest ];
+  checkInputs = [ nose coverage webtest ];
 
   meta = with stdenv.lib; {
     description = "A Python re-implementation of the Rails routes system for mapping URLs to application actions";

--- a/pkgs/development/python-modules/webob/default.nix
+++ b/pkgs/development/python-modules/webob/default.nix
@@ -14,7 +14,10 @@ buildPythonPackage rec {
     sha256 = "05aaab7975e0ee8af2026325d656e5ce14a71f1883c52276181821d6d5bf7086";
   };
 
-  propagatedBuildInputs = [ nose pytest ];
+  checkInputs = [ pytest ];
+  checkPhase = ''
+    pytest tests/
+  '';
 
   meta = with stdenv.lib; {
     description = "WSGI request and response object";

--- a/pkgs/development/tools/devpi-server/default.nix
+++ b/pkgs/development/tools/devpi-server/default.nix
@@ -12,7 +12,16 @@ pythonPackages.buildPythonApplication rec {
 
   propagatedBuildInputs = with pythonPackages;
     [ devpi-common execnet itsdangerous pluggy waitress pyramid passlib ];
-  checkInputs = with pythonPackages; [ nginx webtest pytest beautifulsoup4 pytest-timeout mock pyyaml ];
+
+  checkInputs = with pythonPackages; [
+    nginx
+    webtest
+    beautifulsoup4
+    mock
+    pyyaml
+    pytest_3
+    (pytest-timeout.overrideAttrs (oldAttrs: oldAttrs // { pytest = pytest_3; }))
+  ];
   preCheck = ''
     # These tests pass with pytest 3.3.2 but not with pytest 3.4.0.
     sed -i 's/test_basic/noop/' test_devpi_server/test_log.py


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This is a draft PR because it sits on top of a couple of commits that are already in another PR https://github.com/NixOS/nixpkgs/pull/59431

Similarly it fixes the build by forcing use of `pytest_3`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
