### PR TITLE
buildEnv: Don't warn about collisions if contents match when ignoreCollisions=true.

### DIFF
--- a/pkgs/build-support/buildenv/builder.pl
+++ b/pkgs/build-support/buildenv/builder.pl
@@ -122,14 +122,12 @@ sub findFiles {
     }
 
     unless (-d $target && ($oldTarget eq "" || -d $oldTarget)) {
-        if ($ignoreCollisions) {
-            warn "collision between `$target' and `$oldTarget'\n" if $ignoreCollisions == 1;
-            return;
-        } elsif ($checkCollisionContents && checkCollision($oldTarget, $target)) {
-            return;
-        } else {
-            die "collision between `$target' and `$oldTarget'\n";
+        if (!$checkCollisionContents || !checkCollision($oldTarget, $target)) {
+            my $collisionMessage = "collision between `$target' and `$oldTarget'\n";
+            die $collisionMessage unless $ignoreCollisions;
+            warn $collisionMessage;
         }
+        return;
     }
 
     findFilesInDir($relName, $oldTarget, $ignoreCollisions, $checkCollisionContents, $oldPriority) unless $oldTarget eq "";

--- a/pkgs/build-support/buildenv/default.nix
+++ b/pkgs/build-support/buildenv/default.nix
@@ -14,11 +14,13 @@ lib.makeOverridable
 , # The paths to symlink.
   paths
 
-, # Whether to ignore collisions or abort.
+, # Whether to ignore (and just warn) or abort if there is a collision. Note
+  # that what is considered a collision is affected by checkCollisionContents.
   ignoreCollisions ? false
 
-, # If there is a collision, check whether the contents and permissions match
-  # and only if not, throw a collision error.
+, # Whether to check file contents and attributes to decide if something is
+  # a collision. If this is true, then when two packages have a colliding file
+  # with the same content and attributes, it is not considered a collision.
   checkCollisionContents ? true
 
 , # The paths (relative to each element of `paths') that we want to


### PR DESCRIPTION
This prevents giving many false-positive collision warnings to NixOS users and makes it easier to see real collisions that should be addressed.

Looking at the history, @aszlig at one time committed a version that behaved like this but then immediately [changed it](https://github.com/NixOS/nixpkgs/commit/bfb11fd0301c1c583319bd2e8211ef434e078792) to how it currently works, that is it warns for every collision without checking contents when ignoreCollision=true (as it is for the NixOS system path). While the resulting environment is indeed the same, I think it is worth doing the content check so that users are warned only about real collisions.

This reduced the number of collision warnings on my desktop system from 388 to 56.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Things done
I tested this with the NixOS system path in a hacky way so that it only affected that (the change as-is causes a mass rebuild because lots of things make use of buildEnv).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
