### PR TITLE
treewide: Add passthru.updateScript to gnome pkgs

### DIFF
--- a/pkgs/applications/graphics/glabels/default.nix
+++ b/pkgs/applications/graphics/glabels/default.nix
@@ -4,11 +4,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "glabels-${version}";
+  pname = "glabels";
   version = "3.4.1";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/glabels/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "0f2rki8i27pkd9r0gz03cdl1g4vnmvp0j49nhxqn275vi8lmgr0q";
   };
 
@@ -24,6 +24,13 @@ stdenv.mkDerivation rec {
     wrapProgram "$out/bin/glabels-3" \
       --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
   '';
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+      versionPolicy = "none";
+    };
+  };
 
   meta = with stdenv.lib; {
     description = "Create labels and business cards";

--- a/pkgs/applications/graphics/gthumb/default.nix
+++ b/pkgs/applications/graphics/gthumb/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with stdenv.lib; {
-    homepage = https://wiki.gnome.org/Apps/gthumb;
+    homepage = "https://wiki.gnome.org/Apps/Gthumb";
     description = "Image browser and viewer for GNOME";
     platforms = platforms.linux;
     license = licenses.gpl2;

--- a/pkgs/applications/graphics/gthumb/default.nix
+++ b/pkgs/applications/graphics/gthumb/default.nix
@@ -4,14 +4,12 @@
   libchamplain, librsvg, libwebp, json-glib, webkitgtk, lcms2, bison,
   flex, wrapGAppsHook, shared-mime-info }:
 
-let
+stdenv.mkDerivation rec {
   pname = "gthumb";
   version = "3.6.2";
-in stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "0rjb0bsjhn7nyl5jyjgrypvr6qdr9dc2g586j3lzan96a2vnpgy9";
   };
 

--- a/pkgs/applications/misc/fsv/default.nix
+++ b/pkgs/applications/misc/fsv/default.nix
@@ -4,10 +4,10 @@
 
 let
   gtkglarea = stdenv.mkDerivation rec {
-    name    = "gtkglarea-${version}";
+    pname    = "gtkglarea";
     version = "2.1.0";
     src = fetchurl {
-      url    = "mirror://gnome/sources/gtkglarea/2.1/${name}.tar.xz";
+      url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
       sha256 = "1pl2vdj6l64j864ilhkq1bcggb3hrlxjwk5m029i7xfjfxc587lf";
     };
     nativeBuildInputs = [ pkgconfig ];
@@ -16,13 +16,13 @@ let
   };
 
 in stdenv.mkDerivation rec {
-  name    = "fsv-${version}";
+  pname   = "fsv";
   version = "0.9-1";
 
   src = fetchFromGitHub {
     owner  = "mcuelenaere"; 
     repo   = "fsv";
-    rev    = name;
+    rev    = "${pname}-${version}";
     sha256 = "0n09jd7yqj18mx6zqbg7kab4idg5llr15g6avafj74fpg1h7iimj";
   };
 

--- a/pkgs/applications/misc/pdfmod/default.nix
+++ b/pkgs/applications/misc/pdfmod/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
   dontStrip = true;
 
   meta = with stdenv.lib; {
-    homepage = https://wiki.gnome.org/Apps/PdfMod;
+    homepage = "https://wiki.gnome.org/Attic/PdfMod";
     description = "A simple application for modifying PDF documents";
     platforms = platforms.all;
     maintainers = with maintainers; [ obadz ];

--- a/pkgs/applications/misc/pdfmod/default.nix
+++ b/pkgs/applications/misc/pdfmod/default.nix
@@ -4,11 +4,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "pdfmod-${version}";
+  pname = "pdfmod";
   version = "0.9.1";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/pdfmod/0.9/pdfmod-${version}.tar.bz2";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.bz2";
     sha256 = "eb7c987514a053106ddf03f26544766c751c801d87762909b36415d46bc425c9";
   };
 

--- a/pkgs/applications/networking/instant-messengers/ekiga/default.nix
+++ b/pkgs/applications/networking/instant-messengers/ekiga/default.nix
@@ -53,13 +53,6 @@ stdenv.mkDerivation rec {
       --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"
   '';
 
-  meta = with stdenv.lib; {
-    description = "VOIP/Videoconferencing app with full SIP and H.323 support";
-    maintainers = [ maintainers.raskin ];
-    platforms = platforms.linux;
-    license = licenses.gpl2Plus;
-  };
-
   passthru = {
     updateInfo = {
       downloadPage = "mirror://gnome/sources/ekiga";
@@ -67,6 +60,14 @@ stdenv.mkDerivation rec {
     updateScript = gnome3.updateScript {
       packageName = pname;
     };
+  };
+
+  meta = with stdenv.lib; {
+    description = "VOIP/Videoconferencing app with full SIP and H.323 support";
+    homepage = "https://www.ekiga.org/";
+    maintainers = [ maintainers.raskin ];
+    platforms = platforms.linux;
+    license = licenses.gpl2Plus;
   };
 }
 

--- a/pkgs/applications/networking/instant-messengers/ekiga/default.nix
+++ b/pkgs/applications/networking/instant-messengers/ekiga/default.nix
@@ -5,10 +5,11 @@
 , libXrandr, which, libxslt, libtasn1, gmp, nettle, sqlite, makeWrapper }:
 
 stdenv.mkDerivation rec {
-  name = "ekiga-4.0.1";
+  pname = "ekiga";
+  version = "4.0.1";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/ekiga/4.0/${name}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "5f4f491c9496cf65ba057a9345d6bb0278f4eca07bcda5baeecf50bfcd9a4a3b";
   };
 
@@ -62,6 +63,9 @@ stdenv.mkDerivation rec {
   passthru = {
     updateInfo = {
       downloadPage = "mirror://gnome/sources/ekiga";
+    };
+    updateScript = gnome3.updateScript {
+      packageName = pname;
     };
   };
 }

--- a/pkgs/data/documentation/gnome-user-docs/default.nix
+++ b/pkgs/data/documentation/gnome-user-docs/default.nix
@@ -1,12 +1,20 @@
-{ stdenv, fetchurl, itstool, libxml2, gettext }:
+{ stdenv, fetchurl, itstool, libxml2, gettext, gnome3 }:
 
-stdenv.mkDerivation {
-  name = "gnome-user-docs-3.2.2";
+stdenv.mkDerivation rec {
+  pname = "gnome-user-docs";
+  version = "3.2.2";
 
   src = fetchurl {
-    url = mirror://gnome/sources/gnome-user-docs/3.2/gnome-user-docs-3.2.2.tar.xz;
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "1ka0nw2kc85p10y8x31v0wv06a88k7qrgafp4ys04y9fzz0rkcjj";
   };
 
   nativeBuildInputs = [ itstool libxml2 gettext ];
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+      attrPath = "gnome3.gnome-user-docs";
+    };
+  };
 }

--- a/pkgs/data/fonts/ttf-bitstream-vera/default.nix
+++ b/pkgs/data/fonts/ttf-bitstream-vera/default.nix
@@ -1,9 +1,12 @@
-{stdenv, fetchzip}:
+{ stdenv, fetchzip }:
+let
+  pname = "ttf-bitstream-vera";
+  version = "1.10";
+in
+fetchzip rec {
+  name = "${pname}-${version}";
 
-fetchzip {
-  name = "ttf-bitstream-vera-1.10";
-
-  url = mirror://gnome/sources/ttf-bitstream-vera/1.10/ttf-bitstream-vera-1.10.tar.bz2;
+  url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.bz2";
 
   postFetch = ''
     tar -xjf $downloadedFile --strip-components=1

--- a/pkgs/desktops/gnome-3/apps/gnome-nettool/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-nettool/default.nix
@@ -2,10 +2,11 @@
 , libgtop, intltool, itstool, libxml2, nmap, inetutils }:
 
 stdenv.mkDerivation rec {
-  name = "gnome-nettool-3.8.1";
+  pname = "gnome-nettool";
+  version = "3.8.1";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gnome-nettool/3.8/${name}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "1c9cvzvyqgfwa5zzyvp7118pkclji62fkbb33g4y9sp5kw6m397h";
   };
 
@@ -16,6 +17,14 @@ stdenv.mkDerivation rec {
   ];
 
   propagatedUserEnvPkgs = [ nmap inetutils ];
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+      attrPath = "gnom3.gnome-nettool";
+      versionPolicy = "none";
+    };
+  };
 
   meta = with stdenv.lib; {
     homepage = http://projects.gnome.org/gnome-network;

--- a/pkgs/desktops/gnome-3/apps/gnome-nettool/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-nettool/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with stdenv.lib; {
-    homepage = http://projects.gnome.org/gnome-network;
+    homepage = "https://gitlab.gnome.org/GNOME/gnome-nettool";
     description = "A collection of networking tools";
     maintainers = gnome3.maintainers;
     license = licenses.gpl2;

--- a/pkgs/development/compilers/vala/default.nix
+++ b/pkgs/development/compilers/vala/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchurl, fetchpatch, pkgconfig, flex, bison, libxslt, autoconf, automake, autoreconfHook
-, graphviz, glib, libiconv, libintl, libtool, expat, substituteAll
+, graphviz, glib, libiconv, libintl, libtool, expat, substituteAll, gnome3
 }:
 
 let

--- a/pkgs/development/libraries/cairomm/default.nix
+++ b/pkgs/development/libraries/cairomm/default.nix
@@ -1,15 +1,12 @@
 { fetchurl, stdenv, pkgconfig, darwin, cairo, fontconfig, freetype, libsigcxx }:
-let
-  ver_maj = "1.12";
-  ver_min = "2";
-in
 stdenv.mkDerivation rec {
-  name = "cairomm-${ver_maj}.${ver_min}";
+  pname = "cairomm";
+  version = "1.12.2";
 
   src = fetchurl {
-    url = "https://www.cairographics.org/releases/${name}.tar.gz";
+    url = "https://www.cairographics.org/releases/${pname}-${version}.tar.gz";
     # gnome doesn't have the latest version ATM; beware: same name but different hash
-    # url = "mirror://gnome/sources/cairomm/${ver_maj}/${name}.tar.xz";
+    #url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "16fmigxsaz85c3lgcls7biwyz8zy8c8h3jndfm54cxxas3a7zi25";
   };
 

--- a/pkgs/development/libraries/cairomm/default.nix
+++ b/pkgs/development/libraries/cairomm/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
       when available (e.g., through the X Render Extension).
     '';
 
-    homepage = http://cairographics.org/;
+    homepage = "https://www.cairographics.org/";
 
     license = with licenses; [ lgpl2Plus mpl10 ];
     platforms = platforms.unix;

--- a/pkgs/development/libraries/gcab/default.nix
+++ b/pkgs/development/libraries/gcab/default.nix
@@ -1,15 +1,15 @@
 { stdenv, fetchurl, gettext, gobject-introspection, pkgconfig
-, meson, ninja, glibcLocales, git, vala, glib, zlib
+, meson, ninja, glibcLocales, git, vala, glib, zlib, gnome3
 }:
 
 stdenv.mkDerivation rec {
-  name = "gcab-${version}";
+  pname = "gcab";
   version = "1.2";
 
   LC_ALL = "en_US.UTF-8";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gcab/${version}/${name}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "038h5kk41si2hc9d9169rrlvp8xgsxq27kri7hv2vr39gvz9cbas";
   };
 
@@ -22,10 +22,16 @@ stdenv.mkDerivation rec {
     "-Dtests=false"
   ];
 
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+      versionPolicy = "none";
+    };
+  };
+
   meta = with stdenv.lib; {
     platforms = platforms.linux;
     license = licenses.lgpl21;
     maintainers = [ maintainers.lethalman ];
   };
-
 }

