### PR TITLE
lz4: pick upstream fix for Darwin, move to pname

### DIFF
--- a/pkgs/tools/compression/lz4/default.nix
+++ b/pkgs/tools/compression/lz4/default.nix
@@ -1,17 +1,25 @@
-{ stdenv, fetchFromGitHub, valgrind
+{ stdenv, fetchFromGitHub, valgrind, fetchpatch
 , enableStatic ? false, enableShared ? true
 }:
 
 stdenv.mkDerivation rec {
-  name = "lz4-${version}";
+  pname = "lz4";
   version = "1.9.1";
 
   src = fetchFromGitHub {
     sha256 = "1l1caxrik1hqs40vj3bpv1pikw6b74cfazv5c0v6g48zpcbmshl0";
     rev = "v${version}";
-    repo = "lz4";
-    owner = "lz4";
+    repo = pname;
+    owner = pname;
   };
+
+  patches = [
+    # Fix detection of Darwin
+    (fetchpatch {
+      url = "https://github.com/lz4/lz4/commit/024216ef7394b6411eeaa5b52d0cec9953a44249.patch";
+      sha256 = "0j0j2pr6pkplxf083hlwl5q4cfp86q3wd8mc64bcfcr7ysc5pzl3";
+    })
+  ];
 
   outputs = [ "out" "dev" ];
 


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/59812#issuecomment-488850589

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---