### PR TITLE
liburing: init at 1.0.0pre821_39e0ebd

### DIFF
--- a/pkgs/development/libraries/liburing/default.nix
+++ b/pkgs/development/libraries/liburing/default.nix
@@ -1,0 +1,40 @@
+{ stdenv, fetchgit
+}:
+
+stdenv.mkDerivation rec {
+  name = "liburing-${version}";
+  version = "1.0.0pre821_${builtins.substring 0 7 src.rev}";
+
+  src = fetchgit {
+    url    = "http://git.kernel.dk/liburing";
+    rev    = "39e0ebd4fc66046bf733a47aaa899a556093ebc6";
+    sha256 = "00c72fizxmwxd2jzmlzi4l82cw7h75lfpkkwzwcjpw9zdg9w0ci7";
+  };
+
+  enableParallelBuilding = true;
+
+  outputs = [ "out" "lib" "dev" "man" ];
+
+  installFlags =
+    [ "prefix=$(out)"
+      "includedir=$(dev)/include"
+      "libdir=$(lib)/lib"
+    ];
+
+  # Copy the examples into $out and man pages into $man. This should be handled
+  # by the build system in the future and submitted upstream.
+  postInstall = ''
+    mkdir -p $out/bin $man/share/man/man2/
+    cp -R ./man/* $man/share/man/man2
+    cp ./examples/io_uring-cp examples/io_uring-test $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Userspace library for the Linux io_uring API";
+    homepage    = http://git.kernel.dk/cgit/liburing/;
+    license     = licenses.lgpl21;
+    platforms   = platforms.linux;
+    maintainers = with maintainers; [ thoughtpolice ];
+    badPlatforms = [ "aarch64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11155,6 +11155,8 @@ in
 
   libiio = callPackage ../development/libraries/libiio { };
 
+  liburing = callPackage ../development/libraries/liburing { };
+
   libseccomp = callPackage ../development/libraries/libseccomp { };
 
   libsecret = callPackage ../development/libraries/libsecret { };


### PR DESCRIPTION
This adds preliminary support for a pre-release version of the `liburing` package, which will expose a convenient user-space interface to the upcoming `io_uring` API featured in Linux 5.1.

For the interested, see here for more information about the motivation and design behind this API: http://kernel.dk/io_uring.pdf

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
