### PR TITLE
z88dk: 20180217 -> unstable-2019-02-02

### DIFF
--- a/pkgs/development/compilers/z88dk/default.nix
+++ b/pkgs/development/compilers/z88dk/default.nix
@@ -1,37 +1,46 @@
-{ fetchFromGitHub, fetchpatch, stdenv, makeWrapper, unzip, libxml2, m4, uthash }:
+{ fetchFromGitHub, stdenv, makeWrapper, unzip, libxml2, m4, uthash, which }:
 
 stdenv.mkDerivation rec {
-  name = "z88dk-${version}";
-  version = "20180217";
-  rev = "49a7c6032b2675af742f5b0b3aa5bd5260bdd814";
-  short_rev = "${builtins.substring 0 7 rev}";
+  pname = "z88dk";
+  version = "unstable-2019-05-09";
 
   src = fetchFromGitHub {
     owner = "z88dk";
     repo  = "z88dk";
-    inherit rev;
-    sha256 = "00vbklh6lkq1gyd08ig2vcg6c1mghvlwfx3vq3wldf34hcs3k4pp";
+    rev = "826d68632c3a7c17df88dd2ec54571a6041da69c";
+    sha256 = "104qgb01sdb97mkcxnq1cdlqi5qvjm4rd9bg5r42pdfz81ss49xj";
+    fetchSubmodules = true;
   };
-
-  # https://github.com/z88dk/z88dk/pull/612
-  patches = [(fetchpatch {
-    url = "https://github.com/Mic92/z88dk/commit/5b4ca132fa1f31c9ac48cf2220358715739ca0b2.patch";
-    sha256 = "1p2l31j68p7jzykhkhd9iagn2lr08hdclk3cl9l32p1q6ghdipfv";
-  })];
 
   postPatch = ''
     # we dont rely on build.sh :
     export PATH="$PWD/bin:$PATH" # needed to have zcc in testsuite
     export ZCCCFG=$PWD/lib/config/
+    # we don't want to build zsdcc since it required network (svn)
+    # we test in checkPhase
+    substituteInPlace Makefile \
+      --replace 'testsuite bin/z88dk-lib$(EXESUFFIX)' 'bin/z88dk-lib$(EXESUFFIX)'\
+      --replace 'ALL_EXT = bin/zsdcc$(EXESUFFIX)' 'ALL_EXT ='   
   '';
 
+  checkPhase = ''
+    make testsuite
+  '';
+  #failed on Issue_1105_function_pointer_calls
+  doCheck = stdenv.hostPlatform.system != "aarch64-linux";
+
+  #_FORTIFY_SOURCE requires compiling with optimization (-O)
+  NIX_CFLAGS_COMPILE = "-O";
+
+  short_rev = "${builtins.substring 0 7 src.rev}";
   makeFlags = [
-    "prefix=$(out)"
     "git_rev=${short_rev}"
     "version=${version}"
+    "prefix=$(out)"
     "git_count=0"
   ];
-  nativeBuildInputs = [ makeWrapper unzip ];
+
+  nativeBuildInputs = [ which makeWrapper unzip ];
   buildInputs = [ libxml2 m4 uthash ];
 
   preInstall = ''
@@ -41,10 +50,10 @@ stdenv.mkDerivation rec {
   installTargets = "libs install";
 
   meta = with stdenv.lib; {
-    homepage    = https://www.z88dk.org;
+    homepage    = "https://www.z88dk.org";
     description = "z80 Development Kit";
     license     = licenses.clArtistic;
     maintainers = [ maintainers.genesis ];
-    platforms = [ "x86_64-linux" ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
