### PR TITLE
speech-denoiser: init at unstable-07-10-2019

### DIFF
--- a/pkgs/applications/audio/speech-denoiser/default.nix
+++ b/pkgs/applications/audio/speech-denoiser/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, lv2, meson, ninja }:
+
+let
+  speech-denoiser-src = fetchFromGitHub {
+    owner = "lucianodato";
+    repo = "speech-denoiser";
+    rev = "04cfba929630404f8d4f4ca5bac8d9b09a99152f";
+    sha256 = "189l6lz8sz5vr6bjyzgcsrvksl1w6crqsg0q65r94b5yjsmjnpr4";
+  };
+
+  rnnoise-nu = stdenv.mkDerivation rec {
+    pname = "rnnoise-nu";
+    version = "unstable-07-10-2019";
+    src = speech-denoiser-src;
+    sourceRoot = "source/rnnoise";
+    nativeBuildInputs = [ autoreconfHook ];
+    configureFlags = [ "--disable-examples" "--disable-doc" "--disable-shared" "--enable-static" ];
+    installTargets = [ "install-rnnoise-nu" ];
+  };
+in
+stdenv.mkDerivation  rec {
+  pname = "speech-denoiser";
+  version = "unstable-07-10-2019";
+
+  src = speech-denoiser-src;
+
+  nativeBuildInputs = [ pkgconfig meson ninja ];
+  buildInputs = [ lv2 rnnoise-nu ];
+
+  postPatch = ''
+    substituteInPlace meson.build \
+      --replace "cc.find_library('rnnoise-nu',dirs: meson.current_source_dir() + '/rnnoise/.libs/',required : true)" "cc.find_library('rnnoise-nu', required : true)"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Speech denoise lv2 plugin based on RNNoise library";
+    homepage = https://github.com/lucianodato/speech-denoiser;
+    license = licenses.lgpl3;
+    maintainers = [ maintainers.magnetophon ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5822,6 +5822,8 @@ in
 
   spaceFM = callPackage ../applications/misc/spacefm { };
 
+  speech-denoiser = callPackage ../applications/audio/speech-denoiser {};
+
   squashfsTools = callPackage ../tools/filesystems/squashfs { };
 
   squashfuse = callPackage ../tools/filesystems/squashfuse { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
