### PR TITLE
nukeReferences: fix for store paths with special characters

### DIFF
--- a/pkgs/build-support/nuke-references/builder.sh
+++ b/pkgs/build-support/nuke-references/builder.sh
@@ -7,7 +7,7 @@ cat > $out/bin/nuke-refs <<EOF
 excludes=""
 while getopts e: o; do
     case "\$o" in
-        e) storeId=\$(echo "\$OPTARG" | sed -n "s|^$NIX_STORE/\\([a-z0-9]\{32\}\\)-.*|\1|p")
+        e) storeId=\$(echo "\$OPTARG" | $perl/bin/perl -ne "print \"\\\$1\" if m|^\Q$NIX_STORE\E/([a-z0-9]{32})-.*|")
            if [ -z "\$storeId" ]; then
                echo "-e argument must be a Nix store path"
                exit 1
@@ -20,7 +20,7 @@ shift \$((\$OPTIND-1))
 
 for i in "\$@"; do
     if test ! -L "\$i" -a -f "\$i"; then
-        cat "\$i" | $perl/bin/perl -pe "s|$NIX_STORE/\$excludes[a-z0-9]{32}-|$NIX_STORE/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-|g" > "\$i.tmp"
+        cat "\$i" | $perl/bin/perl -pe "s|\Q$NIX_STORE\E/\$excludes[a-z0-9]{32}-|$NIX_STORE/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-|g" > "\$i.tmp"
         if test -x "\$i"; then chmod +x "\$i.tmp"; fi
         mv "\$i.tmp" "\$i"
     fi


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I'm running nix with store directory in a custom path containing a '+' character. This prevents nukeReferences from working properly because some characters in the path get interpreted as a regular expression special characters. Broken nukeReferences will prevent `python3` from building on my setup because it requires `disallowedReferences = [ openssl.dev ];`.

The proposed fix implements escaping of the special characters in the store path.

###### Things done

Tested with

```nix
with import <nixpkgs> {};

stdenvNoCC.mkDerivation {
  name = "nuke-refs-test";

  nativeBuildInputs = [ nukeReferences ];

  buildCommand = ''
    cat > $out <<EOF
    out: $out
    openssl: ${openssl}
    python: ${python}
    EOF
    nuke-refs -e ${openssl} $out
    echo
    echo "> Only out and python should be nuked:"
    cat "$out"

    echo
    echo "> This should fail:"
    nuke-refs -e /not/a/path $out
  '';
}
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---