### PR TITLE
 pythonPackages.asyncssh: 1.15.1 -> 1.16.1, fixing build with some caveats around ec25519 support

### DIFF
--- a/pkgs/development/python-modules/asyncssh/default.nix
+++ b/pkgs/development/python-modules/asyncssh/default.nix
@@ -3,31 +3,42 @@
 , bcrypt, gssapi, libnacl, libsodium, nettle, pyopenssl
 , openssl }:
 
-buildPythonPackage rec {
+let
+  # asyncssh requires openssl 1.1.x for ec25519 support, but the default cryptography and
+  # pyopenssl packages are built against openssl 1.0.x. to enable ec25519 support, supply
+  # this package with a 1.1.x openssl package. note however that this may produce package
+  # collisions with (and not be installable in the same environment as) any of the python
+  # packages that depend on the default cryptography or pyopenssl.
+  cryptography' = (cryptography.override { inherit openssl; });
+  pyopenssl' = (pyopenssl.override { inherit openssl; cryptography = cryptography'; });
+in buildPythonPackage rec {
   pname = "asyncssh";
-  version = "1.15.1";
+  version = "1.16.1";
   disabled = pythonOlder "3.4";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "f2065a8b3af0c514c8de264e7b01f08df5213b707bacb7e7c080bd46c3e3bc35";
+    sha256 = "0qia1ay2dhwps5sfh0hif7mrv7yxvykxs9l7cmfp4m6hmqnn3r5r";
   };
 
   propagatedBuildInputs = [
     bcrypt
-    cryptography
+    cryptography'
     gssapi
     libnacl
     libsodium
     nettle
-    pyopenssl
+    pyopenssl'
   ];
 
   checkInputs = [ openssl ];
 
-  # Disables windows specific test (specifically the GSSAPI wrapper for Windows)
+  # Disables windows specific test (specifically the GSSAPI wrapper for Windows) and
+  # prevents sftp test from attempting to set permission bits which we're not allowed
+  # to in the sandbox environment.
   postPatch = ''
     rm ./tests/sspi_stub.py
+    substituteInPlace ./tests/test_sftp.py --replace "0o4321" "0o321"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/python-modules/pyopenssl/default.nix
+++ b/pkgs/development/python-modules/pyopenssl/default.nix
@@ -32,12 +32,25 @@ let
     "test_set_notBefore"
   ];
 
+  # these tests are extremely tightly wed to the exact output of the openssl cli tool,
+  # including exact punctuation.
+  failingOpenSSL_1_1Tests = [
+    "test_dump_certificate"
+    "test_dump_privatekey_text"
+    "test_dump_certificate_request"
+    "test_export_text"
+  ];
+
   disabledTests = [
     # https://github.com/pyca/pyopenssl/issues/692
     # These tests, we disable always.
     "test_set_default_verify_paths"
     "test_fallback_default_verify_paths"
-  ] ++ (optionals (hasPrefix "libressl" openssl.meta.name) failingLibresslTests);
+  ] ++ (
+    optionals (hasPrefix "libressl" openssl.meta.name) failingLibresslTests
+  ) ++ (
+    optionals (versionAtLeast (getVersion openssl.name) "1.1") failingOpenSSL_1_1Tests
+  );
 
   # Compose the final string expression, including the "-k" and the single quotes.
   testExpression = optionalString (disabledTests != [])


### PR DESCRIPTION
###### Motivation for this change
This "fixes" the build of `asyncssh` mostly through bumping the version. The thing that broke `asyncssh` was its move in `1.15.1` to depending on openssl 1.1.x for its ec25519 support. The default `cryptography` and `pyopenssl` packages are of course built with openssl 1.0.x, so this caused test failures. `1.16.1` added skip-checks to allow the tests to still pass without ec25519 support.

But of course this means that the package, built against the default `cryptography` and `pyopenssl` packages, **won't** support ec25519, which sucks. But the only way of enabling that support is by using overridden versions of those packages which would of course produce collisions against any packages using the default versions of those dependencies. Which is quite a lot of them.

Sooo... I thought it best not to do that by default, settling for supplying an "easy route" for those needing ec25519 support - overriding the `openssl` argument with a 1.1.x version should cause all of the required overriding to happen, while in the normal case the `.override`s don't end up affecting the output hash and so there should be no duplicate packages produced.

Phew. _That_ was a fun evening.

cc @worldofpeace 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
