### PR TITLE
epubcheck: init at 4.2.0

### DIFF
--- a/pkgs/tools/text/epubcheck/default.nix
+++ b/pkgs/tools/text/epubcheck/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchzip
+, jre, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  pname = "epubcheck";
+  version = "4.2.0";
+
+  src = fetchzip {
+    url = "https://github.com/w3c/epubcheck/releases/download/v${version}/epubcheck-${version}.zip";
+    sha256 = "1bf5jbzqvgpvhbkprynxj75ilk3r6zld157vjf6k7l5g21cwyn9d";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/lib
+    cp -r lib/* $out/lib
+
+    mkdir -p $out/libexec/epubcheck
+    cp epubcheck.jar $out/libexec/epubcheck
+
+    classpath=$out/libexec/epubcheck/epubcheck.jar
+    for jar in $out/lib/*.jar; do
+      classpath="$classpath:$jar"
+    done
+
+    mkdir -p $out/bin
+    makeWrapper ${jre}/bin/java $out/bin/epubcheck \
+      --add-flags "-classpath $classpath com.adobe.epubcheck.tool.Checker"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/w3c/epubcheck;
+    description = "Validation tool for EPUB";
+    license = with licenses; [ asl20 bsd3 mpl10 w3c ];
+    platforms = platforms.all;
+    maintainers = with maintainers; [ eadwu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2560,6 +2560,8 @@ in
 
   eid-mw = callPackage ../tools/security/eid-mw { };
 
+  epubcheck = callPackage ../tools/text/epubcheck { };
+
   mcrcon = callPackage ../tools/networking/mcrcon {};
 
   s-tar = callPackage ../tools/archivers/s-tar {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
