### PR TITLE
biber: Fix eval

### DIFF
--- a/pkgs/tools/typesetting/biber/default.nix
+++ b/pkgs/tools/typesetting/biber/default.nix
@@ -19,10 +19,7 @@ perlPackages.buildPerlModule rec {
     UnicodeLineBreak URI XMLLibXMLSimple XMLLibXSLT XMLWriter
     ClassAccessor TextCSV TextCSV_XS TextRoman DataUniqid LinguaTranslit SortKey
     TestDifferences
-  ];
-
-  checkInputs = with perlPackages; [
-    UnicodeCollate
+    PerlIOutf8_strict
   ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
Remove UnicodeCollate dependency, which is part of Perl 5.28 and does not exist separately anymore.

Add PerlIO::utf8_strict, which lack thereof Biber complains about during build.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
