### PR TITLE
kmymoney: 5.0.1 -> 5.0.4

### DIFF
--- a/pkgs/applications/office/kmymoney/default.nix
+++ b/pkgs/applications/office/kmymoney/default.nix
@@ -14,11 +14,11 @@
 
 stdenv.mkDerivation rec {
   name = "kmymoney-${version}";
-  version = "5.0.1";
+  version = "5.0.4";
 
   src = fetchurl {
     url = "mirror://kde/stable/kmymoney/${version}/src/${name}.tar.xz";
-    sha256 = "1c9apnvc07y17pzy4vygry1dai5ass2z7j354lrcppa85b18yvnx";
+    sha256 = "06lbavhl9b8cybnss2mmy3g5w8qn2vl6zhipvbl11lsr3j9bsa8q";
   };
 
   # Fix build with Qt 5.11.

--- a/pkgs/applications/office/kmymoney/default.nix
+++ b/pkgs/applications/office/kmymoney/default.nix
@@ -5,6 +5,8 @@
 , kcmutils, kcontacts, kdewebkit, kdiagram, kholidays, kidentitymanagement
 , kitemmodels, libical, libofx, qgpgme
 
+, sqlcipher
+
 # Needed for running tests:
 , qtbase, xvfb_run
 
@@ -34,6 +36,7 @@ stdenv.mkDerivation rec {
     akonadi alkimia aqbanking gmp gwenhywfar kactivities karchive kcmutils
     kcontacts kdewebkit kdiagram kholidays kidentitymanagement kitemmodels
     libical libofx qgpgme
+    sqlcipher
 
     # Put it into buildInputs so that CMake can find it, even though we patch
     # it into the interface later.

--- a/pkgs/applications/office/kmymoney/default.nix
+++ b/pkgs/applications/office/kmymoney/default.nix
@@ -21,13 +21,6 @@ stdenv.mkDerivation rec {
     sha256 = "06lbavhl9b8cybnss2mmy3g5w8qn2vl6zhipvbl11lsr3j9bsa8q";
   };
 
-  # Fix build with Qt 5.11.
-  patches = lib.singleton (fetchpatch {
-    url = "https://cgit.kde.org/kmymoney.git/patch/?id="
-        + "e5198a902996b27bf9abde0ad24af82d55ab5dc1";
-    sha256 = "1h2f1xznf7343s26fh94x8n2ci0pijk5j86f24lvghawsw848316";
-  });
-
   # Hidden dependency that wasn't included in CMakeLists.txt:
   NIX_CFLAGS_COMPILE = "-I${kitemmodels.dev}/include/KF5";
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---