### PR TITLE
cockroachdb: 2.1.6 -> 19.1.0

### DIFF
--- a/pkgs/servers/sql/cockroachdb/default.nix
+++ b/pkgs/servers/sql/cockroachdb/default.nix
@@ -13,13 +13,13 @@ let
 in
 buildGoPackage rec {
   name = "cockroach-${version}";
-  version = "2.1.6";
+  version = "19.1.0";
 
   goPackagePath = "github.com/cockroachdb/cockroach";
 
   src = fetchurl {
     url = "https://binaries.cockroachdb.com/cockroach-v${version}.src.tgz";
-    sha256 = "1sry2qvcar7yn80y2azh0lmz4yp12r27hq3w8nyqz2gw36k9k8q4";
+    sha256 = "1kb93jxgxc54c23v72ka116b2j7m82c1jghm7njd64qkbbcgrkkw";
   };
 
   inherit nativeBuildInputs buildInputs;


### PR DESCRIPTION
Signed-off-by: Austin Seipp <aseipp@pobox.com>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
