### PR TITLE
cataclysm-dda{,-git}: bump version

### DIFF
--- a/pkgs/games/cataclysm-dda/common.nix
+++ b/pkgs/games/cataclysm-dda/common.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pkgconfig, gettext, lua, ncurses, CoreFoundation
+{ stdenv, fetchFromGitHub, pkgconfig, gettext, ncurses, CoreFoundation
 , tiles, SDL2, SDL2_image, SDL2_mixer, SDL2_ttf, freetype, Cocoa
 , debug, runtimeShell
 }:
@@ -6,7 +6,7 @@
 let
   inherit (stdenv.lib) optionals optionalString;
 
-  cursesDeps = [ gettext lua ncurses ]
+  cursesDeps = [ gettext ncurses ]
     ++ optionals stdenv.isDarwin [ CoreFoundation ];
 
   tilesDeps = [ SDL2 SDL2_image SDL2_mixer SDL2_ttf freetype ]
@@ -22,7 +22,7 @@ let
     '';
 
     makeFlags = [
-      "PREFIX=$(out)" "LUA=1" "USE_HOME_DIR=1" "LANGUAGES=all"
+      "PREFIX=$(out)" "USE_HOME_DIR=1" "LANGUAGES=all"
     ] ++ optionals (!debug) [
       "RELEASE=1"
     ] ++ optionals tiles [

--- a/pkgs/games/cataclysm-dda/default.nix
+++ b/pkgs/games/cataclysm-dda/default.nix
@@ -4,9 +4,8 @@
 }:
 
 let
