### PR TITLE
yad: 0.40.0 -> 0.42.0

### DIFF
--- a/pkgs/tools/misc/yad/default.nix
+++ b/pkgs/tools/misc/yad/default.nix
@@ -1,31 +1,40 @@
-{ stdenv, fetchurl, pkgconfig, intltool, gtk2, hicolor-icon-theme
-, wrapGAppsHook }:
+{ stdenv, fetchFromGitHub, pkgconfig, intltool, autoreconfHook, wrapGAppsHook
+, gtk3, hicolor-icon-theme, netpbm }:
 
 stdenv.mkDerivation rec {
-  name = "yad-0.40.0";
+  pname = "yad";
+  version = "0.42.0";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/yad-dialog/files/${name}.tar.xz";
-    sha256 = "1x0fsv8nfkm8lchdawnf3zw79jaqbnvhv87sk5r8g86knv8vgl62";
+  src = fetchFromGitHub {
+    owner = "v1cont";
+    repo = "yad";
+    rev = "v${version}";
+    sha256 = "0ym8pgbzx7ydk5rmi2kwwdyzi6pdpcps86i0c20cqcjmqh8kdl36";
   };
 
   configureFlags = [
     "--enable-icon-browser"
+    "--with-gtk=gtk3"
+    "--with-rgb=${placeholder "out"}/share/yad/rgb.txt"
   ];
 
-  # for gcc5: c11 inline semantics breaks the build
-  NIX_CFLAGS_COMPILE = "-fgnu89-inline";
+  buildInputs = [ gtk3 hicolor-icon-theme ];
 
-  buildInputs = [ gtk2 hicolor-icon-theme ];
-
-  nativeBuildInputs = [ pkgconfig intltool wrapGAppsHook ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig intltool wrapGAppsHook ];
 
   postPatch = ''
     sed -i src/file.c -e '21i#include <glib/gprintf.h>'
     sed -i src/form.c -e '21i#include <stdlib.h>'
+
+    # there is no point to bring in the whole netpbm package just for this file
+    install -Dm644 ${netpbm}/share/netpbm/misc/rgb.txt $out/share/yad/rgb.txt
   '';
 
-  meta = {
+  postAutoreconf = ''
+    intltoolize
+  '';
+
+  meta = with stdenv.lib; {
     homepage = https://sourceforge.net/projects/yad-dialog/;
     description = "GUI dialog tool for shell scripts";
     longDescription = ''
@@ -34,9 +43,8 @@ stdenv.mkDerivation rec {
       dialogs, pop-up menu in notification icon and more.
     '';
 
-    platforms = with stdenv.lib.platforms; linux;
-    maintainers = with stdenv.lib.maintainers; [ smironov ];
-    license = stdenv.lib.licenses.gpl3;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ smironov ];
+    platforms = with platforms; linux;
   };
 }
-


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Upstream update. Also move from gtk2 to gtk3.

Cc: @grwlf 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
