### PR TITLE
gweled: init at unstable-2018-02-15

### DIFF
--- a/pkgs/games/gweled/default.nix
+++ b/pkgs/games/gweled/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchbzr, intltool
+, gtk2, wrapGAppsHook, autoreconfHook, pkgconfig
+, libmikmod, librsvg, libcanberra-gtk2, hicolor-icon-theme }:
+
+stdenv.mkDerivation rec {
+  pname = "gweled";
+  version = "unstable-2018-02-15";
+
+  src = fetchbzr {
+    url = "lp:gweled";
+    rev = "94";
+    sha256 = "01c38y4df5a06wqbsmsn8ysxx7hav9yvw6zdwbc9m5m55z7vmdb8";
+  };
+
+  doCheck = false;
+
+  nativeBuildInputs = [ wrapGAppsHook intltool autoreconfHook pkgconfig ];
+
+  buildInputs = [ gtk2 libmikmod librsvg hicolor-icon-theme libcanberra-gtk2 ];
+
+  configureFlags = [ "--disable-setgid" ];
+
+  meta = with stdenv.lib; {
+    description = "Bejeweled clone game";
+    homepage = "https://gweled.org";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.genesis ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21201,6 +21201,8 @@ in
 
   gtypist = callPackage ../games/gtypist { };
 
+  gweled = callPackage ../games/gweled {};
+
   gzdoom = callPackage ../games/gzdoom { };
 
   hawkthorne = callPackage ../games/hawkthorne { love = love_0_9; };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The latest released is 2011-03-31 and won't work. This is why i packed unstable. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
