### PR TITLE
httplz: init at 1.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -578,6 +578,11 @@
     github = "bbarker";
     name = "Brandon Elam Barker";
   };
+  bbigras = {
+    email = "bigras.bruno@gmail.com";
+    github = "bbigras";
+    name = "Bruno Bigras";
+  };
   bcarrell = {
     email = "brandoncarrell@gmail.com";
     github = "bcarrell";

--- a/pkgs/tools/networking/httplz/cargo-lock.patch
+++ b/pkgs/tools/networking/httplz/cargo-lock.patch
@@ -1,0 +1,1211 @@
+diff --git a/Cargo.lock b/Cargo.lock
+new file mode 100644
+index 0000000..ff2d50d
+--- /dev/null
++++ b/Cargo.lock
+@@ -0,0 +1,1205 @@
++[[package]]
++name = "adler32"
++version = "1.0.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "aho-corasick"
++version = "0.7.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "ansi_term"
++version = "0.11.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "antidote"
++version = "1.0.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "atty"
++version = "0.2.11"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
++ "termion 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "autocfg"
++version = "0.1.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "base64"
++version = "0.9.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "base64"
++version = "0.10.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "bitflags"
++version = "0.9.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "bitflags"
++version = "1.0.4"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "brotli-sys"
++version = "0.3.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "brotli2"
++version = "0.3.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "brotli-sys 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "build_const"
++version = "0.2.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "byteorder"
++version = "1.3.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "bzip2"
++version = "0.3.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "bzip2-sys 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "bzip2-sys"
++version = "0.1.7"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "cc"
++version = "1.0.35"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "cfg-if"
++version = "0.1.7"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "clap"
++version = "2.33.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
++ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
++ "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
++ "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "cloudabi"
++version = "0.0.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "core-foundation"
++version = "0.2.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "core-foundation-sys"
++version = "0.2.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "crc"
++version = "1.8.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "crc32fast"
++version = "1.2.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "ctrlc"
++version = "3.1.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "nix 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "dtoa"
++version = "0.4.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "embed-resource"
++version = "1.2.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "vswhom 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winreg 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "flate2"
++version = "1.0.7"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
++ "miniz-sys 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
++ "miniz_oxide_c_api 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "foreign-types"
++version = "0.3.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "foreign-types-shared"
++version = "0.1.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "fuchsia-cprng"
++version = "0.1.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "gcc"
++version = "0.3.55"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "httparse"
++version = "1.3.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "https"
++version = "1.5.0"
++dependencies = [
++ "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "brotli2 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "bzip2 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
++ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "ctrlc 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "embed-resource 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "flate2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
++ "hyper-native-tls 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
++ "iron 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "lazysort 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
++ "md6 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "mime_guess 1.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
++ "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rfsapi 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
++ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "trivial_colours 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "unicase 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "hyper"
++version = "0.10.16"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
++ "mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
++ "traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "hyper-native-tls"
++version = "0.2.4"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "hyper 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)",
++ "native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "idna"
++version = "0.1.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
++ "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
++ "unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "iron"
++version = "0.6.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "hyper 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)",
++ "hyper-native-tls 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
++ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
++ "mime_guess 1.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "modifier 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "typemap 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "itoa"
++version = "0.3.4"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "language-tags"
++version = "0.2.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "lazy_static"
++version = "0.2.11"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "lazy_static"
++version = "1.3.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "lazysort"
++version = "0.2.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "libc"
++version = "0.2.53"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "log"
++version = "0.3.9"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "log"
++version = "0.4.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "matches"
++version = "0.1.8"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "md6"
++version = "2.0.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "memchr"
++version = "2.2.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "mime"
++version = "0.2.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "mime_guess"
++version = "1.8.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "phf 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
++ "phf_codegen 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
++ "unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "miniz-sys"
++version = "0.1.11"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "miniz_oxide"
++version = "0.2.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "miniz_oxide_c_api"
++version = "0.2.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
++ "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
++ "miniz_oxide 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "modifier"
++version = "0.1.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "native-tls"
++version = "0.1.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
++ "openssl 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)",
++ "schannel 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
++ "security-framework 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
++ "security-framework-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
++ "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "nix"
++version = "0.13.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
++ "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
++ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
++ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "num-traits"
++version = "0.1.43"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "num-traits"
++version = "0.2.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "num_cpus"
++version = "1.10.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "numtoa"
++version = "0.1.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "openssl"
++version = "0.9.24"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
++ "openssl-sys 0.9.43 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "openssl-sys"
++version = "0.9.43"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
++ "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "percent-encoding"
++version = "1.0.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "phf"
++version = "0.7.24"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "phf_codegen"
++version = "0.7.24"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "phf_generator 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
++ "phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "phf_generator"
++version = "0.7.24"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "phf_shared"
++version = "0.7.24"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "pkg-config"
++version = "0.3.14"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "plugin"
++version = "0.2.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "typemap 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "quote"
++version = "0.3.15"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "rand"
++version = "0.4.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "rand"
++version = "0.6.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand_jitter 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "rand_chacha"
++version = "0.1.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "rand_core"
++version = "0.3.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "rand_core"
++version = "0.4.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "rand_hc"
++version = "0.1.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "rand_isaac"
++version = "0.1.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "rand_jitter"
++version = "0.1.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "rand_os"
++version = "0.1.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "rand_pcg"
++version = "0.1.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "rand_xorshift"
++version = "0.1.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "rdrand"
++version = "0.4.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "redox_syscall"
++version = "0.1.54"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "redox_termios"
++version = "0.1.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "regex"
++version = "1.1.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "aho-corasick 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "regex-syntax 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "regex-syntax"
++version = "0.6.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "remove_dir_all"
++version = "0.5.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "rfsapi"
++version = "0.1.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "hyper 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)",
++ "mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde_derive 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
++ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "rustc_version"
++version = "0.2.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "safemem"
++version = "0.3.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "schannel"
++version = "0.1.15"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "security-framework"
++version = "0.1.16"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
++ "security-framework-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "security-framework-sys"
++version = "0.1.16"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "semver"
++version = "0.9.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "semver-parser"
++version = "0.7.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "serde"
++version = "0.9.15"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "serde_codegen_internals"
++version = "0.14.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "serde_derive"
++version = "0.9.15"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde_codegen_internals 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
++ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "serde_json"
++version = "0.9.10"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
++ "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
++ "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "siphasher"
++version = "0.2.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "smallvec"
++version = "0.6.9"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "strsim"
++version = "0.8.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "syn"
++version = "0.11.11"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
++ "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "synom"
++version = "0.11.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "tempdir"
++version = "0.3.7"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
++ "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "termion"
++version = "1.5.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
++ "numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
++ "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "textwrap"
++version = "0.11.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "thread_local"
++version = "0.3.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "time"
++version = "0.1.42"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
++ "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "traitobject"
++version = "0.1.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "trivial_colours"
++version = "0.3.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "typeable"
++version = "0.1.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "typemap"
++version = "0.3.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "unsafe-any 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "ucd-util"
++version = "0.1.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "unicase"
++version = "1.4.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "unicase"
++version = "2.3.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "unicode-bidi"
++version = "0.3.4"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "unicode-normalization"
++version = "0.1.8"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "unicode-width"
++version = "0.1.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "unicode-xid"
++version = "0.0.4"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "unsafe-any"
++version = "0.4.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "url"
++version = "1.7.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
++ "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
++ "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "utf8-ranges"
++version = "1.0.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "vcpkg"
++version = "0.2.6"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "vec_map"
++version = "0.8.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "version_check"
++version = "0.1.5"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "void"
++version = "1.0.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "vswhom"
++version = "0.1.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
++ "vswhom-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "vswhom-sys"
++version = "0.1.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
++ "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "winapi"
++version = "0.3.7"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
++ "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[[package]]
++name = "winapi-i686-pc-windows-gnu"
++version = "0.4.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "winapi-x86_64-pc-windows-gnu"
++version = "0.4.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++
++[[package]]
++name = "winreg"
++version = "0.5.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++dependencies = [
++ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
++]
++
++[metadata]
++"checksum adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
++"checksum aho-corasick 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e6f484ae0c99fec2e858eb6134949117399f222608d84cadb3f58c1f97c2364c"
++"checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
++"checksum antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
++"checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
++"checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
++"checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
++"checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
++"checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
++"checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
++"checksum brotli-sys 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4445dea95f4c2b41cde57cc9fee236ae4dbae88d8fcbdb4750fc1bb5d86aaecd"
++"checksum brotli2 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0cb036c3eade309815c15ddbacec5b22c4d1f3983a774ab2eac2e3e9ea85568e"
++"checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
++"checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
++"checksum bzip2 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "42b7c3cbf0fa9c1b82308d57191728ca0256cb821220f4e2fd410a72ade26e3b"
++"checksum bzip2-sys 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6584aa36f5ad4c9247f5323b0a42f37802b37a836f0ad87084d7a33961abe25f"
++"checksum cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)" = "5e5f3fee5eeb60324c2781f1e41286bdee933850fff9b3c672587fed5ec58c83"
++"checksum cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11d43355396e872eefb45ce6342e4374ed7bc2b3a502d1b28e36d6e23c05d1f4"
++"checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
++"checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
++"checksum core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25bfd746d203017f7d5cbd31ee5d8e17f94b6521c7af77ece6c9e4b2d4b16c67"
++"checksum core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "065a5d7ffdcbc8fa145d6f0746f3555025b9097a9e9cda59f7467abae670c78d"
++"checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
++"checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
++"checksum ctrlc 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5531b7f0698d9220b4729f8811931dbe0e91a05be2f7b3245fdc50dd856bae26"
++"checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
++"checksum embed-resource 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee11dd277e159f3a7845341f8c800899cf918a366956e31dd52f35eff638a403"
++"checksum flate2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f87e68aa82b2de08a6e037f1385455759df6e445a8df5e005b4297191dbf18aa"
++"checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
++"checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
++"checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
++"checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
++"checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
++"checksum hyper 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)" = "0a0652d9a2609a968c14be1a9ea00bf4b1d64e2e1f53a1b51b6fff3a6e829273"
++"checksum hyper-native-tls 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "72332e4a35d3059583623b50e98e491b78f8b96c5521fcb3f428167955aa56e8"
++"checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
++"checksum iron 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d8e17268922834707e1c29e8badbf9c712c9c43378e1b6a3388946baff10be2"
++"checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
++"checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
++"checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
++"checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
++"checksum lazysort 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d0e22ff43b231e0e2f87d74984e53ebc73b90ae13397e041214fb07efc64168f"
++"checksum libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)" = "ec350a9417dfd244dc9a6c4a71e13895a4db6b92f0b106f07ebbc3f3bc580cee"
++"checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
++"checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
++"checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
++"checksum md6 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "54e5826684849cecd3fa05a6a5052c50a3542f163a9917ff0b91379426a2e45d"
++"checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
++"checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
++"checksum mime_guess 1.8.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2d4c0961143b8efdcfa29c3ae63281601b446a4a668165454b6c90f8024954c5"
++"checksum miniz-sys 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0300eafb20369952951699b68243ab4334f4b10a88f411c221d444b36c40e649"
++"checksum miniz_oxide 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c468f2369f07d651a5d0bb2c9079f8488a66d5466efe42d0c5c6466edcb7f71e"
++"checksum miniz_oxide_c_api 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b7fe927a42e3807ef71defb191dc87d4e24479b221e67015fe38ae2b7b447bab"
++"checksum modifier 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "41f5c9112cb662acd3b204077e0de5bc66305fa8df65c8019d5adb10e9ab6e58"
++"checksum native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f74dbadc8b43df7864539cedb7bc91345e532fdd913cfdc23ad94f4d2d40fbc0"
++"checksum nix 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46f0f3210768d796e8fa79ec70ee6af172dacbe7147f5e69be5240a47778302b"
++"checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
++"checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
++"checksum num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a23f0ed30a54abaa0c7e83b1d2d87ada7c3c23078d1d87815af3e3b6385fbba"
++"checksum numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
++"checksum openssl 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)" = "a3605c298474a3aa69de92d21139fb5e2a81688d308262359d85cdd0d12a7985"
++"checksum openssl-sys 0.9.43 (registry+https://github.com/rust-lang/crates.io-index)" = "33c86834957dd5b915623e94f2f4ab2c70dd8f6b70679824155d5ae21dbd495d"
++"checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
++"checksum phf 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "b3da44b85f8e8dfaec21adae67f95d93244b2ecf6ad2a692320598dcc8e6dd18"
++"checksum phf_codegen 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "b03e85129e324ad4166b06b2c7491ae27fe3ec353af72e72cd1654c7225d517e"
++"checksum phf_generator 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "09364cc93c159b8b06b1f4dd8a4398984503483891b0c26b867cf431fb132662"
++"checksum phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
++"checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
++"checksum plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1a6a0dc3910bc8db877ffed8e457763b317cf880df4ae19109b9f77d277cf6e0"
++"checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
++"checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
++"checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
++"checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
++"checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
++"checksum rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0"
++"checksum rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
++"checksum rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
++"checksum rand_jitter 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b9ea758282efe12823e0d952ddb269d2e1897227e464919a554f2a03ef1b832"
++"checksum rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
++"checksum rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
++"checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
++"checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
++"checksum redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)" = "12229c14a0f65c4f1cb046a3b52047cdd9da1f4b30f8a39c5063c8bae515e252"
++"checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
++"checksum regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8f0a0bcab2fd7d1d7c54fa9eae6f43eddeb9ce2e7352f8518a814a4f65d60c58"
++"checksum regex-syntax 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "dcfd8681eebe297b81d98498869d4aae052137651ad7b96822f09ceb690d0a96"
++"checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
++"checksum rfsapi 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1b6fbc119d00459f80252adb96e554766d75de071ed5d3c49f46a000d137cd49"
++"checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
++"checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
++"checksum schannel 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "f2f6abf258d99c3c1c5c2131d99d064e94b7b3dd5f416483057f308fea253339"
++"checksum security-framework 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "dfa44ee9c54ce5eecc9de7d5acbad112ee58755239381f687e564004ba4a2332"
++"checksum security-framework-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "5421621e836278a0b139268f36eee0dc7e389b784dc3f79d8f11aabadf41bead"
++"checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
++"checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
++"checksum serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)" = "34b623917345a631dc9608d5194cc206b3fe6c3554cd1c75b937e55e285254af"
++"checksum serde_codegen_internals 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bc888bd283bd2420b16ad0d860e35ad8acb21941180a83a189bb2046f9d00400"
++"checksum serde_derive 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)" = "978fd866f4d4872084a81ccc35e275158351d3b9fe620074e7d7504b816b74ba"
++"checksum serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ad8bcf487be7d2e15d3d543f04312de991d631cfe1b43ea0ade69e6a8a5b16a1"
++"checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
++"checksum smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be"
++"checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
++"checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
++"checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
++"checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
++"checksum termion 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dde0593aeb8d47accea5392b39350015b5eccb12c0d98044d856983d89548dea"
++"checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
++"checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
++"checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
++"checksum traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
++"checksum trivial_colours 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7153365ea16c5a0ce2eebc4da1b33339a6b21d90c49f670e82130639656bb458"
++"checksum typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
++"checksum typemap 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "653be63c80a3296da5551e1bfd2cca35227e13cdd08c6668903ae2f4f77aa1f6"
++"checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
++"checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
++"checksum unicase 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "41d17211f887da8e4a70a45b9536f26fc5de166b81e2d5d80de4a17fd22553bd"
++"checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
++"checksum unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
++"checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
++"checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
++"checksum unsafe-any 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f30360d7979f5e9c6e6cea48af192ea8fab4afb3cf72597154b8f08935bc9c7f"
++"checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
++"checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
++"checksum vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "def296d3eb3b12371b2c7d0e83bfe1403e4db2d7a0bba324a12b21c4ee13143d"
++"checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
++"checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
++"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
++"checksum vswhom 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "be979b7f07507105799e854203b470ff7c78a1639e330a58f183b5fea574608b"
++"checksum vswhom-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc2f5402d3d0e79a069714f7b48e3ecc60be7775a2c049cb839457457a239532"
++"checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"
++"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
++"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
++"checksum winreg 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a27a759395c1195c4cc5cda607ef6f8f6498f64e78f7900f5de0a127a424704a"

