### PR TITLE
nixbox: init at unstable-2019-04-20

### DIFF
--- a/pkgs/applications/misc/nixbox/default.nix
+++ b/pkgs/applications/misc/nixbox/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "nixbox";
+  version = "unstable-2019-04-20";
+
+  src = fetchFromGitHub {
+    owner = "LinArcX";
+    repo = pname;
+    rev = "c9a202e59b635816708b49da370029f1412fa372";
+    sha256 = "1glr0kz9r0bs3pzq8l76hpl6hwh47p65snvp4riqzxpcjxywgh86";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    chmod +x nixbox
+    cp nixbox $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/LinArcX/nixbox;
+    description = "A menu driven shell script to manage nixos operations";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.linarcx ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4587,6 +4587,8 @@ in
 
   ngrok-1 = callPackage ../tools/networking/ngrok-1 { };
 
+  nixbox = callPackage ../applications/misc/nixbox { };
+
   noice = callPackage ../applications/misc/noice { };
 
   noip = callPackage ../tools/networking/noip { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
I need a central app to manage all nixos operations in one place. So with nixbox i can manage Derivations, Generations(delete them, list them, ..), manage channels, fix nix store, ... in single application without worry to memorize their commands. 


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
