### PR TITLE
accountsservice: 0.6.54 -> 0.6.55

### DIFF
--- a/pkgs/development/libraries/accountsservice/default.nix
+++ b/pkgs/development/libraries/accountsservice/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "accountsservice-${version}";
-  version = "0.6.54";
+  version = "0.6.55";
 
   src = fetchurl {
     url = "https://www.freedesktop.org/software/accountsservice/accountsservice-${version}.tar.xz";
-    sha256 = "1b115n0a4yfa06kgxc69qfc1rc0w4frgs3id3029czkrhhn0ds96";
+    sha256 = "16wwd633jak9ajyr1f1h047rmd09fhf3kzjz6g5xjsz0lwcj8azz";
   };
 
   nativeBuildInputs = [ pkgconfig makeWrapper meson ninja python3 ];

--- a/pkgs/development/libraries/accountsservice/no-create-dirs.patch
+++ b/pkgs/development/libraries/accountsservice/no-create-dirs.patch
@@ -1,15 +1,15 @@
 diff --git a/meson_post_install.py b/meson_post_install.py
-index ba95055..17f7926 100644
+index 5cc2dc4..dd27ad5 100644
 --- a/meson_post_install.py
 +++ b/meson_post_install.py
 @@ -9,8 +9,8 @@ localstatedir = os.path.normpath(destdir + os.sep + sys.argv[1])
  # FIXME: meson will not track the creation of these directories
  #        https://github.com/mesonbuild/meson/blob/master/mesonbuild/scripts/uninstall.py#L39
  dst_dirs = [
--  os.path.join(localstatedir, 'lib', 'AccountsService', 'icons'),
--  os.path.join(localstatedir, 'lib', 'AccountsService', 'users'),
-+  #os.path.join(localstatedir, 'lib', 'AccountsService', 'icons'),
-+  #os.path.join(localstatedir, 'lib', 'AccountsService', 'users'),
+-  (os.path.join(localstatedir, 'lib', 'AccountsService', 'icons'), 0o775),
+-  (os.path.join(localstatedir, 'lib', 'AccountsService', 'users'), 0o700),
++#  (os.path.join(localstatedir, 'lib', 'AccountsService', 'icons'), 0o775),
++#  (os.path.join(localstatedir, 'lib', 'AccountsService', 'users'), 0o700),
  ]
  
- for dst_dir in dst_dirs:
+ for (dst_dir, dst_dir_mode) in dst_dirs:


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

https://cgit.freedesktop.org/accountsservice/tag/?h=0.6.55

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---