### PR TITLE
xkcd-font: init at 2017-08-24

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -145,6 +145,12 @@ lib.mapAttrs (n: v: v // { shortName = n; }) rec {
     free = false;
   };
 
+  cc-by-nc-30 = spdx {
+    spdxId = "CC-BY-NC-3.0";
+    fullName = "Creative Commons Attribution Non Commercial 3.0 Unported";
+    free = false;
+  };
+
   cc-by-nc-40 = spdx {
     spdxId = "CC-BY-NC-4.0";
     fullName = "Creative Commons Attribution Non Commercial 4.0 International";

--- a/pkgs/data/fonts/xkcd-font/default.nix
+++ b/pkgs/data/fonts/xkcd-font/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "xkcd-font";
+  version = "unstable-2017-08-24";
+
+  src = fetchFromGitHub {
+    owner = "ipython";
+    repo = pname;
+    rev = "5632fde618845dba5c22f14adc7b52bf6c52d46d";
+    sha256 = "01wpfc1yp93b37r472mx2b459il5gywnv5sl7pp9afpycb3i4f6l";
+  };
+
+  phases = [ "unpackPhase" "installPhase" ];
+
+  installPhase = ''
+    install -Dm444 -t $out/share/fonts/opentype/ xkcd/build/xkcd.otf
+    install -Dm444 -t $out/share/fonts/truetype/ xkcd-script/font/xkcd-script.ttf
+  '';
+
+  meta = with stdenv.lib; {
+    description = "The xkcd font";
+    homepage = https://github.com/ipython/xkcd-font;
+    license = licenses.cc-by-nc-30;
+    platforms = platforms.all;
+    maintainers = [ maintainers.marsam ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16413,6 +16413,8 @@ in
 
   xits-math = callPackage ../data/fonts/xits-math { };
 
+  xkcd-font = callPackage ../data/fonts/xkcd-font { };
+
   xkeyboard_config = xorg.xkeyboardconfig;
 
   xlsx2csv = with python3Packages; toPythonApplication xlsx2csv;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add https://github.com/ipython/xkcd-font/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
