### PR TITLE
miraclecast: 20170427 -> 20190403

### DIFF
--- a/pkgs/os-specific/linux/miraclecast/default.nix
+++ b/pkgs/os-specific/linux/miraclecast/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   name = "miraclecast-${version}";
-  version = "1.0-20170427";
+  version = "1.0-20190403";
 
   src = fetchFromGitHub {
     owner  = "albfan";
     repo   = "miraclecast";
-    rev    = "a395c3c7afc39a958ae8ab805dea0f5d22118f0c";
-    sha256 = "03kbjajv2x0i2g68c5aij0icf9waxnqkc9pp32z60nc8zxy9jk1y";
+    rev    = "960a785e10523cc525885380dd03aa2c5ba11bc7";
+    sha256 = "05afqi33rv7k6pbkkw4mynj6p97vkzhhh13y5nh0yxkyhcgf45pm";
   };
 
   nativeBuildInputs = [ meson ninja pkgconfig ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The new version of miraclecast adds features and bug fixes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
