### PR TITLE
jush: init at 0.1

### DIFF
--- a/pkgs/shells/jush/default.nix
+++ b/pkgs/shells/jush/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, editline }:
+
+stdenv.mkDerivation rec {
+  pname = "jush";
+  version = "0.1";
+
+  src = fetchFromGitHub {
+    owner = "troglobit";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1azvghrh31gawd798a254ml4id642qvbva64zzg30pjszh1087n8";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+
+  buildInputs = [ editline ];
+
+  passthru.shellPath = "/bin/jush";
+
+  meta = with stdenv.lib; {
+    description = "just a useless shell";
+    homepage = https://github.com/troglobit/jush;
+    license = licenses.isc;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6831,6 +6831,8 @@ in
 
   ion = callPackage ../shells/ion { };
 
+  jush = callPackage ../shells/jush { };
+
   ksh = callPackage ../shells/ksh { };
 
   mksh = callPackage ../shells/mksh { };


### PR DESCRIPTION
###### Motivation for this change

"just a useless shell" :grin:

From maintainer of editline, FWIW :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---