### PR TITLE
mate: 1.20 -> 1.22

### DIFF
--- a/pkgs/desktops/mate/atril/default.nix
+++ b/pkgs/desktops/mate/atril/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "atril-${version}";
-  version = "1.22.0";
+  version = "1.22.1";
 
   src = fetchurl {
     url = "https://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1xd49j4qwrlg2nh2zvspf91yk033dp8a58dy9azqg2yz4bcvywxb";
+    sha256 = "0i2wgsksgwhrmajj1lay3iym4dcyj8cdd813yh5mrfz4rkv49190";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/atril/default.nix
+++ b/pkgs/desktops/mate/atril/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.22.0";
 
   src = fetchurl {
-    url = "https://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
+    url = "https://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "1xd49j4qwrlg2nh2zvspf91yk033dp8a58dy9azqg2yz4bcvywxb";
   };
 

--- a/pkgs/desktops/mate/atril/default.nix
+++ b/pkgs/desktops/mate/atril/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "atril-${version}";
-  version = "1.20.3";
+  version = "1.22.0";
 
   src = fetchurl {
     url = "https://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "00vrqyfk370fdhlfv3m6n0l6hnx30hrsrcg1xja03957cgvcvnvr";
+    sha256 = "1xd49j4qwrlg2nh2zvspf91yk033dp8a58dy9azqg2yz4bcvywxb";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/caja-dropbox/default.nix
+++ b/pkgs/desktops/mate/caja-dropbox/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, fetchurl, pkgconfig, gtk3, mate, pythonPackages }:
+{ stdenv, fetchurl, pkgconfig, gtk3, mate, python3Packages }:
 
 stdenv.mkDerivation rec {
   name = "caja-dropbox-${version}";
-  version = "1.20.0";
+  version = "1.22.0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "0xjqcfi5n6hsfyw77blplkn30as0slkfzngxid1n6z7jz5yjq7vj";
+    sha256 = "1bnvqybsfrfxxvfchvpki77hg6r9vbpq0h80smc47rks5hzj6lyi";
   };
 
   nativeBuildInputs = [
@@ -16,9 +16,9 @@ stdenv.mkDerivation rec {
   buildInputs = [
     gtk3
     mate.caja
-    pythonPackages.python
-    pythonPackages.pygtk
-    pythonPackages.docutils
+    python3Packages.python
+    python3Packages.pygtk
+    python3Packages.docutils
   ];
 
   configureFlags = [ "--with-caja-extension-dir=$$out/lib/caja/extensions-2.0" ];

--- a/pkgs/desktops/mate/caja-dropbox/default.nix
+++ b/pkgs/desktops/mate/caja-dropbox/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "caja-dropbox-${version}";
-  version = "1.22.0";
+  version = "1.22.1";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1bnvqybsfrfxxvfchvpki77hg6r9vbpq0h80smc47rks5hzj6lyi";
+    sha256 = "18cnd3yw2ingvl38mhmfbl5k0kfg8pzcf2649j00i6v90cwiril5";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/caja-dropbox/default.nix
+++ b/pkgs/desktops/mate/caja-dropbox/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.22.0";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "1bnvqybsfrfxxvfchvpki77hg6r9vbpq0h80smc47rks5hzj6lyi";
   };
 

--- a/pkgs/desktops/mate/caja-extensions/default.nix
+++ b/pkgs/desktops/mate/caja-extensions/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, fetchurl, pkgconfig, intltool, gtk3, dbus-glib, gupnp, mate, imagemagick, wrapGAppsHook }:
+{ stdenv, fetchurl, pkgconfig, intltool, gtk3, gupnp, mate, imagemagick, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "caja-extensions-${version}";
-  version = "1.20.2";
+  version = "1.22.0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "14w1xd33ggn6wdzqvcmj8rqc68w4k094lai6mqrgmv1zljifydqz";
+    sha256 = "1h866jmdd3qpjzi7wjj11krwiaadnlf21844g1zqfb4jgrzj773p";
   };
 
   nativeBuildInputs = [
@@ -17,7 +17,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     gtk3
-    dbus-glib
     gupnp
     mate.caja
     mate.mate-desktop

--- a/pkgs/desktops/mate/caja-extensions/default.nix
+++ b/pkgs/desktops/mate/caja-extensions/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.22.0";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "1h866jmdd3qpjzi7wjj11krwiaadnlf21844g1zqfb4jgrzj773p";
   };
 

--- a/pkgs/desktops/mate/caja/default.nix
+++ b/pkgs/desktops/mate/caja/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "caja-${version}";
-  version = "1.20.3";
+  version = "1.22.0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "1wlrhcvhqving3pphbz50xnbp7z57mlkf7m36lfh8mim62kfmmd0";
+    sha256 = "14x9n9q7vip5zp4mdgccj1p1dm4xn429g0bjw2v8iz7zmjb7vcgl";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/caja/default.nix
+++ b/pkgs/desktops/mate/caja/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "caja-${version}";
-  version = "1.22.0";
+  version = "1.22.1";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "14x9n9q7vip5zp4mdgccj1p1dm4xn429g0bjw2v8iz7zmjb7vcgl";
+    sha256 = "10b7yjimblymp1fpsrl4jb2k7kbhla2izsj3njfmg2n6fv9fy9iv";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/caja/default.nix
+++ b/pkgs/desktops/mate/caja/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.22.0";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "14x9n9q7vip5zp4mdgccj1p1dm4xn429g0bjw2v8iz7zmjb7vcgl";
   };
 

--- a/pkgs/desktops/mate/default.nix
+++ b/pkgs/desktops/mate/default.nix
@@ -4,9 +4,6 @@ let
   callPackage = newScope self;
 
   self = rec {
-
-    getRelease = version:
-      pkgs.stdenv.lib.concatStringsSep "." (pkgs.stdenv.lib.take 2 (pkgs.stdenv.lib.splitString "." version));
   
     atril = callPackage ./atril { };
     caja = callPackage ./caja { };

--- a/pkgs/desktops/mate/default.nix
+++ b/pkgs/desktops/mate/default.nix
@@ -75,7 +75,6 @@ let
       mate-applets
       mate-backgrounds
       mate-calc
-      mate-icon-theme-faenza
       mate-indicator-applet
       mate-media
       mate-netbook

--- a/pkgs/desktops/mate/engrampa/default.nix
+++ b/pkgs/desktops/mate/engrampa/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "engrampa-${version}";
-  version = "1.22.0";
+  version = "1.22.1";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "16yjplfl2sqa7n6404hjn0vwkh0xkdch73q7n5czynihmh3azc7p";
+    sha256 = "06z38vfs15f5crrrgvcsqfb557fhpq1mqkj5fd9wb0hvi77hasrk";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/engrampa/default.nix
+++ b/pkgs/desktops/mate/engrampa/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.22.0";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "16yjplfl2sqa7n6404hjn0vwkh0xkdch73q7n5czynihmh3azc7p";
   };
 

