### PR TITLE
ocamlPackages: fix regression in zarith-dependent libraries

### DIFF
--- a/pkgs/development/ocaml-modules/zarith/default.nix
+++ b/pkgs/development/ocaml-modules/zarith/default.nix
@@ -6,9 +6,9 @@
 let source =
   if stdenv.lib.versionAtLeast ocaml.version "4.02"
   then {
-    version = "1.7";
-    url = https://github.com/ocaml/Zarith/archive/release-1.7.tar.gz;
-    sha256 = "0fmblap5nsbqq0dab63d6b7lsxpc3snkgz7jfldi2qa4s1kbnhfn";
+    version = "1.8";
+    url = https://github.com/ocaml/Zarith/archive/release-1.8.tar.gz;
+    sha256 = "1cn63c97aij19nrw5hc1zh1jpnbsdkzq99zyyk649c4s3xi3iqq7";
   } else {
     version = "1.3";
     url = http://forge.ocamlcore.org/frs/download.php/1471/zarith-1.3.tgz;

--- a/pkgs/development/ocaml-modules/zarith/default.nix
+++ b/pkgs/development/ocaml-modules/zarith/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl
+{ stdenv, buildOcaml, fetchurl
 , ocaml, findlib, pkgconfig, perl
 , gmp
 }:
@@ -6,9 +6,9 @@
 let source =
   if stdenv.lib.versionAtLeast ocaml.version "4.02"
   then {
-    version = "1.8";
-    url = https://github.com/ocaml/Zarith/archive/release-1.8.tar.gz;
-    sha256 = "1cn63c97aij19nrw5hc1zh1jpnbsdkzq99zyyk649c4s3xi3iqq7";
+    version = "1.7";
+    url = https://github.com/ocaml/Zarith/archive/release-1.7.tar.gz;
+    sha256 = "0fmblap5nsbqq0dab63d6b7lsxpc3snkgz7jfldi2qa4s1kbnhfn";
   } else {
     version = "1.3";
     url = http://forge.ocamlcore.org/frs/download.php/1471/zarith-1.3.tgz;
@@ -16,20 +16,25 @@ let source =
   };
 in
 
-stdenv.mkDerivation rec {
-  name = "ocaml${ocaml.version}-zarith-${version}";
+buildOcaml rec {
+  name = "zarith";
   inherit (source) version;
   src = fetchurl { inherit (source) url sha256; };
+
+  minimumSupportedOcamlVersion = "3.12.1";
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ ocaml findlib perl ];
   propagatedBuildInputs = [ gmp ];
 
+  # needed so setup-hook.sh sets CAML_LD_LIBRARY_PATH for dllzarith.so
+  hasSharedObjects = true;
+
   patchPhase = "patchShebangs ./z_pp.pl";
   configurePhase = ''
     ./configure -installdir $out/lib/ocaml/${ocaml.version}/site-lib
   '';
-  createFindlibDestdir = true;
+  preInstall = "mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib";
 
   meta = with stdenv.lib; {
     description = "Fast, arbitrary precision OCaml integers";


### PR DESCRIPTION
###### Motivation for this change

See https://github.com/NixOS/nixpkgs/pull/58932#issuecomment-485443775, as well as the explanation in 564653f91d7031495a0b955c744a578352f34576.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
