### PR TITLE
gimpPlugins.resynthesizer2: 2.0.1 → 2.0.3

### DIFF
--- a/pkgs/applications/graphics/gimp/plugins/default.nix
+++ b/pkgs/applications/graphics/gimp/plugins/default.nix
@@ -23,7 +23,7 @@ let
   }
   // a
   // {
-      name = "gimp-plugin-${a.name}";
+      name = "gimp-plugin-${a.name or "${a.pname}-${a.version}"}";
       buildInputs = [ gimp gimp.gtk glib ] ++ (a.buildInputs or []);
       nativeBuildInputs = [ pkgconfig intltool ] ++ (a.nativeBuildInputs or []);
     }
@@ -110,22 +110,23 @@ rec {
     ";
   };
 
-  resynthesizer2 = pluginDerivation {
+  resynthesizer2 = pluginDerivation rec {
     /* menu:
       Filters/Map/Resynthesize
       Filters/Enhance/Smart enlarge
       Filters/Enhance/Smart sharpen
       Filters/Enhance/Smart remove selection
     */
-    name = "resynthesizer-2.0.1";
+    pname = "resynthesizer";
+    version = "2.0.3";
     buildInputs = with pkgs; [ fftw ];
     nativeBuildInputs = with pkgs; [ autoreconfHook ];
-    makeFlags = "GIMP_LIBDIR=$out/lib/gimp/2.0/";
+    makeFlags = [ "GIMP_LIBDIR=${placeholder "out"}/lib/gimp/2.0" ];
     src = fetchFromGitHub {
       owner = "bootchk";
       repo = "resynthesizer";
-      rev = "2.0.1";
-      sha256 = "1d214s0jsqxz83l9dd8vhnz3siw9fyw7xdhhir25ra7jiwxc99hd";
+      rev = "v${version}";
+      sha256 = "1jwc8bhhm21xhrgw56nzbma6fwg59gc8anlmyns7jdiw83y0zx3j";
     };
   };
 


### PR DESCRIPTION
###### Motivation for this change
Fixes `makeFlags`: `$out` is not sufficient to install the binaries, let's use `placeholder`.

Also update and clean up the expression.

Closes: https://github.com/NixOS/nixpkgs/issues/60834

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [c] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @typedfern