### PR TITLE
rtl8821au: update for Linux 5.0

### DIFF
--- a/pkgs/os-specific/linux/rtl8821au/default.nix
+++ b/pkgs/os-specific/linux/rtl8821au/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "rtl8821au-${kernel.version}-${version}";
-  version = "5.1.5";
+  version = "5.1.5+41";
 
   src = fetchFromGitHub {
     owner = "zebulon2";
     repo = "rtl8812au";
-    rev = "61d0cd95afc01eae64da0c446515803910de1a00";
-    sha256 = "0dlzyiaa3hmb2qj3lik52px88n4mgrx7nblbm4s0hn36g19ylssw";
+    rev = "ecd3494c327c54110d21346ca335ef9e351cb0be";
+    sha256 = "1kmdxgbh0s0v9809kdsi39p0jbm5cf10ivy40h8qj9hn70g1gw8q";
   };
 
   nativeBuildInputs = [ bc ];


### PR DESCRIPTION
I've upgraded to NixOS 19.03 and this was the only issue.
This change is simple enough, but the lack of a version change upstream puts this in the same spot as the [rtl8814au driver](https://github.com/NixOS/nixpkgs/blob/master/pkgs/os-specific/linux/rtl8814au/default.nix). The nixpkgs manual doesn't seem to contain a policy for this - is it even a problem?