### PR TITLE
idrisPackages.build-idris-package: Install binaries

### DIFF
--- a/pkgs/development/idris-modules/build-idris-package.nix
+++ b/pkgs/development/idris-modules/build-idris-package.nix
@@ -53,8 +53,20 @@ stdenv.mkDerivation ({
 
   installPhase = ''
     runHook preInstall
+
     idris --install ${ipkgName}.ipkg --ibcsubdir $out/libs
+
     IDRIS_DOC_PATH=$out/doc idris --installdoc ${ipkgName}.ipkg || true
+
+    # If the ipkg file defines an executable, install that
+    executable=$(grep -Po '^executable = \K.*' ${ipkgName}.ipkg || true)
+    # $executable intentionally not quoted because it must be quoted correctly
+    # in the ipkg file already
+    if [ ! -z "$executable" ] && [ -f $executable ]; then
+      mkdir -p $out/bin
+      mv $executable $out/bin/$executable
+    fi
+
     runHook postInstall
   '';
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
https://discourse.nixos.org/t/buidling-hello-world-in-idris/2793

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
