### PR TITLE
rxvt_unicode: fix build

### DIFF
--- a/pkgs/applications/misc/rxvt_unicode/wrapper.nix
+++ b/pkgs/applications/misc/rxvt_unicode/wrapper.nix
@@ -12,10 +12,10 @@ in symlinkJoin {
 
   postBuild = ''
     wrapProgram $out/bin/urxvt \
-      --set PERL5LIB : "${perlPackages.makePerlPath perlDeps}" \
+      --prefix PERL5LIB : "${perlPackages.makePerlPath perlDeps}" \
       --suffix-each URXVT_PERL_LIB ':' "$out/lib/urxvt/perl"
     wrapProgram $out/bin/urxvtd \
-      --set PERL5LIB : "${perlPackages.makePerlPath perlDeps}" \
+      --prefix PERL5LIB : "${perlPackages.makePerlPath perlDeps}" \
       --suffix-each URXVT_PERL_LIB ':' "$out/lib/urxvt/perl"
   '';
 


### PR DESCRIPTION
###### Motivation for this change

Fixes a last-minute change introduced in #59896 that broke the rxvt package:

```
> :b pkgs.rxvt_unicode-with-plugins
builder for '/nix/store/a41snhm28vmqqgxnwbc9645cn403y6ng-rxvt-unicode-with-perl-with-unicode3-with-plugins-9.22.drv' failed with exit code 1; last 9 log lines:
  
  Builder called die: makeWrapper doesn't understand the arg 
  Backtrace:
  108 makeWrapper /nix/store/2j5wxs045w8svy2494hh1p8y1d3ah8ak-hook/nix-support/setup-hook
  152 wrapProgram /nix/store/2j5wxs045w8svy2494hh1p8y1d3ah8ak-hook/nix-support/setup-hook
  5 source /build/.attr-0
  1273 genericBuild /nix/store/jqavib0kpn83cp0gjcq9pw8bvfas1kc0-stdenv-linux/setup
  2 main /nix/store/9krlzvny65gdc8s7kpb6lkx8cd02c25b-default-builder.sh
```

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @rnhmjoj @joachifm