### PR TITLE
nanum-gothic-coding: init at VER2.5

### DIFF
--- a/pkgs/data/fonts/nanum-gothic-coding/default.nix
+++ b/pkgs/data/fonts/nanum-gothic-coding/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchzip, unzip}:
+
+let
+  version = "VER2.5";
+  fullName = "NanumGothicCoding-2.5";
+
+in fetchzip rec {
+  name = "nanum-gothic-coding";
+  url = "https://github.com/naver/nanumfont/releases/download/${version}/${fullName}.zip";
+
+  postFetch = ''
+    mkdir -p $out/share/fonts/NanumGothicCoding
+    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/NanumGothicCoding
+  '';
+
+  sha256 = "0b3pkhd6xn6393zi0dhj3ah08w1y1ji9fl6584bi0c8lanamf2pc";
+
+  meta = with stdenv.lib; {
+    description = "A contemporary monospaced sans-serif typeface with a warm touch";
+    homepage = https://github.com/naver/nanumfont;
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ linarcx ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3950,6 +3950,8 @@ in
     pythonPackages = python3Packages;
   };
 
+  nanum-gothic-coding = callPackage ../data/fonts/nanum-gothic-coding {  };
+
   nbench = callPackage ../tools/misc/nbench { };
 
   netdata = callPackage ../tools/system/netdata {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
