### PR TITLE
iwd: split ell to separate derivation, update iwd and ell

### DIFF
--- a/pkgs/os-specific/linux/ell/default.nix
+++ b/pkgs/os-specific/linux/ell/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchgit, autoreconfHook, pkgconfig }:
+
+stdenv.mkDerivation rec {
+  pname = "ell";
+  version = "0.19";
+
+  src = fetchgit {
+     url = https://git.kernel.org/pub/scm/libs/ell/ell.git;
+     rev = version;
+     sha256 = "0qvgn5yxffgmlggixf6kh57gxricf57iyc8mqwn46j615bijvjs8";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+
+  meta = with stdenv.lib; {
+    homepage = https://git.kernel.org/pub/scm/libs/ell/ell.git;
+    description = "Embedded Linux Library";
+    license = licenses.lgpl21;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ mic92 dtzWill ];
+  };
+}

--- a/pkgs/os-specific/linux/iwd/default.nix
+++ b/pkgs/os-specific/linux/iwd/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, autoreconfHook, pkgconfig, ell, coreutils, readline80, python3Packages }:
+{ stdenv, fetchgit, autoreconfHook, pkgconfig, ell, coreutils, readline, python3Packages }:
 
 stdenv.mkDerivation rec {
   pname = "iwd";
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     ell
-    readline80
+    readline
     python3Packages.python
   ];
 

--- a/pkgs/os-specific/linux/iwd/default.nix
+++ b/pkgs/os-specific/linux/iwd/default.nix
@@ -1,19 +1,14 @@
-{ stdenv, fetchgit, autoreconfHook, pkgconfig, coreutils, readline, python3Packages }:
+{ stdenv, fetchgit, autoreconfHook, pkgconfig, ell, coreutils, readline80, python3Packages }:
 
-let
-  ell = fetchgit {
-     url = https://git.kernel.org/pub/scm/libs/ell/ell.git;
-     rev = "0.17";
-     sha256 = "0yk1qmvpy61qp82bb0w55n062jqzlkzbz0b1v5k763j98czz9rvz";
-  };
-in stdenv.mkDerivation rec {
-  name = "iwd-${version}";
-  version = "0.14";
+stdenv.mkDerivation rec {
+  pname = "iwd";
+
+  version = "0.17";
 
   src = fetchgit {
     url = https://git.kernel.org/pub/scm/network/wireless/iwd.git;
     rev = version;
-    sha256 = "08ijlnwvj1w354gbv3hdnm3l4iy24qzq4bq5a9z0wynysasw09lv";
+    sha256 = "1bqkzl03qvzfq5hqd9nsfc98k0iyz864nzcrnbf3fr0n9wnzqffz";
   };
 
   nativeBuildInputs = [
@@ -23,7 +18,8 @@ in stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    readline
+    ell
+    readline80
     python3Packages.python
   ];
 
@@ -36,12 +32,13 @@ in stdenv.mkDerivation rec {
     "--with-dbus-datadir=${placeholder "out"}/etc/"
     "--with-dbus-busdir=${placeholder "out"}/share/dbus-1/system-services/"
     "--with-systemd-unitdir=${placeholder "out"}/lib/systemd/system/"
+    "--with-systemd-modloaddir=${placeholder "out"}/etc/modules-load.d/" # maybe
     "--localstatedir=/var/"
     "--enable-wired"
+    "--enable-external-ell"
   ];
 
   postUnpack = ''
-    ln -s ${ell} ell
     patchShebangs .
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1420,6 +1420,8 @@ in
 
   elementary-xfce-icon-theme = callPackage ../data/icons/elementary-xfce-icon-theme { };
 
+  ell = callPackage ../os-specific/linux/ell { };
+
   elm-github-install = callPackage ../tools/package-management/elm-github-install { };
 
   emby = callPackage ../servers/emby { };


### PR DESCRIPTION
###### Motivation for this change

https://git.kernel.org/pub/scm/network/wireless/iwd.git/plain/ChangeLog?h=0.17
https://git.kernel.org/pub/scm/network/wireless/iwd.git/plain/ChangeLog?h=0.16
https://git.kernel.org/pub/scm/network/wireless/iwd.git/plain/ChangeLog?h=0.15

https://git.kernel.org/pub/scm/libs/ell/ell.git/tree/ChangeLog?h=0.19
https://git.kernel.org/pub/scm/libs/ell/ell.git/tree/ChangeLog?h=0.18

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---