### PR TITLE
memtest86-efi: init at 8.0

### DIFF
--- a/pkgs/tools/misc/memtest86-efi/default.nix
+++ b/pkgs/tools/misc/memtest86-efi/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     downloadPage = "https://www.memtest86.com/download.htm";
     description = "A tool to detect memory errors, to be run from a bootloader";
     longDescription = ''
-      An UEFI app that is able to detect errors in RAM.  It can be run from a
+      A UEFI app that is able to detect errors in RAM.  It can be run from a
       bootloader.  Released under a proprietary freeware license.
     '';
     # The Memtest86 License for the Free Edition states,

--- a/pkgs/tools/misc/memtest86-efi/default.nix
+++ b/pkgs/tools/misc/memtest86-efi/default.nix
@@ -1,0 +1,55 @@
+{ lib, stdenv, fetchurl, unzip, utillinux, libguestfs-with-appliance }:
+
+stdenv.mkDerivation rec {
+  pname = "memtest86-efi";
+  version = "8.0";
+
+  src = fetchurl {
+    # TODO: The latest version of memtest86 is actually 8.1, but apparently the
+    # company has stopped distributing versioned binaries of memtest86:
+    # https://www.passmark.com/forum/memtest86/44494-version-8-1-distribution-file-is-not-versioned?p=44505#post44505
+    # However, it does look like redistribution is okay, so if we had
+    # somewhere to host binaries that we make sure to version, then we could
+    # probably keep up with the latest versions released by the company.
+    url = "https://www.memtest86.com/downloads/memtest86-${version}-usb.zip";
+    sha256 = "147mnd7fnx2wvbzscw7pkg9ljiczhz05nb0cjpmww49a0ms4yknw";
+  };
+
+  nativeBuildInputs = [ libguestfs-with-appliance unzip ];
+
+  unpackPhase = ''
+    unzip -q $src -d .
+  '';
+
+  installPhase = ''
+    mkdir -p $out
+
+    # memtest86 is distributed as a bootable USB image.  It contains the actual
+    # memtest86 EFI app.
+    #
+    # The following command uses libguestfs to extract the actual EFI app from the
+    # usb image so that it can be installed directly on the hard drive.  This creates
+    # the ./BOOT/ directory with the memtest86 EFI app.
+    guestfish --ro --add ./memtest86-usb.img --mount /dev/sda1:/  copy-out /EFI/BOOT .
+
+    cp -r BOOT/* $out/
+  '';
+
+  meta = with lib; {
+    homepage = http://memtest86.com/;
+    downloadPage = "https://www.memtest86.com/download.htm";
+    description = "A tool to detect memory errors, to be run from a bootloader";
+    longDescription = ''
+      An UEFI app that is able to detect errors in RAM.  It can be run from a
+      bootloader.  Released under a proprietary freeware license.
+    '';
+    # The Memtest86 License for the Free Edition states,
+    # "MemTest86 Free Edition is free to download with no restrictions on usage".
+    # However the source code for Memtest86 does not appear to be available.
+    #
+    # https://www.memtest86.com/license.htm
+    license = licenses.unfreeRedistributable;
+    maintainers = with maintainers; [ cdepillabout ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/misc/memtest86/default.nix
+++ b/pkgs/tools/misc/memtest86/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     homepage = http://memtest86.com/;
-    downloadPage = https://www.memtest86.com/download.htm;
+    downloadPage = "https://www.memtest86.com/download.htm";
     description = "A tool to detect memory errors, to be run from a bootloader";
     # The Memtest86 License for the Free Edition states,
     # "MemTest86 Free Edition is free to download with no restrictions on usage".

--- a/pkgs/tools/misc/memtest86/default.nix
+++ b/pkgs/tools/misc/memtest86/default.nix
@@ -1,32 +1,51 @@
-{ stdenv, fetchurl }:
+{ lib, stdenv, fetchurl, unzip, utillinux, libguestfs-with-appliance }:
 
-stdenv.mkDerivation {
-  name = "memtest86-4.3.6";
-  
+stdenv.mkDerivation rec {
+  name = "memtest86";
+  version = "8.0";
+
   src = fetchurl {
-    url = https://www.memtest86.com/downloads/memtest86-4.3.6-src.tar.gz;
-    sha256 = "0qbksyl2hmkm12n7zbmf2m2n3q811skhykxx6a9a7y6r7k8y5qmv";
+    # TODO: The latest version of memtest86 is actually 8.1, but apparently the
+    # company has stopped distributing versioned binaries of memtest86:
+    # https://www.passmark.com/forum/memtest86/44494-version-8-1-distribution-file-is-not-versioned?p=44505#post44505
+    # However, it does look like redistribution is okay, so if we had
+    # somewhere to host binaries that we make sure to version, then we could
+    # probably keep up with the latest versions released by the company.
+    url = "https://www.memtest86.com/downloads/memtest86-${version}-usb.zip";
+    sha256 = "147mnd7fnx2wvbzscw7pkg9ljiczhz05nb0cjpmww49a0ms4yknw";
   };
 
-  preBuild = ''
-    # Really dirty hack to get Memtest to build without needing a Glibc
-    # with 32-bit libraries and headers.
-    if test "$system" = x86_64-linux; then
-        mkdir gnu
-        touch gnu/stubs-32.h
-    fi
+  nativeBuildInputs = [ libguestfs-with-appliance unzip ];
+
+  unpackPhase = ''
+    unzip -q $src -d .
   '';
 
-  NIX_CFLAGS_COMPILE = "-I.";
-  
   installPhase = ''
     mkdir -p $out
-    cp memtest.bin $out/
+
+    # memtest86 is distributed as a bootable USB image.  It contains the actual
+    # memtest86 EFI app.
+    #
+    # The following command uses libguestfs to extract the actual EFI app from the
+    # usb image so that it can be installed directly on the hard drive.  This creates
+    # the ./BOOT/ directory with the memtest86 EFI app.
+    guestfish --ro --add ./memtest86-usb.img --mount /dev/sda1:/  copy-out /EFI/BOOT .
+
+    cp -r BOOT/* $out/
   '';
 
-  meta = {
+  meta = with lib; {
     homepage = http://memtest86.com/;
+    downloadPage = https://www.memtest86.com/download.htm;
     description = "A tool to detect memory errors, to be run from a bootloader";
-    broken = true;
+    # The Memtest86 License for the Free Edition states,
+    # "MemTest86 Free Edition is free to download with no restrictions on usage".
+    # However the source code for Memtest86 does not appear to be available.
+    #
+    # https://www.memtest86.com/license.htm
+    license = licenses.unfreeRedistributable;
+    maintainers = with maintainers; [ cdepillabout ];
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4374,6 +4374,8 @@ in
 
   memtest86 = callPackage ../tools/misc/memtest86 { };
 
+  memtest86-efi = callPackage ../tools/misc/memtest86-efi { };
+
   memtest86plus = callPackage ../tools/misc/memtest86+ { };
 
   meo = callPackage ../tools/security/meo {


### PR DESCRIPTION
This updates memtest86 to (almost) the latest version.

memtest86-4.3.6 is the older version.  It was open source, but marked broken.  memtest86-8.0 is the newer version.  It is no longer open source, but it is possible to build and use.  There appear to be no restrictions on its use or redistribution.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The old memtest86 was marked as broken.

I plan to send a future PR that actually adds memtest86 as an option for the bootloader.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
