### PR TITLE
waf: make reproducible

### DIFF
--- a/pkgs/development/tools/build-managers/waf/default.nix
+++ b/pkgs/development/tools/build-managers/waf/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitLab, python, ensureNewerSourcesForZipFilesHook }:
+{ stdenv, fetchFromGitLab, fetchpatch, python, ensureNewerSourcesForZipFilesHook }:
 
 stdenv.mkDerivation rec {
   name = "waf-${version}";
@@ -10,6 +10,13 @@ stdenv.mkDerivation rec {
     rev = name;
     sha256 = "006a4wb9i569pahs8ji86hrv58g2hm8xikgchnll3bdqgxllhnrs";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://gitlab.com/grahamc/waf/commit/fc1c98f1fb575fb26b867a61cbca79aa894db2ea.patch";
+      sha256 = "0kzfrr6nh1ay8nyk0i69nhkkrq7hskn7yw1qyjxrda1y3wxj6jp8";
+    })
+  ];
 
   buildInputs = [ python ensureNewerSourcesForZipFilesHook ];
 


### PR DESCRIPTION

###### Motivation for this change

Make waf reproducible.

Please test to see if this is reproducible on your system:

```
grep REVISION= $(nix-build . -A waf )
```

I hope you get `REVISION="492eeeb1294054d82d4520c9c5990db3"`.
