### PR TITLE
jetbrains-jdk: 8.202b1483.37 -> 11.0.2b164

### DIFF
--- a/pkgs/development/compilers/jetbrains-jdk/default.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/default.nix
@@ -1,19 +1,19 @@
 { stdenv, lib, fetchurl, file, glib, libxml2, libav_0_8, ffmpeg, libxslt
 , libGL , xorg, alsaLib, fontconfig, freetype, pango, gtk2, cairo
-, gdk_pixbuf, atk }:
+, gdk_pixbuf, atk, zlib }:
 
 # TODO: Investigate building from source instead of patching binaries.
 # TODO: Binary patching for not just x86_64-linux but also x86_64-darwin i686-linux
 
 let drv = stdenv.mkDerivation rec {
   pname = "jetbrainsjdk";
-  version = "202b1483.37";
+  version = "164";
   name = pname + "-" + version;
 
   src = if stdenv.hostPlatform.system == "x86_64-linux" then
     fetchurl {
-      url = "https://bintray.com/jetbrains/intellij-jdk/download_file?file_path=jbrsdk8u${version}_linux_x64.tar.gz";
-      sha256 = "12l81g8zhaymh4rzyfl9nyzmpkgzc7wrphm3j4plxx129yn9i7d7";
+      url = "https://bintray.com/jetbrains/intellij-jdk/download_file?file_path=jbrsdk-11_0_2-linux-x64-b${version}.tar.gz";
+      sha256 = "121yzgvkfx7lq0k9s8wjnhz09a564br5y7zlkxgh191sbm2i7zdi";
     }
   else
     throw "unsupported system: ${stdenv.hostPlatform.system}";
@@ -29,16 +29,7 @@ let drv = stdenv.mkDerivation rec {
     jrePath=$out/jre
   '';
 
-  postFixup = let
-    arch = "amd64";
-    rSubPaths = [
-      "lib/${arch}/jli"
-      "lib/${arch}/server"
-      "lib/${arch}/xawt"
-      "lib/${arch}"
-    ];
-    in ''
-    rpath+="''${rpath:+:}${stdenv.lib.concatStringsSep ":" (map (a: "$jrePath/${a}") rSubPaths)}"
+  postFixup = ''
     find $out -type f -perm -0100 \
         -exec patchelf --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
         --set-rpath "$rpath" {} \;
@@ -47,10 +38,11 @@ let drv = stdenv.mkDerivation rec {
 
   rpath = lib.makeLibraryPath ([
     stdenv.cc.cc stdenv.cc.libc glib libxml2 libav_0_8 ffmpeg libxslt libGL
-    alsaLib fontconfig freetype pango gtk2 cairo gdk_pixbuf atk
+    alsaLib fontconfig freetype pango gtk2 cairo gdk_pixbuf atk zlib
+    (placeholder "out")
   ] ++ (with xorg; [
     libX11 libXext libXtst libXi libXp libXt libXrender libXxf86vm
-  ]));
+  ])) + ":${placeholder "out"}/lib/jli";
 
   passthru.home = drv;
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fancy Java 11 stuff. I haven't tested this exhaustively, but PHPStorm does run with this.

cc @calbrecht 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
