### PR TITLE
pkgs/misc/mosquitto-go-auth: init at 0.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2921,6 +2921,11 @@
     github = "marcweber";
     name = "Marc Weber";
   };
+	marenz = {
+		email = "marenz@arkom.men";
+		github = "marenz2569";
+		name = "Markus Schmidl";
+	};
   markus1189 = {
     email = "markus1189@gmail.com";
     github = "markus1189";

--- a/pkgs/misc/mosquitto-go-auth/default.nix
+++ b/pkgs/misc/mosquitto-go-auth/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitHub, pkgs }:
+
+buildGoPackage rec {
+  name = "mosquitto-go-auth-${version}";
+  version = "v0.2.0";
+  rev = "0.2.0";
+
+  goPackagePath = "github.com/iegomez/mosquitto-go-auth";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "iegomez";
+    repo = "mosquitto-go-auth";
+    sha256 = "0wmi1w6nzl2nf0shrfb17n61ny625gpys03xlpx4h4sagvlwrsyn";
+  };
+
+  goDeps = ./deps.nix;
+
+  buildInputs = with pkgs; [
+    mosquitto
+  ];
+
+  outputs = [ "out" ];
+
+  dontRenameImports = true;
+  allowGoReference = true;
+
+  buildPhase = ''
+    cd ./go/src/${goPackagePath}
+    export CGO_FLAGS="-I${pkgs.mosquitto}/include -fPIC"
+    export CGO_LDFLAGS="-shared"
+    go build -buildmode=c-archive go-auth.go
+    go build -buildmode=c-shared -o go-auth.so
+  '';
+
+  installPhase = ''
+    install -m644 -D go-auth.so $out/lib/go-auth.so
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/iegomez/mosquitto-go-auth";
+    description = "Auth plugin for mosquitto";
+    maintainers = [ maintainers.marenz ];
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/misc/mosquitto-go-auth/deps.nix
+++ b/pkgs/misc/mosquitto-go-auth/deps.nix
@@ -1,0 +1,156 @@
+# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
+[
+  {
+    goPackagePath  = "github.com/dgrijalva/jwt-go";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dgrijalva/jwt-go";
+      rev =  "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e";
+      sha256 = "08m27vlms74pfy5z79w67f9lk9zkx6a9jd68k3c4msxy75ry36mp";
+    };
+  }
+  {
+    goPackagePath  = "github.com/go-redis/redis";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-redis/redis";
+      rev =  "f3bba01df2026fc865f7782948845db9cf44cf23";
+      sha256 = "1437wcisbh4iz3sdn8z5aghd6ga149giwh94nr1hrxg203r9z2aw";
+    };
+  }
+  {
+    goPackagePath  = "github.com/go-sql-driver/mysql";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-sql-driver/mysql";
+      rev =  "d523deb1b23d913de5bdada721a6071e71283618";
+      sha256 = "1jwz2j3vd5hlzmnkh20d4276yd8cxy7pac3x3dfi52jkm82ms99n";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gopherjs/gopherjs";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gopherjs/gopherjs";
+      rev =  "bf5fc7d381404c2a218d4c28865b251d6e8e1cb8";
+      sha256 = "0awfas2wxwyqzj98lq2hb5jax7gr4r3azjjp3212n9l3jif1k6qf";
+    };
+  }
+  {
+    goPackagePath  = "github.com/jmoiron/sqlx";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jmoiron/sqlx";
+      rev =  "0dae4fefe7c0e190f7b5a78dac28a1c82cc8d849";
+      sha256 = "0r8fyj70n0v84byvagw8w8rzz532s94mjr72b9sx018j0b6xglmy";
+    };
+  }
+  {
+    goPackagePath  = "github.com/jtolds/gls";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jtolds/gls";
+      rev =  "77f18212c9c7edc9bd6a33d383a7b545ce62f064";
+      sha256 = "1vm37pvn0k4r6d3m620swwgama63laz8hhj3pyisdhxwam4m2g1h";
+    };
+  }
+  {
+    goPackagePath  = "github.com/konsorten/go-windows-terminal-sequences";
+    fetch = {
+      type = "git";
+      url = "https://github.com/konsorten/go-windows-terminal-sequences";
+      rev =  "b729f2633dfe35f4d1d8a32385f6685610ce1cb5";
+      sha256 = "0wwyqidla8ryzdxgkrwrn1lqbjp2j0c0126yz5sp30jd8q0025ly";
+    };
+  }
+  {
+    goPackagePath  = "github.com/lib/pq";
+    fetch = {
+      type = "git";
+      url = "https://github.com/lib/pq";
+      rev =  "4ded0e9383f75c197b3a2aaa6d590ac52df6fd79";
+      sha256 = "1zqnnyczaf00xi6xh53vq758v5bdlf0iz7kf22l02cal4i6px47i";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mattn/go-sqlite3";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-sqlite3";
+      rev =  "25ecb14adfc7543176f7d85291ec7dba82c6f7e4";
+      sha256 = "14vw8bwyaz9lrd1rqhfri5cwpimiimhp75pkbqxxsjsr5jz89s7m";
+    };
+  }
+  {
+    goPackagePath  = "github.com/pkg/errors";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pkg/errors";
+      rev =  "645ef00459ed84a119197bfb8d8205042c6df63d";
+      sha256 = "001i6n71ghp2l6kdl3qq1v2vmghcz3kicv9a5wgcihrzigm75pp5";
+    };
+  }
+  {
+    goPackagePath  = "github.com/sirupsen/logrus";
+    fetch = {
+      type = "git";
+      url = "https://github.com/sirupsen/logrus";
+      rev =  "a67f783a3814b8729bd2dac5780b5f78f8dbd64d";
+      sha256 = "0mpf1pjs0gpysnxx3mwpdr7jhdc7a5icmmisihkcza0rnnc7wvn4";
+    };
+  }
+  {
+    goPackagePath  = "github.com/smartystreets/assertions";
+    fetch = {
+      type = "git";
+      url = "https://github.com/smartystreets/assertions";
+      rev =  "7678a5452ebea5b7090a6b163f844c133f523da2";
+      sha256 = "0df2z0f4l0yzbx38bphwyjsyxfgsza1yw4cq46zikbnknqjb8s1c";
+    };
+  }
+  {
+    goPackagePath  = "github.com/smartystreets/goconvey";
+    fetch = {
+      type = "git";
+      url = "https://github.com/smartystreets/goconvey";
+      rev =  "9e8dc3f972df6c8fcc0375ef492c24d0bb204857";
+      sha256 = "1ph18rkl3ns3fgin5i4j54w5a69grrmf3apcsmnpdn1wlrbs3dxh";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev =  "e3636079e1a4c1f337f212cc5cd2aca108f6c900";
+      sha256 = "0idxlx1h0001s7dkihvdd78fydj9bgns3ihrmh0pw69h3vw8lckr";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev =  "af653ce8b74f808d092db8ca9741fbb63d2a469d";
+      sha256 = "10h2dmgyw1f6na9c6j0cyvzp0bj1mv5df47w36dkda99w1zwm0q7";
+    };
+  }
+  {
+    goPackagePath  = "google.golang.org/appengine";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/appengine";
+      rev =  "ae0ab99deb4dc413a2b4bd6c8bdd0eb67f1e4d06";
+      sha256 = "1iabxnqgxvvn1239i6fvfl375vlbvhfrc03m1x2rvalmx4d6w9c7";
+    };
+  }
+  {
+    goPackagePath  = "gopkg.in/mgo.v2";
+    fetch = {
+      type = "git";
+      url = "https://github.com/go-mgo/mgo";
+      rev =  "9856a29383ce1c59f308dd1cf0363a79b5bef6b5";
+      sha256 = "1gfbcmvpwwf1lydxj3g42wv2g9w3pf0y02igqk4f4f21h02sazkw";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1819,6 +1819,8 @@ in
 
   moosefs = callPackage ../tools/filesystems/moosefs { };
 
+  mosquitto-go-auth = callPackage ../misc/mosquitto-go-auth { };
+
   mozlz4a = callPackage ../tools/compression/mozlz4a { };
 
   msr-tools = callPackage ../os-specific/linux/msr-tools { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
