### PR TITLE
carla: init at 2.0.0

### DIFF
--- a/pkgs/applications/audio/carla/default.nix
+++ b/pkgs/applications/audio/carla/default.nix
@@ -1,0 +1,71 @@
+{ stdenv, fetchFromGitHub, alsaLib, file, fluidsynth, ffmpeg, fftw, jack2,
+  liblo, libpulseaudio, libsndfile, makeWrapper, pkgconfig, python3Packages,
+  which, withFrontend ? true,
+  withQt ? true, qtbase ? null,
+  withGtk2 ? true, gtk2 ? null,
+  withGtk3 ? true, gtk3 ? null }:
+
+with stdenv.lib;
+
+assert withFrontend -> python3Packages ? pyqt5;
+assert withQt -> qtbase != null;
+assert withGtk2 -> gtk2 != null;
+assert withGtk3 -> gtk3 != null;
+
+stdenv.mkDerivation rec {
+  pname = "carla";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "falkTX";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0fqgncqlr86n38yy7pa118mswfacmfczj7w9xx6c6k0jav3wk29k";
+  };
+
+  nativeBuildInputs = [ python3Packages.wrapPython pkgconfig which ];
+
+  pythonPath = with python3Packages; [
+    rdflib pyliblo
+  ] ++ optional withFrontend pyqt5;
+
+  buildInputs = [
+    file liblo alsaLib fluidsynth ffmpeg jack2 libpulseaudio libsndfile
+  ] ++ pythonPath
+    ++ optional withQt qtbase
+    ++ optional withGtk2 gtk2
+    ++ optional withGtk3 gtk3;
+
+  installFlags = [ "PREFIX=$(out)" ];
+
+  postFixup = ''
+    # Also sets program_PYTHONPATH and program_PATH variables
+    wrapPythonPrograms
+
+    find "$out/share/carla" -maxdepth 1 -type f -not -name "*.py" -print0 | while read -d "" f; do
+      patchPythonScript "$f"
+    done
+    patchPythonScript "$out/share/carla/carla_settings.py"
+
+    for program in $out/bin/*; do
+      wrapProgram "$program" \
+        --prefix PATH : "$program_PATH:${which}/bin" \
+        --set PYTHONNOUSERSITE true \
+        --prefix QT_PLUGIN_PATH : "${qtbase.bin}/${qtbase.qtPluginPrefix}"
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://kxstudio.sf.net/carla;
+    description = "An audio plugin host";
+    longDescription = ''
+      It currently supports LADSPA (including LRDF), DSSI, LV2, VST2/3
+      and AU plugin formats, plus GIG, SF2 and SFZ file support.
+      It uses JACK as the default and preferred audio driver but also
+      supports native drivers like ALSA, DirectSound or CoreAudio.
+    '';
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.minijackson ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16775,6 +16775,8 @@ in
 
   carddav-util = callPackage ../tools/networking/carddav-util { };
 
+  carla = qt5.callPackage ../applications/audio/carla { };
+
   catfish = callPackage ../applications/search/catfish { };
 
   catimg = callPackage ../tools/misc/catimg { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

To have more choices in audio production software. Carla seems fairly used by people using the Jack ecosystem. #11190 mentions Carla, so @Pitometsu, @joelmo and @magnetophon might be interested.

Tested (a bit) from the release-19.03 branch because I don't have the resources of compiling QT from scratch ^^

If someone with a more complete audio setup wants to test it, I'd be happy :D 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
