### PR TITLE
pythonPackages.cartopy: fix tests for python2.7 using xvfb

### DIFF
--- a/pkgs/development/python-modules/cartopy/default.nix
+++ b/pkgs/development/python-modules/cartopy/default.nix
@@ -1,8 +1,9 @@
 { buildPythonPackage, lib, fetchPypi
 , pytest, filelock, mock, pep8
-, cython, isPy37, glibcLocales
+, cython, isPy27, isPy37, glibcLocales
 , six, pyshp, shapely, geos, proj, numpy
 , gdal, pillow, matplotlib, pyepsg, pykdtree, scipy, owslib, fiona
+, xvfb_run
 }:
 
 buildPythonPackage rec {
@@ -17,10 +18,14 @@ buildPythonPackage rec {
 
   checkInputs = [ filelock mock pytest pep8 ];
 
-  # several tests require network connectivity: we disable them
-  checkPhase = ''
+  # several tests require network connectivity: we disable them.
+  # also py2.7's tk is over-eager in trying to open an x display,
+  # so give it xvfb
+  checkPhase = let
+    maybeXvfbRun = lib.optionalString isPy27 "${xvfb_run}/bin/xvfb-run";
+  in ''
     export HOME=$(mktemp -d)
-    pytest --pyargs cartopy \
+    ${maybeXvfbRun} pytest --pyargs cartopy \
       -m "not network and not natural_earth" \
       -k "not test_nightshade_image"
   '';


### PR DESCRIPTION
###### Motivation for this change
~Draft PR because this sits on top of https://github.com/NixOS/nixpkgs/pull/60936~

Python 2.7's tk is over-eager in trying to open an x display, so run the tests in `xvfb`. `xvfb` is quite a heavy dependency (albeit only a build-time one), so ensure this is only used when needed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
