### PR TITLE
dart: 2.0.0 -> 2.2.0

### DIFF
--- a/pkgs/development/interpreters/dart/default.nix
+++ b/pkgs/development/interpreters/dart/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, version ? "2.2.0" }:
+{ stdenv, fetchurl, unzip, version ? "2.3.0" }:
 
 let
 
@@ -72,6 +72,14 @@ let
     "2.3.0-dev.0.3-i686-linux" = fetchurl {
       url = "${dev}/${version}/sdk/dartsdk-linux-ia32-release.zip";
       sha256 = "41cba9b8ef03c7f8d2ec3f54aedf7ac1eb7ad379871fc69d23060e94653d572e";
+    };
+    "2.3.0-x86_64-linux" = fetchurl {
+      url = "${stable}/${version}/sdk/dartsdk-linux-x64-release.zip";
+      sha256 = "f2b9a2ba51ba71b025075b60dc31ccf5161c7a5a7061ed8e073efb309b718524";
+    };
+    "2.3.0-i686-linux" = fetchurl {
+      url = "${stable}/${version}/sdk/dartsdk-linux-ia32-release.zip";
+      sha256 = "b55626c0f855088c04e85fc7856012db281ea68846e9466e1cc0151c2508b432";
     };
   };
 

--- a/pkgs/development/interpreters/dart/default.nix
+++ b/pkgs/development/interpreters/dart/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, unzip, version ? "2.0.0" }:
+{ stdenv, fetchurl, unzip, version ? "2.2.0" }:
 
 let
 
@@ -40,6 +40,38 @@ let
     "2.0.0-dev.26.0-i686-linux" = fetchurl {
       url = "${dev}/${version}/sdk/dartsdk-linux-ia32-release.zip";
       sha256 = "83ba8b64c76f48d8de4e0eb887e49b7960053f570d27e7ea438cc0bac789955e";
+    };
+    "2.1.0-x86_64-linux" = fetchurl {
+      url = "${stable}/${version}/sdk/dartsdk-linux-x64-release.zip";
+      sha256 = "24673028fbc506dbded6c273b3f5fb8f0f169bd900083d0113ddd5ce0a8adcb6";
+    };
+    "2.1.0-i686-linux" = fetchurl {
+      url = "${stable}/${version}/sdk/dartsdk-linux-ia32-release.zip";
+      sha256 = "db84d4fe7671f61d95797362b63e0588a721d8a3086d77517f4e1619e1a9318c";
+    };
+    "2.1.1-x86_64-linux" = fetchurl {
+      url = "${stable}/${version}/sdk/dartsdk-linux-x64-release.zip";
+      sha256 = "b223f095e2eb836481b6d5041d23a627745f0b45f70f9ce31cc1fbc68e9a9f90";
+    };
+    "2.1.1-i686-linux" = fetchurl {
+      url = "${stable}/${version}/sdk/dartsdk-linux-ia32-release.zip";
+      sha256 = "8c7d359f00f3569dffd9d02fc213cd895a5c3e524d386cf65c89c2373630ca7e";
+    };
+    "2.2.0-x86_64-linux" = fetchurl {
+      url = "${stable}/${version}/sdk/dartsdk-linux-x64-release.zip";
+      sha256 = "89777ceba8227d4dad6081c44bc70d301a259f3c2fdb4c1391961e376ec3af68";
+    };
+    "2.2.0-i686-linux" = fetchurl {
+      url = "${stable}/${version}/sdk/dartsdk-linux-ia32-release.zip";
+      sha256 = "d6d5edab837301bde218c97b074af8390d5dbe00a99961605159fa9e53609b81";
+    };
+    "2.3.0-dev.0.3-x86_64-linux" = fetchurl {
+      url = "${dev}/${version}/sdk/dartsdk-linux-x64-release.zip";
+      sha256 = "5feebfd7ba3274222e22f1d1990883b6c3acaf0e26eae057a4a8667a5c9041cd";
+    };
+    "2.3.0-dev.0.3-i686-linux" = fetchurl {
+      url = "${dev}/${version}/sdk/dartsdk-linux-ia32-release.zip";
+      sha256 = "41cba9b8ef03c7f8d2ec3f54aedf7ac1eb7ad379871fc69d23060e94653d572e";
     };
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23713,9 +23713,8 @@ in
   spdlog = spdlog_1;
 
   dart = callPackage ../development/interpreters/dart { };
-  dart_stable = dart.override { version = "2.2.0"; };
+  dart_stable = dart.override { version = "2.3.0"; };
   dart_old = dart.override { version = "1.24.3"; };
-  dart_dev = dart.override { version = "2.3.0-dev.0.3"; };
 
   httrack = callPackage ../tools/backup/httrack { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23713,9 +23713,9 @@ in
   spdlog = spdlog_1;
 
   dart = callPackage ../development/interpreters/dart { };
-  dart_stable = dart.override { version = "2.0.0"; };
+  dart_stable = dart.override { version = "2.2.0"; };
   dart_old = dart.override { version = "1.24.3"; };
-  dart_dev = dart.override { version = "2.0.0-dev.26.0"; };
+  dart_dev = dart.override { version = "2.3.0-dev.0.3"; };
 
   httrack = callPackage ../tools/backup/httrack { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
There are newer versions of Dart available.

###### Things done
Added 2.1.0, 2.1.1, 2.2.0, and the latest dev channel release of the 2.3.0 series. I'm not actually sure what the `dart_stable`, `dart_old`, and `dart_dev` values are for, I can't actually figure out how to use them other than the fact that they cause the corresponding versions to show up in a query. However, this means 2.2.0 shows up twice, so maybe we ought to drop `dart_stable`?

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions (Fedora 30)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
