### PR TITLE
mosquitto: 1.5.8 -> 1.6 + nixos tests

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -143,6 +143,7 @@ in
   misc = handleTest ./misc.nix {};
   mongodb = handleTest ./mongodb.nix {};
   morty = handleTest ./morty.nix {};
+  mosquitto = handleTest ./mosquitto.nix {};
   mpd = handleTest ./mpd.nix {};
   mumble = handleTest ./mumble.nix {};
   munin = handleTest ./munin.nix {};

--- a/nixos/tests/mosquitto.nix
+++ b/nixos/tests/mosquitto.nix
@@ -1,0 +1,69 @@
+import ./make-test.nix ({ pkgs, ... }:
+
+let
+  port = 1888;
+  username = "mqtt";
+  password = "VERY_secret";
+  topic = "test/foo";
+
+  cmd = bin: pkgs.lib.concatStringsSep " " [
+    "${pkgs.mosquitto}/bin/mosquitto_${bin}"
+    "-V mqttv311"
+    "-h server"
+    "-p ${toString port}"
+    "-u ${username}"
+    "-P '${password}'"
+    "-t ${topic}"
+  ];
+
+in rec {
+  name = "mosquitto";
+  meta = with pkgs.stdenv.lib; {
+    maintainers = with maintainers; [ peterhoeg ];
+  };
+
+  nodes = let
+    client = { pkgs, ... }: {
+      environment.systemPackages = with pkgs; [ mosquitto ];
+    };
+  in {
+    server = { pkgs, ... }: {
+      networking.firewall.allowedTCPPorts = [ port ];
+      services.mosquitto = {
+        inherit port;
+        enable = true;
+        host = "0.0.0.0";
+        checkPasswords = true;
+        users."${username}" = {
+          inherit password;
+          acl = [
+            "topic readwrite ${topic}"
+          ];
+        };
+      };
+    };
+
+    client1 = client;
+    client2 = client;
+  };
+
+  testScript = let
+    file = "/tmp/msg";
+    payload = "wootWOOT";
+  in ''
+    startAll;
+    $server->waitForUnit("mosquitto.service");
+
+    $server->fail("test -f ${file}");
+    $server->execute("(${cmd "sub"} -C 1 | tee ${file} &)");
+
+    $client1->fail("test -f ${file}");
+    $client1->execute("(${cmd "sub"} -C 1 | tee ${file} &)");
+
+    $client2->succeed("${cmd "pub"} -m ${payload}");
+
+    $server->succeed("grep -q ${payload} ${file}");
+
+    $client1->succeed("grep -q ${payload} ${file}");
+  '';
+})

--- a/pkgs/servers/mqtt/mosquitto/default.nix
+++ b/pkgs/servers/mqtt/mosquitto/default.nix
@@ -1,19 +1,16 @@
 { stdenv, lib, fetchFromGitHub, fetchpatch, cmake, docbook_xsl, libxslt
 , openssl, libuuid, libwebsockets, c-ares, libuv
-, systemd ? null }:
+, systemd ? null, withSystemd ? stdenv.isLinux }:
 
-let
-  withSystemd = stdenv.isLinux;
-
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   name = "mosquitto-${version}";
-  version = "1.5.8";
+  version = "1.6";
 
   src = fetchFromGitHub {
     owner  = "eclipse";
     repo   = "mosquitto";
     rev    = "v${version}";
-    sha256 = "1rf8g6fq7g1mhwsajsgvvlynasybgc51v0qg5j6ynsxfh8yi7s6r";
+    sha256 = "1yvn0yj9hb502lvk2yrshpvrnq2fddjyarnw37ip34mhxynnz5gb";
   };
 
   postPatch = ''
@@ -37,8 +34,6 @@ in stdenv.mkDerivation rec {
   ] ++ lib.optional withSystemd systemd;
 
   nativeBuildInputs = [ cmake docbook_xsl libxslt ];
-
-  enableParallelBuilding = true;
 
   cmakeFlags = [
     "-DWITH_THREADING=ON"


### PR DESCRIPTION
###### Motivation for this change

https://github.com/eclipse/mosquitto/blob/master/ChangeLog.txt

Also we need some kind of test in place - this is very basic but better than nothing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
