### PR TITLE
ghq: 0.8.0 -> 0.10.2

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/ghq/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/ghq/default.nix
@@ -2,7 +2,7 @@
 
 buildGoPackage rec {
   name = "ghq-${version}";
-  version = "0.8.0";
+  version = "0.10.2";
 
   goPackagePath = "github.com/motemen/ghq";
 
@@ -10,7 +10,7 @@ buildGoPackage rec {
     owner = "motemen";
     repo = "ghq";
     rev = "v${version}";
-    sha256 = "1gdi0sbmq9kfi8hzd0dpgmhbmcf8q93jy3x08dd8smayrhbbwmld";
+    sha256 = "1i7zmgv7760nrw8sayag90b8vvmbsiifgiqki5s3gs3ldnvlki5w";
   };
 
   goDeps = ./deps.nix;

--- a/pkgs/applications/version-management/git-and-tools/ghq/deps.nix
+++ b/pkgs/applications/version-management/git-and-tools/ghq/deps.nix
@@ -1,20 +1,75 @@
+# file generated from go.mod using vgo2nix (https://github.com/adisbladis/vgo2nix)
 [
+  {
+    goPackagePath = "github.com/blang/semver";
+    fetch = {
+      type = "git";
+      url = "https://github.com/blang/semver";
+      rev = "v3.5.1";
+      sha256 = "13ws259bwcibkclbr82ilhk6zadm63kxklxhk12wayklj8ghhsmy";
+    };
+  }
   {
     goPackagePath = "github.com/daviddengcn/go-colortext";
     fetch = {
       type = "git";
       url = "https://github.com/daviddengcn/go-colortext";
-      rev = "805cee6e0d43c72ba1d4e3275965ff41e0da068a";
-      sha256 = "0z0ggqnprqchnd8zyrz99w53kr4sgv372lyx12z5nsh9q342pmyf";
+      rev = "186a3d44e920";
+      sha256 = "18piv4zzcb8abbc7fllz9p6rd4zhsy1gc6iygym381caggmmgxgk";
     };
   }
   {
-    goPackagePath = "github.com/mitchellh/go-homedir";
+    goPackagePath = "github.com/fsnotify/fsnotify";
     fetch = {
       type = "git";
-      url = "https://github.com/mitchellh/go-homedir";
-      rev = "b8bc1bf767474819792c23f32d8286a45736f1c6";
-      sha256 = "13ry4lylalkh4g2vny9cxwvryslzyzwp9r92z0b10idhdq3wad1q";
+      url = "https://github.com/fsnotify/fsnotify";
+      rev = "v1.4.7";
+      sha256 = "07va9crci0ijlivbb7q57d2rz9h27zgn2fsm60spjsqpdbvyrx4g";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/protobuf";
+      rev = "v1.2.0";
+      sha256 = "0kf4b59rcbb1cchfny2dm9jyznp8ri2hsb14n8iak1q8986xa0ab";
+    };
+  }
+  {
+    goPackagePath = "github.com/golangplus/bytes";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golangplus/bytes";
+      rev = "45c989fe5450";
+      sha256 = "1fpwg1idakpbvkmk8j8yyhv9g7mhr9c922kvff6kj4br4k05zyzr";
+    };
+  }
+  {
+    goPackagePath = "github.com/golangplus/fmt";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golangplus/fmt";
+      rev = "2a5d6d7d2995";
+      sha256 = "1242q05qnawhv0klzy1pbq63q8jxkms5hc7421992hzq2m40k5yn";
+    };
+  }
+  {
+    goPackagePath = "github.com/golangplus/testing";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golangplus/testing";
+      rev = "af21d9c3145e";
+      sha256 = "1g83sjvcavqbh92vyirc48mrqd18yfci08zya0hrgk840cr94czc";
+    };
+  }
+  {
+    goPackagePath = "github.com/hpcloud/tail";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hpcloud/tail";
+      rev = "v1.0.0";
+      sha256 = "1njpzc0pi1acg5zx9y6vj9xi6ksbsc5d387rd6904hy6rh2m6kn0";
     };
   }
   {
@@ -22,8 +77,26 @@
     fetch = {
       type = "git";
       url = "https://github.com/motemen/go-colorine";
-      rev = "49ff36b8fa42db28092361cd20dcefd0b03b1472";
-      sha256 = "1rfi5gggf2sxb52whgxfl37p22r2xp27rndixbiicw6swllmml9l";
+      rev = "45d19169413a";
+      sha256 = "1mdy6q0926s1frj027nlzlvm2qssmkpjis7ic3l2smajkzh07118";
+    };
+  }
+  {
+    goPackagePath = "github.com/onsi/ginkgo";
+    fetch = {
+      type = "git";
+      url = "https://github.com/onsi/ginkgo";
+      rev = "v1.6.0";
+      sha256 = "0x0gc89vgq38xhgmi2h22bhr73cf2gmk42g89nz89k8dgg9hhr25";
+    };
+  }
+  {
+    goPackagePath = "github.com/onsi/gomega";
+    fetch = {
+      type = "git";
+      url = "https://github.com/onsi/gomega";
+      rev = "v1.5.0";
+      sha256 = "1n7i4hksdgv410m43v2sw14bl5vy59dkp6nlw5l76nibbh37syr9";
     };
   }
   {
@@ -31,8 +104,89 @@
     fetch = {
       type = "git";
       url = "https://github.com/urfave/cli";
-      rev = "f017f86fccc5a039a98f23311f34fdf78b014f78";
-      sha256 = "1biq4wl4z8l0ycinb39mfavnk13d0qnqqdplqybl7klxmk67cvhv";
+      rev = "v1.20.0";
+      sha256 = "0y6f4sbzkiiwrxbl15biivj8c7qwxnvm3zl2dd3mw4wzg4x10ygj";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev = "c2843e01d9a2";
+      sha256 = "01xgxbj5r79nmisdvpq48zfy8pzaaj90bn6ngd4nf33j9ar1dp8r";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev = "4829fb13d2c6";
+      sha256 = "05nwpw41d7xsdln5rj381n8j9dsbq5ng1wp52bxslqc4x0l5s9fj";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sync";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sync";
+      rev = "1d60e4601c6f";
+      sha256 = "046jlanz2lkxq1r57x9bl6s4cvfqaic6p2xybsj8mq1120jv4rs6";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev = "d0b11bdaac8a";
+      sha256 = "18yfsmw622l7gc5sqriv5qmck6903vvhivpzp8i3xfy3z33dybdl";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev = "v0.3.0";
+      sha256 = "0r6x6zjzhr8ksqlpiwm5gdd7s209kwk5p4lw54xjvz10cs3qlq19";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/check.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/check.v1";
+      rev = "20d25e280405";
+      sha256 = "0k1m83ji9l1a7ng8a7v40psbymxasmssbrrhpdv2wl4rhs0nc3np";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/fsnotify.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/fsnotify.v1";
+      rev = "v1.4.7";
+      sha256 = "07va9crci0ijlivbb7q57d2rz9h27zgn2fsm60spjsqpdbvyrx4g";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/tomb.v1";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/tomb.v1";
+      rev = "dd632973f1e7";
+      sha256 = "1lqmq1ag7s4b3gc3ddvr792c5xb5k6sfn0cchr3i2s7f1c231zjv";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/yaml.v2";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/yaml.v2";
+      rev = "v2.2.1";
+      sha256 = "0dwjrs2lp2gdlscs7bsrmyc5yf6mm4fvgw71bzr9mv2qrd2q73s1";
     };
   }
 ]


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

To use newer version of `ghq`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
