### PR TITLE
waifu2x-converter-cpp: init at 5.2.4

### DIFF
--- a/pkgs/tools/graphics/waifu2x-converter-cpp/default.nix
+++ b/pkgs/tools/graphics/waifu2x-converter-cpp/default.nix
@@ -1,0 +1,34 @@
+{ cmake, fetchFromGitHub, opencv3, stdenv, opencl-headers
+, cudaSupport ? false, cudatoolkit ? null
+}:
+
+stdenv.mkDerivation rec {
+  pname = "waifu2x-converter-cpp";
+  version = "5.2.4";
+
+  src = fetchFromGitHub {
+    owner = "DeadSix27";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0r7xcjqbyaa20gsgmjj7645640g3nb2bn1pc1nlfplwlzjxmz213";
+  };
+
+  patchPhase = ''
+    # https://github.com/DeadSix27/waifu2x-converter-cpp/issues/123
+    sed -i 's:{"PNG",  false},:{"PNG",  true},:' src/main.cpp
+  '';
+
+  buildInputs = [
+    opencv3 opencl-headers
+  ] ++ stdenv.lib.optional cudaSupport cudatoolkit;
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "Improved fork of Waifu2X C++ using OpenCL and OpenCV";
+    homepage = https://github.com/DeadSix27/waifu2x-converter-cpp;
+    license = stdenv.lib.licenses.mit;
+    maintainers = [ stdenv.lib.maintainers.xzfc ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6342,6 +6342,8 @@ in
 
   vtun = callPackage ../tools/networking/vtun { };
 
+  waifu2x-converter-cpp = callPackage ../tools/graphics/waifu2x-converter-cpp { };
+
   wakatime = pythonPackages.callPackage ../tools/misc/wakatime { };
 
   weather = callPackage ../applications/misc/weather { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add waifu2x-converter-cpp, an anime image superresolution tool.
Tested on NVIDIA CUDA, and CPU. Not tested on OpenCL/AMDGPU.
Previous PR: #50398.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---