### PR TITLE
KDE / Plasma updates

### DIFF
--- a/pkgs/applications/kde/akonadi/0001-Revert-Make-Akonadi-installation-properly-relocatabl.patch
+++ b/pkgs/applications/kde/akonadi/0001-Revert-Make-Akonadi-installation-properly-relocatabl.patch
@@ -38,12 +38,15 @@ index 75abede50..10f039376 100644
  
  find_dependency(Boost "@Boost_MINIMUM_VERSION@")
  
-@@ -22,4 +22,4 @@ include(${CMAKE_CURRENT_LIST_DIR}/KF5AkonadiTargets.cmake)
+@@ -22,7 +22,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/KF5AkonadiTargets.cmake)
  include(${CMAKE_CURRENT_LIST_DIR}/KF5AkonadiMacros.cmake)
- 
+
  # The directory where akonadi-xml.xsd and kcfg2dbus.xsl are installed
 -set(KF5Akonadi_DATA_DIR "@PACKAGE_KF5Akonadi_DATA_DIR@")
 +set(KF5Akonadi_DATA_DIR "@KF5Akonadi_DATA_DIR@")
+
+ ####################################################################################
+ # CMAKE_AUTOMOC
 -- 
 2.15.1
 

--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -102,7 +102,7 @@ let
       kdegraphics-thumbnailers = callPackage ./kdegraphics-thumbnailers.nix {};
       kdenetwork-filesharing = callPackage ./kdenetwork-filesharing.nix {};
       kdenlive = callPackage ./kdenlive.nix {};
-      kdepim-runtime = callPackage ./kdepim-runtime.nix {};
+      kdepim-runtime = callPackage ./kdepim-runtime {};
       kdepim-addons = callPackage ./kdepim-addons.nix {};
       kdepim-apps-libs = callPackage ./kdepim-apps-libs {};
       kdf = callPackage ./kdf.nix {};

--- a/pkgs/applications/kde/default.nix
+++ b/pkgs/applications/kde/default.nix
@@ -108,6 +108,7 @@ let
       kdf = callPackage ./kdf.nix {};
       kdialog = callPackage ./kdialog.nix {};
       keditbookmarks = callPackage ./keditbookmarks.nix {};
+      kfind = callPackage ./kfind.nix {};
       kget = callPackage ./kget.nix {};
       kgpg = callPackage ./kgpg.nix {};
       khelpcenter = callPackage ./khelpcenter.nix {};

--- a/pkgs/applications/kde/fetch.sh
+++ b/pkgs/applications/kde/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/applications/18.12.3/ )
+WGET_ARGS=( https://download.kde.org/stable/applications/19.04.0/ )

--- a/pkgs/applications/kde/kcalc.nix
+++ b/pkgs/applications/kde/kcalc.nix
@@ -1,8 +1,8 @@
 {
   mkDerivation, lib,
   extra-cmake-modules, kdoctools,
-  gmp, kconfig, kconfigwidgets, kguiaddons, ki18n, kinit, knotifications,
-  kxmlgui,
+  gmp, kconfig, kconfigwidgets, kcrash, kguiaddons, ki18n, kinit,
+  knotifications, kxmlgui,
 }:
 
 mkDerivation {
@@ -13,6 +13,7 @@ mkDerivation {
   };
   nativeBuildInputs = [ extra-cmake-modules kdoctools ];
   buildInputs = [
-    gmp kconfig kconfigwidgets kguiaddons ki18n kinit knotifications kxmlgui
+    gmp kconfig kconfigwidgets kcrash kguiaddons ki18n kinit knotifications
+    kxmlgui
   ];
 }

--- a/pkgs/applications/kde/kdegraphics-thumbnailers.nix
+++ b/pkgs/applications/kde/kdegraphics-thumbnailers.nix
@@ -1,6 +1,6 @@
 {
   mkDerivation, lib,
-  extra-cmake-modules, kio, libkexiv2, libkdcraw
+  extra-cmake-modules, karchive, kio, libkexiv2, libkdcraw
 }:
 
 mkDerivation {
@@ -10,5 +10,5 @@ mkDerivation {
     maintainers = [ lib.maintainers.ttuegel ];
   };
   nativeBuildInputs = [ extra-cmake-modules ];
-  buildInputs = [ kio libkexiv2 libkdcraw ];
+  buildInputs = [ karchive kio libkexiv2 libkdcraw ];
 }

--- a/pkgs/applications/kde/kdepim-runtime/00-no-facebook.patch
+++ b/pkgs/applications/kde/kdepim-runtime/00-no-facebook.patch
@@ -1,0 +1,12 @@
+diff --git a/resources/CMakeLists.txt b/resources/CMakeLists.txt
+index 99f7dbf..03e953b 100644
+--- a/resources/CMakeLists.txt
++++ b/resources/CMakeLists.txt
+@@ -45,7 +45,6 @@ add_subdirectory( imap )
+ if (Libkolabxml_FOUND)
+     add_subdirectory( kolab )
+ endif()
+-add_subdirectory( facebook )
+ add_subdirectory( maildir )
+ 
+ add_subdirectory( openxchange )

--- a/pkgs/applications/kde/kdepim-runtime/default.nix
+++ b/pkgs/applications/kde/kdepim-runtime/default.nix
@@ -1,11 +1,11 @@
 {
-  mkDerivation, lib, kdepimTeam,
+  mkDerivation, copyPathsToStore, lib, kdepimTeam,
   extra-cmake-modules, kdoctools,
   shared-mime-info,
   akonadi, akonadi-calendar, akonadi-contacts, akonadi-mime, akonadi-notes,
   kalarmcal, kcalutils, kcontacts, kdav, kdelibs4support, kidentitymanagement,
   kimap, kmailtransport, kmbox, kmime, knotifications, knotifyconfig,
-  pimcommon, qtwebengine, libkgapi, qtspeech, qtxmlpatterns
+  pimcommon, qtwebengine, libkgapi, qtnetworkauth, qtspeech, qtxmlpatterns,
 }:
 
 mkDerivation {
@@ -14,12 +14,13 @@ mkDerivation {
     license = with lib.licenses; [ gpl2 lgpl21 fdl12 ];
     maintainers = kdepimTeam;
   };
+  patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);
   nativeBuildInputs = [ extra-cmake-modules kdoctools shared-mime-info ];
   buildInputs = [
     akonadi akonadi-calendar akonadi-contacts akonadi-mime akonadi-notes
     kalarmcal kcalutils kcontacts kdav kdelibs4support kidentitymanagement kimap
     kmailtransport kmbox kmime knotifications knotifyconfig qtwebengine
-    pimcommon libkgapi qtspeech qtxmlpatterns
+    pimcommon libkgapi qtnetworkauth qtspeech qtxmlpatterns
   ];
   # Attempts to build some files before dependencies have been generated
   enableParallelBuilding = false;

--- a/pkgs/applications/kde/kdepim-runtime/series
+++ b/pkgs/applications/kde/kdepim-runtime/series
@@ -1,0 +1,1 @@
+00-no-facebook.patch

--- a/pkgs/applications/kde/kfind.nix
+++ b/pkgs/applications/kde/kfind.nix
@@ -1,0 +1,17 @@
+{
+  mkDerivation, lib,
+  extra-cmake-modules, kdoctools,
+  karchive, kcoreaddons, kfilemetadata, ktextwidgets, kwidgetsaddons, kio
+}:
+
+mkDerivation {
+  name = "kfind";
+  meta = {
+    license = with lib.licenses; [ gpl2 ];
+    maintainers = [ lib.maintainers.iblech ];
+  };
+  nativeBuildInputs = [ extra-cmake-modules kdoctools ];
+  buildInputs = [
+    karchive kcoreaddons kfilemetadata ktextwidgets kwidgetsaddons kio
+  ];
+}

--- a/pkgs/applications/kde/kio-extras.nix
+++ b/pkgs/applications/kde/kio-extras.nix
@@ -3,7 +3,7 @@
   exiv2, kactivities, karchive, kbookmarks, kconfig, kconfigwidgets,
   kcoreaddons, kdbusaddons, kguiaddons, kdnssd, kiconthemes, ki18n, kio, khtml,
   kdelibs4support, kpty, libmtp, libssh, openexr, ilmbase, openslp, phonon,
-  qtsvg, samba, solid, gperf
+  qtsvg, samba, solid, syntax-highlighting, gperf
 }:
 
 mkDerivation {
@@ -16,7 +16,8 @@ mkDerivation {
   buildInputs = [
     exiv2 kactivities karchive kbookmarks kconfig kconfigwidgets kcoreaddons
     kdbusaddons kguiaddons kdnssd kiconthemes ki18n kio khtml kdelibs4support
-    kpty libmtp libssh openexr openslp phonon qtsvg samba solid gperf
+    kpty libmtp libssh openexr openslp phonon qtsvg samba solid
+    syntax-highlighting gperf
   ];
   CXXFLAGS = [ "-I${ilmbase.dev}/include/OpenEXR" ];
 }

--- a/pkgs/applications/kde/kmail.nix
+++ b/pkgs/applications/kde/kmail.nix
@@ -26,4 +26,5 @@ mkDerivation {
     libksieve mailcommon messagelib pim-sieve-editor qtscript qtwebengine
   ];
   propagatedUserEnvPkgs = [ kdepim-runtime kwallet ];
+  patches = [ ./kmail.patch ];
 }

--- a/pkgs/applications/kde/kmail.patch
+++ b/pkgs/applications/kde/kmail.patch
@@ -1,0 +1,24 @@
+diff --git a/agents/archivemailagent/CMakeLists.txt b/agents/archivemailagent/CMakeLists.txt
+index 48ed076..9c56896 100644
+--- a/agents/archivemailagent/CMakeLists.txt
++++ b/agents/archivemailagent/CMakeLists.txt
+@@ -22,6 +22,7 @@ ki18n_wrap_ui(libarchivemailagent_SRCS ui/archivemailwidget.ui )
+ add_library(archivemailagent STATIC ${libarchivemailagent_SRCS})
+ target_link_libraries(archivemailagent
+     KF5::MailCommon
++    KF5::Libkdepim
+     KF5::I18n
+     KF5::Notifications
+     KF5::IconThemes
+diff --git a/agents/followupreminderagent/CMakeLists.txt b/agents/followupreminderagent/CMakeLists.txt
+index a56b730..83604cf 100644
+--- a/agents/followupreminderagent/CMakeLists.txt
++++ b/agents/followupreminderagent/CMakeLists.txt
+@@ -23,6 +23,7 @@ target_link_libraries(followupreminderagent
+     KF5::AkonadiMime
+     KF5::AkonadiAgentBase
+     KF5::DBusAddons
++    KF5::FollowupReminder
+     KF5::XmlGui
+     KF5::KIOWidgets
+     KF5::Notifications

--- a/pkgs/applications/kde/minuet.nix
+++ b/pkgs/applications/kde/minuet.nix
@@ -2,17 +2,17 @@
 , lib, extra-cmake-modules, gettext, python
 , drumstick, fluidsynth
 , kcoreaddons, kcrash, kdoctools
-, qtquickcontrols2, qtsvg, qttools
+, qtquickcontrols2, qtsvg, qttools, qtdeclarative
 }:
 
 mkDerivation {
   name = "minuet";
   meta = with lib; {
     license = with licenses; [ lgpl21 gpl3 ];
-    maintainers = with maintainers; [ peterhoeg ];
+    maintainers = with maintainers; [ peterhoeg HaoZeke ];
   };
 
-  nativeBuildInputs = [ extra-cmake-modules gettext kdoctools python ];
+  nativeBuildInputs = [ extra-cmake-modules gettext kdoctools python qtdeclarative ];
 
   propagatedBuildInputs = [
     drumstick fluidsynth

--- a/pkgs/applications/kde/srcs.nix
+++ b/pkgs/applications/kde/srcs.nix
@@ -3,1723 +3,1723 @@
 
 {
   akonadi = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/akonadi-18.12.3.tar.xz";
-      sha256 = "f930deaade1cac1488b8af05cc28f4a78a441c34dbe875b673af3423f8a14658";
-      name = "akonadi-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/akonadi-19.04.0.tar.xz";
+      sha256 = "c0a2c4259b51293d21487cfe2295df6e8dcfb7ab50eb1a698f531dc7d3253e9a";
+      name = "akonadi-19.04.0.tar.xz";
     };
   };
   akonadi-calendar = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/akonadi-calendar-18.12.3.tar.xz";
-      sha256 = "19f92642ba4d62dfccca19ac3ced94495e9137d60a77a672c5443585f30cdaee";
-      name = "akonadi-calendar-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/akonadi-calendar-19.04.0.tar.xz";
+      sha256 = "5a2897a1e96897159a3e2980f407c4c225434efd45167ad699a14aaa2ec445fd";
+      name = "akonadi-calendar-19.04.0.tar.xz";
     };
   };
   akonadi-calendar-tools = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/akonadi-calendar-tools-18.12.3.tar.xz";
-      sha256 = "636ea364bea079cae0b899204add76b0d1d9a80d1955c914bc1dad3a6fc731ed";
-      name = "akonadi-calendar-tools-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/akonadi-calendar-tools-19.04.0.tar.xz";
+      sha256 = "f9869574d880c53bfb87319348d75d8169ffb38bfdeb3b6066f25074409321ef";
+      name = "akonadi-calendar-tools-19.04.0.tar.xz";
     };
   };
   akonadiconsole = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/akonadiconsole-18.12.3.tar.xz";
-      sha256 = "d052084ecc1665976f7db08d11a15609f017b0803dd30b71b5d1dccc60ac6ed0";
-      name = "akonadiconsole-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/akonadiconsole-19.04.0.tar.xz";
+      sha256 = "5118720b6e0ecdf689c7b7f005f732386d0b7a6258cc11fb44fcaac5cc9518a8";
+      name = "akonadiconsole-19.04.0.tar.xz";
     };
   };
   akonadi-contacts = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/akonadi-contacts-18.12.3.tar.xz";
-      sha256 = "6ad8e352744c258b66a0c6155322681fa4ec50422c81fe4248414b0834e645cc";
-      name = "akonadi-contacts-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/akonadi-contacts-19.04.0.tar.xz";
+      sha256 = "65dd20c467daf8d6107a1856c7f112eb937438b5884fe62a09a1763214a7442a";
+      name = "akonadi-contacts-19.04.0.tar.xz";
     };
   };
   akonadi-import-wizard = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/akonadi-import-wizard-18.12.3.tar.xz";
-      sha256 = "a74ca212ab05706d5beb94696a933cb46dfd83d5ebd6723de97f7ce4efbe6104";
-      name = "akonadi-import-wizard-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/akonadi-import-wizard-19.04.0.tar.xz";
+      sha256 = "541b858278d56a5d41858bfa644656d4f04bf6e5a52ce8014d207d64812d6d22";
+      name = "akonadi-import-wizard-19.04.0.tar.xz";
     };
   };
   akonadi-mime = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/akonadi-mime-18.12.3.tar.xz";
-      sha256 = "ff7d91c77b629bba6b93ee6b15c0ebee08aa37368aa8bcae48ecbbacf64bc1b4";
-      name = "akonadi-mime-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/akonadi-mime-19.04.0.tar.xz";
+      sha256 = "b06ca4140b10548b9aecd188bd9b72405af2f4097c80e9b4e9aa3e863750b6da";
+      name = "akonadi-mime-19.04.0.tar.xz";
     };
   };
   akonadi-notes = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/akonadi-notes-18.12.3.tar.xz";
-      sha256 = "ac2f5ef0a3f4621d6af6fef028d641334212d940a1fc3ffc1e3cc6534ca6be60";
-      name = "akonadi-notes-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/akonadi-notes-19.04.0.tar.xz";
+      sha256 = "a9aa05ca2b5f846fed51e4c32907eedc6893a40ab3b9d4832e11bab118664e5f";
+      name = "akonadi-notes-19.04.0.tar.xz";
     };
   };
   akonadi-search = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/akonadi-search-18.12.3.tar.xz";
-      sha256 = "6436a0f71229cf7917cb4f269f34a2046c24860ecfc03e7018b9d2a7f9e66346";
-      name = "akonadi-search-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/akonadi-search-19.04.0.tar.xz";
+      sha256 = "6046a540ace526cbb8c0909762ad333426266afbf58a59ecc71cb923298e84bb";
+      name = "akonadi-search-19.04.0.tar.xz";
     };
   };
   akregator = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/akregator-18.12.3.tar.xz";
-      sha256 = "d3a4f0f4b677825d1b3e1461a020c17a36abe458d7e3ab40389627e2d8163ea1";
-      name = "akregator-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/akregator-19.04.0.tar.xz";
+      sha256 = "5104b0b66ac3917c7cb78f4a6cca952f7e4360cfcd0aa7ce1575d0551470fcee";
+      name = "akregator-19.04.0.tar.xz";
     };
   };
   analitza = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/analitza-18.12.3.tar.xz";
-      sha256 = "c241b6a3d849534ccd50601c0aebd5cd785220bb7957ed7f6b1d3db35ba0f925";
-      name = "analitza-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/analitza-19.04.0.tar.xz";
+      sha256 = "ac8bf7d66f8a2fc7198238f23d82efd1021943ffe8bd5915808e31b800a802f6";
+      name = "analitza-19.04.0.tar.xz";
     };
   };
   ark = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ark-18.12.3.tar.xz";
-      sha256 = "ecf781b5d3691bb967c9170938c1133e2972ee97d71aab2de65487a952700722";
-      name = "ark-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ark-19.04.0.tar.xz";
+      sha256 = "35e8e516a8554e086264d9a9a4fa66c2b47fa227eb9e512a1d0d24172cd07a84";
+      name = "ark-19.04.0.tar.xz";
     };
   };
   artikulate = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/artikulate-18.12.3.tar.xz";
-      sha256 = "f40cc532dd1093d53ab4f825716ea4f4f4d7f954ac6c58ef412b63323a76c278";
-      name = "artikulate-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/artikulate-19.04.0.tar.xz";
+      sha256 = "527ebdb2db6eab3e05810c5e56d53611d80bd23508563457b459e4e32a68ef08";
+      name = "artikulate-19.04.0.tar.xz";
     };
   };
   audiocd-kio = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/audiocd-kio-18.12.3.tar.xz";
-      sha256 = "c15ebda9330688c0304be36999f4900ccd7c0b1ce11e19c296975414dafe53c8";
-      name = "audiocd-kio-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/audiocd-kio-19.04.0.tar.xz";
+      sha256 = "0f347be9c873eb75144d2b8f3f2e28d2e52be4c1a0f59a19be99edd867f17371";
+      name = "audiocd-kio-19.04.0.tar.xz";
     };
   };
   baloo-widgets = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/baloo-widgets-18.12.3.tar.xz";
-      sha256 = "b8475ba1a74f8ebc6a36029b60ac803ab0d2c81c253b8c16bd05b6249454c3e3";
-      name = "baloo-widgets-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/baloo-widgets-19.04.0.tar.xz";
+      sha256 = "ab3d83bb1f2007620273d1a3eb580d821e0655aaf7e3efd2dc81087a24d1c275";
+      name = "baloo-widgets-19.04.0.tar.xz";
     };
   };
   blinken = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/blinken-18.12.3.tar.xz";
-      sha256 = "2b6a11fa56b8837618e157a4a974eb1dff956cfb8b93e6cb0601bda66a234579";
-      name = "blinken-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/blinken-19.04.0.tar.xz";
+      sha256 = "5d470c7f0d232ea01c99fbe1ed08e103291e80c3cfe74e245aba1c2009573eed";
+      name = "blinken-19.04.0.tar.xz";
     };
   };
   bomber = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/bomber-18.12.3.tar.xz";
-      sha256 = "5b8e24aba4fb14ffc72313f9754315d6a7d98a3e00ee118a2551ac3357ead771";
-      name = "bomber-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/bomber-19.04.0.tar.xz";
+      sha256 = "4f82f3f42aff36de837f7c9ddc5986f6c73cb50de122b46320dba0a0b03f9a7d";
+      name = "bomber-19.04.0.tar.xz";
     };
   };
   bovo = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/bovo-18.12.3.tar.xz";
-      sha256 = "7fc7ff304cf5b5bf2049fdd53fbb4a819bddefc77fde94702c5118240403d972";
-      name = "bovo-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/bovo-19.04.0.tar.xz";
+      sha256 = "2cfccb09087a32d8a75f6dd763168e2ef5928f55b58505a542bc36fdac8e141e";
+      name = "bovo-19.04.0.tar.xz";
     };
   };
   calendarsupport = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/calendarsupport-18.12.3.tar.xz";
-      sha256 = "e3c23c152a3e339628e79b168e56c22c5c2610600013f3aa8706168569cacfa5";
-      name = "calendarsupport-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/calendarsupport-19.04.0.tar.xz";
+      sha256 = "d767f077a9d41a9c6d266c4b5fe7bedd6f4eb7b71824e7544cf3a1df11ce362f";
+      name = "calendarsupport-19.04.0.tar.xz";
     };
   };
   cantor = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/cantor-18.12.3.tar.xz";
-      sha256 = "2537b8e8a9e5b72a2b3bf2b08d24c4978f52ef18ced61cdcfd2a09069f670398";
-      name = "cantor-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/cantor-19.04.0.tar.xz";
+      sha256 = "ef0381a65cd2f3a3bb68a7211140077fc1a9bf31ed5302fa368fd874c8441bf4";
+      name = "cantor-19.04.0.tar.xz";
     };
   };
   cervisia = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/cervisia-18.12.3.tar.xz";
-      sha256 = "a5e4034b0d1ee07c2efaef6e8eef17b48a340e9d046cd23efceaf67f07ab5a85";
-      name = "cervisia-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/cervisia-19.04.0.tar.xz";
+      sha256 = "011d9b38a82508ae73328dc56723af11fa8403c0dcf5b7d7703118d79f2ad8f4";
+      name = "cervisia-19.04.0.tar.xz";
     };
   };
   dolphin = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/dolphin-18.12.3.tar.xz";
-      sha256 = "c4921759bdfec9a96201a5d76a67869f867ec7e3caf92f8e46fa5d853a0741b1";
-      name = "dolphin-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/dolphin-19.04.0.tar.xz";
+      sha256 = "f3f45b9048c283252067eebfad8c6e1efc6bc64d43fcba78b933850ea4762375";
+      name = "dolphin-19.04.0.tar.xz";
     };
   };
   dolphin-plugins = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/dolphin-plugins-18.12.3.tar.xz";
-      sha256 = "1bff5f828f11e9b9a527b59f12ec16745fa19fb09392ca1872d6b0c909212427";
-      name = "dolphin-plugins-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/dolphin-plugins-19.04.0.tar.xz";
+      sha256 = "c2898e0a64d5a9eab2a4bd661694b75805adfd0a925f1a21f894892264f96469";
+      name = "dolphin-plugins-19.04.0.tar.xz";
     };
   };
   dragon = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/dragon-18.12.3.tar.xz";
-      sha256 = "115d60bfdef498ea75bc077a7091fb738615b399b03ec2a76a4bf34f19b407f3";
-      name = "dragon-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/dragon-19.04.0.tar.xz";
+      sha256 = "42bde9f6a4f3dfe7a6b2bfa35502474c2866e2649695302d602a97f00842fcf2";
+      name = "dragon-19.04.0.tar.xz";
     };
   };
   eventviews = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/eventviews-18.12.3.tar.xz";
-      sha256 = "994ddea6894fd73eeb851b04083bc886288e4531aa770c0b2e5d8e1740bbe4d0";
-      name = "eventviews-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/eventviews-19.04.0.tar.xz";
+      sha256 = "ed34f228012ad2d45b0f07da469633118f35c28b1ddc7157149f4a5ab999500c";
+      name = "eventviews-19.04.0.tar.xz";
     };
   };
   ffmpegthumbs = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ffmpegthumbs-18.12.3.tar.xz";
-      sha256 = "4db8ab905d80863f898b6a3ea8cd0cc7baad91ad953d6b65df230079be04b338";
-      name = "ffmpegthumbs-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ffmpegthumbs-19.04.0.tar.xz";
+      sha256 = "6b96cea0c142651cb586eb40d88792329f8da9a777d9a457ba76d0e94ddf4995";
+      name = "ffmpegthumbs-19.04.0.tar.xz";
     };
   };
   filelight = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/filelight-18.12.3.tar.xz";
-      sha256 = "9090bc7c7ac2586e857cdc246a94621c1453e7f65c6d491f2f374f43d3e4af1a";
-      name = "filelight-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/filelight-19.04.0.tar.xz";
+      sha256 = "22eaa8f0e9e69652240554687b2cecb55449e67caac6055c2d868f3089d835ad";
+      name = "filelight-19.04.0.tar.xz";
     };
   };
   granatier = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/granatier-18.12.3.tar.xz";
-      sha256 = "ad065e488f9a751423d571f51449e766c625e88ca7d3c30d21ff3b9027fc04af";
-      name = "granatier-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/granatier-19.04.0.tar.xz";
+      sha256 = "d83e91a5056e4caf1e522921025cb79355c0c2d53b7f0e98444d37291d80d63a";
+      name = "granatier-19.04.0.tar.xz";
     };
   };
   grantlee-editor = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/grantlee-editor-18.12.3.tar.xz";
-      sha256 = "d46831a589815581bce45c3954eb12fcbb1692fb407f566952a39e3e8c546b9c";
-      name = "grantlee-editor-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/grantlee-editor-19.04.0.tar.xz";
+      sha256 = "ac888f2f2ccd4b289deac1d2df4415124e14bf183db1ff1088e88fa782f9f342";
+      name = "grantlee-editor-19.04.0.tar.xz";
     };
   };
   grantleetheme = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/grantleetheme-18.12.3.tar.xz";
-      sha256 = "7853075503f2a19713ce43ba077dde8036f892dee7f41e64ebc9af06b4005402";
-      name = "grantleetheme-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/grantleetheme-19.04.0.tar.xz";
+      sha256 = "6896a7e1db662bea03b6bdd9f92214b5fa50dfbebbbaa7b3156ddb87ccd55a3e";
+      name = "grantleetheme-19.04.0.tar.xz";
     };
   };
   gwenview = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/gwenview-18.12.3.tar.xz";
-      sha256 = "0b4ff869fc09140e258e894f5169fc6c96f1126891b8ed1a391d4624d6ab0c35";
-      name = "gwenview-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/gwenview-19.04.0.tar.xz";
+      sha256 = "c7d422bddf031fa9d5a23459c65ea6dbb5919e964cc194178a864ee98912b46d";
+      name = "gwenview-19.04.0.tar.xz";
     };
   };
   incidenceeditor = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/incidenceeditor-18.12.3.tar.xz";
-      sha256 = "b0fa13390b31a24a8bca99f20b132841849d95dba9de3b8a4c9ae979d226ec02";
-      name = "incidenceeditor-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/incidenceeditor-19.04.0.tar.xz";
+      sha256 = "c34fd55acd2f92705e43628fd0c9c4a550c73d45f30beba71dc75698143cbd5f";
+      name = "incidenceeditor-19.04.0.tar.xz";
     };
   };
   juk = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/juk-18.12.3.tar.xz";
-      sha256 = "8755710f551b3173561ebfcc996f32b3fd8de78d5574584f8e37015541a9fdca";
-      name = "juk-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/juk-19.04.0.tar.xz";
+      sha256 = "952366e14526701109e83c1979c2a7b3dfdf3c054ecb86c9b5a6cf9825196f60";
+      name = "juk-19.04.0.tar.xz";
     };
   };
   k3b = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/k3b-18.12.3.tar.xz";
-      sha256 = "cee825ff0c058cc1cbe3bf47a7acbe3889949460ba383ffae3756b67b418362e";
-      name = "k3b-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/k3b-19.04.0.tar.xz";
+      sha256 = "ab0293d0dab2048dcacd4fc54ee2e12d2f55adcecde7cd02e4c31ffd5917ee39";
+      name = "k3b-19.04.0.tar.xz";
     };
   };
   kaccounts-integration = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kaccounts-integration-18.12.3.tar.xz";
-      sha256 = "6e7e4d7aac270f605a5fd4ec9efea8c13807ccb67c11fd3412c1d794ab09e6ce";
-      name = "kaccounts-integration-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kaccounts-integration-19.04.0.tar.xz";
+      sha256 = "d7b257f6b7278361690b2c1d948c92bdb8b14f741ce96ef35f37c8eea3feb687";
+      name = "kaccounts-integration-19.04.0.tar.xz";
     };
   };
   kaccounts-providers = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kaccounts-providers-18.12.3.tar.xz";
-      sha256 = "4d084ffdac10a8a8cc8b79a9b17116893c023288c9e29d1cbabe3d28cd0ba5f6";
-      name = "kaccounts-providers-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kaccounts-providers-19.04.0.tar.xz";
+      sha256 = "4eb74ef042c30ea44f5391f8798d9ceca44d46bf46480355160af61bcb6236d7";
+      name = "kaccounts-providers-19.04.0.tar.xz";
     };
   };
   kaddressbook = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kaddressbook-18.12.3.tar.xz";
-      sha256 = "81d3ba7d5e8ed14b0cc32825f1efbdccbf9f79ffe4e1f8c888179c3d04b5bd28";
-      name = "kaddressbook-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kaddressbook-19.04.0.tar.xz";
+      sha256 = "821708c0a33063de050682c7768faeb51a467de9c4314901761449c09a8a3265";
+      name = "kaddressbook-19.04.0.tar.xz";
     };
   };
   kajongg = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kajongg-18.12.3.tar.xz";
-      sha256 = "e3fba4ddb19e8dfd43f917d737bf13c2391a3042c6941181ab81f4bcd66096f9";
-      name = "kajongg-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kajongg-19.04.0.tar.xz";
+      sha256 = "832e76252321900f3bb3d3a96bb9f9a93235260803621c06d112b7cc48bd1555";
+      name = "kajongg-19.04.0.tar.xz";
     };
   };
   kalarm = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kalarm-18.12.3.tar.xz";
-      sha256 = "5c116221e78755b8afd80287885cb50380c2136acd25aa615d3f6041cc0fbeb3";
-      name = "kalarm-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kalarm-19.04.0.tar.xz";
+      sha256 = "ed8f656e4aebb78d78f068ccde605489090ed0467452629784472b685fae331a";
+      name = "kalarm-19.04.0.tar.xz";
     };
   };
   kalarmcal = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kalarmcal-18.12.3.tar.xz";
-      sha256 = "2658b2d8055558878cf84d50daf333a5f694a586800b9ccfd3eded3304af8ef8";
-      name = "kalarmcal-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kalarmcal-19.04.0.tar.xz";
+      sha256 = "ec0790d2b04bcd3a37a221bdbf4a10f94ff7dd8ac0228e773ce9fac14bbebf6e";
+      name = "kalarmcal-19.04.0.tar.xz";
     };
   };
   kalgebra = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kalgebra-18.12.3.tar.xz";
-      sha256 = "a93b319c6a3fab3d3a12923f8153a6f38281887e176fffaa37ca6cc677a280b5";
-      name = "kalgebra-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kalgebra-19.04.0.tar.xz";
+      sha256 = "a46c4fc2b0891183d0a3b859182eef8d49206b81cbf6d2c6ed6d5448f2663a4a";
+      name = "kalgebra-19.04.0.tar.xz";
     };
   };
   kalzium = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kalzium-18.12.3.tar.xz";
-      sha256 = "100f63b0c1624c10ce7bb54a6a8fa6dfaf6800f580bfc0889745e171fe135fef";
-      name = "kalzium-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kalzium-19.04.0.tar.xz";
+      sha256 = "16fe2873dfad5de78b9a07a4c528e8ac747a54eced9feaa65f1c9fccc23b0d03";
+      name = "kalzium-19.04.0.tar.xz";
     };
   };
   kamera = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kamera-18.12.3.tar.xz";
-      sha256 = "5e0e5a710cffd95019279d68daa27fdd4fba1401450673efa757ffc8a7ca495f";
-      name = "kamera-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kamera-19.04.0.tar.xz";
+      sha256 = "b6b5891e886f543140d1ea6775ec1f1f4575e698d34af04fd65acbafa7e42392";
+      name = "kamera-19.04.0.tar.xz";
     };
   };
   kamoso = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kamoso-18.12.3.tar.xz";
-      sha256 = "ed62bbdf8eeefb85605113c3a916b01eec16846825cffe9b0b0c1f5a4580feb3";
-      name = "kamoso-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kamoso-19.04.0.tar.xz";
+      sha256 = "200c805ba80a89026edcd02d4cd6d058eff1d537eb3da28807cb2162cc014765";
+      name = "kamoso-19.04.0.tar.xz";
     };
   };
   kanagram = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kanagram-18.12.3.tar.xz";
-      sha256 = "dcc06543830ab06066f2f37eba6722f5cb0893355e30cee8d522085ed5fb2204";
-      name = "kanagram-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kanagram-19.04.0.tar.xz";
+      sha256 = "dda3ce8211957e016521597a923de92d261e32c31ebf84faa697bd26cf16647c";
+      name = "kanagram-19.04.0.tar.xz";
     };
   };
   kapman = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kapman-18.12.3.tar.xz";
-      sha256 = "ad4a6377d260df76d000631ab4c95e5cb82ce47d031edc9801b6ed92d856305c";
-      name = "kapman-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kapman-19.04.0.tar.xz";
+      sha256 = "f77dd3210bcdfb2d424f7a919848e25a4b4ae994d74b59111f352e41c2086324";
+      name = "kapman-19.04.0.tar.xz";
     };
   };
   kapptemplate = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kapptemplate-18.12.3.tar.xz";
-      sha256 = "dd4e34e1ed60f4cb03836576dfd5d306ec1890cd0fe583b516bf49c628f1078f";
-      name = "kapptemplate-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kapptemplate-19.04.0.tar.xz";
+      sha256 = "7983c4576c6168731958790851d732f8bd4f4313d2cd00a8bf4dd37a4b6a4bb4";
+      name = "kapptemplate-19.04.0.tar.xz";
     };
   };
   kate = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kate-18.12.3.tar.xz";
-      sha256 = "f7f2cba41a4c88b65885532db6b6161c66055a6697d20ee88adb70f302d387e1";
-      name = "kate-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kate-19.04.0.tar.xz";
+      sha256 = "64c3c312a69d45624e3619309b86de796f67d30a864433a5c24aeb4e299bacc9";
+      name = "kate-19.04.0.tar.xz";
     };
   };
   katomic = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/katomic-18.12.3.tar.xz";
