### PR TITLE
Add mutter nvidiga eglstream support

### DIFF
--- a/pkgs/desktops/gnome-3/core/mutter/default.nix
+++ b/pkgs/desktops/gnome-3/core/mutter/default.nix
@@ -7,6 +7,7 @@
 , xorgserver
 , python3
 , wrapGAppsHook
+, egl-wayland
 }:
 
 stdenv.mkDerivation rec {
@@ -20,6 +21,8 @@ stdenv.mkDerivation rec {
 
   mesonFlags = [
     "-Dxwayland-path=${xwayland}/bin/Xwayland"
+    "-Dwayland_eglstream=true"
+    "-Degl_device=true"
   ];
 
   propagatedBuildInputs = [
@@ -45,6 +48,7 @@ stdenv.mkDerivation rec {
     libcanberra-gtk3 zenity xkeyboard_config libxkbfile
     libxkbcommon pipewire xwayland
     gnome-settings-daemon
+    egl-wayland
   ];
 
   patches = [

--- a/pkgs/development/libraries/egl-wayland/default.nix
+++ b/pkgs/development/libraries/egl-wayland/default.nix
@@ -1,0 +1,73 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkgconfig
+, meson
+, ninja
+, libX11
+, mesa
+, wayland
+}:
+
+let
+  eglexternalplatform = stdenv.mkDerivation {
+    pname = "eglexternalplatform";
+    version = "1.1";
+
+    src = fetchFromGitHub {
+      owner = "Nvidia";
+      repo = "eglexternalplatform";
+      rev = "7c8f8e2218e46b1a4aa9538520919747f1184d86";
+      sha256 = "0lr5s2xa1zn220ghmbsiwgmx77l156wk54c7hybia0xpr9yr2nhb";
+    };
+
+    installPhase = ''
+      mkdir -p "$out/include/"
+      cp interface/eglexternalplatform.h "$out/include/"
+      cp interface/eglexternalplatformversion.h "$out/include/"
+
+      substituteInPlace eglexternalplatform.pc \
+        --replace "/usr/include/EGL" "$out/include"
+      mkdir -p "$out/share/pkgconfig"
+      cp eglexternalplatform.pc "$out/share/pkgconfig/"
+    '';
+
+    meta = {
+      license = lib.licenses.mit;
+    };
+  };
+
+in stdenv.mkDerivation rec {
+  pname = "egl-wayland";
+  version = "1.1.2";
+
+  outputs = [ "out" "dev" ];
+
+  src = fetchFromGitHub {
+    owner = "Nvidia";
+    repo = pname;
+    rev = version;
+    sha256 = "0hskxb5riy2bc6z9nq05as57y51gi01303wqg53cfm2d8gqwljv3";
+  };
+
+  nativeBuildInputs = [
+    pkgconfig
+    meson
+    ninja
+    eglexternalplatform
+  ];
+
+  buildInputs = [
+    wayland
+    mesa
+    libX11
+  ];
+
+  meta = {
+    description = "The EGLStream-based Wayland external platform";
+    homepage = https://github.com/NVIDIA/egl-wayland/;
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ hedning ];
+  };
+}

--- a/pkgs/servers/x11/xorg/xwayland.nix
+++ b/pkgs/servers/x11/xorg/xwayland.nix
@@ -1,16 +1,18 @@
-{ stdenv, wayland, wayland-protocols, xorgserver, xkbcomp, xkeyboard_config, epoxy, libxslt, libunwind, makeWrapper }:
+{ stdenv, wayland, wayland-protocols, xorgserver, xkbcomp, xkeyboard_config, epoxy, libxslt, libunwind, makeWrapper, egl-wayland }:
 
 with stdenv.lib;
 
 xorgserver.overrideAttrs (oldAttrs: {
 
   name = "xwayland-${xorgserver.version}";
+  buildInputs = oldAttrs.buildInputs ++ [ egl-wayland ];
   propagatedBuildInputs = oldAttrs.propagatedBuildInputs
     ++ [wayland wayland-protocols epoxy libxslt makeWrapper libunwind];
   configureFlags = [
     "--disable-docs"
     "--disable-devel-docs"
     "--enable-xwayland"
+    "--enable-xwayland-eglstream"
     "--disable-xorg"
     "--disable-xvfb"
     "--disable-xnest"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10018,6 +10018,8 @@ in
     inherit (darwin.apple_sdk.frameworks) Accelerate CoreGraphics CoreVideo;
   };
 
+  egl-wayland = callPackage ../development/libraries/egl-wayland {};
+
   elastix = callPackage ../development/libraries/science/biology/elastix { };
 
   enchant = callPackage ../development/libraries/enchant { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Make it possible to run a gnome shell wayland session using nvidia drivers.

This is supported on both [fedora](https://src.fedoraproject.org/rpms/mutter/blob/master/f/mutter.spec#_125) and [arch](https://git.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/mutter#n44).

###### Things done

Checked that `mutter` runs (`mutter --wayland --nested`), but I don't have any nvidia hardware so can't be sure that the intended functionality actually works.

I opted to package https://github.com/NVIDIA/eglexternalplatform inline.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
