### PR TITLE
gorun: Init at 2018-04-08

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -98,6 +98,7 @@ in
   gocd-server = handleTest ./gocd-server.nix {};
   google-oslogin = handleTest ./google-oslogin {};
   graphene = handleTest ./graphene.nix {};
+  gorun = handleTest ./gorun.nix {};
   grafana = handleTest ./grafana.nix {};
   graphite = handleTest ./graphite.nix {};
   graylog = handleTest ./graylog.nix {};

--- a/nixos/tests/gorun.nix
+++ b/nixos/tests/gorun.nix
@@ -1,0 +1,30 @@
+import ./make-test.nix ({ pkgs, ... }:
+let
+  scriptFileData = ''
+    #!/run/current-system/sw/bin/gorun
+    package main
+
+    import "fmt"
+
+    func main() {
+      fmt.Println("Hello World!")
+    }
+  '';
+  scriptFileName = "hello.go";
+in {
+  name = "gorun";
+
+  meta = {
+    maintainers = pkgs.development.tools.gorun.meta.maintainers;
+  };
+
+  machine = { pkgs, ... }: {
+    environment.systemPackages = with pkgs; [ gorun ];
+  };
+
+  testScript = ''
+    $machine->succeed("echo '${scriptFileData}' > ${scriptFileName}");
+    $machine->succeed("chmod +x ${scriptFileName}");
+    $machine->succeed("./${scriptFileName}");
+  '';
+})

--- a/pkgs/development/tools/gorun/default.nix
+++ b/pkgs/development/tools/gorun/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  pname = "gorun";
+  version = "2018-04-08";
+  goPackagePath = "github.com/erning/gorun";
+
+  src = fetchFromGitHub {
+    owner = "erning";
+    repo = "gorun";
+    rev = "85cd5f5e084af0863ed0c3f18c00e64526d1b899";
+    sha256 = "1hdqimfzpynnpqc7p8m8hkcv9dlfbd8kl22979i6626nq57dvln8";
+  };
+
+  meta = with stdenv.lib; {
+    description = "Tool enabling one to put a \"bang line\" in the source code of a Go program to run it, or to run such a source code file explicitly.";
+    homepage = https://github.com/erning/gorun;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ Gonzih ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21768,6 +21768,8 @@ in
 
   gogui = callPackage ../games/gogui {};
 
+  gorun = callPackage ../development/tools/gorun {};
+
   gscrabble = python3Packages.callPackage ../games/gscrabble {};
 
   gshogi = python3Packages.callPackage ../games/gshogi {};


### PR DESCRIPTION
###### Motivation for this change
Added `gorun` tool that allows use go files in shebang fashion.
This PR represents package definition ported from my own configuration in to mainstream repository.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
