### PR TITLE
pythonPackages.box2d: fix build by moving swig2 to nativeBuildInputs, remove box2d dependency

### DIFF
--- a/pkgs/development/python-modules/box2d/default.nix
+++ b/pkgs/development/python-modules/box2d/default.nix
@@ -20,7 +20,8 @@ buildPythonPackage rec {
     sed -i "s/'Box2D.tests' : 'tests'//" setup.py
   '';
 
-  buildInputs = [ swig2 pkgs-box2d ];
+  nativeBuildInputs = [ swig2 ];
+  buildInputs = [ pkgs-box2d ];
 
   # tests not included with pypi release
   doCheck = false;

--- a/pkgs/development/python-modules/box2d/default.nix
+++ b/pkgs/development/python-modules/box2d/default.nix
@@ -2,7 +2,6 @@
 , buildPythonPackage
 , fetchPypi
 , swig2
-, pkgs-box2d
 , isPy3k
 }:
 
@@ -21,7 +20,6 @@ buildPythonPackage rec {
   '';
 
   nativeBuildInputs = [ swig2 ];
-  buildInputs = [ pkgs-box2d ];
 
   # tests not included with pypi release
   doCheck = false;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1314,7 +1314,7 @@ in {
 
   bottle = callPackage ../development/python-modules/bottle { };
 
-  box2d = callPackage ../development/python-modules/box2d { pkgs-box2d = pkgs.box2d; };
+  box2d = callPackage ../development/python-modules/box2d { };
 
   branca = callPackage ../development/python-modules/branca { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
...fix build by moving swig2 to nativeBuildInputs

Looking at the future of this package, the original source appears to be unmaintained, and the pypi entry's homepage is an old broken googlecode.com address.

It's probably worth looking at switching to one of the forks, but which one I'm not particularly sure. I'm not sure how one would gauge the credibility of these sources - https://github.com/pybox2d/pybox2d probably looks the most promising, but then again, anyone can register the "pybox2d" github organization. The bonus from switching upstream would be being able to pull the complete package from github including the tests, which we could then enable.

**Edit:** Looking at this closer, I realized I was able to remove the `pkgs-box2d` `buildInput` entirely. This dependency turns out to be completely unnecessary - the pypi package includes its own bundled copy of the source (I know - ew.) and building without `pkgs-box2d` results in a binary-identical `.so`.

This has the side-effect of enabling this package on darwin, which was previously restricted by the apparently linux-only `pkgs-box2d`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
