### PR TITLE
timemachine: 0.3.1 -> 0.3.3

### DIFF
--- a/pkgs/applications/audio/timemachine/default.nix
+++ b/pkgs/applications/audio/timemachine/default.nix
@@ -3,13 +3,13 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "timemachine-${version}";
-  version = "0.3.1";
+  pname = "timemachine";
+  version = "0.3.3";
   src = fetchFromGitHub {
     owner = "swh";
     repo = "timemachine";
-    rev = "1966d8524d4e4c47c525473bab3b010a168adc98";
-    sha256 = "0w5alysixnvlkfl79wf7vs5wsw2vgxl3gqxxcm0zbmhjdpmjpcal";
+    rev = "v${version}";
+    sha256 = "1jsvd29wiqigxyqxl2xjklla11fwyjy68vqivcnlr9f2af4ylym8";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
