### PR TITLE
buildRustCrate: Fix #60125 -  Always set additional env variables during build

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/configure-crate.nix
@@ -6,6 +6,7 @@
 , completeDeps
 , crateAuthors
 , crateDescription
+, crateHomepage
 , crateFeatures
 , crateName
 , crateVersion
@@ -91,12 +92,11 @@ in ''
   export CARGO_PKG_VERSION_MAJOR=${builtins.elemAt version 0}
   export CARGO_PKG_VERSION_MINOR=${builtins.elemAt version 1}
   export CARGO_PKG_VERSION_PATCH=${builtins.elemAt version 2}
+  export CARGO_PKG_VERSION_PRE="${versionPre}"
+  export CARGO_PKG_HOMEPAGE="${crateHomepage}"
   export NUM_JOBS=1
   export RUSTC="rustc"
   export RUSTDOC="rustdoc"
-  if [[ -n "${versionPre}" ]]; then
-    export CARGO_PKG_VERSION_PRE="${versionPre}"
-  fi
 
   BUILD=""
   if [[ ! -z "${build}" ]] ; then

--- a/pkgs/build-support/rust/build-rust-crate/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/default.nix
@@ -131,6 +131,7 @@ stdenv.mkDerivation (rec {
     crateVersion = crate.version;
     crateDescription = crate.description or "";
     crateAuthors = if crate ? authors && lib.isList crate.authors then crate.authors else [];
+    crateHomepage = crate.homepage or "";
     crateType =
       if lib.attrByPath ["procMacro"] false crate then ["proc-macro"] else
       if lib.attrByPath ["plugin"] false crate then ["dylib"] else
@@ -144,7 +145,7 @@ stdenv.mkDerivation (rec {
       inherit crateName buildDependencies completeDeps completeBuildDeps crateDescription
               crateFeatures libName build workspace_member release libPath crateVersion
               extraLinkFlags extraRustcOpts
-              crateAuthors verbose colors target_os;
+              crateAuthors crateHomepage verbose colors target_os;
     };
     buildPhase = buildCrate {
       inherit crateName dependencies


### PR DESCRIPTION
Namely `CARGO_PKG_VERSION_PRE` and `CARGO_PKG_HOMEPAGE`
(as cargo does)

@P-E-Meunier

###### Motivation for this change

The `built` crate assumes that these environment variables are always set at build time. Cargo does that. Since we are emulating cargo, we should, too.

###### Things done

I build the crate that failed before using the update nixpkgs.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS) 
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
