### PR TITLE
[WIP] nixos/mautrix-telegram: init module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -419,6 +419,7 @@
   ./services/misc/mantisbt.nix
   ./services/misc/mathics.nix
   ./services/misc/matrix-synapse.nix
+  ./services/misc/mautrix-telegram.nix
   ./services/misc/mbpfan.nix
   ./services/misc/mediatomb.nix
   ./services/misc/mesos-master.nix

--- a/nixos/modules/services/misc/mautrix-telegram.nix
+++ b/nixos/modules/services/misc/mautrix-telegram.nix
@@ -42,6 +42,9 @@ in
       serviceConfig = {
         DynamicUser = true;
         StateDirectory = "mautrix-telegram";
+        preStart = ''
+          ${pkgs.mautrix-telegram.alembic}/bin/alembic -x config=${configFile}/config.yaml upgrade head
+        '';
         ExecStart = ''
           ${pkgs.mautrix-telegram}/bin/mautrix-telegram -c "${configFile}/config.yaml"
         '';

--- a/nixos/modules/services/misc/mautrix-telegram.nix
+++ b/nixos/modules/services/misc/mautrix-telegram.nix
@@ -1,0 +1,55 @@
+{ lib, config, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.mautrix-telegram;
+
+  configFile = pkgs.runCommand "mautrix-telegram" {
+    buildInputs = [ pkgs.mautrix-telegram pkgs.remarshal ];
+    preferLocalBuild = true;
+  } ''
+    mkdir -p $out
+    remarshal -if json -of yaml \
+      < ${pkgs.writeText "config.json" (builtins.toJSON cfg.configOptions)} \
+      > $out/config.yaml
+
+    ${pkgs.mautrix-telegram}/bin/mautrix-telegram -c $out/config.yaml -g -r $out/registration.yaml
+  '';
+
+in
+{
+  options.services.mautrix-telegram = {
+    enable = mkEnableOption "Mautrix-telegram, a bridge between Matrix and Telegram";
+
+    configOptions = mkOption {
+      type = types.attrs;
+      description = ''
+        This options will be transform in YAML configuration file for the bridge
+
+        Look at the <link xlink:href="https://github.com/tulir/mautrix-telegram/wiki/Bridge-setup">documentation</link> for more details.
+        You will found the list of options <link xlink:href="https://github.com/tulir/mautrix-telegram/blob/master/example-config.yaml">here</link>
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.mautrix-telegram = {
+      description = "Mautrix-Telegram Service - A Telegram bridge for Matrix";
+      after = [ "network.target" "matrix-synapse.service" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        DynamicUser = true;
+        StateDirectory = "mautrix-telegram";
+        ExecStart = ''
+          ${pkgs.mautrix-telegram}/bin/mautrix-telegram -c "${configFile}/config.yaml"
+        '';
+        Restart = "on-failure";
+      };
+    };
+
+    services.matrix-synapse.app_service_config_files = [ "${configFile}/registration.yaml" ];
+
+  };
+}


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
On the same pattern that mautrix-whatsapp, I suggest this service for mautrix-telegram.
What do you think about it @Ma27 :-) ?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
