### PR TITLE
matter-compiler: use bundlerApp

### DIFF
--- a/pkgs/development/compilers/matter-compiler/Gemfile.lock
+++ b/pkgs/development/compilers/matter-compiler/Gemfile.lock
@@ -10,4 +10,4 @@ DEPENDENCIES
   matter_compiler
 
 BUNDLED WITH
-   1.10.6
+   1.17.2

--- a/pkgs/development/compilers/matter-compiler/default.nix
+++ b/pkgs/development/compilers/matter-compiler/default.nix
@@ -1,11 +1,9 @@
+{ lib, bundlerApp }:
 
-{ lib, bundlerEnv, ruby }:
-
-bundlerEnv {
-  name = "matter_compiler-0.5.1";
-
-  inherit ruby;
+bundlerApp {
+  pname = "matter_compiler";
   gemdir = ./.;
+  exes = [ "matter_compiler" ];
 
   meta = with lib; {
     description = ''
@@ -14,7 +12,7 @@ bundlerEnv {
     '';
     homepage    = https://github.com/apiaryio/matter_compiler/;
     license     = licenses.mit;
-    maintainers = with maintainers; [ rvlander ];
+    maintainers = with maintainers; [ rvlander manveru ];
     platforms   = platforms.unix;
   };
 }

--- a/pkgs/development/compilers/matter-compiler/gemset.nix
+++ b/pkgs/development/compilers/matter-compiler/gemset.nix
@@ -1,9 +1,12 @@
 {
-  "matter_compiler" = {
-    version = "0.5.1";
+  matter_compiler = {
+    groups = ["default"];
+    platforms = [];
     source = {
-      type = "gem";
+      remotes = ["https://rubygems.org"];
       sha256 = "16501zdiqxk34v2d0nlbwrcrjm6g57hrsmsw0crwssn29v5zbykf";
+      type = "gem";
     };
+    version = "0.5.1";
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Exposed more executables than needed and was outdated.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
