### PR TITLE
nix.systemFeatures: minor fix

### DIFF
--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -498,7 +498,7 @@ in
           "broadwell"      = [ "gccarch-westmere" "gccarch-sandybridge" "gccarch-ivybridge" "gccarch-haswell" ];
           "skylake"        = [ "gccarch-westmere" "gccarch-sandybridge" "gccarch-ivybridge" "gccarch-haswell" "gccarch-broadwell" ];
           "skylake-avx512" = [ "gccarch-westmere" "gccarch-sandybridge" "gccarch-ivybridge" "gccarch-haswell" "gccarch-broadwell" "gccarch-skylake" ];
-        }.${pkgs.hostPlatform.platform.gcc.arch}
+        }.${pkgs.hostPlatform.platform.gcc.arch} or []
       )
     );
 


### PR DESCRIPTION
following up #59148
I forgot the default case of the architectures which do not have minor brothers whose code they can run ("westmere" or any of AMDs)
