### PR TITLE
lorri: init at 2019-04-24

### DIFF
--- a/pkgs/tools/misc/lorri/default.nix
+++ b/pkgs/tools/misc/lorri/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, rustPlatform, CoreServices, Security, cf-private }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "lorri";
+  version = "unstable-2019-04-24";
+
+  src = fetchFromGitHub {
+    owner = "target";
+    repo = pname;
+    rev = "71983296d121a8bc1af7dbeec78b7aa6dacf1e46";
+    sha256 = "0lkv4h1z04dfy30mckh8ni613jb8f045nzgy2ap6g49x456zipay";
+  };
+
+  BUILD_REV_COUNT = 1;
+
+  buildInputs = stdenv.lib.optionals stdenv.isDarwin [ CoreServices Security cf-private /* for _CFURLResourceIsReachable */ ];
+
+  cargoSha256 = "0lx4r05hf3snby5mky7drbnp006dzsg9ypsi4ni5wfl0hffx3a8g";
+
+  # too complicated to setup, but Travis ensures a proper build
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Your project's nix-env";
+    homepage = https://github.com/target/lorri;
+    license = licenses.asl20;
+    maintainers = [ maintainers.marsam ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1626,6 +1626,11 @@ in
 
   long-shebang = callPackage ../misc/long-shebang {};
 
+  lorri = callPackage ../tools/misc/lorri {
+    inherit (darwin) cf-private;
+    inherit (darwin.apple_sdk.frameworks) CoreServices Security;
+  };
+
   numatop = callPackage ../os-specific/linux/numatop { };
 
   iio-sensor-proxy = callPackage ../os-specific/linux/iio-sensor-proxy { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add https://github.com/target/lorri

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
