### PR TITLE
openblas: turn off AVX512 optimizations

### DIFF
--- a/pkgs/development/libraries/science/math/openblas/default.nix
+++ b/pkgs/development/libraries/science/math/openblas/default.nix
@@ -58,6 +58,7 @@ let
       BINARY = 64;
       TARGET = setTarget "ATHLON";
       DYNAMIC_ARCH = true;
+      NO_AVX512 = true;
       USE_OPENMP = true;
     };
   };


### PR DESCRIPTION
###### Motivation for this change
The AVX512 optimization has a bug in openblas-0.3.5 and can also lead to slower code on Xeon Silver CPUs.

Closes https://github.com/NixOS/nixpkgs/issues/59708

Needs backport to 19.03
###### Things done
I checked the fix by running a benchmark test on NixOS 19.03 with the modified make flags on a Xeon Silver 4114 system. The tests that previously failed (see https://github.com/xianyi/OpenBLAS/issues/2029) are now working. Performance is now comparable a fixed target version with `DYANMIC_ARCH=0` and `TARGET=HASWELL`, which is expected.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
