### PR TITLE
krunner-pass: fix the build

### DIFF
--- a/pkgs/tools/security/krunner-pass/default.nix
+++ b/pkgs/tools/security/krunner-pass/default.nix
@@ -1,15 +1,10 @@
-{ mkDerivation, stdenv,
-  fetchFromGitHub,
-  cmake, extra-cmake-modules, gnumake,
+{ mkDerivation, lib, fetchFromGitHub, fetchpatch, cmake, extra-cmake-modules
+, kauth, krunner
+, pass, pass-otp ? null }:
 
-  pass, pass-otp ? null, krunner,
-}:
-let
+mkDerivation rec {
   pname = "krunner-pass";
   version = "1.3.0";
-in
-mkDerivation rec {
-  name = "${pname}-${version}";
 
   src = fetchFromGitHub {
     owner = "akermu";
@@ -19,22 +14,26 @@ mkDerivation rec {
   };
 
   buildInputs  = [
-    pass
-    pass-otp
-    krunner
+    kauth krunner
+    pass pass-otp
   ];
 
-  nativeBuildInputs = [cmake extra-cmake-modules gnumake];
+  nativeBuildInputs = [ cmake extra-cmake-modules ];
 
   patches = [
+    (fetchpatch {
+      url = https://github.com/peterhoeg/krunner-pass/commit/be2695f4ae74b0cccec8294defcc92758583d96b.patch;
+      sha256 = "098dqnal57994p51p2srfzg4lgcd6ybp29h037llr9cdv02hdxvl";
+      name = "fix_build.patch";
+    })
     ./pass-path.patch
   ];
 
   CXXFLAGS = [
-    ''-DNIXPKGS_PASS=\"${stdenv.lib.getBin pass}/bin/pass\"''
+    ''-DNIXPKGS_PASS=\"${lib.getBin pass}/bin/pass\"''
   ];
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Integrates krunner with pass the unix standard password manager (https://www.passwordstore.org/)";
     homepage = https://github.com/akermu/krunner-pass;
     license = licenses.gpl3;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fixes #59355

Cc: @seqizz @worldofpeace 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
