### PR TITLE
nixos/tiddlywiki: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -469,6 +469,7 @@
   ./services/misc/synergy.nix
   ./services/misc/sysprof.nix
   ./services/misc/taskserver
+  ./services/misc/tiddlywiki.nix
   ./services/misc/tzupdate.nix
   ./services/misc/uhub.nix
   ./services/misc/weechat.nix

--- a/nixos/modules/services/misc/tiddlywiki.nix
+++ b/nixos/modules/services/misc/tiddlywiki.nix
@@ -1,0 +1,52 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.tiddlywiki;
+  listenParams = concatStrings (mapAttrsToList (n: v: " '${n}=${toString v}' ") cfg.listenOptions);
+  exe = "${pkgs.nodePackages.tiddlywiki}/lib/node_modules/.bin/tiddlywiki";
+  name = "tiddlywiki";
+  dataDir = "/var/lib/" + name;
+
+in {
+
+  options.services.tiddlywiki = {
+
+    enable = mkEnableOption "TiddlyWiki nodejs server";
+
+    listenOptions = mkOption {
+      type = types.attrs;
+      default = {};
+      example = {
+        credentials = "../credentials.csv";
+        readers="(authenticated)";
+        port = 3456;
+      };
+      description = ''
+        Parameters passed to <literal>--listen</literal> command.
+        Refer to <link xlink:href="https://tiddlywiki.com/#WebServer"/>
+        for details on supported values.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd = {
+      services.tiddlywiki = {
+        description = "TiddlyWiki nodejs server";
+        after = [ "network.target" ];
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          Type = "simple";
+          Restart = "on-failure";
+          DynamicUser = true;
+          StateDirectory = name;
+          ExecStartPre = "-${exe} ${dataDir} --init server";
+          ExecStart = "${exe} ${dataDir} --listen ${listenParams}";
+        };
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -245,6 +245,7 @@ in
   pdns-recursor = handleTest ./pdns-recursor.nix {};
   taskserver = handleTest ./taskserver.nix {};
   telegraf = handleTest ./telegraf.nix {};
+  tiddlywiki = handleTest ./tiddlywiki.nix {};
   tinydns = handleTest ./tinydns.nix {};
   tomcat = handleTest ./tomcat.nix {};
   tor = handleTest ./tor.nix {};

--- a/nixos/tests/tiddlywiki.nix
+++ b/nixos/tests/tiddlywiki.nix
@@ -1,0 +1,67 @@
+import ./make-test.nix ({ ... }: {
+  name = "tiddlywiki";
+  nodes = {
+    default = {
+      services.tiddlywiki.enable = true;
+    };
+    configured = {
+      boot.postBootCommands = ''
+        echo "username,password
+        somelogin,somesecret" > /var/lib/wikiusers.csv
+      '';
+      services.tiddlywiki = {
+        enable = true;
+        listenOptions = {
+          port = 3000;
+          credentials="../wikiusers.csv";
+          readers="(authenticated)";
+        };
+      };
+    };
+  };
+
+  testScript = ''
+    startAll;
+
+    subtest "by default works without configuration", sub {
+      $default->waitForUnit("tiddlywiki.service");
+    };
+
+    subtest "by default available on port 8080 without auth", sub {
+      $default->waitForUnit("tiddlywiki.service");
+      $default->waitForOpenPort(8080);
+      $default->succeed("curl --fail 127.0.0.1:8080");
+    };
+
+    subtest "by default creates empty wiki", sub {
+      $default->succeed("test -f /var/lib/tiddlywiki/tiddlywiki.info");
+    };
+
+    subtest "configured on port 3000 with basic auth", sub {
+      $configured->waitForUnit("tiddlywiki.service");
+      $configured->waitForOpenPort(3000);
+      $configured->fail("curl --fail 127.0.0.1:3000");
+      $configured->succeed("curl --fail 127.0.0.1:3000 --user somelogin:somesecret");
+    };
+
+    subtest "configured with different wikifolder", sub {
+      $configured->succeed("test -f /var/lib/tiddlywiki/tiddlywiki.info");
+    };
+
+    subtest "restart preserves changes", sub {
+      # given running wiki
+      $default->waitForUnit("tiddlywiki.service");
+      # with some changes
+      $default->succeed("curl --fail --request PUT --header 'X-Requested-With:TiddlyWiki' --data '{ \"title\": \"title\", \"text\": \"content\" }' --url 127.0.0.1:8080/recipes/default/tiddlers/somepage ");
+      $default->succeed("sleep 2"); # server syncs to filesystem on timer
+
+      # when wiki is cycled
+      $default->systemctl("restart tiddlywiki.service");
+      $default->waitForUnit("tiddlywiki.service");
+      $default->waitForOpenPort(8080);
+
+      # the change is preserved
+      $default->succeed("curl --fail 127.0.0.1:8080/recipes/default/tiddlers/somepage");
+    };
+  '';
+})


### PR DESCRIPTION
###### Motivation for this change

Service that runs TiddlyWiki nodejs server.

Exposed options to
 * enable basic auth
 * path to existing wiki files

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
