### PR TITLE
redis-dump: 0.3.5 -> 0.4.0

### DIFF
--- a/pkgs/development/tools/redis-dump/Gemfile.lock
+++ b/pkgs/development/tools/redis-dump/Gemfile.lock
@@ -2,14 +2,14 @@ GEM
   remote: https://rubygems.org/
   specs:
     drydock (0.6.9)
-    redis (3.3.0)
-    redis-dump (0.3.5)
+    redis (4.1.0)
+    redis-dump (0.4.0)
       drydock (>= 0.6.9)
-      redis (>= 2.0)
+      redis (>= 4.0)
       uri-redis (>= 0.4.0)
       yajl-ruby (>= 0.1)
     uri-redis (0.4.2)
-    yajl-ruby (1.2.1)
+    yajl-ruby (1.4.1)
 
 PLATFORMS
   ruby
@@ -18,4 +18,4 @@ DEPENDENCIES
   redis-dump
 
 BUNDLED WITH
-   1.11.2
+   1.17.2

--- a/pkgs/development/tools/redis-dump/default.nix
+++ b/pkgs/development/tools/redis-dump/default.nix
@@ -1,19 +1,15 @@
-{ lib, bundlerEnv, ruby, perl, autoconf }:
+{ lib, bundlerApp }:
 
-bundlerEnv {
-  name = "redis-dump-0.3.5";
-
-  inherit ruby;
+bundlerApp {
+  pname = "redis-dump";
   gemdir = ./.;
-
-  buildInputs = [ perl autoconf ];
+  exes = [ "redis-dump" ];
 
   meta = with lib; {
-    broken = true; # needs ruby 2.0
     description = "Backup and restore your Redis data to and from JSON";
     homepage    = http://delanotes.com/redis-dump/;
     license     = licenses.mit;
-    maintainers = with maintainers; [ offline ];
+    maintainers = with maintainers; [ offline manveru ];
     platforms   = platforms.unix;
   };
 }

--- a/pkgs/development/tools/redis-dump/gemset.nix
+++ b/pkgs/development/tools/redis-dump/gemset.nix
@@ -1,5 +1,7 @@
 {
   drydock = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "0grf3361mh93lczljmnwafl7gbcp9kk1bjpfwx4ykpd43fzdbfyj";
@@ -8,22 +10,29 @@
     version = "0.6.9";
   };
   redis = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1v68ggm0pwcyml3ngfyngwgvypwmsrmji1kyx48qqcg045zjs5p6";
+      sha256 = "0rk6mmy3y2jd34llrf591ribl1p54ghkw7m96wrbamy8fwva5zqv";
       type = "gem";
     };
-    version = "3.3.0";
+    version = "4.1.0";
   };
   redis-dump = {
+    dependencies = ["drydock" "redis" "uri-redis" "yajl-ruby"];
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0y6s3nvcw84jqqvp9pjg9qmqyc0b8jkrp0dknhjjr0lg2q3fq87h";
+      sha256 = "1gvip73kgm8xvyjmjkz4b986wni9blsmrnpvp5jrsxjz3g0sqzwg";
       type = "gem";
     };
-    version = "0.3.5";
+    version = "0.4.0";
   };
   uri-redis = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
       sha256 = "13n8ak41rikkbmml054pir4i1xbgjpmf3dbqihc2kcrgmz3dg81a";
@@ -32,10 +41,13 @@
     version = "0.4.2";
   };
   yajl-ruby = {
+    groups = ["default"];
+    platforms = [];
     source = {
-      sha256 = "0zvvb7i1bl98k3zkdrnx9vasq0rp2cyy5n7p9804dqs4fz9xh9vf";
+      remotes = ["https://rubygems.org"];
+      sha256 = "16v0w5749qjp13xhjgr2gcsvjv6mf35br7iqwycix1n2h7kfcckf";
       type = "gem";
     };
-    version = "1.2.1";
+    version = "1.4.1";
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

General update, includes security fixes, uses cleaner `bundlerApp`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
