### PR TITLE
ffsend: 0.2.45 -> 0.2.46

### DIFF
--- a/pkgs/tools/misc/ffsend/Cargo.lock.patch
+++ b/pkgs/tools/misc/ffsend/Cargo.lock.patch
@@ -1,0 +1,13 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 2344bfd..08413d8 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -614,7 +614,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ 
+ [[package]]
+ name = "ffsend"
+-version = "0.2.45"
++version = "0.2.46"
+ dependencies = [
+  "chbs 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
###### Motivation for this change
https://github.com/timvisee/ffsend/releases/tag/v0.2.46

Extend the xclip/xsel support to all BSD variants and add BSD to the supported platforms list.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

A change in this version tweaks clipboard support for all BSD variants, so I figured it was safe to declare that this supported all BSD variants. It seems there's no pre-built `lib.platforms` entry for BSD, just for specific BSD flavors, which is why I ended up using `[ stdenv.lib.systems.inspect.patterns.isBSD ]`. I wasn't sure if there's a better way to do this. I'm also wondering if I should just give up and use `platforms.unix`, except I don't know if `ffsend` works on Cygwin (which is part of `platforms.unix`).