### PR TITLE
rrdtool: add passthru.perlModule

### DIFF
--- a/pkgs/tools/misc/rrdtool/default.nix
+++ b/pkgs/tools/misc/rrdtool/default.nix
@@ -1,7 +1,7 @@
 { fetchurl, fetchpatch, stdenv, gettext, perl, pkgconfig, libxml2, pango, cairo, groff
 , tcl-8_5, darwin }:
 
-stdenv.mkDerivation rec {
+perl.pkgs.toPerlModule(stdenv.mkDerivation rec {
   name = "rrdtool-1.7.1";
 
   src = fetchurl {
@@ -27,4 +27,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ pSub ];
   };
-}
+})


### PR DESCRIPTION
... so it can be used in `perl.withPackages`

A bit tricky though, because rrdtool is not in `perlPackages`
```nix
perl.withPackages(p: [ (rrdtool.override{ inherit (p) perl; }) ])
```
