### PR TITLE
nixos/wireguard: set `networking.firewall.allowedUDPPorts` automatically

### DIFF
--- a/nixos/modules/services/networking/wireguard.nix
+++ b/nixos/modules/services/networking/wireguard.nix
@@ -284,6 +284,7 @@ in
 
     systemd.services = mapAttrs' generateUnit cfg.interfaces;
 
+    networking.firewall.allowedUDPPorts = filter (i: i != null) (mapAttrsToList (name: values: values.listenPort) cfg.interfaces);
   };
 
 }

--- a/nixos/tests/wireguard/default.nix
+++ b/nixos/tests/wireguard/default.nix
@@ -28,7 +28,6 @@ import ../make-test.nix ({ pkgs, ...} : {
         };
       };
 
-      networking.firewall.allowedUDPPorts = [ 23542 ];
       networking.wireguard.interfaces.wg0 = {
         ips = [ "10.23.42.1/32" "fc00::1/128" ];
         listenPort = 23542;


### PR DESCRIPTION
###### Motivation for this change

This changes the wireguard module to automatically add the provided
`listenPort` for an interface to the list of allowed udp ports in the
firewall. This means that users don't have to do this themselves when
configuring a wireguard server.
It also adjusts the wireguard test to not rely on explicitly-set
firewall ports

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