--- a/pkgs/desktops/mate/engrampa/default.nix
+++ b/pkgs/desktops/mate/engrampa/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "engrampa-${version}";
-  version = "1.20.2";
+  version = "1.22.0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "0fj957dfagw6p7mq5545h9j2w3hv18yqnkpypnr719r4g13d3f2v";
+    sha256 = "16yjplfl2sqa7n6404hjn0vwkh0xkdch73q7n5czynihmh3azc7p";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/eom/default.nix
+++ b/pkgs/desktops/mate/eom/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.22.0";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "093vbip848bp9y603yasbrg1bcp68m64hma7zhi5m37x2r103r6l";
   };
 

--- a/pkgs/desktops/mate/eom/default.nix
+++ b/pkgs/desktops/mate/eom/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, fetchurl, pkgconfig, intltool, itstool, dbus-glib, exempi, lcms2, libexif, libjpeg, librsvg, libxml2, libpeas, shared-mime-info, gnome3, gtk3, mate, hicolor-icon-theme, wrapGAppsHook }:
+{ stdenv, fetchurl, pkgconfig, intltool, itstool, exempi, lcms2, libexif, libjpeg, librsvg, libxml2, libpeas, shared-mime-info, gnome3, gtk3, mate, hicolor-icon-theme, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "eom-${version}";
-  version = "1.20.2";
+  version = "1.22.0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "0440sfbidizn860w5avgwld08qc2fslrm0nx2659651cf3r7rw05";
+    sha256 = "093vbip848bp9y603yasbrg1bcp68m64hma7zhi5m37x2r103r6l";
   };
 
   nativeBuildInputs = [
@@ -17,7 +17,6 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    dbus-glib
     exempi
     lcms2
     libexif

--- a/pkgs/desktops/mate/eom/default.nix
+++ b/pkgs/desktops/mate/eom/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "eom-${version}";
-  version = "1.22.0";
+  version = "1.22.1";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "093vbip848bp9y603yasbrg1bcp68m64hma7zhi5m37x2r103r6l";
+    sha256 = "03lpxqvyaqhz4wmi07nxcyn5q73ym3dzm41cdid53f2dp9lk1mv4";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/libmatekbd/default.nix
+++ b/pkgs/desktops/mate/libmatekbd/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl, fetchpatch, pkgconfig, intltool, gtk3, mate, libxklavier }:
+{ stdenv, fetchurl, fetchpatch, pkgconfig, intltool, gtk3, libxklavier }:
 
 stdenv.mkDerivation rec {
   name = "libmatekbd-${version}";
   version = "1.22.0";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "1dsr7618c92mhwabwhgxqsfp7gnf9zrz2z790jc5g085dxhg13y8";
   };
 

--- a/pkgs/desktops/mate/libmatekbd/default.nix
+++ b/pkgs/desktops/mate/libmatekbd/default.nix
@@ -2,20 +2,12 @@
 
 stdenv.mkDerivation rec {
   name = "libmatekbd-${version}";
-  version = "1.20.2";
+  version = "1.22.0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "1l1zbphs4snswf4bkrwkk6gsmb44bdhymcfgaaspzbrcmw3y7hr1";
+    sha256 = "1dsr7618c92mhwabwhgxqsfp7gnf9zrz2z790jc5g085dxhg13y8";
   };
-
-  patches = [
-    # Fix build with glib 2.60 (TODO: remove after 1.22.0 update)
-    (fetchpatch {
-      url = https://github.com/mate-desktop/libmatekbd/commit/dc04e969dd61a2b1f82beae2d3c8ad105447812d.patch;
-      sha256 = "1ps6mbj6hrm9djn4riya049w2cb0dknghysny8pafmvpkaqvckrb";
-    })
-  ];
 
   nativeBuildInputs = [ pkgconfig intltool ];
 

--- a/pkgs/desktops/mate/libmatemixer/default.nix
+++ b/pkgs/desktops/mate/libmatemixer/default.nix
@@ -1,4 +1,4 @@
-{ config, stdenv, fetchurl, pkgconfig, intltool, glib, mate
+{ config, stdenv, fetchurl, pkgconfig, intltool, glib
 , alsaSupport ? stdenv.isLinux, alsaLib
 , pulseaudioSupport ? config.pulseaudio or true, libpulseaudio
 , ossSupport ? false
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
   version = "1.22.0";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "1v0gpr55gj4mj8hzxbhgzrmhaxvs2inxhsmirvjw39sc7iplvrh9";
   };
 

--- a/pkgs/desktops/mate/libmatemixer/default.nix
+++ b/pkgs/desktops/mate/libmatemixer/default.nix
@@ -6,11 +6,11 @@
 
 stdenv.mkDerivation rec {
   name = "libmatemixer-${version}";
-  version = "1.20.1";
+  version = "1.22.0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "00p67mi0flsbgn15qpwq60rzf917s5islbmhirbvz6npcvv0d493";
+    sha256 = "1v0gpr55gj4mj8hzxbhgzrmhaxvs2inxhsmirvjw39sc7iplvrh9";
   };
 
   nativeBuildInputs = [ pkgconfig intltool ];

--- a/pkgs/desktops/mate/libmateweather/default.nix
+++ b/pkgs/desktops/mate/libmateweather/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "libmateweather-${version}";
-  version = "1.20.2";
+  version = "1.22.0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "1ksp1xn13m94sjnnrx2dyv7hlbgjbnbahwdyaq35r2419b366hxv";
+    sha256 = "1ribgcwl4ncfbcf9bkcbxrgc7yzajdnxg12837psngymkqswlp6a";
   };
 
   nativeBuildInputs = [ pkgconfig intltool ];

--- a/pkgs/desktops/mate/libmateweather/default.nix
+++ b/pkgs/desktops/mate/libmateweather/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl, pkgconfig, intltool, gtk3, libsoup, tzdata, mate }:
+{ stdenv, fetchurl, pkgconfig, intltool, gtk3, libsoup, tzdata }:
 
 stdenv.mkDerivation rec {
   name = "libmateweather-${version}";
   version = "1.22.0";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "1ribgcwl4ncfbcf9bkcbxrgc7yzajdnxg12837psngymkqswlp6a";
   };
 

