### PR TITLE
Support patching nixpkgs

### DIFF
--- a/doc/manual.xml
+++ b/doc/manual.xml
@@ -11,6 +11,7 @@
  <xi:include href="multiple-output.xml" />
  <xi:include href="cross-compilation.xml" />
  <xi:include href="configuration.xml" />
+ <xi:include href="patching-nixpkgs.xml" />
  <xi:include href="functions.xml" />
  <xi:include href="meta.xml" />
  <xi:include href="languages-frameworks/index.xml" />

--- a/doc/patching-nixpkgs.xml
+++ b/doc/patching-nixpkgs.xml
@@ -1,0 +1,70 @@
+<chapter xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xml:id="chap-patching-nixpkgs">
+ <title>Patching nixpkgs</title>
+ <para>
+   Sometimes you want to track a specific branch of nixpkgs (like
+   <literal>nixpkgs-unstable</literal> or some release branch) but you would
+   like to apply some unmerged pull requests or some other patches to that
+   revision.
+ </para>
+ <para>
+   Note that overlays are not always sufficient in this case because they don't
+   work for NixOS modules and you're forced to duplicate code which already
+   exists in some commit.
+ </para>
+ <para>
+   In this case you could fork nixpkgs, create a branch based on your desired
+   upstream branch and cherry-pick the commits you need on top of that
+   branch. Then everytime you need to upgrade nixpkgs you rebase your branch on
+   the latest upstream branch that you're tracking. This process works but is a
+   bit involved and somewhat untransparent.
+ </para>
+ <para>
+   nixpkgs also supports a simpler and more transparent mechanism to apply some
+   patches to an existing revision. First you fetch your desired revision of
+   nixpkgs like for example:
+   <programlisting>
+     let
+       nixpkgs =
+         builtins.fetchTarball {
+           url = "https://github.com/NixOS/nixpkgs/archive/86d58407a6bb8ef2e1a58ab50318b149ffd4feda.tar.gz";
+           sha256 = "0a2lkvacn78nza9hlmdx9znp1my3c3jf3xyhk9ydw6lxa348b7sl";
+         };
+   </programlisting>
+   Then you import that revision and apply it to a list of patches, for example:
+   <programlisting>
+       patchedPkgs = import nixpkgs {
+         patches = pkgs : [
+           # https://github.com/NixOS/nixpkgs/pull/59950
+           (pkgs.fetchpatch {
+             url = https://github.com/NixOS/nixpkgs/commit/1f770d20550a413e508e081ddc08464e9d08ba3d.patch;
+             sha256 = "1nlzx171y3r3jbk0qhvnl711kmdk57jlq4na8f8bs8wz2pbffymr";
+           })
+         ];
+         overlays = [ ... ];
+         config = { ... };
+         localSystem = { ... };
+       };
+     in patchedPkgs...
+   </programlisting>
+ </para>
+ <para>
+   Note that <literal>patches</literal> should be a function from a nixpkgs set
+   <literal>pkgs</literal> to a list of patch files that can be applied to a
+   nixpkgs directory tree. The <literal>pkgs</literal> set should mainly be used
+   to get the <literal>fetchpatch</literal> or <literal>fetchurl</literal>
+   functions from. Note that <literal>pkgs</literal> is a nixpkgs set for the
+   specified <literal>localSystem</literal> and <literal>config</literal> but
+   without <literal>overlays</literal> and <literal>crossOverlays</literal> defined.
+ </para>
+ <para>
+   Overlays are applied after patching which means you can have overlays which
+   can depend on the patched content.
+ </para>
+ <para>
+   Note that the implementation uses <link
+   xlink:href="https://nixos.wiki/wiki/Import_From_Derivation">IFD (Import From
+   Derivation)</link>.
+  </para>
+</chapter>

--- a/pkgs/build-support/trivial-builders.nix
+++ b/pkgs/build-support/trivial-builders.nix
@@ -344,4 +344,35 @@ rec {
   # Copy a list of paths to the Nix store.
   copyPathsToStore = builtins.map copyPathToStore;
 
+
+  /* Applies a list of patches to a source directory.
+   *
+   * Examples:
+   *
+   * # Patching nixpkgs:
+   * applyPatches {
+   *   name = "nixpkgs-patched";
+   *   src = pkgs.path;
+   *   patches = [
+   *     (pkgs.fetchpatch {
+   *       url = https://github.com/NixOS/nixpkgs/commit/1f770d20550a413e508e081ddc08464e9d08ba3d.patch;
+   *       sha256 = "1nlzx171y3r3jbk0qhvnl711kmdk57jlq4na8f8bs8wz2pbffymr";
+   *     })
+   *   ];
+   * }
+   */
+  applyPatches =
+      { src
+      , name
+      , patches   ? []
+      , postPatch ? ""
+      , ...
+      } @ args : stdenvNoCC.mkDerivation ({
+    inherit name src patches postPatch;
+    preferLocalBuild = true;
+    allowSubstitutes = false;
+    phases = "unpackPhase patchPhase installPhase";
+    installPhase = "cp -R ./ $out";
+  } // args);
+
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Sometimes you want to track a specific branch of nixpkgs (like nixpkgs-unstable or some release branch) but you would like to apply some unmerged pull requests or some other patches to that revision.

Note that overlays are not always sufficient in this case because they don't work for NixOS modules and you're forced to duplicate code which already exists in some commit.

In this case you could fork nixpkgs, create a branch based on your desired upstream branch and cherry-pick the commits you need on top of that branch. Then everytime you need to upgrade nixpkgs you rebase your branch on the latest upstream branch that you're tracking. This process works but is a
bit involved and somewhat untransparent.

This PR implements support in nixpkgs for a simpler and more transparent mechanism to apply some patches to an existing revision. First you fetch your desired revision of nixpkgs like for example:

```
  let
    nixpkgs =
      builtins.fetchTarball {
	url = "https://github.com/NixOS/nixpkgs/archive/86d58407a6bb8ef2e1a58ab50318b149ffd4feda.tar.gz";
	sha256 = "0a2lkvacn78nza9hlmdx9znp1my3c3jf3xyhk9ydw6lxa348b7sl";
      };
```

Then you import that revision and apply it to a list of patches, for example:

```
    patchedPkgs = import nixpkgs {
      patches = pkgs : [
	# https://github.com/NixOS/nixpkgs/pull/59950
	(pkgs.fetchpatch {
	  url = https://github.com/NixOS/nixpkgs/commit/1f770d20550a413e508e081ddc08464e9d08ba3d.patch;
	  sha256 = "1nlzx171y3r3jbk0qhvnl711kmdk57jlq4na8f8bs8wz2pbffymr";
	})
      ];
    };
  in patchedPkgs...
```

Note that `patches` should be a function from a nixpkgs set `pkgs` to a list of patch files that can be applied to a nixpkgs directory tree. The `pkgs` set should mainly be used to get the `fetchpatch` function from. Note that `pkgs` is a nixpkgs set for the specified `localSystem` but without `overlays` and `crossOverlays` defined.

Overlays are applied after patching which means you can have overlays which can depend on the patched content.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
