### PR TITLE
ledmon: init at 0.92

### DIFF
--- a/pkgs/tools/system/ledmon/default.nix
+++ b/pkgs/tools/system/ledmon/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, udev, sg3_utils }:
+
+stdenv.mkDerivation rec {
+  pname = "ledmon";
+  version = "0.92";
+
+  src = fetchFromGitHub {
+    owner = "intel";
+    repo = "ledmon";
+    rev = "v${version}";
+    sha256 = "1lz59606vf2sws5xwijxyffm8kxcf8p9qbdpczsq1b5mm3dk6lvp";
+  };
+
+  buildInputs = [ udev sg3_utils ];
+
+  installTargets = [ "install" "install-systemd" ];
+
+  makeFlags = [
+    "MAN_INSTDIR=${placeholder "out"}/share/man"
+    "SYSTEMD_SERVICE_INSTDIR=${placeholder "out"}/lib/systemd/system"
+    "LEDCTL_INSTDIR=${placeholder "out"}/sbin"
+    "LEDMON_INSTDIR=${placeholder "out"}/sbin"
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/intel/ledmon;
+    description = "Enclosure LED Utilities";
+    platforms = platforms.linux;
+    license = with licenses; [ gpl2 ];
+    maintainers = with stdenv.lib.maintainers; [ sorki ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4120,6 +4120,8 @@ in
 
   leatherman = callPackage ../development/libraries/leatherman { };
 
+  ledmon = callPackage ../tools/system/ledmon { };
+
   leela = callPackage ../tools/graphics/leela { };
 
   lftp = callPackage ../tools/networking/lftp { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

New package

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
