### PR TITLE
cedille: fix hash

### DIFF
--- a/pkgs/applications/science/logic/cedille/default.nix
+++ b/pkgs/applications/science/logic/cedille/default.nix
@@ -1,8 +1,6 @@
 { stdenv
 , lib
 , fetchFromGitHub
-, fetchpatch
-, texinfo
 , alex
 , happy
 , Agda
@@ -19,11 +17,11 @@ stdenv.mkDerivation rec {
     owner = "cedille";
     repo = "cedille";
     rev = "v${version}";
-    sha256 = "17j7an5bharc8q1pj06615zmflipjdd0clf67cnfdhsmqwzf6l9r";
+    sha256 = "16pc72wz6kclq9yv2r8hx85mkp0s125h12snrhcjxkbl41xx2ynb";
     fetchSubmodules = true;
   };
 
-  nativeBuildInputs = [ texinfo alex happy ];
+  nativeBuildInputs = [ alex happy ];
   buildInputs = [ Agda (ghcWithPackages (ps: [ps.ieee])) ];
 
   LANG = "en_US.UTF-8";
@@ -31,25 +29,9 @@ stdenv.mkDerivation rec {
     lib.optionalString (buildPlatform.libc == "glibc")
       "${buildPackages.glibcLocales}/lib/locale/locale-archive";
 
-  patches = [
-    # texinfo direntry fix. See: https://github.com/cedille/cedille/pull/86
-    (fetchpatch {
-      url = "https://github.com/cedille/cedille/commit/c058f42179a635c7b6179772c30f0eba4ac53724.patch";
-      sha256 = "02qd86k5bdrygjzh2k0j0q5qk4nk2vwnsz7nvlssvysbvsmiba7x";
-    })
-  ];
-
   postPatch = ''
     patchShebangs create-libraries.sh
-    patchShebangs docs/src/compile-docs.sh
   '';
-
-  # We regenerate the info file in order to fix the direntry
-  preBuild = ''
-    rm -f docs/info/cedille-info-main.info
-  '';
-
-  buildFlags = [ "all" "cedille-docs" ];
 
   installPhase = ''
     install -Dm755 -t $out/bin/ cedille


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Cedille retagged v.1.1.1 https://github.com/cedille/cedille/releases/tag/v1.1.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
