### PR TITLE
kde_applications: 18.12.03 -> 19.04.1; kdeFrameworks: 5.56 -> 5.58; plasma-5: 5.15.3 -> 5.15.5

### DIFF
--- a/pkgs/applications/kde/akonadi/0001-Revert-Make-Akonadi-installation-properly-relocatabl.patch
+++ b/pkgs/applications/kde/akonadi/0001-Revert-Make-Akonadi-installation-properly-relocatabl.patch
@@ -38,12 +38,15 @@ index 75abede50..10f039376 100644
  
  find_dependency(Boost "@Boost_MINIMUM_VERSION@")
  
-@@ -22,4 +22,4 @@ include(${CMAKE_CURRENT_LIST_DIR}/KF5AkonadiTargets.cmake)
+@@ -22,7 +22,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/KF5AkonadiTargets.cmake)
  include(${CMAKE_CURRENT_LIST_DIR}/KF5AkonadiMacros.cmake)
  
  # The directory where akonadi-xml.xsd and kcfg2dbus.xsl are installed
 -set(KF5Akonadi_DATA_DIR "@PACKAGE_KF5Akonadi_DATA_DIR@")
 +set(KF5Akonadi_DATA_DIR "@KF5Akonadi_DATA_DIR@")
+
+ ####################################################################################
+ # CMAKE_AUTOMOC
 -- 
 2.15.1
 

--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -102,7 +102,7 @@ let
       kdegraphics-thumbnailers = callPackage ./kdegraphics-thumbnailers.nix {};
       kdenetwork-filesharing = callPackage ./kdenetwork-filesharing.nix {};
       kdenlive = callPackage ./kdenlive.nix {};
-      kdepim-runtime = callPackage ./kdepim-runtime.nix {};
+      kdepim-runtime = callPackage ./kdepim-runtime {};
       kdepim-addons = callPackage ./kdepim-addons.nix {};
       kdepim-apps-libs = callPackage ./kdepim-apps-libs {};
       kdf = callPackage ./kdf.nix {};

--- a/pkgs/applications/kde/fetch.sh
+++ b/pkgs/applications/kde/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/applications/19.04.0/ )
+WGET_ARGS=( https://download.kde.org/stable/applications/19.04.1/ )

--- a/pkgs/applications/kde/fetch.sh
+++ b/pkgs/applications/kde/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/applications/18.12.3/ )
+WGET_ARGS=( https://download.kde.org/stable/applications/19.04.0/ )

--- a/pkgs/applications/kde/kcalc.nix
+++ b/pkgs/applications/kde/kcalc.nix
@@ -1,8 +1,8 @@
 {
   mkDerivation, lib,
   extra-cmake-modules, kdoctools,
-  gmp, kconfig, kconfigwidgets, kguiaddons, ki18n, kinit, knotifications,
-  kxmlgui,
+  gmp, kconfig, kconfigwidgets, kcrash, kguiaddons, ki18n, kinit,
+  knotifications, kxmlgui,
 }:
 
 mkDerivation {
@@ -13,6 +13,7 @@ mkDerivation {
   };
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [
-    gmp kconfig kconfigwidgets kguiaddons ki18n kinit knotifications kxmlgui
+    gmp kconfig kconfigwidgets kcrash kguiaddons ki18n kinit knotifications
+    kxmlgui
   ];
 }

--- a/pkgs/applications/kde/kdegraphics-thumbnailers.nix
+++ b/pkgs/applications/kde/kdegraphics-thumbnailers.nix
@@ -1,6 +1,6 @@
 {
   mkDerivation, lib,
-  extra-cmake-modules, kio, libkexiv2, libkdcraw
+  extra-cmake-modules, karchive, kio, libkexiv2, libkdcraw
 }:
 
 mkDerivation {
@@ -10,5 +10,5 @@ mkDerivation {
     maintainers = [ lib.maintainers.ttuegel ];
   };
   nativeBuildInputs = [ extra-cmake-modules ];
-  buildInputs = [ kio libkexiv2 libkdcraw ];
+  buildInputs = [ karchive kio libkexiv2 libkdcraw ];
 }

--- a/pkgs/applications/kde/kdenlive.nix
+++ b/pkgs/applications/kde/kdenlive.nix
@@ -25,6 +25,9 @@
 , qtquickcontrols
 , qtscript
 , qtwebkit
+, rttr
+, kpurpose
+, kdeclarative
 }:
 
 mkDerivation {
@@ -57,6 +60,9 @@ mkDerivation {
     shared-mime-info
     libv4l
     ffmpeg
+    rttr
+    kpurpose
+    kdeclarative
   ];
   postPatch =
     # Module Qt5::Concurrent must be included in `find_package` before it is used.

--- a/pkgs/applications/kde/kdepim-runtime.nix
+++ b/pkgs/applications/kde/kdepim-runtime.nix
@@ -24,4 +24,9 @@ mkDerivation {
   ];
   # Attempts to build some files before dependencies have been generated
   enableParallelBuilding = false;
+
+  # build failure, not worth fixing, rc anyway
+  postPatch = ''
+    sed -i resources/CMakeLists.txt -e '/facebook/d'
+  '';
 }

--- a/pkgs/applications/kde/kdepim-runtime.nix
+++ b/pkgs/applications/kde/kdepim-runtime.nix
@@ -5,7 +5,8 @@
   akonadi, akonadi-calendar, akonadi-contacts, akonadi-mime, akonadi-notes,
   kalarmcal, kcalutils, kcontacts, kdav, kdelibs4support, kidentitymanagement,
   kimap, kmailtransport, kmbox, kmime, knotifications, knotifyconfig,
-  pimcommon, qtwebengine, libkgapi, qtspeech, qtxmlpatterns
+  pimcommon, qtwebengine, libkgapi, qtspeech, qtxmlpatterns,
+  qca-qt5, qtnetworkauth
 }:
 
 mkDerivation {
@@ -19,7 +20,7 @@ mkDerivation {
     akonadi akonadi-calendar akonadi-contacts akonadi-mime akonadi-notes
     kalarmcal kcalutils kcontacts kdav kdelibs4support kidentitymanagement kimap
     kmailtransport kmbox kmime knotifications knotifyconfig qtwebengine
-    pimcommon libkgapi qtspeech qtxmlpatterns
+    pimcommon libkgapi qtspeech qtxmlpatterns qca-qt5 qtnetworkauth
   ];
   # Attempts to build some files before dependencies have been generated
   enableParallelBuilding = false;

--- a/pkgs/applications/kde/kdepim-runtime/00-no-facebook.patch
+++ b/pkgs/applications/kde/kdepim-runtime/00-no-facebook.patch
@@ -1,0 +1,12 @@
+diff --git a/resources/CMakeLists.txt b/resources/CMakeLists.txt
+index 99f7dbf..03e953b 100644
+--- a/resources/CMakeLists.txt
++++ b/resources/CMakeLists.txt
+@@ -45,7 +45,6 @@ add_subdirectory( imap )
+ if (Libkolabxml_FOUND)
+     add_subdirectory( kolab )
+ endif()
+-add_subdirectory( facebook )
+ add_subdirectory( maildir )
+ 
+ add_subdirectory( openxchange )

--- a/pkgs/applications/kde/kdepim-runtime/default.nix
+++ b/pkgs/applications/kde/kdepim-runtime/default.nix
@@ -1,12 +1,11 @@
 {
-  mkDerivation, lib, kdepimTeam,
+  mkDerivation, copyPathsToStore, lib, kdepimTeam,
   extra-cmake-modules, kdoctools,
   shared-mime-info,
   akonadi, akonadi-calendar, akonadi-contacts, akonadi-mime, akonadi-notes,
   kalarmcal, kcalutils, kcontacts, kdav, kdelibs4support, kidentitymanagement,
   kimap, kmailtransport, kmbox, kmime, knotifications, knotifyconfig,
-  pimcommon, qtwebengine, libkgapi, qtspeech, qtxmlpatterns,
-  qca-qt5, qtnetworkauth
+  pimcommon, qtwebengine, libkgapi, qtnetworkauth, qtspeech, qtxmlpatterns,
 }:
 
 mkDerivation {
@@ -15,18 +14,14 @@ mkDerivation {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;
   };
+  patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);
   nativeBuildInputs = [ extra-cmake-modules kdoctools shared-mime-info ];
   buildInputs = [
     akonadi akonadi-calendar akonadi-contacts akonadi-mime akonadi-notes
     kalarmcal kcalutils kcontacts kdav kdelibs4support kidentitymanagement kimap
     kmailtransport kmbox kmime knotifications knotifyconfig qtwebengine
-    pimcommon libkgapi qtspeech qtxmlpatterns qca-qt5 qtnetworkauth
+    pimcommon libkgapi qtnetworkauth qtspeech qtxmlpatterns
   ];
   # Attempts to build some files before dependencies have been generated
   enableParallelBuilding = false;
-
-  # build failure, not worth fixing, rc anyway
-  postPatch = ''
-    sed -i resources/CMakeLists.txt -e '/facebook/d'
-  '';
 }

--- a/pkgs/applications/kde/kdepim-runtime/series
+++ b/pkgs/applications/kde/kdepim-runtime/series
@@ -1,0 +1,1 @@
+00-no-facebook.patch

--- a/pkgs/applications/kde/kio-extras.nix
+++ b/pkgs/applications/kde/kio-extras.nix
@@ -2,8 +2,8 @@
   mkDerivation, lib, extra-cmake-modules, kdoctools, shared-mime-info,
   exiv2, kactivities, karchive, kbookmarks, kconfig, kconfigwidgets,
   kcoreaddons, kdbusaddons, kguiaddons, kdnssd, kiconthemes, ki18n, kio, khtml,
-  kdelibs4support, kpty, libmtp, libssh, openexr, ilmbase, openslp, phonon,
-  qtsvg, samba, solid, gperf
+  kdelibs4support, kpty, syntax-highlighting, libmtp, libssh, openexr, ilmbase,
+  openslp, phonon, qtsvg, samba, solid, gperf
 }:
 
 mkDerivation {
@@ -16,7 +16,8 @@ mkDerivation {
   buildInputs = [
     exiv2 kactivities karchive kbookmarks kconfig kconfigwidgets kcoreaddons
     kdbusaddons kguiaddons kdnssd kiconthemes ki18n kio khtml kdelibs4support
-    kpty libmtp libssh openexr openslp phonon qtsvg samba solid gperf
+    kpty syntax-highlighting libmtp libssh openexr openslp phonon qtsvg samba
+    solid gperf
   ];
   CXXFLAGS = [ "-I${ilmbase.dev}/include/OpenEXR" ];
 }

--- a/pkgs/applications/kde/kmail.nix
+++ b/pkgs/applications/kde/kmail.nix
@@ -26,4 +26,5 @@ mkDerivation {
     libksieve mailcommon messagelib pim-sieve-editor qtscript qtwebengine
   ];
   propagatedUserEnvPkgs = [ kdepim-runtime kwallet ];
+  patches = [ ./kmail.patch ];
 }

--- a/pkgs/applications/kde/kmail.patch
+++ b/pkgs/applications/kde/kmail.patch
@@ -1,0 +1,24 @@
+diff --git a/agents/archivemailagent/CMakeLists.txt b/agents/archivemailagent/CMakeLists.txt
+index 48ed076..9c56896 100644
+--- a/agents/archivemailagent/CMakeLists.txt
++++ b/agents/archivemailagent/CMakeLists.txt
+@@ -22,6 +22,7 @@ ki18n_wrap_ui(libarchivemailagent_SRCS ui/archivemailwidget.ui )
+ add_library(archivemailagent STATIC ${libarchivemailagent_SRCS})
+ target_link_libraries(archivemailagent
+     KF5::MailCommon
++    KF5::Libkdepim
+     KF5::I18n
+     KF5::Notifications
+     KF5::IconThemes
+diff --git a/agents/followupreminderagent/CMakeLists.txt b/agents/followupreminderagent/CMakeLists.txt
+index a56b730..83604cf 100644
+--- a/agents/followupreminderagent/CMakeLists.txt
++++ b/agents/followupreminderagent/CMakeLists.txt
+@@ -23,6 +23,7 @@ target_link_libraries(followupreminderagent
+     KF5::AkonadiMime
+     KF5::AkonadiAgentBase
+     KF5::DBusAddons
++    KF5::FollowupReminder
+     KF5::XmlGui
+     KF5::KIOWidgets
+     KF5::Notifications

--- a/pkgs/applications/kde/krdc.nix
+++ b/pkgs/applications/kde/krdc.nix
@@ -2,7 +2,7 @@
   mkDerivation, lib,
   extra-cmake-modules, kdoctools, makeWrapper,
   kcmutils, kcompletion, kconfig, kdnssd, knotifyconfig, kwallet, kwidgetsaddons,
-  libvncserver, freerdp
+  kwindowsystem, libvncserver, freerdp
 }:
 
 mkDerivation {
@@ -10,7 +10,7 @@ mkDerivation {
   nativeBuildInputs = [ extra-cmake-modules kdoctools makeWrapper ];
   buildInputs = [
     kcmutils kcompletion kconfig kdnssd knotifyconfig kwallet kwidgetsaddons
-    freerdp libvncserver
+    kwindowsystem freerdp libvncserver
   ];
   postFixup = ''
     wrapProgram $out/bin/krdc \

--- a/pkgs/applications/kde/srcs.nix
+++ b/pkgs/applications/kde/srcs.nix
@@ -3,1723 +3,1723 @@
 
 {
   akonadi = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/akonadi-19.04.0.tar.xz";
-      sha256 = "c0a2c4259b51293d21487cfe2295df6e8dcfb7ab50eb1a698f531dc7d3253e9a";
-      name = "akonadi-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/akonadi-19.04.1.tar.xz";
+      sha256 = "b157c4199e3b913c4f684f56ed9d76bef67b3c120c319c88ae24bded6fc927bc";
+      name = "akonadi-19.04.1.tar.xz";
     };
   };
   akonadi-calendar = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/akonadi-calendar-19.04.0.tar.xz";
-      sha256 = "5a2897a1e96897159a3e2980f407c4c225434efd45167ad699a14aaa2ec445fd";
-      name = "akonadi-calendar-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/akonadi-calendar-19.04.1.tar.xz";
+      sha256 = "6ef352dc20998416b8d379b085edfcfba5bcf6a5f448e11a4e51aca6b3241e48";
+      name = "akonadi-calendar-19.04.1.tar.xz";
     };
   };
   akonadi-calendar-tools = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/akonadi-calendar-tools-19.04.0.tar.xz";
-      sha256 = "f9869574d880c53bfb87319348d75d8169ffb38bfdeb3b6066f25074409321ef";
-      name = "akonadi-calendar-tools-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/akonadi-calendar-tools-19.04.1.tar.xz";
+      sha256 = "6a8eb905d0e5a1602ce59d5cf28322d844dc178c4daf98db1cf9e0c95eeb3531";
+      name = "akonadi-calendar-tools-19.04.1.tar.xz";
     };
   };
   akonadiconsole = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/akonadiconsole-19.04.0.tar.xz";
-      sha256 = "5118720b6e0ecdf689c7b7f005f732386d0b7a6258cc11fb44fcaac5cc9518a8";
-      name = "akonadiconsole-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/akonadiconsole-19.04.1.tar.xz";
+      sha256 = "33846348b0308eaf4ca81e8d577ce0eb6c17d49632e034607506413e86531262";
+      name = "akonadiconsole-19.04.1.tar.xz";
     };
   };
   akonadi-contacts = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/akonadi-contacts-19.04.0.tar.xz";
-      sha256 = "65dd20c467daf8d6107a1856c7f112eb937438b5884fe62a09a1763214a7442a";
-      name = "akonadi-contacts-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/akonadi-contacts-19.04.1.tar.xz";
+      sha256 = "4c58a73db7924250e47fb030657dc768fe44405806ec2d94ee00a264b414febc";
+      name = "akonadi-contacts-19.04.1.tar.xz";
     };
   };
   akonadi-import-wizard = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/akonadi-import-wizard-19.04.0.tar.xz";
-      sha256 = "541b858278d56a5d41858bfa644656d4f04bf6e5a52ce8014d207d64812d6d22";
-      name = "akonadi-import-wizard-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/akonadi-import-wizard-19.04.1.tar.xz";
+      sha256 = "2699ca57ea6a04228875dd795255fd32a1120e2e5c4834290aea3270c43403e7";
+      name = "akonadi-import-wizard-19.04.1.tar.xz";
     };
   };
   akonadi-mime = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/akonadi-mime-19.04.0.tar.xz";
-      sha256 = "b06ca4140b10548b9aecd188bd9b72405af2f4097c80e9b4e9aa3e863750b6da";
-      name = "akonadi-mime-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/akonadi-mime-19.04.1.tar.xz";
+      sha256 = "4572aa7c953cc641a98ae3c2685dcdf259d621dcbbab1ccb7d11e2748c67b1a8";
+      name = "akonadi-mime-19.04.1.tar.xz";
     };
   };
   akonadi-notes = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/akonadi-notes-19.04.0.tar.xz";
-      sha256 = "a9aa05ca2b5f846fed51e4c32907eedc6893a40ab3b9d4832e11bab118664e5f";
-      name = "akonadi-notes-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/akonadi-notes-19.04.1.tar.xz";
+      sha256 = "e503101e8806485ecf6ef22d1bafd8c299676ca75a388499e5418b8641604277";
+      name = "akonadi-notes-19.04.1.tar.xz";
     };
   };
   akonadi-search = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/akonadi-search-19.04.0.tar.xz";
-      sha256 = "6046a540ace526cbb8c0909762ad333426266afbf58a59ecc71cb923298e84bb";
-      name = "akonadi-search-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/akonadi-search-19.04.1.tar.xz";
+      sha256 = "8438876407e9fd8fa08afe6942ab8dd3677202bc2ff1eba4fd7a49dd926f26d6";
+      name = "akonadi-search-19.04.1.tar.xz";
     };
   };
   akregator = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/akregator-19.04.0.tar.xz";
-      sha256 = "5104b0b66ac3917c7cb78f4a6cca952f7e4360cfcd0aa7ce1575d0551470fcee";
-      name = "akregator-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/akregator-19.04.1.tar.xz";
+      sha256 = "b2e731a3eac0a68865a90b71f17307c3aea8db304bf6663b551bc95907a490f1";
+      name = "akregator-19.04.1.tar.xz";
     };
   };
   analitza = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/analitza-19.04.0.tar.xz";
-      sha256 = "ac8bf7d66f8a2fc7198238f23d82efd1021943ffe8bd5915808e31b800a802f6";
-      name = "analitza-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/analitza-19.04.1.tar.xz";
+      sha256 = "b96da492805a48faff72e93e1b8b211c468b041fe217489eb097d554773d3381";
+      name = "analitza-19.04.1.tar.xz";
     };
   };
   ark = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/ark-19.04.0.tar.xz";
-      sha256 = "35e8e516a8554e086264d9a9a4fa66c2b47fa227eb9e512a1d0d24172cd07a84";
-      name = "ark-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/ark-19.04.1.tar.xz";
+      sha256 = "6d348b2b9566ce0b8a1ba1b56d0a8c5d434d4748c479c5a853fdcdecfec753e6";
+      name = "ark-19.04.1.tar.xz";
     };
   };
   artikulate = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/artikulate-19.04.0.tar.xz";
-      sha256 = "527ebdb2db6eab3e05810c5e56d53611d80bd23508563457b459e4e32a68ef08";
-      name = "artikulate-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/artikulate-19.04.1.tar.xz";
+      sha256 = "11a54ef7abf001bd3debcaf46bc60764af55a2dbda6320c3c220461374f74432";
+      name = "artikulate-19.04.1.tar.xz";
     };
   };
   audiocd-kio = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/audiocd-kio-19.04.0.tar.xz";
-      sha256 = "0f347be9c873eb75144d2b8f3f2e28d2e52be4c1a0f59a19be99edd867f17371";
-      name = "audiocd-kio-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/audiocd-kio-19.04.1.tar.xz";
+      sha256 = "fad61ea586db7a4ce202fbb16854f69a20e8e16518dd60c27112447a904edb98";
+      name = "audiocd-kio-19.04.1.tar.xz";
     };
   };
   baloo-widgets = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/baloo-widgets-19.04.0.tar.xz";
-      sha256 = "ab3d83bb1f2007620273d1a3eb580d821e0655aaf7e3efd2dc81087a24d1c275";
-      name = "baloo-widgets-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/baloo-widgets-19.04.1.tar.xz";
+      sha256 = "7f7f0b3ba1bbdb3a47cdfa85830295b4b91fa5ac6c87b41d1cf29c354d8a4cf6";
+      name = "baloo-widgets-19.04.1.tar.xz";
     };
   };
   blinken = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/blinken-19.04.0.tar.xz";
-      sha256 = "5d470c7f0d232ea01c99fbe1ed08e103291e80c3cfe74e245aba1c2009573eed";
-      name = "blinken-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/blinken-19.04.1.tar.xz";
+      sha256 = "87fbf14568692885e7a496a8dae0c4f53a2837d1a824f9c7cf1038a7e8c861ca";
+      name = "blinken-19.04.1.tar.xz";
     };
   };
   bomber = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/bomber-19.04.0.tar.xz";
-      sha256 = "4f82f3f42aff36de837f7c9ddc5986f6c73cb50de122b46320dba0a0b03f9a7d";
-      name = "bomber-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/bomber-19.04.1.tar.xz";
+      sha256 = "1359ebcaab26acd2dfa738160f9dd7a86e5bfa3d3b2f8a86c656ee187ad6c3fe";
+      name = "bomber-19.04.1.tar.xz";
     };
   };
   bovo = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/bovo-19.04.0.tar.xz";
-      sha256 = "2cfccb09087a32d8a75f6dd763168e2ef5928f55b58505a542bc36fdac8e141e";
-      name = "bovo-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/bovo-19.04.1.tar.xz";
+      sha256 = "46b5286349ba7765b81edf92f834c3e8e5c0ecd65466deb5fa593477e76f0763";
+      name = "bovo-19.04.1.tar.xz";
     };
   };
   calendarsupport = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/calendarsupport-19.04.0.tar.xz";
-      sha256 = "d767f077a9d41a9c6d266c4b5fe7bedd6f4eb7b71824e7544cf3a1df11ce362f";
-      name = "calendarsupport-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/calendarsupport-19.04.1.tar.xz";
+      sha256 = "9b44e868a24494c3ce595dc71e8981f97a8ce75dc4646e1417ebde973ee5f535";
+      name = "calendarsupport-19.04.1.tar.xz";
     };
   };
   cantor = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/cantor-19.04.0.tar.xz";
-      sha256 = "ef0381a65cd2f3a3bb68a7211140077fc1a9bf31ed5302fa368fd874c8441bf4";
-      name = "cantor-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/cantor-19.04.1.tar.xz";
+      sha256 = "95ce049f38182f9c0f7fb749c0940c24a51cc88053d218148ac82e925d9dfbb1";
+      name = "cantor-19.04.1.tar.xz";
     };
   };
   cervisia = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/cervisia-19.04.0.tar.xz";
-      sha256 = "011d9b38a82508ae73328dc56723af11fa8403c0dcf5b7d7703118d79f2ad8f4";
-      name = "cervisia-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/cervisia-19.04.1.tar.xz";
+      sha256 = "fe72361330b055922e4ae66edb2e6958897b7c443ab3066ab7bbef1b8fd9d41b";
+      name = "cervisia-19.04.1.tar.xz";
     };
   };
   dolphin = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/dolphin-19.04.0.tar.xz";
-      sha256 = "f3f45b9048c283252067eebfad8c6e1efc6bc64d43fcba78b933850ea4762375";
-      name = "dolphin-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/dolphin-19.04.1.tar.xz";
+      sha256 = "72cab4d9f49ac05d3e0e8e1ff67cf29c0cacbe2c3a43506eca4c849ea878370a";
+      name = "dolphin-19.04.1.tar.xz";
     };
   };
   dolphin-plugins = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/dolphin-plugins-19.04.0.tar.xz";
-      sha256 = "c2898e0a64d5a9eab2a4bd661694b75805adfd0a925f1a21f894892264f96469";
-      name = "dolphin-plugins-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/dolphin-plugins-19.04.1.tar.xz";
+      sha256 = "dc528e93d3f7809b8480da5134ead3886205a172a85b25ffdd5720ec67892105";
+      name = "dolphin-plugins-19.04.1.tar.xz";
     };
   };
   dragon = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/dragon-19.04.0.tar.xz";
-      sha256 = "42bde9f6a4f3dfe7a6b2bfa35502474c2866e2649695302d602a97f00842fcf2";
-      name = "dragon-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/dragon-19.04.1.tar.xz";
+      sha256 = "f8acfc09aeec180850345f8881f963c19a3956cd7e07e42463bbe95ff2227ab8";
+      name = "dragon-19.04.1.tar.xz";
     };
   };
   eventviews = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/eventviews-19.04.0.tar.xz";
-      sha256 = "ed34f228012ad2d45b0f07da469633118f35c28b1ddc7157149f4a5ab999500c";
-      name = "eventviews-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/eventviews-19.04.1.tar.xz";
+      sha256 = "1fae8263d17a802393e5b1ece80879b66303f4d5bc8cc040cf142d6d5e8cc763";
+      name = "eventviews-19.04.1.tar.xz";
     };
   };
   ffmpegthumbs = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/ffmpegthumbs-19.04.0.tar.xz";
-      sha256 = "6b96cea0c142651cb586eb40d88792329f8da9a777d9a457ba76d0e94ddf4995";
-      name = "ffmpegthumbs-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/ffmpegthumbs-19.04.1.tar.xz";
+      sha256 = "76f912f09c01698ed020bce2109f7cb893a9ca3ca7c014b118c0f97b4b4982ae";
+      name = "ffmpegthumbs-19.04.1.tar.xz";
     };
   };
   filelight = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/filelight-19.04.0.tar.xz";
-      sha256 = "22eaa8f0e9e69652240554687b2cecb55449e67caac6055c2d868f3089d835ad";
-      name = "filelight-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/filelight-19.04.1.tar.xz";
+      sha256 = "7595efbff5cbbe59b3fc4f6af69b9557107bc8661f38951577947503ac7883bd";
+      name = "filelight-19.04.1.tar.xz";
     };
   };
   granatier = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/granatier-19.04.0.tar.xz";
-      sha256 = "d83e91a5056e4caf1e522921025cb79355c0c2d53b7f0e98444d37291d80d63a";
-      name = "granatier-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/granatier-19.04.1.tar.xz";
+      sha256 = "372dd577805457425bb9c35b5f434089aa2bb7c1e6f54908b2be60d4dda2cb22";
+      name = "granatier-19.04.1.tar.xz";
     };
   };
   grantlee-editor = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/grantlee-editor-19.04.0.tar.xz";
-      sha256 = "ac888f2f2ccd4b289deac1d2df4415124e14bf183db1ff1088e88fa782f9f342";
-      name = "grantlee-editor-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/grantlee-editor-19.04.1.tar.xz";
+      sha256 = "b07f3c3179010b1d9a9170bc6e2b85517c3dfbd277336316882f4503823e076a";
+      name = "grantlee-editor-19.04.1.tar.xz";
     };
   };
   grantleetheme = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/grantleetheme-19.04.0.tar.xz";
-      sha256 = "6896a7e1db662bea03b6bdd9f92214b5fa50dfbebbbaa7b3156ddb87ccd55a3e";
-      name = "grantleetheme-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/grantleetheme-19.04.1.tar.xz";
+      sha256 = "fdcf77c996123daea0559cc2ac4251b330e2c4388104ee95f814af770fc33d8b";
+      name = "grantleetheme-19.04.1.tar.xz";
     };
   };
   gwenview = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/gwenview-19.04.0.tar.xz";
-      sha256 = "c7d422bddf031fa9d5a23459c65ea6dbb5919e964cc194178a864ee98912b46d";
-      name = "gwenview-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/gwenview-19.04.1.tar.xz";
+      sha256 = "636498100284be86194d328c40ed70166cc96a5fc7665090e4a1ca9538b2f13c";
+      name = "gwenview-19.04.1.tar.xz";
     };
   };
   incidenceeditor = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/incidenceeditor-19.04.0.tar.xz";
-      sha256 = "c34fd55acd2f92705e43628fd0c9c4a550c73d45f30beba71dc75698143cbd5f";
-      name = "incidenceeditor-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/incidenceeditor-19.04.1.tar.xz";
+      sha256 = "f0f5191e4246068fb941fde10df87b76b5ca1d6f491d864e4b7e4acacebcae58";
+      name = "incidenceeditor-19.04.1.tar.xz";
     };
   };
   juk = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/juk-19.04.0.tar.xz";
-      sha256 = "952366e14526701109e83c1979c2a7b3dfdf3c054ecb86c9b5a6cf9825196f60";
-      name = "juk-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/juk-19.04.1.tar.xz";
+      sha256 = "f141c0e33eccd931438a1b1fe37810951ab177b3fe853d6dd387f28f59382e51";
+      name = "juk-19.04.1.tar.xz";
     };
   };
   k3b = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/k3b-19.04.0.tar.xz";
-      sha256 = "ab0293d0dab2048dcacd4fc54ee2e12d2f55adcecde7cd02e4c31ffd5917ee39";
-      name = "k3b-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/k3b-19.04.1.tar.xz";
+      sha256 = "8de611bec14deee5b5c2b340fa4b32d22a7df93a72b657979118b510396f0942";
+      name = "k3b-19.04.1.tar.xz";
     };
   };
   kaccounts-integration = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kaccounts-integration-19.04.0.tar.xz";
-      sha256 = "d7b257f6b7278361690b2c1d948c92bdb8b14f741ce96ef35f37c8eea3feb687";
-      name = "kaccounts-integration-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kaccounts-integration-19.04.1.tar.xz";
+      sha256 = "0e37dc9b7b1520ea16afc7209da3cbaab1d43c3909896eba2f0422fb23f15433";
+      name = "kaccounts-integration-19.04.1.tar.xz";
     };
   };
   kaccounts-providers = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kaccounts-providers-19.04.0.tar.xz";
-      sha256 = "4eb74ef042c30ea44f5391f8798d9ceca44d46bf46480355160af61bcb6236d7";
-      name = "kaccounts-providers-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kaccounts-providers-19.04.1.tar.xz";
+      sha256 = "006ccdc20738b8f77155e849b83987b9c9eeb50acf4e88d2fb948060c5f51011";
+      name = "kaccounts-providers-19.04.1.tar.xz";
     };
   };
   kaddressbook = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kaddressbook-19.04.0.tar.xz";
-      sha256 = "821708c0a33063de050682c7768faeb51a467de9c4314901761449c09a8a3265";
-      name = "kaddressbook-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kaddressbook-19.04.1.tar.xz";
+      sha256 = "15e84e6785e20e4f48020c093555e6c28930fcd946aa3421c56956564eba84fd";
+      name = "kaddressbook-19.04.1.tar.xz";
     };
   };
   kajongg = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kajongg-19.04.0.tar.xz";
-      sha256 = "832e76252321900f3bb3d3a96bb9f9a93235260803621c06d112b7cc48bd1555";
-      name = "kajongg-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kajongg-19.04.1.tar.xz";
+      sha256 = "5139ec428d4951b8e3dca8d30134002bc06b186c5c63c69831b3a98b49198475";
+      name = "kajongg-19.04.1.tar.xz";
     };
   };
   kalarm = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kalarm-19.04.0.tar.xz";
-      sha256 = "ed8f656e4aebb78d78f068ccde605489090ed0467452629784472b685fae331a";
-      name = "kalarm-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kalarm-19.04.1.tar.xz";
+      sha256 = "e8a58584e765c1d98beb4b6bcac0ab835dcb1f1c1bab8cf1c01fa01a2a56bbfd";
+      name = "kalarm-19.04.1.tar.xz";
     };
   };
   kalarmcal = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kalarmcal-19.04.0.tar.xz";
-      sha256 = "ec0790d2b04bcd3a37a221bdbf4a10f94ff7dd8ac0228e773ce9fac14bbebf6e";
-      name = "kalarmcal-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kalarmcal-19.04.1.tar.xz";
+      sha256 = "69a265ad7e82034974a47c795b81ee8768873dcb76018dc794a9905365111646";
+      name = "kalarmcal-19.04.1.tar.xz";
     };
   };
   kalgebra = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kalgebra-19.04.0.tar.xz";
-      sha256 = "a46c4fc2b0891183d0a3b859182eef8d49206b81cbf6d2c6ed6d5448f2663a4a";
-      name = "kalgebra-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kalgebra-19.04.1.tar.xz";
+      sha256 = "689d65f1a62623fc67d5de0a551aef03b241d85b105f31e91bd873d3b818c74f";
+      name = "kalgebra-19.04.1.tar.xz";
     };
   };
   kalzium = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kalzium-19.04.0.tar.xz";
-      sha256 = "16fe2873dfad5de78b9a07a4c528e8ac747a54eced9feaa65f1c9fccc23b0d03";
-      name = "kalzium-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kalzium-19.04.1.tar.xz";
+      sha256 = "80798b3dca98cdd5ae24bbe7f077ecbe8def6bb96ad02a66ff69cb5312a459f5";
+      name = "kalzium-19.04.1.tar.xz";
     };
   };
   kamera = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kamera-19.04.0.tar.xz";
-      sha256 = "b6b5891e886f543140d1ea6775ec1f1f4575e698d34af04fd65acbafa7e42392";
-      name = "kamera-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kamera-19.04.1.tar.xz";
+      sha256 = "3d5f97ac4b454c1512762f4039003d5745372aafa4fda4f293bda885ee70984f";
+      name = "kamera-19.04.1.tar.xz";
     };
   };
   kamoso = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kamoso-19.04.0.tar.xz";
-      sha256 = "200c805ba80a89026edcd02d4cd6d058eff1d537eb3da28807cb2162cc014765";
-      name = "kamoso-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kamoso-19.04.1.tar.xz";
+      sha256 = "72f31d26319aed86daf200db7cc0bbe1e6ad77d891b644001ffd4c992a68e796";
+      name = "kamoso-19.04.1.tar.xz";
     };
   };
   kanagram = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kanagram-19.04.0.tar.xz";
-      sha256 = "dda3ce8211957e016521597a923de92d261e32c31ebf84faa697bd26cf16647c";
-      name = "kanagram-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kanagram-19.04.1.tar.xz";
+      sha256 = "70b0f7b20f2ebd951e3a10097990f9232cd1e3e6c11441d93513d435a7cb7f38";
+      name = "kanagram-19.04.1.tar.xz";
     };
   };
   kapman = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kapman-19.04.0.tar.xz";
-      sha256 = "f77dd3210bcdfb2d424f7a919848e25a4b4ae994d74b59111f352e41c2086324";
-      name = "kapman-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kapman-19.04.1.tar.xz";
+      sha256 = "7714a0cbd8e24f3ce46679d1f16d690c8bc62a988f0b3175095e0f0c23ce1400";
+      name = "kapman-19.04.1.tar.xz";
     };
   };
   kapptemplate = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kapptemplate-19.04.0.tar.xz";
