### PR TITLE
ckb-next service: apply udev rules provided by package

### DIFF
--- a/nixos/modules/hardware/ckb-next.nix
+++ b/nixos/modules/hardware/ckb-next.nix
@@ -36,6 +36,7 @@ in
 
     config = mkIf cfg.enable {
       environment.systemPackages = [ cfg.package ];
+      services.udev.packages = [ cfg.package ];
 
       systemd.services.ckb-next = {
         description = "Corsair Keyboards and Mice Daemon";

--- a/pkgs/tools/misc/ckb-next/default.nix
+++ b/pkgs/tools/misc/ckb-next/default.nix
@@ -1,5 +1,5 @@
 { stdenv, mkDerivation, fetchFromGitHub, substituteAll, udev
-, pkgconfig, qtbase, cmake, zlib, kmod }:
+, pkgconfig, qtbase, cmake, zlib, kmod, gnused }:
 
 mkDerivation rec {
   version = "0.4.2";
@@ -38,6 +38,9 @@ mkDerivation rec {
       inherit kmod;
     })
   ];
+  postPatch = ''
+    sed -i 's:/usr/bin/env sed:${gnused}/bin/sed:g' linux/udev/99-ckb-next-daemon.rules
+  '';
 
   meta = with stdenv.lib; {
     description = "Driver and configuration tool for Corsair keyboards and mice";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The package provides these udev rules with the presumption that OS maintainers will install and use them.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after) - *increase by 0.21%*
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).