### PR TITLE
libressl: 2.9.0 -> 2.9.1

### DIFF
--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -46,7 +46,7 @@ in {
   };
 
   libressl_2_9 = generic {
-    version = "2.9.0";
-    sha256 = "1x1wl6b449m6hfhyxxzxbf2v8yfb5q92q6d01hdg28xp1222jpzb";
+    version = "2.9.1";
+    sha256 = "1y32iz64rqh74m1g641b39h3293dqi4la7i0ckai1p4lcs2xvr1r";
   };
 }

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, lib }:
+{ stdenv, fetchurl, lib, cmake }:
 
 let
 
@@ -11,7 +11,17 @@ let
       inherit sha256;
     };
 
-    configureFlags = [ "--enable-nc" ];
+    nativeBuildInputs = [ cmake ];
+
+    cmakeFlags = [ "-DENABLE_NC=ON" ];
+
+    # The autoconf build is broken as of 2.9.1, resulting in the following error:
+    # libressl-2.9.1/tls/.libs/libtls.a', needed by 'handshake_table'.
+    # Fortunately LibreSSL provides a CMake build as well, so opt for CMake by
+    # removing ./configure pre-config.
+    preConfigure = ''
+      rm configure
+    '';
 
     enableParallelBuilding = true;
 
@@ -19,6 +29,8 @@ let
 
     postFixup = ''
       moveToOutput "bin/nc" "$nc"
+      moveToOutput "bin/openssl" "$bin"
+      moveToOutput "bin/ocspcheck" "$bin"
       moveToOutput "share/man/man1/nc.1${lib.optionalString (dontGzipMan==null) ".gz"}" "$nc"
     '';
 

--- a/pkgs/development/libraries/libressl/default.nix
+++ b/pkgs/development/libraries/libressl/default.nix
@@ -13,7 +13,7 @@ let
 
     nativeBuildInputs = [ cmake ];
 
-    cmakeFlags = [ "-DENABLE_NC=ON" ];
+    cmakeFlags = [ "-DENABLE_NC=ON" "-DBUILD_SHARED_LIBS=ON" ];
 
     # The autoconf build is broken as of 2.9.1, resulting in the following error:
     # libressl-2.9.1/tls/.libs/libtls.a', needed by 'handshake_table'.


### PR DESCRIPTION
###### Motivation for this change

[LibreSSL upstream released version 2.9.1](https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.9.1-relnotes.txt), a stable release in the 2.9 series.

###### Things done

Just bumping the version was not enough, 2.9.1 would not build. Buildroot ran into the same issue, and resolved it in https://github.com/buildroot/buildroot/commit/e783d60473944f8b39f1def45d8d6b483a062158 by switching to CMake, so I did the same here.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

I did test compiling `nginx` and `acme-client` against the new `libressl_2_9`.