### PR TITLE
Changelog meta entry

### DIFF
--- a/doc/meta.xml
+++ b/doc/meta.xml
@@ -152,6 +152,19 @@ hello-2.3  A program that produces a familiar, friendly greeting
    </varlistentry>
    <varlistentry>
     <term>
+     <varname>changelog</varname>
+    </term>
+    <listitem>
+     <para>
+      A link or a list of links to the location of Changelog for a package.
+     A link may use expansion to refer to the correct changelog version.
+             Example:
+      <literal>"http://git.savannah.gnu.org/cgit/hello.git/tree/NEWS?h=v${version}"</literal>
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
      <varname>license</varname>
     </term>
     <listitem>

--- a/doc/meta.xml
+++ b/doc/meta.xml
@@ -159,7 +159,7 @@ hello-2.3  A program that produces a familiar, friendly greeting
       A link or a list of links to the location of Changelog for a package.
      A link may use expansion to refer to the correct changelog version.
              Example:
-      <literal>"http://git.savannah.gnu.org/cgit/hello.git/tree/NEWS?h=v${version}"</literal>
+      <literal>"https://git.savannah.gnu.org/cgit/hello.git/plain/NEWS?h=v${version}"</literal>
      </para>
     </listitem>
    </varlistentry>

--- a/pkgs/applications/misc/hello/default.nix
+++ b/pkgs/applications/misc/hello/default.nix
@@ -18,6 +18,7 @@ stdenv.mkDerivation rec {
       It is fully customizable.
     '';
     homepage = https://www.gnu.org/software/hello/manual/;
+    changelog = "http://git.savannah.gnu.org/cgit/hello.git/tree/NEWS?h=v${version}";
     license = licenses.gpl3Plus;
     maintainers = [ maintainers.eelco ];
     platforms = platforms.all;

--- a/pkgs/applications/misc/hello/default.nix
+++ b/pkgs/applications/misc/hello/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
       It is fully customizable.
     '';
     homepage = https://www.gnu.org/software/hello/manual/;
-    changelog = "http://git.savannah.gnu.org/cgit/hello.git/tree/NEWS?h=v${version}";
+    changelog = "https://git.savannah.gnu.org/cgit/hello.git/plain/NEWS?h=v${version}";
     license = licenses.gpl3Plus;
     maintainers = [ maintainers.eelco ];
     platforms = platforms.all;

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -165,6 +165,7 @@ let
     branch = str;
     homepage = either (listOf str) str;
     downloadPage = str;
+    changelog = either (listOf str) str;
     license = either (listOf lib.types.attrs) (either lib.types.attrs str);
     maintainers = listOf (attrsOf str);
     priority = int;


### PR DESCRIPTION
###### Motivation for this change

There are various calls to pay attention to changelog. For easier location of the changelog and for better tooling support, we should allow putting a link to the changelog into `meta`.

This only changes the documentation and the `meta` correctness check.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- N/A Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).