### PR TITLE
fasttext: init at 0.2.0

### DIFF
--- a/pkgs/applications/science/machine-learning/fasttext/default.nix
+++ b/pkgs/applications/science/machine-learning/fasttext/default.nix
@@ -1,0 +1,23 @@
+{stdenv, fetchFromGitHub, cmake}:
+
+stdenv.mkDerivation rec {
+  pname = "fasttext";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "facebookresearch";
+    repo = "fastText";
+    rev = version;
+    sha256 = "1fcrz648r2s80bf7vc0l371xillz5jk3ldaiv9jb7wnsyri831b4";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with stdenv.lib; {
+    description = "Library for text classification and representation learning";
+    homepage = https://fasttext.cc/;
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.danieldk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17446,6 +17446,8 @@ in
 
   exrtools = callPackage ../applications/graphics/exrtools { };
 
+  fasttext = callPackage ../applications/science/machine-learning/fasttext { };
+
   fbpanel = callPackage ../applications/window-managers/fbpanel { };
 
   fbreader = callPackage ../applications/misc/fbreader {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This change adds a derivation for fasttext. Fasttext is a tool + library for training word embeddings with subword units and text classification models. Fasttext is a popular tool in the computational linguistics and natural language processing communities.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
