### PR TITLE
peco: fix incorrect termbox-go rev in deps.nix

### DIFF
--- a/pkgs/tools/text/peco/deps.nix
+++ b/pkgs/tools/text/peco/deps.nix
@@ -41,8 +41,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/nsf/termbox-go";
-      rev = "abe82ce5fb7a42fbd6784a5ceb71aff977e09ed8";
-      sha256 = "156i8apkga8b3272kjhapyqwspgcfkrr9kpqwc5lii43k4swghpv";
+      rev = "e2050e41c8847748ec5288741c0b19a8cb26d084";
+      sha256 = "181b1df2b6fcn5wizq2qqxl1kwqbih5k15n08rx3bcz36q34n23s";
     };
   }
   {


### PR DESCRIPTION
Peco 0.5.3 included an update to the `termbox-go` dependency to fix a bug, this change did not make it into `deps.nix`.

See:

 - peco/peco#446
 - peco/peco#447
 - nsf/termbox-go#185


###### Motivation for this change

Peco 0.5.3 is currently broken for me on 19.03 due to garbled text, see the linked issues above for an example.

Also see the [`glide.lock`](https://github.com/peco/peco/blob/814932819adaed444cdfd32747de7047329f573f/glide.lock) for Peco 0.5.3 to see the mismatch.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
