### PR TITLE
dico: 2.7 -> 2.9

### DIFF
--- a/pkgs/servers/dico/default.nix
+++ b/pkgs/servers/dico/default.nix
@@ -2,25 +2,20 @@
 , guile, python, pcre, libffi, groff }:
 
 stdenv.mkDerivation rec {
-  name = "dico-2.7";
+  pname = "dico";
+  version = "2.9";
 
   src = fetchurl {
-    url = "mirror://gnu/dico/${name}.tar.xz";
-    sha256 = "0dg4aacnmlf3ljssd7dwh8z5644xzq8k1501mbsx8nz8p8a9mbsq";
+    url = "mirror://gnu/${pname}/${pname}-${version}.tar.xz";
+    sha256 = "0i9xqhy3h5nlizcmav4mv5ay8ivdgn4l4k0k7fxix3fsc87nijyr";
   };
 
   hardeningDisable = [ "format" ];
 
-  # XXX: Add support for GNU SASL.
   buildInputs =
     [ libtool gettext zlib readline gsasl guile python pcre libffi groff ];
 
-  # dicod fails to load modules, so the tests fail
-  doCheck = false;
-
-  preBuild = ''
-    sed -i -e '/gets is a security/d' gnu/stdio.in.h
-  '';
+  doCheck = true;
 
   meta = with stdenv.lib; {
     description = "Flexible dictionary server and client implementing RFC 2229";


### PR DESCRIPTION
###### Motivation for this change

2.9: http://lists.gnu.org/archive/html/info-gnu/2019-04/msg00009.html
2.8: http://lists.gnu.org/archive/html/info-gnu/2019-02/msg00011.html

also: pname, enable tests, remove stale TODO

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---