### PR TITLE
chromium: add myself as maintainer

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/browser.nix
+++ b/pkgs/applications/networking/browsers/chromium/browser.nix
@@ -47,7 +47,7 @@ mkChromiumDerivation (base: rec {
   meta = {
     description = "An open source web browser from Google";
     homepage = http://www.chromium.org/;
-    maintainers = with maintainers; [ bendlas ];
+    maintainers = with maintainers; [ bendlas ivan ];
     license = licenses.bsd3;
     platforms = platforms.linux;
     hydraPlatforms = if channel == "stable" then ["aarch64-linux" "x86_64-linux"] else [];


### PR DESCRIPTION
###### Motivation for this change

I would like to nominate myself for Chromium maintenance. My goal is to get Chromium updates (almost always fixing CVEs) into `master` a little more quickly when other maintainers are busy. I use Chromium heavily and closely watch [Google's stable updates](https://chromereleases.googleblog.com/search/label/Stable%20updates). I have fixed a [NixOS-related audio issue](https://github.com/NixOS/nixpkgs/commit/03960a323db7b83ba0ef46e6906640fa6de0402e) and [a vulnerable version](https://github.com/NixOS/nixpkgs/issues/56998). I also [report Chromium bugs upstream](https://bugs.chromium.org/p/chromium/issues/list?can=1&q=Reporter%3Aivan%40ludios.org+OS%3DLinux&sort=-modified&colspec=ID+Pri+M+Stars+ReleaseBlock+Component+Status+Owner+Summary+OS+Modified).
