### PR TITLE
patchShebangs: Allow multiple args

### DIFF
--- a/pkgs/build-support/setup-hooks/patch-shebangs.sh
+++ b/pkgs/build-support/setup-hooks/patch-shebangs.sh
@@ -4,6 +4,8 @@
 # /usr/bin/env gets special treatment so that ".../bin/env python" is
 # rewritten to /nix/store/<hash>/bin/python.  Interpreters that are
 # already in the store are left untouched.
+# A script file must be marked as executable, otherwise it will not be
+# considered.
 
 fixupOutputHooks+=(patchShebangsAuto)
 

--- a/pkgs/build-support/setup-hooks/patch-shebangs.sh
+++ b/pkgs/build-support/setup-hooks/patch-shebangs.sh
@@ -9,8 +9,9 @@
 
 fixupOutputHooks+=(patchShebangsAuto)
 
-# Run patch shebangs on a directory.
-# patchShebangs [--build | --host] directory
+# Run patch shebangs on a directory or file.
+# Can take multiple paths as arguments.
+# patchShebangs [--build | --host] PATH...
 
 # Flags:
 # --build : Lookup commands available at build-time
@@ -31,9 +32,7 @@ patchShebangs() {
         shift
     fi
 
-    local dir="$1"
-
-    header "patching script interpreter paths in $dir"
+    header "patching script interpreter paths in $@"
     local f
     local oldPath
     local newPath
@@ -41,8 +40,6 @@ patchShebangs() {
     local args
     local oldInterpreterLine
     local newInterpreterLine
-
-    [ -e "$dir" ] || return 0
 
     local f
     while IFS= read -r -d $'\0' f; do
@@ -97,7 +94,7 @@ patchShebangs() {
                 rm "$timestamp"
             fi
         fi
-    done < <(find "$dir" -type f -perm -0100 -print0)
+    done < <(find "$@" -type f -perm -0100 -print0)
 
     stopNest
 }

--- a/pkgs/build-support/setup-hooks/patch-shebangs.sh
+++ b/pkgs/build-support/setup-hooks/patch-shebangs.sh
@@ -32,7 +32,7 @@ patchShebangs() {
         shift
     fi
 
-    header "patching script interpreter paths in $@"
+    echo "patching script interpreter paths in $@"
     local f
     local oldPath
     local newPath
@@ -40,6 +40,11 @@ patchShebangs() {
     local args
     local oldInterpreterLine
     local newInterpreterLine
+
+    if [ $# -eq 0 ]; then
+        echo "No arguments supplied to patchShebangs" >0
+        return 0
+    fi
 
     local f
     while IFS= read -r -d $'\0' f; do
@@ -61,7 +66,7 @@ patchShebangs() {
             # - options: something starting with a '-'
             # - environment variables: foo=bar
             if $(echo "$arg0" | grep -q -- "^-.*\|.*=.*"); then
-                echo "$f: unsupported interpreter directive \"$oldInterpreterLine\" (set dontPatchShebangs=1 and handle shebang patching yourself)"
+                echo "$f: unsupported interpreter directive \"$oldInterpreterLine\" (set dontPatchShebangs=1 and handle shebang patching yourself)" >0
                 exit 1
             fi
 


### PR DESCRIPTION
###### Motivation for this change
It's tempting to think patchShebangs supports multiple arguments.
Without this patch it just silently ignores all but the first. Now it
patches the shebangs in all of its arguments.

Fixes: #57695

Obviously I haven't tested it on nixpkgs because it rebuilds *everything*. Please check whether there might be some edge cases that I forgot which could break with these changes.
I tried the function on its own (copied tothe `patchPhase` of a derivation) and it seems to work as intended.

Seems like there's no docbook documentation for this function. I think I'll do that next.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
