### PR TITLE
rtorrent-ps, libtorrent-ps: init at 1.1-37c9d4b

### DIFF
--- a/pkgs/tools/networking/p2p/libtorrent/default.nix
+++ b/pkgs/tools/networking/p2p/libtorrent/default.nix
@@ -1,7 +1,7 @@
 # NOTE: this is rakshava's version of libtorrent, used mainly by rtorrent
 # This is NOT libtorrent-rasterbar, used by Deluge, qbitttorent, and others
 { stdenv, fetchFromGitHub, pkgconfig
-, libtool, autoconf, automake, cppunit
+, autoreconfHook, cppunit
 , openssl, libsigcxx, zlib }:
 
 stdenv.mkDerivation rec {
@@ -15,10 +15,8 @@ stdenv.mkDerivation rec {
     sha256 = "027qanwcisxhx0bq8dn8cpg8563q0k2pm8ls278f04n7jqvvwkp0";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ libtool autoconf automake cppunit openssl libsigcxx zlib ];
-
-  preConfigure = "./autogen.sh";
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  buildInputs = [ cppunit openssl libsigcxx zlib ];
 
   meta = with stdenv.lib; {
     inherit (src.meta) homepage;

--- a/pkgs/tools/networking/p2p/libtorrent/ps.nix
+++ b/pkgs/tools/networking/p2p/libtorrent/ps.nix
@@ -1,0 +1,42 @@
+{ stdenv, libtorrent, openssl, openssl_1_1, fetchFromGitHub }:
+let
+  ps = fetchFromGitHub {
+    rev = "37c9d4b45be2ab5f0b7ff9123c471fd517c22033";
+    owner = "pyroscope";
+    repo = "rtorrent-ps";
+    sha256 = "1hl7mwndra30q3bcjprzqh2j9dirx6ym8mzamgydp1iywk0dqdwj";
+  };
+  libtorrent_0_13_6 = libtorrent.overrideAttrs (o: rec {
+    name = "libtorrent-${version}";
+    version = "0.13.6";
+    src = fetchFromGitHub {
+      owner = "rakshasa";
+      repo = "libtorrent";
+      rev = "${version}";
+      sha256 = "1rvrxgb131snv9r6ksgzmd74rd9z7q46bhky0zazz7dwqqywffcp";
+    };
+  });
+in
+libtorrent_0_13_6.overrideAttrs (o: rec {
+  version = "1.1-${builtins.substring 0 7 ps.rev}";
+  name = "libtorrent-ps-${version}";
+  buildInputs = (stdenv.lib.remove openssl o.buildInputs) ++ [ openssl_1_1 ];
+  patches = (o.patches or []) ++ (map (x: "${ps}/patches/${x}") [
+    "backport*_${o.version}_*.patch"
+    "backport*_all_*.patch"
+    "lt-base-cppunit-pkgconfig.patch" # 0.13.6
+    "lt-open-ssl-1.1.patch"
+    "lt-ps-*_${o.version}.patch"
+    "lt-ps-*_all.patch"
+  ]);
+  enableParallelBuilding = true;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/pyroscope/rtorrent-ps;
+    description = "BitTorrent library written in C++ for use with rtorrent-ps";
+
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ yorickvp ];
+    license = licenses.gpl2Plus;
+  };
+})

