### PR TITLE
altcoins.bitcoin-abc: 0.18.2 -> 0.19.4

### DIFF
--- a/pkgs/applications/altcoins/bitcoin-abc.nix
+++ b/pkgs/applications/altcoins/bitcoin-abc.nix
@@ -7,13 +7,13 @@ with stdenv.lib;
 stdenv.mkDerivation rec {
 
   name = "bitcoin" + (toString (optional (!withGui) "d")) + "-abc-" + version;
-  version = "0.18.2";
+  version = "0.19.4";
 
   src = fetchFromGitHub {
     owner = "bitcoin-ABC";
     repo = "bitcoin-abc";
     rev = "v${version}";
-    sha256 = "1ha219xnd61qicf7r3j0wbfrifh7blwp3lyk3ycgdn381q1qln29";
+    sha256 = "1z4x25ygcw1pqml2ww02vqrvmihlv4f5gnnn1iyfirrjxgpfaxd7";
   };
 
   patches = [ ./fix-bitcoin-qt-build.patch ];

--- a/pkgs/applications/altcoins/fix-bitcoin-qt-build.patch
+++ b/pkgs/applications/altcoins/fix-bitcoin-qt-build.patch
@@ -4,12 +4,12 @@
  dnl Output: $1 is set to the path of $2 if found. $2 are searched in order.
  AC_DEFUN([BITCOIN_QT_PATH_PROGS],[
    BITCOIN_QT_CHECK([
--    if test "x$3" != "x"; then
+-    if test "x$3" != x; then
 -      AC_PATH_PROGS($1,$2,,$3)
 -    else
 -      AC_PATH_PROGS($1,$2)
 -    fi
 +    AC_PATH_PROGS($1,$2)
-     if test "x$$1" = "x" && test "x$4" != "xyes"; then
+     if test "x$$1" = x && test "x$4" != xyes; then
        BITCOIN_QT_FAIL([$1 not found])
      fi


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