--- a/pkgs/desktops/mate/marco/default.nix
+++ b/pkgs/desktops/mate/marco/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "marco-${version}";
-  version = "1.20.3";
+  version = "1.22.0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "192nlr4ylisxisk0ljabm8v0a5sapdncj4gbw39q2fpr938ifs32";
+    sha256 = "1i1pi1z9mrb6564mxcwb93jqpdppfv58c2viwmicsixis62hv5wx";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/marco/default.nix
+++ b/pkgs/desktops/mate/marco/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl, pkgconfig, intltool, itstool, libxml2, libcanberra-gtk3, libgtop, libstartup_notification, gnome3, gtk3, mate, wrapGAppsHook }:
+{ stdenv, fetchurl, pkgconfig, intltool, itstool, libxml2, libcanberra-gtk3, libgtop, libstartup_notification, gnome3, gtk3, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "marco-${version}";
   version = "1.22.0";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "1i1pi1z9mrb6564mxcwb93jqpdppfv58c2viwmicsixis62hv5wx";
   };
 

--- a/pkgs/desktops/mate/mate-applets/default.nix
+++ b/pkgs/desktops/mate/mate-applets/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mate-applets-${version}";
-  version = "1.20.3";
+  version = "1.22.0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "0y5501wliipxf43p2q9917r3ird7azlrbcwnj2q2q2zy00hvvk5f";
+    sha256 = "0f5ym6z7awi0kw6i1sdkj2qly88sl692j5r1zhklihyz1z9a6j0h";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/mate-applets/default.nix
+++ b/pkgs/desktops/mate/mate-applets/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mate-applets-${version}";
-  version = "1.22.0";
+  version = "1.22.1";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0f5ym6z7awi0kw6i1sdkj2qly88sl692j5r1zhklihyz1z9a6j0h";
+    sha256 = "19sjm2180ir8a264rz8m528qaqjpl3q3cq095ab0sbkp2igksrfx";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/mate-applets/default.nix
+++ b/pkgs/desktops/mate/mate-applets/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.22.0";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "0f5ym6z7awi0kw6i1sdkj2qly88sl692j5r1zhklihyz1z9a6j0h";
   };
 

--- a/pkgs/desktops/mate/mate-backgrounds/default.nix
+++ b/pkgs/desktops/mate/mate-backgrounds/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl, intltool, mate }:
+{ stdenv, fetchurl, intltool }:
 
 stdenv.mkDerivation rec {
   name = "mate-backgrounds-${version}";
   version = "1.22.0";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "1j9ch04qi2q4mdcvb92w667ra9hpfdf2bfpi1dpw0nbph7r6qvj9";
   };
 

--- a/pkgs/desktops/mate/mate-backgrounds/default.nix
+++ b/pkgs/desktops/mate/mate-backgrounds/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mate-backgrounds-${version}";
-  version = "1.20.0";
+  version = "1.22.0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "0pcnjcw00y8hf2bwfrb5sbk2511cbg4fr8vgvgqswcwjp9y15cjp";
+    sha256 = "1j9ch04qi2q4mdcvb92w667ra9hpfdf2bfpi1dpw0nbph7r6qvj9";
   };
 
   nativeBuildInputs = [ intltool ];

--- a/pkgs/desktops/mate/mate-calc/default.nix
+++ b/pkgs/desktops/mate/mate-calc/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mate-calc-${version}";
-  version = "1.20.3";
+  version = "1.22.0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "0nv0q2c93rv36dhid7vf0w0rb6zdwyqaibfsmc7flj00qgsn3r5a";
+    sha256 = "1njk6v7z3969ikvcrabr1lw5f5572vb14w064zm3mydj8cc5inlr";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/mate-calc/default.nix
+++ b/pkgs/desktops/mate/mate-calc/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl, pkgconfig, intltool, itstool, gtk3, libxml2, mate, wrapGAppsHook }:
+{ stdenv, fetchurl, pkgconfig, intltool, itstool, gtk3, libxml2, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "mate-calc-${version}";
   version = "1.22.0";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "1njk6v7z3969ikvcrabr1lw5f5572vb14w064zm3mydj8cc5inlr";
   };
 

--- a/pkgs/desktops/mate/mate-common/default.nix
+++ b/pkgs/desktops/mate/mate-common/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mate-common-${version}";
-  version = "1.20.0";
+  version = "1.22.0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "0h8s2qhc6f5flslx05cd3xxg243c67vv03spjiag14p8kqqrqvb1";
+    sha256 = "11lwckndizawbq993ws8lqp59vsc873zri0m8s1i5zyc4qx9f69z";
   };
 
   meta = {

--- a/pkgs/desktops/mate/mate-common/default.nix
+++ b/pkgs/desktops/mate/mate-common/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl, mate }:
+{ stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
   name = "mate-common-${version}";
   version = "1.22.0";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "11lwckndizawbq993ws8lqp59vsc873zri0m8s1i5zyc4qx9f69z";
   };
 

--- a/pkgs/desktops/mate/mate-control-center/default.nix
+++ b/pkgs/desktops/mate/mate-control-center/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   name = "mate-control-center-${version}";
-  version = "1.20.4";
+  version = "1.22.0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "1rjxndikj0w516nlvyzcss31l9qjwkzvns7ygasnjbl02bgml9a4";
+    sha256 = "06wpfsxsiv7w3dl7p395r5vcxqbjlllydqbnvbr6yn0lrac15i71";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/mate-control-center/default.nix
+++ b/pkgs/desktops/mate/mate-control-center/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   name = "mate-control-center-${version}";
-  version = "1.22.0";
+  version = "1.22.1";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "06wpfsxsiv7w3dl7p395r5vcxqbjlllydqbnvbr6yn0lrac15i71";
+    sha256 = "0w9w3wkxksbhzyd96y1x6yxb0q5lkp16y8i42564b6njvwqch5a0";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/mate-control-center/default.nix
+++ b/pkgs/desktops/mate/mate-control-center/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   version = "1.22.0";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "06wpfsxsiv7w3dl7p395r5vcxqbjlllydqbnvbr6yn0lrac15i71";
   };
 

--- a/pkgs/desktops/mate/mate-desktop/default.nix
+++ b/pkgs/desktops/mate/mate-desktop/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl, pkgconfig, intltool, isocodes, gnome3, gtk3, mate, wrapGAppsHook }:
+{ stdenv, fetchurl, pkgconfig, intltool, isocodes, gnome3, gtk3, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "mate-desktop-${version}";
   version = "1.22.0";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "09gn840p6qds21kxab4pidjd53g76s76i7178fdibrz462mda217";
   };
 