-  inherit (stdenv.lib) optionals optionalString;
-  inherit (callPackage ./common.nix { inherit tiles Cocoa debug; }) common utils;
-  inherit (utils) fetchFromCleverRaven installXDGAppLauncher installMacOSAppLauncher;
+  inherit (callPackage ./common.nix { inherit tiles CoreFoundation Cocoa debug; }) common utils;
+  inherit (utils) fetchFromCleverRaven;
 in
 
 stdenv.mkDerivation (common // rec {
@@ -18,23 +17,11 @@ stdenv.mkDerivation (common // rec {
     sha256 = "00zzhx1mh1qjq668cga5nbrxp2qk6b82j5ak65skhgnlr6ii4ysc";
   };
 
-  buildInputs = common.buildInputs
-    ++ optionals stdenv.isDarwin [ CoreFoundation ];
-
   patches = [ ./patches/fix_locale_dir.patch ];
 
   postPatch = common.postPatch + ''
     substituteInPlace lua/autoexec.lua --replace "/usr/share" "$out/share"
   '';
-
-  postInstall = optionalString tiles
-  ( if !stdenv.isDarwin
-    then installXDGAppLauncher
-    else installMacOSAppLauncher
-  );
-
-  # Disable, possible problems with hydra
-  #enableParallelBuilding = true;
 
   meta = with stdenv.lib.maintainers; common.meta // {
     maintainers = common.meta.maintainers ++ [ skeidel ];

--- a/pkgs/games/cataclysm-dda/default.nix
+++ b/pkgs/games/cataclysm-dda/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, callPackage, CoreFoundation
+{ stdenv, callPackage, lua, CoreFoundation
 , tiles ? true, Cocoa
 , debug ? false
 }:
@@ -17,11 +17,17 @@ stdenv.mkDerivation (common // rec {
     sha256 = "00zzhx1mh1qjq668cga5nbrxp2qk6b82j5ak65skhgnlr6ii4ysc";
   };
 
+  buildInputs = common.buildInputs ++ [ lua ];
+
   patches = [ ./patches/fix_locale_dir.patch ];
 
   postPatch = common.postPatch + ''
     substituteInPlace lua/autoexec.lua --replace "/usr/share" "$out/share"
   '';
+
+  makeFlags = common.makeFlags ++ [
+    "LUA=1"
+  ];
 
   meta = with stdenv.lib.maintainers; common.meta // {
     maintainers = common.meta.maintainers ++ [ skeidel ];

--- a/pkgs/games/cataclysm-dda/default.nix
+++ b/pkgs/games/cataclysm-dda/default.nix
@@ -1,47 +1,37 @@
-{ stdenv, callPackage, ncurses
-, tiles ? true, Cocoa, libicns
+{ stdenv, callPackage, CoreFoundation
+, tiles ? true, Cocoa
 , debug ? false
 }:
 
 let
   inherit (stdenv.lib) optionals optionalString;
   inherit (callPackage ./common.nix { inherit tiles Cocoa debug; }) common utils;
-  inherit (utils) fetchFromCleverRaven installMacOSAppLauncher;
+  inherit (utils) fetchFromCleverRaven installXDGAppLauncher installMacOSAppLauncher;
 in
 
 stdenv.mkDerivation (common // rec {
-  version = "0.C";
+  version = "0.D";
   name = "cataclysm-dda-${version}";
 
   src = fetchFromCleverRaven {
     rev = "${version}";
-    sha256 = "03sdzsk4qdq99qckq0axbsvg1apn6xizscd8pwp5w6kq2fyj5xkv";
+    sha256 = "00zzhx1mh1qjq668cga5nbrxp2qk6b82j5ak65skhgnlr6ii4ysc";
   };
 
-  nativeBuildInputs = common.nativeBuildInputs
-    ++ optionals (tiles && stdenv.isDarwin) [ libicns ];
+  buildInputs = common.buildInputs
+    ++ optionals stdenv.isDarwin [ CoreFoundation ];
 
   patches = [ ./patches/fix_locale_dir.patch ];
 
-  makeFlags = common.makeFlags
-    ++ optionals stdenv.isDarwin [
-    "OSX_MIN=10.6"  # SDL for macOS only supports deploying on 10.6 and above
-  ] ++ optionals stdenv.cc.isGNU [
-    "WARNINGS+=-Wno-deprecated-declarations"
-    "WARNINGS+=-Wno-ignored-attributes"
-  ] ++ optionals stdenv.cc.isClang [
-    "WARNINGS+=-Wno-inconsistent-missing-override"
-  ];
-
-  NIX_CFLAGS_COMPILE = optionalString stdenv.cc.isClang "-Wno-user-defined-warnings";
-
-  postBuild = optionalString (tiles && stdenv.isDarwin) ''
-    # iconutil on macOS is not available in nixpkgs
-    png2icns data/osx/AppIcon.icns data/osx/AppIcon.iconset/*
+  postPatch = common.postPatch + ''
+    substituteInPlace lua/autoexec.lua --replace "/usr/share" "$out/share"
   '';
 
-  postInstall = optionalString (tiles && stdenv.isDarwin)
-    installMacOSAppLauncher;
+  postInstall = optionalString tiles
+  ( if !stdenv.isDarwin
+    then installXDGAppLauncher
+    else installMacOSAppLauncher
+  );
 
   # Disable, possible problems with hydra
   #enableParallelBuilding = true;

--- a/pkgs/games/cataclysm-dda/git.nix
+++ b/pkgs/games/cataclysm-dda/git.nix
@@ -1,5 +1,5 @@
-{ stdenv, callPackage
-, tiles ? true, Cocoa, CoreFoundation
+{ stdenv, callPackage, CoreFoundation
+, tiles ? true, Cocoa
 , debug ? false
 }:
 
@@ -10,12 +10,12 @@ let
 in
 
 stdenv.mkDerivation (common // rec {
-  version = "2018-07-15";
+  version = "2019-05-03";
   name = "cataclysm-dda-git-${version}";
 
   src = fetchFromCleverRaven {
-    rev = "e1e5d81";
-    sha256 = "198wfj8l1p8xlwicj92cq237pzv2ha9pcf240y7ijhjpmlc9jkr1";
+    rev = "65a05026e7306b5d1228dc6ed885c43447f128b5";
+    sha256 = "18yn0h6b4j9lx67sq1d886la3l6l7bqsnwj6mw2khidssiy18y0n";
   };
 
   buildInputs = common.buildInputs

--- a/pkgs/games/cataclysm-dda/git.nix
+++ b/pkgs/games/cataclysm-dda/git.nix
@@ -4,9 +4,9 @@
 }:
 
 let
-  inherit (stdenv.lib) optionals optionalString substring;
-  inherit (callPackage ./common.nix { inherit tiles Cocoa debug; }) common utils;
-  inherit (utils) fetchFromCleverRaven installXDGAppLauncher installMacOSAppLauncher;
+  inherit (stdenv.lib) substring;
+  inherit (callPackage ./common.nix { inherit tiles CoreFoundation Cocoa debug; }) common utils;
+  inherit (utils) fetchFromCleverRaven;
 in
 
 stdenv.mkDerivation (common // rec {
@@ -18,25 +18,11 @@ stdenv.mkDerivation (common // rec {
     sha256 = "18yn0h6b4j9lx67sq1d886la3l6l7bqsnwj6mw2khidssiy18y0n";
   };
 
-  buildInputs = common.buildInputs
-    ++ optionals stdenv.isDarwin [ CoreFoundation ];
-
   patches = [ ./patches/fix_locale_dir_git.patch ];
 
   makeFlags = common.makeFlags ++ [
     "VERSION=git-${version}-${substring 0 8 src.rev}"
   ];
-
-  postInstall = optionalString tiles
-  ( if !stdenv.isDarwin
-    then installXDGAppLauncher
-    else installMacOSAppLauncher
-  );
-
-  # https://hydra.nixos.org/build/65193254
-  # src/weather_data.cpp:203:1: fatal error: opening dependency file obj/tiles/weather_data.d: No such file or directory
-  # make: *** [Makefile:687: obj/tiles/weather_data.o] Error 1
-  enableParallelBuilding = false;
 
   meta = with stdenv.lib.maintainers; common.meta // {
     maintainers = common.meta.maintainers ++ [ rardiol ];

--- a/pkgs/games/cataclysm-dda/patches/fix_locale_dir.patch
+++ b/pkgs/games/cataclysm-dda/patches/fix_locale_dir.patch
@@ -1,20 +1,20 @@
 diff --git a/src/translations.cpp b/src/translations.cpp
-index 6520cfe..49f7b2c 100644
+index 2585b7ec56..7bb005823c 100644
 --- a/src/translations.cpp
 +++ b/src/translations.cpp
-@@ -72,15 +72,11 @@ void set_language(bool reload_options)
- 
-     // Step 2. Bind to gettext domain.
-     const char *locale_dir;
--#ifdef __linux__
-     if (!FILENAMES["base_path"].empty()) {
-         locale_dir = std::string(FILENAMES["base_path"] + "share/locale").c_str();
+@@ -195,14 +195,12 @@ void set_language()
+     auto env = getenv( "LANGUAGE" );
+     locale_dir = std::string( FILENAMES["base_path"] + "lang/mo/" + ( env ? env : "none" ) +
+                               "/LC_MESSAGES/cataclysm-dda.mo" );
+-#elif (defined __linux__ || (defined MACOSX && !defined TILES))
++#else
+     if( !FILENAMES["base_path"].empty() ) {
+         locale_dir = FILENAMES["base_path"] + "share/locale";
      } else {
          locale_dir = "lang/mo";
      }
 -#else
 -    locale_dir = "lang/mo";
--#endif // __linux__
+ #endif
  
-     bindtextdomain("cataclysm-dda", locale_dir);
-     bind_textdomain_codeset("cataclysm-dda", "UTF-8");
+     const char *locale_dir_char = locale_dir.c_str();

--- a/pkgs/games/cataclysm-dda/patches/fix_locale_dir_git.patch
+++ b/pkgs/games/cataclysm-dda/patches/fix_locale_dir_git.patch
@@ -1,12 +1,13 @@
 diff --git a/src/translations.cpp b/src/translations.cpp
-index 3a86291..e6c5f84 100644
+index 0068a35785..c8034cbeac 100644
 --- a/src/translations.cpp
 +++ b/src/translations.cpp
-@@ -176,15 +176,11 @@ void set_language()
- 
-     // Step 2. Bind to gettext domain.
-     std::string locale_dir;
--#if (defined __linux__ || (defined MACOSX && !defined TILES))
+@@ -202,14 +202,12 @@ void set_language()
+     auto env = getenv( "LANGUAGE" );
+     locale_dir = std::string( FILENAMES["base_path"] + "lang/mo/" + ( env ? env : "none" ) +
+                               "/LC_MESSAGES/cataclysm-dda.mo" );
+-#elif (defined(__linux__) || (defined(MACOSX) && !defined(TILES)))
++#else
      if( !FILENAMES["base_path"].empty() ) {
          locale_dir = FILENAMES["base_path"] + "share/locale";
      } else {
@@ -14,7 +15,6 @@ index 3a86291..e6c5f84 100644
      }
 -#else
 -    locale_dir = "lang/mo";
--#endif // __linux__
+ #endif
  
      const char *locale_dir_char = locale_dir.c_str();
-     bindtextdomain( "cataclysm-dda", locale_dir_char );

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21008,8 +21008,7 @@ in
   };
 
   cataclysm-dda = callPackage ../games/cataclysm-dda {
-    inherit (darwin.apple_sdk.frameworks) Cocoa;
-    ncurses = ncurses5;
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Cocoa;
   };
 
   cataclysm-dda-git = callPackage ../games/cataclysm-dda/git.nix {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Version 0.D was released a while ago.
The git version in nixpkgs seems too old.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
