### PR TITLE
pythonPackages.purepng: fix for py3.7, enable tests 

### DIFF
--- a/pkgs/development/python-modules/purepng/default.nix
+++ b/pkgs/development/python-modules/purepng/default.nix
@@ -42,6 +42,7 @@ buildPythonPackage rec {
     description = "Pure Python library for PNG image encoding/decoding";
     homepage    = https://github.com/scondo/purepng;
     license     = licenses.mit;
+    maintainers = with maintainers; [ ris ];
   };
 
 }

--- a/pkgs/development/python-modules/purepng/default.nix
+++ b/pkgs/development/python-modules/purepng/default.nix
@@ -1,16 +1,42 @@
 { stdenv
 , buildPythonPackage
-, fetchPypi
+, python
+, fetchFromGitHub
+, fetchpatch
+, cython ? null
+, numpy ? null
 }:
 
 buildPythonPackage rec {
   pname = "purepng";
   version = "0.2.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "1kcl7a6d7d59360fbz2jwfk6ha6pmqgn396962p4s62j893d2r0d";
+  src = fetchFromGitHub {
+    owner = "Scondo";
+    repo = "purepng";
+    rev = "449aa00e97a8d7b8a200eb9048056d4da600a345";
+    sha256 = "105p7sxn2f21icfnqpah69mnd74r31szj330swbpz53k7gr6nlsv";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "fix-py37-stopiteration-in-generators.patch";
+      url = "https://github.com/Scondo/purepng/pull/28/commits/62d71dfc2be9ffdc4b3e5f642af0281a8ce8f946.patch";
+      sha256 = "1ag0pji3p012hmj8kadcd0vydv9702188c0isizsi964qcl4va6m";
+    })
+  ];
+  patchFlags = "-p1 -d code";
+
+  # cython is optional - if not supplied, the "pure python" implementation will be used
+  nativeBuildInputs = [ cython ];
+
+  # numpy is optional - if not supplied, tests simply have less coverage
+  checkInputs = [ numpy ];
+  # checkPhase begins by deleting source dir to force test execution against installed version
+  checkPhase = ''
+    rm -r code/png
+    ${python.interpreter} code/test_png.py
+  '';
 
   meta = with stdenv.lib; {
     description = "Pure Python library for PNG image encoding/decoding";


### PR DESCRIPTION
###### Motivation for this change
Didn't build on py3.7.

The pypi package we were using includes pre-cythonized versions of some components, however these were cythonized with a py3.7-unaware cython which is what caused the main breakage. Fetching the equivalent version from github allows us to offer either the pure-python version or one we cythonize ourselves dependent on whether the `cython` package is provided.

The added bonus of using a github checkout is that the tests are included, so I've enabled these.

These tests revealed that for full py3.7 compatibility an additional patch is needed from an upstream PR - added.

I've done a `nox-review` on this and there's one depending package (`worldengine`) that still doesn't build. Think I can probably fix that another time.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
