### PR TITLE
pwsafe: 1.06 -> 1.07

### DIFF
--- a/pkgs/applications/misc/pwsafe/default.nix
+++ b/pkgs/applications/misc/pwsafe/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig, zip, gettext, perl
 , wxGTK31, libXext, libXi, libXt, libXtst, xercesc
-, libqrencode, libuuid, libyubikey, yubikey-personalization
+, qrencode, libuuid, libyubikey, yubikey-personalization
 , curl, openssl
 }:
 
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   ];
   buildInputs = [
     libXext libXi libXt libXtst wxGTK31
-    curl libqrencode libuuid openssl xercesc
+    curl qrencode libuuid openssl xercesc
     libyubikey yubikey-personalization
   ];
 

--- a/pkgs/applications/misc/pwsafe/default.nix
+++ b/pkgs/applications/misc/pwsafe/default.nix
@@ -1,26 +1,29 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig, zip, gettext, perl
-, wxGTK31, libXi, libXt, libXtst, xercesc, xorgproto
-, qrencode, libuuid, libyubikey, yubikey-personalization
+, wxGTK31, libXext, libXi, libXt, libXtst, xercesc
+, libqrencode, libuuid, libyubikey, yubikey-personalization
+, curl, openssl
 }:
 
 stdenv.mkDerivation rec {
   pname = "pwsafe";
-  version = "1.06";
-  name = "${pname}-${version}";
+  version = "1.07";
 
   src = fetchFromGitHub {
     owner = "${pname}";
     repo = "${pname}";
     rev = "${version}BETA";
-    sha256 = "1q3xi7i4r3nmz3hc79lx8l15sr1nqhwbi3lrnfqr356nv6aaf03y";
+    sha256 = "0syxmliybgvm9j6d426l7j12ryrl42azy80m66jc56fv9nkqwaya";
   };
 
-  nativeBuildInputs = [ cmake pkgconfig zip ];
+  nativeBuildInputs = [ 
+  	cmake gettext perl pkgconfig zip
+  ];
   buildInputs = [
-    gettext perl qrencode libuuid
-    libXi libXt libXtst wxGTK31 xercesc xorgproto
+    libXext libXi libXt libXtst wxGTK31
+    curl libqrencode libuuid openssl xercesc
     libyubikey yubikey-personalization
   ];
+
   cmakeFlags = [
     "-DNO_GTEST=ON"
     "-DCMAKE_CXX_FLAGS=-I${yubikey-personalization}/include/ykpers-1"


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Package update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
