### PR TITLE
jupyterlab: Fix build

### DIFF
--- a/pkgs/development/python-modules/jupyterlab/default.nix
+++ b/pkgs/development/python-modules/jupyterlab/default.nix
@@ -4,6 +4,7 @@
 , jupyterlab_server
 , notebook
 , pythonOlder
+, fetchpatch
 }:
 
 buildPythonPackage rec {
@@ -20,6 +21,14 @@ buildPythonPackage rec {
 
   makeWrapperArgs = [
     "--set" "JUPYTERLAB_DIR" "$out/share/jupyter/lab"
+  ];
+
+  patches = [
+    (fetchpatch {
+      name = "bump-jupyterlab_server-version";
+      url = https://github.com/jupyterlab/jupyterlab/commit/3b8d451e6f9a4c609e60cde5fbb3cc84aae79951.patch;
+      sha256 = "08vv6rp1k5fbmvj4v9x1d9zb6ymm9pv8ml80j7p45r9fay34rndf";
+    })
   ];
 
   # Depends on npm


### PR DESCRIPTION
The build was broken by updating the underlying python library.
This is the quickfix.

Fixes: ca67a7200cf ("python37Packages.jupyterlab_server: 0.2.0 -> 0.3.0")

Closes #60154

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] other Linux distributions (centos7)
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
