### PR TITLE
perl.meta.priority += 1

### DIFF
--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -168,6 +168,7 @@ let
       license = licenses.artistic1;
       maintainers = [ maintainers.eelco ];
       platforms = platforms.all;
+      priority = 6; # in `buildEnv' (including the one inside `perl.withPackages') the library files will have priority over files in `perl`
     };
   } // stdenv.lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) rec {
     crossVersion = "276849e62f472c1b241d9e7b38a28e4cc9f98563"; # Dez 02, 2018

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -5105,7 +5105,6 @@ let
       url = "mirror://cpan/authors/id/D/DA/DANKOGAI/${name}.tar.gz";
       sha256 = "4b538b47459cf5747b7395ccc8c8c9b3b661cc016c50b8a67e10fe19590fea5e";
     };
-    postInstall = "rm $out/bin/{enc2xs,encguess,piconv} $out/share/man/man1/{enc2xs,encguess,piconv}.1"; # remove the files perl-5.28 already has
     meta = {
       description = "Character encodings in Perl";
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];


### PR DESCRIPTION
give priority to ```perl``` libraries when they meet the perl derivation in ```buildEnv```.

The notable case is ```buildEnv``` inside ```perl.withPackages```.

The ```perl``` derivation includes obsolete versions of some CPAN packages
which leads to collissions when there are newer versions
of the same libraries are on the right hand side
of ```perl.withPackages``` (perhaps indirectly).

Fixes #60025

https://github.com/NixOS/nixpkgs/commit/f73eb61113998952f742e3c542a9e95d9791abd4 is undone as no longer needed

@aanderse