### PR TITLE
nixos/nginx: Sandbox the service using systemd

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1909.xml
+++ b/nixos/doc/manual/release-notes/rl-1909.xml
@@ -91,6 +91,34 @@
       the module for some time and so was removed as cleanup.
     </para>
    </listitem>
+   <listitem>
+    <para>
+      The nginx web server previously started its master process as root
+      privileged, then ran worker processes as a less privileged identity. This
+      was changed to start all of nginx as a less privileged user (defined by
+      <option>services.nginx.user</option> and
+      <option>services.nginx.group</option>). As a consequence, all files that
+      are needed for nginx to run (included configuration fragments, SSL
+      certificates and keys, etc.) must now be readable by this less privileged
+      identity.
+      Additionally, systemd sandboxing is now in place to prevent nginx from writing
+      to the filesystem.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+      The option <option>services.nginx.stateDiretory</option> was changed to
+      <option>services.nginx.stateDirectoryName</option> which means the
+      nginx state directory is always under <literal>/var/lib/</literal>.
+      This also means the old state directory needs to be moved from <literal>/var/spool/nginx</literal>,
+      for example using
+      <programlisting>
+        services.nginx.preStart = ''
+          cp -r /var/spool/nginx/* /var/lib/nginx/
+        '';
+      </programlisting>
+    </para>
+   </listitem>
   </itemizedlist>
  </section>
 


### PR DESCRIPTION
- nginx is not running as root anymore (Closes #56255)
- Prevents nginx from accessing the filesystem
- Enables most sandboxing options systemd offers
- Moves the state directory to /var/lib

The only downside is that the worker processes are now able to read the certificates.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

nginx is running on most of my servers on a well-known port and is therefore a great attack vector. Restricting it as much as possible should help around some zero-day exploits.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
