### PR TITLE
seasocks: init at 1.4.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1687,6 +1687,11 @@
     github = "fps";
     name = "Florian Paul Schmidt";
   };
+  fredeb = {
+    email = "im@fredeb.dev";
+    github = "fredeeb";
+    name = "Frede Emil";
+  };
   freepotion = {
     email = "freepotion@protonmail.com";
     github = "freepotion";

--- a/pkgs/development/libraries/seasocks/default.nix
+++ b/pkgs/development/libraries/seasocks/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, cmake, python, zlib }:
+
+stdenv.mkDerivation rec {
+  pname = "seasocks";
+  version = "1.4.2";
+
+  src = fetchFromGitHub {
+    owner = "mattgodbolt";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1vzdhp61bq2bddz7kkpygdq5adxdspjw1q6a03j6qyyimapblrg8";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ zlib python ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/mattgodbolt/seasocks;
+    description = "Tiny embeddable C++ HTTP and WebSocket server";
+    license = licenses.bsd2;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ fredeb ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12793,6 +12793,8 @@ in
 
   selinux-sandbox = callPackage ../os-specific/linux/selinux-sandbox { };
 
+  seasocks = callPackage ../development/libraries/seasocks { };
+
   serd = callPackage ../development/libraries/serd {};
 
   serf = callPackage ../development/libraries/serf {};


### PR DESCRIPTION
###### Motivation for this change

Needed seasocks for a project, so i made a nix package for it!

###### Things done

- Added `pkgs/development/libraries/seasocks/default.nix`
- Added `seasocks = callPacakge ../development/libraries/seasocks {};`
- Only tested in nix shell. But works as intended in development environment, correctly setting `$NIX_LDFLAGS` and `$NIX_CFLAGS_COMPILE` to include the needed library and header files.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions (Manjaro)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