--- a/pkgs/desktops/mate/mate-desktop/default.nix
+++ b/pkgs/desktops/mate/mate-desktop/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, fetchurl, pkgconfig, intltool, gnome3, gtk3, mate, wrapGAppsHook }:
+{ stdenv, fetchurl, pkgconfig, intltool, isocodes, gnome3, gtk3, mate, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "mate-desktop-${version}";
-  version = "1.20.4";
+  version = "1.22.0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "073hn68f57ahif0znbx850x6ncsq50m7jg0sy1mllxjjqf3b1fxr";
+    sha256 = "09gn840p6qds21kxab4pidjd53g76s76i7178fdibrz462mda217";
   };
 
   nativeBuildInputs = [
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     gnome3.dconf
     gtk3
+    isocodes
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/desktops/mate/mate-desktop/default.nix
+++ b/pkgs/desktops/mate/mate-desktop/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mate-desktop-${version}";
-  version = "1.22.0";
+  version = "1.22.1";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "09gn840p6qds21kxab4pidjd53g76s76i7178fdibrz462mda217";
+    sha256 = "1hr4r69855csqrcaqpbcyplsy4cwjfz7gabps2pzkh5132jycfr0";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/mate-icon-theme-faenza/default.nix
+++ b/pkgs/desktops/mate/mate-icon-theme-faenza/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.20.0";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "000vr9cnbl2qlysf2gyg1lsjirqdzmwrnh6d3hyrsfc0r2vh4wna";
   };
 

--- a/pkgs/desktops/mate/mate-icon-theme/default.nix
+++ b/pkgs/desktops/mate/mate-icon-theme/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl, pkgconfig, intltool, iconnamingutils, librsvg, hicolor-icon-theme, gtk3, mate }:
+{ stdenv, fetchurl, pkgconfig, intltool, iconnamingutils, librsvg, hicolor-icon-theme, gtk3 }:
 
 stdenv.mkDerivation rec {
   name = "mate-icon-theme-${version}";
   version = "1.22.1";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "1pn1xbmr4w4mi45nwk1qh18z9rlngmkhp9bw671yn4k6sii8fi3k";
   };
 

--- a/pkgs/desktops/mate/mate-icon-theme/default.nix
+++ b/pkgs/desktops/mate/mate-icon-theme/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mate-icon-theme-${version}";
-  version = "1.20.3";
+  version = "1.22.1";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "10l58mjc2a69pm7srxvlav2b8b7nbzyvwjrlrk79a3gr6dd1mbk4";
+    sha256 = "1pn1xbmr4w4mi45nwk1qh18z9rlngmkhp9bw671yn4k6sii8fi3k";
   };
 
   nativeBuildInputs = [ pkgconfig intltool iconnamingutils ];

--- a/pkgs/desktops/mate/mate-indicator-applet/default.nix
+++ b/pkgs/desktops/mate/mate-indicator-applet/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mate-indicator-applet-${version}";
-  version = "1.20.1";
+  version = "1.22.0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "0gxis834w8h33xmrx335jjad2xaqpkamirl0x4j7wsk4zs25jkyd";
+    sha256 = "0zad81qvcin4m329hfxhv4a5j8gf4gj8944mvjrdgdh71bzan2x1";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/mate-indicator-applet/default.nix
+++ b/pkgs/desktops/mate/mate-indicator-applet/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.22.0";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "0zad81qvcin4m329hfxhv4a5j8gf4gj8944mvjrdgdh71bzan2x1";
   };
 

--- a/pkgs/desktops/mate/mate-media/default.nix
+++ b/pkgs/desktops/mate/mate-media/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.22.1";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "13g1n2ddgr1yxgl4fsqj3sgb9344b756kam9v3sq6vh0bxlr4yf2";
   };
 

--- a/pkgs/desktops/mate/mate-media/default.nix
+++ b/pkgs/desktops/mate/mate-media/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mate-media-${version}";
-  version = "1.20.2";
+  version = "1.22.1";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "06fka82smrphzj4dz9dw1566kmdscxvxl0rchj9qxg7aidy0rmnv";
+    sha256 = "13g1n2ddgr1yxgl4fsqj3sgb9344b756kam9v3sq6vh0bxlr4yf2";
   };
 
   buildInputs = [
@@ -14,6 +14,7 @@ stdenv.mkDerivation rec {
     libcanberra-gtk3
     gtk3
     mate.libmatemixer
+    mate.mate-panel
     mate.mate-desktop
   ];
 

--- a/pkgs/desktops/mate/mate-menus/default.nix
+++ b/pkgs/desktops/mate/mate-menus/default.nix
@@ -1,17 +1,17 @@
-{ stdenv, fetchurl, pkgconfig, intltool, glib, gobject-introspection, python, mate }:
+{ stdenv, fetchurl, pkgconfig, intltool, glib, gobject-introspection, python3, mate }:
 
 stdenv.mkDerivation rec {
   name = "mate-menus-${version}";
-  version = "1.20.2";
+  version = "1.22.0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "18y4nka38dqqxycxpf7ig4vmrk4i05xqqjk4fxr1ghkj60xxyxz2";
+    sha256 = "1lkakbf2f1815c146z4xp5f0h4lim6jzr02681wbvzalc6k97v5c";
   };
 
   nativeBuildInputs = [ pkgconfig intltool gobject-introspection ];
 
-  buildInputs = [ glib python ];
+  buildInputs = [ glib python3 ];
 
   makeFlags = [
     "INTROSPECTION_GIRDIR=$(out)/share/gir-1.0/"

--- a/pkgs/desktops/mate/mate-menus/default.nix
+++ b/pkgs/desktops/mate/mate-menus/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl, pkgconfig, intltool, glib, gobject-introspection, python3, mate }:
+{ stdenv, fetchurl, pkgconfig, intltool, glib, gobject-introspection, python3 }:
 
 stdenv.mkDerivation rec {
   name = "mate-menus-${version}";
   version = "1.22.0";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "1lkakbf2f1815c146z4xp5f0h4lim6jzr02681wbvzalc6k97v5c";
   };
 

--- a/pkgs/desktops/mate/mate-netbook/default.nix
+++ b/pkgs/desktops/mate/mate-netbook/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mate-netbook-${version}";
-  version = "1.22.0";
+  version = "1.22.1";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "17p1wv9bcr3kvlahnxmxj786vka86nysi90x5xci6ilwyjlaxh0l";
+    sha256 = "00n162bskbvxhy4k2w14f9zwlsg3wgi43228ssx7sc2p95psmm64";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/mate-netbook/default.nix
+++ b/pkgs/desktops/mate/mate-netbook/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mate-netbook-${version}";
-  version = "1.20.1";
+  version = "1.22.0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "1ils0lav6j779kgz2py6zdalcfifpnp01clspbnkhb3v1ha1ncsq";
+    sha256 = "17p1wv9bcr3kvlahnxmxj786vka86nysi90x5xci6ilwyjlaxh0l";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/mate-netbook/default.nix
+++ b/pkgs/desktops/mate/mate-netbook/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.22.0";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "17p1wv9bcr3kvlahnxmxj786vka86nysi90x5xci6ilwyjlaxh0l";
   };
 

