### PR TITLE
gcalcli: 4.0.4 -> 4.1.0

### DIFF
--- a/pkgs/applications/misc/gcalcli/default.nix
+++ b/pkgs/applications/misc/gcalcli/default.nix
@@ -5,31 +5,25 @@ with python3.pkgs;
 
 buildPythonApplication rec {
   pname = "gcalcli";
-  version = "4.0.4";
+  version = "4.1.0";
 
   src = fetchFromGitHub {
     owner  = "insanum";
     repo   = pname;
     rev    = "v${version}";
-    sha256 = "0bl4cmc24iw12zn5mlj5qn141s2k2mzdixbcb92pfng4w2s4dq66";
+    sha256 = "06iijpwlvvn8bj81s4znhykilvwvydxjmzd3d4nsa5j2kj3iwshi";
   };
 
   postPatch = lib.optionalString stdenv.isLinux ''
-    substituteInPlace gcalcli/argparsers.py --replace \
-      "command = 'notify-send -u critical" \
-      "command = '${libnotify}/bin/notify-send -u critical"
+    substituteInPlace gcalcli/argparsers.py \
+      --replace "'notify-send" "'${libnotify}/bin/notify-send"
   '';
 
   propagatedBuildInputs = [
     dateutil gflags httplib2 parsedatetime six vobject
     google_api_python_client oauth2client uritemplate
+    libnotify
   ] ++ lib.optional (!isPy3k) futures;
-
-  postInstall = lib.optionalString stdenv.isLinux ''
-    substituteInPlace $out/bin/gcalcli --replace \
-      "command = 'notify-send -u critical -a gcalcli %s'" \
-      "command = '${libnotify}/bin/notify-send -i view-calendar-upcoming-events -u critical -a Calendar %s'"
-  '';
 
   # There are no tests as of 4.0.0a4
   doCheck = false;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

https://github.com/insanum/gcalcli/releases/tag/v4.1.0

Works here and I'm quite dependent on this thing doing its job.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
