### PR TITLE
ipfs: 0.4.19 -> 0.4.20

### DIFF
--- a/pkgs/applications/networking/ipfs/default.nix
+++ b/pkgs/applications/networking/ipfs/default.nix
@@ -1,24 +1,19 @@
-{ stdenv, buildGoPackage, fetchFromGitHub, fetchgx }:
+{ stdenv, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
   name = "ipfs-${version}";
-  version = "0.4.19";
+  version = "0.4.20";
   rev = "v${version}";
 
   goPackagePath = "github.com/ipfs/go-ipfs";
 
-  extraSrcPaths = [
-    (fetchgx {
-      inherit name src;
-      sha256 = "0bj2kzxjssp7szp1wr9pp08bsi55jgf0k7gi4h70phlib2q673j2";
-    })
-  ];
+  goDeps = ./deps.nix;
 
   src = fetchFromGitHub {
     owner = "ipfs";
     repo = "go-ipfs";
     inherit rev;
-    sha256 = "061mgkawimhw3gq506h8m6kw50a2v26qysa5kc5jdqgaqx5yvqh4";
+    sha256 = "1xnjn4pcgknywfndrp2zwln3v1msaffhhfiym5mdz543rsxav0yp";
   };
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/networking/ipfs/deps.nix
+++ b/pkgs/applications/networking/ipfs/deps.nix
@@ -1,0 +1,2190 @@
+# file generated from go.mod using vgo2nix (https://github.com/adisbladis/vgo2nix)
+[
+  {
+    goPackagePath = "github.com/dgraph-io/badger";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dgraph-io/badger";
+      rev = "1fcc96ec";
+      sha256 = "09sdr64ay8wbw4m8a7dppha357wx2395vpni554353v7b22gyk59";
+    };
+  }
+  {
+    goPackagePath = "bazil.org/fuse";
+    fetch = {
+      type = "git";
+      url = "https://github.com/bazil/fuse";
+      rev = "65cc252bf669";
+      sha256 = "0qjm9yrhc5h632wwhklqzhalid4lxcm9iwsqs3jahp303rm27vpk";
+    };
+  }
+  {
+    goPackagePath = "github.com/AndreasBriese/bbloom";
+    fetch = {
+      type = "git";
+      url = "https://github.com/AndreasBriese/bbloom";
+      rev = "343706a395b7";
+      sha256 = "0pz4wph915gm2b0admq4bc5d2ir218s954z27gmc86l0rik13a5d";
+    };
+  }
+  {
+    goPackagePath = "github.com/Kubuxu/go-os-helper";
+    fetch = {
+      type = "git";
+      url = "https://github.com/Kubuxu/go-os-helper";
+      rev = "v0.0.1";
+      sha256 = "08v88ylhvv65hdqr2pp94qf2ncppzib5sx66fv432vhgkz00ddyr";
+    };
+  }
+  {
+    goPackagePath = "github.com/Kubuxu/gocovmerge";
+    fetch = {
+      type = "git";
+      url = "https://github.com/Kubuxu/gocovmerge";
+      rev = "7ecaa51963cd";
+      sha256 = "0xbx83h44hsiidmr69sn4k0zn7bmbwcna76fn0akjb5il1r4bjyr";
+    };
+  }
+  {
+    goPackagePath = "github.com/Stebalien/go-bitfield";
+    fetch = {
+      type = "git";
+      url = "https://github.com/Stebalien/go-bitfield";
+      rev = "076a62f9ce6e";
+      sha256 = "17iqkx2dyh6ykgapgvbyrm8c15qw24pspjhi3ww2sx4y0qhkycf4";
+    };
+  }
+  {
+    goPackagePath = "github.com/aead/siphash";
+    fetch = {
+      type = "git";
+      url = "https://github.com/aead/siphash";
+      rev = "v1.0.1";
+      sha256 = "01kd1z82sc4nh3nj9c25aryyp396s7jrqc2kz9d7qq1vy2hdbznc";
+    };
+  }
+  {
+    goPackagePath = "github.com/beorn7/perks";
+    fetch = {
+      type = "git";
+      url = "https://github.com/beorn7/perks";
+      rev = "3a771d992973";
+      sha256 = "1l2lns4f5jabp61201sh88zf3b0q793w4zdgp9nll7mmfcxxjif3";
+    };
+  }
+  {
+    goPackagePath = "github.com/blang/semver";
+    fetch = {
+      type = "git";
+      url = "https://github.com/blang/semver";
+      rev = "v3.5.1";
+      sha256 = "13ws259bwcibkclbr82ilhk6zadm63kxklxhk12wayklj8ghhsmy";
+    };
+  }
+  {
+    goPackagePath = "github.com/bren2010/proquint";
+    fetch = {
+      type = "git";
+      url = "https://github.com/bren2010/proquint";
+      rev = "38337c27106d";
+      sha256 = "1ws3hb27n4c4mfp2pfj9nc59ch6dv93333a83n7qazf74lhf8ixl";
+    };
+  }
+  {
+    goPackagePath = "github.com/btcsuite/btcd";
+    fetch = {
+      type = "git";
+      url = "https://github.com/btcsuite/btcd";
+      rev = "306aecffea32";
+      sha256 = "130np0bfic9q7ga8a9y5gd3amy6mgfb7igd3lgicikjclfhiqwf4";
+    };
+  }
+  {
+    goPackagePath = "github.com/btcsuite/btclog";
+    fetch = {
+      type = "git";
+      url = "https://github.com/btcsuite/btclog";
+      rev = "84c8d2346e9f";
+      sha256 = "02dl46wcnfpg9sqvg0ipipkpnd7lrf4fnvb9zy56jqa7mfcwc7wk";
+    };
+  }
+  {
+    goPackagePath = "github.com/btcsuite/btcutil";
+    fetch = {
+      type = "git";
+      url = "https://github.com/btcsuite/btcutil";
+      rev = "4c204d697803";
+      sha256 = "16s27k8xnvhlpv0ibs60sqgnyn3zhnvprv1647svmzs3rwcsqgvp";
+    };
+  }
+  {
+    goPackagePath = "github.com/btcsuite/go-socks";
+    fetch = {
+      type = "git";
+      url = "https://github.com/btcsuite/go-socks";
+      rev = "4720035b7bfd";
+      sha256 = "18cv2icj059lq4s99p6yh91hlas5f2gi3f1p4c10sjgwrs933d7b";
+    };
+  }
+  {
+    goPackagePath = "github.com/btcsuite/goleveldb";
+    fetch = {
+      type = "git";
+      url = "https://github.com/btcsuite/goleveldb";
+      rev = "7834afc9e8cd";
+      sha256 = "0gy156sn2cy2maii3p058f7q60gjdbmba34i9qvk8msxlg7hlfjv";
+    };
+  }
+  {
+    goPackagePath = "github.com/btcsuite/snappy-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/btcsuite/snappy-go";
+      rev = "0bdef8d06723";
+      sha256 = "00i5fsb1wf2dwal1jfwbpk9a7cbzjyg7rnz2xib3qfz9h82kd4jw";
+    };
+  }
+  {
+    goPackagePath = "github.com/btcsuite/websocket";
+    fetch = {
+      type = "git";
+      url = "https://github.com/btcsuite/websocket";
+      rev = "31079b680792";
+      sha256 = "0xpkf257ml6fpfdgv7hxxc41n0d5yxxm3njm50qpzp7j71l9cjwa";
+    };
+  }
+  {
+    goPackagePath = "github.com/btcsuite/winsvc";
+    fetch = {
+      type = "git";
+      url = "https://github.com/btcsuite/winsvc";
+      rev = "v1.0.0";
+      sha256 = "0nsw8y86a5hzr2a3j6ch9myrpccj5bnsgaxpgajhzfk5d31xlw1z";
+    };
+  }
+  {
+    goPackagePath = "github.com/cenkalti/backoff";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cenkalti/backoff";
+      rev = "v2.1.1";
+      sha256 = "1mf4lsl3rbb8kk42x0mrhzzy4ikqy0jf6nxpzhkr02rdgwh6rjk8";
+    };
+  }
+  {
+    goPackagePath = "github.com/cheekybits/genny";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cheekybits/genny";
+      rev = "v1.0.0";
+      sha256 = "1pcir5ic86713aqa51581rfb67rgc3m0c72ddjfcp3yakv9vyq87";
+    };
+  }
+  {
+    goPackagePath = "github.com/coreos/go-semver";
+    fetch = {
+      type = "git";
+      url = "https://github.com/coreos/go-semver";
+      rev = "v0.2.0";
+      sha256 = "1gghi5bnqj50hfxhqc1cxmynqmh2yk9ii7ab9gsm75y5cp94ymk0";
+    };
+  }
+  {
+    goPackagePath = "github.com/cskr/pubsub";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cskr/pubsub";
+      rev = "v1.0.2";
+      sha256 = "0wr8cg5axrlz9xg33r9dqvkp5ix9q8h8c7qw78mj22qprwh3zj9f";
+    };
+  }
+  {
+    goPackagePath = "github.com/davecgh/go-spew";
+    fetch = {
+      type = "git";
+      url = "https://github.com/davecgh/go-spew";
+      rev = "v1.1.1";
+      sha256 = "0hka6hmyvp701adzag2g26cxdj47g21x6jz4sc6jjz1mn59d474y";
+    };
+  }
+  {
+    goPackagePath = "github.com/davidlazar/go-crypto";
+    fetch = {
+      type = "git";
+      url = "https://github.com/davidlazar/go-crypto";
+      rev = "dcfb0a7ac018";
+      sha256 = "1lir8slwykn0h5bg5lj22qsdg4kw09kcqlks974g1428d42rqlcp";
+    };
+  }
+  {
+    goPackagePath = "github.com/dgryski/go-farm";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dgryski/go-farm";
+      rev = "3adb47b1fb0f";
+      sha256 = "04bkvr6xvfh83cn83gqzyxx45wbk3j1bdpgrck0b424x48z2x4jh";
+    };
+  }
+  {
+    goPackagePath = "github.com/dustin/go-humanize";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dustin/go-humanize";
+      rev = "v1.0.0";
+      sha256 = "1kqf1kavdyvjk7f8kx62pnm7fbypn9z1vbf8v2qdh3y7z7a0cbl3";
+    };
+  }
+  {
+    goPackagePath = "github.com/elgris/jsondiff";
+    fetch = {
+      type = "git";
+      url = "https://github.com/elgris/jsondiff";
+      rev = "765b5c24c302";
+      sha256 = "0jm1q0s531hmkqdx8jqphfpmzysn44aphkpwlzqwp3hkz89g4d4q";
+    };
+  }
+  {
+    goPackagePath = "github.com/facebookgo/atomicfile";
+    fetch = {
+      type = "git";
+      url = "https://github.com/facebookgo/atomicfile";
+      rev = "2de1f203e7d5";
+      sha256 = "1vsx6r6y601jxvjqc8msbpr5v1037dfxxdd8h1q3s8wm6xhvj2v6";
+    };
+  }
+  {
+    goPackagePath = "github.com/fatih/color";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fatih/color";
+      rev = "v1.7.0";
+      sha256 = "0v8msvg38r8d1iiq2i5r4xyfx0invhc941kjrsg5gzwvagv55inv";
+    };
+  }
+  {
+    goPackagePath = "github.com/fsnotify/fsnotify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fsnotify/fsnotify";
+      rev = "v1.4.7";
+      sha256 = "07va9crci0ijlivbb7q57d2rz9h27zgn2fsm60spjsqpdbvyrx4g";
+    };
+  }
+  {
+    goPackagePath = "github.com/go-check/check";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-check/check";
+      rev = "788fd7840127";
+      sha256 = "0v3bim0j375z81zrpr5qv42knqs0y2qv2vkjiqi5axvb78slki1a";
+    };
+  }
+  {
+    goPackagePath = "github.com/gogo/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gogo/protobuf";
+      rev = "v1.2.1";
+      sha256 = "06yqa6h0kw3gr5pc3qmas7f7435a96zf7iw7p0l00r2hqf6fqq6m";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/mock";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/mock";
+      rev = "v1.2.0";
+      sha256 = "12ddj2g8ab87id6n2n67vnbhq6p8dvgsq1pzpqfriym4dk8w54fg";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/protobuf";
+      rev = "v1.3.0";
+      sha256 = "0dm1ip7742qz2k1cr6ywy0av6mpcxd2kc4ayfqi8cxz3ai7zhbdr";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/snappy";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/snappy";
+      rev = "2e65f85255db";
+      sha256 = "05w6mpc4qcy0pv8a2bzng8nf4s5rf5phfang4jwy9rgf808q0nxf";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/go-cmp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/go-cmp";
+      rev = "v0.2.0";
+      sha256 = "1fbv0x27k9sn8svafc0hjwsnckk864lv4yi7bvzrxvmd3d5hskds";
+    };
+  }
+  {
+    goPackagePath = "github.com/google/uuid";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/uuid";
+      rev = "v1.1.1";
+      sha256 = "0hfxcf9frkb57k6q0rdkrmnfs78ms21r1qfk9fhlqga2yh5xg8zb";
+    };
+  }
+  {
+    goPackagePath = "github.com/gopherjs/gopherjs";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gopherjs/gopherjs";
+      rev = "0766667cb4d1";
+      sha256 = "13pfc9sxiwjky2lm1xb3i3lcisn8p6mgjk2d927l7r92ysph8dmw";
+    };
+  }
+  {
+    goPackagePath = "github.com/gorilla/websocket";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gorilla/websocket";
+      rev = "v1.4.0";
+      sha256 = "00i4vb31nsfkzzk7swvx3i75r2d960js3dri1875vypk3v2s0pzk";
+    };
+  }
+  {
+    goPackagePath = "github.com/gxed/go-shellwords";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gxed/go-shellwords";
+      rev = "v1.0.3";
+      sha256 = "1pg7pl25wvpl2dbpyrv9p1r7prnqimxlf6136vn0dfm54j2x4mnr";
+    };
+  }
+  {
+    goPackagePath = "github.com/gxed/hashland";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gxed/hashland";
+      rev = "v0.0.1";
+      sha256 = "1b921dh9i6zw7y8jfzwvrmdbhnwid12a5z1zjawslfq2vvsajwmm";
+    };
+  }
+  {
+    goPackagePath = "github.com/gxed/pubsub";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gxed/pubsub";
+      rev = "26ebdf44f824";
+      sha256 = "0q0r6bvimjxwi3yd0w2wjkx1x8m0d9pwi25b7n4s4g10h36rabjp";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/errwrap";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/errwrap";
+      rev = "v1.0.0";
+      sha256 = "0slfb6w3b61xz04r32bi0a1bygc82rjzhqkxj2si2074wynqnr1c";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/go-multierror";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/go-multierror";
+      rev = "v1.0.0";
+      sha256 = "00nyn8llqzbfm8aflr9kwsvpzi4kv8v45c141v88xskxp5xf6z49";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/golang-lru";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/golang-lru";
+      rev = "v0.5.1";
+      sha256 = "13f870cvk161bzjj6x41l45r5x9i1z9r2ymwmvm7768kg08zznpy";
+    };
+  }
+  {
+    goPackagePath = "github.com/hpcloud/tail";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hpcloud/tail";
+      rev = "v1.0.0";
+      sha256 = "1njpzc0pi1acg5zx9y6vj9xi6ksbsc5d387rd6904hy6rh2m6kn0";
+    };
+  }
+  {
+    goPackagePath = "github.com/hsanjuan/go-libp2p-gostream";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hsanjuan/go-libp2p-gostream";
+      rev = "v0.0.31";
+      sha256 = "0q4k1ahns9j061iajp8525330mwgbdv5mnyzldpg64r5c2igp9qf";
+    };
+  }
+  {
+    goPackagePath = "github.com/hsanjuan/go-libp2p-http";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hsanjuan/go-libp2p-http";
+      rev = "v0.0.2";
+      sha256 = "0pq80qvhm2f53gx438ws5nnj1r2ara48radzxc5br57scp2bjlgk";
+    };
+  }
+  {
+    goPackagePath = "github.com/huin/goupnp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/huin/goupnp";
+      rev = "v1.0.0";
+      sha256 = "12f7rigf1f4xh1an1qis61xkj5s1r8ygk48zahf3n4gaqxmgm7i6";
+    };
+  }
+  {
+    goPackagePath = "github.com/huin/goutil";
+    fetch = {
+      type = "git";
+      url = "https://github.com/huin/goutil";
+      rev = "1ca381bf3150";
+      sha256 = "0alhyacsfqic2wxyqn4gvk9wzjl4pkmy8rhvqjk84xsghgx5xf12";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/bbloom";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/bbloom";
+      rev = "v0.0.1";
+      sha256 = "0ji1dgxvg338wx2agh0ld9x6wwr6zc8zwjxs5mwdb99p56dc34nz";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/dir-index-html";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/dir-index-html";
+      rev = "v1.0.3";
+      sha256 = "1asd58w53i97jxk2r1asy8h5lgq0086lnjq3gi7fs20xvgv20bfy";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-bitswap";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-bitswap";
+      rev = "v0.0.4";
+      sha256 = "0998qyxzp5frmkf5kjqxrhdwl4c0i7a2kh24rldix934afbmfz3r";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-block-format";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-block-format";
+      rev = "v0.0.2";
+      sha256 = "1j73r946z0gs98a2r1z7q3vkpk8v7wqwc68x8c3ngiff9sijq1kf";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-blockservice";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-blockservice";
+      rev = "v0.0.3";
+      sha256 = "1c2fnrqlvg16xf7jla1x38qi56yw61w1ms70kghhafmw008bgkvn";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-cid";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-cid";
+      rev = "v0.0.1";
+      sha256 = "11hdrac0wf82m69fkpwby1mg2k7swmw884rv3250i0kymwi93lak";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-cidutil";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-cidutil";
+      rev = "v0.0.1";
+      sha256 = "00bdn7cg7rg8amh8zaqakf6phd14sn2z9kw73cscfhpyg9di1p9h";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-datastore";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-datastore";
+      rev = "v0.0.3";
+      sha256 = "147nnmgb2b4iiky4hsn5wn4hk0kp39xs1yj3blm2gxxxkmjqsdk4";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-detect-race";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-detect-race";
+      rev = "v0.0.1";
+      sha256 = "0rqb0q66d7z852j5mhlr025dz698c44w014g4mx587amr1rvwqna";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-ds-badger";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-ds-badger";
+      rev = "v0.0.3";
+      sha256 = "0bl7zh8gmas54577v501n17z1254f1yaggkgslz9qjz4rihq4wq1";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-ds-flatfs";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-ds-flatfs";
+      rev = "v0.0.2";
+      sha256 = "1z6z717pkv2yqb0wdhw73vir253305wkqcg5pln8km8kl2fjwwyi";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-ds-leveldb";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-ds-leveldb";
+      rev = "v0.0.2";
+      sha256 = "0x70z31g0l04lm6nsv1p0wnhdwqvck2pzy59ygfxk707n0x5vqpc";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-ds-measure";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-ds-measure";
+      rev = "v0.0.1";
+      sha256 = "1ndb10x5g95g8kapfr116qa3cav2xcwwm4dppp99bi15kq1yk742";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-fs-lock";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-fs-lock";
+      rev = "v0.0.1";
+      sha256 = "02mr83xkflf0sjrii11pd9k4a4545jggqgq6pdpsmkx2r3b01j2q";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-ipfs-addr";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-ipfs-addr";
+      rev = "v0.0.1";
+      sha256 = "02f7vhf6kra7h58ny71zfb0k5q9mz6yplypnk36i6gv4fn5v9c5i";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-ipfs-blockstore";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-ipfs-blockstore";
+      rev = "v0.0.1";
+      sha256 = "0vw6i4n9xss21yri5wkj9pvzapm9yqgxh5l6vq2858n50xz72r31";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-ipfs-blocksutil";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-ipfs-blocksutil";
+      rev = "v0.0.1";
+      sha256 = "06bip9adk70i0g0hkf4aczvhkhd3s31x19668ls26dl62rq9h7di";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-ipfs-chunker";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-ipfs-chunker";
+      rev = "v0.0.1";
+      sha256 = "19p8a4xfi62fj5nw7ad81yppn0slq3pddk0gb0c3zydaxcjkhzw6";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-ipfs-cmdkit";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-ipfs-cmdkit";
+      rev = "v0.0.1";
+      sha256 = "1aqdpszvibkm1h7p852ajzb9gjgsz5jlk4j2s9j8q1wbmz3vslms";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-ipfs-cmds";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-ipfs-cmds";
+      rev = "v0.0.5";
+      sha256 = "1b302hvah5scykcjn5al9a6jf7sygqi6snd664a6sxf2xgpwk0s8";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-ipfs-config";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-ipfs-config";
+      rev = "v0.0.1";
+      sha256 = "055igsi5bv312p2590dvpr9d290c4c0cwbzvwv52l7j60v79vlkc";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-ipfs-delay";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-ipfs-delay";
+      rev = "v0.0.1";
+      sha256 = "0a5acj622sk1hibnh893mya4h86nsy1dan0wlh9q444c04iqpviw";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-ipfs-ds-help";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-ipfs-ds-help";
+      rev = "v0.0.1";
+      sha256 = "173kmvyk2f5f1p30avb8nzvkcmq9xkdfpydavqw3bxg0yq0714ic";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-ipfs-exchange-interface";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-ipfs-exchange-interface";
+      rev = "v0.0.1";
+      sha256 = "12h4pj5g9d1j5gmd8gf774fqwkx0x5cm3pg7c81hi0f43x5lrmwn";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-ipfs-exchange-offline";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-ipfs-exchange-offline";
+      rev = "v0.0.1";
+      sha256 = "0nlb5llmj9kjas2p5jqg2x3krk5jm40xd36k0g5l87c992dy7f0i";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-ipfs-files";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-ipfs-files";
+      rev = "v0.0.2";
+      sha256 = "12554whcmg60rgnzyd7673hgxnrs1j176lw8839wf260pjq6rs39";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-ipfs-flags";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-ipfs-flags";
+      rev = "v0.0.1";
+      sha256 = "0pf9nq0n6nlfxbfhn9v46a2s7kkkwmvl04si8ihz08nahanb13r6";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-ipfs-posinfo";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-ipfs-posinfo";
+      rev = "v0.0.1";
+      sha256 = "0hh88i9sk5h53z2xx2nwxrpcx0r0jhlb5sq54x5qyhp5mjfqbyi2";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-ipfs-pq";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-ipfs-pq";
+      rev = "v0.0.1";
+      sha256 = "05q7b7g49ni59c6593v51kkkd6ppc2ipkfsx05qbfg8md9r7a93x";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-ipfs-routing";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-ipfs-routing";
+      rev = "v0.0.1";
+      sha256 = "15vvvc0z5sbyhmwl3nfrpziiy3gsivb02xcalsz6mxvam68xy4x5";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-ipfs-util";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-ipfs-util";
+      rev = "v0.0.1";
+      sha256 = "1j87wqxh8ap5qqvnhnhz3zg6fn50axnnd69wqg287hh36xcpy6ss";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-ipld-cbor";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-ipld-cbor";
+      rev = "v0.0.1";
+      sha256 = "0zppzca1ar8pqrzi68ysx4ih1mnhlyrg046xwj7sggr4aki1fh5j";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-ipld-format";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-ipld-format";
+      rev = "v0.0.1";
+      sha256 = "0lb4wp30jlamk604bagzf28zf2hm2b4lxnayqvq7rh0jxhbdb61d";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-ipld-git";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-ipld-git";
+      rev = "v0.0.1";
+      sha256 = "0d5kl3kvam1hv589cg9cg1dkjyanzp727zrnzyjnrysv3fk8yv66";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-ipns";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-ipns";
+      rev = "v0.0.1";
+      sha256 = "1r9531v35336sf36s8pzi3jiyqd22ld9p7xpaznzmp57ygwfxlwj";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-log";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-log";
+      rev = "v0.0.1";
+      sha256 = "0r3pk46g9vjjb9ljaxda18w488xa9vyj30g23y9vprknkd9dqfgw";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-merkledag";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-merkledag";
+      rev = "v0.0.3";
+      sha256 = "0j7dgca9vyhj6ra074cddblcjkxh1c1k51krch09lqxxjwasgg60";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-metrics-interface";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-metrics-interface";
+      rev = "v0.0.1";
+      sha256 = "09xc71175sfnqlizkbw066jagnbag9ihvs240z6g6dm2yx3w5xgy";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-metrics-prometheus";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-metrics-prometheus";
+      rev = "v0.0.2";
+      sha256 = "1z1zwjj0a3gyzs4r25b9kl7z3kmsqp3jskvy7x02a3v1dlr3nkfp";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-mfs";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-mfs";
+      rev = "v0.0.4";
+      sha256 = "13jjxbfjl6wd89nxqibvp8q3hd2vzh0vpfhp3vrbapghkzp08rbb";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-path";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-path";
+      rev = "v0.0.3";
+      sha256 = "019zpy92k2rilkhn928jf91d8y3x8cxcw04mc2pxv5ja29nkyc91";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-todocounter";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-todocounter";
+      rev = "v0.0.1";
+      sha256 = "1nsf56hh6n2y3m14b1ismcpsyi65ffxa5i6ks6il9qppm21mm5nx";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-unixfs";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-unixfs";
+      rev = "v0.0.4";
+      sha256 = "0fbqqi9h2xalnyc58ppaiyac3qd6hb4ycn46wwnr7idp0z7wxl5j";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/go-verifcid";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/go-verifcid";
+      rev = "v0.0.1";
+      sha256 = "06ii8934s52d9n1lvzx29didh667pm2i7qdag443vqn0ilmkjvh9";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/hang-fds";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/hang-fds";
+      rev = "v0.0.1";
+      sha256 = "0axgmx1vcqsvys4vhqfrixfss2vk3qly1cqlm0aqrlhscggflkn4";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/interface-go-ipfs-core";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/interface-go-ipfs-core";
+      rev = "v0.0.6";
+      sha256 = "13sr18vzsfsik1nnkdcmi7afagbcnzh95mxzlbss366x802g8d8q";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/iptb";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/iptb";
+      rev = "v1.4.0";
+      sha256 = "0nfiqf1k114ydp6c37yq4qn6j3bmw94wvc096vfljq8493jr8jvv";
+    };
+  }
+  {
+    goPackagePath = "github.com/ipfs/iptb-plugins";
+    fetch = {
+      type = "git";
+      url = "https://github.com/ipfs/iptb-plugins";
+      rev = "v0.0.2";
+      sha256 = "10kyvjhmlvza3xlmfvwhndscjm6807pmk9nld7d2660mvh18w626";
+    };
+  }
+  {
+    goPackagePath = "github.com/jackpal/gateway";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jackpal/gateway";
+      rev = "v1.0.5";
+      sha256 = "1ird5xmizj632l3dq24s2xgb8w1dn6v8xznlqz252gvngyr2gjl1";
+    };
+  }
+  {
+    goPackagePath = "github.com/jackpal/go-nat-pmp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jackpal/go-nat-pmp";
+      rev = "v1.0.1";
+      sha256 = "0sr23mcxbv9f65is4p1amb5yn026p7cfamlwpb2f8q218idwy3zk";
+    };
+  }
+  {
+    goPackagePath = "github.com/jbenet/go-cienv";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jbenet/go-cienv";
+      rev = "1bb1476777ec";
+      sha256 = "0mk04dk572gdd0y63vark0362y42w7kbwdlmmw9bg78qmmiikjb3";
+    };
+  }
+  {
+    goPackagePath = "github.com/jbenet/go-context";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jbenet/go-context";
+      rev = "d14ea06fba99";
+      sha256 = "0q91f5549n81w3z5927n4a1mdh220bdmgl42zi3h992dcc4ls0sl";
+    };
+  }
+  {
+    goPackagePath = "github.com/jbenet/go-is-domain";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jbenet/go-is-domain";
+      rev = "v1.0.2";
+      sha256 = "1cf4qmlg54975z5j7njyqsq0vr8gsxzg85c5iys08nr3cizr7551";
+    };
+  }
+  {
+    goPackagePath = "github.com/jbenet/go-random";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jbenet/go-random";
+      rev = "123a90aedc0c";
+      sha256 = "0kgx19m8p76rmin8s8y6j1padciv1dx37qzy7jkh9bw49ai3haw3";
+    };
+  }
+  {
+    goPackagePath = "github.com/jbenet/go-random-files";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jbenet/go-random-files";
+      rev = "31b3f20ebded";
+      sha256 = "0d52wwzgxxh2a1bwmixfa6nfhhqdq6l9g4s6kmsdnc6kqf38c818";
+    };
+  }
+  {
+    goPackagePath = "github.com/jbenet/go-temp-err-catcher";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jbenet/go-temp-err-catcher";
+      rev = "aac704a3f4f2";
+      sha256 = "1fyqkcggnrzwxa8iii15g60w2jikdm26sr7l36km7y0nc2kvf7jc";
+    };
+  }
+  {
+    goPackagePath = "github.com/jbenet/goprocess";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jbenet/goprocess";
+      rev = "b497e2f366b8";
+      sha256 = "1lnvkzki7vnqn5c4m6bigk0k85haicmg27w903kwg30rdvblm82s";
+    };
+  }
+  {
+    goPackagePath = "github.com/jessevdk/go-flags";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jessevdk/go-flags";
+      rev = "1679536dcc89";
+      sha256 = "15jgsymwg0wjslxrw391sw7qzwwjcnjxiiksq84z7ng9sqy96c1c";
+    };
+  }
+  {
+    goPackagePath = "github.com/jonboulle/clockwork";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jonboulle/clockwork";
+      rev = "v0.1.0";
+      sha256 = "1pqxhsdavbp1n5grgyx2j6ylvql2fzn2cvpsgkc8li69dil7sibl";
+    };
+  }
+  {
+    goPackagePath = "github.com/jrick/logrotate";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jrick/logrotate";
+      rev = "v1.0.0";
+      sha256 = "0srl6figwjqpi3nbp7br8sxpmvh4v8lzbny1b4lar4ny0156p5nl";
+    };
+  }
+  {
+    goPackagePath = "github.com/jtolds/gls";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jtolds/gls";
+      rev = "v4.2.1";
+      sha256 = "1vm37pvn0k4r6d3m620swwgama63laz8hhj3pyisdhxwam4m2g1h";
+    };
+  }
+  {
+    goPackagePath = "github.com/kisielk/errcheck";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kisielk/errcheck";
+      rev = "v1.1.0";
+      sha256 = "19vd4rxmqbk5lpiav3pf7df3yjlz0l0dwx9mn0gjq5f998iyhy6y";
+    };
+  }
+  {
+    goPackagePath = "github.com/kisielk/gotool";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kisielk/gotool";
+      rev = "v1.0.0";
+      sha256 = "14af2pa0ssyp8bp2mvdw184s5wcysk6akil3wzxmr05wwy951iwn";
+    };
+  }
+  {
+    goPackagePath = "github.com/kkdai/bstream";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kkdai/bstream";
+      rev = "f391b8402d23";
+      sha256 = "1hd9caz0yf3r8kciw2pqwrsr8z4w0rhbqv1z7iq08d0542s05j3z";
+    };
+  }
+  {
+    goPackagePath = "github.com/koron/go-ssdp";
+    fetch = {
+      type = "git";
+      url = "https://github.com/koron/go-ssdp";
+      rev = "4a0ed625a78b";
+      sha256 = "11d1xf07xs4j7qbxpndxbrfk2zk48k9fa3cxnhfb5lh24bd4sa0f";
+    };
+  }
+  {
+    goPackagePath = "github.com/kr/pretty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/pretty";
+      rev = "v0.1.0";
+      sha256 = "18m4pwg2abd0j9cn5v3k2ksk9ig4vlwxmlw9rrglanziv9l967qp";
+    };
+  }
+  {
+    goPackagePath = "github.com/kr/pty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/pty";
+      rev = "v1.1.1";
+      sha256 = "0383f0mb9kqjvncqrfpidsf8y6ns5zlrc91c6a74xpyxjwvzl2y6";
+    };
+  }
+  {
+    goPackagePath = "github.com/kr/text";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/text";
+      rev = "v0.1.0";
+      sha256 = "1gm5bsl01apvc84bw06hasawyqm4q84vx1pm32wr9jnd7a8vjgj1";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-addr-util";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-addr-util";
+      rev = "v0.0.1";
+      sha256 = "1kjdk5214l8gna7f4hvb0iwmmlzsfccjankkxjmil80ibhcvjw60";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-buffer-pool";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-buffer-pool";
+      rev = "v0.0.1";
+      sha256 = "1239hkhckgx1fzd43k56q3c0283p1mjl8w7i2j4xymvs6f6q6ygi";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-conn-security";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-conn-security";
+      rev = "v0.0.1";
+      sha256 = "0z1zw0aq5jcks0vcdm5zxjyz9z6c6jklm0s74gc2m7jfs2jj2r5r";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-conn-security-multistream";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-conn-security-multistream";
+      rev = "v0.0.1";
+      sha256 = "19slvlmapzs952gfn4aym4dg0l49x0vpn5v696vf80v2k00ipa32";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-flow-metrics";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-flow-metrics";
+      rev = "v0.0.1";
+      sha256 = "04zrwl579qkhiw3b655cw7lnlp2yvq1xl3f1rkxnhx8llwsy3x49";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-libp2p";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-libp2p";
+      rev = "v0.0.12";
+      sha256 = "04hm36fi45jpq5zjl1a7jlyq82adwwrgvvgnkllppq2zg85mlvvi";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-libp2p-autonat";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-libp2p-autonat";
+      rev = "v0.0.4";
+      sha256 = "03523s4kdwswgfnwly5ynld2lny142j8xl6mr88vni4xn7pijn1l";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-libp2p-autonat-svc";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-libp2p-autonat-svc";
+      rev = "v0.0.5";
+      sha256 = "0plph1nnh0ig9d54hizpiyhfrlrwhb1ylx6pry5jcppgpxngi79c";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-libp2p-blankhost";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-libp2p-blankhost";
+      rev = "v0.0.1";
+      sha256 = "1q29b880l95811ara95187y9pmqq542bxh50cg0ykwzfj94xgla4";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-libp2p-circuit";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-libp2p-circuit";
+      rev = "v0.0.4";
+      sha256 = "1bnwjf3p5r8ng360l2fjx0szdiwm2yfiifjkwflin00hx0gzyq7d";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-libp2p-connmgr";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-libp2p-connmgr";
+      rev = "v0.0.1";
+      sha256 = "07kvnhavr4k1birgqp9c4y0yl1ii3pl1cc8pn4dzci87krachz2z";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-libp2p-crypto";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-libp2p-crypto";
+      rev = "v0.0.1";
+      sha256 = "0wgq0ayg1656gvmi4d1nwgq7dbnyyb30xp3z571q495mmq483fbk";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-libp2p-daemon";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-libp2p-daemon";
+      rev = "v0.0.6";
+      sha256 = "0pq6557ykbi3a8pasvm9zlhdysrq6h1fj48z4imv2gq30nmy3l6l";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-libp2p-discovery";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-libp2p-discovery";
+      rev = "v0.0.1";
+      sha256 = "06h621llfx7bmkcnrkkxb3j85221albf18ig8mbh9c8wrpmsi438";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-libp2p-host";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-libp2p-host";
+      rev = "v0.0.1";
+      sha256 = "102qyl7qkmq8p1gpxbfi5z2lrd8mysji28fx25ma4h312ci96rqz";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-libp2p-interface-connmgr";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-libp2p-interface-connmgr";
+      rev = "v0.0.1";
+      sha256 = "107khappq5w48p17s22cp7djd5ii1bbg968wsa9bq9znzxdkzm43";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-libp2p-interface-pnet";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-libp2p-interface-pnet";
+      rev = "v0.0.1";
+      sha256 = "1kqxm4rpcss2ajfnc3gzww4ng5pjj5qc0szr5x2vz15vvx2kp9bi";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-libp2p-kad-dht";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-libp2p-kad-dht";
+      rev = "v0.0.7";
+      sha256 = "1nbq4240vnd3sfmiy8ry6pwnnf2k7hnwn1ln32mgqq32dywx664r";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-libp2p-kbucket";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-libp2p-kbucket";
+      rev = "v0.1.1";
+      sha256 = "0pgy89mp9r23axs8gapnkzks89q7539l2g46r6ffyd4a675qampg";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-libp2p-loggables";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-libp2p-loggables";
+      rev = "v0.0.1";
+      sha256 = "15whxhipm06fnd8ky7gxf59bvbw2wxl44g0v2dbnbr2j9a2n5ivv";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-libp2p-metrics";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-libp2p-metrics";
+      rev = "v0.0.1";
+      sha256 = "14wvnmcwr40iwbpvfwdcbb6cff7rcrhqf42z32aqjhisp32irn1x";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-libp2p-nat";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-libp2p-nat";
+      rev = "v0.0.4";
+      sha256 = "179d5jj4sznjns9p17gmrd86pf7ba7k4qq5kiv17ra4b666kd88f";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-libp2p-net";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-libp2p-net";
+      rev = "v0.0.2";
+      sha256 = "0cfi57hvkz6yhi2nw63p2p7fnaw91zrcphxmchk2a4xn5rnwgjak";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-libp2p-netutil";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-libp2p-netutil";
+      rev = "v0.0.1";
+      sha256 = "1zzkfddfmja6dsk8nxybi5cccd2v38sahp8xx676a38g3ydvqvs6";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-libp2p-peer";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-libp2p-peer";
+      rev = "v0.0.1";
+      sha256 = "0hixdbj47njyzj885fzm9dlylw21g406yqxfidag2qrn06b2qicl";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-libp2p-peerstore";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-libp2p-peerstore";
+      rev = "v0.0.2";
+      sha256 = "1asfl9sp3mi5pg9gpy45wvsc8hpdf48i7ml37sh5sjmn30aj4f6i";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-libp2p-pnet";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-libp2p-pnet";
+      rev = "v0.0.1";
+      sha256 = "1gh2hw0dbywwp7vr4n9xws8nxraa00rigzxa86g8nf50n9cdq2cr";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-libp2p-protocol";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-libp2p-protocol";
+      rev = "v0.0.1";
+      sha256 = "18fhmhfsdzw7dd618y4344qka08zq4b5jzpdgxbglar9dkkralg7";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-libp2p-pubsub";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-libp2p-pubsub";
+      rev = "v0.0.1";
+      sha256 = "1n67ajql9527mzrc06jk4rb3xb63vmlnzx6i4aywcfn66pjg9kmh";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-libp2p-pubsub-router";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-libp2p-pubsub-router";
+      rev = "v0.0.3";
+      sha256 = "1cjscq213ky11vzdalcfnkqkj2s53npymzjvv6ahn34c6bidan4s";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-libp2p-quic-transport";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-libp2p-quic-transport";
+      rev = "v0.0.3";
+      sha256 = "0kiisb35fvblg4xaz188by4rn90chynzm94f83prqq7h9y9b3s5s";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-libp2p-record";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-libp2p-record";
+      rev = "v0.0.1";
+      sha256 = "131zjkplylwam3gnw8f9lfvjgzi8xbjhb2qf57fys4c89pz868mg";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-libp2p-routing";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-libp2p-routing";
+      rev = "v0.0.1";
+      sha256 = "09mm12abdzy6k1dw3ix8v2c8w3warc52jazvwwwvwhlq924jzdp0";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-libp2p-routing-helpers";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-libp2p-routing-helpers";
+      rev = "v0.0.2";
+      sha256 = "0lxpf1vzhapj2q18wv5g7kkqhnwz1b08lyxjp57qa33z5j4jclgw";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-libp2p-secio";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-libp2p-secio";
+      rev = "v0.0.1";
+      sha256 = "1v51whaww3bv14kl7gpapq6ld6m6v7w9cipkflh8czpgrs096yyq";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-libp2p-swarm";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-libp2p-swarm";
+      rev = "v0.0.2";
+      sha256 = "0v75wb96rddjxd8faqri076xba5ffqg4bpddw16k4bw8kk2b46w0";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-libp2p-transport";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-libp2p-transport";
+      rev = "v0.0.4";
+      sha256 = "0pgyxzb489xzcm9q11br6sgsz166cw65xhfcksy3yy5n0c1c6mvb";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-libp2p-transport-upgrader";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-libp2p-transport-upgrader";
+      rev = "v0.0.1";
+      sha256 = "0czy16zvbz2k9jn8w7iddf7xph3bn054abxybjxm4dhp7g83mf65";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-maddr-filter";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-maddr-filter";
+      rev = "v0.0.1";
+      sha256 = "039qj86k4dam6kch52kcdk5dsg36gfrfwambqjg1nv2xaq8j1hx8";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-mplex";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-mplex";
+      rev = "v0.0.1";
+      sha256 = "1f0h2hmh4c0xvv1fsjciyc8v7sn0ymanr9my2smr6z1nar7nziqn";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-msgio";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-msgio";
+      rev = "v0.0.1";
+      sha256 = "1my8w8k7c3mz2aazsg45q7nlr4ywmix6jspri2sv7fqrs1kjxrjm";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-nat";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-nat";
+      rev = "v0.0.3";
+      sha256 = "19ihybcpmz2wpi6mk3rhgjbv4cgiiang92d9ym3xw7y3iv8mlzc0";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-reuseport";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-reuseport";
+      rev = "v0.0.1";
+      sha256 = "1qbxhycckjv7mazg06llbx9708f1z4453yaxxp4641gwcrbns7zk";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-reuseport-transport";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-reuseport-transport";
+      rev = "v0.0.2";
+      sha256 = "14lqhdkx5nmrvislim7qlvnx78dnfngxvcrll9d851r04p703qrn";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-stream-muxer";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-stream-muxer";
+      rev = "v0.0.1";
+      sha256 = "1swqw77jn00a7cl3lb7x5wyybhv4mkqk36z407ihid44gds7djqh";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-tcp-transport";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-tcp-transport";
+      rev = "v0.0.2";
+      sha256 = "0qrl4mgs16wnc0dnwg3x2k3mlv9grzl8maclbkq22vqk34c5in4y";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-testutil";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-testutil";
+      rev = "v0.0.1";
+      sha256 = "1jmqk6cyp52fgmayx0dwas27rswrvn9lpsiv6bnabhz1gvb91ahp";
+    };
+  }
+  {
+    goPackagePath = "github.com/libp2p/go-ws-transport";
+    fetch = {
+      type = "git";
+      url = "https://github.com/libp2p/go-ws-transport";
+      rev = "v0.0.2";
+      sha256 = "1j321z8m82a43v70jmglh2v0hv1wmgsizr5zrlgwqsx3wsih9phx";
+    };
+  }
+  {
+    goPackagePath = "github.com/lucas-clemente/quic-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/lucas-clemente/quic-go";
+      rev = "v0.11.1";
+      sha256 = "1vhswcbiyaq94rwc6vd8vl13x3lfwilpfw7kqx7bflxj7zvvd18y";
+    };
+  }
+  {
+    goPackagePath = "github.com/marten-seemann/qtls";
+    fetch = {
+      type = "git";
+      url = "https://github.com/marten-seemann/qtls";
+      rev = "v0.2.3";
+      sha256 = "0b9p7bwkm9hfg1mb565q4nw5k7xyks0z2xagz5fp95azy2psbnfg";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-colorable";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-colorable";
+      rev = "v0.1.1";
+      sha256 = "0l640974j804c1yyjfgyxqlsivz0yrzmbql4mhcw2azryigkp08p";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-isatty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-isatty";
+      rev = "v0.0.5";
+      sha256 = "114d5xm8rfxplzd7nxz97gfngb4bhqy102szl084d1afcxsvm4aa";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-runewidth";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-runewidth";
+      rev = "v0.0.4";
+      sha256 = "00b3ssm7wiqln3k54z2wcnxr3k3c7m1ybyhb9h8ixzbzspld0qzs";
+    };
+  }
+  {
+    goPackagePath = "github.com/matttproud/golang_protobuf_extensions";
+    fetch = {
+      type = "git";
+      url = "https://github.com/matttproud/golang_protobuf_extensions";
+      rev = "v1.0.1";
+      sha256 = "1d0c1isd2lk9pnfq2nk0aih356j30k3h1gi2w0ixsivi5csl7jya";
+    };
+  }
+  {
+    goPackagePath = "github.com/mgutz/ansi";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mgutz/ansi";
+      rev = "9520e82c474b";
+      sha256 = "00bz22314j26736w1f0q4jy9d9dfaml17vn890n5zqy3cmvmww1j";
+    };
+  }
+  {
+    goPackagePath = "github.com/miekg/dns";
+    fetch = {
+      type = "git";
+      url = "https://github.com/miekg/dns";
+      rev = "v1.1.4";
+      sha256 = "17apnm7q5v7bhmpvrk3rbi0gjqk8z3cwkm90q1dfzrfvbvp71z5d";
+    };
+  }
+  {
+    goPackagePath = "github.com/minio/blake2b-simd";
+    fetch = {
+      type = "git";
+      url = "https://github.com/minio/blake2b-simd";
+      rev = "3f5f724cb5b1";
+      sha256 = "0b6jbnj62c0gmmfd4zdmh8xbg01p80f13yygir9xprqkzk6fikmd";
+    };
+  }
+  {
+    goPackagePath = "github.com/minio/sha256-simd";
+    fetch = {
+      type = "git";
+      url = "https://github.com/minio/sha256-simd";
+      rev = "2d45a736cd16";
+      sha256 = "1hfhpy8fczd0mnwvxkp2nk3dydv1nzqx59ig8ajqjraq6kli66p5";
+    };
+  }
+  {
+    goPackagePath = "github.com/mitchellh/go-homedir";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/go-homedir";
+      rev = "v1.1.0";
+      sha256 = "0ydzkipf28hwj2bfxqmwlww47khyk6d152xax4bnyh60f4lq3nx1";
+    };
+  }
+  {
+    goPackagePath = "github.com/mr-tron/base58";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mr-tron/base58";
+      rev = "v1.1.0";
+      sha256 = "00w28mhinf8dvzrh71dijryfhrggi7j9wqiiyddpk41ixx3rmfy4";
+    };
+  }
+  {
+    goPackagePath = "github.com/multiformats/go-base32";
+    fetch = {
+      type = "git";
+      url = "https://github.com/multiformats/go-base32";
+      rev = "v0.0.3";
+      sha256 = "1f4pjnqw4687p8l7vr1qaq6g6i9pcr80fc4pk2kpgrcwzpd1lprg";
+    };
+  }
+  {
+    goPackagePath = "github.com/multiformats/go-multiaddr";
+    fetch = {
+      type = "git";
+      url = "https://github.com/multiformats/go-multiaddr";
+      rev = "v0.0.1";
+      sha256 = "1r1w4036bpi97xb70833bpdpdhqm5gl6m8fllfdxqbg10ab1a938";
+    };
+  }
+  {
+    goPackagePath = "github.com/multiformats/go-multiaddr-dns";
+    fetch = {
+      type = "git";
+      url = "https://github.com/multiformats/go-multiaddr-dns";
+      rev = "v0.0.2";
+      sha256 = "1fnv7lbd7q1kssaxp2fgrvj9dhn5aiqspd4090iqwys5hjr1xvmf";
+    };
+  }
+  {
+    goPackagePath = "github.com/multiformats/go-multiaddr-net";
+    fetch = {
+      type = "git";
+      url = "https://github.com/multiformats/go-multiaddr-net";
+      rev = "v0.0.1";
+      sha256 = "1075xs6gbiblfbwgf84yvg1nrywmvvrrxzqa8wp9j75zyakab81p";
+    };
+  }
+  {
+    goPackagePath = "github.com/multiformats/go-multibase";
+    fetch = {
+      type = "git";
+      url = "https://github.com/multiformats/go-multibase";
+      rev = "v0.0.1";
+      sha256 = "083adnq79pyxhngv91saygh076196qin1nw1vppz7nk04zw4aymg";
+    };
+  }
+  {
+    goPackagePath = "github.com/multiformats/go-multicodec";
+    fetch = {
+      type = "git";
+      url = "https://github.com/multiformats/go-multicodec";
+      rev = "v0.1.6";
+      sha256 = "08wnxhb4rd7rln2mzxnhv3csy19l9qgf5dx3437x4zsgkaqabb96";
+    };
+  }
+  {
+    goPackagePath = "github.com/multiformats/go-multihash";
+    fetch = {
+      type = "git";
+      url = "https://github.com/multiformats/go-multihash";
+      rev = "v0.0.1";
+      sha256 = "1aw4ra22g3l98bk7c3h1n968vi5a3gk528g4byj3xig76r0r731n";
+    };
+  }
+  {
+    goPackagePath = "github.com/multiformats/go-multistream";
+    fetch = {
+      type = "git";
+      url = "https://github.com/multiformats/go-multistream";
+      rev = "v0.0.1";
+      sha256 = "1k79w7zd92cs9sjvsr31vi6n3j30xqz83mb3a3pqva11wl1gbnlz";
+    };
+  }
+  {
+    goPackagePath = "github.com/onsi/ginkgo";
+    fetch = {
+      type = "git";
+      url = "https://github.com/onsi/ginkgo";
+      rev = "v1.7.0";
+      sha256 = "14wgpdrvpc35rdz3859bz53sc1g4vpr1fysy15wy3ff9gmqs14yg";
+    };
+  }
+  {
+    goPackagePath = "github.com/onsi/gomega";
+    fetch = {
+      type = "git";
+      url = "https://github.com/onsi/gomega";
+      rev = "v1.4.3";
+      sha256 = "1c8rqg5i2hz3snmq7s41yar1zjnzilb0fyiyhkg83v97afcfx79v";
+    };
+  }
+  {
+    goPackagePath = "github.com/opentracing/opentracing-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/opentracing/opentracing-go";
+      rev = "v1.0.2";
+      sha256 = "0i0ghg94dg8lk05mw5n23983wq04yjvkjmdkc9z5y1f3508938h9";
+    };
+  }
+  {
+    goPackagePath = "github.com/pkg/errors";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pkg/errors";
+      rev = "v0.8.1";
+      sha256 = "0g5qcb4d4fd96midz0zdk8b9kz8xkzwfa8kr1cliqbg8sxsy5vd1";
+    };
+  }
+  {
+    goPackagePath = "github.com/pmezard/go-difflib";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pmezard/go-difflib";
+      rev = "v1.0.0";
+      sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
+    };
+  }
+  {
+    goPackagePath = "github.com/polydawn/refmt";
+    fetch = {
+      type = "git";
+      url = "https://github.com/polydawn/refmt";
+      rev = "df39d6c2d992";
+      sha256 = "07hj5wimwgwj8xzzbvk0y7d6fmqf44d7fjicp1digh4kvjsbg3dz";
+    };
+  }
+  {
+    goPackagePath = "github.com/prometheus/client_golang";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/client_golang";
+      rev = "v0.9.2";
+      sha256 = "02b4yg6rfag0m3j0i39sillcm5xczwv8h133vn12yr8qw04cnigs";
+    };
+  }
+  {
+    goPackagePath = "github.com/prometheus/client_model";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/client_model";
+      rev = "5c3871d89910";
+      sha256 = "04psf81l9fjcwascsys428v03fx4fi894h7fhrj2vvcz723q57k0";
+    };
+  }
+  {
+    goPackagePath = "github.com/prometheus/common";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/common";
+      rev = "4724e9255275";
+      sha256 = "0pcx8hlnrxx5nnmpk786cn99rsgqk1jrd3c9f6fsx8qd8y5iwjy6";
+    };
+  }
+  {
+    goPackagePath = "github.com/prometheus/procfs";
+    fetch = {
+      type = "git";
+      url = "https://github.com/prometheus/procfs";
+      rev = "1dc9a6cbc91a";
+      sha256 = "1zlv1x30xp7z5c3vn5vp870v4bjim0zcidzc3mr2l3xhazc0svab";
+    };
+  }
+  {
+    goPackagePath = "github.com/rs/cors";
+    fetch = {
+      type = "git";
+      url = "https://github.com/rs/cors";
+      rev = "v1.6.0";
+      sha256 = "12j838rj6xl9y1xqs1mnh9zkc3dkpn94iqkp6jkdkxw631aa94dr";
+    };
+  }
+  {
+    goPackagePath = "github.com/sirupsen/logrus";
+    fetch = {
+      type = "git";
+      url = "https://github.com/sirupsen/logrus";
+      rev = "v1.0.5";
+      sha256 = "0g5z7al7kky11ai2dhac6gkp3b5pxsvx72yj3xg4wg3265gbn7yz";
+    };
+  }
+  {
+    goPackagePath = "github.com/smartystreets/assertions";
+    fetch = {
+      type = "git";
+      url = "https://github.com/smartystreets/assertions";
+      rev = "b2de0cb4f26d";
+      sha256 = "1i7ldgavgl35c7gk25p7bvdr282ckng090zr4ch9mk1705akx09y";
+    };
+  }
+  {
+    goPackagePath = "github.com/smartystreets/goconvey";
+    fetch = {
+      type = "git";
+      url = "https://github.com/smartystreets/goconvey";
+      rev = "a17d461953aa";
+      sha256 = "1942lhpv7c16dq27wjj2cjxsgra5lpsnxn52a9zvj8d0nip8nhq6";
+    };
+  }
+  {
+    goPackagePath = "github.com/spaolacci/murmur3";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spaolacci/murmur3";
+      rev = "f09979ecbc72";
+      sha256 = "1lv3zyz3jy2d76bhvvs8svygx66606iygdvwy5cwc0p5z8yghq25";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/pflag";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/pflag";
+      rev = "v1.0.1";
+      sha256 = "0nr4mdpfhhk94hq4ymn5b2sxc47b29p1akxd8b0hx4dvdybmipb5";
+    };
+  }
+  {
+    goPackagePath = "github.com/stretchr/objx";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/objx";
+      rev = "v0.1.0";
+      sha256 = "19ynspzjdynbi85xw06mh8ad5j0qa1vryvxjgvbnyrr8rbm4vd8w";
+    };
+  }
+  {
+    goPackagePath = "github.com/stretchr/testify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/testify";
+      rev = "v1.3.0";
+      sha256 = "0wjchp2c8xbgcbbq32w3kvblk6q6yn533g78nxl6iskq6y95lxsy";
+    };
+  }
+  {
+    goPackagePath = "github.com/syndtr/goleveldb";
+    fetch = {
+      type = "git";
+      url = "https://github.com/syndtr/goleveldb";
+      rev = "v1.0.0";
+      sha256 = "042k0gbzs5waqpxmd7nv5h93mlva861s66c3s9gfg1fym5dx4vmd";
+    };
+  }
+  {
+    goPackagePath = "github.com/texttheater/golang-levenshtein";
+    fetch = {
+      type = "git";
+      url = "https://github.com/texttheater/golang-levenshtein";
+      rev = "d188e65d659e";
+      sha256 = "0dmaxmwz2vx2v51hybjpcwz260apaq3v8gm84ran38fcs8xl529c";
+    };
+  }
+  {
+    goPackagePath = "github.com/urfave/cli";
+    fetch = {
+      type = "git";
+      url = "https://github.com/urfave/cli";
+      rev = "v1.20.0";
+      sha256 = "0y6f4sbzkiiwrxbl15biivj8c7qwxnvm3zl2dd3mw4wzg4x10ygj";
+    };
+  }
+  {
+    goPackagePath = "github.com/warpfork/go-wish";
+    fetch = {
+      type = "git";
+      url = "https://github.com/warpfork/go-wish";
+      rev = "5ad1f5abf436";
+      sha256 = "1jns04jdb07f695ipf0pfal2k7ss47jxgdi2ahqmskzglb26zm62";
+    };
+  }
+  {
+    goPackagePath = "github.com/whyrusleeping/base32";
+    fetch = {
+      type = "git";
+      url = "https://github.com/whyrusleeping/base32";
+      rev = "c30ac30633cc";
+      sha256 = "060jj8j9rnm3m47vv7jfz9ddybch3ryvn1p9vhc63bqn73knalhf";
+    };
+  }
+  {
+    goPackagePath = "github.com/whyrusleeping/cbor";
+    fetch = {
+      type = "git";
+      url = "https://github.com/whyrusleeping/cbor";
+      rev = "63513f603b11";
+      sha256 = "0v3kgzk8grz17my2vhv12qi9dgpx3z86hy9ff1c4qw83mg8hm67s";
+    };
+  }
+  {
+    goPackagePath = "github.com/whyrusleeping/chunker";
+    fetch = {
+      type = "git";
+      url = "https://github.com/whyrusleeping/chunker";
+      rev = "fe64bd25879f";
+      sha256 = "13q4flp9iwwyi0izqar786h42713rf3m22qlvg0masbmdi69qjr2";
+    };
+  }
+  {
+    goPackagePath = "github.com/whyrusleeping/go-ctrlnet";
+    fetch = {
+      type = "git";
+      url = "https://github.com/whyrusleeping/go-ctrlnet";
+      rev = "f564fbbdaa95";
+      sha256 = "1ni4fb9bbaiicy8yd9w8i442v94k59czlmpvjqg0y5am67x73gxk";
+    };
+  }
+  {
+    goPackagePath = "github.com/whyrusleeping/go-keyspace";
+    fetch = {
+      type = "git";
+      url = "https://github.com/whyrusleeping/go-keyspace";
+      rev = "5b898ac5add1";
+      sha256 = "0fkk7i7qxwbz1g621mm6a6inb69lr57cyc9ayyfiwhnjwfz78rbb";
+    };
+  }
+  {
+    goPackagePath = "github.com/whyrusleeping/go-logging";
+    fetch = {
+      type = "git";
+      url = "https://github.com/whyrusleeping/go-logging";
+      rev = "0457bb6b88fc";
+      sha256 = "1bl180mhg03hdqhyr5sfjcg16ns2ppal625g9ag5m10l2pvlwnqn";
+    };
+  }
+  {
+    goPackagePath = "github.com/whyrusleeping/go-notifier";
+    fetch = {
+      type = "git";
+      url = "https://github.com/whyrusleeping/go-notifier";
+      rev = "097c5d47330f";
+      sha256 = "081h4a33603n0mlh53by1mg21rr42xjvxk7r10x8l4v671bq0kha";
+    };
+  }
+  {
+    goPackagePath = "github.com/whyrusleeping/go-smux-multiplex";
+    fetch = {
+      type = "git";
+      url = "https://github.com/whyrusleeping/go-smux-multiplex";
+      rev = "v3.0.16";
+      sha256 = "0y696zqrbdyvz9gkxd9armhxa82z2fg0wpm8yqp7swyxdsg15f8k";
+    };
+  }
+  {
+    goPackagePath = "github.com/whyrusleeping/go-smux-multistream";
+    fetch = {
+      type = "git";
+      url = "https://github.com/whyrusleeping/go-smux-multistream";
+      rev = "v2.0.2";
+      sha256 = "0sbxmn56fx1py6nijk9prkm4rqswynsw68frvlm11w5m57szi5pj";
+    };
+  }
+  {
+    goPackagePath = "github.com/whyrusleeping/go-smux-yamux";
+    fetch = {
+      type = "git";
+      url = "https://github.com/whyrusleeping/go-smux-yamux";
+      rev = "v2.0.9";
+      sha256 = "046nx0d9974shd6y3ic2dznij0yzaijp6z6g46kpa4iwf2w41jwk";
+    };
+  }
+  {
+    goPackagePath = "github.com/whyrusleeping/go-sysinfo";
+    fetch = {
+      type = "git";
+      url = "https://github.com/whyrusleeping/go-sysinfo";
+      rev = "4a357d4b90b1";
+      sha256 = "0s6yjp9incc579wbbga33vq0hcanv8j2xh9l90ya0r4fihz39jiq";
+    };
+  }
+  {
+    goPackagePath = "github.com/whyrusleeping/mafmt";
+    fetch = {
+      type = "git";
+      url = "https://github.com/whyrusleeping/mafmt";
+      rev = "v1.2.8";
+      sha256 = "0sr602pbxid3ncfd8v0dgjd1a79qg3k4bzniq811jjdq9zm9jccv";
+    };
+  }
+  {
+    goPackagePath = "github.com/whyrusleeping/mdns";
+    fetch = {
+      type = "git";
+      url = "https://github.com/whyrusleeping/mdns";
+      rev = "ef14215e6b30";
+      sha256 = "17hid8s9asqyqgbw20wp4ip5sy03b5sayzld2i09w9l42217502q";
+    };
+  }
+  {
+    goPackagePath = "github.com/whyrusleeping/multiaddr-filter";
+    fetch = {
+      type = "git";
+      url = "https://github.com/whyrusleeping/multiaddr-filter";
+      rev = "e903e4adabd7";
+      sha256 = "0ksd8vnp207dvphmhrazwldj8if900fnyc1pqa9pfvj04qp92640";
+    };
+  }
+  {
+    goPackagePath = "github.com/whyrusleeping/tar-utils";
+    fetch = {
+      type = "git";
+      url = "https://github.com/whyrusleeping/tar-utils";
+      rev = "8c6c8ba81d5c";
+      sha256 = "14jjdw3yics0k467xsyk388684wdpi0bbx8nqj0y4pqxa0s0in6s";
+    };
+  }
+  {
+    goPackagePath = "github.com/whyrusleeping/timecache";
+    fetch = {
+      type = "git";
+      url = "https://github.com/whyrusleeping/timecache";
+      rev = "cfcb2f1abfee";
+      sha256 = "0nnra7ivq7cj34rj2ib8hgfdpik3smr1hy7x18svhfin8z1xsj2s";
+    };
+  }
+  {
+    goPackagePath = "github.com/whyrusleeping/yamux";
+    fetch = {
+      type = "git";
+      url = "https://github.com/whyrusleeping/yamux";
+      rev = "v1.1.5";
+      sha256 = "08a4v0akdxg16g6mi32ixsldjbg3pp3j4x0xicaxc4fd6cfmi1wv";
+    };
+  }
+  {
+    goPackagePath = "go4.org";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go4org/go4";
+      rev = "ce4c26f7be8e";
+      sha256 = "0lzvmspdqqf251lrgawnss2wn3bnd3pj89xjxlvpgg6q0853580j";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev = "8dd112bcdc25";
+      sha256 = "0gbcz7gxmgg88s28vb90dsp1vdq0har7zvg2adsqbp8bm05x9q6b";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev = "c95aed5357e7";
+      sha256 = "0b1vjnzd67sp9lggs0yn9qfgp6f5djqgx40lyncd7j720q04kk2h";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sync";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sync";
+      rev = "42b317875d0f";
+      sha256 = "0mrjhk7al7yyh76x9flvxy4jm5jyqh2fxbxagpaazxn1xdgkaif3";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev = "b6889370fb10";
+      sha256 = "01c1ag1qr95iksp38rypfbrlk6sdqjhk7jgj3qf342ndhvqb08sa";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev = "v0.3.0";
+      sha256 = "0r6x6zjzhr8ksqlpiwm5gdd7s209kwk5p4lw54xjvz10cs3qlq19";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/tools";
+      rev = "90fa682c2a6e";
+      sha256 = "03ic2xsy51jw9749wl7gszdbz99iijbd2bckgygl6cm9w5m364ak";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/xerrors";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/xerrors";
+      rev = "a5947ffaace3";
+      sha256 = "1bgn7j704mf891qcwcbqzr5sq9ar7z2a81887k8pp0b1g2giwgfz";
+    };
+  }
+  {
+    goPackagePath = "google.golang.org/genproto";
+    fetch = {
+      type = "git";
+      url = "https://github.com/google/go-genproto";
+      rev = "11092d34479b";
+      sha256 = "12qcrjq658zga5fj4n0wgm11pzpr3gafwg25cinl5qcq4p9cnl0r";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/airbrake/gobrake.v2";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/airbrake/gobrake.v2";
+      rev = "v2.0.9";
+      sha256 = "1x06f7n7qlyzqgyz0sdfcidf3w4ldn6zs6qx2mhibggk2z4whcjw";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/check.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/check.v1";
+      rev = "788fd7840127";
+      sha256 = "0v3bim0j375z81zrpr5qv42knqs0y2qv2vkjiqi5axvb78slki1a";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/cheggaaa/pb.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/cheggaaa/pb.v1";
+      rev = "v1.0.28";
+      sha256 = "13a66cqbpdif804qj12z9ad8r24va9q41gfk71qbc4zg1wsxs3rh";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/fsnotify.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/fsnotify.v1";
+      rev = "v1.4.7";
+      sha256 = "07va9crci0ijlivbb7q57d2rz9h27zgn2fsm60spjsqpdbvyrx4g";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/gemnasium/logrus-airbrake-hook.v2";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/gemnasium/logrus-airbrake-hook.v2";
+      rev = "v2.1.2";
+      sha256 = "0sbg0dn6cysmf8f2bi209jwl4jnpiwp4rdghnxlzirw3c32ms5y5";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/tomb.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/tomb.v1";
+      rev = "dd632973f1e7";
+      sha256 = "1lqmq1ag7s4b3gc3ddvr792c5xb5k6sfn0cchr3i2s7f1c231zjv";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/yaml.v2";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/yaml.v2";
+      rev = "v2.2.1";
+      sha256 = "0dwjrs2lp2gdlscs7bsrmyc5yf6mm4fvgw71bzr9mv2qrd2q73s1";
+    };
+  }
+  {
+    goPackagePath = "gotest.tools";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gotestyourself/gotest.tools";
+      rev = "v2.1.0";
+      sha256 = "11k6hmfhaf0qxpddp3i5kfpacdx51q6pv4n1kn3jnf1hjs0yny2k";
+    };
+  }
+  {
+    goPackagePath = "gotest.tools/gotestsum";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gotestyourself/gotestsum";
+      rev = "v0.3.3";
+      sha256 = "0wkh49yixvh5y1z96sanjfyvd7c63pvryz605lz0hzdbvcwciy7i";
+    };
+  }
+]


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

The upstream repo no longer uses gx, so I had to generate a deps.nix using vgo2nix, and hand-add 1 broken entry to it.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