-      sha256 = "0e18087d0de067282023a98b800807632dd6a91bab51cf0d43d53bffba9b33f1";
-      name = "katomic-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/katomic-19.04.0.tar.xz";
+      sha256 = "ea6e6642e16f985653caf2cd9dd61248e7038fb0246e9af4d4daec20401537a2";
+      name = "katomic-19.04.0.tar.xz";
     };
   };
   kbackup = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kbackup-18.12.3.tar.xz";
-      sha256 = "7b42f7fff48f4cf735e27603d0e44ecd13d5c85474680f8d24850eaadd4f13bf";
-      name = "kbackup-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kbackup-19.04.0.tar.xz";
+      sha256 = "84b8f7b05a1812deb128a85aa2d6f1010fb7b2f8cb51aa3771077ef20fd4b4ce";
+      name = "kbackup-19.04.0.tar.xz";
     };
   };
   kblackbox = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kblackbox-18.12.3.tar.xz";
-      sha256 = "d88b2906de45b129f1706b3d250b80f86acb0cc926a3cee679265b86c8934a9b";
-      name = "kblackbox-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kblackbox-19.04.0.tar.xz";
+      sha256 = "9363167664b6b4e54325f9691333df912eefa1e19d387c9a2780626914b813f9";
+      name = "kblackbox-19.04.0.tar.xz";
     };
   };
   kblocks = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kblocks-18.12.3.tar.xz";
-      sha256 = "e981107096893a8078ab978c429f367432a74de1bdeffe8fb628ccc397701332";
-      name = "kblocks-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kblocks-19.04.0.tar.xz";
+      sha256 = "c70a60f3a2e4c8f7756a1f9b1e025f8f91ec83c4f54feedf0ba05eea36b0037e";
+      name = "kblocks-19.04.0.tar.xz";
     };
   };
   kblog = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kblog-18.12.3.tar.xz";
-      sha256 = "cd84b34312f6c5a9cf56322614caafcf434a800aeff66173a2c6f7cccc0fd2cc";
-      name = "kblog-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kblog-19.04.0.tar.xz";
+      sha256 = "719c6ce92c006231869dcad84b14e3db7c8b71eff60e234a94353e2ef580d577";
+      name = "kblog-19.04.0.tar.xz";
     };
   };
   kbounce = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kbounce-18.12.3.tar.xz";
-      sha256 = "c62cb68b4246c1aef73efb04ea883599384afbd977e8da93893346cbd835f343";
-      name = "kbounce-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kbounce-19.04.0.tar.xz";
+      sha256 = "cd28d777db8ff1dc1437fb6456c2fdfe8b9005c0cea3ce05337fbf425803834f";
+      name = "kbounce-19.04.0.tar.xz";
     };
   };
   kbreakout = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kbreakout-18.12.3.tar.xz";
-      sha256 = "23e1cc935eab6a2520e683185cb223243c71553b1ef6059a21f09d72e8fe00af";
-      name = "kbreakout-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kbreakout-19.04.0.tar.xz";
+      sha256 = "c4aa847def701be288e53ceb27c8c63c34aa527f8e64c91fb007d053b1119db8";
+      name = "kbreakout-19.04.0.tar.xz";
     };
   };
   kbruch = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kbruch-18.12.3.tar.xz";
-      sha256 = "e98f79865c4d095d7682ab97b0e4e7d23715e402be676d66f184cfbe3eff598d";
-      name = "kbruch-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kbruch-19.04.0.tar.xz";
+      sha256 = "7762c233529b75859ab264bcfd9847acc06889b0ff96183a1af63effd40f3f38";
+      name = "kbruch-19.04.0.tar.xz";
     };
   };
   kcachegrind = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kcachegrind-18.12.3.tar.xz";
-      sha256 = "48011190a0ef28998e6c96b9d644e3d06b68606b7d1467c84a8d176eeebb9adf";
-      name = "kcachegrind-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kcachegrind-19.04.0.tar.xz";
+      sha256 = "7021ac1b133e86692dad92ff8de6a0467c2b488d7e5c2977ee4880c166e088ca";
+      name = "kcachegrind-19.04.0.tar.xz";
     };
   };
   kcalc = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kcalc-18.12.3.tar.xz";
-      sha256 = "10b3ebb5efab3731e9f12a8632546685281179881b03aae98f96a2cdbd21f02f";
-      name = "kcalc-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kcalc-19.04.0.tar.xz";
+      sha256 = "0384ebf83c62e74a2412f71f648bad112f91ef3ec6aa64fe55e63fd88a156593";
+      name = "kcalc-19.04.0.tar.xz";
     };
   };
   kcalcore = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kcalcore-18.12.3.tar.xz";
-      sha256 = "d6d6ce1bbdea4eac352b74bcc4bee77da107fdbafab47440b6be5fc3f9d90452";
-      name = "kcalcore-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kcalcore-19.04.0.tar.xz";
+      sha256 = "0cdcfebabb9af96650b71ba6361a4557df35144f0b1041f004bff7510c6334b2";
+      name = "kcalcore-19.04.0.tar.xz";
     };
   };
   kcalutils = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kcalutils-18.12.3.tar.xz";
-      sha256 = "715c48c46cd62f773da4e804e66cdb97eae7c4832a7fe058db2fca61dc4111f9";
-      name = "kcalutils-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kcalutils-19.04.0.tar.xz";
+      sha256 = "2841291555bf5ab85390e56b1c6c231bb6f1f5c9cbd12a634491781c3cfd83c8";
+      name = "kcalutils-19.04.0.tar.xz";
     };
   };
   kcharselect = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kcharselect-18.12.3.tar.xz";
-      sha256 = "e24e0268c5810cd3cf733dd8fcc8a9e04a111b761d4c1351d9976b3888278dcb";
-      name = "kcharselect-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kcharselect-19.04.0.tar.xz";
+      sha256 = "788e6e97bb53216b4777fb19602d823a8e62f9ea25082f545e970a561fb3a78f";
+      name = "kcharselect-19.04.0.tar.xz";
     };
   };
   kcolorchooser = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kcolorchooser-18.12.3.tar.xz";
-      sha256 = "8defdb9450922b675dc80561a0f4bb119e621a85dd73661fc4caacef8db91228";
-      name = "kcolorchooser-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kcolorchooser-19.04.0.tar.xz";
+      sha256 = "8f338ba51349cb056f25266d884ca318d3fd3933288ec96f9f17df6c842bc839";
+      name = "kcolorchooser-19.04.0.tar.xz";
     };
   };
   kcontacts = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kcontacts-18.12.3.tar.xz";
-      sha256 = "ba244937e36456065ec4c40fd1b44d011df487a940756ddc0ddd761f58454dd3";
-      name = "kcontacts-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kcontacts-19.04.0.tar.xz";
+      sha256 = "81ad5b3eada7c91b4b7ed09a0a17a146e87b3075925caa3d23b82c2a6f67f5b4";
+      name = "kcontacts-19.04.0.tar.xz";
     };
   };
   kcron = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kcron-18.12.3.tar.xz";
-      sha256 = "ba1d7e3ed5453a4867b4900deb957f1020f1533bdadfc36a1c6f83921bfd6ca3";
-      name = "kcron-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kcron-19.04.0.tar.xz";
+      sha256 = "58a84503da74d7c0e26ab14c95f92f57f0a9f0c5e1ce0fa4be30276728c8be35";
+      name = "kcron-19.04.0.tar.xz";
     };
   };
   kdav = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kdav-18.12.3.tar.xz";
-      sha256 = "3ce99c65573d6374e91abff50b3a738515da07371f07c1b6e4b1800069a77c23";
-      name = "kdav-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kdav-19.04.0.tar.xz";
+      sha256 = "dce315916a993dbff7f7748538da91944b20df3cb6fc042e0d145d53904ff5d9";
+      name = "kdav-19.04.0.tar.xz";
     };
   };
   kdebugsettings = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kdebugsettings-18.12.3.tar.xz";
-      sha256 = "680eeec77314d23ca3a40c803b4c22a1800dc982fa81cba9f44dbfa9222539f7";
-      name = "kdebugsettings-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kdebugsettings-19.04.0.tar.xz";
+      sha256 = "7c06b1c5b1f14c3a67d34fda52494a8d47495b3473ecd9fe03e97cb1c88012c5";
+      name = "kdebugsettings-19.04.0.tar.xz";
     };
   };
   kde-dev-scripts = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kde-dev-scripts-18.12.3.tar.xz";
-      sha256 = "c62f05b86615a810beb2573ee2106bc68fc8be586b66bcdde62d3ba4e4c16fb4";
-      name = "kde-dev-scripts-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kde-dev-scripts-19.04.0.tar.xz";
+      sha256 = "23b777143c9402bf089cd2f84c5ac363183b74dcf81be8c08d74d5d099e898e5";
+      name = "kde-dev-scripts-19.04.0.tar.xz";
     };
   };
   kde-dev-utils = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kde-dev-utils-18.12.3.tar.xz";
-      sha256 = "f53b896b62b7d2267b78d23fb24cf495932c4c8b552d8bf56c722a49acc54be6";
-      name = "kde-dev-utils-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kde-dev-utils-19.04.0.tar.xz";
+      sha256 = "ec2df1ab8b73f19ffc8ec7abeba0577b42d15bc372a19b456a2a04ebb4691031";
+      name = "kde-dev-utils-19.04.0.tar.xz";
     };
   };
   kdeedu-data = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kdeedu-data-18.12.3.tar.xz";
-      sha256 = "cebaa135b21cba27015b1679e02a6625b9b444828ec7595e1a46f53dd7ae3999";
-      name = "kdeedu-data-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kdeedu-data-19.04.0.tar.xz";
+      sha256 = "ddba1b8f78b1614ac8b43b605a9021d611765dea6152e0997c84d4f9b17d9be6";
+      name = "kdeedu-data-19.04.0.tar.xz";
     };
   };
   kdegraphics-mobipocket = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kdegraphics-mobipocket-18.12.3.tar.xz";
-      sha256 = "69ae8b6f45b8c9ec3a73e636f7a779257ebbd6f8016d24294bec844a51f2cc52";
-      name = "kdegraphics-mobipocket-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kdegraphics-mobipocket-19.04.0.tar.xz";
+      sha256 = "37db302ed0d70766cf75e052f27150553b875428b68c886fe4d16452edd18939";
+      name = "kdegraphics-mobipocket-19.04.0.tar.xz";
     };
   };
   kdegraphics-thumbnailers = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kdegraphics-thumbnailers-18.12.3.tar.xz";
-      sha256 = "9bc36ea2eb8a177899bf81b1cdc63a92b8e5dae12308f3e71046a63e58aafec0";
-      name = "kdegraphics-thumbnailers-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kdegraphics-thumbnailers-19.04.0.tar.xz";
+      sha256 = "7af5fb986c493649a1eec9ba881f8b9c06c5d7459f0acc59e7ee7d185bc7ee70";
+      name = "kdegraphics-thumbnailers-19.04.0.tar.xz";
     };
   };
   kdenetwork-filesharing = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kdenetwork-filesharing-18.12.3.tar.xz";
-      sha256 = "296c71526de0e51b4385962c76c2870cfe344b9dafdd2f5f2fba81801350d503";
-      name = "kdenetwork-filesharing-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kdenetwork-filesharing-19.04.0.tar.xz";
+      sha256 = "a88277659bc1dd5ddfea9dd63c3764a1f31d06235aa07c528c12a63a7605c943";
+      name = "kdenetwork-filesharing-19.04.0.tar.xz";
     };
   };
   kdenlive = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kdenlive-18.12.3.tar.xz";
-      sha256 = "fcfe2474bc271e730ed95edb21ae46e93c1ce773ed036f63c9fb2db02cbc7e64";
-      name = "kdenlive-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kdenlive-19.04.0.tar.xz";
+      sha256 = "274ae17b4376258ef83d810cb33677ca3224e205ea8b69982dd0fc4e5ee5878a";
+      name = "kdenlive-19.04.0.tar.xz";
     };
   };
   kdepim-addons = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kdepim-addons-18.12.3.tar.xz";
-      sha256 = "450a3f257e998e733b69703a1a813abab93c571c602702cbb4d9ab4ac25e8ce5";
-      name = "kdepim-addons-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kdepim-addons-19.04.0.tar.xz";
+      sha256 = "778e946e74f36d368f484226ccc6f9cbd548d1cb2b0c3536e87d9374c64ddd88";
+      name = "kdepim-addons-19.04.0.tar.xz";
     };
   };
   kdepim-apps-libs = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kdepim-apps-libs-18.12.3.tar.xz";
-      sha256 = "40a6fb24fc262f5340fda4aed453c5d515976aea745765e83cf8053b44d60164";
-      name = "kdepim-apps-libs-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kdepim-apps-libs-19.04.0.tar.xz";
+      sha256 = "f335f736d854b56bab89814db44761c7e49b35e5266dddee78d22c6465e305c1";
+      name = "kdepim-apps-libs-19.04.0.tar.xz";
     };
   };
   kdepim-runtime = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kdepim-runtime-18.12.3.tar.xz";
-      sha256 = "f3a5da19bb0f60e148d071cf07fd9fd4e6ea116f6125567c767c03b98ea844c3";
-      name = "kdepim-runtime-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kdepim-runtime-19.04.0.tar.xz";
+      sha256 = "944e956d260ba5a735b3c94c6c075f207a9c38bf977ed19507b4dd0f3eaa4993";
+      name = "kdepim-runtime-19.04.0.tar.xz";
     };
   };
   kdesdk-kioslaves = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kdesdk-kioslaves-18.12.3.tar.xz";
-      sha256 = "1f1951eca1c4081277782e80ef6b7c6768b2bb5a7d1830d69954f2fec27462ad";
-      name = "kdesdk-kioslaves-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kdesdk-kioslaves-19.04.0.tar.xz";
+      sha256 = "8765a03f1a6930f28f053b920839e673dbc19bd1947900d84324be963147381a";
+      name = "kdesdk-kioslaves-19.04.0.tar.xz";
     };
   };
   kdesdk-thumbnailers = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kdesdk-thumbnailers-18.12.3.tar.xz";
-      sha256 = "a4694da94bd671a1395a32a527c919fb2207e8a959ceff32a11488e2015a784b";
-      name = "kdesdk-thumbnailers-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kdesdk-thumbnailers-19.04.0.tar.xz";
+      sha256 = "195f539bec6e19de83e07dce117f7cd656f77199c2863a6a5738112d53843243";
+      name = "kdesdk-thumbnailers-19.04.0.tar.xz";
     };
   };
   kdf = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kdf-18.12.3.tar.xz";
-      sha256 = "a8a9e8a4c2bdc1855078383f10720b4b3a388c678dee148494dc18ba5019a6ae";
-      name = "kdf-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kdf-19.04.0.tar.xz";
+      sha256 = "f1204fddefe5492c860a77ff2c343f9b885625b321a37673763d73510dd469fd";
+      name = "kdf-19.04.0.tar.xz";
     };
   };
   kdialog = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kdialog-18.12.3.tar.xz";
-      sha256 = "8b17013ced4b02ceaf89ed3d3fdcfa4fce06fac54d54041fb1e47169f2def212";
-      name = "kdialog-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kdialog-19.04.0.tar.xz";
+      sha256 = "2cdd5a65046cfc09246bd1fbc8be818db486e35437f00e20e372d58988f04ace";
+      name = "kdialog-19.04.0.tar.xz";
     };
   };
   kdiamond = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kdiamond-18.12.3.tar.xz";
-      sha256 = "b3d959cc195b924ca877df2762c3e8ef115ac41c2355f34efbbcaabe9b02b500";
-      name = "kdiamond-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kdiamond-19.04.0.tar.xz";
+      sha256 = "121ef36611bf7fe9a7d1d4700622a4cc8a349fe262b7c568026a4da55dfd4b26";
+      name = "kdiamond-19.04.0.tar.xz";
     };
   };
   keditbookmarks = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/keditbookmarks-18.12.3.tar.xz";
-      sha256 = "8d1f1a6ffa3b68d318ac6eb72707e5e5bb4f6f43ebb25c0475121469a71f6a8d";
-      name = "keditbookmarks-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/keditbookmarks-19.04.0.tar.xz";
+      sha256 = "23770a42aa72eb275b2b5a21f8e2f0959eec112ab048c6d89999ee156cd2ef65";
+      name = "keditbookmarks-19.04.0.tar.xz";
     };
   };
   kfind = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kfind-18.12.3.tar.xz";
-      sha256 = "ad123b24f88e1ade5a845c16a84a483835cce31b92741107d8dbd02f462d4cd9";
-      name = "kfind-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kfind-19.04.0.tar.xz";
+      sha256 = "7eec5b096738bb28264bf870bdd85e24f97c62677be2d2a061f6c426ecfc3a47";
+      name = "kfind-19.04.0.tar.xz";
     };
   };
   kfloppy = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kfloppy-18.12.3.tar.xz";
-      sha256 = "d68af7c572591a1a297cc823c1cb16a8a15973983c31f2e598d75dcc09ae2363";
-      name = "kfloppy-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kfloppy-19.04.0.tar.xz";
+      sha256 = "fafa66fddf5fe938b5666ef94ea4a1f41487cb3cc815fa6bc65332ee7574f7e1";
+      name = "kfloppy-19.04.0.tar.xz";
     };
   };
   kfourinline = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kfourinline-18.12.3.tar.xz";
-      sha256 = "cd3c3129c50502d9fe35f2382fcb1a512519626eb1b776600fdac2190390b9ce";
-      name = "kfourinline-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kfourinline-19.04.0.tar.xz";
+      sha256 = "458bc34c169df064c8d974d6f27e18e3cc5f3e9fb069358817d00a590f2e200a";
+      name = "kfourinline-19.04.0.tar.xz";
     };
   };
   kgeography = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kgeography-18.12.3.tar.xz";
-      sha256 = "ae019c4fc6c2b52344466266a19c6047e5dc414a92461a21d0e9c003dd4433c9";
-      name = "kgeography-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kgeography-19.04.0.tar.xz";
+      sha256 = "ee126fc91ba164e0c095e7cef231a1389a4e1423256773c4e7d4b7306077eb41";
+      name = "kgeography-19.04.0.tar.xz";
     };
   };
   kget = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kget-18.12.3.tar.xz";
-      sha256 = "3386c07c61f072df4259f83895be43c64559c059c24df1b31ca66c4f2b599f86";
-      name = "kget-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kget-19.04.0.tar.xz";
+      sha256 = "e1ec10f36f8b451c2cfc02108e00c6ab3e1115719342b9fa1f1f5829746fbeb9";
+      name = "kget-19.04.0.tar.xz";
     };
   };
   kgoldrunner = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kgoldrunner-18.12.3.tar.xz";
-      sha256 = "1d54b485ccb81106853d5229422c753a5b0bbd2f9239a17b1c44f737a32d93b6";
-      name = "kgoldrunner-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kgoldrunner-19.04.0.tar.xz";
+      sha256 = "3d2eb37695328065ee5cf4c4ba4ee707ce514b4c7aab84c93cd3bef8d329b8ba";
+      name = "kgoldrunner-19.04.0.tar.xz";
     };
   };
   kgpg = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kgpg-18.12.3.tar.xz";
-      sha256 = "05d70923f4c9d068b339dc0a3d3f28890cafe1fbef9820dd6157c1f5fd8f19e8";
-      name = "kgpg-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kgpg-19.04.0.tar.xz";
+      sha256 = "2fb47d9d08cfca94dce1c4d19bce5d2955c3cd3ceec6265a8b537de612a53128";
+      name = "kgpg-19.04.0.tar.xz";
     };
   };
   khangman = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/khangman-18.12.3.tar.xz";
-      sha256 = "1a7cdd27abf229603965ff6b3392bd7935f7f5a2d6418b23f802cfae45f74013";
-      name = "khangman-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/khangman-19.04.0.tar.xz";
+      sha256 = "2a7120f7a54848dc017efdb86c22a964626029d9ca300d8e1488d385f10dc61c";
+      name = "khangman-19.04.0.tar.xz";
     };
   };
   khelpcenter = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/khelpcenter-18.12.3.tar.xz";
-      sha256 = "5b4a9ed17d0898c74cf7fd1612e2d055086d5e04148b3b17df5977255fc240b8";
-      name = "khelpcenter-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/khelpcenter-19.04.0.tar.xz";
+      sha256 = "5fc4f9553e8575055edf259baa3d0b0c663db5caf67dc392db9e519d6b85699f";
+      name = "khelpcenter-19.04.0.tar.xz";
     };
   };
   kidentitymanagement = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kidentitymanagement-18.12.3.tar.xz";
-      sha256 = "4e8cac86c2ecfe6325bbf8fb7e50a026f6af978be3809f327eddfed7b3aed662";
-      name = "kidentitymanagement-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kidentitymanagement-19.04.0.tar.xz";
+      sha256 = "1ddce9330947fdfd970f07b60d6e9ff012e21a673262796ccb29e56e277b55a3";
+      name = "kidentitymanagement-19.04.0.tar.xz";
     };
   };
   kig = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kig-18.12.3.tar.xz";
-      sha256 = "abba87c3569e571e6d1761dc2e6c0e32969ea09eba6d9c0462cb4dc7bd62d7a2";
-      name = "kig-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kig-19.04.0.tar.xz";
+      sha256 = "781243a23a94d7a9882bd69ddfcd74a5b9df0ce28cd45488e62dcf54e3633234";
+      name = "kig-19.04.0.tar.xz";
     };
   };
   kigo = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kigo-18.12.3.tar.xz";
-      sha256 = "fa767319c3ac3e2dea48a5b09284e47e5f0c5d1862af813258758773998d1484";
-      name = "kigo-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kigo-19.04.0.tar.xz";
+      sha256 = "30f12515ec4d22d39c6c90690545e1975a3ba9917180503ef42cba40ffbd874c";
+      name = "kigo-19.04.0.tar.xz";
     };
   };
   killbots = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/killbots-18.12.3.tar.xz";
-      sha256 = "4efb4fcd4f34f1843b990a92e5b0309c196071f0778cdc8376eff5eef405deb9";
-      name = "killbots-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/killbots-19.04.0.tar.xz";
+      sha256 = "0cc928a1956b72bc207feed237598b445b5a7d7d26a266ec88080c1510870359";
+      name = "killbots-19.04.0.tar.xz";
     };
   };
   kimagemapeditor = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kimagemapeditor-18.12.3.tar.xz";
-      sha256 = "addaaf257c35e8169288a8e7a50a1628f3ceeb6a2a845c3d260dfe94662438c6";
-      name = "kimagemapeditor-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kimagemapeditor-19.04.0.tar.xz";
+      sha256 = "8d3ff906926fe8f82b21cf19d784dbddfcda15de9513feaa9defa6e4ff3b1869";
+      name = "kimagemapeditor-19.04.0.tar.xz";
     };
   };
   kimap = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kimap-18.12.3.tar.xz";
-      sha256 = "00aed701a3bdcc218902998e63e7c587549f77a1aa0d1bd7dad4a1837adc9992";
-      name = "kimap-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kimap-19.04.0.tar.xz";
+      sha256 = "cda62c81c47011ad2adbf78222eab4528a62116487531ce1aa98f6100706d2fd";
+      name = "kimap-19.04.0.tar.xz";
     };
   };
   kio-extras = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kio-extras-18.12.3.tar.xz";
-      sha256 = "f8879abaea6fcf31ee0bd4a55d0c24a5fded6d61abed1b059f704f797793aef2";
-      name = "kio-extras-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kio-extras-19.04.0.tar.xz";
+      sha256 = "0f3f2eaf40512cf4a61b09b94ca365d7d05c7b1a75f4e8afd047143a8e962d85";
+      name = "kio-extras-19.04.0.tar.xz";
     };
   };
   kirigami-gallery = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kirigami-gallery-18.12.3.tar.xz";
-      sha256 = "64da8da506718e6b7b62e04a9d2fc40ec73f909f9a6b5afd29b4c81c20053e39";
-      name = "kirigami-gallery-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kirigami-gallery-19.04.0.tar.xz";
+      sha256 = "c0ac9e9a07072d1a538d2535fd21dede86cc4ee9287c7b1ca3d6b8f8726a7155";
+      name = "kirigami-gallery-19.04.0.tar.xz";
     };
   };
   kiriki = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kiriki-18.12.3.tar.xz";
-      sha256 = "0b67b5069625fe04f6ffaa65d0d4abcf86f2f067483b4db15508d2b5ee9742ac";
-      name = "kiriki-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kiriki-19.04.0.tar.xz";
+      sha256 = "feb7b4fce0e6b1749bddd254a46a5d34bf5584a3d60aef460816380141ad630e";
+      name = "kiriki-19.04.0.tar.xz";
     };
   };
   kiten = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kiten-18.12.3.tar.xz";
-      sha256 = "0e0bc0b0b2609a7872b45647976c87ec92ccb068d05113b8dc58e43c6eb1facf";
-      name = "kiten-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kiten-19.04.0.tar.xz";
+      sha256 = "53f5e4ef48b18989084858ab5c96b7dedf357cecf4dba3b2d2a967b4b4b8a742";
+      name = "kiten-19.04.0.tar.xz";
     };
   };
   kitinerary = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kitinerary-18.12.3.tar.xz";
-      sha256 = "f45ef90cb3fb53d83a30837c304b9f7cfa5dbf2953421233d97c101d66a81f35";
-      name = "kitinerary-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kitinerary-19.04.0.tar.xz";
+      sha256 = "b56c93b7114cad54313471e6ab4cebde461a2b39859b47e9b8f7f146d3471889";
+      name = "kitinerary-19.04.0.tar.xz";
     };
   };
   kjumpingcube = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kjumpingcube-18.12.3.tar.xz";
-      sha256 = "6409a3bb398ab90959afc24fa42b01b6e544526b1dab6f36bb700703fa794993";
-      name = "kjumpingcube-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kjumpingcube-19.04.0.tar.xz";
+      sha256 = "28fabf01d0a2481c54018d00985254acb107579c5afa93bbec7b3795c2a3f143";
+      name = "kjumpingcube-19.04.0.tar.xz";
     };
   };
   kldap = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kldap-18.12.3.tar.xz";
-      sha256 = "dc5c8f33aad9e82f0cee65c6fc530f6bd9b82ec9cc21d1ce904f0fe9bdf5140e";
-      name = "kldap-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kldap-19.04.0.tar.xz";
+      sha256 = "2cddadf995a10b854b28e34c18db14c32ad985c18af466edde6a1b2a9a2d8a23";
+      name = "kldap-19.04.0.tar.xz";
     };
   };
   kleopatra = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kleopatra-18.12.3.tar.xz";
-      sha256 = "ea165519846d70206e951d8d904bc02d17ed724db100638e657f7c930c4c490b";
-      name = "kleopatra-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kleopatra-19.04.0.tar.xz";
+      sha256 = "8ad7ec0b99efabdbc270559098dfca64e39ddd30a64b13915c04988a9c8b8b70";
+      name = "kleopatra-19.04.0.tar.xz";
     };
   };
   klettres = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/klettres-18.12.3.tar.xz";
-      sha256 = "4ca89a54858d1f8ac43e8cb485b80a3bb5ead501d39e7e30d8c9b6b8d2d7fd93";
-      name = "klettres-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/klettres-19.04.0.tar.xz";
+      sha256 = "c8a5596638ea7bbe7e26c246c5904840bf544e632e5649430bb32159aedefd60";
+      name = "klettres-19.04.0.tar.xz";
     };
   };
   klickety = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/klickety-18.12.3.tar.xz";
-      sha256 = "45ed455fd9628aaf081bfa6b672199fbb6913c7dc5d5c04ad9df206a3bd962a5";
-      name = "klickety-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/klickety-19.04.0.tar.xz";
+      sha256 = "2ad160e3ea0a6f11c828f3b4bcea8f75db4121dda6d6e498fa1fc095e82e80e5";
+      name = "klickety-19.04.0.tar.xz";
     };
   };
   klines = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/klines-18.12.3.tar.xz";
-      sha256 = "6d93e5bee1135f4eeb67e7f845a4fd658be7e5fb33f42c0ad6320200bc86fd80";
-      name = "klines-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/klines-19.04.0.tar.xz";
+      sha256 = "139c0a4da7186e6e57228fcbe8666aa40e52ae01f328fea4d53ed8611ed54a96";
+      name = "klines-19.04.0.tar.xz";
     };
   };
   kmag = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kmag-18.12.3.tar.xz";
-      sha256 = "04f1357e46bb3e32c85f08c9d5655cde6351c6efd27824a17019ea8562e8d5ba";
-      name = "kmag-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kmag-19.04.0.tar.xz";
+      sha256 = "c6725654846e83b383ff6c624683e4132538f2e812d8131cadefd6926316520e";
+      name = "kmag-19.04.0.tar.xz";
     };
   };
   kmahjongg = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kmahjongg-18.12.3.tar.xz";
-      sha256 = "188a8d921b72965d4ed0f6490048cde7b9d5606cca7d3cea12463dc71a90ccf6";
-      name = "kmahjongg-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kmahjongg-19.04.0.tar.xz";
+      sha256 = "519bf6bb0bc098f74467d3ec9b49c82d22241dfd518d004163565e86dbc21a36";
+      name = "kmahjongg-19.04.0.tar.xz";
     };
   };
   kmail = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kmail-18.12.3.tar.xz";
-      sha256 = "9dd9865d4a463ac552c25126ecaee662b83548091c5abef168bdc7a6d2fb5c76";
-      name = "kmail-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kmail-19.04.0.tar.xz";
+      sha256 = "c191057769513d51d6604e0f51e441e54770ac07a982175a5be29b7797d6f486";
+      name = "kmail-19.04.0.tar.xz";
     };
   };
   kmail-account-wizard = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kmail-account-wizard-18.12.3.tar.xz";
-      sha256 = "102a4170cb4f80c7a9ba3aec7a4d34a3e6a8ca18c975b5c0ea33cf7bac9e21df";
-      name = "kmail-account-wizard-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kmail-account-wizard-19.04.0.tar.xz";
+      sha256 = "640d63ceca23644e2f358c7117eb54daa0fffc669628398f7930fe273d7944a9";
+      name = "kmail-account-wizard-19.04.0.tar.xz";
     };
   };
   kmailtransport = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kmailtransport-18.12.3.tar.xz";
-      sha256 = "8aaa6045f29195074c61fd58112ca7dfbe594df66cac91bac7b246ab2ab9fad1";
-      name = "kmailtransport-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kmailtransport-19.04.0.tar.xz";
+      sha256 = "35104e661fd501bd5848006dfd907f8cd1dfe88609ed4f9fbc4ce599a2f20c8f";
+      name = "kmailtransport-19.04.0.tar.xz";
     };
   };
   kmbox = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kmbox-18.12.3.tar.xz";
-      sha256 = "13a88db1ab0d628a3053a0d6ab5d89cd2f6cbadb3082b52e5dc7048516a10841";
-      name = "kmbox-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kmbox-19.04.0.tar.xz";
+      sha256 = "cd37b698e4ad12317a6d1f7df786345f5df7112ea3d21c2c23545e48a67e8544";
+      name = "kmbox-19.04.0.tar.xz";
     };
   };
   kmime = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kmime-18.12.3.tar.xz";
-      sha256 = "a09b0757e6ba663bf52d9bb8f7f104f3f19f734a858f6d532a6a20888ebcd274";
-      name = "kmime-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kmime-19.04.0.tar.xz";
+      sha256 = "2081adec0e6972e513206bee69c0e165904670b7bcf34c52e7da07323537d513";
+      name = "kmime-19.04.0.tar.xz";
     };
   };
   kmines = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kmines-18.12.3.tar.xz";
-      sha256 = "40c16b57614098555c32252c75e3890922b62d7005b9059f6ae92e11c96d980f";
-      name = "kmines-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kmines-19.04.0.tar.xz";
+      sha256 = "56452ab18c74f2863efc99200a5facd53827382c06fc8534d095bffaca497566";
+      name = "kmines-19.04.0.tar.xz";
     };
   };
   kmix = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kmix-18.12.3.tar.xz";
-      sha256 = "4edf31a36a5d700cc190ba7a5a0d76789729069d48324a22bda7977cb4ed081a";
-      name = "kmix-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kmix-19.04.0.tar.xz";
+      sha256 = "f372d50ccdb496a3bb7a3f68c84c921c12d3d535a792400e701ed7c640e45f2a";
+      name = "kmix-19.04.0.tar.xz";
     };
   };
   kmousetool = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kmousetool-18.12.3.tar.xz";
-      sha256 = "34f6bb6f69c284e9cc88d8a31d59c16f003310c33e1e1affd5c363d18f8a91a8";
-      name = "kmousetool-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kmousetool-19.04.0.tar.xz";
+      sha256 = "89e383a395ec5f1c7d25cc5fb45ecb73a3a0931919a2be533634d77c01cb3fa9";
+      name = "kmousetool-19.04.0.tar.xz";
     };
   };
   kmouth = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kmouth-18.12.3.tar.xz";
-      sha256 = "89b83fb8b4a5eb3c7a6409cd25c730a8bc3be72983c1a75f5e3d3abf01064486";
-      name = "kmouth-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kmouth-19.04.0.tar.xz";
+      sha256 = "32666760ed76dd2dc816df52c990cb3b8487346ac37bf065e4b109fb6661ebc3";
+      name = "kmouth-19.04.0.tar.xz";
     };
   };
   kmplot = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kmplot-18.12.3.tar.xz";
-      sha256 = "2dd6eec34088b5d3b591091cce41616ee310a66aa2d16e5800db56044d60dd7b";
-      name = "kmplot-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kmplot-19.04.0.tar.xz";
+      sha256 = "fb981354dd6fea18e83003df957f65a9580d458b377adde88a838d4db9a97ee6";
+      name = "kmplot-19.04.0.tar.xz";
     };
   };
   knavalbattle = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/knavalbattle-18.12.3.tar.xz";
-      sha256 = "bce9294830a55e96b234c93fa20eb7d7ae963223e724ab0211ec472c79d35fa3";
-      name = "knavalbattle-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/knavalbattle-19.04.0.tar.xz";
+      sha256 = "1e6fbd202092230017c268cd825438debf766e3cc810244b63dc8690b5a69585";
+      name = "knavalbattle-19.04.0.tar.xz";
     };
   };
   knetwalk = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/knetwalk-18.12.3.tar.xz";
-      sha256 = "75ed9859ebb0c40d4efadaf1724b50c1a0436a5d3cd7cb540031cf5535794e3f";
-      name = "knetwalk-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/knetwalk-19.04.0.tar.xz";
+      sha256 = "84b03a6b7c3ff6634402b016089a54ed0116ace221fdfb04ad3d2a8997f68b4b";
+      name = "knetwalk-19.04.0.tar.xz";
     };
   };
   knights = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/knights-18.12.3.tar.xz";
