### PR TITLE
networkmanager: match pre-meson pre-upgrade behavior more closely

### DIFF
--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -28,6 +28,7 @@ in stdenv.mkDerivation rec {
     "-Ddnsmasq=${dnsmasq}/bin/dnsmasq"
     # Upstream prefers dhclient, so don't add dhcpcd to the closure
     "-Ddhcpcd=no"
+    "-Ddhcpcanon=no"
     "-Dpppd=${ppp}/bin/pppd"
     "-Diptables=${iptables}/bin/iptables"
     # to enable link-local connections

--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -50,6 +50,7 @@ in stdenv.mkDerivation rec {
     "-Dqt=false"
     # Allow using iwd when configured to do so
     "-Diwd=true"
+    "-Dlibaudit=yes-disabled-by-default"
   ];
 
   patches = [

--- a/pkgs/tools/networking/network-manager/default.nix
+++ b/pkgs/tools/networking/network-manager/default.nix
@@ -51,6 +51,12 @@ in stdenv.mkDerivation rec {
     # Allow using iwd when configured to do so
     "-Diwd=true"
     "-Dlibaudit=yes-disabled-by-default"
+    "-Dpolkit=true"
+    "-Dpolkit_agent=true"
+    # Default is symlink, we previously used resolvconf, dunno.
+    "-Dconfig_dns_rc_manager_default=resolvconf"
+    # This is experimental, but is what we've used historically AFAICT.
+    "-Debpf=true"
   ];
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change

I don't have a great way to share this information
as a link or something, haha, but try something
like the following to see what's changed:

```
$ vim -d <(nix log -f channel:nixos-unstable networkmanager) <(nix log -f channel:nixos-19.03 networkmanager)
```

Particularly look at the post-configure dump of options.
The version was changed as well, but even so it's unclear
how many of these changes were intentional or desirable.

Beyond the values in these commits, changes that may
be worth discussing/revisitng:

* asserts and warnings -- we used to specify `--disable-more-warnings`
  which doesn't trivially map (I don't think) but now we're end up
  with "more-logging: true" instead of "more-logging: no" and
  "more-asserts: 100" instead of "more-asserts: 0".
  I don't know this is bad or not but let's just make sure
  these are set as we'd like :).

We added a number of deps that also enable features/changes
but since they were blatant in the diff (add arg, add to buildInputs, etc)
these are presumably what we want (but confirmation would be good).

Related PRs and such:
* #59916 - move to meson
* f748cc85bd2539619aeb1d205120d5bee8e2520a
* #60903 (submitted a few minutes ago, fixes invalid path for `sed`)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---