### PR TITLE
termshark: init at 1.0.0

### DIFF
--- a/pkgs/tools/networking/termshark/default.nix
+++ b/pkgs/tools/networking/termshark/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, makeWrapper, buildGoModule, wireshark-cli }:
+
+buildGoModule rec {
+  pname = "termshark";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "gcla";
+    repo = "termshark";
+    rev = "v${version}";
+    sha256 = "1h9wysvd7i4vzn9qyswrmckmshxmh24ypvca98balkyhsxjwlb6j";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ wireshark-cli ];
+
+  modSha256 = "09mbjbk5wa18z4xis5b2v2v0b04mf4d896yp88vcj8d8hsmbmc6g";
+
+  postFixup = ''
+    wrapProgram $out/bin/termshark --prefix PATH : ${stdenv.lib.makeBinPath [ wireshark-cli ]}
+  '';
+
+  buildFlagsArray = ''
+    -ldflags=
+    -X github.com/gcla/termshark.Version=${version}
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://termshark.io/;
+    description = "A terminal UI for wireshark-cli, inspired by Wireshark";
+    platforms = platforms.linux;
+    license = licenses.mit;
+    maintainers = [ maintainers.winpat ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17633,6 +17633,8 @@ in
   wireshark-gtk = throw "Not supported anymore. Use wireshark-qt or wireshark-cli instead.";
   wireshark-cli = wireshark.override { withQt = false; };
 
+  termshark = callPackage ../tools/networking/termshark { };
+
   fbida = callPackage ../applications/graphics/fbida { };
 
   fdupes = callPackage ../tools/misc/fdupes { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
