### PR TITLE
pythonPackages.asana: 0.7.1 -> 0.8.2, disable for py3.7

### DIFF
--- a/pkgs/development/python-modules/asana/default.nix
+++ b/pkgs/development/python-modules/asana/default.nix
@@ -1,16 +1,20 @@
-{ buildPythonPackage, pytest, requests, requests_oauthlib, six
+{ buildPythonPackage, pythonAtLeast, pytest, requests, requests_oauthlib, six
 , fetchFromGitHub, responses, stdenv
 }:
 
 buildPythonPackage rec {
   pname = "asana";
-  version = "0.7.1";
+  version = "0.8.2";
+
+  # upstream reportedly doesn't support 3.7 yet, blocked on
+  # https://bugs.python.org/issue34226
+  disabled = pythonAtLeast "3.7";
 
   src = fetchFromGitHub {
     owner = "asana";
     repo = "python-asana";
     rev = "v${version}";
-    sha256 = "0vmpy4j1n54gkkg0l8bhw0xf4yby5kqzxnsv07cjc2w38snj5vy1";
+    sha256 = "113zwnrpim1pdw8dzid2wpp5gzr2zk26jjl4wrwhgj0xk1cw94yi";
   };
 
   checkInputs = [ pytest responses ];


### PR DESCRIPTION
###### Motivation for this change
Bump and "fix" python 3.7 package by disabling it for 3.7 (upstream reportedly doesn't support 3.7 yet, blocked on https://bugs.python.org/issue34226)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
