### PR TITLE
waybar: 0.5.1 -> 0.6.1

### DIFF
--- a/pkgs/applications/misc/waybar/default.nix
+++ b/pkgs/applications/misc/waybar/default.nix
@@ -5,16 +5,17 @@
 , nlSupport    ? true,  libnl
 , udevSupport  ? true,  udev
 , swaySupport  ? true,  sway
+, mpdSupport   ? true,  mpd_clientlib
 }:
   stdenv.mkDerivation rec {
     name = "waybar-${version}";
-    version = "0.5.1";
+    version = "0.6.1";
 
     src = fetchFromGitHub {
       owner = "Alexays";
       repo = "Waybar";
       rev = version;
-      sha256 = "1h3ifiklzcbrvqzzhs7rij8w45k96cir2d4kkyd2ap93akvcnsr9";
+      sha256 = "1hzwqg22sjiirx6743512271p3jlakrw0155av1phrv5b7p3ws8a";
     };
 
     nativeBuildInputs = [
@@ -27,13 +28,15 @@
       ++ optional  pulseSupport libpulseaudio
       ++ optional  nlSupport    libnl
       ++ optional  udevSupport  udev
-      ++ optional  swaySupport  sway;
+      ++ optional  swaySupport  sway
+      ++ optional  mpdSupport   mpd_clientlib;
 
     mesonFlags = [
       "-Ddbusmenu-gtk=${ if traySupport then "enabled" else "disabled" }"
       "-Dpulseaudio=${ if pulseSupport then "enabled" else "disabled" }"
       "-Dlibnl=${ if nlSupport then "enabled" else "disabled" }"
       "-Dlibudev=${ if udevSupport then "enabled" else "disabled" }"
+      "-Dmpd=${ if mpdSupport then "enabled" else "disabled" }"
       "-Dout=${placeholder "out"}"
     ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Changelog:

- https://github.com/Alexays/Waybar/releases/tag/0.6.0
- https://github.com/Alexays/Waybar/releases/tag/0.6.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
