### PR TITLE
platform.gcc.arch: support for AMD CPUs

### DIFF
--- a/lib/systems/architectures.nix
+++ b/lib/systems/architectures.nix
@@ -43,13 +43,13 @@ rec {
     skylake-avx512 = [ "skylake"     ] ++ inferiors.skylake;
     # x86_64 AMD
     btver1         = [ ];
-    btver2         = [ ];
-    bdver1         = [ ];
-    bdver2         = [ ];
-    bdver3         = [ ];
-    bdver4         = [ ];
-    znver1         = [ ];
-    znver2         = [ ];
+    btver2         = [ ]; # TODO: fill this (need testing)
+    bdver1         = [ ]; # TODO: fill this (need testing)
+    bdver2         = [ ]; # TODO: fill this (need testing)
+    bdver3         = [ ]; # TODO: fill this (need testing)
+    bdver4         = [ ]; # TODO: fill this (need testing)
+    znver1         = [ ]; # TODO: fill this (need testing)
+    znver2         = [ ]; # TODO: fill this (need testing)
     # other
     armv5te        = [ ];
     armv6          = [ ];

--- a/lib/systems/architectures.nix
+++ b/lib/systems/architectures.nix
@@ -35,12 +35,12 @@ rec {
     # x86_64 Intel
     default        = [ ];
     westmere       = [ ];
-    sandybridge    = [ "westmere" ];
-    ivybridge      = [ "westmere" "sandybridge" ];
-    haswell        = [ "westmere" "sandybridge" "ivybridge" ];
-    broadwell      = [ "westmere" "sandybridge" "ivybridge" "haswell" ];
-    skylake        = [ "westmere" "sandybridge" "ivybridge" "haswell" "broadwell" ];
-    skylake-avx512 = [ "westmere" "sandybridge" "ivybridge" "haswell" "broadwell" "skylake" ];
+    sandybridge    = [ "westmere"    ] ++ inferiors.westmere;
+    ivybridge      = [ "sandybridge" ] ++ inferiors.sandybridge;
+    haswell        = [ "ivybridge"   ] ++ inferiors.ivybridge;
+    broadwell      = [ "haswell"     ] ++ inferiors.haswell;
+    skylake        = [ "broadwell"   ] ++ inferiors.broadwell;
+    skylake-avx512 = [ "skylake"     ] ++ inferiors.skylake;
     # x86_64 AMD
     btver1         = [ ];
     btver2         = [ ];

--- a/lib/systems/architectures.nix
+++ b/lib/systems/architectures.nix
@@ -59,8 +59,9 @@ rec {
     loongson2f     = [ ];
   };
 
-  predicates = rec {
+  predicates = let
     featureSupport = feature: x: builtins.elem feature features.${x};
+  in {
     sse3Support    = featureSupport "sse3";
     ssse3Support   = featureSupport "ssse3";
     sse4_1Support  = featureSupport "sse4_1";

--- a/lib/systems/architectures.nix
+++ b/lib/systems/architectures.nix
@@ -1,0 +1,75 @@
+{ lib }:
+
+rec {
+  # platform.gcc.arch to its features (as in /proc/cpuinfo)
+  features = {
+    default        = [ ];
+    # x86_64 Intel
+    westmere       = [ "sse3" "ssse3" "sse4_1" "sse4_2"         "aes"                                    ];
+    sandybridge    = [ "sse3" "ssse3" "sse4_1" "sse4_2"         "aes" "avx"                              ];
+    ivybridge      = [ "sse3" "ssse3" "sse4_1" "sse4_2"         "aes" "avx"                              ];
+    haswell        = [ "sse3" "ssse3" "sse4_1" "sse4_2"         "aes" "avx" "avx2"          "fma"        ];
+    broadwell      = [ "sse3" "ssse3" "sse4_1" "sse4_2"         "aes" "avx" "avx2"          "fma"        ];
+    skylake        = [ "sse3" "ssse3" "sse4_1" "sse4_2"         "aes" "avx" "avx2"          "fma"        ];
+    skylake-avx512 = [ "sse3" "ssse3" "sse4_1" "sse4_2"         "aes" "avx" "avx2" "avx512" "fma"        ];
+    # x86_64 AMD
+    btver1         = [ "sse3" "ssse3" "sse4_1" "sse4_2"                                                  ];
+    btver2         = [ "sse3" "ssse3" "sse4_1" "sse4_2"         "aes" "avx"                              ];
+    bdver1         = [ "sse3" "ssse3" "sse4_1" "sse4_2" "sse4a" "aes" "avx"                 "fma" "fma4" ];
+    bdver2         = [ "sse3" "ssse3" "sse4_1" "sse4_2" "sse4a" "aes" "avx"                 "fma" "fma4" ];
+    bdver3         = [ "sse3" "ssse3" "sse4_1" "sse4_2" "sse4a" "aes" "avx"                 "fma" "fma4" ];
+    bdver4         = [ "sse3" "ssse3" "sse4_1" "sse4_2" "sse4a" "aes" "avx" "avx2"          "fma" "fma4" ];
+    znver1         = [ "sse3" "ssse3" "sse4_1" "sse4_2" "sse4a" "aes" "avx" "avx2"          "fma"        ];
+    znver2         = [ "sse3" "ssse3" "sse4_1" "sse4_2" "sse4a" "aes" "avx" "avx2"          "fma"        ];
+    # other
+    armv5te        = [ ];
+    armv6          = [ ];
+    armv7-a        = [ ];
+    armv8-a        = [ ];
+    mips32         = [ ];
+    loongson2f     = [ ];
+  };
+
+  # a superior CPU has all the features of an inferior and is able to build and test code for it
+  inferiors = {
+    # x86_64 Intel
+    default        = [ ];
+    westmere       = [ ];
+    sandybridge    = [ "westmere" ];
+    ivybridge      = [ "westmere" "sandybridge" ];
+    haswell        = [ "westmere" "sandybridge" "ivybridge" ];
+    broadwell      = [ "westmere" "sandybridge" "ivybridge" "haswell" ];
+    skylake        = [ "westmere" "sandybridge" "ivybridge" "haswell" "broadwell" ];
+    skylake-avx512 = [ "westmere" "sandybridge" "ivybridge" "haswell" "broadwell" "skylake" ];
+    # x86_64 AMD
+    btver1         = [ ];
+    btver2         = [ ];
+    bdver1         = [ ];
+    bdver2         = [ ];
+    bdver3         = [ ];
+    bdver4         = [ ];
+    znver1         = [ ];
+    znver2         = [ ];
+    # other
+    armv5te        = [ ];
+    armv6          = [ ];
+    armv7-a        = [ ];
+    armv8-a        = [ ];
+    mips32         = [ ];
+    loongson2f     = [ ];
+  };
+
+  predicates = {
+    sse3Support    = x: builtins.elem "sse3"   features.${x};
+    ssse3Support   = x: builtins.elem "ssse3"  features.${x};
+    sse4_1Support  = x: builtins.elem "sse4_1" features.${x};
+    sse4_2Support  = x: builtins.elem "sse4_2" features.${x};
+    sse4_aSupport  = x: builtins.elem "sse4a"  features.${x};
+    avxSupport     = x: builtins.elem "avx"    features.${x};
+    avx2Support    = x: builtins.elem "avx2"   features.${x};
+    avx512Support  = x: builtins.elem "avx512" features.${x};
+    aesSupport     = x: builtins.elem "aes"    features.${x};
+    fmaSupport     = x: builtins.elem "fma"    features.${x};
+    fma4Support    = x: builtins.elem "fma4"   features.${x};
+  };
+}

--- a/lib/systems/architectures.nix
+++ b/lib/systems/architectures.nix
@@ -59,17 +59,18 @@ rec {
     loongson2f     = [ ];
   };
 
-  predicates = {
-    sse3Support    = x: builtins.elem "sse3"   features.${x};
-    ssse3Support   = x: builtins.elem "ssse3"  features.${x};
-    sse4_1Support  = x: builtins.elem "sse4_1" features.${x};
-    sse4_2Support  = x: builtins.elem "sse4_2" features.${x};
-    sse4_aSupport  = x: builtins.elem "sse4a"  features.${x};
-    avxSupport     = x: builtins.elem "avx"    features.${x};
-    avx2Support    = x: builtins.elem "avx2"   features.${x};
-    avx512Support  = x: builtins.elem "avx512" features.${x};
-    aesSupport     = x: builtins.elem "aes"    features.${x};
-    fmaSupport     = x: builtins.elem "fma"    features.${x};
-    fma4Support    = x: builtins.elem "fma4"   features.${x};
+  predicates = rec {
+    featureSupport = feature: x: builtins.elem feature features.${x};
+    sse3Support    = featureSupport "sse3";
+    ssse3Support   = featureSupport "ssse3";
+    sse4_1Support  = featureSupport "sse4_1";
+    sse4_2Support  = featureSupport "sse4_2";
+    sse4_aSupport  = featureSupport "sse4a";
+    avxSupport     = featureSupport "avx";
+    avx2Support    = featureSupport "avx2";
+    avx512Support  = featureSupport "avx512";
+    aesSupport     = featureSupport "aes";
+    fmaSupport     = featureSupport "fma";
+    fma4Support    = featureSupport "fma4";
   };
 }

--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -7,6 +7,7 @@ rec {
   inspect = import ./inspect.nix { inherit lib; };
   platforms = import ./platforms.nix { inherit lib; };
   examples = import ./examples.nix { inherit lib; };
+  architectures = import ./architectures.nix { inherit lib; };
 
   # Elaborate a `localSystem` or `crossSystem` so that it contains everything
   # necessary.
@@ -125,6 +126,7 @@ rec {
         else throw "Don't know how to run ${final.config} executables.";
 
     } // mapAttrs (n: v: v final.parsed) inspect.predicates
+      // mapAttrs (n: v: v final.platform.gcc.arch or "default") architectures.predicates
       // args;
   in assert final.useAndroidPrebuilt -> final.isAndroid;
      assert lib.foldl

--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -594,7 +594,7 @@ in
 
     nix.systemFeatures = mkDefault (
       [ "nixos-test" "benchmark" "big-parallel" "kvm" ] ++
-      optionals (pkgs.stdenv.isx86_64 && pkgs.hostPlatform.platform ? gcc.arch) (
+      optionals (pkgs.hostPlatform.platform ? gcc.arch) (
         # a x86_64 builder can run code for `platform.gcc.arch` and inferior architectures:
         [ "gccarch-${pkgs.hostPlatform.platform.gcc.arch}" ] ++ map (x: "gccarch-${x}") lib.systems.architectures.inferiors.${pkgs.hostPlatform.platform.gcc.arch}
       )

--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -595,15 +595,8 @@ in
     nix.systemFeatures = mkDefault (
       [ "nixos-test" "benchmark" "big-parallel" "kvm" ] ++
       optionals (pkgs.stdenv.isx86_64 && pkgs.hostPlatform.platform ? gcc.arch) (
-        # a x86_64 builder can run code for `platform.gcc.arch` and minor architectures:
-        [ "gccarch-${pkgs.hostPlatform.platform.gcc.arch}" ] ++ {
-          sandybridge    = [ "gccarch-westmere" ];
-          ivybridge      = [ "gccarch-westmere" "gccarch-sandybridge" ];
-          haswell        = [ "gccarch-westmere" "gccarch-sandybridge" "gccarch-ivybridge" ];
-          broadwell      = [ "gccarch-westmere" "gccarch-sandybridge" "gccarch-ivybridge" "gccarch-haswell" ];
-          skylake        = [ "gccarch-westmere" "gccarch-sandybridge" "gccarch-ivybridge" "gccarch-haswell" "gccarch-broadwell" ];
-          skylake-avx512 = [ "gccarch-westmere" "gccarch-sandybridge" "gccarch-ivybridge" "gccarch-haswell" "gccarch-broadwell" "gccarch-skylake" ];
-        }.${pkgs.hostPlatform.platform.gcc.arch} or []
+        # a x86_64 builder can run code for `platform.gcc.arch` and inferior architectures:
+        [ "gccarch-${pkgs.hostPlatform.platform.gcc.arch}" ] ++ map (x: "gccarch-${x}") lib.systems.architectures.inferiors.${pkgs.hostPlatform.platform.gcc.arch}
       )
     );
 

--- a/nixos/modules/services/misc/nix-daemon.nix
+++ b/nixos/modules/services/misc/nix-daemon.nix
@@ -595,8 +595,9 @@ in
     nix.systemFeatures = mkDefault (
       [ "nixos-test" "benchmark" "big-parallel" "kvm" ] ++
       optionals (pkgs.hostPlatform.platform ? gcc.arch) (
-        # a x86_64 builder can run code for `platform.gcc.arch` and inferior architectures:
-        [ "gccarch-${pkgs.hostPlatform.platform.gcc.arch}" ] ++ map (x: "gccarch-${x}") lib.systems.architectures.inferiors.${pkgs.hostPlatform.platform.gcc.arch}
+        # a builder can run code for `platform.gcc.arch` and inferior architectures
+        [ "gccarch-${pkgs.hostPlatform.platform.gcc.arch}" ] ++
+        map (x: "gccarch-${x}") lib.systems.architectures.inferiors.${pkgs.hostPlatform.platform.gcc.arch}
       )
     );
 

--- a/pkgs/applications/science/math/nauty/default.nix
+++ b/pkgs/applications/science/math/nauty/default.nix
@@ -10,15 +10,13 @@ stdenv.mkDerivation rec {
     sha256 = "1nym0p2djws8ylkpr0kgpxfa6fxdlh46cmvz0gn5vd02jzgs0aww";
   };
   outputs = [ "out" "dev" ];
-  configureFlags = {
+  configureFlags = [
     # Prevent nauty from sniffing some cpu features. While those are very
     # widely available, it can lead to nasty bugs when they are not available:
     # https://groups.google.com/forum/#!topic/sage-packaging/Pe4SRDNYlhA
-    default        = [ "--disable-clz" "--disable-popcnt" ];
-    westmere       = [ "--disable-clz" ];
-    sandybridge    = [ "--disable-clz" ];
-    ivybridge      = [ "--disable-clz" ];
-  }.${stdenv.hostPlatform.platform.gcc.arch or "default"} or [];
+    "--${if stdenv.hostPlatform.sse4_2Support then "enable" else "disable"}-popcnt"
+    "--${if stdenv.hostPlatform.sse4_aSupport then "enable" else "disable"}-clz"
+  ];
   installPhase = ''
     mkdir -p "$out"/{bin,share/doc/nauty} "$dev"/{lib,include/nauty}
 

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -72,6 +72,7 @@ let
         knm            = versionAtLeast ccVersion "8.0";
         # AMD
         znver1         = versionAtLeast ccVersion "6.0";
+        znver2         = versionAtLeast ccVersion "9.0";
       }.${arch} or true
     else if isClang then
       { # Intel
@@ -81,6 +82,7 @@ let
         knm            = versionAtLeast ccVersion "7.0";
         # AMD
         znver1         = versionAtLeast ccVersion "4.0";
+        znver2         = versionAtLeast ccVersion "9.0";
       }.${arch} or true
     else
       false;

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -63,18 +63,24 @@ let
   # older compilers (for example bootstrap's GCC 5) fail with -march=too-modern-cpu
   isGccArchSupported = arch:
     if isGNU then
-      { skylake        = versionAtLeast ccVersion "6.0";
+      { # Intel
+        skylake        = versionAtLeast ccVersion "6.0";
         skylake-avx512 = versionAtLeast ccVersion "6.0";
         cannonlake     = versionAtLeast ccVersion "8.0";
         icelake-client = versionAtLeast ccVersion "8.0";
         icelake-server = versionAtLeast ccVersion "8.0";
         knm            = versionAtLeast ccVersion "8.0";
+        # AMD
+        znver1         = versionAtLeast ccVersion "6.0";
       }.${arch} or true
     else if isClang then
-      { cannonlake     = versionAtLeast ccVersion "5.0";
+      { # Intel
+        cannonlake     = versionAtLeast ccVersion "5.0";
         icelake-client = versionAtLeast ccVersion "7.0";
         icelake-server = versionAtLeast ccVersion "7.0";
         knm            = versionAtLeast ccVersion "7.0";
+        # AMD
+        znver1         = versionAtLeast ccVersion "4.0";
       }.${arch} or true
     else
       false;

--- a/pkgs/development/interpreters/j/default.nix
+++ b/pkgs/development/interpreters/j/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, readline, libedit, bc
-, avxSupport ? false
+, avxSupport ? builtins.elem (stdenv.hostPlatform.platform.gcc.arch or "default") [ "sandybridge" "ivybridge" "haswell" "broadwell" "skylake" "skylake-avx512" "btver2" "bdver1" "bdver2" "bdver3" "bdver4" "znver1"]
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/interpreters/j/default.nix
+++ b/pkgs/development/interpreters/j/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, readline, libedit, bc
-, avxSupport ? builtins.elem (stdenv.hostPlatform.platform.gcc.arch or "default") [ "sandybridge" "ivybridge" "haswell" "broadwell" "skylake" "skylake-avx512" "btver2" "bdver1" "bdver2" "bdver3" "bdver4" "znver1"]
+, avxSupport ? stdenv.hostPlatform.avxSupport
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/development/libraries/dlib/default.nix
+++ b/pkgs/development/libraries/dlib/default.nix
@@ -2,7 +2,7 @@
 , guiSupport ? false, libX11
 
   # see http://dlib.net/compile.html
-, avxSupport ? builtins.elem (stdenv.hostPlatform.platform.gcc.arch or "default") [ "sandybridge" "ivybridge" "haswell" "broadwell" "skylake" "skylake-avx512" "btver2" "bdver1" "bdver2" "bdver3" "bdver4" "znver1"]
+, avxSupport ? stdenv.hostPlatform.avxSupport
 , cudaSupport ? true
 }:
 

--- a/pkgs/development/libraries/dlib/default.nix
+++ b/pkgs/development/libraries/dlib/default.nix
@@ -2,7 +2,7 @@
 , guiSupport ? false, libX11
 
   # see http://dlib.net/compile.html
-, avxSupport ? true
+, avxSupport ? builtins.elem (stdenv.hostPlatform.platform.gcc.arch or "default") [ "sandybridge" "ivybridge" "haswell" "broadwell" "skylake" "skylake-avx512" "btver2" "bdver1" "bdver2" "bdver3" "bdver4" "znver1"]
 , cudaSupport ? true
 }:
 
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     rm -rf dlib/external
   '';
 
-  cmakeFlags = [ 
+  cmakeFlags = [
     "-DUSE_DLIB_USE_CUDA=${if cudaSupport then "1" else "0"}"
     "-DUSE_AVX_INSTRUCTIONS=${if avxSupport then "yes" else "no"}" ];
 

--- a/pkgs/development/libraries/fflas-ffpack/default.nix
+++ b/pkgs/development/libraries/fflas-ffpack/default.nix
@@ -35,13 +35,22 @@ stdenv.mkDerivation rec {
     # disable SIMD instructions (which are enabled *when available* by default)
     # for now we need to be careful to disable *all* relevant versions of an instruction set explicitly (https://github.com/linbox-team/fflas-ffpack/issues/284)
     default        = [ "--disable-sse3" "--disable-ssse3" "--disable-sse41" "--disable-sse42" "--disable-avx" "--disable-avx2" "--disable-avx512f" "--disable-avx512dq" "--disable-avx512vl" "--disable-fma" "--disable-fma4" ];
+    # Intel
     westmere       = [                                                                        "--disable-avx" "--disable-avx2" "--disable-avx512f" "--disable-avx512dq" "--disable-avx512vl" "--disable-fma" "--disable-fma4" ];
     sandybridge    = [                                                                                        "--disable-avx2" "--disable-avx512f" "--disable-avx512dq" "--disable-avx512vl" "--disable-fma" "--disable-fma4" ];
     ivybridge      = [                                                                                        "--disable-avx2" "--disable-avx512f" "--disable-avx512dq" "--disable-avx512vl" "--disable-fma" "--disable-fma4" ];
-    haswell        = [                                                                                                                                                                       "--disable-fma4" ];
-    broadwell      = [                                                                                                                                                                       "--disable-fma4" ];
-    skylake        = [                                                                                                                                                                       "--disable-fma4" ];
-    skylake-avx512 = [                                                                                                                                                                       "--disable-fma4" ];
+    haswell        = [                                                                                                                                                                                       "--disable-fma4" ];
+    broadwell      = [                                                                                                                                                                                       "--disable-fma4" ];
+    skylake        = [                                                                                                                                                                                       "--disable-fma4" ];
+    skylake-avx512 = [                                                                                                                                                                                       "--disable-fma4" ];
+    # AMD
+    btver1         = [                                                                        "--disable-avx" "--disable-avx2" "--disable-avx512f" "--disable-avx512dq" "--disable-avx512vl" "--disable-fma" "--disable-fma4" ];
+    btver2         = [                                                                                        "--disable-avx2"                                                               "--disable-fma" "--disable-fma4" ];
+    bdver1         = [                                                                                        "--disable-avx2" "--disable-avx512f" "--disable-avx512dq" "--disable-avx512vl"                                  ];
+    bdver2         = [                                                                                        "--disable-avx2" "--disable-avx512f" "--disable-avx512dq" "--disable-avx512vl"                                  ];
+    bdver3         = [                                                                                        "--disable-avx2" "--disable-avx512f" "--disable-avx512dq" "--disable-avx512vl"                                  ];
+    bdver4         = [                                                                                                                                                                                                        ];
+    znver1         = [                                                                                                                                                                                       "--disable-fma4" ];
   }.${stdenv.hostPlatform.platform.gcc.arch or "default"};
 
   doCheck = true;

--- a/pkgs/development/libraries/fflas-ffpack/default.nix
+++ b/pkgs/development/libraries/fflas-ffpack/default.nix
@@ -31,28 +31,21 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--with-blas-libs=-lcblas"
     "--with-lapack-libs=-llapacke"
-  ] ++ stdenv.lib.optionals stdenv.isx86_64 {
+  ] ++ stdenv.lib.optionals stdenv.isx86_64 [
     # disable SIMD instructions (which are enabled *when available* by default)
     # for now we need to be careful to disable *all* relevant versions of an instruction set explicitly (https://github.com/linbox-team/fflas-ffpack/issues/284)
-    default        = [ "--disable-sse3" "--disable-ssse3" "--disable-sse41" "--disable-sse42" "--disable-avx" "--disable-avx2" "--disable-avx512f" "--disable-avx512dq" "--disable-avx512vl" "--disable-fma" "--disable-fma4" ];
-    # Intel
-    westmere       = [                                                                        "--disable-avx" "--disable-avx2" "--disable-avx512f" "--disable-avx512dq" "--disable-avx512vl" "--disable-fma" "--disable-fma4" ];
-    sandybridge    = [                                                                                        "--disable-avx2" "--disable-avx512f" "--disable-avx512dq" "--disable-avx512vl" "--disable-fma" "--disable-fma4" ];
-    ivybridge      = [                                                                                        "--disable-avx2" "--disable-avx512f" "--disable-avx512dq" "--disable-avx512vl" "--disable-fma" "--disable-fma4" ];
-    haswell        = [                                                                                                                                                                                       "--disable-fma4" ];
-    broadwell      = [                                                                                                                                                                                       "--disable-fma4" ];
-    skylake        = [                                                                                                                                                                                       "--disable-fma4" ];
-    skylake-avx512 = [                                                                                                                                                                                       "--disable-fma4" ];
-    # AMD
-    btver1         = [                                                                        "--disable-avx" "--disable-avx2" "--disable-avx512f" "--disable-avx512dq" "--disable-avx512vl" "--disable-fma" "--disable-fma4" ];
-    btver2         = [                                                                                        "--disable-avx2"                                                               "--disable-fma" "--disable-fma4" ];
-    bdver1         = [                                                                                        "--disable-avx2" "--disable-avx512f" "--disable-avx512dq" "--disable-avx512vl"                                  ];
-    bdver2         = [                                                                                        "--disable-avx2" "--disable-avx512f" "--disable-avx512dq" "--disable-avx512vl"                                  ];
-    bdver3         = [                                                                                        "--disable-avx2" "--disable-avx512f" "--disable-avx512dq" "--disable-avx512vl"                                  ];
-    bdver4         = [                                                                                                                                                                                                        ];
-    znver1         = [                                                                                                                                                                                       "--disable-fma4" ];
-  }.${stdenv.hostPlatform.platform.gcc.arch or "default"};
-
+    "--${if stdenv.hostPlatform.sse3Support   then "enable" else "disable"}-sse3"
+    "--${if stdenv.hostPlatform.ssse3Support  then "enable" else "disable"}-ssse3"
+    "--${if stdenv.hostPlatform.sse4_1Support then "enable" else "disable"}-sse41"
+    "--${if stdenv.hostPlatform.sse4_2Support then "enable" else "disable"}-sse42"
+    "--${if stdenv.hostPlatform.avxSupport    then "enable" else "disable"}-avx"
+    "--${if stdenv.hostPlatform.avx2Support   then "enable" else "disable"}-avx2"
+    "--${if stdenv.hostPlatform.avx512Support then "enable" else "disable"}-avx512f"
+    "--${if stdenv.hostPlatform.avx512Support then "enable" else "disable"}-avx512dq"
+    "--${if stdenv.hostPlatform.avx512Support then "enable" else "disable"}-avx512vl"
+    "--${if stdenv.hostPlatform.fmaSupport    then "enable" else "disable"}-fma"
+    "--${if stdenv.hostPlatform.fma4Support   then "enable" else "disable"}-fma4"
+  ];
   doCheck = true;
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/g2o/default.nix
+++ b/pkgs/development/libraries/g2o/default.nix
@@ -27,16 +27,13 @@ mkDerivation rec {
     # Detection script is broken
     "-DQGLVIEWER_INCLUDE_DIR=${libqglviewer}/include/QGLViewer"
     "-DG2O_BUILD_EXAMPLES=OFF"
-  ] ++ lib.optionals stdenv.isx86_64 ([ "-DDO_SSE_AUTODETECT=OFF" ] ++ {
-    default        = [ "-DDISABLE_SSE3=ON" "-DDISABLE_SSE4_1=ON" "-DDISABLE_SSE4_2=ON" "-DDISABLE_SSE4_A=ON" ];
-    westmere       = [                                                                 "-DDISABLE_SSE4_A=ON" ];
-    sandybridge    = [                                                                 "-DDISABLE_SSE4_A=ON" ];
-    ivybridge      = [                                                                 "-DDISABLE_SSE4_A=ON" ];
-    haswell        = [                                                                 "-DDISABLE_SSE4_A=ON" ];
-    broadwell      = [                                                                 "-DDISABLE_SSE4_A=ON" ];
-    skylake        = [                                                                 "-DDISABLE_SSE4_A=ON" ];
-    skylake-avx512 = [                                                                 "-DDISABLE_SSE4_A=ON" ];
-  }.${stdenv.hostPlatform.platform.gcc.arch or "default"});
+  ] ++ lib.optionals stdenv.isx86_64 [
+    "-DDO_SSE_AUTODETECT=OFF"
+    "-DDISABLE_SSE3=${  if stdenv.hostPlatform.sse3Support   then "OFF" else "ON"}"
+    "-DDISABLE_SSE4_1=${if stdenv.hostPlatform.sse4_1Support then "OFF" else "ON"}"
+    "-DDISABLE_SSE4_2=${if stdenv.hostPlatform.sse4_2Support then "OFF" else "ON"}"
+    "-DDISABLE_SSE4_A=${if stdenv.hostPlatform.sse4_aSupport then "OFF" else "ON"}"
+  ];
 
   meta = with lib; {
     description = "A General Framework for Graph Optimization";

--- a/pkgs/development/libraries/givaro/default.nix
+++ b/pkgs/development/libraries/givaro/default.nix
@@ -17,26 +17,17 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--disable-optimization"
-  ] ++ stdenv.lib.optionals stdenv.isx86_64 {
+  ] ++ stdenv.lib.optionals stdenv.isx86_64 [
     # disable SIMD instructions (which are enabled *when available* by default)
-    default        = [ "--disable-sse3" "--disable-ssse3" "--disable-sse41" "--disable-sse42" "--disable-avx" "--disable-avx2" "--disable-fma" "--disable-fma4" ];
-    # Intel
-    westmere       = [                                                                        "--disable-avx" "--disable-avx2" "--disable-fma" "--disable-fma4" ];
-    sandybridge    = [                                                                                        "--disable-avx2" "--disable-fma" "--disable-fma4" ];
-    ivybridge      = [                                                                                        "--disable-avx2" "--disable-fma" "--disable-fma4" ];
-    haswell        = [                                                                                                                         "--disable-fma4" ];
-    broadwell      = [                                                                                                                         "--disable-fma4" ];
-    skylake        = [                                                                                                                         "--disable-fma4" ];
-    skylake-avx512 = [                                                                                                                         "--disable-fma4" ];
-    # AMD
-    btver1         = [                                                                        "--disable-avx" "--disable-avx2" "--disable-fma" "--disable-fma4" ];
-    btver2         = [                                                                                        "--disable-avx2" "--disable-fma" "--disable-fma4" ];
-    bdver1         = [                                                                                        "--disable-avx2"                                  ];
-    bdver2         = [                                                                                        "--disable-avx2"                                  ];
-    bdver3         = [                                                                                        "--disable-avx2"                                  ];
-    bdver4         = [                                                                                                                                          ];
-    znver1         = [                                                                                                                         "--disable-fma4" ];
-  }.${stdenv.hostPlatform.platform.gcc.arch or "default"};
+    "--${if stdenv.hostPlatform.sse3Support   then "enable" else "disable"}-sse3"
+    "--${if stdenv.hostPlatform.ssse3Support  then "enable" else "disable"}-ssse3"
+    "--${if stdenv.hostPlatform.sse4_1Support then "enable" else "disable"}-sse41"
+    "--${if stdenv.hostPlatform.sse4_2Support then "enable" else "disable"}-sse42"
+    "--${if stdenv.hostPlatform.avxSupport    then "enable" else "disable"}-avx"
+    "--${if stdenv.hostPlatform.avx2Support   then "enable" else "disable"}-avx2"
+    "--${if stdenv.hostPlatform.fmaSupport    then "enable" else "disable"}-fma"
+    "--${if stdenv.hostPlatform.fma4Support   then "enable" else "disable"}-fma4"
+  ];
 
   # On darwin, tests are linked to dylib in the nix store, so we need to make
   # sure tests run after installPhase.

--- a/pkgs/development/libraries/givaro/default.nix
+++ b/pkgs/development/libraries/givaro/default.nix
@@ -20,6 +20,7 @@ stdenv.mkDerivation rec {
   ] ++ stdenv.lib.optionals stdenv.isx86_64 {
     # disable SIMD instructions (which are enabled *when available* by default)
     default        = [ "--disable-sse3" "--disable-ssse3" "--disable-sse41" "--disable-sse42" "--disable-avx" "--disable-avx2" "--disable-fma" "--disable-fma4" ];
+    # Intel
     westmere       = [                                                                        "--disable-avx" "--disable-avx2" "--disable-fma" "--disable-fma4" ];
     sandybridge    = [                                                                                        "--disable-avx2" "--disable-fma" "--disable-fma4" ];
     ivybridge      = [                                                                                        "--disable-avx2" "--disable-fma" "--disable-fma4" ];
@@ -27,6 +28,14 @@ stdenv.mkDerivation rec {
     broadwell      = [                                                                                                                         "--disable-fma4" ];
     skylake        = [                                                                                                                         "--disable-fma4" ];
     skylake-avx512 = [                                                                                                                         "--disable-fma4" ];
+    # AMD
+    btver1         = [                                                                        "--disable-avx" "--disable-avx2" "--disable-fma" "--disable-fma4" ];
+    btver2         = [                                                                                        "--disable-avx2" "--disable-fma" "--disable-fma4" ];
+    bdver1         = [                                                                                        "--disable-avx2"                                  ];
+    bdver2         = [                                                                                        "--disable-avx2"                                  ];
+    bdver3         = [                                                                                        "--disable-avx2"                                  ];
+    bdver4         = [                                                                                                                                          ];
+    znver1         = [                                                                                                                         "--disable-fma4" ];
   }.${stdenv.hostPlatform.platform.gcc.arch or "default"};
 
   # On darwin, tests are linked to dylib in the nix store, so we need to make

--- a/pkgs/development/libraries/linbox/default.nix
+++ b/pkgs/development/libraries/linbox/default.nix
@@ -42,6 +42,7 @@ stdenv.mkDerivation rec {
   ] ++ stdenv.lib.optionals stdenv.isx86_64 {
     # disable SIMD instructions (which are enabled *when available* by default)
     default        = [ "--disable-sse3" "--disable-ssse3" "--disable-sse41" "--disable-sse42" "--disable-avx" "--disable-avx2" "--disable-fma" "--disable-fma4" ];
+    # Intel
     westmere       = [                                                                        "--disable-avx" "--disable-avx2" "--disable-fma" "--disable-fma4" ];
     sandybridge    = [                                                                                        "--disable-avx2" "--disable-fma" "--disable-fma4" ];
     ivybridge      = [                                                                                        "--disable-avx2" "--disable-fma" "--disable-fma4" ];
@@ -49,6 +50,14 @@ stdenv.mkDerivation rec {
     broadwell      = [                                                                                                                         "--disable-fma4" ];
     skylake        = [                                                                                                                         "--disable-fma4" ];
     skylake-avx512 = [                                                                                                                         "--disable-fma4" ];
+    # AMD
+    btver1         = [                                                                        "--disable-avx" "--disable-avx2" "--disable-fma" "--disable-fma4" ];
+    btver2         = [                                                                                        "--disable-avx2" "--disable-fma" "--disable-fma4" ];
+    bdver1         = [                                                                                        "--disable-avx2"                                  ];
+    bdver2         = [                                                                                        "--disable-avx2"                                  ];
+    bdver3         = [                                                                                        "--disable-avx2"                                  ];
+    bdver4         = [                                                                                                                                          ];
+    znver1         = [                                                                                                                         "--disable-fma4" ];
   }.${stdenv.hostPlatform.platform.gcc.arch or "default"}
   ++ stdenv.lib.optionals withSage [
     "--enable-sage"

--- a/pkgs/development/libraries/linbox/default.nix
+++ b/pkgs/development/libraries/linbox/default.nix
@@ -39,27 +39,17 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--with-blas-libs=-lblas"
     "--disable-optimization"
-  ] ++ stdenv.lib.optionals stdenv.isx86_64 {
+  ] ++ stdenv.lib.optionals stdenv.isx86_64 [
     # disable SIMD instructions (which are enabled *when available* by default)
-    default        = [ "--disable-sse3" "--disable-ssse3" "--disable-sse41" "--disable-sse42" "--disable-avx" "--disable-avx2" "--disable-fma" "--disable-fma4" ];
-    # Intel
-    westmere       = [                                                                        "--disable-avx" "--disable-avx2" "--disable-fma" "--disable-fma4" ];
-    sandybridge    = [                                                                                        "--disable-avx2" "--disable-fma" "--disable-fma4" ];
-    ivybridge      = [                                                                                        "--disable-avx2" "--disable-fma" "--disable-fma4" ];
-    haswell        = [                                                                                                                         "--disable-fma4" ];
-    broadwell      = [                                                                                                                         "--disable-fma4" ];
-    skylake        = [                                                                                                                         "--disable-fma4" ];
-    skylake-avx512 = [                                                                                                                         "--disable-fma4" ];
-    # AMD
-    btver1         = [                                                                        "--disable-avx" "--disable-avx2" "--disable-fma" "--disable-fma4" ];
-    btver2         = [                                                                                        "--disable-avx2" "--disable-fma" "--disable-fma4" ];
-    bdver1         = [                                                                                        "--disable-avx2"                                  ];
-    bdver2         = [                                                                                        "--disable-avx2"                                  ];
-    bdver3         = [                                                                                        "--disable-avx2"                                  ];
-    bdver4         = [                                                                                                                                          ];
-    znver1         = [                                                                                                                         "--disable-fma4" ];
-  }.${stdenv.hostPlatform.platform.gcc.arch or "default"}
-  ++ stdenv.lib.optionals withSage [
+    "--${if stdenv.hostPlatform.sse3Support   then "enable" else "disable"}-sse3"
+    "--${if stdenv.hostPlatform.ssse3Support  then "enable" else "disable"}-ssse3"
+    "--${if stdenv.hostPlatform.sse4_1Support then "enable" else "disable"}-sse41"
+    "--${if stdenv.hostPlatform.sse4_2Support then "enable" else "disable"}-sse42"
+    "--${if stdenv.hostPlatform.avxSupport    then "enable" else "disable"}-avx"
+    "--${if stdenv.hostPlatform.avx2Support   then "enable" else "disable"}-avx2"
+    "--${if stdenv.hostPlatform.fmaSupport    then "enable" else "disable"}-fma"
+    "--${if stdenv.hostPlatform.fma4Support   then "enable" else "disable"}-fma4"
+  ] ++ stdenv.lib.optionals withSage [
     "--enable-sage"
   ];
 

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -259,6 +259,7 @@ stdenv.mkDerivation {
       then [ "-no-sse2" ]
       else lib.optionals (compareVersion "5.9.0" >= 0) {
         default        = [ "-sse2" "-no-sse3" "-no-ssse3" "-no-sse4.1" "-no-sse4.2" "-no-avx" "-no-avx2" ];
+        # Intel
         westmere       = [ "-sse2"    "-sse3"    "-ssse3"    "-sse4.1"    "-sse4.2" "-no-avx" "-no-avx2" ];
         sandybridge    = [ "-sse2"    "-sse3"    "-ssse3"    "-sse4.1"    "-sse4.2"    "-avx" "-no-avx2" ];
         ivybridge      = [ "-sse2"    "-sse3"    "-ssse3"    "-sse4.1"    "-sse4.2"    "-avx" "-no-avx2" ];
@@ -266,6 +267,14 @@ stdenv.mkDerivation {
         broadwell      = [ "-sse2"    "-sse3"    "-ssse3"    "-sse4.1"    "-sse4.2"    "-avx"    "-avx2" ];
         skylake        = [ "-sse2"    "-sse3"    "-ssse3"    "-sse4.1"    "-sse4.2"    "-avx"    "-avx2" ];
         skylake-avx512 = [ "-sse2"    "-sse3"    "-ssse3"    "-sse4.1"    "-sse4.2"    "-avx"    "-avx2" ];
+        # AMD
+        btver1         = [ "-sse2"    "-sse3"    "-ssse3"    "-sse4.1"    "-sse4.2" "-no-avx" "-no-avx2" ];
+        btver2         = [ "-sse2"    "-sse3"    "-ssse3"    "-sse4.1"    "-sse4.2"    "-avx" "-no-avx2" ];
+        bdver1         = [ "-sse2"    "-sse3"    "-ssse3"    "-sse4.1"    "-sse4.2"    "-avx" "-no-avx2" ];
+        bdver2         = [ "-sse2"    "-sse3"    "-ssse3"    "-sse4.1"    "-sse4.2"    "-avx" "-no-avx2" ];
+        bdver3         = [ "-sse2"    "-sse3"    "-ssse3"    "-sse4.1"    "-sse4.2"    "-avx" "-no-avx2" ];
+        bdver4         = [ "-sse2"    "-sse3"    "-ssse3"    "-sse4.1"    "-sse4.2"    "-avx"    "-avx2" ];
+        znver1         = [ "-sse2"    "-sse3"    "-ssse3"    "-sse4.1"    "-sse4.2"    "-avx"    "-avx2" ];
       }.${stdenv.hostPlatform.platform.gcc.arch or "default"}
     )
     ++ [

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -255,27 +255,18 @@ stdenv.mkDerivation {
       "-no-warnings-are-errors"
     ]
     ++ (
-      if (!stdenv.hostPlatform.isx86_64)
-      then [ "-no-sse2" ]
-      else lib.optionals (compareVersion "5.9.0" >= 0) {
-        default        = [ "-sse2" "-no-sse3" "-no-ssse3" "-no-sse4.1" "-no-sse4.2" "-no-avx" "-no-avx2" ];
-        # Intel
-        westmere       = [ "-sse2"    "-sse3"    "-ssse3"    "-sse4.1"    "-sse4.2" "-no-avx" "-no-avx2" ];
-        sandybridge    = [ "-sse2"    "-sse3"    "-ssse3"    "-sse4.1"    "-sse4.2"    "-avx" "-no-avx2" ];
-        ivybridge      = [ "-sse2"    "-sse3"    "-ssse3"    "-sse4.1"    "-sse4.2"    "-avx" "-no-avx2" ];
-        haswell        = [ "-sse2"    "-sse3"    "-ssse3"    "-sse4.1"    "-sse4.2"    "-avx"    "-avx2" ];
-        broadwell      = [ "-sse2"    "-sse3"    "-ssse3"    "-sse4.1"    "-sse4.2"    "-avx"    "-avx2" ];
-        skylake        = [ "-sse2"    "-sse3"    "-ssse3"    "-sse4.1"    "-sse4.2"    "-avx"    "-avx2" ];
-        skylake-avx512 = [ "-sse2"    "-sse3"    "-ssse3"    "-sse4.1"    "-sse4.2"    "-avx"    "-avx2" ];
-        # AMD
-        btver1         = [ "-sse2"    "-sse3"    "-ssse3"    "-sse4.1"    "-sse4.2" "-no-avx" "-no-avx2" ];
-        btver2         = [ "-sse2"    "-sse3"    "-ssse3"    "-sse4.1"    "-sse4.2"    "-avx" "-no-avx2" ];
-        bdver1         = [ "-sse2"    "-sse3"    "-ssse3"    "-sse4.1"    "-sse4.2"    "-avx" "-no-avx2" ];
-        bdver2         = [ "-sse2"    "-sse3"    "-ssse3"    "-sse4.1"    "-sse4.2"    "-avx" "-no-avx2" ];
-        bdver3         = [ "-sse2"    "-sse3"    "-ssse3"    "-sse4.1"    "-sse4.2"    "-avx" "-no-avx2" ];
-        bdver4         = [ "-sse2"    "-sse3"    "-ssse3"    "-sse4.1"    "-sse4.2"    "-avx"    "-avx2" ];
-        znver1         = [ "-sse2"    "-sse3"    "-ssse3"    "-sse4.1"    "-sse4.2"    "-avx"    "-avx2" ];
-      }.${stdenv.hostPlatform.platform.gcc.arch or "default"}
+      if (!stdenv.hostPlatform.isx86_64) then [
+        "-no-sse2"
+      ] else if (compareVersion "5.9.0" >= 0) then [
+        "-sse2"
+        "${if stdenv.hostPlatform.sse3Support   then "" else "-no"}-sse3"
+        "${if stdenv.hostPlatform.ssse3Support  then "" else "-no"}-ssse3"
+        "${if stdenv.hostPlatform.sse4_1Support then "" else "-no"}-sse4.1"
+        "${if stdenv.hostPlatform.sse4_2Support then "" else "-no"}-sse4.2"
+        "${if stdenv.hostPlatform.avxSupport    then "" else "-no"}-avx"
+        "${if stdenv.hostPlatform.avx2Support   then "" else "-no"}-avx2"
+      ] else [
+      ]
     )
     ++ [
       "-no-mips_dsp"

--- a/pkgs/development/python-modules/dlib/default.nix
+++ b/pkgs/development/python-modules/dlib/default.nix
@@ -1,4 +1,6 @@
-{ buildPythonPackage, dlib, python, pytest, more-itertools, avxSupport ? true, lib }:
+{ buildPythonPackage, lib, dlib, python, pytest, more-itertools,
+  avxSupport ? builtins.elem (stdenv.hostPlatform.platform.gcc.arch or "default") [ "sandybridge" "ivybridge" "haswell" "broadwell" "skylake" "skylake-avx512" "btver2" "bdver1" "bdver2" "bdver3" "bdver4" "znver1"]
+}:
 
 buildPythonPackage {
   inherit (dlib) name src nativeBuildInputs buildInputs meta;

--- a/pkgs/development/python-modules/dlib/default.nix
+++ b/pkgs/development/python-modules/dlib/default.nix
@@ -1,5 +1,5 @@
-{ buildPythonPackage, lib, dlib, python, pytest, more-itertools,
-  avxSupport ? builtins.elem (stdenv.hostPlatform.platform.gcc.arch or "default") [ "sandybridge" "ivybridge" "haswell" "broadwell" "skylake" "skylake-avx512" "btver2" "bdver1" "bdver2" "bdver3" "bdver4" "znver1"]
+{ buildPythonPackage, stdenv, lib, dlib, python, pytest, more-itertools
+, avxSupport ? stdenv.hostPlatform.avxSupport
 }:
 
 buildPythonPackage {

--- a/pkgs/development/python-modules/tensorflow/1/default.nix
+++ b/pkgs/development/python-modules/tensorflow/1/default.nix
@@ -23,9 +23,9 @@
 , xlaSupport ? cudaSupport
 # Default from ./configure script
 , cudaCapabilities ? [ "3.5" "5.2" ]
-, sse42Support ? builtins.elem (stdenv.hostPlatform.platform.gcc.arch or "default") ["westmere" "sandybridge" "ivybridge" "haswell" "broadwell" "skylake" "skylake-avx512"]
-, avx2Support  ? builtins.elem (stdenv.hostPlatform.platform.gcc.arch or "default") [                                     "haswell" "broadwell" "skylake" "skylake-avx512"]
-, fmaSupport   ? builtins.elem (stdenv.hostPlatform.platform.gcc.arch or "default") [                                     "haswell" "broadwell" "skylake" "skylake-avx512"]
+, sse42Support ? builtins.elem (stdenv.hostPlatform.platform.gcc.arch or "default") ["westmere" "sandybridge" "ivybridge" "haswell" "broadwell" "skylake" "skylake-avx512" "btver2" "bdver1" "bdver2" "bdver3" "bdver4" "znver1"]
+, avx2Support  ? builtins.elem (stdenv.hostPlatform.platform.gcc.arch or "default") [                                     "haswell" "broadwell" "skylake" "skylake-avx512"                                     "bdver4" "znver1"]
+, fmaSupport   ? builtins.elem (stdenv.hostPlatform.platform.gcc.arch or "default") [                                     "haswell" "broadwell" "skylake" "skylake-avx512"                   "bdver2" "bdver3" "bdver4" "znver1"]
 # Darwin deps
 , Foundation, Security
 }:

--- a/pkgs/development/python-modules/tensorflow/1/default.nix
+++ b/pkgs/development/python-modules/tensorflow/1/default.nix
@@ -23,9 +23,9 @@
 , xlaSupport ? cudaSupport
 # Default from ./configure script
 , cudaCapabilities ? [ "3.5" "5.2" ]
-, sse42Support ? builtins.elem (stdenv.hostPlatform.platform.gcc.arch or "default") ["westmere" "sandybridge" "ivybridge" "haswell" "broadwell" "skylake" "skylake-avx512" "btver2" "bdver1" "bdver2" "bdver3" "bdver4" "znver1"]
-, avx2Support  ? builtins.elem (stdenv.hostPlatform.platform.gcc.arch or "default") [                                     "haswell" "broadwell" "skylake" "skylake-avx512"                                     "bdver4" "znver1"]
-, fmaSupport   ? builtins.elem (stdenv.hostPlatform.platform.gcc.arch or "default") [                                     "haswell" "broadwell" "skylake" "skylake-avx512"                   "bdver2" "bdver3" "bdver4" "znver1"]
+, sse42Support ? stdenv.hostPlatform.sse4_2Support
+, avx2Support  ? stdenv.hostPlatform.avx2Support
+, fmaSupport   ? stdenv.hostPlatform.fmaSupport
 # Darwin deps
 , Foundation, Security
 }:

--- a/pkgs/development/python-modules/tensorflow/2/default.nix
+++ b/pkgs/development/python-modules/tensorflow/2/default.nix
@@ -23,9 +23,9 @@
 , xlaSupport ? cudaSupport
 # Default from ./configure script
 , cudaCapabilities ? [ "3.5" "5.2" ]
-, sse42Support ? builtins.elem (stdenv.hostPlatform.platform.gcc.arch or "default") ["westmere" "sandybridge" "ivybridge" "haswell" "broadwell" "skylake" "skylake-avx512"]
-, avx2Support  ? builtins.elem (stdenv.hostPlatform.platform.gcc.arch or "default") [                                     "haswell" "broadwell" "skylake" "skylake-avx512"]
-, fmaSupport   ? builtins.elem (stdenv.hostPlatform.platform.gcc.arch or "default") [                                     "haswell" "broadwell" "skylake" "skylake-avx512"]
+, sse42Support ? builtins.elem (stdenv.hostPlatform.platform.gcc.arch or "default") ["westmere" "sandybridge" "ivybridge" "haswell" "broadwell" "skylake" "skylake-avx512" "btver2" "bdver1" "bdver2" "bdver3" "bdver4" "znver1"]
+, avx2Support  ? builtins.elem (stdenv.hostPlatform.platform.gcc.arch or "default") [                                     "haswell" "broadwell" "skylake" "skylake-avx512"                                     "bdver4" "znver1"]
+, fmaSupport   ? builtins.elem (stdenv.hostPlatform.platform.gcc.arch or "default") [                                     "haswell" "broadwell" "skylake" "skylake-avx512"                   "bdver2" "bdver3" "bdver4" "znver1"]
 # Darwin deps
 , Foundation, Security
 }:

--- a/pkgs/development/python-modules/tensorflow/2/default.nix
+++ b/pkgs/development/python-modules/tensorflow/2/default.nix
@@ -23,9 +23,9 @@
 , xlaSupport ? cudaSupport
 # Default from ./configure script
 , cudaCapabilities ? [ "3.5" "5.2" ]
-, sse42Support ? builtins.elem (stdenv.hostPlatform.platform.gcc.arch or "default") ["westmere" "sandybridge" "ivybridge" "haswell" "broadwell" "skylake" "skylake-avx512" "btver2" "bdver1" "bdver2" "bdver3" "bdver4" "znver1"]
-, avx2Support  ? builtins.elem (stdenv.hostPlatform.platform.gcc.arch or "default") [                                     "haswell" "broadwell" "skylake" "skylake-avx512"                                     "bdver4" "znver1"]
-, fmaSupport   ? builtins.elem (stdenv.hostPlatform.platform.gcc.arch or "default") [                                     "haswell" "broadwell" "skylake" "skylake-avx512"                   "bdver2" "bdver3" "bdver4" "znver1"]
+, sse42Support ? stdenv.hostPlatform.sse4_2Support
+, avx2Support  ? stdenv.hostPlatform.avx2Support
+, fmaSupport   ? stdenv.hostPlatform.fmaSupport
 # Darwin deps
 , Foundation, Security
 }:

--- a/pkgs/servers/nosql/arangodb/default.nix
+++ b/pkgs/servers/nosql/arangodb/default.nix
@@ -32,15 +32,9 @@ let
       # do not set GCC's -march=xxx based on builder's /proc/cpuinfo
       "-DUSE_OPTIMIZE_FOR_ARCHITECTURE=OFF"
       # also avoid using builder's /proc/cpuinfo
-    ] ++
-    { westmere       = [ "-DHAVE_SSE42=ON" "-DASM_OPTIMIZATIONS=ON" ];
-      sandybridge    = [ "-DHAVE_SSE42=ON" "-DASM_OPTIMIZATIONS=ON" ];
-      ivybridge      = [ "-DHAVE_SSE42=ON" "-DASM_OPTIMIZATIONS=ON" ];
-      haswell        = [ "-DHAVE_SSE42=ON" "-DASM_OPTIMIZATIONS=ON" ];
-      broadwell      = [ "-DHAVE_SSE42=ON" "-DASM_OPTIMIZATIONS=ON" ];
-      skylake        = [ "-DHAVE_SSE42=ON" "-DASM_OPTIMIZATIONS=ON" ];
-      skylake-avx512 = [ "-DHAVE_SSE42=ON" "-DASM_OPTIMIZATIONS=ON" ];
-    }.${stdenv.hostPlatform.platform.gcc.arch or ""} or [ "-DHAVE_SSE42=OFF" "-DASM_OPTIMIZATIONS=OFF" ];
+      "-DHAVE_SSE42=${if stdenv.hostPlatform.sse4_2Support then "ON" else "OFF"}"
+      "-DASM_OPTIMIZATIONS=${if stdenv.hostPlatform.sse4_2Support then "ON" else "OFF"}"
+    ];
 
     enableParallelBuilding = true;
 

--- a/pkgs/tools/misc/cpuminer-multi/default.nix
+++ b/pkgs/tools/misc/cpuminer-multi/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchgit, curl, jansson, autoconf, automake
-, aesni ? true }:
+, aesni ? stdenv.hostPlatform.aesSupport }:
 
 let
   rev = "8393e03089c0abde61bd5d72aba8f926c3d6eca4";
@@ -28,6 +28,6 @@ stdenv.mkDerivation {
     license = licenses.gpl2;
     maintainers = [ maintainers.ehmry ];
     # does not build on i686 https://github.com/lucasjones/cpuminer-multi/issues/27
-    platforms = [ "x86_64-linux" ]; 
+    platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/tools/networking/i2pd/default.nix
+++ b/pkgs/tools/networking/i2pd/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub
 , boost, zlib, openssl
 , upnpSupport ? true, miniupnpc ? null
-, aesniSupport ? false
-, avxSupport ? false
+, aesniSupport ? builtins.elem (stdenv.hostPlatform.platform.gcc.arch or "default") [ "sandybridge" "ivybridge" "haswell" "broadwell" "skylake" "skylake-avx512" "btver2" "bdver1" "bdver2" "bdver3" "bdver4" "znver1"]
+, avxSupport   ? builtins.elem (stdenv.hostPlatform.platform.gcc.arch or "default") [ "sandybridge" "ivybridge" "haswell" "broadwell" "skylake" "skylake-avx512" "btver2" "bdver1" "bdver2" "bdver3" "bdver4" "znver1"]
 }:
 
 assert upnpSupport -> miniupnpc != null;

--- a/pkgs/tools/networking/i2pd/default.nix
+++ b/pkgs/tools/networking/i2pd/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub
 , boost, zlib, openssl
 , upnpSupport ? true, miniupnpc ? null
-, aesniSupport ? builtins.elem (stdenv.hostPlatform.platform.gcc.arch or "default") [ "sandybridge" "ivybridge" "haswell" "broadwell" "skylake" "skylake-avx512" "btver2" "bdver1" "bdver2" "bdver3" "bdver4" "znver1"]
-, avxSupport   ? builtins.elem (stdenv.hostPlatform.platform.gcc.arch or "default") [ "sandybridge" "ivybridge" "haswell" "broadwell" "skylake" "skylake-avx512" "btver2" "bdver1" "bdver2" "bdver3" "bdver4" "znver1"]
+, aesniSupport ? stdenv.hostPlatform.aesSupport
+, avxSupport   ? stdenv.hostPlatform.avxSupport
 }:
 
 assert upnpSupport -> miniupnpc != null;


### PR DESCRIPTION
support for AMD CPUs in ```localSystem.hostPlatform.platform.gcc.arch```

I have (or can rent) a test park of
 - [ ] ```AMD Opteron(tm) X2150 APU``` (corresponds to ```-march=btver2```)
 - [ ] ```AMD Opteron(tm) Processor 3365``` (corresponds to ```-march=bdver2```)
 - [ ] ```AMD EPYC 7401P 24-Core Processor``` (this one is problematic, ```-march=bdver4``` as well as ```-march=znver1``` enable too many features; the GCC flags should be either ```-march=bdver4 -mno-fma4 -mno-tbm -mno-xop -mno-lwp``` or ```-march=znver1 -mno-clzero mno-mwaitx -mno-xsaves```, which is impossible to set within constrains of #59225)
 - [x] ```AMD Ryzen 5 2400G with Radeon Vega Graphics``` (corresponds to ```-march=znver1```)

cc: @matthewbauer @7c6f434c

