### PR TITLE
grip-0.8: indexed grip

### DIFF
--- a/pkgs/tools/text/grip-search/default.nix
+++ b/pkgs/tools/text/grip-search/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, boost, pkgconfig, cmake, catch2 }:
+
+stdenv.mkDerivation rec {
+  pname = "grip-search";
+  version = "0.8";
+
+  src = fetchFromGitHub {
+    owner = "sc0ty";
+    repo = "grip";
+    rev = "v${version}";
+    sha256 = "0bkqarylgzhis6fpj48qbifcd6a26cgnq8784hgnm707rq9kb0rx";
+  };
+
+  nativeBuildInputs = [ pkgconfig cmake catch2 ];
+
+  doCheck = true;
+
+  buildInputs = [ boost ];
+
+  patchPhase = ''
+    substituteInPlace src/general/config.h --replace "CUSTOM-BUILD" "${version}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Fast, indexed regexp search over large file trees";
+    homepage = "https://github.com/sc0ty/grip";
+    license = licenses.gpl3;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ tex ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17529,6 +17529,8 @@ in
 
   grepm = callPackage ../applications/search/grepm { };
 
+  grip-search = callPackage ../tools/text/grip-search { };
+
   grip = callPackage ../applications/misc/grip {
     inherit (gnome2) libgnome libgnomeui vte;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

New CLI application for indexed grepping. Fast. Useful. Can be cross-compiled for Windows.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
