### PR TITLE
timetrap: use bundlerApp

### DIFF
--- a/pkgs/applications/office/timetrap/Gemfile.lock
+++ b/pkgs/applications/office/timetrap/Gemfile.lock
@@ -16,4 +16,4 @@ DEPENDENCIES
   timetrap
 
 BUNDLED WITH
-   1.10.6
+   1.17.2

--- a/pkgs/applications/office/timetrap/default.nix
+++ b/pkgs/applications/office/timetrap/default.nix
@@ -1,17 +1,15 @@
-{ lib, bundlerEnv, ruby }:
+{ lib, bundlerApp }:
 
-bundlerEnv rec {
-  name = "timetrap-${version}";
-
-  version = (import gemset).timetrap.version;
-  inherit ruby;
+bundlerApp {
+  pname = "timetrap";
   gemdir = ./.;
-  gemset = ./gemset.nix;
+  exes = [ "timetrap" ];
 
   meta = with lib; {
     description = "A simple command line time tracker written in ruby";
-    homepage = https://github.com/samg/timetrap;
-    license = licenses.mit;
-    maintainers = [ maintainers.jerith666 ];
+    homepage    = https://github.com/samg/timetrap;
+    license     = licenses.mit;
+    maintainers = with maintainers; [ jerith666 manveru ];
+    platforms   = platforms.unix;
   };
 }

--- a/pkgs/applications/office/timetrap/gemset.nix
+++ b/pkgs/applications/office/timetrap/gemset.nix
@@ -1,5 +1,7 @@
 {
   chronic = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "1hrdkn4g8x7dlzxwb1rfgr8kw3bp4ywg5l4y4i9c2g5cwv62yvvn";
@@ -8,6 +10,8 @@
     version = "0.10.2";
   };
   sequel = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "121z4sq2m4vsgxwy8hs6d12cc1i4xa5rjiv0nbviyj87jldxapw0";
@@ -16,6 +20,8 @@
     version = "4.43.0";
   };
   sqlite3 = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "01ifzp8nwzqppda419c9wcvr8n82ysmisrs0hph9pdmv1lpa4f5i";
@@ -25,6 +31,8 @@
   };
   timetrap = {
     dependencies = ["chronic" "sequel" "sqlite3"];
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0ylaz9q99hbxnw6h1df6wphmh68fj847d1l4f9jylcx3nzzp5cyd";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Exposed more executables than needed and was outdated.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