-      sha256 = "7983c4576c6168731958790851d732f8bd4f4313d2cd00a8bf4dd37a4b6a4bb4";
-      name = "kapptemplate-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kapptemplate-19.04.1.tar.xz";
+      sha256 = "5985705081aa94d282d173277e5717eede6f923eef4ed2d99182c46fbd1c9fd3";
+      name = "kapptemplate-19.04.1.tar.xz";
     };
   };
   kate = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kate-19.04.0.tar.xz";
-      sha256 = "64c3c312a69d45624e3619309b86de796f67d30a864433a5c24aeb4e299bacc9";
-      name = "kate-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kate-19.04.1.tar.xz";
+      sha256 = "af55513f00af1712a39631352e393dbd2f63ec6bd471831b44853a16d4bfbe8f";
+      name = "kate-19.04.1.tar.xz";
     };
   };
   katomic = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/katomic-19.04.0.tar.xz";
-      sha256 = "ea6e6642e16f985653caf2cd9dd61248e7038fb0246e9af4d4daec20401537a2";
-      name = "katomic-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/katomic-19.04.1.tar.xz";
+      sha256 = "2addfb86ec0043ab81046d64862e8fbeb3b4dd3b8d18f618ac8c39d995a05ce5";
+      name = "katomic-19.04.1.tar.xz";
     };
   };
   kbackup = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kbackup-19.04.0.tar.xz";
-      sha256 = "84b8f7b05a1812deb128a85aa2d6f1010fb7b2f8cb51aa3771077ef20fd4b4ce";
-      name = "kbackup-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kbackup-19.04.1.tar.xz";
+      sha256 = "29bed4258ec218edf05702808d0cfbff757016b7f3a80eb99e18610ab398036f";
+      name = "kbackup-19.04.1.tar.xz";
     };
   };
   kblackbox = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kblackbox-19.04.0.tar.xz";
-      sha256 = "9363167664b6b4e54325f9691333df912eefa1e19d387c9a2780626914b813f9";
-      name = "kblackbox-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kblackbox-19.04.1.tar.xz";
+      sha256 = "9b5d57d0058c2458b7e24bd885d164cc1523d0c45827082e55af6ce669992431";
+      name = "kblackbox-19.04.1.tar.xz";
     };
   };
   kblocks = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kblocks-19.04.0.tar.xz";
-      sha256 = "c70a60f3a2e4c8f7756a1f9b1e025f8f91ec83c4f54feedf0ba05eea36b0037e";
-      name = "kblocks-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kblocks-19.04.1.tar.xz";
+      sha256 = "0ae62f1aa9aeaa58f6e5fd62d6281159ef8a2bbee28d84b9d7a2ab207ec95390";
+      name = "kblocks-19.04.1.tar.xz";
     };
   };
   kblog = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kblog-19.04.0.tar.xz";
-      sha256 = "719c6ce92c006231869dcad84b14e3db7c8b71eff60e234a94353e2ef580d577";
-      name = "kblog-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kblog-19.04.1.tar.xz";
+      sha256 = "6c162cd25a67c4fddbdc1063942fdfad1bbb239c714f205ae4f89585c2f65e93";
+      name = "kblog-19.04.1.tar.xz";
     };
   };
   kbounce = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kbounce-19.04.0.tar.xz";
-      sha256 = "cd28d777db8ff1dc1437fb6456c2fdfe8b9005c0cea3ce05337fbf425803834f";
-      name = "kbounce-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kbounce-19.04.1.tar.xz";
+      sha256 = "729662f29e1b5b17b775bfa6895088cf3a7ee4ce3d4f2bc3db4f69ab0f07ca12";
+      name = "kbounce-19.04.1.tar.xz";
     };
   };
   kbreakout = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kbreakout-19.04.0.tar.xz";
-      sha256 = "c4aa847def701be288e53ceb27c8c63c34aa527f8e64c91fb007d053b1119db8";
-      name = "kbreakout-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kbreakout-19.04.1.tar.xz";
+      sha256 = "9f40bb1c2d2e29a1098e371ffd0e97595d8e23cc7af2111fd143b67fac1393ad";
+      name = "kbreakout-19.04.1.tar.xz";
     };
   };
   kbruch = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kbruch-19.04.0.tar.xz";
-      sha256 = "7762c233529b75859ab264bcfd9847acc06889b0ff96183a1af63effd40f3f38";
-      name = "kbruch-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kbruch-19.04.1.tar.xz";
+      sha256 = "ab9033b6b8758803a87f046d05c9f6a5d247d1929bad147628cb6c2e5ba65b00";
+      name = "kbruch-19.04.1.tar.xz";
     };
   };
   kcachegrind = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kcachegrind-19.04.0.tar.xz";
-      sha256 = "7021ac1b133e86692dad92ff8de6a0467c2b488d7e5c2977ee4880c166e088ca";
-      name = "kcachegrind-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kcachegrind-19.04.1.tar.xz";
+      sha256 = "4b862becaa415601dc33391814637d8f089f2e2732192111ec029beb89991ac2";
+      name = "kcachegrind-19.04.1.tar.xz";
     };
   };
   kcalc = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kcalc-19.04.0.tar.xz";
-      sha256 = "0384ebf83c62e74a2412f71f648bad112f91ef3ec6aa64fe55e63fd88a156593";
-      name = "kcalc-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kcalc-19.04.1.tar.xz";
+      sha256 = "46d992a9e746231b57398b9bcdbe3933f6601e3cee7e3932ccc2e312779a4c91";
+      name = "kcalc-19.04.1.tar.xz";
     };
   };
   kcalcore = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kcalcore-19.04.0.tar.xz";
-      sha256 = "0cdcfebabb9af96650b71ba6361a4557df35144f0b1041f004bff7510c6334b2";
-      name = "kcalcore-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kcalcore-19.04.1.tar.xz";
+      sha256 = "d14bf2f8270c0072e415cf8fe87c0fb8eefad1b95a8713e184bba3e3ae6002f9";
+      name = "kcalcore-19.04.1.tar.xz";
     };
   };
   kcalutils = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kcalutils-19.04.0.tar.xz";
-      sha256 = "2841291555bf5ab85390e56b1c6c231bb6f1f5c9cbd12a634491781c3cfd83c8";
-      name = "kcalutils-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kcalutils-19.04.1.tar.xz";
+      sha256 = "8856a1e812f81848f1e2adc179182349acfac9e189b55f29afeb020c148909ec";
+      name = "kcalutils-19.04.1.tar.xz";
     };
   };
   kcharselect = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kcharselect-19.04.0.tar.xz";
-      sha256 = "788e6e97bb53216b4777fb19602d823a8e62f9ea25082f545e970a561fb3a78f";
-      name = "kcharselect-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kcharselect-19.04.1.tar.xz";
+      sha256 = "c54570a6f968b2ccbe42c0a8dbaecb1f263fbd392f67b2d735ade492553ff9ec";
+      name = "kcharselect-19.04.1.tar.xz";
     };
   };
   kcolorchooser = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kcolorchooser-19.04.0.tar.xz";
-      sha256 = "8f338ba51349cb056f25266d884ca318d3fd3933288ec96f9f17df6c842bc839";
-      name = "kcolorchooser-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kcolorchooser-19.04.1.tar.xz";
+      sha256 = "bfc2cdafd709d8829e19367151f59725152af2f4a80c583df671a9df1378e57a";
+      name = "kcolorchooser-19.04.1.tar.xz";
     };
   };
   kcontacts = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kcontacts-19.04.0.tar.xz";
-      sha256 = "81ad5b3eada7c91b4b7ed09a0a17a146e87b3075925caa3d23b82c2a6f67f5b4";
-      name = "kcontacts-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kcontacts-19.04.1.tar.xz";
+      sha256 = "1773a5ddcec46dbf72cef2bbcc8c3143a0ba18ce6fa462ba642011b36b9cc088";
+      name = "kcontacts-19.04.1.tar.xz";
     };
   };
   kcron = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kcron-19.04.0.tar.xz";
-      sha256 = "58a84503da74d7c0e26ab14c95f92f57f0a9f0c5e1ce0fa4be30276728c8be35";
-      name = "kcron-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kcron-19.04.1.tar.xz";
+      sha256 = "a58e8c99072e10a0b0a6acfecbbadef822c6f2818202bbaccdbee6b2a5b7e951";
+      name = "kcron-19.04.1.tar.xz";
     };
   };
   kdav = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kdav-19.04.0.tar.xz";
-      sha256 = "dce315916a993dbff7f7748538da91944b20df3cb6fc042e0d145d53904ff5d9";
-      name = "kdav-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kdav-19.04.1.tar.xz";
+      sha256 = "356e59f904f075521df60499b7f84d7868dbb78968b04fd15be6d359c154e737";
+      name = "kdav-19.04.1.tar.xz";
     };
   };
   kdebugsettings = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kdebugsettings-19.04.0.tar.xz";
-      sha256 = "7c06b1c5b1f14c3a67d34fda52494a8d47495b3473ecd9fe03e97cb1c88012c5";
-      name = "kdebugsettings-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kdebugsettings-19.04.1.tar.xz";
+      sha256 = "f04334f954d48fbd5a7bf41327563081966fb31950c131a943cf0a1a86281aa2";
+      name = "kdebugsettings-19.04.1.tar.xz";
     };
   };
   kde-dev-scripts = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kde-dev-scripts-19.04.0.tar.xz";
-      sha256 = "23b777143c9402bf089cd2f84c5ac363183b74dcf81be8c08d74d5d099e898e5";
-      name = "kde-dev-scripts-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kde-dev-scripts-19.04.1.tar.xz";
+      sha256 = "aa039d08b0e151703b6be0571d254d3656589d0b8422214110c460bd1f2aa6c2";
+      name = "kde-dev-scripts-19.04.1.tar.xz";
     };
   };
   kde-dev-utils = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kde-dev-utils-19.04.0.tar.xz";
-      sha256 = "ec2df1ab8b73f19ffc8ec7abeba0577b42d15bc372a19b456a2a04ebb4691031";
-      name = "kde-dev-utils-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kde-dev-utils-19.04.1.tar.xz";
+      sha256 = "9bca818e44f80ece758c0430aebcaf56252bbdffed6c8f65d04ccb4d019f2d9b";
+      name = "kde-dev-utils-19.04.1.tar.xz";
     };
   };
   kdeedu-data = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kdeedu-data-19.04.0.tar.xz";
-      sha256 = "ddba1b8f78b1614ac8b43b605a9021d611765dea6152e0997c84d4f9b17d9be6";
-      name = "kdeedu-data-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kdeedu-data-19.04.1.tar.xz";
+      sha256 = "751ec4df18d4ec3e7498a279bb891d6eb9a835fd786c8dd77ee883c9b55a0c30";
+      name = "kdeedu-data-19.04.1.tar.xz";
     };
   };
   kdegraphics-mobipocket = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kdegraphics-mobipocket-19.04.0.tar.xz";
-      sha256 = "37db302ed0d70766cf75e052f27150553b875428b68c886fe4d16452edd18939";
-      name = "kdegraphics-mobipocket-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kdegraphics-mobipocket-19.04.1.tar.xz";
+      sha256 = "345be42b0fb4f2040ce1430c872c0d20b0abaa266159a19beac1b067b2723821";
+      name = "kdegraphics-mobipocket-19.04.1.tar.xz";
     };
   };
   kdegraphics-thumbnailers = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kdegraphics-thumbnailers-19.04.0.tar.xz";
-      sha256 = "7af5fb986c493649a1eec9ba881f8b9c06c5d7459f0acc59e7ee7d185bc7ee70";
-      name = "kdegraphics-thumbnailers-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kdegraphics-thumbnailers-19.04.1.tar.xz";
+      sha256 = "e82515177c1c465c1d499095ff51d71caf286505a0fd3b9bfd2f1cdc1744706e";
+      name = "kdegraphics-thumbnailers-19.04.1.tar.xz";
     };
   };
   kdenetwork-filesharing = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kdenetwork-filesharing-19.04.0.tar.xz";
-      sha256 = "a88277659bc1dd5ddfea9dd63c3764a1f31d06235aa07c528c12a63a7605c943";
-      name = "kdenetwork-filesharing-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kdenetwork-filesharing-19.04.1.tar.xz";
+      sha256 = "5f3ae681f58a9877c7133778ff44c7be2a96cf26afbff10465984dae033251bd";
+      name = "kdenetwork-filesharing-19.04.1.tar.xz";
     };
   };
   kdenlive = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kdenlive-19.04.0.tar.xz";
-      sha256 = "274ae17b4376258ef83d810cb33677ca3224e205ea8b69982dd0fc4e5ee5878a";
-      name = "kdenlive-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kdenlive-19.04.1.tar.xz";
+      sha256 = "feb3202ee1aa0f47acc12ad7d6ca78977a4c9af0d705f8792ca2f8e3e6defbe5";
+      name = "kdenlive-19.04.1.tar.xz";
     };
   };
   kdepim-addons = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kdepim-addons-19.04.0.tar.xz";
-      sha256 = "778e946e74f36d368f484226ccc6f9cbd548d1cb2b0c3536e87d9374c64ddd88";
-      name = "kdepim-addons-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kdepim-addons-19.04.1.tar.xz";
+      sha256 = "d4e36a6d0043ad0ed5e3c427559bfaa29523578f99b613c82c3aaef16b2a7882";
+      name = "kdepim-addons-19.04.1.tar.xz";
     };
   };
   kdepim-apps-libs = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kdepim-apps-libs-19.04.0.tar.xz";
-      sha256 = "f335f736d854b56bab89814db44761c7e49b35e5266dddee78d22c6465e305c1";
-      name = "kdepim-apps-libs-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kdepim-apps-libs-19.04.1.tar.xz";
+      sha256 = "c3530a810a1eddfa06a27f24b723f971e7e2e144bbb2dac7ff30e7dec948a15d";
+      name = "kdepim-apps-libs-19.04.1.tar.xz";
     };
   };
   kdepim-runtime = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kdepim-runtime-19.04.0.tar.xz";
-      sha256 = "944e956d260ba5a735b3c94c6c075f207a9c38bf977ed19507b4dd0f3eaa4993";
-      name = "kdepim-runtime-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kdepim-runtime-19.04.1.tar.xz";
+      sha256 = "1587eca5a206768917443bd5274c03d8cbb2cbc6dcbe60449110c326b1aa0744";
+      name = "kdepim-runtime-19.04.1.tar.xz";
     };
   };
   kdesdk-kioslaves = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kdesdk-kioslaves-19.04.0.tar.xz";
-      sha256 = "8765a03f1a6930f28f053b920839e673dbc19bd1947900d84324be963147381a";
-      name = "kdesdk-kioslaves-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kdesdk-kioslaves-19.04.1.tar.xz";
+      sha256 = "80bbbdc91bc6a2b0c47a47044fdb2e107b89c63dd358b694c1c3f8e7cd1bbb16";
+      name = "kdesdk-kioslaves-19.04.1.tar.xz";
     };
   };
   kdesdk-thumbnailers = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kdesdk-thumbnailers-19.04.0.tar.xz";
-      sha256 = "195f539bec6e19de83e07dce117f7cd656f77199c2863a6a5738112d53843243";
-      name = "kdesdk-thumbnailers-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kdesdk-thumbnailers-19.04.1.tar.xz";
+      sha256 = "554d291605ac8827a2a4f6513a2230d9f9b0b8fcd6a37b0acd41c4db81fa3442";
+      name = "kdesdk-thumbnailers-19.04.1.tar.xz";
     };
   };
   kdf = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kdf-19.04.0.tar.xz";
-      sha256 = "f1204fddefe5492c860a77ff2c343f9b885625b321a37673763d73510dd469fd";
-      name = "kdf-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kdf-19.04.1.tar.xz";
+      sha256 = "835881e8f829c3c64ca529019f599ce89b95139d502673d5e6fb560a98eedce5";
+      name = "kdf-19.04.1.tar.xz";
     };
   };
   kdialog = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kdialog-19.04.0.tar.xz";
-      sha256 = "2cdd5a65046cfc09246bd1fbc8be818db486e35437f00e20e372d58988f04ace";
-      name = "kdialog-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kdialog-19.04.1.tar.xz";
+      sha256 = "48e77dc4827af2445f8ac583bef319b7fd274f9b84a19635bf673801e96b259a";
+      name = "kdialog-19.04.1.tar.xz";
     };
   };
   kdiamond = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kdiamond-19.04.0.tar.xz";
-      sha256 = "121ef36611bf7fe9a7d1d4700622a4cc8a349fe262b7c568026a4da55dfd4b26";
-      name = "kdiamond-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kdiamond-19.04.1.tar.xz";
+      sha256 = "a7588f21e7151c1053787f75a17c1062a9c0b43611b824632ed1b8689f4996f3";
+      name = "kdiamond-19.04.1.tar.xz";
     };
   };
   keditbookmarks = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/keditbookmarks-19.04.0.tar.xz";
-      sha256 = "23770a42aa72eb275b2b5a21f8e2f0959eec112ab048c6d89999ee156cd2ef65";
-      name = "keditbookmarks-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/keditbookmarks-19.04.1.tar.xz";
+      sha256 = "05788d55020f330b52bd8641e47990c90c7585871489993888ce0f40fa1686db";
+      name = "keditbookmarks-19.04.1.tar.xz";
     };
   };
   kfind = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kfind-19.04.0.tar.xz";
-      sha256 = "7eec5b096738bb28264bf870bdd85e24f97c62677be2d2a061f6c426ecfc3a47";
-      name = "kfind-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kfind-19.04.1.tar.xz";
+      sha256 = "496dd642473bfaa881387d2fb3a3507a9bf8c84b8a6874525221b561a50ef9fd";
+      name = "kfind-19.04.1.tar.xz";
     };
   };
   kfloppy = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kfloppy-19.04.0.tar.xz";
-      sha256 = "fafa66fddf5fe938b5666ef94ea4a1f41487cb3cc815fa6bc65332ee7574f7e1";
-      name = "kfloppy-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kfloppy-19.04.1.tar.xz";
+      sha256 = "bde5c16c679a34aa6c74844caeea5e1746629ac7d35dfac0493e9d8f7d78aa75";
+      name = "kfloppy-19.04.1.tar.xz";
     };
   };
   kfourinline = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kfourinline-19.04.0.tar.xz";
-      sha256 = "458bc34c169df064c8d974d6f27e18e3cc5f3e9fb069358817d00a590f2e200a";
-      name = "kfourinline-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kfourinline-19.04.1.tar.xz";
+      sha256 = "9ba39703ccf64b76a0b9a2705d65b7c6c2067db795cfed298f0e3a2eac48b973";
+      name = "kfourinline-19.04.1.tar.xz";
     };
   };
   kgeography = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kgeography-19.04.0.tar.xz";
-      sha256 = "ee126fc91ba164e0c095e7cef231a1389a4e1423256773c4e7d4b7306077eb41";
-      name = "kgeography-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kgeography-19.04.1.tar.xz";
+      sha256 = "44e7297243a2f5ebd6c8e18e3380b7c66b3d085f64952937abf1683ddcb9d502";
+      name = "kgeography-19.04.1.tar.xz";
     };
   };
   kget = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kget-19.04.0.tar.xz";
-      sha256 = "e1ec10f36f8b451c2cfc02108e00c6ab3e1115719342b9fa1f1f5829746fbeb9";
-      name = "kget-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kget-19.04.1.tar.xz";
+      sha256 = "a7dff0134d0ce6643fbde1ddfb73ce7d3300b927373a0907aec510f29d0d1629";
+      name = "kget-19.04.1.tar.xz";
     };
   };
   kgoldrunner = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kgoldrunner-19.04.0.tar.xz";
-      sha256 = "3d2eb37695328065ee5cf4c4ba4ee707ce514b4c7aab84c93cd3bef8d329b8ba";
-      name = "kgoldrunner-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kgoldrunner-19.04.1.tar.xz";
+      sha256 = "11db3aecf77b7097b7d3d626dba4a3b4bcd3d5ab02a1e04cf7f6932b0b73a760";
+      name = "kgoldrunner-19.04.1.tar.xz";
     };
   };
   kgpg = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kgpg-19.04.0.tar.xz";
-      sha256 = "2fb47d9d08cfca94dce1c4d19bce5d2955c3cd3ceec6265a8b537de612a53128";
-      name = "kgpg-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kgpg-19.04.1.tar.xz";
+      sha256 = "2c9c64491592db79397be3769413fae657ca991dd45d02690bbe533c1cba0ceb";
+      name = "kgpg-19.04.1.tar.xz";
     };
   };
   khangman = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/khangman-19.04.0.tar.xz";
-      sha256 = "2a7120f7a54848dc017efdb86c22a964626029d9ca300d8e1488d385f10dc61c";
-      name = "khangman-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/khangman-19.04.1.tar.xz";
+      sha256 = "5d35620bc048ecabd21b20cadfa8df07e72f195bdc5b9ad2c7e86e17d27afe27";
+      name = "khangman-19.04.1.tar.xz";
     };
   };
   khelpcenter = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/khelpcenter-19.04.0.tar.xz";
-      sha256 = "5fc4f9553e8575055edf259baa3d0b0c663db5caf67dc392db9e519d6b85699f";
-      name = "khelpcenter-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/khelpcenter-19.04.1.tar.xz";
+      sha256 = "3436502f6fae659b930aa63e5ace088e0982804386cf1b24b042328796549114";
+      name = "khelpcenter-19.04.1.tar.xz";
     };
   };
   kidentitymanagement = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kidentitymanagement-19.04.0.tar.xz";
-      sha256 = "1ddce9330947fdfd970f07b60d6e9ff012e21a673262796ccb29e56e277b55a3";
-      name = "kidentitymanagement-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kidentitymanagement-19.04.1.tar.xz";
+      sha256 = "5216d26aef0c483f3dff51564e8b1526821b25279d7c5e9c21c87a5d5e20822a";
+      name = "kidentitymanagement-19.04.1.tar.xz";
     };
   };
   kig = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kig-19.04.0.tar.xz";
-      sha256 = "781243a23a94d7a9882bd69ddfcd74a5b9df0ce28cd45488e62dcf54e3633234";
-      name = "kig-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kig-19.04.1.tar.xz";
+      sha256 = "37684e2d1893c2f3a412add1edd73047d3ae8ff501b035943a9793b94d468a79";
+      name = "kig-19.04.1.tar.xz";
     };
   };
   kigo = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kigo-19.04.0.tar.xz";
-      sha256 = "30f12515ec4d22d39c6c90690545e1975a3ba9917180503ef42cba40ffbd874c";
-      name = "kigo-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kigo-19.04.1.tar.xz";
+      sha256 = "5b5cae565a79309dc23b26acf2f596d36fd62950af58405094e4fa9a38e5e4ad";
+      name = "kigo-19.04.1.tar.xz";
     };
   };
   killbots = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/killbots-19.04.0.tar.xz";
-      sha256 = "0cc928a1956b72bc207feed237598b445b5a7d7d26a266ec88080c1510870359";
-      name = "killbots-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/killbots-19.04.1.tar.xz";
+      sha256 = "8829dba8a3af320b03e21cd356e53fef0e70c10831ffeb6a70b722dde9877938";
+      name = "killbots-19.04.1.tar.xz";
     };
   };
   kimagemapeditor = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kimagemapeditor-19.04.0.tar.xz";
-      sha256 = "8d3ff906926fe8f82b21cf19d784dbddfcda15de9513feaa9defa6e4ff3b1869";
-      name = "kimagemapeditor-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kimagemapeditor-19.04.1.tar.xz";
+      sha256 = "d85d2f3d043a29e56f4234ce24dd75545e06c2812d5fe45cafde4c3dbe280533";
+      name = "kimagemapeditor-19.04.1.tar.xz";
     };
   };
   kimap = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kimap-19.04.0.tar.xz";
-      sha256 = "cda62c81c47011ad2adbf78222eab4528a62116487531ce1aa98f6100706d2fd";
-      name = "kimap-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kimap-19.04.1.tar.xz";
+      sha256 = "ff933fba7ce8412fd64439e5f4c5a7be3a06fd39c79f520acfc648923819aa1f";
+      name = "kimap-19.04.1.tar.xz";
     };
   };
   kio-extras = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kio-extras-19.04.0.tar.xz";
-      sha256 = "0f3f2eaf40512cf4a61b09b94ca365d7d05c7b1a75f4e8afd047143a8e962d85";
-      name = "kio-extras-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kio-extras-19.04.1.tar.xz";
+      sha256 = "ddf389a50142211566124ba902bb9f6b2988b1b94fefed7620a6ec421e3ff0bd";
+      name = "kio-extras-19.04.1.tar.xz";
     };
   };
   kirigami-gallery = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kirigami-gallery-19.04.0.tar.xz";
-      sha256 = "c0ac9e9a07072d1a538d2535fd21dede86cc4ee9287c7b1ca3d6b8f8726a7155";
-      name = "kirigami-gallery-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kirigami-gallery-19.04.1.tar.xz";
+      sha256 = "ed7390a015a77f8285b4db4185533fa327a142a191c27afa7c2ce963ae6ad7e2";
+      name = "kirigami-gallery-19.04.1.tar.xz";
     };
   };
   kiriki = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kiriki-19.04.0.tar.xz";
-      sha256 = "feb7b4fce0e6b1749bddd254a46a5d34bf5584a3d60aef460816380141ad630e";
-      name = "kiriki-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kiriki-19.04.1.tar.xz";
+      sha256 = "131c6b5bd8f2b014a28bd5cb9985111f63991974b672dcfbc0266d32f069954b";
+      name = "kiriki-19.04.1.tar.xz";
     };
   };
   kiten = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kiten-19.04.0.tar.xz";
-      sha256 = "53f5e4ef48b18989084858ab5c96b7dedf357cecf4dba3b2d2a967b4b4b8a742";
-      name = "kiten-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kiten-19.04.1.tar.xz";
+      sha256 = "be904abd0386a9ac6d622178f37e55d5a05f5eaa31c6a5cd661959ee4b03d2d4";
+      name = "kiten-19.04.1.tar.xz";
     };
   };
   kitinerary = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kitinerary-19.04.0.tar.xz";
-      sha256 = "b56c93b7114cad54313471e6ab4cebde461a2b39859b47e9b8f7f146d3471889";
-      name = "kitinerary-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kitinerary-19.04.1.tar.xz";
+      sha256 = "4053e16e847f0e234ffba2bb0533e947eae7b315304677a784279d03f13c0318";
+      name = "kitinerary-19.04.1.tar.xz";
     };
   };
   kjumpingcube = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kjumpingcube-19.04.0.tar.xz";
-      sha256 = "28fabf01d0a2481c54018d00985254acb107579c5afa93bbec7b3795c2a3f143";
-      name = "kjumpingcube-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kjumpingcube-19.04.1.tar.xz";
+      sha256 = "13d6a138e09c9088ce38fe9a124bd600386dc097b929f6f85416bc1da0012ab1";
+      name = "kjumpingcube-19.04.1.tar.xz";
     };
   };
   kldap = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kldap-19.04.0.tar.xz";
-      sha256 = "2cddadf995a10b854b28e34c18db14c32ad985c18af466edde6a1b2a9a2d8a23";
-      name = "kldap-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kldap-19.04.1.tar.xz";
+      sha256 = "638e62d39fbe935b1df3c03f9617acbe5ade4ad617245bc590ca07b7fd0b723b";
+      name = "kldap-19.04.1.tar.xz";
     };
   };
   kleopatra = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kleopatra-19.04.0.tar.xz";
-      sha256 = "8ad7ec0b99efabdbc270559098dfca64e39ddd30a64b13915c04988a9c8b8b70";
-      name = "kleopatra-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kleopatra-19.04.1.tar.xz";
+      sha256 = "bc8895a506164df0fa0f7fc317fe8b961cb75d8c67f04474e1c12e25be358c67";
+      name = "kleopatra-19.04.1.tar.xz";
     };
   };
   klettres = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/klettres-19.04.0.tar.xz";
-      sha256 = "c8a5596638ea7bbe7e26c246c5904840bf544e632e5649430bb32159aedefd60";
-      name = "klettres-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/klettres-19.04.1.tar.xz";
+      sha256 = "d0db0773513fa35d1224e90cf5b09ac75b7b8f559d1080ee6026ba74df0f0847";
+      name = "klettres-19.04.1.tar.xz";
     };
   };
   klickety = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/klickety-19.04.0.tar.xz";
-      sha256 = "2ad160e3ea0a6f11c828f3b4bcea8f75db4121dda6d6e498fa1fc095e82e80e5";
-      name = "klickety-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/klickety-19.04.1.tar.xz";
+      sha256 = "d4ae4d002f008200a6ce920f2aff6841d9ad58b22c392d7eefac7867b32340af";
+      name = "klickety-19.04.1.tar.xz";
     };
   };
   klines = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/klines-19.04.0.tar.xz";
-      sha256 = "139c0a4da7186e6e57228fcbe8666aa40e52ae01f328fea4d53ed8611ed54a96";
-      name = "klines-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/klines-19.04.1.tar.xz";
+      sha256 = "2ca4ad74fefa87bbf3a38ea90b55025ab8554bfdc47d7e4323e0906e9e1c8962";
+      name = "klines-19.04.1.tar.xz";
     };
   };
   kmag = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kmag-19.04.0.tar.xz";
-      sha256 = "c6725654846e83b383ff6c624683e4132538f2e812d8131cadefd6926316520e";
-      name = "kmag-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kmag-19.04.1.tar.xz";
+      sha256 = "aa5ec91dcffc1a2f1037332aeacb096ab55388624c844c7fa311ca38a5e40874";
+      name = "kmag-19.04.1.tar.xz";
     };
   };
   kmahjongg = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kmahjongg-19.04.0.tar.xz";
-      sha256 = "519bf6bb0bc098f74467d3ec9b49c82d22241dfd518d004163565e86dbc21a36";
-      name = "kmahjongg-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kmahjongg-19.04.1.tar.xz";
+      sha256 = "75dbcfb5747530a3b69574fdc87b532067516415f962e7943feef97549237c99";
+      name = "kmahjongg-19.04.1.tar.xz";
     };
   };
   kmail = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kmail-19.04.0.tar.xz";
-      sha256 = "c191057769513d51d6604e0f51e441e54770ac07a982175a5be29b7797d6f486";
-      name = "kmail-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kmail-19.04.1.tar.xz";
+      sha256 = "62fcd78318d35848e5ae461f7ebd3b6f202c57c51008c71d7e2a1d1c3d58f2c5";
+      name = "kmail-19.04.1.tar.xz";
     };
   };
   kmail-account-wizard = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kmail-account-wizard-19.04.0.tar.xz";
-      sha256 = "640d63ceca23644e2f358c7117eb54daa0fffc669628398f7930fe273d7944a9";
-      name = "kmail-account-wizard-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kmail-account-wizard-19.04.1.tar.xz";
+      sha256 = "c6714c425daa3d79dfb47b5d18cff26b10b1b087e4472f627738494f06d04ab8";
+      name = "kmail-account-wizard-19.04.1.tar.xz";
     };
   };
   kmailtransport = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kmailtransport-19.04.0.tar.xz";
-      sha256 = "35104e661fd501bd5848006dfd907f8cd1dfe88609ed4f9fbc4ce599a2f20c8f";
-      name = "kmailtransport-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kmailtransport-19.04.1.tar.xz";
+      sha256 = "b8c0cf5cb8f7ad93bb3d1b2adab68fbc2470bc14160650fb45d1c4d40e8549fa";
+      name = "kmailtransport-19.04.1.tar.xz";
     };
   };
   kmbox = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kmbox-19.04.0.tar.xz";
-      sha256 = "cd37b698e4ad12317a6d1f7df786345f5df7112ea3d21c2c23545e48a67e8544";
-      name = "kmbox-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kmbox-19.04.1.tar.xz";
+      sha256 = "701eda3a4831ed0daf9bd14a93ff845f42e4f93c6ca16d83ebda958c27021fc0";
+      name = "kmbox-19.04.1.tar.xz";
     };
   };
   kmime = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kmime-19.04.0.tar.xz";
-      sha256 = "2081adec0e6972e513206bee69c0e165904670b7bcf34c52e7da07323537d513";
-      name = "kmime-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kmime-19.04.1.tar.xz";
+      sha256 = "25ee2e49ea62d32fcd09a710f971c6fcdc5434c6fdf711e93c19fc4baa325775";
+      name = "kmime-19.04.1.tar.xz";
     };
   };
   kmines = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kmines-19.04.0.tar.xz";
-      sha256 = "56452ab18c74f2863efc99200a5facd53827382c06fc8534d095bffaca497566";
-      name = "kmines-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kmines-19.04.1.tar.xz";
+      sha256 = "98a3860113a51e215a42791e3eb845978cda51fb5001b8e8bb41fe9182765d12";
+      name = "kmines-19.04.1.tar.xz";
     };
   };
   kmix = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kmix-19.04.0.tar.xz";
-      sha256 = "f372d50ccdb496a3bb7a3f68c84c921c12d3d535a792400e701ed7c640e45f2a";
-      name = "kmix-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kmix-19.04.1.tar.xz";
+      sha256 = "ca02ed8db5e4a3a58622b10668efb4c4a828de584b9f57116fee802e136352ea";
+      name = "kmix-19.04.1.tar.xz";
     };
   };
   kmousetool = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kmousetool-19.04.0.tar.xz";
-      sha256 = "89e383a395ec5f1c7d25cc5fb45ecb73a3a0931919a2be533634d77c01cb3fa9";
-      name = "kmousetool-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kmousetool-19.04.1.tar.xz";
+      sha256 = "fd0fcebda4d7303a9c6f1117c08e091d96bfddf92a64e1cde2dc6b555daa0624";
+      name = "kmousetool-19.04.1.tar.xz";
     };
   };
   kmouth = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kmouth-19.04.0.tar.xz";
-      sha256 = "32666760ed76dd2dc816df52c990cb3b8487346ac37bf065e4b109fb6661ebc3";
-      name = "kmouth-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kmouth-19.04.1.tar.xz";
+      sha256 = "9a8d0f9b1f09f1363d38b2a942ffe515521ffc410f869ed1a875ff1059ef8068";
+      name = "kmouth-19.04.1.tar.xz";
     };
   };
   kmplot = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kmplot-19.04.0.tar.xz";
-      sha256 = "fb981354dd6fea18e83003df957f65a9580d458b377adde88a838d4db9a97ee6";
-      name = "kmplot-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kmplot-19.04.1.tar.xz";
+      sha256 = "c2e0855182d1ab0977b96669999976fb84c2f4b2645fcee0cb35b839bc1da206";
+      name = "kmplot-19.04.1.tar.xz";
     };
   };
   knavalbattle = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/knavalbattle-19.04.0.tar.xz";
-      sha256 = "1e6fbd202092230017c268cd825438debf766e3cc810244b63dc8690b5a69585";
-      name = "knavalbattle-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/knavalbattle-19.04.1.tar.xz";
+      sha256 = "f7b5ad956e4b1c06b04fec2d6f39331e81f2c44c716c2e666ef75b9d786982bc";
+      name = "knavalbattle-19.04.1.tar.xz";
     };
   };
   knetwalk = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/knetwalk-19.04.0.tar.xz";
