### PR TITLE
pazi: init at 0.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -578,6 +578,11 @@
     github = "bbarker";
     name = "Brandon Elam Barker";
   };
+  bbigras = {
+    email = "bigras.bruno@gmail.com";
+    github = "bbigras";
+    name = "Bruno Bigras";
+  };
   bcarrell = {
     email = "brandoncarrell@gmail.com";
     github = "bcarrell";

--- a/pkgs/tools/misc/pazi/cargo-lock.patch
+++ b/pkgs/tools/misc/pazi/cargo-lock.patch
@@ -1,0 +1,13 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 074b0ca..22f3bc5 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -286,7 +286,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "pazi"
+-version = "0.1.0"
++version = "0.2.0"
+ dependencies = [
+  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+  "crossbeam-channel 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/pkgs/tools/misc/pazi/default.nix
+++ b/pkgs/tools/misc/pazi/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, rustPlatform}:
+{ stdenv, fetchFromGitHub, rustPlatform }:
 
 rustPlatform.buildRustPackage rec {
   pname = "pazi";

--- a/pkgs/tools/misc/pazi/default.nix
+++ b/pkgs/tools/misc/pazi/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, rustPlatform}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "pazi";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "euank";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "12z2vyzmyxfq1krbbrjar7c2gvyq1969v16pb2pm7f4g4k24g0c8";
+  };
+
+  cargoSha256 = "0mgjl5vazk5z1859lb2va9af9yivz47jw4b01rjr4mq67v9jfld1";
+
+  cargoPatches = [ ./cargo-lock.patch ];
+
+  meta = with stdenv.lib; {
+    description = "An autojump \"zap to directory\" helper";
+    homepage = https://github.com/euank/pazi;
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ bbigras ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3941,6 +3941,7 @@ in
   lolcat = callPackage ../tools/misc/lolcat { };
 
   lsd = callPackage ../tools/misc/lsd { };
+  pazi = callPackage ../tools/misc/pazi { };
 
   lsdvd = callPackage ../tools/cd-dvd/lsdvd {};
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3941,7 +3941,6 @@ in
   lolcat = callPackage ../tools/misc/lolcat { };
 
   lsd = callPackage ../tools/misc/lsd { };
-  pazi = callPackage ../tools/misc/pazi { };
 
   lsdvd = callPackage ../tools/cd-dvd/lsdvd {};
 
@@ -4951,6 +4950,8 @@ in
   parted = callPackage ../tools/misc/parted { };
 
   paulstretch = callPackage ../applications/audio/paulstretch { };
+
+  pazi = callPackage ../tools/misc/pazi { };
 
   pell = callPackage ../applications/misc/pell { };
 


### PR DESCRIPTION
###### Motivation for this change

Add pazi. A supposedly fast autojump tool.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
