### PR TITLE
pythonPackages.ColanderAlchemy: fix build by pinning to colander 1.6.0

### DIFF
--- a/pkgs/development/python-modules/colanderalchemy/default.nix
+++ b/pkgs/development/python-modules/colanderalchemy/default.nix
@@ -30,6 +30,9 @@ buildPythonPackage rec {
     description = "Autogenerate Colander schemas based on SQLAlchemy models";
     homepage = https://github.com/stefanofontanelli/ColanderAlchemy;
     license = licenses.mit;
+    # ColanderAlchemy's tests currently fail with colander >1.6.0
+    # (see https://github.com/stefanofontanelli/ColanderAlchemy/issues/107)
+    broken = versionOlder "1.6.0" colander.version;
   };
 
 }


### PR DESCRIPTION

###### Motivation for this change
ColanderAlchemy doesn't seem to have been updated for colander 1.7.0, or at least its tests haven't been and we get a single, subtle test failure around null handling which I don't feel comfortable disabling. Issue filed upstream https://github.com/stefanofontanelli/ColanderAlchemy/issues/107


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
