### PR TITLE
cubicsdr: init at 0.2.5

### DIFF
--- a/pkgs/applications/radio/cubicsdr/default.nix
+++ b/pkgs/applications/radio/cubicsdr/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub, cmake, fftw, hamlib, libpulseaudio, libGL, libX11, liquid-dsp,
+  pkgconfig, soapysdr-with-plugins, wxGTK, enableDigitalLab ? false }:
+
+stdenv.mkDerivation rec {
+  name = "cubicsdr-${version}";
+  version = "0.2.5";
+
+  src = fetchFromGitHub {
+    owner = "cjcliffe";
+    repo = "CubicSDR";
+    rev = version;
+    sha256 = "1ihbn18bzdcdvwpa4hnb55ns38bj4b8xy53hkmra809f9qpbcjhn";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = [ fftw hamlib libpulseaudio libGL libX11 liquid-dsp soapysdr-with-plugins wxGTK ];
+
+  cmakeFlags = [ "-DUSE_HAMLIB=ON" ]
+    ++ stdenv.lib.optional enableDigitalLab "-DENABLE_DIGITAL_LAB=ON";
+
+  meta = with stdenv.lib; {
+    homepage = https://cubicsdr.com;
+    description = "Software Defined Radio application";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ lasandell ];
+    platforms = platforms.linux;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16917,6 +16917,8 @@ in
 
   ctop = callPackage ../tools/system/ctop { };
 
+  cubicsdr = callPackage ../applications/radio/cubicsdr { wxGTK = wxGTK31; };
+
   cuneiform = callPackage ../tools/graphics/cuneiform {};
 
   curseradio = callPackage ../applications/audio/curseradio { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Nice GUI client for SoapySDR devices, including RTL-SDR. I'm also working on support for SDRPlay.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
