### PR TITLE
mousetweaks: init at 3.32.0

### DIFF
--- a/pkgs/applications/accessibility/mousetweaks/default.nix
+++ b/pkgs/applications/accessibility/mousetweaks/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchurl, pkgconfig
+, glib, gtk3, gnome3, gsettings-desktop-schemas, wrapGAppsHook
+, libX11, libXtst, libXfixes, libXcursor
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mousetweaks";
+  version = "3.32.0";
+
+  src = fetchurl {
+   url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+   sha256 = "005fhmvb45sa9mq17dpa23n1xnspiissx5rnpiy7hiqmy3g5rg8f";
+  };
+
+  nativeBuildInputs = [ pkgconfig wrapGAppsHook ];
+
+  buildInputs = [
+    glib gtk3 gsettings-desktop-schemas
+    libX11 libXtst libXfixes libXcursor
+  ];
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+    };
+  };
+
+  meta = with stdenv.lib; {
+    description = "Provides mouse accessibility enhancements for the GNOME desktop";
+    longDescription = ''
+      Mousetweaks provides mouse accessibility enhancements for the GNOME
+      desktop. These enhancements are:
+
+      - It offers a way to perform the various clicks without using any
+      physical mouse buttons. (Hover Click)
+
+      - It allows users to perform a secondary click by keeping the primary
+      mouse button pressed for a predetermined amount of time. (Simulated
+      Secondary Click)
+
+      The features can be activated and configured through the Universal Access
+      panel of the GNOME Control Center.
+    '';
+    homepage = https://wiki.gnome.org/Projects/Mousetweaks;
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.johnazoidberg ];
+  };
+}

--- a/pkgs/applications/misc/onboard/default.nix
+++ b/pkgs/applications/misc/onboard/default.nix
@@ -1,5 +1,6 @@
 { fetchurl
 , stdenv
+, substituteAll
 , aspellWithDicts
 , at-spi2-core ? null
 , atspiSupport ? true
@@ -16,6 +17,7 @@
 , intltool
 , isocodes
 , libcanberra-gtk3
+, mousetweaks
 , udev
 , libxkbcommon
 , pkgconfig
@@ -38,6 +40,10 @@ in python3.pkgs.buildPythonApplication rec {
   };
 
   patches = [
+    (substituteAll {
+      src = ./fix-paths.patch;
+      inherit mousetweaks;
+    })
     # Allow loading hunspell dictionaries installed in NixOS system path
     ./hunspell-use-xdg-datadirs.patch
   ];
@@ -79,6 +85,7 @@ in python3.pkgs.buildPythonApplication rec {
     hunspell
     isocodes
     libcanberra-gtk3
+    mousetweaks
     udev
     libxkbcommon
     wrapGAppsHook

--- a/pkgs/applications/misc/onboard/fix-paths.patch
+++ b/pkgs/applications/misc/onboard/fix-paths.patch
@@ -1,0 +1,11 @@
+--- a/Onboard/ClickSimulator.py
++++ b/Onboard/ClickSimulator.py
+@@ -479,7 +479,7 @@ class CSMousetweaks(ConfigObject, ClickSimulator):
+         self._daemon_running_notify_callbacks = []
+
+     def _launch_daemon(self, delay):
+-        self.launcher.launch_delayed(["mousetweaks"], delay)
++        self.launcher.launch_delayed(["@mousetweaks@/bin/mousetweaks"], delay)
+
+     def _set_connection(self, active):
+         ''' Update interface object, state and notify listeners '''

--- a/pkgs/desktops/gnome-3/core/gnome-settings-daemon/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-settings-daemon/default.nix
@@ -13,6 +13,7 @@
 , libgnomekbd
 , lcms2
 , libpulseaudio
+, mousetweaks
 , alsaLib
 , libcanberra-gtk3
 , upower
@@ -48,7 +49,7 @@ stdenv.mkDerivation rec {
   patches = [
     (substituteAll {
       src = ./fix-paths.patch;
-      inherit tzdata;
+      inherit tzdata mousetweaks;
     })
   ];
 

--- a/pkgs/desktops/gnome-3/core/gnome-settings-daemon/fix-paths.patch
+++ b/pkgs/desktops/gnome-3/core/gnome-settings-daemon/fix-paths.patch
@@ -13,3 +13,14 @@
  
  typedef struct _TzDB TzDB;
  typedef struct _TzLocation TzLocation;
+--- a/plugins/mouse/gsd-mouse-manager.c
++++ b/plugins/mouse/gsd-mouse-manager.c
+@@ -118,7 +118,7 @@ set_mousetweaks_daemon (GsdMouseManager *manager,
+         gboolean run_daemon = dwell_click_enabled || secondary_click_enabled;
+
+         if (run_daemon || manager->priv->mousetweaks_daemon_running)
+-                comm = g_strdup_printf ("mousetweaks %s",
++                comm = g_strdup_printf ("@mousetweaks@/bin/mousetweaks %s",
+                                         run_daemon ? "" : "-s");
+         else
+                 return;

--- a/pkgs/desktops/pantheon/services/elementary-settings-daemon/default.nix
+++ b/pkgs/desktops/pantheon/services/elementary-settings-daemon/default.nix
@@ -22,6 +22,7 @@
 , libxml2
 , libxslt
 , meson
+, mousetweaks
 , networkmanager
 , ninja
 , nss
@@ -30,12 +31,12 @@
 , pkgconfig
 , polkit
 , python3
+, stdenv
 , substituteAll
 , systemd
 , tzdata
 , upower
 , wrapGAppsHook
-, stdenv
 }:
 
 stdenv.mkDerivation rec {
@@ -63,7 +64,7 @@ stdenv.mkDerivation rec {
   patches = let patchPath = "${src2}/debian/patches"; in [
     (substituteAll {
       src = ./fix-paths.patch;
-      inherit tzdata;
+      inherit tzdata mousetweaks;
     })
     "${patchPath}/45_suppress-printer-may-not-be-connected-notification.patch"
     "${patchPath}/64_restore_terminal_keyboard_shortcut_schema.patch"

--- a/pkgs/desktops/pantheon/services/elementary-settings-daemon/fix-paths.patch
+++ b/pkgs/desktops/pantheon/services/elementary-settings-daemon/fix-paths.patch
@@ -13,3 +13,14 @@
  
  typedef struct _TzDB TzDB;
  typedef struct _TzLocation TzLocation;
+--- a/plugins/mouse/gsd-mouse-manager.c
++++ b/plugins/mouse/gsd-mouse-manager.c
+@@ -118,7 +118,7 @@ set_mousetweaks_daemon (GsdMouseManager *manager,
+         gboolean run_daemon = dwell_click_enabled || secondary_click_enabled;
+
+         if (run_daemon || manager->priv->mousetweaks_daemon_running)
+-                comm = g_strdup_printf ("mousetweaks %s",
++                comm = g_strdup_printf ("@mousetweaks@/bin/mousetweaks %s",
+                                         run_daemon ? "" : "-s");
+         else
+                 return;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1660,6 +1660,10 @@ in
 
   monetdb = callPackage ../servers/sql/monetdb { };
 
+  mousetweaks = callPackage ../applications/accessibility/mousetweaks {
+    inherit (pkgs.xorg) libX11 libXtst libXfixes;
+  };
+
   mp3blaster = callPackage ../applications/audio/mp3blaster { };
 
   mp3fs = callPackage ../tools/filesystems/mp3fs { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
We should have more accessibility programs.

Runs fine but I haven't tested with Gnome so I don't know if it does the
right thing. So I guess it's WIP.
I'd be glad if somebody tried it on Gnome :)

Solves #39509

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
