### PR TITLE
perlPackages.HTTPDaemon: 6.04 -> 6.01

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -7275,18 +7275,17 @@ let
     };
   };
 
-  HTTPDaemon = buildPerlModule {
-    name = "HTTP-Daemon-6.04";
+  HTTPDaemon = buildPerlPackage {
+    name = "HTTP-Daemon-6.01";
     src = fetchurl {
-      url = mirror://cpan/authors/id/O/OA/OALDERS/HTTP-Daemon-6.04.tar.gz;
-      sha256 = "12m8iasnmp2dh28jrgmi7z10a3gcyz85khyff2j5h7jqbs6ks1fz";
+      url = mirror://cpan/authors/id/G/GA/GAAS/HTTP-Daemon-6.01.tar.gz;
+      sha256 = "1hmd2isrkilf0q0nkxms1q64kikjmcw9imbvrjgky6kh89vqdza3";
     };
     propagatedBuildInputs = [ HTTPMessage ];
     meta = {
       description = "A simple http server class";
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
     };
-    buildInputs = [ ModuleBuildTiny TestNeeds ];
   };
 
   HTTPDate = buildPerlPackage {


### PR DESCRIPTION
This undoes https://github.com/NixOS/nixpkgs/commit/6fb0e7a4e0fab0dd2f90a3c6eae8daf0ab40518d
The only problem with 6.04 is: it got new dependencies which fail to cross-compile.
Failure to cross-compile HTTP::Daemon leads to failure of LWP and XML::Parser, which are used in switch-to-configuration.pl
Thus upgrade HTTPDaemon from 6.01 to 6.04 broke cross-compilation of whole system closures.
