### PR TITLE
superTuxKart: 0.9.3 -> 1.0

### DIFF
--- a/pkgs/games/super-tux-kart/default.nix
+++ b/pkgs/games/super-tux-kart/default.nix
@@ -1,27 +1,26 @@
 { stdenv, fetchFromGitHub, fetchsvn, fetchpatch, cmake, pkgconfig
 , openal, freealut, libGLU_combined, libvorbis, libogg, gettext, curl, freetype
-, fribidi, libtool, bluez, libjpeg, libpng, zlib, libX11, libXrandr }:
+, fribidi, libtool, bluez, libjpeg, libpng, zlib, libX11, libXrandr, enet }:
 
 let
   dir = "stk-code";
 
 in stdenv.mkDerivation rec {
-  name = "supertuxkart-${version}";
-
-  version = "0.9.3";
+  pname = "supertuxkart";
+  version = "1.0";
 
   srcs = [
     (fetchFromGitHub {
       owner  = "supertuxkart";
       repo   = "stk-code";
       rev    = version;
-      sha256 = "1smnanjjaj4yq2ywikv0l6xysh6n2h1cm549plbg5xdk9mx2sfia";
+      sha256 = "03mrnzrvfdgjc687n718f5zsray6vbdlv4irzy2mfi78bz3bkjll";
       name   = dir;
     })
     (fetchsvn {
       url    = "https://svn.code.sf.net/p/supertuxkart/code/stk-assets";
-      rev    = "17448";
-      sha256 = "0lxbb4k57gv4gj12l5hnvhwdycpzcxjwg7qdfwglj2bdvaxf9f21";
+      rev    = "18212";
+      sha256 = "1dyj8r5rfifhnhayga8w8irkpa99vw57xjmy74cp8xz8g7zvdzqf";
       name   = "stk-assets";
     })
   ];
@@ -31,15 +30,7 @@ in stdenv.mkDerivation rec {
   buildInputs = [
     libX11 libXrandr
     openal freealut libGLU_combined libvorbis libogg zlib freetype
-    curl fribidi bluez libjpeg libpng
-  ];
-
-  # https://github.com/supertuxkart/stk-code/issues/3557#issuecomment-440794379
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/supertuxkart/stk-code/commit/3a3953f38c3555e87f3608d0291dbfccf34e9775.patch";
-      sha256 = "13mr5pwf45g7frpxzlxiyiq39qi3z9spd7l6gi8i3dr3li9wrb1k";
-    })
+    curl fribidi bluez libjpeg libpng enet
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
http://blog.supertuxkart.net/2019/04/supertuxkart-10-release.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
