### PR TITLE
[19.03] writeC: fix finding of libraries

### DIFF
--- a/pkgs/build-support/writers/default.nix
+++ b/pkgs/build-support/writers/default.nix
@@ -94,8 +94,8 @@ rec {
         ]}
         gcc \
             ${optionalString (libraries != [])
-              "$(pkgs.pkgconfig}/bin/pkg-config --cflags --libs ${
-                concatMapStringsSep " " (lib: escapeShellArg (builtins.parseDrvName lib.name).name) (libraries)
+              "$(pkg-config --cflags --libs ${
+                concatMapStringsSep " " (pkg: "$(find ${escapeShellArg pkg}/lib/pkgsconfig -name \*.pc -exec basename {} \;)") libraries
               })"
             } \
             -O \


### PR DESCRIPTION
(cherry picked from commit ea9161e0955fd9fcc330471464f24ebc4aedaae1)
