### PR TITLE
Revert "osinfo-db: 20190301 -> 20190319"

### DIFF
--- a/pkgs/data/misc/osinfo-db/default.nix
+++ b/pkgs/data/misc/osinfo-db/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "osinfo-db";
-  version = "20190319";
+  version = "20190301";
 
   src = fetchurl {
     url = "https://releases.pagure.org/libosinfo/${pname}-${version}.tar.xz";
-    sha256 = "1dgmi30q0jncban1fy87pdyz8j6lddmnsh48is2jg2bwyiqwc0cw";
+    sha256 = "1rjqizsglgdcjxi7kpbwm26krdkrlxacinjp9684sfzhqwdqi4as";
   };
 
   nativeBuildInputs = [ osinfo-db-tools intltool libxml2 ];


### PR DESCRIPTION
Reverts NixOS/nixpkgs#59626

It's breaking `libosinfo` test suite
```
/isodetect/haiku: **
ERROR:test-isodetect.c:414:test_one: assertion failed (shortid == info->shortid): ("haikur1beta1" == "haikunightly")
FAIL
```