### PR TITLE
mdds: 1.3.1 -> 1.4.3

### DIFF
--- a/pkgs/development/libraries/mdds/default.nix
+++ b/pkgs/development/libraries/mdds/default.nix
@@ -1,17 +1,17 @@
 { stdenv, fetchurl, boost }:
 
 stdenv.mkDerivation rec {
-  version = "1.3.1";
-  name = "mdds-${version}";
+  pname = "mdds";
+  version = "1.4.3";
 
   src = fetchurl {
-    url = "https://kohei.us/files/mdds/src/mdds-${version}.tar.bz2";
-    sha256 = "18g511z1lgfxrga2ld9yr95phmyfbd3ymbv4q5g5lyjn4ljcvf6w";
+    url = "https://kohei.us/files/${pname}/src/${pname}-${version}.tar.bz2";
+    sha256 = "10cw6irdm6d15nxnys2v5akp8yz52qijpcjvw0frwq7nz5d3vki5";
   };
 
   postInstall = ''
-   mkdir -p "$out/lib/pkgconfig"
-   cp "$out/share/pkgconfig/"* "$out/lib/pkgconfig"
+    mkdir -p "$out/lib/pkgconfig"
+    cp "$out/share/pkgconfig/"* "$out/lib/pkgconfig"
   '';
 
   checkInputs = [ boost ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Changelog: https://gitlab.com/mdds/mdds/blob/1.4.3/CHANGELOG
This update does not break LibreOffice builds anymore

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
