### PR TITLE
python.pkgs.pyasn1-modules: fix python2 tests

### DIFF
--- a/pkgs/development/python-modules/pyasn1-modules/default.nix
+++ b/pkgs/development/python-modules/pyasn1-modules/default.nix
@@ -1,4 +1,10 @@
-{ stdenv, buildPythonPackage, fetchPypi, pyasn1, isPyPy }:
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, pyasn1
+, isPyPy
+, pytest
+}:
 
 buildPythonPackage rec {
   pname = "pyasn1-modules";
@@ -10,6 +16,16 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ pyasn1 ];
+
+  checkInputs = [
+    pytest
+  ];
+
+  # running tests through setup.py fails only for python2 for some reason:
+  # AttributeError: 'module' object has no attribute 'suitetests'
+  checkPhase = ''
+    py.test
+  '';
 
   meta = with stdenv.lib; {
     description = "A collection of ASN.1-based protocols modules";


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Broken by the update in e03d55130fbf50563322fe5ad6fe76fe17a508ac.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
