### PR TITLE
pytorch: Move cudatoolkit to nativeBuildInputs

### DIFF
--- a/pkgs/development/python-modules/pytorch/default.nix
+++ b/pkgs/development/python-modules/pytorch/default.nix
@@ -81,11 +81,11 @@ in buildPythonPackage rec {
      cmake
      utillinux
      which
-  ];
+  ] ++ lib.optionals cudaSupport [ cudatoolkit_joined ];
 
   buildInputs = [
      numpy.blas
-  ] ++ lib.optionals cudaSupport [ cudatoolkit_joined cudnn ]
+  ] ++ lib.optionals cudaSupport [ cudnn ]
     ++ lib.optionals stdenv.isLinux [ numactl ];
 
   propagatedBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

`nvcc` must be available in `PATH` at build time; otherwise CUDA support will be disabled.

This is a more minimal version of #57438.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
