### PR TITLE
pythonPackages.basemap: 1.0.7 -> 1.2.0, fixes build on py3.7

### DIFF
--- a/pkgs/development/python-modules/basemap/default.nix
+++ b/pkgs/development/python-modules/basemap/default.nix
@@ -1,24 +1,29 @@
 { stdenv
 , buildPythonPackage
-, fetchurl
+, fetchFromGitHub
 , numpy
 , matplotlib
 , pillow
 , setuptools
+, pyproj
+, pyshp
+, six
 , pkgs
 }:
 
 buildPythonPackage rec {
   pname = "basemap";
-  version = "1.0.7";
+  version = "1.2.0";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/project/matplotlib/matplotlib-toolkits/basemap-1.0.7/basemap-1.0.7.tar.gz";
-    sha256 = "0ca522zirj5sj10vg3fshlmgi615zy5gw2assapcj91vsvhc4zp0";
+  src = fetchFromGitHub {
+    owner = "matplotlib";
+    repo = "basemap";
+    rev = "v${version}rel";
+    sha256 = "1p3app8n65rlppkdbp1pb7fa4250kh7hi7lzdsryi2iv88np7193";
   };
 
-  propagatedBuildInputs = [ numpy matplotlib pillow ];
-  buildInputs = [ setuptools pkgs.geos pkgs.proj ];
+  propagatedBuildInputs = [ numpy matplotlib pillow pyproj pyshp six ];
+  buildInputs = [ setuptools pkgs.geos ];
 
   # Standard configurePhase from `buildPythonPackage` seems to break the setup.py script
   configurePhase = ''


### PR DESCRIPTION
###### Motivation for this change
Upstream seems to have moved to github without updating its pypi packages.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
