### PR TITLE
weechatScripts.weechat-autosort: unstable-2018-01-11 -> 3.4

### DIFF
--- a/pkgs/applications/networking/irc/weechat/scripts/weechat-autosort/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/weechat-autosort/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
-  name = "weechat-autosort-${version}";
-  version = "unstable-2018-01-11";
+  pname = "weechat-autosort";
+  version = "3.4";
 
   src = fetchFromGitHub {
     owner = "de-vri-es";
-    repo = "weechat-autosort";
-    rev = "35ccd6335afd78ae8a6e050ed971d54c8524e37e";
-    sha256 = "1rgws960xys65cd1m529csalcgny87h7fkiwjv1yj9rpqp088z26";
+    repo = pname;
+    rev = version;
+    sha256 = "1sbr6ga9krrfgqznvsxjd3hdxzkvslh41ls5xrj7l2p4ws4gwlkn";
   };
 
   passthru.scripts = [ "autosort.py" ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
