### PR TITLE
gnome3.mutter328: backport changes from 3.32

### DIFF
--- a/pkgs/desktops/gnome-3/core/mutter/3.28.nix
+++ b/pkgs/desktops/gnome-3/core/mutter/3.28.nix
@@ -1,5 +1,5 @@
 { fetchFromGitLab, stdenv, substituteAll, pkgconfig, gnome3, intltool, gobject-introspection, upower, cairo
-, glib, gtk3, pango, cogl, clutter, libstartup_notification, zenity, libcanberra-gtk3
+, glib, gtk3, pango, cogl, clutter, libstartup_notification, zenity, libcanberra-gtk3, fetchpatch
 , gsettings-desktop-schemas, gnome-desktop, wrapGAppsHook
 , libtool, makeWrapper, xkeyboard_config, libxkbfile, libxkbcommon, libXtst, libinput
 , geocode-glib, libgudev, libwacom, xwayland, autoreconfHook }:
@@ -20,6 +20,33 @@ stdenv.mkDerivation rec {
     (substituteAll {
       src = ./fix-paths-328.patch;
       inherit zenity;
+    })
+
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1700337
+    # https://gitlab.gnome.org/GNOME/mutter/merge_requests/133
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/mutter328/raw/fff28bebda02111b4c534952465ff967ba7efced/f/0070-clutter-Add-API-to-retrieve-the-physical-size-of-abs.patch";
+      sha256 = "11xg0clrqwvssy2r6hv4iya8g87z2v5f47fimd2b4hha6ki3g1is";
+    })
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/mutter328/raw/fff28bebda02111b4c534952465ff967ba7efced/f/0071-backends-Add-MetaInputMapper.patch";
+      sha256 = "1kcp42hg8sy1q21w5586gdgmi95nf36829kkfswbah61h6bkb518";
+    })
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/mutter328/raw/fff28bebda02111b4c534952465ff967ba7efced/f/0072-backends-Delegate-on-MetaInputMapper-for-unmapped-di.patch";
+      sha256 = "0zf4yxhq5s3dnzmn15mx4yb978g27ij4vmq055my9p7xgh6h9ga8";
+    })
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/mutter328/raw/fff28bebda02111b4c534952465ff967ba7efced/f/0073-backends-Add-MetaInputMapper-method-to-lookup-device.patch";
+      sha256 = "0dnb2hqx5in6x9ar6wnr1hy3bg2wdcl3wbdx4jn66c7bi7s1k5zd";
+    })
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/mutter328/raw/fff28bebda02111b4c534952465ff967ba7efced/f/0074-backends-Turn-builtin-touchscreen-on-off-together-wi.patch";
+      sha256 = "17fvs7j5ws4sz6fkch93gjlik0nm4z426w4n348gyw5llh0r76pg";
+    })
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/mutter328/raw/fff28bebda02111b4c534952465ff967ba7efced/f/0075-backends-Update-to-new-output-setting-for-tablets-to.patch";
+      sha256 = "141p3an83s042f67fw2fqmr79i5g634ndrbpd8cs47fd4wwiwpj5";
     })
   ];
 


### PR DESCRIPTION
gsettings-desktop-schemas made the following change in 3.32[0]
> Change tablets'/touchscreens' "display" setting to "output" one
> with different semantics.

That coincides with GNOME/mutter#133[1]

This caused a segmentation fault in gala on Fedora[2]
> Settings schema 'org.gnome.desktop.peripherals.touchscreen'
> does not contain a key named 'display'

I haven't experienced said segfault here in NixOS but I don't see
a reason not to use the solution reached there, which was to backport
relevant change[1] to mutter 3.28.

[0]: https://gitlab.gnome.org/GNOME/gsettings-desktop-schemas/commit/c7eee129c6edbc1a5b121fa3327d83049325becb
[1]: https://gitlab.gnome.org/GNOME/mutter/merge_requests/133
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=1700337

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
