### PR TITLE
nixos/pazi: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -117,6 +117,7 @@
   ./programs/nm-applet.nix
   ./programs/npm.nix
   ./programs/oblogout.nix
+  ./programs/pazi.nix
   ./programs/plotinus.nix
   ./programs/qt5ct.nix
   ./programs/screen.nix

--- a/nixos/modules/programs/pazi.nix
+++ b/nixos/modules/programs/pazi.nix
@@ -4,11 +4,6 @@ with lib;
 
 let
   cfg = config.programs.pazi;
-  prg = config.programs;
-
-  initScript = shell: ''
-    eval $(${pkgs.pazi}/bin/pazi init ${shell})
-  '';
 in
 {
   options = {
@@ -28,10 +23,8 @@ in
   config = mkIf cfg.enable {
     environment.systemPackages = [ pkgs.pazi ];
 
-    programs.bash.interactiveShellInit = initScript "bash";
-    programs.zsh.interactiveShellInit = mkIf prg.zsh.enable initScript "zsh";
-    programs.fish.interactiveShellInit = mkIf prg.fish.enable ''
-      ${pkgs.pazi}/bin/pazi init fish | source
-    '';
+    programs.bash.interactiveShellInit = "source ${pkgs.pazi}/share/pazi.bash";
+    programs.fish.interactiveShellInit = "source ${pkgs.pazi}/share/pazi.fish";
+    programs.zsh.interactiveShellInit = "source ${pkgs.pazi}/share/pazi.zsh";
   };
 }

--- a/nixos/modules/programs/pazi.nix
+++ b/nixos/modules/programs/pazi.nix
@@ -1,0 +1,37 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.pazi;
+  prg = config.programs;
+
+  initScript = shell: ''
+    eval $(${pkgs.pazi}/bin/pazi init ${shell})
+  '';
+in
+{
+  options = {
+    programs.pazi = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to enable pazi.
+        '';
+      };
+    };
+  };
+
+  ###### implementation
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.pazi ];
+
+    programs.bash.interactiveShellInit = initScript "bash";
+    programs.zsh.interactiveShellInit = mkIf prg.zsh.enable initScript "zsh";
+    programs.fish.interactiveShellInit = mkIf prg.fish.enable ''
+      ${pkgs.pazi}/bin/pazi init fish | source
+    '';
+  };
+}

--- a/pkgs/tools/misc/pazi/default.nix
+++ b/pkgs/tools/misc/pazi/default.nix
@@ -15,6 +15,13 @@ rustPlatform.buildRustPackage rec {
 
   cargoPatches = [ ./cargo-lock.patch ];
 
+  postInstall = ''
+    mkdir -p $out/share
+    $out/bin/pazi init bash > "$out/share/pazi.bash"
+    $out/bin/pazi init fish > "$out/share/pazi.fish"
+    $out/bin/pazi init zsh > "$out/share/pazi.zsh"
+  '';
+
   meta = with stdenv.lib; {
     description = "An autojump \"zap to directory\" helper";
     homepage = https://github.com/euank/pazi;


### PR DESCRIPTION
###### Motivation for this change

Shell integration.

@teto

###### Things done

I'm still running `nixos-build` but the module seems pretty simple. I'll update after testing.

I manually tested that eval works for bash and zsh. And `pazi init fish | source` for fish.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
