### PR TITLE
swi-prolog: updated version + packs support

### DIFF
--- a/pkgs/development/compilers/swi-prolog/default.nix
+++ b/pkgs/development/compilers/swi-prolog/default.nix
@@ -1,22 +1,30 @@
-{ stdenv, fetchurl, jdk, gmp, readline, openssl, libjpeg, unixODBC, zlib
+{ stdenv, fetchgit, jdk, gmp, readline, openssl, libjpeg, unixODBC, zlib
 , libXinerama, libarchive, db, pcre, libedit, libossp_uuid, libXft, libXpm
 , libSM, libXt, freetype, pkgconfig, fontconfig, makeWrapper ? stdenv.isDarwin
+, git, cacert, cmake, libyaml
+, extraLibraries ? [ jdk unixODBC libXpm libSM libXt freetype fontconfig ]
+, extraPacks     ? []
 }:
 
 let
-  version = "7.6.4";
+  version = "8.1.4";
+  packInstall = swiplPath: pack:
+    ''${swiplPath}/bin/swipl -g "pack_install(${pack}, [package_directory(\"${swiplPath}/lib/swipl/pack\"), silent(true), interactive(false)])." -t "halt."
+    '';
 in
 stdenv.mkDerivation {
   name = "swi-prolog-${version}";
 
-  src = fetchurl {
-    url = "http://www.swi-prolog.org/download/stable/src/swipl-${version}.tar.gz";
-    sha256 = "14bq4sqs61maqpnmgy6687jjj0shwc27cpfsqbf056nrssmplg9d";
+  src = fetchgit {
+    url = "https://github.com/SWI-Prolog/swipl-devel";
+    rev = "V${version}";
+    sha256 = "0qxa6f5dypwczxajlf0l736adbjb17cbak3qsh5g04hpv2bxm6dh";
   };
 
-  buildInputs = [ jdk gmp readline openssl libjpeg unixODBC libXinerama
-    libarchive db pcre libedit libossp_uuid libXft libXpm libSM libXt
-    zlib freetype pkgconfig fontconfig ]
+  buildInputs = [ cacert git cmake gmp readline openssl
+    libarchive libyaml db pcre libedit libossp_uuid
+    zlib pkgconfig ]
+  ++ extraLibraries
   ++ stdenv.lib.optional stdenv.isDarwin makeWrapper;
 
   hardeningDisable = [ "format" ];
@@ -27,7 +35,20 @@ stdenv.mkDerivation {
     "--enable-shared"
   ];
 
-  buildFlags = "world";
+  installPhase = ''
+    mkdir -p $out
+    mkdir build
+    cd build
+    ${cmake}/bin/cmake -DCMAKE_INSTALL_PREFIX=$out ..
+    cd ../
+    make
+    make install
+    make clean
+    mkdir -p $out/lib/swipl/pack
+  ''
+  + builtins.concatStringsSep "\n"
+  ( builtins.map (packInstall "$out") extraPacks
+  );
 
   # For macOS: still not fixed in upstream: "abort trap 6" when called
   # through symlink, so wrap binary.


### PR DESCRIPTION
Using "extraPacks" and "extraLibraries" arguments
it is possible to create fully functional virtual-envs
for SWI-Prolog projects.
(In a way similar to what "ghcWithPackages" does for Haskell)

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
