### PR TITLE
WIP faust 2.5.23 -> 2.15.11

### DIFF
--- a/pkgs/applications/audio/faust/faust2jack.nix
+++ b/pkgs/applications/audio/faust/faust2jack.nix
@@ -1,6 +1,7 @@
 { faust
 , gtk2
 , jack2Full
+, alsaLib
 , opencv
 , libsndfile
 }:
@@ -18,6 +19,7 @@ faust.wrapWithBuildEnv {
   propagatedBuildInputs = [
     gtk2
     jack2Full
+    alsaLib
     opencv
     libsndfile
   ];

--- a/pkgs/applications/audio/faust/faust2jackrust.nix
+++ b/pkgs/applications/audio/faust/faust2jackrust.nix
@@ -1,0 +1,18 @@
+{ stdenv
+, faust
+, libjack2
+, cargo
+, binutils
+, gcc
+, gnumake
+, openssl
+, pkgconfig
+
+}:
+
+faust.wrapWithBuildEnv {
+
+  baseName = "faust2jackrust";
+
+  propagatedBuildInputs = [ libjack2 cargo binutils gcc gnumake openssl pkgconfig ];
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24788,7 +24788,7 @@ in
   faust1 = callPackage ../applications/audio/faust/faust1.nix { };
 
   faust2 = callPackage ../applications/audio/faust/faust2.nix {
-    llvm = llvm_5;
+    llvm = llvm_9;
   };
 
   faust2alqt = callPackage ../applications/audio/faust/faust2alqt.nix { };
@@ -24800,6 +24800,8 @@ in
   faust2firefox = callPackage ../applications/audio/faust/faust2firefox.nix { };
 
   faust2jack = callPackage ../applications/audio/faust/faust2jack.nix { };
+
+  faust2jackrust = callPackage ../applications/audio/faust/faust2jackrust.nix { };
 
   faust2jaqt = callPackage ../applications/audio/faust/faust2jaqt.nix { };
 


### PR DESCRIPTION
This is a partly working upgrade of faust.
The compiler works fine, but not all scripts do.
Here's the status of all the scripts that are packages so far, using ``tst.dsp`` which contains ``process=+;``:

### faust2alqt -time tst.dsp
```
end generateCode (duration : 0.122584)
tst.cpp:5432:10: fatal error: alsa/asoundlib.h: No such file or directory
 #include <alsa/asoundlib.h>
          ^~~~~~~~~~~~~~~~~~
compilation terminated.
```
### faust2asa -time tst.dsp
```
end generateCode (duration : 0.114479)
/nix/store/1kl6ms8x56iyhylb2r83lq7j3jbnix7w-binutils-2.31.1/bin/ld: /tmp/ccqZMBr6.o: undefined reference to symbol 'pthread_create@@GLIBC_2.2.5'
/nix/store/1kl6ms8x56iyhylb2r83lq7j3jbnix7w-binutils-2.31.1/bin/ld: /nix/store/681354n3k44r8z90m35hm8945vsp95h1-glibc-2.27/lib/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```
### faust2atomsnippets tst.dsp                                                                                                                                                                                            [18:13:22]
```
  File "/nix/store/yrynh0b1mffdbk6gcfnkxv6wvfh2rqbn-faust-2.5.23/bin/.faust2atomsnippets-wrapped", line 136
    raise getopt.error, "At least one file argument required"
                      ^
SyntaxError: invalid syntax
```
### faust2graph tst.dsp
gives a non-valid (or just empty?) pdf
### faust2graph -svg tst.dsp
gives an svg containing an oval with the text: 
```
L0
: 0x30ba0b0
```
### faust2graphviewer tst.dsp
opens a pdf with the above content
### faust2jack tst.dsp
works
### faust2jackconsole -time tst.dsp 
works
### faust2jackinternal tst.dsp                                                                                                                                                                                            [18:28:45]
```
tst.dsp.cpp:168:72: error: ‘Soundfile’ has not been declared
     virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) {}
```
### faust2jackrust tst.dsp
```
     Created binary (application) `tst-rust` package
    Updating crates.io index
  Downloaded libc v0.2.53
   Compiling libloading v0.4.3
   Compiling libc v0.2.53
   Compiling lazy_static v1.3.0
   Compiling bitflags v0.7.0
   Compiling jack-sys v0.2.0
   Compiling jack v0.5.7
   Compiling tst-rust v0.1.0 (/home/bart/tmp3/tst-rust)
warning: unused variable: `samplingFreq`
   --> src/main.rs:136:19
    |
136 |     pub fn classInit(samplingFreq: i32) {
    |                      ^^^^^^^^^^^^ help: consider prefixing with an underscore: `_samplingFreq`
    |
    = note: #[warn(unused_variables)] on by default

warning: variable does not need to be mutable
   --> src/main.rs:100:7
    |
100 |         let mut rate: i32;
    |             ----^^^^
    |             |
    |             help: remove this `mut`
    |
    = note: #[warn(unused_mut)] on by default

warning: variable does not need to be mutable
   --> src/main.rs:120:7
    |
120 |         let mut rate: i32;
    |             ----^^^^
    |             |
    |             help: remove this `mut`

warning: field is never used: `fDummy`
  --> src/main.rs:68:2
   |
68 |     fDummy: f32,
   |     ^^^^^^^^^^^
   |
   = note: #[warn(dead_code)] on by default

error: linking with `cc` failed: exit code: 1
  |
  = note: "cc" "-Wl,--as-needed" "-Wl,-z,noexecstack" "-m64" "-L" "/nix/store/4qgsj8k3iww9h6i3iyjdp9pm567jz2hp-rustc-1.34.0/lib/rustlib/x86_64-unknown-linux-gnu/lib" "/home/bart/tmp3/tst-rust/target/release/deps/tst_rust-4ea5652acbc17abe.tst_rust.6yjh5b7j-cgu.0.rcgu.o" "/home/bart/tmp3/tst-rust/target/release/deps/tst_rust-4ea5652acbc17abe.tst_rust.6yjh5b7j-cgu.1.rcgu.o" "/home/bart/tmp3/tst-rust/target/release/deps/tst_rust-4ea5652acbc17abe.tst_rust.6yjh5b7j-cgu.10.rcgu.o" "/home/bart/tmp3/tst-rust/target/release/deps/tst_rust-4ea5652acbc17abe.tst_rust.6yjh5b7j-cgu.11.rcgu.o" "/home/bart/tmp3/tst-rust/target/release/deps/tst_rust-4ea5652acbc17abe.tst_rust.6yjh5b7j-cgu.12.rcgu.o" "/home/bart/tmp3/tst-rust/target/release/deps/tst_rust-4ea5652acbc17abe.tst_rust.6yjh5b7j-cgu.13.rcgu.o" "/home/bart/tmp3/tst-rust/target/release/deps/tst_rust-4ea5652acbc17abe.tst_rust.6yjh5b7j-cgu.14.rcgu.o" "/home/bart/tmp3/tst-rust/target/release/deps/tst_rust-4ea5652acbc17abe.tst_rust.6yjh5b7j-cgu.15.rcgu.o" "/home/bart/tmp3/tst-rust/target/release/deps/tst_rust-4ea5652acbc17abe.tst_rust.6yjh5b7j-cgu.2.rcgu.o" "/home/bart/tmp3/tst-rust/target/release/deps/tst_rust-4ea5652acbc17abe.tst_rust.6yjh5b7j-cgu.3.rcgu.o" "/home/bart/tmp3/tst-rust/target/release/deps/tst_rust-4ea5652acbc17abe.tst_rust.6yjh5b7j-cgu.4.rcgu.o" "/home/bart/tmp3/tst-rust/target/release/deps/tst_rust-4ea5652acbc17abe.tst_rust.6yjh5b7j-cgu.5.rcgu.o" "/home/bart/tmp3/tst-rust/target/release/deps/tst_rust-4ea5652acbc17abe.tst_rust.6yjh5b7j-cgu.6.rcgu.o" "/home/bart/tmp3/tst-rust/target/release/deps/tst_rust-4ea5652acbc17abe.tst_rust.6yjh5b7j-cgu.7.rcgu.o" "/home/bart/tmp3/tst-rust/target/release/deps/tst_rust-4ea5652acbc17abe.tst_rust.6yjh5b7j-cgu.8.rcgu.o" "/home/bart/tmp3/tst-rust/target/release/deps/tst_rust-4ea5652acbc17abe.tst_rust.6yjh5b7j-cgu.9.rcgu.o" "-o" "/home/bart/tmp3/tst-rust/target/release/deps/tst_rust-4ea5652acbc17abe" "/home/bart/tmp3/tst-rust/target/release/deps/tst_rust-4ea5652acbc17abe.9xvqa2kxnflmvw0.rcgu.o" "-Wl,--gc-sections" "-pie" "-Wl,-zrelro" "-Wl,-znow" "-Wl,-O1" "-nodefaultlibs" "-L" "/home/bart/tmp3/tst-rust/target/release/deps" "-L" "/nix/store/4qgsj8k3iww9h6i3iyjdp9pm567jz2hp-rustc-1.34.0/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-Wl,-Bstatic" "/home/bart/tmp3/tst-rust/target/release/deps/libjack-5a0c7de637acc196.rlib" "/home/bart/tmp3/tst-rust/target/release/deps/libjack_sys-f2ceccd62db381e8.rlib" "/home/bart/tmp3/tst-rust/target/release/deps/liblibloading-0fb39a6cb36a8244.rlib" "/home/bart/tmp3/tst-rust/target/release/deps/liblazy_static-5609bde1d8b00d84.rlib" "/home/bart/tmp3/tst-rust/target/release/deps/liblibc-788d7c81589383a8.rlib" "/home/bart/tmp3/tst-rust/target/release/deps/libbitflags-1ae9f01c49b9375f.rlib" "-Wl,--start-group" "/nix/store/4qgsj8k3iww9h6i3iyjdp9pm567jz2hp-rustc-1.34.0/lib/rustlib/x86_64-unknown-linux-gnu/lib/libstd-b61b94468244492b.rlib" "/nix/store/4qgsj8k3iww9h6i3iyjdp9pm567jz2hp-rustc-1.34.0/lib/rustlib/x86_64-unknown-linux-gnu/lib/libpanic_unwind-cd6a0d364e127a99.rlib" "/nix/store/4qgsj8k3iww9h6i3iyjdp9pm567jz2hp-rustc-1.34.0/lib/rustlib/x86_64-unknown-linux-gnu/lib/libbacktrace_sys-fb8d6ce3854556c5.rlib" "/nix/store/4qgsj8k3iww9h6i3iyjdp9pm567jz2hp-rustc-1.34.0/lib/rustlib/x86_64-unknown-linux-gnu/lib/libunwind-e2aef31080e323f7.rlib" "/nix/store/4qgsj8k3iww9h6i3iyjdp9pm567jz2hp-rustc-1.34.0/lib/rustlib/x86_64-unknown-linux-gnu/lib/librustc_demangle-c53f21a0078ba8e2.rlib" "/nix/store/4qgsj8k3iww9h6i3iyjdp9pm567jz2hp-rustc-1.34.0/lib/rustlib/x86_64-unknown-linux-gnu/lib/liblibc-7aa7a075c8f9be89.rlib" "/nix/store/4qgsj8k3iww9h6i3iyjdp9pm567jz2hp-rustc-1.34.0/lib/rustlib/x86_64-unknown-linux-gnu/lib/liballoc-f72bb3d7779350e2.rlib" "/nix/store/4qgsj8k3iww9h6i3iyjdp9pm567jz2hp-rustc-1.34.0/lib/rustlib/x86_64-unknown-linux-gnu/lib/librustc_std_workspace_core-1bb93267982d1de1.rlib" "/nix/store/4qgsj8k3iww9h6i3iyjdp9pm567jz2hp-rustc-1.34.0/lib/rustlib/x86_64-unknown-linux-gnu/lib/libcore-ef88149d34bea248.rlib" "-Wl,--end-group" "/nix/store/4qgsj8k3iww9h6i3iyjdp9pm567jz2hp-rustc-1.34.0/lib/rustlib/x86_64-unknown-linux-gnu/lib/libcompiler_builtins-f589aec74a5f183d.rlib" "-Wl,-Bdynamic" "-ljack" "-ldl" "-lutil" "-lutil" "-ldl" "-lrt" "-lpthread" "-lgcc_s" "-lc" "-lm" "-lrt" "-lpthread" "-lutil" "-lutil"
  = note: /nix/store/1kl6ms8x56iyhylb2r83lq7j3jbnix7w-binutils-2.31.1/bin/ld: cannot find -ljack
          collect2: error: ld returned 1 exit status
```
          

### faust2jackserver -time tst.dsp
```
tst.cpp:5431:10: fatal error: jack/jack.h: No such file or directory
 #include <jack/jack.h>
          ^~~~~~~~~~~~~
compilation terminated.
make: *** [Makefile:219: tst.o] Error 1
```
### faust2jaqt -time tst.dsp
```
end generateCode (duration : 0.131924)
tst.cpp:5431:10: fatal error: jack/jack.h: No such file or directory
 #include <jack/jack.h>
          ^~~~~~~~~~~~~
compilation terminated.
```
### faust2lv2 -time tst.dsp
```
end generateCode (duration : 0.0313551)
lv2.cpp:292:10: fatal error: boost/circular_buffer.hpp: No such file or directory
compilation terminated.
### faust2md tst.dsp > tst.md                                                                                                                                                                                             [18:32:48]
  File "/nix/store/yrynh0b1mffdbk6gcfnkxv6wvfh2rqbn-faust-2.5.23/bin/.faust2md-wrapped", line 133
    raise getopt.error, "At least one file argument required"
                      ^
SyntaxError: invalid syntax
```
### faust2plot tst.dsp
works
### faust2sigviewer tst.dsp
works
### faust2svg tst.dsp
works


###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
