### PR TITLE
socat: fix darwin build

### DIFF
--- a/pkgs/tools/networking/socat/default.nix
+++ b/pkgs/tools/networking/socat/default.nix
@@ -8,6 +8,8 @@ stdenv.mkDerivation rec {
     sha256 = "0jnhjijyq74g3wa4ph0am83z6vq7qna7ac0xqjma8s4197z3zmhd";
   };
 
+  patches = stdenv.lib.optional stdenv.isDarwin ./speed-type-fix.patch;
+
   postPatch = ''
     patchShebangs test.sh
     substituteInPlace test.sh \

--- a/pkgs/tools/networking/socat/speed-type-fix.patch
+++ b/pkgs/tools/networking/socat/speed-type-fix.patch
@@ -1,0 +1,13 @@
+diff --git a/xio-termios.h b/xio-termios.h
+index a288a2f..9858aab 100644
+--- a/xio-termios.h
++++ b/xio-termios.h
+@@ -148,7 +148,7 @@ extern int xiotermiosflag_applyopt(int fd, struct opt *opt);
+ extern int xiotermios_value(int fd, int word, tcflag_t mask, tcflag_t value);
+ extern int xiotermios_char(int fd, int n, unsigned char c);
+ #ifdef HAVE_TERMIOS_ISPEED
+-extern int xiotermios_speed(int fd, int n, unsigned int speed);
++extern int xiotermios_speed(int fd, int n, speed_t speed);
+ #endif
+ extern int xiotermios_spec(int fd, int optcode);
+ extern int xiotermios_flush(int fd);


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Make it build on Darwin. I'll try to upstream it too.

```
xio-termios.c:359:5: error: conflicting types for 'xiotermios_speed'
int xiotermios_speed(int fd, int n, speed_t speed) {
    ^
./xio-termios.h:151:12: note: previous declaration is here
extern int xiotermios_speed(int fd, int n, unsigned int speed);
           ^
1 error generated.
make: *** [<builtin>: xio-termios.o] Error 1
```

https://hydra.nixos.org/build/92405399/nixlog/3/tail

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
