### PR TITLE
chromium: add useOzone and 'chromiumOzone' variant

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -21,10 +21,12 @@
 # optional dependencies
 , libgcrypt ? null # gnomeSupport || cupsSupport
 , libva ? null # useVaapi
+, libxkbcommon, libdrm, wayland # useOzone
 
 # package customization
 , enableNaCl ? false
 , useVaapi ? false
+, useOzone ? false
 , gnomeSupport ? false, gnome ? null
 , gnomeKeyringSupport ? false, libgnome-keyring3 ? null
 , proprietaryCodecs ? true
@@ -130,6 +132,7 @@ let
       ++ optionals cupsSupport [ libgcrypt cups ]
       ++ optional useVaapi libva
       ++ optional pulseSupport libpulseaudio
+      ++ optionals useOzone [ libxkbcommon libdrm wayland ]
       ++ optional (versionAtLeast version "72") jdk.jre;
 
     patches = [
@@ -267,6 +270,14 @@ let
       ffmpeg_branding = "Chrome";
     } // optionalAttrs useVaapi {
       use_vaapi = true;
+    } // optionalAttrs useOzone {
+      use_ozone = true;
+      use_system_minigbm = true;
+      ozone_auto_platforms = false;
+      ozone_platform = "wayland";
+      ozone_platform_wayland = true;
+      ozone_platform_x11 = true;
+      ozone_platform_headless = true;
     } // optionalAttrs pulseSupport {
       use_pulseaudio = true;
       link_pulseaudio = true;

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -2,6 +2,7 @@
 , makeWrapper, ed
 , glib, gtk3, gnome3, gsettings-desktop-schemas
 , libva ? null
+, libglvnd ? null
 , gcc, nspr, nss, patchelfUnstable, runCommand
 , lib
 
@@ -14,6 +15,7 @@
 , enablePepperFlash ? false
 , enableWideVine ? false
 , useVaapi ? false # test video on radeon, before enabling this
+, useOzone ? false
 , cupsSupport ? true
 , pulseSupport ? config.pulseaudio or stdenv.isLinux
 , commandLineArgs ? ""
@@ -36,7 +38,7 @@ in let
     mkChromiumDerivation = callPackage ./common.nix {
       inherit enableNaCl gnomeSupport gnome
               gnomeKeyringSupport proprietaryCodecs cupsSupport pulseSupport
-              useVaapi;
+              useVaapi useOzone;
     };
 
     browser = callPackage ./browser.nix { inherit channel enableWideVine; };
@@ -141,6 +143,7 @@ in stdenv.mkDerivation {
     getWrapperFlags = plugin: "$(< \"${plugin}/nix-support/wrapper-flags\")";
     libPath = stdenv.lib.makeLibraryPath ([]
       ++ stdenv.lib.optional useVaapi libva
+      ++ stdenv.lib.optional useOzone libglvnd
     );
 
   in with stdenv.lib; ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17730,6 +17730,8 @@ in
 
   chromiumDev = lowPrio (chromium.override { channel = "dev"; });
 
+  chromiumOzone = lowPrio (chromium.override { channel = "dev"; useOzone = true; });
+
   chuck = callPackage ../applications/audio/chuck {
     inherit (darwin.apple_sdk.frameworks) AppKit Carbon CoreAudio CoreMIDI CoreServices Kernel;
   };


### PR DESCRIPTION
###### Motivation for this change

Since I did this, apparently talked about it on HN, and someone asked in IRC, I figured I'd send this.

This adds a new chromium variant that enables Ozone and builds relevant ozone backends.

Last time I built it, it wasn't really usable due to where upstream is at with Wayland support. Furthermore, the HiDPI handling is pretty completely broken still.

NOTE: I could use some advice on how to instruct Hydra to not build this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