--- a/pkgs/tools/networking/httplz/default.nix
+++ b/pkgs/tools/networking/httplz/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub, rustPlatform, pkgs }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "httplz";
+  version = "1.5.0";
+
+  src = fetchFromGitHub {
+    owner = "thecoshman";
+    repo = "http";
+    rev = "v${version}";
+    sha256 = "0mb2wifz8pba03bdpiqadih33jimhg9crs4b72rcyfmj9l8fd1ba";
+  };
+
+  buildInputs = with pkgs; [ openssl pkgconfig ];
+
+  cargoBuildFlags = [ "--bin httplz" ];
+  cargoPatches = [ ./cargo-lock.patch ];
+  cargoSha256 = "0cy23smal6y5qj6a202zf7l76vwkpzvcjmlbq0ffyph3gq07ps7b";
+
+  meta = with stdenv.lib; {
+    description = "A basic http server for hosting a folder fast and simply";
+    homepage = https://github.com/thecoshman/http;
+    license = licenses.mit;
+    maintainers = with maintainers; [ bbigras ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1689,6 +1689,8 @@ in
 
   nx-libs = callPackage ../tools/X11/nx-libs { };
 
+  httplz = callPackage ../tools/networking/httplz { };
+
   nyx = callPackage ../tools/networking/nyx { };
 
   onboard = callPackage ../applications/misc/onboard { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1689,8 +1689,6 @@ in
 
   nx-libs = callPackage ../tools/X11/nx-libs { };
 
-  httplz = callPackage ../tools/networking/httplz { };
-
   nyx = callPackage ../tools/networking/nyx { };
 
   onboard = callPackage ../applications/misc/onboard { };
@@ -3523,6 +3521,8 @@ in
   httpie = callPackage ../tools/networking/httpie { };
 
   httping = callPackage ../tools/networking/httping {};
+
+  httplz = callPackage ../tools/networking/httplz { };
 
   httpfs2 = callPackage ../tools/filesystems/httpfs { };
 


### PR DESCRIPTION
###### Motivation for this change

Note that the project's name is "http" and it provides 2 identical binaries ("http" and "httplz").

"http" collides with the very popular httpie's "http" so I named the package "httplz" and I only build the "httplz" binary.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
