### PR TITLE
 lollypop: 1.0.5 -> 1.0.7, other stuff

### DIFF
--- a/pkgs/applications/audio/lollypop/default.nix
+++ b/pkgs/applications/audio/lollypop/default.nix
@@ -5,7 +5,7 @@
 
 python3.pkgs.buildPythonApplication rec  {
   pname = "lollypop";
-  version = "1.0.5";
+  version = "1.0.7";
 
   format = "other";
   doCheck = false;
@@ -14,7 +14,7 @@ python3.pkgs.buildPythonApplication rec  {
     url = "https://gitlab.gnome.org/World/lollypop";
     rev = "refs/tags/${version}";
     fetchSubmodules = true;
-    sha256 = "1p6glzvbbha3cvq462ymbn1q58skclfk469kk28cr1hlsf5x2pry";
+    sha256 = "0gdds4qssn32axsa5janqny5i4426azj5wyj6bzn026zs3z38svn";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/audio/lollypop/default.nix
+++ b/pkgs/applications/audio/lollypop/default.nix
@@ -1,7 +1,23 @@
-{ stdenv, fetchgit, meson, ninja, pkgconfig
-, python3, gtk3, gst_all_1, libsecret, libsoup
-, appstream-glib, desktop-file-utils, totem-pl-parser
-, hicolor-icon-theme, gobject-introspection, wrapGAppsHook }:
+{ lib
+, fetchgit
+, meson
+, ninja
+, pkgconfig
+, python3
+, gtk3
+, gst_all_1
+, libsecret
+, libsoup
+, appstream-glib
+, desktop-file-utils
+, totem-pl-parser
+, hicolor-icon-theme
+, gobject-introspection
+, wrapGAppsHook
+, lastFMSupport ? true
+, wikipediaSupport ? true
+, youtubeSupport ? true, youtube-dl
+}:
 
 python3.pkgs.buildPythonApplication rec  {
   pname = "lollypop";
@@ -37,10 +53,9 @@ python3.pkgs.buildPythonApplication rec  {
     gstreamer
     gtk3
     hicolor-icon-theme
-    libsecret
     libsoup
     totem-pl-parser
-  ];
+  ] ++ lib.optional lastFMSupport libsecret;
 
   propagatedBuildInputs = with python3.pkgs; [
     beautifulsoup4
@@ -49,8 +64,11 @@ python3.pkgs.buildPythonApplication rec  {
     pycairo
     pydbus
     pygobject3
-    pylast
-  ];
+  ]
+  ++ lib.optional lastFMSupport pylast
+  ++ lib.optional wikipediaSupport wikipedia
+  ++ lib.optional youtubeSupport youtube-dl
+  ;
 
   postPatch = ''
     chmod +x meson_post_install.py
@@ -62,7 +80,7 @@ python3.pkgs.buildPythonApplication rec  {
     patchPythonScript "$out/libexec/lollypop-sp"
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A modern music player for GNOME";
     homepage = https://wiki.gnome.org/Apps/Lollypop;
     license = licenses.gpl3Plus;

--- a/pkgs/development/python-modules/wikipedia/default.nix
+++ b/pkgs/development/python-modules/wikipedia/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, beautifulsoup4
+, requests
+, python
+}:
+
+buildPythonPackage rec {
+  pname = "wikipedia";
+  version = "1.4.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "db0fad1829fdd441b1852306e9856398204dc0786d2996dd2e0c8bb8e26133b2";
+  };
+
+  propagatedBuildInputs = [
+    beautifulsoup4
+    requests
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    ${python.interpreter} -m unittest discover tests/ '*test.py'
+
+    runHook postCheck
+  '';
+
+  meta = with lib; {
+    description = "Wikipedia API for Python";
+    homepage = https://github.com/goldsmith/Wikipedia;
+    license = licenses.mit;
+    maintainers = [ maintainers.worldofpeace ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4434,6 +4434,8 @@ in {
 
   wordfreq = callPackage ../development/python-modules/wordfreq { };
 
+  wikipedia = callPackage ../development/python-modules/wikipedia { };
+
   magic-wormhole = callPackage ../development/python-modules/magic-wormhole { };
 
   magic-wormhole-mailbox-server = callPackage ../development/python-modules/magic-wormhole-mailbox-server { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
