### PR TITLE
libglvnd, ocl-icd, vulkan-loader: Add /run/opengl-driver(-32) to RUNPATH.

### DIFF
--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -2,7 +2,7 @@
 , ilmbase, libXi, libX11, libXext, libXrender
 , libjpeg, libpng, libsamplerate, libsndfile
 , libtiff, libGLU_combined, openal, opencolorio, openexr, openimageio, openjpeg_1, pythonPackages
-, zlib, fftw, opensubdiv, freetype, jemalloc, ocl-icd
+, zlib, fftw, opensubdiv, freetype, jemalloc, ocl-icd, addOpenGLRunpath
 , jackaudioSupport ? false, libjack2
 , cudaSupport ? config.cudaSupport or false, cudatoolkit
 , colladaSupport ? true, opencollada
@@ -21,8 +21,9 @@ stdenv.mkDerivation rec {
     sha256 = "1g4kcdqmf67srzhi3hkdnr4z1ph4h9sza1pahz38mrj998q4r52c";
   };
 
+  nativeBuildInputs = [ cmake ] ++ optional cudaSupport addOpenGLRunpath;
   buildInputs =
-    [ boost cmake ffmpeg gettext glew ilmbase
+    [ boost ffmpeg gettext glew ilmbase
       libXi libX11 libXext libXrender
       freetype libjpeg libpng libsamplerate libsndfile libtiff libGLU_combined openal
       opencolorio openexr openimageio openjpeg_1 python zlib fftw jemalloc
@@ -79,6 +80,15 @@ stdenv.mkDerivation rec {
       wrapProgram $out/bin/blender \
         --prefix PYTHONPATH : ${pythonPackages.numpy}/${python.sitePackages}
     '';
+
+  # Set RUNPATH so that libcuda and libnvrtc in /run/opengl-driver(-32)/lib can be
+  # found. See the explanation in libglvnd.
+  postFixup = optionalString cudaSupport ''
+    for program in $out/bin/blender $out/bin/.blender-wrapped; do
+      isELF "$program" || continue
+      addOpenGLRunpath "$program"
+    done
+  '';
 
   meta = with stdenv.lib; {
     description = "3D Creation/Animation/Publishing System";

--- a/pkgs/build-support/add-opengl-runpath/default.nix
+++ b/pkgs/build-support/add-opengl-runpath/default.nix
@@ -1,0 +1,12 @@
+{ lib, stdenv }:
+
+stdenv.mkDerivation {
+  name = "add-opengl-runpath";
+
+  driverLink = "/run/opengl-driver" + lib.optionalString stdenv.isi686 "-32";
+
+  buildCommand = ''
+    mkdir -p $out/nix-support
+    substituteAll ${./setup-hook.sh} $out/nix-support/setup-hook
+  '';
+}

--- a/pkgs/build-support/add-opengl-runpath/setup-hook.sh
+++ b/pkgs/build-support/add-opengl-runpath/setup-hook.sh
@@ -1,0 +1,28 @@
+# Set RUNPATH so that driver libraries in /run/opengl-driver(-32)/lib can be found.
+# This is needed to not rely on LD_LIBRARY_PATH which does not work with setuid
+# executables. Fixes https://github.com/NixOS/nixpkgs/issues/22760. It must be run
+# in postFixup because RUNPATH stripping in fixup would undo it. Note that patchelf
+# actually sets RUNPATH not RPATH, which applies only to dependencies of the binary
+# it set on (including for dlopen), so the RUNPATH must indeed be set on these
+# libraries and would not work if set only on executables.
+addOpenGLRunpath() {
+    local forceRpath=
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --) shift; break;;
+            --force-rpath) shift; forceRpath=1;;
+            --*)
+                echo "addOpenGLRunpath: ERROR: Invalid command line" \
+                     "argument: $1" >&2
+                return 1;;
+            *) break;;
+        esac
+    done
+
+    for file in "$@"; do
+        local origRpath="$(patchelf --print-rpath "$file")"
+        patchelf --set-rpath "@driverLink@/lib:$origRpath" ${forceRpath:+--force-rpath} "$file"
+    done
+}
+

