### PR TITLE
dex-oidc: 2.4.1 -> 2.16.0

### DIFF
--- a/pkgs/servers/dex/default.nix
+++ b/pkgs/servers/dex/default.nix
@@ -21,6 +21,11 @@ buildGoPackage rec {
     "-ldflags=-w -X ${goPackagePath}/version.Version=${src.rev}"
   ];
 
+  postInstall = ''
+    mkdir -p $out/share
+    cp -r go/src/${goPackagePath}/web $out/share/web
+  '';
+
   meta = {
     description = "OpenID Connect and OAuth2 identity provider with pluggable connectors";
     license = lib.licenses.asl20;

--- a/pkgs/servers/dex/default.nix
+++ b/pkgs/servers/dex/default.nix
@@ -1,17 +1,16 @@
 { lib, buildGoPackage, fetchFromGitHub }:
 
-let version = "2.4.1"; in
-
 buildGoPackage rec {
-  name = "dex-${version}";
+  pname = "dex";
+  version = "2.16.0";
 
-  goPackagePath = "github.com/coreos/dex";
+  goPackagePath = "github.com/dexidp/dex";
 
   src = fetchFromGitHub {
     rev = "v${version}";
-    owner = "coreos";
-    repo = "dex";
-    sha256 = "11qpn3wh74mq16xgl9l50n2v02ffqcd14xccf77j5il04xr764nx";
+    owner = "dexidp";
+    repo = pname;
+    sha256 = "0w8nl7inqp4grbaq320dgynmznbrln8vihd799dwb2cx86laxsi1";
   };
 
   subPackages = [
@@ -25,7 +24,7 @@ buildGoPackage rec {
   meta = {
     description = "OpenID Connect and OAuth2 identity provider with pluggable connectors";
     license = lib.licenses.asl20;
-    homepage = https://github.com/coreos/dex;
+    homepage = https://github.com/dexidp/dex;
     maintainers = with lib.maintainers; [benley];
     platforms = lib.platforms.unix;
   };


### PR DESCRIPTION
repo organisation changed from coreos to dexidp

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
