### PR TITLE
libsForQt5.qtkeychain: add libsecret support

### DIFF
--- a/pkgs/development/libraries/qtkeychain/default.nix
+++ b/pkgs/development/libraries/qtkeychain/default.nix
@@ -1,6 +1,7 @@
-{ stdenv, fetchFromGitHub, cmake, qt4 ? null
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, qt4 ? null
 , withQt5 ? false, qtbase ? null, qttools ? null
 , darwin ? null
+, libsecret
 }:
 
 assert withQt5 -> qtbase != null;
@@ -22,11 +23,14 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [ "-DQT_TRANSLATIONS_DIR=share/qt/translations" ];
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ]
+    ++ stdenv.lib.optional (!stdenv.isDarwin) [ pkgconfig ] # for finding libsecret
+  ;
 
-  buildInputs = if withQt5 then [ qtbase qttools ] else [ qt4 ]
+  buildInputs = stdenv.lib.optional (!stdenv.isDarwin) [ libsecret ]
+    ++ (if withQt5 then [ qtbase qttools ] else [ qt4 ])
     ++ stdenv.lib.optional stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
-         CoreFoundation Security
+      CoreFoundation Security
     ])
   ;
 


### PR DESCRIPTION
###### Motivation for this change
qtkeychain uses pkg-config to detect whether libsecret is available,
otherwise it just builds a stub object file.

We need libsecret support to allow nextcloud-client storing passwords
on Freedesktop platforms.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
