### PR TITLE
testssl: 2.9.5-7 -> 3.0rc5

### DIFF
--- a/pkgs/applications/networking/testssl/default.nix
+++ b/pkgs/applications/networking/testssl/default.nix
@@ -1,17 +1,15 @@
 { stdenv, fetchFromGitHub, makeWrapper, lib
 , dnsutils, coreutils, openssl, nettools, utillinux, procps }:
 
-let
-  version = "2.9.5-7";
-
-in stdenv.mkDerivation rec {
-  name = "testssl.sh-${version}";
+stdenv.mkDerivation rec {
+  pname = "testssl.sh";
+  version = "2.9.5-8";
 
   src = fetchFromGitHub {
     owner = "drwetter";
     repo = "testssl.sh";
     rev = "v${version}";
-    sha256 = "02xp0yi53xf6jw6v633zs2ws2iyyvq3mlkimg0cv3zvj7nw9x5wr";
+    sha256 = "1fpakzm2gsv8yva58s23lhlgxkkvi3pixil2mjrlkmr0qk66rc32";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -31,12 +29,10 @@ in stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    install -Dt $out/bin testssl.sh
-
-    wrapProgram $out/bin/testssl.sh                                            \
-      --prefix PATH ':' ${lib.makeBinPath buildInputs}
-
+    install -D testssl.sh $out/bin/testssl.sh
     cp -r etc $out
+
+    wrapProgram $out/bin/testssl.sh --prefix PATH ':' ${lib.makeBinPath buildInputs}
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/networking/testssl/default.nix
+++ b/pkgs/applications/networking/testssl/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "testssl.sh";
-  version = "2.9.5-8";
+  version = "3.0rc4";
 
   src = fetchFromGitHub {
     owner = "drwetter";
     repo = "testssl.sh";
-    rev = "v${version}";
-    sha256 = "1fpakzm2gsv8yva58s23lhlgxkkvi3pixil2mjrlkmr0qk66rc32";
+    rev = version;
+    sha256 = "1qmsi3f4977ig8s14my5z2w9gydddanrij78f7jhyr2c8kkip7q7";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/applications/networking/testssl/default.nix
+++ b/pkgs/applications/networking/testssl/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "testssl.sh";
-  version = "3.0rc4";
+  version = "3.0rc5";
 
   src = fetchFromGitHub {
     owner = "drwetter";
-    repo = "testssl.sh";
+    repo = pname;
     rev = version;
-    sha256 = "1qmsi3f4977ig8s14my5z2w9gydddanrij78f7jhyr2c8kkip7q7";
+    sha256 = "14b9n0h4f2dsa292wi9gnan5ncgqblis6wyh5978lhjzi1d7gyds";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -25,7 +25,8 @@ stdenv.mkDerivation rec {
   postPatch = ''
     substituteInPlace testssl.sh                                               \
       --replace /bin/pwd                    pwd                                \
-      --replace TESTSSL_INSTALL_DIR:-\"\"   TESTSSL_INSTALL_DIR:-\"$out\"
+      --replace TESTSSL_INSTALL_DIR:-\"\"   TESTSSL_INSTALL_DIR:-\"$out\"      \
+      --replace PROG_NAME=\"\$\(basename\ \"\$0\"\)\" PROG_NAME=\"testssl.sh\"
   '';
 
   installPhase = ''


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
These updates aren't really in sequence as the numbers would suggest, but I decided to update and clean it up a bit to latest 2.9.5-8 and then to 3.0rc4. 
Changelog: https://github.com/drwetter/testssl.sh/releases/tag/v2.9.5-8
Changelog: https://github.com/drwetter/testssl.sh/releases/tag/3.0rc4

The reasoning for this is that I'm going to backport 2.9.5-8 to stable and then have unstable upgraded to 3.0rc4.

Upstream have stressed for a while that 3.0 is the new supported series but I think our stable can be fine on 2.9.5-8 for the rest of the lifetime.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
