### PR TITLE
[19.03] gitlab: 11.9.1 -> 11.9.8

### DIFF
--- a/pkgs/applications/version-management/gitlab/data.json
+++ b/pkgs/applications/version-management/gitlab/data.json
@@ -1,17 +1,17 @@
 {
   "ce": {
-    "version": "11.9.1",
-    "repo_hash": "11dx931n79ynw8j6vbjsb832dkkp2s4vzji53km4ib9njn5nja0l",
-    "deb_hash": "133qjxmrn2rl9avi0nwcdbky53vgxbzp4g3vcgwg21xyfr8k8s4n",
-    "deb_url": "https://packages.gitlab.com/gitlab/gitlab-ce/packages/debian/stretch/gitlab-ce_11.9.1-ce.0_amd64.deb/download.deb",
+    "version": "11.9.8",
+    "repo_hash": "10xlabp7ziw1vpyy9dvhaiwf5l340d3yzvlh2aq6ly3xlqr5ip07",
+    "deb_hash": "0apw0w5grhpfxwl76w7as5xb6injr7ka8wwk2azllamrxrnn30dv",
+    "deb_url": "https://packages.gitlab.com/gitlab/gitlab-ce/packages/debian/stretch/gitlab-ce_11.9.8-ce.0_amd64.deb/download.deb",
     "owner": "gitlab-org",
     "repo": "gitlab-ce",
-    "rev": "v11.9.1",
+    "rev": "v11.9.8",
     "passthru": {
       "GITALY_SERVER_VERSION": "1.27.1",
       "GITLAB_PAGES_VERSION": "1.5.0",
       "GITLAB_SHELL_VERSION": "8.7.1",
-      "GITLAB_WORKHORSE_VERSION": "8.3.1"
+      "GITLAB_WORKHORSE_VERSION": "8.3.3"
     }
   },
   "ee": {

--- a/pkgs/applications/version-management/gitlab/data.json
+++ b/pkgs/applications/version-management/gitlab/data.json
@@ -15,18 +15,18 @@
     }
   },
   "ee": {
-    "version": "11.9.1",
-    "repo_hash": "13d6vg505rifgxpks9b7x2zq65b41naj7znkzm5i1kdvklfygqpd",
-    "deb_hash": "1z5i04cxwgcmx55yzhpw0ss1rwaqz1jl6hwpgbyly6prrbl5h59x",
-    "deb_url": "https://packages.gitlab.com/gitlab/gitlab-ee/packages/debian/stretch/gitlab-ee_11.9.1-ee.0_amd64.deb/download.deb",
+    "version": "11.9.8",
+    "repo_hash": "0h6lpaiwsvyn5cdga08zbgr6cwp3k6xi5jpb7n37hc6y4c7b36ry",
+    "deb_hash": "1bsy8qrr2sjvavzv4nslx14x4cx5xjx55d2v7zz6fvjzmgb98hgv",
+    "deb_url": "https://packages.gitlab.com/gitlab/gitlab-ee/packages/debian/stretch/gitlab-ee_11.9.8-ee.0_amd64.deb/download.deb",
     "owner": "gitlab-org",
     "repo": "gitlab-ee",
-    "rev": "v11.9.1-ee",
+    "rev": "v11.9.8-ee",
     "passthru": {
       "GITALY_SERVER_VERSION": "1.27.1",
       "GITLAB_PAGES_VERSION": "1.5.0",
       "GITLAB_SHELL_VERSION": "8.7.1",
-      "GITLAB_WORKHORSE_VERSION": "8.3.1"
+      "GITLAB_WORKHORSE_VERSION": "8.3.3"
     }
   }
 }

--- a/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "gitlab-workhorse-${version}";
 
-  version = "8.3.1";
+  version = "8.3.3";
 
   src = fetchFromGitLab {
     owner = "gitlab-org";
     repo = "gitlab-workhorse";
     rev = "v${version}";
-    sha256 = "14zmxajzx6r2wrsxkmqp7j94yxnq4qpg27wih5l8lhf1imzgnk3j";
+    sha256 = "08v5ga9qbrs1xciw4cjhsjpqcp6cxzymc2y39la2a4lgb2cgyi10";
   };
 
   buildInputs = [ git go ];

