### PR TITLE
[demo, do not merge] nix-serve: $PERL5LIB -> perl.withPackages

### DIFF
--- a/pkgs/tools/package-management/nix-serve/default.nix
+++ b/pkgs/tools/package-management/nix-serve/default.nix
@@ -18,21 +18,16 @@ stdenv.mkDerivation rec {
     inherit rev sha256;
   };
 
-  buildInputs = [ bzip2 perl nix nix.perl-bindings ]
-    ++ (with perlPackages; [ DBI DBDSQLite Plack Starman ]);
-
+  nativeBuildInputs = [ makeWrapper ];
+  
   dontBuild = true;
 
   installPhase = ''
-    mkdir -p $out/libexec/nix-serve
-    cp nix-serve.psgi $out/libexec/nix-serve/nix-serve.psgi
+    install -Dm0755 nix-serve.psgi $out/libexec/nix-serve/nix-serve.psgi
 
-    mkdir -p $out/bin
-    cat > $out/bin/nix-serve <<EOF
-    #! ${stdenv.shell}
-    PATH=${makeBinPath [ bzip2 nix ]}:\$PATH PERL5LIB=$PERL5LIB exec ${perlPackages.Starman}/bin/starman $out/libexec/nix-serve/nix-serve.psgi "\$@"
-    EOF
-    chmod +x $out/bin/nix-serve
+    makeWrapper ${perl.withPackages(p: [ p.DBI p.DBDSQLite p.Plack p.Starman nix.perl-bindings ])}/bin/starman $out/bin/nix-serve \
+                --prefix PATH : "${makeBinPath [ bzip2 nix ]}" \
+                --add-flags $out/libexec/nix-serve/nix-serve.psgi
   '';
 
   meta = {


### PR DESCRIPTION
###### Motivation for this change

Do not merge.

Just a demo how to get rid of manipulation with long ```$PERL5LIB``` using ```perl.withPackages```
Related discussions in https://github.com/NixOS/nixpkgs/pull/55786 https://github.com/NixOS/nixpkgs/pull/53495
