### PR TITLE
Add support for booting as Xen dom0 on EFI systems

### DIFF
--- a/pkgs/applications/virtualization/xen/0004-makefile-use-efi-ld.patch
+++ b/pkgs/applications/virtualization/xen/0004-makefile-use-efi-ld.patch
@@ -1,0 +1,27 @@
+diff -Naur xen-4.10.0/xen/arch/x86/Makefile xen-4.10.0-patched/xen/arch/x86/Makefile
+--- xen-4.10.0/xen/arch/x86/Makefile	2017-12-13 22:37:59.000000000 +1100
++++ xen-4.10.0-patched/xen/arch/x86/Makefile	2019-04-26 22:59:19.739495304 +1000
+@@ -177,20 +177,20 @@
+ 
+ $(TARGET).efi: prelink-efi.o $(note_file) efi.lds efi/relocs-dummy.o $(BASEDIR)/common/symbols-dummy.o efi/mkreloc
+ 	$(foreach base, $(VIRT_BASE) $(ALT_BASE), \
+-	          $(guard) $(LD) $(call EFI_LDFLAGS,$(base)) -T efi.lds -N $< efi/relocs-dummy.o \
++	          $(guard) $(EFI_LD) $(call EFI_LDFLAGS,$(base)) -T efi.lds -N $< efi/relocs-dummy.o \
+ 	                $(BASEDIR)/common/symbols-dummy.o $(note_file) -o $(@D)/.$(@F).$(base).0 &&) :
+ 	$(guard) efi/mkreloc $(foreach base,$(VIRT_BASE) $(ALT_BASE),$(@D)/.$(@F).$(base).0) >$(@D)/.$(@F).0r.S
+ 	$(guard) $(NM) -pa --format=sysv $(@D)/.$(@F).$(VIRT_BASE).0 \
+ 		| $(guard) $(BASEDIR)/tools/symbols $(all_symbols) --sysv --sort >$(@D)/.$(@F).0s.S
+ 	$(guard) $(MAKE) -f $(BASEDIR)/Rules.mk $(@D)/.$(@F).0r.o $(@D)/.$(@F).0s.o
+ 	$(foreach base, $(VIRT_BASE) $(ALT_BASE), \
+-	          $(guard) $(LD) $(call EFI_LDFLAGS,$(base)) -T efi.lds -N $< \
++	          $(guard) $(EFI_LD) $(call EFI_LDFLAGS,$(base)) -T efi.lds -N $< \
+ 	                $(@D)/.$(@F).0r.o $(@D)/.$(@F).0s.o $(note_file) -o $(@D)/.$(@F).$(base).1 &&) :
+ 	$(guard) efi/mkreloc $(foreach base,$(VIRT_BASE) $(ALT_BASE),$(@D)/.$(@F).$(base).1) >$(@D)/.$(@F).1r.S
+ 	$(guard) $(NM) -pa --format=sysv $(@D)/.$(@F).$(VIRT_BASE).1 \
+ 		| $(guard) $(BASEDIR)/tools/symbols $(all_symbols) --sysv --sort >$(@D)/.$(@F).1s.S
+ 	$(guard) $(MAKE) -f $(BASEDIR)/Rules.mk $(@D)/.$(@F).1r.o $(@D)/.$(@F).1s.o
+-	$(guard) $(LD) $(call EFI_LDFLAGS,$(VIRT_BASE)) -T efi.lds -N $< \
++	$(guard) $(EFI_LD) $(call EFI_LDFLAGS,$(VIRT_BASE)) -T efi.lds -N $< \
+ 	                $(@D)/.$(@F).1r.o $(@D)/.$(@F).1s.o $(note_file) -o $@
+ 	if $(guard) false; then rm -f $@; echo 'EFI support disabled'; \
+ 	else $(NM) -pa --format=sysv $(@D)/$(@F) \

--- a/pkgs/applications/virtualization/xen/0005-makefile-fix-efi-mountdir-use.patch
+++ b/pkgs/applications/virtualization/xen/0005-makefile-fix-efi-mountdir-use.patch
@@ -1,0 +1,35 @@
+EFI_MOUNTPOINT is conventionally /boot/efi or /boot/EFI or something
+like that, and (on my machine) has directories within that called
+{Boot, nixos, gummiboot}.
+
+This patch does two things:
+
+1) Xen apparently wants to put files in
+$(EFI_MOUNTPOINT)/efi/$(EFI_VENDOR) - we remove the duplicate 'efi' name
+because I can't see why we have it
+
+2) Ensures the said directory exists
+
+
+--- a/xen/Makefile	2016-01-08 01:50:58.028045657 +0000
++++ b/xen/Makefile	2016-01-08 01:51:33.560268718 +0000
+@@ -49,7 +49,9 @@
+ 		ln -sf $(T)-$(XEN_FULLVERSION).efi $(D)$(EFI_DIR)/$(T)-$(XEN_VERSION).efi; \
+ 		ln -sf $(T)-$(XEN_FULLVERSION).efi $(D)$(EFI_DIR)/$(T).efi; \
+ 		if [ -n '$(EFI_MOUNTPOINT)' -a -n '$(EFI_VENDOR)' ]; then \
+-			$(INSTALL_DATA) $(TARGET).efi $(D)$(EFI_MOUNTPOINT)/efi/$(EFI_VENDOR)/$(T)-$(XEN_FULLVERSION).efi; \
++			[ -d $(D)$(EFI_MOUNTPOINT)/$(EFI_VENDOR) ] || \
++			  $(INSTALL_DIR) $(D)$(EFI_MOUNTPOINT)/$(EFI_VENDOR) ;\
++			$(INSTALL_DATA) $(TARGET).efi $(D)$(EFI_MOUNTPOINT)/$(EFI_VENDOR)/$(T)-$(XEN_FULLVERSION).efi; \
+ 		elif [ "$(D)" = "$(patsubst $(shell cd $(XEN_ROOT) && pwd)/%,%,$(D))" ]; then \
+ 			echo 'EFI installation only partially done (EFI_VENDOR not set)' >&2; \
+ 		fi; \
+@@ -69,7 +69,7 @@
+ 	rm -f $(D)$(EFI_DIR)/$(T)-$(XEN_VERSION).$(XEN_SUBVERSION).efi
+ 	rm -f $(D)$(EFI_DIR)/$(T)-$(XEN_VERSION).efi
+ 	rm -f $(D)$(EFI_DIR)/$(T).efi
+-	rm -f $(D)$(EFI_MOUNTPOINT)/efi/$(EFI_VENDOR)/$(T)-$(XEN_FULLVERSION).efi
++	rm -f $(D)$(EFI_MOUNTPOINT)/$(EFI_VENDOR)/$(T)-$(XEN_FULLVERSION).efi
+ 
+ .PHONY: _debug
+ _debug:

