### PR TITLE
pythonPackages.imread: 0.6 -> 0.7.0

### DIFF
--- a/pkgs/development/python-modules/imread/default.nix
+++ b/pkgs/development/python-modules/imread/default.nix
@@ -1,22 +1,28 @@
 { stdenv
 , buildPythonPackage
-, fetchurl
+, fetchPypi
 , nose
-, pkgs
+, pkgconfig
+, libjpeg
+, libpng
+, libtiff
+, libwebp
 , numpy
 }:
 
 buildPythonPackage rec {
   pname = "python-imread";
-  version = "0.6";
+  version = "0.7.0";
 
-  src = pkgs.fetchurl {
-    url = "https://github.com/luispedro/imread/archive/release-${version}.tar.gz";
-    sha256 = "0i14bc67200zhzxc41g5dfp2m0pr1zaa2gv59p2va1xw0ji2dc0f";
+  src = fetchPypi {
+    inherit version;
+    pname = "imread";
+    sha256 = "0yb0fmy6ilh5fvbk69wl2bzqgss2g0951668mx8z9yyj4jhr1z2y";
   };
 
-  nativeBuildInputs = [ pkgs.pkgconfig ];
-  buildInputs = [ nose pkgs.libjpeg pkgs.libpng pkgs.libtiff pkgs.libwebp ];
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ nose libjpeg libpng libtiff libwebp ];
   propagatedBuildInputs = [ numpy ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Mostly trivial update of version and hashes, but also explicitly use the
right dependencies

###### Motivation for this change

Updates imread to latest version.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
      - [x] other Linux distributions

