### PR TITLE
rapid-photo-downloader: add vmtouch to wrapped PATH

### DIFF
--- a/pkgs/applications/graphics/rapid-photo-downloader/default.nix
+++ b/pkgs/applications/graphics/rapid-photo-downloader/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, python3Packages
 , file, intltool, gobject-introspection, libgudev
 , udisks, gexiv2, gst_all_1, libnotify
-, exiftool, gdk_pixbuf, libmediainfo
+, exiftool, gdk_pixbuf, libmediainfo, vmtouch
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -69,7 +69,7 @@ python3Packages.buildPythonApplication rec {
   makeWrapperArgs = [
     "--set GI_TYPELIB_PATH \"$GI_TYPELIB_PATH\""
     "--set PYTHONPATH \"$PYTHONPATH\""
-    "--prefix PATH : ${stdenv.lib.makeBinPath [ exiftool ]}"
+    "--prefix PATH : ${stdenv.lib.makeBinPath [ exiftool vmtouch ]}"
     "--prefix LD_LIBRARY_PATH : ${stdenv.lib.makeLibraryPath [ libmediainfo ]}"
     "--prefix GST_PLUGIN_SYSTEM_PATH_1_0 : \"$GST_PLUGIN_SYSTEM_PATH_1_0\""
   ];


### PR DESCRIPTION
###### Motivation for this change
When testing another PR, noticed that without this, the `analyze-pv-structure` executable complains:
`To run this program, you need to install vmtouch.`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
