### PR TITLE
bemenu: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4892,6 +4892,11 @@
     github = "ctheune";
     name = "Christian Theune";
   };
+  thiagokokada = {
+    email = "thiagokokada@gmail.com";
+    github = "thiagokokada";
+    name = "Thiago K. Okada";
+  };
   ThomasMader = {
     email = "thomas.mader@gmail.com";
     github = "ThomasMader";

--- a/pkgs/applications/misc/bemenu/default.nix
+++ b/pkgs/applications/misc/bemenu/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchFromGitHub, cairo, cmake, libxkbcommon
+, pango, fribidi, harfbuzz, pcre, pkgconfig
+, ncursesSupport ? true, ncurses ? null
+, waylandSupport ? true, wayland ? null
+, x11Support ? true, xlibs ? null, xorg ? null
+}:
+
+assert ncursesSupport -> ncurses != null;
+assert waylandSupport -> wayland != null;
+assert x11Support -> xlibs != null && xorg != null;
+
+stdenv.mkDerivation rec {
+  pname = "bemenu";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "Cloudef";
+    repo = "bemenu";
+    rev = "33e540a2b04ce78f5c7ab4a60b899c67f586cc32";
+    sha256 = "11h55m9dx6ai12pqij52ydjm36dvrcc856pa834njihrp626pl4w";
+  };
+
+  nativeBuildInputs = [ cmake pkgconfig pcre ];
+
+  buildInputs = with stdenv.lib; [
+    cairo
+    fribidi
+    harfbuzz
+    libxkbcommon
+    pango
+  ] ++ optionals ncursesSupport [ ncurses ]
+    ++ optionals waylandSupport [ wayland ]
+    ++ optionals x11Support [
+      xlibs.libX11 xlibs.libXinerama xlibs.libXft
+      xorg.libXdmcp xorg.libpthreadstubs xorg.libxcb
+    ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/Cloudef/bemenu";
+    description = "Dynamic menu library and client program inspired by dmenu";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ thiagokokada ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23877,4 +23877,6 @@ in
 
   wasmtime = callPackage ../development/interpreters/wasmtime {};
 
+  bemenu = callPackage ../applications/misc/bemenu { };
+
 }


### PR DESCRIPTION
###### Motivation for this change

Bemenu is a dynamic menu library and client program inspired by dmenu with support for wayland compositors (and also X11 and ncurses).

Build and tested in NixOS `19.03.172392.6d7ed96429` in X11 (`i3wm`), wayland (`sway`) and ncurses (`kitty`).

There seems to be a package for [bemenu already in master](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/window-managers/orbment/bemenu.nix), however this is based in a very old commit (~2017) when `bemenu` used to only run in `orbment`. Nowadays `bemenu` also runs in other wayland compositors like `sway`, so it is a interesting alternative to `dmenu`, `rofi` for wayland users.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
