### PR TITLE
openafs: 1.8.2 -> 1.8.3

### DIFF
--- a/pkgs/servers/openafs/1.8/module.nix
+++ b/pkgs/servers/openafs/1.8/module.nix
@@ -11,36 +11,6 @@ in stdenv.mkDerivation rec {
   name = "openafs-${version}-${kernel.modDirVersion}";
   inherit version src;
 
-  patches = [
-    # Linux 4.20
-    (fetchpatch {
-      name = "openafs_1_8-do_settimeofday.patch";
-      url = "http://git.openafs.org/?p=openafs.git;a=patch;h=aa80f892ec39e2984818090a6bb2047430836ee2";
-      sha256 = "11zw676zqi9sj3vhp7n7ndxcxhp17cq9g2g41n030mcd3ap4g53h";
-    })
-    (fetchpatch {
-      name = "openafs_1_8-current_kernel_time.patch";
-      url = "http://git.openafs.org/?p=openafs.git;a=patch;h=3c454b39d04f4886536267c211171dae30dc0344";
-      sha256 = "16fl9kp0l95dqm166jx3x4ijbzhf2bc9ilnipn3k1j00mfy4lnia";
-    })
-    # Linux 5.0
-    (fetchpatch {
-      name = "openafs_1_8-ktime_get_coarse_real_ts64.patch";
-      url = "http://git.openafs.org/?p=openafs.git;a=patch;h=21ad6a0c826c150c4227ece50554101641ab4626";
-      sha256 = "0cd2bzfn4gkb68qf27wpgcg9kvaky7kll22b8p2vmw5x4xkckq2y";
-    })
-    (fetchpatch {
-      name = "openafs_1_8-ktime_get_real_ts64.patch";
-      url = "http://git.openafs.org/?p=openafs.git;a=patch;h=b892fb127815bdf72103ae41ee70aadd87931b0c";
-      sha256 = "1xmf2l4g5nb9rhca7zn0swynvq8f9pd0k9drsx9bpnwp662y9l8m";
-    })
-    (fetchpatch {
-      name = "openafs_1_8-super_block.patch";
-      url = "http://git.openafs.org/?p=openafs.git;a=patch;h=3969bbca6017eb0ce6e1c3099b135f210403f661";
-      sha256 = "0cdd76s1h1bhxj0hl7r6mcha1jcy5vhlvc5dc8m2i83a6281yjsa";
-    })
-  ];
-
   nativeBuildInputs = [ autoconf automake flex libtool_2 perl which yacc ]
     ++ kernel.moduleBuildDependencies;
 

--- a/pkgs/servers/openafs/1.8/srcs.nix
+++ b/pkgs/servers/openafs/1.8/srcs.nix
@@ -1,14 +1,14 @@
 { fetchurl }:
 rec {
-  version = "1.8.2";
+  version = "1.8.3";
   src = fetchurl {
     url = "http://www.openafs.org/dl/openafs/${version}/openafs-${version}-src.tar.bz2";
-    sha256 = "13hksffp7k5f89c9lc5g5b1q0pc9h7wyarq3sjyjqam7c513xz95";
+    sha256 = "19ffchxwgqg4wl98l456jdpgq2w8b5izn8hxdsq9hjs0a1nc3nga";
   };
 
   srcs = [ src
     (fetchurl {
       url = "http://www.openafs.org/dl/openafs/${version}/openafs-${version}-doc.tar.bz2";
-      sha256 = "09n8nymrhpyb0fhahpln2spzhy9pn48hvry35ccqif2jd4wsxdmr";
+      sha256 = "14smdhn1f6f3cbvvwxgjjld0m4b17vqh3rzkxf5apmjsdda21njq";
     })];
 }


### PR DESCRIPTION
###### Motivation for this change

General improvements and stability fixes coming from upstream. Upstream now includes necessary changes for newest kernels.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
- [x] Verified that it builds against the current `linuxPackages_latest` 

---
