### PR TITLE
alkimia: 7.0.1 -> 8.0.1, new url

### DIFF
--- a/pkgs/development/libraries/alkimia/default.nix
+++ b/pkgs/development/libraries/alkimia/default.nix
@@ -1,5 +1,6 @@
 { mkDerivation, fetchurl, lib
-, extra-cmake-modules, doxygen, graphviz, qtbase, mpir
+, extra-cmake-modules, doxygen, graphviz, qtbase, qtwebkit, mpir
+, kdelibs4support, plasma-framework, knewstuff, kpackage
 }:
 
 mkDerivation rec {
@@ -13,7 +14,7 @@ mkDerivation rec {
 
   nativeBuildInputs = [ extra-cmake-modules doxygen graphviz ];
 
-  buildInputs = [ qtbase ];
+  buildInputs = [ qtbase qtwebkit kdelibs4support plasma-framework knewstuff kpackage ];
   propagatedBuildInputs = [ mpir ];
 
   meta = {

--- a/pkgs/development/libraries/alkimia/default.nix
+++ b/pkgs/development/libraries/alkimia/default.nix
@@ -4,11 +4,11 @@
 
 mkDerivation rec {
   name = "alkimia-${version}";
-  version = "7.0.1";
+  version = "8.0.1";
 
   src = fetchurl {
-    url = "mirror://kde/stable/alkimia/${version}/src/${name}.tar.xz";
-    sha256 = "1fri76465058fgsyrmdrc3hj1javz4g10mfzqp5rsj7qncjr1i22";
+    url = "mirror://kde/stable/alkimia/${version}/${name}.tar.xz";
+    sha256 = "059i6vn36sdq5zn2vqzh4asvvgdgs7n478nk9phvb5gdys01fq7m";
   };
 
   nativeBuildInputs = [ extra-cmake-modules doxygen graphviz ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---