### PR TITLE
wireguard: allow routes to overlap with other routes

### DIFF
--- a/nixos/modules/services/networking/wireguard.nix
+++ b/nixos/modules/services/networking/wireguard.nix
@@ -276,11 +276,17 @@ let
 
           ip link set up dev ${name}
 
-          ${optionalString (values.allowedIPsAsRoutes != false) (concatStringsSep "\n" (concatMap (peer:
-              (map (allowedIP:
-                "ip route replace ${allowedIP} dev ${name} table ${values.table}"
-              ) peer.allowedIPs)
-            ) values.peers))}
+          ${optionalString (values.allowedIPsAsRoutes != false) ''
+            ip route show dev ${name} | while read ROUTE ; do
+              ip route del $ROUTE
+            done
+            ${concatStringsSep "\n" (concatMap (peer:
+                (map (allowedIP:
+                  "ip route add ${allowedIP} dev ${name} table ${values.table} metric 10000"
+                ) peer.allowedIPs)
+              ) values.peers)
+            }
+          ''}
 
           ${values.postSetup}
         '';


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
I like to use wireguard to maintain a constant connection to my office and my home network, but I'm frequently physically connected to those networks.  Without this patch, starting wireguard would fail for whichever network I was physically connected to, because `ip route replace` didn't play nicely with the (correct) overlapping local routes.

This patch fixes this by explicitly deleting the routes for the wireguard interface, then re-adding the new ones (in case they have changed).  I didn't make an attempt to avoid deleting and re-adding unchanged routes, because I figure people will expect restarting wireguard to entail a short downtime (and this is very short).

I also arbitrarily picked a metric of 10000 to ensure that traffic is directed to the local connection in preference to wireguard, when the local connection is available.  I'm sure there's a better way of choosing a metric, but this works 100% reliably for me, and I suspect it will also for most others.

This is the kind of PR that often languishes, so if I don't get any pushback within the next week or so, I'll assume it's good and go ahead and merge.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [N/A] macOS
   - [N/A] other Linux distributions
- [N/A] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [N/A] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [N/A] Tested execution of all binary files (usually in `./result/bin/`)
- [N/A] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [N/A] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
