### PR TITLE
quaternion: 0.0.9.4-rc3 -> 0.0.9.4

### DIFF
--- a/pkgs/applications/networking/instant-messengers/quaternion/default.nix
+++ b/pkgs/applications/networking/instant-messengers/quaternion/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, lib, fetchFromGitHub, qtbase, qtquickcontrols, cmake
-, qttools, qtmultimedia
+{ stdenv, lib, fetchFromGitHub, cmake
+, qtbase, qtquickcontrols, qtkeychain, qtmultimedia, qttools
 , libqmatrixclient_0_4, libqmatrixclient_0_5 }:
 
 let
@@ -13,7 +13,7 @@ let
       inherit sha256;
     };
 
-    buildInputs = [ qtbase qtmultimedia qtquickcontrols qttools library ];
+    buildInputs = [ qtbase qtmultimedia qtquickcontrols qtkeychain qttools library ];
 
     nativeBuildInputs = [ cmake ];
 
@@ -37,6 +37,6 @@ let
   };
 
 in rec {
-  quaternion     = generic "0.0.9.3"     "1hr9zqf301rg583n9jv256vzj7y57d8qgayk7c723bfknf1s6hh3" "v" libqmatrixclient_0_4;
-  quaternion-git = generic "0.0.9.4-rc3" "1fc3ya9fr3zw1cx7565s2rswzry98avslrryvdi0qa9yn0m3sw7p" ""  libqmatrixclient_0_5;
+  quaternion     = generic "0.0.9.4"     "12mkwiqqbi4774kwl7gha72jyf0jf547acy6rw8ry249zl4lja54" "" libqmatrixclient_0_5;
+  quaternion-git = quaternion;
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I feel a little bit silly about merging the new ```quaternion-git``` this morning...

https://github.com/QMatrixClient/Quaternion/releases/tag/0.0.9.4

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
