### PR TITLE
[19.03] Security backport for signing-party

### DIFF
--- a/pkgs/tools/security/signing-party/default.nix
+++ b/pkgs/tools/security/signing-party/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, autoconf, automake, makeWrapper
+{ stdenv, fetchFromGitLab, autoconf, automake, makeWrapper
 , python3, perl, perlPackages
 , libmd, gnupg1, which, getopt, libpaper, nettools, qprint
 , sendmailPath ? "/run/wrappers/bin/sendmail" }:
@@ -13,12 +13,15 @@ let
   ];
 in stdenv.mkDerivation rec {
   pname = "signing-party";
-  version = "2.9";
+  version = "2.10";
   name = "${pname}-${version}";
 
-  src = fetchurl {
-    url = "mirror://debian/pool/main/s/${pname}/${pname}_${version}.orig.tar.gz";
-    sha256 = "14pgi45zqa0zd1ldfj9mnf9jgv5kfrhl78lr8iy7k88p9h6b9n7n";
+  src = fetchFromGitLab {
+    domain = "salsa.debian.org";
+    owner = "signing-party-team";
+    repo = "signing-party";
+    rev = "v${version}";
+    sha256 = "0lq8nmwjmysry0n4jg6vb7bh0lagbyb9pa11ii3s41p1mhzchf2r";
   };
 
   # TODO: Get this patch upstream...

--- a/pkgs/tools/security/signing-party/default.nix
+++ b/pkgs/tools/security/signing-party/default.nix
@@ -13,12 +13,12 @@ let
   ];
 in stdenv.mkDerivation rec {
   pname = "signing-party";
-  version = "2.8";
+  version = "2.9";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://debian/pool/main/s/${pname}/${pname}_${version}.orig.tar.gz";
-    sha256 = "1dfry04gsa8kv7a2kr4p7a4b616sql41hsyff4pmfvrhiv2fz39z";
+    sha256 = "14pgi45zqa0zd1ldfj9mnf9jgv5kfrhl78lr8iy7k88p9h6b9n7n";
   };
 
   # TODO: Get this patch upstream...


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
