### PR TITLE
kreport: 3.1.0 -> 3.2.0

### DIFF
--- a/pkgs/development/libraries/kreport/default.nix
+++ b/pkgs/development/libraries/kreport/default.nix
@@ -6,12 +6,12 @@
 
 mkDerivation rec {
   pname = "kreport";
-  version = "3.1.0";
+  version = "3.2.0";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://kde/stable/${pname}/src/${name}.tar.xz";
-    sha256 = "0v7krpfx0isij9wzwam28fqn039i4wcznbplvnvl6hsykdi8ar1v";
+    sha256 = "1mycsvkz5rphi9df2i4ch4ykvprd4m76acsdzs3zis2ljrqnsw92";
   };
 
   nativeBuildInputs = [ extra-cmake-modules ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---