### PR TITLE
networkmanager: sed from gnused, not coreutils! fix bad path

### DIFF
--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -54,7 +54,7 @@ in stdenv.mkDerivation rec {
   patches = [
     (substituteAll {
       src = ./fix-paths.patch;
-      inherit iputils kmod openconnect ethtool coreutils dbus;
+      inherit iputils kmod openconnect ethtool gnused dbus;
       inherit (stdenv) shell;
     })
 

--- a/pkgs/tools/networking/network-manager/fix-paths.patch
+++ b/pkgs/tools/networking/network-manager/fix-paths.patch
@@ -19,7 +19,7 @@
  ENV{ID_NET_DRIVER}=="?*", GOTO="nm_drivers_end"
  DRIVERS=="?*", GOTO="nm_drivers_end"
 -PROGRAM="/bin/sh -c 'ethtool -i $1 | sed -n s/^driver:\ //p' -- $env{INTERFACE}", RESULT=="?*", ENV{ID_NET_DRIVER}="%c"
-+PROGRAM="@shell@ -c '@ethtool@/bin/ethtool -i $1 | @coreutils@/bin/sed -n s/^driver:\ //p' -- $env{INTERFACE}", RESULT=="?*", ENV{ID_NET_DRIVER}="%c"
++PROGRAM="@shell@ -c '@ethtool@/bin/ethtool -i $1 | @gnused@/bin/sed -n s/^driver:\ //p' -- $env{INTERFACE}", RESULT=="?*", ENV{ID_NET_DRIVER}="%c"
  
  LABEL="nm_drivers_end"
 --- a/data/NetworkManager.service.in


### PR DESCRIPTION
###### Motivation for this change

Eep!
Not sure how likely this is to be causing folks problems
but definitely should be fixed!

Don't we check udev rules for valid paths?
Maybe we can add a check for this sort of thing,
although TBH really hope there are no other instances.. !

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---