### PR TITLE
oraclejdk8cpu: 8u201 -> 8u211, oracledjdk8psu: 8u202 -> 8u212

### DIFF
--- a/pkgs/development/compilers/oraclejdk/jdk8cpu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8cpu-linux.nix
@@ -2,13 +2,13 @@
 # jce download url: http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "201";
-  buildVersion = "09";
-  sha256.i686-linux = "1f9n93zmkggchaxkchp4bqasvxznn96zjci34f52h7v392jkzqac";
-  sha256.x86_64-linux = "0w730v2q0iaxf2lprabwmy7129byrs0hhdbwas575p1xmk00qw6b";
-  sha256.armv7l-linux = "0y6bvq93lsf21v6ca536dpfhkk5ljsj7c6di0qzkban37bivj0si";
-  sha256.aarch64-linux = "1bybysgg9llqzllsmdszmmb73v5az2l1shxn6lxwv3wwiazpf47q";
-  releaseToken = "42970487e3af4f5aa5bca3f542482c60";
+  patchVersion = "211";
+  buildVersion = "12";
+  sha256.i686-linux = "0mdrljs0rw9s4pvaa3sn791nqgdrp8749z3qn80y7hhad74kvsnp";
+  sha256.x86_64-linux = "13b6qk4sn8jdhxa22na9d2aazm4yjh6yxrlxr189gxy3619y9dy0";
+  sha256.armv7l-linux = "1ij1x925k7lyp5f98gy8r0xfr41qhczf2rb74plwwmrccc1k00p5";
+  sha256.aarch64-linux = "041r615qj9qy34a9gxm8968qlmf060ba2as5w97v86mbik4rca05";
+  releaseToken = "478a62b7d4e34b78b671c754eaaf38ab";
   jceName = "jce_policy-8.zip";
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";
 }

--- a/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
+++ b/pkgs/development/compilers/oraclejdk/jdk8psu-linux.nix
@@ -2,13 +2,13 @@
 # jce download url: http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html;
 import ./jdk-linux-base.nix {
   productVersion = "8";
-  patchVersion = "202";
-  buildVersion = "09";
-  sha256.i686-linux = "19np392dwdqdq39lmm10607w2h042lrm5953fnsfh1bb9jli1pgj";
-  sha256.x86_64-linux = "1q4l8pymjvsvxfwaw0rdcnhryh1la2bvg5f4d4my41ka390k4p4s";
-  sha256.armv7l-linux = "06aljl7dqmmhmp7xswgvkcgh9mam71wnqydg9yb3hkcc443cm581";
-  sha256.aarch64-linux = "12v9ndv7a2c9zqq6ai2vsgwad0lzmf4c6jxy4p9miapmhjzx5vii";
-  releaseToken = "42970487e3af4f5aa5bca3f542482c60";
+  patchVersion = "212";
+  buildVersion = "10";
+  sha256.i686-linux = "03dj9q0bi3ib731f4zl9hylkrgw417h6qlg2wi7nw71b0fqhijn1";
+  sha256.x86_64-linux = "1yzddxzfh6h14bpzis1abp52x4jjljg8a3zyqz483q6qm05caq1i";
+  sha256.armv7l-linux = "0x333alkqdx8mmiirair7g5iiwif5v9ka4j3qr0f42ilvmk8csnx";
+  sha256.aarch64-linux = "0vcbdvcsl8rm47i07s93jmrrs5laibf937d8vacjqqgh9bbhsr2c";
+  releaseToken = "59066701cf1a433da9770636fbc4c9aa";
   jceName = "jce_policy-8.zip";
   sha256JCE = "0n8b6b8qmwb14lllk2lk1q1ahd3za9fnjigz5xn65mpg48whl0pk";
 }


### PR DESCRIPTION
###### Motivation for this change

Version update (the old versions are no longer available for download). This also updates the PSU versions as requested in #60222. Thanks to the fix in #59947 all of the downloads work correctly, without manual prefetch (though to discover the hashes and token I needed to log in with an oracle account 😬 )

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
