### PR TITLE
microsoft_gsl: 2017-02-13 -> 2.0.0

### DIFF
--- a/pkgs/development/libraries/microsoft_gsl/default.nix
+++ b/pkgs/development/libraries/microsoft_gsl/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, cmake
+{ stdenv, fetchgit, catch, cmake
 }:
 
 let
@@ -6,18 +6,18 @@ let
 in
 stdenv.mkDerivation rec {
   name = "microsoft_gsl-${version}";
-  version = "2017-02-13";
+  version = "2.0.0";
 
   src = fetchgit {
     url = "https://github.com/Microsoft/GSL.git";
-    rev = "3819df6e378ffccf0e29465afe99c3b324c2aa70";
-    sha256 = "03d17mnx6n175aakin313308q14wzvaa9pd0m1yfk6ckhha4qf35";
+    rev = "v${version}";
+    sha256 = "1kxfca9ik934nkzyn34ingkyvwpc09li81cg1yc6vqcrdw51l4ri";
   };
 
 
   # build phase just runs the unit tests, so skip it if
   # we're doing a cross build
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ catch cmake ];
   buildPhase = if nativeBuild then "make" else "true";
 
   installPhase = ''

--- a/pkgs/development/libraries/microsoft_gsl/default.nix
+++ b/pkgs/development/libraries/microsoft_gsl/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, catch, cmake
+{ stdenv, fetchFromGitHub, catch, cmake
 }:
 
 let
@@ -8,8 +8,9 @@ stdenv.mkDerivation rec {
   name = "microsoft_gsl-${version}";
   version = "2.0.0";
 
-  src = fetchgit {
-    url = "https://github.com/Microsoft/GSL.git";
+  src = fetchFromGitHub {
+    owner = "Microsoft";
+    repo = "GSL";
     rev = "v${version}";
     sha256 = "1kxfca9ik934nkzyn34ingkyvwpc09li81cg1yc6vqcrdw51l4ri";
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

GSL now has an official release. Upgrade microsoft_gsl to the latest release (made August 20, 2018).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