-      sha256 = "84b03a6b7c3ff6634402b016089a54ed0116ace221fdfb04ad3d2a8997f68b4b";
-      name = "knetwalk-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/knetwalk-19.04.1.tar.xz";
+      sha256 = "e762415b6891c4098febc090bc80e5698cd3fb9ac2b8f4988aaf096816e3b62b";
+      name = "knetwalk-19.04.1.tar.xz";
     };
   };
   knights = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/knights-19.04.0.tar.xz";
-      sha256 = "53eb3214550fc104755ffe076c970cf5499c9553b543d83df42a3b5f5d8d309a";
-      name = "knights-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/knights-19.04.1.tar.xz";
+      sha256 = "d722fad8e835ea402337ffe1e6b8d1a5bda5a0e1c36ee3a89a6782b666a8534e";
+      name = "knights-19.04.1.tar.xz";
     };
   };
   knotes = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/knotes-19.04.0.tar.xz";
-      sha256 = "e2f98d029105d18c5c14b774782287e281e2367eebeb84d52727a5156abe4092";
-      name = "knotes-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/knotes-19.04.1.tar.xz";
+      sha256 = "b5cc805c657622e8cc4ab0ea07f30ea0258e767a87e525bc02fbc7d6ee9d7ec9";
+      name = "knotes-19.04.1.tar.xz";
     };
   };
   kolf = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kolf-19.04.0.tar.xz";
-      sha256 = "431b31dc6290214be5f5df1d3c6a8eb4a910b4f72135840d4ec3fa6945319c81";
-      name = "kolf-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kolf-19.04.1.tar.xz";
+      sha256 = "92a56f5e5602a898537f87e12968e47cfe6f76d10daac6240e9f60e6751d06d7";
+      name = "kolf-19.04.1.tar.xz";
     };
   };
   kollision = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kollision-19.04.0.tar.xz";
-      sha256 = "f218ef5691235155911b4d03cd301ee6caa0bde6eb324cd55117e722002b0927";
-      name = "kollision-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kollision-19.04.1.tar.xz";
+      sha256 = "2c243790feb8d7a7760fcadff6b06b21aea930218d0915664b420dccdc1c7de9";
+      name = "kollision-19.04.1.tar.xz";
     };
   };
   kolourpaint = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kolourpaint-19.04.0.tar.xz";
-      sha256 = "d6cd087ba34a1a8fec9349dea06c1b71a70f6e8455adb41d4820a376eb2ed141";
-      name = "kolourpaint-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kolourpaint-19.04.1.tar.xz";
+      sha256 = "a2f78f1a2f99fa8176980ecd224ccfd8848ff8357e3434b463d4f83bcc7b5e46";
+      name = "kolourpaint-19.04.1.tar.xz";
     };
   };
   kompare = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kompare-19.04.0.tar.xz";
-      sha256 = "49453b90e21d3b2acd766aac244f579e2dc446ec8abf854ceb2faf34fc3e647f";
-      name = "kompare-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kompare-19.04.1.tar.xz";
+      sha256 = "ca270cde7c77fb44b40779ee22d556f14b9e0720e865ad6e3cf5cebbba4d7261";
+      name = "kompare-19.04.1.tar.xz";
     };
   };
   konqueror = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/konqueror-19.04.0.tar.xz";
-      sha256 = "8da6fdd7de037bed79b6341e670a7491d371d084c59fdbefb4ffae0d2da82e4c";
-      name = "konqueror-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/konqueror-19.04.1.tar.xz";
+      sha256 = "b5f3c5a005b71886bfa2318bf13f14e6bab8fb84e1db54192409769bc3bf0e92";
+      name = "konqueror-19.04.1.tar.xz";
     };
   };
   konquest = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/konquest-19.04.0.tar.xz";
-      sha256 = "5361a865fefc0dac19e166d282188b732cfbe4389afe095c38c8d30b56f7ff6f";
-      name = "konquest-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/konquest-19.04.1.tar.xz";
+      sha256 = "cac10983efbc026d5c8cd3330c94865b43b1a229ff9bb76077ab25d734133aab";
+      name = "konquest-19.04.1.tar.xz";
     };
   };
   konsole = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/konsole-19.04.0.tar.xz";
-      sha256 = "62d53840f6cac4686feafa7f75d641bb56867b7dfc12e6ce95afa7e796e37cef";
-      name = "konsole-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/konsole-19.04.1.tar.xz";
+      sha256 = "711c67c5d43eb2c02be177e9d1157c142ab99ac5b808f951ab9a70e2397119d8";
+      name = "konsole-19.04.1.tar.xz";
     };
   };
   kontact = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kontact-19.04.0.tar.xz";
-      sha256 = "710d72ba01afa2aea89efca61f6c25245c0db04dc675b8871f7109a42a945cca";
-      name = "kontact-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kontact-19.04.1.tar.xz";
+      sha256 = "d60cc3165460a3e395778e4709ff55cbfbb80cc3536edb43d5d2335c70bd4714";
+      name = "kontact-19.04.1.tar.xz";
     };
   };
   kontactinterface = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kontactinterface-19.04.0.tar.xz";
-      sha256 = "268005d61e97dab34f200b0e7a461afddb32a88ccc7c553b6c967865a6915392";
-      name = "kontactinterface-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kontactinterface-19.04.1.tar.xz";
+      sha256 = "034dcf0b2740273037a40ce2c1dd0d4eb17aac1eba608eca81f7e905a336cbc2";
+      name = "kontactinterface-19.04.1.tar.xz";
     };
   };
   kopete = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kopete-19.04.0.tar.xz";
-      sha256 = "88068ceb8735e1b7ecaac9a9e4c36d40629b53d514c987823c987cfac6dc99df";
-      name = "kopete-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kopete-19.04.1.tar.xz";
+      sha256 = "27586d90bd47abe6d8d6eddd7e41dbb6e3b3736984186cd24f84eee216e98b85";
+      name = "kopete-19.04.1.tar.xz";
     };
   };
   korganizer = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/korganizer-19.04.0.tar.xz";
-      sha256 = "3e8c69db9f504e3ec80307d1552af21440621c0e480abf874a5a73482800bcaf";
-      name = "korganizer-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/korganizer-19.04.1.tar.xz";
+      sha256 = "cb5c06d13f9f6eb4191ef6b86dab72ecde92fe6d9c8b6d9a4396645c94f83b67";
+      name = "korganizer-19.04.1.tar.xz";
     };
   };
   kpat = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kpat-19.04.0.tar.xz";
-      sha256 = "bcd295a3df422b5cfa8258bb3cd0be7e4405f44604681d98589f2982c44414a1";
-      name = "kpat-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kpat-19.04.1.tar.xz";
+      sha256 = "2c0b29e5d372d55d77ceced098b8262b11a431518e818eec052d867c21ad6896";
+      name = "kpat-19.04.1.tar.xz";
     };
   };
   kpimtextedit = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kpimtextedit-19.04.0.tar.xz";
-      sha256 = "b4c640ee8ae5c4356bc26819763721580ca87477eb39258c1eaacdffbfc5311a";
-      name = "kpimtextedit-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kpimtextedit-19.04.1.tar.xz";
+      sha256 = "2fb2dc59a016dd70424c0fbad45ca1d750c2578f539e79d89bcace85bafd24d1";
+      name = "kpimtextedit-19.04.1.tar.xz";
     };
   };
   kpkpass = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kpkpass-19.04.0.tar.xz";
-      sha256 = "0121e03af506451a39b34a2f0ca063228454a40f71d9706dea3cee644a4c8f28";
-      name = "kpkpass-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kpkpass-19.04.1.tar.xz";
+      sha256 = "fb3554b04d00b326d5f5e14af9c0272c020092d3329808a6177fb0714f6a1cb7";
+      name = "kpkpass-19.04.1.tar.xz";
     };
   };
   kqtquickcharts = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kqtquickcharts-19.04.0.tar.xz";
-      sha256 = "c8a270932f11fc5ee9270c77205b1a93edfe73c2e629a602940acb15d853803f";
-      name = "kqtquickcharts-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kqtquickcharts-19.04.1.tar.xz";
+      sha256 = "7e05638f534257e901e02b6fa377747efa7881760dd66484b5a882c65e778e72";
+      name = "kqtquickcharts-19.04.1.tar.xz";
     };
   };
   krdc = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/krdc-19.04.0.tar.xz";
-      sha256 = "2a1ac548992eaaff82cafe386eef0a611b96f06ce3887a363b25d6ca17c6eacc";
-      name = "krdc-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/krdc-19.04.1.tar.xz";
+      sha256 = "8238b6969352d896751d28baeef770705feb5a0866e7b950e9eb0b377c098b19";
+      name = "krdc-19.04.1.tar.xz";
     };
   };
   kreversi = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kreversi-19.04.0.tar.xz";
-      sha256 = "a715d068eaf381a26e1f432f2d6b3f3ffffb388282b484cd8ad0833acf429d82";
-      name = "kreversi-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kreversi-19.04.1.tar.xz";
+      sha256 = "c8bce72bff0bd8b452335c158900d41a419ce3e62afd996f67a4b77abf38cdc9";
+      name = "kreversi-19.04.1.tar.xz";
     };
   };
   krfb = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/krfb-19.04.0.tar.xz";
-      sha256 = "321b1b296dfbd69e64048fbf991aec1a9d8c251e9f0084a396081f62287c6b40";
-      name = "krfb-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/krfb-19.04.1.tar.xz";
+      sha256 = "73dee235940cb0512cd218d88f90e6d2d62f232a6553f327b07e54c114c8480b";
+      name = "krfb-19.04.1.tar.xz";
     };
   };
   kross-interpreters = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kross-interpreters-19.04.0.tar.xz";
-      sha256 = "e910e76e58603077177b7835bed2b9562b266e2fc0ab78c8b2642edc752ccd27";
-      name = "kross-interpreters-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kross-interpreters-19.04.1.tar.xz";
+      sha256 = "d745f844ebe6ecefbf0d234e1e972cc7d7933a9ef75999839a709ba008ec55fe";
+      name = "kross-interpreters-19.04.1.tar.xz";
     };
   };
   kruler = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kruler-19.04.0.tar.xz";
-      sha256 = "7d29eac1d7f4e39f7d754ebb9d68aba70ab3dc12e8241007de750572ce761d73";
-      name = "kruler-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kruler-19.04.1.tar.xz";
+      sha256 = "fdbff79128c8f4cb51f39dbb6f173726404d25c743aa68313651bb7a51addb53";
+      name = "kruler-19.04.1.tar.xz";
     };
   };
   kshisen = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kshisen-19.04.0.tar.xz";
-      sha256 = "c7d2799105c71d5d0077383c9b24a52ae85705c39977c8dc167a2594651c17eb";
-      name = "kshisen-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kshisen-19.04.1.tar.xz";
+      sha256 = "a9e0e7324bb1bcad6c9427c0563236e557de85ad9724a52cfc917b43726b1aa6";
+      name = "kshisen-19.04.1.tar.xz";
     };
   };
   ksirk = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/ksirk-19.04.0.tar.xz";
-      sha256 = "3dcd578050807aa37652e5e589ddff7a5aec46c82309db85aab588bd3060d5a0";
-      name = "ksirk-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/ksirk-19.04.1.tar.xz";
+      sha256 = "170cc0f9dea3f35e15de5d1090e8e3fa2b2ed16fa1722dfeaef47339667f322e";
+      name = "ksirk-19.04.1.tar.xz";
     };
   };
   ksmtp = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/ksmtp-19.04.0.tar.xz";
-      sha256 = "c92b8b6b9de60bca7b9bb7befdd519041625188a955e55b63860d9de4b3e0bab";
-      name = "ksmtp-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/ksmtp-19.04.1.tar.xz";
+      sha256 = "965f5f1c44cd64f9899ff5919372fe449e0f8b63e492f566017c9b8d5eb324bb";
+      name = "ksmtp-19.04.1.tar.xz";
     };
   };
   ksnakeduel = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/ksnakeduel-19.04.0.tar.xz";
-      sha256 = "e9ca727c7e7cef21e9bedbb1504b2023baac9ab5ba0b624dc91e1bf716eb8335";
-      name = "ksnakeduel-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/ksnakeduel-19.04.1.tar.xz";
+      sha256 = "89de9e20e71ac8225e94d406cd3d25f057df35c96d4a3b7d418ffe5e6b0ef046";
+      name = "ksnakeduel-19.04.1.tar.xz";
     };
   };
   kspaceduel = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kspaceduel-19.04.0.tar.xz";
-      sha256 = "486b8d84f3070b7795456ec5847d7b5a9bb3c2b5d3e1c4bcdfedff18b8d735a7";
-      name = "kspaceduel-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kspaceduel-19.04.1.tar.xz";
+      sha256 = "388eaf152c996bd7326f0a4cd18fafb2600659513750d0aadd98b780eb6ec8b7";
+      name = "kspaceduel-19.04.1.tar.xz";
     };
   };
   ksquares = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/ksquares-19.04.0.tar.xz";
-      sha256 = "c5a7dc34619f1ee4d621c3371b65bdcd46cf3433c183b4bc85c8a7586b6e85b4";
-      name = "ksquares-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/ksquares-19.04.1.tar.xz";
+      sha256 = "3c9b0cb0921d1c29c6c451a22b318151010a3321350292d0d5fc26cc16618773";
+      name = "ksquares-19.04.1.tar.xz";
     };
   };
   ksudoku = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/ksudoku-19.04.0.tar.xz";
-      sha256 = "4f5cff274741326bff02108fef4996f289c56ff026fd6e2921e4a2bf492a14cb";
-      name = "ksudoku-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/ksudoku-19.04.1.tar.xz";
+      sha256 = "4f95ccd1b162c7fb7cad2b04e08e3a29cfc98ad27b87e6e76e389418d09c0f7b";
+      name = "ksudoku-19.04.1.tar.xz";
     };
   };
   ksystemlog = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/ksystemlog-19.04.0.tar.xz";
-      sha256 = "6a9f389b04fac92b0e2955e86e4a45aa73494f6dd24c9a6704826b469414fb5d";
-      name = "ksystemlog-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/ksystemlog-19.04.1.tar.xz";
+      sha256 = "c8e6cb81803b8754d394d9365d3a6533706c742c822a5ef9d46bdc2def356db4";
+      name = "ksystemlog-19.04.1.tar.xz";
     };
   };
   kteatime = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kteatime-19.04.0.tar.xz";
-      sha256 = "8672fa70912e9bf4488d5258258a14babbf65ee160dc537ab665ff2136a0c490";
-      name = "kteatime-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kteatime-19.04.1.tar.xz";
+      sha256 = "68a23aa6a8bc575586966388315f403e464b43e1b2f4b669689f3161db1669f0";
+      name = "kteatime-19.04.1.tar.xz";
     };
   };
   ktimer = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/ktimer-19.04.0.tar.xz";
-      sha256 = "d772292fa447aec07ff763d7bdfc351fbf2fd7d09160a574ec36ff2905ea5b79";
-      name = "ktimer-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/ktimer-19.04.1.tar.xz";
+      sha256 = "7ec4ebbdb8fc388763d832f8601bc7a32848836edc235f4c877bfb6d1726d809";
+      name = "ktimer-19.04.1.tar.xz";
     };
   };
   ktnef = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/ktnef-19.04.0.tar.xz";
-      sha256 = "bc3e826bc831ffac5b3b92cef14fca3f4b077d30652ce2ebdcffa07dafd58c56";
-      name = "ktnef-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/ktnef-19.04.1.tar.xz";
+      sha256 = "6f9449307d83a7bf0dc30022c36e3d854a06b370af18e44ca6e2eab684b97c93";
+      name = "ktnef-19.04.1.tar.xz";
     };
   };
   ktouch = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/ktouch-19.04.0.tar.xz";
-      sha256 = "707fca9ee9d0d217683e2bb562f5f8f984ddbd0ed7274b022a43bdc176898390";
-      name = "ktouch-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/ktouch-19.04.1.tar.xz";
+      sha256 = "09aa2ef862fffcdfc580b4aefff96a0591d99f470055365a90a41b25a3c6dcf2";
+      name = "ktouch-19.04.1.tar.xz";
     };
   };
   ktp-accounts-kcm = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/ktp-accounts-kcm-19.04.0.tar.xz";
-      sha256 = "e7c11f4310dd4cb119336fb569cc9799dbdd3d7f4b87af9e265f8fc4439ec7f8";
-      name = "ktp-accounts-kcm-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/ktp-accounts-kcm-19.04.1.tar.xz";
+      sha256 = "c4ecda8ca35438e45b48b9b86415bea1a44eeb2b2cd9af11ab1739f7ceeff045";
+      name = "ktp-accounts-kcm-19.04.1.tar.xz";
     };
   };
   ktp-approver = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/ktp-approver-19.04.0.tar.xz";
-      sha256 = "ec273b9eabcedd47c97fa60c68a3037115b9b06a91892d32871e8ded4c04cdfe";
-      name = "ktp-approver-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/ktp-approver-19.04.1.tar.xz";
+      sha256 = "e12421c0e79692532497dbd6db6b09faba010d99c57db1893eae3e59f7df47cd";
+      name = "ktp-approver-19.04.1.tar.xz";
     };
   };
   ktp-auth-handler = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/ktp-auth-handler-19.04.0.tar.xz";
-      sha256 = "db459ed02c5ed37ce41ec9728d931ca1ab987c43d1b48f501d38b40e1e4f19e9";
-      name = "ktp-auth-handler-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/ktp-auth-handler-19.04.1.tar.xz";
+      sha256 = "8d06e90a7e73b034c6087079b510e0ac1c27728c885e9aa2e8baef463a892d65";
+      name = "ktp-auth-handler-19.04.1.tar.xz";
     };
   };
   ktp-call-ui = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/ktp-call-ui-19.04.0.tar.xz";
-      sha256 = "b63ef1f0bcaed631f9106a355dd60e48edb6e7e39bb6bd0603b504fc33949427";
-      name = "ktp-call-ui-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/ktp-call-ui-19.04.1.tar.xz";
+      sha256 = "ad2efd84dc45cf55366dbc182d9301816129335ec4dc021dbbcc097c52656a0f";
+      name = "ktp-call-ui-19.04.1.tar.xz";
     };
   };
   ktp-common-internals = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/ktp-common-internals-19.04.0.tar.xz";
-      sha256 = "12e3e0733eef78a649fa1e55f2f3d228b581fb1a0ba401e154dd57d4eb286eaa";
-      name = "ktp-common-internals-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/ktp-common-internals-19.04.1.tar.xz";
+      sha256 = "041e5971071a060cef24abe68f699b5fcc657ba15a1e77feb227312fb1c13fd1";
+      name = "ktp-common-internals-19.04.1.tar.xz";
     };
   };
   ktp-contact-list = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/ktp-contact-list-19.04.0.tar.xz";
-      sha256 = "745a1b403e3e1bfd0604521709f44634ab15a053b45f5c390d9a8e80fa405668";
-      name = "ktp-contact-list-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/ktp-contact-list-19.04.1.tar.xz";
+      sha256 = "7d8f7d841142d75036dc9dc4e31aefe8ff8906de6205b0e348b48e57da1400d9";
+      name = "ktp-contact-list-19.04.1.tar.xz";
     };
   };
   ktp-contact-runner = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/ktp-contact-runner-19.04.0.tar.xz";
-      sha256 = "12d9e3cf2a230e590c9e3e17462b8e061641a70840492971434b131c15594773";
-      name = "ktp-contact-runner-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/ktp-contact-runner-19.04.1.tar.xz";
+      sha256 = "68580e429fe0c9472a924af4f71df2da74684c5c11374464c110b9faca28c66f";
+      name = "ktp-contact-runner-19.04.1.tar.xz";
     };
   };
   ktp-desktop-applets = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/ktp-desktop-applets-19.04.0.tar.xz";
-      sha256 = "ba5d0422156e0ea38db1abeb317310266fd96b2b259a40df4233880d15037d8c";
-      name = "ktp-desktop-applets-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/ktp-desktop-applets-19.04.1.tar.xz";
+      sha256 = "1114d5bcbc5a20c2d4822b1e2ad07d5d493ceace0a75b77575e978c30dc5fa75";
+      name = "ktp-desktop-applets-19.04.1.tar.xz";
     };
   };
   ktp-filetransfer-handler = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/ktp-filetransfer-handler-19.04.0.tar.xz";
-      sha256 = "3088b79a79b35fc52f38ae2941e9f1ca8a80a1eed1c3bcdfd489b2e069febcfd";
-      name = "ktp-filetransfer-handler-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/ktp-filetransfer-handler-19.04.1.tar.xz";
+      sha256 = "3e53fc28f4a1a8dd0dd2cb63b0a287061176a5c6e1db6480d50ebc70e2d8f189";
+      name = "ktp-filetransfer-handler-19.04.1.tar.xz";
     };
   };
   ktp-kded-module = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/ktp-kded-module-19.04.0.tar.xz";
-      sha256 = "3409e3ec270f0ba2f558b6e6a84e9948936c128cc536fc6c16c4dd5bd8a3c94b";
-      name = "ktp-kded-module-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/ktp-kded-module-19.04.1.tar.xz";
+      sha256 = "fe5fc292618b28d11dddec435e86a89899c52b074b7c729aefe951b0b7697a66";
+      name = "ktp-kded-module-19.04.1.tar.xz";
     };
   };
   ktp-send-file = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/ktp-send-file-19.04.0.tar.xz";
-      sha256 = "f0be593d3101cbc5027e7dcc23a767d2e3e753d140afe97d5790db20eea07226";
-      name = "ktp-send-file-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/ktp-send-file-19.04.1.tar.xz";
+      sha256 = "8d3100de23666e3cb449663db376ed20e38647758371d37d721385af2b0d8d7a";
+      name = "ktp-send-file-19.04.1.tar.xz";
     };
   };
   ktp-text-ui = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/ktp-text-ui-19.04.0.tar.xz";
-      sha256 = "78ac51d23e54d6044b70083db8d2c6972643a207a7f475cde15292e08b6b6469";
-      name = "ktp-text-ui-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/ktp-text-ui-19.04.1.tar.xz";
+      sha256 = "dfc51070d1a25edde7c0f33d4eb83185738a70e6feb40a8b385403e833cca0b5";
+      name = "ktp-text-ui-19.04.1.tar.xz";
     };
   };
   ktuberling = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/ktuberling-19.04.0.tar.xz";
-      sha256 = "984c29562bd20f93117e7d79aa120dd906e6d4490ae5d2b52ad03f7bbfb85ace";
-      name = "ktuberling-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/ktuberling-19.04.1.tar.xz";
+      sha256 = "f8146ecbe3a1005871a589054b996d059e5ff08b9d7fdeaa06591ae0ab05b8cb";
+      name = "ktuberling-19.04.1.tar.xz";
     };
   };
   kturtle = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kturtle-19.04.0.tar.xz";
-      sha256 = "89e836a2737c98caf1ceb16b7ac648262d6a6770ac5bb5b0d9fbfed4abeeda7d";
-      name = "kturtle-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kturtle-19.04.1.tar.xz";
+      sha256 = "f932a56d8f380cc422215e580d8c4d51eabd189f2b4ca3b4205e617d52e6e10d";
+      name = "kturtle-19.04.1.tar.xz";
     };
   };
   kubrick = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kubrick-19.04.0.tar.xz";
-      sha256 = "72adc4e07df6062dd444c4bb9571429acf9c2ee68e273bc42c7925b1c06aad5e";
-      name = "kubrick-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kubrick-19.04.1.tar.xz";
+      sha256 = "636080a8cac2f689f5af8de9aacef9e90029eafaaf7f1867b8a53a8a558e94c7";
+      name = "kubrick-19.04.1.tar.xz";
     };
   };
   kwalletmanager = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kwalletmanager-19.04.0.tar.xz";
-      sha256 = "5cc25daaa8511694b01ba4b0a7ca39f8f2eef9fce10e99411ae287013fc27734";
-      name = "kwalletmanager-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kwalletmanager-19.04.1.tar.xz";
+      sha256 = "793a3a335e53b6af36272398d7933ff0cc77918860799db2b5688ee249ce215d";
+      name = "kwalletmanager-19.04.1.tar.xz";
     };
   };
   kwave = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kwave-19.04.0.tar.xz";
-      sha256 = "510b99740c87ade2e644b8b62ece9ac46721e636aeb83f253939d4d191d03a52";
-      name = "kwave-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kwave-19.04.1.tar.xz";
+      sha256 = "1fd7e256a5d9b77ef691642891b2423357ef4aea7f40ae64304ec922e5930fd6";
+      name = "kwave-19.04.1.tar.xz";
     };
   };
   kwordquiz = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/kwordquiz-19.04.0.tar.xz";
-      sha256 = "a6433b5a2497398ed790965ef5469b53e406882f93b5a05e574d05cb193ef866";
-      name = "kwordquiz-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/kwordquiz-19.04.1.tar.xz";
+      sha256 = "970381004a7382f4f24dad61eda8a386e138735d78c2609c92603e14acbe0158";
+      name = "kwordquiz-19.04.1.tar.xz";
     };
   };
   libgravatar = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/libgravatar-19.04.0.tar.xz";
-      sha256 = "ee62597fffa534b45f89056028d1d9ff871c7da7093d11a128a6decfb5312d12";
-      name = "libgravatar-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/libgravatar-19.04.1.tar.xz";
+      sha256 = "7d4af799effc13af4f4b056d21b188bd67cd503d1528a7ff37e19d228619b522";
+      name = "libgravatar-19.04.1.tar.xz";
     };
   };
   libkcddb = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/libkcddb-19.04.0.tar.xz";
-      sha256 = "d15cef6fe986daba5ea051fda7146c784d993e83ca495faf58fad586ca370c32";
-      name = "libkcddb-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/libkcddb-19.04.1.tar.xz";
+      sha256 = "6773266408c0a68c128b08aca2df594249c210ff9b8fb3553b2bb82c591a2f51";
+      name = "libkcddb-19.04.1.tar.xz";
     };
   };
   libkcompactdisc = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/libkcompactdisc-19.04.0.tar.xz";
-      sha256 = "7236af70872c7b20070d9c096a8d4da45cdf62874d6d1314b183edf8b0d701d6";
-      name = "libkcompactdisc-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/libkcompactdisc-19.04.1.tar.xz";
+      sha256 = "146d842741c24a379a0e134b8c0cbef916f5bd94fb8c6102703e5c764bf9b0ee";
+      name = "libkcompactdisc-19.04.1.tar.xz";
     };
   };
   libkdcraw = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/libkdcraw-19.04.0.tar.xz";
-      sha256 = "30df02047c0f1b97a7c90c8eb5f7a3c5d322f13e0158395d3f9798ff21ed529e";
-      name = "libkdcraw-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/libkdcraw-19.04.1.tar.xz";
+      sha256 = "54576a803929a0adb3d25e239395b541c0820fecd633f09ea40677882c82e42c";
+      name = "libkdcraw-19.04.1.tar.xz";
     };
   };
   libkdegames = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/libkdegames-19.04.0.tar.xz";
-      sha256 = "2965e4a313609f6408becb13e54e26bfe14b37b58e7737e051129896f6e8bcd3";
-      name = "libkdegames-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/libkdegames-19.04.1.tar.xz";
+      sha256 = "a16baa2818ab6f553d9c2635b252530538812787c50f9fbc0d18781943150e5c";
+      name = "libkdegames-19.04.1.tar.xz";
     };
   };
   libkdepim = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/libkdepim-19.04.0.tar.xz";
-      sha256 = "099c7bd90e540c6996f333393afa4831c94b6fbe65f7800bde712ebae4ba8a8e";
-      name = "libkdepim-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/libkdepim-19.04.1.tar.xz";
+      sha256 = "28217ce30663955168d39eaa4e0c7efb47a437f59df77971f3e98efea99adc45";
+      name = "libkdepim-19.04.1.tar.xz";
     };
   };
   libkeduvocdocument = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/libkeduvocdocument-19.04.0.tar.xz";
-      sha256 = "bb0300ca6a89c7174714b005032380b81e6e7bfdf3a3bab82b6f42fc0693045e";
-      name = "libkeduvocdocument-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/libkeduvocdocument-19.04.1.tar.xz";
+      sha256 = "c0b5e23a677cea13a2e15989a5b2240ddab2948b00be67e6306cf916e7ca2e59";
+      name = "libkeduvocdocument-19.04.1.tar.xz";
     };
   };
   libkexiv2 = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/libkexiv2-19.04.0.tar.xz";
-      sha256 = "9fcafa932631429af1693642415d2f202ad29338b63949b5e8661135eb69dc19";
-      name = "libkexiv2-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/libkexiv2-19.04.1.tar.xz";
+      sha256 = "138e1bf75cbbf16c46b6ba35f25e700ad93fa8a2134d0ad4c344174c7701cbae";
+      name = "libkexiv2-19.04.1.tar.xz";
     };
   };
   libkgapi = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/libkgapi-19.04.0.tar.xz";
-      sha256 = "014084b04ee76939a318f711259bbb540037b45fe57a25b200ed4095b74970dc";
-      name = "libkgapi-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/libkgapi-19.04.1.tar.xz";
+      sha256 = "a9d499fe1f5371112ceb94b3b03f8e2b1a1faa4ee69722b4c1c9ba28e8f9052e";
+      name = "libkgapi-19.04.1.tar.xz";
     };
   };
   libkgeomap = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/libkgeomap-19.04.0.tar.xz";
-      sha256 = "12cf73da1d406b8f6efe88c1d1bc56ecf3260bbe41759c4dec061df627e990e9";
-      name = "libkgeomap-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/libkgeomap-19.04.1.tar.xz";
+      sha256 = "519345f30e46fc95816d145177347547c9c9eb440eab017c5ee928fa0ef8cf5a";
+      name = "libkgeomap-19.04.1.tar.xz";
     };
   };
   libkipi = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/libkipi-19.04.0.tar.xz";
-      sha256 = "6fc176e72e829dafe19e17a1d97b032f464d837621989751efe38cdd03d7d285";
-      name = "libkipi-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/libkipi-19.04.1.tar.xz";
+      sha256 = "1f1a8b881f61c9fc151a2f0b98c6ba07baa0fe1ca8a0f77d7502e81c08a84020";
+      name = "libkipi-19.04.1.tar.xz";
     };
   };
   libkleo = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/libkleo-19.04.0.tar.xz";
-      sha256 = "fbd97ae860c0361fca8bfa8a80a2d19e96779eb8d436a9a32c10cfe9767d8981";
-      name = "libkleo-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/libkleo-19.04.1.tar.xz";
+      sha256 = "a75084129e44028ff3f7742cdcb1800df94845d8c6ace38389da317144fa0529";
+      name = "libkleo-19.04.1.tar.xz";
     };
   };
   libkmahjongg = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/libkmahjongg-19.04.0.tar.xz";
-      sha256 = "1ab4461ba92de0cc56bd349a859d5c647f816b20923692237e7f3098ba9dd76e";
-      name = "libkmahjongg-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/libkmahjongg-19.04.1.tar.xz";
+      sha256 = "7a1df5a03e1da1b801ca4530be3b9008b92cb4872ce8ec0038f2686ac325efbb";
+      name = "libkmahjongg-19.04.1.tar.xz";
     };
   };
   libkomparediff2 = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/libkomparediff2-19.04.0.tar.xz";
-      sha256 = "ffb3370aa869831f86dc009353abd72a5f0c7a7d1c570d5fecf9747131247464";
-      name = "libkomparediff2-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/libkomparediff2-19.04.1.tar.xz";
+      sha256 = "2ab1a9cb25996bd6fb80bf556ba4b91a07385e62688249e9415b1ead8b3ad1b3";
+      name = "libkomparediff2-19.04.1.tar.xz";
     };
   };
   libksane = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/libksane-19.04.0.tar.xz";
-      sha256 = "15a4f14ddb26e7e0ed54926c54941b29eebba1fabb2e75ad9f5cd48b9b673f58";
-      name = "libksane-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/libksane-19.04.1.tar.xz";
+      sha256 = "c89039afa641640cbc65b01ae735ee9b70bd3283095d6b034665ddb048d33417";
+      name = "libksane-19.04.1.tar.xz";
     };
   };
   libksieve = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/libksieve-19.04.0.tar.xz";
-      sha256 = "451d71d6c6e8cdfe0ef540cbcca94dae57260563e1e435b41f7070ecb86f6312";
-      name = "libksieve-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/libksieve-19.04.1.tar.xz";
+      sha256 = "23cca1dfc1d79242f24dd95e8817a9672629276bced3a9ee56067570ef69ccff";
+      name = "libksieve-19.04.1.tar.xz";
     };
   };
   lokalize = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/lokalize-19.04.0.tar.xz";
-      sha256 = "e2e8cd6f9bb0e59ffd4b88e5513b757df3b63892ce90e7000c872e896ef74266";
-      name = "lokalize-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/lokalize-19.04.1.tar.xz";
+      sha256 = "1e68faa5af9079e691e5d207b0397c0250fb6e1209b370e9762bfa949c35dce1";
+      name = "lokalize-19.04.1.tar.xz";
     };
   };
   lskat = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/lskat-19.04.0.tar.xz";
-      sha256 = "c3358e62eb8a0c428c32f1ac759f5ead15d4ab552b1ae5b273e6927d14bb0ad1";
-      name = "lskat-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/lskat-19.04.1.tar.xz";
+      sha256 = "f83f9df9e4786a8d6d8d197defb8ac7f40b8bed8e88578673b2660c14c7a4edf";
+      name = "lskat-19.04.1.tar.xz";
     };
   };
   mailcommon = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/mailcommon-19.04.0.tar.xz";
-      sha256 = "cd599079d290f540c83919182eab7e2d236a939a3405d1f882385822fc5d3682";
-      name = "mailcommon-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/mailcommon-19.04.1.tar.xz";
+      sha256 = "37b06e85e74d6ef1801485b8d99529fde5ca11bb446c231a6f5406e99f9c4d0f";
+      name = "mailcommon-19.04.1.tar.xz";
     };
   };
   mailimporter = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/mailimporter-19.04.0.tar.xz";
-      sha256 = "d5649d24aca659fbb00284a70aef868e31a56a9c688a0457945ec0d31c7a22ed";
-      name = "mailimporter-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/mailimporter-19.04.1.tar.xz";
+      sha256 = "e77c5c43f20f821664a3a559b929eb2f97ba5105e000875b1642516a6f298696";
+      name = "mailimporter-19.04.1.tar.xz";
     };
   };
   marble = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/marble-19.04.0.tar.xz";
-      sha256 = "7405c76970d6ec500e5dc99ea2926cc11571e69f29c2e79f025f0f3ec4048960";
-      name = "marble-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/marble-19.04.1.tar.xz";
+      sha256 = "acd9c15c4758684f6eff6c2318fc4dd88fd68dd41336de9458cad4d5f6832c61";
+      name = "marble-19.04.1.tar.xz";
     };
   };
   mbox-importer = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/mbox-importer-19.04.0.tar.xz";