-      sha256 = "9472ffa7800bd79a84dd0c36e3058d3f6e0813b5695aeffeb73bccb801870990";
-      name = "knights-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/knights-19.04.0.tar.xz";
+      sha256 = "53eb3214550fc104755ffe076c970cf5499c9553b543d83df42a3b5f5d8d309a";
+      name = "knights-19.04.0.tar.xz";
     };
   };
   knotes = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/knotes-18.12.3.tar.xz";
-      sha256 = "4cd3a4e5064211f3df6ebf4711c2f4e01b09c77580493de9070c9ee842059578";
-      name = "knotes-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/knotes-19.04.0.tar.xz";
+      sha256 = "e2f98d029105d18c5c14b774782287e281e2367eebeb84d52727a5156abe4092";
+      name = "knotes-19.04.0.tar.xz";
     };
   };
   kolf = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kolf-18.12.3.tar.xz";
-      sha256 = "330cd299702e282a8b248b81cd50ee7ff60a6f512967029730ab87bedb69652f";
-      name = "kolf-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kolf-19.04.0.tar.xz";
+      sha256 = "431b31dc6290214be5f5df1d3c6a8eb4a910b4f72135840d4ec3fa6945319c81";
+      name = "kolf-19.04.0.tar.xz";
     };
   };
   kollision = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kollision-18.12.3.tar.xz";
-      sha256 = "17376f73da0ea5e05998a4f9f0ccb6c0e41461007b8815637ac1980673e9a856";
-      name = "kollision-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kollision-19.04.0.tar.xz";
+      sha256 = "f218ef5691235155911b4d03cd301ee6caa0bde6eb324cd55117e722002b0927";
+      name = "kollision-19.04.0.tar.xz";
     };
   };
   kolourpaint = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kolourpaint-18.12.3.tar.xz";
-      sha256 = "450b714f0d73b59d31c4ceda142a3496d14e51d84b8c8968548a15e05c138f98";
-      name = "kolourpaint-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kolourpaint-19.04.0.tar.xz";
+      sha256 = "d6cd087ba34a1a8fec9349dea06c1b71a70f6e8455adb41d4820a376eb2ed141";
+      name = "kolourpaint-19.04.0.tar.xz";
     };
   };
   kompare = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kompare-18.12.3.tar.xz";
-      sha256 = "7a132a0aced98079fdec37188e9a46f5399e7584ab9d39801d7f0f8176623285";
-      name = "kompare-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kompare-19.04.0.tar.xz";
+      sha256 = "49453b90e21d3b2acd766aac244f579e2dc446ec8abf854ceb2faf34fc3e647f";
+      name = "kompare-19.04.0.tar.xz";
     };
   };
   konqueror = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/konqueror-18.12.3.tar.xz";
-      sha256 = "d9eb2bb4cd121f9967c6d6e7275dfb56bd41aec03c2b9d903d543b330ca4666a";
-      name = "konqueror-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/konqueror-19.04.0.tar.xz";
+      sha256 = "8da6fdd7de037bed79b6341e670a7491d371d084c59fdbefb4ffae0d2da82e4c";
+      name = "konqueror-19.04.0.tar.xz";
     };
   };
   konquest = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/konquest-18.12.3.tar.xz";
-      sha256 = "3698253f8e873819680ed99f377a679bacf5351f3fadc92c07fbaa0f6b269172";
-      name = "konquest-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/konquest-19.04.0.tar.xz";
+      sha256 = "5361a865fefc0dac19e166d282188b732cfbe4389afe095c38c8d30b56f7ff6f";
+      name = "konquest-19.04.0.tar.xz";
     };
   };
   konsole = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/konsole-18.12.3.tar.xz";
-      sha256 = "01ff3245d755a6e38207e58e50e5f82e5c681ead2ad7176d46aec00a8a562e08";
-      name = "konsole-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/konsole-19.04.0.tar.xz";
+      sha256 = "62d53840f6cac4686feafa7f75d641bb56867b7dfc12e6ce95afa7e796e37cef";
+      name = "konsole-19.04.0.tar.xz";
     };
   };
   kontact = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kontact-18.12.3.tar.xz";
-      sha256 = "81426545a958d6d71210040f5ede6407048a16d320ea90c405318cdd7e8e9315";
-      name = "kontact-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kontact-19.04.0.tar.xz";
+      sha256 = "710d72ba01afa2aea89efca61f6c25245c0db04dc675b8871f7109a42a945cca";
+      name = "kontact-19.04.0.tar.xz";
     };
   };
   kontactinterface = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kontactinterface-18.12.3.tar.xz";
-      sha256 = "4895e884c93ebff36a721f5161386105e729925dbbbf6fafb94c75ba4b291e41";
-      name = "kontactinterface-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kontactinterface-19.04.0.tar.xz";
+      sha256 = "268005d61e97dab34f200b0e7a461afddb32a88ccc7c553b6c967865a6915392";
+      name = "kontactinterface-19.04.0.tar.xz";
     };
   };
   kopete = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kopete-18.12.3.tar.xz";
-      sha256 = "8ca7a41e39be23ca6802deade7b5edb88b7e3000bc8e6fb2f68efbc15c2c8d3b";
-      name = "kopete-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kopete-19.04.0.tar.xz";
+      sha256 = "88068ceb8735e1b7ecaac9a9e4c36d40629b53d514c987823c987cfac6dc99df";
+      name = "kopete-19.04.0.tar.xz";
     };
   };
   korganizer = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/korganizer-18.12.3.tar.xz";
-      sha256 = "6a63e60b60af6cb95c78382da15e9e3cf04f936689ce12b62fe38968fad75a9c";
-      name = "korganizer-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/korganizer-19.04.0.tar.xz";
+      sha256 = "3e8c69db9f504e3ec80307d1552af21440621c0e480abf874a5a73482800bcaf";
+      name = "korganizer-19.04.0.tar.xz";
     };
   };
   kpat = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kpat-18.12.3.tar.xz";
-      sha256 = "62c31d6f7a9bb49c09725722bea472811d897b149e29558ca6e248b5d2a41377";
-      name = "kpat-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kpat-19.04.0.tar.xz";
+      sha256 = "bcd295a3df422b5cfa8258bb3cd0be7e4405f44604681d98589f2982c44414a1";
+      name = "kpat-19.04.0.tar.xz";
     };
   };
   kpimtextedit = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kpimtextedit-18.12.3.tar.xz";
-      sha256 = "54586fc97eb863eaa57e589d4461dd9cfbc4d12e58425afadcd22d64ba8a570d";
-      name = "kpimtextedit-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kpimtextedit-19.04.0.tar.xz";
+      sha256 = "b4c640ee8ae5c4356bc26819763721580ca87477eb39258c1eaacdffbfc5311a";
+      name = "kpimtextedit-19.04.0.tar.xz";
     };
   };
   kpkpass = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kpkpass-18.12.3.tar.xz";
-      sha256 = "cd70809ab7a052e0ca2a18266ec5564bde16ac917988798290e3f01e428bd84f";
-      name = "kpkpass-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kpkpass-19.04.0.tar.xz";
+      sha256 = "0121e03af506451a39b34a2f0ca063228454a40f71d9706dea3cee644a4c8f28";
+      name = "kpkpass-19.04.0.tar.xz";
     };
   };
   kqtquickcharts = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kqtquickcharts-18.12.3.tar.xz";
-      sha256 = "739859dc261856cf253ac67e2273b20dee476735b4107ece991d7146d45c1bbe";
-      name = "kqtquickcharts-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kqtquickcharts-19.04.0.tar.xz";
+      sha256 = "c8a270932f11fc5ee9270c77205b1a93edfe73c2e629a602940acb15d853803f";
+      name = "kqtquickcharts-19.04.0.tar.xz";
     };
   };
   krdc = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/krdc-18.12.3.tar.xz";
-      sha256 = "c01896b73ab058a20f4c3d8997c28cbb81a7000f5aec346592a9315412c10666";
-      name = "krdc-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/krdc-19.04.0.tar.xz";
+      sha256 = "2a1ac548992eaaff82cafe386eef0a611b96f06ce3887a363b25d6ca17c6eacc";
+      name = "krdc-19.04.0.tar.xz";
     };
   };
   kreversi = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kreversi-18.12.3.tar.xz";
-      sha256 = "818ef2ded02caacf2ccf3c012e992070c3b898db319682e8a42cf5726d56b3fc";
-      name = "kreversi-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kreversi-19.04.0.tar.xz";
+      sha256 = "a715d068eaf381a26e1f432f2d6b3f3ffffb388282b484cd8ad0833acf429d82";
+      name = "kreversi-19.04.0.tar.xz";
     };
   };
   krfb = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/krfb-18.12.3.tar.xz";
-      sha256 = "9596adfe7135930c6c9c8ecd05035e401d80a5e2cd532ba343b7d4c0f57a799b";
-      name = "krfb-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/krfb-19.04.0.tar.xz";
+      sha256 = "321b1b296dfbd69e64048fbf991aec1a9d8c251e9f0084a396081f62287c6b40";
+      name = "krfb-19.04.0.tar.xz";
     };
   };
   kross-interpreters = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kross-interpreters-18.12.3.tar.xz";
-      sha256 = "ce2231b2faa9accc6342a37024651b988eefbcb9b3968025ffa4752d0cbdc70c";
-      name = "kross-interpreters-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kross-interpreters-19.04.0.tar.xz";
+      sha256 = "e910e76e58603077177b7835bed2b9562b266e2fc0ab78c8b2642edc752ccd27";
+      name = "kross-interpreters-19.04.0.tar.xz";
     };
   };
   kruler = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kruler-18.12.3.tar.xz";
-      sha256 = "1b347c552648caca99364a0524945d0849cd84b29e4d07f62ee518ec07a98e33";
-      name = "kruler-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kruler-19.04.0.tar.xz";
+      sha256 = "7d29eac1d7f4e39f7d754ebb9d68aba70ab3dc12e8241007de750572ce761d73";
+      name = "kruler-19.04.0.tar.xz";
     };
   };
   kshisen = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kshisen-18.12.3.tar.xz";
-      sha256 = "00c5de16c335262287bab37b07822b6fd2997abcec25a0ad0a7d1ece6769060f";
-      name = "kshisen-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kshisen-19.04.0.tar.xz";
+      sha256 = "c7d2799105c71d5d0077383c9b24a52ae85705c39977c8dc167a2594651c17eb";
+      name = "kshisen-19.04.0.tar.xz";
     };
   };
   ksirk = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ksirk-18.12.3.tar.xz";
-      sha256 = "cb8f3cc98fe861b0f4ebff77aeeffa12905b98b6db0c8800525f4fb052be4e7a";
-      name = "ksirk-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ksirk-19.04.0.tar.xz";
+      sha256 = "3dcd578050807aa37652e5e589ddff7a5aec46c82309db85aab588bd3060d5a0";
+      name = "ksirk-19.04.0.tar.xz";
     };
   };
   ksmtp = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ksmtp-18.12.3.tar.xz";
-      sha256 = "90578b1b3ac1ce14bf4f34799b1b400b06734c72f3fecd41f5f07aed37ed3b74";
-      name = "ksmtp-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ksmtp-19.04.0.tar.xz";
+      sha256 = "c92b8b6b9de60bca7b9bb7befdd519041625188a955e55b63860d9de4b3e0bab";
+      name = "ksmtp-19.04.0.tar.xz";
     };
   };
   ksnakeduel = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ksnakeduel-18.12.3.tar.xz";
-      sha256 = "5d55e4c11baecbd77b94dd004b490a7f73870a383e0bf3ad0381f22d36a27a36";
-      name = "ksnakeduel-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ksnakeduel-19.04.0.tar.xz";
+      sha256 = "e9ca727c7e7cef21e9bedbb1504b2023baac9ab5ba0b624dc91e1bf716eb8335";
+      name = "ksnakeduel-19.04.0.tar.xz";
     };
   };
   kspaceduel = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kspaceduel-18.12.3.tar.xz";
-      sha256 = "f40d0a7c578f461875efaf9e25d2b061486a21f750ce8bc922db4aed6fed1f11";
-      name = "kspaceduel-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kspaceduel-19.04.0.tar.xz";
+      sha256 = "486b8d84f3070b7795456ec5847d7b5a9bb3c2b5d3e1c4bcdfedff18b8d735a7";
+      name = "kspaceduel-19.04.0.tar.xz";
     };
   };
   ksquares = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ksquares-18.12.3.tar.xz";
-      sha256 = "82a90b7fe5ca8e46950a0de1742783c522fcd85bbc3aabe5955834865bc36b7d";
-      name = "ksquares-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ksquares-19.04.0.tar.xz";
+      sha256 = "c5a7dc34619f1ee4d621c3371b65bdcd46cf3433c183b4bc85c8a7586b6e85b4";
+      name = "ksquares-19.04.0.tar.xz";
     };
   };
   ksudoku = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ksudoku-18.12.3.tar.xz";
-      sha256 = "4a44248f2bde9c66c911fe7ed7bd54e31956053dac18e29217a355ad2b3a05e1";
-      name = "ksudoku-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ksudoku-19.04.0.tar.xz";
+      sha256 = "4f5cff274741326bff02108fef4996f289c56ff026fd6e2921e4a2bf492a14cb";
+      name = "ksudoku-19.04.0.tar.xz";
     };
   };
   ksystemlog = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ksystemlog-18.12.3.tar.xz";
-      sha256 = "93f276698b74af654f3ed147d5c025162bd919ec6c79a7c7dd7678051c307e52";
-      name = "ksystemlog-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ksystemlog-19.04.0.tar.xz";
+      sha256 = "6a9f389b04fac92b0e2955e86e4a45aa73494f6dd24c9a6704826b469414fb5d";
+      name = "ksystemlog-19.04.0.tar.xz";
     };
   };
   kteatime = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kteatime-18.12.3.tar.xz";
-      sha256 = "24b3e51edc9d6625ca5b3542bd5edd1d42d79142f2c30f886e1b9515dcdfac6d";
-      name = "kteatime-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kteatime-19.04.0.tar.xz";
+      sha256 = "8672fa70912e9bf4488d5258258a14babbf65ee160dc537ab665ff2136a0c490";
+      name = "kteatime-19.04.0.tar.xz";
     };
   };
   ktimer = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ktimer-18.12.3.tar.xz";
-      sha256 = "b3808fa9821c3a624b880b9a5607c8e12287cd38418ff06dd9af8345f324fe7e";
-      name = "ktimer-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ktimer-19.04.0.tar.xz";
+      sha256 = "d772292fa447aec07ff763d7bdfc351fbf2fd7d09160a574ec36ff2905ea5b79";
+      name = "ktimer-19.04.0.tar.xz";
     };
   };
   ktnef = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ktnef-18.12.3.tar.xz";
-      sha256 = "7633f86514d01a1e3709f6854b3b9c859fa1905043bb53240c1ae53f3b76a6ec";
-      name = "ktnef-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ktnef-19.04.0.tar.xz";
+      sha256 = "bc3e826bc831ffac5b3b92cef14fca3f4b077d30652ce2ebdcffa07dafd58c56";
+      name = "ktnef-19.04.0.tar.xz";
     };
   };
   ktouch = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ktouch-18.12.3.tar.xz";
-      sha256 = "194f308a114c89873ee88eb069ecda88d5d1e1ad97c150e2d61cf248719b4bb6";
-      name = "ktouch-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ktouch-19.04.0.tar.xz";
+      sha256 = "707fca9ee9d0d217683e2bb562f5f8f984ddbd0ed7274b022a43bdc176898390";
+      name = "ktouch-19.04.0.tar.xz";
     };
   };
   ktp-accounts-kcm = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ktp-accounts-kcm-18.12.3.tar.xz";
-      sha256 = "ab6ab0f6cb438ec68b110158f7c6555572f04ad69da04f5e1d144cfc4a8ee8cb";
-      name = "ktp-accounts-kcm-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ktp-accounts-kcm-19.04.0.tar.xz";
+      sha256 = "e7c11f4310dd4cb119336fb569cc9799dbdd3d7f4b87af9e265f8fc4439ec7f8";
+      name = "ktp-accounts-kcm-19.04.0.tar.xz";
     };
   };
   ktp-approver = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ktp-approver-18.12.3.tar.xz";
-      sha256 = "0616fcad79fdeae5f2a58b167419f1745e94cea21950faa535e7b5a6c2e53cf6";
-      name = "ktp-approver-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ktp-approver-19.04.0.tar.xz";
+      sha256 = "ec273b9eabcedd47c97fa60c68a3037115b9b06a91892d32871e8ded4c04cdfe";
+      name = "ktp-approver-19.04.0.tar.xz";
     };
   };
   ktp-auth-handler = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ktp-auth-handler-18.12.3.tar.xz";
-      sha256 = "91d6e0148c9006117bc67969012f7a12405e186fc8ffd4011732dc3e7c16a4be";
-      name = "ktp-auth-handler-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ktp-auth-handler-19.04.0.tar.xz";
+      sha256 = "db459ed02c5ed37ce41ec9728d931ca1ab987c43d1b48f501d38b40e1e4f19e9";
+      name = "ktp-auth-handler-19.04.0.tar.xz";
     };
   };
   ktp-call-ui = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ktp-call-ui-18.12.3.tar.xz";
-      sha256 = "3558b9ef7a2a000f6b49454c4477dcd9700168a1f2c060267b24c78725097571";
-      name = "ktp-call-ui-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ktp-call-ui-19.04.0.tar.xz";
+      sha256 = "b63ef1f0bcaed631f9106a355dd60e48edb6e7e39bb6bd0603b504fc33949427";
+      name = "ktp-call-ui-19.04.0.tar.xz";
     };
   };
   ktp-common-internals = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ktp-common-internals-18.12.3.tar.xz";
-      sha256 = "3913a515d98f74940e0db6b85fc5c6c128c68cffb427c93164052be437634740";
-      name = "ktp-common-internals-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ktp-common-internals-19.04.0.tar.xz";
+      sha256 = "12e3e0733eef78a649fa1e55f2f3d228b581fb1a0ba401e154dd57d4eb286eaa";
+      name = "ktp-common-internals-19.04.0.tar.xz";
     };
   };
   ktp-contact-list = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ktp-contact-list-18.12.3.tar.xz";
-      sha256 = "8f858371ec3760bc042dbf6f022ba834ca5b9ae43997e67bf395978df603d0c1";
-      name = "ktp-contact-list-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ktp-contact-list-19.04.0.tar.xz";
+      sha256 = "745a1b403e3e1bfd0604521709f44634ab15a053b45f5c390d9a8e80fa405668";
+      name = "ktp-contact-list-19.04.0.tar.xz";
     };
   };
   ktp-contact-runner = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ktp-contact-runner-18.12.3.tar.xz";
-      sha256 = "886d561952ac1a8a5fa50ffdff8699358480d18d58cbaec217ed865d2047f0a9";
-      name = "ktp-contact-runner-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ktp-contact-runner-19.04.0.tar.xz";
+      sha256 = "12d9e3cf2a230e590c9e3e17462b8e061641a70840492971434b131c15594773";
+      name = "ktp-contact-runner-19.04.0.tar.xz";
     };
   };
   ktp-desktop-applets = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ktp-desktop-applets-18.12.3.tar.xz";
-      sha256 = "439dca1046beba0d2579918f2e409e6629e5063da6eeb1001bcd65ff3edb32c4";
-      name = "ktp-desktop-applets-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ktp-desktop-applets-19.04.0.tar.xz";
+      sha256 = "ba5d0422156e0ea38db1abeb317310266fd96b2b259a40df4233880d15037d8c";
+      name = "ktp-desktop-applets-19.04.0.tar.xz";
     };
   };
   ktp-filetransfer-handler = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ktp-filetransfer-handler-18.12.3.tar.xz";
-      sha256 = "898c7f4ffc8d8bec691cc9744fb356722cf7957f39d2d855138492b647542231";
-      name = "ktp-filetransfer-handler-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ktp-filetransfer-handler-19.04.0.tar.xz";
+      sha256 = "3088b79a79b35fc52f38ae2941e9f1ca8a80a1eed1c3bcdfd489b2e069febcfd";
+      name = "ktp-filetransfer-handler-19.04.0.tar.xz";
     };
   };
   ktp-kded-module = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ktp-kded-module-18.12.3.tar.xz";
-      sha256 = "ebbd02a1441caf8e9ced851c8f814255ac4b9e75485a4bc59026f647d3fd4854";
-      name = "ktp-kded-module-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ktp-kded-module-19.04.0.tar.xz";
+      sha256 = "3409e3ec270f0ba2f558b6e6a84e9948936c128cc536fc6c16c4dd5bd8a3c94b";
+      name = "ktp-kded-module-19.04.0.tar.xz";
     };
   };
   ktp-send-file = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ktp-send-file-18.12.3.tar.xz";
-      sha256 = "0015551c42d66f14ae508eee76f138584bbec3b77a4aff4a003255b52d8414f2";
-      name = "ktp-send-file-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ktp-send-file-19.04.0.tar.xz";
+      sha256 = "f0be593d3101cbc5027e7dcc23a767d2e3e753d140afe97d5790db20eea07226";
+      name = "ktp-send-file-19.04.0.tar.xz";
     };
   };
   ktp-text-ui = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ktp-text-ui-18.12.3.tar.xz";
-      sha256 = "6a37a26b0b226d5d30b298a4d6d85f8dcfe9f39cbc35e1b6322651678815a34e";
-      name = "ktp-text-ui-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ktp-text-ui-19.04.0.tar.xz";
+      sha256 = "78ac51d23e54d6044b70083db8d2c6972643a207a7f475cde15292e08b6b6469";
+      name = "ktp-text-ui-19.04.0.tar.xz";
     };
   };
   ktuberling = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/ktuberling-18.12.3.tar.xz";
-      sha256 = "b69815f3553f843c30ab9d026ca7da97e62e66b58851111d1e4d29e57d67bd04";
-      name = "ktuberling-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/ktuberling-19.04.0.tar.xz";
+      sha256 = "984c29562bd20f93117e7d79aa120dd906e6d4490ae5d2b52ad03f7bbfb85ace";
+      name = "ktuberling-19.04.0.tar.xz";
     };
   };
   kturtle = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kturtle-18.12.3.tar.xz";
-      sha256 = "4677335b4f8a3e363425652815d19ae13e9f8942b01051553b485100c4996253";
-      name = "kturtle-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kturtle-19.04.0.tar.xz";
+      sha256 = "89e836a2737c98caf1ceb16b7ac648262d6a6770ac5bb5b0d9fbfed4abeeda7d";
+      name = "kturtle-19.04.0.tar.xz";
     };
   };
   kubrick = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kubrick-18.12.3.tar.xz";
-      sha256 = "0deb9022a028a6c068203e5bf20820b5561c92b5117735e8a58f212c2ba460e3";
-      name = "kubrick-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kubrick-19.04.0.tar.xz";
+      sha256 = "72adc4e07df6062dd444c4bb9571429acf9c2ee68e273bc42c7925b1c06aad5e";
+      name = "kubrick-19.04.0.tar.xz";
     };
   };
   kwalletmanager = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kwalletmanager-18.12.3.tar.xz";
-      sha256 = "78232285c08241dc06cd6da88dcdce0d850417dd73f0d07034ec6d9a6f97f478";
-      name = "kwalletmanager-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kwalletmanager-19.04.0.tar.xz";
+      sha256 = "5cc25daaa8511694b01ba4b0a7ca39f8f2eef9fce10e99411ae287013fc27734";
+      name = "kwalletmanager-19.04.0.tar.xz";
     };
   };
   kwave = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kwave-18.12.3.tar.xz";
-      sha256 = "4ca9a15ecd06b96e013855f8109b52fcd4a848652438b2e7a2f55a8fcb1d1c48";
-      name = "kwave-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kwave-19.04.0.tar.xz";
+      sha256 = "510b99740c87ade2e644b8b62ece9ac46721e636aeb83f253939d4d191d03a52";
+      name = "kwave-19.04.0.tar.xz";
     };
   };
   kwordquiz = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/kwordquiz-18.12.3.tar.xz";
-      sha256 = "e609d6b7f93abe0ca7ba844c51dff8d89d435daa9d0a6be68e789b70370459cc";
-      name = "kwordquiz-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/kwordquiz-19.04.0.tar.xz";
+      sha256 = "a6433b5a2497398ed790965ef5469b53e406882f93b5a05e574d05cb193ef866";
+      name = "kwordquiz-19.04.0.tar.xz";
     };
   };
   libgravatar = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/libgravatar-18.12.3.tar.xz";
-      sha256 = "c44c139fbaffda352f0fe461065622cff65b6f1cc13cee8a0137acb27de143ee";
-      name = "libgravatar-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/libgravatar-19.04.0.tar.xz";
+      sha256 = "ee62597fffa534b45f89056028d1d9ff871c7da7093d11a128a6decfb5312d12";
+      name = "libgravatar-19.04.0.tar.xz";
     };
   };
   libkcddb = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/libkcddb-18.12.3.tar.xz";
-      sha256 = "38bffd551b82628a25b46bd598c257927855b77c6b6b73a9b69ac7bf538afc29";
-      name = "libkcddb-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/libkcddb-19.04.0.tar.xz";
+      sha256 = "d15cef6fe986daba5ea051fda7146c784d993e83ca495faf58fad586ca370c32";
+      name = "libkcddb-19.04.0.tar.xz";
     };
   };
   libkcompactdisc = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/libkcompactdisc-18.12.3.tar.xz";
-      sha256 = "a464ebfdd1a2834c2597e7ffd1b0d946ddfda348eea5ac8d1d42b46d6c478926";
-      name = "libkcompactdisc-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/libkcompactdisc-19.04.0.tar.xz";
+      sha256 = "7236af70872c7b20070d9c096a8d4da45cdf62874d6d1314b183edf8b0d701d6";
+      name = "libkcompactdisc-19.04.0.tar.xz";
     };
   };
   libkdcraw = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/libkdcraw-18.12.3.tar.xz";
-      sha256 = "c4b6541419b2ebee15d24744d10e67c9a137e616766e765c13e5056c2a37ef99";
-      name = "libkdcraw-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/libkdcraw-19.04.0.tar.xz";
+      sha256 = "30df02047c0f1b97a7c90c8eb5f7a3c5d322f13e0158395d3f9798ff21ed529e";
+      name = "libkdcraw-19.04.0.tar.xz";
     };
   };
   libkdegames = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/libkdegames-18.12.3.tar.xz";
-      sha256 = "7c833fe476043f0492a09a52af60ee7652805cccbbb72e5f473a9d35abff9ed9";
-      name = "libkdegames-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/libkdegames-19.04.0.tar.xz";
+      sha256 = "2965e4a313609f6408becb13e54e26bfe14b37b58e7737e051129896f6e8bcd3";
+      name = "libkdegames-19.04.0.tar.xz";
     };
   };
   libkdepim = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/libkdepim-18.12.3.tar.xz";
-      sha256 = "1c53148dd9f477b1ca2ea622b25100eab95531115e9798264d3e65d28183e640";
-      name = "libkdepim-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/libkdepim-19.04.0.tar.xz";
+      sha256 = "099c7bd90e540c6996f333393afa4831c94b6fbe65f7800bde712ebae4ba8a8e";
+      name = "libkdepim-19.04.0.tar.xz";
     };
   };
   libkeduvocdocument = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/libkeduvocdocument-18.12.3.tar.xz";
-      sha256 = "907076104f445f22fa31c2fa5ecfdabbb8b18faab52fc10c879a53d6245aaad4";
-      name = "libkeduvocdocument-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/libkeduvocdocument-19.04.0.tar.xz";
+      sha256 = "bb0300ca6a89c7174714b005032380b81e6e7bfdf3a3bab82b6f42fc0693045e";
+      name = "libkeduvocdocument-19.04.0.tar.xz";
     };
   };
   libkexiv2 = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/libkexiv2-18.12.3.tar.xz";
-      sha256 = "1d14ff63af42ab7e19e2039648a95ea5dc946afbe3e3df52c17ce1618a02ebdc";
-      name = "libkexiv2-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/libkexiv2-19.04.0.tar.xz";
+      sha256 = "9fcafa932631429af1693642415d2f202ad29338b63949b5e8661135eb69dc19";
+      name = "libkexiv2-19.04.0.tar.xz";
     };
   };
   libkgapi = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/libkgapi-18.12.3.tar.xz";
-      sha256 = "de0314fd83d8fa8f88e6a355c4725047d2e507e0d40f1950c8ae083c2bc21924";
-      name = "libkgapi-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/libkgapi-19.04.0.tar.xz";
+      sha256 = "014084b04ee76939a318f711259bbb540037b45fe57a25b200ed4095b74970dc";
+      name = "libkgapi-19.04.0.tar.xz";
     };
   };
   libkgeomap = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/libkgeomap-18.12.3.tar.xz";
-      sha256 = "2c4459e61e471f0344d03cfa5f00fe2a1890cd2c1501323ceed26d522496c47b";
-      name = "libkgeomap-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/libkgeomap-19.04.0.tar.xz";
+      sha256 = "12cf73da1d406b8f6efe88c1d1bc56ecf3260bbe41759c4dec061df627e990e9";
+      name = "libkgeomap-19.04.0.tar.xz";
     };
   };
   libkipi = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/libkipi-18.12.3.tar.xz";
-      sha256 = "96abf4552d535cf101c76ff5b1cb0198eccfd4bdfb7dc192b66bf709af037a31";
-      name = "libkipi-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/libkipi-19.04.0.tar.xz";
+      sha256 = "6fc176e72e829dafe19e17a1d97b032f464d837621989751efe38cdd03d7d285";
+      name = "libkipi-19.04.0.tar.xz";
     };
   };
   libkleo = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/libkleo-18.12.3.tar.xz";
-      sha256 = "e528ed366352404d48313a8c154f56c672470bf06524ea7a150a726d3eb87d69";
-      name = "libkleo-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/libkleo-19.04.0.tar.xz";
+      sha256 = "fbd97ae860c0361fca8bfa8a80a2d19e96779eb8d436a9a32c10cfe9767d8981";
+      name = "libkleo-19.04.0.tar.xz";
     };
   };
   libkmahjongg = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/libkmahjongg-18.12.3.tar.xz";
-      sha256 = "25e5cea50b6c96f18efa8d013ab58abfaac7845edb969b8e63e0c297482a6be4";
-      name = "libkmahjongg-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/libkmahjongg-19.04.0.tar.xz";
+      sha256 = "1ab4461ba92de0cc56bd349a859d5c647f816b20923692237e7f3098ba9dd76e";
+      name = "libkmahjongg-19.04.0.tar.xz";
     };
   };
   libkomparediff2 = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/libkomparediff2-18.12.3.tar.xz";
-      sha256 = "f70bf7470f67419a7071a4df23d929c4c4ed80d588b3096d48486ee0f27d890c";
-      name = "libkomparediff2-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/libkomparediff2-19.04.0.tar.xz";
+      sha256 = "ffb3370aa869831f86dc009353abd72a5f0c7a7d1c570d5fecf9747131247464";
+      name = "libkomparediff2-19.04.0.tar.xz";
     };
   };
   libksane = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/libksane-18.12.3.tar.xz";
-      sha256 = "40bf814cebac7ef00dc18fbdeabb2f9fd786c9144d787d5dc36a58fe18c33034";
-      name = "libksane-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/libksane-19.04.0.tar.xz";
+      sha256 = "15a4f14ddb26e7e0ed54926c54941b29eebba1fabb2e75ad9f5cd48b9b673f58";
+      name = "libksane-19.04.0.tar.xz";
     };
   };
   libksieve = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/libksieve-18.12.3.tar.xz";
-      sha256 = "ce18756940d86dff8eafd77883d202ab90e3d8273f5248ffd97627b974211754";
-      name = "libksieve-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/libksieve-19.04.0.tar.xz";
+      sha256 = "451d71d6c6e8cdfe0ef540cbcca94dae57260563e1e435b41f7070ecb86f6312";
+      name = "libksieve-19.04.0.tar.xz";
     };
   };
   lokalize = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/lokalize-18.12.3.tar.xz";
-      sha256 = "cce11b9384d27006855a141d2241a67d05679baa7096db2311c49a78bd642fed";
-      name = "lokalize-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/lokalize-19.04.0.tar.xz";
+      sha256 = "e2e8cd6f9bb0e59ffd4b88e5513b757df3b63892ce90e7000c872e896ef74266";
+      name = "lokalize-19.04.0.tar.xz";
     };
   };
   lskat = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/lskat-18.12.3.tar.xz";
-      sha256 = "d81d3af26b9f23abc40f1e2f97410d662c11d4641b67c32d427846a561f0b1e2";
-      name = "lskat-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/lskat-19.04.0.tar.xz";
+      sha256 = "c3358e62eb8a0c428c32f1ac759f5ead15d4ab552b1ae5b273e6927d14bb0ad1";
+      name = "lskat-19.04.0.tar.xz";
     };
   };
   mailcommon = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/mailcommon-18.12.3.tar.xz";
-      sha256 = "789d89fad58af80202dfcc41f7c7435871a60309d1d46f93cabcb37dd6ae97e1";
-      name = "mailcommon-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/mailcommon-19.04.0.tar.xz";
+      sha256 = "cd599079d290f540c83919182eab7e2d236a939a3405d1f882385822fc5d3682";
+      name = "mailcommon-19.04.0.tar.xz";
     };
   };
   mailimporter = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/mailimporter-18.12.3.tar.xz";
-      sha256 = "1c0e583fa36fc1b87154367cbe02cf1ec68d9f36d8a37bd6b220e9d9aadfcfa3";
-      name = "mailimporter-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/mailimporter-19.04.0.tar.xz";
+      sha256 = "d5649d24aca659fbb00284a70aef868e31a56a9c688a0457945ec0d31c7a22ed";
+      name = "mailimporter-19.04.0.tar.xz";
     };
   };
   marble = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/marble-18.12.3.tar.xz";
-      sha256 = "0bfd7ae576e42ebbddadc8c83c2fec5edaf462bcf284642b1002d36d751b24ee";
-      name = "marble-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/marble-19.04.0.tar.xz";
+      sha256 = "7405c76970d6ec500e5dc99ea2926cc11571e69f29c2e79f025f0f3ec4048960";
+      name = "marble-19.04.0.tar.xz";
     };
   };
   mbox-importer = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/mbox-importer-18.12.3.tar.xz";