--- a/pkgs/tools/networking/p2p/rtorrent/default.nix
+++ b/pkgs/tools/networking/p2p/rtorrent/default.nix
@@ -1,10 +1,7 @@
 { stdenv, fetchurl, fetchFromGitHub, pkgconfig
-, libtool, autoconf, automake, cppunit
+, autoreconfHook, cppunit
 , libtorrent, ncurses, libsigcxx, curl
 , zlib, openssl, xmlrpc_c
-
-# This no longer works
-, colorSupport ? false
 }:
 
 stdenv.mkDerivation rec {
@@ -18,20 +15,10 @@ stdenv.mkDerivation rec {
     sha256 = "0a9dk3cz56f7gad8ghsma79iy900rwdvzngs6k6x08nlwaqid8ga";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
   buildInputs = [
-    libtool autoconf automake cppunit
-    libtorrent ncurses libsigcxx curl zlib openssl xmlrpc_c
+    cppunit libtorrent ncurses libsigcxx curl zlib openssl xmlrpc_c
   ];
-
-  # Optional patch adds support for custom configurable colors
-  # https://github.com/Chlorm/chlorm_overlay/blob/master/net-p2p/rtorrent/README.md
-  patches = stdenv.lib.optional colorSupport (fetchurl {
-    url = "https://gist.githubusercontent.com/codyopel/a816c2993f8013b5f4d6/raw/b952b32da1dcf14c61820dfcf7df00bc8918fec4/rtorrent-color.patch";
-    sha256 = "00gcl7yq6261rrfzpz2k8bd7mffwya0ifji1xqcvhfw50syk8965";
-  });
-
-  preConfigure = "./autogen.sh";
 
   configureFlags = [ "--with-xmlrpc-c" "--with-posix-fallocate" ];
 

--- a/pkgs/tools/networking/p2p/rtorrent/ps.nix
+++ b/pkgs/tools/networking/p2p/rtorrent/ps.nix
@@ -1,0 +1,53 @@
+{ stdenv, rtorrent, openssl, openssl_1_1, libtorrent, libtorrent-ps, fetchFromGitHub }:
+let
+  ps = fetchFromGitHub {
+    rev = "37c9d4b45be2ab5f0b7ff9123c471fd517c22033";
+    owner = "pyroscope";
+    repo = "rtorrent-ps";
+    sha256 = "1hl7mwndra30q3bcjprzqh2j9dirx6ym8mzamgydp1iywk0dqdwj";
+  };
+  rtorrent_0_9_6 = rtorrent.overrideAttrs (o: rec {
+    name = "rtorrent-${version}";
+    version = "0.9.6";
+    src = fetchFromGitHub {
+      owner = "rakshasa";
+      repo = "rtorrent";
+      rev = "${version}";
+      sha256 = "0iyxmjr1984vs7hrnxkfwgrgckacqml0kv4bhj185w9bhjqvgfnf";
+    };
+  });
+in
+
+rtorrent_0_9_6.overrideAttrs (o: rec {
+  version = "1.1-${builtins.substring 0 7 ps.rev}";
+  name = "rtorrent-ps-${version}";
+  buildInputs = (stdenv.lib.subtractLists [ libtorrent openssl ] o.buildInputs) ++ [ libtorrent-ps openssl_1_1 ];
+  
+  patches = (o.patches or []) ++ (map (x: "${ps}/patches/${x}") [
+    "backport*_${o.version}_*.patch"
+    "rt-base-cppunit-pkgconfig.patch"
+    "ps-*_all.patch"
+    "ps-*_${o.version}.patch"
+    "pyroscope.patch"
+    "ui_pyroscope.patch"
+  ]);
+  
+  postPatch = ''
+    ln -s ${ps}/patches/*.{cc,h} src/
+    RT_HEX_VERSION=$(printf "0x%02X%02X%02X" ${stdenv.lib.replaceChars ["."] [" "] o.version})
+    sed -i -e "s:\\(AC_DEFINE(HAVE_CONFIG_H.*\\):\1  AC_DEFINE(RT_HEX_VERSION, "$RT_HEX_VERSION", for CPP if checks):" configure.ac
+    grep "AC_DEFINE.*API_VERSION" configure.ac >/dev/null || sed -i -e "s:\\(AC_DEFINE(HAVE_CONFIG_H.*\\):\1  AC_DEFINE(API_VERSION, 0, api version):" configure.ac
+    sed -i -e 's/rTorrent \" VERSION/rTorrent PS-'"${version}"' " VERSION/' src/ui/download_list.cc
+  '';
+  
+  enableParallelBuilding = true;
+  
+  meta = with stdenv.lib; {
+    homepage = https://github.com/pyroscope/rtorrent-ps;
+    description = "Extended rTorrent distribution with UI enhancements, colorization, and some added features";
+
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ yorickvp ];
+    license = licenses.gpl2Plus;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4222,6 +4222,7 @@ in
   libnids = callPackage ../tools/networking/libnids { };
 
   libtorrent = callPackage ../tools/networking/p2p/libtorrent { };
+  libtorrent-ps = callPackage ../tools/networking/p2p/libtorrent/ps.nix { };
 
   libmpack = callPackage ../development/libraries/libmpack { };
 
@@ -5524,6 +5525,7 @@ in
   rsstail = callPackage ../applications/networking/feedreaders/rsstail { };
 
   rtorrent = callPackage ../tools/networking/p2p/rtorrent { };
+  rtorrent-ps = callPackage ../tools/networking/p2p/rtorrent/ps.nix { };
 
   rubber = callPackage ../tools/typesetting/rubber { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

[rtorrent-ps](https://github.com/pyroscope/rtorrent-ps/) is a popular patch set for rtorrent. These packages are inspired by the [aur PKGBUILD](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=rtorrent-ps)

(cc: @pyroscope, @ebzzry, @codyopel)

I also have a pyrocore (python) package that should be upstreamed at some point.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