--- a/pkgs/development/compilers/cudatoolkit/default.nix
+++ b/pkgs/development/compilers/cudatoolkit/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv, makeWrapper, fetchurl, requireFile, perl, ncurses5, expat, python27, zlib
 , gcc48, gcc49, gcc5, gcc6, gcc7
 , xorg, gtk2, gdk_pixbuf, glib, fontconfig, freetype, unixODBC, alsaLib, glibc
+, addOpenGLRunpath
 }:
 
 let
@@ -39,7 +40,7 @@ let
 
       outputs = [ "out" "lib" "doc" ];
 
-      nativeBuildInputs = [ perl makeWrapper ];
+      nativeBuildInputs = [ perl makeWrapper addOpenGLRunpath ];
       buildInputs = [ gdk_pixbuf ]; # To get $GDK_PIXBUF_MODULE_FILE via setup-hook
       runtimeDependencies = [
         ncurses5 expat python zlib glibc
@@ -143,8 +144,17 @@ let
           else
             rpath2=$rpath:$lib/lib:$out/jre/lib/amd64/jli:$out/lib:$out/lib64:$out/nvvm/lib:$out/nvvm/lib64
           fi
-          patchelf --set-rpath $rpath2 --force-rpath $i
+          patchelf --set-rpath "$rpath2" --force-rpath $i
         done < <(find $out $lib $doc -type f -print0)
+      '';
+
+      # Set RPATH so that libcuda and other libraries in
+      # /run/opengl-driver(-32)/lib can be found. See the explanation in
+      # addOpenGLRunpath.  Don't try to figure out which libraries really need
+      # it, just patch all (but not the stubs libraries). Note that
+      # --force-rpath prevents changing RPATH (set above) to RUNPATH.
+      postFixup = ''
+        addOpenGLRunpath --force-rpath {$out,$lib}/lib/lib*.so
       '';
 
       # cuda-gdb doesn't run correctly when not using sandboxing, so

--- a/pkgs/development/libraries/ocl-icd/default.nix
+++ b/pkgs/development/libraries/ocl-icd/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl, ruby, opencl-headers, libGL_driver }:
+{stdenv, fetchurl, ruby, opencl-headers, addOpenGLRunpath }:
 
 stdenv.mkDerivation rec {
   name = "ocl-icd-${version}";
@@ -9,12 +9,18 @@ stdenv.mkDerivation rec {
     sha256 = "0f14gpa13sdm0kzqv5yycp4pschbmi6n5fj7wl4ilspzsrqcgqr2";
   };
 
-  nativeBuildInputs = [ ruby ];
+  nativeBuildInputs = [ ruby addOpenGLRunpath ];
 
   buildInputs = [ opencl-headers ];
 
   postPatch = ''
-    sed -i 's,"/etc/OpenCL/vendors","${libGL_driver.driverLink}/etc/OpenCL/vendors",g' ocl_icd_loader.c
+    sed -i 's,"/etc/OpenCL/vendors","${addOpenGLRunpath.driverLink}/etc/OpenCL/vendors",g' ocl_icd_loader.c
+  '';
+
+  # Set RUNPATH so that driver libraries in /run/opengl-driver(-32)/lib can be found.
+  # See the explanation in addOpenGLRunpath.
+  postFixup = ''
+    addOpenGLRunpath $out/lib/libOpenCL.so
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/science/math/cudnn/generic.nix
+++ b/pkgs/development/libraries/science/math/cudnn/generic.nix
@@ -7,6 +7,7 @@
 , lib
 , cudatoolkit
 , fetchurl
+, addOpenGLRunpath
 }:
 
 stdenv.mkDerivation rec {
@@ -19,6 +20,8 @@ stdenv.mkDerivation rec {
     inherit sha256;
   };
 
+  nativeBuildInputs = [ addOpenGLRunpath ];
+
   installPhase = ''
     function fixRunPath {
       p=$(patchelf --print-rpath $1)
@@ -29,6 +32,12 @@ stdenv.mkDerivation rec {
     mkdir -p $out
     cp -a include $out/include
     cp -a lib64 $out/lib64
+  '';
+
+  # Set RUNPATH so that libcuda in /run/opengl-driver(-32)/lib can be found.
+  # See the explanation in addOpenGLRunpath.
+  postFixup = ''
+    addOpenGLRunpath $out/lib/lib*.so
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/development/libraries/science/math/nccl/default.nix
+++ b/pkgs/development/libraries/science/math/nccl/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, which, cudatoolkit }:
+{ stdenv, fetchFromGitHub, which, cudatoolkit, addOpenGLRunpath }:
 
 stdenv.mkDerivation rec {
   name = "nccl-${version}-cuda-${cudatoolkit.majorVersion}";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" ];
 
-  nativeBuildInputs = [ which ];
+  nativeBuildInputs = [ which addOpenGLRunpath ];
 
   buildInputs = [ cudatoolkit ];
 
@@ -28,6 +28,10 @@ stdenv.mkDerivation rec {
 
   postFixup = ''
     moveToOutput lib/libnccl_static.a $dev
+
+    # Set RUNPATH so that libnvidia-ml in /run/opengl-driver(-32)/lib can be found.
+    # See the explanation in addOpenGLRunpath.
+    addOpenGLRunpath $out/lib/lib*.so
   '';
 
   NIX_CFLAGS_COMPILE = [ "-Wno-unused-function" ];

--- a/pkgs/development/libraries/vulkan-loader/default.nix
+++ b/pkgs/development/libraries/vulkan-loader/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, cmake, python3, vulkan-headers, pkgconfig
-, xlibsWrapper, libxcb, libXrandr, libXext, wayland, libGL_driver }:
+, xlibsWrapper, libxcb, libXrandr, libXext, wayland, addOpenGLRunpath }:
 
 let
   version = "1.1.106";
@@ -17,16 +17,22 @@ stdenv.mkDerivation rec {
     sha256 = "0zhrwj1gi90x2w8gaaaw5h4b969a8gfy244kn0drrplhhb1nqz3b";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig addOpenGLRunpath ];
   buildInputs = [ cmake python3 xlibsWrapper libxcb libXrandr libXext wayland ];
   enableParallelBuilding = true;
 
   cmakeFlags = [
-    "-DFALLBACK_DATA_DIRS=${libGL_driver.driverLink}/share:/usr/local/share:/usr/share"
+    "-DFALLBACK_DATA_DIRS=${addOpenGLRunpath.driverLink}/share:/usr/local/share:/usr/share"
     "-DVULKAN_HEADERS_INSTALL_DIR=${vulkan-headers}"
   ];
 
   outputs = [ "out" "dev" ];
+
+  # Set RUNPATH so that driver libraries in /run/opengl-driver(-32)/lib can be found.
+  # See the explanation in addOpenGLRunpath.
+  postFixup = ''
+    addOpenGLRunpath $out/lib/libvulkan.so
+  '';
 
   meta = with stdenv.lib; {
     description = "LunarG Vulkan loader";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -126,6 +126,8 @@ in
       }
     '');
 
+  addOpenGLRunpath = callPackage ../build-support/add-opengl-runpath { };
+
   # Zip file format only allows times after year 1980, which makes e.g. Python wheel building fail with:
   # ValueError: ZIP does not support timestamps before 1980
   ensureNewerSourcesForZipFilesHook = ensureNewerSourcesHook { year = "1980"; };


### PR DESCRIPTION
Previously we were relying on LD_LIBRARY_PATH to discover vendor driver libraries (libGL, ligGLX, libEGL, OpenCL and Vulkan). This has the problem that setuid programs (in particular VirtualBox) ignore LD_LIBRARY_PATH. Fix it by setting RUNPATH in various dispatch libraries to look in /run/opengl-driver(-32).

Setting this on the VirtualBoxVM binary (which would be simpler) would not solve the problem, the RUNPATH must be on the library which performs the dlopen(). The dlopen man page claims that the RUNPATH from the executable is used but that is incorrect, only RUNPATH from the module performing dlopen() is used.

Note that setting *RPATH* on the executable would work, but patchelf manipulates RUNPATH and not RPATH (RPATH is a legacy feature).

Fixes https://github.com/NixOS/nixpkgs/issues/22760
Fixes https://github.com/NixOS/nixpkgs/issues/18457.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
3D acceleration in VirtualBox does not work with NVidia drivers when hardening is enabled for VirtualBox (the default) (https://github.com/NixOS/nixpkgs/issues/22760)

###### Things done
Tested this on 19.03, with this change there is no error when starting a VM with 3D acceleration enabled and the VM log shows that OpenGL was initialized successfully.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