-      sha256 = "a220ca69dd6f78cf18c3d8cb1bb293dc2ab2ff45f2a25df72cad8df78f581201";
-      name = "mbox-importer-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/mbox-importer-19.04.0.tar.xz";
+      sha256 = "0fba78f2feee2ec7c11e64511195546b9c34695c091632494c1d77c2555eb888";
+      name = "mbox-importer-19.04.0.tar.xz";
     };
   };
   messagelib = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/messagelib-18.12.3.tar.xz";
-      sha256 = "0064a8df62a08d0dfb06af28d4aff8a645a0e8bb01d91ab23647b3d26d3af7d8";
-      name = "messagelib-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/messagelib-19.04.0.tar.xz";
+      sha256 = "1fb76bcd7aa9792095519c585dbb93552726e3cfe514446eb52edf5ed1517a1a";
+      name = "messagelib-19.04.0.tar.xz";
     };
   };
   minuet = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/minuet-18.12.3.tar.xz";
-      sha256 = "9244ec364d031c73f9aed9568012a28b847ec4dceca61040324af7afd3d64009";
-      name = "minuet-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/minuet-19.04.0.tar.xz";
+      sha256 = "3bdf5470a154b2be4bfcd97db7374ef81ca8eefba3bb12030dd6d39f1466cc78";
+      name = "minuet-19.04.0.tar.xz";
     };
   };
   okular = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/okular-18.12.3.tar.xz";
-      sha256 = "d7ef9b59acb5746ebc64399f4c1a99faf0c1530bf6a818b3bfd34b73476d90ab";
-      name = "okular-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/okular-19.04.0.tar.xz";
+      sha256 = "1947b394dfd8da9c7cc4234e308e2476ffa44dc58542d246eafc8397d8991b6e";
+      name = "okular-19.04.0.tar.xz";
     };
   };
   palapeli = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/palapeli-18.12.3.tar.xz";
-      sha256 = "b28fa1cf7a763125a09baa8f4e7562e17892475444d3907e566281328502e593";
-      name = "palapeli-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/palapeli-19.04.0.tar.xz";
+      sha256 = "21f8b6b109d6cc61acbb0ee01aa31982bb6e27e8894e4f00407f52904d177a2b";
+      name = "palapeli-19.04.0.tar.xz";
     };
   };
   parley = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/parley-18.12.3.tar.xz";
-      sha256 = "289bc5aa88d7a33fdf0d668b45412f163d74e86d3deb9492db53a11f7c6a7f75";
-      name = "parley-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/parley-19.04.0.tar.xz";
+      sha256 = "243f7f1a89bb603c059b0610a9bb7f51627540d439b4026d736062b693879ed2";
+      name = "parley-19.04.0.tar.xz";
     };
   };
   picmi = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/picmi-18.12.3.tar.xz";
-      sha256 = "0691c70d746aa9d444559970e002561a1123963d617b36ceef4a8c3ee4730f49";
-      name = "picmi-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/picmi-19.04.0.tar.xz";
+      sha256 = "edb10bc29d6817dffeb51762c5fa793ee8de3b3a70c2c6616012f5a043799d86";
+      name = "picmi-19.04.0.tar.xz";
     };
   };
   pimcommon = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/pimcommon-18.12.3.tar.xz";
-      sha256 = "f4a0bf8146d1140c0252a5315baa826651968352a828c004d91b06e0e98c6b9e";
-      name = "pimcommon-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/pimcommon-19.04.0.tar.xz";
+      sha256 = "b25d10571e55ab11b758ad6b1040ef2d148b4b5b913f41665c355df25bceb12e";
+      name = "pimcommon-19.04.0.tar.xz";
     };
   };
   pim-data-exporter = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/pim-data-exporter-18.12.3.tar.xz";
-      sha256 = "7deb5baf5a36b96f1414e0b67192cd1ad48f396fb3cb5f5eb2fc90a312d74941";
-      name = "pim-data-exporter-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/pim-data-exporter-19.04.0.tar.xz";
+      sha256 = "ae1c3bbfffebb85533b0bbf4b0f8b54c06e29fcdf7284295c89ab43d196a6ac3";
+      name = "pim-data-exporter-19.04.0.tar.xz";
     };
   };
   pim-sieve-editor = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/pim-sieve-editor-18.12.3.tar.xz";
-      sha256 = "6e755ec258b0a75e4e83adb82551c1779c2ab7766aef26d2f1c9c00f3809deb5";
-      name = "pim-sieve-editor-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/pim-sieve-editor-19.04.0.tar.xz";
+      sha256 = "0843df57695ca4dc359d048a7e3bf2b6bb66bd10d861714d316baa8ecb387dd1";
+      name = "pim-sieve-editor-19.04.0.tar.xz";
     };
   };
   poxml = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/poxml-18.12.3.tar.xz";
-      sha256 = "6714e371957d175b859894149a3791acb3b8ef62b653b7b09f34819e92c8eaf7";
-      name = "poxml-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/poxml-19.04.0.tar.xz";
+      sha256 = "c0a24557cc7e243790c5273fb2a4ff585a3e89cc994772a52979015d2e57a985";
+      name = "poxml-19.04.0.tar.xz";
     };
   };
   print-manager = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/print-manager-18.12.3.tar.xz";
-      sha256 = "917ea500bcd11d2ca3cc1e7de1b38d7ef72f1d397182aaac2c6a31cd338f387d";
-      name = "print-manager-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/print-manager-19.04.0.tar.xz";
+      sha256 = "f9dfe61ba341013ae59892cd6715b7c00ee6777ca4d2e81deeda1cf2d283f6ba";
+      name = "print-manager-19.04.0.tar.xz";
     };
   };
   rocs = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/rocs-18.12.3.tar.xz";
-      sha256 = "6b007b0b11a8128787c316f055a99dde83619dd35287e04867949e84661c2b11";
-      name = "rocs-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/rocs-19.04.0.tar.xz";
+      sha256 = "65557205a86ddc682c9f9378731b1cf0dacd170742a5bdf110eeeef8ae4b26c8";
+      name = "rocs-19.04.0.tar.xz";
     };
   };
   signon-kwallet-extension = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/signon-kwallet-extension-18.12.3.tar.xz";
-      sha256 = "9a6c25cf19a382cbfd219c043838ad691c4c53ae8c3bc9f4b59f9f6f98bd3a4f";
-      name = "signon-kwallet-extension-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/signon-kwallet-extension-19.04.0.tar.xz";
+      sha256 = "eb93120d2acfbac4b823bc301b3724d250dc7e7041eef347c1337c7df84c0c40";
+      name = "signon-kwallet-extension-19.04.0.tar.xz";
     };
   };
   spectacle = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/spectacle-18.12.3.tar.xz";
-      sha256 = "8abf85b85de7844c503ef84182303c47cf425f5c14d71e723e3c887ee87ce06e";
-      name = "spectacle-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/spectacle-19.04.0.tar.xz";
+      sha256 = "2c4d891d5850e13d912ad0885086170f45178ed5fb4d0ccfef7b22a9a76c35a8";
+      name = "spectacle-19.04.0.tar.xz";
     };
   };
   step = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/step-18.12.3.tar.xz";
-      sha256 = "35abaf0a4597e141f4db08ad91ebcefafe43609b986a93a11e5f3ec19165c755";
-      name = "step-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/step-19.04.0.tar.xz";
+      sha256 = "c37cbd4a7179d796dd4458dbdd98e48d59c5f0278f19026a4f5cc2b50e140319";
+      name = "step-19.04.0.tar.xz";
     };
   };
   svgpart = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/svgpart-18.12.3.tar.xz";
-      sha256 = "675ab3b652b0d2619abb305ce7c00beb8a80067416e4ea7e216cfa201a7ff8ef";
-      name = "svgpart-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/svgpart-19.04.0.tar.xz";
+      sha256 = "6dbec1dcb6853c06f7cb10677a2c99678b398b4a658eb4206a146f24b0fa158a";
+      name = "svgpart-19.04.0.tar.xz";
     };
   };
   sweeper = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/sweeper-18.12.3.tar.xz";
-      sha256 = "8007da0f4d835e376fb049d539ca9fd6840ef7196f25b62cf652374a645fc6e0";
-      name = "sweeper-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/sweeper-19.04.0.tar.xz";
+      sha256 = "7ed57321ba601725291e1cfa6cdfe2060ad0405d42124dc8d8d44d137b852f72";
+      name = "sweeper-19.04.0.tar.xz";
     };
   };
   umbrello = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/umbrello-18.12.3.tar.xz";
-      sha256 = "2ab53b33cf1fcaea470c01b2421e911d4287b1d0421fa33e0b60043fe6943cc7";
-      name = "umbrello-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/umbrello-19.04.0.tar.xz";
+      sha256 = "7c37363a92bd91f2a515438068ba6f1c8747269ddaf2eda5a7998539ece4468d";
+      name = "umbrello-19.04.0.tar.xz";
     };
   };
   zeroconf-ioslave = {
-    version = "18.12.3";
+    version = "19.04.0";
     src = fetchurl {
-      url = "${mirror}/stable/applications/18.12.3/src/zeroconf-ioslave-18.12.3.tar.xz";
-      sha256 = "b3adcaec0ebd89ddaf839954fb387e59791683d98f93da0c3dacb0266cd02a12";
-      name = "zeroconf-ioslave-18.12.3.tar.xz";
+      url = "${mirror}/stable/applications/19.04.0/src/zeroconf-ioslave-19.04.0.tar.xz";
+      sha256 = "e1f7465f200d1c7c53c56a8ebf9a463022a27d6c244d0d1768ff58763e5b53dc";
+      name = "zeroconf-ioslave-19.04.0.tar.xz";
     };
   };
 }

--- a/pkgs/desktops/plasma-5/breeze-gtk.nix
+++ b/pkgs/desktops/plasma-5/breeze-gtk.nix
@@ -1,10 +1,10 @@
-{ mkDerivation, lib, extra-cmake-modules, gtk2, qtbase, }:
+{ mkDerivation, lib, extra-cmake-modules, gtk2, qtbase, sassc, python3, breeze-qt5 }:
 
 let inherit (lib) getLib; in
 
 mkDerivation {
   name = "breeze-gtk";
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [ extra-cmake-modules sassc python3 python3.pkgs.pycairo breeze-qt5 ];
   buildInputs = [ qtbase ];
   postPatch = ''
     sed -i cmake/FindGTKEngine.cmake \

--- a/pkgs/desktops/plasma-5/fetch.sh
+++ b/pkgs/desktops/plasma-5/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/plasma/5.14.5/ )
+WGET_ARGS=( https://download.kde.org/stable/plasma/5.15.3/ )

--- a/pkgs/desktops/plasma-5/fetch.sh
+++ b/pkgs/desktops/plasma-5/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/plasma/5.15.3/ )
+WGET_ARGS=( https://download.kde.org/stable/plasma/5.15.4/ )

--- a/pkgs/desktops/plasma-5/plasma-workspace/plasma-workspace.patch
+++ b/pkgs/desktops/plasma-5/plasma-workspace/plasma-workspace.patch
@@ -1,5 +1,5 @@
 diff --git a/sddm-theme/theme.conf.cmake b/sddm-theme/theme.conf.cmake
-index 69d30705..52e91028 100644
+index 69d3070..52e9102 100644
 --- a/sddm-theme/theme.conf.cmake
 +++ b/sddm-theme/theme.conf.cmake
 @@ -1,4 +1,4 @@
@@ -9,13 +9,13 @@ index 69d30705..52e91028 100644
 -background=${CMAKE_INSTALL_PREFIX}/${WALLPAPER_INSTALL_DIR}/Next/contents/images/3200x2000.png
 +background=${NIXPKGS_WALLPAPER_INSTALL_DIR}/Next/contents/images/3200x2000.png
 diff --git a/startkde/CMakeLists.txt b/startkde/CMakeLists.txt
-index cb75aeca..247db953 100644
+index 6a1a212..f03fd34 100644
 --- a/startkde/CMakeLists.txt
 +++ b/startkde/CMakeLists.txt
-@@ -3,11 +3,6 @@ add_subdirectory(kstartupconfig)
- add_subdirectory(ksyncdbusenv)
+@@ -4,11 +4,6 @@ add_subdirectory(ksyncdbusenv)
  add_subdirectory(waitforname)
- 
+ add_subdirectory(kcheckrunning)
+
 -#FIXME: reconsider, looks fishy
 -if(NOT CMAKE_INSTALL_PREFIX STREQUAL "/usr")
 -    set(EXPORT_XCURSOR_PATH "XCURSOR_PATH=${KDE_INSTALL_FULL_DATAROOTDIR}/icons:$XCURSOR_PATH\":~/.icons:/usr/share/icons:/usr/share/pixmaps:/usr/X11R6/lib/X11/icons\"; export XCURSOR_PATH")
@@ -25,7 +25,7 @@ index cb75aeca..247db953 100644
  configure_file(startplasmacompositor.cmake ${CMAKE_CURRENT_BINARY_DIR}/startplasmacompositor  @ONLY)
  configure_file(startplasma.cmake ${CMAKE_CURRENT_BINARY_DIR}/startplasma  @ONLY)
 diff --git a/startkde/kstartupconfig/kstartupconfig.cpp b/startkde/kstartupconfig/kstartupconfig.cpp
-index 493218ea..d507aa55 100644
+index 493218e..d507aa5 100644
 --- a/startkde/kstartupconfig/kstartupconfig.cpp
 +++ b/startkde/kstartupconfig/kstartupconfig.cpp
 @@ -147,5 +147,5 @@ int main()
@@ -36,7 +36,7 @@ index 493218ea..d507aa55 100644
 +    return system( NIXPKGS_KDOSTARTUPCONFIG5 );
      }
 diff --git a/startkde/startkde.cmake b/startkde/startkde.cmake
-index 714a9bf1..9733c612 100644
+index b68f0c6..a0ec214 100644
 --- a/startkde/startkde.cmake
 +++ b/startkde/startkde.cmake
 @@ -1,22 +1,31 @@
@@ -45,7 +45,7 @@ index 714a9bf1..9733c612 100644
 -#  DEFAULT Plasma STARTUP SCRIPT ( @PROJECT_VERSION@ )
 +#  NIXPKGS KDE STARTUP SCRIPT ( @PROJECT_VERSION@ )
  #
- 
+
 +if test "x$1" = x--failsafe; then
 +    KDE_FAILSAFE=1 # General failsafe flag
 +    KWIN_COMPOSE=N # Disable KWin's compositing
@@ -56,7 +56,7 @@ index 714a9bf1..9733c612 100644
  # When the X server dies we get a HUP signal from xinit. We must ignore it
  # because we still need to do some cleanup.
  trap 'echo GOT SIGHUP' HUP
- 
+
 -# Check if a Plasma session already is running and whether it's possible to connect to X
 -kcheckrunning
 +# we have to unset this for Darwin since it will screw up KDE's dynamic-loading
@@ -79,12 +79,12 @@ index 714a9bf1..9733c612 100644
 +    echo "\$DISPLAY is not set or cannot connect to the X server."
 +    exit 1
  fi
- 
+
  # Boot sequence:
-@@ -33,61 +42,142 @@ fi
+@@ -33,62 +42,143 @@ fi
  #
  # * Then ksmserver is started which takes control of the rest of the startup sequence
- 
+
 -if [  ${XDG_CONFIG_HOME} ]; then
 -  configDir=$XDG_CONFIG_HOME;
 -else
@@ -122,7 +122,7 @@ index 714a9bf1..9733c612 100644
 +    @NIXPKGS_SED@ -e '/nix\\store\|nix\/store/ d' -i $XDG_CONFIG_HOME/Trolltech.conf
  fi
  sysConfigDirs=${XDG_CONFIG_DIRS:-/etc/xdg}
- 
+
 -# We need to create config folder so we can write startupconfigkeys
 -mkdir -p $configDir
 +@NIXPKGS_KBUILDSYCOCA5@
@@ -176,7 +176,7 @@ index 714a9bf1..9733c612 100644
 +cursorSize=0
 +EOF
 +fi
- 
+
  #This is basically setting defaults so we can use them with kstartupconfig5
 -cat >$configDir/startupconfigkeys <<EOF
 +cat >"$XDG_CONFIG_HOME/startupconfigkeys" <<EOF
@@ -185,11 +185,12 @@ index 714a9bf1..9733c612 100644
 -ksplashrc KSplash Theme Breeze
 +ksplashrc KSplash Theme org.kde.breeze.desktop
  ksplashrc KSplash Engine KSplashQML
+ kdeglobals KScreen ScaleFactor ''
  kdeglobals KScreen ScreenScaleFactors ''
  kcmfonts General forceFontDPI 0
 +kcmfonts General dontChangeAASettings true
  EOF
- 
+
  # preload the user's locale on first start
 -plasmalocalerc=$configDir/plasma-localerc
 -test -f $plasmalocalerc || {
@@ -202,7 +203,7 @@ index 714a9bf1..9733c612 100644
  EOF
 -}
 +fi
- 
+
  # export LC_* variables set by kcmshell5 formats into environment
  # so it can be picked up by QLocale and friends.
 -exportformatssettings=$configDir/plasma-locale-settings.sh
@@ -213,7 +214,7 @@ index 714a9bf1..9733c612 100644
 +if [ -r "$exportformatssettings" ]; then
 +    . "$exportformatssettings"
 +fi
- 
+
  # Write a default kdeglobals file to set up the font
 -kdeglobalsfile=$configDir/kdeglobals
 -test -f $kdeglobalsfile || {
@@ -236,7 +237,7 @@ index 714a9bf1..9733c612 100644
  EOF
 -}
 +fi
- 
+
 -kstartupconfig5
 -returncode=$?
 -if test $returncode -ne 0; then
@@ -250,13 +251,13 @@ index 714a9bf1..9733c612 100644
 +if [ -r "$XDG_CONFIG_HOME/startupconfig" ]; then
 +    . "$XDG_CONFIG_HOME/startupconfig"
 +fi
- 
+
  #Do not sync any of this section with the wayland versions as there scale factors are
  #sent properly over wl_output
-@@ -99,26 +180,33 @@ fi
+@@ -104,26 +194,33 @@ fi
  #otherwise apps that manually opt in for high DPI get auto scaled by the developer AND manually scaled by us
  export QT_AUTO_SCREEN_SCALE_FACTOR=0
- 
+
 +#Set the QtQuickControls style to our own: for QtQuickControls1
 +#it will fall back to Desktop, while it will use our own org.kde.desktop
 +#for QtQuickControlsStyle and Kirigami
@@ -292,7 +293,7 @@ index 714a9bf1..9733c612 100644
 +        export XCURSOR_SIZE="$kcminputrc_mouse_cursorsize"
      fi
  fi
- 
+
 -if test "$kcmfonts_general_forcefontdpi" -ne 0; then
 -    xrdb -quiet -merge -nocpp <<EOF
 +if [ "${kcmfonts_general_forcefontdpi:-0}" -ne 0 ]; then
@@ -300,9 +301,9 @@ index 714a9bf1..9733c612 100644
  Xft.dpi: $kcmfonts_general_forcefontdpi
  EOF
  fi
-@@ -127,11 +215,11 @@ dl=$DESKTOP_LOCKED
+@@ -132,11 +229,11 @@ dl=$DESKTOP_LOCKED
  unset DESKTOP_LOCKED # Don't want it in the environment
- 
+
  ksplash_pid=
 -if test -z "$dl"; then
 +if [ -z "$dl" ]; then
@@ -314,10 +315,10 @@ index 714a9bf1..9733c612 100644
        ;;
      None)
        ;;
-@@ -140,69 +228,6 @@ if test -z "$dl"; then
+@@ -145,27 +242,6 @@ if test -z "$dl"; then
    esac
  fi
- 
+
 -# Source scripts found in <config locations>/plasma-workspace/env/*.sh
 -# (where <config locations> correspond to the system and user's configuration
 -# directory.
@@ -339,70 +340,28 @@ index 714a9bf1..9733c612 100644
 -  done
 -done
 -
--# Activate the kde font directories.
--#
--# There are 4 directories that may be used for supplying fonts for KDE.
--#
--# There are two system directories. These belong to the administrator.
--# There are two user directories, where the user may add her own fonts.
--#
--# The 'override' versions are for fonts that should come first in the list,
--# i.e. if you have a font in your 'override' directory, it will be used in
--# preference to any other.
--#
--# The preference order looks like this:
--# user override, system override, X, user, system
--#
--# Where X is the original font database that was set up before this script
--# runs.
--
--usr_odir=$HOME/.fonts/kde-override
--usr_fdir=$HOME/.fonts
--
--if test -n "$KDEDIRS"; then
--  kdedirs_first=`echo "$KDEDIRS"|sed -e 's/:.*//'`
--  sys_odir=$kdedirs_first/share/fonts/override
--  sys_fdir=$kdedirs_first/share/fonts
--else
--  sys_odir=$KDEDIR/share/fonts/override
--  sys_fdir=$KDEDIR/share/fonts
--fi
--
--# We run mkfontdir on the user's font dirs (if we have permission) to pick
--# up any new fonts they may have installed. If mkfontdir fails, we still
--# add the user's dirs to the font path, as they might simply have been made
--# read-only by the administrator, for whatever reason.
--
--test -d "$sys_odir" && xset +fp "$sys_odir"
--test -d "$usr_odir" && (mkfontdir "$usr_odir" ; xset +fp "$usr_odir")
--test -d "$usr_fdir" && (mkfontdir "$usr_fdir" ; xset fp+ "$usr_fdir")
--test -d "$sys_fdir" && xset fp+ "$sys_fdir"
--
--# Ask X11 to rebuild its font list.
--xset fp rehash
--
  # Set a left cursor instead of the standard X11 "X" cursor, since I've heard
  # from some users that they're confused and don't know what to do. This is
  # especially necessary on slow machines, where starting KDE takes one or two
-@@ -257,44 +282,65 @@ export XDG_DATA_DIRS
+@@ -221,44 +297,65 @@ export XDG_DATA_DIRS
  #
  KDE_FULL_SESSION=true
  export KDE_FULL_SESSION
 -xprop -root -f KDE_FULL_SESSION 8t -set KDE_FULL_SESSION true
 +@NIXPKGS_XPROP@ -root -f KDE_FULL_SESSION 8t -set KDE_FULL_SESSION true
- 
+
  KDE_SESSION_VERSION=5
  export KDE_SESSION_VERSION
 -xprop -root -f KDE_SESSION_VERSION 32c -set KDE_SESSION_VERSION 5
 +@NIXPKGS_XPROP@ -root -f KDE_SESSION_VERSION 32c -set KDE_SESSION_VERSION 5
- 
+
 -KDE_SESSION_UID=`id -ru`
 +KDE_SESSION_UID=$(@NIXPKGS_ID@ -ru)
  export KDE_SESSION_UID
- 
+
  XDG_CURRENT_DESKTOP=KDE
  export XDG_CURRENT_DESKTOP
- 
+
 +# Enforce xcb QPA. Helps switching between Wayland and X sessions.
 +export QT_QPA_PLATFORM=xcb
 +
@@ -445,7 +404,7 @@ index 714a9bf1..9733c612 100644
 -  xmessage -geometry 500x100 "Could not sync environment to dbus."
    exit 1
  fi
- 
+
  # We set LD_BIND_NOW to increase the efficiency of kdeinit.
  # kdeinit unsets this variable before loading applications.
 -LD_BIND_NOW=true @CMAKE_INSTALL_FULL_LIBEXECDIR_KF5@/start_kdeinit_wrapper --kded +kcminit_startup
@@ -457,13 +416,13 @@ index 714a9bf1..9733c612 100644
 -  xmessage -geometry 500x100 "Could not start kdeinit5. Check your installation."
    exit 1
  fi
- 
+
 -qdbus org.kde.KSplash /KSplash org.kde.KSplash.setStage kinit &
 +@NIXPKGS_QDBUS@ org.kde.KSplash /KSplash org.kde.KSplash.setStage kinit &
- 
+
  # finally, give the session control to the session manager
  # see kdebase/ksmserver for the description of the rest of the startup sequence
-@@ -306,12 +352,16 @@ qdbus org.kde.KSplash /KSplash org.kde.KSplash.setStage kinit &
+@@ -270,12 +367,16 @@ qdbus org.kde.KSplash /KSplash org.kde.KSplash.setStage kinit &
  # We only check for 255 which means that the ksmserver process could not be
  # started, any problems thereafter, e.g. ksmserver failing to initialize,
  # will remain undetected.
@@ -483,13 +442,13 @@ index 714a9bf1..9733c612 100644
  if test $? -eq 255; then
    # Startup error
    echo 'startkde: Could not start ksmserver. Check your installation.'  1>&2
-@@ -322,36 +372,36 @@ fi
+@@ -286,36 +387,36 @@ fi
  #Anything after here is logout
  #It is not called after shutdown/restart
- 
+
 -wait_drkonqi=`kreadconfig5 --file startkderc --group WaitForDrKonqi --key Enabled --default true`
 +wait_drkonqi=$(@NIXPKGS_KREADCONFIG5@ --file startkderc --group WaitForDrKonqi --key Enabled --default true)
- 
+
 -if test x"$wait_drkonqi"x = x"true"x ; then
 +if [ x"$wait_drkonqi"x = x"true"x ]; then
      # wait for remaining drkonqi instances with timeout (in seconds)
@@ -512,18 +471,18 @@ index 714a9bf1..9733c612 100644
          fi
      done
  fi
- 
+
  echo 'startkde: Shutting down...'  1>&2
  # just in case
 -test -n "$ksplash_pid" && kill "$ksplash_pid" 2>/dev/null
 +if [ -n "$ksplash_pid" ]; then
 +    kill "$ksplash_pid" 2>/dev/null
 +fi
- 
+
  # Clean up
 -kdeinit5_shutdown
 +@NIXPKGS_KDEINIT5_SHUTDOWN@
- 
+
  unset KDE_FULL_SESSION
 -xprop -root -remove KDE_FULL_SESSION
 +@NIXPKGS_XPROP@ -root -remove KDE_FULL_SESSION
@@ -531,10 +490,10 @@ index 714a9bf1..9733c612 100644
 -xprop -root -remove KDE_SESSION_VERSION
 +@NIXPKGS_XPROP@ -root -remove KDE_SESSION_VERSION
  unset KDE_SESSION_UID
- 
+
  echo 'startkde: Done.'  1>&2
 diff --git a/startkde/startplasma.cmake b/startkde/startplasma.cmake
-index de98541c..39c0b521 100644
+index 1fe41c5..11757df 100644
 --- a/startkde/startplasma.cmake
 +++ b/startkde/startplasma.cmake
 @@ -1,6 +1,6 @@
@@ -543,12 +502,12 @@ index de98541c..39c0b521 100644
 -#  DEFAULT Plasma STARTUP SCRIPT ( @PROJECT_VERSION@ )
 +#  NIXPKGS Plasma STARTUP SCRIPT ( @PROJECT_VERSION@ )
  #
- 
+
  # Boot sequence:
 @@ -17,28 +17,26 @@
  #
  # * Then ksmserver is started which takes control of the rest of the startup sequence
- 
+
 -# We need to create config folder so we can write startupconfigkeys
 -if [  ${XDG_CONFIG_HOME} ]; then
 -  configDir=$XDG_CONFIG_HOME;
@@ -558,7 +517,7 @@ index de98541c..39c0b521 100644
 +if [ -r "$XDG_CONFIG_HOME/startupconfig" ]; then
 +    . "$XDG_CONFIG_HOME/startupconfig"
  fi
- 
+
 -[ -r $configDir/startupconfig ] && . $configDir/startupconfig
 -
 -xrdb -quiet -merge -nocpp <<EOF
@@ -567,10 +526,10 @@ index de98541c..39c0b521 100644
  Xft.dpi: $QT_WAYLAND_FORCE_DPI
  EOF
 +fi
- 
+
  dl=$DESKTOP_LOCKED
  unset DESKTOP_LOCKED # Don't want it in the environment
- 
+
  ksplash_pid=
 -if test -z "$dl"; then
 +if [ -z "$dl" ]; then
@@ -582,62 +541,14 @@ index de98541c..39c0b521 100644
        ;;
      None)
        ;;
-@@ -50,48 +48,6 @@ fi
- #In wayland we want Plasma to use Qt's scaling
- export PLASMA_USE_QT_SCALING=1
- 
--# Activate the kde font directories.
--#
--# There are 4 directories that may be used for supplying fonts for KDE.
--#
--# There are two system directories. These belong to the administrator.
--# There are two user directories, where the user may add her own fonts.
--#
--# The 'override' versions are for fonts that should come first in the list,
--# i.e. if you have a font in your 'override' directory, it will be used in
--# preference to any other.
--#
--# The preference order looks like this:
--# user override, system override, X, user, system
--#
--# Where X is the original font database that was set up before this script
--# runs.
--
--usr_odir=$HOME/.fonts/kde-override
--usr_fdir=$HOME/.fonts
--
--if test -n "$KDEDIRS"; then
--  kdedirs_first=`echo "$KDEDIRS"|sed -e 's/:.*//'`
--  sys_odir=$kdedirs_first/share/fonts/override
--  sys_fdir=$kdedirs_first/share/fonts
--else
--  sys_odir=$KDEDIR/share/fonts/override
--  sys_fdir=$KDEDIR/share/fonts
--fi
--
--# We run mkfontdir on the user's font dirs (if we have permission) to pick
--# up any new fonts they may have installed. If mkfontdir fails, we still
--# add the user's dirs to the font path, as they might simply have been made
--# read-only by the administrator, for whatever reason.
--
--test -d "$sys_odir" && xset +fp "$sys_odir"
--test -d "$usr_odir" && (mkfontdir "$usr_odir" ; xset +fp "$usr_odir")
--test -d "$usr_fdir" && (mkfontdir "$usr_fdir" ; xset fp+ "$usr_fdir")
--test -d "$sys_fdir" && xset fp+ "$sys_fdir"
--
--# Ask X11 to rebuild its font list.
--xset fp rehash
--
- # Set a left cursor instead of the standard X11 "X" cursor, since I've heard
- # from some users that they're confused and don't know what to do. This is
- # especially necessary on slow machines, where starting KDE takes one or two
-@@ -100,22 +56,13 @@ xset fp rehash
+@@ -58,23 +56,13 @@ export PLASMA_USE_QT_SCALING=1
  # If the user has overwritten fonts, the cursor font may be different now
  # so don't move this up.
  #
 -xsetroot -cursor_name left_ptr
 -
 -# Get Ghostscript to look into user's KDE fonts dir for additional Fontmap
+-usr_fdir=$HOME/.fonts
 -if test -n "$GS_LIB" ; then
 -    GS_LIB=$usr_fdir:$GS_LIB
 -    export GS_LIB
@@ -646,19 +557,19 @@ index de98541c..39c0b521 100644
 -    export GS_LIB
 -fi
 +@NIXPKGS_XSETROOT@ -cursor_name left_ptr
- 
+
  echo 'startplasma: Starting up...'  1>&2
- 
+
  # export our session variables to the Xwayland server
 -xprop -root -f KDE_FULL_SESSION 8t -set KDE_FULL_SESSION true
 -xprop -root -f KDE_SESSION_VERSION 32c -set KDE_SESSION_VERSION 5
 +@NIXPKGS_XPROP@ -root -f KDE_FULL_SESSION 8t -set KDE_FULL_SESSION true
 +@NIXPKGS_XPROP@ -root -f KDE_SESSION_VERSION 32c -set KDE_SESSION_VERSION 5
- 
+
  # At this point all environment variables are set, let's send it to the DBus session server to update the activation environment
  if which dbus-update-activation-environment >/dev/null 2>/dev/null ; then
-@@ -131,16 +78,15 @@ fi
- 
+@@ -90,16 +78,15 @@ fi
+
  # We set LD_BIND_NOW to increase the efficiency of kdeinit.
  # kdeinit unsets this variable before loading applications.
 -LD_BIND_NOW=true @CMAKE_INSTALL_FULL_LIBEXECDIR_KF5@/start_kdeinit_wrapper --kded +kcminit_startup
@@ -670,21 +581,20 @@ index de98541c..39c0b521 100644
 -  xmessage -geometry 500x100 "Could not start kdeinit5. Check your installation."
    exit 1
  fi
- 
+
 -qdbus org.kde.KSplash /KSplash org.kde.KSplash.setStage kinit &
 +@NIXPKGS_QDBUS@ org.kde.KSplash /KSplash org.kde.KSplash.setStage kinit &
- 
+
  # finally, give the session control to the session manager
  # see kdebase/ksmserver for the description of the rest of the startup sequence
-@@ -166,19 +112,19 @@ fi
+@@ -125,19 +112,19 @@ fi
  #Anything after here is logout
  #It is not called after shutdown/restart
- 
+
 -wait_drkonqi=`kreadconfig5 --file startkderc --group WaitForDrKonqi --key Enabled --default true`
--
--if test x"$wait_drkonqi"x = x"true"x ; then
 +wait_drkonqi=$(@NIXPKGS_KREADCONFIG5@ --file startkderc --group WaitForDrKonqi --key Enabled --default true)
-+ 
+
+-if test x"$wait_drkonqi"x = x"true"x ; then
 +if [ x"$wait_drkonqi"x = x"true"x ]; then
      # wait for remaining drkonqi instances with timeout (in seconds)
 -    wait_drkonqi_timeout=`kreadconfig5 --file startkderc --group WaitForDrKonqi --key Timeout --default 900`
@@ -704,19 +614,19 @@ index de98541c..39c0b521 100644
              done
              break
          fi
-@@ -187,15 +133,17 @@ fi
- 
+@@ -146,15 +133,17 @@ fi
+
  echo 'startplasma: Shutting down...'  1>&2
  # just in case
 -test -n "$ksplash_pid" && kill "$ksplash_pid" 2>/dev/null
 +if [ -n "$ksplash_pid" ]; then
 + "$ksplash_pid" 2>/dev/null
 +fi
- 
+
  # Clean up
 -kdeinit5_shutdown
 +@NIXPKGS_KDEINIT5_SHUTDOWN@
- 
+
  unset KDE_FULL_SESSION
 -xprop -root -remove KDE_FULL_SESSION
 +@NIXPKGS_XPROP@ -root -remove KDE_FULL_SESSION
@@ -724,10 +634,10 @@ index de98541c..39c0b521 100644
 -xprop -root -remove KDE_SESSION_VERSION
 +@NIXPKGS_XPROP@ -root -remove KDE_SESSION_VERSION
  unset KDE_SESSION_UID
- 
+
  echo 'startplasma: Done.'  1>&2
 diff --git a/startkde/startplasmacompositor.cmake b/startkde/startplasmacompositor.cmake
