### PR TITLE
compsize: 2018-04-07 -> 1.3

### DIFF
--- a/pkgs/os-specific/linux/compsize/default.nix
+++ b/pkgs/os-specific/linux/compsize/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, btrfs-progs }:
 
 stdenv.mkDerivation rec {
-  name = "compsize-${version}";
-  version = "2018-04-07";
+  pname = "compsize";
+  version = "1.3";
 
   src = fetchFromGitHub {
     owner = "kilobyte";
     repo = "compsize";
-    rev = "903f772e37fc0ac6d6cf94ddbc98c691763c1e62";
-    sha256 = "0jps8n0xsdh4mcww5q29rzysbv50iq6rmihxrf99lzgrw0sw5m7k";
+    rev = "v${version}";
+    sha256 = "1c69whla844nwis30jxbj00zkpiw3ccndhkmzjii8av5358mjn43";
   };
 
   buildInputs = [ btrfs-progs ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Updates [compsize](https://github.com/kilobyte/compsize) to version 1.3 (latest stable version).
Tested on a real btrfs filesystem with different compression algorithms.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
