### PR TITLE
getopt: 1.1.4 -> 1.1.6, modernize a bit

### DIFF
--- a/pkgs/tools/misc/getopt/builder.sh
+++ b/pkgs/tools/misc/getopt/builder.sh
@@ -1,4 +1,0 @@
-source $stdenv/setup
-installFlags="prefix=$out"
-makeFlags="CFLAGS=-DWITHOUT_GETTEXT LIBCGETOPT=0"
-genericBuild

--- a/pkgs/tools/misc/getopt/default.nix
+++ b/pkgs/tools/misc/getopt/default.nix
@@ -1,15 +1,19 @@
 {stdenv, fetchurl}:
 
-stdenv.mkDerivation {
-  name = "getopt-1.1.4";
-  builder = ./builder.sh;
+stdenv.mkDerivation rec {
+  pname = "getopt";
+  version = "1.1.6";
   src = fetchurl {
-    url = http://tarballs.nixos.org/getopt-1.1.4.tar.gz;
-    sha256 = "1arvjfzw6p310zbgv629w5hkyslrj44imf3r3s2r4ry2jfcks221";
+    url = "http://frodo.looijaard.name/system/files/software/${pname}/${pname}-${version}.tar.gz";
+    sha256 = "1zn5kp8ar853rin0ay2j3p17blxy16agpp8wi8wfg4x98b31vgyh";
   };
-  preBuild = ''
-    export buildFlags=CC="$CC" # for darwin
-  '';
+
+  makeFlags = [
+    "WITHOUT_GETTEXT=1"
+    "LIBCGETOPT=0"
+    "prefix=${placeholder "out"}"
+    "CC:=$(CC)"
+  ];
 
   meta = {
     platforms = stdenv.lib.platforms.unix;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

http://frodo.looijaard.name/project/getopt/release/1-1-6
http://frodo.looijaard.name/project/getopt/release/1-1-5

* don't rely on tarballs.nixos.org
* no need for custom builder

Unfortunately triggers rebuild-all-the-things.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---