--- a/pkgs/desktops/mate/mate-notification-daemon/default.nix
+++ b/pkgs/desktops/mate/mate-notification-daemon/default.nix
@@ -1,13 +1,13 @@
-{ stdenv, fetchurl, pkgconfig, intltool, dbus-glib, libcanberra-gtk3,
+{ stdenv, fetchurl, pkgconfig, intltool, glib, libcanberra-gtk3,
   libnotify, libwnck3, gnome3, gtk3, mate, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "mate-notification-daemon-${version}";
-  version = "1.20.2";
+  version = "1.22.0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "0a60f67yjvlffrnviqgc64jz5l280f30h8br7wz2x415if5dmjyn";
+    sha256 = "06z3xczhz5diy4kk7b8lrzljrnql6fz0n1jyy916cf8pnnanpg0j";
   };
 
   nativeBuildInputs = [
@@ -17,12 +17,13 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    dbus-glib
     libcanberra-gtk3
     libnotify
     libwnck3
     gtk3
   ];
+
+  NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/gio-unix-2.0";
 
   meta = with stdenv.lib; {
     description = "Notification daemon for MATE";

--- a/pkgs/desktops/mate/mate-notification-daemon/default.nix
+++ b/pkgs/desktops/mate/mate-notification-daemon/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, pkgconfig, intltool, glib, libcanberra-gtk3,
-  libnotify, libwnck3, gnome3, gtk3, mate, wrapGAppsHook }:
+  libnotify, libwnck3, gnome3, gtk3, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "mate-notification-daemon-${version}";
   version = "1.22.0";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "06z3xczhz5diy4kk7b8lrzljrnql6fz0n1jyy916cf8pnnanpg0j";
   };
 

--- a/pkgs/desktops/mate/mate-panel/default.nix
+++ b/pkgs/desktops/mate/mate-panel/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mate-panel-${version}";
-  version = "1.22.0";
+  version = "1.22.1";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "17l4ryy71bkszr6shm9dm31zcsd7m0digi1mmvdlib5hqzvc7li7";
+    sha256 = "0pb9dpgsfjp6gsldg4ad2jz23xdvjfarmz4cjwkpakygkq5i6dma";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/mate-panel/default.nix
+++ b/pkgs/desktops/mate/mate-panel/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.22.0";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "17l4ryy71bkszr6shm9dm31zcsd7m0digi1mmvdlib5hqzvc7li7";
   };
 

--- a/pkgs/desktops/mate/mate-panel/default.nix
+++ b/pkgs/desktops/mate/mate-panel/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, fetchurl, pkgconfig, intltool, itstool, glib, dbus-glib, libwnck3, librsvg, libxml2, gnome3, gtk3, mate, hicolor-icon-theme, gobject-introspection, wrapGAppsHook }:
+{ stdenv, fetchurl, pkgconfig, intltool, itstool, glib, libwnck3, librsvg, libxml2, gnome3, gtk3, mate, hicolor-icon-theme, gobject-introspection, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "mate-panel-${version}";
-  version = "1.20.4";
+  version = "1.22.0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "02pdrwgl3plgv6l6nc45nsnmjppkxs4ybggwibd6mm777i9nb44d";
+    sha256 = "17l4ryy71bkszr6shm9dm31zcsd7m0digi1mmvdlib5hqzvc7li7";
   };
 
   nativeBuildInputs = [
@@ -19,7 +19,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     glib
-    dbus-glib
     libwnck3
     librsvg
     libxml2

--- a/pkgs/desktops/mate/mate-polkit/default.nix
+++ b/pkgs/desktops/mate/mate-polkit/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl, pkgconfig, intltool, gtk3, gobject-introspection, libappindicator-gtk3, libindicator-gtk3, polkit, mate }:
+{ stdenv, fetchurl, pkgconfig, intltool, gtk3, gobject-introspection, libappindicator-gtk3, libindicator-gtk3, polkit }:
 
 stdenv.mkDerivation rec {
   name = "mate-polkit-${version}";
   version = "1.22.0";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "02r8n71xflhvw2hsf6g4svdahzyg3r4n6xamasyzqfhyn0mqmjy0";
   };
 

--- a/pkgs/desktops/mate/mate-polkit/default.nix
+++ b/pkgs/desktops/mate/mate-polkit/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mate-polkit-${version}";
-  version = "1.20.2";
+  version = "1.22.0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "0zajisavrxiynmp4qg7zamvkpnhy9nra01czwn21h6hm2yakbayr";
+    sha256 = "02r8n71xflhvw2hsf6g4svdahzyg3r4n6xamasyzqfhyn0mqmjy0";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/mate-power-manager/default.nix
+++ b/pkgs/desktops/mate/mate-power-manager/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mate-power-manager-${version}";
-  version = "1.20.3";
+  version = "1.22.0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "17x47j5dkxxsq63bv2jwf3xgnddyy2dya4y14ryivq8q3jh5yhr5";
+    sha256 = "03c09h41qfz83wmjfvwzkq4xqc54aswmki4h034qcxbgfnyfmk1i";
   };
 
   buildInputs = [

--- a/pkgs/desktops/mate/mate-power-manager/default.nix
+++ b/pkgs/desktops/mate/mate-power-manager/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mate-power-manager-${version}";
-  version = "1.22.0";
+  version = "1.22.1";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "03c09h41qfz83wmjfvwzkq4xqc54aswmki4h034qcxbgfnyfmk1i";
+    sha256 = "06vs2w44l1s25j0mifkid02yncw0nvdxw8r4pp2jm18kxan4frms";
   };
 
   buildInputs = [

--- a/pkgs/desktops/mate/mate-power-manager/default.nix
+++ b/pkgs/desktops/mate/mate-power-manager/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.22.0";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "03c09h41qfz83wmjfvwzkq4xqc54aswmki4h034qcxbgfnyfmk1i";
   };
 

