### PR TITLE
light: support brightness control keys

### DIFF
--- a/nixos/modules/programs/light.nix
+++ b/nixos/modules/programs/light.nix
@@ -9,6 +9,7 @@ in
 {
   options = {
     programs.light = {
+
       enable = mkOption {
         default = false;
         type = types.bool;
@@ -17,11 +18,60 @@ in
           and udev rules granting access to members of the "video" group.
         '';
       };
+
+      brightnessKeys = {
+        enable = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            Whether to enable brightness control with keyboard keys.
+
+            This is mainly useful for minimalistic (desktop) environments. You
+            may want to leave this disabled if you run a feature-rich desktop
+            environment such as KDE, GNOME or Xfce as those handle the
+            brightness keys themselves. However, enabling brightness control
+            with this setting makes the control independent of X, so the keys
+            work in non-graphical ttys, so you might want to consider using this
+            instead of the default offered by the desktop environment.
+
+            Enabling this will turn on {option}`services.actkbd`.
+          '';
+        };
+
+        step = mkOption {
+          type = types.int;
+          default = 10;
+          description = ''
+            The percentage value by which to increase/decrease brightness.
+          '';
+        };
+
+      };
+
     };
   };
 
   config = mkIf cfg.enable {
     environment.systemPackages = [ pkgs.light ];
     services.udev.packages = [ pkgs.light ];
+    services.actkbd = mkIf cfg.brightnessKeys.enable {
+      enable = true;
+      bindings = let
+        light = "${pkgs.light}/bin/light";
+        step = toString cfg.brightnessKeys.step;
+      in [
+        {
+          keys = [ 224 ];
+          events = [ "key" ];
+          # Use minimum brightness 0.1 so the display won't go totally black.
+          command = "${light} -N 0.1 && ${light} -U ${step}";
+        }
+        {
+          keys = [ 225 ];
+          events = [ "key" ];
+          command = "${light} -A ${step}";
+        }
+      ];
+    };
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

###### Motivation for this change

`light` is a great program for managing display brightness. This pull request maps the brightness control keys in keyboards to commands for `light`. There are a few reasons:

- Minimalistic desktop environments (e.g., i3) don't have built-in configuration for the keys. This configuration works for those without any need for configuration on the desktop/window manager side.

- As far as I understand, KDE/GNOME/etc do handle the brightness keys, but then the brightness keys don't work in non-X ttys. This configuration makes the buttons work also in non-X ttys.

- At least KDE has a "bug" that the brightness can be put to zero which causes the display to go totally black. In my opinion, the screen brightness shouldn't be allowed to go that low, because there are separate buttons/actions to turn on/off the display. So, this configuration uses a minimum brightness of 0.1 to avoid this issue.

This configuration is similar to `sound.mediaKeys`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
