### PR TITLE
obfs4: init at 0.0.10, use in tor-browser-bundle's, tor service

### DIFF
--- a/nixos/modules/services/security/tor.nix
+++ b/nixos/modules/services/security/tor.nix
@@ -81,7 +81,7 @@ let
 
     ${optionalString (elem cfg.relay.role ["bridge" "private-bridge"]) ''
       BridgeRelay 1
-      ServerTransportPlugin obfs2,obfs3 exec ${pkgs.pythonPackages.obfsproxy}/bin/obfsproxy managed
+      ServerTransportPlugin ${concatStringsSep "," cfg.relay.bridgeTransports} exec ${obfs4}/bin/obfs4proxy managed
       ExtORPort auto
       ${optionalString (cfg.relay.role == "private-bridge") ''
         ExtraInfoStatistics 0
@@ -355,7 +355,7 @@ in
                 <para>
                   Regular bridge. Works like a regular relay, but
                   doesn't list you in the public relay directory and
-                  hides your Tor node behind obfsproxy.
+                  hides your Tor node behind obfs4proxy.
                 </para>
 
                 <para>
@@ -422,6 +422,13 @@ in
             </varlistentry>
             </variablelist>
           '';
+        };
+
+        bridgeTransports = mkOption {
+          type = types.listOf types.str;
+          default = ["obfs4"];
+          example = ["obfs2" "obfs3" "obfs4" "scramblesuit"];
+          description = "List of pluggable transports";
         };
 
         nickname = mkOption {

--- a/pkgs/applications/networking/browsers/tor-browser-bundle/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser-bundle/default.nix
@@ -34,7 +34,7 @@
 , rsync
 
 # Pluggable transports
-, obfsproxy
+, obfs4
 
 # Customization
 , extraPrefs ? ""
@@ -171,9 +171,9 @@ stdenv.mkDerivation rec {
     EOF
 
     # Configure pluggable transports
-    cat >>$TBDATA_PATH/torrc-defaults <<EOF
-    ClientTransportPlugin obfs2,obfs3 exec ${obfsproxy}/bin/obfsproxy managed
-    EOF
+    substituteInPlace $TBDATA_PATH/torrc-defaults \
+      --replace "./TorBrowser/Tor/PluggableTransports/obfs4proxy" \
+                "${obfs4}/bin/obfs4proxy"
 
     # Hard-code path to TBB fonts; xref: FONTCONFIG_FILE in the wrapper below
     sed $bundleData/$bundlePlatform/Data/fontconfig/fonts.conf \

--- a/pkgs/tools/networking/obfs4/default.nix
+++ b/pkgs/tools/networking/obfs4/default.nix
@@ -1,0 +1,21 @@
+{ lib, fetchgit, buildGoModule }:
+
+buildGoModule rec {
+  pname = "obfs4";
+  version = "0.0.10";
+
+  src = fetchgit {
+    url = meta.repositories.git;
+    rev = "refs/tags/${pname}proxy-${version}";
+    sha256 = "05aqmw8x8s0yqyqmdj5zcsq06gsbcmrlcd52gaqm20m1pg9503ad";
+  };
+
+  modSha256 = "150kg22kznrdj5icjxk3qd70g7wpq8zd2zklw1y2fgvrggw8zvyv";
+
+  meta = with lib; {
+    description = "A pluggable transport proxy";
+    homepage = https://www.torproject.org/projects/obfsproxy;
+    repositories.git = https://git.torproject.org/pluggable-transports/obfs4.git;
+    maintainers = with maintainers; [ phreedom thoughtpolice ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4785,6 +4785,8 @@ in
 
   obexd = callPackage ../tools/bluetooth/obexd { };
 
+  obfs4 = callPackage ../tools/networking/obfs4 { };
+
   oci-image-tool = callPackage ../tools/misc/oci-image-tool { };
 
   ocproxy = callPackage ../tools/networking/ocproxy { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6093,7 +6093,6 @@ in
   tor-browser-bundle = callPackage ../applications/networking/browsers/tor-browser-bundle {
     stdenv = stdenvNoCC;
     tor-browser-unwrapped = firefoxPackages.tor-browser;
-    inherit (python27Packages) obfsproxy;
   };
 
   touchegg = callPackage ../tools/inputmethods/touchegg { };


### PR DESCRIPTION
(Alt PR title: OBFS4 Service Pack)

###### Introduction and Motivation for this change

This enables obfs4 for use in our tor service
and our tor-browser-bundle!

This is important because
(source)[https://2019.www.torproject.org/docs/bridges.html.en]:

> Sadly, pluggable transports are not immune to detection, if a censor
> is given enough time. In the past, we promoted obfs and obfs2 as safe
> transports. These are now deprecated and were replaced by obfs3,
> scramblesuit, fte, and obfs4.

Happily obfs4proxy supports scramblesuit too, as well as the other
obfs transports, which is particularly important for interacting
with peers that don't "yet" support obfs4.

In the tor and our bundle, this replaces the python-based obfsproxy
and makes it possible to replace obfs4proxy in tor-browser-bundle-bin
instead of patchelf'ing.

(we may wish to use the shipped binary anyway for fingerprinting
reasons, but since we patchelf it anyway I'm not sure if
there's good cause for using the version provided?)

For our built-from-source bundle this means
these transports are newly available for use.

###### Testing

I have not tested the tor module with this "yet",
help appreciated and especially any feedback from
folks using the module in a way this would impact :).

I've tested the browser bundles in a few bridge configurations
and am able to use obfs4 bridges and such.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---