### PR TITLE
nixos/hardware.deviceTree: new module

### DIFF
--- a/nixos/modules/hardware/device-tree.nix
+++ b/nixos/modules/hardware/device-tree.nix
@@ -19,8 +19,8 @@ in {
         base = mkOption {
           default = "${config.boot.kernelPackages.kernel}/dtbs";
           defaultText = "\${config.boot.kernelPackages.kernel}/dtbs";
-          example = literalExample "pkgs.deviceTree.raspberryPiDtbs";
-          type = types.nullOr types.path;
+          example = literalExample "pkgs.deviceTree_rpi";
+          type = types.path;
           description = ''
             The package containing the base device-tree (.dtb) to boot. Contains
             device trees bundled with the Linux kernel by default.
@@ -30,7 +30,7 @@ in {
         overlays = mkOption {
           default = [];
           example = literalExample
-            "[\"\${pkgs.deviceTree.raspberryPiOverlays}/w1-gpio.dtbo\"]";
+            "[\"\${pkgs.deviceTree_rpi.overlays}/w1-gpio.dtbo\"]";
           type = types.listOf types.path;
           description = ''
             A path containing device tree overlays (.dtbo) to be applied to all
@@ -41,9 +41,9 @@ in {
         package = mkOption {
           default = null;
           type = types.nullOr types.path;
+          internal = true;
           description = ''
-            A path containing device tree overlays (.dtbo) to be applied to all
-            base device-trees. Overrides `base` and `overlays`.
+            A path containing the result of applying `overlays` to `base`.
           '';
         };
       };

--- a/nixos/modules/hardware/device-tree.nix
+++ b/nixos/modules/hardware/device-tree.nix
@@ -1,0 +1,56 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.hardware.deviceTree;
+in {
+  options = {
+      hardware.deviceTree = {
+        enable = mkOption {
+          default = pkgs.stdenv.hostPlatform.platform.kernelDTB or false;
+          type = types.bool;
+          description = ''
+            Build device tree files. These are used to describe the
+            non-discoverable hardware of a system.
+          '';
+        };
+
+        base = mkOption {
+          default = "${config.boot.kernelPackages.kernel}/dtbs";
+          defaultText = "\${config.boot.kernelPackages.kernel}/dtbs";
+          example = literalExample "pkgs.deviceTree.raspberryPiDtbs";
+          type = types.nullOr types.path;
+          description = ''
+            The package containing the base device-tree (.dtb) to boot. Contains
+            device trees bundled with the Linux kernel by default.
+          '';
+        };
+
+        overlays = mkOption {
+          default = [];
+          example = literalExample
+            "[\"\${pkgs.deviceTree.raspberryPiOverlays}/w1-gpio.dtbo\"]";
+          type = types.listOf types.path;
+          description = ''
+            A path containing device tree overlays (.dtbo) to be applied to all
+            base device-trees.
+          '';
+        };
+
+        package = mkOption {
+          default = null;
+          type = types.nullOr types.path;
+          description = ''
+            A path containing device tree overlays (.dtbo) to be applied to all
+            base device-trees. Overrides `base` and `overlays`.
+          '';
+        };
+      };
+  };
+
+  config = mkIf (cfg.enable) {
+    hardware.deviceTree.package = if (cfg.overlays != [])
+      then pkgs.deviceTree.applyOverlays cfg.base cfg.overlays else cfg.base;
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -46,6 +46,7 @@
   ./hardware/cpu/amd-microcode.nix
   ./hardware/cpu/intel-microcode.nix
   ./hardware/digitalbitbox.nix
+  ./hardware/device-tree.nix
   ./hardware/sensor/iio.nix
   ./hardware/ksm.nix
   ./hardware/ledger.nix

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -46,8 +46,8 @@ let
 
         ln -s ${kernelPath} $out/kernel
         ln -s ${config.system.modulesTree} $out/kernel-modules
-        ${optionalString (pkgs.stdenv.hostPlatform.platform.kernelDTB or false) ''
-          ln -s ${config.boot.kernelPackages.kernel}/dtbs $out/dtbs
+        ${optionalString (config.hardware.deviceTree.package != null) ''
+          ln -s ${config.hardware.deviceTree.package} $out/dtbs
         ''}
 
         echo -n "$kernelParams" > $out/kernel-params

--- a/nixos/modules/system/boot/loader/generic-extlinux-compatible/extlinux-conf-builder.sh
+++ b/nixos/modules/system/boot/loader/generic-extlinux-compatible/extlinux-conf-builder.sh
@@ -75,9 +75,8 @@ addEntry() {
 
     copyToKernelsDir "$path/kernel"; kernel=$result
     copyToKernelsDir "$path/initrd"; initrd=$result
-    # XXX UGLY: maybe the system config should have a top-level "dtbs" entry?
-    dtbDir=$(readlink -m "$path/kernel/../dtbs")
-    if [ -d "$dtbDir" ]; then
+    dtbDir=$(readlink -m "$path/dtbs")
+    if [ -e "$dtbDir" ]; then
         copyToKernelsDir "$dtbDir"; dtbs=$result
     fi
 

--- a/pkgs/os-specific/linux/device-tree.nix
+++ b/pkgs/os-specific/linux/device-tree.nix
@@ -1,0 +1,28 @@
+{ stdenvNoCC, dtc, findutils, raspberrypifw }:
+
+with stdenvNoCC.lib; {
+  applyOverlays = (base: overlays: stdenvNoCC.mkDerivation {
+    name = "device-tree-overlays";
+    nativeBuildInputs = [ dtc findutils ];
+    buildCommand = let
+      quotedDtbos = concatMapStringsSep " " (o: "\"${toString o}\"") (toList overlays);
+    in ''
+      for dtb in $(find ${base} -name "*.dtb" ); do
+        outDtb=$out/$(realpath --relative-to "${base}" "$dtb")
+        mkdir -p "$(dirname "$outDtb")"
+        fdtoverlay -o "$outDtb" -i "$dtb" ${quotedDtbos};
+      done
+    '';
+  });
+
+  raspberryPiDtbs = stdenvNoCC.mkDerivation {
+    name = "raspberrypi-dtbs-${raspberrypifw.version}";
+    nativeBuildInputs = [ raspberrypifw ];
+    buildCommand = ''
+      mkdir -p $out/broadcom/
+      cp ${raspberrypifw}/share/raspberrypi/boot/bcm*.dtb $out/broadcom
+    '';
+  };
+
+  raspberryPiOverlays = "${raspberrypifw}/share/raspberrypi/boot/overlays";
+}

--- a/pkgs/os-specific/linux/device-tree/default.nix
+++ b/pkgs/os-specific/linux/device-tree/default.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, dtc, findutils, raspberrypifw }:
+{ stdenvNoCC, dtc, findutils }:
 
 with stdenvNoCC.lib; {
   applyOverlays = (base: overlays: stdenvNoCC.mkDerivation {
@@ -14,15 +14,4 @@ with stdenvNoCC.lib; {
       done
     '';
   });
-
-  raspberryPiDtbs = stdenvNoCC.mkDerivation {
-    name = "raspberrypi-dtbs-${raspberrypifw.version}";
-    nativeBuildInputs = [ raspberrypifw ];
-    buildCommand = ''
-      mkdir -p $out/broadcom/
-      cp ${raspberrypifw}/share/raspberrypi/boot/bcm*.dtb $out/broadcom
-    '';
-  };
-
-  raspberryPiOverlays = "${raspberrypifw}/share/raspberrypi/boot/overlays";
 }

--- a/pkgs/os-specific/linux/device-tree/raspberrypi.nix
+++ b/pkgs/os-specific/linux/device-tree/raspberrypi.nix
@@ -3,10 +3,28 @@
 stdenvNoCC.mkDerivation {
   name = "raspberrypi-dtbs-${raspberrypifw.version}";
   nativeBuildInputs = [ raspberrypifw ];
+
+  # Rename DTBs so u-boot finds them, like linux-rpi.nix
   buildCommand = ''
     mkdir -p $out/broadcom/
-    cp ${raspberrypifw}/share/raspberrypi/boot/bcm*.dtb $out/broadcom
+    cd $out/broadcom/
+
+    cp ${raspberrypifw}/share/raspberrypi/boot/bcm*.dtb .
+
+    cp bcm2708-rpi-0-w.dtb bcm2835-rpi-zero-w.dtb
+    cp bcm2708-rpi-b.dtb bcm2835-rpi-a.dtb
+    cp bcm2708-rpi-b.dtb bcm2835-rpi-b.dtb
+    cp bcm2708-rpi-b.dtb bcm2835-rpi-b-rev2.dtb
+    cp bcm2708-rpi-b-plus.dtb bcm2835-rpi-a-plus
+    cp bcm2708-rpi-b-plus.dtb bcm2835-rpi-b-plus
+    cp bcm2708-rpi-b-plus.dtb bcm2835-rpi-zero.dtb
+    cp bcm2708-rpi-cm.dtb bcm2835-rpi-cm.dtb
+    cp bcm2709-rpi-2-b.dtb bcm2836-rpi-2-b.dtb
+    cp bcm2710-rpi-3-b.dtb bcm2837-rpi-3-b.dtb
+    cp bcm2710-rpi-3-b-plus.dtb bcm2837-rpi-3-b-plus.dtb
+    cp bcm2710-rpi-cm3.dtb bcm2837-rpi-cm3.dtb
   '';
+
   passthru = {
     # Compatible overlays that may be used
     overlays = "${raspberrypifw}/share/raspberrypi/boot/overlays";

--- a/pkgs/os-specific/linux/device-tree/raspberrypi.nix
+++ b/pkgs/os-specific/linux/device-tree/raspberrypi.nix
@@ -1,0 +1,14 @@
+{ stdenvNoCC, raspberrypifw }:
+
+stdenvNoCC.mkDerivation {
+  name = "raspberrypi-dtbs-${raspberrypifw.version}";
+  nativeBuildInputs = [ raspberrypifw ];
+  buildCommand = ''
+    mkdir -p $out/broadcom/
+    cp ${raspberrypifw}/share/raspberrypi/boot/bcm*.dtb $out/broadcom
+  '';
+  passthru = {
+    # Compatible overlays that may be used
+    overlays = "${raspberrypifw}/share/raspberrypi/boot/overlays";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -169,6 +169,8 @@ in
 
   demoit = callPackage ../servers/demoit { };
 
+  deviceTree = callPackage ../os-specific/linux/device-tree.nix {};
+
   diffPlugins = (callPackage ../build-support/plugins.nix {}).diffPlugins;
 
   dieHook = makeSetupHook {} ../build-support/setup-hooks/die.sh;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -169,7 +169,9 @@ in
 
   demoit = callPackage ../servers/demoit { };
 
-  deviceTree = callPackage ../os-specific/linux/device-tree.nix {};
+  deviceTree = callPackage ../os-specific/linux/device-tree {};
+
+  device-tree_rpi = callPackage ../os-specific/linux/device-tree/raspberrypi.nix {};
 
   diffPlugins = (callPackage ../build-support/plugins.nix {}).diffPlugins;
 


### PR DESCRIPTION
###### Motivation for this change

Add support for custom device-tree files, as well as configuring overlays applied to device-trees. These are needed in embedded devices to expose non-discoverable hardware to the kernel, and are common on Raspberry Pi and similar.

This does not include support for Raspberry Pi style device-tree parameters (`dtparam`), as there does not seem to be a command-line tool available to apply these parameters to an overlay (if there is one in nixpkgs, I'm happy to extend this PR to include support).

@samueldr was particularly interested on IRC.

An example configuration might be: 

```
hardware.deviceTree = {
  enable = true;
  base = pkgs.deviceTree.raspberryPiDtbs;
  overlays = [ "${pkgs.deviceTree.raspberryPiOverlays}/w1-gpio.dtbo" ];
};
```

###### Things done

This  can be used to build a sd-image, that contains appropriately modified device-tree files. I'll test the result over the next few days, but would appreciate some comments on the API in the meantime.

I'm particularly not sure about how things should be split between `nixos` and `nixpkgs`, and whether I've understood the options interface correctly.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