-      sha256 = "0fba78f2feee2ec7c11e64511195546b9c34695c091632494c1d77c2555eb888";
-      name = "mbox-importer-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/mbox-importer-19.04.1.tar.xz";
+      sha256 = "3fcd5c6b3824dea9ff4145dde6bf7b472675e3927ce91258d89cbfe4d0ebb77a";
+      name = "mbox-importer-19.04.1.tar.xz";
     };
   };
   messagelib = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/messagelib-19.04.0.tar.xz";
-      sha256 = "1fb76bcd7aa9792095519c585dbb93552726e3cfe514446eb52edf5ed1517a1a";
-      name = "messagelib-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/messagelib-19.04.1.tar.xz";
+      sha256 = "7e4d0e2f2d6dfcb235408af0e4af235ab10dc8a8c4f1e169a672f03b37b180ad";
+      name = "messagelib-19.04.1.tar.xz";
     };
   };
   minuet = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/minuet-19.04.0.tar.xz";
-      sha256 = "3bdf5470a154b2be4bfcd97db7374ef81ca8eefba3bb12030dd6d39f1466cc78";
-      name = "minuet-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/minuet-19.04.1.tar.xz";
+      sha256 = "5f2e3692c0b7ae9496fa7952bfd02045aa87ba5ee10c6ef84fb4557abe83d0f0";
+      name = "minuet-19.04.1.tar.xz";
     };
   };
   okular = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/okular-19.04.0.tar.xz";
-      sha256 = "1947b394dfd8da9c7cc4234e308e2476ffa44dc58542d246eafc8397d8991b6e";
-      name = "okular-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/okular-19.04.1.tar.xz";
+      sha256 = "7145b1eea61c56a5b413e960e5b24038c7af5d3cb583a524deca344dae3a0e0e";
+      name = "okular-19.04.1.tar.xz";
     };
   };
   palapeli = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/palapeli-19.04.0.tar.xz";
-      sha256 = "21f8b6b109d6cc61acbb0ee01aa31982bb6e27e8894e4f00407f52904d177a2b";
-      name = "palapeli-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/palapeli-19.04.1.tar.xz";
+      sha256 = "dc661c88dcf6e3a17b9a2a403cac1ba9bd8f7144ff2c01ff3c286564159f796b";
+      name = "palapeli-19.04.1.tar.xz";
     };
   };
   parley = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/parley-19.04.0.tar.xz";
-      sha256 = "243f7f1a89bb603c059b0610a9bb7f51627540d439b4026d736062b693879ed2";
-      name = "parley-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/parley-19.04.1.tar.xz";
+      sha256 = "c52746417d32e31f66c1165fd08ab87696d5ef4b5a020a175fe00e60474bc73f";
+      name = "parley-19.04.1.tar.xz";
     };
   };
   picmi = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/picmi-19.04.0.tar.xz";
-      sha256 = "edb10bc29d6817dffeb51762c5fa793ee8de3b3a70c2c6616012f5a043799d86";
-      name = "picmi-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/picmi-19.04.1.tar.xz";
+      sha256 = "10abab6e48f48e1e1308fbd2a687bb4c5051c6ae2a670b737d6974432fdef30c";
+      name = "picmi-19.04.1.tar.xz";
     };
   };
   pimcommon = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/pimcommon-19.04.0.tar.xz";
-      sha256 = "b25d10571e55ab11b758ad6b1040ef2d148b4b5b913f41665c355df25bceb12e";
-      name = "pimcommon-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/pimcommon-19.04.1.tar.xz";
+      sha256 = "bc4612711775ea4665c0827c7935397503b5cf82f906bcf22a64b3ab1eaaaa72";
+      name = "pimcommon-19.04.1.tar.xz";
     };
   };
   pim-data-exporter = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/pim-data-exporter-19.04.0.tar.xz";
-      sha256 = "ae1c3bbfffebb85533b0bbf4b0f8b54c06e29fcdf7284295c89ab43d196a6ac3";
-      name = "pim-data-exporter-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/pim-data-exporter-19.04.1.tar.xz";
+      sha256 = "0fa9e20ef67f64d5a9c967f4ea32a476438b23ab8405774035cd4584e6100ebd";
+      name = "pim-data-exporter-19.04.1.tar.xz";
     };
   };
   pim-sieve-editor = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/pim-sieve-editor-19.04.0.tar.xz";
-      sha256 = "0843df57695ca4dc359d048a7e3bf2b6bb66bd10d861714d316baa8ecb387dd1";
-      name = "pim-sieve-editor-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/pim-sieve-editor-19.04.1.tar.xz";
+      sha256 = "3a8ce54140233fa7ae618fc05ae9d882cab6e56835e9fdb29e2242885ce50e10";
+      name = "pim-sieve-editor-19.04.1.tar.xz";
     };
   };
   poxml = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/poxml-19.04.0.tar.xz";
-      sha256 = "c0a24557cc7e243790c5273fb2a4ff585a3e89cc994772a52979015d2e57a985";
-      name = "poxml-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/poxml-19.04.1.tar.xz";
+      sha256 = "d8439996821ded53dea321f84619f3754cc677b5fa08b5fd37aabb09b8dac2f9";
+      name = "poxml-19.04.1.tar.xz";
     };
   };
   print-manager = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/print-manager-19.04.0.tar.xz";
-      sha256 = "f9dfe61ba341013ae59892cd6715b7c00ee6777ca4d2e81deeda1cf2d283f6ba";
-      name = "print-manager-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/print-manager-19.04.1.tar.xz";
+      sha256 = "33d553bb048959ecfc5e404f3a1e118b0ed78305d96b3a6042ffd576a164e9fa";
+      name = "print-manager-19.04.1.tar.xz";
     };
   };
   rocs = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/rocs-19.04.0.tar.xz";
-      sha256 = "65557205a86ddc682c9f9378731b1cf0dacd170742a5bdf110eeeef8ae4b26c8";
-      name = "rocs-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/rocs-19.04.1.tar.xz";
+      sha256 = "5c0740d68ed26f7291e114faa811a2ae104ee682181f5ebed381865dd7d8db61";
+      name = "rocs-19.04.1.tar.xz";
     };
   };
   signon-kwallet-extension = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/signon-kwallet-extension-19.04.0.tar.xz";
-      sha256 = "eb93120d2acfbac4b823bc301b3724d250dc7e7041eef347c1337c7df84c0c40";
-      name = "signon-kwallet-extension-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/signon-kwallet-extension-19.04.1.tar.xz";
+      sha256 = "658bbae2534896e13a7aced654f38164130ee3c748349d044000d0d7dcaa1c38";
+      name = "signon-kwallet-extension-19.04.1.tar.xz";
     };
   };
   spectacle = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/spectacle-19.04.0.tar.xz";
-      sha256 = "2c4d891d5850e13d912ad0885086170f45178ed5fb4d0ccfef7b22a9a76c35a8";
-      name = "spectacle-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/spectacle-19.04.1.tar.xz";
+      sha256 = "6f420fc6a660e25a08449cfb6d2795e07a37f8dca25f1862d857121b43f9262c";
+      name = "spectacle-19.04.1.tar.xz";
     };
   };
   step = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/step-19.04.0.tar.xz";
-      sha256 = "c37cbd4a7179d796dd4458dbdd98e48d59c5f0278f19026a4f5cc2b50e140319";
-      name = "step-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/step-19.04.1.tar.xz";
+      sha256 = "4fafff95339473e6449e9a45e273fe15758daf743e8697ff73f16129eb1dca05";
+      name = "step-19.04.1.tar.xz";
     };
   };
   svgpart = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/svgpart-19.04.0.tar.xz";
-      sha256 = "6dbec1dcb6853c06f7cb10677a2c99678b398b4a658eb4206a146f24b0fa158a";
-      name = "svgpart-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/svgpart-19.04.1.tar.xz";
+      sha256 = "3e30eb3b0f95073639697c73f1cc1d4689e53921cc87fe23cd0ec04ef6835624";
+      name = "svgpart-19.04.1.tar.xz";
     };
   };
   sweeper = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/sweeper-19.04.0.tar.xz";
-      sha256 = "7ed57321ba601725291e1cfa6cdfe2060ad0405d42124dc8d8d44d137b852f72";
-      name = "sweeper-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/sweeper-19.04.1.tar.xz";
+      sha256 = "70ccd7a1d8d81ee2a54df724a1ad908157672bb20e80c81aff8db946241b6637";
+      name = "sweeper-19.04.1.tar.xz";
     };
   };
   umbrello = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/umbrello-19.04.0.tar.xz";
-      sha256 = "7c37363a92bd91f2a515438068ba6f1c8747269ddaf2eda5a7998539ece4468d";
-      name = "umbrello-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/umbrello-19.04.1.tar.xz";
+      sha256 = "42f9ba60320558439a1d5c68cc4d730c6b17e0b2b8a57b4686031bbecb3ab3c2";
+      name = "umbrello-19.04.1.tar.xz";
     };
   };
   zeroconf-ioslave = {
-    version = "19.04.0";
+    version = "19.04.1";
     src = fetchurl {
-      url = "${mirror}/stable/applications/19.04.0/src/zeroconf-ioslave-19.04.0.tar.xz";
-      sha256 = "e1f7465f200d1c7c53c56a8ebf9a463022a27d6c244d0d1768ff58763e5b53dc";
-      name = "zeroconf-ioslave-19.04.0.tar.xz";
+      url = "${mirror}/stable/applications/19.04.1/src/zeroconf-ioslave-19.04.1.tar.xz";
+      sha256 = "e59c8a4b6ff93ead29b322fb40c94a3584d5c463077d58575720fcba2c511d87";
+      name = "zeroconf-ioslave-19.04.1.tar.xz";
     };
   };
 }

--- a/pkgs/applications/kde/srcs.nix
+++ b/pkgs/applications/kde/srcs.nix
@@ -3,1723 +3,1723 @@
 
 {
   akonadi = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/akonadi-18.12.3.tar.xz";
-      sha256 = "f930deaade1cac1488b8af05cc28f4a78a441c34dbe875b673af3423f8a14658";
-      name = "akonadi-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/akonadi-19.04.0.tar.xz";
+      sha256 = "c0a2c4259b51293d21487cfe2295df6e8dcfb7ab50eb1a698f531dc7d3253e9a";
+      name = "akonadi-19.04.0.tar.xz";
     };
   };
   akonadi-calendar = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/akonadi-calendar-18.12.3.tar.xz";
-      sha256 = "19f92642ba4d62dfccca19ac3ced94495e9137d60a77a672c5443585f30cdaee";
-      name = "akonadi-calendar-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/akonadi-calendar-19.04.0.tar.xz";
+      sha256 = "5a2897a1e96897159a3e2980f407c4c225434efd45167ad699a14aaa2ec445fd";
+      name = "akonadi-calendar-19.04.0.tar.xz";
     };
   };
   akonadi-calendar-tools = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/akonadi-calendar-tools-18.12.3.tar.xz";
-      sha256 = "636ea364bea079cae0b899204add76b0d1d9a80d1955c914bc1dad3a6fc731ed";
-      name = "akonadi-calendar-tools-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/akonadi-calendar-tools-19.04.0.tar.xz";
+      sha256 = "f9869574d880c53bfb87319348d75d8169ffb38bfdeb3b6066f25074409321ef";
+      name = "akonadi-calendar-tools-19.04.0.tar.xz";
     };
   };
   akonadiconsole = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/akonadiconsole-18.12.3.tar.xz";
-      sha256 = "d052084ecc1665976f7db08d11a15609f017b0803dd30b71b5d1dccc60ac6ed0";
-      name = "akonadiconsole-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/akonadiconsole-19.04.0.tar.xz";
+      sha256 = "5118720b6e0ecdf689c7b7f005f732386d0b7a6258cc11fb44fcaac5cc9518a8";
+      name = "akonadiconsole-19.04.0.tar.xz";
     };
   };
   akonadi-contacts = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/akonadi-contacts-18.12.3.tar.xz";
-      sha256 = "6ad8e352744c258b66a0c6155322681fa4ec50422c81fe4248414b0834e645cc";
-      name = "akonadi-contacts-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/akonadi-contacts-19.04.0.tar.xz";
+      sha256 = "65dd20c467daf8d6107a1856c7f112eb937438b5884fe62a09a1763214a7442a";
+      name = "akonadi-contacts-19.04.0.tar.xz";
     };
   };
   akonadi-import-wizard = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/akonadi-import-wizard-18.12.3.tar.xz";
-      sha256 = "a74ca212ab05706d5beb94696a933cb46dfd83d5ebd6723de97f7ce4efbe6104";
-      name = "akonadi-import-wizard-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/akonadi-import-wizard-19.04.0.tar.xz";
+      sha256 = "541b858278d56a5d41858bfa644656d4f04bf6e5a52ce8014d207d64812d6d22";
+      name = "akonadi-import-wizard-19.04.0.tar.xz";
     };
   };
   akonadi-mime = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/akonadi-mime-18.12.3.tar.xz";
-      sha256 = "ff7d91c77b629bba6b93ee6b15c0ebee08aa37368aa8bcae48ecbbacf64bc1b4";
-      name = "akonadi-mime-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/akonadi-mime-19.04.0.tar.xz";
+      sha256 = "b06ca4140b10548b9aecd188bd9b72405af2f4097c80e9b4e9aa3e863750b6da";
+      name = "akonadi-mime-19.04.0.tar.xz";
     };
   };
   akonadi-notes = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/akonadi-notes-18.12.3.tar.xz";
-      sha256 = "ac2f5ef0a3f4621d6af6fef028d641334212d940a1fc3ffc1e3cc6534ca6be60";
-      name = "akonadi-notes-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/akonadi-notes-19.04.0.tar.xz";
+      sha256 = "a9aa05ca2b5f846fed51e4c32907eedc6893a40ab3b9d4832e11bab118664e5f";
+      name = "akonadi-notes-19.04.0.tar.xz";
     };
   };
   akonadi-search = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/akonadi-search-18.12.3.tar.xz";
-      sha256 = "6436a0f71229cf7917cb4f269f34a2046c24860ecfc03e7018b9d2a7f9e66346";
-      name = "akonadi-search-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/akonadi-search-19.04.0.tar.xz";
+      sha256 = "6046a540ace526cbb8c0909762ad333426266afbf58a59ecc71cb923298e84bb";
+      name = "akonadi-search-19.04.0.tar.xz";
     };
   };
   akregator = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/akregator-18.12.3.tar.xz";
-      sha256 = "d3a4f0f4b677825d1b3e1461a020c17a36abe458d7e3ab40389627e2d8163ea1";
-      name = "akregator-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/akregator-19.04.0.tar.xz";
+      sha256 = "5104b0b66ac3917c7cb78f4a6cca952f7e4360cfcd0aa7ce1575d0551470fcee";
+      name = "akregator-19.04.0.tar.xz";
     };
   };
   analitza = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/analitza-18.12.3.tar.xz";
-      sha256 = "c241b6a3d849534ccd50601c0aebd5cd785220bb7957ed7f6b1d3db35ba0f925";
-      name = "analitza-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/analitza-19.04.0.tar.xz";
+      sha256 = "ac8bf7d66f8a2fc7198238f23d82efd1021943ffe8bd5915808e31b800a802f6";
+      name = "analitza-19.04.0.tar.xz";
     };
   };
   ark = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ark-18.12.3.tar.xz";
-      sha256 = "ecf781b5d3691bb967c9170938c1133e2972ee97d71aab2de65487a952700722";
-      name = "ark-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ark-19.04.0.tar.xz";
+      sha256 = "35e8e516a8554e086264d9a9a4fa66c2b47fa227eb9e512a1d0d24172cd07a84";
+      name = "ark-19.04.0.tar.xz";
     };
   };
   artikulate = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/artikulate-18.12.3.tar.xz";
-      sha256 = "f40cc532dd1093d53ab4f825716ea4f4f4d7f954ac6c58ef412b63323a76c278";
-      name = "artikulate-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/artikulate-19.04.0.tar.xz";
+      sha256 = "527ebdb2db6eab3e05810c5e56d53611d80bd23508563457b459e4e32a68ef08";
+      name = "artikulate-19.04.0.tar.xz";
     };
   };
   audiocd-kio = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/audiocd-kio-18.12.3.tar.xz";
-      sha256 = "c15ebda9330688c0304be36999f4900ccd7c0b1ce11e19c296975414dafe53c8";
-      name = "audiocd-kio-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/audiocd-kio-19.04.0.tar.xz";
+      sha256 = "0f347be9c873eb75144d2b8f3f2e28d2e52be4c1a0f59a19be99edd867f17371";
+      name = "audiocd-kio-19.04.0.tar.xz";
     };
   };
   baloo-widgets = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/baloo-widgets-18.12.3.tar.xz";
-      sha256 = "b8475ba1a74f8ebc6a36029b60ac803ab0d2c81c253b8c16bd05b6249454c3e3";
-      name = "baloo-widgets-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/baloo-widgets-19.04.0.tar.xz";
+      sha256 = "ab3d83bb1f2007620273d1a3eb580d821e0655aaf7e3efd2dc81087a24d1c275";
+      name = "baloo-widgets-19.04.0.tar.xz";
     };
   };
   blinken = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/blinken-18.12.3.tar.xz";
-      sha256 = "2b6a11fa56b8837618e157a4a974eb1dff956cfb8b93e6cb0601bda66a234579";
-      name = "blinken-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/blinken-19.04.0.tar.xz";
+      sha256 = "5d470c7f0d232ea01c99fbe1ed08e103291e80c3cfe74e245aba1c2009573eed";
+      name = "blinken-19.04.0.tar.xz";
     };
   };
   bomber = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/bomber-18.12.3.tar.xz";
-      sha256 = "5b8e24aba4fb14ffc72313f9754315d6a7d98a3e00ee118a2551ac3357ead771";
-      name = "bomber-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/bomber-19.04.0.tar.xz";
+      sha256 = "4f82f3f42aff36de837f7c9ddc5986f6c73cb50de122b46320dba0a0b03f9a7d";
+      name = "bomber-19.04.0.tar.xz";
     };
   };
   bovo = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/bovo-18.12.3.tar.xz";
-      sha256 = "7fc7ff304cf5b5bf2049fdd53fbb4a819bddefc77fde94702c5118240403d972";
-      name = "bovo-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/bovo-19.04.0.tar.xz";
+      sha256 = "2cfccb09087a32d8a75f6dd763168e2ef5928f55b58505a542bc36fdac8e141e";
+      name = "bovo-19.04.0.tar.xz";
     };
   };
   calendarsupport = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/calendarsupport-18.12.3.tar.xz";
-      sha256 = "e3c23c152a3e339628e79b168e56c22c5c2610600013f3aa8706168569cacfa5";
-      name = "calendarsupport-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/calendarsupport-19.04.0.tar.xz";
+      sha256 = "d767f077a9d41a9c6d266c4b5fe7bedd6f4eb7b71824e7544cf3a1df11ce362f";
+      name = "calendarsupport-19.04.0.tar.xz";
     };
   };
   cantor = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/cantor-18.12.3.tar.xz";
-      sha256 = "2537b8e8a9e5b72a2b3bf2b08d24c4978f52ef18ced61cdcfd2a09069f670398";
-      name = "cantor-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/cantor-19.04.0.tar.xz";
+      sha256 = "ef0381a65cd2f3a3bb68a7211140077fc1a9bf31ed5302fa368fd874c8441bf4";
+      name = "cantor-19.04.0.tar.xz";
     };
   };
   cervisia = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/cervisia-18.12.3.tar.xz";
-      sha256 = "a5e4034b0d1ee07c2efaef6e8eef17b48a340e9d046cd23efceaf67f07ab5a85";
-      name = "cervisia-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/cervisia-19.04.0.tar.xz";
+      sha256 = "011d9b38a82508ae73328dc56723af11fa8403c0dcf5b7d7703118d79f2ad8f4";
+      name = "cervisia-19.04.0.tar.xz";
     };
   };
   dolphin = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/dolphin-18.12.3.tar.xz";
-      sha256 = "c4921759bdfec9a96201a5d76a67869f867ec7e3caf92f8e46fa5d853a0741b1";
-      name = "dolphin-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/dolphin-19.04.0.tar.xz";
+      sha256 = "f3f45b9048c283252067eebfad8c6e1efc6bc64d43fcba78b933850ea4762375";
+      name = "dolphin-19.04.0.tar.xz";
     };
   };
   dolphin-plugins = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/dolphin-plugins-18.12.3.tar.xz";
-      sha256 = "1bff5f828f11e9b9a527b59f12ec16745fa19fb09392ca1872d6b0c909212427";
-      name = "dolphin-plugins-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/dolphin-plugins-19.04.0.tar.xz";
+      sha256 = "c2898e0a64d5a9eab2a4bd661694b75805adfd0a925f1a21f894892264f96469";
+      name = "dolphin-plugins-19.04.0.tar.xz";
     };
   };
   dragon = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/dragon-18.12.3.tar.xz";
-      sha256 = "115d60bfdef498ea75bc077a7091fb738615b399b03ec2a76a4bf34f19b407f3";
-      name = "dragon-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/dragon-19.04.0.tar.xz";
+      sha256 = "42bde9f6a4f3dfe7a6b2bfa35502474c2866e2649695302d602a97f00842fcf2";
+      name = "dragon-19.04.0.tar.xz";
     };
   };
   eventviews = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/eventviews-18.12.3.tar.xz";
-      sha256 = "994ddea6894fd73eeb851b04083bc886288e4531aa770c0b2e5d8e1740bbe4d0";
-      name = "eventviews-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/eventviews-19.04.0.tar.xz";
+      sha256 = "ed34f228012ad2d45b0f07da469633118f35c28b1ddc7157149f4a5ab999500c";
+      name = "eventviews-19.04.0.tar.xz";
     };
   };
   ffmpegthumbs = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ffmpegthumbs-18.12.3.tar.xz";
-      sha256 = "4db8ab905d80863f898b6a3ea8cd0cc7baad91ad953d6b65df230079be04b338";
-      name = "ffmpegthumbs-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ffmpegthumbs-19.04.0.tar.xz";
+      sha256 = "6b96cea0c142651cb586eb40d88792329f8da9a777d9a457ba76d0e94ddf4995";
+      name = "ffmpegthumbs-19.04.0.tar.xz";
     };
   };
   filelight = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/filelight-18.12.3.tar.xz";
-      sha256 = "9090bc7c7ac2586e857cdc246a94621c1453e7f65c6d491f2f374f43d3e4af1a";
-      name = "filelight-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/filelight-19.04.0.tar.xz";
+      sha256 = "22eaa8f0e9e69652240554687b2cecb55449e67caac6055c2d868f3089d835ad";
+      name = "filelight-19.04.0.tar.xz";
     };
   };
   granatier = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/granatier-18.12.3.tar.xz";
-      sha256 = "ad065e488f9a751423d571f51449e766c625e88ca7d3c30d21ff3b9027fc04af";
-      name = "granatier-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/granatier-19.04.0.tar.xz";
+      sha256 = "d83e91a5056e4caf1e522921025cb79355c0c2d53b7f0e98444d37291d80d63a";
+      name = "granatier-19.04.0.tar.xz";
     };
   };
   grantlee-editor = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/grantlee-editor-18.12.3.tar.xz";
-      sha256 = "d46831a589815581bce45c3954eb12fcbb1692fb407f566952a39e3e8c546b9c";
-      name = "grantlee-editor-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/grantlee-editor-19.04.0.tar.xz";
+      sha256 = "ac888f2f2ccd4b289deac1d2df4415124e14bf183db1ff1088e88fa782f9f342";
+      name = "grantlee-editor-19.04.0.tar.xz";
     };
   };
   grantleetheme = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/grantleetheme-18.12.3.tar.xz";
-      sha256 = "7853075503f2a19713ce43ba077dde8036f892dee7f41e64ebc9af06b4005402";
-      name = "grantleetheme-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/grantleetheme-19.04.0.tar.xz";
+      sha256 = "6896a7e1db662bea03b6bdd9f92214b5fa50dfbebbbaa7b3156ddb87ccd55a3e";
+      name = "grantleetheme-19.04.0.tar.xz";
     };
   };
   gwenview = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/gwenview-18.12.3.tar.xz";
-      sha256 = "0b4ff869fc09140e258e894f5169fc6c96f1126891b8ed1a391d4624d6ab0c35";
-      name = "gwenview-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/gwenview-19.04.0.tar.xz";
+      sha256 = "c7d422bddf031fa9d5a23459c65ea6dbb5919e964cc194178a864ee98912b46d";
+      name = "gwenview-19.04.0.tar.xz";
     };
   };
   incidenceeditor = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/incidenceeditor-18.12.3.tar.xz";
-      sha256 = "b0fa13390b31a24a8bca99f20b132841849d95dba9de3b8a4c9ae979d226ec02";
-      name = "incidenceeditor-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/incidenceeditor-19.04.0.tar.xz";
+      sha256 = "c34fd55acd2f92705e43628fd0c9c4a550c73d45f30beba71dc75698143cbd5f";
+      name = "incidenceeditor-19.04.0.tar.xz";
     };
   };
   juk = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/juk-18.12.3.tar.xz";
-      sha256 = "8755710f551b3173561ebfcc996f32b3fd8de78d5574584f8e37015541a9fdca";
-      name = "juk-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/juk-19.04.0.tar.xz";
+      sha256 = "952366e14526701109e83c1979c2a7b3dfdf3c054ecb86c9b5a6cf9825196f60";
+      name = "juk-19.04.0.tar.xz";
     };
   };
   k3b = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/k3b-18.12.3.tar.xz";
-      sha256 = "cee825ff0c058cc1cbe3bf47a7acbe3889949460ba383ffae3756b67b418362e";
-      name = "k3b-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/k3b-19.04.0.tar.xz";
+      sha256 = "ab0293d0dab2048dcacd4fc54ee2e12d2f55adcecde7cd02e4c31ffd5917ee39";
+      name = "k3b-19.04.0.tar.xz";
     };
   };
   kaccounts-integration = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kaccounts-integration-18.12.3.tar.xz";
-      sha256 = "6e7e4d7aac270f605a5fd4ec9efea8c13807ccb67c11fd3412c1d794ab09e6ce";
-      name = "kaccounts-integration-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kaccounts-integration-19.04.0.tar.xz";
+      sha256 = "d7b257f6b7278361690b2c1d948c92bdb8b14f741ce96ef35f37c8eea3feb687";
+      name = "kaccounts-integration-19.04.0.tar.xz";
     };
   };
   kaccounts-providers = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kaccounts-providers-18.12.3.tar.xz";
-      sha256 = "4d084ffdac10a8a8cc8b79a9b17116893c023288c9e29d1cbabe3d28cd0ba5f6";
-      name = "kaccounts-providers-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kaccounts-providers-19.04.0.tar.xz";
+      sha256 = "4eb74ef042c30ea44f5391f8798d9ceca44d46bf46480355160af61bcb6236d7";
+      name = "kaccounts-providers-19.04.0.tar.xz";
     };
   };
   kaddressbook = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kaddressbook-18.12.3.tar.xz";
-      sha256 = "81d3ba7d5e8ed14b0cc32825f1efbdccbf9f79ffe4e1f8c888179c3d04b5bd28";
-      name = "kaddressbook-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kaddressbook-19.04.0.tar.xz";
+      sha256 = "821708c0a33063de050682c7768faeb51a467de9c4314901761449c09a8a3265";
+      name = "kaddressbook-19.04.0.tar.xz";
     };
   };
   kajongg = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kajongg-18.12.3.tar.xz";
-      sha256 = "e3fba4ddb19e8dfd43f917d737bf13c2391a3042c6941181ab81f4bcd66096f9";
-      name = "kajongg-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kajongg-19.04.0.tar.xz";
+      sha256 = "832e76252321900f3bb3d3a96bb9f9a93235260803621c06d112b7cc48bd1555";
+      name = "kajongg-19.04.0.tar.xz";
     };
   };
   kalarm = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kalarm-18.12.3.tar.xz";
-      sha256 = "5c116221e78755b8afd80287885cb50380c2136acd25aa615d3f6041cc0fbeb3";
-      name = "kalarm-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kalarm-19.04.0.tar.xz";
+      sha256 = "ed8f656e4aebb78d78f068ccde605489090ed0467452629784472b685fae331a";
+      name = "kalarm-19.04.0.tar.xz";
     };
   };
   kalarmcal = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kalarmcal-18.12.3.tar.xz";
-      sha256 = "2658b2d8055558878cf84d50daf333a5f694a586800b9ccfd3eded3304af8ef8";
-      name = "kalarmcal-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kalarmcal-19.04.0.tar.xz";
+      sha256 = "ec0790d2b04bcd3a37a221bdbf4a10f94ff7dd8ac0228e773ce9fac14bbebf6e";
+      name = "kalarmcal-19.04.0.tar.xz";
     };
   };
   kalgebra = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kalgebra-18.12.3.tar.xz";
-      sha256 = "a93b319c6a3fab3d3a12923f8153a6f38281887e176fffaa37ca6cc677a280b5";
-      name = "kalgebra-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kalgebra-19.04.0.tar.xz";
+      sha256 = "a46c4fc2b0891183d0a3b859182eef8d49206b81cbf6d2c6ed6d5448f2663a4a";
+      name = "kalgebra-19.04.0.tar.xz";
     };
   };
   kalzium = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kalzium-18.12.3.tar.xz";
-      sha256 = "100f63b0c1624c10ce7bb54a6a8fa6dfaf6800f580bfc0889745e171fe135fef";
-      name = "kalzium-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kalzium-19.04.0.tar.xz";
+      sha256 = "16fe2873dfad5de78b9a07a4c528e8ac747a54eced9feaa65f1c9fccc23b0d03";
+      name = "kalzium-19.04.0.tar.xz";
     };
   };
   kamera = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kamera-18.12.3.tar.xz";
-      sha256 = "5e0e5a710cffd95019279d68daa27fdd4fba1401450673efa757ffc8a7ca495f";
-      name = "kamera-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kamera-19.04.0.tar.xz";
+      sha256 = "b6b5891e886f543140d1ea6775ec1f1f4575e698d34af04fd65acbafa7e42392";
+      name = "kamera-19.04.0.tar.xz";
     };
   };
   kamoso = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kamoso-18.12.3.tar.xz";
-      sha256 = "ed62bbdf8eeefb85605113c3a916b01eec16846825cffe9b0b0c1f5a4580feb3";
-      name = "kamoso-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kamoso-19.04.0.tar.xz";
+      sha256 = "200c805ba80a89026edcd02d4cd6d058eff1d537eb3da28807cb2162cc014765";
+      name = "kamoso-19.04.0.tar.xz";
     };
   };
   kanagram = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kanagram-18.12.3.tar.xz";
-      sha256 = "dcc06543830ab06066f2f37eba6722f5cb0893355e30cee8d522085ed5fb2204";
-      name = "kanagram-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kanagram-19.04.0.tar.xz";
+      sha256 = "dda3ce8211957e016521597a923de92d261e32c31ebf84faa697bd26cf16647c";
+      name = "kanagram-19.04.0.tar.xz";
     };
   };
   kapman = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kapman-18.12.3.tar.xz";
-      sha256 = "ad4a6377d260df76d000631ab4c95e5cb82ce47d031edc9801b6ed92d856305c";
-      name = "kapman-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kapman-19.04.0.tar.xz";
+      sha256 = "f77dd3210bcdfb2d424f7a919848e25a4b4ae994d74b59111f352e41c2086324";
+      name = "kapman-19.04.0.tar.xz";
     };
   };
   kapptemplate = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kapptemplate-18.12.3.tar.xz";
-      sha256 = "dd4e34e1ed60f4cb03836576dfd5d306ec1890cd0fe583b516bf49c628f1078f";
-      name = "kapptemplate-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kapptemplate-19.04.0.tar.xz";
+      sha256 = "7983c4576c6168731958790851d732f8bd4f4313d2cd00a8bf4dd37a4b6a4bb4";
+      name = "kapptemplate-19.04.0.tar.xz";
     };
   };
   kate = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kate-18.12.3.tar.xz";
-      sha256 = "f7f2cba41a4c88b65885532db6b6161c66055a6697d20ee88adb70f302d387e1";
-      name = "kate-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kate-19.04.0.tar.xz";
+      sha256 = "64c3c312a69d45624e3619309b86de796f67d30a864433a5c24aeb4e299bacc9";
+      name = "kate-19.04.0.tar.xz";
     };
   };
   katomic = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/katomic-18.12.3.tar.xz";
-      sha256 = "0e18087d0de067282023a98b800807632dd6a91bab51cf0d43d53bffba9b33f1";
-      name = "katomic-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/katomic-19.04.0.tar.xz";
+      sha256 = "ea6e6642e16f985653caf2cd9dd61248e7038fb0246e9af4d4daec20401537a2";
+      name = "katomic-19.04.0.tar.xz";
     };
   };
   kbackup = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kbackup-18.12.3.tar.xz";
-      sha256 = "7b42f7fff48f4cf735e27603d0e44ecd13d5c85474680f8d24850eaadd4f13bf";
-      name = "kbackup-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kbackup-19.04.0.tar.xz";
+      sha256 = "84b8f7b05a1812deb128a85aa2d6f1010fb7b2f8cb51aa3771077ef20fd4b4ce";
+      name = "kbackup-19.04.0.tar.xz";
     };
   };
   kblackbox = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kblackbox-18.12.3.tar.xz";
-      sha256 = "d88b2906de45b129f1706b3d250b80f86acb0cc926a3cee679265b86c8934a9b";
-      name = "kblackbox-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kblackbox-19.04.0.tar.xz";
+      sha256 = "9363167664b6b4e54325f9691333df912eefa1e19d387c9a2780626914b813f9";
+      name = "kblackbox-19.04.0.tar.xz";
     };
   };
   kblocks = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kblocks-18.12.3.tar.xz";
-      sha256 = "e981107096893a8078ab978c429f367432a74de1bdeffe8fb628ccc397701332";
-      name = "kblocks-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kblocks-19.04.0.tar.xz";
+      sha256 = "c70a60f3a2e4c8f7756a1f9b1e025f8f91ec83c4f54feedf0ba05eea36b0037e";
+      name = "kblocks-19.04.0.tar.xz";
     };
   };
   kblog = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kblog-18.12.3.tar.xz";
-      sha256 = "cd84b34312f6c5a9cf56322614caafcf434a800aeff66173a2c6f7cccc0fd2cc";
-      name = "kblog-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kblog-19.04.0.tar.xz";
+      sha256 = "719c6ce92c006231869dcad84b14e3db7c8b71eff60e234a94353e2ef580d577";
+      name = "kblog-19.04.0.tar.xz";
     };
   };
   kbounce = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kbounce-18.12.3.tar.xz";
-      sha256 = "c62cb68b4246c1aef73efb04ea883599384afbd977e8da93893346cbd835f343";
-      name = "kbounce-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kbounce-19.04.0.tar.xz";
+      sha256 = "cd28d777db8ff1dc1437fb6456c2fdfe8b9005c0cea3ce05337fbf425803834f";
+      name = "kbounce-19.04.0.tar.xz";
     };
   };
   kbreakout = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kbreakout-18.12.3.tar.xz";
