### PR TITLE
xv: init at 0.1.0

### DIFF
--- a/pkgs/tools/misc/xv/default.nix
+++ b/pkgs/tools/misc/xv/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub, rustPlatform, ncurses }:
+
+rustPlatform.buildRustPackage rec {
+  pname   = "xv";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner  = "chrisvest";
+    repo   = pname;
+    rev    = "${version}";
+    sha256 = "1cghg3ypxx6afllvwzc6j4z4h7mylapapipqghpdndrfizk7rsxi";
+  };
+
+  cargoSha256 = "0iwx9cxnxlif135s2v2hji8xil38xk5a1h147ryb54v6nabaxvjw";
+
+  buildInputs = [ ncurses ];
+
+  meta = with stdenv.lib; {
+    description = "A visual hex viewer for the terminal";
+    longDescription = ''
+      XV is a terminal hex viewer with a text user interface, written in 100% safe Rust.
+    '';
+    homepage    = https://chrisvest.github.io/xv/;
+    license     = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ lilyball ];
+    platforms   = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6662,6 +6662,8 @@ in
 
   xurls = callPackage ../tools/text/xurls {};
 
+  xv = callPackage ../tools/misc/xv {};
+
   xvfb_run = callPackage ../tools/misc/xvfb-run { inherit (texFunctions) fontsConf; };
 
   xvkbd = callPackage ../tools/X11/xvkbd {};


### PR DESCRIPTION
###### Motivation for this change
New tool `xv`: https://chrisvest.github.io/xv/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [X] other Linux distributions (Linux in Docker)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Running the Linux build in Docker didn't print the unicode characters correctly, but I'm assuming that's some artifact of the Docker environment. I tested on NixOS and it works properly there.