### PR TITLE
ejson: 1.2.0 -> 1.2.1

### DIFF
--- a/pkgs/development/tools/ejson/Gemfile.lock
+++ b/pkgs/development/tools/ejson/Gemfile.lock
@@ -3,23 +3,23 @@ GEM
   specs:
     arr-pm (0.0.10)
       cabin (> 0)
-    backports (3.8.0)
+    backports (3.14.0)
     cabin (0.9.0)
-    childprocess (0.7.1)
+    childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     clamp (1.0.1)
-    dotenv (2.2.1)
-    ffi (1.9.18)
-    fpm (1.9.2)
+    dotenv (2.7.2)
+    ffi (1.10.0)
+    fpm (1.11.0)
       arr-pm (~> 0.0.10)
       backports (>= 2.6.2)
       cabin (>= 0.6.0)
-      childprocess
+      childprocess (= 0.9.0)
       clamp (~> 1.0.0)
       ffi
       json (>= 1.7.7, < 2.0)
       pleaserun (~> 0.0.29)
-      ruby-xz
+      ruby-xz (~> 0.2.3)
       stud
     hpricot (0.8.6)
     insist (1.0.0)
@@ -51,4 +51,4 @@ DEPENDENCIES
   ronn
 
 BUNDLED WITH
-   1.16.0
+   1.17.2

--- a/pkgs/development/tools/ejson/default.nix
+++ b/pkgs/development/tools/ejson/default.nix
@@ -8,7 +8,7 @@ let
   };
 in buildGoPackage rec {
   name = "ejson-${version}";
-  version = "1.2.0";
+  version = "1.2.1";
   rev = "v${version}";
 
   nativeBuildInputs = [ gems ];
@@ -22,7 +22,7 @@ in buildGoPackage rec {
     owner = "Shopify";
     repo = "ejson";
     inherit rev;
-    sha256 = "07ig24fryb9n0mfyqb0sgpj7di9y7wbvh2ppwfs2jqfpvpncd7yh";
+    sha256 = "09356kp059hbzmqpzlz4b3agg93yqqygh5l5ddbxcsaqx4qiwdr7";
   };
 
   # set HOME, otherwise bundler will insert stuff in the manpages

--- a/pkgs/development/tools/ejson/gemset.nix
+++ b/pkgs/development/tools/ejson/gemset.nix
@@ -15,10 +15,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "17pcz0z6jms5jydr1r95kf1bpk3ms618hgr26c62h34icy9i1dpm";
+      sha256 = "17j5pf0b69bkn043wi4xd530ky53jbbnljr4bsjzlm4k8bzlknfn";
       type = "gem";
     };
-    version = "3.8.0";
+    version = "3.14.0";
   };
   cabin = {
     groups = ["default"];
@@ -36,10 +36,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "04cypmwyy4aj5p9b5dmpwiz5p1gzdpz6jaxb42fpckdbmkpvn6j1";
+      sha256 = "0a61922kmvcxyj5l70fycapr87gz1dzzlkfpq85rfqk5vdh3d28p";
       type = "gem";
     };
-    version = "0.7.1";
+    version = "0.9.0";
   };
   clamp = {
     groups = ["default"];
@@ -56,20 +56,20 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1pgzlvs0sswnqlgfm9gkz2hlhkc0zd3vnlp2vglb1wbgnx37pjjv";
+      sha256 = "13cis6bf06hmz744xrsl163p6gb78xcm8g8q4pcabsy5ywyv6kag";
       type = "gem";
     };
-    version = "2.2.1";
+    version = "2.7.2";
   };
   ffi = {
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "034f52xf7zcqgbvwbl20jwdyjwznvqnwpbaps9nk18v9lgb1dpx0";
+      sha256 = "0j8pzj8raxbir5w5k6s7a042sb5k02pg0f8s4na1r5lan901j00p";
       type = "gem";
     };
-    version = "1.9.18";
+    version = "1.10.0";
   };
   fpm = {
     dependencies = ["arr-pm" "backports" "cabin" "childprocess" "clamp" "ffi" "json" "pleaserun" "ruby-xz" "stud"];
@@ -77,10 +77,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "09vzjsiwa2dlhph6fc519x5l0bfn2qfhayfld48cdl2561x5c7fb";
+      sha256 = "0khzsiqzswxpql6w2ws9dawb27zgv4nmgrjszydmm0xpv6h21jrm";
       type = "gem";
     };
-    version = "1.9.2";
+    version = "1.11.0";
   };
   hpricot = {
     groups = ["default"];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fixes security issues.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
