### PR TITLE
swift: 4.3.2 -> 5.0.1

### DIFF
--- a/pkgs/development/compilers/swift/default.nix
+++ b/pkgs/development/compilers/swift/default.nix
@@ -231,7 +231,9 @@ stdenv.mkDerivation rec {
       -e 's/^validation-test$/# \0/' \
       -e 's/^long-test$/# \0/' \
       -e 's/^stress-test$/# \0/' \
-      -e 's/^test-optimized$/# \0/'
+      -e 's/^test-optimized$/# \0/' \
+      \
+      -e 's/^swift-install-components=autolink.*$/\0;editor-integration/'
 
     # https://bugs.swift.org/browse/SR-10559
     patch -p1 -d swift-corelibs-libdispatch -i ${./patches/libdispatch-fortify-fix.patch}

--- a/pkgs/development/compilers/swift/default.nix
+++ b/pkgs/development/compilers/swift/default.nix
@@ -135,23 +135,25 @@ in
 stdenv.mkDerivation rec {
   name = "swift-${version_friendly}";
 
-  buildInputs = devInputs ++ [
+  nativeBuildInputs = [
     autoconf
     automake
     bash
-    clang
     cmake
     coreutils
+    findutils
+    gnumake
     libtool
+    makeWrapper
     ninja
     perl
     pkgconfig
     python
     rsync
     which
-    findutils
-    makeWrapper
-    gnumake
+  ];
+  buildInputs = devInputs ++ [
+    clang
   ];
 
   # TODO: Revisit what's propagated and how

--- a/pkgs/development/compilers/swift/default.nix
+++ b/pkgs/development/compilers/swift/default.nix
@@ -250,9 +250,19 @@ stdenv.mkDerivation rec {
       --replace usr/lib "$PREFIX/lib"
   '';
 
+  buildPhase = builder;
+
   doCheck = false;
 
-  buildPhase = builder;
+  checkInputs = [ file ];
+
+  # TODO: investigate the non-working tests
+  checkPhase = ''
+    checkTarget=check-swift-all
+    ninjaFlags='-C buildbot_linux/swift-${stdenv.hostPlatform.parsed.kernel.name}-${stdenv.hostPlatform.parsed.cpu.name}'
+
+    ninjaCheckPhase
+  '';
 
   installPhase = ''
     mkdir -p $out

--- a/pkgs/development/compilers/swift/default.nix
+++ b/pkgs/development/compilers/swift/default.nix
@@ -34,7 +34,7 @@
 }:
 
 let
-  v_base = "4.2.3";
+  v_base = "5.0.1";
   version = "${v_base}-RELEASE";
   version_friendly = "${v_base}";
 
@@ -52,48 +52,48 @@ let
     # For more inforation, see: https://github.com/apple/swift/pull/3594#issuecomment-234169759
     clang = fetch {
       repo = "swift-clang";
-      sha256 = "0l6w4xzpl3w2nax9a0b885nfzhfj38p2g99158nb5bzfd4s0man7";
+      sha256 = "1ap26425zhn2sdw3m9snyrqhi4phv2fgblyv9wp8xppjlnjkax9k";
     };
     llvm = fetch {
       repo = "swift-llvm";
-      sha256 = "1664zwxbq0a1cmxr9n5a0vw6vdk6ygr7rpglpdsfc7ki857vpsyv";
+      sha256 = "1bnscqsiljiclij60f44h2fyx5c84pzry0lz1jbwknphwmqd6f84";
     };
     compilerrt = fetch {
       repo = "swift-compiler-rt";
-      sha256 = "19s6qxn4i0kxpf39xjp2i7zg427iinbmaxqkbb1p91g616y367sf";
+      sha256 = "0bba54xa7z0wj6k7a24q74gc4yajc6s64g1m894i3yd6swdk7f6r";
     };
     cmark = fetch {
       repo = "swift-cmark";
-      sha256 = "1nmxp0fj749sgar682c5nsj7zxxigqwg973baxj2r656a7ybh325";
+      sha256 = "079smm79hbwr06bvghd2sb86b8gpkprnzlyj9kh95jy38xhlhdnj";
     };
     lldb = fetch {
       repo = "swift-lldb";
-      sha256 = "00kz0xhj1p6ckyandj2gs1yfl29kxv84x9pfph00r8crbkd2jz7b";
+      sha256 = "01yrhc1ggv89qii03fdjdvb2aq9v4hd1wk83n8ygrwwc75p44qmi";
     };
     llbuild = fetch {
       repo = "swift-llbuild";
-      sha256 = "1mkkhydshhxr28igbldzr0hhqvb6ql43cpf3ba5vglfkbcz6wh6q";
+      sha256 = "0ipwryzpqxpk3rzkxilfahlkz06k39j91q2lv7fprf0slqknrdms";
     };
     pm = fetch {
       repo = "swift-package-manager";
-      sha256 = "1aqvmgq9g5zs4k2qnkvw3h3mar66d690hqq6g2dmrapsyb321j9l";
+      sha256 = "1mnywlm7i2mbp16q0rskskvnbx1ap8lchwr8q3gx0xs3b2fs6chh";
     };
     xctest = fetch {
       repo = "swift-corelibs-xctest";
-      sha256 = "1n4w7bfgy73vjzbvbphlwayy0dw73bbrayrpkqq8lbidg0x9lam8";
+      sha256 = "1vpljkxhfk3yd07ry0xsv3qwbn62pwd2mdn9cw22jhbhvqinc13z";
     };
     foundation = fetch {
       repo = "swift-corelibs-foundation";
-      sha256 = "11kwc5pcq4ibxkyglmqs7h7gka3xkzl9j856x1rq2xdvq756wq2s";
+      sha256 = "11w0iapccrk13hjbrwylq8g71znrncnc3mrm345gvnjfgz08ffaq";
     };
     libdispatch = fetch {
       repo = "swift-corelibs-libdispatch";
-      sha256 = "09c15mn9s5lf2akzfhik70zk91h97nnm8pq1ppfqry2nn3vmib2i";
+      sha256 = "1mgzsq3nfzbkssfkswzvvjgsbv2fx36i1r83d4nzw3di8spxmg32";
       fetchSubmodules = true;
     };
     swift = fetch {
       repo = "swift";
-      sha256 = "09wksqad0w6pk3xdxc278w4mj300h48rvbvx0m4an7npkj6i7n9q";
+      sha256 = "02bv47pd0k0xy4k7q6c3flwxwkm2palnzvpr4w3nmvqk0flrbsq6";
     };
   };
 
@@ -120,6 +120,9 @@ let
   builder = ''
     # gcc-6.4.0/include/c++/6.4.0/cstdlib:75:15: fatal error: 'stdlib.h' file not found
     NIX_CFLAGS_COMPILE="$( echo ${clang.default_cxx_stdlib_compile} ) $NIX_CFLAGS_COMPILE"
+    # During the Swift build, a full local LLVM build is performed and the resulting clang is invoked.
+    # This compiler is not using the Nix wrappers, so it needs some help to find things.
+    export NIX_LDFLAGS_BEFORE="-rpath ${clang.cc.gcc.lib}/lib -L${clang.cc.gcc.lib}/lib $NIX_LDFLAGS_BEFORE"
 
     $SWIFT_SOURCE_ROOT/swift/utils/build-script \
       --preset=buildbot_linux \
@@ -212,13 +215,12 @@ stdenv.mkDerivation rec {
 
     substituteInPlace swift/stdlib/public/Platform/CMakeLists.txt \
       --replace '/usr/include' "${stdenv.cc.libc.dev}/include"
-    substituteInPlace swift-corelibs-libdispatch/src/CMakeLists.txt \
-      --replace '/usr/include' "${stdenv.cc.libc.dev}/include"
     substituteInPlace swift/utils/build-script-impl \
       --replace '/usr/include/c++' "${clang.cc.gcc}/include/c++"
     patch -p1 -d swift -i ${./patches/glibc-arch-headers.patch}
     patch -p1 -d swift -i ${./patches/0001-build-presets-linux-don-t-require-using-Ninja.patch}
     patch -p1 -d swift -i ${./patches/0002-build-presets-linux-allow-custom-install-prefix.patch}
+    patch -p1 -d swift -i ${./patches/0003-build-presets-linux-don-t-build-extra-libs.patch}
     patch -p1 -d swift -i ${./patches/0004-build-presets-linux-plumb-extra-cmake-options.patch}
 
     sed -i swift/utils/build-presets.ini \
@@ -229,8 +231,8 @@ stdenv.mkDerivation rec {
       -e 's/^stress-test$/# \0/' \
       -e 's/^test-optimized$/# \0/'
 
-    # https://bugs.swift.org/browse/SR-5779
-    sed -i -e 's|"-latomic"|"-Wl,-rpath,${clang.cc.gcc.lib}/lib" "-L${clang.cc.gcc.lib}/lib" "-latomic"|' swift/cmake/modules/AddSwift.cmake
+    # https://bugs.swift.org/browse/SR-10559
+    patch -p1 -d swift-corelibs-libdispatch -i ${./patches/libdispatch-fortify-fix.patch}
 
     substituteInPlace clang/lib/Driver/ToolChains/Linux.cpp \
       --replace 'SysRoot + "/usr/lib' '"${glibc}/lib" "'
@@ -241,8 +243,6 @@ stdenv.mkDerivation rec {
     sed -i 's,curses,ncurses,' llbuild/*/*/CMakeLists.txt
 
     PREFIX=''${out/#\/}
-    substituteInPlace swift-corelibs-foundation/build.py \
-      --replace usr/lib "$PREFIX/lib"
     substituteInPlace swift-corelibs-xctest/build_script.py \
       --replace usr "$PREFIX"
     substituteInPlace swiftpm/Utilities/bootstrap \
@@ -262,13 +262,10 @@ stdenv.mkDerivation rec {
     tar xf $INSTALLABLE_PACKAGE -C $out --strip-components=3 $PREFIX
     find $out -type d -empty -delete
 
-    # TODO: Use wrappers to get these on the PATH for swift tools, instead
-    ln -s ${clang}/bin/* $out/bin/
-    ln -s ${targetPackages.stdenv.cc.bintools.bintools_bin}/bin/ar $out/bin/ar
-
     wrapProgram $out/bin/swift \
       --suffix C_INCLUDE_PATH : $out/lib/swift/clang/include \
-      --suffix CPLUS_INCLUDE_PATH : $out/lib/swift/clang/include
+      --suffix CPLUS_INCLUDE_PATH : $out/lib/swift/clang/include \
+      --suffix LIBRARY_PATH : $icu/lib
   '';
 
   # Hack to avoid TMPDIR in RPATHs.

--- a/pkgs/development/compilers/swift/patches/0001-build-presets-linux-don-t-require-using-Ninja.patch
+++ b/pkgs/development/compilers/swift/patches/0001-build-presets-linux-don-t-require-using-Ninja.patch
@@ -11,8 +11,8 @@ diff --git a/utils/build-presets.ini b/utils/build-presets.ini
 index 7ee57ad2df..e6b0af3581 100644
 --- a/utils/build-presets.ini
 +++ b/utils/build-presets.ini
-@@ -717,7 +717,7 @@ swiftpm
- xctest
+@@ -721,7 +721,7 @@ swiftpm
+ 
  dash-dash
  
 -build-ninja

--- a/pkgs/development/compilers/swift/patches/0002-build-presets-linux-allow-custom-install-prefix.patch
+++ b/pkgs/development/compilers/swift/patches/0002-build-presets-linux-allow-custom-install-prefix.patch
@@ -9,17 +9,17 @@ Subject: [PATCH 2/4] build-presets: (linux) allow custom install prefix
 
 diff --git a/utils/build-presets.ini b/utils/build-presets.ini
 index e6b0af3581..1095cbaab7 100644
---- a/utils/build-presets.ini
-+++ b/utils/build-presets.ini
-@@ -723,7 +723,7 @@ install-lldb
- install-llbuild
+--- a/utils/build-presets.ini	2019-04-11 14:51:40.060259462 +0200
++++ b/utils/build-presets.ini	2019-04-11 15:16:17.471137969 +0200
+@@ -728,7 +728,7 @@
  install-swiftpm
  install-xctest
+ install-libicu
 -install-prefix=/usr
 +install-prefix=%(install_prefix)s
- swift-install-components=autolink-driver;compiler;clang-builtin-headers;stdlib;swift-remote-mirror;sdk-overlay;license;sourcekit-inproc
- build-swift-static-stdlib
- build-swift-static-sdk-overlay
+ swift-install-components=autolink-driver;compiler;clang-resource-dir-symlink;stdlib;swift-remote-mirror;sdk-overlay;license;sourcekit-inproc
+ llvm-install-components=llvm-cov;llvm-profdata;IndexStore;clang;clang-headers;compiler-rt
+ install-libcxx
 -- 
 2.12.2
 

--- a/pkgs/development/compilers/swift/patches/0003-build-presets-linux-don-t-build-extra-libs.patch
+++ b/pkgs/development/compilers/swift/patches/0003-build-presets-linux-don-t-build-extra-libs.patch
@@ -1,0 +1,23 @@
+--- a/utils/build-presets.ini	2019-04-11 15:19:57.845178834 +0200
++++ b/utils/build-presets.ini	2019-04-11 15:27:42.041297057 +0200
+@@ -716,8 +716,6 @@
+ llbuild
+ swiftpm
+ xctest
+-libicu
+-libcxx
+ 
+ dash-dash
+ 
+@@ -727,11 +725,9 @@
+ install-llbuild
+ install-swiftpm
+ install-xctest
+-install-libicu
+ install-prefix=%(install_prefix)s
+ swift-install-components=autolink-driver;compiler;clang-resource-dir-symlink;stdlib;swift-remote-mirror;sdk-overlay;license;sourcekit-inproc
+ llvm-install-components=llvm-cov;llvm-profdata;IndexStore;clang;clang-headers;compiler-rt
+-install-libcxx
+ build-swift-static-stdlib
+ build-swift-static-sdk-overlay
+ build-swift-stdlib-unittest-extra

--- a/pkgs/development/compilers/swift/patches/0004-build-presets-linux-plumb-extra-cmake-options.patch
+++ b/pkgs/development/compilers/swift/patches/0004-build-presets-linux-plumb-extra-cmake-options.patch
@@ -11,7 +11,7 @@ diff --git a/utils/build-presets.ini b/utils/build-presets.ini
 index 1739e91dc2..0608fed9c1 100644
 --- a/utils/build-presets.ini
 +++ b/utils/build-presets.ini
-@@ -740,6 +740,8 @@ install-destdir=%(install_destdir)s
+@@ -743,6 +743,8 @@ install-destdir=%(install_destdir)s
  # Path to the .tar.gz package we would create.
  installable-package=%(installable_package)s
  

--- a/pkgs/development/compilers/swift/patches/glibc-arch-headers.patch
+++ b/pkgs/development/compilers/swift/patches/glibc-arch-headers.patch
@@ -1,13 +1,13 @@
 The Nix glibc headers do not use include/x86_64-linux-gnu subdirectories.
 
---- swift/stdlib/public/Platform/CMakeLists.txt	2018-09-30 17:51:51.581766303 +0200
-+++ swift/stdlib/public/Platform/CMakeLists.txt	2018-09-30 18:40:04.118956708 +0200
-@@ -65,7 +65,7 @@
+--- swift/stdlib/public/Platform/CMakeLists.txt	2019-04-09 20:14:44.493801403 +0200
++++ swift/stdlib/public/Platform/CMakeLists.txt	2019-04-09 20:14:44.577800593 +0200
+@@ -68,7 +68,7 @@
      endif()
  
      set(GLIBC_INCLUDE_PATH "${GLIBC_SYSROOT_RELATIVE_INCLUDE_PATH}")
 -    set(GLIBC_ARCH_INCLUDE_PATH "${GLIBC_SYSROOT_RELATIVE_ARCH_INCLUDE_PATH}")
 +    set(GLIBC_ARCH_INCLUDE_PATH "${GLIBC_SYSROOT_RELATIVE_INCLUDE_PATH}")
  
-     if(NOT "${SWIFT_SDK_${sdk}_ARCH_${arch}_PATH}" STREQUAL "/")
+     if(NOT "${SWIFT_SDK_${sdk}_ARCH_${arch}_PATH}" STREQUAL "/" AND NOT "${sdk}" STREQUAL "ANDROID")
        set(GLIBC_INCLUDE_PATH "${SWIFT_SDK_${sdk}_ARCH_${arch}_PATH}${GLIBC_INCLUDE_PATH}")

--- a/pkgs/development/compilers/swift/patches/libdispatch-fortify-fix.patch
+++ b/pkgs/development/compilers/swift/patches/libdispatch-fortify-fix.patch
@@ -1,0 +1,13 @@
+Nix compiles with _FORTIFY_SOURCE enabled. Fix error due to -Werror and an unused return value warning.
+
+--- swift-corelibs-libdispatch/src/internal.h	2019-04-26 09:33:38.287289099 +0200
++++ swift-corelibs-libdispatch/src/internal.h	2019-04-26 15:31:10.485334128 +0200
+@@ -1053,7 +1053,7 @@
+ #else
+ #define _dispatch_client_assert_fail(fmt, ...)  do { \
+ 		char *_msg = NULL; \
+-		asprintf(&_msg, "%s" fmt, DISPATCH_ASSERTION_FAILED_MESSAGE, \
++		(void)asprintf(&_msg, "%s" fmt, DISPATCH_ASSERTION_FAILED_MESSAGE, \
+ 				##__VA_ARGS__); \
+ 		_dispatch_assert_crash(_msg); \
+ 		free(_msg); \

--- a/pkgs/development/compilers/swift/patches/llvm-include-dirs.patch
+++ b/pkgs/development/compilers/swift/patches/llvm-include-dirs.patch
@@ -2,7 +2,7 @@ Only use the Nix include dirs when no sysroot is configured.
 
 --- clang/lib/Driver/ToolChains/Linux.cpp	2018-10-05 18:01:15.731109551 +0200
 +++ clang/lib/Driver/ToolChains/Linux.cpp	2018-10-05 18:00:27.959509924 +0200
-@@ -565,7 +565,7 @@
+@@ -641,7 +641,7 @@
  
    // Check for configure-time C include directories.
    StringRef CIncludeDirs(C_INCLUDE_DIRS);

--- a/pkgs/development/compilers/swift/purity.patch
+++ b/pkgs/development/compilers/swift/purity.patch
@@ -11,7 +11,7 @@ diff --git a/lib/Driver/ToolChains/Gnu.cpp b/lib/Driver/ToolChains/Gnu.cpp
 index fe3c0191bb..c6a482bece 100644
 --- a/lib/Driver/ToolChains/Gnu.cpp
 +++ b/lib/Driver/ToolChains/Gnu.cpp
-@@ -398,13 +398,6 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
+@@ -380,13 +380,6 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
    if (!Args.hasArg(options::OPT_static)) {
      if (Args.hasArg(options::OPT_rdynamic))
        CmdArgs.push_back("-export-dynamic");


### PR DESCRIPTION
I updated Swift to version 5.0.1. This needed relatively minor changes, the biggest one is the addition of the `NIX_LDFLAGS_BEFORE` variable to help the internal clang that is being built during the Swift build process.

I also updated the patches and added two additional ones. One has been filed as an [upstream build issue](https://github.com/apple/swift-corelibs-libdispatch/pull/474), so it can be removed once this trickles down. The other causes the Swift build system not to create its own versions of libicu and libc++.

Some older build tweaks could be removed, because they no longer appear to have an effect.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).