### PR TITLE
bash_5: 5.0-p2 -> 5.0-p7

### DIFF
--- a/pkgs/shells/bash/bash-5.0-patches.nix
+++ b/pkgs/shells/bash/bash-5.0-patches.nix
@@ -3,4 +3,9 @@
 patch: [
 (patch "001" "12bjfdy6bg8nhyw27bdgxn7h4paylx8d927skfmi9pxd1wgrxzpj")
 (patch "002" "01w7yrzmz10mw06ys0546vhl7isv2v402ziyvfd7k67588spvs47")
+(patch "003" "0ny81ridp5n0j69hb8ixrc7dmxybby54jbsz5hikly8kgg1wvssf")
+(patch "004" "021gqqvgydixkrmqss64b6srfdlkvnx88lyfzpxfrn5d6bc7li0l")
+(patch "005" "0xl2kyzm84nlyklrqzkn73ixabhzfhn9x91lzcmis89cppclvxav")
+(patch "006" "0844749ixk1z60437nkznzms1f0nzh9an62kj7sny6r0zyk2k1fn")
+(patch "007" "16xg37gp1b8zlj5969w8mcrparwqlcbj9695vn3qhgb7wdz1xd0p")
 ]


### PR DESCRIPTION
###### Motivation for this change

https://ftp.gnu.org/gnu/bash/bash-5.0-patches/bash50-003
https://ftp.gnu.org/gnu/bash/bash-5.0-patches/bash50-004
https://ftp.gnu.org/gnu/bash/bash-5.0-patches/bash50-005
https://ftp.gnu.org/gnu/bash/bash-5.0-patches/bash50-006
https://ftp.gnu.org/gnu/bash/bash-5.0-patches/bash50-007

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---