### PR TITLE
wordgrinder: Fix build

### DIFF
--- a/pkgs/applications/office/wordgrinder/default.nix
+++ b/pkgs/applications/office/wordgrinder/default.nix
@@ -16,7 +16,11 @@ stdenv.mkDerivation rec {
     "PREFIX=$(out)"
     "LUA_INCLUDE=${lua52Packages.lua}/include"
     "LUA_LIB=${lua52Packages.lua}/lib/liblua.so"
-  ] ++ stdenv.lib.optional stdenv.isLinux "XFT_PACKAGE=--libs=\{-lX11 -lXft\}";
+  ];
+
+  preBuild = stdenv.lib.optionalString stdenv.isLinux ''
+    makeFlagsArray+=('XFT_PACKAGE=--cflags={} --libs={-lX11 -lXft}')
+  '';
 
   dontUseNinjaBuild = true;
   dontUseNinjaInstall = true;


### PR DESCRIPTION
This fixes the build of the wordgrinder package by disabling the build
of "xwordgrinder", the non-curses frontend of wordgrinder.

For re-enabling the build, this patch shall be reverted and then go on
from there.

I opted for disabling the x frontend of this program because the whole
purpose of this is to use a curses writing program (at least for me).
It seems that hacking around the new build system in nixpkgs is a
non-trivial task and I wanted to get this package out of the door as
fast as possible because I already delayed the fix by a few days (or is
it weeks already), so this is the simple fix.

If someone wants to have the X frontend again, I can invest more time at
some point.

Fixes: 6b2bd330fa ("wordgrinder: Fix sha256 hash")
Fixes: 19a3abc1b8 ("wordgrinder: 0.7.1 -> 0.7.2")
CC: @aszlig
CC: @devhell

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
