### PR TITLE
tmuxinator: 0.13.0 -> 1.1.0

### DIFF
--- a/pkgs/tools/misc/tmuxinator/default.nix
+++ b/pkgs/tools/misc/tmuxinator/default.nix
@@ -8,8 +8,8 @@ buildRubyGem rec {
   inherit ruby;
   name = "${gemName}-${version}";
   gemName = "tmuxinator";
-  version = "0.13.0";
-  source.sha256 = "0jyyih8w8b30czfv0dc642vj8yp8iqyci89hjb2279xmmigjzmwc";
+  version = "1.1.0";
+  source.sha256 = "9f4a4fd0242c82844f9af109d2c03b6870060d7e30603e6d9bd017aee5380ec0";
 
   erubis = buildRubyGem rec {
     inherit ruby;


### PR DESCRIPTION
###### Motivation for this change

Tmuxinator was out of date, and 1.1.0 brings compatibility with Tmux 2.9 which is now out on nixpkgs unstable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
