### PR TITLE
vscode-extensions.formulahendry.auto-close-tag: init at 0.5.6

### DIFF
--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -37,16 +37,16 @@ rec {
   };
 
   formulahendry.auto-close-tag = buildVscodeMarketplaceExtension {
-     mktplcRef = {
-       name = "auto-close-tag";
-       publisher = "formulahendry";
-       version = "0.5.6";
-       sha256 = "058jgmllqb0j6gg5anghdp35nkykii28igfcwqgh4bp10pyvspg0";
-     };
-     meta = {
-       license = stdenv.lib.licenses.mit;
-     };
-   };
+    mktplcRef = {
+      name = "auto-close-tag";
+      publisher = "formulahendry";
+      version = "0.5.6";
+      sha256 = "058jgmllqb0j6gg5anghdp35nkykii28igfcwqgh4bp10pyvspg0";
+    };
+    meta = {
+      license = stdenv.lib.licenses.mit;
+    };
+  };
 
   justusadam.language-haskell = buildVscodeMarketplaceExtension {
     mktplcRef = {

--- a/pkgs/misc/vscode-extensions/default.nix
+++ b/pkgs/misc/vscode-extensions/default.nix
@@ -36,6 +36,18 @@ rec {
     };
   };
 
+  formulahendry.auto-close-tag = buildVscodeMarketplaceExtension {
+     mktplcRef = {
+       name = "auto-close-tag";
+       publisher = "formulahendry";
+       version = "0.5.6";
+       sha256 = "058jgmllqb0j6gg5anghdp35nkykii28igfcwqgh4bp10pyvspg0";
+     };
+     meta = {
+       license = stdenv.lib.licenses.mit;
+     };
+   };
+
   justusadam.language-haskell = buildVscodeMarketplaceExtension {
     mktplcRef = {
       name = "language-haskell";


### PR DESCRIPTION
###### Motivation for this change
Add another QoL extension to vscode extensions.

All written in TS, should be consistent behavior across any vscode installation.

Followed level of meta detail to match similar packages.
###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
795.5K closure size
