### PR TITLE
hostapd: 2.7 -> 2.8

### DIFF
--- a/pkgs/os-specific/linux/hostapd/default.nix
+++ b/pkgs/os-specific/linux/hostapd/default.nix
@@ -3,11 +3,11 @@
 with stdenv.lib;
 stdenv.mkDerivation rec {
   name = "hostapd-${version}";
-  version = "2.7";
+  version = "2.8";
 
   src = fetchurl {
     url = "https://w1.fi/releases/${name}.tar.gz";
-    sha256 = "0hd181sghdk944hxd7d41s7zhqd4dmsbkxipjj27bgisrjixvc11";
+    sha256 = "1c74rrazkhy4lr7pwgwa2igzca7h9l4brrs7672kiv7fwqmm57wj";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

https://w1.fi/cgit/hostap/plain/hostapd/ChangeLog?h=hostap_2_8

**Mostly a blind update, other than confirming it builds!**

Anyone running a router using this? :)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---