### PR TITLE
leptonica: 1.74.1 -> 1.78.0

### DIFF
--- a/pkgs/development/libraries/leptonica/default.nix
+++ b/pkgs/development/libraries/leptonica/default.nix
@@ -4,32 +4,12 @@
 
 stdenv.mkDerivation rec {
   name = "leptonica-${version}";
-  version = "1.74.1";
+  version = "1.78.0";
 
   src = fetchurl {
     url = "http://www.leptonica.org/source/${name}.tar.gz";
-    sha256 = "0qpcidvv6igybrrhj0m6j47g642c8sk1qn4dpj82mgd38xx52skl";
+    sha256 = "122s9b8hi93va4lgwnwrbma50x5fp740npy0s92xybd2wy0jxvg2";
   };
-
-  patches = stdenv.lib.singleton (fetchpatch {
-    # configure: Support pkg-config
-    url = "https://github.com/DanBloomberg/leptonica/commit/"
-        + "4476d162cc191a0fefb2ce434153e12bbf188664.patch";
-    sha256 = "1razzp2g49shfaravfqpxm3ivcd1r92lvqysll6nnf6d1wp9865s";
-  });
-
-  postPatch = ''
-    # Remove the AC_SUBST() macros on *_LIBS, because the *_LIBS variables will
-    # be automatically set by PKG_CHECK_MODULES() since autotools 0.24 and
-    # using the ones that are set here in Leptonica's configure.ac do not
-    # include -L linker flags.
-    sed -i -e '/PKG_CHECK_MODULES/,/^ *\])/s/AC_SUBST([^)]*)//' configure.ac
-
-    # The giflib package doesn't ship a pkg-config file, so we need to inject
-    # the linker search path.
-    substituteInPlace configure.ac --replace -lgif \
-      ${stdenv.lib.escapeShellArg "'-L${giflib}/lib -lgif'"}
-  '';
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
   buildInputs = [ giflib libjpeg libpng libtiff libwebp openjpeg zlib ];


### PR DESCRIPTION
###### Motivation for this change

Multiple CVE's, see 1.77.0 notes.

http://www.leptonica.com/source/version-notes.html

Assuming the CVE's impact the version we're using now,
this should be backported please :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---