### PR TITLE
buildPython*: allow overriding strictDeps

### DIFF
--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -33,6 +33,9 @@
 # DEPRECATED: use propagatedBuildInputs
 , pythonPath ? []
 
+# Enabled to detect some (native)BuildInputs mistakes
+, strictDeps ? true
+
 # used to disable derivation, useful for specific python versions
 , disabled ? false
 
@@ -87,8 +90,7 @@ let self = toPythonModule (python.stdenv.mkDerivation (builtins.removeAttrs attr
   # Propagate python and setuptools. We should stop propagating setuptools.
   propagatedBuildInputs = propagatedBuildInputs ++ [ python setuptools ];
 
-  # Enabled to detect some (native)BuildInputs mistakes
-  strictDeps = true;
+  inherit strictDeps;
 
   LANG = "${if python.stdenv.isDarwin then "en_US" else "C"}.UTF-8";
 


### PR DESCRIPTION
###### Motivation for this change
Fixes #59968 

cc @worldofpeace @hedning @FRidh 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
