### PR TITLE
chromium: fix widevine

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/browser.nix
+++ b/pkgs/applications/networking/browsers/chromium/browser.nix
@@ -1,4 +1,4 @@
-{ stdenv, mkChromiumDerivation, channel }:
+{ stdenv, mkChromiumDerivation, channel, enableWideVine }:
 
 with stdenv.lib;
 
@@ -62,7 +62,7 @@ mkChromiumDerivation (base: rec {
     description = "An open source web browser from Google";
     homepage = http://www.chromium.org/;
     maintainers = with maintainers; [ bendlas ivan ];
-    license = licenses.bsd3;
+    license = if enableWideVine then licenses.unfree else licenses.bsd3;
     platforms = platforms.linux;
     hydraPlatforms = if channel == "stable" then ["aarch64-linux" "x86_64-linux"] else [];
     timeout = 172800; # 48 hours

--- a/pkgs/applications/networking/browsers/chromium/browser.nix
+++ b/pkgs/applications/networking/browsers/chromium/browser.nix
@@ -1,47 +1,8 @@
-{ stdenv, mkChromiumDerivation, channel, upstream-info, gcc, glib, nspr, nss, patchelfUnstable, enableWideVine }:
+{ stdenv, mkChromiumDerivation, channel }:
 
 with stdenv.lib;
 
-let
-  mkrpath = p: "${makeSearchPathOutput "lib" "lib64" p}:${makeLibraryPath p}";
-  widevine = stdenv.mkDerivation {
-    name = "chromium-binary-plugin-widevine";
-
-    src = upstream-info.binary;
-
-    nativeBuildInputs = [ patchelfUnstable ];
-
-    phases = [ "unpackPhase" "patchPhase" "installPhase" "checkPhase" ];
-
-    unpackCmd = let
-      chan = if upstream-info.channel == "dev"    then "chrome-unstable"
-        else if upstream-info.channel == "stable" then "chrome"
-        else "chrome-${upstream-info.channel}";
-    in ''
-      mkdir -p plugins
-      ar p "$src" data.tar.xz | tar xJ -C plugins --strip-components=4 \
-        ./opt/google/${chan}/libwidevinecdm.so
-    '';
-
-    doCheck = true;
-    checkPhase = ''
-      ! find -iname '*.so' -exec ldd {} + | grep 'not found'
-    '';
-
-    PATCH_RPATH = mkrpath [ gcc.cc glib nspr nss ];
-
-    patchPhase = ''
-      patchelf --set-rpath "$PATCH_RPATH" libwidevinecdm.so
-    '';
-
-    installPhase = ''
-      install -vD libwidevinecdm.so \
-        "$out/lib/libwidevinecdm.so"
-    '';
-
-    meta.platforms = platforms.x86_64;
-  };
-in mkChromiumDerivation (base: rec {
+mkChromiumDerivation (base: rec {
   name = "chromium-browser";
   packageName = "chromium";
   buildTargets = [ "mksnapshot" "chrome_sandbox" "chrome" ];
@@ -91,8 +52,6 @@ in mkChromiumDerivation (base: rec {
       -e '/\[Desktop Entry\]/a\' \
       -e 'StartupWMClass=chromium-browser' \
       $out/share/applications/chromium-browser.desktop
-
-    ${optionalString enableWideVine "ln -s ${widevine}/lib/libwidevinecdm.so \"$libExecPath/libwidevinecdm.so\""}
   '';
 
   passthru = { inherit sandboxExecutableName; };

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -24,7 +24,6 @@
 
 # package customization
 , enableNaCl ? false
-, enableWideVine ? false
 , useVaapi ? false
 , gnomeSupport ? false, gnome ? null
 , gnomeKeyringSupport ? false, libgnome-keyring3 ? null
@@ -133,11 +132,12 @@ let
       ++ optional pulseSupport libpulseaudio
       ++ optional (versionAtLeast version "72") jdk.jre;
 
-    patches = optional enableWideVine ./patches/widevine.patch ++ [
+    patches = [
       ./patches/nix_plugin_paths_68.patch
       ./patches/remove-webp-include-69.patch
       ./patches/jumbo-sorted.patch
       ./patches/no-build-timestamps.patch
+      ./patches/widevine.patch
 
       # Unfortunately, chromium regularly breaks on major updates and
       # then needs various patches backported in order to be compiled with GCC.
@@ -245,7 +245,7 @@ let
       use_gnome_keyring = gnomeKeyringSupport;
       use_gio = gnomeSupport;
       enable_nacl = enableNaCl;
-      enable_widevine = enableWideVine;
+      enable_widevine = true;
       use_cups = cupsSupport;
 
       treat_warnings_as_errors = false;

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -59,7 +59,8 @@ in let
     unpackCmd = let
       chan = if upstream-info.channel == "dev"    then "chrome-unstable"
         else if upstream-info.channel == "stable" then "chrome"
-        else "chrome-${upstream-info.channel}";
+        else if upstream-info.channel == "beta" then "chrome-beta"
+        else throw "Unknown chromium channel.";
     in ''
       mkdir -p plugins
       ar p "$src" data.tar.xz | tar xJ -C plugins --strip-components=4 \

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -39,7 +39,7 @@ in let
               useVaapi;
     };
 
-    browser = callPackage ./browser.nix { inherit channel; };
+    browser = callPackage ./browser.nix { inherit channel enableWideVine; };
 
     plugins = callPackage ./plugins.nix {
       inherit enablePepperFlash;

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -38,10 +38,10 @@ in let
               enableWideVine;
     };
 
-    browser = callPackage ./browser.nix { inherit channel; };
+    browser = callPackage ./browser.nix { inherit channel enableWideVine; };
 
     plugins = callPackage ./plugins.nix {
-      inherit enablePepperFlash enableWideVine;
+      inherit enablePepperFlash;
     };
   };
 
@@ -113,13 +113,7 @@ in stdenv.mkDerivation {
   '';
 
   inherit (chromium.browser) packageName;
-  meta = chromium.browser.meta // {
-    broken = if enableWideVine then
-          builtins.trace "WARNING: WideVine is not functional, please only use for testing"
-             true
-        else false;
-  };
-
+  meta = chromium.browser.meta;
   passthru = {
     inherit (chromium) upstream-info browser;
     mkDerivation = chromium.mkChromiumDerivation;

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -92,6 +92,10 @@ in let
 
   version = chromium.browser.version;
 
+  # This is here because we want to add the widevine shared object at the last
+  # minute in order to avoid a full rebuild of chromium. Additionally, this
+  # isn't in `browser.nix` so we can avoid having to re-expose attributes of
+  # the chromium derivation (see above: we introspect `sandboxExecutableName`).
   chromiumWV = let browser = chromium.browser; in if enableWideVine then
     runCommand (browser.name + "-wv") { version = browser.version; }
       ''

--- a/pkgs/applications/networking/browsers/chromium/patches/widevine.patch
+++ b/pkgs/applications/networking/browsers/chromium/patches/widevine.patch
@@ -1,16 +1,24 @@
-Minimal WideVine patch from Gentoo:
+Description: enable widevine and set its version string to "undefined"
+Author: Michael Gilbert <mgilbert@debian.org>
+Author: Olivier Tilloy <olivier.tilloy@canonical.com>
 
-https://gitweb.gentoo.org/repo/gentoo.git/tree/www-client/chromium/files/chromium-widevine-r1.patch
-
-BTS: https://bugs.gentoo.org/show_bug.cgi?id=547630
-
---- a/third_party/widevine/cdm/stub/widevine_cdm_version.h
-+++ b/third_party/widevine/cdm/stub/widevine_cdm_version.h
-@@ -10,6 +10,7 @@
- 
- #include "third_party/widevine/cdm/widevine_cdm_common.h"
- 
-+#define WIDEVINE_CDM_VERSION_STRING "unknown"
- #define WIDEVINE_CDM_AVAILABLE
+--- a/third_party/widevine/cdm/widevine_cdm_version.h
++++ b/third_party/widevine/cdm/widevine_cdm_version.h
+@@ -11,5 +11,6 @@
+ // If the Widevine CDM is available define the following:
+ //  - WIDEVINE_CDM_VERSION_STRING (with the version of the CDM that's available
+ //    as a string, e.g., "1.0.123.456").
++#define WIDEVINE_CDM_VERSION_STRING "undefined"
  
  #endif  // WIDEVINE_CDM_VERSION_H_
+--- a/chrome/common/chrome_content_client.cc
++++ b/chrome/common/chrome_content_client.cc
+@@ -99,7 +99,7 @@
+ // Registers Widevine CDM if Widevine is enabled, the Widevine CDM is
+ // bundled and not a component. When the Widevine CDM is a component, it is
+ // registered in widevine_cdm_component_installer.cc.
+-#if BUILDFLAG(BUNDLE_WIDEVINE_CDM) && !BUILDFLAG(ENABLE_WIDEVINE_CDM_COMPONENT)
++#if !BUILDFLAG(ENABLE_WIDEVINE_CDM_COMPONENT)
+ #define REGISTER_BUNDLED_WIDEVINE_CDM
+ #include "third_party/widevine/cdm/widevine_cdm_common.h"  // nogncheck
+ // TODO(crbug.com/663554): Needed for WIDEVINE_CDM_VERSION_STRING. Support


### PR DESCRIPTION
###### Motivation for this change
This change allows widevine to work in chromium (it was previously broken due to a segfault). Newer versions of chromium do not use the libwidevinecdmadapter.so. Instead, libwidevinecdm.so should be installed in the chromium libExec directory.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
