### PR TITLE
Patch Julia to not recompile packages when mtime is 1

### DIFF
--- a/pkgs/development/compilers/julia/allow_nix_mtime.patch
+++ b/pkgs/development/compilers/julia/allow_nix_mtime.patch
@@ -1,0 +1,25 @@
+From f79775378a9eeec5b99f18cc95735b12d172aba3 Mon Sep 17 00:00:00 2001
+From: Tom McLaughlin <pyro777@gmail.com>
+Date: Wed, 12 Dec 2018 13:01:32 -0800
+Subject: [PATCH] Patch to make work better with nix
+
+---
+ base/loading.jl | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/base/loading.jl b/base/loading.jl
+index 51201b98b6..b40c0690f6 100644
+--- a/base/loading.jl
++++ b/base/loading.jl
+@@ -1384,7 +1384,7 @@ function stale_cachefile(modpath::String, cachefile::String)
+                 # Issue #13606: compensate for Docker images rounding mtimes
+                 # Issue #20837: compensate for GlusterFS truncating mtimes to microseconds
+                 ftime = mtime(f)
+-                if ftime != ftime_req && ftime != floor(ftime_req) && ftime != trunc(ftime_req, digits=6)
++                if ftime != ftime_req && ftime != floor(ftime_req) && ftime != trunc(ftime_req, digits=6) && ftime != 1.0
+                     @debug "Rejecting stale cache file $cachefile (mtime $ftime_req) because file $f (mtime $ftime) has changed"
+                     return true
+                 end
+-- 
+2.17.1
+

--- a/pkgs/development/compilers/julia/shared.nix
+++ b/pkgs/development/compilers/julia/shared.nix
@@ -97,6 +97,12 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./0001.1-use-system-utf8proc.patch
+
+    # Julia recompiles a precompiled file if the mtime stored *in* the
+    # .ji file differs from the mtime of the .ji file.  This
+    # doesn't work in Nix because Nix changes the mtime of files in
+    # the Nix store to 1. So patch Julia to accept mtimes of 1.
+    ./allow_nix_mtime.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION

###### Motivation for this change

Julia recompiles a precompiled file if the mtime stored in the `.ji` file differs from the mtime of the `.ji` file. This doesn't work in Nix because Nix changes the mtime of files in the Nix store to 1.

The exact same situation exists with Python `.pyc` files and is fixed with [this patch](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/interpreters/python/cpython/2.7/nix-store-mtime.patch). I applied the exact same solution to Julia in this PR.


###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] Ubuntu
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [N/A] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [N/A] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
