### PR TITLE
homesick: use bundlerApp

### DIFF
--- a/pkgs/tools/misc/homesick/Gemfile.lock
+++ b/pkgs/tools/misc/homesick/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     homesick (1.1.6)
       thor (>= 0.14.0)
-    thor (0.20.0)
+    thor (0.20.3)
 
 PLATFORMS
   ruby
@@ -12,4 +12,4 @@ DEPENDENCIES
   homesick
 
 BUNDLED WITH
-   1.14.6
+   1.17.2

--- a/pkgs/tools/misc/homesick/default.nix
+++ b/pkgs/tools/misc/homesick/default.nix
@@ -1,13 +1,12 @@
-{ lib, bundlerEnv, git}:
-bundlerEnv {
-  name = "homesick-1.1.6";
-
+{ lib, bundlerApp, git}:
+bundlerApp {
+  pname = "homesick";
   gemdir = ./.;
+  exes = [ "homesick" ];
 
   # Cannot use `wrapProgram` because the the help is aware of the file name.
-  postInstall = ''
-    rm $out/bin/thor
-    sed 1a'ENV["PATH"] = "${git}/bin:#{ENV["PATH"] ? ":#{ENV["PATH"]}" : "" }"' -i $out/bin/homesick
+  postBuild = ''
+    sed 1a'ENV["PATH"] = [*ENV["PATH"], "${git}/bin"].join(":")' -i $out/bin/homesick
   '';
 
   meta = with lib; {
@@ -20,7 +19,7 @@ bundlerEnv {
       '';
     homepage = https://github.com/technicalpickles/homesick;
     license = licenses.mit;
-    maintainers = with maintainers; [ aaronschif ];
+    maintainers = with maintainers; [ aaronschif manveru ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/tools/misc/homesick/gemset.nix
+++ b/pkgs/tools/misc/homesick/gemset.nix
@@ -1,6 +1,8 @@
 {
   homesick = {
     dependencies = ["thor"];
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0lxvnp4ncbx0irlblfxbd1f8h4hl11hgmyiy35q79w137r3prxml";
@@ -9,11 +11,13 @@
     version = "1.1.6";
   };
   thor = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0nmqpyj642sk4g16nkbq6pj856adpv91lp4krwhqkh2iw63aszdl";
+      sha256 = "1yhrnp9x8qcy5vc7g438amd5j9sw83ih7c30dr6g6slgw9zj3g29";
       type = "gem";
     };
-    version = "0.20.0";
+    version = "0.20.3";
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Exposed more executables than needed and was outdated.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
