### PR TITLE
oxidized: 0.26.2 -> 0.26.3

### DIFF
--- a/pkgs/tools/admin/oxidized/Gemfile
+++ b/pkgs/tools/admin/oxidized/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'oxidized', '0.26.2'
+gem 'oxidized', '0.26.3'
 gem 'oxidized-web', '0.13.1'
 gem 'oxidized-script', '0.6.0'

--- a/pkgs/tools/admin/oxidized/Gemfile.lock
+++ b/pkgs/tools/admin/oxidized/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     asetus (0.3.0)
-    backports (3.12.0)
+    backports (3.14.0)
     charlock_holmes (0.7.6)
     emk-sinatra-url-for (0.2.1)
       sinatra (>= 0.9.1.1)
@@ -13,9 +13,9 @@ GEM
     htmlentities (4.3.4)
     json (2.2.0)
     multi_json (1.13.1)
-    net-ssh (5.1.0)
+    net-ssh (5.2.0)
     net-telnet (0.1.1)
-    oxidized (0.26.2)
+    oxidized (0.26.3)
       asetus (~> 0.1)
       net-ssh (~> 5)
       net-telnet (~> 0.1.1)
@@ -45,8 +45,8 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
-    rugged (0.28.0)
-    sass (3.7.3)
+    rugged (0.28.1)
+    sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -70,7 +70,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  oxidized (= 0.26.2)
+  oxidized (= 0.26.3)
   oxidized-script (= 0.6.0)
   oxidized-web (= 0.13.1)
 

--- a/pkgs/tools/admin/oxidized/gemset.nix
+++ b/pkgs/tools/admin/oxidized/gemset.nix
@@ -14,10 +14,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0ba6n9l4kki56s2cszarps14zp2wlhw7nfawb8qwsxy3a57v4mw4";
+      sha256 = "17j5pf0b69bkn043wi4xd530ky53jbbnljr4bsjzlm4k8bzlknfn";
       type = "gem";
     };
-    version = "3.12.0";
+    version = "3.14.0";
   };
   charlock_holmes = {
     groups = ["default"];
@@ -96,10 +96,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0jglf8rxvlw6is5019r6kwsdhw38zm3z39jbghdbj449r6h7h77n";
+      sha256 = "101wd2px9lady54aqmkibvy4j62zk32w0rjz4vnigyg974fsga40";
       type = "gem";
     };
-    version = "5.1.0";
+    version = "5.2.0";
   };
   net-telnet = {
     groups = ["default"];
@@ -117,10 +117,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "130h99wijfvv443wgdllxvlq880m0m31rxvrszq5wdii7ad977s5";
+      sha256 = "07hpxmdjkfpkc00ln3hhh5qkj0lyhcmgbi0jza2c8cnjyy9sc73x";
       type = "gem";
     };
-    version = "0.26.2";
+    version = "0.26.3";
   };
   oxidized-script = {
     dependencies = ["oxidized" "slop"];
@@ -212,10 +212,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0crasx5dmbr9ws89137n53l8nap7rdncp8yg5alw1jb99lqslhmi";
+      sha256 = "1yiszpz6y13vvgh3fss1l0ipp0zgsbbc8c28vynnpdyx1sy6krp6";
       type = "gem";
     };
-    version = "0.28.0";
+    version = "0.28.1";
   };
   sass = {
     dependencies = ["sass-listen"];
@@ -223,10 +223,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0vll3bm1dllhqjxxj639nj3afsp12hlppgpysxrgcg24jb2xl2qn";
+      sha256 = "0p95lhs0jza5l7hqci1isflxakz83xkj97lkvxl919is0lwhv2w0";
       type = "gem";
     };
-    version = "3.7.3";
+    version = "3.7.4";
   };
   sass-listen = {
     dependencies = ["rb-fsevent" "rb-inotify"];


### PR DESCRIPTION
###### Motivation for this change
Latest [patch release](https://github.com/ytti/oxidized/releases/tag/0.26.3) which includes a [bug fix](https://github.com/ytti/oxidized/blob/master/CHANGELOG.md).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---