-      sha256 = "23e1cc935eab6a2520e683185cb223243c71553b1ef6059a21f09d72e8fe00af";
-      name = "kbreakout-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kbreakout-19.04.0.tar.xz";
+      sha256 = "c4aa847def701be288e53ceb27c8c63c34aa527f8e64c91fb007d053b1119db8";
+      name = "kbreakout-19.04.0.tar.xz";
     };
   };
   kbruch = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kbruch-18.12.3.tar.xz";
-      sha256 = "e98f79865c4d095d7682ab97b0e4e7d23715e402be676d66f184cfbe3eff598d";
-      name = "kbruch-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kbruch-19.04.0.tar.xz";
+      sha256 = "7762c233529b75859ab264bcfd9847acc06889b0ff96183a1af63effd40f3f38";
+      name = "kbruch-19.04.0.tar.xz";
     };
   };
   kcachegrind = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kcachegrind-18.12.3.tar.xz";
-      sha256 = "48011190a0ef28998e6c96b9d644e3d06b68606b7d1467c84a8d176eeebb9adf";
-      name = "kcachegrind-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kcachegrind-19.04.0.tar.xz";
+      sha256 = "7021ac1b133e86692dad92ff8de6a0467c2b488d7e5c2977ee4880c166e088ca";
+      name = "kcachegrind-19.04.0.tar.xz";
     };
   };
   kcalc = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kcalc-18.12.3.tar.xz";
-      sha256 = "10b3ebb5efab3731e9f12a8632546685281179881b03aae98f96a2cdbd21f02f";
-      name = "kcalc-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kcalc-19.04.0.tar.xz";
+      sha256 = "0384ebf83c62e74a2412f71f648bad112f91ef3ec6aa64fe55e63fd88a156593";
+      name = "kcalc-19.04.0.tar.xz";
     };
   };
   kcalcore = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kcalcore-18.12.3.tar.xz";
-      sha256 = "d6d6ce1bbdea4eac352b74bcc4bee77da107fdbafab47440b6be5fc3f9d90452";
-      name = "kcalcore-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kcalcore-19.04.0.tar.xz";
+      sha256 = "0cdcfebabb9af96650b71ba6361a4557df35144f0b1041f004bff7510c6334b2";
+      name = "kcalcore-19.04.0.tar.xz";
     };
   };
   kcalutils = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kcalutils-18.12.3.tar.xz";
-      sha256 = "715c48c46cd62f773da4e804e66cdb97eae7c4832a7fe058db2fca61dc4111f9";
-      name = "kcalutils-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kcalutils-19.04.0.tar.xz";
+      sha256 = "2841291555bf5ab85390e56b1c6c231bb6f1f5c9cbd12a634491781c3cfd83c8";
+      name = "kcalutils-19.04.0.tar.xz";
     };
   };
   kcharselect = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kcharselect-18.12.3.tar.xz";
-      sha256 = "e24e0268c5810cd3cf733dd8fcc8a9e04a111b761d4c1351d9976b3888278dcb";
-      name = "kcharselect-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kcharselect-19.04.0.tar.xz";
+      sha256 = "788e6e97bb53216b4777fb19602d823a8e62f9ea25082f545e970a561fb3a78f";
+      name = "kcharselect-19.04.0.tar.xz";
     };
   };
   kcolorchooser = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kcolorchooser-18.12.3.tar.xz";
-      sha256 = "8defdb9450922b675dc80561a0f4bb119e621a85dd73661fc4caacef8db91228";
-      name = "kcolorchooser-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kcolorchooser-19.04.0.tar.xz";
+      sha256 = "8f338ba51349cb056f25266d884ca318d3fd3933288ec96f9f17df6c842bc839";
+      name = "kcolorchooser-19.04.0.tar.xz";
     };
   };
   kcontacts = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kcontacts-18.12.3.tar.xz";
-      sha256 = "ba244937e36456065ec4c40fd1b44d011df487a940756ddc0ddd761f58454dd3";
-      name = "kcontacts-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kcontacts-19.04.0.tar.xz";
+      sha256 = "81ad5b3eada7c91b4b7ed09a0a17a146e87b3075925caa3d23b82c2a6f67f5b4";
+      name = "kcontacts-19.04.0.tar.xz";
     };
   };
   kcron = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kcron-18.12.3.tar.xz";
-      sha256 = "ba1d7e3ed5453a4867b4900deb957f1020f1533bdadfc36a1c6f83921bfd6ca3";
-      name = "kcron-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kcron-19.04.0.tar.xz";
+      sha256 = "58a84503da74d7c0e26ab14c95f92f57f0a9f0c5e1ce0fa4be30276728c8be35";
+      name = "kcron-19.04.0.tar.xz";
     };
   };
   kdav = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kdav-18.12.3.tar.xz";
-      sha256 = "3ce99c65573d6374e91abff50b3a738515da07371f07c1b6e4b1800069a77c23";
-      name = "kdav-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kdav-19.04.0.tar.xz";
+      sha256 = "dce315916a993dbff7f7748538da91944b20df3cb6fc042e0d145d53904ff5d9";
+      name = "kdav-19.04.0.tar.xz";
     };
   };
   kdebugsettings = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kdebugsettings-18.12.3.tar.xz";
-      sha256 = "680eeec77314d23ca3a40c803b4c22a1800dc982fa81cba9f44dbfa9222539f7";
-      name = "kdebugsettings-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kdebugsettings-19.04.0.tar.xz";
+      sha256 = "7c06b1c5b1f14c3a67d34fda52494a8d47495b3473ecd9fe03e97cb1c88012c5";
+      name = "kdebugsettings-19.04.0.tar.xz";
     };
   };
   kde-dev-scripts = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kde-dev-scripts-18.12.3.tar.xz";
-      sha256 = "c62f05b86615a810beb2573ee2106bc68fc8be586b66bcdde62d3ba4e4c16fb4";
-      name = "kde-dev-scripts-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kde-dev-scripts-19.04.0.tar.xz";
+      sha256 = "23b777143c9402bf089cd2f84c5ac363183b74dcf81be8c08d74d5d099e898e5";
+      name = "kde-dev-scripts-19.04.0.tar.xz";
     };
   };
   kde-dev-utils = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kde-dev-utils-18.12.3.tar.xz";
-      sha256 = "f53b896b62b7d2267b78d23fb24cf495932c4c8b552d8bf56c722a49acc54be6";
-      name = "kde-dev-utils-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kde-dev-utils-19.04.0.tar.xz";
+      sha256 = "ec2df1ab8b73f19ffc8ec7abeba0577b42d15bc372a19b456a2a04ebb4691031";
+      name = "kde-dev-utils-19.04.0.tar.xz";
     };
   };
   kdeedu-data = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kdeedu-data-18.12.3.tar.xz";
-      sha256 = "cebaa135b21cba27015b1679e02a6625b9b444828ec7595e1a46f53dd7ae3999";
-      name = "kdeedu-data-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kdeedu-data-19.04.0.tar.xz";
+      sha256 = "ddba1b8f78b1614ac8b43b605a9021d611765dea6152e0997c84d4f9b17d9be6";
+      name = "kdeedu-data-19.04.0.tar.xz";
     };
   };
   kdegraphics-mobipocket = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kdegraphics-mobipocket-18.12.3.tar.xz";
-      sha256 = "69ae8b6f45b8c9ec3a73e636f7a779257ebbd6f8016d24294bec844a51f2cc52";
-      name = "kdegraphics-mobipocket-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kdegraphics-mobipocket-19.04.0.tar.xz";
+      sha256 = "37db302ed0d70766cf75e052f27150553b875428b68c886fe4d16452edd18939";
+      name = "kdegraphics-mobipocket-19.04.0.tar.xz";
     };
   };
   kdegraphics-thumbnailers = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kdegraphics-thumbnailers-18.12.3.tar.xz";
-      sha256 = "9bc36ea2eb8a177899bf81b1cdc63a92b8e5dae12308f3e71046a63e58aafec0";
-      name = "kdegraphics-thumbnailers-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kdegraphics-thumbnailers-19.04.0.tar.xz";
+      sha256 = "7af5fb986c493649a1eec9ba881f8b9c06c5d7459f0acc59e7ee7d185bc7ee70";
+      name = "kdegraphics-thumbnailers-19.04.0.tar.xz";
     };
   };
   kdenetwork-filesharing = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kdenetwork-filesharing-18.12.3.tar.xz";
-      sha256 = "296c71526de0e51b4385962c76c2870cfe344b9dafdd2f5f2fba81801350d503";
-      name = "kdenetwork-filesharing-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kdenetwork-filesharing-19.04.0.tar.xz";
+      sha256 = "a88277659bc1dd5ddfea9dd63c3764a1f31d06235aa07c528c12a63a7605c943";
+      name = "kdenetwork-filesharing-19.04.0.tar.xz";
     };
   };
   kdenlive = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kdenlive-18.12.3.tar.xz";
-      sha256 = "fcfe2474bc271e730ed95edb21ae46e93c1ce773ed036f63c9fb2db02cbc7e64";
-      name = "kdenlive-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kdenlive-19.04.0.tar.xz";
+      sha256 = "274ae17b4376258ef83d810cb33677ca3224e205ea8b69982dd0fc4e5ee5878a";
+      name = "kdenlive-19.04.0.tar.xz";
     };
   };
   kdepim-addons = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kdepim-addons-18.12.3.tar.xz";
-      sha256 = "450a3f257e998e733b69703a1a813abab93c571c602702cbb4d9ab4ac25e8ce5";
-      name = "kdepim-addons-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kdepim-addons-19.04.0.tar.xz";
+      sha256 = "778e946e74f36d368f484226ccc6f9cbd548d1cb2b0c3536e87d9374c64ddd88";
+      name = "kdepim-addons-19.04.0.tar.xz";
     };
   };
   kdepim-apps-libs = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kdepim-apps-libs-18.12.3.tar.xz";
-      sha256 = "40a6fb24fc262f5340fda4aed453c5d515976aea745765e83cf8053b44d60164";
-      name = "kdepim-apps-libs-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kdepim-apps-libs-19.04.0.tar.xz";
+      sha256 = "f335f736d854b56bab89814db44761c7e49b35e5266dddee78d22c6465e305c1";
+      name = "kdepim-apps-libs-19.04.0.tar.xz";
     };
   };
   kdepim-runtime = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kdepim-runtime-18.12.3.tar.xz";
-      sha256 = "f3a5da19bb0f60e148d071cf07fd9fd4e6ea116f6125567c767c03b98ea844c3";
-      name = "kdepim-runtime-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kdepim-runtime-19.04.0.tar.xz";
+      sha256 = "944e956d260ba5a735b3c94c6c075f207a9c38bf977ed19507b4dd0f3eaa4993";
+      name = "kdepim-runtime-19.04.0.tar.xz";
     };
   };
   kdesdk-kioslaves = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kdesdk-kioslaves-18.12.3.tar.xz";
-      sha256 = "1f1951eca1c4081277782e80ef6b7c6768b2bb5a7d1830d69954f2fec27462ad";
-      name = "kdesdk-kioslaves-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kdesdk-kioslaves-19.04.0.tar.xz";
+      sha256 = "8765a03f1a6930f28f053b920839e673dbc19bd1947900d84324be963147381a";
+      name = "kdesdk-kioslaves-19.04.0.tar.xz";
     };
   };
   kdesdk-thumbnailers = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kdesdk-thumbnailers-18.12.3.tar.xz";
-      sha256 = "a4694da94bd671a1395a32a527c919fb2207e8a959ceff32a11488e2015a784b";
-      name = "kdesdk-thumbnailers-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kdesdk-thumbnailers-19.04.0.tar.xz";
+      sha256 = "195f539bec6e19de83e07dce117f7cd656f77199c2863a6a5738112d53843243";
+      name = "kdesdk-thumbnailers-19.04.0.tar.xz";
     };
   };
   kdf = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kdf-18.12.3.tar.xz";
-      sha256 = "a8a9e8a4c2bdc1855078383f10720b4b3a388c678dee148494dc18ba5019a6ae";
-      name = "kdf-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kdf-19.04.0.tar.xz";
+      sha256 = "f1204fddefe5492c860a77ff2c343f9b885625b321a37673763d73510dd469fd";
+      name = "kdf-19.04.0.tar.xz";
     };
   };
   kdialog = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kdialog-18.12.3.tar.xz";
-      sha256 = "8b17013ced4b02ceaf89ed3d3fdcfa4fce06fac54d54041fb1e47169f2def212";
-      name = "kdialog-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kdialog-19.04.0.tar.xz";
+      sha256 = "2cdd5a65046cfc09246bd1fbc8be818db486e35437f00e20e372d58988f04ace";
+      name = "kdialog-19.04.0.tar.xz";
     };
   };
   kdiamond = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kdiamond-18.12.3.tar.xz";
-      sha256 = "b3d959cc195b924ca877df2762c3e8ef115ac41c2355f34efbbcaabe9b02b500";
-      name = "kdiamond-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kdiamond-19.04.0.tar.xz";
+      sha256 = "121ef36611bf7fe9a7d1d4700622a4cc8a349fe262b7c568026a4da55dfd4b26";
+      name = "kdiamond-19.04.0.tar.xz";
     };
   };
   keditbookmarks = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/keditbookmarks-18.12.3.tar.xz";
-      sha256 = "8d1f1a6ffa3b68d318ac6eb72707e5e5bb4f6f43ebb25c0475121469a71f6a8d";
-      name = "keditbookmarks-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/keditbookmarks-19.04.0.tar.xz";
+      sha256 = "23770a42aa72eb275b2b5a21f8e2f0959eec112ab048c6d89999ee156cd2ef65";
+      name = "keditbookmarks-19.04.0.tar.xz";
     };
   };
   kfind = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kfind-18.12.3.tar.xz";
-      sha256 = "ad123b24f88e1ade5a845c16a84a483835cce31b92741107d8dbd02f462d4cd9";
-      name = "kfind-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kfind-19.04.0.tar.xz";
+      sha256 = "7eec5b096738bb28264bf870bdd85e24f97c62677be2d2a061f6c426ecfc3a47";
+      name = "kfind-19.04.0.tar.xz";
     };
   };
   kfloppy = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kfloppy-18.12.3.tar.xz";
-      sha256 = "d68af7c572591a1a297cc823c1cb16a8a15973983c31f2e598d75dcc09ae2363";
-      name = "kfloppy-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kfloppy-19.04.0.tar.xz";
+      sha256 = "fafa66fddf5fe938b5666ef94ea4a1f41487cb3cc815fa6bc65332ee7574f7e1";
+      name = "kfloppy-19.04.0.tar.xz";
     };
   };
   kfourinline = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kfourinline-18.12.3.tar.xz";
-      sha256 = "cd3c3129c50502d9fe35f2382fcb1a512519626eb1b776600fdac2190390b9ce";
-      name = "kfourinline-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kfourinline-19.04.0.tar.xz";
+      sha256 = "458bc34c169df064c8d974d6f27e18e3cc5f3e9fb069358817d00a590f2e200a";
+      name = "kfourinline-19.04.0.tar.xz";
     };
   };
   kgeography = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kgeography-18.12.3.tar.xz";
-      sha256 = "ae019c4fc6c2b52344466266a19c6047e5dc414a92461a21d0e9c003dd4433c9";
-      name = "kgeography-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kgeography-19.04.0.tar.xz";
+      sha256 = "ee126fc91ba164e0c095e7cef231a1389a4e1423256773c4e7d4b7306077eb41";
+      name = "kgeography-19.04.0.tar.xz";
     };
   };
   kget = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kget-18.12.3.tar.xz";
-      sha256 = "3386c07c61f072df4259f83895be43c64559c059c24df1b31ca66c4f2b599f86";
-      name = "kget-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kget-19.04.0.tar.xz";
+      sha256 = "e1ec10f36f8b451c2cfc02108e00c6ab3e1115719342b9fa1f1f5829746fbeb9";
+      name = "kget-19.04.0.tar.xz";
     };
   };
   kgoldrunner = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kgoldrunner-18.12.3.tar.xz";
-      sha256 = "1d54b485ccb81106853d5229422c753a5b0bbd2f9239a17b1c44f737a32d93b6";
-      name = "kgoldrunner-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kgoldrunner-19.04.0.tar.xz";
+      sha256 = "3d2eb37695328065ee5cf4c4ba4ee707ce514b4c7aab84c93cd3bef8d329b8ba";
+      name = "kgoldrunner-19.04.0.tar.xz";
     };
   };
   kgpg = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kgpg-18.12.3.tar.xz";
-      sha256 = "05d70923f4c9d068b339dc0a3d3f28890cafe1fbef9820dd6157c1f5fd8f19e8";
-      name = "kgpg-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kgpg-19.04.0.tar.xz";
+      sha256 = "2fb47d9d08cfca94dce1c4d19bce5d2955c3cd3ceec6265a8b537de612a53128";
+      name = "kgpg-19.04.0.tar.xz";
     };
   };
   khangman = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/khangman-18.12.3.tar.xz";
-      sha256 = "1a7cdd27abf229603965ff6b3392bd7935f7f5a2d6418b23f802cfae45f74013";
-      name = "khangman-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/khangman-19.04.0.tar.xz";
+      sha256 = "2a7120f7a54848dc017efdb86c22a964626029d9ca300d8e1488d385f10dc61c";
+      name = "khangman-19.04.0.tar.xz";
     };
   };
   khelpcenter = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/khelpcenter-18.12.3.tar.xz";
-      sha256 = "5b4a9ed17d0898c74cf7fd1612e2d055086d5e04148b3b17df5977255fc240b8";
-      name = "khelpcenter-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/khelpcenter-19.04.0.tar.xz";
+      sha256 = "5fc4f9553e8575055edf259baa3d0b0c663db5caf67dc392db9e519d6b85699f";
+      name = "khelpcenter-19.04.0.tar.xz";
     };
   };
   kidentitymanagement = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kidentitymanagement-18.12.3.tar.xz";
-      sha256 = "4e8cac86c2ecfe6325bbf8fb7e50a026f6af978be3809f327eddfed7b3aed662";
-      name = "kidentitymanagement-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kidentitymanagement-19.04.0.tar.xz";
+      sha256 = "1ddce9330947fdfd970f07b60d6e9ff012e21a673262796ccb29e56e277b55a3";
+      name = "kidentitymanagement-19.04.0.tar.xz";
     };
   };
   kig = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kig-18.12.3.tar.xz";
-      sha256 = "abba87c3569e571e6d1761dc2e6c0e32969ea09eba6d9c0462cb4dc7bd62d7a2";
-      name = "kig-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kig-19.04.0.tar.xz";
+      sha256 = "781243a23a94d7a9882bd69ddfcd74a5b9df0ce28cd45488e62dcf54e3633234";
+      name = "kig-19.04.0.tar.xz";
     };
   };
   kigo = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kigo-18.12.3.tar.xz";
-      sha256 = "fa767319c3ac3e2dea48a5b09284e47e5f0c5d1862af813258758773998d1484";
-      name = "kigo-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kigo-19.04.0.tar.xz";
+      sha256 = "30f12515ec4d22d39c6c90690545e1975a3ba9917180503ef42cba40ffbd874c";
+      name = "kigo-19.04.0.tar.xz";
     };
   };
   killbots = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/killbots-18.12.3.tar.xz";
-      sha256 = "4efb4fcd4f34f1843b990a92e5b0309c196071f0778cdc8376eff5eef405deb9";
-      name = "killbots-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/killbots-19.04.0.tar.xz";
+      sha256 = "0cc928a1956b72bc207feed237598b445b5a7d7d26a266ec88080c1510870359";
+      name = "killbots-19.04.0.tar.xz";
     };
   };
   kimagemapeditor = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kimagemapeditor-18.12.3.tar.xz";
-      sha256 = "addaaf257c35e8169288a8e7a50a1628f3ceeb6a2a845c3d260dfe94662438c6";
-      name = "kimagemapeditor-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kimagemapeditor-19.04.0.tar.xz";
+      sha256 = "8d3ff906926fe8f82b21cf19d784dbddfcda15de9513feaa9defa6e4ff3b1869";
+      name = "kimagemapeditor-19.04.0.tar.xz";
     };
   };
   kimap = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kimap-18.12.3.tar.xz";
-      sha256 = "00aed701a3bdcc218902998e63e7c587549f77a1aa0d1bd7dad4a1837adc9992";
-      name = "kimap-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kimap-19.04.0.tar.xz";
+      sha256 = "cda62c81c47011ad2adbf78222eab4528a62116487531ce1aa98f6100706d2fd";
+      name = "kimap-19.04.0.tar.xz";
     };
   };
   kio-extras = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kio-extras-18.12.3.tar.xz";
-      sha256 = "f8879abaea6fcf31ee0bd4a55d0c24a5fded6d61abed1b059f704f797793aef2";
-      name = "kio-extras-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kio-extras-19.04.0.tar.xz";
+      sha256 = "0f3f2eaf40512cf4a61b09b94ca365d7d05c7b1a75f4e8afd047143a8e962d85";
+      name = "kio-extras-19.04.0.tar.xz";
     };
   };
   kirigami-gallery = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kirigami-gallery-18.12.3.tar.xz";
-      sha256 = "64da8da506718e6b7b62e04a9d2fc40ec73f909f9a6b5afd29b4c81c20053e39";
-      name = "kirigami-gallery-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kirigami-gallery-19.04.0.tar.xz";
+      sha256 = "c0ac9e9a07072d1a538d2535fd21dede86cc4ee9287c7b1ca3d6b8f8726a7155";
+      name = "kirigami-gallery-19.04.0.tar.xz";
     };
   };
   kiriki = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kiriki-18.12.3.tar.xz";
-      sha256 = "0b67b5069625fe04f6ffaa65d0d4abcf86f2f067483b4db15508d2b5ee9742ac";
-      name = "kiriki-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kiriki-19.04.0.tar.xz";
+      sha256 = "feb7b4fce0e6b1749bddd254a46a5d34bf5584a3d60aef460816380141ad630e";
+      name = "kiriki-19.04.0.tar.xz";
     };
   };
   kiten = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kiten-18.12.3.tar.xz";
-      sha256 = "0e0bc0b0b2609a7872b45647976c87ec92ccb068d05113b8dc58e43c6eb1facf";
-      name = "kiten-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kiten-19.04.0.tar.xz";
+      sha256 = "53f5e4ef48b18989084858ab5c96b7dedf357cecf4dba3b2d2a967b4b4b8a742";
+      name = "kiten-19.04.0.tar.xz";
     };
   };
   kitinerary = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kitinerary-18.12.3.tar.xz";
-      sha256 = "f45ef90cb3fb53d83a30837c304b9f7cfa5dbf2953421233d97c101d66a81f35";
-      name = "kitinerary-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kitinerary-19.04.0.tar.xz";
+      sha256 = "b56c93b7114cad54313471e6ab4cebde461a2b39859b47e9b8f7f146d3471889";
+      name = "kitinerary-19.04.0.tar.xz";
     };
   };
   kjumpingcube = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kjumpingcube-18.12.3.tar.xz";
-      sha256 = "6409a3bb398ab90959afc24fa42b01b6e544526b1dab6f36bb700703fa794993";
-      name = "kjumpingcube-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kjumpingcube-19.04.0.tar.xz";
+      sha256 = "28fabf01d0a2481c54018d00985254acb107579c5afa93bbec7b3795c2a3f143";
+      name = "kjumpingcube-19.04.0.tar.xz";
     };
   };
   kldap = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kldap-18.12.3.tar.xz";
-      sha256 = "dc5c8f33aad9e82f0cee65c6fc530f6bd9b82ec9cc21d1ce904f0fe9bdf5140e";
-      name = "kldap-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kldap-19.04.0.tar.xz";
+      sha256 = "2cddadf995a10b854b28e34c18db14c32ad985c18af466edde6a1b2a9a2d8a23";
+      name = "kldap-19.04.0.tar.xz";
     };
   };
   kleopatra = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kleopatra-18.12.3.tar.xz";
-      sha256 = "ea165519846d70206e951d8d904bc02d17ed724db100638e657f7c930c4c490b";
-      name = "kleopatra-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kleopatra-19.04.0.tar.xz";
+      sha256 = "8ad7ec0b99efabdbc270559098dfca64e39ddd30a64b13915c04988a9c8b8b70";
+      name = "kleopatra-19.04.0.tar.xz";
     };
   };
   klettres = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/klettres-18.12.3.tar.xz";
-      sha256 = "4ca89a54858d1f8ac43e8cb485b80a3bb5ead501d39e7e30d8c9b6b8d2d7fd93";
-      name = "klettres-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/klettres-19.04.0.tar.xz";
+      sha256 = "c8a5596638ea7bbe7e26c246c5904840bf544e632e5649430bb32159aedefd60";
+      name = "klettres-19.04.0.tar.xz";
     };
   };
   klickety = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/klickety-18.12.3.tar.xz";
-      sha256 = "45ed455fd9628aaf081bfa6b672199fbb6913c7dc5d5c04ad9df206a3bd962a5";
-      name = "klickety-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/klickety-19.04.0.tar.xz";
+      sha256 = "2ad160e3ea0a6f11c828f3b4bcea8f75db4121dda6d6e498fa1fc095e82e80e5";
+      name = "klickety-19.04.0.tar.xz";
     };
   };
   klines = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/klines-18.12.3.tar.xz";
-      sha256 = "6d93e5bee1135f4eeb67e7f845a4fd658be7e5fb33f42c0ad6320200bc86fd80";
-      name = "klines-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/klines-19.04.0.tar.xz";
+      sha256 = "139c0a4da7186e6e57228fcbe8666aa40e52ae01f328fea4d53ed8611ed54a96";
+      name = "klines-19.04.0.tar.xz";
     };
   };
   kmag = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kmag-18.12.3.tar.xz";
-      sha256 = "04f1357e46bb3e32c85f08c9d5655cde6351c6efd27824a17019ea8562e8d5ba";
-      name = "kmag-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kmag-19.04.0.tar.xz";
+      sha256 = "c6725654846e83b383ff6c624683e4132538f2e812d8131cadefd6926316520e";
+      name = "kmag-19.04.0.tar.xz";
     };
   };
   kmahjongg = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kmahjongg-18.12.3.tar.xz";
-      sha256 = "188a8d921b72965d4ed0f6490048cde7b9d5606cca7d3cea12463dc71a90ccf6";
-      name = "kmahjongg-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kmahjongg-19.04.0.tar.xz";
+      sha256 = "519bf6bb0bc098f74467d3ec9b49c82d22241dfd518d004163565e86dbc21a36";
+      name = "kmahjongg-19.04.0.tar.xz";
     };
   };
   kmail = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kmail-18.12.3.tar.xz";
-      sha256 = "9dd9865d4a463ac552c25126ecaee662b83548091c5abef168bdc7a6d2fb5c76";
-      name = "kmail-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kmail-19.04.0.tar.xz";
+      sha256 = "c191057769513d51d6604e0f51e441e54770ac07a982175a5be29b7797d6f486";
+      name = "kmail-19.04.0.tar.xz";
     };
   };
   kmail-account-wizard = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kmail-account-wizard-18.12.3.tar.xz";
-      sha256 = "102a4170cb4f80c7a9ba3aec7a4d34a3e6a8ca18c975b5c0ea33cf7bac9e21df";
-      name = "kmail-account-wizard-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kmail-account-wizard-19.04.0.tar.xz";
+      sha256 = "640d63ceca23644e2f358c7117eb54daa0fffc669628398f7930fe273d7944a9";
+      name = "kmail-account-wizard-19.04.0.tar.xz";
     };
   };
   kmailtransport = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kmailtransport-18.12.3.tar.xz";
-      sha256 = "8aaa6045f29195074c61fd58112ca7dfbe594df66cac91bac7b246ab2ab9fad1";
-      name = "kmailtransport-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kmailtransport-19.04.0.tar.xz";
+      sha256 = "35104e661fd501bd5848006dfd907f8cd1dfe88609ed4f9fbc4ce599a2f20c8f";
+      name = "kmailtransport-19.04.0.tar.xz";
     };
   };
   kmbox = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kmbox-18.12.3.tar.xz";
-      sha256 = "13a88db1ab0d628a3053a0d6ab5d89cd2f6cbadb3082b52e5dc7048516a10841";
-      name = "kmbox-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kmbox-19.04.0.tar.xz";
+      sha256 = "cd37b698e4ad12317a6d1f7df786345f5df7112ea3d21c2c23545e48a67e8544";
+      name = "kmbox-19.04.0.tar.xz";
     };
   };
   kmime = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kmime-18.12.3.tar.xz";
-      sha256 = "a09b0757e6ba663bf52d9bb8f7f104f3f19f734a858f6d532a6a20888ebcd274";
-      name = "kmime-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kmime-19.04.0.tar.xz";
+      sha256 = "2081adec0e6972e513206bee69c0e165904670b7bcf34c52e7da07323537d513";
+      name = "kmime-19.04.0.tar.xz";
     };
   };
   kmines = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kmines-18.12.3.tar.xz";
-      sha256 = "40c16b57614098555c32252c75e3890922b62d7005b9059f6ae92e11c96d980f";
-      name = "kmines-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kmines-19.04.0.tar.xz";
+      sha256 = "56452ab18c74f2863efc99200a5facd53827382c06fc8534d095bffaca497566";
+      name = "kmines-19.04.0.tar.xz";
     };
   };
   kmix = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kmix-18.12.3.tar.xz";
-      sha256 = "4edf31a36a5d700cc190ba7a5a0d76789729069d48324a22bda7977cb4ed081a";
-      name = "kmix-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kmix-19.04.0.tar.xz";
+      sha256 = "f372d50ccdb496a3bb7a3f68c84c921c12d3d535a792400e701ed7c640e45f2a";
+      name = "kmix-19.04.0.tar.xz";
     };
   };
   kmousetool = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kmousetool-18.12.3.tar.xz";
-      sha256 = "34f6bb6f69c284e9cc88d8a31d59c16f003310c33e1e1affd5c363d18f8a91a8";
-      name = "kmousetool-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kmousetool-19.04.0.tar.xz";
+      sha256 = "89e383a395ec5f1c7d25cc5fb45ecb73a3a0931919a2be533634d77c01cb3fa9";
+      name = "kmousetool-19.04.0.tar.xz";
     };
   };
   kmouth = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kmouth-18.12.3.tar.xz";
-      sha256 = "89b83fb8b4a5eb3c7a6409cd25c730a8bc3be72983c1a75f5e3d3abf01064486";
-      name = "kmouth-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kmouth-19.04.0.tar.xz";
+      sha256 = "32666760ed76dd2dc816df52c990cb3b8487346ac37bf065e4b109fb6661ebc3";
+      name = "kmouth-19.04.0.tar.xz";
     };
   };
   kmplot = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kmplot-18.12.3.tar.xz";
-      sha256 = "2dd6eec34088b5d3b591091cce41616ee310a66aa2d16e5800db56044d60dd7b";
-      name = "kmplot-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kmplot-19.04.0.tar.xz";
+      sha256 = "fb981354dd6fea18e83003df957f65a9580d458b377adde88a838d4db9a97ee6";
+      name = "kmplot-19.04.0.tar.xz";
     };
   };
   knavalbattle = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/knavalbattle-18.12.3.tar.xz";
-      sha256 = "bce9294830a55e96b234c93fa20eb7d7ae963223e724ab0211ec472c79d35fa3";
-      name = "knavalbattle-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/knavalbattle-19.04.0.tar.xz";
+      sha256 = "1e6fbd202092230017c268cd825438debf766e3cc810244b63dc8690b5a69585";
+      name = "knavalbattle-19.04.0.tar.xz";
     };
   };
   knetwalk = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/knetwalk-18.12.3.tar.xz";
-      sha256 = "75ed9859ebb0c40d4efadaf1724b50c1a0436a5d3cd7cb540031cf5535794e3f";
-      name = "knetwalk-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/knetwalk-19.04.0.tar.xz";
+      sha256 = "84b03a6b7c3ff6634402b016089a54ed0116ace221fdfb04ad3d2a8997f68b4b";
+      name = "knetwalk-19.04.0.tar.xz";
     };
   };
   knights = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/knights-18.12.3.tar.xz";
-      sha256 = "9472ffa7800bd79a84dd0c36e3058d3f6e0813b5695aeffeb73bccb801870990";
-      name = "knights-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/knights-19.04.0.tar.xz";
+      sha256 = "53eb3214550fc104755ffe076c970cf5499c9553b543d83df42a3b5f5d8d309a";
+      name = "knights-19.04.0.tar.xz";
     };
   };
   knotes = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/knotes-18.12.3.tar.xz";
-      sha256 = "4cd3a4e5064211f3df6ebf4711c2f4e01b09c77580493de9070c9ee842059578";
-      name = "knotes-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/knotes-19.04.0.tar.xz";
+      sha256 = "e2f98d029105d18c5c14b774782287e281e2367eebeb84d52727a5156abe4092";
+      name = "knotes-19.04.0.tar.xz";
     };
   };
   kolf = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kolf-18.12.3.tar.xz";
-      sha256 = "330cd299702e282a8b248b81cd50ee7ff60a6f512967029730ab87bedb69652f";
-      name = "kolf-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kolf-19.04.0.tar.xz";
+      sha256 = "431b31dc6290214be5f5df1d3c6a8eb4a910b4f72135840d4ec3fa6945319c81";
+      name = "kolf-19.04.0.tar.xz";
     };
   };
   kollision = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kollision-18.12.3.tar.xz";
-      sha256 = "17376f73da0ea5e05998a4f9f0ccb6c0e41461007b8815637ac1980673e9a856";
-      name = "kollision-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kollision-19.04.0.tar.xz";
+      sha256 = "f218ef5691235155911b4d03cd301ee6caa0bde6eb324cd55117e722002b0927";
+      name = "kollision-19.04.0.tar.xz";
     };
   };
   kolourpaint = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kolourpaint-18.12.3.tar.xz";
-      sha256 = "450b714f0d73b59d31c4ceda142a3496d14e51d84b8c8968548a15e05c138f98";
-      name = "kolourpaint-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kolourpaint-19.04.0.tar.xz";
+      sha256 = "d6cd087ba34a1a8fec9349dea06c1b71a70f6e8455adb41d4820a376eb2ed141";
+      name = "kolourpaint-19.04.0.tar.xz";
     };
   };
   kompare = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kompare-18.12.3.tar.xz";
-      sha256 = "7a132a0aced98079fdec37188e9a46f5399e7584ab9d39801d7f0f8176623285";
-      name = "kompare-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kompare-19.04.0.tar.xz";
+      sha256 = "49453b90e21d3b2acd766aac244f579e2dc446ec8abf854ceb2faf34fc3e647f";
+      name = "kompare-19.04.0.tar.xz";
     };
   };
   konqueror = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/konqueror-18.12.3.tar.xz";
-      sha256 = "d9eb2bb4cd121f9967c6d6e7275dfb56bd41aec03c2b9d903d543b330ca4666a";
-      name = "konqueror-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/konqueror-19.04.0.tar.xz";
+      sha256 = "8da6fdd7de037bed79b6341e670a7491d371d084c59fdbefb4ffae0d2da82e4c";
+      name = "konqueror-19.04.0.tar.xz";
     };
   };
   konquest = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/konquest-18.12.3.tar.xz";
