### PR TITLE
Add pplatex- tex error pretty printer

### DIFF
--- a/pkgs/tools/typesetting/tex/pplatex/default.nix
+++ b/pkgs/tools/typesetting/tex/pplatex/default.nix
@@ -1,0 +1,40 @@
+with 
+  import <nixpkgs> {}
+;
+
+stdenv.mkDerivation {
+  name = "pplatex";
+  version = "1.0-rc2";
+
+  src = fetchFromGitHub {
+    owner = "stefanhepp";
+    repo = "pplatex";
+    rev = "25bf7e121178f1fee2452b4fa9961248a045a387";
+    sha256 = "0xw7nvi2l15iyp9sm8vmmqghi54v99bcivqvx89f5v2gw0kw47k3";
+  };
+
+  buildInputs = 
+  [
+    pkgs.cmake
+    pkgs.gnumake
+    pkgs.pkgconfig
+    pkgs.pcre 
+    pkgs.texlive.combined.scheme-small 
+  ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp src/pplatex $out/bin
+  '';
+  
+    meta = {
+    description = "TeX/LaTeX family error parser";
+    longDescription = ''
+      pplatex is a program that displays errors from TeX/LaTeX family programs in a user friendly format.
+    '';
+    homepage = https://github.com/stefanhepp/pplatex;
+    license = stdenv.lib.licenses.gpl3Plus;
+    maintainers = [ stdenv.lib.maintainers.srgom ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
Tested and currently using on my local computer
Sorry for the sloppy pull request but I'm very new to Nix and I cannot justify spending too much time to get everything working perfectly. I feel like I've spent good time getting the initial work done and any expert can bring this up to standard in minutes. That said, I'm sure you guys are busy too so please feel free to reject. 
 
###### Motivation for this change
Sick of terrible TeX errors, pplatex pretty prints them and makes them (actually) readable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- [x] Tested on my own machine by doing an (import .....) inside configuration.nix. 

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
