### PR TITLE
pythonPackages.pythonocc-core: init at 0.18.1

### DIFF
--- a/pkgs/development/libraries/smesh/default.nix
+++ b/pkgs/development/libraries/smesh/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, cmake, ninja, opencascade }:
+
+stdenv.mkDerivation rec {
+  pname = "smesh";
+  version = "6.7.6";
+
+  src = fetchFromGitHub {
+    owner = "tpaviot";
+    repo = "smesh";
+    rev = version;
+    sha256 = "1b07j3bw3lnxk8dk3x1kkl2mbsmfwi98si84054038lflaaijzi0";
+  };
+
+  nativeBuildInputs = [ cmake ninja ];
+  buildInputs = [ opencascade ];
+
+  meta = with stdenv.lib; {
+    description = "Extension to OCE providing advanced meshing features";
+    homepage = "https://github.com/tpaviot/smesh";
+    license = licenses.lgpl21;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ gebner ];
+  };
+}

--- a/pkgs/development/python-modules/pythonocc-core/default.nix
+++ b/pkgs/development/python-modules/pythonocc-core/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, python, fetchFromGitHub, cmake, swig, ninja,
+  opencascade, smesh, freetype, libGL, libGLU, libX11 }:
+
+stdenv.mkDerivation rec {
+  pname = "pythonocc-core";
+  version = "0.18.1";
+
+  src = fetchFromGitHub {
+    owner = "tpaviot";
+    repo = "pythonocc-core";
+    rev = version;
+    sha256 = "1jk4y7f75z9lyawffpfkr50qw5452xzi1imcdlw9pdvf4i0y86k3";
+  };
+
+  nativeBuildInputs = [ cmake swig ninja ];
+  buildInputs = [
+    python opencascade smesh
+    freetype libGL libGLU libX11
+  ];
+
+  cmakeFlags = [
+    "-Wno-dev"
+    "-DPYTHONOCC_INSTALL_DIRECTORY=${placeholder "out"}/${python.sitePackages}/OCC"
+
+    "-DSMESH_INCLUDE_PATH=${smesh}/include/smesh"
+    "-DSMESH_LIB_PATH=${smesh}/lib"
+    "-DPYTHONOCC_WRAP_SMESH=TRUE"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Python wrapper for the OpenCASCADE 3D modeling kernel";
+    homepage = "https://github.com/tpaviot/pythonocc-core";
+    license = licenses.lgpl3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ gebner ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5745,6 +5745,8 @@ in
 
   smenu = callPackage ../tools/misc/smenu { };
 
+  smesh = callPackage ../development/libraries/smesh {};
+
   smugline = python3Packages.smugline;
 
   snabb = callPackage ../tools/networking/snabb { } ;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -782,6 +782,10 @@ in {
 
   python-mnist = callPackage ../development/python-modules/python-mnist { };
 
+  pythonocc-core = toPythonModule (callPackage ../development/python-modules/pythonocc-core {
+    inherit (pkgs.xorg) libX11;
+  });
+
   python-igraph = callPackage ../development/python-modules/python-igraph {
     pkgconfig = pkgs.pkgconfig;
     igraph = pkgs.igraph;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Package [pythonocc](http://www.pythonocc.org/), a python binding to the OpenCASCADE 3D CAD library.  See also previous PR #11373.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
