### PR TITLE
grafana_reporter: 2.0.1 -> 2.1.0

### DIFF
--- a/pkgs/servers/monitoring/grafana-reporter/default.nix
+++ b/pkgs/servers/monitoring/grafana-reporter/default.nix
@@ -4,7 +4,7 @@ with stdenv.lib;
 
 buildGoPackage rec {
   name = "reporter-${version}";
-  version = "2.0.1";
+  version = "2.1.0";
   rev = "v${version}";
 
   goPackagePath = "github.com/IzakMarais/reporter";
@@ -15,7 +15,7 @@ buildGoPackage rec {
     inherit rev;
     owner = "IzakMarais";
     repo = "reporter";
-    sha256 = "0yi7nx8ig5xgkwizddl0gdicnmcdp4qgg1fdxyq04l2y3qs176sg";
+    sha256 = "1zindyypf634l4dd2rsvp67ryz9mmzq779x9d01apd04wivd9yf1";
   };
 
   postInstall = ''


### PR DESCRIPTION
###### Motivation for this change
Upgrade `grafana_reporter` package from version 2.0.1 to 2.1.0.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
