### PR TITLE
hue-cli: use bundlerApp

### DIFF
--- a/pkgs/tools/networking/hue-cli/Gemfile.lock
+++ b/pkgs/tools/networking/hue-cli/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
       json
     hue-lib (0.7.4)
       json
-    json (2.1.0)
+    json (2.2.0)
 
 PLATFORMS
   ruby
@@ -15,4 +15,4 @@ DEPENDENCIES
   hue-cli
 
 BUNDLED WITH
-   1.15.1
+   1.17.2

--- a/pkgs/tools/networking/hue-cli/default.nix
+++ b/pkgs/tools/networking/hue-cli/default.nix
@@ -1,10 +1,15 @@
-{ bundlerEnv, ruby }:
+{ lib, bundlerApp }:
 
-bundlerEnv rec {
-  name = "hue-cli-${version}";
-
-  version = (import gemset).hue-cli.version;
-  inherit ruby;
+bundlerApp {
+  pname = "hue-cli";
   gemdir = ./.;
-  gemset = ./gemset.nix;
+  exes = [ "hue" ];
+
+  meta = with lib; {
+    description = "Command line interface for controlling Philips Hue system's lights and bridge";
+    homepage =  https://github.com/birkirb/hue-cli;
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ manveru ];
+  };
 }

--- a/pkgs/tools/networking/hue-cli/gemset.nix
+++ b/pkgs/tools/networking/hue-cli/gemset.nix
@@ -1,6 +1,8 @@
 {
   hue-cli = {
     dependencies = ["hue-lib" "json"];
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "10gjf59pamfy2m17fs271d9ffrg1194b1m6vxzn6p7smzry52h9z";
@@ -10,6 +12,8 @@
   };
   hue-lib = {
     dependencies = ["json"];
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1pyl8g8gisdhl79gbzvnddqrsbq0lmflzg7n6yi6xrp5b5290shz";
@@ -18,11 +22,13 @@
     version = "0.7.4";
   };
   json = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "01v6jjpvh3gnq6sgllpfqahlgxzj50ailwhj9b3cd20hi2dx0vxp";
+      sha256 = "0sx97bm9by389rbzv8r1f43h06xcz8vwi3h5jv074gvparql7lcx";
       type = "gem";
     };
-    version = "2.1.0";
+    version = "2.2.0";
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Exposed more executables than needed and was outdated.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
