### PR TITLE
bcat: use https rubygems

### DIFF
--- a/pkgs/tools/text/bcat/Gemfile
+++ b/pkgs/tools/text/bcat/Gemfile
@@ -1,2 +1,2 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 gem 'bcat'

--- a/pkgs/tools/text/bcat/Gemfile.lock
+++ b/pkgs/tools/text/bcat/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     bcat (0.6.2)
       rack (~> 1.0)
@@ -12,4 +12,4 @@ DEPENDENCIES
   bcat
 
 BUNDLED WITH
-   1.16.4
+   1.17.2

--- a/pkgs/tools/text/bcat/gemset.nix
+++ b/pkgs/tools/text/bcat/gemset.nix
@@ -1,16 +1,20 @@
 {
   bcat = {
     dependencies = ["rack"];
+    groups = ["default"];
+    platforms = [];
     source = {
-      remotes = ["http://rubygems.org"];
+      remotes = ["https://rubygems.org"];
       sha256 = "0w2wwlngcs7f4lmvifixrb89bjkw2lx8z0nn72w360hz394ic651";
       type = "gem";
     };
     version = "0.6.2";
   };
   rack = {
+    groups = ["default"];
+    platforms = [];
     source = {
-      remotes = ["http://rubygems.org"];
+      remotes = ["https://rubygems.org"];
       sha256 = "1g9926ln2lw12lfxm4ylq1h6nl0rafl10za3xvjzc87qvnqic87f";
       type = "gem";
     };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fixes warning of `bundler-audit`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
