### PR TITLE
go-jsonnet: init at v0.13.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3668,6 +3668,11 @@
     github = "nphilou";
     name = "Philippe Nguyen";
   };
+  nshalman = {
+    email = "nahamu@gmail.com";
+    github = "nshalman";
+    name = "Nahum Shalman";
+  };
   nslqqq = {
     email = "nslqqq@gmail.com";
     name = "Nikita Mikhailov";

--- a/pkgs/development/compilers/go-jsonnet/default.nix
+++ b/pkgs/development/compilers/go-jsonnet/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, lib, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "go-jsonnet-${version}";
+  version = "0.13.0";
+
+  goPackagePath = "github.com/google/go-jsonnet";
+
+  # regenerate deps.nix using following steps:
+  #
+  # go get -u github.com/google/go-jsonnet
+  # cd $GOPATH/src/github.com/google/go-jsonnet
+  # git checkout <version>
+  # dep init
+  # dep2nix
+  goDeps = ./deps.nix;
+
+  src = fetchFromGitHub {
+    rev = "v${version}";
+    owner = "google";
+    repo = "go-jsonnet";
+    sha256 = "0x95sqhrw4pscxq0q8781wix0w881k9my5kn5nf6k0fg1d6qlgiy";
+    fetchSubmodules = true;
+  };
+
+  meta = {
+    description = "An implementation of Jsonnet in pure Go";
+    maintainers = with lib.maintainers; [ nshalman ];
+    license = lib.licenses.asl20;
+    homepage = https://github.com/google/go-jsonnet;
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/development/compilers/go-jsonnet/deps.nix
+++ b/pkgs/development/compilers/go-jsonnet/deps.nix
@@ -1,0 +1,48 @@
+# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
+[
+  {
+    goPackagePath  = "github.com/fatih/color";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fatih/color";
+      rev =  "5b77d2a35fb0ede96d138fc9a99f5c9b6aef11b4";
+      sha256 = "0v8msvg38r8d1iiq2i5r4xyfx0invhc941kjrsg5gzwvagv55inv";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mattn/go-colorable";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-colorable";
+      rev =  "167de6bfdfba052fa6b2d3664c8f5272e23c9072";
+      sha256 = "1nwjmsppsjicr7anq8na6md7b1z84l9ppnlr045hhxjvbkqwalvx";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mattn/go-isatty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-isatty";
+      rev =  "1311e847b0cb909da63b5fecfb5370aa66236465";
+      sha256 = "0rqfh1rj6f5wm8p2ky7inm8g10152p7w6n2cli17kf9gad797i8h";
+    };
+  }
+  {
+    goPackagePath  = "github.com/sergi/go-diff";
+    fetch = {
+      type = "git";
+      url = "https://github.com/sergi/go-diff";
+      rev =  "1744e2970ca51c86172c8190fadad617561ed6e7";
+      sha256 = "0swiazj8wphs2zmk1qgq75xza6m19snif94h2m6fi8dqkwqdl7c7";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev =  "4c4f7f33c9ed00de01c4c741d2177abfcfe19307";
+      sha256 = "191001bxqyc3xfs46nnqmm7jdk0r73vk7a4zqngfl7zwjv9smwsq";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11003,6 +11003,8 @@ in
 
   jsonnet = callPackage ../development/compilers/jsonnet { };
 
+  go-jsonnet = callPackage ../development/compilers/go-jsonnet { };
+
   jsonrpc-glib = callPackage ../development/libraries/jsonrpc-glib { };
 
   jxrlib = callPackage ../development/libraries/jxrlib { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
The go version of jsonnet is faster at compiling. It's nice to have it as an option.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
