### PR TITLE
[19.03] testssl: 2.9.5-7 -> 2.9.5-8

### DIFF
--- a/pkgs/applications/networking/testssl/default.nix
+++ b/pkgs/applications/networking/testssl/default.nix
@@ -1,17 +1,15 @@
 { stdenv, fetchFromGitHub, makeWrapper, lib
 , dnsutils, coreutils, openssl, nettools, utillinux, procps }:
 
-let
-  version = "2.9.5-7";
-
-in stdenv.mkDerivation rec {
-  name = "testssl.sh-${version}";
+stdenv.mkDerivation rec {
+  pname = "testssl.sh";
+  version = "2.9.5-8";
 
   src = fetchFromGitHub {
     owner = "drwetter";
     repo = "testssl.sh";
     rev = "v${version}";
-    sha256 = "02xp0yi53xf6jw6v633zs2ws2iyyvq3mlkimg0cv3zvj7nw9x5wr";
+    sha256 = "1fpakzm2gsv8yva58s23lhlgxkkvi3pixil2mjrlkmr0qk66rc32";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -31,12 +29,10 @@ in stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
-    install -Dt $out/bin testssl.sh
-
-    wrapProgram $out/bin/testssl.sh                                            \
-      --prefix PATH ':' ${lib.makeBinPath buildInputs}
-
+    install -D testssl.sh $out/bin/testssl.sh
     cp -r etc $out
+
+    wrapProgram $out/bin/testssl.sh --prefix PATH ':' ${lib.makeBinPath buildInputs}
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Changelog: https://github.com/drwetter/testssl.sh/releases/tag/v2.9.5-8
(cherry picked from commit 4fbde5bb370ce76312110a5d8238a300f0971f41)

This is a backport of parts from #60183

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
