### PR TITLE
shadow: rely on propagated findXMLCatalogs hook

### DIFF
--- a/pkgs/os-specific/linux/shadow/respect-xml-catalog-files-var.patch
+++ b/pkgs/os-specific/linux/shadow/respect-xml-catalog-files-var.patch
@@ -1,0 +1,30 @@
+diff --git a/acinclude.m4 b/acinclude.m4
+index dd01f165..e23160ee 100644
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -46,9 +46,21 @@ AC_DEFUN([JH_CHECK_XML_CATALOG],
+     ifelse([$3],,,[$3
+ ])dnl
+   else
+-    AC_MSG_RESULT([not found])
+-    ifelse([$4],,
+-       [AC_MSG_ERROR([could not find ifelse([$2],,[$1],[$2]) in XML catalog])],
+-       [$4])
++    jh_check_xml_catalog_saved_ifs="$IFS"
++    IFS=' '
++    for f in $XML_CATALOG_FILES; do
++      if [[ -f "$f" ]] && \
++        AC_RUN_LOG([$XMLCATALOG --noout "$f" "$1" >&2]); then
++        jh_found_xmlcatalog=true
++        AC_MSG_RESULT([found])
++        ifelse([$3],,,[$3])
++        break
++      fi
++    done
++    IFS="$jh_check_xml_catalog_saved_ifs"
++    if ! $jh_found_xmlcatalog; then
++      AC_MSG_RESULT([not found])
++      ifelse([$4],,[AC_MSG_ERROR([could not find ifelse([$2],,[$1],[$2]) in XML catalog])],[$4])
++    fi
+   fi
+ ])


### PR DESCRIPTION
###### Motivation for this change
Cherry-picked from https://github.com/NixOS/nixpkgs/pull/31952

Shadow uses a copy of m4 from gtk-doc so we need to apply the same fix as in 407db7b0196417296677f2a4ef929bb092ec382b.

Also patch it to use the correct DocBook version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
