### PR TITLE
caprice32: unstable-2018-03-05 -> 4.5.0

### DIFF
--- a/pkgs/misc/emulators/caprice32/default.nix
+++ b/pkgs/misc/emulators/caprice32/default.nix
@@ -2,18 +2,22 @@
 
 stdenv.mkDerivation rec {
 
-  repo = "caprice32";
-  version = "unstable-2018-03-05";
-  rev = "317fe638111e245d67e301f6f295094d3c859a70";
-  name = "${repo}-${version}";
+  pname = "caprice32";
+  version = "4.5.0";
 
   src = fetchFromGitHub {
-    inherit rev repo;
+    repo = "caprice32";
+    rev = "v${version}";
     owner = "ColinPitrat";
-    sha256 = "1bywpmkizixcnr057k8zq9nlw0zhcmwkiriln0krgdcm7d3h9b86";
+    sha256 = "056vrf5yq1574g93ix8hnjqqbdqza3qcjv0f8rvpsslqcbizma9y";
   };
 
   postPatch = "substituteInPlace cap32.cfg --replace /usr/local $out";
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ libpng SDL freetype zlib ];
+
+  #fix GIT_HASH avoid depend on git 
+  makeFlags = [ "GIT_HASH=${src.rev}" "DESTDIR=$(out)" "prefix=/"];
 
   meta = with stdenv.lib; {
     description = "A complete emulation of CPC464, CPC664 and CPC6128";
@@ -21,9 +25,5 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     maintainers = [ maintainers.genesis ];
     platforms = platforms.linux;
-  };
-
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ libpng SDL freetype zlib ];
-  makeFlags = [ "GIT_HASH=${src.rev}" "DESTDIR=$(out)" "prefix=/"];
+  };  
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
