### PR TITLE
pythonPackages.ezdxf: 0.8.8 -> 0.9, fix build

### DIFF
--- a/pkgs/development/python-modules/ezdxf/default.nix
+++ b/pkgs/development/python-modules/ezdxf/default.nix
@@ -1,18 +1,20 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub, pyparsing, pytest }:
+{ stdenv, buildPythonPackage, pythonOlder, fetchFromGitHub, pyparsing, pytest }:
 
 buildPythonPackage rec {
-  version = "0.8.8";
+  version = "0.9";
   pname = "ezdxf";
+
+  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "mozman";
     repo = "ezdxf";
     rev = "v${version}";
-    sha256 = "0ap6f6vy71s3y0a048r5ca98i7p8nc9l0mx3mngvvpvjij7j3fcf";
+    sha256 = "1ggimjd9060b696sgzgxy9j9sl45wh9qbxnf0035qclafshprlzl";
   };
 
-  buildInputs = [ pytest ];
-  checkPhase = "python -m unittest discover -s tests";
+  checkInputs = [ pytest ];
+  checkPhase = "pytest tests integration_tests";
 
   propagatedBuildInputs = [ pyparsing ];
 


### PR DESCRIPTION
...though this only "fixes" the py2.7 build by bumping to a version that has deprecated py2 support, and therefore disabled it, but it had to happen eventually...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
