### PR TITLE
kproperty,kreport,kexi: 3.1.0 -> 3.2.0

### DIFF
--- a/pkgs/applications/office/kexi/default.nix
+++ b/pkgs/applications/office/kexi/default.nix
@@ -9,12 +9,12 @@
 
 mkDerivation rec {
   pname = "kexi";
-  version = "3.1.0";
+  version = "3.2.0";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://kde/stable/${pname}/src/${name}.tar.xz";
-    sha256 = "1ysj44qq75wglw4d080l3gfw47695gapf29scxhb1g3py55csmbd";
+    sha256 = "1zy1q7q9rfdaws3rwf3my22ywkn6g747s3ixfcg9r80mm2g3z0bs";
   };
 
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];

--- a/pkgs/applications/office/kexi/default.nix
+++ b/pkgs/applications/office/kexi/default.nix
@@ -29,13 +29,6 @@ mkDerivation rec {
 
   propagatedUserEnvPkgs = [ kproperty ];
 
-  patches = [
-    (fetchpatch {
-      url = "https://phabricator.kde.org/file/data/6iwzltiifyqwjnzbvyo6/PHID-FILE-li4a7j35wkdkm2qdtnp4/D11503.diff";
-      sha256 = "0yj717m4x1zb4xjy1ayhz78xkxpawxgsvjgvf5iw81jnlr8absq9";
-    })
-  ];
-
   meta = with lib; {
     description = "A open source visual database applications creator, a long-awaited competitor for programs like MS Access or Filemaker";
     longDescription = ''

--- a/pkgs/development/libraries/kproperty/default.nix
+++ b/pkgs/development/libraries/kproperty/default.nix
@@ -7,12 +7,12 @@
 
 mkDerivation rec {
   pname = "kproperty";
-  version = "3.1.0";
+  version = "3.2.0";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://kde/stable/${pname}/src/${name}.tar.xz";
-    sha256 = "18qlwp7ajpx16bd0lfzqfx8y9cbrs8k4nax3cr30wj5sd3l8xpky";
+    sha256 = "1yldfsdamk4dag8dyryjn5n9j2pzi42s79kkafymfnbifhnhrbv7";
   };
 
   nativeBuildInputs = [ extra-cmake-modules ];

--- a/pkgs/development/libraries/kreport/default.nix
+++ b/pkgs/development/libraries/kreport/default.nix
@@ -6,12 +6,12 @@
 
 mkDerivation rec {
   pname = "kreport";
-  version = "3.1.0";
+  version = "3.2.0";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://kde/stable/${pname}/src/${name}.tar.xz";
-    sha256 = "0v7krpfx0isij9wzwam28fqn039i4wcznbplvnvl6hsykdi8ar1v";
+    sha256 = "1mycsvkz5rphi9df2i4ch4ykvprd4m76acsdzs3zis2ljrqnsw92";
   };
 
   nativeBuildInputs = [ extra-cmake-modules ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---