--- a/pkgs/applications/virtualization/xen/generic.nix
+++ b/pkgs/applications/virtualization/xen/generic.nix
@@ -20,6 +20,8 @@ config:
 # python2Packages.markdown
 , transfig, ghostscript, texinfo, pandoc
 
+, binutils-unwrapped
+
 , ...} @ args:
 
 with stdenv.lib;
@@ -42,6 +44,17 @@ let
     }
     ( __do )
   '');
+
+  # We don't want to use the wrapped version, because this version of ld is
+  # only used for linking the Xen EFI binary, and the build process really
+  # needs control over the LDFLAGS used
+  efiBinutils = binutils-unwrapped.overrideAttrs (oldAttrs: {
+    name = "efi-binutils";
+    configureFlags = oldAttrs.configureFlags ++ [
+      "--enable-targets=x86_64-pep"
+    ];
+    doInstallCheck = false; # We get a spurious failure otherwise, due to host/target mis-match
+  });
 in
 
 stdenv.mkDerivation (rec {
@@ -119,10 +132,13 @@ stdenv.mkDerivation (rec {
     '')}
   '';
 
-  patches = [ ./0000-fix-ipxe-src.patch
-              ./0000-fix-install-python.patch
-              ./acpica-utils-20180427.patch]
-         ++ (config.patches or []);
+  patches = [
+    ./0000-fix-ipxe-src.patch
+    ./0000-fix-install-python.patch
+    ./acpica-utils-20180427.patch
+    ./0004-makefile-use-efi-ld.patch
+    ./0005-makefile-fix-efi-mountdir-use.patch
+  ] ++ (config.patches or []);
 
   postPatch = ''
     ### Hacks
@@ -182,9 +198,14 @@ stdenv.mkDerivation (rec {
   '';
 
   postConfigure = ''
+    substituteInPlace xen/arch/x86/efi/Makefile \
+      --replace LD EFI_LD
     substituteInPlace tools/hotplug/Linux/xendomains \
       --replace /bin/ls ls
   '';
+
+  EFI_LD = "${efiBinutils}/bin/ld";
+  EFI_VENDOR = "nixos";
 
   # TODO: Flask needs more testing before enabling it by default.
   #makeFlags = "XSM_ENABLE=y FLASK_ENABLE=y PREFIX=$(out) CONFIG_DIR=/etc XEN_EXTFILES_URL=\\$(XEN_ROOT)/xen_ext_files ";


### PR DESCRIPTION
Based on #12230, aims to fix #12225.

###### Progress
- [ ] Get Xen EFI binaries to build on current nixpkgs versions:
    - [ ] 4.5.x (Is it worth spending time on this, given security support ended Jan 2018...?)
    - [x] 4.8.x
    - [x] 4.10.x
- [x] Support booting NixOS as Xen dom0 under EFI for:
    - [x] grub2
    - [x] systemd-boot/gummiboot
- [x] Tested using:
    - [x] Nested virtualization within a qemu-kvm VM
    - [x] Hardware (I hope to do this within the next day or two)
- [x] Confirmed the combined EFI/BIOS grub menu entry works under both

###### Notes, Issues, Questions
- This boots Xen by having the bootloader chainload to Xen's EFI binary, which needs a `xen.cfg` file in the same directory as it, on the ESP, that contains paths to the kernel and initrd (also on the ESP) as well as the Xen and kernel command lines.
- It is apparently possible to have grub2 boot a standard xen.gz using multiboot2/module2, but I could not get this to work (the VM reboots itself part-way through Xen's boot process). I have been able to find very little documentation on this method, as well as only two examples of people using this 'in the wild', so it is possible that this code-path has bit-rotted in the couple of years since it was implemented...
- ~This basically assumes grub is only used for EFI booting on the system, not both EFI and BIOS booting -- all the Xen entries will use the Xen EFI binary if it is avaiable. I think this could be solved by using `grub_platform` within the menu entry to switch between the xen.efi and xen.gz methods?~
- ~A configuration that can boot Xen using either is still possible, using both BIOS-only grub + systemd-boot.~
- I don't much like Perl, and I'm not all that familiar with it, so the changes to `install-grub.pl` are probably due some extra scrutiny.