-index dd9e304d..12132f9e 100644
+index dcb473a..0988740 100644
 --- a/startkde/startplasmacompositor.cmake
 +++ b/startkde/startplasmacompositor.cmake
 @@ -1,118 +1,174 @@
@@ -736,7 +646,7 @@ index dd9e304d..12132f9e 100644
 -#  DEFAULT Plasma STARTUP SCRIPT ( @PROJECT_VERSION@ )
 +#  NIXPKGS Plasma STARTUP SCRIPT ( @PROJECT_VERSION@ )
  #
- 
+
 -# We need to create config folder so we can write startupconfigkeys
 -if [  ${XDG_CONFIG_HOME} ]; then
 -  configDir=$XDG_CONFIG_HOME;
@@ -803,7 +713,7 @@ index dd9e304d..12132f9e 100644
 +EOF
  fi
  sysConfigDirs=${XDG_CONFIG_DIRS:-/etc/xdg}
- 
+
 -# We need to create config folder so we can write startupconfigkeys
 -mkdir -p $configDir
 +# Set the default GTK 3 theme
@@ -832,7 +742,7 @@ index dd9e304d..12132f9e 100644
 +cursorSize=0
 +EOF
 +fi
- 
+
  #This is basically setting defaults so we can use them with kstartupconfig5
 -cat >$configDir/startupconfigkeys <<EOF
 +cat >"$XDG_CONFIG_HOME/startupconfigkeys" <<EOF
@@ -846,7 +756,7 @@ index dd9e304d..12132f9e 100644
 +kcmfonts General forceFontDPI 0
 +kcmfonts General dontChangeAASettings true
  EOF
- 
+
  # preload the user's locale on first start
 -plasmalocalerc=$configDir/plasma-localerc
 -test -f $plasmalocalerc || {
@@ -859,7 +769,7 @@ index dd9e304d..12132f9e 100644
  EOF
 -}
 +fi
- 
+
  # export LC_* variables set by kcmshell5 formats into environment
  # so it can be picked up by QLocale and friends.
 -exportformatssettings=$configDir/plasma-locale-settings.sh
@@ -870,7 +780,7 @@ index dd9e304d..12132f9e 100644
 +if [ -r "$exportformatssettings" ]; then
 +    . "$exportformatssettings"
 +fi
- 
+
  # Write a default kdeglobals file to set up the font
 -kdeglobalsfile=$configDir/kdeglobals
 -test -f $kdeglobalsfile || {
@@ -924,7 +834,7 @@ index dd9e304d..12132f9e 100644
 -        test -h $oxygenDir || ln -s $prefixDir $oxygenDir && fc-cache $oxygenDir
 -    }
  fi
- 
+
 -kstartupconfig5
 +@CMAKE_INSTALL_FULL_BINDIR@/kstartupconfig5
  returncode=$?
@@ -935,11 +845,11 @@ index dd9e304d..12132f9e 100644
 +if [ -r "$XDG_CONFIG_HOME/startupconfig" ]; then
 +    . "$XDG_CONFIG_HOME/startupconfig"
 +fi
- 
+
  #Manually disable auto scaling because we are scaling above
  #otherwise apps that manually opt in for high DPI get auto scaled by the developer AND scaled by the wl_output
  export QT_AUTO_SCREEN_SCALE_FACTOR=0
- 
+
 -# XCursor mouse theme needs to be applied here to work even for kded or ksmserver
 -if test -n "$kcminputrc_mouse_cursortheme" -o -n "$kcminputrc_mouse_cursorsize" ; then
 -    @EXPORT_XCURSOR_PATH@
@@ -949,7 +859,7 @@ index dd9e304d..12132f9e 100644
 +    XCURSOR_PATH="$XCURSOR_PATH:$xdgDir/icons"
 +done
 +export XCURSOR_PATH
- 
+
 -    # TODO: is kapplymousetheme a core app?
 +# XCursor mouse theme needs to be applied here to work even for kded or ksmserver
 +if [ -n "$kcminputrc_mouse_cursortheme" -o -n "$kcminputrc_mouse_cursorsize" ]; then
@@ -972,20 +882,20 @@ index dd9e304d..12132f9e 100644
 +        export XCURSOR_SIZE="$kcminputrc_mouse_cursorsize"
      fi
  fi
- 
+
 -if test "$kcmfonts_general_forcefontdpiwayland" -ne 0; then
 +if [ "${kcmfonts_general_forcefontdpiwayland:-0}" -ne 0 ]; then
      export QT_WAYLAND_FORCE_DPI=$kcmfonts_general_forcefontdpiwayland
  else
      export QT_WAYLAND_FORCE_DPI=96
-@@ -120,12 +167,12 @@ fi
- 
+@@ -120,12 +176,12 @@ fi
+
  # Get a property value from org.freedesktop.locale1
  queryLocale1() {
 -    qdbus --system org.freedesktop.locale1 /org/freedesktop/locale1 "$1"
 +    @NIXPKGS_QDBUS@ --system org.freedesktop.locale1 /org/freedesktop/locale1 "$1"
  }
- 
+
  # Query whether org.freedesktop.locale1 is available. If it is, try to
  # set XKB_DEFAULT_{MODEL,LAYOUT,VARIANT,OPTIONS} accordingly.
 -if qdbus --system org.freedesktop.locale1 >/dev/null 2>/dev/null; then
@@ -993,10 +903,10 @@ index dd9e304d..12132f9e 100644
      # Do not overwrite existing values. There is no point in setting only some
      # of them as then they would not match anymore.
      if [ -z "${XKB_DEFAULT_MODEL}" -a -z "${XKB_DEFAULT_LAYOUT}" -a \
-@@ -141,41 +188,10 @@ if qdbus --system org.freedesktop.locale1 >/dev/null 2>/dev/null; then
+@@ -141,41 +197,10 @@ if qdbus --system org.freedesktop.locale1 >/dev/null 2>/dev/null; then
      fi
  fi
- 
+
 -# Source scripts found in <config locations>/plasma-workspace/env/*.sh
 -# (where <config locations> correspond to the system and user's configuration
 -# directories, as identified by Qt's qtpaths,  e.g.  $HOME/.config
@@ -1020,7 +930,7 @@ index dd9e304d..12132f9e 100644
 -done
 -
  echo 'startplasmacompositor: Starting up...'  1>&2
- 
+
 -# Make sure that the KDE prefix is first in XDG_DATA_DIRS and that it's set at all.
 -# The spec allows XDG_DATA_DIRS to be not set, but X session startup scripts tend
 -# to set it to a list of paths *not* including the KDE prefix if it's not /usr or
@@ -1036,17 +946,19 @@ index dd9e304d..12132f9e 100644
      : # ok
  else
      echo 'startplasmacompositor: Could not start D-Bus. Can you call qdbus?'  1>&2
-@@ -212,26 +228,47 @@ export KDE_FULL_SESSION
+@@ -212,7 +237,7 @@ export KDE_FULL_SESSION
  KDE_SESSION_VERSION=5
  export KDE_SESSION_VERSION
- 
+
 -KDE_SESSION_UID=`id -ru`
 +KDE_SESSION_UID=$(@NIXPKGS_ID@ -ru)
  export KDE_SESSION_UID
- 
+
  XDG_CURRENT_DESKTOP=KDE
- export XDG_CURRENT_DESKTOP
- 
+@@ -221,20 +246,41 @@ export XDG_CURRENT_DESKTOP
+ XDG_SESSION_TYPE=wayland
+ export XDG_SESSION_TYPE
+
 +# Source scripts found in <config locations>/plasma-workspace/env/*.sh
 +# (where <config locations> correspond to the system and user's configuration
 +# directories, as identified by Qt's qtpaths,  e.g.  $HOME/.config
@@ -1089,9 +1001,11 @@ index dd9e304d..12132f9e 100644
 +    echo 'startplasmacompositor: Could not sync environment to dbus.'  1>&2
 +    exit 1
  fi
- 
+
 -@KWIN_WAYLAND_BIN_PATH@ --xwayland --libinput --exit-with-session=@CMAKE_INSTALL_FULL_LIBEXECDIR@/startplasma
 +@KWIN_WAYLAND_BIN_PATH@ --xwayland --libinput --exit-with-session=@NIXPKGS_STARTPLASMA@
- 
+
  echo 'startplasmacompositor: Shutting down...'  1>&2
- 
+
+--
+2.19.2

--- a/pkgs/desktops/plasma-5/srcs.nix
+++ b/pkgs/desktops/plasma-5/srcs.nix
@@ -3,363 +3,363 @@
 
 {
   bluedevil = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/bluedevil-5.14.5.tar.xz";
-      sha256 = "1khqw11apvcf5g5m9z111rvk4scxh3z3yhcpwqws1h0s5c5lr7z7";
-      name = "bluedevil-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/bluedevil-5.15.3.tar.xz";
+      sha256 = "1vdij1ydrwj51nsf3ysmql3wy3y7ayipzrqgxwa52r9n49zckva0";
+      name = "bluedevil-5.15.3.tar.xz";
     };
   };
   breeze = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/breeze-5.14.5.tar.xz";
-      sha256 = "15hphz2mm2m3j0a0hwj7m65rggyaxdxy08yqs73bg3yg67n6x3p7";
-      name = "breeze-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/breeze-5.15.3.tar.xz";
+      sha256 = "0l7yngc32af7gdi8p68c8267bbzhfvpynqclq3il4fvaxc6vbq2b";
+      name = "breeze-5.15.3.tar.xz";
     };
   };
   breeze-grub = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/breeze-grub-5.14.5.tar.xz";
-      sha256 = "0bkaaxfl1ds58qcdrxswaacir7wcc65a960lwdkmpdl16g9f4gix";
-      name = "breeze-grub-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/breeze-grub-5.15.3.tar.xz";
+      sha256 = "0ccx8yfxhc5r3kv7snv80wpz7h5a9l762iz1cx5sfjpmmq2jhi64";
+      name = "breeze-grub-5.15.3.tar.xz";
     };
   };
   breeze-gtk = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/breeze-gtk-5.14.5.tar.xz";
-      sha256 = "0bysq83xbqmhb4wld51zd6lllr66b8w7pinizc99k8z1yz5jdb0m";
-      name = "breeze-gtk-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/breeze-gtk-5.15.3.tar.xz";
+      sha256 = "1rg323fyq0q07k00xi63csi0f3bwzi1cbm6srshqih0cnfgq69j4";
+      name = "breeze-gtk-5.15.3.tar.xz";
     };
   };
   breeze-plymouth = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/breeze-plymouth-5.14.5.tar.xz";
-      sha256 = "1rbdpz9vlami7217v3dk8ljz0fgjz9zi1l0gwkhslayz5sybld96";
-      name = "breeze-plymouth-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/breeze-plymouth-5.15.3.tar.xz";
+      sha256 = "0f654kys4xw2c84iblz2q2x53z4mb2javgngb1dr3jkafysr0h37";
+      name = "breeze-plymouth-5.15.3.tar.xz";
     };
   };
   discover = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/discover-5.14.5.tar.xz";
-      sha256 = "0gxhl2cv5yz3jw8fp8g8idi1k5hlhnvwbnvvg0dgnlzz6jb1s8dd";
-      name = "discover-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/discover-5.15.3.tar.xz";
+      sha256 = "1b6mc81xr4wl29bjw95jm8k72j3hhn1ps8a5dvzanbslfx31hf1b";
+      name = "discover-5.15.3.tar.xz";
     };
   };
   drkonqi = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/drkonqi-5.14.5.tar.xz";
-      sha256 = "0xgym368f9r21wjh9fpv16m90dcj87g9p5df850fnn2k5n8x38z8";
-      name = "drkonqi-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/drkonqi-5.15.3.tar.xz";
+      sha256 = "0y4bkrv7bx69hm4kbbd2jfjnccj99686s0k5lm4ldv3wvf66k4sx";
+      name = "drkonqi-5.15.3.tar.xz";
     };
   };
   kactivitymanagerd = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/kactivitymanagerd-5.14.5.tar.xz";
-      sha256 = "0zms9npis0rklnbz93c69h4yg7dkrmfkzvzsfvkg90w37ap3vyl7";
-      name = "kactivitymanagerd-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/kactivitymanagerd-5.15.3.tar.xz";
+      sha256 = "1lz3mm0bli2w8xwr3n06ss7qqzm4clvs3d9hfydyf7xq03mszrym";
+      name = "kactivitymanagerd-5.15.3.tar.xz";
     };
   };
   kde-cli-tools = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/kde-cli-tools-5.14.5.tar.xz";
-      sha256 = "01mrnjqla4q07cnb1p51nq2pvj9vaamic3dsyj3b7hqky9fna9ln";
-      name = "kde-cli-tools-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/kde-cli-tools-5.15.3.tar.xz";
+      sha256 = "1praysa894m67kwy4xaqh354c0shwfyyrqf4n9wrfwwrchdw6ypg";
+      name = "kde-cli-tools-5.15.3.tar.xz";
     };
   };
   kdecoration = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/kdecoration-5.14.5.tar.xz";
-      sha256 = "115pli0qpa8lx0jasg1886fcg7gb2kk8v6k8r8l8c820l97sq7in";
-      name = "kdecoration-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/kdecoration-5.15.3.tar.xz";
+      sha256 = "1ymp6szphpnfvdnhg8n1wan76z1s5xw68xsmwm21zrjf8lmrwkdh";
+      name = "kdecoration-5.15.3.tar.xz";
     };
   };
   kde-gtk-config = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/kde-gtk-config-5.14.5.tar.xz";
-      sha256 = "12467wkjh2nmcf6r7n8qin1rryd39g0dg7gn43sdg6vdwpyl2kdm";
-      name = "kde-gtk-config-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/kde-gtk-config-5.15.3.tar.xz";
+      sha256 = "1ysw26sfx2wyd79bkknvvcmg5s4b154iyds9c6wp8brmcn6ng3s8";
+      name = "kde-gtk-config-5.15.3.tar.xz";
     };
   };
   kdeplasma-addons = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/kdeplasma-addons-5.14.5.tar.xz";
-      sha256 = "18sph3719d9pq2j5k7swiv9xbrpj659a3q66zvhz3dmh11y73f0m";
-      name = "kdeplasma-addons-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/kdeplasma-addons-5.15.3.tar.xz";
+      sha256 = "071wnwxgywg6bqqgwmjyswai3k0n4c15lq8mspcy92kym3msqkrn";
+      name = "kdeplasma-addons-5.15.3.tar.xz";
     };
   };
   kgamma5 = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/kgamma5-5.14.5.tar.xz";
-      sha256 = "17smrdwyalknb3f6ckqs7kglfpqwajbiyd212wlsmqbva4by0fy0";
-      name = "kgamma5-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/kgamma5-5.15.3.tar.xz";
+      sha256 = "12cnrnmr2wp14afg6x438gm502514pk61mfr26cypvcd6azpc2my";
+      name = "kgamma5-5.15.3.tar.xz";
     };
   };
   khotkeys = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/khotkeys-5.14.5.tar.xz";
-      sha256 = "0572jpgbhacx4gy40m594rbnxy3zaq5w3lcrfd8i2750ljswcq24";
-      name = "khotkeys-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/khotkeys-5.15.3.tar.xz";
+      sha256 = "0gnkdl6kki8xph3787bacggapm4vbakj39y9kcjqvqrqxifp1ml5";
+      name = "khotkeys-5.15.3.tar.xz";
     };
   };
   kinfocenter = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/kinfocenter-5.14.5.tar.xz";
-      sha256 = "1z1i9g923cbdni5gfa6dpv46z1p2v40rfcvhy7i9h5nf49aw2rnc";
-      name = "kinfocenter-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/kinfocenter-5.15.3.tar.xz";
+      sha256 = "0rhhrsp0fmgfsmrfv468l4xinyfyghf6921s1581sgg5fk9qhrwr";
+      name = "kinfocenter-5.15.3.tar.xz";
     };
   };
   kmenuedit = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/kmenuedit-5.14.5.tar.xz";
-      sha256 = "1aa4a35s5h44fc88hmmfdpzy26zc47h9n448cd4vbm4bm411551d";
-      name = "kmenuedit-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/kmenuedit-5.15.3.tar.xz";
+      sha256 = "1s7bhpxiapmx496f3y3klmc9i2347fs25yhd2brg92jziw73jpab";
+      name = "kmenuedit-5.15.3.tar.xz";
     };
   };
   kscreen = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/kscreen-5.14.5.tar.xz";
-      sha256 = "1nb1ysgcx49galbf16mxbawybfik92bpr9vbwgg5ycsdx1f9q8yi";
-      name = "kscreen-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/kscreen-5.15.3.tar.xz";
+      sha256 = "1izq1anl0r9ysmsdnc2ny7cx73xc190qbad59nrnlqcxrsplb68f";
+      name = "kscreen-5.15.3.tar.xz";
     };
   };
   kscreenlocker = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/kscreenlocker-5.14.5.tar.xz";
-      sha256 = "16amr7pz0k6w5vkk1dwn2qi3s1mln0jypwmjazqq2lbwimn8k56m";
-      name = "kscreenlocker-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/kscreenlocker-5.15.3.tar.xz";
+      sha256 = "0bglpgibrc8l6yi24pj4kja33mc02clgi1vbdvw1qpp65ixhpzna";
+      name = "kscreenlocker-5.15.3.tar.xz";
     };
   };
   ksshaskpass = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/ksshaskpass-5.14.5.tar.xz";
-      sha256 = "0skr247k4ky7lpbdwlmkrnr3mj1pa6pxl96pyxwsw7za784qg6dj";
-      name = "ksshaskpass-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/ksshaskpass-5.15.3.tar.xz";
+      sha256 = "1zrjc74srb4jp8sw6pi0ik2i4yxffvgv037d50yk1fif1xyvnf9s";
+      name = "ksshaskpass-5.15.3.tar.xz";
     };
   };
   ksysguard = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/ksysguard-5.14.5.tar.xz";
-      sha256 = "0ybxh6ll080rkrrr4b5ydl06x8zi97702661cajvbv00lhq4vp8b";
-      name = "ksysguard-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/ksysguard-5.15.3.tar.xz";
+      sha256 = "1nxgadymq45yn92cs08gfmv5krc2ylwgbn5qcc2aq6ryrrhrw89q";
+      name = "ksysguard-5.15.3.tar.xz";
     };
   };
   kwallet-pam = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/kwallet-pam-5.14.5.tar.xz";
-      sha256 = "1mkjjc88kqf5x313nifla9pzrgzqm4v92150dbs1f89bsn673pk8";
-      name = "kwallet-pam-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/kwallet-pam-5.15.3.tar.xz";
+      sha256 = "1w3vf92k3k2084cflv4fwav16czc4vqg62gi8x1alri38ziyb793";
+      name = "kwallet-pam-5.15.3.tar.xz";
     };
   };
   kwayland-integration = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/kwayland-integration-5.14.5.tar.xz";
-      sha256 = "0rd0xhb53iixv9i8x0gh3rr1082lj7zdymsqdmi7sfgb66g8c03l";
-      name = "kwayland-integration-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/kwayland-integration-5.15.3.tar.xz";
+      sha256 = "0grb9fnk7pfgwzj3c9d11zl1j9jy9k6d4pw2n2fdrs02g3yg603h";
+      name = "kwayland-integration-5.15.3.tar.xz";
     };
   };
   kwin = {
-    version = "5.14.5";
+    version = "5.15.3.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/kwin-5.14.5.tar.xz";
-      sha256 = "0ifdlnzw3ydrbidzk256vks66d1rxyilhqi09csygx17jqk7szj4";
-      name = "kwin-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/kwin-5.15.3.2.tar.xz";
+      sha256 = "0iri6993zsxmrm7qnf76py7ihc27x9y741ar7g9fry8c8knmqyrw";
+      name = "kwin-5.15.3.2.tar.xz";
     };
   };
   kwrited = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/kwrited-5.14.5.tar.xz";
-      sha256 = "0115qscr8a54h7h8w4xw4fjzp7qipyw3d3jswhii7axnzp6q6qnh";
-      name = "kwrited-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/kwrited-5.15.3.tar.xz";
+      sha256 = "0xhdmnfkpr35sks7k66s5cbq220yrmbn8ixcsdqwsgpji2sx4g7v";
+      name = "kwrited-5.15.3.tar.xz";
     };
   };
   libkscreen = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/libkscreen-5.14.5.tar.xz";
-      sha256 = "1vyaml5ap9siw9idiny92li2bykd0nwjsmwmg0c7ad912j4g1s7y";
-      name = "libkscreen-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/libkscreen-5.15.3.tar.xz";
+      sha256 = "0fzfk8ga5qinsmag61l29cf92r7qm4nlb8hrhddyff7d7c7kr3vj";
+      name = "libkscreen-5.15.3.tar.xz";
     };
   };
   libksysguard = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/libksysguard-5.14.5.tar.xz";
-      sha256 = "11nz0g7dqvpvgsv0a7sai445vgfsfi25plj7jb1i46n7zf8i8mya";
-      name = "libksysguard-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/libksysguard-5.15.3.tar.xz";
+      sha256 = "05cfb51xcmxb8k2k14n2i5ysj47aism9yq7lk2rw216bsdp2mqnj";
+      name = "libksysguard-5.15.3.tar.xz";
     };
   };
   milou = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/milou-5.14.5.tar.xz";
-      sha256 = "1776441mhmwcvrzmdqg531md79azbkbhng51kyq6i9cvkhxyf583";
-      name = "milou-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/milou-5.15.3.tar.xz";
+      sha256 = "1prq9mdrysz8ckf7n6sjfn3qc87135nj69v2jcayn9irb0k8wz01";
+      name = "milou-5.15.3.tar.xz";
     };
   };
   oxygen = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/oxygen-5.14.5.tar.xz";
-      sha256 = "0h70k7af69zdky0g6napd1kdnvbxhnw3nrwr9jqv1fq5762xnkk8";
-      name = "oxygen-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/oxygen-5.15.3.tar.xz";
+      sha256 = "0a069imvw0khkbcih8zvx0i0ks99jkwis6p73n4846qz544f3dvb";
+      name = "oxygen-5.15.3.tar.xz";
     };
   };
   plasma-browser-integration = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/plasma-browser-integration-5.14.5.tar.xz";
-      sha256 = "1260h5sh0gkbkhcj17ss0n0y48i1pxh3f4p5dcbgbz775g1dhi2s";
-      name = "plasma-browser-integration-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/plasma-browser-integration-5.15.3.tar.xz";
+      sha256 = "1mhaa5z63gyd8j7zplmyicnibqsv1xhd9mxip6clhj5bfk8q9jar";
+      name = "plasma-browser-integration-5.15.3.tar.xz";
     };
   };
   plasma-desktop = {
-    version = "5.14.5";
+    version = "5.15.3.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/plasma-desktop-5.14.5.tar.xz";
-      sha256 = "0pr07p36jrpvkk4fp14fb4minnwj5gnmvdg9jf7bi8sjjz6jpnnl";
-      name = "plasma-desktop-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/plasma-desktop-5.15.3.2.tar.xz";
+      sha256 = "12pz0bin3j2f98k88nwmb271lr6v6w3l28li0iri2x8pk144vr91";
+      name = "plasma-desktop-5.15.3.2.tar.xz";
     };
   };
   plasma-integration = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/plasma-integration-5.14.5.tar.xz";
-      sha256 = "15nhrliri4cjx712f1rxbq2f87lj4wxsqgbhw9p02z12h3n9z3ds";
-      name = "plasma-integration-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/plasma-integration-5.15.3.tar.xz";
+      sha256 = "08qw2ibl0j2nhsplc3b117vdc00bd2gn1q48nx0xy349bf64m735";
+      name = "plasma-integration-5.15.3.tar.xz";
     };
   };
   plasma-nm = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/plasma-nm-5.14.5.tar.xz";
-      sha256 = "1hf98c9llcff0h2w4l45nw0vysxvnanf7hczhj93z4562qrafxm2";
-      name = "plasma-nm-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/plasma-nm-5.15.3.tar.xz";
+      sha256 = "1l9wh4hs2v0b9hdagcgl67z0w4amffakxczwy0nwymqzv0mxgqvz";
+      name = "plasma-nm-5.15.3.tar.xz";
     };
   };
   plasma-pa = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/plasma-pa-5.14.5.tar.xz";
-      sha256 = "0z74qg7m4y1ifzni1877hiil3rn6ad3x4fvgv4bib4jhg7ckaiqg";
-      name = "plasma-pa-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/plasma-pa-5.15.3.tar.xz";
+      sha256 = "1lkhidd5b4mjn23mxcp2vfmxf7dwbk7y14svc4wy6xc1xg1pc125";
+      name = "plasma-pa-5.15.3.tar.xz";
     };
   };
   plasma-sdk = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/plasma-sdk-5.14.5.tar.xz";
-      sha256 = "0v90nk6yhrapdszh8sd3m0wffkjgnrhdy1sz1vl9s0ab5sdpmxr1";
-      name = "plasma-sdk-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/plasma-sdk-5.15.3.tar.xz";
+      sha256 = "1qzh0yy4zql7a50ql9ghhvlfxjnbckflbgbzdyd7i9x3ml7s5saw";
+      name = "plasma-sdk-5.15.3.tar.xz";
     };
   };
   plasma-tests = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/plasma-tests-5.14.5.tar.xz";
-      sha256 = "03h889xn6i067d1sdymn6fgj8xik3pa75lljl8kj3vl6bks24jyh";
-      name = "plasma-tests-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/plasma-tests-5.15.3.tar.xz";
+      sha256 = "1z5vhw1dy1qks6w161yamn2fawrgkggv9mvvgpmljmy07qpafgkg";
+      name = "plasma-tests-5.15.3.tar.xz";
     };
   };
   plasma-vault = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/plasma-vault-5.14.5.tar.xz";
-      sha256 = "17r44n0mkcwc2fkjf397ks8xv82m59gvnawbj9713c5l31ln5mi3";
-      name = "plasma-vault-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/plasma-vault-5.15.3.tar.xz";
+      sha256 = "1my9dnqz11frn07fk505pfi2nkf2d642jfgjklh5zfngjxy589jy";
+      name = "plasma-vault-5.15.3.tar.xz";
     };
   };
   plasma-workspace = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/plasma-workspace-5.14.5.tar.xz";
-      sha256 = "14d3wnsm4bi1izx5qlpk0mnqmxwx18bqypa3wwmhn1535kfz8glh";
-      name = "plasma-workspace-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/plasma-workspace-5.15.3.tar.xz";
+      sha256 = "08irdg8divr45z53kr6b1mv4s2jakmq3r79g7df6ja9rb6py5f59";
+      name = "plasma-workspace-5.15.3.tar.xz";
     };
   };
   plasma-workspace-wallpapers = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/plasma-workspace-wallpapers-5.14.5.tar.xz";
-      sha256 = "17q0685i4267ihlrii3b8764ak458kzs0inqfcj9x25m338xz19q";
-      name = "plasma-workspace-wallpapers-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/plasma-workspace-wallpapers-5.15.3.tar.xz";
+      sha256 = "0xgssv66ksljv8xkj20v2x1bppkyn8z17wa3hynwlcqxh2g4afq4";
+      name = "plasma-workspace-wallpapers-5.15.3.tar.xz";
     };
   };
   plymouth-kcm = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/plymouth-kcm-5.14.5.tar.xz";
-      sha256 = "1cwmkprhc4496x4a38l2x7hnifnp4daw8g1gic0ik2sm0a6xn77k";
-      name = "plymouth-kcm-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/plymouth-kcm-5.15.3.tar.xz";
+      sha256 = "0fbr9nf263pc9inakhp901r58mlsm1jgw0xqp9fj08c9lj25z190";
+      name = "plymouth-kcm-5.15.3.tar.xz";
     };
   };
   polkit-kde-agent = {
-    version = "1-5.14.5";
+    version = "1-5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/polkit-kde-agent-1-5.14.5.tar.xz";
-      sha256 = "1lzw4zq2ysnva5g1v85k9k6yck30wfgcy0sn1ncxy183vm36b2ag";
-      name = "polkit-kde-agent-1-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/polkit-kde-agent-1-5.15.3.tar.xz";
+      sha256 = "07gl57h9zmagbw7v2sfksbcbqrfdhr8isfmpcw10rc4k2awlsysy";
+      name = "polkit-kde-agent-1-5.15.3.tar.xz";
     };
   };
   powerdevil = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/powerdevil-5.14.5.tar.xz";
-      sha256 = "0rdrj6k7bb1cisz1g8akxxn68c8rj0zddim1afvcq1iqr727wqj5";
-      name = "powerdevil-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/powerdevil-5.15.3.tar.xz";
+      sha256 = "1f7ik3lh30irqzf0pgy59kkrsn4fkl8xwam1bikfm34bwzrsxb14";
+      name = "powerdevil-5.15.3.tar.xz";
     };
   };
   sddm-kcm = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/sddm-kcm-5.14.5.tar.xz";
-      sha256 = "0aix2grc2h2w8qxcbdwxhvq09ispblnisl017bvb19apkvs0w8m1";
-      name = "sddm-kcm-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/sddm-kcm-5.15.3.tar.xz";
+      sha256 = "1mvp8p1k9csmn6h6iyk29yj1j4b4dfyd6j4v0v2ha1vdfjwjlsh2";
+      name = "sddm-kcm-5.15.3.tar.xz";
     };
   };
   systemsettings = {
-    version = "5.14.5";
+    version = "5.15.3.2";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/systemsettings-5.14.5.tar.xz";
-      sha256 = "1q1ih74vkdhss64ayc3qmbrw4hhvfl3axlkhh63rky09qn83x9zw";
-      name = "systemsettings-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/systemsettings-5.15.3.2.tar.xz";
+      sha256 = "0bqhff2s2qyz1x8nhrphnkyja0mhr7msf58cwdkscsl6lyamn2a2";
+      name = "systemsettings-5.15.3.2.tar.xz";
     };
   };
   user-manager = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/user-manager-5.14.5.tar.xz";
-      sha256 = "0aw2s029547rzx3xg9nib5w30d25978fpv7xyshxmp3z8rmzgcjv";
-      name = "user-manager-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/user-manager-5.15.3.tar.xz";
+      sha256 = "18acg3xjcdhcwk3irsf1hgkwma9mn6msl6qwmf0slz1lydlrljs4";
+      name = "user-manager-5.15.3.tar.xz";
     };
   };
   xdg-desktop-portal-kde = {
-    version = "5.14.5";
+    version = "5.15.3";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.14.5/xdg-desktop-portal-kde-5.14.5.tar.xz";
-      sha256 = "0h6hdk9fkf98jfjaza773k37369ayvwmwrgxn6al2pma6n07vddq";
-      name = "xdg-desktop-portal-kde-5.14.5.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.3/xdg-desktop-portal-kde-5.15.3.tar.xz";
+      sha256 = "10cmy4j54nkwrgibxdpx6d30g596ikvb1dqqmp1gvmzr570gmbi7";
+      name = "xdg-desktop-portal-kde-5.15.3.tar.xz";
     };
   };
 }

--- a/pkgs/desktops/plasma-5/srcs.nix
+++ b/pkgs/desktops/plasma-5/srcs.nix
@@ -3,363 +3,363 @@
 
 {
   bluedevil = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/bluedevil-5.15.3.tar.xz";
-      sha256 = "1vdij1ydrwj51nsf3ysmql3wy3y7ayipzrqgxwa52r9n49zckva0";
-      name = "bluedevil-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/bluedevil-5.15.4.tar.xz";
+      sha256 = "8a686180ae056fd70073e48430864bf9248943f6d8e23665878b87a7cceb3504";
+      name = "bluedevil-5.15.4.tar.xz";
     };
   };
   breeze = {
-    version = "5.15.3";
+    version = "5.15.4.1";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/breeze-5.15.3.tar.xz";
-      sha256 = "0l7yngc32af7gdi8p68c8267bbzhfvpynqclq3il4fvaxc6vbq2b";
-      name = "breeze-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/breeze-5.15.4.1.tar.xz";
+      sha256 = "9a95fb9c5be7c84164d3ce337d15cad57cdd495fe84e1da8487a463d69293497";
+      name = "breeze-5.15.4.1.tar.xz";
     };
   };
   breeze-grub = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/breeze-grub-5.15.3.tar.xz";
-      sha256 = "0ccx8yfxhc5r3kv7snv80wpz7h5a9l762iz1cx5sfjpmmq2jhi64";
-      name = "breeze-grub-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/breeze-grub-5.15.4.tar.xz";
+      sha256 = "d96e57577e05be789140cf9f8b6f54dd310a6ae94c7854f87ee524e2acd8c897";
+      name = "breeze-grub-5.15.4.tar.xz";
     };
   };
   breeze-gtk = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/breeze-gtk-5.15.3.tar.xz";
-      sha256 = "1rg323fyq0q07k00xi63csi0f3bwzi1cbm6srshqih0cnfgq69j4";
-      name = "breeze-gtk-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/breeze-gtk-5.15.4.tar.xz";
+      sha256 = "e3b13105cc39d5c914ab81b6a10da9b16cb9a9a7058c13a0486fd02af40f7bd9";
+      name = "breeze-gtk-5.15.4.tar.xz";
     };
   };
   breeze-plymouth = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/breeze-plymouth-5.15.3.tar.xz";
-      sha256 = "0f654kys4xw2c84iblz2q2x53z4mb2javgngb1dr3jkafysr0h37";
-      name = "breeze-plymouth-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/breeze-plymouth-5.15.4.tar.xz";
+      sha256 = "7e2e65f0d51d585fa462612fa60d7190b4c681b795ad5717086f57240119bdf6";
+      name = "breeze-plymouth-5.15.4.tar.xz";
     };
   };
   discover = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/discover-5.15.3.tar.xz";
-      sha256 = "1b6mc81xr4wl29bjw95jm8k72j3hhn1ps8a5dvzanbslfx31hf1b";
-      name = "discover-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/discover-5.15.4.tar.xz";
+      sha256 = "63b6dff1310291d7cf1ec7e075dfa0f3c039f63c4f910c3ca99d0faeee4ca301";
+      name = "discover-5.15.4.tar.xz";
     };
   };
   drkonqi = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/drkonqi-5.15.3.tar.xz";
-      sha256 = "0y4bkrv7bx69hm4kbbd2jfjnccj99686s0k5lm4ldv3wvf66k4sx";
-      name = "drkonqi-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/drkonqi-5.15.4.tar.xz";
+      sha256 = "8e3b46525f792d5c3264f0d835e7180cda4a0dbd78cd8055f13e166151a6c3de";
+      name = "drkonqi-5.15.4.tar.xz";
     };
   };
   kactivitymanagerd = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/kactivitymanagerd-5.15.3.tar.xz";
