### PR TITLE
libobjc: 1.8.1 -> 1.9 -> 2.0

### DIFF
--- a/pkgs/desktops/gnustep/libobjc2/default.nix
+++ b/pkgs/desktops/gnustep/libobjc2/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libobjc2";
-  version = "1.9";
+  version = "2.0";
 
   src = fetchFromGitHub {
     owner = "gnustep";
     repo = "libobjc2";
     rev = "v${version}";
-    sha256 = "00pscl3ly3rv6alf9vk70kxnnxq2rfgpc1ylcv6cgjs9jxdnrqmn";
+    sha256 = "1b4h0a4pqr8j6300qr2wmi33r7ysvp705gs0ypx69hbmifln0mlf";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/desktops/gnustep/libobjc2/default.nix
+++ b/pkgs/desktops/gnustep/libobjc2/default.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchFromGitHub, cmake }:
 
 let
-  version = "1.8.1";
+  version = "1.9";
 in
 
 stdenv.mkDerivation rec {
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     owner = "gnustep";
     repo = "libobjc2";
     rev = "v${version}";
-    sha256 = "12v9pjg97h56mb114cqd22q1pdwhmxrgdw5hal74ddlrhiq1nzvi";
+    sha256 = "00pscl3ly3rv6alf9vk70kxnnxq2rfgpc1ylcv6cgjs9jxdnrqmn";
   };
 
   buildInputs = [ cmake ];

--- a/pkgs/desktops/gnustep/libobjc2/default.nix
+++ b/pkgs/desktops/gnustep/libobjc2/default.nix
@@ -1,11 +1,8 @@
 { stdenv, lib, fetchFromGitHub, cmake }:
 
-let
-  version = "1.9";
-in
-
 stdenv.mkDerivation rec {
-  name = "libobjc2-${version}";
+  pname = "libobjc2";
+  version = "1.9";
 
   src = fetchFromGitHub {
     owner = "gnustep";
@@ -14,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "00pscl3ly3rv6alf9vk70kxnnxq2rfgpc1ylcv6cgjs9jxdnrqmn";
   };
 
-  buildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ];
 
   cmakeFlags = [ "-DCMAKE_INSTALL_LIBDIR=lib" ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Builds on #60295, moving to 2.0!

I'm not sure if we want to stick with 1.x or not, hence the two PR's.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---