### PR TITLE
librecad: add .desktop file and icon

### DIFF
--- a/pkgs/applications/misc/librecad/default.nix
+++ b/pkgs/applications/misc/librecad/default.nix
@@ -18,8 +18,11 @@ stdenv.mkDerivation rec {
   qmakeFlags = [ "MUPARSER_DIR=${muparser}" "BOOST_DIR=${boost.dev}" ];
 
   installPhase = ''
-    mkdir -p $out/bin $out/share
-    cp -R unix/librecad $out/bin
+    install -m 555 -D unix/librecad $out/bin/librecad
+    install -m 444 -D desktop/librecad.desktop $out/share/applications/librecad.desktop
+    install -m 444 -D desktop/librecad.sharedmimeinfo $out/share/mime/packages/librecad.xml
+    install -m 444 -D desktop/graphics_icons_and_splash/Icon\ LibreCAD/Icon_Librecad.svg \
+      $out/share/icons/hicolor/scalable/apps/librecad.svg
     cp -R unix/resources $out/share/librecad
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Use the .desktop file and app icon included in the source package.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
