### PR TITLE
[19.03] torcs: fetch patch from stable source

### DIFF
--- a/pkgs/games/torcs/default.nix
+++ b/pkgs/games/torcs/default.nix
@@ -12,15 +12,15 @@ stdenv.mkDerivation rec {
 
   patches = [
     (fetchpatch {
-      url = "https://anonscm.debian.org/git/pkg-games/torcs.git/plain/debian/patches/gcc6-isnan.patch";
+      url = "https://salsa.debian.org/games-team/torcs/raw/master/debian/patches/gcc6-isnan.patch";
       sha256 = "16scmq30vwb8429ah9d4ws0v1w6ai59lvn7hcgnvfzyap42ry876";
     })
     (fetchpatch {
-      url = "https://anonscm.debian.org/git/pkg-games/torcs.git/plain/debian/patches/format-argument.patch";
+      url = "https://salsa.debian.org/games-team/torcs/raw/master/debian/patches/format-argument.patch";
       sha256 = "04advcx88yh23ww767iysydzhp370x7cqp2wf9hk2y1qvw7mxsja";
     })
     (fetchpatch {
-      url = "https://anonscm.debian.org/git/pkg-games/torcs.git/plain/debian/patches/glibc-default-source.patch";
+      url = "https://salsa.debian.org/games-team/torcs/raw/master/debian/patches/glibc-default-source.patch";
       sha256 = "0k4hgpddnhv68mdc9ics7ah8q54j60g394d7zmcmzg6l3bjd9pyp";
     })
   ];

--- a/pkgs/games/torcs/default.nix
+++ b/pkgs/games/torcs/default.nix
@@ -12,16 +12,20 @@ stdenv.mkDerivation rec {
 
   patches = [
     (fetchpatch {
-      url = "https://salsa.debian.org/games-team/torcs/raw/master/debian/patches/gcc6-isnan.patch";
+      url = "https://salsa.debian.org/games-team/torcs/raw/fb0711c171b38c4648dc7c048249ec20f79eb8e2/debian/patches/gcc6-isnan.patch";
       sha256 = "16scmq30vwb8429ah9d4ws0v1w6ai59lvn7hcgnvfzyap42ry876";
     })
     (fetchpatch {
-      url = "https://salsa.debian.org/games-team/torcs/raw/master/debian/patches/format-argument.patch";
+      url = "https://salsa.debian.org/games-team/torcs/raw/fb0711c171b38c4648dc7c048249ec20f79eb8e2/debian/patches/format-argument.patch";
       sha256 = "04advcx88yh23ww767iysydzhp370x7cqp2wf9hk2y1qvw7mxsja";
     })
     (fetchpatch {
-      url = "https://salsa.debian.org/games-team/torcs/raw/master/debian/patches/glibc-default-source.patch";
+      url = "https://salsa.debian.org/games-team/torcs/raw/fb0711c171b38c4648dc7c048249ec20f79eb8e2/debian/patches/glibc-default-source.patch";
       sha256 = "0k4hgpddnhv68mdc9ics7ah8q54j60g394d7zmcmzg6l3bjd9pyp";
+    })
+    (fetchpatch {
+      url = "https://salsa.debian.org/games-team/torcs/raw/32bbe77c68b4de07b28c34497f3c0ad666ee618d/debian/patches/gcc7.patch";
+      sha256 = "09iilnvdv8h7b4nb1372arszkbz9hbzsck4rimzz1xjdh9ydniw9";
     })
   ];
 
@@ -29,8 +33,9 @@ stdenv.mkDerivation rec {
     sed -i -e s,/bin/bash,`type -P bash`, src/linux/torcs.in
   '';
 
+  nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ libGLU freeglut libX11 plib openal freealut libXrandr xorgproto
-    libXext libSM libICE libXi libXt libXrender libXxf86vm libpng zlib libvorbis makeWrapper ];
+    libXext libSM libICE libXi libXt libXrender libXxf86vm libpng zlib libvorbis ];
 
   installTargets = "install datainstall";
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Backport of #59316 to unbreak Torcs on the release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
