### PR TITLE
emacs: backport hunspell 1.7.0 support from upstream

### DIFF
--- a/pkgs/applications/editors/emacs/default.nix
+++ b/pkgs/applications/editors/emacs/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, lib, fetchurl, ncurses, xlibsWrapper, libXaw, libXpm, Xaw3d, libXcursor
-, pkgconfig, gettext, libXft, dbus, libpng, libjpeg, libungif
+{ stdenv, lib, fetchpatch, fetchurl, ncurses, xlibsWrapper, libXaw, libXpm
+, Xaw3d, libXcursor,  pkgconfig, gettext, libXft, dbus, libpng, libjpeg, libungif
 , libtiff, librsvg, gconf, libxml2, imagemagick, gnutls, libselinux
 , alsaLib, cairo, acl, gpm, cf-private, AppKit, GSS, ImageIO, m17n_lib, libotf
 , systemd ? null
@@ -43,6 +43,13 @@ stdenv.mkDerivation rec {
   patches = [
     ./clean-env.patch
     ./tramp-detect-wrapped-gvfsd.patch
+
+    # should drop this at next package update
+    (fetchpatch {
+      name = "support-hunspell-1.7.0-in-ispell.el.patch";
+      url = "https://git.savannah.gnu.org/cgit/emacs.git/patch/?id=2925ce5a7ec1424cfaea9f2f86bd3cab27832584";
+      sha256 = "0w7cgw6zgr7phbivb98innps1rlqf5q2lhwkrwdmai8sbca5bd11";
+    })
   ];
 
   postPatch = lib.optionalString srcRepo ''


### PR DESCRIPTION
###### Motivation for this change

Backport of #57237

NixOS 19.03 has hunspell 1.7.0 which is incompatible with emacs 26.1.
This issue has been fixed in upstream and we should drop this patch
after emacs is updated too.

(cherry picked from commit 4952378a8749aabf75c33e73f31b6e93fbf2656d)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