--- a/pkgs/applications/version-management/gitlab/rubyEnv-ce/Gemfile
+++ b/pkgs/applications/version-management/gitlab/rubyEnv-ce/Gemfile
@@ -204,6 +204,9 @@ gem 'connection_pool', '~> 2.0'
 # Discord integration
 gem 'discordrb-webhooks-blackst0ne', '~> 3.3', require: false
 
+# HipChat integration
+gem 'hipchat', '~> 1.5.0'
+
 # JIRA integration
 gem 'jira-ruby', '~> 1.4'
 

--- a/pkgs/applications/version-management/gitlab/rubyEnv-ce/Gemfile.lock
+++ b/pkgs/applications/version-management/gitlab/rubyEnv-ce/Gemfile.lock
@@ -364,6 +364,9 @@ GEM
       hashie (>= 3.0)
     health_check (2.6.0)
       rails (>= 4.0)
+    hipchat (1.5.2)
+      httparty
+      mimemagic
     html-pipeline (2.8.4)
       activesupport (>= 2)
       nokogiri (>= 1.4)
@@ -1041,6 +1044,7 @@ DEPENDENCIES
   hangouts-chat (~> 0.0.5)
   hashie-forbidden_attributes
   health_check (~> 2.6.0)
+  hipchat (~> 1.5.0)
   html-pipeline (~> 2.8)
   html2text
   httparty (~> 0.13.3)

--- a/pkgs/applications/version-management/gitlab/rubyEnv-ce/gemset.nix
+++ b/pkgs/applications/version-management/gitlab/rubyEnv-ce/gemset.nix
@@ -1354,6 +1354,17 @@
     };
     version = "2.6.0";
   };
+  hipchat = {
+    dependencies = ["httparty" "mimemagic"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0hgy5jav479vbzzk53lazhpjj094dcsqw6w1d6zjn52p72bwq60k";
+      type = "gem";
+    };
+    version = "1.5.2";
+  };
   html-pipeline = {
     dependencies = ["activesupport" "nokogiri"];
     source = {

--- a/pkgs/applications/version-management/gitlab/rubyEnv-ee/Gemfile
+++ b/pkgs/applications/version-management/gitlab/rubyEnv-ee/Gemfile
@@ -214,6 +214,9 @@ gem 'connection_pool', '~> 2.0'
 # Discord integration
 gem 'discordrb-webhooks-blackst0ne', '~> 3.3', require: false
 
+# HipChat integration
+gem 'hipchat', '~> 1.5.0'
+
 # JIRA integration
 gem 'jira-ruby', '~> 1.4'
 

--- a/pkgs/applications/version-management/gitlab/rubyEnv-ee/Gemfile.lock
+++ b/pkgs/applications/version-management/gitlab/rubyEnv-ee/Gemfile.lock
@@ -391,6 +391,9 @@ GEM
       hashie (>= 3.0)
     health_check (2.6.0)
       rails (>= 4.0)
+    hipchat (1.5.2)
+      httparty
+      mimemagic
     html-pipeline (2.8.4)
       activesupport (>= 2)
       nokogiri (>= 1.4)
@@ -1078,6 +1081,7 @@ DEPENDENCIES
   hangouts-chat (~> 0.0.5)
   hashie-forbidden_attributes
   health_check (~> 2.6.0)
+  hipchat (~> 1.5.0)
   html-pipeline (~> 2.8)
   html2text
   httparty (~> 0.13.3)

--- a/pkgs/applications/version-management/gitlab/rubyEnv-ee/gemset.nix
+++ b/pkgs/applications/version-management/gitlab/rubyEnv-ee/gemset.nix
@@ -1459,6 +1459,17 @@
     };
     version = "2.6.0";
   };
+  hipchat = {
+    dependencies = ["httparty" "mimemagic"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0hgy5jav479vbzzk53lazhpjj094dcsqw6w1d6zjn52p72bwq60k";
+      type = "gem";
+    };
+    version = "1.5.2";
+  };
   html-pipeline = {
     dependencies = ["activesupport" "nokogiri"];
     source = {


### PR DESCRIPTION
###### Motivation for this change
backport of https://github.com/NixOS/nixpkgs/pull/60061

CVE-2019-10640, https://about.gitlab.com/2019/04/10/critical-security-release-gitlab-11-dot-9-dot-7-released/ (CVE-2019-11000)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
