### PR TITLE
Fix orca and re-add liblouis

### DIFF
--- a/pkgs/applications/misc/orca/default.nix
+++ b/pkgs/applications/misc/orca/default.nix
@@ -38,6 +38,8 @@ buildPythonApplication rec {
     pygobject3 pyatspi dbus-python pyxdg brltty speechd gst-python setproctitle
   ];
 
+  strictDeps = false;
+
   buildInputs = [
     python gtk3 at-spi2-atk at-spi2-core dbus gsettings-desktop-schemas
     gst_all_1.gstreamer gst_all_1.gst-plugins-base gst_all_1.gst-plugins-good

--- a/pkgs/applications/misc/orca/default.nix
+++ b/pkgs/applications/misc/orca/default.nix
@@ -4,7 +4,7 @@
 , python, pygobject3, gtk3, gnome3, substituteAll
 , at-spi2-atk, at-spi2-core, pyatspi, dbus, dbus-python, pyxdg
 , xkbcomp, procps, lsof, coreutils, gsettings-desktop-schemas
-, speechd, brltty, setproctitle, gst_all_1, gst-python
+, speechd, brltty, liblouis, setproctitle, gst_all_1, gst-python
 }:
 
 buildPythonApplication rec {
@@ -34,8 +34,7 @@ buildPythonApplication rec {
   ];
 
   propagatedBuildInputs = [
-    # TODO: re-add liblouis when it is fixed
-    pygobject3 pyatspi dbus-python pyxdg brltty speechd gst-python setproctitle
+    pygobject3 pyatspi dbus-python pyxdg brltty liblouis speechd gst-python setproctitle
   ];
 
   strictDeps = false;


### PR DESCRIPTION
###### Motivation for this change
Orca was broken because of the `gobject-introspection` issue (56943). Adding it to the `propagatedBuildInputs` makes it runnable again. It can't connect to the d-bus but I guess that should work if you have your other braille tools set up properly.

Also `libluois` was removed as a dependency because it had previously been broken - now it works again and we can use it as a dep here :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
