### PR TITLE
rng-tools: fix missing opensc reference

### DIFF
--- a/pkgs/tools/security/rng-tools/default.nix
+++ b/pkgs/tools/security/rng-tools/default.nix
@@ -8,7 +8,7 @@
   # Not sure if jitterentropy is safe to use for cryptography
   # and thus a default entropy source
 , jitterentropy ? null, withJitterEntropy ? false
-, libp11 ? null, withPkcs11 ? true
+, libp11 ? null, opensc ? null, withPkcs11 ? true
 }:
 
 with stdenv.lib;
@@ -26,6 +26,11 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     cp README.md README
+
+    ${optionalString withPkcs11 ''
+      substituteInPlace rngd.c \
+        --replace /usr/lib64/opensc-pkcs11.so ${opensc}/lib/opensc-pkcs11.so
+    ''}
   '';
 
   nativeBuildInputs = [ autoreconfHook libtool pkgconfig ];
@@ -40,7 +45,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ sysfsutils ]
     ++ optionals withGcrypt        [ libgcrypt ]
     ++ optionals withJitterEntropy [ jitterentropy ]
-    ++ optionals withNistBeacon    [ openssl curl libxml2 ]
+    ++ optionals withNistBeacon    [ curl libxml2 openssl ]
     ++ optionals withPkcs11        [ libp11 openssl ];
 
   # This shouldn't be necessary but is as of 6.7


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

PKCS11 support wasn't actually working due to a missing library reference.

Cc: @JohnAZoidberg 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
