### PR TITLE
[19.03] virtualbox: 5.2.26 -> 5.2.28

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -21,8 +21,8 @@ let
   buildType = "release";
   # Remember to change the extpackRev and version in extpack.nix and
   # guest-additions/default.nix as well.
-  main = "0rylf1g0vmv0q19iyvyq4dj5h9yvyqqnmmqaqrx93qrv8s1ybssd";
-  version = "5.2.26";
+  main = "0jmrbyhs92lyarpvylxqn2ajxdg9b290w5nd4g0i4h83d28bwbw0";
+  version = "5.2.28";
 in stdenv.mkDerivation {
   name = "virtualbox-${version}";
 

--- a/pkgs/applications/virtualization/virtualbox/extpack.nix
+++ b/pkgs/applications/virtualization/virtualbox/extpack.nix
@@ -2,7 +2,7 @@
 
 with lib;
 
-let version = "5.2.26";
+let version = "5.2.28";
 in
 fetchurl rec {
   name = "Oracle_VM_VirtualBox_Extension_Pack-${version}.vbox-extpack";
@@ -10,7 +10,7 @@ fetchurl rec {
   sha256 =
     # Manually sha256sum the extensionPack file, must be hex!
     # Thus do not use `nix-prefetch-url` but instead plain old `sha256sum`.
-    let value = "4b7caa9b722840d49f154c3e5efb6463b1b7129f09973a25813dfdbccd9debb7";
+    let value = "376e07cbf2ff2844c95c800346c8e4697d7bc671ae0e21e46153b2e7b4ccc1d6";
     in assert (builtins.stringLength value) == 64; value;
 
   meta = {

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "http://download.virtualbox.org/virtualbox/${version}/VBoxGuestAdditions_${version}.iso";
-    sha256 = "0f3w9wjd5aj2khzqh37vdg86wqbbx4gx9aidaai9syn9sk8ca9xr";
+    sha256 = "0cwdmdgcd1jysyw7c9b3cdk1ngk5nq7slh1zkhxkvvq142cnm1v9";
   };
 
   KERN_DIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";


### PR DESCRIPTION
###### Motivation for this change
backport of https://github.com/NixOS/nixpkgs/pull/60397

```
This is a maintenance release. The following items were fixed and/or added:

User interface: do not change the file and path name when changing the export file format (bug #18476)
User interface: fixed operation progress when deleting snapshots
Network: fixed unwanted padding bytes in Windows host adaptor network packets (bug #18202 and bug #18355)
Windows host: fix unwanted wake-ups from standby (bug #18549)
Windows host: disallow Pause as a host key (bug #18482)
Linux host and guest: support Linux 5.0 and 5.1, thank you Valdis Kletnieks (see also bug #18515)
Linux host: support kernel 4.4.169 (bug #18315)
Linux host: fix logging when building Linux kernel modules (bug #18226)
Linux host: clarified building Linux host drivers with secure boot (bug #18312)
Windows guests: fixed running applications which use complex display topologies with WDDM driver, fixed Skype for Business hangs (bug #17092)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
