### PR TITLE
tmuxPlugins.vim-tmux-navigator: fix runtimepath

### DIFF
--- a/pkgs/misc/tmux-plugins/default.nix
+++ b/pkgs/misc/tmux-plugins/default.nix
@@ -230,6 +230,7 @@ in rec {
 
   vim-tmux-navigator = mkDerivation {
     pluginName = "vim-tmux-navigator";
+    rtpFilePath = "vim-tmux-navigator.tmux";
     src = fetchgit {
       url = "https://github.com/christoomey/vim-tmux-navigator";
       rev = "4e1a877f51a17a961b8c2a285ee80aebf05ccf42";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I was using home-manager to manage my tmux configuration when I noticed that the vim-tmux-navigator plugin didn't seem to work.

After some investigation, I found that the generated runtimepath for the vim-tmux-navigator plugin was broken:

```
$ nix repl
Welcome to Nix version 2.2.2. Type :? for help.

nix-repl> :l <nixpkgs>
Added 10237 variables.

nix-repl> pkgs.tmuxPlugins.vim-tmux-navigator.rtp
"/nix/store/kad7bgna5f6halc84xc793y9c8602iy2-tmuxplugin-vim-tmux-navigator/share/tmux-plugins/vim-tmux-navigator/vim_tmux_navigator.tmux"
```

This file doesn't exist, but `/nix/store/kad7bgna5f6halc84xc793y9c8602iy2-tmuxplugin-vim-tmux-navigator/share/tmux-plugins/vim-tmux-navigator/vim-tmux-navigator.tmux` does. <s>I tracked down the culprit, which was a call to `builtins.replaceStrings` changing the `-` for `_` and removed it; I have no idea why it's there. Perhaps @kalbasit can explain?</s> I added a `rtpFilePath` for vim-tmux-navigator to fix this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
