### PR TITLE
fix lua53Packages.lua

### DIFF
--- a/pkgs/development/interpreters/lua-5/default.nix
+++ b/pkgs/development/interpreters/lua-5/default.nix
@@ -15,11 +15,10 @@ let
 
 in rec {
 
-  lua5_3 = (callPackage ./interpreter.nix {
+  lua5_3 = callPackage ./interpreter.nix {
     sourceVersion = { major = "5"; minor = "3"; patch = "5"; };
     hash = "0c2eed3f960446e1a3e4b9a1ca2f3ff893b6ce41942cf54d5dd59ab4b3b058ac";
     patches = lib.optionals stdenv.isDarwin [ ./5.2.darwin.patch ] ;
-  }).overrideAttrs( oa: {
     postConfigure = lib.optionalString (!stdenv.isDarwin) ''
       cat ${./lua-5.3-dso.make} >> src/Makefile
       sed -e 's/ALL_T *= */& $(LUA_SO)/' -i src/Makefile
@@ -28,7 +27,7 @@ in rec {
     postBuild = stdenv.lib.optionalString (!stdenv.isDarwin) ''
       ( cd src; make $makeFlags "''${makeFlagsArray[@]}" liblua.so )
     '';
-  });
+  };
 
   lua5_3_compat = lua5_3.override({
     compat = true;

--- a/pkgs/development/interpreters/lua-5/interpreter.nix
+++ b/pkgs/development/interpreters/lua-5/interpreter.nix
@@ -5,6 +5,8 @@
 , sourceVersion
 , hash
 , patches ? []
+, postConfigure ? null
+, postBuild ? null
 }:
 let
 luaPackages = callPackage ../../lua-modules {lua=self; overrides=packageOverrides;};
@@ -52,6 +54,9 @@ self = stdenv.mkDerivation rec {
 
     runHook postConfigure
   '';
+  inherit postConfigure;
+
+  inherit postBuild;
 
   postInstall = ''
     mkdir -p "$out/share/doc/lua" "$out/lib/pkgconfig"


### PR DESCRIPTION
###### Motivation for this change

Recent reworking broke lua53Packages.*, root cause
being that lua53Packages.lua didn't have the overrides
needed for the build to succeed.

Instead of overrideAttrs, just plumb the needed additions
directly into the mkDerivation call.

* Check lua53Packages.lua builds successfully
* Check lua53Packages.lua and lua5_3 are same derivation

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---