### PR TITLE
service_identity: 17.0.0 -> 18.1.0

### DIFF
--- a/pkgs/development/python-modules/service_identity/default.nix
+++ b/pkgs/development/python-modules/service_identity/default.nix
@@ -1,10 +1,11 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, characteristic
+, pythonOlder
+, cryptography
+, ipaddress
 , pyasn1
 , pyasn1-modules
-, pyopenssl
 , idna
 , attrs
 , pytest
@@ -12,18 +13,18 @@
 
 buildPythonPackage rec {
   pname = "service_identity";
-  version = "17.0.0";
+  version = "18.1.0";
 
   src = fetchFromGitHub {
     owner = "pyca";
     repo = pname;
     rev = version;
-    sha256 = "1fn332fci776m5a7jx8c1jgbm27160ip5qvv8p01c242ag6by5g0";
+    sha256 = "1aw475ksmd4vpl8cwfdcsw2v063nbhnnxpy633sb75iqp9aazhlx";
   };
 
   propagatedBuildInputs = [
-    characteristic pyasn1 pyasn1-modules pyopenssl idna attrs
-  ];
+    pyasn1 pyasn1-modules idna attrs cryptography
+  ] ++ lib.optionals (pythonOlder "3.3") [ ipaddress ];
 
   checkInputs = [ pytest ];
   checkPhase = "py.test";


### PR DESCRIPTION
Newer version of Twisted requires newer version of service_identity for reasonable certificate subject checking.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