-      sha256 = "1lz3mm0bli2w8xwr3n06ss7qqzm4clvs3d9hfydyf7xq03mszrym";
-      name = "kactivitymanagerd-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/kactivitymanagerd-5.15.4.tar.xz";
+      sha256 = "0201772007295fdca0cb4a9dd2109b61ece6307c21f50c017f73b1df27734ecd";
+      name = "kactivitymanagerd-5.15.4.tar.xz";
     };
   };
   kde-cli-tools = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/kde-cli-tools-5.15.3.tar.xz";
-      sha256 = "1praysa894m67kwy4xaqh354c0shwfyyrqf4n9wrfwwrchdw6ypg";
-      name = "kde-cli-tools-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/kde-cli-tools-5.15.4.tar.xz";
+      sha256 = "909c54f0d04c3c7f5bbc1b6e77b666fb4e92a29f7622ad404c579dc6a5d67ee1";
+      name = "kde-cli-tools-5.15.4.tar.xz";
     };
   };
   kdecoration = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/kdecoration-5.15.3.tar.xz";
-      sha256 = "1ymp6szphpnfvdnhg8n1wan76z1s5xw68xsmwm21zrjf8lmrwkdh";
-      name = "kdecoration-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/kdecoration-5.15.4.tar.xz";
+      sha256 = "22ceaa283df60defdef9f51da568375bf42ec9ddd74fc3bfd7e519f867c69b89";
+      name = "kdecoration-5.15.4.tar.xz";
     };
   };
   kde-gtk-config = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/kde-gtk-config-5.15.3.tar.xz";
-      sha256 = "1ysw26sfx2wyd79bkknvvcmg5s4b154iyds9c6wp8brmcn6ng3s8";
-      name = "kde-gtk-config-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/kde-gtk-config-5.15.4.tar.xz";
+      sha256 = "3689328ddd1e30313f3ad1df02e9c52b29d88b5a3dd42c4507bbc9e58286059a";
+      name = "kde-gtk-config-5.15.4.tar.xz";
     };
   };
   kdeplasma-addons = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/kdeplasma-addons-5.15.3.tar.xz";
-      sha256 = "071wnwxgywg6bqqgwmjyswai3k0n4c15lq8mspcy92kym3msqkrn";
-      name = "kdeplasma-addons-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/kdeplasma-addons-5.15.4.tar.xz";
+      sha256 = "bd1c3dbf46e7c1745ff242adaed9c973e401529dc76d57dab6ffdd994eef71e2";
+      name = "kdeplasma-addons-5.15.4.tar.xz";
     };
   };
   kgamma5 = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/kgamma5-5.15.3.tar.xz";
-      sha256 = "12cnrnmr2wp14afg6x438gm502514pk61mfr26cypvcd6azpc2my";
-      name = "kgamma5-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/kgamma5-5.15.4.tar.xz";
+      sha256 = "972e7734df8e761e0d42b01f45afc0aa1daded409a562555fd8c990791a96cc1";
+      name = "kgamma5-5.15.4.tar.xz";
     };
   };
   khotkeys = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/khotkeys-5.15.3.tar.xz";
-      sha256 = "0gnkdl6kki8xph3787bacggapm4vbakj39y9kcjqvqrqxifp1ml5";
-      name = "khotkeys-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/khotkeys-5.15.4.tar.xz";
+      sha256 = "4e446507872817a6db360707734cc60254918f6026e56a96ba3eb1e938e59ce6";
+      name = "khotkeys-5.15.4.tar.xz";
     };
   };
   kinfocenter = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/kinfocenter-5.15.3.tar.xz";
-      sha256 = "0rhhrsp0fmgfsmrfv468l4xinyfyghf6921s1581sgg5fk9qhrwr";
-      name = "kinfocenter-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/kinfocenter-5.15.4.tar.xz";
+      sha256 = "8c0ecbdd7bb44c08f2c27ed93382d76b5a79a09b876196b3d2db2d2e97e9ae95";
+      name = "kinfocenter-5.15.4.tar.xz";
     };
   };
   kmenuedit = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/kmenuedit-5.15.3.tar.xz";
-      sha256 = "1s7bhpxiapmx496f3y3klmc9i2347fs25yhd2brg92jziw73jpab";
-      name = "kmenuedit-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/kmenuedit-5.15.4.tar.xz";
+      sha256 = "da5d347de97ea50593311a318d12328b0f63805c8f1f411b4f3567826c1fc80e";
+      name = "kmenuedit-5.15.4.tar.xz";
     };
   };
   kscreen = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/kscreen-5.15.3.tar.xz";
-      sha256 = "1izq1anl0r9ysmsdnc2ny7cx73xc190qbad59nrnlqcxrsplb68f";
-      name = "kscreen-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/kscreen-5.15.4.tar.xz";
+      sha256 = "82b103e9ba72d4a50d94c4cb4033d700f28e6615ac63a34675cbe22efdadaf7d";
+      name = "kscreen-5.15.4.tar.xz";
     };
   };
   kscreenlocker = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/kscreenlocker-5.15.3.tar.xz";
-      sha256 = "0bglpgibrc8l6yi24pj4kja33mc02clgi1vbdvw1qpp65ixhpzna";
-      name = "kscreenlocker-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/kscreenlocker-5.15.4.tar.xz";
+      sha256 = "d81e34ac9f22b2fd9ed63e599e9c709e91ecd0b5e7458732e4535a71ce5a9f58";
+      name = "kscreenlocker-5.15.4.tar.xz";
     };
   };
   ksshaskpass = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/ksshaskpass-5.15.3.tar.xz";
-      sha256 = "1zrjc74srb4jp8sw6pi0ik2i4yxffvgv037d50yk1fif1xyvnf9s";
-      name = "ksshaskpass-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/ksshaskpass-5.15.4.tar.xz";
+      sha256 = "af0f99393992e337c69ebd053249de1a882107668f042ef218aaa3f426743899";
+      name = "ksshaskpass-5.15.4.tar.xz";
     };
   };
   ksysguard = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/ksysguard-5.15.3.tar.xz";
-      sha256 = "1nxgadymq45yn92cs08gfmv5krc2ylwgbn5qcc2aq6ryrrhrw89q";
-      name = "ksysguard-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/ksysguard-5.15.4.tar.xz";
+      sha256 = "aa6dd5af4ff47092a3540590bd1c088727f0775b064dacfcb95f3fcf44d02fb7";
+      name = "ksysguard-5.15.4.tar.xz";
     };
   };
   kwallet-pam = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/kwallet-pam-5.15.3.tar.xz";
-      sha256 = "1w3vf92k3k2084cflv4fwav16czc4vqg62gi8x1alri38ziyb793";
-      name = "kwallet-pam-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/kwallet-pam-5.15.4.tar.xz";
+      sha256 = "67d41df8b573ab0e29e731264cc990b34f0ba66004737ce00ae0b2ecabe53fdf";
+      name = "kwallet-pam-5.15.4.tar.xz";
     };
   };
   kwayland-integration = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/kwayland-integration-5.15.3.tar.xz";
-      sha256 = "0grb9fnk7pfgwzj3c9d11zl1j9jy9k6d4pw2n2fdrs02g3yg603h";
-      name = "kwayland-integration-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/kwayland-integration-5.15.4.tar.xz";
+      sha256 = "6e760090dd68aa5fbd4ec2c01c7a277ef15310108fa4368bee82c6f57e8dcd99";
+      name = "kwayland-integration-5.15.4.tar.xz";
     };
   };
   kwin = {
-    version = "5.15.3.2";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/kwin-5.15.3.2.tar.xz";
-      sha256 = "0iri6993zsxmrm7qnf76py7ihc27x9y741ar7g9fry8c8knmqyrw";
-      name = "kwin-5.15.3.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/kwin-5.15.4.tar.xz";
+      sha256 = "4bdb01713d0d5605810bcbfddfbc9cb5e5bb2e7c89846f37f20e083b84c00ec1";
+      name = "kwin-5.15.4.tar.xz";
     };
   };
   kwrited = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/kwrited-5.15.3.tar.xz";
-      sha256 = "0xhdmnfkpr35sks7k66s5cbq220yrmbn8ixcsdqwsgpji2sx4g7v";
-      name = "kwrited-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/kwrited-5.15.4.tar.xz";
+      sha256 = "7c25ed48ce85294ab4d5e3d4ffaaf3dd408f2a97cbb253b9adc9d5b8004db3c4";
+      name = "kwrited-5.15.4.tar.xz";
     };
   };
   libkscreen = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/libkscreen-5.15.3.tar.xz";
-      sha256 = "0fzfk8ga5qinsmag61l29cf92r7qm4nlb8hrhddyff7d7c7kr3vj";
-      name = "libkscreen-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/libkscreen-5.15.4.tar.xz";
+      sha256 = "b9a0fb16a6f96b6203a612c46db36f81f182577b7dc658dff511c703de52e6db";
+      name = "libkscreen-5.15.4.tar.xz";
     };
   };
   libksysguard = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/libksysguard-5.15.3.tar.xz";
-      sha256 = "05cfb51xcmxb8k2k14n2i5ysj47aism9yq7lk2rw216bsdp2mqnj";
-      name = "libksysguard-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/libksysguard-5.15.4.tar.xz";
+      sha256 = "e4476b180f0f342d83ce1097ae10b1b9c88160b0c7fc9432259402ebbbdf4a14";
+      name = "libksysguard-5.15.4.tar.xz";
     };
   };
   milou = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/milou-5.15.3.tar.xz";
-      sha256 = "1prq9mdrysz8ckf7n6sjfn3qc87135nj69v2jcayn9irb0k8wz01";
-      name = "milou-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/milou-5.15.4.tar.xz";
+      sha256 = "bb96f23cd18bf69ea81ae1df9beed14408361529855cfd094e2757137c4d2aba";
+      name = "milou-5.15.4.tar.xz";
     };
   };
   oxygen = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/oxygen-5.15.3.tar.xz";
-      sha256 = "0a069imvw0khkbcih8zvx0i0ks99jkwis6p73n4846qz544f3dvb";
-      name = "oxygen-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/oxygen-5.15.4.tar.xz";
+      sha256 = "4d319eee7adc6feb3f01054b1e9e80776a895303b6935d7597f8503d5a183220";
+      name = "oxygen-5.15.4.tar.xz";
     };
   };
   plasma-browser-integration = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/plasma-browser-integration-5.15.3.tar.xz";
-      sha256 = "1mhaa5z63gyd8j7zplmyicnibqsv1xhd9mxip6clhj5bfk8q9jar";
-      name = "plasma-browser-integration-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/plasma-browser-integration-5.15.4.tar.xz";
+      sha256 = "104225b3d825a387a481c7da570f1ee7b2b556401ed333f0a11f96a324471ac4";
+      name = "plasma-browser-integration-5.15.4.tar.xz";
     };
   };
   plasma-desktop = {
-    version = "5.15.3.2";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/plasma-desktop-5.15.3.2.tar.xz";
-      sha256 = "12pz0bin3j2f98k88nwmb271lr6v6w3l28li0iri2x8pk144vr91";
-      name = "plasma-desktop-5.15.3.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/plasma-desktop-5.15.4.tar.xz";
+      sha256 = "0c4900ce7cc46261185bfc4fce2b47dc69a659f6c1fc8d94d770ee6a0d06d028";
+      name = "plasma-desktop-5.15.4.tar.xz";
     };
   };
   plasma-integration = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/plasma-integration-5.15.3.tar.xz";
-      sha256 = "08qw2ibl0j2nhsplc3b117vdc00bd2gn1q48nx0xy349bf64m735";
-      name = "plasma-integration-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/plasma-integration-5.15.4.tar.xz";
+      sha256 = "c09974edf55eb529d5a73c8a2533649986b5ce8423bdbc86d04a0be5c07aaee9";
+      name = "plasma-integration-5.15.4.tar.xz";
     };
   };
   plasma-nm = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/plasma-nm-5.15.3.tar.xz";
-      sha256 = "1l9wh4hs2v0b9hdagcgl67z0w4amffakxczwy0nwymqzv0mxgqvz";
-      name = "plasma-nm-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/plasma-nm-5.15.4.tar.xz";
+      sha256 = "f4e91790f397b906c10276abf71af93305c8a2c4124796eedd3bbdc0d864cb41";
+      name = "plasma-nm-5.15.4.tar.xz";
     };
   };
   plasma-pa = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/plasma-pa-5.15.3.tar.xz";
-      sha256 = "1lkhidd5b4mjn23mxcp2vfmxf7dwbk7y14svc4wy6xc1xg1pc125";
-      name = "plasma-pa-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/plasma-pa-5.15.4.tar.xz";
+      sha256 = "88239e34e50deed8830d6b0dc846590720341c2c1496c6413a7fecc2ba01af2c";
+      name = "plasma-pa-5.15.4.tar.xz";
     };
   };
   plasma-sdk = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/plasma-sdk-5.15.3.tar.xz";
-      sha256 = "1qzh0yy4zql7a50ql9ghhvlfxjnbckflbgbzdyd7i9x3ml7s5saw";
-      name = "plasma-sdk-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/plasma-sdk-5.15.4.tar.xz";
+      sha256 = "e6c188731e0f73bd6d79c55a12298bb032c2493d083a8cffaeb5f3ab1b1cdbb5";
+      name = "plasma-sdk-5.15.4.tar.xz";
     };
   };
   plasma-tests = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/plasma-tests-5.15.3.tar.xz";
-      sha256 = "1z5vhw1dy1qks6w161yamn2fawrgkggv9mvvgpmljmy07qpafgkg";
-      name = "plasma-tests-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/plasma-tests-5.15.4.tar.xz";
+      sha256 = "f62f54cdb8f478fd8641a8e71dc9600de6f793a2b4c6daa6ca409e8cbd36b485";
+      name = "plasma-tests-5.15.4.tar.xz";
     };
   };
   plasma-vault = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/plasma-vault-5.15.3.tar.xz";
-      sha256 = "1my9dnqz11frn07fk505pfi2nkf2d642jfgjklh5zfngjxy589jy";
-      name = "plasma-vault-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/plasma-vault-5.15.4.tar.xz";
+      sha256 = "2850656445a15243ab23fe2aecb159379ae7d0731b75b1f1a264fc179dfa50c1";
+      name = "plasma-vault-5.15.4.tar.xz";
     };
   };
   plasma-workspace = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/plasma-workspace-5.15.3.tar.xz";
-      sha256 = "08irdg8divr45z53kr6b1mv4s2jakmq3r79g7df6ja9rb6py5f59";
-      name = "plasma-workspace-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/plasma-workspace-5.15.4.tar.xz";
+      sha256 = "f86c2fda5b7dc2c40be1ea3c4791fef3965d2f91809700c849d30c00506753c9";
+      name = "plasma-workspace-5.15.4.tar.xz";
     };
   };
   plasma-workspace-wallpapers = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/plasma-workspace-wallpapers-5.15.3.tar.xz";
-      sha256 = "0xgssv66ksljv8xkj20v2x1bppkyn8z17wa3hynwlcqxh2g4afq4";
-      name = "plasma-workspace-wallpapers-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/plasma-workspace-wallpapers-5.15.4.tar.xz";
+      sha256 = "ba8c66c85fdddc401eecae453d864af954daa181724cc168cddf2d1e93f9bd40";
+      name = "plasma-workspace-wallpapers-5.15.4.tar.xz";
     };
   };
   plymouth-kcm = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/plymouth-kcm-5.15.3.tar.xz";
-      sha256 = "0fbr9nf263pc9inakhp901r58mlsm1jgw0xqp9fj08c9lj25z190";
-      name = "plymouth-kcm-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/plymouth-kcm-5.15.4.tar.xz";
+      sha256 = "d90b559eb948756ec122f1e5f8a737356306b19e4b7f13971df143afdabc19d5";
+      name = "plymouth-kcm-5.15.4.tar.xz";
     };
   };
   polkit-kde-agent = {
-    version = "1-5.15.3";
+    version = "1-5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/polkit-kde-agent-1-5.15.3.tar.xz";
-      sha256 = "07gl57h9zmagbw7v2sfksbcbqrfdhr8isfmpcw10rc4k2awlsysy";
-      name = "polkit-kde-agent-1-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/polkit-kde-agent-1-5.15.4.tar.xz";
+      sha256 = "078f96aed83097e8408db3c03fb3cb13a69e779b2397cc83d462e8ae9409aa7f";
+      name = "polkit-kde-agent-1-5.15.4.tar.xz";
     };
   };
   powerdevil = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/powerdevil-5.15.3.tar.xz";
-      sha256 = "1f7ik3lh30irqzf0pgy59kkrsn4fkl8xwam1bikfm34bwzrsxb14";
-      name = "powerdevil-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/powerdevil-5.15.4.tar.xz";
+      sha256 = "0be3a318cbb160e784b422e226e8c747f2c6829acfd0490604697930acf9047a";
+      name = "powerdevil-5.15.4.tar.xz";
     };
   };
   sddm-kcm = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/sddm-kcm-5.15.3.tar.xz";
-      sha256 = "1mvp8p1k9csmn6h6iyk29yj1j4b4dfyd6j4v0v2ha1vdfjwjlsh2";
-      name = "sddm-kcm-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/sddm-kcm-5.15.4.tar.xz";
+      sha256 = "5402a529998e3b6f38930f2a4abab5e83e186630ef98b87d0bd85f21f42f14e5";
+      name = "sddm-kcm-5.15.4.tar.xz";
     };
   };
   systemsettings = {
-    version = "5.15.3.2";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/systemsettings-5.15.3.2.tar.xz";
-      sha256 = "0bqhff2s2qyz1x8nhrphnkyja0mhr7msf58cwdkscsl6lyamn2a2";
-      name = "systemsettings-5.15.3.2.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/systemsettings-5.15.4.tar.xz";
+      sha256 = "2cff11f842266296192381a214df6fd55debfd444b754b6dec80f70a3154defb";
+      name = "systemsettings-5.15.4.tar.xz";
     };
   };
   user-manager = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/user-manager-5.15.3.tar.xz";
-      sha256 = "18acg3xjcdhcwk3irsf1hgkwma9mn6msl6qwmf0slz1lydlrljs4";
-      name = "user-manager-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/user-manager-5.15.4.tar.xz";
+      sha256 = "e698fcc723a559f54d41b973d17fb26a768edb4058bf1acb036491cb16f66401";
+      name = "user-manager-5.15.4.tar.xz";
     };
   };
   xdg-desktop-portal-kde = {
-    version = "5.15.3";
+    version = "5.15.4";
     src = fetchurl {
-      url = "${mirror}/stable/plasma/5.15.3/xdg-desktop-portal-kde-5.15.3.tar.xz";
-      sha256 = "10cmy4j54nkwrgibxdpx6d30g596ikvb1dqqmp1gvmzr570gmbi7";
-      name = "xdg-desktop-portal-kde-5.15.3.tar.xz";
+      url = "${mirror}/stable/plasma/5.15.4/xdg-desktop-portal-kde-5.15.4.tar.xz";
+      sha256 = "a1a5edd0bc4059e076dd237dbd3301d9aabd128b67776e97842a175fcc7b5576";
+      name = "xdg-desktop-portal-kde-5.15.4.tar.xz";
     };
   };
 }

--- a/pkgs/desktops/plasma-5/xdg-desktop-portal-kde.nix
+++ b/pkgs/desktops/plasma-5/xdg-desktop-portal-kde.nix
@@ -2,14 +2,14 @@
   mkDerivation,
   extra-cmake-modules, gettext, kdoctools, python,
   kcoreaddons, knotifications, kwayland, kwidgetsaddons, kwindowsystem,
-  cups, pcre, pipewire
+  cups, pcre, pipewire, kio
 }:
 
 mkDerivation {
   name = "xdg-desktop-portal-kde";
   nativeBuildInputs = [ extra-cmake-modules gettext kdoctools python ];
   buildInputs = [
-    cups pcre pipewire
+    cups pcre pipewire kio
     kcoreaddons knotifications kwayland kwidgetsaddons kwindowsystem
   ];
 }

--- a/pkgs/development/libraries/kde-frameworks/extra-cmake-modules/nix-lib-path.patch
+++ b/pkgs/development/libraries/kde-frameworks/extra-cmake-modules/nix-lib-path.patch
@@ -1,5 +1,5 @@
 diff --git a/kde-modules/KDEInstallDirs.cmake b/kde-modules/KDEInstallDirs.cmake
-index 52b2eb2..a04596c 100644
+index 275fd65..a04596c 100644
 --- a/kde-modules/KDEInstallDirs.cmake
 +++ b/kde-modules/KDEInstallDirs.cmake
 @@ -232,34 +232,6 @@
@@ -14,7 +14,7 @@ index 52b2eb2..a04596c 100644
 -# reason is: amd64 ABI: http://www.x86-64.org/documentation/abi.pdf
 -# For Debian with multiarch, use 'lib/${CMAKE_LIBRARY_ARCHITECTURE}' if
 -# CMAKE_LIBRARY_ARCHITECTURE is set (which contains e.g. "i386-linux-gnu"
--# See http://wiki.debian.org/Multiarch
+-# See https://wiki.debian.org/Multiarch
 -if((CMAKE_SYSTEM_NAME MATCHES "Linux|kFreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "GNU")
 -   AND NOT CMAKE_CROSSCOMPILING
 -   AND NOT DEFINED ENV{FLATPAK_ID})

--- a/pkgs/development/libraries/kde-frameworks/fetch.sh
+++ b/pkgs/development/libraries/kde-frameworks/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/frameworks/5.54/ )
+WGET_ARGS=( https://download.kde.org/stable/frameworks/5.56/ )

--- a/pkgs/development/libraries/kde-frameworks/fetch.sh
+++ b/pkgs/development/libraries/kde-frameworks/fetch.sh
@@ -1,1 +1,1 @@
-WGET_ARGS=( https://download.kde.org/stable/frameworks/5.56/ )
+WGET_ARGS=( https://download.kde.org/stable/frameworks/5.57/ )

--- a/pkgs/development/libraries/kde-frameworks/kfilemetadata/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kfilemetadata/default.nix
@@ -1,7 +1,7 @@
 {
   mkDerivation, lib, copyPathsToStore,
   extra-cmake-modules,
-  attr, ebook_tools, exiv2, ffmpeg, karchive, ki18n, poppler, qtbase, qtmultimedia, taglib
+  attr, ebook_tools, exiv2, ffmpeg, karchive, kcoreaddons, ki18n, poppler, qtbase, qtmultimedia, taglib
 }:
 
 mkDerivation {
@@ -9,7 +9,7 @@ mkDerivation {
   meta = { maintainers = [ lib.maintainers.ttuegel ]; };
   nativeBuildInputs = [ extra-cmake-modules ];
   buildInputs = [
-    attr ebook_tools exiv2 ffmpeg karchive ki18n poppler qtbase qtmultimedia
+    attr ebook_tools exiv2 ffmpeg karchive kcoreaddons ki18n poppler qtbase qtmultimedia
     taglib
   ];
   patches = copyPathsToStore (lib.readPathsFromFile ./. ./series);

--- a/pkgs/development/libraries/kde-frameworks/kservice/no-canonicalize-path.patch
+++ b/pkgs/development/libraries/kde-frameworks/kservice/no-canonicalize-path.patch
@@ -1,8 +1,8 @@
-Index: kservice-5.21.0/src/sycoca/vfolder_menu.cpp
+Index: kservice-5.27.0/src/sycoca/vfolder_menu.cpp
 ===================================================================
---- kservice-5.21.0.orig/src/sycoca/vfolder_menu.cpp
-+++ kservice-5.21.0/src/sycoca/vfolder_menu.cpp
-@@ -415,7 +415,7 @@ VFolderMenu::absoluteDir(const QString &
+--- kservice-5.27.0.orig/src/sycoca/vfolder_menu.cpp
++++ kservice-5.27.0/src/sycoca/vfolder_menu.cpp
+@@ -417,7 +417,7 @@ VFolderMenu::absoluteDir(const QString &
      }
  
      if (!relative) {

--- a/pkgs/development/libraries/kde-frameworks/kservice/qdiriterator-follow-symlinks.patch
+++ b/pkgs/development/libraries/kde-frameworks/kservice/qdiriterator-follow-symlinks.patch
@@ -1,11 +1,11 @@
-Index: kservice-5.21.0/src/sycoca/kbuildsycoca.cpp
+Index: kservice-5.27.0/src/sycoca/kbuildsycoca.cpp
 ===================================================================
---- kservice-5.21.0.orig/src/sycoca/kbuildsycoca.cpp
-+++ kservice-5.21.0/src/sycoca/kbuildsycoca.cpp
+--- kservice-5.27.0.orig/src/sycoca/kbuildsycoca.cpp
++++ kservice-5.27.0/src/sycoca/kbuildsycoca.cpp
 @@ -203,7 +203,7 @@ bool KBuildSycoca::build()
-         QSet<QString> relFiles;
          const QStringList dirs = QStandardPaths::locateAll(QStandardPaths::GenericDataLocation, m_resourceSubdir, QStandardPaths::LocateDirectory);
-         Q_FOREACH (const QString &dir, dirs) {
+         qCDebug(SYCOCA) << "Looking for subdir" << m_resourceSubdir << "=>" << dirs;
+         for (const QString &dir : dirs) {
 -            QDirIterator it(dir, QDirIterator::Subdirectories);
 +            QDirIterator it(dir, QDirIterator::Subdirectories | QDirIterator::FollowSymlinks);
              while (it.hasNext()) {

--- a/pkgs/development/libraries/kde-frameworks/srcs.nix
+++ b/pkgs/development/libraries/kde-frameworks/srcs.nix
@@ -3,635 +3,635 @@
 
 {
   attica = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/attica-5.54.0.tar.xz";
-      sha256 = "1gr7w0mf3aq5xyl9il3483m9aqgb981vxn02g2khm6dfsr6z2aln";
-      name = "attica-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/attica-5.56.0.tar.xz";
+      sha256 = "1ib68yg7dgfyh2kq72abw5bh8h0m85z3hcada3b3axq2xkcfxfmb";
+      name = "attica-5.56.0.tar.xz";
     };
   };
   baloo = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/baloo-5.54.0.tar.xz";
-      sha256 = "0wv8zi03plr279v9p923rwkx2kwhbpd6xlzyqi4v14vhcrmapg1c";
-      name = "baloo-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/baloo-5.56.0.tar.xz";
+      sha256 = "04hjlhlgw26l2pl4b5jk76xfs7366my71zp1xgiws5aq620bmmcy";
+      name = "baloo-5.56.0.tar.xz";
     };
   };
   bluez-qt = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/bluez-qt-5.54.0.tar.xz";
-      sha256 = "1br9496lahzqmzmvdic5835ig18w3g211l1w4qfzpgr50yin9n5v";
-      name = "bluez-qt-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/bluez-qt-5.56.0.tar.xz";
+      sha256 = "1phph0rjms8n2qpkh9bk1n1n1cd75znsqj9r8njs1siasm6vi4nm";
+      name = "bluez-qt-5.56.0.tar.xz";
     };
   };
   breeze-icons = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/breeze-icons-5.54.0.tar.xz";
-      sha256 = "1g5dppg2iq5bd3r3s8bi8jqnvnh1rm7s3sv51shmaamq5qf0n5jy";
-      name = "breeze-icons-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/breeze-icons-5.56.0.tar.xz";
+      sha256 = "0n6gizmzay98q1vi9ac60p0xq9hpaj9q0gcf8vbmvk4m0yzdd63x";
+      name = "breeze-icons-5.56.0.tar.xz";
     };
   };
   extra-cmake-modules = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/extra-cmake-modules-5.54.0.tar.xz";
-      sha256 = "0i3iqwvdqf2wpg8lsbna4vgmb18pnbv2772sg9k6zzhvkwsskdwi";
-      name = "extra-cmake-modules-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/extra-cmake-modules-5.56.0.tar.xz";
+      sha256 = "0a5mxk805rlmpgbxwa9qkn515jqpcifsrk8ydxc3anjcsq6ffg4i";
+      name = "extra-cmake-modules-5.56.0.tar.xz";
     };
   };
   frameworkintegration = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/frameworkintegration-5.54.0.tar.xz";
-      sha256 = "1rzi3ydw7hjhg4vbsfan7zgaa2a2bmp7mph95h2kidf8x816qv2d";
-      name = "frameworkintegration-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/frameworkintegration-5.56.0.tar.xz";
+      sha256 = "1xc0vdvpjzhb6y1pz27c7x36qjjhcf4bll0fm3yljpm956v4d3gf";
+      name = "frameworkintegration-5.56.0.tar.xz";
     };
   };
   kactivities = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kactivities-5.54.0.tar.xz";
-      sha256 = "0ipq71g6g7q6yncvbiabwn5kg2280k8ssibbbf6jyh2lg09dmjil";
-      name = "kactivities-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kactivities-5.56.0.tar.xz";
+      sha256 = "0l0p966b5rs6xjc61mpzmrkj7qqjvlzi6fwc7lky4z3fr924ssp7";
+      name = "kactivities-5.56.0.tar.xz";
     };
   };
   kactivities-stats = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kactivities-stats-5.54.0.tar.xz";
-      sha256 = "1ns7f110a5vwabb33b1lnpa85kk5radf87bxm1gw4gzglsv7747d";
-      name = "kactivities-stats-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kactivities-stats-5.56.0.tar.xz";
+      sha256 = "1v3pf9drb22qv7039grx4k7q3a1jxd2a7sf818mxpqyys4fzkl3f";
+      name = "kactivities-stats-5.56.0.tar.xz";
     };
   };
   kapidox = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kapidox-5.54.0.tar.xz";
-      sha256 = "0zwjychzcamsky9l67xnw820b9m8r8pi56gsccg023l1rcigz46c";
-      name = "kapidox-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kapidox-5.56.0.tar.xz";
+      sha256 = "0rhqqsv4zf13idk426x84jykw6lc74bz7pk606llbmyw4775c7wp";
+      name = "kapidox-5.56.0.tar.xz";
     };
   };
   karchive = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/karchive-5.54.0.tar.xz";
-      sha256 = "141xqgdk7g3ky0amblrqr4pab1xvvdim5wvckrgawdkjiy5ana4g";
-      name = "karchive-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/karchive-5.56.0.tar.xz";
+      sha256 = "1mnavc5baa4qw90baw5b95760lk61m2rx0vfa3w5d7fid3m6q6i8";
+      name = "karchive-5.56.0.tar.xz";
     };
   };
   kauth = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kauth-5.54.0.tar.xz";
-      sha256 = "1ciabazig77rpfksvdlmixj2sa2qnasq13nwvjn3xksnajfm4p2h";
-      name = "kauth-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kauth-5.56.0.tar.xz";
+      sha256 = "0gb1yh2na2kfphln7arscv5n7llagkkv2y0zdprdy4michqa3k6b";
+      name = "kauth-5.56.0.tar.xz";
     };
   };
   kbookmarks = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kbookmarks-5.54.0.tar.xz";
-      sha256 = "1w4rqnzyars1pxam3nym1qily3ihd2j8cpkq8aha70nbj0dj3ckw";
-      name = "kbookmarks-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kbookmarks-5.56.0.tar.xz";
+      sha256 = "0fwmq70ajyjqcva1n2vnf522gwl44aqsi6s9vf8zxsar14vil082";
+      name = "kbookmarks-5.56.0.tar.xz";
     };
   };
   kcmutils = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kcmutils-5.54.0.tar.xz";
-      sha256 = "0a5jz9m27nyl1vchp68170j9v5z4csyv43vpnfs09l6wk9ggdcwh";
-      name = "kcmutils-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kcmutils-5.56.0.tar.xz";
+      sha256 = "1f1sccwyk6fzqd9ywnhkrsyaklmxi0w0w5jqhp1m4n3l30caixkw";
+      name = "kcmutils-5.56.0.tar.xz";
     };
   };
   kcodecs = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kcodecs-5.54.0.tar.xz";
-      sha256 = "1s0ky187fbi34wabpfvdwb1zbblzvk8g83h37ckj9j4rd69mjksc";
-      name = "kcodecs-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kcodecs-5.56.0.tar.xz";
+      sha256 = "10lw85im4rd3nfdnw2p48cjwq0d47pa2s9v6vmhzmm3hxbflq8z7";
+      name = "kcodecs-5.56.0.tar.xz";
     };
   };
   kcompletion = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kcompletion-5.54.0.tar.xz";
-      sha256 = "0sgg09l97amnng0ddxyjpk535097f87bmn60hjqrmpsqb0n3a460";
-      name = "kcompletion-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kcompletion-5.56.0.tar.xz";
+      sha256 = "1yxsrl0f24ps8xsilh2iqnl88yvw39iw2ch0yk7lwwk47jkgvns9";
+      name = "kcompletion-5.56.0.tar.xz";
     };
   };
   kconfig = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kconfig-5.54.0.tar.xz";
-      sha256 = "14p4w0m04c8msdwb3mjfzx6w0lcmln65j3rfvqp58nv5n4yh5dp7";
-      name = "kconfig-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kconfig-5.56.0.tar.xz";
+      sha256 = "0wii6pn5dq899s1r7p4q5vmm01jk11zwg2ky6760xf8nv8rhg5ra";
+      name = "kconfig-5.56.0.tar.xz";
     };
   };
   kconfigwidgets = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kconfigwidgets-5.54.0.tar.xz";
-      sha256 = "1l3hh7qgnz7mnn55abv03pq7zal9dgcw5gnhfr747wknd4h90w31";
-      name = "kconfigwidgets-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kconfigwidgets-5.56.0.tar.xz";
+      sha256 = "00x5cxgxqza81znzm5rzxzr6scv3s5wbwbhsq61ksmjnlf5wvky5";
+      name = "kconfigwidgets-5.56.0.tar.xz";
     };
   };
   kcoreaddons = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kcoreaddons-5.54.0.tar.xz";
-      sha256 = "1n27786js8j8na7kgxirhmswxcz3qkfiqzfabqmmsd0jp4rx1s79";
-      name = "kcoreaddons-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kcoreaddons-5.56.0.tar.xz";
+      sha256 = "17kvndaab9l6r79rh0pyjgw4yqh99xfyksc4yxzhhlyl3fgh6hcz";
+      name = "kcoreaddons-5.56.0.tar.xz";
     };
   };
   kcrash = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kcrash-5.54.0.tar.xz";
