### PR TITLE
ssh-audit: init at 1.7.0

### DIFF
--- a/pkgs/tools/security/ssh-audit/default.nix
+++ b/pkgs/tools/security/ssh-audit/default.nix
@@ -1,0 +1,53 @@
+{ fetchFromGitHub, python3Packages, stdenv }:
+
+python3Packages.buildPythonPackage rec {
+  pname = "ssh-audit";
+  version = "1.7.0";
+
+  src = fetchFromGitHub {
+    owner = "arthepsy";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    sha256 = "0akrychkdym9f6830ysq787c9nc0bkyqvy4h72498lyghwvwc2ms";
+  };
+
+  checkInputs = [
+    python3Packages.pytest
+    python3Packages.pytestcov
+  ];
+
+  checkPhase = ''
+    py.test --cov-report= --cov=ssh-audit -v test
+  '';
+
+  postPatch = ''
+    printf %s "$setupPy" > setup.py
+    mkdir scripts
+    cp ssh-audit.py scripts/ssh-audit
+    mkdir ssh_audit
+    cp ssh-audit.py ssh_audit/__init__.py
+  '';
+
+  setupPy = /* py */ ''
+    from distutils.core import setup
+    setup(
+      author='arthepsy',
+      description='${meta.description}',
+      license='${meta.license.spdxId}',
+      name='${pname}',
+      packages=['ssh_audit'],
+      scripts=['scripts/ssh-audit'],
+      url='${meta.homepage}',
+      version='${version}',
+    )
+  '';
+
+  meta = {
+    description = "Tool for ssh server auditing";
+    homepage = "https://github.com/arthepsy/ssh-audit";
+    license = stdenv.lib.licenses.mit;
+    maintainers = [
+      stdenv.lib.maintainers.tv
+    ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23461,6 +23461,8 @@ in
 
   ib-controller = callPackage ../applications/office/ib/controller { jdk=oraclejdk8; };
 
+  ssh-audit = callPackage ../tools/security/ssh-audit { };
+
   thermald = callPackage ../tools/system/thermald { };
 
   thinkfan = callPackage ../tools/system/thinkfan { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

[ssh-audit](https://github.com/arthepsy/ssh-audit) is not packaged, yet.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
