### PR TITLE
python3.pkgs.aioesphomeapi: 1.8.0 -> 2.0.1

### DIFF
--- a/pkgs/development/python-modules/aioesphomeapi/default.nix
+++ b/pkgs/development/python-modules/aioesphomeapi/default.nix
@@ -1,12 +1,14 @@
-{ lib, buildPythonPackage, fetchPypi, attrs, protobuf, zeroconf }:
+{ lib, buildPythonPackage, fetchPypi, isPy3k, attrs, protobuf, zeroconf }:
 
 buildPythonPackage rec {
   pname = "aioesphomeapi";
-  version = "1.8.0";
+  version = "2.0.1";
+
+  disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "16ywa7yggmsx8m2r9azdq7w9fxjh736g1vd1aibgh24g7srhwwhj";
+    sha256 = "db09e34dfc148279f303481c7da94b84c9b1442a41794f039c31253e81a58ffb";
   };
 
   propagatedBuildInputs = [ attrs protobuf zeroconf ];
@@ -19,5 +21,9 @@ buildPythonPackage rec {
     homepage = https://github.com/esphome/aioesphomeapi;
     license = licenses.mit;
     maintainers = with maintainers; [ dotlambda ];
+
+    # Home Assistant should pin protobuf to the correct version. Can be tested using
+    #     nix-build -E "with import ./. {}; home-assistant.override { extraPackages = ps: [ ps.aioesphomeapi ]; }"
+    broken = !lib.hasPrefix "3.6.1" protobuf.version;
   };
 }

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, fetchpatch, python3
+{ lib, fetchFromGitHub, fetchpatch, python3, protobuf3_6
 
 # Look up dependencies of specified components in component-packages.nix
 , extraComponents ? []
@@ -76,6 +76,13 @@ let
         };
         doCheck = false; # can be dropped for 2.0
       });
+    })
+
+    # required by aioesphomeapi
+    (self: super: {
+      protobuf = super.protobuf.override {
+        protobuf = protobuf3_6;
+      };
     })
 
     # hass-frontend does not exist in python3.pkgs


### PR DESCRIPTION
Pin the protobuf version used by Home Assistant to the version
required by aioesphomeapi and some components.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
