### PR TITLE
ngrok2: 2.3.18 -> 2.3.29

### DIFF
--- a/pkgs/tools/networking/ngrok-2/default.nix
+++ b/pkgs/tools/networking/ngrok-2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, patchelfUnstable }:
 
 with stdenv.lib;
 
@@ -24,13 +24,18 @@ stdenv.mkDerivation {
 
   sourceRoot = ".";
 
+  nativeBuildInputs = [ patchelfUnstable ];
+
   unpackPhase = "cp $src ngrok";
 
   buildPhase = "chmod a+x ngrok";
 
   installPhase = ''
     install -D ngrok $out/bin/ngrok
-  '';
+
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+              $out/bin/ngrok
+    '';
 
   passthru.updateScript = ./update.sh;
 

--- a/pkgs/tools/networking/ngrok-2/versions.json
+++ b/pkgs/tools/networking/ngrok-2/versions.json
@@ -1,32 +1,32 @@
 {
   "linux-386": {
     "sys": "linux-386",
-    "url": "https://bin.equinox.io/a/jqJ2Vvh67gW/ngrok-2.3.18-linux-386",
-    "sha256": "2bebb8f39a3c19ca03eaf786b97c92876216d2297046e85271478edef2cd6404",
-    "version": "2.3.18"
+    "url": "https://bin.equinox.io/a/6i2VnqLBZqg/ngrok-2.3.29-linux-386",
+    "sha256": "c0859f783e66a661dc1490e0cec95dfcce0ae77deaf0aa1838613afcbd8f9451",
+    "version": "2.3.29"
   },
   "linux-amd64": {
     "sys": "linux-amd64",
-    "url": "https://bin.equinox.io/a/ik4d9aurG9/ngrok-2.3.18-linux-amd64",
-    "sha256": "75e19c343a208bf0e2d3b613d2fa3ce67abbf25c04a1d6be670598a4c25c1694",
-    "version": "2.3.18"
+    "url": "https://bin.equinox.io/a/6ws4BqFTLXR/ngrok-2.3.29-linux-amd64",
+    "sha256": "625e85af6d366be4cc54ba296a6e66d3311b99db36e6ea5fe7f88941874daabb",
+    "version": "2.3.29"
   },
   "linux-arm": {
     "sys": "linux-arm",
-    "url": "https://bin.equinox.io/a/c2KRZoJ5cb6/ngrok-2.3.18-linux-arm",
-    "sha256": "af4cdb9f116104921d7fbeeac9124e545a45495b3623b2b46da996400c305d9c",
-    "version": "2.3.18"
+    "url": "https://bin.equinox.io/a/3Qx4EX7AtXt/ngrok-2.3.29-linux-arm",
+    "sha256": "8a2ec453b407bb0983d22819f3b76044100870888cc976fbf76ced18e6f66fa7",
+    "version": "2.3.29"
   },
   "linux-arm64": {
     "sys": "linux-arm64",
-    "url": "https://bin.equinox.io/a/b2NBP9tpq2E/ngrok-2.3.18-linux-arm64",
-    "sha256": "9e5fa5b83dc65803291b59867c664085de248a4adb3d415c4dbba1dae90a0aaf",
-    "version": "2.3.18"
+    "url": "https://bin.equinox.io/a/7qbe9PkG69E/ngrok-2.3.29-linux-arm64",
+    "sha256": "c49a9c95dc0128e8129f9b7291b5049a45d13f27bb309ca8af59e498f98b97d0",
+    "version": "2.3.29"
   },
   "darwin-amd64": {
     "sys": "darwin-amd64",
-    "url": "https://bin.equinox.io/a/879TXbRQQRV/ngrok-2.3.18-darwin-amd64",
-    "sha256": "abb643bdba7ade5dabd60488b866804d814a41d4d7144fa09e01c9260e93659d",
-    "version": "2.3.18"
+    "url": "https://bin.equinox.io/a/eqL9fYWPxoV/ngrok-2.3.29-darwin-amd64",
+    "sha256": "916ad7b4706e4c770eb58667c5beabf227daa1ad35bbbee41883eb2bce3f254b",
+    "version": "2.3.29"
   }
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Note: this PR depends on updating patchelfUnstable. This change is made in #60944 

To update I ran:

```
nix-shell maintainers/scripts/update.nix --argstr package ngrok-2
```

The result did not run correctly as the binary wasn't patched correctly. The new version of `patchelfUnstable` with the line in the install phase resolved the issue.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
