### PR TITLE
kubernetes: 1.14.0 -> 1.14.1

### DIFF
--- a/pkgs/applications/networking/cluster/kubernetes/default.nix
+++ b/pkgs/applications/networking/cluster/kubernetes/default.nix
@@ -15,13 +15,13 @@ with lib;
 
 stdenv.mkDerivation rec {
   name = "kubernetes-${version}";
-  version = "1.14.0";
+  version = "1.14.1";
 
   src = fetchFromGitHub {
     owner = "kubernetes";
     repo = "kubernetes";
     rev = "v${version}";
-    sha256 = "1c04x474m5b7qqs9kddrx2mygwpv40hvylr3cq34qxdxgang3qc6";
+    sha256 = "1cyln9nwry290fpffx6xxy0ll7ybib5ifja7nnq93f3f2p0sj421";
   };
 
   buildInputs = [ removeReferencesTo makeWrapper which go rsync go-bindata ];


### PR DESCRIPTION

###### Motivation for this change

Bump kubernetes.

###### Things done

Ran tests locally:
```
nix-build nixos/release.nix -A tests.kubernetes.dns.singlenode -A tests.kubernetes.dns.multinode -A tests.kubernetes.rbac.singlenode -A tests.kubernetes.rbac.multinode

/nix/store/2lw8z03wbrn33kbl92jbkzy15cyfrd1c-vm-test-run-kubernetes-dns-singlenode
/nix/store/b3layq239cj4i5lkplv4bxkx1fvgz807-vm-test-run-kubernetes-dns-multinode
/nix/store/5nxvylc1brk1z9synhlxq6flv5qmdgcs-vm-test-run-kubernetes-rbac-singlenode
/nix/store/mapxdsc78pw47hym00ahj6qzqjyl32nb-vm-test-run-kubernetes-rbac-multinode
```

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
