### PR TITLE
sonic-pi: add midi in/out support

### DIFF
--- a/pkgs/applications/audio/osmid/default.nix
+++ b/pkgs/applications/audio/osmid/default.nix
@@ -1,0 +1,33 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+, alsaLib
+, libX11
+}:
+
+stdenv.mkDerivation rec {
+  name = "osmid";
+  version = "0.6.1";
+
+  src = fetchFromGitHub {
+    owner = "llloret";
+    repo = "osmid";
+    rev = "v${version}";
+    sha256 = "1lvdn05y5b0gfpf9y5zk84pw7phm7x0qbivixx8yy111na7p3rd5";
+  };
+
+  buildInputs = [ cmake alsaLib libX11 ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp {m2o,o2m} $out/bin/
+  '';
+
+  meta = {
+    homepage = https://github.com/llloret/osmid;
+    description = "A lightweight, portable, easy to use tool to convert MIDI to OSC and OSC to MIDI";
+    license = stdenv.lib.licenses.mit;
+    maintainers = with stdenv.lib.maintainers; [ c0deaddict ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/applications/audio/sonic-pi/default.nix
+++ b/pkgs/applications/audio/sonic-pi/default.nix
@@ -12,33 +12,13 @@
 , bash
 , makeWrapper
 , jack2Full
-, alsaLib
-, libX11
+, osmid
 }:
 
 let
+
   supercollider = libsForQt5.callPackage ../../../development/interpreters/supercollider {
     fftw = fftwSinglePrec;
-  };
-
-  # sonic-pi uses a specific version of osmid:
-  # https://github.com/samaaron/sonic-pi/blob/0fff19db99350ab143a3a5c3e353c73555ca3574/app/gui/qt/build-debian-app#L12
-  osmid = stdenv.mkDerivation rec {
-    name = "osmid";
-
-    src = fetchFromGitHub {
-      owner = "llloret";
-      repo = "osmid";
-      rev = "391f35f789f18126003d2edf32902eb714726802";
-      sha256 = "sha256:0v5pm5fpz7ckrvz7w2r74nkkvyhjdhl7k12p6vj5n67xf9wvq3ib";
-    };
-
-    buildInputs = [ cmake alsaLib libX11 ];
-
-    installPhase = ''
-      mkdir -p $out/bin
-      cp {m2o,o2m} $out/bin/
-    '';
   };
 
 in stdenv.mkDerivation rec {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12300,6 +12300,8 @@ in
 
   osm-gps-map = callPackage ../development/libraries/osm-gps-map { };
 
+  osmid = callPackage ../applications/audio/osmid { };
+
   osinfo-db = callPackage ../data/misc/osinfo-db { };
   osinfo-db-tools = callPackage ../tools/misc/osinfo-db-tools { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The official Sonic Pi distribution has support for Midi devices (in and out) but the version in nixpkgs did not have this. Missing was the `osmid` dependency (from (this repository)[https://github.com/llloret/osmid]). Since sonic-pi needs a specific version I have inlined this dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
