### PR TITLE
wireguard: add 'namespace' option to set interface netns

### DIFF
--- a/nixos/modules/services/networking/wireguard.nix
+++ b/nixos/modules/services/networking/wireguard.nix
@@ -112,6 +112,19 @@ let
           Determines whether to add allowed IPs as routes or not.
         '';
       };
+
+      namespace = mkOption {
+        default = null;
+        type = with types; nullOr str;
+        example = "container";
+        description = ''
+          Advanced: move the created wireguard interface into a network namespace,
+          as described in the first part of https://www.wireguard.com/netns/ .
+          This allows you to use <command>ip netns exec $namespace COMMAND</command> to execute
+          COMMAND in a network namespace with only this interface available, routing
+          all traffic over the wireguard tunnel.
+        '';
+      };
     };
 
   };
@@ -234,6 +247,8 @@ let
     # exactly one way to specify the private key must be set
     #assert (values.privateKey != null) != (values.privateKeyFile != null);
     let privKey = if values.privateKeyFile != null then values.privateKeyFile else pkgs.writeText "wg-key" values.privateKey;
+        ipns = if !(isNull values.namespace) then ''ip -n "${values.namespace}"'' else "ip";
+        wgns = if !(isNull values.namespace) then ''ip netns exec "${values.namespace}" wg'' else "wg";
     in
     nameValuePair "wireguard-${name}"
       {
@@ -255,30 +270,34 @@ let
           ${values.preSetup}
 
           ip link add dev ${name} type wireguard
+          ${lib.optionalString (!isNull values.namespace) ''
+            ip netns add "${values.namespace}"
+            ip link set ${name} netns "${values.namespace}"
+          ''}
 
           ${concatMapStringsSep "\n" (ip:
-            "ip address add ${ip} dev ${name}"
+            "${ipns} address add ${ip} dev ${name}"
           ) values.ips}
 
-          wg set ${name} private-key ${privKey} ${
+          ${wgns} set ${name} private-key ${privKey} ${
             optionalString (values.listenPort != null) " listen-port ${toString values.listenPort}"}
 
           ${concatMapStringsSep "\n" (peer:
             assert (peer.presharedKeyFile == null) || (peer.presharedKey == null); # at most one of the two must be set
             let psk = if peer.presharedKey != null then pkgs.writeText "wg-psk" peer.presharedKey else peer.presharedKeyFile;
             in
-              "wg set ${name} peer ${peer.publicKey}" +
+              "${wgns} set ${name} peer ${peer.publicKey}" +
               optionalString (psk != null) " preshared-key ${psk}" +
               optionalString (peer.endpoint != null) " endpoint ${peer.endpoint}" +
               optionalString (peer.persistentKeepalive != null) " persistent-keepalive ${toString peer.persistentKeepalive}" +
               optionalString (peer.allowedIPs != []) " allowed-ips ${concatStringsSep "," peer.allowedIPs}"
             ) values.peers}
 
-          ip link set up dev ${name}
+          ${ipns} link set up dev ${name}
 
           ${optionalString (values.allowedIPsAsRoutes != false) (concatStringsSep "\n" (concatMap (peer:
               (map (allowedIP:
-                "ip route replace ${allowedIP} dev ${name} table ${values.table}"
+                "${ipns} route replace ${allowedIP} dev ${name} table ${values.table}"
               ) peer.allowedIPs)
             ) values.peers))}
 
@@ -286,7 +305,8 @@ let
         '';
 
         postStop = ''
-          ip link del dev ${name}
+          ${ipns} link del dev ${name}
+          ${lib.optionalString (!isNull values.namespace) ''ip netns del "${values.namespace}"''}
           ${values.postShutdown}
         '';
       };

--- a/nixos/modules/services/networking/wireguard.nix
+++ b/nixos/modules/services/networking/wireguard.nix
@@ -119,7 +119,7 @@ let
         example = "container";
         description = ''
           Advanced: move the created wireguard interface into a network namespace,
-          as described in the first part of https://www.wireguard.com/netns/ .
+          as described in the first part of https://www.wireguard.com/netns/.
           This allows you to use <command>ip netns exec $namespace COMMAND</command> to execute
           COMMAND in a network namespace with only this interface available, routing
           all traffic over the wireguard tunnel.
@@ -270,7 +270,7 @@ let
           ${values.preSetup}
 
           ip link add dev ${name} type wireguard
-          ${lib.optionalString (!isNull values.namespace) ''
+          ${lib.optionalString !(isNull values.namespace) ''
             ip netns add "${values.namespace}"
             ip link set ${name} netns "${values.namespace}"
           ''}


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The usecase in the first section of https://www.wireguard.com/netns/ (making a network namespace to allow proper sandboxing) is rather easy to support in nixpkgs, and hard outside of it. This PR adds an option to do it.

(cc: @Lucus16 , @grahamc, @mic92, @xeji, @fpletz )

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date **// can update the wiki after merge**
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
