### PR TITLE
buildEnv: Skip paths excluded by pathsToLink as soon as they are encountered.

### DIFF
--- a/pkgs/build-support/buildenv/builder.pl
+++ b/pkgs/build-support/buildenv/builder.pl
@@ -14,14 +14,44 @@ my $out = $ENV{"out"};
 
 my @pathsToLink = split ' ', $ENV{"pathsToLink"};
 
-sub isInPathsToLink {
+# Normalize paths in pathsToLink. Normalized paths do not have duplicated
+# or trailing slashes and have a leading slash except for the root which is
+# an empty string. E.g.: "", "/foo", "/foo/bar".
+foreach my $pathToLink (@pathsToLink) {
+    my @parts = split(/\//, $pathToLink);
+    @parts = grep { $_ ne '' } @parts;
+    $pathToLink = join "", map { "/" . $_ } @parts;
+}
+
+# Determine if two paths are related, that is they are equal or one is below
+# the other. Both paths must be normalized as done above for pathsToLink
+# (note that $relName in findFiles is normalized due to its construction).
+# Examples: ("/a/b", "") -> 1, ("/a/b", "/a") -> 1, ("/a/b", "/a/b") -> 1,
+# ("/a/b", "/a/b/c") -> 1, ("/a/b", "/c") -> 0, ("/a/b", "/c/d/e") -> 0.
+sub pathsAreRelated {
+    my ($path1, $path2) = @_;
+    my $len1 = length($path1);
+    my $len2 = length($path2);
+    if ($len1 == $len2) {
+        return $path1 eq $path2;
+    } elsif ($len1 < $len2) {
+        return $path1 eq substr($path2, 0, $len1) && substr($path2, $len1, 1) eq "/";
+    } else {
+        return $path2 eq substr($path1, 0, $len2) && substr($path1, $len2, 1) eq "/";
+    }
+}
+
+# Determine if a path is related to any of the paths in pathsToLink - see
+# pathsAreRelated. This effectively determines whether findFiles should skip
+# processing of the path in order to include just the right paths (as far as
+# pathsToLink is concerned). This must return true for a path that is above
+# some pathToLink because it may be a directory that contains paths wich must
+# be included! For example, "/a" must not be skipped if pathsToLink contains
+# "/a/b/c".
+sub pathIsRelatedToPathsToLink {
     my $path = shift;
-    $path = "/" if $path eq "";
-    foreach my $elem (@pathsToLink) {
-        return 1 if
-            $elem eq "/" ||
-            (substr($path, 0, length($elem)) eq $elem
-             && (($path eq $elem) || (substr($path, length($elem), 1) eq "/")));
+    foreach my $pathToLink (@pathsToLink) {
+        return 1 if pathsAreRelated($path, $pathToLink);
     }
     return 0;
 }
@@ -95,6 +125,10 @@ sub findFiles {
     if (-f $target && isStorePath $target) {
         die "The store path $target is a file and can't be merged into an environment using pkgs.buildEnv!";
     }
+
+    # Skip the path if it is not related to any pathToLink.
+    # See this function for the explanation.
+    return if !pathIsRelatedToPathsToLink($relName);
 
     # Urgh, hacky...
     return if
@@ -206,7 +240,6 @@ my $nrLinks = 0;
 foreach my $relName (sort keys %symlinks) {
     my ($target, $priority) = @{$symlinks{$relName}};
     my $abs = "$out" . "$extraPrefix" . "/$relName";
-    next unless isInPathsToLink $relName;
     if ($target eq "") {
         #print "creating directory $relName\n";
         mkpath $abs or die "cannot create directory `$abs': $!";


### PR DESCRIPTION
The current code only checked at the end of recursive processing which paths should be excluded by pathsToLink. This resulted in false-positive collision warnings or errors for excluded paths.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
False-positive collision warning from `nixos-rebuild` (`pathsToLink` excludes `/libexec` in my configuration):
```collision between `/nix/store/wmxqm38g1y1y7sd7s9vg7an3klffaiyz-gnutar-1.31/libexec/rmt' and `/nix/store/yxxfkhl59hsy6x198r2df2xr7jd75i23-cpio-2.12/libexec/rmt'```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Tested with the NixOS system-path and checked that it produces the exact same result as before, but does not generate that collision warning.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
