### PR TITLE
d2coding: init at 1.3.2 (coding font)

### DIFF
--- a/pkgs/data/fonts/d2coding/default.nix
+++ b/pkgs/data/fonts/d2coding/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchzip, unzip }:
+
+let
+  version = "1.3.2";
+  pname = "d2codingfont";
+
+in fetchzip rec {
+  name = "${pname}-${version}";
+  url = "https://github.com/naver/${pname}/releases/download/VER${version}/D2Coding-Ver${version}-20180524.zip";
+
+  postFetch = ''
+    mkdir -p $out/share/fonts
+    unzip -j $downloadedFile \*-all.ttc -d $out/share/fonts/truetype/
+  '';
+
+  sha256 = "1812r82530wzfki7k9cm35fy6k2lvis7j6w0w8svc784949m1wwj";
+
+  meta = with stdenv.lib; {
+    description = "Monospace font with support for Korean and latin characters";
+    longDescription = ''
+      D2Coding is a monospace font developed by a Korean IT Company called Naver.
+      Font is good for displaying both Korean characters and latin characters,
+      as sometimes these two languages could share some similar strokes.
+      Since verion 1.3, D2Coding font is officially supported by the font
+      creator, with symbols for Powerline.
+    '';
+    homepage = https://github.com/naver/d2codingfont;
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15965,6 +15965,8 @@ in
 
   cooper-hewitt = callPackage ../data/fonts/cooper-hewitt { };
 
+  d2coding = callPackage ../data/fonts/d2coding { };
+
   dosis = callPackage ../data/fonts/dosis { };
 
   dosemu_fonts = callPackage ../data/fonts/dosemu-fonts { };


### PR DESCRIPTION
###### Motivation for this change

Inspired by recent addition of Nanum Gothic Coding :D.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---