### PR TITLE
redeclipse: init at 1.6.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2648,6 +2648,11 @@
     github = "lasandell";
     name = "Luke Sandell";
   };
+  lambda-11235 = {
+    email = "taranlynn0@gmail.com";
+    github = "lambda-11235";
+    name = "Taran Lynn";
+  };
   lassulus = {
     email = "lassulus@gmail.com";
     github = "Lassulus";

--- a/pkgs/games/redeclipse/default.nix
+++ b/pkgs/games/redeclipse/default.nix
@@ -1,0 +1,57 @@
+{ stdenv, fetchFromGitHub, fetchurl, fetchpatch
+, curl, ed, pkgconfig, zlib, libX11
+, SDL2, SDL2_image, SDL2_mixer
+}:
+
+stdenv.mkDerivation rec {
+  pname = "redeclipse";
+  version = "1.6.0";
+
+  src = fetchurl {
+    url = "https://github.com/red-eclipse/base/releases/download/v${version}/redeclipse_${version}_nix.tar.bz2";
+    sha256 = "0j98zk7nivdsap4y50dlqnql17hdila1ikvps6vicwaqb3l4gaa8";
+  };
+
+  buildInputs = [
+    libX11 zlib
+    SDL2 SDL2_image SDL2_mixer
+  ];
+
+  nativeBuildInputs = [
+    curl ed pkgconfig
+  ];
+
+  makeFlags = [ "-C" "src/" "prefix=$(out)" ];
+
+  patches = [
+    # "remove gamma name hack" - Can't find `____gammaf128_r_finite` otherwise
+    # Is likely to be included in next release
+    (fetchpatch {
+       url = "https://github.com/red-eclipse/base/commit/b16b4963c1ad81bb9ef784bc4913a4c8ab5f1bb4.diff";
+       sha256 = "1bm07qrq60bbmbf5k9255qq115mcyfphfy2f7xl1yx40mb9ns65p";
+    })
+  ];
+
+  enableParallelBuilding = true;
+
+  installTargets = [ "system-install" ];
+
+  postInstall = ''
+      cp -R -t $out/share/redeclipse/data/ data/*
+  '';
+
+  meta = {
+    description = "A first person arena shooter, featuring parkour, impulse boosts, and more.";
+    longDescription = ''
+      Red Eclipse is a fun-filled new take on the first person arena shooter,
+      featuring parkour, impulse boosts, and more. The development is geared
+      toward balanced gameplay, with a general theme of agility in a variety of
+      environments.
+    '';
+    homepage = https://www.redeclipse.net;
+    license = with stdenv.lib.licenses; [ zlib cc-by-sa-30 ];
+    maintainers = with stdenv.lib.maintainers; [ lambda-11235 ];
+    platforms = stdenv.lib.platforms.linux;
+    hydraPlatforms = [];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21424,6 +21424,8 @@ in
 
   racer = callPackage ../games/racer { };
 
+  redeclipse = callPackage ../games/redeclipse { };
+
   residualvm = callPackage ../games/residualvm { };
 
   rftg = callPackage ../games/rftg { };


### PR DESCRIPTION
Added a package for the FPS Red Eclipse. See https://www.redeclipse.net/.

###### Motivation for this change
I like the game and think others will as well. I also wanted to learn how to package for Nix.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
