### PR TITLE
libredirect: do not redirect dlopen by default

### DIFF
--- a/pkgs/build-support/libredirect/libredirect.c
+++ b/pkgs/build-support/libredirect/libredirect.c
@@ -167,9 +167,11 @@ int execv(const char *path, char *const argv[])
     return execv_real(rewrite(path, buf), argv);
 }
 
+#ifdef REDIRECT_DLOPEN
 void *dlopen(const char *filename, int flag)
 {
     void * (*__dlopen_real) (const char *, int) = dlsym(RTLD_NEXT, "dlopen");
     char buf[PATH_MAX];
     return __dlopen_real(rewrite(filename, buf), flag);
 }
+#endif

--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -89,7 +89,7 @@ in stdenv.mkDerivation rec {
     patchShebangs libnm/generate-setting-docs.py
 
     substituteInPlace libnm/meson.build \
-      --subst-var-by DOCS_LD_PRELOAD "${libredirect}/lib/libredirect.so" \
+      --subst-var-by DOCS_LD_PRELOAD "${libredirect.override { redirectDlopen = true; }}/lib/libredirect.so" \
       --subst-var-by DOCS_NIX_REDIRECTS "${placeholder "out"}/lib/libnm.so.0=$PWD/build/libnm/libnm.so.0"
   '';
 


### PR DESCRIPTION
For reasons unknown, some programs cannot handle dlopen being overridden, even when no libraries are rewritten. See https://github.com/NixOS/nixpkgs/issues/60807

As a hack, let's disable dlopen redirection by default. We can investigate in the future.

Also adding a test for dlopen. It did not detect any issues.

cc @worldofpeace

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
