### PR TITLE
gnomeExtensions.battery-status: mark as not broken

### DIFF
--- a/pkgs/desktops/gnome-3/extensions/battery-status/default.nix
+++ b/pkgs/desktops/gnome-3/extensions/battery-status/default.nix
@@ -1,15 +1,19 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv, fetchFromGitHub, gnome3 }:
 
 stdenv.mkDerivation rec {
   name = "gnome-shell-extension-battery-status-${version}";
   version = "6";
 
   src = fetchFromGitHub {
-    owner = "milliburn";
+    owner = "roberth-k";
     repo = "gnome-shell-extension-battery_status";
     rev = "v${version}";
     sha256 = "1w83h863mzffjnmk322xq90qf3y9dzay1w9yw5r0qnbsq1ljl8p4";
   };
+
+  patches = [
+    ./fix-versions.patch
+  ];
 
   uuid = "battery_status@milliburn.github.com";
 
@@ -21,8 +25,8 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Configurable lightweight battery charge indicator and autohider";
     license = licenses.gpl2;
-    broken = true; # not compatable with latest GNOME
     maintainers = with maintainers; [ jonafato ];
-    homepage = https://github.com/milliburn/gnome-shell-extension-battery_status;
+    platforms = gnome3.gnome-shell.meta.platforms;
+    homepage = https://github.com/roberth-k/gnome-shell-extension-battery_status;
   };
 }

--- a/pkgs/desktops/gnome-3/extensions/battery-status/fix-versions.patch
+++ b/pkgs/desktops/gnome-3/extensions/battery-status/fix-versions.patch
@@ -1,0 +1,14 @@
+diff --git a/battery_status@milliburn.github.com/metadata.json b/battery_status@milliburn.github.com/metadata.json
+index 6484e0a..6d95f87 100644
+--- a/battery_status@milliburn.github.com/metadata.json
++++ b/battery_status@milliburn.github.com/metadata.json
+@@ -1,7 +1,7 @@
+ {
+-  "version": 6,
++  "version": 8,
+   "shell-version": [
+-    "3.10", "3.12", "3.14"
++    "3.10", "3.12", "3.14", "3.16", "3.18", "3.20", "3.28", "3.30", "3.32"
+   ],
+   "settings-schema": "org.gnome.shell.extensions.battery_status",
+   "original-author": "roberth@winter-weht.net",


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This extension does not declare support for GNOME 3.32 (or any other
recent version), but it does work. I've opened an [upstream pull
request] to address this. Additionally, add `meta.platforms` and update
the homepage and GitHub owner to reflect the user that `milliburn`
redirects to.

[upstream pull request]: https://github.com/roberth-k/gnome-shell-extension-battery_status/pull/18

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
