### PR TITLE
chromaprint: 1.3.2 -> 1.4.3

### DIFF
--- a/pkgs/applications/audio/clementine/default.nix
+++ b/pkgs/applications/audio/clementine/default.nix
@@ -28,6 +28,11 @@ let
       url = "https://github.com/clementine-player/Clementine/pull/5630.patch";
       sha256 = "0px7xp1m4nvrncx8sga1qlxppk562wrk2qqk19iiry84nxg20mk4";
     })
+    (fetchpatch {
+      # Fixes compilation with newer chromaprint
+      url = "https://github.com/clementine-player/Clementine/pull/5553.patch";
+      sha256 = "1c27akly256zwcsp8qipwnlc15j2llly3x5cqsasbx4xb7gwkjac";
+    })
   ];
 
   nativeBuildInputs = [ cmake pkgconfig ];

--- a/pkgs/development/libraries/chromaprint/default.nix
+++ b/pkgs/development/libraries/chromaprint/default.nix
@@ -1,19 +1,21 @@
-{ stdenv, fetchurl, cmake, boost, ffmpeg }:
+{ stdenv, fetchFromGitHub, cmake, boost, ffmpeg }:
 
 stdenv.mkDerivation rec {
-  name = "chromaprint-${version}";
-  version = "1.3.2";
+  pname = "chromaprint";
+  version = "1.4.3";
 
-  src = fetchurl {
-    url = "https://bitbucket.org/acoustid/chromaprint/downloads/${name}.tar.gz";
-    sha256 = "0lln8dh33gslb9cbmd1hcv33pr6jxdwipd8m8gbsyhksiq6r1by3";
+  src = fetchFromGitHub {
+    owner = "acoustid";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "110js8gspaamqpy6wqshr6vjc55xbgiqy4bqni5jr8ljsialll26";
   };
 
   nativeBuildInputs = [ cmake ];
 
   buildInputs = [ boost ffmpeg ];
 
-  cmakeFlags = [ "-DBUILD_EXAMPLES=ON" ];
+  cmakeFlags = [ "-DBUILD_TOOLS=ON" ];
 
   meta = with stdenv.lib; {
     homepage = https://acoustid.org/chromaprint;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

B"H

This pull updates `chromaprint`, and applies a patch to `clementine` so it builds with the newer `chromaprint`.

See https://github.com/acoustid/chromaprint/releases/tag/v1.4.3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
 - [ ] Assured whether relevant documentation is up to date
 - [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
