### PR TITLE
 twemoji-color-font: 11.2.0 -> 12.0.1 + refactor

### DIFF
--- a/pkgs/data/fonts/twemoji-color-font/default.nix
+++ b/pkgs/data/fonts/twemoji-color-font/default.nix
@@ -1,11 +1,12 @@
 { stdenv, fetchFromGitHub, inkscape, imagemagick, potrace, svgo, scfbuild }:
 
 stdenv.mkDerivation rec {
-  name = "twemoji-color-font-${meta.version}";
+  pname = "twemoji-color-font";
+  version = "12.0.1";
   src = fetchFromGitHub {
     owner = "eosrei";
     repo = "twemoji-color-font";
-    rev = "v${meta.version}";
+    rev = "v${version}";
     sha256 = "00pbgqpkq21wl8fs0q1xp49xb10m48b9sz8cdc58flkd2vqfssw2";
   };
 
@@ -21,7 +22,6 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    version = "12.0.1";
     description = "Color emoji SVGinOT font using Twitter Unicode 10 emoji with diversity and country flags";
     longDescription = ''
       A color and B&W emoji SVGinOT font built from the Twitter Emoji for

--- a/pkgs/data/fonts/twemoji-color-font/default.nix
+++ b/pkgs/data/fonts/twemoji-color-font/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
     owner = "eosrei";
     repo = "twemoji-color-font";
     rev = "v${meta.version}";
-    sha256 = "07yawvbdkk15d7ac9dj7drs1rqln9sba1fd6jx885ms7ww2sfm7r";
+    sha256 = "00pbgqpkq21wl8fs0q1xp49xb10m48b9sz8cdc58flkd2vqfssw2";
   };
 
   nativeBuildInputs = [ inkscape imagemagick potrace svgo scfbuild ];
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    version = "11.2.0";
+    version = "12.0.1";
     description = "Color emoji SVGinOT font using Twitter Unicode 10 emoji with diversity and country flags";
     longDescription = ''
       A color and B&W emoji SVGinOT font built from the Twitter Emoji for


### PR DESCRIPTION
###### Motivation for this change

Unicode 12 \o/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Not tested since I'm on an underpowered machine and this is fairly heavy to build. Let's see what ofborg says.