### PR TITLE
plex-media-player: remove custom desktopItem

### DIFF
--- a/pkgs/applications/video/plex-media-player/default.nix
+++ b/pkgs/applications/video/plex-media-player/default.nix
@@ -59,11 +59,6 @@ in stdenv.mkDerivation rec {
     ln -s ${webClientTv} build/dependencies/web-client-tv-${webClientTvBuildId}.tar.xz
   '';
 
-  postInstall = ''
-    mkdir -p $out/share/{applications,pixmaps}
-    cp ${src}/resources/images/icon.png $out/share/pixmaps/plex-media-player.png
-  '';
-
   cmakeFlags = [ "-DCMAKE_BUILD_TYPE=RelWithDebInfo" "-DQTROOT=${qtbase}" ];
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/video/plex-media-player/default.nix
+++ b/pkgs/applications/video/plex-media-player/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, fetchurl, makeDesktopItem, pkgconfig, cmake, python3
+{ stdenv, fetchFromGitHub, fetchurl, pkgconfig, cmake, python3
 , libX11, libXrandr, qtbase, qtwebchannel, qtwebengine, qtx11extras
 , libvdpau, SDL2, mpv, libGL }:
 let
@@ -50,16 +50,6 @@ in stdenv.mkDerivation rec {
   buildInputs = [ libX11 libXrandr qtbase qtwebchannel qtwebengine qtx11extras
                   libvdpau SDL2 mpv libGL ];
 
-  desktopItem = makeDesktopItem {
-    name = "plex-media-player";
-    exec = "plexmediaplayer";
-    icon = "plex-media-player";
-    comment = "View your media";
-    desktopName = "Plex Media Player";
-    genericName = "Media Player";
-    categories = "AudioVideo;Video;Player;TV;";
-  };
-
   preConfigure = with depSrcs; ''
     mkdir -p build/dependencies
     ln -s ${webClient} build/dependencies/buildid-${webClientBuildId}.cmake
@@ -72,7 +62,6 @@ in stdenv.mkDerivation rec {
   postInstall = ''
     mkdir -p $out/share/{applications,pixmaps}
     cp ${src}/resources/images/icon.png $out/share/pixmaps/plex-media-player.png
-    cp ${desktopItem}/share/applications/* $out/share/applications
   '';
 
   cmakeFlags = [ "-DCMAKE_BUILD_TYPE=RelWithDebInfo" "-DQTROOT=${qtbase}" ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fixes #60437: `plex-media-player` comes with a working desktop file, so there is no need to add our own custom one unless we remove the original. Both seem to work fine, so let's keep it simple.

###### Things done

- Removed `makeDesktopItem` dependency
- Removed creation and copy of the custom desktop item `desktopItem` (`plex-media-player.desktop`)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
