### PR TITLE
Trezor LUKS initrd

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3803,6 +3803,11 @@
     github = "peti";
     name = "Peter Simons";
   };
+  petrkr = {
+    email = "petrkr@petrkr.net";
+    github = "petrkr";
+    name = "Petr Kracik";
+  };
   philandstuff = {
     email = "philip.g.potter@gmail.com";
     github = "philandstuff";

--- a/pkgs/tools/misc/trezorencrypt/default.nix
+++ b/pkgs/tools/misc/trezorencrypt/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  name = "trezorencrypt-${version}";
+  version = "0.1.2";
+
+  # Fixes Cgo related build failures (see https://github.com/NixOS/nixpkgs/issues/25959 )
+  hardeningDisable = [ "fortify" ];
+
+  goPackagePath = "github.com/petrkr/trezorencrypt";
+
+  src = fetchFromGitHub {
+    owner  = "petrkr";
+    repo   = "trezorencrypt";
+    rev    = "v${version}";
+    sha256 = "0hp0p933af7z67biya9sb7136pm808pmp7ycnzlpyc0l7bi10jnq";
+  };
+
+  # Compile helper Askpass from debian cryptsetup package
+  postInstall = ''
+  gcc -pedantic -std=c99 $src/tools/askpass.c -o $bin/bin/trezor-askpass
+  '';
+
+  goDeps = ./deps.nix;
+
+  meta = with stdenv.lib; {
+    description = "Pipeline utlility to encrypt/decrypt values using TREZOR device";
+    homepage = https://www.github.com/petrkr/trezorencrypt;
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ petrkr ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/misc/trezorencrypt/deps.nix
+++ b/pkgs/tools/misc/trezorencrypt/deps.nix
@@ -1,0 +1,11 @@
+[
+  {
+    goPackagePath = "github.com/golang/protobuf";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/protobuf";
+      rev = "d3c38a4eb4970272b87a425ae00ccc4548e2f9bb";
+      sha256 = "0sz6x3qaw1gcq9zf90f8arizg5hpczpangz9aq5syxj8iziyi114";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6198,6 +6198,8 @@ in
 
   tpm2-tools = callPackage ../tools/security/tpm2-tools { };
 
+  trezorencrypt = callPackage ../tools/misc/trezorencrypt { };
+
   trezord = callPackage ../servers/trezord { };
 
   tthsum = callPackage ../applications/misc/tthsum { };


### PR DESCRIPTION
###### Motivation for this change
Use TREZOR as root disk encryption option, for this is need trezorencrypt from other PR #58968 

###### Things done
Initial support, tested Trezor One, Trezor T, crash (fallback to passphrase), missing trezor (fallback) or canceled (again fallback).

Not tested: situation with Yubikey combination as I do not own any yubikey

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
