### PR TITLE
pythonPackages.fastpair: force use of pytest_3

### DIFF
--- a/pkgs/development/python-modules/fastpair/default.nix
+++ b/pkgs/development/python-modules/fastpair/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub, pytestrunner, pytest, scipy }:
+{ stdenv, buildPythonPackage, fetchFromGitHub, pytestrunner, pytest_3, scipy }:
 
 buildPythonPackage {
   pname = "fastpair";
@@ -11,16 +11,16 @@ buildPythonPackage {
     sha256 = "1pv9sxycxdk567s5gs947rhlqngrb9nn9yh4dhdvg1ix1i8dca71";
   };
 
-  buildInputs = [ pytestrunner ];
+  nativeBuildInputs = [ (pytestrunner.override { pytest = pytest_3; }) ];
 
-  checkInputs = [ pytest ];
+  checkInputs = [ pytest_3 ];
 
   propagatedBuildInputs = [
     scipy
   ];
 
   checkPhase = ''
-    py.test fastpair
+    pytest fastpair
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
Fix build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
