### PR TITLE
dropbox-cli: Fix and add Nautilus extension

### DIFF
--- a/pkgs/applications/networking/dropbox/cli.nix
+++ b/pkgs/applications/networking/dropbox/cli.nix
@@ -1,4 +1,15 @@
-{ stdenv, pkgconfig, fetchurl, python3, dropbox }:
+{ stdenv
+, substituteAll
+, pkgconfig
+, fetchurl
+, python3
+, dropbox
+, gtk3
+, gnome3
+, gdk_pixbuf
+, gobject-introspection
+}:
+
 let
   version = "2019.02.14";
   dropboxd = "${dropbox}/bin/dropbox";
@@ -6,35 +17,52 @@ in
 stdenv.mkDerivation {
   name = "dropbox-cli-${version}";
 
+  outputs = [ "out" "nautilusExtension" ];
+
   src = fetchurl {
     url = "https://linux.dropboxstatic.com/packages/nautilus-dropbox-${version}.tar.bz2";
     sha256 = "09yg7q45sycl88l3wq0byz4a9k6sxx3m0r3szinvisfay9wlj35f";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ python3 ];
+  strictDeps = true;
 
-  phases = "unpackPhase installPhase";
+  patches = [
+    (substituteAll {
+      src = ./fix-cli-paths.patch;
+      inherit dropboxd;
+    })
+  ];
 
-  installPhase = ''
-    mkdir -p "$out/bin/" "$out/share/applications"
-    cp data/dropbox.desktop "$out/share/applications"
-    cp -a data/icons "$out/share/icons"
-    find "$out/share/icons" -type f \! -name '*.png' -delete
-    substitute "dropbox.in" "$out/bin/dropbox" \
-      --replace '@PACKAGE_VERSION@' ${version} \
-      --replace '@DESKTOP_FILE_DIR@' "$out/share/applications" \
-      --replace '@IMAGEDATA16@' '"too-lazy-to-fix"' \
-      --replace '@IMAGEDATA64@' '"too-lazy-to-fix"'
-    sed -i 's:db_path = .*:db_path = "${dropboxd}":' $out/bin/dropbox
-    chmod +x "$out/bin/"*
-    patchShebangs "$out/bin"
-  '';
+  nativeBuildInputs = [
+    pkgconfig
+    gobject-introspection
+    gdk_pixbuf
+    # only for build, the install command also wants to use GTK through introspection
+    # but we are using Nix for installation so we will not need that.
+    (python3.withPackages (ps: with ps; [
+      docutils
+      pygobject3
+    ]))
+  ];
+
+  buildInputs = [
+    python3
+    gtk3
+    gnome3.nautilus
+  ];
+
+  configureFlags = [
+    "--with-nautilus-extension-dir=${placeholder ''nautilusExtension''}/lib/nautilus/extensions-3.0"
+  ];
+
+  makeFlags = [
+    "EMBLEM_DIR=${placeholder ''nautilusExtension''}/share/nautilus-dropbox/emblems"
+  ];
 
   meta = {
-    homepage = http://dropbox.com;
+    homepage = https://www.dropbox.com;
     description = "Command line client for the dropbox daemon";
-    license = stdenv.lib.licenses.gpl3;
+    license = stdenv.lib.licenses.gpl3Plus;
     maintainers = with stdenv.lib.maintainers; [ the-kenny ];
     # NOTE: Dropbox itself only works on linux, so this is ok.
     platforms = stdenv.lib.platforms.linux;

--- a/pkgs/applications/networking/dropbox/fix-cli-paths.patch
+++ b/pkgs/applications/networking/dropbox/fix-cli-paths.patch
@@ -1,0 +1,11 @@
+--- a/dropbox.in
++++ b/dropbox.in
+@@ -71,7 +71,7 @@
+ 
+ PARENT_DIR = os.path.expanduser("~")
+ DROPBOX_DIST_PATH = "%s/.dropbox-dist" % PARENT_DIR
+-DROPBOXD_PATH = os.path.join(DROPBOX_DIST_PATH, "dropboxd")
++DROPBOXD_PATH = "@dropboxd@"
+ DESKTOP_FILE = "@DESKTOP_FILE_DIR@/dropbox.desktop"
+ 
+ enc = locale.getpreferredencoding()


### PR DESCRIPTION
…since this is actually dropbox-nautilus project.

In one of the previous updates, the source code responsible for finding dropboxd
was changed, rendering our sed replacement not working. That triggered the installer
which in turn failed on the unavailability of gobject-introspection typelibs. And
when that was fixed, we got bitten by our lazy packaging putting a broken code
into the installer.

This is a proper fix for all the issues, except for making typelibs available to
the installer since we shall use Nix instead.

Fixes: https://github.com/NixOS/nixpkgs/issues/60714

cc @mnacamura


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
