### PR TITLE
kipi-plugins: 5.9.0 -> 5.9.1, build from dedicated tarball

### DIFF
--- a/pkgs/applications/graphics/kipi-plugins/default.nix
+++ b/pkgs/applications/graphics/kipi-plugins/default.nix
@@ -6,17 +6,13 @@
 }:
 
 stdenv.mkDerivation rec {
-  name    = "kipi-plugins-${version}";
-  version = "5.9.0";
+  pname    = "kipi-plugins";
+  version = "5.9.1";
 
   src = fetchurl {
-    url = "http://download.kde.org/stable/digikam/digikam-${version}.tar.xz";
-    sha256 = "06qdalf2mwx2f43p3bljy3vn5bk8n3x539kha6ky2vzxvkp343b6";
+    url = "http://download.kde.org/stable/${pname}/${pname}-${version}.tar.xz";
+    sha256 = "0hjm05nkz0w926sn4lav5258rda6zkd6gfnqd8hh3fa2q0dd7cq4";
   };
-
-  prePatch = ''
-    cd extra/kipi-plugins
-  '';
 
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Update. Also,

Don't pick out from digikam's source.
(presumably the plugins used to live there primarily?)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---