### PR TITLE
pythonPackages.asyncssh: 1.15.1 -> 1.16.1

### DIFF
--- a/pkgs/development/python-modules/asyncssh/default.nix
+++ b/pkgs/development/python-modules/asyncssh/default.nix
@@ -1,17 +1,34 @@
-{ stdenv, buildPythonPackage, fetchPypi, pythonOlder
+{ stdenv, buildPythonPackage, fetchPypi, pythonOlder, fetchpatch
 , cryptography
 , bcrypt, gssapi, libnacl, libsodium, nettle, pyopenssl
-, openssl }:
+, openssl, openssh }:
 
 buildPythonPackage rec {
   pname = "asyncssh";
-  version = "1.15.1";
+  version = "1.16.1";
   disabled = pythonOlder "3.4";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "f2065a8b3af0c514c8de264e7b01f08df5213b707bacb7e7c080bd46c3e3bc35";
+    sha256 = "0qia1ay2dhwps5sfh0hif7mrv7yxvykxs9l7cmfp4m6hmqnn3r5r";
   };
+
+  patches = [
+    # Reverts https://github.com/ronf/asyncssh/commit/4b3dec994b3aa821dba4db507030b569c3a32730
+    #
+    # This changed the test to avoid setting the sticky bit
+    # because that's not allowed for plain files in FreeBSD.
+    # However that broke the test on NixOS, failing with
+    # "Operation not permitted"
+    ./fix-sftp-chmod-test-nixos.patch
+
+    # Restore libnacl support for curve25519/ed25519 as a fallback for PyCA
+    # Fixes https://github.com/ronf/asyncssh/issues/206 with older openssl
+    (fetchpatch {
+      url = "https://github.com/ronf/asyncssh/commit/1dee113bb3e4a6888de562b0413e9abd6a0f0f04.patch";
+      sha256 = "04bckdj7i6xk24lizkn3a8cj375pkz7yc57fc0vk222c6jzwzaml";
+    })
+  ];
 
   propagatedBuildInputs = [
     bcrypt
@@ -23,17 +40,20 @@ buildPythonPackage rec {
     pyopenssl
   ];
 
-  checkInputs = [ openssl ];
+  checkInputs = [
+    openssh
+    openssl
+  ];
 
   # Disables windows specific test (specifically the GSSAPI wrapper for Windows)
   postPatch = ''
-    rm ./tests/sspi_stub.py
+    rm tests/sspi_stub.py
   '';
 
   meta = with stdenv.lib; {
     description = "Provides an asynchronous client and server implementation of the SSHv2 protocol on top of the Python asyncio framework";
-    homepage    = https://pypi.python.org/pypi/asyncssh;
-    license     = licenses.epl20;
+    homepage = https://asyncssh.readthedocs.io/en/latest;
+    license = licenses.epl20;
     maintainers = with maintainers; [ worldofpeace ];
   };
 }

--- a/pkgs/development/python-modules/asyncssh/fix-sftp-chmod-test-nixos.patch
+++ b/pkgs/development/python-modules/asyncssh/fix-sftp-chmod-test-nixos.patch
@@ -1,0 +1,15 @@
+diff --git a/tests/test_sftp.py b/tests/test_sftp.py
+index db9cc88..234004b 100644
+--- a/tests/test_sftp.py
++++ b/tests/test_sftp.py
+@@ -957,8 +957,8 @@ class _TestSFTP(_CheckSFTP):
+ 
+         try:
+             self._create_file('file')
+-            yield from sftp.chmod('file', 0o4321)
+-            self.assertEqual(stat.S_IMODE(os.stat('file').st_mode), 0o4321)
++            yield from sftp.chmod('file', 0o1234)
++            self.assertEqual(stat.S_IMODE(os.stat('file').st_mode), 0o1234)
+         finally:
+             remove('file')
+ 


### PR DESCRIPTION
https://github.com/ronf/asyncssh/blob/master/docs/changes.rst#release-1161-30-mar-2019

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Been waiting forever to pr this :rofl: 


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
