### PR TITLE
qtwebkit: fix path for libgdk-x11-2.0, it's in gtk2 apparently

### DIFF
--- a/pkgs/development/libraries/qt-4.x/4.8/default.nix
+++ b/pkgs/development/libraries/qt-4.x/4.8/default.nix
@@ -100,7 +100,6 @@ stdenv.mkDerivation rec {
     ++ lib.optional flashplayerFix (substituteAll {
         src = ./dlopen-webkit-nsplugin.diff;
         gtk = gtk2.out;
-        gdk_pixbuf = gdk_pixbuf.out;
       })
     ++ lib.optional stdenv.isAarch64 (fetchpatch {
         url = "https://src.fedoraproject.org/rpms/qt/raw/ecf530486e0fb7fe31bad26805cde61115562b2b/f/qt-aarch64.patch";

--- a/pkgs/development/libraries/qt-4.x/4.8/dlopen-webkit-nsplugin.diff
+++ b/pkgs/development/libraries/qt-4.x/4.8/dlopen-webkit-nsplugin.diff
@@ -20,7 +20,7 @@ index 2fe69d1..b658e4a 100644
      // The code below has the same effect as this one:
      // Display *gdkDisplay = gdk_x11_display_get_xdisplay(gdk_display_get_default());
 -    QLibrary library(QLatin1String("libgdk-x11-2.0"), 0);
-+    QLibrary library(QLatin1String("@gdk_pixbuf@/lib/libgdk-x11-2.0"), 0);
++    QLibrary library(QLatin1String("@gtk@/lib/libgdk-x11-2.0"), 0);
      if (!library.load())
          return 0;
  
@@ -46,7 +46,7 @@ index b8c8f2a..e7f4dc5 100644
      // Display *gdkDisplay = gdk_x11_display_get_xdisplay(gdk_display_get_default());
  
 -    QLibrary library(QLatin1String("libgdk-x11-2.0"), 0);
-+    QLibrary library(QLatin1String("@gdk_pixbuf@/lib/libgdk-x11-2.0"), 0);
++    QLibrary library(QLatin1String("@gtk@/lib/libgdk-x11-2.0"), 0);
      if (!library.load())
          return 0;
  

--- a/pkgs/development/libraries/qt-5/modules/qtwebkit.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebkit.nix
@@ -58,7 +58,8 @@ qtModule {
     ++ optionals flashplayerFix
       [
         ''-DNIXPKGS_LIBGTK2="${getLib gtk2}/lib/libgtk-x11-2.0"''
-        ''-DNIXPKGS_LIBGDK2="${getLib gdk_pixbuf}/lib/libgdk-x11-2.0"''
+        # this file used to exist in gdk_pixbuf?
+        ''-DNIXPKGS_LIBGDK2="${getLib gtk2}/lib/libgdk-x11-2.0"''
       ]
     ++ optional (!stdenv.isDarwin) ''-DNIXPKGS_LIBUDEV="${getLib systemd}/lib/libudev"'';
 


### PR DESCRIPTION
###### Motivation for this change

This seems like it would cause breakage as-is, but was looking
for libgdk-x11-2.0 for something else and noticed that it apparently
is not from `gdk_pixbuf` but from `gtk2`?

Not sure if this changed for some reason, but seems strange
to bake into the library a path to a file that doesn't exist o:).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---