### PR TITLE
neo.map: fix URL

### DIFF
--- a/pkgs/os-specific/linux/kbd/keymaps.nix
+++ b/pkgs/os-specific/linux/kbd/keymaps.nix
@@ -24,7 +24,8 @@
 
     src = fetchurl {
       name = "neo.map";
-      url = "https://svn.neo-layout.org/linux/console/neo.map?r=${version}";
+      url = "https://raw.githubusercontent.com/neo-layout/neo-layout/"
+          + "a0dee06fed824abfad658b7f10e6d907b270be0a/linux/console/neo.map";
       sha256 = "19mfrd31vzpsjiwc7pshxm0b0sz5dd17xrz6k079cy4im1vf0r4g";
     };
 


### PR DESCRIPTION
###### Motivation for this change
Current URL is no longer available, due to the migration from svn to github.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
