### PR TITLE
taskopen: init at 1.1.4

### DIFF
--- a/pkgs/applications/misc/taskopen/default.nix
+++ b/pkgs/applications/misc/taskopen/default.nix
@@ -1,0 +1,34 @@
+{ fetchurl, stdenv, makeWrapper, which, perl, perlPackages }:
+
+stdenv.mkDerivation rec {
+  name = "taskopen-1.1.4";
+  src = fetchurl {
+    url = "https://github.com/ValiValpas/taskopen/archive/v1.1.4.tar.gz";
+    sha256 = "774dd89f5c92462098dd6227e181268e5ec9930bbc569f25784000df185c71ba";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ which perl ] ++ (with perlPackages; [ JSON ]);
+
+  installPhase = ''
+    # We don't need a DESTDIR and an empty string results in an absolute path
+    # (due to the trailing slash) which breaks the build.
+    sed 's|$(DESTDIR)/||' -i Makefile
+
+    make PREFIX=$out
+    make PREFIX=$out install
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/taskopen \
+         --set PERL5LIB "$PERL5LIB"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Script for taking notes and open urls with taskwarrior";
+    homepage = https://github.com/ValiValpas/taskopen;
+    platforms = platforms.linux;
+    license = stdenv.lib.licenses.free ;
+    maintainers = [ maintainers.winpat ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19995,6 +19995,8 @@ in
 
   taskserver = callPackage ../servers/misc/taskserver { };
 
+  taskopen = callPackage ../applications/misc/taskopen { };
+
   tdesktopPackages = dontRecurseIntoAttrs (callPackage ../applications/networking/instant-messengers/telegram/tdesktop { });
   tdesktop = tdesktopPackages.stable;
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
