### PR TITLE
gnome 3.32.1 staging updates

### DIFF
--- a/pkgs/development/libraries/glib/default.nix
+++ b/pkgs/development/libraries/glib/default.nix
@@ -46,7 +46,7 @@ let
   '';
 
   binPrograms = optional (!stdenv.isDarwin) "gapplication" ++ [ "gdbus" "gio" "gsettings" ];
-  version = "2.60.0";
+  version = "2.60.1";
 in
 
 stdenv.mkDerivation rec {
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/glib/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0ls3njqknb345ni5i8hn9nr1n70kn6s8bi0g6kcqj3c4js5mv1i0";
+    sha256 = "0q2mkdvp20v6dvrhik8k5j875kj29hcfz346xi0624n6spsq9y49";
   };
 
   patches = optional stdenv.isDarwin ./darwin-compilation.patch

--- a/pkgs/development/libraries/libcroco/default.nix
+++ b/pkgs/development/libraries/libcroco/default.nix
@@ -1,26 +1,13 @@
-{ stdenv, fetchurl, pkgconfig, libxml2, glib, fetchpatch, gnome3 }:
+{ stdenv, fetchurl, pkgconfig, libxml2, glib, gnome3 }:
 
 stdenv.mkDerivation rec {
   pname = "libcroco";
-  version = "0.6.12";
+  version = "0.6.13";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0q7qhi7z64i26zabg9dbs5706fa8pmzp1qhpa052id4zdiabbi6x";
+    sha256 = "1m110rbj5d2raxcdp4iz0qp172284945awrsbdlq99ksmqsc4zkn";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "CVE-2017-7960.patch";
-      url = https://gitlab.gnome.org/GNOME/libcroco/commit/898e3a8c8c0314d2e6b106809a8e3e93cf9d4394.patch;
-      sha256 = "1xjwdqijxf4b7mhdp3kkgnb6c14y0bn3b3gg79kyrm82x696d94l";
-    })
-    (fetchpatch {
-      name = "CVE-2017-7961.patch";
-      url = https://gitlab.gnome.org/GNOME/libcroco/commit/9ad72875e9f08e4c519ef63d44cdbd94aa9504f7.patch;
-      sha256 = "0zakd72ynzjgzskwyvqglqiznsb93j1bkvc1lgyrzgv9rwrbwv9s";
-    })
-  ];
 
   outputs = [ "out" "dev" ];
   outputBin = "dev";

--- a/pkgs/development/libraries/libsoup/default.nix
+++ b/pkgs/development/libraries/libsoup/default.nix
@@ -5,11 +5,11 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "libsoup";
-  version = "2.66.0";
+  version = "2.66.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "08c9kkdhzy504gv23pfdm4sq3dd3j20sikwz6gv0qrwcdjnw5bai";
+    sha256 = "1zs3bhspwg7fggxd7x1rrggpkcf2j9ch6dhncq9syh252z0vcb2a";
   };
 
   postPatch = ''


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Some gnome 3.32.1 updates for staging:
https://gitlab.gnome.org/GNOME/glib/blob/2.60.1/NEWS
https://gitlab.gnome.org/GNOME/libsoup/blob/2.66.1/NEWS
https://gitlab.gnome.org/GNOME/libcroco/blob/0.6.13/NEWS

Should probably be merged together with https://github.com/NixOS/nixpkgs/pull/59406

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
