### PR TITLE
pythonPackages.worldengine: fix tests by moving nose to checkInputs 

### DIFF
--- a/pkgs/development/python-modules/worldengine/default.nix
+++ b/pkgs/development/python-modules/worldengine/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , buildPythonPackage
+, pythonOlder
 , fetchFromGitHub
 , nose
 , noise
@@ -33,7 +34,6 @@ buildPythonPackage rec {
     ln -s ${src-data} worldengine-data
   '';
 
-  buildInputs = [ nose ];
   propagatedBuildInputs = [ noise numpy pyplatec protobuf purepng h5py gdal ];
 
   prePatch = ''
@@ -46,9 +46,10 @@ buildPythonPackage rec {
       --replace 'PyPlatec==1.4.0' 'PyPlatec' \
   '';
 
-  doCheck = true;
-
-  postCheck = ''
+  # with python<3.5, unittest fails to discover tests because of their filenames
+  # so nose is used instead.
+  checkInputs = stdenv.lib.optional (pythonOlder "3.5") [ nose ];
+  postCheck = stdenv.lib.optionalString (pythonOlder "3.5") ''
     nosetests tests
   '';
 


### PR DESCRIPTION
###### Motivation for this change
~This is a draft PR because it sits on top of a required fix for `purepng` @ https://github.com/NixOS/nixpkgs/pull/60813, will rebase once that's merged.~ Done.

The tests are all actually `unittest` tests, it seems `nose` is only necessary on python <3.5 where the naming of the test modules causes `unittest` itself not to be able to pick them up.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
