### PR TITLE
openjdk11: Update source hashes for aarch64

### DIFF
--- a/pkgs/development/compilers/adoptopenjdk-bin/sources.json
+++ b/pkgs/development/compilers/adoptopenjdk-bin/sources.json
@@ -5,7 +5,7 @@
         "hotspot": {
           "aarch64": {
             "build": "7",
-            "sha256": "ac367f3261fb53508c07f7eeb767b11ab53681b7613b81b6b7030c4db00b1aa8",
+            "sha256": "894a846600ddb0df474350037a2fb43e3343dc3606809a20c65e750580d8f2b9",
             "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.3_7.tar.gz",
             "version": "11.0.3"
           },

--- a/pkgs/development/compilers/adoptopenjdk-bin/sources.json
+++ b/pkgs/development/compilers/adoptopenjdk-bin/sources.json
@@ -33,7 +33,7 @@
         "hotspot": {
           "aarch64": {
             "build": "7",
-            "sha256": "4af5b7d6678d03f2207029a7c610d81b1f016462c1dfcd8153a227b1df973a42",
+            "sha256": "de31fab70640c6d5099de5fc8fa8b4d6b484a7352fa48a9fafbdc088ca708564",
             "url": "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.3%2B7/OpenJDK11U-jre_aarch64_linux_hotspot_11.0.3_7.tar.gz",
             "version": "11.0.3"
           },


### PR DESCRIPTION
###### Motivation for this change
Seems like they replaced the release file.
See: https://github.com/NixOS/nixpkgs/pull/59179#issuecomment-486742706
and: https://hydra.nixos.org/eval/1516026?filter=jdk&compare=1516009&full=

I haven't tested it as I don't have an aarch64 build machine and we don't have anything to bootstrap the cross compilation.
But I updated with `pkgs/development/compilers/adoptopenjdk-bin/generate-sources.py` so it should be reasonably safe.

Question: Why does the `jre` on `aarch64` default to `adoptopenjdk` while the `jdk` defaults to Oracle? See: https://github.com/NixOS/nixpkgs/blob/master/pkgs/top-level/all-packages.nix#L7459

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