-      sha256 = "3698253f8e873819680ed99f377a679bacf5351f3fadc92c07fbaa0f6b269172";
-      name = "konquest-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/konquest-19.04.0.tar.xz";
+      sha256 = "5361a865fefc0dac19e166d282188b732cfbe4389afe095c38c8d30b56f7ff6f";
+      name = "konquest-19.04.0.tar.xz";
     };
   };
   konsole = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/konsole-18.12.3.tar.xz";
-      sha256 = "01ff3245d755a6e38207e58e50e5f82e5c681ead2ad7176d46aec00a8a562e08";
-      name = "konsole-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/konsole-19.04.0.tar.xz";
+      sha256 = "62d53840f6cac4686feafa7f75d641bb56867b7dfc12e6ce95afa7e796e37cef";
+      name = "konsole-19.04.0.tar.xz";
     };
   };
   kontact = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kontact-18.12.3.tar.xz";
-      sha256 = "81426545a958d6d71210040f5ede6407048a16d320ea90c405318cdd7e8e9315";
-      name = "kontact-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kontact-19.04.0.tar.xz";
+      sha256 = "710d72ba01afa2aea89efca61f6c25245c0db04dc675b8871f7109a42a945cca";
+      name = "kontact-19.04.0.tar.xz";
     };
   };
   kontactinterface = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kontactinterface-18.12.3.tar.xz";
-      sha256 = "4895e884c93ebff36a721f5161386105e729925dbbbf6fafb94c75ba4b291e41";
-      name = "kontactinterface-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kontactinterface-19.04.0.tar.xz";
+      sha256 = "268005d61e97dab34f200b0e7a461afddb32a88ccc7c553b6c967865a6915392";
+      name = "kontactinterface-19.04.0.tar.xz";
     };
   };
   kopete = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kopete-18.12.3.tar.xz";
-      sha256 = "8ca7a41e39be23ca6802deade7b5edb88b7e3000bc8e6fb2f68efbc15c2c8d3b";
-      name = "kopete-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kopete-19.04.0.tar.xz";
+      sha256 = "88068ceb8735e1b7ecaac9a9e4c36d40629b53d514c987823c987cfac6dc99df";
+      name = "kopete-19.04.0.tar.xz";
     };
   };
   korganizer = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/korganizer-18.12.3.tar.xz";
-      sha256 = "6a63e60b60af6cb95c78382da15e9e3cf04f936689ce12b62fe38968fad75a9c";
-      name = "korganizer-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/korganizer-19.04.0.tar.xz";
+      sha256 = "3e8c69db9f504e3ec80307d1552af21440621c0e480abf874a5a73482800bcaf";
+      name = "korganizer-19.04.0.tar.xz";
     };
   };
   kpat = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kpat-18.12.3.tar.xz";
-      sha256 = "62c31d6f7a9bb49c09725722bea472811d897b149e29558ca6e248b5d2a41377";
-      name = "kpat-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kpat-19.04.0.tar.xz";
+      sha256 = "bcd295a3df422b5cfa8258bb3cd0be7e4405f44604681d98589f2982c44414a1";
+      name = "kpat-19.04.0.tar.xz";
     };
   };
   kpimtextedit = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kpimtextedit-18.12.3.tar.xz";
-      sha256 = "54586fc97eb863eaa57e589d4461dd9cfbc4d12e58425afadcd22d64ba8a570d";
-      name = "kpimtextedit-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kpimtextedit-19.04.0.tar.xz";
+      sha256 = "b4c640ee8ae5c4356bc26819763721580ca87477eb39258c1eaacdffbfc5311a";
+      name = "kpimtextedit-19.04.0.tar.xz";
     };
   };
   kpkpass = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kpkpass-18.12.3.tar.xz";
-      sha256 = "cd70809ab7a052e0ca2a18266ec5564bde16ac917988798290e3f01e428bd84f";
-      name = "kpkpass-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kpkpass-19.04.0.tar.xz";
+      sha256 = "0121e03af506451a39b34a2f0ca063228454a40f71d9706dea3cee644a4c8f28";
+      name = "kpkpass-19.04.0.tar.xz";
     };
   };
   kqtquickcharts = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kqtquickcharts-18.12.3.tar.xz";
-      sha256 = "739859dc261856cf253ac67e2273b20dee476735b4107ece991d7146d45c1bbe";
-      name = "kqtquickcharts-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kqtquickcharts-19.04.0.tar.xz";
+      sha256 = "c8a270932f11fc5ee9270c77205b1a93edfe73c2e629a602940acb15d853803f";
+      name = "kqtquickcharts-19.04.0.tar.xz";
     };
   };
   krdc = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/krdc-18.12.3.tar.xz";
-      sha256 = "c01896b73ab058a20f4c3d8997c28cbb81a7000f5aec346592a9315412c10666";
-      name = "krdc-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/krdc-19.04.0.tar.xz";
+      sha256 = "2a1ac548992eaaff82cafe386eef0a611b96f06ce3887a363b25d6ca17c6eacc";
+      name = "krdc-19.04.0.tar.xz";
     };
   };
   kreversi = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kreversi-18.12.3.tar.xz";
-      sha256 = "818ef2ded02caacf2ccf3c012e992070c3b898db319682e8a42cf5726d56b3fc";
-      name = "kreversi-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kreversi-19.04.0.tar.xz";
+      sha256 = "a715d068eaf381a26e1f432f2d6b3f3ffffb388282b484cd8ad0833acf429d82";
+      name = "kreversi-19.04.0.tar.xz";
     };
   };
   krfb = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/krfb-18.12.3.tar.xz";
-      sha256 = "9596adfe7135930c6c9c8ecd05035e401d80a5e2cd532ba343b7d4c0f57a799b";
-      name = "krfb-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/krfb-19.04.0.tar.xz";
+      sha256 = "321b1b296dfbd69e64048fbf991aec1a9d8c251e9f0084a396081f62287c6b40";
+      name = "krfb-19.04.0.tar.xz";
     };
   };
   kross-interpreters = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kross-interpreters-18.12.3.tar.xz";
-      sha256 = "ce2231b2faa9accc6342a37024651b988eefbcb9b3968025ffa4752d0cbdc70c";
-      name = "kross-interpreters-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kross-interpreters-19.04.0.tar.xz";
+      sha256 = "e910e76e58603077177b7835bed2b9562b266e2fc0ab78c8b2642edc752ccd27";
+      name = "kross-interpreters-19.04.0.tar.xz";
     };
   };
   kruler = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kruler-18.12.3.tar.xz";
-      sha256 = "1b347c552648caca99364a0524945d0849cd84b29e4d07f62ee518ec07a98e33";
-      name = "kruler-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kruler-19.04.0.tar.xz";
+      sha256 = "7d29eac1d7f4e39f7d754ebb9d68aba70ab3dc12e8241007de750572ce761d73";
+      name = "kruler-19.04.0.tar.xz";
     };
   };
   kshisen = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kshisen-18.12.3.tar.xz";
-      sha256 = "00c5de16c335262287bab37b07822b6fd2997abcec25a0ad0a7d1ece6769060f";
-      name = "kshisen-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kshisen-19.04.0.tar.xz";
+      sha256 = "c7d2799105c71d5d0077383c9b24a52ae85705c39977c8dc167a2594651c17eb";
+      name = "kshisen-19.04.0.tar.xz";
     };
   };
   ksirk = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ksirk-18.12.3.tar.xz";
-      sha256 = "cb8f3cc98fe861b0f4ebff77aeeffa12905b98b6db0c8800525f4fb052be4e7a";
-      name = "ksirk-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ksirk-19.04.0.tar.xz";
+      sha256 = "3dcd578050807aa37652e5e589ddff7a5aec46c82309db85aab588bd3060d5a0";
+      name = "ksirk-19.04.0.tar.xz";
     };
   };
   ksmtp = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ksmtp-18.12.3.tar.xz";
-      sha256 = "90578b1b3ac1ce14bf4f34799b1b400b06734c72f3fecd41f5f07aed37ed3b74";
-      name = "ksmtp-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ksmtp-19.04.0.tar.xz";
+      sha256 = "c92b8b6b9de60bca7b9bb7befdd519041625188a955e55b63860d9de4b3e0bab";
+      name = "ksmtp-19.04.0.tar.xz";
     };
   };
   ksnakeduel = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ksnakeduel-18.12.3.tar.xz";
-      sha256 = "5d55e4c11baecbd77b94dd004b490a7f73870a383e0bf3ad0381f22d36a27a36";
-      name = "ksnakeduel-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ksnakeduel-19.04.0.tar.xz";
+      sha256 = "e9ca727c7e7cef21e9bedbb1504b2023baac9ab5ba0b624dc91e1bf716eb8335";
+      name = "ksnakeduel-19.04.0.tar.xz";
     };
   };
   kspaceduel = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kspaceduel-18.12.3.tar.xz";
-      sha256 = "f40d0a7c578f461875efaf9e25d2b061486a21f750ce8bc922db4aed6fed1f11";
-      name = "kspaceduel-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kspaceduel-19.04.0.tar.xz";
+      sha256 = "486b8d84f3070b7795456ec5847d7b5a9bb3c2b5d3e1c4bcdfedff18b8d735a7";
+      name = "kspaceduel-19.04.0.tar.xz";
     };
   };
   ksquares = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ksquares-18.12.3.tar.xz";
-      sha256 = "82a90b7fe5ca8e46950a0de1742783c522fcd85bbc3aabe5955834865bc36b7d";
-      name = "ksquares-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ksquares-19.04.0.tar.xz";
+      sha256 = "c5a7dc34619f1ee4d621c3371b65bdcd46cf3433c183b4bc85c8a7586b6e85b4";
+      name = "ksquares-19.04.0.tar.xz";
     };
   };
   ksudoku = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ksudoku-18.12.3.tar.xz";
-      sha256 = "4a44248f2bde9c66c911fe7ed7bd54e31956053dac18e29217a355ad2b3a05e1";
-      name = "ksudoku-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ksudoku-19.04.0.tar.xz";
+      sha256 = "4f5cff274741326bff02108fef4996f289c56ff026fd6e2921e4a2bf492a14cb";
+      name = "ksudoku-19.04.0.tar.xz";
     };
   };
   ksystemlog = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ksystemlog-18.12.3.tar.xz";
-      sha256 = "93f276698b74af654f3ed147d5c025162bd919ec6c79a7c7dd7678051c307e52";
-      name = "ksystemlog-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ksystemlog-19.04.0.tar.xz";
+      sha256 = "6a9f389b04fac92b0e2955e86e4a45aa73494f6dd24c9a6704826b469414fb5d";
+      name = "ksystemlog-19.04.0.tar.xz";
     };
   };
   kteatime = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kteatime-18.12.3.tar.xz";
-      sha256 = "24b3e51edc9d6625ca5b3542bd5edd1d42d79142f2c30f886e1b9515dcdfac6d";
-      name = "kteatime-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kteatime-19.04.0.tar.xz";
+      sha256 = "8672fa70912e9bf4488d5258258a14babbf65ee160dc537ab665ff2136a0c490";
+      name = "kteatime-19.04.0.tar.xz";
     };
   };
   ktimer = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ktimer-18.12.3.tar.xz";
-      sha256 = "b3808fa9821c3a624b880b9a5607c8e12287cd38418ff06dd9af8345f324fe7e";
-      name = "ktimer-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ktimer-19.04.0.tar.xz";
+      sha256 = "d772292fa447aec07ff763d7bdfc351fbf2fd7d09160a574ec36ff2905ea5b79";
+      name = "ktimer-19.04.0.tar.xz";
     };
   };
   ktnef = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ktnef-18.12.3.tar.xz";
-      sha256 = "7633f86514d01a1e3709f6854b3b9c859fa1905043bb53240c1ae53f3b76a6ec";
-      name = "ktnef-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ktnef-19.04.0.tar.xz";
+      sha256 = "bc3e826bc831ffac5b3b92cef14fca3f4b077d30652ce2ebdcffa07dafd58c56";
+      name = "ktnef-19.04.0.tar.xz";
     };
   };
   ktouch = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ktouch-18.12.3.tar.xz";
-      sha256 = "194f308a114c89873ee88eb069ecda88d5d1e1ad97c150e2d61cf248719b4bb6";
-      name = "ktouch-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ktouch-19.04.0.tar.xz";
+      sha256 = "707fca9ee9d0d217683e2bb562f5f8f984ddbd0ed7274b022a43bdc176898390";
+      name = "ktouch-19.04.0.tar.xz";
     };
   };
   ktp-accounts-kcm = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ktp-accounts-kcm-18.12.3.tar.xz";
-      sha256 = "ab6ab0f6cb438ec68b110158f7c6555572f04ad69da04f5e1d144cfc4a8ee8cb";
-      name = "ktp-accounts-kcm-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ktp-accounts-kcm-19.04.0.tar.xz";
+      sha256 = "e7c11f4310dd4cb119336fb569cc9799dbdd3d7f4b87af9e265f8fc4439ec7f8";
+      name = "ktp-accounts-kcm-19.04.0.tar.xz";
     };
   };
   ktp-approver = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ktp-approver-18.12.3.tar.xz";
-      sha256 = "0616fcad79fdeae5f2a58b167419f1745e94cea21950faa535e7b5a6c2e53cf6";
-      name = "ktp-approver-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ktp-approver-19.04.0.tar.xz";
+      sha256 = "ec273b9eabcedd47c97fa60c68a3037115b9b06a91892d32871e8ded4c04cdfe";
+      name = "ktp-approver-19.04.0.tar.xz";
     };
   };
   ktp-auth-handler = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ktp-auth-handler-18.12.3.tar.xz";
-      sha256 = "91d6e0148c9006117bc67969012f7a12405e186fc8ffd4011732dc3e7c16a4be";
-      name = "ktp-auth-handler-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ktp-auth-handler-19.04.0.tar.xz";
+      sha256 = "db459ed02c5ed37ce41ec9728d931ca1ab987c43d1b48f501d38b40e1e4f19e9";
+      name = "ktp-auth-handler-19.04.0.tar.xz";
     };
   };
   ktp-call-ui = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ktp-call-ui-18.12.3.tar.xz";
-      sha256 = "3558b9ef7a2a000f6b49454c4477dcd9700168a1f2c060267b24c78725097571";
-      name = "ktp-call-ui-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ktp-call-ui-19.04.0.tar.xz";
+      sha256 = "b63ef1f0bcaed631f9106a355dd60e48edb6e7e39bb6bd0603b504fc33949427";
+      name = "ktp-call-ui-19.04.0.tar.xz";
     };
   };
   ktp-common-internals = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ktp-common-internals-18.12.3.tar.xz";
-      sha256 = "3913a515d98f74940e0db6b85fc5c6c128c68cffb427c93164052be437634740";
-      name = "ktp-common-internals-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ktp-common-internals-19.04.0.tar.xz";
+      sha256 = "12e3e0733eef78a649fa1e55f2f3d228b581fb1a0ba401e154dd57d4eb286eaa";
+      name = "ktp-common-internals-19.04.0.tar.xz";
     };
   };
   ktp-contact-list = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ktp-contact-list-18.12.3.tar.xz";
-      sha256 = "8f858371ec3760bc042dbf6f022ba834ca5b9ae43997e67bf395978df603d0c1";
-      name = "ktp-contact-list-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ktp-contact-list-19.04.0.tar.xz";
+      sha256 = "745a1b403e3e1bfd0604521709f44634ab15a053b45f5c390d9a8e80fa405668";
+      name = "ktp-contact-list-19.04.0.tar.xz";
     };
   };
   ktp-contact-runner = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ktp-contact-runner-18.12.3.tar.xz";
-      sha256 = "886d561952ac1a8a5fa50ffdff8699358480d18d58cbaec217ed865d2047f0a9";
-      name = "ktp-contact-runner-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ktp-contact-runner-19.04.0.tar.xz";
+      sha256 = "12d9e3cf2a230e590c9e3e17462b8e061641a70840492971434b131c15594773";
+      name = "ktp-contact-runner-19.04.0.tar.xz";
     };
   };
   ktp-desktop-applets = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ktp-desktop-applets-18.12.3.tar.xz";
-      sha256 = "439dca1046beba0d2579918f2e409e6629e5063da6eeb1001bcd65ff3edb32c4";
-      name = "ktp-desktop-applets-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ktp-desktop-applets-19.04.0.tar.xz";
+      sha256 = "ba5d0422156e0ea38db1abeb317310266fd96b2b259a40df4233880d15037d8c";
+      name = "ktp-desktop-applets-19.04.0.tar.xz";
     };
   };
   ktp-filetransfer-handler = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ktp-filetransfer-handler-18.12.3.tar.xz";
-      sha256 = "898c7f4ffc8d8bec691cc9744fb356722cf7957f39d2d855138492b647542231";
-      name = "ktp-filetransfer-handler-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ktp-filetransfer-handler-19.04.0.tar.xz";
+      sha256 = "3088b79a79b35fc52f38ae2941e9f1ca8a80a1eed1c3bcdfd489b2e069febcfd";
+      name = "ktp-filetransfer-handler-19.04.0.tar.xz";
     };
   };
   ktp-kded-module = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ktp-kded-module-18.12.3.tar.xz";
-      sha256 = "ebbd02a1441caf8e9ced851c8f814255ac4b9e75485a4bc59026f647d3fd4854";
-      name = "ktp-kded-module-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ktp-kded-module-19.04.0.tar.xz";
+      sha256 = "3409e3ec270f0ba2f558b6e6a84e9948936c128cc536fc6c16c4dd5bd8a3c94b";
+      name = "ktp-kded-module-19.04.0.tar.xz";
     };
   };
   ktp-send-file = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ktp-send-file-18.12.3.tar.xz";
-      sha256 = "0015551c42d66f14ae508eee76f138584bbec3b77a4aff4a003255b52d8414f2";
-      name = "ktp-send-file-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ktp-send-file-19.04.0.tar.xz";
+      sha256 = "f0be593d3101cbc5027e7dcc23a767d2e3e753d140afe97d5790db20eea07226";
+      name = "ktp-send-file-19.04.0.tar.xz";
     };
   };
   ktp-text-ui = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ktp-text-ui-18.12.3.tar.xz";
-      sha256 = "6a37a26b0b226d5d30b298a4d6d85f8dcfe9f39cbc35e1b6322651678815a34e";
-      name = "ktp-text-ui-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ktp-text-ui-19.04.0.tar.xz";
+      sha256 = "78ac51d23e54d6044b70083db8d2c6972643a207a7f475cde15292e08b6b6469";
+      name = "ktp-text-ui-19.04.0.tar.xz";
     };
   };
   ktuberling = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ktuberling-18.12.3.tar.xz";
-      sha256 = "b69815f3553f843c30ab9d026ca7da97e62e66b58851111d1e4d29e57d67bd04";
-      name = "ktuberling-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ktuberling-19.04.0.tar.xz";
+      sha256 = "984c29562bd20f93117e7d79aa120dd906e6d4490ae5d2b52ad03f7bbfb85ace";
+      name = "ktuberling-19.04.0.tar.xz";
     };
   };
   kturtle = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kturtle-18.12.3.tar.xz";
-      sha256 = "4677335b4f8a3e363425652815d19ae13e9f8942b01051553b485100c4996253";
-      name = "kturtle-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kturtle-19.04.0.tar.xz";
+      sha256 = "89e836a2737c98caf1ceb16b7ac648262d6a6770ac5bb5b0d9fbfed4abeeda7d";
+      name = "kturtle-19.04.0.tar.xz";
     };
   };
   kubrick = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kubrick-18.12.3.tar.xz";
-      sha256 = "0deb9022a028a6c068203e5bf20820b5561c92b5117735e8a58f212c2ba460e3";
-      name = "kubrick-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kubrick-19.04.0.tar.xz";
+      sha256 = "72adc4e07df6062dd444c4bb9571429acf9c2ee68e273bc42c7925b1c06aad5e";
+      name = "kubrick-19.04.0.tar.xz";
     };
   };
   kwalletmanager = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kwalletmanager-18.12.3.tar.xz";
-      sha256 = "78232285c08241dc06cd6da88dcdce0d850417dd73f0d07034ec6d9a6f97f478";
-      name = "kwalletmanager-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kwalletmanager-19.04.0.tar.xz";
+      sha256 = "5cc25daaa8511694b01ba4b0a7ca39f8f2eef9fce10e99411ae287013fc27734";
+      name = "kwalletmanager-19.04.0.tar.xz";
     };
   };
   kwave = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kwave-18.12.3.tar.xz";
-      sha256 = "4ca9a15ecd06b96e013855f8109b52fcd4a848652438b2e7a2f55a8fcb1d1c48";
-      name = "kwave-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kwave-19.04.0.tar.xz";
+      sha256 = "510b99740c87ade2e644b8b62ece9ac46721e636aeb83f253939d4d191d03a52";
+      name = "kwave-19.04.0.tar.xz";
     };
   };
   kwordquiz = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kwordquiz-18.12.3.tar.xz";
-      sha256 = "e609d6b7f93abe0ca7ba844c51dff8d89d435daa9d0a6be68e789b70370459cc";
-      name = "kwordquiz-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kwordquiz-19.04.0.tar.xz";
+      sha256 = "a6433b5a2497398ed790965ef5469b53e406882f93b5a05e574d05cb193ef866";
+      name = "kwordquiz-19.04.0.tar.xz";
     };
   };
   libgravatar = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/libgravatar-18.12.3.tar.xz";
-      sha256 = "c44c139fbaffda352f0fe461065622cff65b6f1cc13cee8a0137acb27de143ee";
-      name = "libgravatar-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/libgravatar-19.04.0.tar.xz";
+      sha256 = "ee62597fffa534b45f89056028d1d9ff871c7da7093d11a128a6decfb5312d12";
+      name = "libgravatar-19.04.0.tar.xz";
     };
   };
   libkcddb = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/libkcddb-18.12.3.tar.xz";
-      sha256 = "38bffd551b82628a25b46bd598c257927855b77c6b6b73a9b69ac7bf538afc29";
-      name = "libkcddb-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/libkcddb-19.04.0.tar.xz";
+      sha256 = "d15cef6fe986daba5ea051fda7146c784d993e83ca495faf58fad586ca370c32";
+      name = "libkcddb-19.04.0.tar.xz";
     };
   };
   libkcompactdisc = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/libkcompactdisc-18.12.3.tar.xz";
-      sha256 = "a464ebfdd1a2834c2597e7ffd1b0d946ddfda348eea5ac8d1d42b46d6c478926";
-      name = "libkcompactdisc-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/libkcompactdisc-19.04.0.tar.xz";
+      sha256 = "7236af70872c7b20070d9c096a8d4da45cdf62874d6d1314b183edf8b0d701d6";
+      name = "libkcompactdisc-19.04.0.tar.xz";
     };
   };
   libkdcraw = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/libkdcraw-18.12.3.tar.xz";
-      sha256 = "c4b6541419b2ebee15d24744d10e67c9a137e616766e765c13e5056c2a37ef99";
-      name = "libkdcraw-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/libkdcraw-19.04.0.tar.xz";
+      sha256 = "30df02047c0f1b97a7c90c8eb5f7a3c5d322f13e0158395d3f9798ff21ed529e";
+      name = "libkdcraw-19.04.0.tar.xz";
     };
   };
   libkdegames = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/libkdegames-18.12.3.tar.xz";
-      sha256 = "7c833fe476043f0492a09a52af60ee7652805cccbbb72e5f473a9d35abff9ed9";
-      name = "libkdegames-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/libkdegames-19.04.0.tar.xz";
+      sha256 = "2965e4a313609f6408becb13e54e26bfe14b37b58e7737e051129896f6e8bcd3";
+      name = "libkdegames-19.04.0.tar.xz";
     };
   };
   libkdepim = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/libkdepim-18.12.3.tar.xz";
-      sha256 = "1c53148dd9f477b1ca2ea622b25100eab95531115e9798264d3e65d28183e640";
-      name = "libkdepim-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/libkdepim-19.04.0.tar.xz";
+      sha256 = "099c7bd90e540c6996f333393afa4831c94b6fbe65f7800bde712ebae4ba8a8e";
+      name = "libkdepim-19.04.0.tar.xz";
     };
   };
   libkeduvocdocument = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/libkeduvocdocument-18.12.3.tar.xz";
-      sha256 = "907076104f445f22fa31c2fa5ecfdabbb8b18faab52fc10c879a53d6245aaad4";
-      name = "libkeduvocdocument-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/libkeduvocdocument-19.04.0.tar.xz";
+      sha256 = "bb0300ca6a89c7174714b005032380b81e6e7bfdf3a3bab82b6f42fc0693045e";
+      name = "libkeduvocdocument-19.04.0.tar.xz";
     };
   };
   libkexiv2 = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/libkexiv2-18.12.3.tar.xz";
-      sha256 = "1d14ff63af42ab7e19e2039648a95ea5dc946afbe3e3df52c17ce1618a02ebdc";
-      name = "libkexiv2-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/libkexiv2-19.04.0.tar.xz";
+      sha256 = "9fcafa932631429af1693642415d2f202ad29338b63949b5e8661135eb69dc19";
+      name = "libkexiv2-19.04.0.tar.xz";
     };
   };
   libkgapi = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/libkgapi-18.12.3.tar.xz";
-      sha256 = "de0314fd83d8fa8f88e6a355c4725047d2e507e0d40f1950c8ae083c2bc21924";
-      name = "libkgapi-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/libkgapi-19.04.0.tar.xz";
+      sha256 = "014084b04ee76939a318f711259bbb540037b45fe57a25b200ed4095b74970dc";
+      name = "libkgapi-19.04.0.tar.xz";
     };
   };
   libkgeomap = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/libkgeomap-18.12.3.tar.xz";
-      sha256 = "2c4459e61e471f0344d03cfa5f00fe2a1890cd2c1501323ceed26d522496c47b";
-      name = "libkgeomap-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/libkgeomap-19.04.0.tar.xz";
+      sha256 = "12cf73da1d406b8f6efe88c1d1bc56ecf3260bbe41759c4dec061df627e990e9";
+      name = "libkgeomap-19.04.0.tar.xz";
     };
   };
   libkipi = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/libkipi-18.12.3.tar.xz";
-      sha256 = "96abf4552d535cf101c76ff5b1cb0198eccfd4bdfb7dc192b66bf709af037a31";
-      name = "libkipi-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/libkipi-19.04.0.tar.xz";
+      sha256 = "6fc176e72e829dafe19e17a1d97b032f464d837621989751efe38cdd03d7d285";
+      name = "libkipi-19.04.0.tar.xz";
     };
   };
   libkleo = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/libkleo-18.12.3.tar.xz";
-      sha256 = "e528ed366352404d48313a8c154f56c672470bf06524ea7a150a726d3eb87d69";
-      name = "libkleo-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/libkleo-19.04.0.tar.xz";
+      sha256 = "fbd97ae860c0361fca8bfa8a80a2d19e96779eb8d436a9a32c10cfe9767d8981";
+      name = "libkleo-19.04.0.tar.xz";
     };
   };
   libkmahjongg = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/libkmahjongg-18.12.3.tar.xz";
-      sha256 = "25e5cea50b6c96f18efa8d013ab58abfaac7845edb969b8e63e0c297482a6be4";
-      name = "libkmahjongg-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/libkmahjongg-19.04.0.tar.xz";
+      sha256 = "1ab4461ba92de0cc56bd349a859d5c647f816b20923692237e7f3098ba9dd76e";
+      name = "libkmahjongg-19.04.0.tar.xz";
     };
   };
   libkomparediff2 = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/libkomparediff2-18.12.3.tar.xz";
-      sha256 = "f70bf7470f67419a7071a4df23d929c4c4ed80d588b3096d48486ee0f27d890c";
-      name = "libkomparediff2-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/libkomparediff2-19.04.0.tar.xz";
+      sha256 = "ffb3370aa869831f86dc009353abd72a5f0c7a7d1c570d5fecf9747131247464";
+      name = "libkomparediff2-19.04.0.tar.xz";
     };
   };
   libksane = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/libksane-18.12.3.tar.xz";
-      sha256 = "40bf814cebac7ef00dc18fbdeabb2f9fd786c9144d787d5dc36a58fe18c33034";
-      name = "libksane-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/libksane-19.04.0.tar.xz";
+      sha256 = "15a4f14ddb26e7e0ed54926c54941b29eebba1fabb2e75ad9f5cd48b9b673f58";
+      name = "libksane-19.04.0.tar.xz";
     };
   };
   libksieve = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/libksieve-18.12.3.tar.xz";
-      sha256 = "ce18756940d86dff8eafd77883d202ab90e3d8273f5248ffd97627b974211754";
-      name = "libksieve-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/libksieve-19.04.0.tar.xz";
+      sha256 = "451d71d6c6e8cdfe0ef540cbcca94dae57260563e1e435b41f7070ecb86f6312";
+      name = "libksieve-19.04.0.tar.xz";
     };
   };
   lokalize = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/lokalize-18.12.3.tar.xz";
-      sha256 = "cce11b9384d27006855a141d2241a67d05679baa7096db2311c49a78bd642fed";
-      name = "lokalize-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/lokalize-19.04.0.tar.xz";
+      sha256 = "e2e8cd6f9bb0e59ffd4b88e5513b757df3b63892ce90e7000c872e896ef74266";
+      name = "lokalize-19.04.0.tar.xz";
     };
   };
   lskat = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/lskat-18.12.3.tar.xz";
-      sha256 = "d81d3af26b9f23abc40f1e2f97410d662c11d4641b67c32d427846a561f0b1e2";
-      name = "lskat-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/lskat-19.04.0.tar.xz";
+      sha256 = "c3358e62eb8a0c428c32f1ac759f5ead15d4ab552b1ae5b273e6927d14bb0ad1";
+      name = "lskat-19.04.0.tar.xz";
     };
   };
   mailcommon = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/mailcommon-18.12.3.tar.xz";
-      sha256 = "789d89fad58af80202dfcc41f7c7435871a60309d1d46f93cabcb37dd6ae97e1";
-      name = "mailcommon-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/mailcommon-19.04.0.tar.xz";
+      sha256 = "cd599079d290f540c83919182eab7e2d236a939a3405d1f882385822fc5d3682";
+      name = "mailcommon-19.04.0.tar.xz";
     };
   };
   mailimporter = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/mailimporter-18.12.3.tar.xz";
-      sha256 = "1c0e583fa36fc1b87154367cbe02cf1ec68d9f36d8a37bd6b220e9d9aadfcfa3";
-      name = "mailimporter-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/mailimporter-19.04.0.tar.xz";
+      sha256 = "d5649d24aca659fbb00284a70aef868e31a56a9c688a0457945ec0d31c7a22ed";
+      name = "mailimporter-19.04.0.tar.xz";
     };
   };
   marble = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/marble-18.12.3.tar.xz";
-      sha256 = "0bfd7ae576e42ebbddadc8c83c2fec5edaf462bcf284642b1002d36d751b24ee";
-      name = "marble-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/marble-19.04.0.tar.xz";
+      sha256 = "7405c76970d6ec500e5dc99ea2926cc11571e69f29c2e79f025f0f3ec4048960";
+      name = "marble-19.04.0.tar.xz";
     };
   };
   mbox-importer = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/mbox-importer-18.12.3.tar.xz";
-      sha256 = "a220ca69dd6f78cf18c3d8cb1bb293dc2ab2ff45f2a25df72cad8df78f581201";
-      name = "mbox-importer-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/mbox-importer-19.04.0.tar.xz";
+      sha256 = "0fba78f2feee2ec7c11e64511195546b9c34695c091632494c1d77c2555eb888";
+      name = "mbox-importer-19.04.0.tar.xz";
     };
   };
   messagelib = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/messagelib-18.12.3.tar.xz";
-      sha256 = "0064a8df62a08d0dfb06af28d4aff8a645a0e8bb01d91ab23647b3d26d3af7d8";
-      name = "messagelib-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/messagelib-19.04.0.tar.xz";
+      sha256 = "1fb76bcd7aa9792095519c585dbb93552726e3cfe514446eb52edf5ed1517a1a";
+      name = "messagelib-19.04.0.tar.xz";
     };
   };
   minuet = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/minuet-18.12.3.tar.xz";
-      sha256 = "9244ec364d031c73f9aed9568012a28b847ec4dceca61040324af7afd3d64009";
-      name = "minuet-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/minuet-19.04.0.tar.xz";
+      sha256 = "3bdf5470a154b2be4bfcd97db7374ef81ca8eefba3bb12030dd6d39f1466cc78";
+      name = "minuet-19.04.0.tar.xz";
     };
   };
   okular = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/okular-18.12.3.tar.xz";
-      sha256 = "d7ef9b59acb5746ebc64399f4c1a99faf0c1530bf6a818b3bfd34b73476d90ab";
-      name = "okular-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/okular-19.04.0.tar.xz";
+      sha256 = "1947b394dfd8da9c7cc4234e308e2476ffa44dc58542d246eafc8397d8991b6e";
+      name = "okular-19.04.0.tar.xz";
     };
   };
   palapeli = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/palapeli-18.12.3.tar.xz";
-      sha256 = "b28fa1cf7a763125a09baa8f4e7562e17892475444d3907e566281328502e593";
-      name = "palapeli-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/palapeli-19.04.0.tar.xz";
+      sha256 = "21f8b6b109d6cc61acbb0ee01aa31982bb6e27e8894e4f00407f52904d177a2b";
+      name = "palapeli-19.04.0.tar.xz";
     };
   };
   parley = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/parley-18.12.3.tar.xz";
-      sha256 = "289bc5aa88d7a33fdf0d668b45412f163d74e86d3deb9492db53a11f7c6a7f75";
-      name = "parley-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/parley-19.04.0.tar.xz";
+      sha256 = "243f7f1a89bb603c059b0610a9bb7f51627540d439b4026d736062b693879ed2";
+      name = "parley-19.04.0.tar.xz";
     };
   };
   picmi = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/picmi-18.12.3.tar.xz";
-      sha256 = "0691c70d746aa9d444559970e002561a1123963d617b36ceef4a8c3ee4730f49";
-      name = "picmi-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/picmi-19.04.0.tar.xz";
+      sha256 = "edb10bc29d6817dffeb51762c5fa793ee8de3b3a70c2c6616012f5a043799d86";
+      name = "picmi-19.04.0.tar.xz";
     };
   };
   pimcommon = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/pimcommon-18.12.3.tar.xz";
-      sha256 = "f4a0bf8146d1140c0252a5315baa826651968352a828c004d91b06e0e98c6b9e";
-      name = "pimcommon-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/pimcommon-19.04.0.tar.xz";
+      sha256 = "b25d10571e55ab11b758ad6b1040ef2d148b4b5b913f41665c355df25bceb12e";
+      name = "pimcommon-19.04.0.tar.xz";
     };
   };
   pim-data-exporter = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/pim-data-exporter-18.12.3.tar.xz";
-      sha256 = "7deb5baf5a36b96f1414e0b67192cd1ad48f396fb3cb5f5eb2fc90a312d74941";
-      name = "pim-data-exporter-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/pim-data-exporter-19.04.0.tar.xz";
+      sha256 = "ae1c3bbfffebb85533b0bbf4b0f8b54c06e29fcdf7284295c89ab43d196a6ac3";
+      name = "pim-data-exporter-19.04.0.tar.xz";
     };
   };
   pim-sieve-editor = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/pim-sieve-editor-18.12.3.tar.xz";
