### PR TITLE
Fix home-assistant fitbit support

### DIFF
--- a/pkgs/development/python-modules/fitbit/default.nix
+++ b/pkgs/development/python-modules/fitbit/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, coverage
+, dateutil
+, freezegun
+, mock
+, requests-mock
+, requests_oauthlib
+, sphinx
+}:
+
+buildPythonPackage rec {
+  pname = "fitbit";
+  version = "0.3.0";
+
+  checkInputs = [ coverage freezegun mock requests-mock sphinx ];
+  propagatedBuildInputs = [ dateutil requests_oauthlib ];
+
+  # The source package on PyPi is missing files required for unit testing.
+  # https://github.com/orcasgit/python-fitbit/issues/148
+  src = fetchFromGitHub {
+    rev = version;
+    owner = "orcasgit";
+    repo = "python-fitbit";
+    sha256 = "0s1kp4qcxvxghqf9nb71843slm4r5lhl2rlvj3yvhbby3cqs4g84";
+  };
+
+  postPatch = ''
+    substituteInPlace requirements/test.txt \
+      --replace 'Sphinx>=1.2,<1.4' 'Sphinx' \
+      --replace 'coverage>=3.7,<4.0' 'coverage'
+  '';
+
+  meta = with lib; {
+    description = "Fitbit API Python Client Implementation";
+    license = licenses.asl20;
+    homepage = https://github.com/orcasgit/python-fitbit;
+    maintainers = with maintainers; [ delroth ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2606,6 +2606,8 @@ in {
 
   fiona = callPackage ../development/python-modules/fiona { gdal = pkgs.gdal; };
 
+  fitbit = callPackage ../development/python-modules/fitbit { };
+
   flake8 = callPackage ../development/python-modules/flake8 { };
 
   flake8-blind-except = callPackage ../development/python-modules/flake8-blind-except { };


### PR DESCRIPTION
###### Motivation for this change
Similar to #60947. The fitbit components for home-assistant are broken in current nixpkgs due to a missing dependency. That dependency (python-fitbit) happens to not be packaged yet, so I'm adding it to nixpkgs as part of this PR.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