--- a/pkgs/development/libraries/gcab/default.nix
+++ b/pkgs/development/libraries/gcab/default.nix
@@ -32,6 +32,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     platforms = platforms.linux;
     license = licenses.lgpl21;
+    homepage = "https://wiki.gnome.org/msitools";
     maintainers = [ maintainers.lethalman ];
   };
 }

--- a/pkgs/development/libraries/gnome-menus/default.nix
+++ b/pkgs/development/libraries/gnome-menus/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, gettext, glib, gobject-introspection }:
+{ stdenv, fetchurl, pkgconfig, gettext, glib, gobject-introspection, gnome3 }:
 
 stdenv.mkDerivation rec {
   pname = "gnome-menus";
@@ -16,6 +16,12 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig gettext ];
   buildInputs = [ glib gobject-introspection ];
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+    };
+  };
 
   meta = {
     homepage = https://www.gnome.org;

--- a/pkgs/development/libraries/gnome-menus/default.nix
+++ b/pkgs/development/libraries/gnome-menus/default.nix
@@ -20,12 +20,14 @@ stdenv.mkDerivation rec {
   passthru = {
     updateScript = gnome3.updateScript {
       packageName = pname;
+      versionPolicy = "none";
     };
   };
 
-  meta = {
-    homepage = https://www.gnome.org;
+  meta = with stdenv.lib; {
+    homepage = "https://gitlab.gnome.org/GNOME/gnome-menus";
     description = "Library that implements freedesktops's Desktop Menu Specification in GNOME";
-    platforms = stdenv.lib.platforms.linux;
+    license = with licenses; [ gpl2 lgpl2 ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/development/libraries/goocanvas/default.nix
+++ b/pkgs/development/libraries/goocanvas/default.nix
@@ -1,17 +1,22 @@
-{ stdenv, fetchurl, gtk2, cairo, glib, pkgconfig }:
+{ stdenv, fetchurl, gtk2, cairo, glib, pkgconfig, gnome3 }:
 
 stdenv.mkDerivation rec {
-  majVersion = "1.0";
-  version = "${majVersion}.0";
-  name = "goocanvas-${version}";
+  pname = "goocanvas";
+  version = "1.0.0";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/goocanvas/${majVersion}/${name}.tar.bz2";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.bz2";
     sha256 = "07kicpcacbqm3inp7zq32ldp95mxx4kfxpaazd0x5jk7hpw2w1qw";
   };
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ gtk2 cairo glib ];
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+    };
+  };
 
   meta = { 
     description = "Canvas widget for GTK+ based on the the Cairo 2D library";

--- a/pkgs/development/libraries/goocanvas/default.nix
+++ b/pkgs/development/libraries/goocanvas/default.nix
@@ -15,13 +15,14 @@ stdenv.mkDerivation rec {
   passthru = {
     updateScript = gnome3.updateScript {
       packageName = pname;
+      versionPolicy = "none";
     };
   };
 
-  meta = { 
+  meta = with stdenv.lib; {
     description = "Canvas widget for GTK+ based on the the Cairo 2D library";
-    homepage = http://goocanvas.sourceforge.net/;
-    license = ["GPL" "LGPL"];
+    homepage = "https://wiki.gnome.org/Projects/GooCanvas";
+    license = licenses.lgpl2;
     platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/development/libraries/gstreamer/gstreamermm/default.nix
+++ b/pkgs/development/libraries/gstreamer/gstreamermm/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "C++ interface for GStreamer";
-    homepage = https://gstreamer.freedesktop.org/bindings/cplusplus.html;
+    homepage = "https://gstreamer.freedesktop.org/bindings/cplusplus.html";
     license = licenses.lgpl21Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ romildo ];

--- a/pkgs/development/libraries/gstreamer/gstreamermm/default.nix
+++ b/pkgs/development/libraries/gstreamer/gstreamermm/default.nix
@@ -1,14 +1,10 @@
-{ stdenv, fetchurl, pkgconfig, file, glibmm, gst_all_1 }:
-
-let
-  ver_maj = "1.10";
-  ver_min = "0";
-in
+{ stdenv, fetchurl, pkgconfig, file, glibmm, gst_all_1, gnome3 }:
 stdenv.mkDerivation rec {
-  name = "gstreamermm-${ver_maj}.${ver_min}";
+  pname = "gstreamermm";
+  version = "1.10.0";
 
   src = fetchurl {
-    url    = "mirror://gnome/sources/gstreamermm/${ver_maj}/${name}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "0q4dx9sncqbwgpzma0zvj6zssc279yl80pn8irb95qypyyggwn5y";
   };
 
@@ -19,6 +15,13 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ glibmm gst_all_1.gst-plugins-base ];
 
   enableParallelBuilding = true;
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+      versionPolicy = "none"; # Unpredictable version stability
+    };
+  };
 
   meta = with stdenv.lib; {
     description = "C++ interface for GStreamer";

--- a/pkgs/development/libraries/hyena/default.nix
+++ b/pkgs/development/libraries/hyena/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   inherit monoDLLFixer;
 
   meta = with stdenv.lib; {
-    homepage = https://wiki.gnome.org/Hyena;
+    homepage = "https://wiki.gnome.org/Attic/Hyena";
     description = "A C# library which contains a hodge-podge of random stuff";
     longDescription = ''
       Hyena is a C# library used to make awesome applications. It contains a lot of random things,

--- a/pkgs/development/libraries/hyena/default.nix
+++ b/pkgs/development/libraries/hyena/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, pkgconfig, mono, gtk-sharp-2_0, monoDLLFixer }:
 
 stdenv.mkDerivation rec {
-  name = "hyena-${version}";
+  pname = "hyena";
   version = "0.5";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/hyena/${version}/hyena-${version}.tar.bz2" ;
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.bz2";
     sha256 = "eb7154a42b6529bb9746c39272719f3168d6363ed4bad305a916ed7d90bc8de9";
   };
 

--- a/pkgs/development/libraries/libgnome-keyring/default.nix
+++ b/pkgs/development/libraries/libgnome-keyring/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl, glib, dbus, libgcrypt, pkgconfig,
-intltool }:
+{ stdenv, fetchurl, glib, dbus, libgcrypt, pkgconfig, intltool }:
 
-stdenv.mkDerivation {
-  name = "libgnome-keyring-2.32.0";
+stdenv.mkDerivation rec {
+  pname = "libgnome-keyring";
+  version = "2.32.0";
 
   src = fetchurl {
-    url = mirror://gnome/sources/libgnome-keyring/2.32/libgnome-keyring-2.32.0.tar.bz2;
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.bz2";
     sha256 = "030gka96kzqg1r19b4xrmac89hf1xj1kr5p461yvbzfxh46qqf2n";
   };
 

--- a/pkgs/development/libraries/libgnome-keyring/default.nix
+++ b/pkgs/development/libraries/libgnome-keyring/default.nix
@@ -16,6 +16,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     inherit (glib.meta) platforms maintainers;
+    homepage = "https://wiki.gnome.org/Projects/GnomeKeyring";
     license = with stdenv.lib.licenses; [ gpl2 lgpl2 ];
   };
 }

--- a/pkgs/development/libraries/libunique/default.nix
+++ b/pkgs/development/libraries/libunique/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = {
-    homepage = https://wiki.gnome.org/Attic/LibUnique;
+    homepage = "https://wiki.gnome.org/Attic/LibUnique";
     description = "A library for writing single instance applications";
     license = stdenv.lib.licenses.lgpl21;
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/development/libraries/libunique/default.nix
+++ b/pkgs/development/libraries/libunique/default.nix
@@ -1,27 +1,28 @@
 { stdenv, fetchurl, pkgconfig, glib, gtk2, dbus-glib }:
 
 stdenv.mkDerivation rec {
-  name = "libunique-1.1.6";
+  pname = "libunique";
+  version = "1.1.6";
+
   src = fetchurl {
-    url = "mirror://gnome/sources/libunique/1.1/${name}.tar.bz2";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.bz2";
     sha256 = "1fsgvmncd9caw552lyfg8swmsd6bh4ijjsph69bwacwfxwf09j75";
   };
 
   NIX_CFLAGS_COMPILE = "-Wno-error=deprecated-declarations";
 
-  # patches from Gentoo portage
+  # Patches from Gentoo portage
   patches = [
     ./1.1.6-compiler-warnings.patch
     ./1.1.6-fix-test.patch
     ./1.1.6-G_CONST_RETURN.patch
     ./1.1.6-include-terminator.patch
-  ]
-    ++ [ ./gcc7-bug.patch ];
+  ] ++ [ ./gcc7-bug.patch ];
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ glib gtk2 dbus-glib ];
 
-  # don't make deprecated usages hard errors
+  # Don't make deprecated usages hard errors
   preBuild = ''substituteInPlace unique/dbus/Makefile --replace -Werror ""'';
 
   doCheck = true;

--- a/pkgs/development/libraries/libwnck/default.nix
+++ b/pkgs/development/libraries/libwnck/default.nix
@@ -1,14 +1,11 @@
 { stdenv, fetchurl, pkgconfig, gtk2, intltool, xorg }:
 
-let
-  ver_maj = "2.31";
-  ver_min = "0";
-in
 stdenv.mkDerivation rec {
-  name = "libwnck-${ver_maj}.${ver_min}";
+  pname = "libwnck";
+  version = "2.31.0";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/libwnck/${ver_maj}/${name}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "17isfjvrzgj5znld2a7zsk9vd39q9wnsysnw5jr8iz410z935xw3";
   };
 

--- a/pkgs/development/libraries/libwnck/default.nix
+++ b/pkgs/development/libraries/libwnck/default.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A library for creating task lists and pagers";
+    homepage = "https://gitlab.gnome.org/GNOME/libwnck";
     license = stdenv.lib.licenses.lgpl21;
+    maintainers = with stdenv.lib.maintainers; [ johnazoidberg ];
   };
 }

--- a/pkgs/development/libraries/libxmlxx/default.nix
+++ b/pkgs/development/libraries/libxmlxx/default.nix
@@ -1,12 +1,11 @@
-{ stdenv, fetchurl, pkgconfig, libxml2, glibmm, perl }:
+{ stdenv, fetchurl, pkgconfig, libxml2, glibmm, perl, gnome3 }:
 
 stdenv.mkDerivation rec {
-  name = "libxml++-${maj_ver}.${min_ver}";
-  maj_ver = "2.40";
-  min_ver = "1";
+  pname = "libxml++";
+  version = "2.40.1";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/libxml++/${maj_ver}/${name}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "1sb3akryklvh2v6m6dihdnbpf1lkx441v972q9hlz1sq6bfspm2a";
   };
 
@@ -15,6 +14,12 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ pkgconfig perl ];
 
   propagatedBuildInputs = [ libxml2 glibmm ];
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+    };
+  };
 
   meta = with stdenv.lib; {
     homepage = http://libxmlplusplus.sourceforge.net/;

--- a/pkgs/development/libraries/libxmlxx/default.nix
+++ b/pkgs/development/libraries/libxmlxx/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with stdenv.lib; {
-    homepage = http://libxmlplusplus.sourceforge.net/;
+    homepage = "http://libxmlplusplus.sourceforge.net/";
     description = "C++ wrapper for the libxml2 XML parser library";
     license = licenses.lgpl2Plus;
     platforms = platforms.unix;

--- a/pkgs/development/libraries/opal/default.nix
+++ b/pkgs/development/libraries/opal/default.nix
@@ -1,11 +1,12 @@
-{ stdenv, fetchurl, pkgconfig, ptlib, srtp, libtheora, speex
+{ stdenv, fetchurl, pkgconfig, ptlib, srtp, libtheora, speex, gnome3
 , ffmpeg, x264, cyrus_sasl, openldap, openssl, expat, unixODBC }:
 
 stdenv.mkDerivation rec {
-  name = "opal-3.10.10";
+  pname = "opal";
+  version = "3.10.10";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/opal/3.10/${name}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "f208985003461b2743575eccac13ad890b3e5baac35b68ddef17162460aff864";
   };
 
@@ -32,6 +33,9 @@ stdenv.mkDerivation rec {
   passthru = {
     updateInfo = {
       downloadPage = "http://ftp.gnome.org/pub/GNOME/sources/opal";
+    };
+    updateScript = gnome3.updateScript {
+      packageName = pname;
     };
   };
 }

--- a/pkgs/development/libraries/opal/default.nix
+++ b/pkgs/development/libraries/opal/default.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
     description = "VoIP library";
     maintainers = [ maintainers.raskin ];
     platforms = platforms.linux;
+    homepage = "http://www.opalvoip.org/";
     license = with licenses; [ bsdOriginal mpl10 gpl2Plus lgpl21 ];
   };
 

--- a/pkgs/development/libraries/pangox-compat/default.nix
+++ b/pkgs/development/libraries/pangox-compat/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A compatibility library for pango>1.30.*";
-    homepage = https://www.pango.org/;
+    homepage = "https://gitlab.gnome.org/Archive/pangox-compat";
     license = stdenv.lib.licenses.lgpl2Plus;
     platforms = stdenv.lib.platforms.unix;
   };

--- a/pkgs/development/libraries/pangox-compat/default.nix
+++ b/pkgs/development/libraries/pangox-compat/default.nix
@@ -1,10 +1,11 @@
 { stdenv, fetchurl, pkgconfig, glib, pango, libX11 }:
 
 stdenv.mkDerivation rec {
-  name = "pangox-compat-0.0.2";
+  pname = "pangox-compat";
+  version = "0.0.2";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/pangox-compat/0.0/${name}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "0ip0ziys6mrqqmz4n71ays0kf5cs1xflj1gfpvs4fgy2nsrr482m";
   };
 
@@ -13,7 +14,6 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A compatibility library for pango>1.30.*";
-
     homepage = https://www.pango.org/;
     license = stdenv.lib.licenses.lgpl2Plus;
     platforms = stdenv.lib.platforms.unix;

--- a/pkgs/development/libraries/ptlib/default.nix
+++ b/pkgs/development/libraries/ptlib/default.nix
@@ -1,11 +1,12 @@
-{ stdenv, fetchurl, fetchpatch, pkgconfig, bison, flex, unixODBC
+{ stdenv, fetchurl, fetchpatch, pkgconfig, bison, flex, unixODBC, gnome3
 , openssl, openldap, cyrus_sasl, kerberos, expat, SDL, libdv, libv4l, alsaLib }:
 
 stdenv.mkDerivation rec {
-  name = "ptlib-2.10.11";
+  pname = "ptlib";
+  version = "2.10.11";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/ptlib/2.10/${name}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "1jf27mjz8vqnclhrhrpn7niz4c177kcjbd1hc7vn65ihcqfz05rs";
   };
 
@@ -44,6 +45,9 @@ stdenv.mkDerivation rec {
   passthru = {
     updateInfo = {
       downloadPage = "http://ftp.gnome.org/sources/ptlib/";
+    };
+    updateScript = gnome3.updateScript {
+      packageName = pname;
     };
   };
 }

--- a/pkgs/development/libraries/ptlib/default.nix
+++ b/pkgs/development/libraries/ptlib/default.nix
@@ -38,6 +38,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Portable Tools from OPAL VoIP";
     maintainers = [ maintainers.raskin ];
+    homepage = "http://www.opalvoip.org/";
     platforms = platforms.linux;
     license = with licenses; [ beerware bsdOriginal mpl10 ];
   };

--- a/pkgs/development/python-modules/pygtk/default.nix
+++ b/pkgs/development/python-modules/pygtk/default.nix
@@ -4,18 +4,16 @@
 buildPythonPackage rec {
   pname = "pygtk";
   version = "2.24.0";
-  name = pname + "-" + version;
 
   disabled = isPy3k;
 
   src = fetchurl {
-    url = "mirror://gnome/sources/pygtk/2.24/${name}.tar.bz2";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.bz2";
     sha256 = "04k942gn8vl95kwf0qskkv6npclfm31d78ljkrkgyqxxcni1w76d";
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ ]
-    ++ stdenv.lib.optional (libglade != null) libglade;
+  buildInputs = stdenv.lib.optional (libglade != null) libglade;
 
   propagatedBuildInputs = [ gtk2 pygobject2 pycairo ];
 
@@ -50,6 +48,13 @@ buildPythonPackage rec {
     rm $out/bin/pygtk-codegen-2.0
     ln -s ${pygobject2}/bin/pygobject-codegen-2.0  $out/bin/pygtk-codegen-2.0
     ln -s ${pygobject2}/lib/${python.libPrefix}/site-packages/pygobject-${pygobject2.version}.pth \
-                  $out/lib/${python.libPrefix}/site-packages/${name}.pth
+                  $out/lib/${python.libPrefix}/site-packages/${pname}-${version}.pth
   '';
+
+  meta = with stdenv.lib; {
+    description = "GTK+-2 bindings";
+    homepage = "https://gitlab.gnome.org/Archive/pygtk";
+    platforms = platforms.all;
+    license = with licenses; [ lgpl21Plus ];
+  };
 }

--- a/pkgs/development/tools/documentation/gnome-doc-utils/default.nix
+++ b/pkgs/development/tools/documentation/gnome-doc-utils/default.nix
@@ -30,8 +30,8 @@ python2Packages.buildPythonApplication rec {
   };
 
   meta = with stdenv.lib; {
-    description = "Collection of documentation utilities for the Gnome project";
-    homepage = https://gitlab.gnome.org/GNOME/gnome-doc-utils;
+    description = "Collection of documentation utilities for the GNOME project";
+    homepage = "https://gitlab.gnome.org/GNOME/gnome-doc-utils";
     license = with licenses; [ gpl2Plus lgpl2Plus ];
     platforms = platforms.all;
   };

--- a/pkgs/development/tools/documentation/gnome-doc-utils/default.nix
+++ b/pkgs/development/tools/documentation/gnome-doc-utils/default.nix
@@ -1,12 +1,14 @@
-{fetchurl, pkgconfig, libxml2Python, libxslt, intltool
+{ stdenv, fetchurl, pkgconfig, libxml2Python, libxslt, intltool, gnome3
 , python2Packages }:
 
-python2Packages.buildPythonApplication {
-  name = "gnome-doc-utils-0.20.10";
+python2Packages.buildPythonApplication rec {
+  pname = "gnome-doc-utils";
+  version = "0.20.10";
+
   format = "other";
 
   src = fetchurl {
-    url = mirror://gnome/sources/gnome-doc-utils/0.20/gnome-doc-utils-0.20.10.tar.xz;
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "19n4x25ndzngaciiyd8dd6s2mf9gv6nv3wv27ggns2smm7zkj1nb";
   };
 
@@ -20,4 +22,17 @@ python2Packages.buildPythonApplication {
   '';
 
   propagatedBuildInputs = [ libxml2Python ];
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+    };
+  };
+
+  meta = with stdenv.lib; {
+    description = "Collection of documentation utilities for the Gnome project";
+    homepage = https://gitlab.gnome.org/GNOME/gnome-doc-utils;
+    license = with licenses; [ gpl2Plus lgpl2Plus ];
+    platforms = platforms.all;
+  };
 }

--- a/pkgs/development/tools/documentation/gtk-doc/default.nix
+++ b/pkgs/development/tools/documentation/gtk-doc/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchurl, autoreconfHook, pkgconfig, perl, python3, libxml2Python, libxslt, which
-, docbook_xml_dtd_43, docbook_xsl, gnome-doc-utils, gettext, itstool
+, docbook_xml_dtd_43, docbook_xsl, gnome-doc-utils, gettext, itstool, gnome3
 , withDblatex ? false, dblatex
 }:
 
 stdenv.mkDerivation rec {
-  name = "gtk-doc-${version}";
+  pname = "gtk-doc";
   version = "1.30";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gtk-doc/${version}/${name}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "17h6nwhis66z4dxjrc833wvfl6pqjp81yfx3fq6x7k1qp2749xm4";
   };
 
@@ -38,6 +38,10 @@ stdenv.mkDerivation rec {
   passthru = {
     # Consumers are expected to copy the m4 files to their source tree, let them reuse the patch
     respect_xml_catalog_files_var_patch = ./respect-xml-catalog-files-var.patch;
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+      versionPolicy = "none";
+    };
   };
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/documentation/gtk-doc/default.nix
+++ b/pkgs/development/tools/documentation/gtk-doc/default.nix
@@ -45,8 +45,8 @@ stdenv.mkDerivation rec {
   };
 
   meta = with stdenv.lib; {
-    homepage = https://www.gtk.org/gtk-doc;
     description = "Tools to extract documentation embedded in GTK+ and GNOME source code";
+    homepage = "https://www.gtk.org/gtk-doc";
     license = licenses.gpl2;
     maintainers = with maintainers; [ pSub ];
   };

--- a/pkgs/development/tools/misc/gob2/default.nix
+++ b/pkgs/development/tools/misc/gob2/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Preprocessor for making GObjects with inline C code";
-    homepage = https://www.jirka.org/gob.html;
+    homepage = "https://www.jirka.org/gob.html";
     license = stdenv.lib.licenses.gpl2Plus;
     platforms = stdenv.lib.platforms.unix;
   };

--- a/pkgs/development/tools/misc/gob2/default.nix
+++ b/pkgs/development/tools/misc/gob2/default.nix
@@ -1,17 +1,24 @@
-{ stdenv, fetchurl, pkgconfig, glib, bison, flex }:
+{ stdenv, fetchurl, pkgconfig, glib, bison, flex, gnome3 }:
 
 stdenv.mkDerivation rec {
-  name = "gob2-${minVer}.20";
-  minVer = "2.0";
+  pname = "gob2";
+  version = "2.0.20";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gob2/${minVer}/${name}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "5fe5d7990fd65b0d4b617ba894408ebaa6df453f2781c15a1cfdf2956c0c5428";
   };
 
   # configure script looks for d-bus but it is only needed for tests
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ glib bison flex ];
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+      versionPolicy = "none";
+    };
+  };
 
   meta = {
     description = "Preprocessor for making GObjects with inline C code";

--- a/pkgs/development/tools/misc/msitools/default.nix
+++ b/pkgs/development/tools/misc/msitools/default.nix
@@ -1,16 +1,22 @@
-{ stdenv, fetchurl, intltool, glib, pkgconfig, libgsf, libuuid, gcab, bzip2 }:
+{ stdenv, fetchurl, intltool, glib, pkgconfig, libgsf, libuuid, gcab, bzip2, gnome3 }:
 
 stdenv.mkDerivation rec {
+  pname = "msitools";
   version = "0.98";
-  name = "msitools-${version}";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/msitools/${version}/${name}.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "19wb3n3nwkpc6bjr0q3f1znaxsfaqgjbdxxnbx8ic8bb5b49hwac";
   };
 
   nativeBuildInputs = [ intltool pkgconfig ];
   buildInputs = [ glib libgsf libuuid gcab bzip2 ];
+
+  passthru = {
+    updateScript = gnome3.updateScript {
+      packageName = pname;
+    };
+  };
 
   meta = with stdenv.lib; {
     description = "Set of programs to inspect and build Windows Installer (.MSI) files";

--- a/pkgs/misc/themes/gtk2/gtk-engine-murrine/default.nix
+++ b/pkgs/misc/themes/gtk2/gtk-engine-murrine/default.nix
@@ -14,6 +14,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A very flexible theme engine";
+    homepage = "https://gitlab.gnome.org/Archive/murrine";
     license = stdenv.lib.licenses.lgpl3;
     platforms = stdenv.lib.platforms.linux;
   };

--- a/pkgs/misc/themes/gtk2/gtk-engine-murrine/default.nix
+++ b/pkgs/misc/themes/gtk2/gtk-engine-murrine/default.nix
@@ -1,10 +1,11 @@
 { stdenv, fetchurl, pkgconfig, intltool, gtk2 }:
 
-stdenv.mkDerivation {
-  name = "gtk-engine-murrine-0.98.2";
+stdenv.mkDerivation rec {
+  pname = "gtk-engine-murrine";
+  version = "0.98.2";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/murrine/0.98/murrine-0.98.2.tar.xz";
+    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "129cs5bqw23i76h3nmc29c9mqkm9460iwc8vkl7hs4xr07h8mip9";
   };
 

--- a/pkgs/tools/security/polkit-gnome/default.nix
+++ b/pkgs/tools/security/polkit-gnome/default.nix
@@ -1,13 +1,10 @@
 { stdenv, fetchurl, polkit, gtk3, pkgconfig, intltool }:
-
-let
+stdenv.mkDerivation rec {
+  pname = "polkit-gnome";
   version = "0.105";
 
-in stdenv.mkDerivation rec {
-  name = "polkit-gnome-${version}";
-
   src = fetchurl {
-    url = "mirror://gnome/sources/polkit-gnome/${version}/${name}.tar.xz";
+    url = "mirror://gnome/sources/polkit-gnome/${version}/${pname}-${version}.tar.xz";
     sha256 = "0sckmcbxyj6sbrnfc5p5lnw27ccghsid6v6wxq09mgxqcd4lk10p";
   };
 
@@ -20,7 +17,7 @@ in stdenv.mkDerivation rec {
   postInstall = ''
     mkdir -p $out/etc/xdg/autostart
     substituteAll ${./polkit-gnome-authentication-agent-1.desktop} $out/etc/xdg/autostart/polkit-gnome-authentication-agent-1.desktop
-    '';
+  '';
 
   meta = {
     homepage = https://hal.freedesktop.org/docs/PolicyKit/;

--- a/pkgs/tools/security/polkit-gnome/default.nix
+++ b/pkgs/tools/security/polkit-gnome/default.nix
@@ -20,9 +20,9 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    homepage = https://hal.freedesktop.org/docs/PolicyKit/;
+    homepage = "https://gitlab.gnome.org/Archive/policykit-gnome";
     description = "A dbus session bus service that is used to bring up authentication dialogs";
-    license = stdenv.lib.licenses.gpl2;
+    license = stdenv.lib.licenses.lgpl2Plus;
     maintainers = with stdenv.lib.maintainers; [ phreedom ];
     platforms = stdenv.lib.platforms.linux;
   };


### PR DESCRIPTION
###### Motivation for this change
For packages that are hosted on the gnome mirror it's very easy.
Inspired by https://github.com/NixOS/nixpkgs/issues/36150

I changed some source URLs but they should be equivalent to the original.

Changed some derivations to use `pname` instead of `name` so that causes many package rebuilds :/

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
