### PR TITLE
sway: Read the configuration from /etc before /nix/store

### DIFF
--- a/nixos/modules/programs/sway.nix
+++ b/nixos/modules/programs/sway.nix
@@ -78,9 +78,9 @@ in {
     environment = {
       systemPackages = [ swayJoined ] ++ cfg.extraPackages;
       etc = {
-        "sway/config".source = "${swayPackage}/etc/sway/config";
-        #"sway/security.d".source = "${swayPackage}/etc/sway/security.d/";
-        #"sway/config.d".source = "${swayPackage}/etc/sway/config.d/";
+        "sway/config".source = mkOptionDefault "${swayPackage}/etc/sway/config";
+        #"sway/security.d".source = mkOptionDefault "${swayPackage}/etc/sway/security.d/";
+        #"sway/config.d".source = mkOptionDefault "${swayPackage}/etc/sway/config.d/";
       };
     };
     security.pam.services.swaylock = {};

--- a/pkgs/applications/window-managers/sway/default.nix
+++ b/pkgs/applications/window-managers/sway/default.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation rec {
       sha256 = "0r583nmqvq43ib93yv6flw8pj833v32lbs0q0xld56s3rnzvvdcp";
     })
     ./sway-config-no-nix-store-references.patch
+    ./load-configuration-from-etc.patch
   ];
 
   nativeBuildInputs = [ pkgconfig meson ninja scdoc ];

--- a/pkgs/applications/window-managers/sway/load-configuration-from-etc.patch
+++ b/pkgs/applications/window-managers/sway/load-configuration-from-etc.patch
@@ -1,0 +1,42 @@
+From 26f9c65ef037892977a824f0d7d7111066856b53 Mon Sep 17 00:00:00 2001
+From: Michael Weiss <dev.primeos@gmail.com>
+Date: Sat, 27 Apr 2019 14:26:16 +0200
+Subject: [PATCH] Load configs from /etc but fallback to /nix/store
+
+This change will load all configuration files from /etc, to make it easy
+to override them, but fallback to /nix/store/.../etc/sway/config to make
+Sway work out-of-the-box with the default configuration on non NixOS
+systems.
+---
+ meson.build   | 3 ++-
+ sway/config.c | 1 +
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index 02b5d606..c03a9c0f 100644
+--- a/meson.build
++++ b/meson.build
+@@ -129,7 +129,8 @@ if scdoc.found()
+ 	endforeach
+ endif
+ 
+-add_project_arguments('-DSYSCONFDIR="/@0@"'.format(join_paths(prefix, sysconfdir)), language : 'c')
++add_project_arguments('-DSYSCONFDIR="/@0@"'.format(sysconfdir), language : 'c')
++add_project_arguments('-DNIX_SYSCONFDIR="/@0@"'.format(join_paths(prefix, sysconfdir)), language : 'c')
+ 
+ version = '"@0@"'.format(meson.project_version())
+ if git.found()
+diff --git a/sway/config.c b/sway/config.c
+index 4cd21bbc..dd855753 100644
+--- a/sway/config.c
++++ b/sway/config.c
+@@ -317,6 +317,7 @@ static char *get_config_path(void) {
+ 		"$XDG_CONFIG_HOME/i3/config",
+ 		SYSCONFDIR "/sway/config",
+ 		SYSCONFDIR "/i3/config",
++		NIX_SYSCONFDIR "/sway/config",
+ 	};
+ 
+ 	char *config_home = getenv("XDG_CONFIG_HOME");
+-- 
+2.19.2


### PR DESCRIPTION
This change will load all configuration files from /etc, to make it easy
to override them, but fallback to /nix/store/.../etc/sway/config to make
Sway work out-of-the-box with the default configuration on non NixOS
systems.

Notes: I'm using `mkOptionDefault` instead of `mkDefault` so that setting `environment.etc."sway/config".text = "...";` works as well (see `nixos/modules/system/etc/etc.nix`, which implements `text` via `source` and also uses `mkDefault`).

See https://github.com/NixOS/nixpkgs/commit/578fe3f5a02f855c5d1ad14e2440b9359a750c40#r33300320 for the motivation of this change.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
