### PR TITLE
networkmanager: network-online --wants--> NetworkManager-wait-online

### DIFF
--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -477,6 +477,10 @@ in {
       '';
     };
 
+    systemd.services.NetworkManager-wait-online = {
+      wantedBy = [ "network-online.target" ];
+    };
+
     systemd.services.nm-setup-hostsdirs = mkIf dynamicHostsEnabled {
       wantedBy = [ "NetworkManager.service" ];
       before = [ "NetworkManager.service" ];


### PR DESCRIPTION
###### Motivation for this change

Services relying on `network-online.target` were running before
the network was ready, every time.

Looking at why this was happening, it seems our `network-online`
had no actual dependency on the appropriate connectivity check
when using networkmanager, namely `NetworkManager-wait-online.service`.

(we get this right for configurations using networkd, I believe)

Looking at networkmanager's provided service
`etc/systemd/system/NetworkManager-wait-online.service` there's
a `WantedBy` in `[Install]` that should be accounted for.

Running this command before/after the included commit should
help see the difference:

(this is after:)
```
$ systemctl show -p Wants,After network-online.target
Wants=NetworkManager-wait-online.service
After=network.target NetworkManager-wait-online.service
```

Now my services don't all complain when trying to run
just a tiny bit too early in my boot :).

If there's agreement this is the correct configuration
please 'backport' to at least 19.03.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---