### PR TITLE
atomicparsley: fix cross

### DIFF
--- a/pkgs/tools/video/atomicparsley/default.nix
+++ b/pkgs/tools/video/atomicparsley/default.nix
@@ -18,6 +18,12 @@ stdenv.mkDerivation rec {
       cf-private
     ];
 
+  configureFlags = stdenv.lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    # AC_FUNC_MALLOC is broken on cross builds.
+    "ac_cv_func_malloc_0_nonnull=yes"
+    "ac_cv_func_realloc_0_nonnull=yes"
+  ];
+
   installPhase = "install -D AtomicParsley $out/bin/AtomicParsley";
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

https://nerdland.net/unstumping-the-internet/malloc-has-not-been-declared/

fixes:
```
aarch64-unknown-linux-gnu-g++ -DHAVE_CONFIG_H -I. -I./src  -DHAVE_CONFIG_H    -D_FILE_OFFSET_BITS=64 -g -O2 -Wall -c -o src/util.o src/util.cpp
In file included from /nix/store/b9iyqcsd1gmlfagpi4xqqlswcpx079r1-aarch64-unknown-linux-gnu-stage-final-gcc-debug-7.4.0/aarch64-unknown-linux-gnu/include/c++/7.4.0/stdlib.h:36:0,
                 from src/AtomicParsley.h:54,
                 from src/util.cpp:29:
/nix/store/b9iyqcsd1gmlfagpi4xqqlswcpx079r1-aarch64-unknown-linux-gnu-stage-final-gcc-debug-7.4.0/aarch64-unknown-linux-gnu/include/c++/7.4.0/cstdlib:151:11: error: '::malloc' has not been declared
   using ::malloc;
           ^~~~~~
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- N/A Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
