### PR TITLE
rng-tools: 6.6 -> 6.7 and libp11: 0.4.9 -> 0.4.10

### DIFF
--- a/pkgs/development/libraries/libp11/default.nix
+++ b/pkgs/development/libraries/libp11/default.nix
@@ -1,25 +1,31 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, libtool, openssl, pkgconfig }:
+{ stdenv, fetchFromGitHub, autoreconfHook, libtool, pkgconfig
+, openssl }:
 
 stdenv.mkDerivation rec {
   name = "libp11-${version}";
-  version = "0.4.9";
+  version = "0.4.10";
 
   src = fetchFromGitHub {
     owner = "OpenSC";
     repo = "libp11";
     rev = name;
-    sha256 = "1f0ir1mnr4wxxnql8ld2aa6288fn04fai5pr0sics7kbdm1g0cki";
+    sha256 = "1m4aw45bqichhx7cn78d8l1r1v0ccvwzlfj09fay2l9rfic5jgfz";
   };
 
-  makeFlags = [ "DESTDIR=$(out)" "PREFIX=" ];
+  configureFlags = [
+    "--with-enginesdir=${placeholder "out"}/lib/engines"
+  ];
 
   nativeBuildInputs = [ autoreconfHook pkgconfig libtool ];
+
   buildInputs = [ openssl ];
 
+  enableParallelBuilding = true;
+
   meta = with stdenv.lib; {
+    description = "Small layer on top of PKCS#11 API to make PKCS#11 implementations easier";
     homepage = https://github.com/OpenSC/libp11;
     license = licenses.lgpl21Plus;
-    description = "Small layer on top of PKCS#11 API to make PKCS#11 implementations easier";
     platforms = platforms.all;
   };
 }

--- a/pkgs/tools/security/rng-tools/default.nix
+++ b/pkgs/tools/security/rng-tools/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, libtool, autoconf, automake, pkgconfig
+{ stdenv, fetchFromGitHub, libtool, autoreconfHook, pkgconfig
 , sysfsutils
   # WARNING: DO NOT USE BEACON GENERATED VALUES AS SECRET CRYPTOGRAPHIC KEYS
   # https://www.nist.gov/programs-projects/nist-randomness-beacon
@@ -8,32 +8,43 @@
   # Not sure if jitterentropy is safe to use for cryptography
   # and thus a default entropy source
 , jitterentropy ? null, withJitterEntropy ? false
+, libp11 ? null, withPkcs11 ? true
 }:
+
 with stdenv.lib;
+
 stdenv.mkDerivation rec {
-  name = "rng-tools-${version}";
-  version = "6.6";
+  pname = "rng-tools";
+  version = "6.7";
 
   src = fetchFromGitHub {
     owner = "nhorman";
     repo = "rng-tools";
     rev = "v${version}";
-    sha256 = "0c32sxfvngdjzfmxn5ngc5yxwi8ij3yl216nhzyz9r31qi3m14v7";
+    sha256 = "19f75m6mzg8h7b4snzg7d6ypvkz6nq32lrpi9ja95gqz4wsd18a5";
   };
 
-  nativeBuildInputs = [ libtool autoconf automake pkgconfig ];
+  postPatch = ''
+    cp README.md README
+  '';
 
-  preConfigure = "./autogen.sh";
+  nativeBuildInputs = [ autoreconfHook libtool pkgconfig ];
 
-  configureFlags =
-       optional (!withJitterEntropy) "--disable-jitterentropy"
-    ++ optional (!withNistBeacon) "--without-nistbeacon"
-    ++ optional (!withGcrypt) "--without-libgcrypt";
+  configureFlags = [
+    (withFeature   withGcrypt        "libgcrypt")
+    (enableFeature withJitterEntropy "jitterentropy")
+    (withFeature   withNistBeacon    "nistbeacon")
+    (withFeature   withPkcs11        "pkcs11")
+  ];
 
   buildInputs = [ sysfsutils ]
-    ++ optional withJitterEntropy [ jitterentropy ]
-    ++ optional withGcrypt [ libgcrypt.dev ]
-    ++ optional withNistBeacon [ openssl.dev curl.dev libxml2.dev ];
+    ++ optionals withGcrypt        [ libgcrypt ]
+    ++ optionals withJitterEntropy [ jitterentropy ]
+    ++ optionals withNistBeacon    [ openssl curl libxml2 ]
+    ++ optionals withPkcs11        [ libp11 openssl ];
+
+  # This shouldn't be necessary but is as of 6.7
+  NIX_LDFLAGS = optionalString withPkcs11 "-lcrypto";
 
   enableParallelBuilding = true;
 
@@ -43,8 +54,8 @@ stdenv.mkDerivation rec {
   meta = {
     description = "A random number generator daemon";
     homepage = https://github.com/nhorman/rng-tools;
-    license = stdenv.lib.licenses.gpl2Plus;
-    platforms = stdenv.lib.platforms.linux;
-    maintainers = with stdenv.lib.maintainers; [ johnazoidberg ];
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ johnazoidberg ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

https://github.com/nhorman/rng-tools/releases/tag/v6.7

The libp11 change is included here as rng-tools is now the first consumer of libp11.

A few other changes:

 - use autoreconfHook instead of doing it manually
 - clean up with/enable flags
 - add support for PKCS11 entropy sources

PKCS11 is not fully tested yet as my hardware hasn't arrived.

Cc: @JohnAZoidberg 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
