### PR TITLE
monaco: init at unstable-2012-06-03

### DIFF
--- a/pkgs/data/fonts/monaco/default.nix
+++ b/pkgs/data/fonts/monaco/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "monaco";
+  version = "unstable-2012-06-03";
+
+  src = fetchFromGitHub {
+    owner = "todylu";
+    repo = "monaco.ttf";
+    rev = "d258639b562cab674da79e9e3316998e709e8960";
+    sha256 = "0kdnn01gb08j0cdmnv8l7xym8fm7mz2jpwk3yvihbmq92pq0hjb9";
+  };
+
+  installPhase = ''
+    mkdir -p $out/share/fonts/monaco
+    cp -v $( find . -name '*.ttf') $out/share/fonts/monaco
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/todylu/monaco.ttf;
+    description = "A monospaced sans-serif typeface by Apple Inc";
+    license = licenses.unfree;
+    platforms = platforms.all;
+    maintainers = [ maintainers.linarcx ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3934,6 +3934,8 @@ in
 
   mmv = callPackage ../tools/misc/mmv { };
 
+  monaco = callPackage ../data/fonts/monaco {};
+
   most = callPackage ../tools/misc/most { };
 
   motion = callPackage ../applications/video/motion { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
A monospaced sans-serif typeface by Apple Inc.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