--- a/pkgs/desktops/mate/mate-screensaver/default.nix
+++ b/pkgs/desktops/mate/mate-screensaver/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.22.0";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "17fxyccsc410wbyxmds1sm7gjqbj6z46x5cjk1791hfzf0sh82sy";
   };
 

--- a/pkgs/desktops/mate/mate-screensaver/default.nix
+++ b/pkgs/desktops/mate/mate-screensaver/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mate-screensaver-${version}";
-  version = "1.22.0";
+  version = "1.22.1";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "17fxyccsc410wbyxmds1sm7gjqbj6z46x5cjk1791hfzf0sh82sy";
+    sha256 = "0c4qq5szsbfrz8hgkmlby2k7f1qs8kgqf2shd63z0pc8p6f47vvc";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/mate-screensaver/default.nix
+++ b/pkgs/desktops/mate/mate-screensaver/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mate-screensaver-${version}";
-  version = "1.20.3";
+  version = "1.22.0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "0kmaj4psg7261h02dzarga6k5cb7n709d60xbfrhywnf5fb9787i";
+    sha256 = "17fxyccsc410wbyxmds1sm7gjqbj6z46x5cjk1791hfzf0sh82sy";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/mate-sensors-applet/default.nix
+++ b/pkgs/desktops/mate/mate-sensors-applet/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, fetchurl, pkgconfig, intltool, itstool, gtk3, libxml2, libxslt, libatasmart, libnotify, dbus-glib, lm_sensors, mate, hicolor-icon-theme, wrapGAppsHook }:
+{ stdenv, fetchurl, pkgconfig, intltool, itstool, gtk3, libxml2, libxslt, libatasmart, libnotify, lm_sensors, mate, hicolor-icon-theme, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "mate-sensors-applet-${version}";
-  version = "1.20.3";
+  version = "1.22.0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "0s98qy3jkri9zh5xqffprqd00cqspaq9av0mcrcakjkl8wyfh2g6";
+    sha256 = "0wf07ppzdg9ql4limnq5vd2c2imyww9dy477hcgxl4vfw45vy19k";
   };
 
   nativeBuildInputs = [
@@ -23,7 +23,6 @@ stdenv.mkDerivation rec {
     libxslt
     libatasmart
     libnotify
-    dbus-glib
     lm_sensors
     mate.mate-panel
     hicolor-icon-theme

--- a/pkgs/desktops/mate/mate-sensors-applet/default.nix
+++ b/pkgs/desktops/mate/mate-sensors-applet/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mate-sensors-applet-${version}";
-  version = "1.22.0";
+  version = "1.22.1";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0wf07ppzdg9ql4limnq5vd2c2imyww9dy477hcgxl4vfw45vy19k";
+    sha256 = "0rv19jxxviqqwk2wlhxlm98jsxa26scvs7ilp2i6plhn3ap2alq3";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/mate-sensors-applet/default.nix
+++ b/pkgs/desktops/mate/mate-sensors-applet/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.22.0";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "0wf07ppzdg9ql4limnq5vd2c2imyww9dy477hcgxl4vfw45vy19k";
   };
 

--- a/pkgs/desktops/mate/mate-session-manager/default.nix
+++ b/pkgs/desktops/mate/mate-session-manager/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   name = "mate-session-manager-${version}";
-  version = "1.20.2";
+  version = "1.22.0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "05qq07b568qf6zyy459wajhfpbx1wfrinw3hsbky7abdjfn529dy";
+    sha256 = "1kpfmgay01gm74paaxccs3lim4jfb4hsm7i85jfdypr51985pwyj";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/mate-session-manager/default.nix
+++ b/pkgs/desktops/mate/mate-session-manager/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   version = "1.22.0";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "1kpfmgay01gm74paaxccs3lim4jfb4hsm7i85jfdypr51985pwyj";
   };
 

--- a/pkgs/desktops/mate/mate-settings-daemon/default.nix
+++ b/pkgs/desktops/mate/mate-settings-daemon/default.nix
@@ -1,14 +1,15 @@
-{ stdenv, fetchurl, pkgconfig, intltool, dbus-glib, libxklavier, libcanberra-gtk3, libnotify, nss, polkit, gnome3, gtk3, mate, wrapGAppsHook
-, pulseaudioSupport ? stdenv.config.pulseaudio or true, libpulseaudio
-}:
+{ stdenv, fetchurl, pkgconfig, intltool, glib, dbus-glib, libxklavier,
+  libcanberra-gtk3, libnotify, nss, polkit, gnome3, gtk3, mate,
+  pulseaudioSupport ? stdenv.config.pulseaudio or true, libpulseaudio,
+  wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "mate-settings-daemon-${version}";
-  version = "1.20.4";
+  version = "1.22.0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "10xlg2gb7fypnn5cnr14kbpjy5jdfz98ji615scz61zf5lljksxh";
+    sha256 = "0yr5v6b9hdk20j29smbw1k4fkyg82i5vlflmgly0vi5whgc74gym";
   };
 
   nativeBuildInputs = [
@@ -32,6 +33,8 @@ stdenv.mkDerivation rec {
   ] ++ stdenv.lib.optional pulseaudioSupport libpulseaudio;
 
   configureFlags = stdenv.lib.optional pulseaudioSupport "--enable-pulse";
+
+  NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/gio-unix-2.0";
 
   meta = with stdenv.lib; {
     description = "MATE settings daemon";

--- a/pkgs/desktops/mate/mate-settings-daemon/default.nix
+++ b/pkgs/desktops/mate/mate-settings-daemon/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   version = "1.22.0";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "0yr5v6b9hdk20j29smbw1k4fkyg82i5vlflmgly0vi5whgc74gym";
   };
 

--- a/pkgs/desktops/mate/mate-system-monitor/default.nix
+++ b/pkgs/desktops/mate/mate-system-monitor/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl, pkgconfig, intltool, itstool, gtkmm3, libxml2, libgtop, libwnck3, librsvg, systemd, mate, wrapGAppsHook }:
+{ stdenv, fetchurl, pkgconfig, intltool, itstool, gtkmm3, libxml2, libgtop, libwnck3, librsvg, systemd, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "mate-system-monitor-${version}";
   version = "1.22.0";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "0rs0n5ivmvi355fp3ymcp1jj2sz9viw31475aw7zh7s1l7dn969x";
   };
 

