### PR TITLE
sd: init at 0.5.0

### DIFF
--- a/pkgs/tools/text/sd/default.nix
+++ b/pkgs/tools/text/sd/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, rustPlatform
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "sd";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "chmln";
+    repo = pname;
+    rev = "sd-${version}";
+    sha256 = "1y44qizciir75d1srwm1mlskhflab2b6153d19vblw410in82f5d";
+  };
+
+  cargoSha256 = "1gls68lw8a2c3gsav70l2wasrgav68q5w1nf50jsrbqq9kb4i7nb";
+
+  meta = with stdenv.lib; {
+    description = "Intuitive find & replace CLI (sed alternative)";
+    homepage = https://github.com/chmln/sd;
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = [ maintainers.amar1729 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5575,6 +5575,8 @@ in
 
   scrypt = callPackage ../tools/security/scrypt { };
 
+  sd = callPackage ../tools/text/sd { };
+
   sdate = callPackage ../tools/misc/sdate { };
 
   sdcv = callPackage ../applications/misc/sdcv { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Note on the relevant documentation -
`sd` doesn't seem to build `man` pages yet