### PR TITLE
stdenv, treewide: Better configure platforms

### DIFF
--- a/pkgs/applications/video/mplayer/default.nix
+++ b/pkgs/applications/video/mplayer/default.nix
@@ -133,7 +133,6 @@ stdenv.mkDerivation rec {
     ++ (with darwin.apple_sdk.frameworks; optionals stdenv.isDarwin [ Cocoa OpenGL ])
     ;
 
-  configurePlatforms = [ ];
   configureFlags = with stdenv.lib; [
     "--enable-freetype"
     (if fontconfigSupport then "--enable-fontconfig" else "--disable-fontconfig")

--- a/pkgs/applications/video/omxplayer/default.nix
+++ b/pkgs/applications/video/omxplayer/default.nix
@@ -11,7 +11,6 @@ let
       sha256 = "03s1zsprz5p6gjgwwqcf7b6cvzwwid6l8k7bamx9i0f1iwkgdm0j";
     };
     
-    configurePlatforms = [];
     configureFlags = [
       "--arch=${stdenv.hostPlatform.parsed.cpu.name}"
     ] ++ stdenv.lib.optionals stdenv.hostPlatform.isAarch32 [

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -200,7 +200,6 @@ in stdenv.mkDerivation rec {
     find $out/lib -name "*.so" -type f -exec remove-references-to -t ${llvmShared} '{}' '+'
   '';
 
-  configurePlatforms = [];
 
   # https://github.com/NixOS/nixpkgs/pull/21742#issuecomment-272305764
   # https://github.com/rust-lang/rust/issues/30181

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -356,7 +356,6 @@ stdenv.mkDerivation ({
   '';
 
   # Cabal takes flags like `--configure-option=--host=...` instead
-  configurePlatforms = [];
   inherit configureFlags;
 
   configurePhase = ''

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -148,7 +148,6 @@ stdenv.mkDerivation {
     ++ optional enableNumpy python.pkgs.numpy;
 
   configureScript = "./bootstrap.sh";
-  configurePlatforms = [];
   configureFlags = [
     "--includedir=$(dev)/include"
     "--libdir=$(out)/lib"

--- a/pkgs/development/libraries/ffmpeg-full/default.nix
+++ b/pkgs/development/libraries/ffmpeg-full/default.nix
@@ -250,7 +250,6 @@ stdenv.mkDerivation rec {
       --replace /usr/local/lib/frei0r-1 ${frei0r}/lib/frei0r-1
   '';
 
-  configurePlatforms = [];
   configureFlags = [
     "--target_os=${stdenv.hostPlatform.parsed.kernel.name}"
     "--arch=${stdenv.hostPlatform.parsed.cpu.name}"

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -80,7 +80,6 @@ stdenv.mkDerivation rec {
     ++ optional (reqMin "1.0") "doc" ; # just dev-doc
   setOutputFlags = false; # doesn't accept all and stores configureFlags in libs!
 
-  configurePlatforms = [];
   configureFlags = [
       "--arch=${stdenv.hostPlatform.parsed.cpu.name}"
       "--target_os=${stdenv.hostPlatform.parsed.kernel.name}"

--- a/pkgs/development/libraries/libav/default.nix
+++ b/pkgs/development/libraries/libav/default.nix
@@ -50,7 +50,6 @@ let
       substituteInPlace ./configure --replace "#! /bin/sh" "#!${bash}/bin/sh"
     '';
 
-    configurePlatforms = [];
     configureFlags = assert stdenv.lib.all (x: x!=null) buildInputs; [
       "--arch=${stdenv.hostPlatform.parsed.cpu.name}"
       "--target_os=${stdenv.hostPlatform.parsed.kernel.name}"

--- a/pkgs/development/libraries/libvpx/default.nix
+++ b/pkgs/development/libraries/libvpx/default.nix
@@ -70,7 +70,6 @@ stdenv.mkDerivation rec {
   outputs = [ "bin" "dev" "out" ];
   setOutputFlags = false;
 
-  configurePlatforms = [];
   configureFlags = [
     (enableFeature (vp8EncoderSupport || vp8DecoderSupport) "vp8")
     (enableFeature vp8EncoderSupport "vp8-encoder")

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -41,7 +41,6 @@ let
     buildInputs = stdenv.lib.optional withCryptodev cryptodev;
 
     # TODO(@Ericson2314): Improve with mass rebuild
-    configurePlatforms = [];
     configureScript = {
         "x86_64-darwin"  = "./Configure darwin64-x86_64-cc";
         "x86_64-solaris" = "./Configure solaris64-x86_64-gcc";

--- a/pkgs/development/libraries/qt-4.x/4.8/default.nix
+++ b/pkgs/development/libraries/qt-4.x/4.8/default.nix
@@ -140,7 +140,6 @@ stdenv.mkDerivation rec {
 
   prefixKey = "-prefix ";
 
-  configurePlatforms = [];
   configureFlags = let
     mk = cond: name: "-${lib.optionalString (!cond) "no-"}${name}";
     platformFlag =

--- a/pkgs/development/libraries/zlib/default.nix
+++ b/pkgs/development/libraries/zlib/default.nix
@@ -55,7 +55,6 @@ stdenv.mkDerivation (rec {
   NIX_CFLAGS_COMPILE = stdenv.lib.optionalString (!stdenv.hostPlatform.isDarwin) "-static-libgcc";
 
   dontStrip = stdenv.hostPlatform != stdenv.buildPlatform && static;
-  configurePlatforms = [];
 
   installFlags = stdenv.lib.optionals (stdenv.hostPlatform.libc == "msvcrt") [
     "BINARY_PATH=$(out)/bin"

--- a/pkgs/development/tools/build-managers/cmake/default.nix
+++ b/pkgs/development/tools/build-managers/cmake/default.nix
@@ -105,7 +105,6 @@ stdenv.mkDerivation rec {
 
   # This isn't an autoconf configure script; triples are passed via
   # CMAKE_SYSTEM_NAME, etc.
-  configurePlatforms = [ ];
 
   doCheck = false; # fails
 

--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -71,8 +71,6 @@ stdenv.mkDerivation {
 
   NIX_CFLAGS_COMPILE = [ "-I${libxml2.dev}/include/libxml2" ] ++ optional stdenv.isDarwin "-Wno-error=deprecated-declarations";
 
-  configurePlatforms = [];
-
   preConfigure = (concatMapStringsSep "\n" (mod: mod.preConfigure or "") modules);
 
   patches = stdenv.lib.singleton (substituteAll {

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -53,9 +53,14 @@ in rec {
       # Including it then would cause needless mass rebuilds.
       #
       # TODO(@Ericson2314): Make [ "build" "host" ] always the default.
-      configurePlatforms ? lib.optionals
+      configurePlatforms ? [ "build" ] ++ lib.optional
         (stdenv.hostPlatform != stdenv.buildPlatform)
-        [ "build" "host" ]
+        "host"
+    , # By default we use env var, since this works for autoconf and won't mess
+      # up other build systems. But some of those other build systems also accept
+      # `--build` and `--host`, and those alone, and so we still have the
+      # `configureFlags` method too.
+      configurePlatformsMethod ? "env-vars"
 
     # TODO(@Ericson2314): Make unconditional / resolve #33599
     # Check phase
@@ -227,13 +232,30 @@ in rec {
           depsTargetTargetPropagated  = lib.elemAt (lib.elemAt propagatedDependencies 2) 0;
 
           # This parameter is sometimes a string, sometimes null, and sometimes a list, yuck
-          configureFlags = let inherit (lib) optional elem; in
+          configureFlags =
             (/**/ if lib.isString configureFlags then [configureFlags]
              else if configureFlags == null      then []
              else                                     configureFlags)
-            ++ optional (elem "build"  configurePlatforms) "--build=${stdenv.buildPlatform.config}"
-            ++ optional (elem "host"   configurePlatforms) "--host=${stdenv.hostPlatform.config}"
-            ++ optional (elem "target" configurePlatforms) "--target=${stdenv.targetPlatform.config}";
+            ++ lib.optionals (configurePlatformsMethod == "configure-flags") (lib.concatLists [
+                (lib.optional (lib.elem "build"  configurePlatforms) "--build=${stdenv.buildPlatform.config}")
+                (lib.optional (lib.elem "host"   configurePlatforms) "--host=${stdenv.hostPlatform.config}")
+                (lib.optional (lib.elem "target" configurePlatforms) "--target=${stdenv.targetPlatform.config}")
+              ]);
+
+          # We use autoconf-style env vars not `--{build,host,arget}` configure
+          # flags to avoid interfering with packages that don't accept those.
+          build_alias =
+            if configurePlatformsMethod == "env-var" && lib.elem "build" configurePlatforms
+            then stdenv.buildPlatform.config
+            else null;
+          host_alias =
+            if configurePlatformsMethod == "env-var" && lib.elem "host" configurePlatforms
+            then stdenv.hostPlatform.config
+            else null;
+          target_alias =
+            if configurePlatformsMethod == "env-var" && lib.elem "target" configurePlatforms
+            then stdenv.targetPlatform.config
+            else null;
 
           inherit doCheck doInstallCheck;
 

--- a/pkgs/tools/security/rhash/default.nix
+++ b/pkgs/tools/security/rhash/default.nix
@@ -14,7 +14,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ which ];
 
   # configure script is not autotools-based, doesn't support these options
-  configurePlatforms = [ ];
 
   doCheck = true;
 


### PR DESCRIPTION
###### Motivation for this change

1. Use @lheckemann's trick of an env var, so we don't screw up non-autoconf.
2. Always pass `build_alias`, so that building `x86_32` on `x86_64`, or `aarch32` on `aarch64`, etc should work.
3. Remove all `configurePlatforms = [ ];` now that they are not needed.

CC @Volth, can you confirm this mostly works? We can combine with any package-specific fixes needed from https://github.com/NixOS/nixpkgs/pull/60131.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