-      sha256 = "6e755ec258b0a75e4e83adb82551c1779c2ab7766aef26d2f1c9c00f3809deb5";
-      name = "pim-sieve-editor-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/pim-sieve-editor-19.04.0.tar.xz";
+      sha256 = "0843df57695ca4dc359d048a7e3bf2b6bb66bd10d861714d316baa8ecb387dd1";
+      name = "pim-sieve-editor-19.04.0.tar.xz";
     };
   };
   poxml = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/poxml-18.12.3.tar.xz";
-      sha256 = "6714e371957d175b859894149a3791acb3b8ef62b653b7b09f34819e92c8eaf7";
-      name = "poxml-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/poxml-19.04.0.tar.xz";
+      sha256 = "c0a24557cc7e243790c5273fb2a4ff585a3e89cc994772a52979015d2e57a985";
+      name = "poxml-19.04.0.tar.xz";
     };
   };
   print-manager = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/print-manager-18.12.3.tar.xz";
-      sha256 = "917ea500bcd11d2ca3cc1e7de1b38d7ef72f1d397182aaac2c6a31cd338f387d";
-      name = "print-manager-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/print-manager-19.04.0.tar.xz";
+      sha256 = "f9dfe61ba341013ae59892cd6715b7c00ee6777ca4d2e81deeda1cf2d283f6ba";
+      name = "print-manager-19.04.0.tar.xz";
     };
   };
   rocs = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/rocs-18.12.3.tar.xz";
-      sha256 = "6b007b0b11a8128787c316f055a99dde83619dd35287e04867949e84661c2b11";
-      name = "rocs-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/rocs-19.04.0.tar.xz";
+      sha256 = "65557205a86ddc682c9f9378731b1cf0dacd170742a5bdf110eeeef8ae4b26c8";
+      name = "rocs-19.04.0.tar.xz";
     };
   };
   signon-kwallet-extension = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/signon-kwallet-extension-18.12.3.tar.xz";
-      sha256 = "9a6c25cf19a382cbfd219c043838ad691c4c53ae8c3bc9f4b59f9f6f98bd3a4f";
-      name = "signon-kwallet-extension-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/signon-kwallet-extension-19.04.0.tar.xz";
+      sha256 = "eb93120d2acfbac4b823bc301b3724d250dc7e7041eef347c1337c7df84c0c40";
+      name = "signon-kwallet-extension-19.04.0.tar.xz";
     };
   };
   spectacle = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/spectacle-18.12.3.tar.xz";
-      sha256 = "8abf85b85de7844c503ef84182303c47cf425f5c14d71e723e3c887ee87ce06e";
-      name = "spectacle-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/spectacle-19.04.0.tar.xz";
+      sha256 = "2c4d891d5850e13d912ad0885086170f45178ed5fb4d0ccfef7b22a9a76c35a8";
+      name = "spectacle-19.04.0.tar.xz";
     };
   };
   step = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/step-18.12.3.tar.xz";
-      sha256 = "35abaf0a4597e141f4db08ad91ebcefafe43609b986a93a11e5f3ec19165c755";
-      name = "step-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/step-19.04.0.tar.xz";
+      sha256 = "c37cbd4a7179d796dd4458dbdd98e48d59c5f0278f19026a4f5cc2b50e140319";
+      name = "step-19.04.0.tar.xz";
     };
   };
   svgpart = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/svgpart-18.12.3.tar.xz";
-      sha256 = "675ab3b652b0d2619abb305ce7c00beb8a80067416e4ea7e216cfa201a7ff8ef";
-      name = "svgpart-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/svgpart-19.04.0.tar.xz";
+      sha256 = "6dbec1dcb6853c06f7cb10677a2c99678b398b4a658eb4206a146f24b0fa158a";
+      name = "svgpart-19.04.0.tar.xz";
     };
   };
   sweeper = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/sweeper-18.12.3.tar.xz";
-      sha256 = "8007da0f4d835e376fb049d539ca9fd6840ef7196f25b62cf652374a645fc6e0";
-      name = "sweeper-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/sweeper-19.04.0.tar.xz";
+      sha256 = "7ed57321ba601725291e1cfa6cdfe2060ad0405d42124dc8d8d44d137b852f72";
+      name = "sweeper-19.04.0.tar.xz";
     };
   };
   umbrello = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/umbrello-18.12.3.tar.xz";
-      sha256 = "2ab53b33cf1fcaea470c01b2421e911d4287b1d0421fa33e0b60043fe6943cc7";
-      name = "umbrello-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/umbrello-19.04.0.tar.xz";
+      sha256 = "7c37363a92bd91f2a515438068ba6f1c8747269ddaf2eda5a7998539ece4468d";
+      name = "umbrello-19.04.0.tar.xz";
     };
   };
   zeroconf-ioslave = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/zeroconf-ioslave-18.12.3.tar.xz";
-      sha256 = "b3adcaec0ebd89ddaf839954fb387e59791683d98f93da0c3dacb0266cd02a12";
-      name = "zeroconf-ioslave-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/zeroconf-ioslave-19.04.0.tar.xz";
+      sha256 = "e1f7465f200d1c7c53c56a8ebf9a463022a27d6c244d0d1768ff58763e5b53dc";
+      name = "zeroconf-ioslave-19.04.0.tar.xz";
     };
   };
 }

--- a/pkgs/desktops/plasma-5/fetch.sh
+++ b/pkgs/desktops/plasma-5/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/plasma/5.15.3/ )
+WGET_ARGS=( https://download.kde.org/stable/plasma/5.15.5/ )

--- a/pkgs/desktops/plasma-5/srcs.nix
+++ b/pkgs/desktops/plasma-5/srcs.nix
@@ -3,363 +3,363 @@
 
 {
   bluedevil = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/bluedevil-5.15.3.tar.xz";
-      sha256 = "1vdij1ydrwj51nsf3ysmql3wy3y7ayipzrqgxwa52r9n49zckva0";
-      name = "bluedevil-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/bluedevil-5.15.5.tar.xz";
+      sha256 = "7379230de96c5e6d4ea40f4dfa8732e20a6ee3bd291e6f119ccb57646c33fe1f";
+      name = "bluedevil-5.15.5.tar.xz";
     };
   };
   breeze = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/breeze-5.15.3.tar.xz";
-      sha256 = "0l7yngc32af7gdi8p68c8267bbzhfvpynqclq3il4fvaxc6vbq2b";
-      name = "breeze-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/breeze-5.15.5.tar.xz";
+      sha256 = "a13de0472dacd5240c3d38d0841ea7b9098405cf1f8cff77504d1824d09dcac4";
+      name = "breeze-5.15.5.tar.xz";
     };
   };
   breeze-grub = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/breeze-grub-5.15.3.tar.xz";
-      sha256 = "0ccx8yfxhc5r3kv7snv80wpz7h5a9l762iz1cx5sfjpmmq2jhi64";
-      name = "breeze-grub-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/breeze-grub-5.15.5.tar.xz";
+      sha256 = "4a27689446d66b7de043321022093e8f457dd4d47c124186f233b0606ddcfd64";
+      name = "breeze-grub-5.15.5.tar.xz";
     };
   };
   breeze-gtk = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/breeze-gtk-5.15.3.tar.xz";
-      sha256 = "1rg323fyq0q07k00xi63csi0f3bwzi1cbm6srshqih0cnfgq69j4";
-      name = "breeze-gtk-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/breeze-gtk-5.15.5.tar.xz";
+      sha256 = "d4e16ffbcbe74c48fda7c5bfd18c3f479f56d54b761d9b1d9678119479412ca8";
+      name = "breeze-gtk-5.15.5.tar.xz";
     };
   };
   breeze-plymouth = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/breeze-plymouth-5.15.3.tar.xz";
-      sha256 = "0f654kys4xw2c84iblz2q2x53z4mb2javgngb1dr3jkafysr0h37";
-      name = "breeze-plymouth-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/breeze-plymouth-5.15.5.tar.xz";
+      sha256 = "0a518d5a9e1bddeb3e1c7329966ce178a36ab0a0bd6dd28caf803fe8c1680de8";
+      name = "breeze-plymouth-5.15.5.tar.xz";
     };
   };
   discover = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/discover-5.15.3.tar.xz";
-      sha256 = "1b6mc81xr4wl29bjw95jm8k72j3hhn1ps8a5dvzanbslfx31hf1b";
-      name = "discover-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/discover-5.15.5.tar.xz";
+      sha256 = "6f2bbaade87b959c8bd847e90ecec0c9aa8b4accee63318d25e5beb77deaf854";
+      name = "discover-5.15.5.tar.xz";
     };
   };
   drkonqi = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/drkonqi-5.15.3.tar.xz";
-      sha256 = "0y4bkrv7bx69hm4kbbd2jfjnccj99686s0k5lm4ldv3wvf66k4sx";
-      name = "drkonqi-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/drkonqi-5.15.5.tar.xz";
+      sha256 = "8669913aa8485257cbb19bbe5bb6956044d0a6896a365cea024b1247d0a6502e";
+      name = "drkonqi-5.15.5.tar.xz";
     };
   };
   kactivitymanagerd = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/kactivitymanagerd-5.15.3.tar.xz";
-      sha256 = "1lz3mm0bli2w8xwr3n06ss7qqzm4clvs3d9hfydyf7xq03mszrym";
-      name = "kactivitymanagerd-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/kactivitymanagerd-5.15.5.tar.xz";
+      sha256 = "e38ec9074e0bc5c1a21bd5eee97b7d99e6528186918e832fecf1e3f95da239db";
+      name = "kactivitymanagerd-5.15.5.tar.xz";
     };
   };
   kde-cli-tools = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/kde-cli-tools-5.15.3.tar.xz";
-      sha256 = "1praysa894m67kwy4xaqh354c0shwfyyrqf4n9wrfwwrchdw6ypg";
-      name = "kde-cli-tools-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/kde-cli-tools-5.15.5.tar.xz";
+      sha256 = "fbff40188d7864a11aa6aea0b6d8cca2c66025924b3cb29275ac6d282ece9ace";
+      name = "kde-cli-tools-5.15.5.tar.xz";
     };
   };
   kdecoration = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/kdecoration-5.15.3.tar.xz";
-      sha256 = "1ymp6szphpnfvdnhg8n1wan76z1s5xw68xsmwm21zrjf8lmrwkdh";
-      name = "kdecoration-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/kdecoration-5.15.5.tar.xz";
+      sha256 = "33d613b706b83c025675d7d2b20e074219c9a0953a500c306081c24fcf84d99f";
+      name = "kdecoration-5.15.5.tar.xz";
     };
   };
   kde-gtk-config = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/kde-gtk-config-5.15.3.tar.xz";
-      sha256 = "1ysw26sfx2wyd79bkknvvcmg5s4b154iyds9c6wp8brmcn6ng3s8";
-      name = "kde-gtk-config-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/kde-gtk-config-5.15.5.tar.xz";
+      sha256 = "958163b1134b7c9e9735b5b6a4448973f09dbf43991511f768b29bd038baa185";
+      name = "kde-gtk-config-5.15.5.tar.xz";
     };
   };
   kdeplasma-addons = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/kdeplasma-addons-5.15.3.tar.xz";
-      sha256 = "071wnwxgywg6bqqgwmjyswai3k0n4c15lq8mspcy92kym3msqkrn";
-      name = "kdeplasma-addons-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/kdeplasma-addons-5.15.5.tar.xz";
+      sha256 = "1e11158f636e1d4bb25bbe4bb2f2fca37728c6aae07340ca6c2c1ec9e882ece3";
+      name = "kdeplasma-addons-5.15.5.tar.xz";
     };
   };
   kgamma5 = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/kgamma5-5.15.3.tar.xz";
-      sha256 = "12cnrnmr2wp14afg6x438gm502514pk61mfr26cypvcd6azpc2my";
-      name = "kgamma5-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/kgamma5-5.15.5.tar.xz";
+      sha256 = "5e5d2dd439d4fd298eb0283fd9f2bad009c5efe22f72aea795138d22adfdc1e7";
+      name = "kgamma5-5.15.5.tar.xz";
     };
   };
   khotkeys = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/khotkeys-5.15.3.tar.xz";
-      sha256 = "0gnkdl6kki8xph3787bacggapm4vbakj39y9kcjqvqrqxifp1ml5";
-      name = "khotkeys-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/khotkeys-5.15.5.tar.xz";
+      sha256 = "59dd6a571d52401b1963cde732b6c6c589a328438155ec0e0c5c77b5ac029127";
+      name = "khotkeys-5.15.5.tar.xz";
     };
   };
   kinfocenter = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/kinfocenter-5.15.3.tar.xz";
-      sha256 = "0rhhrsp0fmgfsmrfv468l4xinyfyghf6921s1581sgg5fk9qhrwr";
-      name = "kinfocenter-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/kinfocenter-5.15.5.tar.xz";
+      sha256 = "0119da58b2274bab76ef27d37032b5b104bad162675bfbee631286186d2e17a8";
+      name = "kinfocenter-5.15.5.tar.xz";
     };
   };
   kmenuedit = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/kmenuedit-5.15.3.tar.xz";
-      sha256 = "1s7bhpxiapmx496f3y3klmc9i2347fs25yhd2brg92jziw73jpab";
-      name = "kmenuedit-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/kmenuedit-5.15.5.tar.xz";
+      sha256 = "ad407757e93928dc506271998881a2e5f4a4c96bf763c25e80347e3e23361c26";
+      name = "kmenuedit-5.15.5.tar.xz";
     };
   };
   kscreen = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/kscreen-5.15.3.tar.xz";
-      sha256 = "1izq1anl0r9ysmsdnc2ny7cx73xc190qbad59nrnlqcxrsplb68f";
-      name = "kscreen-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/kscreen-5.15.5.tar.xz";
+      sha256 = "c0c47c6d5c618e2c40794dd37586a1733ef6939383b4bb760638e8758a0bd6f7";
+      name = "kscreen-5.15.5.tar.xz";
     };
   };
   kscreenlocker = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/kscreenlocker-5.15.3.tar.xz";
-      sha256 = "0bglpgibrc8l6yi24pj4kja33mc02clgi1vbdvw1qpp65ixhpzna";
-      name = "kscreenlocker-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/kscreenlocker-5.15.5.tar.xz";
+      sha256 = "09d9d63e81a60d1c95532639287ba29403e0b04d7e4d46f5a49adbfccf215dcd";
+      name = "kscreenlocker-5.15.5.tar.xz";
     };
   };
   ksshaskpass = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/ksshaskpass-5.15.3.tar.xz";
-      sha256 = "1zrjc74srb4jp8sw6pi0ik2i4yxffvgv037d50yk1fif1xyvnf9s";
-      name = "ksshaskpass-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/ksshaskpass-5.15.5.tar.xz";
+      sha256 = "4b6eae3b594480f6265843fa0b2f3d2051fd45894d27eee3681b7b33c4f52e7e";
+      name = "ksshaskpass-5.15.5.tar.xz";
     };
   };
   ksysguard = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/ksysguard-5.15.3.tar.xz";
-      sha256 = "1nxgadymq45yn92cs08gfmv5krc2ylwgbn5qcc2aq6ryrrhrw89q";
-      name = "ksysguard-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/ksysguard-5.15.5.tar.xz";
+      sha256 = "c767cfff83cb8d6d99a6ba13fa534656d6d31666a3eaa7cdce677535e9f9624a";
+      name = "ksysguard-5.15.5.tar.xz";
     };
   };
   kwallet-pam = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/kwallet-pam-5.15.3.tar.xz";
-      sha256 = "1w3vf92k3k2084cflv4fwav16czc4vqg62gi8x1alri38ziyb793";
-      name = "kwallet-pam-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/kwallet-pam-5.15.5.tar.xz";
+      sha256 = "36f3e50019dcd9919755d47b62abf99412299aa87ee27fecbf1dca212a94d22e";
+      name = "kwallet-pam-5.15.5.tar.xz";
     };
   };
   kwayland-integration = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/kwayland-integration-5.15.3.tar.xz";
-      sha256 = "0grb9fnk7pfgwzj3c9d11zl1j9jy9k6d4pw2n2fdrs02g3yg603h";
-      name = "kwayland-integration-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/kwayland-integration-5.15.5.tar.xz";
+      sha256 = "8dec5719104a551fc8c1d6249568accedce9b8d18691d818f2b7abc13f21fd17";
+      name = "kwayland-integration-5.15.5.tar.xz";
     };
   };
   kwin = {
-    version = "5.15.3.2";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/kwin-5.15.3.2.tar.xz";
-      sha256 = "0iri6993zsxmrm7qnf76py7ihc27x9y741ar7g9fry8c8knmqyrw";
-      name = "kwin-5.15.3.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/kwin-5.15.5.tar.xz";
+      sha256 = "e341c8165354643fd201292e53418050970bf8819b2cd0dd932423a342d2f805";
+      name = "kwin-5.15.5.tar.xz";
     };
   };
   kwrited = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/kwrited-5.15.3.tar.xz";
-      sha256 = "0xhdmnfkpr35sks7k66s5cbq220yrmbn8ixcsdqwsgpji2sx4g7v";
-      name = "kwrited-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/kwrited-5.15.5.tar.xz";
+      sha256 = "fbc27517898e57aa6b4c476673971f310121ac3d61e1d30a23e9289930056510";
+      name = "kwrited-5.15.5.tar.xz";
     };
   };
   libkscreen = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/libkscreen-5.15.3.tar.xz";
-      sha256 = "0fzfk8ga5qinsmag61l29cf92r7qm4nlb8hrhddyff7d7c7kr3vj";
-      name = "libkscreen-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/libkscreen-5.15.5.tar.xz";
+      sha256 = "bee15b0ce38e17475542b0e500a82567fdbe0a635e84a543b2f3255ac8c58d87";
+      name = "libkscreen-5.15.5.tar.xz";
     };
   };
   libksysguard = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/libksysguard-5.15.3.tar.xz";
-      sha256 = "05cfb51xcmxb8k2k14n2i5ysj47aism9yq7lk2rw216bsdp2mqnj";
-      name = "libksysguard-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/libksysguard-5.15.5.tar.xz";
+      sha256 = "4255a997c4f0b2039201db6e00038e08519c5fde73032ba709ae9bcfaceabfd0";
+      name = "libksysguard-5.15.5.tar.xz";
     };
   };
   milou = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/milou-5.15.3.tar.xz";
-      sha256 = "1prq9mdrysz8ckf7n6sjfn3qc87135nj69v2jcayn9irb0k8wz01";
-      name = "milou-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/milou-5.15.5.tar.xz";
+      sha256 = "2740cbfae30483c402471349f4d1315b98edf054827ec70980bb966cd6b3fcf9";
+      name = "milou-5.15.5.tar.xz";
     };
   };
   oxygen = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/oxygen-5.15.3.tar.xz";
-      sha256 = "0a069imvw0khkbcih8zvx0i0ks99jkwis6p73n4846qz544f3dvb";
-      name = "oxygen-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/oxygen-5.15.5.tar.xz";
+      sha256 = "0791314c8894331bfa46d8b8aa30805972d09497a9e4bbe3f82270d4455be62c";
+      name = "oxygen-5.15.5.tar.xz";
     };
   };
   plasma-browser-integration = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/plasma-browser-integration-5.15.3.tar.xz";
-      sha256 = "1mhaa5z63gyd8j7zplmyicnibqsv1xhd9mxip6clhj5bfk8q9jar";
-      name = "plasma-browser-integration-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/plasma-browser-integration-5.15.5.tar.xz";
+      sha256 = "f1883b504cb5e86a43e16fea803b93c81b09e4ce1339ae8bcf6cf35d7e734d3b";
+      name = "plasma-browser-integration-5.15.5.tar.xz";
     };
   };
   plasma-desktop = {
-    version = "5.15.3.2";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/plasma-desktop-5.15.3.2.tar.xz";
-      sha256 = "12pz0bin3j2f98k88nwmb271lr6v6w3l28li0iri2x8pk144vr91";
-      name = "plasma-desktop-5.15.3.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/plasma-desktop-5.15.5.tar.xz";
+      sha256 = "42097c0b2553dd4767b6fde441db371d5e2defbd4e82389ca91d076f62ae3741";
+      name = "plasma-desktop-5.15.5.tar.xz";
     };
   };
   plasma-integration = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/plasma-integration-5.15.3.tar.xz";
-      sha256 = "08qw2ibl0j2nhsplc3b117vdc00bd2gn1q48nx0xy349bf64m735";
-      name = "plasma-integration-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/plasma-integration-5.15.5.tar.xz";
+      sha256 = "05920610c68981a9effb1a97395a22d281d3b61e42d55d66adf8bb587da29621";
+      name = "plasma-integration-5.15.5.tar.xz";
     };
   };
   plasma-nm = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/plasma-nm-5.15.3.tar.xz";
-      sha256 = "1l9wh4hs2v0b9hdagcgl67z0w4amffakxczwy0nwymqzv0mxgqvz";
-      name = "plasma-nm-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/plasma-nm-5.15.5.tar.xz";
+      sha256 = "6a2cde83ff031de3565465d48538578380301debb8e49345e25ff3f723c908ee";
+      name = "plasma-nm-5.15.5.tar.xz";
     };
   };
   plasma-pa = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/plasma-pa-5.15.3.tar.xz";
-      sha256 = "1lkhidd5b4mjn23mxcp2vfmxf7dwbk7y14svc4wy6xc1xg1pc125";
-      name = "plasma-pa-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/plasma-pa-5.15.5.tar.xz";
+      sha256 = "326a6d3f6f9d462a3b88402ae6be2dac976f166995a5cb750d294d51085a0a92";
+      name = "plasma-pa-5.15.5.tar.xz";
     };
   };
   plasma-sdk = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/plasma-sdk-5.15.3.tar.xz";
-      sha256 = "1qzh0yy4zql7a50ql9ghhvlfxjnbckflbgbzdyd7i9x3ml7s5saw";
-      name = "plasma-sdk-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/plasma-sdk-5.15.5.tar.xz";
+      sha256 = "f91ccb03f016328c2bd54ac11a916b4f874cfe2304da1600f3fa014faeb7d329";
+      name = "plasma-sdk-5.15.5.tar.xz";
     };
   };
   plasma-tests = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/plasma-tests-5.15.3.tar.xz";
-      sha256 = "1z5vhw1dy1qks6w161yamn2fawrgkggv9mvvgpmljmy07qpafgkg";
-      name = "plasma-tests-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/plasma-tests-5.15.5.tar.xz";
+      sha256 = "534c018f45f8545f027aeccea8731a26311179328e7a746522fa11961c5c5827";
+      name = "plasma-tests-5.15.5.tar.xz";
     };
   };
   plasma-vault = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/plasma-vault-5.15.3.tar.xz";
-      sha256 = "1my9dnqz11frn07fk505pfi2nkf2d642jfgjklh5zfngjxy589jy";
-      name = "plasma-vault-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/plasma-vault-5.15.5.tar.xz";
+      sha256 = "2d7c356fa951b341fcb5ea48ed819f396fe9096e06e6f2026c9f59a59fa48fd5";
+      name = "plasma-vault-5.15.5.tar.xz";
     };
   };
   plasma-workspace = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/plasma-workspace-5.15.3.tar.xz";
-      sha256 = "08irdg8divr45z53kr6b1mv4s2jakmq3r79g7df6ja9rb6py5f59";
-      name = "plasma-workspace-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/plasma-workspace-5.15.5.tar.xz";
+      sha256 = "c25f9b348e3ab2d370325f7da989a3f599a408dabfadda65cbb590fb26a2f973";
+      name = "plasma-workspace-5.15.5.tar.xz";
     };
   };
   plasma-workspace-wallpapers = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/plasma-workspace-wallpapers-5.15.3.tar.xz";
-      sha256 = "0xgssv66ksljv8xkj20v2x1bppkyn8z17wa3hynwlcqxh2g4afq4";
-      name = "plasma-workspace-wallpapers-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/plasma-workspace-wallpapers-5.15.5.tar.xz";
+      sha256 = "0dc21728f3a08d823106bae7dd99d9b6b28b9b77abe8cf8f213bd4cf5b66b945";
+      name = "plasma-workspace-wallpapers-5.15.5.tar.xz";
     };
   };
   plymouth-kcm = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/plymouth-kcm-5.15.3.tar.xz";
-      sha256 = "0fbr9nf263pc9inakhp901r58mlsm1jgw0xqp9fj08c9lj25z190";
-      name = "plymouth-kcm-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/plymouth-kcm-5.15.5.tar.xz";
+      sha256 = "9454cff23e7acae549bdd61818cb351332b334f9cf0b7a7eb065d6dd784950aa";
+      name = "plymouth-kcm-5.15.5.tar.xz";
     };
   };
   polkit-kde-agent = {
-    version = "1-5.15.3";
+    version = "1-5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/polkit-kde-agent-1-5.15.3.tar.xz";
-      sha256 = "07gl57h9zmagbw7v2sfksbcbqrfdhr8isfmpcw10rc4k2awlsysy";
-      name = "polkit-kde-agent-1-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/polkit-kde-agent-1-5.15.5.tar.xz";
+      sha256 = "628ce9a02defa31e98a6a373abb6a1f2bf39f065eaf82fdbb4f93bf07165e267";
+      name = "polkit-kde-agent-1-5.15.5.tar.xz";
     };
   };
   powerdevil = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/powerdevil-5.15.3.tar.xz";
-      sha256 = "1f7ik3lh30irqzf0pgy59kkrsn4fkl8xwam1bikfm34bwzrsxb14";
-      name = "powerdevil-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/powerdevil-5.15.5.tar.xz";
+      sha256 = "c435cdcab2ff367ca86f91a45ac43fa9f9b68251e8e444b285b7edd33482ad06";
+      name = "powerdevil-5.15.5.tar.xz";
     };
   };
   sddm-kcm = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/sddm-kcm-5.15.3.tar.xz";
-      sha256 = "1mvp8p1k9csmn6h6iyk29yj1j4b4dfyd6j4v0v2ha1vdfjwjlsh2";
-      name = "sddm-kcm-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/sddm-kcm-5.15.5.tar.xz";
+      sha256 = "4d5ee74e494f78a90d1586862749d53f4dc34970f47307d62a4e6ead9161c25b";
+      name = "sddm-kcm-5.15.5.tar.xz";
     };
   };
   systemsettings = {
-    version = "5.15.3.2";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/systemsettings-5.15.3.2.tar.xz";
-      sha256 = "0bqhff2s2qyz1x8nhrphnkyja0mhr7msf58cwdkscsl6lyamn2a2";
-      name = "systemsettings-5.15.3.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/systemsettings-5.15.5.tar.xz";
+      sha256 = "a29227329f8ddd2db2ba8aafb3eb5f2b09d01e3a6f761d291afba95935ceb93a";
+      name = "systemsettings-5.15.5.tar.xz";
     };
   };
   user-manager = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/user-manager-5.15.3.tar.xz";
-      sha256 = "18acg3xjcdhcwk3irsf1hgkwma9mn6msl6qwmf0slz1lydlrljs4";
-      name = "user-manager-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/user-manager-5.15.5.tar.xz";
+      sha256 = "09e746e14bc732e296e93290929dfd1d378abe0b6b47fce084c97dd82a3f2431";
+      name = "user-manager-5.15.5.tar.xz";
     };
   };
   xdg-desktop-portal-kde = {
-    version = "5.15.3";
+    version = "5.15.5";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/xdg-desktop-portal-kde-5.15.3.tar.xz";
-      sha256 = "10cmy4j54nkwrgibxdpx6d30g596ikvb1dqqmp1gvmzr570gmbi7";
-      name = "xdg-desktop-portal-kde-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.5/xdg-desktop-portal-kde-5.15.5.tar.xz";
+      sha256 = "fd98af5fe77e5a387bee25bcbdfa39607d1b91ba1cd431ae72cff8103548ac50";
+      name = "xdg-desktop-portal-kde-5.15.5.tar.xz";
     };
   };
 }

--- a/pkgs/development/libraries/kde-frameworks/fetch.sh
+++ b/pkgs/development/libraries/kde-frameworks/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/frameworks/5.56/ )
+WGET_ARGS=( https://download.kde.org/stable/frameworks/5.58/ )

--- a/pkgs/development/libraries/kde-frameworks/srcs.nix
+++ b/pkgs/development/libraries/kde-frameworks/srcs.nix
@@ -3,635 +3,635 @@
 
 {
   attica = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/attica-5.57.0.tar.xz";
-      sha256 = "a13682bccaca3529df6e3b54e1d4e48fb3d1654fe1b142701e73ce9fe0b87655";
-      name = "attica-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/attica-5.58.0.tar.xz";
+      sha256 = "edba3f94705f904edb0bddd5bab491575bb15ee8f278b92b41272d6f566cad2a";
+      name = "attica-5.58.0.tar.xz";
     };
   };
   baloo = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/baloo-5.57.0.tar.xz";
-      sha256 = "32ab4ed2d295fe734a4a475403dea72e2feef27f662ae64c841c410eb7bb3dd3";
-      name = "baloo-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/baloo-5.58.0.tar.xz";
+      sha256 = "a1e9340f1046f2df1568da6cd07b26bac9361725cd32b46fd69c370aab0c7227";
+      name = "baloo-5.58.0.tar.xz";
     };
   };
   bluez-qt = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/bluez-qt-5.57.0.tar.xz";
-      sha256 = "43e1be1882832cef88186255a6b692d9fd1366bad09db0c2075a126b0fc0df65";
-      name = "bluez-qt-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/bluez-qt-5.58.0.tar.xz";
+      sha256 = "530dc2f89ca26cda23a6383ccfdb00584083d2fbee3b437e5337a77f51513da0";
+      name = "bluez-qt-5.58.0.tar.xz";
     };
   };
   breeze-icons = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/breeze-icons-5.57.0.tar.xz";
-      sha256 = "c3ba92acb5bfcff66f41232ebc6e8c893dab78ac59a713fa4bfa2a0e097f4ed2";
-      name = "breeze-icons-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/breeze-icons-5.58.0.tar.xz";
+      sha256 = "536d2790a143bf0d8cc9ee4de74dea0924eb7d3ac4888fece7bf7c7038066491";
+      name = "breeze-icons-5.58.0.tar.xz";
     };
   };
   extra-cmake-modules = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/extra-cmake-modules-5.57.0.tar.xz";
-      sha256 = "aa53f8953792b452672f275c2ea9b96ab2adf3e13d9645c3451b06dbc8055b18";
-      name = "extra-cmake-modules-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/extra-cmake-modules-5.58.0.tar.xz";
+      sha256 = "514011c12eeb2ac99d3118975832a279af2c2eea5e8b36b49c81962930b2ecc7";
+      name = "extra-cmake-modules-5.58.0.tar.xz";
     };
   };
   frameworkintegration = {
-    version = "5.57.0";
+    version = "5.58.1";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/frameworkintegration-5.57.0.tar.xz";
-      sha256 = "9c5850c1d41900bcb81e7929d54856d0cdd2565a276e5e262f624eb1217cbb78";
-      name = "frameworkintegration-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/frameworkintegration-5.58.1.tar.xz";
+      sha256 = "30a9e6c4bde295a031f94ea622ce2324b8a98536f51f0a008b148ea11c44a274";
+      name = "frameworkintegration-5.58.1.tar.xz";
     };
   };
   kactivities = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kactivities-5.57.0.tar.xz";
-      sha256 = "442527db8710b9045dc574816bc9c32cad5f8a404e681fb030d7e9c2f3d77761";
-      name = "kactivities-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kactivities-5.58.0.tar.xz";
+      sha256 = "5295cfdc392a8146ca9c3822f1250ceaf5b54990d69c2e3dec4b072519a5ce5b";
+      name = "kactivities-5.58.0.tar.xz";
     };
   };
   kactivities-stats = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kactivities-stats-5.57.0.tar.xz";
-      sha256 = "4c7a49905ec1b6e03831986b254d0fd091e44fe920fffa123c969765c6474ba3";
-      name = "kactivities-stats-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kactivities-stats-5.58.0.tar.xz";
+      sha256 = "5f3bde50ffe0c23ad5f28c7327d375f223535f139ff014c5d53aef2f41e80611";
+      name = "kactivities-stats-5.58.0.tar.xz";
     };
   };
   kapidox = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kapidox-5.57.0.tar.xz";
-      sha256 = "16f53e4722adddaa8729b4cccc374d16bdbfdd987f8655d2b431a91b046fe2b2";
-      name = "kapidox-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kapidox-5.58.0.tar.xz";
+      sha256 = "8635b09f7d0daa8554f228d471bbb1147cf412b779e3a8ab7c2bf7c24ec85165";
+      name = "kapidox-5.58.0.tar.xz";
     };
   };
   karchive = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/karchive-5.57.0.tar.xz";
-      sha256 = "e0e64e7e88c8df96f894de20aff4d12925e0d362c5134df83473ea48c0432783";
-      name = "karchive-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/karchive-5.58.0.tar.xz";
+      sha256 = "cd5a42101e5cc50f026f48002dc8125e0c898b148fea5fba4451023ec1e181ad";
+      name = "karchive-5.58.0.tar.xz";
     };
   };
   kauth = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kauth-5.57.0.tar.xz";
-      sha256 = "9d6b9135cc47710b28e2a7731c4c5c1f6dba2b0e5fe982b9d2a82a11d7d497c2";
-      name = "kauth-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kauth-5.58.0.tar.xz";
+      sha256 = "8c004199f1e7aa14f9244299bb8b288f6d077e5c2557f089a530d0c1cd072f4f";
+      name = "kauth-5.58.0.tar.xz";
     };
   };
   kbookmarks = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kbookmarks-5.57.0.tar.xz";
-      sha256 = "bf57f111e176ab2ecb79646b1f93cf5d84a8d3fcfb13b805b5140e75b42eb085";
-      name = "kbookmarks-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kbookmarks-5.58.0.tar.xz";
+      sha256 = "9b34f49703101e4d9f6338b66edded7b2c1b7826938a81025ede85a7edc71b02";
+      name = "kbookmarks-5.58.0.tar.xz";
     };
   };
   kcmutils = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kcmutils-5.57.0.tar.xz";
-      sha256 = "f3ee63a356e18be95a15141346356f3f43bb067d0326021d99f4b73ee4716fbb";
-      name = "kcmutils-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kcmutils-5.58.0.tar.xz";
+      sha256 = "2eec73ffca93eb5fc9975a96e072c565a4907b05c161f49877684f4ab252fd9d";
+      name = "kcmutils-5.58.0.tar.xz";
     };
   };
   kcodecs = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kcodecs-5.57.0.tar.xz";
-      sha256 = "c98b98cf7258c03fa5131a987e278f348d52f792dcb9f2a5664fe35aadea6995";
-      name = "kcodecs-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kcodecs-5.58.0.tar.xz";
+      sha256 = "6e5b3c2083c840947e255d58b338128a5e498a4176969f6ac724d56ca3cae8ef";
+      name = "kcodecs-5.58.0.tar.xz";
     };
   };
   kcompletion = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kcompletion-5.57.0.tar.xz";
