### PR TITLE
python.pkgs.forbiddenfruit: 0.1.2 -> 0.1.3

### DIFF
--- a/pkgs/development/python-modules/forbiddenfruit/default.nix
+++ b/pkgs/development/python-modules/forbiddenfruit/default.nix
@@ -5,22 +5,20 @@
 }:
 
 buildPythonPackage rec {
-  version = "0.1.2";
+  version = "0.1.3";
   pname = "forbiddenfruit";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "09ee1959fa34936c15417defa28bfd09cf88ad54c15454bc863d465ed42b8922";
+    sha256 = "1188a07cc24a9bd2c529dad06490b80a6fc88cde968af4d7861da81686b2cc8c";
   };
 
   checkInputs = [ nose ];
 
   checkPhase = ''
+    find ./build -name '*.so' -exec mv {} tests/unit \;
     nosetests
   '';
-
-  # tests directory missing in PyPI tarball
-  doCheck = false;
 
   meta = with stdenv.lib; {
     description = "Patch python built-in objects";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
run tests

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
