### PR TITLE
lorri: reserve attribute name

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7644,6 +7644,8 @@ in
 
   llvmPackages_latest = llvmPackages_8;
 
+  lorri = throw "lorri is not stable yet. Please go to https://github.com/target/lorri and follow the installation instructions there, for the time being.";
+
   manticore = callPackage ../development/compilers/manticore { };
 
   mercury = callPackage ../development/compilers/mercury { };


### PR DESCRIPTION
lorri is a nix-shell replacement for project development.
Since it’s public beta announcement was noticed by many people, they
are going to assume it is available from nixpkgs. We lead them to the
installation instructions while the tool is not yet ready for nixpkgs.

Related-issue: https://github.com/NixOS/nixpkgs/pull/60211

- [x] tested warning thrown when the user tries to build lorri.