### PR TITLE
gdk-pixbuf: Use a different GDK_PIXBUF_MODULE_FILE environment variable on 32-bit and 64-bit systems.

### DIFF
--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -2563,7 +2563,7 @@ addEnvHooks "$hostOffset" myBashFunction
      </term>
      <listitem>
       <para>
-       Exports <envar>GDK_PIXBUF_MODULE_FILE</envar> environment variable to
+       Exports <envar>GDK_PIXBUF_MODULE_FILE32/64</envar> environment variable to
        the builder. Add librsvg package to <varname>buildInputs</varname> to
        get svg support.
       </para>

--- a/nixos/modules/services/x11/display-managers/lightdm-greeters/enso-os.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm-greeters/enso-os.nix
@@ -20,7 +20,7 @@ let
       makeWrapper ${pkgs.lightdm-enso-os-greeter}/bin/pantheon-greeter \
         $out/greeter \
         --prefix PATH : "${pkgs.glibc.bin}/bin" \
-        --set GDK_PIXBUF_MODULE_FILE "${pkgs.librsvg.out}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache" \
+        --set ${pkgs.gdk_pixbuf.moduleFileVar} "${pkgs.librsvg.out}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache" \
         --set GTK_PATH "${theme}:${pkgs.gtk3.out}" \
         --set GTK_EXE_PREFIX "${theme}" \
         --set GTK_DATA_PREFIX "${theme}" \

--- a/nixos/modules/services/x11/display-managers/lightdm-greeters/gtk.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm-greeters/gtk.nix
@@ -26,7 +26,7 @@ let
       makeWrapper ${pkgs.lightdm_gtk_greeter}/sbin/lightdm-gtk-greeter \
         $out/greeter \
         --prefix PATH : "${lib.getBin pkgs.stdenv.cc.libc}/bin" \
-        --set GDK_PIXBUF_MODULE_FILE "${pkgs.librsvg.out}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache" \
+        --set ${pkgs.gdk_pixbuf.moduleFileVar} "${pkgs.librsvg.out}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache" \
         --set GTK_PATH "${theme}:${pkgs.gtk3.out}" \
         --set GTK_EXE_PREFIX "${theme}" \
         --set GTK_DATA_PREFIX "${theme}" \

--- a/nixos/modules/services/x11/gdk-pixbuf.nix
+++ b/nixos/modules/services/x11/gdk-pixbuf.nix
@@ -36,10 +36,10 @@ in
 
   # If there is any package configured in modulePackages, we generate the
   # loaders.cache based on that and set the environment variable
-  # GDK_PIXBUF_MODULE_FILE to point to it.
+  # GDK_PIXBUF_MODULE_FILE32/64 to point to it.
   config = mkIf (cfg.modulePackages != []) {
     environment.variables = {
-      GDK_PIXBUF_MODULE_FILE = "${loadersCache}";
+      "${pkgs.gdk_pixbuf.moduleFileVar}" = "${loadersCache}";
     };
   };
 }

