### PR TITLE
thin-provisioning-tools: fix patch url

### DIFF
--- a/pkgs/tools/misc/thin-provisioning-tools/default.nix
+++ b/pkgs/tools/misc/thin-provisioning-tools/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
       #    dynamically using sysconf(_SC_PAGE_SIZE) instead of hardcoded value that hopefully is correct.
       # [1] http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/limits.h.html
       # [2] http://www.openwall.com/lists/musl/2015/09/11/8
-      url = "https://raw.githubusercontent.com/voidlinux/void-packages/a0ece13ad7ab2aae760e09e41e0459bd999a3695/srcpkgs/thin-provisioning-tools/patches/musl.patch";
+      url = "https://raw.githubusercontent.com/void-linux/void-packages/a0ece13ad7ab2aae760e09e41e0459bd999a3695/srcpkgs/thin-provisioning-tools/patches/musl.patch";
       sha256 = "1m8r3vhrnsy8drgs0svs3fgpi3mmxzdcqsv6bmvc0j52cvfqvhvy";
       extraPrefix = ""; # empty means add 'a/' and 'b/'
     })


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Void Linux changed its github organization from "voidlinux" to "void-linux"
See: https://voidlinux.org/news/2018/06/GitHub-Organisation-is-moving.html

Fixes https://github.com/NixOS/nixpkgs/issues/60654

cc: @nixbitcoin 
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
