### PR TITLE
glulxe: init at 0.5.4

### DIFF
--- a/pkgs/games/glulxe/default.nix
+++ b/pkgs/games/glulxe/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchurl, ncurses }:
+
+stdenv.mkDerivation rec {
+  pname = "glulxe";
+  version = "0.5.4";
+
+  buildInputs = [ ncurses ]; 
+
+  srcs = [
+    (fetchurl {
+      url = "https://eblong.com/zarf/glulx/glulxe-054.tar.gz";
+      sha256 = "0vipydg6ra90yf9b3ipgppwxyb2xdhcxwvirgjy0v20wlf56zhhz";
+    })
+    (fetchurl {
+      url = "https://eblong.com/zarf/glk/glkterm-104.tar.gz";
+      sha256 = "0zlj9nlnkdlvgbiliczinirqygiq8ikg5hzh5vgcmnpg9pvnwga7";
+    })
+  ];
+
+  sourceRoot = "glulxe";
+
+  configurePhase = ''
+  substituteInPlace Makefile \
+    --replace "#GLKINCLUDEDIR = ../glkterm" "GLKINCLUDEDIR = ../glkterm" \
+    --replace "#GLKLIBDIR = ../glkterm" "GLKLIBDIR = ../glkterm" \
+    --replace "#GLKMAKEFILE = Make.glkterm" "GLKMAKEFILE = Make.glkterm"
+
+    cd ../glkterm
+    make
+    cd ../glulxe
+  '';
+
+  installPhase = ''
+    install -Dm755 glulxe $out/bin/glulxe
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Interpreter for a 32-bit portable virtual machine intended for playing interactive fiction, relieving some of the restrictions in the venerable Z-machine format";
+    license = licenses.mit;
+    maintainers = with maintainers; [ kisonecat ];
+    homepage = http://eblong.com/zarf/glulx/;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3102,6 +3102,8 @@ in
 
   gitea = callPackage ../applications/version-management/gitea { };
 
+  glulxe = callPackage ../games/glulxe { };
+    
   glusterfs = callPackage ../tools/filesystems/glusterfs { };
 
   glmark2 = callPackage ../tools/graphics/glmark2 { };


### PR DESCRIPTION
###### Motivation for this change

glulxe is available in guix but not in nixpkgs

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
