### PR TITLE
xlayoutdisplay: 1.0.2 -> 1.1.0

### DIFF
--- a/pkgs/tools/X11/xlayoutdisplay/default.nix
+++ b/pkgs/tools/X11/xlayoutdisplay/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, xorg, boost, cmake, gtest }:
 
 stdenv.mkDerivation rec {
-  name = "xlayoutdisplay-${version}";
-  version = "1.0.2";
+  pname = "xlayoutdisplay";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "alex-courtis";
-    repo = "xlayoutdisplay";
+    repo = pname;
     rev = "v${version}";
-    sha256 = "1cqn98lpx9rkfhavbqalaaljw351hvqsrszgqnwvcyq05vq26dwx";
+    sha256 = "0wm6a48ym0wn2w0872mfq40ghajfrg1bccj1g342w899qh5x3bc4";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -23,6 +23,7 @@ stdenv.mkDerivation rec {
       --replace 'fprintf(lidStateFile, contents);' \
                 'fputs(contents, lidStateFile);'
 
+    substituteInPlace CMakeLists.txt --replace "set(Boost_USE_STATIC_LIBS ON)" ""
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/X11/xlayoutdisplay/default.nix
+++ b/pkgs/tools/X11/xlayoutdisplay/default.nix
@@ -31,5 +31,6 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/alex-courtis/xlayoutdisplay;
     maintainers = with maintainers; [ dtzWill ];
     license = licenses.asl20;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

https://github.com/alex-courtis/xlayoutdisplay/releases/tag/v1.1.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---