### PR TITLE
doit: fix darwin build

### DIFF
--- a/pkgs/development/python-modules/macfsevents/default.nix
+++ b/pkgs/development/python-modules/macfsevents/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildPythonPackage, fetchPypi, CoreFoundation, CoreServices }:
+
+buildPythonPackage rec {
+  pname = "MacFSEvents";
+  version = "0.8.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1324b66b356051de662ba87d84f73ada062acd42b047ed1246e60a449f833e10";
+  };
+
+  buildInputs = [ CoreFoundation CoreServices ];
+
+  # Some tests fail under nix build directory
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = https://github.com/malthe/macfsevents;
+    description = "Thread-based interface to file system observation primitives";
+    license = licenses.bsd2;
+    maintainers = [ maintainers.marsam ];
+    platforms = platforms.darwin;
+  };
+}

--- a/pkgs/development/tools/build-managers/doit/default.nix
+++ b/pkgs/development/tools/build-managers/doit/default.nix
@@ -15,7 +15,9 @@ in python3Packages.buildPythonApplication {
 
   buildInputs = with python3Packages; [ mock pytest ];
 
-  propagatedBuildInputs = with python3Packages; [ cloudpickle pyinotify ];
+  propagatedBuildInputs = with python3Packages; [ cloudpickle ]
+    ++ stdenv.lib.optional stdenv.isLinux pyinotify
+    ++ stdenv.lib.optional stdenv.isDarwin macfsevents;
 
   # Tests fail due to mysterious gdbm.open() resource temporarily
   # unavailable errors.

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3136,6 +3136,10 @@ in {
 
   Mako = callPackage ../development/python-modules/Mako { };
 
+  macfsevents = callPackage ../development/python-modules/macfsevents {
+    inherit (pkgs.darwin.apple_sdk.frameworks) CoreFoundation CoreServices;
+  };
+
   manifestparser = callPackage ../development/python-modules/marionette-harness/manifestparser.nix {};
   marionette_driver = callPackage ../development/python-modules/marionette-harness/marionette_driver.nix {};
   mozcrash = callPackage ../development/python-modules/marionette-harness/mozcrash.nix {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
