### PR TITLE
rmount: init at 1.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2673,11 +2673,6 @@
     github = "lejonet";
     name = "Daniel Kuehn";
   };
-  luis = {
-      email = "luis.nixos@gmail.com";
-      github = "Luis-Hebendanz";
-      name = "Luis Hebendanz";
-  };
   leo60228 = {
     email = "iakornfeld@gmail.com";
     github = "leo60228";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2673,6 +2673,11 @@
     github = "lejonet";
     name = "Daniel Kuehn";
   };
+  luis = {
+      email = "luis.nixos@gmail.com";
+      github = "Luis-Hebendanz";
+      name = "Luis Hebendanz";
+  };
   leo60228 = {
     email = "iakornfeld@gmail.com";
     github = "leo60228";

--- a/pkgs/tools/filesystems/rmount/default.nix
+++ b/pkgs/tools/filesystems/rmount/default.nix
@@ -4,33 +4,29 @@ stdenv.mkDerivation rec {
 
   pname   = "rmount";
   version = "1.0.1";
-  name    = "rmount-${version}";
 
   src = fetchFromGitHub rec {
     rev = "v${version}";
-    owner="Luis-Hebendanz";
-    repo="rmount";
+    owner = "Luis-Hebendanz";
+    repo = "rmount";
     sha256 = "1wjmfvbsq3126z51f2ivj85cjmkrzdm2acqsiyqs57qga2g6w5p9";
   };
 
   buildInputs = [ makeWrapper ];
 
   installPhase = ''
-    mkdir -p $out/bin
-    mkdir -p $out/share/man/man1
-    cp ${src}/rmount.man $out/share/man/man1/rmount.1
-    cp ${src}/rmount.bash $out/bin/rmount
-    cp ${src}/config.json $out/share/config.json
-    chmod +x $out/bin/rmount
+    install -D ${src}/rmount.man  $out/share/man/man1/rmount.1
+    install -D ${src}/rmount.bash $out/bin/rmount
+    install -D ${src}/config.json $out/share/config.json
 
     wrapProgram $out/bin/rmount --prefix PATH : ${stdenv.lib.makeBinPath [ nmap jq cifs-utils sshfs ]}
   '';
 
-  meta = {
-      homepage = "https://github.com/Luis-Hebendanz/rmount";
-      description = "Remote mount utility which parses a json file";
-      license = stdenv.lib.licenses.mit;
-      maintainers = [ stdenv.lib.maintainers.luis ];
-      platforms = stdenv.lib.platforms.linux;
-    };
+  meta = with stdenv.lib; {
+    homepage = https://github.com/Luis-Hebendanz/rmount;
+    description = "Remote mount utility which parses a json file";
+    license = licenses.mit;
+    maintainers = [ maintainers.luis ];
+    platforms = platforms.linux;
+  };
 }

--- a/pkgs/tools/filesystems/rmount/default.nix
+++ b/pkgs/tools/filesystems/rmount/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, nmap, jq, cifs-utils, sshfs, fetchFromGitHub, makeWrapper }:
+
+stdenv.mkDerivation rec {
+
+  pname   = "rmount";
+  version = "1.0.1";
+  name    = "rmount-${version}";
+
+  src = fetchFromGitHub rec {
+    rev = "v${version}";
+    owner="Luis-Hebendanz";
+    repo="rmount";
+    sha256 = "1wjmfvbsq3126z51f2ivj85cjmkrzdm2acqsiyqs57qga2g6w5p9";
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/man/man1
+    cp ${src}/rmount.man $out/share/man/man1/rmount.1
+    cp ${src}/rmount.bash $out/bin/rmount
+    cp ${src}/config.json $out/share/config.json
+    chmod +x $out/bin/rmount
+
+    wrapProgram $out/bin/rmount --prefix PATH : ${stdenv.lib.makeBinPath [ nmap jq cifs-utils sshfs ]}
+  '';
+
+  meta = {
+      homepage = "https://github.com/Luis-Hebendanz/rmount";
+      description = "Remote mount utility which parses a json file";
+      license = stdenv.lib.licenses.mit;
+      maintainers = [ stdenv.lib.maintainers.luis ];
+      platforms = stdenv.lib.platforms.linux;
+    };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23280,6 +23280,8 @@ in
 
   ricty = callPackage ../data/fonts/ricty { };
 
+  rmount = callPackage ../tools/filesystems/rmount {};
+
   rss-glx = callPackage ../misc/screensavers/rss-glx { };
 
   run-scaled = callPackage ../tools/X11/run-scaled { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
-  [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

