### PR TITLE
nixos/kubernetes: fix control-plane-online prestart dependency

### DIFF
--- a/nixos/modules/services/cluster/kubernetes/default.nix
+++ b/nixos/modules/services/cluster/kubernetes/default.nix
@@ -273,11 +273,10 @@ in {
         wantedBy = [ "kube-control-plane-online.target" ];
         after = [ "kube-scheduler.service" "kube-controller-manager.service" ];
         before = [ "kube-control-plane-online.target" ];
-        environment.KUBECONFIG = cfg.lib.mkKubeConfig "default" cfg.kubeconfig;
-        path = [ pkgs.kubectl ];
+        path = [ pkgs.curl ];
         preStart = ''
-          until kubectl get --raw=/healthz 2>/dev/null; do
-            echo kubectl get --raw=/healthz: exit status $?
+          until curl -Ssf ${cfg.apiserverAddress}/healthz do
+            echo curl -Ssf ${cfg.apiserverAddress}/healthz: exit status $?
             sleep 3
           done
         '';


### PR DESCRIPTION

###### Motivation for this change
This fixes a startup problem in the kubernetes module caused by some changes to the kubectl behavior introduced in version >=1.13.5.

The kubeconfig provided to the kubernetes-control-plane-online.service is invalid. 
However, the apiserver /healthz endpoint can be accessed without auth so it's simpler to just use curl for that.

Related discussion can be found in #56789.

cc @calbrecht @srhb

Tests run clean locally:

```
nix-build nixos/release.nix \
-A tests.kubernetes.dns.singlenode \
-A tests.kubernetes.dns.multinode \
-A tests.kubernetes.rbac.singlenode \
-A tests.kubernetes.rbac.multinode

/nix/store/5vjb7wyzhxls1nmm5vgj6bvbi4kbx5ls-vm-test-run-kubernetes-dns-singlenode
/nix/store/38yfrsmrahp83p7h5zg76qiphjjb51jz-vm-test-run-kubernetes-dns-multinode
/nix/store/jqa7yq08i4yxsqayix9dfdy1qjv0x2vm-vm-test-run-kubernetes-rbac-singlenode
/nix/store/mmxswlv5clz5ac0q2h5wssbnzlak4vbn-vm-test-run-kubernetes-rbac-multinode
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
