### PR TITLE
Warn on deprecated /var/run in shell paths

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -239,6 +239,13 @@ rec {
       check = x: (package.check x) && (hasAttr "shellPath" x);
     };
 
+    shell = either path shellPackage // {
+      check = x: (path.check x || shellPackage.check) &&
+        builtins.substring 0 8 (toString x) != "/var/run" || throw ''
+          /var/run is deprecated. Please use ${builtins.substring 4 100 (toString x)} instead of ${x} for your shell.
+        '';
+    };
+
     path = mkOptionType {
       name = "path";
       # Hacky: there is no ‘isPath’ primop.

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -240,10 +240,11 @@ rec {
     };
 
     shell = either path shellPackage // {
-      check = x: (path.check x || shellPackage.check) &&
-        hasPrefix "/var/run/" (toString x) || throw ''
+      check = x: (path.check x || shellPackage.check x) &&
+        (!hasPrefix "/var/run/" (toString x)) || warn ''
           /var/run is deprecated. Please use ${removePrefix "/var" (toString x)} instead of ${x} for your shell.
-        '';
+        '' false;
+      description = "valid shell path or shell package";
     };
 
     path = mkOptionType {

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -241,8 +241,8 @@ rec {
 
     shell = either path shellPackage // {
       check = x: (path.check x || shellPackage.check) &&
-        builtins.substring 0 8 (toString x) != "/var/run" || throw ''
-          /var/run is deprecated. Please use ${builtins.substring 4 100 (toString x)} instead of ${x} for your shell.
+        hasPrefix "/var/run/" (toString x) || throw ''
+          /var/run is deprecated. Please use ${removePrefix "/var" (toString x)} instead of ${x} for your shell.
         '';
     };
 

--- a/nixos/modules/config/shells-environment.nix
+++ b/nixos/modules/config/shells-environment.nix
@@ -142,7 +142,7 @@ in
         No need to mention <literal>/bin/sh</literal>
         here, it is placed into this list implicitly.
       '';
-      type = types.listOf (types.either types.shellPackage types.path);
+      type = types.listOf types.shell;
     };
 
   };

--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -119,7 +119,7 @@ let
       };
 
       shell = mkOption {
-        type = types.either types.shellPackage types.path;
+        type = types.shell;
         default = pkgs.shadow;
         defaultText = "pkgs.shadow";
         example = literalExample "pkgs.bashInteractive";

--- a/nixos/modules/programs/shadow.nix
+++ b/nixos/modules/programs/shadow.nix
@@ -50,7 +50,7 @@ in
         used outside the store (in particular in /etc/passwd).
       '';
       example = literalExample "pkgs.zsh";
-      type = types.either types.path types.shellPackage;
+      type = types.shell;
     };
 
   };


### PR DESCRIPTION
###### Motivation for this change

The /var/run deprecation in nixpkgs removed
/var/run/current-system/sw/<shell> from `environment.shells` and hence
from `/etc/shells` without any warning to users still using
`/var/run/..` paths in `users.defaultUserShell` or in `users.*.shell`.

This PR tries to smooth the migration by throwing an error on such
shells in configs.

It may be better to warn instead of throwing an error, but at the same time you do not want users to be locked out of their machine because ssh thinks that their shell is invalid/not allowed.

The issue was raised by @Mic92 in @peterhoeg 's PR https://github.com/NixOS/nixpkgs/pull/47856#pullrequestreview-161473775 but was lost in the other comments and the migration to another PR.

###### Things done

- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

/cc @bobvanderlinden, @globin, @flokli for working on #51918