### PR TITLE
kwalletcli: fix pinentry-kwallet

### DIFF
--- a/pkgs/tools/security/kwalletcli/default.nix
+++ b/pkgs/tools/security/kwalletcli/default.nix
@@ -1,48 +1,48 @@
-{
-  mkDerivation, fetchurl, lib,
-  pkgconfig,
-  kcoreaddons, ki18n, kwallet,
-  mksh
-}:
+{ mkDerivation, fetchFromGitHub, lib, makeWrapper, pkgconfig
+, kcoreaddons, ki18n, kwallet, mksh, pinentry_qt5 }:
 
-let
+mkDerivation rec {
   pname = "kwalletcli";
   version = "3.02";
-in
-mkDerivation rec {
-  name = "${pname}-${version}";
 
-  src = fetchurl {
-    url = "https://www.mirbsd.org/MirOS/dist/hosted/kwalletcli/${name}.tar.gz";
-    sha256 = "05njayi07996ljfl8a6frlk2s60grk5w27f0f445nmvd5n0bzgpn";
+  src = fetchFromGitHub {
+    owner = "MirBSD";
+    repo = pname;
+    rev = "${pname}-${lib.replaceStrings [ "." ] [ "_" ] version}";
+    sha256 = "1gq45afb5nmmjfqxglv7wvcxcjd9822pc7nysq0350jmmmqwb474";
   };
 
   postPatch = ''
     substituteInPlace GNUmakefile \
-      --replace '-I/usr/include/KF5/KCoreAddons' '-I${kcoreaddons.dev}/include/KF5/KCoreAddons' \
-      --replace '-I/usr/include/KF5/KI18n'       '-I${ki18n.dev}/include/KF5/KI18n' \
-      --replace '-I/usr/include/KF5/KWallet'     '-I${kwallet.dev}/include/KF5/KWallet' \
-      --replace /usr/bin                         $out/bin \
-      --replace /usr/share/man                   $out/share/man
+      --replace -I/usr/include/KF5/KCoreAddons -I${kcoreaddons.dev}/include/KF5/KCoreAddons \
+      --replace -I/usr/include/KF5/KI18n       -I${ki18n.dev}/include/KF5/KI18n \
+      --replace -I/usr/include/KF5/KWallet     -I${kwallet.dev}/include/KF5/KWallet \
+      --replace /usr/bin                       $out/bin \
+      --replace /usr/share/man                 $out/share/man
+
+    substituteInPlace pinentry-kwallet \
+      --replace '/usr/bin/env mksh' ${mksh}/bin/mksh
   '';
 
   makeFlags = [ "KDE_VER=5" ];
 
-  # we need this when building against qt 5.8+
-  NIX_CFLAGS_COMPILE = [ "-std=c++11" ];
-
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ makeWrapper pkgconfig ];
   # if using just kwallet, cmake will be added as a buildInput and fail the build
   propagatedBuildInputs = [ kcoreaddons ki18n (lib.getLib kwallet) ];
-  propagatedUserEnvPkgs = [ mksh ];
 
   preInstall = ''
     mkdir -p $out/bin $out/share/man/man1
   '';
 
+  postInstall = ''
+    wrapProgram $out/bin/pinentry-kwallet \
+      --prefix PATH : $out/bin:${lib.makeBinPath [ pinentry_qt5 ]} \
+      --set-default PINENTRY pinentry-qt
+  '';
+
   meta = with lib; {
     description = "Command-Line Interface to the KDE Wallet";
-    homepage = http://www.mirbsd.org/kwalletcli.htm;
+    homepage = https://www.mirbsd.org/kwalletcli.htm;
     license = licenses.miros;
     maintainers = with maintainers; [ peterhoeg ];
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The standard builder doesn't fix up ```mksh``` scripts, so we have to do this manually in for ```pinentry-kwallet``` to actually work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