--- a/pkgs/desktops/mate/mate-system-monitor/default.nix
+++ b/pkgs/desktops/mate/mate-system-monitor/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mate-system-monitor-${version}";
-  version = "1.20.2";
+  version = "1.22.0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "0f6sh23axzmcmyv0d837gbc0dixf1afh8951zrzp1y53rdgpa9qn";
+    sha256 = "0rs0n5ivmvi355fp3ymcp1jj2sz9viw31475aw7zh7s1l7dn969x";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/mate-terminal/default.nix
+++ b/pkgs/desktops/mate/mate-terminal/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.22.0";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "16r492s34la2fs2cj1xr0r93wkjglwy77jyrc66i2ahs9gnivj4g";
   };
 

--- a/pkgs/desktops/mate/mate-terminal/default.nix
+++ b/pkgs/desktops/mate/mate-terminal/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mate-terminal-${version}";
-  version = "1.20.2";
+  version = "1.22.0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "0fqyi0az4ax1gyk5gymd7ssq2crdcd7slmqljc1b1pa283ql7p3q";
+    sha256 = "16r492s34la2fs2cj1xr0r93wkjglwy77jyrc66i2ahs9gnivj4g";
   };
 
   buildInputs = [

--- a/pkgs/desktops/mate/mate-terminal/default.nix
+++ b/pkgs/desktops/mate/mate-terminal/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mate-terminal-${version}";
-  version = "1.22.0";
+  version = "1.22.1";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "16r492s34la2fs2cj1xr0r93wkjglwy77jyrc66i2ahs9gnivj4g";
+    sha256 = "08210ry5lrivsgzqpdaxrchhpj0n5s1q0x4pxmwdpnksjpcj11mn";
   };
 
   buildInputs = [

--- a/pkgs/desktops/mate/mate-themes/default.nix
+++ b/pkgs/desktops/mate/mate-themes/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "mate-themes-${version}";
-  version = "3.22.18";
+  version = "3.22.19";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/themes/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "0538bw8qismp16ymxbjk0ww7yjw1ch5v3f3d4vib3770xvgmmcfm";
+    sha256 = "1ycb8b8r0s8d1h1477135mynr53s5781gdb2ap8xlvj2g58492wq";
   };
 
   nativeBuildInputs = [ pkgconfig intltool gtk3 ];

--- a/pkgs/desktops/mate/mate-themes/default.nix
+++ b/pkgs/desktops/mate/mate-themes/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
   version = "3.22.19";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/themes/${mate.getRelease version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/themes/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "1ycb8b8r0s8d1h1477135mynr53s5781gdb2ap8xlvj2g58492wq";
   };
 

--- a/pkgs/desktops/mate/mate-user-guide/default.nix
+++ b/pkgs/desktops/mate/mate-user-guide/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl, intltool, itstool, libxml2, yelp, mate }:
+{ stdenv, fetchurl, intltool, itstool, libxml2, yelp }:
 
 stdenv.mkDerivation rec {
   name = "mate-user-guide-${version}";
   version = "1.22.0";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "0ckn7h7l0qdgdx440dwx1h8i601s22sxlf5a7179hfirk9016j0z";
   };
 

--- a/pkgs/desktops/mate/mate-user-guide/default.nix
+++ b/pkgs/desktops/mate/mate-user-guide/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mate-user-guide-${version}";
-  version = "1.20.2";
+  version = "1.22.0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "0cbi625xd7nsifvxbixsb29kj2zj14sn0sl61wkcvasz7whg7w6r";
+    sha256 = "0ckn7h7l0qdgdx440dwx1h8i601s22sxlf5a7179hfirk9016j0z";
   };
 
   nativeBuildInputs = [ itstool intltool libxml2 ];

--- a/pkgs/desktops/mate/mate-user-guide/default.nix
+++ b/pkgs/desktops/mate/mate-user-guide/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mate-user-guide-${version}";
-  version = "1.22.0";
+  version = "1.22.1";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0ckn7h7l0qdgdx440dwx1h8i601s22sxlf5a7179hfirk9016j0z";
+    sha256 = "02zlfdhrvamd299pbf5s19pr90y8yah84g12shwihlxff7d3hxvs";
   };
 
   nativeBuildInputs = [ itstool intltool libxml2 ];

--- a/pkgs/desktops/mate/mate-user-share/default.nix
+++ b/pkgs/desktops/mate/mate-user-share/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.22.0";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "14bhr6fv6gj3ka3sf13q64ck4svx8f4x8kzbppxv0jygpjp48w7h";
   };
 

--- a/pkgs/desktops/mate/mate-user-share/default.nix
+++ b/pkgs/desktops/mate/mate-user-share/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, fetchurl, pkgconfig, intltool, itstool, gtk3, dbus-glib, libnotify, libxml2, libcanberra-gtk3, mod_dnssd, apacheHttpd, hicolor-icon-theme, mate, wrapGAppsHook }:
+{ stdenv, fetchurl, pkgconfig, intltool, itstool, gtk3, libnotify, libxml2, libcanberra-gtk3, mod_dnssd, apacheHttpd, hicolor-icon-theme, mate, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "mate-user-share-${version}";
-  version = "1.20.1";
+  version = "1.22.0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "0v5xilk978zl5443vlxf25z8z1g5sw9xl5sq76gvrmdlz2parfrn";
+    sha256 = "14bhr6fv6gj3ka3sf13q64ck4svx8f4x8kzbppxv0jygpjp48w7h";
   };
 
   nativeBuildInputs = [
@@ -18,7 +18,6 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     gtk3
-    dbus-glib
     libnotify
     libcanberra-gtk3
     libxml2

--- a/pkgs/desktops/mate/mate-utils/default.nix
+++ b/pkgs/desktops/mate/mate-utils/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.22.0";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "0kz95hicjksgkwaj83fdp2rnaygfgjbj0jsnwy4n0lj5q90j7r28";
   };
 

