### PR TITLE
cucumber: 2.4.0 -> 3.1.2, use bundlerApp

### DIFF
--- a/pkgs/development/tools/cucumber/Gemfile.lock
+++ b/pkgs/development/tools/cucumber/Gemfile.lock
@@ -1,21 +1,27 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    backports (3.14.0)
     builder (3.2.3)
-    cucumber (2.4.0)
+    cucumber (3.1.2)
       builder (>= 2.1.2)
-      cucumber-core (~> 1.5.0)
+      cucumber-core (~> 3.2.0)
+      cucumber-expressions (~> 6.0.1)
       cucumber-wire (~> 0.0.1)
-      diff-lcs (>= 1.1.3)
-      gherkin (~> 4.0)
+      diff-lcs (~> 1.3)
+      gherkin (~> 5.1.0)
       multi_json (>= 1.7.5, < 2.0)
       multi_test (>= 0.1.2)
-    cucumber-core (1.5.0)
-      gherkin (~> 4.0)
+    cucumber-core (3.2.1)
+      backports (>= 3.8.0)
+      cucumber-tag_expressions (~> 1.1.0)
+      gherkin (~> 5.0)
+    cucumber-expressions (6.0.1)
+    cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
     diff-lcs (1.3)
-    gherkin (4.1.3)
-    multi_json (1.12.1)
+    gherkin (5.1.0)
+    multi_json (1.13.1)
     multi_test (0.1.2)
 
 PLATFORMS
@@ -25,4 +31,4 @@ DEPENDENCIES
   cucumber
 
 BUNDLED WITH
-   1.14.4
+   1.17.2

--- a/pkgs/development/tools/cucumber/default.nix
+++ b/pkgs/development/tools/cucumber/default.nix
@@ -1,19 +1,15 @@
-{ lib, bundlerEnv, ruby }:
+{ lib, bundlerApp }:
 
-bundlerEnv rec {
-  name = "cucumber-${version}";
-
-  version = (import gemset).cucumber.version;
-  inherit ruby;
-  # expects Gemfile, Gemfile.lock and gemset.nix in the same directory
-  gemfile = ./Gemfile;
-  lockfile = ./Gemfile.lock;
-  gemset = ./gemset.nix;
+bundlerApp {
+  pname = "cucumber";
+  gemdir = ./.;
+  exes = [ "cucumber" ];
 
   meta = with lib; {
     description = "A tool for executable specifications";
     homepage    = https://cucumber.io/;
     license     = with licenses; mit;
+    maintainers = with maintainers; [ manveru ];
     platforms   = platforms.unix;
   };
 }

--- a/pkgs/development/tools/cucumber/gemset.nix
+++ b/pkgs/development/tools/cucumber/gemset.nix
@@ -1,5 +1,17 @@
 {
+  backports = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "17j5pf0b69bkn043wi4xd530ky53jbbnljr4bsjzlm4k8bzlknfn";
+      type = "gem";
+    };
+    version = "3.14.0";
+  };
   builder = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0qibi5s67lpdv1wgcj66wcymcr04q6j4mzws6a479n0mlrmh5wr1";
@@ -8,22 +20,50 @@
     version = "3.2.3";
   };
   cucumber = {
+    dependencies = ["builder" "cucumber-core" "cucumber-expressions" "cucumber-wire" "diff-lcs" "gherkin" "multi_json" "multi_test"];
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1k4j31a93r0zhvyq2mm2k8irppbvkzbsg44r3mf023959v18fzih";
+      sha256 = "1s2brssrpal8hyhcgg974x3xyhpmvpwps5ypd9p8w2lg01l1pp3j";
       type = "gem";
     };
-    version = "2.4.0";
+    version = "3.1.2";
   };
   cucumber-core = {
+    dependencies = ["backports" "cucumber-tag_expressions" "gherkin"];
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0qj2fsqvp94nggnikbnrfvnmzr1pl6ifmdsxj69kdw1kkab30jjr";
+      sha256 = "1iavlh8hqj9lwljbpkw06259gdicbr1bdb6pbj5yy3n8szgr8k3c";
       type = "gem";
     };
-    version = "1.5.0";
+    version = "3.2.1";
+  };
+  cucumber-expressions = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0zwmv6hznyz9vk81f5dhwcr9jhxx2vmbk8yyazayvllvhy0fkpdw";
+      type = "gem";
+    };
+    version = "6.0.1";
+  };
+  cucumber-tag_expressions = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0cvmbljybws0qzjs1l67fvr9gqr005l8jk1ni5gcsis9pfmqh3vc";
+      type = "gem";
+    };
+    version = "1.1.1";
   };
   cucumber-wire = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "09ymvqb0sbw2if1nxg8rcj33sf0va88ancq5nmp8g01dfwzwma2f";
@@ -32,6 +72,8 @@
     version = "0.0.1";
   };
   diff-lcs = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "18w22bjz424gzafv6nzv98h0aqkwz3d9xhm7cbr1wfbyas8zayza";
@@ -40,22 +82,28 @@
     version = "1.3";
   };
   gherkin = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1d18r8mf2qyd9jbq9xxvca8adyysdzvwdy8v9c2s5hrd6p02kg79";
+      sha256 = "1cgcdchwwdm10rsk44frjwqd4ihprhxjbm799nscqy2q1raqfj5s";
       type = "gem";
     };
-    version = "4.1.3";
+    version = "5.1.0";
   };
   multi_json = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1wpc23ls6v2xbk3l1qncsbz16npvmw8p0b38l8czdzri18mp51xk";
+      sha256 = "1rl0qy4inf1mp8mybfk56dfga0mvx97zwpmq5xmiwl5r770171nv";
       type = "gem";
     };
-    version = "1.12.1";
+    version = "1.13.1";
   };
   multi_test = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1sx356q81plr67hg16jfwz9hcqvnk03bd9n75pmdw8pfxjfy1yxd";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Exposed more executables than needed and was outdated.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
