### PR TITLE
calf: 0.90.0 -> 0.90.2

### DIFF
--- a/pkgs/applications/audio/calf/default.nix
+++ b/pkgs/applications/audio/calf/default.nix
@@ -3,21 +3,14 @@
 
 stdenv.mkDerivation rec {
   name = "calf-${version}";
-  version = "0.90.0";
+  version = "0.90.2";
 
   src = fetchurl {
     url = "https://calf-studio-gear.org/files/${name}.tar.gz";
-    sha256 = "0dijv2j7vlp76l10s4v8gbav26ibaqk8s24ci74vrc398xy00cib";
+    sha256 = "0bn4j1klw2yfxz8clbmasaydifq25rdfsv0n6iisxrzcj1lx7sgh";
   };
 
-  patches = [
-    # Fix memory leak in limiter
-    # https://github.com/flathub/com.github.wwmm.pulseeffects/issues/12
-    (fetchpatch {
-      url = https://github.com/calf-studio-gear/calf/commit/7afdefc0d0489a6227fd10f15843d81dc82afd62.patch;
-      sha256 = "056662iw6hp4ykwk4jyrzg5yarcn17ni97yc060y5kcnzy29ddg6";
-    })
-  ];
+  enableParallelBuilding = true;
 
   buildInputs = [
     cairo expat fftwSinglePrec fluidsynth glib gtk2 libjack2 ladspaH


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fixes https://github.com/NixOS/nixpkgs/issues/60383

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
