### PR TITLE
mate.mate-control-center: look up keyboard shortcuts in system data dirs

### DIFF
--- a/pkgs/desktops/mate/mate-control-center/default.nix
+++ b/pkgs/desktops/mate/mate-control-center/default.nix
@@ -37,7 +37,21 @@ stdenv.mkDerivation rec {
     mate.mate-settings-daemon
   ];
 
+  patches = [
+    # look up keyboard shortcuts in system data dirs
+    ./mate-control-center.keybindings-dir.patch
+  ];
+
   configureFlags = [ "--disable-update-mimedb" ];
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      # WM keyboard shortcuts
+      --prefix XDG_DATA_DIRS : "${mate.marco}/share"
+    )
+  '';
+
+  enableParallelBuilding = true;
 
   meta = with stdenv.lib; {
     description = "Utilities to configure the MATE desktop";

--- a/pkgs/desktops/mate/mate-control-center/mate-control-center.keybindings-dir.patch
+++ b/pkgs/desktops/mate/mate-control-center/mate-control-center.keybindings-dir.patch
@@ -1,0 +1,106 @@
+From faeb322b01d3856f3cf163470cc38f4e88a8527c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jos=C3=A9=20Romildo=20Malaquias?= <malaquias@gmail.com>
+Date: Sun, 28 Apr 2019 21:45:39 -0300
+Subject: [PATCH] Use system data dirs to locate key bindings
+
+---
+ capplets/keybindings/Makefile.am              |  3 +-
+ .../keybindings/mate-keybinding-properties.c  | 58 ++++++++++++-------
+ 2 files changed, 39 insertions(+), 22 deletions(-)
+
+diff --git a/capplets/keybindings/Makefile.am b/capplets/keybindings/Makefile.am
+index e5efb109..9501dd8f 100644
+--- a/capplets/keybindings/Makefile.am
++++ b/capplets/keybindings/Makefile.am
+@@ -33,8 +33,7 @@ AM_CPPFLAGS = \
+ 	$(MATECC_CAPPLETS_CFLAGS) \
+ 	-DMATELOCALEDIR="\"$(datadir)/locale\"" \
+ 	-DMATECC_DATA_DIR="\"$(pkgdatadir)\"" \
+-	-DMATECC_UI_DIR="\"$(uidir)\"" \
+-	-DMATECC_KEYBINDINGS_DIR="\"$(pkgdatadir)/keybindings\""
++	-DMATECC_UI_DIR="\"$(uidir)\""
+ CLEANFILES = \
+ 	$(MATECC_CAPPLETS_CLEANFILES) \
+ 	$(desktop_DATA) \
+diff --git a/capplets/keybindings/mate-keybinding-properties.c b/capplets/keybindings/mate-keybinding-properties.c
+index 4f257333..cf1891d2 100644
+--- a/capplets/keybindings/mate-keybinding-properties.c
++++ b/capplets/keybindings/mate-keybinding-properties.c
+@@ -1033,39 +1033,57 @@ static void
+ reload_key_entries (GtkBuilder *builder)
+ {
+   gchar **wm_keybindings;
+-  GDir *dir;
+-  const char *name;
+   GList *list, *l;
++  const gchar * const * data_dirs;
++  GHashTable *loaded_files;
++  guint i;
+ 
+   wm_keybindings = wm_common_get_current_keybindings();
+ 
+   clear_old_model (builder);
+ 
+-  dir = g_dir_open (MATECC_KEYBINDINGS_DIR, 0, NULL);
+-  if (!dir)
+-      return;
+-
+-  list = NULL;
+-  for (name = g_dir_read_name (dir) ; name ; name = g_dir_read_name (dir))
++  loaded_files = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
++  data_dirs = g_get_system_data_dirs ();
++  for (i = 0; data_dirs[i] != NULL; i++)
+     {
+-      if (g_str_has_suffix (name, ".xml"))
++      g_autofree gchar *dir_path = NULL;
++      GDir *dir;
++      const gchar *name;
++
++      dir_path = g_build_filename (data_dirs[i], "mate-control-center", "keybindings", NULL);
++      g_debug ("Keybinding dir: %s", dir_path);
++
++      dir = g_dir_open (dir_path, 0, NULL);
++      if (!dir)
++        continue;
++
++      for (name = g_dir_read_name (dir) ; name ; name = g_dir_read_name (dir))
+         {
+-      list = g_list_insert_sorted (list, g_strdup (name),
+-                       (GCompareFunc) g_ascii_strcasecmp);
+-    }
+-    }
+-  g_dir_close (dir);
++          if (g_str_has_suffix (name, ".xml") == FALSE)
++            continue;
++
++          if (g_hash_table_lookup (loaded_files, name) != NULL)
++            {
++              g_debug ("Not loading %s, it was already loaded from another directory", name);
++              continue;
++            }
+ 
++          g_hash_table_insert (loaded_files, g_strdup (name), g_strdup (dir_path));
++        }
++
++      g_dir_close (dir);
++    }
++  list = g_hash_table_get_keys (loaded_files);
++  list = g_list_sort(list, (GCompareFunc) g_str_equal);
+   for (l = list; l != NULL; l = l->next)
+     {
+-        gchar *path;
+-
+-    path = g_build_filename (MATECC_KEYBINDINGS_DIR, l->data, NULL);
+-        append_keys_to_tree_from_file (builder, path, wm_keybindings);
+-    g_free (l->data);
+-    g_free (path);
++      g_autofree gchar *path = NULL;
++      path = g_build_filename (g_hash_table_lookup (loaded_files, l->data), l->data, NULL);
++      g_debug ("Keybinding file: %s", path);
++      append_keys_to_tree_from_file (builder, path, wm_keybindings);
+     }
+   g_list_free (list);
++  g_hash_table_destroy (loaded_files);
+ 
+   /* Load custom shortcuts _after_ system-provided ones,
+    * since some of the custom shortcuts may also be listed


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fixes https://github.com/NixOS/nixpkgs/issues/60400.

> The mate keybinding properties does not include window management actions, provided by the marco (the mate window manager) package.

![Screenshot from 2019-04-28 22-29-45](https://user-images.githubusercontent.com/1217934/56873203-17e96d80-6a07-11e9-9478-065f187f0b4f.png)

Mate control center looks for keybinding shortcuts in files located at `${mate-control-center}/share/mate-control-center/keybindings/`.

Marco installs its keybinding shortcut files at `${marco}/share/mate-control-center/keybindings/`, which is not being used by the mate control center.

This PR:
-  changes mate control center to look for keybinding shortcut files in the system data dirs (defined by the `XDG_DATA_DIRS` environment variable in the freedesktop standards), inspired by `gnome-control-center`
- adds `${marco}/share` to `XDG_DATA_DIRS` in the wrapper for the mate control center applications.

Tested on a virtual machine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).