-      sha256 = "0wlrlzwdi9dpxkky9sadmbgw0rjisxhym9hr8gzydd2y8q4cr8a7";
-      name = "kcrash-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kcrash-5.56.0.tar.xz";
+      sha256 = "1q5iyqi1qgk5ngc9fdilrc5mjxy2mb0xbdnlx234hn1a44aq47jq";
+      name = "kcrash-5.56.0.tar.xz";
     };
   };
   kdbusaddons = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kdbusaddons-5.54.0.tar.xz";
-      sha256 = "1fvlspqc3w3y4p04gnqz6vrfvl93iwckfk16p608fz7yfgdmlzbf";
-      name = "kdbusaddons-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kdbusaddons-5.56.0.tar.xz";
+      sha256 = "0wmrcz92k27j0s2iyzd9ldynv4p52x70sxzby2m807ffrs692c5r";
+      name = "kdbusaddons-5.56.0.tar.xz";
     };
   };
   kdeclarative = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kdeclarative-5.54.0.tar.xz";
-      sha256 = "0ankjqrlpnj3c9sjnv5p8w279zizkl5ps3i5zw16hg44v6hdmcj0";
-      name = "kdeclarative-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kdeclarative-5.56.0.tar.xz";
+      sha256 = "0slhxqzbrj23vw7f017cx3brpqkw3933jj7z8kc2bgfzjypj373r";
+      name = "kdeclarative-5.56.0.tar.xz";
     };
   };
   kded = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kded-5.54.0.tar.xz";
-      sha256 = "131hvxpqvkyh1sfb1j19jjzy7fyy6xisvpmx12lw1pvks0cnrqgn";
-      name = "kded-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kded-5.56.0.tar.xz";
+      sha256 = "0fdzpsrigjqssqw25gxz5d1i0j8g3hc8xpv4v74mp0pcv9g10apz";
+      name = "kded-5.56.0.tar.xz";
     };
   };
   kdelibs4support = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/portingAids/kdelibs4support-5.54.0.tar.xz";
-      sha256 = "02kklfcjsll4pf4rfll7jrr7jpcwd57954ypjjhn3xgr6p0w0hdm";
-      name = "kdelibs4support-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/portingAids/kdelibs4support-5.56.0.tar.xz";
+      sha256 = "1yhfnvzgwmnivm99gkq67gnx0ar02j043mq3fg2lgwlrarqi9k7d";
+      name = "kdelibs4support-5.56.0.tar.xz";
     };
   };
   kdesignerplugin = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kdesignerplugin-5.54.0.tar.xz";
-      sha256 = "0hlywnzd3d6bvhib1xqiqx39m7k8g16wsj102f7awd5gw3xrz8ga";
-      name = "kdesignerplugin-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kdesignerplugin-5.56.0.tar.xz";
+      sha256 = "05nqayzafn2zz74lx8zj7hi7knclcip7zbqmpk1g3nriysc39x4v";
+      name = "kdesignerplugin-5.56.0.tar.xz";
     };
   };
   kdesu = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kdesu-5.54.0.tar.xz";
-      sha256 = "1qhw1hmq2b6rkyibidmg532llv31vkhmp0a7j2myzi40ydbx1lar";
-      name = "kdesu-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kdesu-5.56.0.tar.xz";
+      sha256 = "0fc77rbkd1m7rv4rq56g0fg4vg0siamdm5g788816ig9gn1j76ll";
+      name = "kdesu-5.56.0.tar.xz";
     };
   };
   kdewebkit = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kdewebkit-5.54.0.tar.xz";
-      sha256 = "0prl9751a8nv7qhg7fv8qygq0llh71w2p25sldl3zif44340jnhf";
-      name = "kdewebkit-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kdewebkit-5.56.0.tar.xz";
+      sha256 = "1c1mxs30182ilxybp0xwaljrjg5y9j1ri79169hn8664xs3wcbc2";
+      name = "kdewebkit-5.56.0.tar.xz";
     };
   };
   kdnssd = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kdnssd-5.54.0.tar.xz";
-      sha256 = "00sqx2hyqd9yw4nwdl8kmbzm0v0szgqv4nz0q6bchv3hfbax6zk7";
-      name = "kdnssd-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kdnssd-5.56.0.tar.xz";
+      sha256 = "1gskwc8sbj6cicblmrxh7qnh1gap0qivs8k5zf5qs94p1xc864vy";
+      name = "kdnssd-5.56.0.tar.xz";
     };
   };
   kdoctools = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kdoctools-5.54.0.tar.xz";
-      sha256 = "0xbmdqlvyw9s2g8kwn1wmvz09pn4vs386ibm1p92wdnpspp5did6";
-      name = "kdoctools-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kdoctools-5.56.0.tar.xz";
+      sha256 = "01y06rf1nhw2p8s0j60anr2qvssrqfimddvp2mqqkvx9xkx3py74";
+      name = "kdoctools-5.56.0.tar.xz";
     };
   };
   kemoticons = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kemoticons-5.54.0.tar.xz";
-      sha256 = "0ypcffpp0m75qwam386q6pyfbsij16y2vgpkn38li6ypxlxsvx2v";
-      name = "kemoticons-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kemoticons-5.56.0.tar.xz";
+      sha256 = "00hbd09gnwyfszdwa9yf5m8wpbbapc4kwhs3qxhbvvmll0jv9vl2";
+      name = "kemoticons-5.56.0.tar.xz";
     };
   };
   kfilemetadata = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kfilemetadata-5.54.0.tar.xz";
-      sha256 = "1hl61y15nqr5h5k4jqfz9bjj4gw6wdaiacxaslcwzn0sg4xyavab";
-      name = "kfilemetadata-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kfilemetadata-5.56.0.tar.xz";
+      sha256 = "04pmd2f77zxi14l3rhw4dyrh9dafchxqw1xjyv60j97gmm1b9796";
+      name = "kfilemetadata-5.56.0.tar.xz";
     };
   };
   kglobalaccel = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kglobalaccel-5.54.0.tar.xz";
-      sha256 = "10gl8prc1n0si52cmiglkz8dx79dylmxrh5mjpmyy5yy16chs1s1";
-      name = "kglobalaccel-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kglobalaccel-5.56.0.tar.xz";
+      sha256 = "0pmgvizc2dwrwr7m49125ybcpsc95r9riwxnihf37napyaacd9y3";
+      name = "kglobalaccel-5.56.0.tar.xz";
     };
   };
   kguiaddons = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kguiaddons-5.54.0.tar.xz";
-      sha256 = "0lkqxsqdjmc7060pxi5j8gx15kmrb8450cpinzn89nzpdl7rj935";
-      name = "kguiaddons-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kguiaddons-5.56.0.tar.xz";
+      sha256 = "0gp2i29y1vws8i3q8s1bhyxksa42l6q55m459yczddcvcw0vd45i";
+      name = "kguiaddons-5.56.0.tar.xz";
     };
   };
   kholidays = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kholidays-5.54.0.tar.xz";
-      sha256 = "1xp6mpnhlqkfl3pdaj6nq9sqy30z5wm6gms0ycy33n4ly2s8wb1y";
-      name = "kholidays-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kholidays-5.56.0.tar.xz";
+      sha256 = "0lm2ls3a15qbsfhamh2ldzvr62wi9nrhxd83rhyk3ifsgac4mg18";
+      name = "kholidays-5.56.0.tar.xz";
     };
   };
   khtml = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/portingAids/khtml-5.54.0.tar.xz";
-      sha256 = "17d8cim4ph7nxc5gkidhxc659yn9a7dqvnrihx9sj1cy01qnc7da";
-      name = "khtml-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/portingAids/khtml-5.56.0.tar.xz";
+      sha256 = "1wmcqc4546mqagqpgb97h3yd7nxaq4si2484li5hnw8mglm1qf3x";
+      name = "khtml-5.56.0.tar.xz";
     };
   };
   ki18n = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/ki18n-5.54.0.tar.xz";
-      sha256 = "0drbyr2y44h1d88nbgxvp4ix46lin51r8vzhhnjhq2ydqy5za3p3";
-      name = "ki18n-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/ki18n-5.56.0.tar.xz";
+      sha256 = "0hdfad9vmyzfni9ln0dc9p26gpjksk754z28v35hww6z9kgbr1dq";
+      name = "ki18n-5.56.0.tar.xz";
     };
   };
   kiconthemes = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kiconthemes-5.54.0.tar.xz";
-      sha256 = "0hc3a6ax3yizpbvklxw3pm0r6j0r5jqx2ffbz1980g21lcgshd7g";
-      name = "kiconthemes-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kiconthemes-5.56.0.tar.xz";
+      sha256 = "0rdpvbqsb2wqi3glmggilm1mhpy6nc80am5hl4c34269mxd55q8a";
+      name = "kiconthemes-5.56.0.tar.xz";
     };
   };
   kidletime = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kidletime-5.54.0.tar.xz";
-      sha256 = "1x0z0ipdizgv6jkklxp6maclx8f6ya2bv1q39hvxxnnmly8q3vjm";
-      name = "kidletime-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kidletime-5.56.0.tar.xz";
+      sha256 = "09184bi8fvq34hwkldyibji7r79wd2wvhxk1i4kzkjg177dnaa95";
+      name = "kidletime-5.56.0.tar.xz";
     };
   };
   kimageformats = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kimageformats-5.54.0.tar.xz";
-      sha256 = "0xfzpzaqgdncwxvg27qb0ryqi78nbsi0xcsg9cjmgspfx5mlgi15";
-      name = "kimageformats-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kimageformats-5.56.0.tar.xz";
+      sha256 = "1cgh32jkg0ybfp8z6qwn7y6yr9mb0fiqly4pb0qc1lcm6awdx3d5";
+      name = "kimageformats-5.56.0.tar.xz";
     };
   };
   kinit = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kinit-5.54.0.tar.xz";
-      sha256 = "0pmr6ckysdqpni49i9jgapsk88jfbrnlfybpcp3v51kl2nkwm0i9";
-      name = "kinit-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kinit-5.56.0.tar.xz";
+      sha256 = "1ihrannyaj33wsir20qy363vdjafhlsmj45qzl3xkl4rbyl6ngs7";
+      name = "kinit-5.56.0.tar.xz";
     };
   };
   kio = {
-    version = "5.54.1";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kio-5.54.1.tar.xz";
-      sha256 = "11wdsq87w1ddkrm0mpik2qf0c0k897f1rflszfrrwkplfb0z63xp";
-      name = "kio-5.54.1.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kio-5.56.0.tar.xz";
+      sha256 = "1m2c3a5isj966snmzs97i9kyhwnbzlwf61lqw5yxck25x7d0pyyn";
+      name = "kio-5.56.0.tar.xz";
     };
   };
   kirigami2 = {
-    version = "5.54.0";
+    version = "5.56.1";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kirigami2-5.54.0.tar.xz";
-      sha256 = "0iny9br3vpakvv0bmgy0mmw2y10d4kqbahjpfa3726qai4gligp2";
-      name = "kirigami2-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kirigami2-5.56.1.tar.xz";
+      sha256 = "0npq65kslwkdsylmv5hgcqsa5i9386dmnx8ig79rlf3409awn2f8";
+      name = "kirigami2-5.56.1.tar.xz";
     };
   };
   kitemmodels = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kitemmodels-5.54.0.tar.xz";
-      sha256 = "1s3wv75sbb4kpgz02cbm7smp8h6rk1ixv0gafbvz9514i9g4d760";
-      name = "kitemmodels-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kitemmodels-5.56.0.tar.xz";
+      sha256 = "13m1bvhljyc1jb9hdlz5v009kmkz7q0qf06l5zkck5k0fq41rkrg";
+      name = "kitemmodels-5.56.0.tar.xz";
     };
   };
   kitemviews = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kitemviews-5.54.0.tar.xz";
-      sha256 = "1cw9i8xik287rvb12alpqsph902nhfmbn4cfjx5gj7k888n8k3mk";
-      name = "kitemviews-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kitemviews-5.56.0.tar.xz";
+      sha256 = "1ar492jpyprxvzcgnq0gnbyxlndb3rd0z32drk7xsx19vpk3ch58";
+      name = "kitemviews-5.56.0.tar.xz";
     };
   };
   kjobwidgets = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kjobwidgets-5.54.0.tar.xz";
-      sha256 = "0d3jxabjlf2s4p34pzrpfsg4xp9s8qd7dmg50yxl59dijd42xgxq";
-      name = "kjobwidgets-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kjobwidgets-5.56.0.tar.xz";
+      sha256 = "1dh4ilry575k6z0glqb60ldjfkwpnkvijdzfyrc22bn84hbh19iy";
+      name = "kjobwidgets-5.56.0.tar.xz";
     };
   };
   kjs = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/portingAids/kjs-5.54.0.tar.xz";
-      sha256 = "0bidbvbwbrbwwm0drw6l43vgmsp50c946jjq7pgnq1gf7mhscwcy";
-      name = "kjs-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/portingAids/kjs-5.56.0.tar.xz";
+      sha256 = "1b3l76ipf0fr8bvp3f4njimmg5yw9ciwzzgvb34ds65aycplagln";
+      name = "kjs-5.56.0.tar.xz";
     };
   };
   kjsembed = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/portingAids/kjsembed-5.54.0.tar.xz";
-      sha256 = "1pjpk8ysrnh78infq99i0wrf78h8h7hbfnr1m7agzffhbqa671z8";
-      name = "kjsembed-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/portingAids/kjsembed-5.56.0.tar.xz";
+      sha256 = "0lkfq7099yiwvlycrix3s0dbk860rqfnix5fiw5vmi855is7mpkv";
+      name = "kjsembed-5.56.0.tar.xz";
     };
   };
   kmediaplayer = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/portingAids/kmediaplayer-5.54.0.tar.xz";
-      sha256 = "0qalqqkn2yvxgr45l7zm36bcpxwbgn8ngxsvyb5cxfaalwr0mkyf";
-      name = "kmediaplayer-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/portingAids/kmediaplayer-5.56.0.tar.xz";
+      sha256 = "0blqbi40l1pk8qf9054ha4a8r7cb4pddbqydsqlsscl4gm8530jh";
+      name = "kmediaplayer-5.56.0.tar.xz";
     };
   };
   knewstuff = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/knewstuff-5.54.0.tar.xz";
-      sha256 = "1l3ibadjvaqqjsb1lhkf6jkzy80dk15fgid125bqk4amwsyygnd3";
-      name = "knewstuff-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/knewstuff-5.56.0.tar.xz";
+      sha256 = "0r0ia0521vfri7mc6wpg3ihryqj48s3krgmliwbh635rfd3lcj9j";
+      name = "knewstuff-5.56.0.tar.xz";
     };
   };
   knotifications = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/knotifications-5.54.0.tar.xz";
-      sha256 = "1agglvwaf0wh3fcs0ww3jxn900ych4dsvbaylrx4qip6girfmiyn";
-      name = "knotifications-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/knotifications-5.56.0.tar.xz";
+      sha256 = "05nf2870fq9cwacgyy8iky5v37fq4jrsh4hl9xy9928d19qnmb24";
+      name = "knotifications-5.56.0.tar.xz";
     };
   };
   knotifyconfig = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/knotifyconfig-5.54.0.tar.xz";
-      sha256 = "1ibxqi0y43qgjj4nikxwfppmda9xjmz63c5fml8c4w5d9mdag3if";
-      name = "knotifyconfig-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/knotifyconfig-5.56.0.tar.xz";
+      sha256 = "0zwq0p779482sxxjg62z1rkpiiyn6b3r47l450dm6hm56vkf7vxl";
+      name = "knotifyconfig-5.56.0.tar.xz";
     };
   };
   kpackage = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kpackage-5.54.0.tar.xz";
-      sha256 = "1s1n7r3j7l4kvd85dgssaaz70dd2w8vp34kwg49ak58cdai01vzb";
-      name = "kpackage-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kpackage-5.56.0.tar.xz";
+      sha256 = "037r0ldp70q0yafld1ddff1d4wipb5ras88r72qazjcfqfg9rzjr";
+      name = "kpackage-5.56.0.tar.xz";
     };
   };
   kparts = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kparts-5.54.0.tar.xz";
-      sha256 = "0y2dr286hb2w4r7ifq39vd7ajsalqyh9d91dm19b2rpgdmvgxai6";
-      name = "kparts-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kparts-5.56.0.tar.xz";
+      sha256 = "1vj5ard5ff0wzpjqzrkd2kb31dkjly1cf4ww1ljrrwi7qgzxgw0z";
+      name = "kparts-5.56.0.tar.xz";
     };
   };
   kpeople = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kpeople-5.54.0.tar.xz";
-      sha256 = "0sl8wcj7w9vgczcv8mfvjlnghidyadbh1qsiv0pj63ywl7xgr1hx";
-      name = "kpeople-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kpeople-5.56.0.tar.xz";
+      sha256 = "0h456kjhx4ylbkiv3706g8ccdq55aamrhj5rgiql2gaw3d5dbrkr";
+      name = "kpeople-5.56.0.tar.xz";
     };
   };
   kplotting = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kplotting-5.54.0.tar.xz";
-      sha256 = "02mab80jyfgdj8xwbwkm181cc5vpsmbn561242q7ayjgxdiszzw9";
-      name = "kplotting-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kplotting-5.56.0.tar.xz";
+      sha256 = "1hrk3iv77s46lcs6c5mfiyzr80vpg9261mlixc3qwps0mww43r1r";
+      name = "kplotting-5.56.0.tar.xz";
     };
   };
   kpty = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kpty-5.54.0.tar.xz";
-      sha256 = "04sj612x15311yk2jmr3ak430syp5p59w559670sd18ih99mf8m3";
-      name = "kpty-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kpty-5.56.0.tar.xz";
+      sha256 = "1dzp4a6rz6hsp1y8m5l73i8v2a3bpwkv4rrypkd00051ajcch47k";
+      name = "kpty-5.56.0.tar.xz";
     };
   };
   kross = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/portingAids/kross-5.54.0.tar.xz";
-      sha256 = "18ij9339khskla4r0afl0n6x4pd157y1l5bk2ldb9anpck3p71kd";
-      name = "kross-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/portingAids/kross-5.56.0.tar.xz";
+      sha256 = "0ry6fpl0rb8z5r08bzh6kj14mp7l94calvdk3vrnc89cpm5gxymv";
+      name = "kross-5.56.0.tar.xz";
     };
   };
   krunner = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/krunner-5.54.0.tar.xz";
-      sha256 = "06y592v32926wq9iaypryj0173ca05vv0p5rrs4n77kwhkl0zq0v";
-      name = "krunner-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/krunner-5.56.0.tar.xz";
+      sha256 = "1gs0fr78zbhxl8c08zj4s98zshc42zxzwv7p9l7rmq8h21spc8ga";
+      name = "krunner-5.56.0.tar.xz";
     };
   };
   kservice = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kservice-5.54.0.tar.xz";
-      sha256 = "10qmrqyfjhf5nzjailgmb86nq62ffrmiddk3880mh49fwxs4l3qx";
-      name = "kservice-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kservice-5.56.0.tar.xz";
+      sha256 = "1hsc8pagigwspyv9ipl3l2b9mf8amfksk8a2k3iic9nw1hmpxinv";
+      name = "kservice-5.56.0.tar.xz";
     };
   };
   ktexteditor = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/ktexteditor-5.54.0.tar.xz";
-      sha256 = "12yywvv82lmqmx89j1qxj45an49vx34brifxs9rpy3nxyh9c3vzy";
-      name = "ktexteditor-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/ktexteditor-5.56.0.tar.xz";
+      sha256 = "1a2r97v3xwh61q688jvwkk99bphfd0v0ldqms5d73q3m6w1x122c";
+      name = "ktexteditor-5.56.0.tar.xz";
     };
   };
   ktextwidgets = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/ktextwidgets-5.54.0.tar.xz";
-      sha256 = "154j3an7x787l44hw1fmksm3h6kziyaw4l61zw9mas24z3d86hl5";
-      name = "ktextwidgets-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/ktextwidgets-5.56.0.tar.xz";
+      sha256 = "1km19z577y29di8zp6amlccqdavxk4f4sg1dblj6gp64zkw9dbqp";
+      name = "ktextwidgets-5.56.0.tar.xz";
     };
   };
   kunitconversion = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kunitconversion-5.54.0.tar.xz";
-      sha256 = "0lxrydnjlilfm92aqrpd76dk8yfprgnb7nr66dwmbdmqz7znbl8h";
-      name = "kunitconversion-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kunitconversion-5.56.0.tar.xz";
+      sha256 = "1kf5dc6p77mkx2i23ppfs0k3laybmx5vqq7aq1bxnkxj1ws75144";
+      name = "kunitconversion-5.56.0.tar.xz";
     };
   };
   kwallet = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kwallet-5.54.0.tar.xz";
-      sha256 = "0hyipka97g2djk43x8pqbjvrgswsp8kph6za0s5dl4napfikq8k2";
-      name = "kwallet-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kwallet-5.56.0.tar.xz";
+      sha256 = "02i6xkq9ki6sybjvcxkznf5v8b34pqxysg9pi5v4z6jkw2jpr5fj";
+      name = "kwallet-5.56.0.tar.xz";
     };
   };
   kwayland = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kwayland-5.54.0.tar.xz";
-      sha256 = "0y1710l68qlf37zy26nyn25r50a00mrm5cnwgfs9f40s749amigf";
-      name = "kwayland-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kwayland-5.56.0.tar.xz";
+      sha256 = "1779in51z63sv6607xd7y30wprs9vs8nnqa28fxg1q4nicwnvrxv";
+      name = "kwayland-5.56.0.tar.xz";
     };
   };
   kwidgetsaddons = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kwidgetsaddons-5.54.0.tar.xz";
-      sha256 = "01qxklhigfazhma0f6m1fkcbh9waxpvzpz6y2jlflvgbw2db82gh";
-      name = "kwidgetsaddons-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kwidgetsaddons-5.56.0.tar.xz";
+      sha256 = "0flmw1wfzs49dmmlbbimizjwj09wp4qwr9znxn3h5yfn0mxfc1lv";
+      name = "kwidgetsaddons-5.56.0.tar.xz";
     };
   };
   kwindowsystem = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kwindowsystem-5.54.0.tar.xz";
-      sha256 = "1n9h4gg5ih29avvcpplqfy7nq58xx6jv6a04m1wkjr1rzn4dyfnb";
-      name = "kwindowsystem-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kwindowsystem-5.56.0.tar.xz";
+      sha256 = "0dk9ymlpdpvra2zm1f2rcx2dwnn9qc49n2y7p6iw094fwk5rzczc";
+      name = "kwindowsystem-5.56.0.tar.xz";
     };
   };
   kxmlgui = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kxmlgui-5.54.0.tar.xz";
-      sha256 = "01napbq81mcp9ngyl26an52l6ndsgrhzhy2mfd8jrbil2sbrcxq7";
-      name = "kxmlgui-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kxmlgui-5.56.0.tar.xz";
+      sha256 = "1ipa0qnkh6gs3f6ygvb7cf0yv1m89m3cdl1z23br4fn14d5mxbrl";
+      name = "kxmlgui-5.56.0.tar.xz";
     };
   };
   kxmlrpcclient = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/kxmlrpcclient-5.54.0.tar.xz";
-      sha256 = "199syc5wl8myc4vcvbnw4a8mlfkb2gcmgs57p8w7akp7mz6l75y6";
-      name = "kxmlrpcclient-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/kxmlrpcclient-5.56.0.tar.xz";
+      sha256 = "1bjnpl4521gv35zghaanz6v5bap2b9n2kz7b0rif1bf6iak018ql";
+      name = "kxmlrpcclient-5.56.0.tar.xz";
     };
   };
   modemmanager-qt = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/modemmanager-qt-5.54.0.tar.xz";
-      sha256 = "0n54gh83b6d42azv40km7j223qb2f4f9ng23xvvawzc7l2ksm350";
-      name = "modemmanager-qt-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/modemmanager-qt-5.56.0.tar.xz";
+      sha256 = "1xwx6yybij8nlaqfpz76pindfxshcyg9p21nqm6ddpgyzh74klbc";
+      name = "modemmanager-qt-5.56.0.tar.xz";
     };
   };
   networkmanager-qt = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/networkmanager-qt-5.54.0.tar.xz";
-      sha256 = "0bh5li6r7r3nws5zj0hp4iy4xhiyh7rszzwpp6ag93vz5g5fsl9y";
-      name = "networkmanager-qt-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/networkmanager-qt-5.56.0.tar.xz";
+      sha256 = "0p0b3rq7s1yzy6zspd6xnzjc0hza9d7fixm8pw369kn5k3pi5lk1";
+      name = "networkmanager-qt-5.56.0.tar.xz";
     };
   };
   oxygen-icons5 = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/oxygen-icons5-5.54.0.tar.xz";
-      sha256 = "1sdd8ygkyl4d1mwrachcf0ahpikkby3xhdyz212xj9qmhmsgwa46";
-      name = "oxygen-icons5-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/oxygen-icons5-5.56.0.tar.xz";
+      sha256 = "17cjcfmc8vywh8n2ck0s3b0i88ilamdah0gipicn7vj65l4wc1qb";
+      name = "oxygen-icons5-5.56.0.tar.xz";
     };
   };
   plasma-framework = {
-    version = "5.54.0";
+    version = "5.56.1";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/plasma-framework-5.54.0.tar.xz";
-      sha256 = "1933i8irn76ilz3nychbnhy1bsc39iscn3qrab0lwmshfmw8c4zj";
-      name = "plasma-framework-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/plasma-framework-5.56.1.tar.xz";
+      sha256 = "0wn7q2cfrgzcprzgqj1d4calc0mmrrn615698fish7x9s1n7ag6w";
+      name = "plasma-framework-5.56.1.tar.xz";
     };
   };
   prison = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/prison-5.54.0.tar.xz";
-      sha256 = "1z7gymk4hkwaa0ni1454ndvpm2lwqyyfbih38h0lfb8lrswnv3kb";
-      name = "prison-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/prison-5.56.0.tar.xz";
+      sha256 = "05hy6fz05snpgjz6bnm3qcr7smg65a0m6rdmyv7avrpbs4qpbghx";
+      name = "prison-5.56.0.tar.xz";
     };
   };
   purpose = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/purpose-5.54.0.tar.xz";
-      sha256 = "07rz8bqwvlz5g914q4vxdcdmrja5hxa29iazxz8nr171xnpg9x0w";
-      name = "purpose-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/purpose-5.56.0.tar.xz";
+      sha256 = "0rvywfkhqbmd39g950mpnn35i3kg7j63ylvdy2px2d71am6acal8";
+      name = "purpose-5.56.0.tar.xz";
     };
   };
   qqc2-desktop-style = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/qqc2-desktop-style-5.54.0.tar.xz";
-      sha256 = "1shw3c6cr5xanzyl5zv3isyhvzi20zn3xf7m963z1qn8ypaz1by8";
-      name = "qqc2-desktop-style-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/qqc2-desktop-style-5.56.0.tar.xz";
+      sha256 = "08afy1gsy0lvpzqmv5azzfiy5x9lvffsf6qvzxxab4v5ch8fn00b";
+      name = "qqc2-desktop-style-5.56.0.tar.xz";
     };
   };
   solid = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/solid-5.54.0.tar.xz";
-      sha256 = "0hmh9hndfs1ikaja07ddag7jr8804q4g6p74rhqsrfk2sjz0pmr9";
-      name = "solid-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/solid-5.56.0.tar.xz";
+      sha256 = "17kfwj0y41pkd0kxj2fj9m9qs7bq05vka9ngfr022lfwdhs907c4";
+      name = "solid-5.56.0.tar.xz";
     };
   };
   sonnet = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/sonnet-5.54.0.tar.xz";
-      sha256 = "0ccz0gbypzdndaxrfkjhry90jjdh5a56pm4j41z835q96w6piclz";
-      name = "sonnet-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/sonnet-5.56.0.tar.xz";
+      sha256 = "0r8bsf7a9rjvv4jirycwf3xvkqa9iax23p93m301x82hdvmkjr9w";
+      name = "sonnet-5.56.0.tar.xz";
     };
   };
   syndication = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/syndication-5.54.0.tar.xz";
-      sha256 = "0zj8nv0hj5sf79v3clg2bqhs3m8hi1pzjar1cq6hkxprymw0hzx8";
-      name = "syndication-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/syndication-5.56.0.tar.xz";
+      sha256 = "0wnrhfp5b4wgmigqh39c0f2qfblgmc3x6018b4wcayfs8gb4m1q9";
+      name = "syndication-5.56.0.tar.xz";
     };
   };
   syntax-highlighting = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/syntax-highlighting-5.54.0.tar.xz";
-      sha256 = "022mpkbgc458qcn25pn3a3m2dzy6lq23r7fqbgp22jr6xalfi5hl";
-      name = "syntax-highlighting-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/syntax-highlighting-5.56.0.tar.xz";
+      sha256 = "0gl0v1bscqd6xhl3644wix8ix04lax0h1zzr1v65704c4qp87h8l";
+      name = "syntax-highlighting-5.56.0.tar.xz";
     };
   };
   threadweaver = {
-    version = "5.54.0";
+    version = "5.56.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.54/threadweaver-5.54.0.tar.xz";
-      sha256 = "011k2pm0wr60sxnydicnchnarx4r6qja0w6iih3jfkw733qm6bxp";
-      name = "threadweaver-5.54.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.56/threadweaver-5.56.0.tar.xz";
+      sha256 = "1gyvj0v1zhfk8shi31pivvf5rwxkgv9bjmy2vippk2vxvkh0qc5x";
+      name = "threadweaver-5.56.0.tar.xz";
     };
   };
 }

--- a/pkgs/development/libraries/kde-frameworks/srcs.nix
+++ b/pkgs/development/libraries/kde-frameworks/srcs.nix
@@ -3,635 +3,635 @@
 
 {
   attica = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/attica-5.56.0.tar.xz";
-      sha256 = "1ib68yg7dgfyh2kq72abw5bh8h0m85z3hcada3b3axq2xkcfxfmb";
-      name = "attica-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/attica-5.57.0.tar.xz";
+      sha256 = "a13682bccaca3529df6e3b54e1d4e48fb3d1654fe1b142701e73ce9fe0b87655";
+      name = "attica-5.57.0.tar.xz";
     };
   };
   baloo = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/baloo-5.56.0.tar.xz";
-      sha256 = "04hjlhlgw26l2pl4b5jk76xfs7366my71zp1xgiws5aq620bmmcy";
-      name = "baloo-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/baloo-5.57.0.tar.xz";
+      sha256 = "32ab4ed2d295fe734a4a475403dea72e2feef27f662ae64c841c410eb7bb3dd3";
+      name = "baloo-5.57.0.tar.xz";
     };
   };
   bluez-qt = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/bluez-qt-5.56.0.tar.xz";
-      sha256 = "1phph0rjms8n2qpkh9bk1n1n1cd75znsqj9r8njs1siasm6vi4nm";
-      name = "bluez-qt-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/bluez-qt-5.57.0.tar.xz";
+      sha256 = "43e1be1882832cef88186255a6b692d9fd1366bad09db0c2075a126b0fc0df65";
+      name = "bluez-qt-5.57.0.tar.xz";
     };
   };
   breeze-icons = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/breeze-icons-5.56.0.tar.xz";
-      sha256 = "0n6gizmzay98q1vi9ac60p0xq9hpaj9q0gcf8vbmvk4m0yzdd63x";
-      name = "breeze-icons-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/breeze-icons-5.57.0.tar.xz";
+      sha256 = "c3ba92acb5bfcff66f41232ebc6e8c893dab78ac59a713fa4bfa2a0e097f4ed2";
+      name = "breeze-icons-5.57.0.tar.xz";
     };
   };
   extra-cmake-modules = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/extra-cmake-modules-5.56.0.tar.xz";
-      sha256 = "0a5mxk805rlmpgbxwa9qkn515jqpcifsrk8ydxc3anjcsq6ffg4i";
-      name = "extra-cmake-modules-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/extra-cmake-modules-5.57.0.tar.xz";
+      sha256 = "aa53f8953792b452672f275c2ea9b96ab2adf3e13d9645c3451b06dbc8055b18";
+      name = "extra-cmake-modules-5.57.0.tar.xz";
     };
   };
   frameworkintegration = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/frameworkintegration-5.56.0.tar.xz";
-      sha256 = "1xc0vdvpjzhb6y1pz27c7x36qjjhcf4bll0fm3yljpm956v4d3gf";
-      name = "frameworkintegration-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/frameworkintegration-5.57.0.tar.xz";
+      sha256 = "9c5850c1d41900bcb81e7929d54856d0cdd2565a276e5e262f624eb1217cbb78";
+      name = "frameworkintegration-5.57.0.tar.xz";
     };
   };
   kactivities = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kactivities-5.56.0.tar.xz";
-      sha256 = "0l0p966b5rs6xjc61mpzmrkj7qqjvlzi6fwc7lky4z3fr924ssp7";
-      name = "kactivities-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kactivities-5.57.0.tar.xz";
+      sha256 = "442527db8710b9045dc574816bc9c32cad5f8a404e681fb030d7e9c2f3d77761";
+      name = "kactivities-5.57.0.tar.xz";
     };
   };
   kactivities-stats = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kactivities-stats-5.56.0.tar.xz";
-      sha256 = "1v3pf9drb22qv7039grx4k7q3a1jxd2a7sf818mxpqyys4fzkl3f";
-      name = "kactivities-stats-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kactivities-stats-5.57.0.tar.xz";
+      sha256 = "4c7a49905ec1b6e03831986b254d0fd091e44fe920fffa123c969765c6474ba3";
+      name = "kactivities-stats-5.57.0.tar.xz";
     };
   };
   kapidox = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kapidox-5.56.0.tar.xz";
-      sha256 = "0rhqqsv4zf13idk426x84jykw6lc74bz7pk606llbmyw4775c7wp";
-      name = "kapidox-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kapidox-5.57.0.tar.xz";
+      sha256 = "16f53e4722adddaa8729b4cccc374d16bdbfdd987f8655d2b431a91b046fe2b2";
+      name = "kapidox-5.57.0.tar.xz";
     };
   };
   karchive = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/karchive-5.56.0.tar.xz";
-      sha256 = "1mnavc5baa4qw90baw5b95760lk61m2rx0vfa3w5d7fid3m6q6i8";
-      name = "karchive-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/karchive-5.57.0.tar.xz";
+      sha256 = "e0e64e7e88c8df96f894de20aff4d12925e0d362c5134df83473ea48c0432783";
+      name = "karchive-5.57.0.tar.xz";
     };
   };
   kauth = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kauth-5.56.0.tar.xz";
