### PR TITLE
tup: Let tup passthrough NIX_* env vars

### DIFF
--- a/pkgs/development/tools/build-managers/tup/default.nix
+++ b/pkgs/development/tools/build-managers/tup/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ fuse pcre ];
 
+  patches = [ ./tup_passthrough_nix_env.patch ];
+
   configurePhase = ''
     sed -i 's/`git describe`/v${version}/g' src/tup/link.sh
     sed -i 's/pcre-confg/pkg-config pcre/g' Tupfile Tuprules.tup

--- a/pkgs/development/tools/build-managers/tup/tup_passthrough_nix_env.patch
+++ b/pkgs/development/tools/build-managers/tup/tup_passthrough_nix_env.patch
@@ -1,0 +1,58 @@
+diff --git a/src/tup/environ.c b/src/tup/environ.c
+index c68a3f19..5ed728c8 100644
+--- a/src/tup/environ.c
++++ b/src/tup/environ.c
+@@ -22,6 +22,9 @@
+ #include "entry.h"
+ #include "db.h"
+ 
++#include <stdio.h>
++#include <string.h>
++
+ static const char *default_env[] = {
+ /* NOTE: Please increment PARSER_VERSION if these are modified */
+ 	"PATH",
+@@ -44,15 +47,40 @@ static const char *default_env[] = {
+ /* NOTE: Please increment PARSER_VERSION if these are modified */
+ };
+ 
++extern char **environ;
++
++static int environ_add_var(struct tupid_entries *root, const char *var)
++{
++	struct tup_entry *tent;
++	if(tup_db_findenv(var, &tent) < 0)
++		return -1;
++	if(tupid_tree_add_dup(root, tent->tnode.tupid) < 0)
++		return -1;
++	return 0;
++}
++
+ int environ_add_defaults(struct tupid_entries *root)
+ {
+ 	unsigned int x;
+-	struct tup_entry *tent;
++	char **env;
++	char *prefix;
+ 	for(x=0; x<sizeof(default_env) / sizeof(default_env[0]); x++) {
+-		if(tup_db_findenv(default_env[x], &tent) < 0)
++		if(environ_add_var(root, default_env[x]) < 0)
+ 			return -1;
+-		if(tupid_tree_add_dup(root, tent->tnode.tupid) < 0)
++	}
++	for(env=environ; *env; ++env) {
++		if(strncmp("NIX_", *env, 4)) {
++			continue;
++		}
++
++		for (x=0; (*env)[x] && (*env)[x] != '='; ++x) {}
++		prefix = strndup(*env, x);
++
++		if(environ_add_var(root, prefix) < 0)  {
++			free(prefix);
+ 			return -1;
++		}
++		free(prefix);
+ 	}
+ 	return 0;
+ }


### PR DESCRIPTION
###### Motivation for this change

`tup` prunes all environment variables for all subprocesses that it starts. Some variables like `PATH` are passed through. This prevents `nix-shell` C and C++ environments from giving the compiler the right include and library folders for compiling/linking with/against external libraries.

At least the variables are needed for the typical c/c++ wrapper in nix:

- `NIX_CFLAGS_COMPILE`
- `NIX_LDFLAGS`
- `NIX_CC_WRAPPER_x86_64_unknown_linux_gnu_TARGET_HOST` (If this is not set in the env, then the compiler wrapper will also not consume the other two vars, which is critical)

This PR adds a patch to `tup` which passes through all environment variables that are prefixed with `NIX_` in order to provide a painless build experience in e.g. C++ projects with external libs.

This only affects the tup workflow in `nix-shell`. (For sandboxed nix build environments, users typically use `tup generate` to generate a shell script that performs the build process, because `tup` wants the SUID bit set, which is not allowed within `nix-build`)

Example:

Tup project with `hello.cpp`:

```c++
#include <boost/lexical_cast.hpp>
#include <iostream>

int main() {
  std::cout << "Hello World!\n"
    << "Boost: " << (BOOST_VERSION / 100000) << '.'
                 << (BOOST_VERSION / 100 % 1000) << '.'
                 << (BOOST_VERSION % 100) << '\n';
}
```

...and `Tupfile`:

```
: hello.cpp |> c++ hello.cpp -o hello |> hello
```

When building this with an unpatched `tup` in a `nix-shell`, you get the following error:

```bash
$ nix-shell -p boost tup --run "tup"
[ tup ] [0.000s] Scanning filesystem...
[ tup ] [0.000s] Reading in new environment variables...
[ tup ] [0.000s] No Tupfiles to parse.
[ tup ] [0.000s] No files to delete.
[ tup ] [0.000s] Executing Commands...
* 0) c++ hello.cpp -o hello                                                                                         
hello.cpp:1:10: fatal error: boost/lexical_cast.hpp: No such file or directory
 #include <boost/lexical_cast.hpp>
          ^~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
 *** tup messages ***
 *** Command ID=28 failed with return value 1
 [ ] 100%
 *** tup: 1 job failed.
```

The patched version correctly passes through all the nix vars to the compiler wrapper and then it works:

```bash
$ NIX_PATH=nixpkgs=patchednixpkgs nix-shell -p boost tup --run "tup"
[ tup ] [0.000s] Scanning filesystem...
[ tup ] [0.011s] Reading in new environment variables...
[ tup ] [0.011s] Parsing Tupfiles...
 0) [0.003s] .
 [ ] 100%
[ tup ] [0.020s] No files to delete.                                                                                              
[ tup ] [0.020s] Generating .gitignore files...
[ tup ] [0.026s] Executing Commands...
 0) [0.592s] c++ hello.cpp -o hello                                                                                               
 [ ] 100%
[ tup ] [0.628s] Updated.     
```

...because this time the compiler got all the include folders right via `NIX_CFLAGS_COMPILE`.

(please note that in order to perform this at home one needs to delete the `.tup` directory in the project and rerun `tup init` because that folder's state would lead to the same old error)

An alternative to this patch is prepending the following lines to every tup project's root `Tupfile`:

```
export NIX_CFLAGS_COMPILE
export NIX_LDFLAGS
export NIX_CC_WRAPPER_x86_64_unknown_linux_gnu_TARGET_HOST
```

This does also work, but please note that:

- This is the same for _all_ tup projects just to be able to use `nix-shell`, so i'd personally prefer `tup` not taking these nix-specific env vars away in the first place
- the `NIX_CC_WRAPPER...` env var name is arch- and OS-specific, so this is not a portable addition to tupfiles... The `tup` patch presented does it right, no matter what target platform is selected, because it is generic.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
