### PR TITLE
plex: modernize package, support i686

### DIFF
--- a/pkgs/servers/plex/update.sh
+++ b/pkgs/servers/plex/update.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p common-updater-scripts coreutils curl findutils jq
+
+set -eu -o pipefail
+
+manifest=$(curl -s https://plex.tv/api/downloads/5.json)
+version=$(echo "$manifest" | jq -r '.computer.Linux.version | split("-") | .[0]')
+
+# Mapping of nixpkgs platform to plex platform.
+systems='{"i686-linux": "linux-x86", "x86_64-linux": "linux-x86_64"}'
+
+for system in "i686-linux" "x86_64-linux"; do
+  # The script will not perform an update when the version attribute is updated for the previous
+  # system, so we need to clear it before each run.
+  update-source-version plex 0 0000000000000000000000000000000000000000000000000000000000000000 \
+   --system=$system
+
+  echo "$manifest" \
+      | jq -r --arg system "$system" --argjson systems "$systems" '
+        ($systems | .[$system]) as $build
+        | .computer.Linux.releases
+        | map(select(.distro == "redhat" and .build == $build))
+        | .[]
+        | .url' \
+      | xargs -i update-source-version plex "$version" '' {} --system=$system
+done


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I've been running this modified package on my server for a while now, and have been meaning to clean it up and submit a PR.

Essentially, this replaces the manual `patchelf` calls with `autoPatchelfHook`. I did this because Plex would not start on my system since they've added some libraries over time, such as `libboost`, which weren't accounted for in the install script.

I also added `passthru.updateScript` which queries the same release manifest as the [Plex downloads page](https://www.plex.tv/media-server-downloads/) and does some parsing with `jq` to fetch the latest version and URL. This happens to work for multiple platforms as well, so I threw `i686-linux` support in the package. In the future, it should be possible to support AArch64 and Darwin builds.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