--- a/pkgs/desktops/mate/mate-utils/default.nix
+++ b/pkgs/desktops/mate/mate-utils/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mate-utils-${version}";
-  version = "1.22.0";
+  version = "1.22.1";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0kz95hicjksgkwaj83fdp2rnaygfgjbj0jsnwy4n0lj5q90j7r28";
+    sha256 = "0768y6x33ljc9dxjlfmvplsn4lrxj5xhjddbyab9h6pqav8527rg";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/mate-utils/default.nix
+++ b/pkgs/desktops/mate/mate-utils/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "mate-utils-${version}";
-  version = "1.20.2";
+  version = "1.22.0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "0w7hw192jzhad8jab8mjms4x6k2xijvb3rhlbxb6z5n5880xgfqf";
+    sha256 = "0kz95hicjksgkwaj83fdp2rnaygfgjbj0jsnwy4n0lj5q90j7r28";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/mate-utils/default.nix
+++ b/pkgs/desktops/mate/mate-utils/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, intltool, itstool, gtk3, libxml2, libgtop, libcanberra-gtk3, mate, hicolor-icon-theme, wrapGAppsHook }:
+{ stdenv, fetchurl, pkgconfig, intltool, itstool, gtk3, libxml2, libgtop, libcanberra-gtk3, inkscape, mate, hicolor-icon-theme, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "mate-utils-${version}";
@@ -13,6 +13,7 @@ stdenv.mkDerivation rec {
     pkgconfig
     intltool
     itstool
+    inkscape
     wrapGAppsHook
   ];
 

--- a/pkgs/desktops/mate/mozo/default.nix
+++ b/pkgs/desktops/mate/mozo/default.nix
@@ -8,7 +8,7 @@ python3.pkgs.buildPythonApplication rec {
   doCheck = false;
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${pname}-${version}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "0pmkprby10ys1xas9w1xqdm48l3bl82cysyj39n7br9ddijwb7kz";
   };
 

--- a/pkgs/desktops/mate/mozo/default.nix
+++ b/pkgs/desktops/mate/mozo/default.nix
@@ -1,20 +1,20 @@
-{ stdenv, python, fetchurl, pkgconfig, intltool, mate, gtk3, glib, wrapGAppsHook, gobject-introspection }:
+{ stdenv, python3, fetchurl, pkgconfig, intltool, mate, gtk3, glib, wrapGAppsHook, gobject-introspection }:
 
-python.pkgs.buildPythonApplication rec {
+python3.pkgs.buildPythonApplication rec {
   pname = "mozo";
-  version = "1.20.2";
+  version = "1.22.0";
 
   format = "other";
   doCheck = false;
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${pname}-${version}.tar.xz";
-    sha256 = "1q4hqhigimxav2a8xxyd53lq8q80szsphcv37y2jhm6g6wvdmvhd";
+    sha256 = "0pmkprby10ys1xas9w1xqdm48l3bl82cysyj39n7br9ddijwb7kz";
   };
 
   nativeBuildInputs = [ pkgconfig intltool gobject-introspection wrapGAppsHook ];
 
-  propagatedBuildInputs =  [ mate.mate-menus python.pkgs.pygobject3 ];
+  propagatedBuildInputs =  [ mate.mate-menus python3.pkgs.pygobject3 ];
 
   buildInputs = [ gtk3 glib ];
 

--- a/pkgs/desktops/mate/mozo/default.nix
+++ b/pkgs/desktops/mate/mozo/default.nix
@@ -2,14 +2,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "mozo";
-  version = "1.22.0";
+  version = "1.22.1";
 
   format = "other";
   doCheck = false;
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0pmkprby10ys1xas9w1xqdm48l3bl82cysyj39n7br9ddijwb7kz";
+    sha256 = "0yffp7p3b6ynpf7ck21klym7h09l35amnyahm71dxbv2kzj6hlqh";
   };
 
   nativeBuildInputs = [ pkgconfig intltool gobject-introspection wrapGAppsHook ];

--- a/pkgs/desktops/mate/pluma/default.nix
+++ b/pkgs/desktops/mate/pluma/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.22.0";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "07rr5asdjr9slmaijp4m8v9vxscihvm36mfrwlp3lv12kry42a05";
   };
 

--- a/pkgs/desktops/mate/pluma/default.nix
+++ b/pkgs/desktops/mate/pluma/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, fetchurl, pkgconfig, intltool, itstool, isocodes, enchant, libxml2, python, gnome3, gtksourceview3, libpeas, mate, wrapGAppsHook }:
+{ stdenv, fetchurl, pkgconfig, intltool, itstool, isocodes, enchant, libxml2, python3, gnome3, gtksourceview3, libpeas, mate, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "pluma-${version}";
-  version = "1.20.4";
+  version = "1.22.0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "0qdbm5y6q8lbabd81mg3rnls5bdvbmfii82f6syqw1cw6381mzgz";
+    sha256 = "07rr5asdjr9slmaijp4m8v9vxscihvm36mfrwlp3lv12kry42a05";
   };
 
   nativeBuildInputs = [
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     enchant
     libxml2
-    python
+    python3
     gtksourceview3
     libpeas
     gnome3.adwaita-icon-theme

--- a/pkgs/desktops/mate/pluma/default.nix
+++ b/pkgs/desktops/mate/pluma/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "pluma-${version}";
-  version = "1.22.0";
+  version = "1.22.1";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "07rr5asdjr9slmaijp4m8v9vxscihvm36mfrwlp3lv12kry42a05";
+    sha256 = "14d5c5fg31d7br9h1y3gdcr53j4sxlgybf326jvdcw8mgy91k3dg";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/mate/python-caja/default.nix
+++ b/pkgs/desktops/mate/python-caja/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.22.0";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
     sha256 = "1zwdjvxci72j0181nlfq6912lw3aq8j3746brlp7wlzn22qp7b0k";
   };
 

--- a/pkgs/desktops/mate/python-caja/default.nix
+++ b/pkgs/desktops/mate/python-caja/default.nix
@@ -1,25 +1,25 @@
-{ stdenv, fetchurl, pkgconfig, intltool, gtk3, mate, pythonPackages }:
+{ stdenv, fetchurl, pkgconfig, intltool, gtk3, mate, python3Packages }:
 
 stdenv.mkDerivation rec {
   name = "python-caja-${version}";
-  version = "1.20.2";
+  version = "1.22.0";
 
   src = fetchurl {
     url = "http://pub.mate-desktop.org/releases/${mate.getRelease version}/${name}.tar.xz";
-    sha256 = "16r8mz1b44qgs19d14zadwzshzrdc5sdwgjp9f9av3fa6g09yd7b";
+    sha256 = "1zwdjvxci72j0181nlfq6912lw3aq8j3746brlp7wlzn22qp7b0k";
   };
 
   nativeBuildInputs = [
     pkgconfig
     intltool
-    pythonPackages.wrapPython
+    python3Packages.wrapPython
   ];
 
   buildInputs = [
     gtk3
     mate.caja
-    pythonPackages.python
-    pythonPackages.pygobject3
+    python3Packages.python
+    python3Packages.pygobject3
   ];
 
   configureFlags = [ "--with-cajadir=$$out/lib/caja/extensions-2.0" ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update the [MATE Desktop Environment](https://mate-desktop.org) to version 1.22.

[MATE 1.22 released](https://mate-desktop.org/blog/2019-03-18-mate-1-22-released/)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).