### PR TITLE
docbook-xsl: update patch

### DIFF
--- a/pkgs/data/sgml+xml/stylesheets/xslt/docbook-xsl/default.nix
+++ b/pkgs/data/sgml+xml/stylesheets/xslt/docbook-xsl/default.nix
@@ -47,13 +47,7 @@ in {
     pname = "docbook-xsl";
     sha256 = "0s59lihif2fr7rznckxr2kfyrvkirv76r1zvidp9b5mj28p4apvj";
 
-    patches = [(fetchpatch {
-      name = "potential-infinite-template-recursion.patch";
-      url = "https://src.fedoraproject.org/cgit/rpms/docbook-style-xsl.git/"
-          + "plain/docbook-style-xsl-non-recursive-string-subst.patch?id=bf9e5d16fd";
-      sha256 = "1pfb468bsj3j879ip0950waih0r1s6rzfbm2p70glbz0g3903p7h";
-      stripLen = "1";
-    })];
+    patches = [ ./docbook-xsl-infinite.patch ];
 
   };
 

--- a/pkgs/data/sgml+xml/stylesheets/xslt/docbook-xsl/docbook-xsl-infinite.patch
+++ b/pkgs/data/sgml+xml/stylesheets/xslt/docbook-xsl/docbook-xsl-infinite.patch
@@ -1,0 +1,24 @@
+--- a/lib/lib.xsl	2013-09-04 20:09:43.000000000 +0200
++++ b/lib/lib.xsl	2019-05-02 00:23:45.153009947 +0200
+@@ -10,7 +10,10 @@
+      This module implements DTD-independent functions
+ 
+      ******************************************************************** -->
+-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
++<xsl:stylesheet exclude-result-prefixes="d" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
++								xmlns:d="http://docbook.org/ns/docbook"
++								xmlns:str="http://exslt.org/strings"
++								version="1.0">
+ 
+ <xsl:template name="dot.count">
+   <!-- Returns the number of "." characters in a string -->
+@@ -56,6 +59,9 @@
+   <xsl:param name="replacement"/>
+ 
+   <xsl:choose>
++		<xsl:when test="function-available('str:replace')">
++			<xsl:value-of select="str:replace($string, string($target), string($replacement))"/>
++		</xsl:when>
+     <xsl:when test="contains($string, $target)">
+       <xsl:variable name="rest">
+         <xsl:call-template name="string.subst">


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
