### PR TITLE
Fix Android NDK for 19.03

### DIFF
--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -44,14 +44,6 @@ rec {
     platform = platforms.aarch64-multiplatform;
   };
 
-  armv5te-android-prebuilt = rec {
-    config = "armv5tel-unknown-linux-androideabi";
-    sdkVer = "21";
-    ndkVer = "18b";
-    platform = platforms.armv5te-android;
-    useAndroidPrebuilt = true;
-  };
-
   armv7a-android-prebuilt = rec {
     config = "armv7a-unknown-linux-androideabi";
     sdkVer = "24";

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -253,16 +253,6 @@ rec {
     kernelTarget = "zImage";
   };
 
-  # https://developer.android.com/ndk/guides/abis#armeabi
-  armv5te-android = {
-    name = "armeabi";
-    gcc = {
-      arch = "armv5te";
-      float = "soft";
-      float-abi = "soft";
-    };
-  };
-
   # https://developer.android.com/ndk/guides/abis#v7a
   armv7a-android =  {
     name = "armeabi-v7a";

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -258,7 +258,6 @@ rec {
     name = "armeabi-v7a";
     gcc = {
       arch = "armv7-a";
-      float = "hard";
       float-abi = "softfp";
       fpu = "vfpv3-d16";
     };

--- a/pkgs/development/androidndk-pkgs/androidndk-pkgs.nix
+++ b/pkgs/development/androidndk-pkgs/androidndk-pkgs.nix
@@ -99,7 +99,6 @@ rec {
           (lib.optional (p ? cpu) "-mcpu=${p.cpu}")
           (lib.optional (p ? abi) "-mabi=${p.abi}")
           (lib.optional (p ? fpu) "-mfpu=${p.fpu}")
-          (lib.optional (p ? float) "-mfloat=${p.float}")
           (lib.optional (p ? float-abi) "-mfloat-abi=${p.float-abi}")
           (lib.optional (p ? mode) "-mmode=${p.mode}")
         ];

--- a/pkgs/development/androidndk-pkgs/androidndk-pkgs.nix
+++ b/pkgs/development/androidndk-pkgs/androidndk-pkgs.nix
@@ -27,7 +27,7 @@ let
     "x86_64-unknown-linux-android" = {
       triple = "x86_64-linux-android";
       arch = "x86_64";
-      toolchain = "x86";
+      toolchain = "x86_64";
       gccVer = "4.9";
     };
     "armv7a-unknown-linux-androideabi" = {

--- a/pkgs/development/androidndk-pkgs/androidndk-pkgs.nix
+++ b/pkgs/development/androidndk-pkgs/androidndk-pkgs.nix
@@ -100,8 +100,7 @@ rec {
           $out/bin/${stdenv.targetPlatform.config}-c++ \
           $out/bin/${stdenv.targetPlatform.config}-gcc \
           $out/bin/${stdenv.targetPlatform.config}-g++ \
-          -e '130i    extraBefore+=(-Wl,--fix-cortex-a8)' \
-          -e 's|^(extraBefore=)\(\)$|\1(${builtins.toString flags})|'
+          -e 's|^(extraBefore=)\((.*)\)$|\1(\2 -Wl,--fix-cortex-a8 ${builtins.toString flags})|'
       '')
       # GCC 4.9 is the first relase with "-fstack-protector"
       + lib.optionalString (lib.versionOlder targetInfo.gccVer "4.9") ''

--- a/pkgs/development/androidndk-pkgs/androidndk-pkgs.nix
+++ b/pkgs/development/androidndk-pkgs/androidndk-pkgs.nix
@@ -18,19 +18,28 @@ let
     "x86_64-unknown-linux-gnu" = {
       double = "linux-x86_64";
     };
-    "armv5tel-unknown-linux-androideabi" = {
-      arch = "arm";
-      triple = "arm-linux-androideabi";
-      gccVer = "4.8";
+    "i686-unknown-linux-android" = {
+      triple = "i686-linux-android";
+      arch = "x86";
+      toolchain = "x86";
+      gccVer = "4.9";
+    };
+    "x86_64-unknown-linux-android" = {
+      triple = "x86_64-linux-android";
+      arch = "x86_64";
+      toolchain = "x86";
+      gccVer = "4.9";
     };
     "armv7a-unknown-linux-androideabi" = {
       arch = "arm";
       triple = "arm-linux-androideabi";
+      toolchain = "arm-linux-androideabi";
       gccVer = "4.9";
     };
     "aarch64-unknown-linux-android" = {
       arch = "arm64";
       triple = "aarch64-linux-android";
+      toolchain = "aarch64-linux-android";
       gccVer = "4.9";
     };
   }.${config} or
@@ -38,49 +47,49 @@ let
 
   hostInfo = ndkInfoFun stdenv.hostPlatform;
   targetInfo = ndkInfoFun stdenv.targetPlatform;
+
+  prefix = stdenv.lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform) (stdenv.targetPlatform.config + "-");
 in
 
 rec {
   # Misc tools
-  binaries = let
-      ndkBinDir =
-        "${androidndk}/libexec/android-sdk/ndk-bundle/toolchains/${targetInfo.triple}-${targetInfo.gccVer}/prebuilt/${hostInfo.double}/bin";
-      ndkGCCLibDir =
-        "${androidndk}/libexec/android-sdk/ndk-bundle/toolchains/${targetInfo.triple}-${targetInfo.gccVer}/prebuilt/${hostInfo.double}/lib/gcc/${targetInfo.triple}/4.9.x";
+  binaries = runCommand "ndk-gcc-binutils" {
+    isClang = true; # clang based cc, but bintools ld
+    nativeBuildInputs = [ makeWrapper ];
+    propgatedBuildInputs = [ androidndk ];
+  } ''
+    mkdir -p $out/bin
 
-    in runCommand "ndk-gcc-binutils" {
-      isGNU = true; # for cc-wrapper
-      nativeBuildInputs = [ makeWrapper ];
-      propgatedBuildInputs = [ androidndk ];
-    } ''
-      mkdir -p $out/bin
-      for prog in ${ndkBinDir}/${targetInfo.triple}-*; do
-        prog_suffix=$(basename $prog | sed 's/${targetInfo.triple}-//')
-        cat > $out/bin/${stdenv.targetPlatform.config}-$prog_suffix <<EOF
-      #! ${stdenv.shell} -e
-      $prog "\$@"
-      EOF
-        chmod +x $out/bin/${stdenv.targetPlatform.config}-$prog_suffix
-      done
+    # llvm toolchain
+    for prog in ${androidndk}/libexec/android-sdk/ndk-bundle/toolchains/llvm/prebuilt/${hostInfo.double}/bin/*; do
+      ln -s $prog $out/bin/$(basename $prog)
+      ln -s $prog $out/bin/${prefix}$(basename $prog)
+    done
 
-      ln -s $out/bin/${stdenv.targetPlatform.config}-ld $out/bin/ld
-      ln -s ${ndkGCCLibDir} $out/lib
-    '';
+    # bintools toolchain
+    for prog in ${androidndk}/libexec/android-sdk/ndk-bundle/toolchains/${targetInfo.toolchain}-${targetInfo.gccVer}/prebuilt/${hostInfo.double}/bin/*; do
+      prog_suffix=$(basename $prog | sed 's/${targetInfo.triple}-//')
+      ln -s $prog $out/bin/${stdenv.targetPlatform.config}-$prog_suffix
+    done
+
+    # shitty googly wrappers
+    rm -f $out/bin/${stdenv.targetPlatform.config}-gcc $out/bin/${stdenv.targetPlatform.config}-g++
+  '';
 
   binutils = wrapBintoolsWith {
     bintools = binaries;
     libc = targetAndroidndkPkgs.libraries;
-    extraBuildCommands = ''
-      echo "--build-id" >> $out/nix-support/libc-ldflags
-    '';
   };
 
-  gcc = wrapCCWith {
+  clang = wrapCCWith {
     cc = binaries;
     bintools = binutils;
     libc = targetAndroidndkPkgs.libraries;
     extraBuildCommands = ''
       echo "-D__ANDROID_API__=${stdenv.targetPlatform.sdkVer}" >> $out/nix-support/cc-cflags
+      echo "-target ${stdenv.targetPlatform.config}" >> $out/nix-support/cc-cflags
+      echo "-resource-dir=$(echo ${androidndk}/libexec/android-sdk/ndk-bundle/toolchains/llvm/prebuilt/${hostInfo.double}/lib*/clang/*)" >> $out/nix-support/cc-cflags
+      echo "--gcc-toolchain=${androidndk}/libexec/android-sdk/ndk-bundle/toolchains/${targetInfo.toolchain}-${targetInfo.gccVer}/prebuilt/${hostInfo.double}" >> $out/nix-support/cc-cflags
     ''
     + lib.optionalString stdenv.targetPlatform.isAarch32 (let
         p =  stdenv.targetPlatform.platform.gcc or {}
@@ -98,16 +107,10 @@ rec {
         sed -E -i \
           $out/bin/${stdenv.targetPlatform.config}-cc \
           $out/bin/${stdenv.targetPlatform.config}-c++ \
-          $out/bin/${stdenv.targetPlatform.config}-gcc \
-          $out/bin/${stdenv.targetPlatform.config}-g++ \
+          $out/bin/${stdenv.targetPlatform.config}-clang \
+          $out/bin/${stdenv.targetPlatform.config}-clang++ \
           -e 's|^(extraBefore=)\((.*)\)$|\1(\2 -Wl,--fix-cortex-a8 ${builtins.toString flags})|'
-      '')
-      # GCC 4.9 is the first relase with "-fstack-protector"
-      + lib.optionalString (lib.versionOlder targetInfo.gccVer "4.9") ''
-        sed -E \
-        -i $out/nix-support/add-hardening.sh \
-        -e 's|(-fstack-protector)-strong|\1|g'
-      '';
+      '');
   };
 
   # Bionic lib C and other libraries.
@@ -115,17 +118,11 @@ rec {
   # We use androidndk from the previous stage, else we waste time or get cycles
   # cross-compiling packages to wrap incorrectly wrap binaries we don't include
   # anyways.
-  libraries =
-    let
-      includePath = "${buildAndroidndk}/libexec/android-sdk/ndk-bundle/sysroot/usr/include";
-      asmIncludePath = "${buildAndroidndk}/libexec/android-sdk/ndk-bundle/sysroot/usr/include/${targetInfo.triple}";
-      libPath = "${buildAndroidndk}/libexec/android-sdk/ndk-bundle/platforms/android-${stdenv.hostPlatform.sdkVer}/arch-${hostInfo.arch}/usr/lib/";
-    in
-    runCommand "bionic-prebuilt" {} ''
-      mkdir -p $out
-      cp -r ${includePath} $out/include
-      chmod +w $out/include
-      cp -r ${asmIncludePath}/* $out/include
-      ln -s ${libPath} $out/lib
-    '';
+  libraries = runCommand "bionic-prebuilt" {} ''
+    mkdir -p $out
+    cp -r ${buildAndroidndk}/libexec/android-sdk/ndk-bundle/sysroot/usr/include $out/include
+    chmod +w $out/include
+    cp -r ${buildAndroidndk}/libexec/android-sdk/ndk-bundle/sysroot/usr/include/${targetInfo.triple}/* $out/include
+    ln -s ${buildAndroidndk}/libexec/android-sdk/ndk-bundle/platforms/android-${stdenv.hostPlatform.sdkVer}/arch-${hostInfo.arch}/usr/lib $out/lib
+  '';
 }

--- a/pkgs/development/compilers/llvm/3.8/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.8/llvm.nix
@@ -79,8 +79,8 @@ in stdenv.mkDerivation rec {
     "-DLLVM_ENABLE_RTTI=ON"
 
     "-DLLVM_HOST_TRIPLE=${stdenv.hostPlatform.config}"
-    "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.targetPlatform.config}"
-    "-DTARGET_TRIPLE=${stdenv.targetPlatform.config}"
+    "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.hostPlatform.config}"
+    "-DTARGET_TRIPLE=${stdenv.hostPlatform.config}"
   ] ++ stdenv.lib.optional enableSharedLibraries [
     "-DLLVM_LINK_LLVM_DYLIB=ON"
   ] ++ stdenv.lib.optional (!isDarwin)

--- a/pkgs/development/compilers/llvm/3.9/llvm.nix
+++ b/pkgs/development/compilers/llvm/3.9/llvm.nix
@@ -120,8 +120,8 @@ in stdenv.mkDerivation rec {
     "-DCOMPILER_RT_INCLUDE_TESTS=OFF" # FIXME: requires clang source code
 
     "-DLLVM_HOST_TRIPLE=${stdenv.hostPlatform.config}"
-    "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.targetPlatform.config}"
-    "-DTARGET_TRIPLE=${stdenv.targetPlatform.config}"
+    "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.hostPlatform.config}"
+    "-DTARGET_TRIPLE=${stdenv.hostPlatform.config}"
   ] ++ stdenv.lib.optional enableSharedLibraries [
     "-DLLVM_LINK_LLVM_DYLIB=ON"
   ] ++ stdenv.lib.optional (!isDarwin)

--- a/pkgs/development/compilers/llvm/4/llvm.nix
+++ b/pkgs/development/compilers/llvm/4/llvm.nix
@@ -100,8 +100,8 @@ in stdenv.mkDerivation (rec {
     "-DCOMPILER_RT_INCLUDE_TESTS=OFF" # FIXME: requires clang source code
 
     "-DLLVM_HOST_TRIPLE=${stdenv.hostPlatform.config}"
-    "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.targetPlatform.config}"
-    "-DTARGET_TRIPLE=${stdenv.targetPlatform.config}"
+    "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.hostPlatform.config}"
+    "-DTARGET_TRIPLE=${stdenv.hostPlatform.config}"
   ]
   ++ stdenv.lib.optional enableSharedLibraries
     "-DLLVM_LINK_LLVM_DYLIB=ON"

--- a/pkgs/development/compilers/llvm/6/llvm.nix
+++ b/pkgs/development/compilers/llvm/6/llvm.nix
@@ -94,7 +94,7 @@ in stdenv.mkDerivation (rec {
     "-DLLVM_ENABLE_FFI=ON"
     "-DLLVM_ENABLE_RTTI=ON"
     "-DLLVM_HOST_TRIPLE=${stdenv.hostPlatform.config}"
-    "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.targetPlatform.config}"
+    "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.hostPlatform.config}"
     "-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly"
     "-DLLVM_ENABLE_DUMP=ON"
   ] ++ optionals enableSharedLibraries [

--- a/pkgs/development/compilers/llvm/7/llvm.nix
+++ b/pkgs/development/compilers/llvm/7/llvm.nix
@@ -106,7 +106,7 @@ in stdenv.mkDerivation (rec {
     "-DLLVM_ENABLE_FFI=ON"
     "-DLLVM_ENABLE_RTTI=ON"
     "-DLLVM_HOST_TRIPLE=${stdenv.hostPlatform.config}"
-    "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.targetPlatform.config}"
+    "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.hostPlatform.config}"
     "-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly"
     "-DLLVM_ENABLE_DUMP=ON"
   ] ++ optionals enableSharedLibraries [

--- a/pkgs/development/libraries/readline/6.3.nix
+++ b/pkgs/development/libraries/readline/6.3.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   patches =
     [ ./link-against-ncurses.patch
       ./no-arch_only-6.3.patch
-    ]
+    ] ++ stdenv.lib.optional stdenv.hostPlatform.useAndroidPrebuilt ./android.patch
     ++
     (let
        patch = nr: sha256:

--- a/pkgs/development/libraries/readline/android.patch
+++ b/pkgs/development/libraries/readline/android.patch
@@ -1,0 +1,16 @@
+diff --git histlib.h histlib.h
+index c938a10..925ab72 100644
+--- histlib.h
++++ histlib.h
+@@ -51,9 +51,9 @@
+ #endif
+ 
+ #ifndef member
+-#  ifndef strchr
++#  if !defined (strchr) && !defined (__STDC__)
+ extern char *strchr ();
+-#  endif
++#  endif /* !strchr && !__STDC__ */
+ #define member(c, s) ((c) ? ((char *)strchr ((s), (c)) != (char *)NULL) : 0)
+ #endif
+ 

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -53,7 +53,7 @@ in lib.init bootStages ++ [
       cc = if crossSystem.useiOSPrebuilt or false
              then buildPackages.darwin.iosSdkPkgs.clang
            else if crossSystem.useAndroidPrebuilt or false
-             then buildPackages."androidndkPkgs_${crossSystem.ndkVer}".gcc
+             then buildPackages."androidndkPkgs_${crossSystem.ndkVer}".clang
            else buildPackages.gcc;
 
       extraNativeBuildInputs = old.extraNativeBuildInputs


### PR DESCRIPTION
This backports https://github.com/NixOS/nixpkgs/pull/59253 and https://github.com/NixOS/nixpkgs/pull/59743, along with https://github.com/NixOS/nixpkgs/commit/ead13a3acaba83b0b7409f0c37c64239d0abfd74 which is necessary for LLVM.

###### Motivation for this change

This works on 18.09 and master but not 19.03.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

```
nix-build -A hello --arg crossSystem '(import ./lib).systems.examples.armv7a-android-prebuilt'
```

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