-      sha256 = "5ad8746a57cef2b12da5a97e296cbb0b708e8ecfb4253786a899fa86951395ec";
-      name = "kcompletion-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kcompletion-5.58.0.tar.xz";
+      sha256 = "4f5be9d3a70183e0580126c6395d34e3e4141d6e6f852f5f0bb578b20205f5dd";
+      name = "kcompletion-5.58.0.tar.xz";
     };
   };
   kconfig = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kconfig-5.57.0.tar.xz";
-      sha256 = "155b0dbba8772aa8ea3e75217029daa00ada8699e5a807154214f66b2462c010";
-      name = "kconfig-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kconfig-5.58.0.tar.xz";
+      sha256 = "6f464a63079f43f11deb7f1661dadaa12539b8a8c75e3fa7476dae8ab6886a5e";
+      name = "kconfig-5.58.0.tar.xz";
     };
   };
   kconfigwidgets = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kconfigwidgets-5.57.0.tar.xz";
-      sha256 = "771c5641a9ae465feaf00ffbb3f3c0433ad8d4a90355dc50d5b6b1b472912eb0";
-      name = "kconfigwidgets-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kconfigwidgets-5.58.0.tar.xz";
+      sha256 = "8d68cf5618b7123a39e62a8ee52a01af7f95325b1d7b7bcac097c0d723c054c0";
+      name = "kconfigwidgets-5.58.0.tar.xz";
     };
   };
   kcoreaddons = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kcoreaddons-5.57.0.tar.xz";
-      sha256 = "7c2573de9b745e55fe61cff26941839cff0d2e40b6c5d791c24c9d6cc8cf7485";
-      name = "kcoreaddons-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kcoreaddons-5.58.0.tar.xz";
+      sha256 = "f01f3d8b8086085e034a530821a929e56943e33002091d29ab45e0772b6f8e5e";
+      name = "kcoreaddons-5.58.0.tar.xz";
     };
   };
   kcrash = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kcrash-5.57.0.tar.xz";
-      sha256 = "4b12719a20f2ff0fe0a2656609d0aa277245cd2a9f764a7b6cfaa6da9d928dc0";
-      name = "kcrash-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kcrash-5.58.0.tar.xz";
+      sha256 = "cf921f0ced115107a57a4f15e95ea2d0478b56baf23102abc2470ecd6b8e3c44";
+      name = "kcrash-5.58.0.tar.xz";
     };
   };
   kdbusaddons = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kdbusaddons-5.57.0.tar.xz";
-      sha256 = "86946d97e74420637f59ea0fff93e303bcbdc5b1d5e1c6361e2d9a3ceb0e1259";
-      name = "kdbusaddons-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kdbusaddons-5.58.0.tar.xz";
+      sha256 = "42f176b737f81e120d2fa78c20891b3b7e3f182c6e144ec9c99935a32d63f9b1";
+      name = "kdbusaddons-5.58.0.tar.xz";
     };
   };
   kdeclarative = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kdeclarative-5.57.0.tar.xz";
-      sha256 = "5335b39ac1cca34209c0420dab867b67ddb0e9ee483bdd6d4192269a1d5f654f";
-      name = "kdeclarative-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kdeclarative-5.58.0.tar.xz";
+      sha256 = "267d1dbe55ca65c74289e56200b51de95bcbc231b2d4a2867cb6735d04783bec";
+      name = "kdeclarative-5.58.0.tar.xz";
     };
   };
   kded = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kded-5.57.0.tar.xz";
-      sha256 = "04327dda12fa547bebb8e1b1bc26373e8f4174007dd629231403d59ce004201f";
-      name = "kded-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kded-5.58.0.tar.xz";
+      sha256 = "c8ca04174ff9997ccedb382fce7bc4573670ac5dabc69c0d6594589098ab6dc1";
+      name = "kded-5.58.0.tar.xz";
     };
   };
   kdelibs4support = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/portingAids/kdelibs4support-5.57.0.tar.xz";
-      sha256 = "e9d1c06191031b482ea01d891756d125ff32927239c36a3011fc7b8f17aca1b0";
-      name = "kdelibs4support-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/portingAids/kdelibs4support-5.58.0.tar.xz";
+      sha256 = "c86db5d334c022d804cd9473f893b462904e336aad1ce2c350a1c87039d9473a";
+      name = "kdelibs4support-5.58.0.tar.xz";
     };
   };
   kdesignerplugin = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kdesignerplugin-5.57.0.tar.xz";
-      sha256 = "9e85a4ac798122b459722773a6e81f639be6dfe9c9714a16704f555c88334393";
-      name = "kdesignerplugin-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kdesignerplugin-5.58.0.tar.xz";
+      sha256 = "c80a88a525c25fb699412e5c4a4a142ae388ab056aa826a9f5433e78da9c6e6b";
+      name = "kdesignerplugin-5.58.0.tar.xz";
     };
   };
   kdesu = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kdesu-5.57.0.tar.xz";
-      sha256 = "76d98db52f7f375991cd7ccbbf1dc100716f99a5792b71ef31a75cc33cf45b19";
-      name = "kdesu-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kdesu-5.58.0.tar.xz";
+      sha256 = "9121dd13a37e0fe5d5d42bbc164d4e20228f85a9ed745829393d3292f7c8183b";
+      name = "kdesu-5.58.0.tar.xz";
     };
   };
   kdewebkit = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kdewebkit-5.57.0.tar.xz";
-      sha256 = "809e9df4ac3ca8b59799c8781694092cb1793f03af0b87a347a1c6019f96a592";
-      name = "kdewebkit-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kdewebkit-5.58.0.tar.xz";
+      sha256 = "9f0629902e60717ee455f0a3e1201c735794f9c60e2fb6ec55b5983f532a2cbc";
+      name = "kdewebkit-5.58.0.tar.xz";
     };
   };
   kdnssd = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kdnssd-5.57.0.tar.xz";
-      sha256 = "5a61b942fd14c9d96370e19fd7a29594bfcbd3074e12625caac083206fce2789";
-      name = "kdnssd-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kdnssd-5.58.0.tar.xz";
+      sha256 = "d3b6ee64f4ed491120351732abf99712e64d43deb1b796d4b701e28df9efad05";
+      name = "kdnssd-5.58.0.tar.xz";
     };
   };
   kdoctools = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kdoctools-5.57.0.tar.xz";
-      sha256 = "649dbaff4f1559302e7da07f423a0bc9e3faa1c7a93dfeb170e50bf452d8def2";
-      name = "kdoctools-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kdoctools-5.58.0.tar.xz";
+      sha256 = "5c0b915d0f054098b47c5c1ef6ee0d174a9a607405f23c3921276189cefd48f4";
+      name = "kdoctools-5.58.0.tar.xz";
     };
   };
   kemoticons = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kemoticons-5.57.0.tar.xz";
-      sha256 = "c07b69c9275c117507166622e185c2bf0f36e1e4e8ad7b25fa3e1d793da4711b";
-      name = "kemoticons-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kemoticons-5.58.0.tar.xz";
+      sha256 = "a34159566511f4c012186c52ae203c033d0cb81eef349fd89dbdc225f89b98bd";
+      name = "kemoticons-5.58.0.tar.xz";
     };
   };
   kfilemetadata = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kfilemetadata-5.57.0.tar.xz";
-      sha256 = "49e6c281fdffd4f5fe363c6cefdb6c3022ef57c935d7d6b135607cdde9b2d116";
-      name = "kfilemetadata-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kfilemetadata-5.58.0.tar.xz";
+      sha256 = "76665ba8ba6ab90cc0e8d682a5c5421fde7c436f5521c614d0b63c5277fabf9c";
+      name = "kfilemetadata-5.58.0.tar.xz";
     };
   };
   kglobalaccel = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kglobalaccel-5.57.0.tar.xz";
-      sha256 = "46370dcd4f110e6ccde3b3bf9c075deb1f22ad54016137925e4aea97b03cc2fe";
-      name = "kglobalaccel-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kglobalaccel-5.58.0.tar.xz";
+      sha256 = "4fd49052697d4659f793b8f7d678a9333a850ed6cf17472eaba9c023430b5bbf";
+      name = "kglobalaccel-5.58.0.tar.xz";
     };
   };
   kguiaddons = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kguiaddons-5.57.0.tar.xz";
-      sha256 = "744eb0ec35c936c17c3d11a08d19014e2166c4a307370207e0f5a38f01a91ebd";
-      name = "kguiaddons-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kguiaddons-5.58.0.tar.xz";
+      sha256 = "d6d5884f31072fe93804ecad72c8f612fa03d6841318211ad8f6ebf1f5f020f3";
+      name = "kguiaddons-5.58.0.tar.xz";
     };
   };
   kholidays = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kholidays-5.57.0.tar.xz";
-      sha256 = "f7db45906623c33dfbb297810082f8ff30c949e6a7d477f3b72de0521b0c9452";
-      name = "kholidays-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kholidays-5.58.0.tar.xz";
+      sha256 = "ec05faf5290a83d2450be6e1a68c086e4d2da934b3aaf61d578e3cda72295eef";
+      name = "kholidays-5.58.0.tar.xz";
     };
   };
   khtml = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/portingAids/khtml-5.57.0.tar.xz";
-      sha256 = "63d22fbc8cad3075a0b7ef195291c4b79ebc65da5de81b4885cac1063d783da3";
-      name = "khtml-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/portingAids/khtml-5.58.0.tar.xz";
+      sha256 = "f75635e4d0ad9816953bbd0f8c18aea7cd470dc130a6294fa1d32c37bd66dcff";
+      name = "khtml-5.58.0.tar.xz";
     };
   };
   ki18n = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/ki18n-5.57.0.tar.xz";
-      sha256 = "bbd60981c9a0c1f9d9a52c8dd86adef7c4c30caf603f806d8730febaa36f0dd9";
-      name = "ki18n-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/ki18n-5.58.0.tar.xz";
+      sha256 = "ea0181b15ff47b34ae7dd7a3a419c461cf05554f9014886d8b8b2ab2ec243977";
+      name = "ki18n-5.58.0.tar.xz";
     };
   };
   kiconthemes = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kiconthemes-5.57.0.tar.xz";
-      sha256 = "09abb03a97027948a1116bfb2ca9842d3f8fb2def83b0b02aaed194dd5bd16f3";
-      name = "kiconthemes-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kiconthemes-5.58.0.tar.xz";
+      sha256 = "ec12602159b7115c91b30373321ab631f75b12f814769166b4ee2e3abd83c480";
+      name = "kiconthemes-5.58.0.tar.xz";
     };
   };
   kidletime = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kidletime-5.57.0.tar.xz";
-      sha256 = "e99a07f814573526ed5141fc9e4bc2df12298df53a0d2787c3b7a4c3af915665";
-      name = "kidletime-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kidletime-5.58.0.tar.xz";
+      sha256 = "86d8c4ff13b864c07f98d0475683838708c43e4ba6275e05f21766e2a79cfd90";
+      name = "kidletime-5.58.0.tar.xz";
     };
   };
   kimageformats = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kimageformats-5.57.0.tar.xz";
-      sha256 = "d7ce6c4737ae2846f015633e7479b60460d960a3a578777c2a884d499bd6cc14";
-      name = "kimageformats-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kimageformats-5.58.0.tar.xz";
+      sha256 = "deb5b18c8289e2ce1988769f6b87dd7ad57dde6c15e51a474e51eef76568a9d9";
+      name = "kimageformats-5.58.0.tar.xz";
     };
   };
   kinit = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kinit-5.57.0.tar.xz";
-      sha256 = "7d5ca84d7bd554531aa6d720d3dc41ac091cf047a52d097a23e5c8fad08b684c";
-      name = "kinit-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kinit-5.58.0.tar.xz";
+      sha256 = "22c2adb9b1b52d0f90db9c36bd0313250d986a207f781c0582e85c4805297e53";
+      name = "kinit-5.58.0.tar.xz";
     };
   };
   kio = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kio-5.57.0.tar.xz";
-      sha256 = "d68151d58f1ed2e0724074c6bca42510dd3e19617baa4b4130198ad3a36a64ab";
-      name = "kio-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kio-5.58.0.tar.xz";
+      sha256 = "14c74959824a288d7fae17acbd2786eee1f0a2545cb9bf39c43bbd862ec55069";
+      name = "kio-5.58.0.tar.xz";
     };
   };
   kirigami2 = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kirigami2-5.57.0.tar.xz";
-      sha256 = "3cdbea0e472293e85e625820f6b9e2d20f59cff263ed150904b6b2acad81062b";
-      name = "kirigami2-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kirigami2-5.58.0.tar.xz";
+      sha256 = "ad54e15c03807181313e29013057cf89cb70113f74a26ab7aec6420cdc18d9b3";
+      name = "kirigami2-5.58.0.tar.xz";
     };
   };
   kitemmodels = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kitemmodels-5.57.0.tar.xz";
-      sha256 = "b0eef30ce3e5f2fe9afb60d589bea16a0d0e4a57ffffb37ae0e14a54f1681464";
-      name = "kitemmodels-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kitemmodels-5.58.0.tar.xz";
+      sha256 = "f861844a6d24ecdddd7b2b29d47dc03bccbd5dc2c8053f5c3a839a5ff59cd491";
+      name = "kitemmodels-5.58.0.tar.xz";
     };
   };
   kitemviews = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kitemviews-5.57.0.tar.xz";
-      sha256 = "6b499a21c88d5998c903e8e4dd480c612b96e5e31d17430a507c07566febdd30";
-      name = "kitemviews-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kitemviews-5.58.0.tar.xz";
+      sha256 = "bb073f96236102a953a2298039d0c380458c0a2393d7dc7bb657ee4e2ea9b6e6";
+      name = "kitemviews-5.58.0.tar.xz";
     };
   };
   kjobwidgets = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kjobwidgets-5.57.0.tar.xz";
-      sha256 = "4b98e7cd9b8d877326854addcee300071afc92f4378d3a94734e470271638002";
-      name = "kjobwidgets-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kjobwidgets-5.58.0.tar.xz";
+      sha256 = "d43ea4eede2d88edd1753f4d1b6808bf04bf1e67ab58f00ef70b6a20b9607133";
+      name = "kjobwidgets-5.58.0.tar.xz";
     };
   };
   kjs = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/portingAids/kjs-5.57.0.tar.xz";
-      sha256 = "865fb86566a0ea904ab0a3bd6a63787161b28578660d475fc316c50c8a7b1e90";
-      name = "kjs-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/portingAids/kjs-5.58.0.tar.xz";
+      sha256 = "9e95cb54f4323f31f88e3fb5946b4f990d8a5f1ba8fecf166844af672037a60c";
+      name = "kjs-5.58.0.tar.xz";
     };
   };
   kjsembed = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/portingAids/kjsembed-5.57.0.tar.xz";
-      sha256 = "741aae8db274febe7e5d0d10dc99271efc590b2465d2c4d4e4a9162d2b36e3b4";
-      name = "kjsembed-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/portingAids/kjsembed-5.58.0.tar.xz";
+      sha256 = "ffbcd9de767d62497db146acd7bcaeaa59b3f6b418616d4562d1a2269048131d";
+      name = "kjsembed-5.58.0.tar.xz";
     };
   };
   kmediaplayer = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/portingAids/kmediaplayer-5.57.0.tar.xz";
-      sha256 = "521dcb4b3f9a67203e9eac27b8d777cb22557861b9fae0006c2aecda96d9bad4";
-      name = "kmediaplayer-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/portingAids/kmediaplayer-5.58.0.tar.xz";
+      sha256 = "1cc831eae5f0e71375118c01b72e7961d42888fca0726800ce8c42bf4e1f21ea";
+      name = "kmediaplayer-5.58.0.tar.xz";
     };
   };
   knewstuff = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/knewstuff-5.57.0.tar.xz";
-      sha256 = "6a9d77a62b036b4ed0f32ffaa9f204db1403030d01dbe8fb055d02361db2f981";
-      name = "knewstuff-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/knewstuff-5.58.0.tar.xz";
+      sha256 = "06d3ee09652f166ad66e003523bafe43741a99d2cd5dca3268ac7a13498cefbd";
+      name = "knewstuff-5.58.0.tar.xz";
     };
   };
   knotifications = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/knotifications-5.57.0.tar.xz";
-      sha256 = "7de068f4cf9bcefef54ae1cb180e2c0af9be951afbcaa960245507259620cf15";
-      name = "knotifications-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/knotifications-5.58.0.tar.xz";
+      sha256 = "5a388e05ae3416a5120c268e48fa505e6666403772e8f03fe4670ab1d0bb0469";
+      name = "knotifications-5.58.0.tar.xz";
     };
   };
   knotifyconfig = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/knotifyconfig-5.57.0.tar.xz";
-      sha256 = "e7fe39ed72b7f79d8cafe6c30d5c62ade0f33be37a62d9e5b929064dd1750ac1";
-      name = "knotifyconfig-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/knotifyconfig-5.58.0.tar.xz";
+      sha256 = "a40555d9645c4ed283e61a9e5718d5476359124e23d52a838e30fca7e089dc01";
+      name = "knotifyconfig-5.58.0.tar.xz";
     };
   };
   kpackage = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kpackage-5.57.0.tar.xz";
-      sha256 = "2d2d497d50e8ce986d6de4462391122963d9b7605889fd20cd3ceb4dd6910814";
-      name = "kpackage-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kpackage-5.58.0.tar.xz";
+      sha256 = "41deff40eb17b3f667fd03f4a30dcf734ca060ebd7e2320eb38ff36ed6a9ce90";
+      name = "kpackage-5.58.0.tar.xz";
     };
   };
   kparts = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kparts-5.57.0.tar.xz";
-      sha256 = "5a079986963d186e98a1174e19e490731012732ad5ad31a431a8f7a31c6b6ed2";
-      name = "kparts-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kparts-5.58.0.tar.xz";
+      sha256 = "6fe1ca552f14dd262cf33e60d0c85536ca04617757e39f91dbfe061abf624bb4";
+      name = "kparts-5.58.0.tar.xz";
     };
   };
   kpeople = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kpeople-5.57.0.tar.xz";
-      sha256 = "7c239b80b7976e3bfa46338e05a048aecb9c1972548dc33cc8a17e66eb08a85c";
-      name = "kpeople-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kpeople-5.58.0.tar.xz";
+      sha256 = "2588f7a4df4c03fe756d9e766120e35b0f991df5c8e5f75c3a507cc5739ded32";
+      name = "kpeople-5.58.0.tar.xz";
     };
   };
   kplotting = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kplotting-5.57.0.tar.xz";
-      sha256 = "c2c35030b1a2ca25f503c1a2df7ca225d156a9ea80f52883e136679aea6efc8e";
-      name = "kplotting-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kplotting-5.58.0.tar.xz";
+      sha256 = "4d46b4c78abcaf171132f4a17f35d28f7bd89b346fbe7b2e494f5212ee2cc81b";
+      name = "kplotting-5.58.0.tar.xz";
     };
   };
   kpty = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kpty-5.57.0.tar.xz";
-      sha256 = "14a0f9d5ecc387c88d24270dbf4c128deb8ad18ab64b39766b335ad03a47c3b6";
-      name = "kpty-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kpty-5.58.0.tar.xz";
+      sha256 = "808a9f159e3d34630ae16d13c3ed6310c07fc9a38737110190892dcc903d5017";
+      name = "kpty-5.58.0.tar.xz";
     };
   };
   kross = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/portingAids/kross-5.57.0.tar.xz";
-      sha256 = "3b0f92751bb70c64b2ac25b466f886cc8b02babf02c744bcc909aa3ce6915a66";
-      name = "kross-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/portingAids/kross-5.58.0.tar.xz";
+      sha256 = "b71c521718acd9829124264e97990222c458eca4a2e0be471a853db55b07d872";
+      name = "kross-5.58.0.tar.xz";
     };
   };
   krunner = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/krunner-5.57.0.tar.xz";
-      sha256 = "40f52d4d883748f5b9a78b5bd7dd6aaa52eae88b89d7a33eafbcbb9ccf6f4805";
-      name = "krunner-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/krunner-5.58.0.tar.xz";
+      sha256 = "d83220210980117459e49a44b2173063faa70ea5524c744cde4ca3dc031a6c8c";
+      name = "krunner-5.58.0.tar.xz";
     };
   };
   kservice = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kservice-5.57.0.tar.xz";
-      sha256 = "531940baa47273714fbc35941f2ef5fbdb801b7a5ed5fef5a8ff1d86bf1dae14";
-      name = "kservice-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kservice-5.58.0.tar.xz";
+      sha256 = "03e1d69b1558c4d38946e1ffdec4249e58d8a0f15575ce984c751d93b3ff1395";
+      name = "kservice-5.58.0.tar.xz";
     };
   };
   ktexteditor = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/ktexteditor-5.57.0.tar.xz";
-      sha256 = "aa510656f632ef09c18af4263386265c293cb929f139786acd102881250314c3";
-      name = "ktexteditor-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/ktexteditor-5.58.0.tar.xz";
+      sha256 = "dc28916db7eb8a24f89b6570358d576b73e1ca60f7364871a0ef67f9fd62db8e";
+      name = "ktexteditor-5.58.0.tar.xz";
     };
   };
   ktextwidgets = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/ktextwidgets-5.57.0.tar.xz";
-      sha256 = "b74036eea1ec19a22aa0e76cd1a8338f55e5c32a30dc47d602783c6bc5ba54bf";
-      name = "ktextwidgets-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/ktextwidgets-5.58.0.tar.xz";
+      sha256 = "056601d7c1aa412a9628fae8eb6ca6cf51d0f0fab03345bb4be8e7072827fed7";
+      name = "ktextwidgets-5.58.0.tar.xz";
     };
   };
   kunitconversion = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kunitconversion-5.57.0.tar.xz";
-      sha256 = "157f4d21e83a6e92e30894f472b65452ecd2183ac2e25e24f740e971befed383";
-      name = "kunitconversion-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kunitconversion-5.58.0.tar.xz";
+      sha256 = "5716474c4d031d9b5fdb3fe460957d4ceecd1d9c4e441df81a42bfbb993232fa";
+      name = "kunitconversion-5.58.0.tar.xz";
     };
   };
   kwallet = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kwallet-5.57.0.tar.xz";
-      sha256 = "ad089026f4d5b10d567d0fd56f8b63749acd214fb8029d43187ba42afaf36975";
-      name = "kwallet-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kwallet-5.58.0.tar.xz";
+      sha256 = "5203765ba2061727d0280bf7e9cbbade462ba2c5e7389f4f8d78afc522ba2030";
+      name = "kwallet-5.58.0.tar.xz";
     };
   };
   kwayland = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kwayland-5.57.0.tar.xz";
-      sha256 = "f00d2997163f559cecf30f5e945d5456628a0d120acafba49fa14af28c22b1d6";
-      name = "kwayland-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kwayland-5.58.0.tar.xz";
+      sha256 = "a273a64ac06698e7c7d297da05c3b4889893c8b4179b01aa7ae1c2fb8681a4f1";
+      name = "kwayland-5.58.0.tar.xz";
     };
   };
   kwidgetsaddons = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kwidgetsaddons-5.57.0.tar.xz";
-      sha256 = "abd80a566e1003bca7c72d3a0dc1ee470bc9935d11371cfff0d960f11e1ef5c2";
-      name = "kwidgetsaddons-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kwidgetsaddons-5.58.0.tar.xz";
+      sha256 = "f4bcb1e22d8dfec214f4f55dbf4492229c4cb6ab63031f826ef68896c27ca6c0";
+      name = "kwidgetsaddons-5.58.0.tar.xz";
     };
   };
   kwindowsystem = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kwindowsystem-5.57.0.tar.xz";
-      sha256 = "0c8a009dde7ca1722810777b99aa4e1a3471687460c25e0f41645c9e11daf274";
-      name = "kwindowsystem-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kwindowsystem-5.58.0.tar.xz";
+      sha256 = "0b25d55bc9be6329c5cf91328c4414b547f26496a1af83f9454c0e5d85a10129";
+      name = "kwindowsystem-5.58.0.tar.xz";
     };
   };
   kxmlgui = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kxmlgui-5.57.0.tar.xz";
-      sha256 = "325124518e8fa4847c898dee193d96b76a7ba27d7c79d875f34c632f46fe1f90";
-      name = "kxmlgui-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kxmlgui-5.58.0.tar.xz";
+      sha256 = "ab08ed118f6806154fe10414d81dace413ecf80df3a561811f41879b48b7179f";
+      name = "kxmlgui-5.58.0.tar.xz";
     };
   };
   kxmlrpcclient = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/kxmlrpcclient-5.57.0.tar.xz";
-      sha256 = "d47d5cc49f050dda3a26f7654226c0d124ca5ba5503a60e606307426bbe43b9d";
-      name = "kxmlrpcclient-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/kxmlrpcclient-5.58.0.tar.xz";
+      sha256 = "53f647bb8d9165ddf6326703486470c7e9fc4ef392991501319e5c69f25f0ea3";
+      name = "kxmlrpcclient-5.58.0.tar.xz";
     };
   };
   modemmanager-qt = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/modemmanager-qt-5.57.0.tar.xz";
-      sha256 = "030bfcfafd5079f25a165aaa5f52693a8fe4b3c15c1345a641716c4329e0929d";
-      name = "modemmanager-qt-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/modemmanager-qt-5.58.0.tar.xz";
+      sha256 = "cec892b58603fd95656b2cac356e8076a65122d110e3f5175bbabfaa296b16cb";
+      name = "modemmanager-qt-5.58.0.tar.xz";
     };
   };
   networkmanager-qt = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/networkmanager-qt-5.57.0.tar.xz";
-      sha256 = "4d2da2556bfeef4be03833d707284573b469a1f6ad66ba73eae80835bd2e1982";
-      name = "networkmanager-qt-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/networkmanager-qt-5.58.0.tar.xz";
+      sha256 = "113f48b1ed07b7541bc205220197e245f547e0a08382c3aeb29b0c02e6ec4abe";
+      name = "networkmanager-qt-5.58.0.tar.xz";
     };
   };
   oxygen-icons5 = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/oxygen-icons5-5.57.0.tar.xz";
-      sha256 = "2b12a9de3767d233b4b01bc97e23899d94c02b13fee4d20483d3f5d2baaaa1e5";
-      name = "oxygen-icons5-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/oxygen-icons5-5.58.0.tar.xz";
+      sha256 = "0e6a6fd611893c870901b78f601caf8ae9afd2a666088a5a167f3cbf815bd3e7";
+      name = "oxygen-icons5-5.58.0.tar.xz";
     };
   };
   plasma-framework = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/plasma-framework-5.57.0.tar.xz";
-      sha256 = "b886aeee6691911ead25e6fd5631fa41ce2330b0fbbdc040717fa576bacae2ca";
-      name = "plasma-framework-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/plasma-framework-5.58.0.tar.xz";
+      sha256 = "0b0826a2292612112e78198938d660e913756f8712d1f2c71eafbead42605cad";
+      name = "plasma-framework-5.58.0.tar.xz";
     };
   };
   prison = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/prison-5.57.0.tar.xz";
-      sha256 = "6613decb2e0b61af5af3a3a9995970c2fdaa72f36bcfd7e9db547017ee4ca235";
-      name = "prison-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/prison-5.58.0.tar.xz";
+      sha256 = "2bd97bf19e70b67cac49eaefb89a0fe8bd506e710e10df41f9b7c65d9dc30b1d";
+      name = "prison-5.58.0.tar.xz";
     };
   };
   purpose = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/purpose-5.57.0.tar.xz";
-      sha256 = "4b38f1b88e6e621bc20c04a5f7bc7293fba6c851209167c5e794b6becaea244e";
-      name = "purpose-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/purpose-5.58.0.tar.xz";
+      sha256 = "8acbf11af0d9f149ca52c15d07a62107d83b02306102af9e37ee32aeaef831df";
+      name = "purpose-5.58.0.tar.xz";
     };
   };
   qqc2-desktop-style = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/qqc2-desktop-style-5.57.0.tar.xz";
-      sha256 = "ff40fd6d48815c39e46e19eadf4048f04e79f34f7522a9ba655e6d4a1690546e";
-      name = "qqc2-desktop-style-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/qqc2-desktop-style-5.58.0.tar.xz";
+      sha256 = "71b2c94aece8c0f4cda33170a84240d1f7ed9ec774dcf5bd292bda861bda46a3";
+      name = "qqc2-desktop-style-5.58.0.tar.xz";
     };
   };
   solid = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/solid-5.57.0.tar.xz";
-      sha256 = "fbdb0678a5a1b9f902661b4823dbae4629a88708b729d827dd0598799f727209";
-      name = "solid-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/solid-5.58.0.tar.xz";
+      sha256 = "7d7f2daaffe8536ee9373375b866c94b949e58f0365990dfe16f9cc05f98bd00";
+      name = "solid-5.58.0.tar.xz";
     };
   };
   sonnet = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/sonnet-5.57.0.tar.xz";
-      sha256 = "08e13a707b64055f512bba982ec5e69a9e7c62c02d1ee8b6fdc67c67b1265334";
-      name = "sonnet-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/sonnet-5.58.0.tar.xz";
+      sha256 = "e67ffab7674175588883a9b444973e9edef2257e025f99657bb13d09e72bf823";
+      name = "sonnet-5.58.0.tar.xz";
     };
   };
   syndication = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/syndication-5.57.0.tar.xz";
-      sha256 = "251b2333bd3e49f833ef5ac12e0d2540a7640c84625090a85d99715927653728";
-      name = "syndication-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/syndication-5.58.0.tar.xz";
+      sha256 = "48d321fdefd57ef9380492652c765ded047d4a54ba6aed5abb1434e30e327643";
+      name = "syndication-5.58.0.tar.xz";
     };
   };
   syntax-highlighting = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/syntax-highlighting-5.57.0.tar.xz";
-      sha256 = "e82261e791005a55414fc81a396ca33ee8c061acd66c2c351492d866b3592e9f";
-      name = "syntax-highlighting-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/syntax-highlighting-5.58.0.tar.xz";
+      sha256 = "b97e58e9fe64bc21368d18c57b69dd5696328a0722c01ae2e113826e2e35ba76";
+      name = "syntax-highlighting-5.58.0.tar.xz";
     };
   };
   threadweaver = {
-    version = "5.57.0";
+    version = "5.58.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.57/threadweaver-5.57.0.tar.xz";
-      sha256 = "83969d0f6e4a337fba6b554708f867654af86368066ccef75a4fde85569d1ee0";
-      name = "threadweaver-5.57.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.58/threadweaver-5.58.0.tar.xz";
+      sha256 = "d9f95ed3a5ccedaa10ae086c82d8794a9ae9e82e094c352869bc6459ead8409d";
+      name = "threadweaver-5.58.0.tar.xz";
     };
   };
 }

--- a/pkgs/development/libraries/qt-5/5.11/default.nix
+++ b/pkgs/development/libraries/qt-5/5.11/default.nix
@@ -106,6 +106,7 @@ let
       qtmultimedia = callPackage ../modules/qtmultimedia.nix {
         inherit gstreamer gst-plugins-base;
       };
+      qtnetworkauth = callPackage ../modules/qtnetworkauth.nix {};
       qtquick1 = null;
       qtquickcontrols = callPackage ../modules/qtquickcontrols.nix {};
       qtquickcontrols2 = callPackage ../modules/qtquickcontrols2.nix {};

--- a/pkgs/development/libraries/qt-5/5.12/default.nix
+++ b/pkgs/development/libraries/qt-5/5.12/default.nix
@@ -110,6 +110,7 @@ let
       qtmultimedia = callPackage ../modules/qtmultimedia.nix {
         inherit gstreamer gst-plugins-base;
       };
+      qtnetworkauth = callPackage ../modules/qtnetworkauth.nix {};
       qtquick1 = null;
       qtquickcontrols = callPackage ../modules/qtquickcontrols.nix {};
       qtquickcontrols2 = callPackage ../modules/qtquickcontrols2.nix {};

--- a/pkgs/development/libraries/qt-5/5.9/default.nix
+++ b/pkgs/development/libraries/qt-5/5.9/default.nix
@@ -108,6 +108,7 @@ let
       qtmultimedia = callPackage ../modules/qtmultimedia.nix {
         inherit gstreamer gst-plugins-base;
       };
+      qtnetworkauth = callPackage ../modules/qtnetworkauth.nix {};
       qtquick1 = null;
       qtquickcontrols = callPackage ../modules/qtquickcontrols.nix {};
       qtquickcontrols2 = callPackage ../modules/qtquickcontrols2.nix {};

--- a/pkgs/development/libraries/qt-5/modules/qtnetworkauth.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtnetworkauth.nix
@@ -3,5 +3,4 @@
 qtModule {
   name = "qtnetworkauth";
   qtInputs = [ qtbase ];
-  outputs = [ "out" "dev" "bin" ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtnetworkauth.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtnetworkauth.nix
@@ -1,0 +1,7 @@
+{ qtModule, qtbase }:
+
+qtModule {
+  name = "qtnetworkauth";
+  qtInputs = [ qtbase ];
+  outputs = [ "out" "dev" "bin" ];
+}

--- a/pkgs/development/libraries/rttr/default.nix
+++ b/pkgs/development/libraries/rttr/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, cmake, ninja }:
+
+stdenv.mkDerivation rec {
+  pname = "rttr";
+  version = "0.9.6";
+
+  src = fetchFromGitHub {
+    owner = "${pname}org";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1yxad8sj40wi75hny8w6imrsx8wjasjmsipnlq559n4b6kl84ijp";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ];
+
+  cmakeFlags = [
+    "-DBUILD_EXAMPLES=OFF"
+    "-DBUILD_UNIT_TESTS=OFF"
+    "-DBUILD_PACKAGE=OFF"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "C++ Reflection Library";
+    homepage = https://www.rttr.org;
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12932,6 +12932,8 @@ in
 
   rshell = python3.pkgs.callPackage ../development/tools/rshell { };
 
+  rttr = callPackage ../development/libraries/rttr { };
+
   rubberband = callPackage ../development/libraries/rubberband {
     inherit (vamp) vampSDK;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Some work will need to be done to make some application work.

Fixed apps:
- [x] akonadi
- [x] kdegraphics-thumbnailers
- [x] kdenlive
- [x] kdepim-runtime
- [x] kio-extras
- [x] kcalc
- [x] kmail

~kdenlive is trying to download https://github.com/rttrorg/rttr during build~

~kdepim-runtime error:~
```
[ 31%] Building CXX object resources/facebook/CMakeFiles/facebookresourcelib.dir/listjob.cpp.o
In file included from /build/kdepim-runtime-19.04.0/resources/facebook/listjob.cpp:18:0:
/build/kdepim-runtime-19.04.0/resources/facebook/listjob.h:23:10: fatal error: AkonadiCore/Item: No such file or directory
 #include <AkonadiCore/Item>
          ^~~~~~~~~~~~~~~~~~
```

the plasma5 test is passing and every dependencies are cached on https://nyanloutre.cachix.org

any help is welcome

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
