### PR TITLE
networkmanager: 1.16.0 -> 1.18.0

### DIFF
--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -2,7 +2,7 @@
 , gnome3, systemd, libuuid, polkit, gnutls, ppp, dhcp, iptables, python3, vala
 , libgcrypt, dnsmasq, bluez5, readline, libselinux, audit
 , gobject-introspection, modemmanager, openresolv, libndp, newt, libsoup
-, ethtool, gnused, coreutils, inetutils, kmod, jansson, gtk-doc, libxslt
+, ethtool, gnused, coreutils, iputils, kmod, jansson, gtk-doc, libxslt
 , docbook_xsl, docbook_xml_dtd_412, docbook_xml_dtd_42, docbook_xml_dtd_43
 , openconnect, curl, meson, ninja, libpsl, libredirect }:
 
@@ -11,11 +11,11 @@ let
   pythonForDocs = python3.withPackages (pkgs: with pkgs; [ pygobject3 ]);
 in stdenv.mkDerivation rec {
   name = "network-manager-${version}";
-  version = "1.16.0";
+  version = "1.18.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "0b2x9hrg41cd17psqi0vacwj733v99hxczn53gdfs0yanqrji5lf";
+    sha256 = "19lb5afx4iq8dgfsy26x9j4194v8f64vwr3nq6dk1ix3wljxzs66";
   };
 
   outputs = [ "out" "dev" "devdoc" "man" "doc" ];
@@ -43,15 +43,18 @@ in stdenv.mkDerivation rec {
     "-Dmodem_manager=true"
     "-Dnmtui=true"
     "-Ddocs=true"
-    "-Dlibnm_glib=true" # legacy library, TODO: remove
+    # TODO: legacy library, will be *removed* in next release!
+    "-Dlibnm_glib=true"
     "-Dtests=no"
     "-Dqt=false"
+    # Allow using iwd when configured to do so
+    "-Diwd=true"
   ];
 
   patches = [
     (substituteAll {
       src = ./fix-paths.patch;
-      inherit inetutils kmod openconnect ethtool coreutils dbus;
+      inherit iputils kmod openconnect ethtool coreutils dbus;
       inherit (stdenv) shell;
     })
 
@@ -83,6 +86,8 @@ in stdenv.mkDerivation rec {
   ];
 
   doCheck = false; # requires /sys, the net
+
+  enableParallelBuilding = true;
 
   postPatch = ''
     patchShebangs ./tools

--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -87,7 +87,6 @@ in stdenv.mkDerivation rec {
 
   doCheck = false; # requires /sys, the net
 
-  enableParallelBuilding = true;
 
   postPatch = ''
     patchShebangs ./tools

--- a/pkgs/tools/networking/network-manager/fix-paths.patch
+++ b/pkgs/tools/networking/network-manager/fix-paths.patch
@@ -35,12 +35,12 @@
  Restart=on-failure
 --- a/src/devices/nm-device.c
 +++ b/src/devices/nm-device.c
-@@ -12350,14 +12350,14 @@
+@@ -12451,14 +12451,14 @@ nm_device_start_ip_check (NMDevice *self)
  			gw = nm_ip4_config_best_default_route_get (priv->ip_config_4);
  			if (gw) {
  				nm_utils_inet4_ntop (NMP_OBJECT_CAST_IP4_ROUTE (gw)->gateway, buf);
 -				ping_binary = nm_utils_find_helper ("ping", "/usr/bin/ping", NULL);
-+				ping_binary = "@inetutils@/bin/ping";
++				ping_binary = "@iputils@/bin/ping";
  				log_domain = LOGD_IP4;
  			}
  		} else if (priv->ip_config_6 && priv->ip_state_6 == NM_DEVICE_IP_STATE_DONE) {
@@ -48,13 +48,15 @@
  			if (gw) {
  				nm_utils_inet6_ntop (&NMP_OBJECT_CAST_IP6_ROUTE (gw)->gateway, buf);
 -				ping_binary = nm_utils_find_helper ("ping6", "/usr/bin/ping6", NULL);
-+				ping_binary = "@inetutils@/bin/ping";
++				ping_binary = "@iputils@/bin/ping";
  				log_domain = LOGD_IP6;
  			}
  		}
+diff --git a/src/nm-core-utils.c b/src/nm-core-utils.c
+index 6f55e62a7..93721e7fb 100644
 --- a/src/nm-core-utils.c
 +++ b/src/nm-core-utils.c
-@@ -421,8 +421,8 @@
+@@ -442,7 +442,7 @@ nm_utils_modprobe (GError **error, gboolean suppress_error_logging, const char *
  
  	/* construct the argument list */
  	argv = g_ptr_array_sized_new (4);
@@ -63,4 +65,3 @@
  	g_ptr_array_add (argv, "--use-blacklist");
  	g_ptr_array_add (argv, (char *) arg1);
  
- 	va_start (ap, arg1);


### PR DESCRIPTION
###### Motivation for this change

* build w/iwd support since it's free (no dep required!)
* move to iputils for minor utilities, instead of inetutils
* ~~libnm-glib has been deprecated for 5 years, don't build support for it~~
  * This is the last release offering this as an option
* parallel building :)

https://gitlab.freedesktop.org/NetworkManager/NetworkManager/raw/1.18.0/NEWS

###### Things done

(following is marked based on my testing with a similar branch,
but not exactly current 'staging'.  FWIW.)
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

FWIW been using this on my system since packaging it yesterday morning.
---