### PR TITLE
phpPackages: Wrap mkDerivation to prepend package names

### DIFF
--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -7,6 +7,12 @@ let
       inherit (pkgs) stdenv autoreconfHook fetchurl;
     };
 
+    # Wrap mkDerivation to prepend pname with "php-" to make names consistent
+    # with how buildPecl does it and make the file easier to overview.
+    mkDerivation = { pname, ... }@args: pkgs.stdenv.mkDerivation (args // {
+      pname = "php-${pname}";
+    });
+
   isPhp73 = pkgs.lib.versionAtLeast php.version "7.3";
 
   apcu = buildPecl rec {
@@ -39,9 +45,9 @@ let
     sha256 = "0ja74k2lmxwhhvp9y9kc7khijd7s2dqma5x8ghbhx9ajkn0wg8iq";
   };
 
-  box = pkgs.stdenv.mkDerivation rec {
+  box = mkDerivation rec {
     version = "2.7.5";
-    pname = "php-box";
+    pname = "box";
 
     src = pkgs.fetchurl {
       url = "https://github.com/box-project/box2/releases/download/${version}/box-${version}.phar";
@@ -66,9 +72,9 @@ let
     };
   };
 
-  composer = pkgs.stdenv.mkDerivation rec {
+  composer = mkDerivation rec {
     version = "1.8.5";
-    pname = "php-composer";
+    pname = "composer";
 
     src = pkgs.fetchurl {
       url = "https://getcomposer.org/download/${version}/composer.phar";
@@ -210,7 +216,7 @@ let
     buildInputs = [ pkgs.unixODBC ];
   };
 
-  php-cs-fixer = pkgs.stdenv.mkDerivation rec {
+  php-cs-fixer = mkDerivation rec {
     version = "2.14.2";
     pname = "php-cs-fixer";
 
@@ -237,7 +243,7 @@ let
     };
   };
 
-  php-parallel-lint = pkgs.stdenv.mkDerivation rec {
+  php-parallel-lint = mkDerivation rec {
     version = "1.0.0";
     pname = "php-parallel-lint";
 
@@ -286,9 +292,9 @@ let
     meta.broken = true;
   };
 
-  phpcbf = pkgs.stdenv.mkDerivation rec {
+  phpcbf = mkDerivation rec {
     version = "3.4.2";
-    pname = "php-phpcbf";
+    pname = "phpcbf";
 
     src = pkgs.fetchurl {
       url = "https://github.com/squizlabs/PHP_CodeSniffer/releases/download/${version}/phpcbf.phar";
@@ -313,9 +319,9 @@ let
     };
   };
 
-  phpcs = pkgs.stdenv.mkDerivation rec {
+  phpcs = mkDerivation rec {
     version = "3.4.2";
-    pname = "php-phpcs";
+    pname = "phpcs";
 
     src = pkgs.fetchurl {
       url = "https://github.com/squizlabs/PHP_CodeSniffer/releases/download/${version}/phpcs.phar";
@@ -340,9 +346,9 @@ let
     };
   };
 
-  phpstan = pkgs.stdenv.mkDerivation rec {
+  phpstan = mkDerivation rec {
     version = "0.11.5";
-    pname = "php-phpstan";
+    pname = "phpstan";
 
     src = pkgs.fetchurl {
       url = "https://github.com/phpstan/phpstan/releases/download/${version}/phpstan.phar";
@@ -374,9 +380,9 @@ let
     };
   };
 
-  psysh = pkgs.stdenv.mkDerivation rec {
+  psysh = mkDerivation rec {
     version = "0.9.9";
-    pname = "php-psysh";
+    pname = "psysh";
 
     src = pkgs.fetchurl {
       url = "https://github.com/bobthecow/psysh/releases/download/v${version}/psysh-v${version}.tar.gz";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This will make the file more consistent and easier to follow when we
have a mixture of buildPecl (which already does this) and straight up
regular derivations.

This is a followup from #60099.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
