### PR TITLE
perlPackages: fix build packages for non-default perl

### DIFF
--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -23,7 +23,7 @@ let
   libcLib = lib.getLib libc;
   crossCompiling = stdenv.buildPlatform != stdenv.hostPlatform;
 
-  common = { self, version, sha256 }: stdenv.mkDerivation (rec {
+  common = { self, buildPerl, version, sha256 }: stdenv.mkDerivation (rec {
     inherit version;
 
     name = "perl-${version}";
@@ -110,6 +110,7 @@ let
       libPrefix = "lib/perl5/site_perl";
       pkgs = callPackage ../../../top-level/perl-packages.nix {
         perl = self;
+        inherit buildPerl;
         overrides = config.perlPackageOverrides or (p: {}); # TODO: (self: super: {}) like in python
       };
       buildEnv = callPackage ./wrapper.nix {
@@ -194,6 +195,7 @@ in rec {
   # the latest Maint version
   perl528 = common {
     self = perl528;
+    buildPerl = buildPackages.perl528;
     version = "5.28.2";
     sha256 = "1iynpsxdym4h76kgndmn3ykvwxhqz444xvaz8z2irsxkvmnlb5da";
   };
@@ -201,6 +203,7 @@ in rec {
   # the latest Devel version
   perldevel = common {
     self = perldevel;
+    buildPerl = buildPackages.perldevel;
     version = "5.29.9";
     sha256 = "017x3nghyc5m8q1yqnrdma96b3d5rlfx87vv5mi64jq0r8k6zppm";
   };

--- a/pkgs/development/perl-modules/generic/builder.sh
+++ b/pkgs/development/perl-modules/generic/builder.sh
@@ -22,7 +22,7 @@ preConfigure() {
         fi
     done
 
-    perl Makefile.PL PREFIX=$out INSTALLDIRS=site $makeMakerFlags PERL=$(type -P perl) FULLPERL=\"$perl/bin/perl\"
+    perl Makefile.PL PREFIX=$out INSTALLDIRS=site $makeMakerFlags PERL=$(type -P perl) FULLPERL=\"$fullperl/bin/perl\"
 }
 
 

--- a/pkgs/development/perl-modules/generic/default.nix
+++ b/pkgs/development/perl-modules/generic/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, perl, buildPackages, toPerlModule }:
+{ lib, stdenv, perl, buildPerl, toPerlModule }:
 
 { nativeBuildInputs ? [], name, ... } @ attrs:
 
@@ -37,6 +37,6 @@ toPerlModule(stdenv.mkDerivation (
     name = "perl${perl.version}-${name}";
     builder = ./builder.sh;
     nativeBuildInputs = nativeBuildInputs ++ [ (perl.dev or perl) ];
-    perl = buildPackages.perl;
+    fullperl = buildPerl;
   }
 ))

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -6,7 +6,7 @@
    be almost as much code as the function itself. */
 
 {config, pkgs, fetchurl, fetchFromGitHub, stdenv, gnused, perl, overrides,
-  buildPackages}:
+  buildPerl}:
 
 # cpan2nix assumes that perl-packages.nix will be used only with perl 5.28.2 or above
 assert stdenv.lib.versionAtLeast perl.version "5.28.2";
@@ -37,7 +37,7 @@ let
     });
 
   buildPerlPackage = callPackage ../development/perl-modules/generic {
-    inherit toPerlModule;
+    inherit buildPerl;
   };
 
   # Helper functions for packages that use Module::Build to build.
@@ -14820,8 +14820,8 @@ let
 
     # use native libraries from the host when running build commands
     postConfigure = if cross then let
-      host_perl = buildPackages.perl;
-      host_self = buildPackages.perlPackages.TermReadKey;
+      host_perl = buildPerl;
+      host_self = buildPerl.pkgs.TermReadKey;
       perl_lib = "${host_perl}/lib/perl5/${host_perl.version}";
       self_lib = "${host_self}/lib/perl5/site_perl/${host_perl.version}";
     in ''
@@ -14830,7 +14830,7 @@ let
 
     # TermReadKey uses itself in the build process
     nativeBuildInputs = if cross then [
-      buildPackages.perlPackages.TermReadKey
+      buildPerl.pkgs.TermReadKey
     ] else [];
   };
 


### PR DESCRIPTION
@aanderse has found a bug https://github.com/NixOS/nixpkgs/pull/60702#issuecomment-488880736  with compiling some packages using non-default ```perl``` (currently there is only ```5.29.9``` as ```perldevel```).

It seems like a regression after https://github.com/NixOS/nixpkgs/pull/56019 where ```perl``` has been replaced with ```buildPackages.perl``` to fix cross-compilation issues, but while ```perl``` is overrideable and points to ```perl``` in current context (which could be ```pkgs.perl```, ```pkgs.perldevel```, etc), ```buildPackages.perl``` always point to ```pkgs.buildPackages.perl``` which is always ```perl-5.28```.
Thus two versions of perl (5.28.2 and 5.29.9) are used to build some packages which lead to errors.

@illegalprime to test cross-compilation things