### PR TITLE
fcitx-configtool: Point exec_prefix to installed location of fcitx-remote

### DIFF
--- a/pkgs/tools/inputmethods/fcitx/0001-Fix-exec_prefix.patch
+++ b/pkgs/tools/inputmethods/fcitx/0001-Fix-exec_prefix.patch
@@ -1,0 +1,25 @@
+From 47c46f913add20e894165050fde9e0416bfa8661 Mon Sep 17 00:00:00 2001
+From: Robert Irelan <rirelan@gmail.com>
+Date: Sun, 28 Apr 2019 09:51:08 -0700
+Subject: [PATCH] Fix exec_prefix
+
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6f1b23d..45ef2fc 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -41,7 +41,7 @@ string(REGEX REPLACE "^[0-9]+\\.[0-9]+\\.([0-9]+).*" "\\1" FCITX4_PATCH_VERSION
+ 
+ set(datadir ${CMAKE_INSTALL_PREFIX}/share)
+ set(localedir ${CMAKE_INSTALL_PREFIX}/share/locale)
+-set(exec_prefix "${CMAKE_INSTALL_PREFIX}")
++set(exec_prefix "${FCITX4_PREFIX}")
+ set(liblocaledir ${CMAKE_INSTALL_PREFIX}/lib/locale)
+ 
+ configure_file(config.h.in config.h)
+-- 
+2.21.0
+

--- a/pkgs/tools/inputmethods/fcitx/fcitx-configtool.nix
+++ b/pkgs/tools/inputmethods/fcitx/fcitx-configtool.nix
@@ -19,6 +19,14 @@ stdenv.mkDerivation rec {
   buildInputs = [ makeWrapper fcitx cmake isocodes gtk3
     gnome3.adwaita-icon-theme ];
 
+  # Point exec_prefix to installed location of fcitx-remote (in the fcitx
+  # package).
+  preConfigure = ''
+    sed -ie '/^set(exec_prefix /d' CMakeLists.txt
+    substituteInPlace config.h.in \
+      --subst-var-by exec_prefix ${fcitx}
+  '';
+
   preFixup = ''
     wrapProgram $out/bin/fcitx-config-gtk3 \
       --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS";

--- a/pkgs/tools/inputmethods/fcitx/fcitx-configtool.nix
+++ b/pkgs/tools/inputmethods/fcitx/fcitx-configtool.nix
@@ -21,11 +21,7 @@ stdenv.mkDerivation rec {
 
   # Point exec_prefix to installed location of fcitx-remote (in the fcitx
   # package).
-  preConfigure = ''
-    sed -ie '/^set(exec_prefix /d' CMakeLists.txt
-    substituteInPlace config.h.in \
-      --subst-var-by exec_prefix ${fcitx}
-  '';
+  patches = [ ./0001-Fix-exec_prefix.patch ];
 
   preFixup = ''
     wrapProgram $out/bin/fcitx-config-gtk3 \


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fixes errors like this printed to the console when changing settings using `fcitx-config-gtk3`:

```
(fcitx-config-gtk3:17980): GLib-WARNING **: 12:24:47.394: GError set over the top of a previous GError or uninitialized memory.
This indicates a bug in someone's code. You must ensure an error is NULL before it's set.
The overwriting error message was: Failed to execute child process “/nix/store/02i4q909l3jk6080zb57jmd23ra4244x-fcitx-configtool-0.4.10/bin/fcitx-remote” (No such file or directory)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