--- a/pkgs/applications/audio/pavucontrol/default.nix
+++ b/pkgs/applications/audio/pavucontrol/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, stdenv, pkgconfig, intltool, libpulseaudio, gtkmm3
-, libcanberra-gtk3, makeWrapper, gnome3 }:
+, libcanberra-gtk3, makeWrapper, gnome3, librsvg }:
 
 stdenv.mkDerivation rec {
   pname = "pavucontrol";
@@ -12,12 +12,12 @@ stdenv.mkDerivation rec {
 
   preFixup = ''
     wrapProgram "$out/bin/pavucontrol" \
-     --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
+     --set $gdkPixbufModuleFileVar "''${!gdkPixbufModuleFileVar}" \
      --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS"
   '';
 
   buildInputs = [ libpulseaudio gtkmm3 libcanberra-gtk3 makeWrapper
-                  gnome3.adwaita-icon-theme ];
+                  gnome3.adwaita-icon-theme librsvg ];
 
   nativeBuildInputs = [ pkgconfig intltool ];
 

--- a/pkgs/applications/editors/howl/default.nix
+++ b/pkgs/applications/editors/howl/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   # Required for the program to properly load its SVG assets
   postInstall = ''
     wrapProgram $out/bin/howl \
-      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"
+      --set $gdkPixbufModuleFileVar "''${!gdkPixbufModuleFileVar}"
   '';
 
   meta = {

--- a/pkgs/applications/graphics/ahoviewer/default.nix
+++ b/pkgs/applications/graphics/ahoviewer/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   postInstall = ''
     wrapProgram $out/bin/ahoviewer \
     --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0" \
-    --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"
+    --set $gdkPixbufModuleFileVar "''${!gdkPixbufModuleFileVar}"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/graphics/gimp/default.nix
+++ b/pkgs/applications/graphics/gimp/default.nix
@@ -52,7 +52,7 @@ in stdenv.mkDerivation rec {
     wrapPythonProgramsIn $out/lib/gimp/${passthru.majorVersion}/plug-ins/
     wrapProgram $out/bin/gimp-${stdenv.lib.versions.majorMinor version} \
       --prefix PYTHONPATH : "$PYTHONPATH" \
-      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"
+      --set $gdkPixbufModuleFileVar "''${!gdkPixbufModuleFileVar}"
   '';
 
   passthru = rec {

--- a/pkgs/applications/graphics/shutter/default.nix
+++ b/pkgs/applications/graphics/shutter/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
       --set PERL5LIB "${perlPackages.makePerlPath perlModules}" \
       --prefix PATH : "${imagemagick.out}/bin" \
       --suffix XDG_DATA_DIRS : "${hicolor-icon-theme}/share" \
-      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"
+      --set $gdkPixbufModuleFileVar "''${!gdkPixbufModuleFileVar}"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/graphics/vimiv/default.nix
+++ b/pkgs/applications/graphics/vimiv/default.nix
@@ -44,7 +44,7 @@ python3Packages.buildPythonApplication rec {
   makeWrapperArgs = [
     "--prefix GI_TYPELIB_PATH : \"$GI_TYPELIB_PATH\""
     "--suffix XDG_DATA_DIRS : \"$XDG_ICON_DIRS:$out/share\""
-    "--set GDK_PIXBUF_MODULE_FILE \"$GDK_PIXBUF_MODULE_FILE\""
+    "--set $gdkPixbufModuleFileVar \"\${!gdkPixbufModuleFileVar}\""
   ];
 
   postCheck = ''

--- a/pkgs/applications/misc/batti/default.nix
+++ b/pkgs/applications/misc/batti/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl
 , pkgconfig, gettext, pythonPackages
-, gtk2, gdk_pixbuf, upower
+, gtk2, gdk_pixbuf, librsvg, upower
 , makeWrapper }:
 
 let
@@ -16,7 +16,7 @@ in stdenv.mkDerivation rec {
   };
 
   buildInputs = with stdenv.lib;
-  [ pkgconfig gettext python gtk2 pygtk dbus-python gdk_pixbuf upower makeWrapper ];
+  [ pkgconfig gettext python gtk2 pygtk dbus-python gdk_pixbuf librsvg upower makeWrapper ];
 
   configurePhase = "true";
 
@@ -28,7 +28,7 @@ in stdenv.mkDerivation rec {
     python setup.py install --prefix $out
     wrapProgram "$out/bin/batti" \
       --set PYTHONPATH "$PYTHONPATH:$(toPythonPath $out)" \
-      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
+      --set $gdkPixbufModuleFileVar "''${!gdkPixbufModuleFileVar}" \
       --prefix XDG_DATA_DIRS : "$out/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"
   '';
 

--- a/pkgs/applications/misc/dunst/default.nix
+++ b/pkgs/applications/misc/dunst/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
     install -Dm755 dunstify $out/bin
   '' + ''
     wrapProgram $out/bin/dunst \
-      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"
+      --set $gdkPixbufModuleFileVar "''${!gdkPixbufModuleFileVar}"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/misc/pdfpc/default.nix
+++ b/pkgs/applications/misc/pdfpc/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     wrapProgram $out/bin/pdfpc \
-      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"
+      --set $gdkPixbufModuleFileVar "''${!gdkPixbufModuleFileVar}"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/networking/remote/citrix-receiver/default.nix
+++ b/pkgs/applications/networking/remote/citrix-receiver/default.nix
@@ -13,6 +13,7 @@
 , gtk2
 , atk
 , gdk_pixbuf
+, librsvg
 , cairo
 , pango
 , gnome3
@@ -101,6 +102,7 @@ let
         file
         gtk2
         gdk_pixbuf
+        librsvg
       ];
 
       libPath = stdenv.lib.makeLibraryPath [
@@ -185,7 +187,7 @@ let
           --add-flags "-icaroot $ICAInstDir" \
           --set ICAROOT "$ICAInstDir" \
           --set GTK_PATH "${gtk2.out}/lib/gtk-2.0:${gnome3.gnome-themes-extra}/lib/gtk-2.0" \
-          --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
+          --set $gdkPixbufModuleFileVar "''${!gdkPixbufModuleFileVar}" \
           --set LD_PRELOAD "${libredirect}/lib/libredirect.so" \
           --set LD_LIBRARY_PATH "$libPath" \
           --set NIX_REDIRECTS "/usr/share/zoneinfo=${tzdata}/share/zoneinfo:/etc/zoneinfo=${tzdata}/share/zoneinfo:/etc/timezone=$ICAInstDir/timezone"

--- a/pkgs/applications/office/paperwork/default.nix
+++ b/pkgs/applications/office/paperwork/default.nix
@@ -66,7 +66,7 @@ python3Packages.buildPythonApplication rec {
 
   makeWrapperArgs = [
     "--set GI_TYPELIB_PATH \"$GI_TYPELIB_PATH\""
-    "--set GDK_PIXBUF_MODULE_FILE \"$GDK_PIXBUF_MODULE_FILE\""
+    "--set $gdkPixbufModuleFileVar \"\${!gdkPixbufModuleFileVar}\""
     "--prefix XDG_DATA_DIRS : \"$out/share\""
     "--suffix XDG_DATA_DIRS : \"$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH\""
   ];

--- a/pkgs/applications/office/tryton/default.nix
+++ b/pkgs/applications/office/tryton/default.nix
@@ -37,7 +37,7 @@ python2Packages.buildPythonApplication rec {
     goocanvas2
   ];
   makeWrapperArgs = [
-    ''--set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"''
+    ''--set $gdkPixbufModuleFileVar "''${!gdkPixbufModuleFileVar}"''
     ''--set GI_TYPELIB_PATH "$GI_TYPELIB_PATH"''
     ''--suffix XDG_DATA_DIRS : "$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH"''
   ];

--- a/pkgs/applications/video/key-mon/default.nix
+++ b/pkgs/applications/video/key-mon/default.nix
@@ -16,7 +16,7 @@ pythonPackages.buildPythonApplication rec {
   doCheck = false;
 
   preFixup = ''
-      export makeWrapperArgs="--set GDK_PIXBUF_MODULE_FILE $GDK_PIXBUF_MODULE_FILE"
+      export makeWrapperArgs="--set $gdkPixbufModuleFileVar \"''${!gdkPixbufModuleFileVar}\""
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/window-managers/awesome/default.nix
+++ b/pkgs/applications/window-managers/awesome/default.nix
@@ -47,7 +47,7 @@ with luaPackages; stdenv.mkDerivation rec {
 
   postInstall = ''
     wrapProgram $out/bin/awesome \
-      --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
+      --set $gdkPixbufModuleFileVar "''${!gdkPixbufModuleFileVar}" \
       --add-flags '--search ${lgi}/lib/lua/${lua.luaversion}' \
       --add-flags '--search ${lgi}/share/lua/${lua.luaversion}' \
       --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH" \

--- a/pkgs/build-support/setup-hooks/wrap-gapps-hook.sh
+++ b/pkgs/build-support/setup-hooks/wrap-gapps-hook.sh
@@ -14,8 +14,8 @@ wrapGAppsHook() {
   [ -z "$wrapGAppsHookHasRun" ] || return 0
   wrapGAppsHookHasRun=1
 
-  if [ -n "$GDK_PIXBUF_MODULE_FILE" ]; then
-    gappsWrapperArgs+=(--set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE")
+  if [ -n "${!gdkPixbufModuleFileVar}" ]; then
+    gappsWrapperArgs+=(--set $gdkPixbufModuleFileVar "${!gdkPixbufModuleFileVar}")
   fi
 
   if [ -n "$XDG_ICON_DIRS" ]; then

--- a/pkgs/desktops/maxx/default.nix
+++ b/pkgs/desktops/maxx/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     stdenv.cc.cc libX11 libXext libXi libXau libXrender libXft libXmu libSM libXcomposite libXfixes libXpm
     libXinerama libXdamage libICE libXtst libXaw fontconfig pango cairo glib libxml2 atk gtk2
-    gdk_pixbuf libGL ncurses5
+    gdk_pixbuf libGL ncurses5 librsvg
   ];
 
   buildPhase = ''
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
 
     wrapProgram $maxx/etc/skel/Xsession.dt \
       --prefix GTK_PATH : "${gtk-engine-murrine}/lib/gtk-2.0:${gtk_engines}/lib/gtk-2.0" \
-      --prefix GDK_PIXBUF_MODULE_FILE : "$(echo ${librsvg.out}/lib/gdk-pixbuf-2.0/*/loaders.cache)"
+      --set $gdkPixbufModuleFileVar "''${!gdkPixbufModuleFileVar}"
 
     while IFS= read -r -d ''$'\0' i; do
       if isExecutable "$i"; then

--- a/pkgs/development/compilers/cudatoolkit/default.nix
+++ b/pkgs/development/compilers/cudatoolkit/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, makeWrapper, fetchurl, requireFile, perl, ncurses5, expat, python27, zlib
 , gcc48, gcc49, gcc5, gcc6, gcc7
-, xorg, gtk2, gdk_pixbuf, glib, fontconfig, freetype, unixODBC, alsaLib, glibc
+, xorg, gtk2, gdk_pixbuf, librsvg, glib, fontconfig, freetype, unixODBC, alsaLib, glibc
 }:
 
 let
@@ -40,7 +40,7 @@ let
       outputs = [ "out" "lib" "doc" ];
 
       nativeBuildInputs = [ perl makeWrapper ];
-      buildInputs = [ gdk_pixbuf ]; # To get $GDK_PIXBUF_MODULE_FILE via setup-hook
+      buildInputs = [ gdk_pixbuf librsvg ]; # To get $gdkPixbufModuleFileVar via setup-hook
       runtimeDependencies = [
         ncurses5 expat python zlib glibc
         xorg.libX11 xorg.libXext xorg.libXrender xorg.libXt xorg.libXtst xorg.libXi xorg.libXext
@@ -126,7 +126,7 @@ let
       postInstall = ''
         for b in nvvp nsight; do
           wrapProgram "$out/bin/$b" \
-            --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"
+            --set $gdkPixbufModuleFileVar "''${!gdkPixbufModuleFileVar}"
         done
       '';
 

--- a/pkgs/development/libraries/flatpak/unset-env-vars.patch
+++ b/pkgs/development/libraries/flatpak/unset-env-vars.patch
@@ -1,10 +1,12 @@
 --- a/common/flatpak-run.c
 +++ b/common/flatpak-run.c
-@@ -1192,6 +1192,7 @@ static const ExportData default_exports[] = {
+@@ -1192,6 +1192,9 @@ static const ExportData default_exports[] = {
    {"PERLLIB", NULL},
    {"PERL5LIB", NULL},
    {"XCURSOR_PATH", NULL},
 +  {"GDK_PIXBUF_MODULE_FILE", NULL},
++  {"GDK_PIXBUF_MODULE_FILE32", NULL},
++  {"GDK_PIXBUF_MODULE_FILE64", NULL},
  };
  
  static const ExportData no_ld_so_cache_exports[] = {

--- a/pkgs/development/libraries/gdk-pixbuf/setup-hook.sh
+++ b/pkgs/development/libraries/gdk-pixbuf/setup-hook.sh
@@ -1,14 +1,17 @@
+# Expose this, for example to use when generating wrappers.
+export gdkPixbufModuleFileVar="@gdkPixbufModuleFileVar@"
+
 findGdkPixbufLoaders() {
 
 	# choose the longest loaders.cache
 	local loadersCache="$1/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache"
 	if [ -f "$loadersCache" ]; then
-		if [ -f "$GDK_PIXBUF_MODULE_FILE" ]; then
-			if [ $(cat "$loadersCache"|wc -l) -gt $(cat "$GDK_PIXBUF_MODULE_FILE"|wc -l) ]; then
-				export GDK_PIXBUF_MODULE_FILE="$loadersCache"
+		if [ -f "${@gdkPixbufModuleFileVar@}" ]; then
+			if [ $(cat "$loadersCache"|wc -l) -gt $(cat "$@gdkPixbufModuleFileVar@"|wc -l) ]; then
+				export @gdkPixbufModuleFileVar@="$loadersCache"
 			fi
 		else
-			export GDK_PIXBUF_MODULE_FILE="$loadersCache"
+			export @gdkPixbufModuleFileVar@="$loadersCache"
 		fi
 	fi
 

--- a/pkgs/development/libraries/librsvg/default.nix
+++ b/pkgs/development/libraries/librsvg/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
   # It wants to add loaders and update the loaders.cache in gdk-pixbuf
   # Patching the Makefiles to it creates rsvg specific loaders and the
   # relevant loader.cache here.
-  # The loaders.cache can be used by setting GDK_PIXBUF_MODULE_FILE to
+  # The loaders.cache can be used by setting $gdkPixbufModuleFileVar to
   # point to this file in a wrapper.
   postConfigure = ''
     GDK_PIXBUF=$out/lib/gdk-pixbuf-2.0/2.10.0

--- a/pkgs/misc/drivers/sc-controller/default.nix
+++ b/pkgs/misc/drivers/sc-controller/default.nix
@@ -34,9 +34,6 @@ buildPythonApplication rec {
 
   preFixup = ''
     gappsWrapperArgs+=(--prefix LD_LIBRARY_PATH : "$LD_LIBRARY_PATH")
-    # gdk-pixbuf setup hook can not choose between propagated librsvg
-    # and our librsvg with GObject introspection.
-    GDK_PIXBUF_MODULE_FILE=$(echo ${librsvg}/lib/gdk-pixbuf-2.0/*/loaders.cache)
   '';
 
   postFixup = ''

--- a/pkgs/misc/solfege/default.nix
+++ b/pkgs/misc/solfege/default.nix
@@ -33,7 +33,7 @@ in stdenv.mkDerivation rec {
       set -x
       wrapProgram "$out/bin/solfege" \
           --prefix PYTHONPATH ':' "$PYTHONPATH" \
-          --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"
+           --set $gdkPixbufModuleFileVar "''${!gdkPixbufModuleFileVar}"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/inputmethods/ibus/wrapper.nix
+++ b/pkgs/tools/inputmethods/ibus/wrapper.nix
@@ -5,7 +5,7 @@
 let
   name = "ibus-with-plugins-" + (builtins.parseDrvName ibus.name).version;
   env = {
-    buildInputs = [ ibus ] ++ plugins;
+    buildInputs = [ ibus librsvg ] ++ plugins;
     nativeBuildInputs = [ lndir makeWrapper ];
     propagatedUserEnvPackages = [ hicolor-icon-theme ];
     paths = [ ibus ] ++ plugins;
@@ -23,7 +23,7 @@ let
 
     for prog in ibus; do
         wrapProgram "$out/bin/$prog" \
-          --set GDK_PIXBUF_MODULE_FILE ${librsvg.out}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache \
+          --set $gdkPixbufModuleFileVar "''${!gdkPixbufModuleFileVar}" \
           --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH:$out/lib/girepository-1.0" \
           --prefix GIO_EXTRA_MODULES : "${stdenv.lib.getLib dconf}/lib/gio/modules" \
           --set IBUS_COMPONENT_PATH "$out/share/ibus/component/" \
@@ -42,7 +42,7 @@ let
 
     for prog in ibus-daemon; do
         wrapProgram "$out/bin/$prog" \
-          --set GDK_PIXBUF_MODULE_FILE ${librsvg.out}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache \
+          --set $gdkPixbufModuleFileVar "''${!gdkPixbufModuleFileVar}" \
           --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH:$out/lib/girepository-1.0" \
           --prefix GIO_EXTRA_MODULES : "${stdenv.lib.getLib dconf}/lib/gio/modules" \
           --set IBUS_COMPONENT_PATH "$out/share/ibus/component/" \


### PR DESCRIPTION
Pull request #42562 caused a regression that running a 32-bit program that uses
gdk-pixbuf would result in a crash because it would try to load a 64-bit
library and fail. This change fixes this issue by patching gdk-pixbuf and many
places where this variable is defined to use different variable names on
32-bit and 64-bit systems.

###### Motivation for this change

Fix regression running 32-bit programs.

This only intends to fix the 32-bit program issue. The situation is still a mess. The way I understand the situation is:

- Desktops want to set `GDK_PIXBUF_MODULE_FILE` such that all GTK apps will be able to load SVG icons. I presume this is because the desktop comes with SVG icons and the apps should be able to use the desktop-provided icons to integrate visually.
- Some apps need to specifically support SVG icons, probably because they ship with them. Those set `GDK_PIXBUF_MODULE_FILE` in the wrapper (the value comes from the gdk-pixbuf setup hook). In these cases the wrapper sets the variable to point to the cache file in librsvg.
- Some apps set `GDK_PIXBUF_MODULE_FILE` in the wrapper without depending on librsvg, which results in the wraper setting the variable to the cache file from gdk-pixbuf. This wrapping might be to ensure the app works even if `GDK_PIXBUF_MODULE_FILE` is set incorrectly (e.g. when NixOS is updated, if running outside NixOS) (if it is not set gdk-pixbuf will use its default cache file). Note that these apps will never support SVG icons even if the desktop sets the variable, because the wrapper overrides it! That's why I added a librsvg dependency to some apps, but I didn't check this for the many apps that get wrapped indirectly via `wrapGAppsHook`.

My suggestion going forward would be to try to ensure that (almost?) all GTK apps are wrapped to set `GDK_PIXBUF_MODULE_FILE` to the one from librsvg (yes, it results in a larger closure in some cases), and then remove the code in desktops to set the environment variable together with the gdk-pixbuf NixOS module.

###### Things done

I have testes this on 19.03 branch and it seems to work as intended. I have checked that the correct variable is set by the gdk_pixbuf NixOS module and that the apps which set it in the wrapper set the correct variable. I have observed no breakage on my desktop system (KDE-based). I have tried running a 32-bit application (pavucontrol) and it does start and run (though there are errors loading 64-bit GVFS plugins).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
