### PR TITLE
chromium: Use upstream desktop entry

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/browser.nix
+++ b/pkgs/applications/networking/browsers/chromium/browser.nix
@@ -38,6 +38,25 @@ mkChromiumDerivation (base: rec {
       mkdir -vp "$logo_output_path"
       cp -v "$icon_file" "$logo_output_path/$packageName.png"
     done
+
+    # Install Desktop Entry
+    install -D chrome/installer/linux/common/desktop.template \
+      $out/share/applications/chromium-browser.desktop
+
+    substituteInPlace $out/share/applications/chromium-browser.desktop \
+      --replace "@@MENUNAME@@" "Chromium" \
+      --replace "@@PACKAGE@@" "chromium" \
+      --replace "Exec=/usr/bin/@@USR_BIN_SYMLINK_NAME@@" "Exec=chromium"
+
+    # Append more mime types to the end
+    sed -i '/^MimeType=/ s,$,x-scheme-handler/webcal;x-scheme-handler/mailto;x-scheme-handler/about;x-scheme-handler/unknown,' \
+      $out/share/applications/chromium-browser.desktop
+
+    # See https://github.com/NixOS/nixpkgs/issues/12433
+    sed -i \
+      -e '/\[Desktop Entry\]/a\' \
+      -e 'StartupWMClass=chromium-browser' \
+      $out/share/applications/chromium-browser.desktop
   '';
 
   passthru = { inherit sandboxExecutableName; };

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -45,31 +45,6 @@ in let
     };
   };
 
-  desktopItem = makeDesktopItem {
-    name = "chromium-browser";
-    exec = "chromium %U";
-    icon = "chromium";
-    comment = "An open source web browser from Google";
-    desktopName = "Chromium";
-    genericName = "Web browser";
-    mimeType = stdenv.lib.concatStringsSep ";" [
-      "text/html"
-      "text/xml"
-      "application/xhtml+xml"
-      "x-scheme-handler/http"
-      "x-scheme-handler/https"
-      "x-scheme-handler/ftp"
-      "x-scheme-handler/mailto"
-      "x-scheme-handler/webcal"
-      "x-scheme-handler/about"
-      "x-scheme-handler/unknown"
-    ];
-    categories = "Network;WebBrowser";
-    extraEntries = ''
-      StartupWMClass=chromium-browser
-    '';
-  };
-
   suffix = if channel != "stable" then "-" + channel else "";
 
   sandboxExecutableName = chromium.browser.passthru.sandboxExecutableName;
@@ -135,7 +110,6 @@ in stdenv.mkDerivation {
     for f in '${chromium.browser}'/share/*; do # hello emacs */
       ln -s -t "$out/share/" "$f"
     done
-    cp -v "${desktopItem}/share/applications/"* "$out/share/applications"
   '';
 
   inherit (chromium.browser) packageName;


### PR DESCRIPTION
###### Motivation for this change
Upstream provides a much more featureful desktop entry file. If we use
that we take advantage of all of those features and don't have to maintain it
ourselves.

`${pkgs.desktop-file-utils}/bin/desktop-file-validate result/share/applications/chromium-browser.desktop` says it's okay.

Solves #58226 as the upstream file provides `Actions=new-window;new-private-window;`

I kept the other things that we had and which the upstream file doesn't.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->



###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
