### PR TITLE
lolcat: use bundlerApp, fix audit warning

### DIFF
--- a/pkgs/tools/misc/lolcat/Gemfile
+++ b/pkgs/tools/misc/lolcat/Gemfile
@@ -1,2 +1,2 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 gem "lolcat"

--- a/pkgs/tools/misc/lolcat/Gemfile.lock
+++ b/pkgs/tools/misc/lolcat/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     lolcat (99.9.69)
       manpages (~> 0.6.1)
@@ -16,4 +16,4 @@ DEPENDENCIES
   lolcat
 
 BUNDLED WITH
-   1.16.3
+   1.17.2

--- a/pkgs/tools/misc/lolcat/default.nix
+++ b/pkgs/tools/misc/lolcat/default.nix
@@ -1,19 +1,14 @@
-{ lib, bundlerEnv, ruby }:
+{ lib, bundlerApp }:
 
-bundlerEnv rec {
-  name = "${pname}-${version}";
+bundlerApp {
   pname = "lolcat";
-  version = (import ./gemset.nix).lolcat.version;
-
-  inherit ruby;
-
-  # expects Gemfile, Gemfile.lock and gemset.nix in the same directory
   gemdir = ./.;
+  exes = [ "lolcat" ];
 
   meta = with lib; {
     description = "A rainbow version of cat";
     homepage    = https://github.com/busyloop/lolcat;
     license     = licenses.bsd3;
-    maintainers = with maintainers; [ StillerHarpo ];
+    maintainers = with maintainers; [ StillerHarpo manveru ];
   };
 }

--- a/pkgs/tools/misc/lolcat/gemset.nix
+++ b/pkgs/tools/misc/lolcat/gemset.nix
@@ -1,32 +1,40 @@
 {
   lolcat = {
     dependencies = ["manpages" "optimist" "paint"];
+    groups = ["default"];
+    platforms = [];
     source = {
-      remotes = ["http://rubygems.org"];
+      remotes = ["https://rubygems.org"];
       sha256 = "0d1yh2ikyhyh7am4qznd6fzv2pyvk82xrnsrsbbyxzcqfz9x6aa9";
       type = "gem";
     };
     version = "99.9.69";
   };
   manpages = {
+    groups = ["default"];
+    platforms = [];
     source = {
-      remotes = ["http://rubygems.org"];
+      remotes = ["https://rubygems.org"];
       sha256 = "11p6ilnfda6af15ks3xiz2pr0hkvdvadnk1xm4ahqlf84dld3fnd";
       type = "gem";
     };
     version = "0.6.1";
   };
   optimist = {
+    groups = ["default"];
+    platforms = [];
     source = {
-      remotes = ["http://rubygems.org"];
+      remotes = ["https://rubygems.org"];
       sha256 = "05jxrp3nbn5iilc1k7ir90mfnwc5abc9h78s5rpm3qafwqxvcj4j";
       type = "gem";
     };
     version = "3.0.0";
   };
   paint = {
+    groups = ["default"];
+    platforms = [];
     source = {
-      remotes = ["http://rubygems.org"];
+      remotes = ["https://rubygems.org"];
       sha256 = "0ldb269l3pzkihmsws19cr9h3l6naw8c2fqpav8ck3nllnyiv7r2";
       type = "gem";
     };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fixes the warning of `bundler-audit` and uses the cleaner `bundlerApp`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
