### PR TITLE
dovecot: fix CVE-2019-11494 and CVE-2019-11499

### DIFF
--- a/pkgs/servers/mail/dovecot/default.nix
+++ b/pkgs/servers/mail/dovecot/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, perl, pkgconfig, systemd, openssl
+{ stdenv, lib, fetchurl, fetchpatch, perl, pkgconfig, systemd, openssl
 , bzip2, zlib, lz4, inotify-tools, pam, libcap
 , clucene_core_2, icu, openldap, libsodium, libstemmer, cyrus_sasl
 , nixosTests
@@ -43,6 +43,18 @@ stdenv.mkDerivation rec {
     # so we can symlink plugins from several packages there.
     # The symlinking needs to be done in NixOS.
     ./2.2.x-module_dir.patch
+
+    (fetchpatch {
+      name = "CVE-2019-11494.patch";
+      url = https://github.com/dovecot/core/commit/f79745dae4a9a5fca33320e03a4fc9064b88d01e.patch;
+      sha256 = "0qyhcw8xsnjhk7s29mhsqa46m28r2bcjz7bxbjr48d7wl9r3v3fm";
+    })
+    (fetchpatch {
+      name = "CVE-2019-11499.patch";
+      url = https://github.com/dovecot/core/commit/e9d60648abb9bbceff89882a5309cb9532e702e9.patch;
+      sha256 = "1di6adkd8f6gjkpf8aiqxzwvscsq188qqah6b7r23q9j3zlv47mv";
+    })
+
   ];
 
   configureFlags = [


### PR DESCRIPTION
Please check if I have picked the correct patches from https://github.com/dovecot/core/commits/2.3.6!!

This should also be applied on 18.09.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
https://dovecot.org/pipermail/dovecot-news/2019-April/000409.html
https://dovecot.org/pipermail/dovecot-news/2019-April/000410.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
