### PR TITLE
Flume module

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -340,6 +340,7 @@
       cockroachdb = 313;
       zoneminder = 314;
       paperless = 315;
+      apache-flume = 316;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -374,6 +374,7 @@
   ./services/mail/roundcube.nix
   ./services/mail/nullmailer.nix
   ./services/misc/airsonic.nix
+  ./services/misc/apache-flume.nix
   ./services/misc/apache-kafka.nix
   ./services/misc/autofs.nix
   ./services/misc/autorandr.nix

--- a/nixos/modules/services/misc/apache-flume.nix
+++ b/nixos/modules/services/misc/apache-flume.nix
@@ -1,0 +1,138 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.apache-flume;
+
+  flumeEnvSh = pkgs.writeTextDir "flume-env.sh" cfg.flumeEnvSh;
+  flumeConf = pkgs.writeText "flume.conf" cfg.flumeConf;
+  logConfig = pkgs.writeText "log4j.properties" cfg.log4jProperties;
+
+in {
+
+  options.services.apache-flume = {
+    enable = mkOption {
+      description = "Whether to enable Apache flume.";
+      default = false;
+      type = types.bool;
+    };
+
+    homeDir = mkOption {
+      description = "Home directory for the flume user.";
+      default = "/var/lib/apache-flume";
+      type = types.path;
+    };
+
+    flumeConf = mkOption {
+      description = "Complete flume.conf content.";
+      type = types.lines;
+      example = ''
+        a1.sources = r1
+        a1.sources.r1.type = netcat
+        a1.sources.r1.bind = localhost
+        a1.sources.r1.port = 44444
+      '';
+      default = ''
+        # example.conf: A single-node Flume configuration
+
+        # Name the components on this agent
+        a1.sources = r1
+        a1.sinks = k1
+        a1.channels = c1
+
+        # Describe/configure the source
+        a1.sources.r1.type = netcat
+        a1.sources.r1.bind = localhost
+        a1.sources.r1.port = 44444
+
+        # Describe the sink
+        a1.sinks.k1.type = logger
+
+        # Use a channel which buffers events in memory
+        a1.channels.c1.type = memory
+        a1.channels.c1.capacity = 1000
+        a1.channels.c1.transactionCapacity = 100
+
+        # Bind the source and sink to the channel
+        a1.sources.r1.channels = c1
+        a1.sinks.k1.channel = c1
+      '';
+    };
+
+    hadoopPackage = mkOption {
+      description = "Which hadoop package to use for Flume.";
+      default = pkgs.hadoop;
+      defaultText = "pkgs.hadoop";
+      type = types.package;
+    };
+
+    log4jProperties = mkOption {
+      description = "Flume log4j property configuration.";
+      default = ''
+        log4j.rootLogger=INFO, stdout
+        log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+        log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+        log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
+      '';
+      type = types.lines;
+    };
+
+    flumeEnvSh = mkOption {
+      description = ''
+        Flume environment config. This is sourced by flume on startup to
+        set certain environment variables.
+      '';
+      default = ''
+        export FLUME_JAVA_LIBRARY_PATH="${cfg.hadoopPackage}/lib/native"
+        export FLUME_JAVA_OPTS="-Dlog4j.configuration=file:${logConfig}"
+      '';
+      defaultText = "";
+      type = types.lines;
+      example = ''
+        export FLUME_CLASSPATH=/path/to/other/jars
+      '';
+    };
+
+    javaOptions = mkOption {
+      description = "Extra command line options for the JVM running flume.";
+      default = ''JAVA_OPTS="-Xmx20m"'';
+      type = types.str;
+      example = ''JAVA_OPTS="-Xmx20m"'';
+    };
+
+    package = mkOption {
+      description = "The flume package to use";
+      default = pkgs.apacheFlume;
+      defaultText = "pkgs.apacheFlume";
+      type = types.package;
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+
+    environment.systemPackages = [cfg.package];
+
+    users.users = singleton {
+      name = "apache-flume";
+      uid = config.ids.uids.apache-flume;
+      description = "Apache flume daemon user";
+      home = cfg.homeDir;
+    };
+
+    systemd.services.apache-flume = {
+      description = "Apache flume Daemon";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      serviceConfig = {
+        ExecStart = ''
+          ${cfg.package}/bin/flume-ng agent --conf ${flumeEnvSh} --conf-file ${flumeConf} --name agent
+        '';
+        User = "apache-flume";
+        SuccessExitStatus = "0 143";
+      };
+    };
+
+  };
+}

--- a/pkgs/servers/apache-flume/default.nix
+++ b/pkgs/servers/apache-flume/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, jre, makeWrapper, hadoop, majorVersion ? "1.9.0" }:
+{ stdenv, fetchurl, jre, makeWrapper, majorVersion ? "1.9.0" }:
 
 let
   versionMap = {
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     inherit sha256;
   };
 
