### PR TITLE
dragonfly-reverb: 1.0.0 -> 1.1.4

### DIFF
--- a/pkgs/applications/audio/dragonfly-reverb/default.nix
+++ b/pkgs/applications/audio/dragonfly-reverb/default.nix
@@ -1,13 +1,14 @@
 { stdenv, fetchFromGitHub, libjack2, libGL, pkgconfig, xorg }:
 
 stdenv.mkDerivation rec {
-  name = "dragonfly-reverb-${src.rev}";
+  pname = "dragonfly-reverb";
+  version = "1.1.4";
 
   src = fetchFromGitHub {
     owner = "michaelwillis";
     repo = "dragonfly-reverb";
-    rev = "1.0.0";
-    sha256 = "05m4hd8lg0a7iiia6cbiw5qmc4p8vbkxp2qh7ywaabawiwa9r24x";
+    rev = version;
+    sha256 = "060g4ddh1z222n39wqj8jxj0zgmpjrgraw76qgyg6xkn15cn9q9y";
     fetchSubmodules = true;
   };
 
@@ -21,15 +22,20 @@ stdenv.mkDerivation rec {
   ];
 
   installPhase = ''
+    mkdir -p $out/bin
     mkdir -p $out/lib/lv2/
-    cp -a bin/DragonflyReverb.lv2/ $out/lib/lv2/
+    mkdir -p $out/lib/vst/
+    cd bin
+    cp -a DragonflyReverb        $out/bin/
+    cp -a DragonflyReverb-vst.so $out/lib/vst/
+    cp -a DragonflyReverb.lv2/   $out/lib/lv2/
   '';
 
   meta = with stdenv.lib; {
     homepage = https://github.com/michaelwillis/dragonfly-reverb;
     description = "A hall-style reverb based on freeverb3 algorithms";
     maintainers = [ maintainers.magnetophon ];
-    license = licenses.gpl2;
+    license = licenses.gpl3;
     platforms = ["x86_64-linux"];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
