### PR TITLE
rustup: 1.17.0 -> 1.18.1

### DIFF
--- a/pkgs/development/tools/rust/rustup/0001-dynamically-patchelf-binaries.patch
+++ b/pkgs/development/tools/rust/rustup/0001-dynamically-patchelf-binaries.patch
@@ -1,32 +1,25 @@
-From c21cc756b69a5f33c8a7758b746a816f40f55932 Mon Sep 17 00:00:00 2001
-From: Leon Isenberg <ljli@users.noreply.github.com>
-Date: Sat, 28 Oct 2017 17:58:17 +0200
-Subject: [PATCH] nix customization: patchelf installed binaries
-
----
- src/rustup-dist/src/component/package.rs | 21 ++++++++++++++++++++-
- 1 file changed, 20 insertions(+), 1 deletion(-)
-
-diff --git a/src/rustup-dist/src/component/package.rs b/src/rustup-dist/src/component/package.rs
-index 70c54dcd..f0318986 100644
---- a/src/rustup-dist/src/component/package.rs
-+++ b/src/rustup-dist/src/component/package.rs
-@@ -100,7 +100,10 @@ impl Package for DirectoryPackage {
-             let src_path = root.join(&path);
- 
+diff --git a/src/dist/component/package.rs b/src/dist/component/package.rs
+index e0fdea28..38d9d0e4 100644
+--- a/src/dist/component/package.rs
++++ b/src/dist/component/package.rs
+@@ -104,10 +104,11 @@ impl Package for DirectoryPackage {
              match &*part.0 {
--                "file" => builder.copy_file(path.clone(), &src_path)?,
-+                "file" => {
-+                    builder.copy_file(path.clone(), &src_path)?;
+                 "file" => {
+                     if self.copy {
+-                        builder.copy_file(path.clone(), &src_path)?
++                        builder.copy_file(path.clone(), &src_path)?;
+                     } else {
+-                        builder.move_file(path.clone(), &src_path)?
++                        builder.move_file(path.clone(), &src_path)?;
+                     }
 +                    nix_patchelf_if_needed(&target.prefix().path().join(path.clone()), &src_path)
-+                }
-                 "dir" => builder.copy_dir(path.clone(), &src_path)?,
-                 _ => return Err(ErrorKind::CorruptComponent(name.to_owned()).into()),
-             }
-@@ -118,6 +121,22 @@ impl Package for DirectoryPackage {
+                 }
+                 "dir" => {
+                     if self.copy {
+@@ -132,6 +133,22 @@ impl Package for DirectoryPackage {
      }
  }
- 
+
 +fn nix_patchelf_if_needed(dest_path: &Path, src_path: &Path) {
 +    let is_bin = if let Some(p) = src_path.parent() {
 +        p.ends_with("bin")
@@ -46,6 +39,3 @@ index 70c54dcd..f0318986 100644
  // On Unix we need to set up the file permissions correctly so
  // binaries are executable and directories readable. This shouldn't be
  // necessary: the source files *should* have the right permissions,
--- 
-2.17.1
-

--- a/pkgs/development/tools/rust/rustup/default.nix
+++ b/pkgs/development/tools/rust/rustup/default.nix
@@ -3,17 +3,17 @@
 , pkgconfig, curl, Security }:
 
 rustPlatform.buildRustPackage rec {
-  name = "rustup-${version}";
-  version = "1.17.0";
+  pname = "rustup";
+  version = "1.18.1";
 
   src = fetchFromGitHub {
     owner = "rust-lang";
     repo = "rustup.rs";
     rev = version;
-    sha256 = "1mf92z89wqqaj3cg2cqf6basvcz47krldmy8ianfkzp323fimqmn";
+    sha256 = "0932n708ikxzjv7y78zcrnnnps3rgimsnpaximhm9vmjjnkdgm7x";
   };
 
-  cargoSha256 = "0y7kbihdrpd35dw24qqqzmccvjdy6arka10p5rnv38d420f1bpzd";
+  cargoSha256 = "0kw8a9prqjf939g0h8ryyhlm1n84fwdycvl0nkykkwlfqd6hh9hb";
 
   nativeBuildInputs = [ pkgconfig ];
 
@@ -49,9 +49,16 @@ rustPlatform.buildRustPackage rec {
     # tries to create .rustup
     export HOME=$(mktemp -d)
     mkdir -p "$out/share/"{bash-completion/completions,fish/vendor_completions.d,zsh/site-functions}
-    $out/bin/rustup completions bash > "$out/share/bash-completion/completions/rustup"
-    $out/bin/rustup completions fish > "$out/share/fish/vendor_completions.d/rustup.fish"
-    $out/bin/rustup completions zsh >  "$out/share/zsh/site-functions/_rustup"
+
+    # generate completion scripts for rustup
+    $out/bin/rustup completions bash rustup > "$out/share/bash-completion/completions/rustup"
+    $out/bin/rustup completions fish rustup > "$out/share/fish/vendor_completions.d/rustup.fish"
+    $out/bin/rustup completions zsh rustup >  "$out/share/zsh/site-functions/_rustup"
+
+    # generate completion scripts for cargo
+    # Note: fish completion script is not supported.
+    $out/bin/rustup completions bash cargo > "$out/share/bash-completion/completions/cargo"
+    $out/bin/rustup completions zsh cargo >  "$out/share/zsh/site-functions/_cargo"
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update `rustup` to the latest release.
https://github.com/rust-lang/rustup.rs/releases/tag/1.18.1
Changes: https://github.com/rust-lang/rustup.rs/blob/1.18.1/CHANGELOG.md

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
