### PR TITLE
nixos/packagekit: make it not error out + test

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -180,6 +180,7 @@ in
   osrm-backend = handleTest ./osrm-backend.nix {};
   ostree = handleTest ./ostree.nix {};
   overlayfs = handleTest ./overlayfs.nix {};
+  packagekit = handleTest ./packagekit.nix {};
   pam-oath-login = handleTest ./pam-oath-login.nix {};
   pam-u2f = handleTest ./pam-u2f.nix {};
   pantheon = handleTest ./pantheon.nix {};

--- a/nixos/tests/packagekit.nix
+++ b/nixos/tests/packagekit.nix
@@ -1,0 +1,24 @@
+import ./make-test.nix ({ pkgs, ... }: {
+  name = "packagekit";
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ peterhoeg ];
+  };
+
+  machine = { ... }: {
+    environment.systemPackages = with pkgs; [ dbus ];
+    services.packagekit = {
+      enable = true;
+      backend = "test_nop";
+    };
+  };
+
+  testScript = ''
+    startAll;
+
+    # send a dbus message to activate the service
+    $machine->succeed("dbus-send --system --type=method_call --print-reply --dest=org.freedesktop.PackageKit /org/freedesktop/PackageKit org.freedesktop.DBus.Introspectable.Introspect");
+
+    # so now it should be running
+    $machine->succeed("systemctl is-active packagekit.service");
+  '';
+})


### PR DESCRIPTION
###### Motivation for this change

We have a nixos module for packagekit, but it doesn't work as we do not have a backend for nix (#21230) so we now make the backend configurable and set it to ```test_nop``` which at least means that other software depending on packagekit (#34756 needs it) will at least not error out complaining about not being able to connect to to packagekit over dbus.

Cc: @peti @matthewbauer @wizeman 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
