### PR TITLE
gitAndTools.gitFastExport: (old) -> v190107

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/fast-export/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/fast-export/default.nix
@@ -1,41 +1,42 @@
-{stdenv, fetchgit, mercurial, makeWrapper, subversion}:
+{stdenv, fetchgit, mercurial, makeWrapper}:
 
-with stdenv.lib;
-stdenv.mkDerivation {
-  name = "fast-export";
+stdenv.mkDerivation rec {
+  pname = "fast-export";
+  version = "190107";
 
   src = fetchgit {
     url = git://repo.or.cz/fast-export.git;
-    rev = "d202200fd9daa75cdb37d4cf067d4ca00e269535";
-    sha256 = "0m4llsg9rx4sza1kf39kxsdvhi6y87a18wm5k19c5r2h3vpylwcc";
+    rev = "v${version}";
+    sha256 = "14azfps9jd5anivcvfwflgsvqdyy6gm9jy284kzx2ng9f7871d14";
   };
 
-  buildInputs = [mercurial.python mercurial makeWrapper subversion];
+  buildInputs = [mercurial.python mercurial makeWrapper];
 
-  dontBuild = true; # skip svn for now
-
-  # TODO also support svn stuff
-  # moving .py files into lib directory so that you can't pick the wrong file from PATH.
-  # This requires redefining ROOT
   installPhase = ''
-    sed -i "s@/usr/bin/env.*@$(type -p python)@" *.py
-    l=$out/libexec/git-fast-export
-    mkdir -p $out/{bin,doc/git-fast-export} $l
-    sed -i "s@ROOT=.*@ROOT=$l@" *.sh
-    mv *.sh $out/bin
-    mv *.py $l
-    for p in $out/bin/*.sh; do
-      wrapProgram $p \
-        --prefix PYTHONPATH : "$(echo ${mercurial}/lib/python*/site-packages):$(echo ${mercurial.python}/lib/python*/site-packages)${stdenv.lib.concatMapStrings (x: ":$(echo ${x}/lib/python*/site-packages)") mercurial.pythonPackages or []}" \
-        --prefix PATH : "$(dirname $(type -p python))":$l
+    binPath=$out/bin
+    libexecPath=$out/libexec/${pname}
+    sitepackagesPath=$out/${mercurial.python.sitePackages}
+    mkdir -p $binPath $libexecPath $sitepackagesPath
+
+    # Patch shell scripts so they can execute the Python scripts
+    sed -i "s|ROOT=.*|ROOT=$libexecPath|" *.sh
+
+    mv hg-fast-export.sh hg-reset.sh $binPath
+    mv hg-fast-export.py hg-reset.py $libexecPath
+    mv hg2git.py pluginloader plugins $sitepackagesPath
+
+    for script in $out/bin/*.sh; do
+      wrapProgram $script \
+        --prefix PATH : "${mercurial.python}/bin":$libexec \
+        --prefix PYTHONPATH : "${mercurial}/${mercurial.python.sitePackages}":$sitepackagesPath
     done
   '';
 
-  meta = {
-    description = "Import svn, mercurial into git";
+  meta = with stdenv.lib; {
+    description = "Import mercurial into git";
     homepage = https://repo.or.cz/w/fast-export.git;
     license = licenses.gpl2;
     maintainers = [ maintainers.koral ];
-    platforms = stdenv.lib.platforms.unix;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change

The version in nixpkgs is 4 years old. It is unable to read and export from recent Mercurial repositories.

Updating it fixes that, and it can now successfully convert the repos that I need.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
