### PR TITLE
editline: fix crash with term narrower than completions

### DIFF
--- a/pkgs/development/libraries/editline/default.nix
+++ b/pkgs/development/libraries/editline/default.nix
@@ -17,6 +17,12 @@ stdenv.mkDerivation rec {
       url = "https://github.com/troglobit/editline/commit/a4b67d226829a55bc8501f36708d5e104a52fbe4.patch";
       sha256 = "0dbgdqxa4x9wgr9kx89ql74np4qq6fzdbph9j9c65ns3gnaanjkw";
     })
+    # PR24
+    (fetchpatch {
+      name = "fix-narrow-term-crash.patch";
+      url = https://github.com/troglobit/editline/pull/24/commits/8660aef4b795fbd46a86dca804f067a81757c5df.patch;
+      sha256 = "0pcz1f141qv78xbq09yh0zfcjiqyavr66snz1hvxzvi8x0vixc4i";
+    })
   ];
 
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
###### Motivation for this change

Fixes issue mentioned on #nixos earlier today by @edef1c.

Repro instructions:

* Open a terminal and resize it to very narrow (~20 should work,
haven't calculated the breaking point)
* Run `nix repl`
* Type `:b ` and hit TAB for completions
* Sadface

Compare this with and without this change :).

Submitted upstream, FWIW: https://github.com/troglobit/editline/pull/24

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---