-      sha256 = "0gb1yh2na2kfphln7arscv5n7llagkkv2y0zdprdy4michqa3k6b";
-      name = "kauth-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kauth-5.57.0.tar.xz";
+      sha256 = "9d6b9135cc47710b28e2a7731c4c5c1f6dba2b0e5fe982b9d2a82a11d7d497c2";
+      name = "kauth-5.57.0.tar.xz";
     };
   };
   kbookmarks = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kbookmarks-5.56.0.tar.xz";
-      sha256 = "0fwmq70ajyjqcva1n2vnf522gwl44aqsi6s9vf8zxsar14vil082";
-      name = "kbookmarks-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kbookmarks-5.57.0.tar.xz";
+      sha256 = "bf57f111e176ab2ecb79646b1f93cf5d84a8d3fcfb13b805b5140e75b42eb085";
+      name = "kbookmarks-5.57.0.tar.xz";
     };
   };
   kcmutils = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kcmutils-5.56.0.tar.xz";
-      sha256 = "1f1sccwyk6fzqd9ywnhkrsyaklmxi0w0w5jqhp1m4n3l30caixkw";
-      name = "kcmutils-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kcmutils-5.57.0.tar.xz";
+      sha256 = "f3ee63a356e18be95a15141346356f3f43bb067d0326021d99f4b73ee4716fbb";
+      name = "kcmutils-5.57.0.tar.xz";
     };
   };
   kcodecs = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kcodecs-5.56.0.tar.xz";
-      sha256 = "10lw85im4rd3nfdnw2p48cjwq0d47pa2s9v6vmhzmm3hxbflq8z7";
-      name = "kcodecs-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kcodecs-5.57.0.tar.xz";
+      sha256 = "c98b98cf7258c03fa5131a987e278f348d52f792dcb9f2a5664fe35aadea6995";
+      name = "kcodecs-5.57.0.tar.xz";
     };
   };
   kcompletion = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kcompletion-5.56.0.tar.xz";
-      sha256 = "1yxsrl0f24ps8xsilh2iqnl88yvw39iw2ch0yk7lwwk47jkgvns9";
-      name = "kcompletion-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kcompletion-5.57.0.tar.xz";
+      sha256 = "5ad8746a57cef2b12da5a97e296cbb0b708e8ecfb4253786a899fa86951395ec";
+      name = "kcompletion-5.57.0.tar.xz";
     };
   };
   kconfig = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kconfig-5.56.0.tar.xz";
-      sha256 = "0wii6pn5dq899s1r7p4q5vmm01jk11zwg2ky6760xf8nv8rhg5ra";
-      name = "kconfig-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kconfig-5.57.0.tar.xz";
+      sha256 = "155b0dbba8772aa8ea3e75217029daa00ada8699e5a807154214f66b2462c010";
+      name = "kconfig-5.57.0.tar.xz";
     };
   };
   kconfigwidgets = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kconfigwidgets-5.56.0.tar.xz";
-      sha256 = "00x5cxgxqza81znzm5rzxzr6scv3s5wbwbhsq61ksmjnlf5wvky5";
-      name = "kconfigwidgets-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kconfigwidgets-5.57.0.tar.xz";
+      sha256 = "771c5641a9ae465feaf00ffbb3f3c0433ad8d4a90355dc50d5b6b1b472912eb0";
+      name = "kconfigwidgets-5.57.0.tar.xz";
     };
   };
   kcoreaddons = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kcoreaddons-5.56.0.tar.xz";
-      sha256 = "17kvndaab9l6r79rh0pyjgw4yqh99xfyksc4yxzhhlyl3fgh6hcz";
-      name = "kcoreaddons-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kcoreaddons-5.57.0.tar.xz";
+      sha256 = "7c2573de9b745e55fe61cff26941839cff0d2e40b6c5d791c24c9d6cc8cf7485";
+      name = "kcoreaddons-5.57.0.tar.xz";
     };
   };
   kcrash = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kcrash-5.56.0.tar.xz";
-      sha256 = "1q5iyqi1qgk5ngc9fdilrc5mjxy2mb0xbdnlx234hn1a44aq47jq";
-      name = "kcrash-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kcrash-5.57.0.tar.xz";
+      sha256 = "4b12719a20f2ff0fe0a2656609d0aa277245cd2a9f764a7b6cfaa6da9d928dc0";
+      name = "kcrash-5.57.0.tar.xz";
     };
   };
   kdbusaddons = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kdbusaddons-5.56.0.tar.xz";
-      sha256 = "0wmrcz92k27j0s2iyzd9ldynv4p52x70sxzby2m807ffrs692c5r";
-      name = "kdbusaddons-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kdbusaddons-5.57.0.tar.xz";
+      sha256 = "86946d97e74420637f59ea0fff93e303bcbdc5b1d5e1c6361e2d9a3ceb0e1259";
+      name = "kdbusaddons-5.57.0.tar.xz";
     };
   };
   kdeclarative = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kdeclarative-5.56.0.tar.xz";
-      sha256 = "0slhxqzbrj23vw7f017cx3brpqkw3933jj7z8kc2bgfzjypj373r";
-      name = "kdeclarative-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kdeclarative-5.57.0.tar.xz";
+      sha256 = "5335b39ac1cca34209c0420dab867b67ddb0e9ee483bdd6d4192269a1d5f654f";
+      name = "kdeclarative-5.57.0.tar.xz";
     };
   };
   kded = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kded-5.56.0.tar.xz";
-      sha256 = "0fdzpsrigjqssqw25gxz5d1i0j8g3hc8xpv4v74mp0pcv9g10apz";
-      name = "kded-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kded-5.57.0.tar.xz";
+      sha256 = "04327dda12fa547bebb8e1b1bc26373e8f4174007dd629231403d59ce004201f";
+      name = "kded-5.57.0.tar.xz";
     };
   };
   kdelibs4support = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/portingAids/kdelibs4support-5.56.0.tar.xz";
-      sha256 = "1yhfnvzgwmnivm99gkq67gnx0ar02j043mq3fg2lgwlrarqi9k7d";
-      name = "kdelibs4support-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/portingAids/kdelibs4support-5.57.0.tar.xz";
+      sha256 = "e9d1c06191031b482ea01d891756d125ff32927239c36a3011fc7b8f17aca1b0";
+      name = "kdelibs4support-5.57.0.tar.xz";
     };
   };
   kdesignerplugin = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kdesignerplugin-5.56.0.tar.xz";
-      sha256 = "05nqayzafn2zz74lx8zj7hi7knclcip7zbqmpk1g3nriysc39x4v";
-      name = "kdesignerplugin-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kdesignerplugin-5.57.0.tar.xz";
+      sha256 = "9e85a4ac798122b459722773a6e81f639be6dfe9c9714a16704f555c88334393";
+      name = "kdesignerplugin-5.57.0.tar.xz";
     };
   };
   kdesu = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kdesu-5.56.0.tar.xz";
-      sha256 = "0fc77rbkd1m7rv4rq56g0fg4vg0siamdm5g788816ig9gn1j76ll";
-      name = "kdesu-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kdesu-5.57.0.tar.xz";
+      sha256 = "76d98db52f7f375991cd7ccbbf1dc100716f99a5792b71ef31a75cc33cf45b19";
+      name = "kdesu-5.57.0.tar.xz";
     };
   };
   kdewebkit = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kdewebkit-5.56.0.tar.xz";
-      sha256 = "1c1mxs30182ilxybp0xwaljrjg5y9j1ri79169hn8664xs3wcbc2";
-      name = "kdewebkit-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kdewebkit-5.57.0.tar.xz";
+      sha256 = "809e9df4ac3ca8b59799c8781694092cb1793f03af0b87a347a1c6019f96a592";
+      name = "kdewebkit-5.57.0.tar.xz";
     };
   };
   kdnssd = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kdnssd-5.56.0.tar.xz";
-      sha256 = "1gskwc8sbj6cicblmrxh7qnh1gap0qivs8k5zf5qs94p1xc864vy";
-      name = "kdnssd-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kdnssd-5.57.0.tar.xz";
+      sha256 = "5a61b942fd14c9d96370e19fd7a29594bfcbd3074e12625caac083206fce2789";
+      name = "kdnssd-5.57.0.tar.xz";
     };
   };
   kdoctools = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kdoctools-5.56.0.tar.xz";
-      sha256 = "01y06rf1nhw2p8s0j60anr2qvssrqfimddvp2mqqkvx9xkx3py74";
-      name = "kdoctools-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kdoctools-5.57.0.tar.xz";
+      sha256 = "649dbaff4f1559302e7da07f423a0bc9e3faa1c7a93dfeb170e50bf452d8def2";
+      name = "kdoctools-5.57.0.tar.xz";
     };
   };
   kemoticons = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kemoticons-5.56.0.tar.xz";
-      sha256 = "00hbd09gnwyfszdwa9yf5m8wpbbapc4kwhs3qxhbvvmll0jv9vl2";
-      name = "kemoticons-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kemoticons-5.57.0.tar.xz";
+      sha256 = "c07b69c9275c117507166622e185c2bf0f36e1e4e8ad7b25fa3e1d793da4711b";
+      name = "kemoticons-5.57.0.tar.xz";
     };
   };
   kfilemetadata = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kfilemetadata-5.56.0.tar.xz";
-      sha256 = "04pmd2f77zxi14l3rhw4dyrh9dafchxqw1xjyv60j97gmm1b9796";
-      name = "kfilemetadata-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kfilemetadata-5.57.0.tar.xz";
+      sha256 = "49e6c281fdffd4f5fe363c6cefdb6c3022ef57c935d7d6b135607cdde9b2d116";
+      name = "kfilemetadata-5.57.0.tar.xz";
     };
   };
   kglobalaccel = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kglobalaccel-5.56.0.tar.xz";
-      sha256 = "0pmgvizc2dwrwr7m49125ybcpsc95r9riwxnihf37napyaacd9y3";
-      name = "kglobalaccel-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kglobalaccel-5.57.0.tar.xz";
+      sha256 = "46370dcd4f110e6ccde3b3bf9c075deb1f22ad54016137925e4aea97b03cc2fe";
+      name = "kglobalaccel-5.57.0.tar.xz";
     };
   };
   kguiaddons = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kguiaddons-5.56.0.tar.xz";
-      sha256 = "0gp2i29y1vws8i3q8s1bhyxksa42l6q55m459yczddcvcw0vd45i";
-      name = "kguiaddons-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kguiaddons-5.57.0.tar.xz";
+      sha256 = "744eb0ec35c936c17c3d11a08d19014e2166c4a307370207e0f5a38f01a91ebd";
+      name = "kguiaddons-5.57.0.tar.xz";
     };
   };
   kholidays = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kholidays-5.56.0.tar.xz";
-      sha256 = "0lm2ls3a15qbsfhamh2ldzvr62wi9nrhxd83rhyk3ifsgac4mg18";
-      name = "kholidays-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kholidays-5.57.0.tar.xz";
+      sha256 = "f7db45906623c33dfbb297810082f8ff30c949e6a7d477f3b72de0521b0c9452";
+      name = "kholidays-5.57.0.tar.xz";
     };
   };
   khtml = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/portingAids/khtml-5.56.0.tar.xz";
-      sha256 = "1wmcqc4546mqagqpgb97h3yd7nxaq4si2484li5hnw8mglm1qf3x";
-      name = "khtml-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/portingAids/khtml-5.57.0.tar.xz";
+      sha256 = "63d22fbc8cad3075a0b7ef195291c4b79ebc65da5de81b4885cac1063d783da3";
+      name = "khtml-5.57.0.tar.xz";
     };
   };
   ki18n = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/ki18n-5.56.0.tar.xz";
-      sha256 = "0hdfad9vmyzfni9ln0dc9p26gpjksk754z28v35hww6z9kgbr1dq";
-      name = "ki18n-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/ki18n-5.57.0.tar.xz";
+      sha256 = "bbd60981c9a0c1f9d9a52c8dd86adef7c4c30caf603f806d8730febaa36f0dd9";
+      name = "ki18n-5.57.0.tar.xz";
     };
   };
   kiconthemes = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kiconthemes-5.56.0.tar.xz";
-      sha256 = "0rdpvbqsb2wqi3glmggilm1mhpy6nc80am5hl4c34269mxd55q8a";
-      name = "kiconthemes-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kiconthemes-5.57.0.tar.xz";
+      sha256 = "09abb03a97027948a1116bfb2ca9842d3f8fb2def83b0b02aaed194dd5bd16f3";
+      name = "kiconthemes-5.57.0.tar.xz";
     };
   };
   kidletime = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kidletime-5.56.0.tar.xz";
-      sha256 = "09184bi8fvq34hwkldyibji7r79wd2wvhxk1i4kzkjg177dnaa95";
-      name = "kidletime-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kidletime-5.57.0.tar.xz";
+      sha256 = "e99a07f814573526ed5141fc9e4bc2df12298df53a0d2787c3b7a4c3af915665";
+      name = "kidletime-5.57.0.tar.xz";
     };
   };
   kimageformats = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kimageformats-5.56.0.tar.xz";
-      sha256 = "1cgh32jkg0ybfp8z6qwn7y6yr9mb0fiqly4pb0qc1lcm6awdx3d5";
-      name = "kimageformats-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kimageformats-5.57.0.tar.xz";
+      sha256 = "d7ce6c4737ae2846f015633e7479b60460d960a3a578777c2a884d499bd6cc14";
+      name = "kimageformats-5.57.0.tar.xz";
     };
   };
   kinit = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kinit-5.56.0.tar.xz";
-      sha256 = "1ihrannyaj33wsir20qy363vdjafhlsmj45qzl3xkl4rbyl6ngs7";
-      name = "kinit-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kinit-5.57.0.tar.xz";
+      sha256 = "7d5ca84d7bd554531aa6d720d3dc41ac091cf047a52d097a23e5c8fad08b684c";
+      name = "kinit-5.57.0.tar.xz";
     };
   };
   kio = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kio-5.56.0.tar.xz";
-      sha256 = "1m2c3a5isj966snmzs97i9kyhwnbzlwf61lqw5yxck25x7d0pyyn";
-      name = "kio-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kio-5.57.0.tar.xz";
+      sha256 = "d68151d58f1ed2e0724074c6bca42510dd3e19617baa4b4130198ad3a36a64ab";
+      name = "kio-5.57.0.tar.xz";
     };
   };
   kirigami2 = {
-    version = "5.56.1";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kirigami2-5.56.1.tar.xz";
-      sha256 = "0npq65kslwkdsylmv5hgcqsa5i9386dmnx8ig79rlf3409awn2f8";
-      name = "kirigami2-5.56.1.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kirigami2-5.57.0.tar.xz";
+      sha256 = "3cdbea0e472293e85e625820f6b9e2d20f59cff263ed150904b6b2acad81062b";
+      name = "kirigami2-5.57.0.tar.xz";
     };
   };
   kitemmodels = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kitemmodels-5.56.0.tar.xz";
-      sha256 = "13m1bvhljyc1jb9hdlz5v009kmkz7q0qf06l5zkck5k0fq41rkrg";
-      name = "kitemmodels-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kitemmodels-5.57.0.tar.xz";
+      sha256 = "b0eef30ce3e5f2fe9afb60d589bea16a0d0e4a57ffffb37ae0e14a54f1681464";
+      name = "kitemmodels-5.57.0.tar.xz";
     };
   };
   kitemviews = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kitemviews-5.56.0.tar.xz";
-      sha256 = "1ar492jpyprxvzcgnq0gnbyxlndb3rd0z32drk7xsx19vpk3ch58";
-      name = "kitemviews-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kitemviews-5.57.0.tar.xz";
+      sha256 = "6b499a21c88d5998c903e8e4dd480c612b96e5e31d17430a507c07566febdd30";
+      name = "kitemviews-5.57.0.tar.xz";
     };
   };
   kjobwidgets = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kjobwidgets-5.56.0.tar.xz";
-      sha256 = "1dh4ilry575k6z0glqb60ldjfkwpnkvijdzfyrc22bn84hbh19iy";
-      name = "kjobwidgets-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kjobwidgets-5.57.0.tar.xz";
+      sha256 = "4b98e7cd9b8d877326854addcee300071afc92f4378d3a94734e470271638002";
+      name = "kjobwidgets-5.57.0.tar.xz";
     };
   };
   kjs = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/portingAids/kjs-5.56.0.tar.xz";
-      sha256 = "1b3l76ipf0fr8bvp3f4njimmg5yw9ciwzzgvb34ds65aycplagln";
-      name = "kjs-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/portingAids/kjs-5.57.0.tar.xz";
+      sha256 = "865fb86566a0ea904ab0a3bd6a63787161b28578660d475fc316c50c8a7b1e90";
+      name = "kjs-5.57.0.tar.xz";
     };
   };
   kjsembed = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/portingAids/kjsembed-5.56.0.tar.xz";
-      sha256 = "0lkfq7099yiwvlycrix3s0dbk860rqfnix5fiw5vmi855is7mpkv";
-      name = "kjsembed-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/portingAids/kjsembed-5.57.0.tar.xz";
+      sha256 = "741aae8db274febe7e5d0d10dc99271efc590b2465d2c4d4e4a9162d2b36e3b4";
+      name = "kjsembed-5.57.0.tar.xz";
     };
   };
   kmediaplayer = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/portingAids/kmediaplayer-5.56.0.tar.xz";
-      sha256 = "0blqbi40l1pk8qf9054ha4a8r7cb4pddbqydsqlsscl4gm8530jh";
-      name = "kmediaplayer-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/portingAids/kmediaplayer-5.57.0.tar.xz";
+      sha256 = "521dcb4b3f9a67203e9eac27b8d777cb22557861b9fae0006c2aecda96d9bad4";
+      name = "kmediaplayer-5.57.0.tar.xz";
     };
   };
   knewstuff = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/knewstuff-5.56.0.tar.xz";
-      sha256 = "0r0ia0521vfri7mc6wpg3ihryqj48s3krgmliwbh635rfd3lcj9j";
-      name = "knewstuff-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/knewstuff-5.57.0.tar.xz";
+      sha256 = "6a9d77a62b036b4ed0f32ffaa9f204db1403030d01dbe8fb055d02361db2f981";
+      name = "knewstuff-5.57.0.tar.xz";
     };
   };
   knotifications = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/knotifications-5.56.0.tar.xz";
-      sha256 = "05nf2870fq9cwacgyy8iky5v37fq4jrsh4hl9xy9928d19qnmb24";
-      name = "knotifications-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/knotifications-5.57.0.tar.xz";
+      sha256 = "7de068f4cf9bcefef54ae1cb180e2c0af9be951afbcaa960245507259620cf15";
+      name = "knotifications-5.57.0.tar.xz";
     };
   };
   knotifyconfig = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/knotifyconfig-5.56.0.tar.xz";
-      sha256 = "0zwq0p779482sxxjg62z1rkpiiyn6b3r47l450dm6hm56vkf7vxl";
-      name = "knotifyconfig-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/knotifyconfig-5.57.0.tar.xz";
+      sha256 = "e7fe39ed72b7f79d8cafe6c30d5c62ade0f33be37a62d9e5b929064dd1750ac1";
+      name = "knotifyconfig-5.57.0.tar.xz";
     };
   };
   kpackage = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kpackage-5.56.0.tar.xz";
-      sha256 = "037r0ldp70q0yafld1ddff1d4wipb5ras88r72qazjcfqfg9rzjr";
-      name = "kpackage-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kpackage-5.57.0.tar.xz";
+      sha256 = "2d2d497d50e8ce986d6de4462391122963d9b7605889fd20cd3ceb4dd6910814";
+      name = "kpackage-5.57.0.tar.xz";
     };
   };
   kparts = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kparts-5.56.0.tar.xz";
-      sha256 = "1vj5ard5ff0wzpjqzrkd2kb31dkjly1cf4ww1ljrrwi7qgzxgw0z";
-      name = "kparts-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kparts-5.57.0.tar.xz";
+      sha256 = "5a079986963d186e98a1174e19e490731012732ad5ad31a431a8f7a31c6b6ed2";
+      name = "kparts-5.57.0.tar.xz";
     };
   };
   kpeople = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kpeople-5.56.0.tar.xz";
-      sha256 = "0h456kjhx4ylbkiv3706g8ccdq55aamrhj5rgiql2gaw3d5dbrkr";
-      name = "kpeople-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kpeople-5.57.0.tar.xz";
+      sha256 = "7c239b80b7976e3bfa46338e05a048aecb9c1972548dc33cc8a17e66eb08a85c";
+      name = "kpeople-5.57.0.tar.xz";
     };
   };
   kplotting = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kplotting-5.56.0.tar.xz";
-      sha256 = "1hrk3iv77s46lcs6c5mfiyzr80vpg9261mlixc3qwps0mww43r1r";
-      name = "kplotting-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kplotting-5.57.0.tar.xz";
+      sha256 = "c2c35030b1a2ca25f503c1a2df7ca225d156a9ea80f52883e136679aea6efc8e";
+      name = "kplotting-5.57.0.tar.xz";
     };
   };
   kpty = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kpty-5.56.0.tar.xz";
-      sha256 = "1dzp4a6rz6hsp1y8m5l73i8v2a3bpwkv4rrypkd00051ajcch47k";
-      name = "kpty-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kpty-5.57.0.tar.xz";
+      sha256 = "14a0f9d5ecc387c88d24270dbf4c128deb8ad18ab64b39766b335ad03a47c3b6";
+      name = "kpty-5.57.0.tar.xz";
     };
   };
   kross = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/portingAids/kross-5.56.0.tar.xz";
-      sha256 = "0ry6fpl0rb8z5r08bzh6kj14mp7l94calvdk3vrnc89cpm5gxymv";
-      name = "kross-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/portingAids/kross-5.57.0.tar.xz";
+      sha256 = "3b0f92751bb70c64b2ac25b466f886cc8b02babf02c744bcc909aa3ce6915a66";
+      name = "kross-5.57.0.tar.xz";
     };
   };
   krunner = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/krunner-5.56.0.tar.xz";
-      sha256 = "1gs0fr78zbhxl8c08zj4s98zshc42zxzwv7p9l7rmq8h21spc8ga";
-      name = "krunner-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/krunner-5.57.0.tar.xz";
+      sha256 = "40f52d4d883748f5b9a78b5bd7dd6aaa52eae88b89d7a33eafbcbb9ccf6f4805";
+      name = "krunner-5.57.0.tar.xz";
     };
   };
   kservice = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kservice-5.56.0.tar.xz";
-      sha256 = "1hsc8pagigwspyv9ipl3l2b9mf8amfksk8a2k3iic9nw1hmpxinv";
-      name = "kservice-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kservice-5.57.0.tar.xz";
+      sha256 = "531940baa47273714fbc35941f2ef5fbdb801b7a5ed5fef5a8ff1d86bf1dae14";
+      name = "kservice-5.57.0.tar.xz";
     };
   };
   ktexteditor = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/ktexteditor-5.56.0.tar.xz";
-      sha256 = "1a2r97v3xwh61q688jvwkk99bphfd0v0ldqms5d73q3m6w1x122c";
-      name = "ktexteditor-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/ktexteditor-5.57.0.tar.xz";
+      sha256 = "aa510656f632ef09c18af4263386265c293cb929f139786acd102881250314c3";
+      name = "ktexteditor-5.57.0.tar.xz";
     };
   };
   ktextwidgets = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/ktextwidgets-5.56.0.tar.xz";
-      sha256 = "1km19z577y29di8zp6amlccqdavxk4f4sg1dblj6gp64zkw9dbqp";
-      name = "ktextwidgets-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/ktextwidgets-5.57.0.tar.xz";
+      sha256 = "b74036eea1ec19a22aa0e76cd1a8338f55e5c32a30dc47d602783c6bc5ba54bf";
+      name = "ktextwidgets-5.57.0.tar.xz";
     };
   };
   kunitconversion = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kunitconversion-5.56.0.tar.xz";
-      sha256 = "1kf5dc6p77mkx2i23ppfs0k3laybmx5vqq7aq1bxnkxj1ws75144";
-      name = "kunitconversion-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kunitconversion-5.57.0.tar.xz";
+      sha256 = "157f4d21e83a6e92e30894f472b65452ecd2183ac2e25e24f740e971befed383";
+      name = "kunitconversion-5.57.0.tar.xz";
     };
   };
   kwallet = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kwallet-5.56.0.tar.xz";
-      sha256 = "02i6xkq9ki6sybjvcxkznf5v8b34pqxysg9pi5v4z6jkw2jpr5fj";
-      name = "kwallet-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kwallet-5.57.0.tar.xz";
+      sha256 = "ad089026f4d5b10d567d0fd56f8b63749acd214fb8029d43187ba42afaf36975";
+      name = "kwallet-5.57.0.tar.xz";
     };
   };
   kwayland = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kwayland-5.56.0.tar.xz";
-      sha256 = "1779in51z63sv6607xd7y30wprs9vs8nnqa28fxg1q4nicwnvrxv";
-      name = "kwayland-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kwayland-5.57.0.tar.xz";
+      sha256 = "f00d2997163f559cecf30f5e945d5456628a0d120acafba49fa14af28c22b1d6";
+      name = "kwayland-5.57.0.tar.xz";
     };
   };
   kwidgetsaddons = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kwidgetsaddons-5.56.0.tar.xz";
-      sha256 = "0flmw1wfzs49dmmlbbimizjwj09wp4qwr9znxn3h5yfn0mxfc1lv";
-      name = "kwidgetsaddons-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kwidgetsaddons-5.57.0.tar.xz";
+      sha256 = "abd80a566e1003bca7c72d3a0dc1ee470bc9935d11371cfff0d960f11e1ef5c2";
+      name = "kwidgetsaddons-5.57.0.tar.xz";
     };
   };
   kwindowsystem = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kwindowsystem-5.56.0.tar.xz";
-      sha256 = "0dk9ymlpdpvra2zm1f2rcx2dwnn9qc49n2y7p6iw094fwk5rzczc";
-      name = "kwindowsystem-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kwindowsystem-5.57.0.tar.xz";
+      sha256 = "0c8a009dde7ca1722810777b99aa4e1a3471687460c25e0f41645c9e11daf274";
+      name = "kwindowsystem-5.57.0.tar.xz";
     };
   };
   kxmlgui = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kxmlgui-5.56.0.tar.xz";
-      sha256 = "1ipa0qnkh6gs3f6ygvb7cf0yv1m89m3cdl1z23br4fn14d5mxbrl";
-      name = "kxmlgui-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kxmlgui-5.57.0.tar.xz";
+      sha256 = "325124518e8fa4847c898dee193d96b76a7ba27d7c79d875f34c632f46fe1f90";
+      name = "kxmlgui-5.57.0.tar.xz";
     };
   };
   kxmlrpcclient = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/kxmlrpcclient-5.56.0.tar.xz";
-      sha256 = "1bjnpl4521gv35zghaanz6v5bap2b9n2kz7b0rif1bf6iak018ql";
-      name = "kxmlrpcclient-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/kxmlrpcclient-5.57.0.tar.xz";
+      sha256 = "d47d5cc49f050dda3a26f7654226c0d124ca5ba5503a60e606307426bbe43b9d";
+      name = "kxmlrpcclient-5.57.0.tar.xz";
     };
   };
   modemmanager-qt = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/modemmanager-qt-5.56.0.tar.xz";
-      sha256 = "1xwx6yybij8nlaqfpz76pindfxshcyg9p21nqm6ddpgyzh74klbc";
-      name = "modemmanager-qt-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/modemmanager-qt-5.57.0.tar.xz";
+      sha256 = "030bfcfafd5079f25a165aaa5f52693a8fe4b3c15c1345a641716c4329e0929d";
+      name = "modemmanager-qt-5.57.0.tar.xz";
     };
   };
   networkmanager-qt = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/networkmanager-qt-5.56.0.tar.xz";
-      sha256 = "0p0b3rq7s1yzy6zspd6xnzjc0hza9d7fixm8pw369kn5k3pi5lk1";
-      name = "networkmanager-qt-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/networkmanager-qt-5.57.0.tar.xz";
+      sha256 = "4d2da2556bfeef4be03833d707284573b469a1f6ad66ba73eae80835bd2e1982";
+      name = "networkmanager-qt-5.57.0.tar.xz";
     };
   };
   oxygen-icons5 = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/oxygen-icons5-5.56.0.tar.xz";
-      sha256 = "17cjcfmc8vywh8n2ck0s3b0i88ilamdah0gipicn7vj65l4wc1qb";
-      name = "oxygen-icons5-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/oxygen-icons5-5.57.0.tar.xz";
+      sha256 = "2b12a9de3767d233b4b01bc97e23899d94c02b13fee4d20483d3f5d2baaaa1e5";
+      name = "oxygen-icons5-5.57.0.tar.xz";
     };
   };
   plasma-framework = {
-    version = "5.56.1";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/plasma-framework-5.56.1.tar.xz";
-      sha256 = "0wn7q2cfrgzcprzgqj1d4calc0mmrrn615698fish7x9s1n7ag6w";
-      name = "plasma-framework-5.56.1.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/plasma-framework-5.57.0.tar.xz";
+      sha256 = "b886aeee6691911ead25e6fd5631fa41ce2330b0fbbdc040717fa576bacae2ca";
+      name = "plasma-framework-5.57.0.tar.xz";
     };
   };
   prison = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/prison-5.56.0.tar.xz";
-      sha256 = "05hy6fz05snpgjz6bnm3qcr7smg65a0m6rdmyv7avrpbs4qpbghx";
-      name = "prison-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/prison-5.57.0.tar.xz";
+      sha256 = "6613decb2e0b61af5af3a3a9995970c2fdaa72f36bcfd7e9db547017ee4ca235";
+      name = "prison-5.57.0.tar.xz";
     };
   };
   purpose = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/purpose-5.56.0.tar.xz";
-      sha256 = "0rvywfkhqbmd39g950mpnn35i3kg7j63ylvdy2px2d71am6acal8";
-      name = "purpose-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/purpose-5.57.0.tar.xz";
+      sha256 = "4b38f1b88e6e621bc20c04a5f7bc7293fba6c851209167c5e794b6becaea244e";
+      name = "purpose-5.57.0.tar.xz";
     };
   };
   qqc2-desktop-style = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/qqc2-desktop-style-5.56.0.tar.xz";
-      sha256 = "08afy1gsy0lvpzqmv5azzfiy5x9lvffsf6qvzxxab4v5ch8fn00b";
-      name = "qqc2-desktop-style-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/qqc2-desktop-style-5.57.0.tar.xz";
+      sha256 = "ff40fd6d48815c39e46e19eadf4048f04e79f34f7522a9ba655e6d4a1690546e";
+      name = "qqc2-desktop-style-5.57.0.tar.xz";
     };
   };
   solid = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/solid-5.56.0.tar.xz";
-      sha256 = "17kfwj0y41pkd0kxj2fj9m9qs7bq05vka9ngfr022lfwdhs907c4";
-      name = "solid-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/solid-5.57.0.tar.xz";
+      sha256 = "fbdb0678a5a1b9f902661b4823dbae4629a88708b729d827dd0598799f727209";
+      name = "solid-5.57.0.tar.xz";
     };
   };
   sonnet = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/sonnet-5.56.0.tar.xz";
-      sha256 = "0r8bsf7a9rjvv4jirycwf3xvkqa9iax23p93m301x82hdvmkjr9w";
-      name = "sonnet-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/sonnet-5.57.0.tar.xz";
+      sha256 = "08e13a707b64055f512bba982ec5e69a9e7c62c02d1ee8b6fdc67c67b1265334";
+      name = "sonnet-5.57.0.tar.xz";
     };
   };
   syndication = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/syndication-5.56.0.tar.xz";
-      sha256 = "0wnrhfp5b4wgmigqh39c0f2qfblgmc3x6018b4wcayfs8gb4m1q9";
-      name = "syndication-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/syndication-5.57.0.tar.xz";
+      sha256 = "251b2333bd3e49f833ef5ac12e0d2540a7640c84625090a85d99715927653728";
+      name = "syndication-5.57.0.tar.xz";
     };
   };
   syntax-highlighting = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/syntax-highlighting-5.56.0.tar.xz";
-      sha256 = "0gl0v1bscqd6xhl3644wix8ix04lax0h1zzr1v65704c4qp87h8l";
-      name = "syntax-highlighting-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/syntax-highlighting-5.57.0.tar.xz";
+      sha256 = "e82261e791005a55414fc81a396ca33ee8c061acd66c2c351492d866b3592e9f";
+      name = "syntax-highlighting-5.57.0.tar.xz";
     };
   };
   threadweaver = {
-    version = "5.56.0";
+    version = "5.57.0";
     src = fetchurl {
-      url = "${mirror}/stable/frameworks/5.56/threadweaver-5.56.0.tar.xz";
-      sha256 = "1gyvj0v1zhfk8shi31pivvf5rwxkgv9bjmy2vippk2vxvkh0qc5x";
-      name = "threadweaver-5.56.0.tar.xz";
+      url = "${mirror}/stable/frameworks/5.57/threadweaver-5.57.0.tar.xz";
+      sha256 = "83969d0f6e4a337fba6b554708f867654af86368066ccef75a4fde85569d1ee0";
+      name = "threadweaver-5.57.0.tar.xz";
     };
   };
 }

--- a/pkgs/development/libraries/qt-5/5.12/default.nix
+++ b/pkgs/development/libraries/qt-5/5.12/default.nix
@@ -112,6 +112,7 @@ let
       qtmultimedia = callPackage ../modules/qtmultimedia.nix {
         inherit gstreamer gst-plugins-base;
       };
+      qtnetworkauth = callPackage ../modules/qtnetworkauth.nix {};
       qtquick1 = null;
       qtquickcontrols = callPackage ../modules/qtquickcontrols.nix {};
       qtquickcontrols2 = callPackage ../modules/qtquickcontrols2.nix {};

--- a/pkgs/development/libraries/qt-5/modules/qtnetworkauth.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtnetworkauth.nix
@@ -1,0 +1,6 @@
+{ qtModule, qtbase, qtdeclarative }:
+
+qtModule {
+  name = "qtnetworkauth";
+  qtInputs = [ qtbase ];
+}


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

KDE software in NixOS is not at the latest version. This patch `release-19.03` updates to
 - KDE frameworks 5.57
 - Plasma 5.15
 - KDE applications 19.04

I've been running my desktop on a nix channel with this patch for a few weeks. So far I've observed only one bug (https://bugs.kde.org/show_bug.cgi?id=406829). I have not been able to look into the details of the bug because:
 - I cannot get Qt 5.12.3 to compile to see if that fixes it (https://github.com/NixOS/nixpkgs/pull/60119)
 - I do not know how to install Qt package and up with debug symbols enabled.


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [~] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
