### PR TITLE
Fix kernel oops on boot due to bug in i2c driver.

### DIFF
--- a/pkgs/os-specific/linux/kernel/i2c-oops.patch
+++ b/pkgs/os-specific/linux/kernel/i2c-oops.patch
@@ -1,0 +1,14 @@
+diff --git a/drivers/hid/i2c-hid/i2c-hid-dmi-quirks.c b/drivers/hid/i2c-hid/i2c-hid-dmi-quirks.c
+index 1d645c9ab417bf..cac262a912c124 100644
+--- a/drivers/hid/i2c-hid/i2c-hid-dmi-quirks.c
++++ b/drivers/hid/i2c-hid/i2c-hid-dmi-quirks.c
+@@ -337,7 +337,8 @@ static const struct dmi_system_id i2c_hid_dmi_desc_override_table[] = {
+ 			DMI_EXACT_MATCH(DMI_PRODUCT_NAME, "FlexBook edge11 - M-FBE11"),
+ 		},
+ 		.driver_data = (void *)&sipodev_desc
+-	}
++	},
++	{ }	/* Terminate list */
+ };
+ 
+ 

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -57,4 +57,8 @@ rec {
       sha256 = "1l8xq02rd7vakxg52xm9g4zng0ald866rpgm8kjlh88mwwyjkrwv";
     };
   };
+
+  # Fix kernel OOPS on boot: https://github.com/NixOS/nixpkgs/issues/60126
+  # Remove with the next release.
+  i2c-oops = { name = "i2c-oops"; patch = ./i2c-oops.patch; };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14673,6 +14673,7 @@ in
       [ kernelPatches.bridge_stp_helper
         kernelPatches.cpu-cgroup-v2."4.9"
         kernelPatches.modinst_arg_list_too_long
+        kernelPatches.i2c-oops
       ];
   };
 
@@ -14683,6 +14684,7 @@ in
         # when adding a new linux version
         kernelPatches.cpu-cgroup-v2."4.11"
         kernelPatches.modinst_arg_list_too_long
+        kernelPatches.i2c-oops
       ];
   };
 
@@ -14690,6 +14692,7 @@ in
     kernelPatches =
       [ kernelPatches.bridge_stp_helper
         kernelPatches.modinst_arg_list_too_long
+        kernelPatches.i2c-oops
       ];
   };
 


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/issues/60126
https://lkml.org/lkml/2019/4/24/1123

The patch should be removed in the next round of stable releases because the fix should be included.

###### Motivation for this change

Kernel crash on boot, see https://github.com/NixOS/nixpkgs/issues/60126
I have verified that it fixes the issue with kernel 4.19.36. I added the patch for 4.14 and 4.9 as well because they are affected (they have the broken patch applies without the fix), but I only checked the build goes past the patch application.

This is pretty critical. An alternative to merging this would be to rollback the last kernel updates.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
