### PR TITLE
Added missing dependency needed for testing flent

### DIFF
--- a/pkgs/applications/networking/flent/default.nix
+++ b/pkgs/applications/networking/flent/default.nix
@@ -14,6 +14,8 @@ buildPythonApplication rec {
 
   buildInputs = [ sphinx ];
 
+  checkInputs = [ procps ];
+
   propagatedBuildInputs = [
     matplotlib
     procps


### PR DESCRIPTION
Fixed failing package by adding a missing dependency needed during testing.
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
