### PR TITLE
vcv-rack: Correct license, redistribution is allowed

### DIFF
--- a/pkgs/applications/audio/vcv-rack/default.nix
+++ b/pkgs/applications/audio/vcv-rack/default.nix
@@ -72,8 +72,9 @@ with stdenv.lib; stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "Open-source virtual modular synthesizer";
     homepage = http://vcvrack.com/;
-    # The source is BSD-3 licensed, some of the art is CC-BY-NC 4.0 or unfree
-    license = [ licenses.bsd3 licenses.cc-by-nc-40 licenses.unfree ];
+    # The source is BSD-3 licensed, some of the art is CC-BY-NC 4.0 or under a
+    # no-derivatives clause
+    license = with licenses; [ bsd3 cc-by-nc-40 unfreeRedistributable ];
     maintainers = with maintainers; [ moredread ];
     platforms = platforms.linux;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The package contains resources under different licenses, but they allow redistribution. See https://github.com/VCVRack/Rack/blob/v0.6/README.md

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