-  buildInputs = [ hadoop jre makeWrapper ];
+  buildInputs = [ jre makeWrapper ];
 
   installPhase = ''
     mkdir -p $out
@@ -28,11 +28,9 @@ stdenv.mkDerivation rec {
 
     mkdir -p $out/bin
     cp bin/flume-ng $out/bin
-
     wrapProgram $out/bin/flume-ng \
-      --set JAVA_HOME "${jre}" \
       --set FLUME_HOME "$out" \
-      --set FLUME_JAVA_LIBRARY_PATH "${hadoop}/lib/native"
+      --set JAVA_HOME "${jre}"
     chmod +x $out/bin\/*
   '';
 

--- a/pkgs/servers/apache-flume/default.nix
+++ b/pkgs/servers/apache-flume/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchurl, jre, makeWrapper, hadoop, majorVersion ? "1.9.0" }:
+
+let
+  versionMap = {
+    "1.9.0" = {
+      flumeVersion = "1.9.0";
+      sha256 = "069nnakibv4pdra06fnq08nb7qypzx8j586r4fmw8kflpxdfswq3";
+    };
+  };
+in
+
+with versionMap.${majorVersion};
+
+stdenv.mkDerivation rec {
+  version = "${flumeVersion}";
+  name = "apache-flume-${version}";
+
+  src = fetchurl {
+    url = "mirror://apache/flume/${version}/apache-flume-${version}-bin.tar.gz";
+    inherit sha256;
+  };
+
+  buildInputs = [ hadoop jre makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out
+    cp -R tools conf lib $out
+
+    mkdir -p $out/bin
+    cp bin/flume-ng $out/bin
+
+    wrapProgram $out/bin/flume-ng \
+      --set JAVA_HOME "${jre}" \
+      --set FLUME_HOME "$out" \
+      --set FLUME_JAVA_LIBRARY_PATH "${hadoop}/lib/native"
+    chmod +x $out/bin\/*
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = http://flume.apache.org;
+    description = "Flume is a distributed, reliable, and available service for efficiently collecting, aggregating, and moving large amounts of log data.";
+    license = licenses.asl20;
+    maintainers = [ ];
+    platforms = platforms.unix;
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8743,6 +8743,9 @@ in
   apacheKafka_2_1 = callPackage ../servers/apache-kafka { majorVersion = "2.1"; };
   apacheKafka_2_2 = callPackage ../servers/apache-kafka { majorVersion = "2.2"; };
 
+  apacheFlume = apacheFlume_1_9_0;
+  apacheFlume_1_9_0 = callPackage ../servers/apache-flume { majorVersion = "1.9.0"; };
+
   kt = callPackage ../tools/misc/kt {};
 
   arpa2cm = callPackage ../development/tools/build-managers/arpa2cm { };


### PR DESCRIPTION
###### Motivation for this change

We have recently moved to NixOS and have converted most of our production services over to it (as well as many of our developers desktops! (: ) I have contributed to the nginx and tomcat modules. I found that we use flume internally for data routing, and there was no flume NixOS Package, so I created that here: https://github.com/NixOS/nixpkgs/pull/58728

This is the NixOS Module to go with that package, after this I can finally move my last system over to NixOS!

###### Things done



- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
