### PR TITLE
pythonPackages.pysnooper: init at 0.3.0

### DIFF
--- a/pkgs/development/python-modules/pysnooper/default.nix
+++ b/pkgs/development/python-modules/pysnooper/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, python-toolbox
+, pytest
+, isPy27
+}:
+
+buildPythonPackage rec {
+  version = "0.3.0";
+  pname = "pysnooper";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "PySnooper";
+    sha256 = "14vcxrzfmfhsmdck1cb56a6lbfga15qfhlkap9mh47fgspcq8xkx";
+  };
+
+  # test dependency python-toolbox fails with py27
+  doCheck = !isPy27;
+
+  checkInputs = [
+    python-toolbox
+    pytest
+  ];
+
+  meta = with lib; {
+    description = "A poor man's debugger for Python";
+    homepage = https://github.com/cool-RR/PySnooper;
+    license = licenses.mit;
+    maintainers = with maintainers; [ seqizz ];
+  };
+}

--- a/pkgs/development/python-modules/python-toolbox/default.nix
+++ b/pkgs/development/python-modules/python-toolbox/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, docutils
+, fetchFromGitHub
+, isPy27
+, nose
+}:
+
+buildPythonPackage rec {
+  version = "0.9.4";
+  pname = "python_toolbox";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "cool-RR";
+    repo = pname;
+    rev = version;
+    sha256 = "1qy2sfqfrkgxixmd22v5lkrdykdfiymsd2s3xa7ndlvg084cgj6r";
+  };
+
+  checkInputs = [
+    docutils
+    nose
+  ];
+
+  meta = with lib; {
+    description = "Tools for testing PySnooper";
+    homepage = https://github.com/cool-RR/python_toolbox;
+    license = licenses.mit;
+    maintainers = with maintainers; [ seqizz ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6527,6 +6527,8 @@ in {
 
   python-toolbox = callPackage ../development/python-modules/python-toolbox { };
 
+  pysnooper = callPackage ../development/python-modules/pysnooper { };
+
   sseclient = callPackage ../development/python-modules/sseclient { };
 
   warrant = callPackage ../development/python-modules/warrant { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6525,6 +6525,8 @@ in {
 
   pysensors = callPackage ../development/python-modules/pysensors { };
 
+  python-toolbox = callPackage ../development/python-modules/python-toolbox { };
+
   sseclient = callPackage ../development/python-modules/sseclient { };
 
   warrant = callPackage ../development/python-modules/warrant { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

pysnooper is a python logging library, providing quick logging via decorator

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
