### PR TITLE
mstpd: 0.0.5.20171113 -> 0.0.7

### DIFF
--- a/pkgs/os-specific/linux/mstpd/default.nix
+++ b/pkgs/os-specific/linux/mstpd/default.nix
@@ -1,22 +1,28 @@
 { stdenv, fetchFromGitHub, autoreconfHook }:
 
-stdenv.mkDerivation {
-  name = "mstpd-0.0.5.20171113";
+stdenv.mkDerivation rec {
+  pname = "mstpd";
+  version = "0.0.7";
 
   src = fetchFromGitHub {
-    owner = "mstpd";
-    repo = "mstpd";
-    rev = "2522c6eed201bce8dd81e1583f28748e9c552d0d";
-    sha256 = "0ckk386inwcx3776hf15w78hpw4db2rgv4zgf0i3zcylr83hhsr2";
+    owner = pname;
+    repo = pname;
+    rev = version;
+    sha256 = "01majib6d1rixngf8c8vcrj1akf8nsqpxhdfdxxi2xwg23vx8f1a";
   };
 
   nativeBuildInputs = [ autoreconfHook ];
 
-  installFlags = [ "DESTDIR=$(out)" ];
+  configureFlags = [
+    "--prefix=$(out)"
+    "--sysconfdir=$(out)/etc"
+    "--sbindir=$(out)/sbin"
+    "--libexecdir=$(out)/lib"
+  ];
 
   meta = with stdenv.lib; {
     description = "Multiple Spanning Tree Protocol daemon";
-    homepage = https://sourceforge.net/projects/mstpd/;
+    homepage = "https://github.com/mstpd/mstpd";
     license = licenses.gpl2;
     platforms = platforms.linux;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Package refresh
\+ fixed installed file structure (some tools under $out/lib were symlink to `/sbin/bridge-stp` instead of `$out/sbin/bridge-stp`)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
