### PR TITLE
terra: fix darwin build

### DIFF
--- a/pkgs/development/compilers/terra/default.nix
+++ b/pkgs/development/compilers/terra/default.nix
@@ -37,26 +37,20 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    mkdir -pv $out/lib
-    cp -v release/lib/terra.so $out/lib
-
-    mkdir -pv $bin/bin
-    cp -v release/bin/terra $bin/bin
-
-    mkdir -pv $static/lib
-    cp -v release/lib/libterra.a $static/lib
+    install -Dm755 -t $bin/bin release/bin/terra
+    install -Dm755 -t $out/lib release/lib/terra${stdenv.hostPlatform.extensions.sharedLibrary}
+    install -Dm644 -t $static/lib release/lib/libterra.a
 
     mkdir -pv $dev/include
     cp -rv release/include/terra $dev/include
-  ''
-  ;
+  '';
 
   buildInputs = with llvmPackages; [ lua llvm clang-unwrapped ncurses ];
 
   meta = with stdenv.lib; {
-    inherit (src.meta) homepage;
     description = "A low-level counterpart to Lua";
-    platforms = [ "x86_64-linux" ];
+    homepage = http://terralang.org/;
+    platforms = platforms.x86_64;
     maintainers = with maintainers; [ jb55 ];
     license = licenses.mit;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
