### PR TITLE
[wip] fix aarch32 build on aarch64 builder

### DIFF
--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -72,6 +72,13 @@ let
       (if crossCompiling
        then [ "-Dlibpth=\"\"" "-Dglibpth=\"\"" ]
        else [ "-de" "-Dcc=cc" ])
+
+      # prevent taking architecture of the builder machine which could be "aarch64"
+      # it should be safe to have always enabled, (stdenv.isAarch32 && stdenv.isLinux) here is to prefend mass-rebuild
+      ++ optionals (stdenv.isAarch32 && stdenv.isLinux && !crossCompiling) [
+        ("-Darchname=${stdenv.hostPlatform.parsed.cpu.name}-linux" + (if enableThreading then "-thread-multi" else ""))
+      ]
+
       ++ [
         "-Uinstallusrbinperl"
         "-Dinstallstyle=lib/perl5"

--- a/pkgs/development/interpreters/python/cpython/2.7/default.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/default.nix
@@ -126,6 +126,10 @@ let
       substituteInPlace configure --replace '`/usr/bin/arch`' '"i386"'
       substituteInPlace Lib/multiprocessing/__init__.py \
         --replace 'os.popen(comm)' 'os.popen("${coreutils}/bin/nproc")'
+    '' + optionalString (stdenv.isAarch32 && stdenv.hostPlatform == stdenv.buildPlatform) ''
+      # prevent taking architecture of the builder machine which could be "aarch64"
+      substituteInPlace config.guess                        --replace "uname -m" "echo '${stdenv.hostPlatform.parsed.cpu.name}'"
+      substituteInPlace Modules/_ctypes/libffi/config.guess --replace "uname -m" "echo '${stdenv.hostPlatform.parsed.cpu.name}'"
     '';
 
   configureFlags = [

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -78,6 +78,11 @@ in with passthru; stdenv.mkDerivation {
   prePatch = optionalString stdenv.isDarwin ''
     substituteInPlace configure --replace '`/usr/bin/arch`' '"i386"'
     substituteInPlace configure --replace '-Wl,-stack_size,1000000' ' '
+  ''
+  + optionalString (stdenv.isAarch32 && stdenv.hostPlatform == stdenv.buildPlatform) ''
+      # prevent taking architecture of the builder machine which could be "aarch64"
+      substituteInPlace config.guess                        --replace "uname -m" "echo '${stdenv.hostPlatform.parsed.cpu.name}'"
+      substituteInPlace Modules/_ctypes/libffi/config.guess --replace "uname -m" "echo '${stdenv.hostPlatform.parsed.cpu.name}'"
   '';
 
   patches = [

--- a/pkgs/development/libraries/gnutls/generic.nix
+++ b/pkgs/development/libraries/gnutls/generic.nix
@@ -36,8 +36,12 @@ stdenv.mkDerivation {
     "--disable-dependency-tracking"
     "--enable-fast-install"
     "--with-unbound-root-key-file=${dns-root-data}/root.key"
-  ] ++ lib.optional guileBindings
-    [ "--enable-guile" "--with-guile-site-dir=\${out}/share/guile/site" ];
+  ] ++ lib.optionals guileBindings [
+    "--enable-guile" "--with-guile-site-dir=\${out}/share/guile/site"
+  ] ++ lib.optionals (stdenv.isAarch32 && stdenv.hostPlatform == stdenv.buildPlatform) [
+    # prevent taking architecture of the builder machine which could be "aarch64"
+    "--host=${stdenv.hostPlatform.config}"
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/libffi/default.nix
+++ b/pkgs/development/libraries/libffi/default.nix
@@ -3,7 +3,7 @@
 
 # libffi is used in darwin stdenv
 # we cannot run checks within it
-, doCheck ? !stdenv.isDarwin, dejagnu
+, doCheck ? !stdenv.isDarwin && !stdenv.isAarch32, dejagnu
 }:
 
 stdenv.mkDerivation rec {
@@ -49,6 +49,9 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--with-gcc-arch=generic" # no detection of -march= or -mtune=
     "--enable-pax_emutramp"
+  ] ++ stdenv.lib.optionals (stdenv.isAarch32 && stdenv.hostPlatform == stdenv.buildPlatform) [
+    # prevent taking architecture of the builder machine which could be "aarch64"
+    "--host=${stdenv.hostPlatform.config}"
   ];
 
   preCheck = ''

--- a/pkgs/development/libraries/libgcrypt/default.nix
+++ b/pkgs/development/libraries/libgcrypt/default.nix
@@ -27,7 +27,12 @@ stdenv.mkDerivation rec {
     ++ stdenv.lib.optional stdenv.isDarwin gettext
     ++ stdenv.lib.optional enableCapabilities libcap;
 
-  configureFlags = [ "--with-libgpg-error-prefix=${libgpgerror.dev}" ];
+  configureFlags = [
+    "--with-libgpg-error-prefix=${libgpgerror.dev}"
+  ] ++ stdenv.lib.optionals (stdenv.isAarch32 && stdenv.hostPlatform == stdenv.buildPlatform) [
+    # prevent taking architecture of the builder machine which could be "aarch64"
+    "--host=${stdenv.hostPlatform.config}"
+  ];
 
   # Make sure libraries are correct for .pc and .la files
   # Also make sure includes are fixed for callers who don't use libgpgcrypt-config


### PR DESCRIPTION
The community aarch64 build box with Hi1616 CPU is capable to run aarch32 code, so it can work as aarch32 builder.
It does not requre cross-compilation. It is just like i686 on x86_64.

But some packages detect target architecture by executing `uname -m`, they get aarch64 and then use the value wrongly.

This PR is not the complete fix (if the complete fix even possible).
It fixes essential derivations whose failures prevent to build many other packages/

Related: #60103 https://discourse.nixos.org/t/new-aarch64-and-armv7l-linux-omg-builders/1010