### PR TITLE
 firefox-bin: 66.0.3 -> 66.0.4,  firefox-esr: 60.6.1esr -> 60.6.2esr 

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,995 +1,995 @@
 {
-  version = "66.0.3";
+  version = "66.0.4";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/ach/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/ach/firefox-66.0.4.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "4aa9ae4e34aef99424ca5cd01dc3214d0091a0c419d54647a213e78182f0cb1529e2021b3cdb25b35565a52f04f2e9ec4122635dc49aee0e403cf5c0b480c507";
+      sha512 = "789ecf57dbca48a149a19d60e1a25ae5c1aff21d7ee4dd8e1cd40674f0ec29f891b7e90981e48dc69dc930212b7345ee0ec09f47e09cc8492112d2454fe4f5ad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/af/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/af/firefox-66.0.4.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "5fe5707286b531e23f31f7f80e8f25b08c0e51072494c88d426f4b088063a07a25d36e13182f08ce0a8f88f8abdade59e6f97b7186c89e0de3de463b5070d698";
+      sha512 = "2bc27408660e583abc67b78b05e88c2d8c75a71979bb286609b68d978ccacb2e5edc35494ede290389587b80e6ba3a27cc6bb8f1853fc58e8f138b873b36e2b0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/an/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/an/firefox-66.0.4.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "f58e0f1b026cb3225e8316249458777acf3528ca2da0843b7449abbb64e046f1e8b779a93c131fce99339c781e5d83dbdda321e0b8558e554f92518625292b18";
+      sha512 = "4d3b215c6517633e130a02fa468f92f93e366b645865699729cb4eb4d93fa638ad3a7dc9b15d927cf871412e9e4aef352e882d3804477c6b0d378b47445f325a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/ar/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/ar/firefox-66.0.4.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "bc72e88090fdedd5ca5ffe1b43df899f83e9eeacd3b9cea8f12cf53e6e3197644553fa3398c11c210178bf91efa3b52c17b9e24226c3dfae2a2096bac17e40ef";
+      sha512 = "931322aefdc370f4618d4a595d750840e2d9b573e870531bee97832a878e0ce4787947c09d06ab7d27319ae5e2e56a5a2e1f35a41ab91fe160f843eaa749e22d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/as/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/as/firefox-66.0.4.tar.bz2";
       locale = "as";
       arch = "linux-x86_64";
-      sha512 = "b408a63cdd34aba329b82980d3980ea449d1ceb4f05fe99cb8f502cee6e0d6e5eb974ab848929bc53323f4b725331df42c2c34426df67bb3bc1725de6cbdc975";
+      sha512 = "8b7ca252fb388aa6e29385e78e90f66b377ba1e0bff05f185e7b42aef38eda2bd833a24921cb3d497d68aac3e1b36604d9b9019af3e0a5c8dd6e074c134455f7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/ast/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/ast/firefox-66.0.4.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "3320205930f8b12bdbc618d6588a044b5670e1bc4370c5bff58fd26540561b6d9365bc79fa7084664019ed5d3e0371f135b1ed0906ae7ff3e61b10383bba1e31";
+      sha512 = "42f9447742379e80ec51c9604f002689598b66c6eb6948bd45c276aec6a61390a024aa11256263a4de358d9c219d80d0a784427bf446d63740529cd440d21263";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/az/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/az/firefox-66.0.4.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "6c733a65af52a081dc895bb3603fa1dbd96757da79822bc10378bbab0fda0ce8561b5be58db3282761afad786398186264b7e678efd1c7e7e5d48740cf34cc79";
+      sha512 = "1a27ceb32a711ae960c9637a3557a962142ec959590602a09459af46777477d0320283f6aa1c54015a73dacd3928297b5a1864a0237aa5bc6c48a50ccc7c1636";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/be/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/be/firefox-66.0.4.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "83558f99541aaa238508d7a751594b3ef319a0b7c0e2552856ba31e7bde54646fe70cf31d01433a3f5c605b43c6568d34862f70a49571ad14f68df51f36e3483";
+      sha512 = "f7b8ed7aa47d67d5d71e0887f66e89697add0af6a1de04bdc80d07c6c0c6f0adfcfdf2e1e6bc6194bd624ee8e442f0f0901b550b4621d40340e1e6c37b12f777";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/bg/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/bg/firefox-66.0.4.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "711c9f038a3838bb1e0a2d7ff1182ff16825e3b4bd8de03da41391774ba3fd5bd88882877961d625f796b2ab2c032cd928da7e06b25c3bbd1e4930805d78573f";
+      sha512 = "70066e04e0f1d5a55c09d19668c05123ebcfde74cbba0b1d685c23d48832ba8865576af4cdcaccfa587dd90c7e4cc8477d7397102482933f7fd98bad13260dca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/bn-BD/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/bn-BD/firefox-66.0.4.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "bca2117b3c5155a792d8b5c314bb825b8fca897a6419337ef0dbd64ea32c9c054fe11ecc7510aadbcc9e2242e807857d0c31728a47516c02a6a20009eda917f0";
+      sha512 = "2f31746734cab6b027c7f1503629bdfeb25c6ed8f1d597fbef7bccb0ba67ff02705e3bae74b4c9598bea7063b9e2819fadd582145e6eb81381820935ecacef5a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/bn-IN/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/bn-IN/firefox-66.0.4.tar.bz2";
       locale = "bn-IN";
       arch = "linux-x86_64";
-      sha512 = "139411d16b006279272fea37e8803c93096c7846d2c5be077cf4e0b0e00cbc820496720250c438f7f78b59f47774d77b6c16bf2d713ee2c4703e2ac5a7668ffe";
+      sha512 = "e80862cc2f26b76f7d77404ac693acd9086ff1169cebfbe28775c4199f79907503e034142e522f81fad67c2ae273513c969f4c4fe073ef87e8c619b5a55da950";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/br/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/br/firefox-66.0.4.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "462dbb9305813ef8c528f1b5665b7e27d790c00af40a83e7fc46da9c04dcea17125601cc8763dc3cdadfc4eb523723bb1c5b5b2ee8c3bed4be7d4644a20bdd6d";
+      sha512 = "e7602765bbd77f1e525579f4e20bb151d9201d072b323f9d3625aefe53808159faa4bf22b9ed9f57d85df75aff2a0246b6482d5880d5d9b5ba114e5f815fb3ba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/bs/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/bs/firefox-66.0.4.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "0a40bba9e04a7970f0c4c1b22032bc530facf90f32d3d8af6117d89b4e7118027d463d58441c4ba4913097959bafc8fb687d07945d74a26a6582b54fcc14f6a6";
+      sha512 = "ec5852bcbefaafd13879256e6c6d58ade9a825204f5bbbf01297e0c19de48ee72b47fe1dd26c9f00d4df8605563e8cdb9cfa314c1134bd17d5d4cb80f55b997b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/ca/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/ca/firefox-66.0.4.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "363fb5222734f98bad579fce6042832089737fa76d14072d887582989b0a944b70804b1c5e8cbccde01124d6e4b3cce3d2ce28c9d9d14825a76f3f116887e3e0";
+      sha512 = "7f119a513b64a61ba8f23adda7c8f3681fcdd66ce945bf9060ee4b0cfd2ec8550d55e820b177f896f2f5d43b538ffff10ebd1b2bd5840fc6ab026a7b2e93e3f9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/cak/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/cak/firefox-66.0.4.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "60491e41bf9887b09d72eabd184ee847f6a8c87a13f472a84d7d50aac4a44d3119a5dcbb3635e2ace369fe0e9331de47584bdc09b559a2445e911c094e71bef6";
+      sha512 = "52d73516f4e268410fa0bc0ddbde9cd8c1c70721aed1d28a750e98b2bb8ccfa425082ced20691c4f3074cefe2c7427e9b7ca931bdbf9100249b2aa385a5659b6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/cs/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/cs/firefox-66.0.4.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "66a39a0d2461b9157925c9eadf3d496ebbb43555e4b91d9f8d232ced6b78a71f623e8a02941ecf2a2c0a128d9cbe106c01c84a94358dcb1f8a5399fe17e77c5d";
+      sha512 = "583e6f3682e9126310b11e8ae515dc2a550291b9f6069ac8fbf568d8f0696e896d9b3a410d2ef13a1475e793214674d21e2c357b4acd5908ac6043c259b043d9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/cy/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/cy/firefox-66.0.4.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "ae680998cd82fd70de4ee55ecfca4b289d48d943ca193f1ff2a6d156c6142218542228bff5b429f68bfaadfbb0c43273c68eafce333fb1ab68f2cd6c092df235";
+      sha512 = "9deea20b92d1e8e48bbd0288959ffe8f9795221b4d57d1f2e92b0f6de65caa180684b5ea2354cc442bdd5941722be160b95a455ed7464a683906310459000d0e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/da/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/da/firefox-66.0.4.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "72715546481c63dcbb194a305c8ee1cda05d52d7da1c69ce3a755145e0127bb2118ff5cbcb04ccdfc7c8c7bf22e42feddab81e936b92f367a6198b09e7d803a7";
+      sha512 = "95b0e4aed159fe34cf925174f3ec20a14b296c27541f1aa2b369243261d305751415805321d02259512a18cc422bf0272f3b92d8918f03ccb65a9ff084315061";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/de/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/de/firefox-66.0.4.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "fe1abb6ec0a550a3c1bbc6fea96c26a4d848771dbe45ae75240017d1fd4397e2c80742f95a03223356b5374969eed83a3a92bc86e433cc1b85443e4e41136e0e";
+      sha512 = "dd21fa81e0e85188bcc61519bb4549bbfcb433f88677b79b91da5c3796df985e60b1dc1fec391a70813d61f1a902dd0eb69815c5d81d96a0937373b491d70cbd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/dsb/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/dsb/firefox-66.0.4.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "442fa757fc7f72a9b0b6b2a19dc72a87ec2cd24834378d2aa41788c1bd015f0eaf51acfe7769a4c5cd27d157c777d3b6e183dc134516ca0ebb0870fa667feade";
+      sha512 = "c7fcbf4e008f6c2ad9bfb5c37a57f257011a2eef811e5bfc28cdc05812283db5a69aa0167651dfe9df5dfec2aac74ba128d9bfc396ddda1475630b89e46cc6cf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/el/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/el/firefox-66.0.4.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "84995e7632805e78e2b9b710c8b42881dc071c51f6336c54e30b49640d3bb5284534167392665ed15b88b092cf55db174156ae5f8120324faa842f802790ee77";
+      sha512 = "889e9e88105d12523b0394d4ea8ff2dae753f560c624b2feff3a8c48640052e3dd871446b9b0b9832998d909f2c9cb5dbc0e03f3b099b940bf50779a9db44eed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/en-CA/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/en-CA/firefox-66.0.4.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha512 = "0b687a2271363be6c1458501ba8af8a9ea3f6279f07b89a70b9ed5dcfb0a406215621aa0d001309b823c267932877a2e9634aa14339340f7a259820f5a55c60b";
+      sha512 = "30e54bab160ec76f15c7d44b8ba8840204e297fc3cddd74cf35cb86c9a0677a54548feb3a4b6ab899b10abba142635faaa68888a6cc53ba0f6f9ee401338cb3b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/en-GB/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/en-GB/firefox-66.0.4.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "5a772190ee12a2d0d400f5aa91780ddfec29e4c2f867288e374880e4602efa747555b97ab40eedea5c812ee6f4fc2986bbd98c5f7c9054bd027490df4e9850bb";
+      sha512 = "2c9548a80d26ab338e662c4a2ccd02185afd6bb07812fb4d2118f0acac01dd32f759efcf6921942f6b7db144f293193554ed5678a9762220c9a7e997d9eaca1d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/en-US/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/en-US/firefox-66.0.4.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "bc585bcce2f44354db372c9f96ce5eadb5128c051f4afc95df5a38a68c4c6a8be1f20f7727fd030855d5dd0f36b00e28ce3af0b0b7bd20fb2e380034cd21d381";
+      sha512 = "938d9efd9a344ed755f26a2864d813f848f07907ecd795d74edb352ff44fc7cbf85d6d4bfd496a85a3bb6fb2ea1b14847705c627b40f1af53b49301708c3c1be";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/en-ZA/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/en-ZA/firefox-66.0.4.tar.bz2";
       locale = "en-ZA";
       arch = "linux-x86_64";
-      sha512 = "ed01d89a7fcfdcccd50712ad631fd9ef65630b23e3e6ab68b04aee28fa092cebd0a008f9f1e90a2a3152b03263db78ff6c6c3b67ed9f81c7ba6ff62656bdfee7";
+      sha512 = "2dac84bbed983f8638a9a9e92c217bec73b026eca7d66f585934ce4a89f21bd55b69804df00a61c9613de0c9e5fd331dacc01f3b08f36cf4489b86c85b05d688";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/eo/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/eo/firefox-66.0.4.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "8d38c8d9bce68051eecf89220e5b2c128dd2b5ce48107750139d1fa0bb836f3f583ff6dd8e776321dc0f6c72a8bceb262dd37562545f58a290cc42631f37c988";
+      sha512 = "82b4fc79e2fd0aa29e88570ed3b44967ea888a7df70c74fadacd929d7b64e86aac2abb7b92362fc607c858de5c8619c63267e7ceff951617517569df06accfe2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/es-AR/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/es-AR/firefox-66.0.4.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "d8824e9a261b662dbde83b4db3fbd1254a6de0721df7da7b77bba6eeff2306eb61198f35fce1fc1e4a8c8939d42f332ad8169cc6a27ee757af483e887599482c";
+      sha512 = "78fba3adce26eaaafb72a08a953ee8801c401b650a39c9ae4cac872a86456813976db0c7e98b4255b4b02525c1fca3f3ecb5df8f8d678cb60e29edf5e9d2e103";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/es-CL/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/es-CL/firefox-66.0.4.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "0b912fde247c288d718d7f75c1986c4196c787dbe3377101627338aaf45aa12eafff2fe7321a2bfef47bf3b7a16a8a3c6119ce330cbb577816df85885dfa952a";
+      sha512 = "3f59b8a28afc1255cece3534e639d4a9bbd48f4bdcdaf836b5c5a459d55599c3cdf84c8af45b30b9496f95afad11afa51364b2b0acf9cd08c561dc2f132347e2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/es-ES/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/es-ES/firefox-66.0.4.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "f7d7e0542f80bfdfb75592a938f1ce27b454d994f281a91a3baa922d5db55b9a40ea09c9dd03d9d3a61c62667fdac6e537a567865627277e7db2c855aec89f35";
+      sha512 = "7a01d61bfabf1bdbe9e485ce2cde726ccd3e937e8b951ae2b3cbbd1d7976cc010ac82202fda51f07cef5f0895ce5b53db506bf5d949967f2232c999b52b2d713";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/es-MX/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/es-MX/firefox-66.0.4.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "6f823f7bbb72440429d9c2e16f8e8ccc7a9df5dad199306cf8e5be96a994294b06a67c87bf232a3ede28bfd75bab42b6efa61f3535d6399fadc30c45a4e55af3";
+      sha512 = "6e1849aa7c85b099a61c616bea86f3b809c7ea464b85291415f590d7ea4953005db7ae2fa15417cad9ca0a6d66b17fc3447bca31d3579ce6573609580cde3cb7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/et/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/et/firefox-66.0.4.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "f03bd296e2cae8e28c44732cd05b34866fe6e6eea1b6072e1297f9a3e5ea62be8d6c9fb1da1cd0019f9e760a2a4fbcdcdf3c2b998e0d4a304d9372b5f2c6aea6";
+      sha512 = "2c119e3902073a150d3df9e1d458b155529a2c747f2c96508dd90a0efa73df0fccf7c36ca7e8438dbbc9e463567195d20ba9e4bc1b9a908b13aa4e6a43ef58ff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/eu/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/eu/firefox-66.0.4.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "1563e8e3de7c2c47fb2a3095bf9560c2a5fc79eada4ef89e1a53fcdc5b27f6902607aaca09bcf20d78e784fe2730722466f23ddbacc95687eca047cc25fcd9e7";
+      sha512 = "cc82250530f1a869ce578f05d76e835588e01b359a19748d1d418b9a0b16770878518fb492fe79108b1ade4c8b9ed780b61a6e414b89a1b259aed5eb73510b40";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/fa/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/fa/firefox-66.0.4.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "9eb2c3634d3c188b20cd30c61ea7517b710bc8abc703bfa33285a59c3922104b136f30978660de884089a923b5364226198d170a0c94d8262daa744cccc0576f";
+      sha512 = "bf990360a952060ee71f8f761ea893401775f317d3e1409444d26eeb3f7ed8f641b70226db1549ecac4550cabe8c19308fda99f494560c660afef4a886d27d3e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/ff/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/ff/firefox-66.0.4.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "05723ea64a84eaf5be466b1087a1a47b1fa86f4f0643bfeebfabf42c59fdf9ffa1613fe754f0c84c027b884e209ad90bc917806bca4da0d6bc8c3c7970de4144";
+      sha512 = "22213c96652c3f1dedf400281dfcec1aeda20661e8f9e24cc32d62585b70e3d09a2dd2537f09918a6a9550799162ae196a62158a2e1613f9ec23ea9191f3cd35";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/fi/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/fi/firefox-66.0.4.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "afd9ba38430f04d15508c45e5ba69d9e1ede7e967f57581457723873408ac4205b5caa2bb5b799144962c2735012fe60c778196a607989c629ffa77e3c8fdb76";
+      sha512 = "3b82fd86b0116eb36da8fc2ccebffce4bdb00ce549bd69264a7a837374241bf02f24b2196a4d2e80dd9b82a24674f74ec8035d3f6f252878d28ab9dda028545a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/fr/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/fr/firefox-66.0.4.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "11c83c09bbc02032f99cebe5c6df42f58eac90d16593218ea36f7f0a6c5afa7c2286372b5c187fbc66665f00b23a1b9fc10d773237be9324aceedffe8a9c242d";
+      sha512 = "db70c00d7c60083ca8880cf324f1f510d5ae66399b76790d6689e668aa6e7380ea263f0f5ab18a0ebdbcdb8ec66e1921b4a56540971cf2c641cc026293aeb885";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/fy-NL/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/fy-NL/firefox-66.0.4.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "fd1cc534781849e1af4159244affbb67b6a153a8de13a1bdd5c91ad0f2d4622e042ba67cc457bc293cd480dff120f084b89eec0bdb443c5dc86af1c05c720969";
+      sha512 = "14dea2ad6c8da49716adef7d20efe88933dc69ec7566c07c948c296d145b4b24268c0e08f0123605451699efbd758a3af2229c23d301c8b122cd99596624ff63";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/ga-IE/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/ga-IE/firefox-66.0.4.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "36abf4c99f93595e2e39ae5a5bab73407605ac6f8ba22b623558586b866766215bfef257a416183c8cf7ff13a58bb790ed72552707f994acf930e5a00d9ce324";
+      sha512 = "70110fa27b8cda7b0ffaf52f2931000d886be4763741ca71eb7ccd6b58ee1a0e1e82735599ed19519b4719dee0ef9d0bdcfb599ebbceb7663013f2d5e26bc848";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/gd/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/gd/firefox-66.0.4.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "48c68cdc63c78f37166dcbb144c7363fd27ba98c71c047a245c69a7e76750650f02964119c33d6aefef8114397fd2f2dc7860bb47247a19ffc0a6d850c64e8dd";
+      sha512 = "063f8ef3adfa83637fe15f89ad7b7baf0d9ebc7a54fd743f4b88637f4a29db925d459612c480205744136e6f99f84ff2aa755a58ac89877cce0ac0f93bca5d9f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/gl/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/gl/firefox-66.0.4.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "76a82f38f87fcb5c43cf3e7eedf807862f52febf6d354925fc37bbd9f109e6b8f655823c4c0badec050c8ed46c2c7ee5fb1985934473ee9eafafbaed86c22766";
+      sha512 = "79161f599ba4a916d8bd61b761067dbc3ae05ac4eb0345c941c87aabb826c5a41ce2f3d60dc91062d4e579826120c585e28e2b4364209852966267abdd3ec767";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/gn/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/gn/firefox-66.0.4.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "556b6f2b5e959571fdefb047c0d62ec85ca6160e9752bb579a0fc5c94174d70ca0febbd91429aa10c85c40d3643230531dd7c2594e49723a7eec58cc74e2d464";
+      sha512 = "5a9bde18ffc4f15875dccbff737122d199125e32f3805e904bde0e3b1eced173ababe00b3170f97b140e08861d27a63cc2aa9345231ab12e34785e17e390d3a5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/gu-IN/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/gu-IN/firefox-66.0.4.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "276f9fd0601f83ae9c5743df43c91cd1fd9cb6ac8d4d67c06b31f002a0c3875bbde567fa2b0522ee863c1f47f4effa15c62461ca11a30f71cf2a709b54ea1288";
+      sha512 = "4ab7a824d4da3c1cc5b5eadeb35132a0322c61f86d5c475e0632a0964ea529d3255313501186138848718f33b2ee62bce30952ca5418e7fce784c1e218f80452";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/he/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/he/firefox-66.0.4.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "72cdbb5359408a36f9b31ad7f03761c76f5a13a54b201a9df8cea712964b5b86b6b09e9ccc38bf2873361c7fabc7c96dae0fdb03e3ccf85b7e8025ed63978f57";
+      sha512 = "b552d54f6ae9ba1f565f7ffe86b68eb916a6f53566e8cb05b1a1a7e39ccc8cf38b941c11b25e07fdab9baee8c31f55f1611153609e873b15c36e00ef32ca9871";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/hi-IN/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/hi-IN/firefox-66.0.4.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "9af2079adabae3d7cf3517cf43969eac917ae50d36b1f7cad64b0ccaac2db06f1636dc96a071af08359f0fb0e51acfd9567e070508b9c3bdd02dfdbb8206f0c2";
+      sha512 = "aa39f47e5b56544ba826173048b60fb79723c0af2c93155ee7ec632741795c40cb38b445ca896543b0af2ad0307b2f5c4786b42be1cff992c240298e8786b9d0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/hr/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/hr/firefox-66.0.4.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "273a5732f53df6c69672e3eadd272d35a2421ef6391e360829c42196db33969de86e90dc95c9fbac65ad8647657bca69500a4876845d064a8f8dfad1c2301242";
+      sha512 = "9e4256069c4c094a04df85c899b00d27e5cff171c827c4946973c1f9f58d9fe158dae2f021dcc8e85aeca2ec9baf7ed11d5c8091b7c4705ce3dbeccb089b02c9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/hsb/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/hsb/firefox-66.0.4.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "13605134e7a95f04e8faa64c41babfa7f1b84fe1bb0410c17518e847a81b47ed16794f17b4e833175be79756b48868aacfe46bfdd5365c24ad47075c9f99e5bc";
+      sha512 = "65285b9abdb550dade0705ae530af879cabf9eb0953bf91c5e7485035eff20b4d97134f2ea280c8e7087aba3a6f9fa0f4b30443eb418aad400fe2ac110c56745";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/hu/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/hu/firefox-66.0.4.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "17637c96d5bb0e33c6bc3f8e58435a82a53b648b5d665dfd7a62b913ac3d04030379687e1c65b4a9ece119e92590ba0e141f1903236b623e2b398c2e00417d95";
+      sha512 = "ecfec8847285c14238605f12e29ae9e7fa0540162e08678bd35f20ec135c631df06e1c5cdd31349ab338491443a473b88e5f10bf5528299d4c655a787c94c5fe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/hy-AM/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/hy-AM/firefox-66.0.4.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "02067f5fa5d206c1c8d8392dcff21738f615f8bc77b44e038261cb3f6eacec7be102da3a0d52cefc280b0b71340be5b4ddd9b62524859da99b7554b3d52349c8";
+      sha512 = "e1b4e51a9bdd5b7a41fcad703ec674bc6b602edd94849be310889286bbc22948fcd6370da99c0481f2f4781077856e9766997431f3fe77f0b3d80194e36d76d4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/ia/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/ia/firefox-66.0.4.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha512 = "1195b5031dfdaa35507de6aef21446ace0e68279da0b128e5acacd98d42a09b97a9d1c34e7505cf76c116effb105090dfb623b79a9992e518481bac3121beab5";
+      sha512 = "084e8b0238b1ddc4c441cc8579f28315fdbd0e997eb7a9ea8413a3140a10366fa16b8a0c3e0c03312196af03b12015d498961a4b7673c82c8163b39d702f1ff7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/id/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/id/firefox-66.0.4.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "c6649b3d953f3f416d695a1eaf2aaacde12ce90dbed59f16b312118b1f09ebe98b5a905ff7f55b599166c947a57a8d902852520568dbd31d48f4464acdb3be56";
+      sha512 = "50e18367cd9cf31d9d3df3e31cc78c696e5578d7840c71af55935fed645b149b61c8843ae2f4bf25e2a9389b4ad8da9cb16b587c5c9fd912872e8baf4ade4f22";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/is/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/is/firefox-66.0.4.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "cd2da470396ba1966ee751aa644a7cfeed284dca10ce723805d7f9330bbf2b8b5e4c3c51e2c798b6654743d62d8d57fd3ebceffc3da55c38f8fac3a7d3732341";
+      sha512 = "fd4c9ae4081afafc51285bdce826e92329e8d506a71f649a73bbb2786532cb7929b7577e24f9ca92caee9d6bdb88783a842c55c2c446aae57663fcb6d563815a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/it/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/it/firefox-66.0.4.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "0fe8149fb6be846a6532ca7b1db8694900b431f3e4f8ab27c2d0785438baf6799df107b346ed2c814ce9b7f21671b22fe6246727ce83320199f72a3909ac541c";
+      sha512 = "070ebcbe345b96292d06f10d209144629344cf1b48070465f82ef6d974c648c83fd587a5d629b9fcecfac6c6dfe1e3c5cae4ff25d11518b5536f931bc6675da5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/ja/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/ja/firefox-66.0.4.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "1e7eb7798a2cab863986d95384021f8116dc949aedb3a121f887532d57f512756d6782614b623337f349ca27afcfb80545a450ee3af2a3872cc46cd657115208";
+      sha512 = "58842ab79b1aeff66c40fdb5a27cae809ed4082799301f1f718d695b46b389cf1b6416c26a5b05043778fdb6a7260e85a0080ed3dacc50da74350019643455d9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/ka/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/ka/firefox-66.0.4.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "e3191ecc3a6fa93515deecce972232cd064602c1f2a5f7c807f62ff691459d8f4cba494b33ece05c4662115616099a1232955091e4e647b3f74d6ee4f1b20ebd";
+      sha512 = "dffd3ca8e7530c0f563d7b8309956553b448da98bf6e9fa3ecc8492fa49485287432bb72127285edf6d80c52760dfaed8dc65ed6a48ebc5a4857b80c5e9728c9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/kab/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/kab/firefox-66.0.4.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "27130d1f1ebddec899eb91abd57c8adac8dce60dac6c66e8ae44419ea5924e3c9d46960746b96855c11f903e2dd59d483e9cadc0bc22a33f37faedea3f200fe8";
+      sha512 = "5e87256a8230356a382a4bea207d370e2d4939ae7f1e88ecd1a0afcd004d498e941be648ff12c4fb5912f009e6b192212a44dcc4b563d935699f82842fc16022";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/kk/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/kk/firefox-66.0.4.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "84b0e49645f9fb63f3455e43836778fe839dae24e9ccdcd950ff20dbb3d6258337fa489d22c6066bca71c0b827284459a52154ad037c1ba7ee5acb9e4c88b926";
+      sha512 = "f3a73bfab3e2f69fe366e73860eda64c94da004877a1ded9aa6c6b89d3d48d4dc3daf918036a811cce4a37c2ee2addebbe61f47c6379316a60980316c8c02c1f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/km/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/km/firefox-66.0.4.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "5f1219f19b112a811cba1585eeb99447d5c6f51c657a7f200a5f5620ed5ad849e16ca11e4bf82255f2045a36e9263ca4928a2d930f053cac4a507a748bd00896";
+      sha512 = "cc669ef1e7139ca3561557acbace0455c59c2333d375298d969ab22dd0663425791e3296729e98f514754fba9c119b15f8817835c9d053fb0fdd327baec184e6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/kn/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/kn/firefox-66.0.4.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "9375074fbc21d3d29fd01123c498b115195987c71583c431fdec621a59ffbfa2f2c64c2fa2ef0a2c5c78776c04f7f25777a3ebc0c1022c91d4072624793455b8";
+      sha512 = "b067a1850687a5194c57f1fe1b1ebc875e39d567162454fff8522c2c1c02d6ac7bdd7c23053e66c19552ac7239e95118eca3e93cbf5e74d9e400d61caa80a337";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/ko/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/ko/firefox-66.0.4.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "60e9a077cb23ab7192ea835a9cddc3ee1326b6bc7d2e6b53aad81eb3ad0c230df906628eee531f5fd4fc13b48f77b6c5a0c142cf149314c772bc0f081cc1060b";
+      sha512 = "43571dce5bcb5cd9c44cb6974cf7224e9d03bb9dd546d9b494e2e4126e6b91c3ff0fe7118fd2ddd2cdb3d1bfb96c4433c935d7af52c387cf03f33363f995a062";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/lij/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/lij/firefox-66.0.4.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "22df2f25d025f90571b4f14c92be175108ffbbfa6c34aef1ea8e906c1537e15838b3bc6ef00e4824df4f78840d092fee859ace906efc3526f4a41e60db8c26f1";
+      sha512 = "a8163716dd01731d8914d4f711466277e97107c4d62230319a85d251ac68e04a05554c402d3d29ce5a1d00ad69ecd285c0fe4412ce52e905f3a6c6cc9d8cbc98";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/lt/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/lt/firefox-66.0.4.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "6fd1a4742ba994bd65fd83c3936795d88a92655e6334837fbcc2efc8b4bb4fe75741f8dbe0c0aadf1b69e8a48577d7ef3c0322abd2c3fec3eddb09a098843c9b";
+      sha512 = "ebcc5d3f6eb5c458d27fbf8fefefda113cb6dc78eb6e6b243396aaa85bd7891f5d8aaa8978a81e40653cc73bb6fcdb16839a97f769e437f6c4a9d512ad1cfd48";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/lv/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/lv/firefox-66.0.4.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "4ce0f5a1cfb19f763567278b644fdb8a004bd7b4d65e85b46f2235c67dcb2b04f630f0988fef6d5d55e04ddbb8190fb187b0d81dcbf60ddb20629580007d9788";
+      sha512 = "6573e17058ca50a28751a62ccf87ba0542df55b53c4398a09d0752181cc442e57e967d060d3533af394dee4f122ee784d6ee6168ed2dca08855617121bc4a60e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/mai/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/mai/firefox-66.0.4.tar.bz2";
       locale = "mai";
       arch = "linux-x86_64";
-      sha512 = "c26bbf25d31eb551bd477b99cdfaa9670205b36562e211418ba110eda6f87e06880695620b840e1a767c98dc7c6311e9ee63f1e52c113bceb53f62ac5289c9a5";
+      sha512 = "1e92c29312c635f195a6f52c869f4b4593d9284a8e00c768bfc4490a69c09c69e604d514178e26a1f067a7348088e0022f7c4659c4193ac775261f402e72418a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/mk/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/mk/firefox-66.0.4.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "33893eb9cd5638c2d24403144301c6daf8a3fa4e76a30ce5027213e2a78ba906b73ab4c08e19a4b8b62cceb360263c1efddeb4ef848784ed19f846cbf5706478";
+      sha512 = "493d4ee0450a1a7c54aea2a2541d681a7b18be6f45fe2e9b97d41761e625cfaff4977ddb464dfb6587eb844c23bfcac04015da69d0f19b05b4afcbd42dbfd26c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/ml/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/ml/firefox-66.0.4.tar.bz2";
       locale = "ml";
       arch = "linux-x86_64";
-      sha512 = "397688afaacd32ae434e5e2ee338059d3333ba9e9f73c766960e0b424bbb7b634bbe0a7d1a09d51a3f41b83b4b466bc50dbd4e0658d8e8f21c59e3013c273240";
+      sha512 = "d00043f5b87edf4dbee22289c031a30d9b9b5d4b95ad63bb07c3196270da5fb2e14cc1ee853edc0f4d1de976f4da8f84a92f70fb319135bb6d2a5af21ea5d4b2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/mr/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/mr/firefox-66.0.4.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "885033de3913e8d6eee8e5fcef49166ebacbed5f344e930a809ba48ecb71a253575d52590def405ae0a48d76317d102559038e54b1164f1674c5910c40ca3e84";
+      sha512 = "ed41f4a7e8fed7fe60ee35406a5aea0050e8a3d687a0d4d97fbeb0b34e3593adec6d1b43e6e585e8cd94ee07213341c324289da264503a9c340d26e9cbd6b38f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/ms/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/ms/firefox-66.0.4.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "61e217ad17b4d27c68ad4f16ba07d8ebc059d6bbd1ce58489d65d8229589ad9fbb2a6dd378a8da338c419928247c12cc123f2fa70e6f97a67aec019fbc6939ab";
+      sha512 = "043d73907bee6e333cdd6d1e905cf61d0ff8f78953027dc09f2a845171e5d25c671d529cf2d16aec7b2aa39961482d13ae7c91e3e9cff664aab69f5e8f291a72";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/my/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/my/firefox-66.0.4.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha512 = "4f7ba2e7e59640db6c4d32ccf9c620c3c7895b0763da0e0dcf56b0777b6254a6c33a5d7f80ec3848d5d3f587e0387c9657db4f04ccb84dc08ad4341382feebae";
+      sha512 = "6e3d55ac4dcef62548f309df30853f8ee317d2bea1a1d774af4908e1abccf3cb31cc5dd2406829097b043412a40b8b81c8a87fe9433518e0d811b43a878f99cf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/nb-NO/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/nb-NO/firefox-66.0.4.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "6b43b1f00866ffcf059d4406c2186e18ceb7216ded302df42a5cdc2c5ec8fc154c9f8a3a7f37fa6865128ce2d788c9e4c1e3e43fd9ba8fa759ca414879693199";
+      sha512 = "681935d216c8607ea0f84cce21c1c88251eef0ed4e057f16faa6e485e9bbedc62ab05f1c31dbafc356c2923ec5b6b3d4fb3d74454647917c11896ed1a44f4e63";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/ne-NP/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/ne-NP/firefox-66.0.4.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha512 = "47a40aaa4992d953788ec4a2481705653acb8424f8fd11004ff24e9bb6ae8015e27d7610620940f36b5d0bf25a3c426ed3ce53b97e16fb891da3674c66f713c7";
+      sha512 = "8790899e58535c921b156b89cfaba61dc2d201d84faae066c0c89ab6b39aa6dd961125398ef139571f3ccfdf8c8ea0d1b8287e95bc0f90686569220909572b6c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/nl/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/nl/firefox-66.0.4.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "adca9015850c34ac1cc81dd441b2374bd83aef70914de377b3b9892e0be5cbccb52adfdc40c99db3906214adc5b33ae1885efa10ddf5f14ff958fff2b84bef4f";
+      sha512 = "cdc216a01b1953a313d8d353ca58150c46905dda9019007f04be93459054e57868e7a325792c9a5e5d0d83a3b6a577d60848739bfa908114e4c2189d1fac9978";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/nn-NO/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/nn-NO/firefox-66.0.4.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "bd47c8a559ad3c005ac3463cb1e3f600d67cce0f7f1b6d07722e37c5bb3a47e99699c8ba75c1173b5da626619fd535572fd58f21f01b57e2c5e54c68ae8a4810";
+      sha512 = "79fffbf0c1bfff145461427fb7fd3bd3805e197311b7bbf9915bc5f07ddfb8a66d2348637afbb74d25d70acd536b27464069d0536f0a471476620a76b4e188b3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/oc/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/oc/firefox-66.0.4.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha512 = "b43b79ee7331a0b13e9ac839fbba57a12c9375346ec0f56c0e873f4e14c4d4eada3346179ee6a4aef801039e3e8f890df3c5ef293a11893aed4a6e0aa6251b01";
+      sha512 = "39ace895dbbaf995fe48e7120ba2f400ec5c412b21cd4b6857fdf3ac86857db5b875459d6e4772269b24824ca7f7de1f13d2085b9ac5d6ded930d1afaef724e4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/or/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/or/firefox-66.0.4.tar.bz2";
       locale = "or";
       arch = "linux-x86_64";
-      sha512 = "306980db14e5c728257eafb79a095e1829130b2add9e7798d21f8cb1e0af80688466a809b945617588534de6f8fc0e9de8ad5b1eec3e2d2f1a41cbf580cb307f";
+      sha512 = "028650991e5d17e2626532e29470151a81258748a1f59da216dced05b2f9923fcf8b2b008e3385e954fc2b787e4b4db28703817726dffe1ee10f286acf03da86";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/pa-IN/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/pa-IN/firefox-66.0.4.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "d322060a28bae771316d36d0509e792babfc3d569f5fe9dd5c4e9a1a5da7391395475df6eea8a845932452016b2b8b69f5a745e53111c0cfc939022e73eea24c";
+      sha512 = "53c0c9c88a89d6613199da6a9912920a77cbbba87e5a324ccd3d52129cdc76c48cf26842c2b173308ed64d2bfda2b2019ce4ebccf0ff4ee2003db240a020beb4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/pl/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/pl/firefox-66.0.4.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "6a2cfe2969ba9a778ac604cc80b7418f233e6f87c649f48e2c584e21de874f3b5f6a2eb99669d40e8d091b9f559c7aac41ad513eada9a62bacab420569d9281b";
+      sha512 = "afbfaa5e03fd9559cbaf5d26427fffaafc51abf3ee7e7161cf1d33150a6729d598acae52990a452a628d6df7ecbb37910e1ce121472f169826ea698ad4a4cb58";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/pt-BR/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/pt-BR/firefox-66.0.4.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "5f1d94976c9f495f861881d61c65b51ce75509ee92b3c1b23ec7eeb7ca3c4280b1630e05f1b451a252713c988682e900663e98e4bd3656bfbce1574d9ecb0d6c";
+      sha512 = "46c152920c7f8cc36d845429a9e4c9213a114a965a79c069bd16214c104e29bdcdc014b8629d428a6cfd735327c89659f12dc4e84eb572c0663579a9b19bb858";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/pt-PT/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/pt-PT/firefox-66.0.4.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "2ab8a70d502b1d92842dd579f49e055a9f4c8f5548154579508230219b44f3d0c045331948257ba167aaa2e9e02aa702130289d20c492c508b3bf97eea9eb224";
+      sha512 = "f8052357068416fb3ee87547cb7714c3d59a719bba6e943158560e212062708e8a4bda202d3519f0b2f7fe0933d77edc7030694fb9a40d3269164c17ad46836e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/rm/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/rm/firefox-66.0.4.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "9dec6e52b55f2a5e7fd511b4efa0a237fddb62545441b9af9f3d3cd50fdb577b8f1c8eba0461258b20074f23d37e5a88f1ae4a2b7e7ad598e2c6624ab509aef6";
+      sha512 = "942bec7f8a913fe6f259c1c38af0773268776514453e741e455e0af3c9c2ea0fdca0926557b39e6f65dfe73867fa9de0ecd3c97a1876521651d82b7811e01c50";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/ro/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/ro/firefox-66.0.4.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "0e713fd4fc4c936124fb18c62e198790eaffe4b9e8956724f156f6445505cdc4b29bf463b4192d3868a56f7460f2574f3b9010d60cb2ea1b0bbb6a43c2156f5c";
+      sha512 = "16fc97cc0b16eb7bed5d0fa14f4584caf0a082b322cb59260eb5a1e7303d94d42e055db5c9b192d15e4ea3b515c3e38e6b6f7a421f2a97abdc7821264669f342";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/ru/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/ru/firefox-66.0.4.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "dbb1d1e62bbbb20adca252221c0a01dcf1f7f47eef94918076b57fc61062fbb5f936dbb6727c3c8b109b2d40983b716b389f78e091f1da1097f957f1451e00b3";
+      sha512 = "85b0f38dc56ceaca5ef633beb5303eea41b59112a9d96d839f681da46e41deb9c77b05fed578c6fa431eeb71b5af3117e2d6697f2636ba7bb373c17e5690f65f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/si/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/si/firefox-66.0.4.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "87c2e84635fdb44cf221f84f1fae161c3bb39c06c6c31b1b375f9aa1ee58d835d21fe2958dbd8916fd7dbb96bd8a707bba6fe7f15b83bb77b614d40828af0c5e";
+      sha512 = "e0aa9a503f830bc26f85df5ba952405df73e1b53bebe24198b0400d683f4194a4ca7fca26d89789c6ff347b954dc5e4c99ac2eb07f328985a61ba636f93b24c2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/sk/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/sk/firefox-66.0.4.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "7cc106554dbb7bf8d0f9dfabdd29d0c0d443b11e084f9db1b1d78e56fb5ae7c251c9d89bdfe02677d2d366c0c75f43b669cf6852abbec8dfc2d28c24f7f2c904";
+      sha512 = "231a8c4751839709a65133e7f643a8150468fe9b0760cce308895da47ea1e032f54848cda6ebac27813be3cdce09392e32c6cb1d08471f5e96db0349da592318";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/sl/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/sl/firefox-66.0.4.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "ba298a83e0c429ff6d8195c0b35c3c4c0dbe434f2dc9d19b47e218a6421261ea08b8a767343f120b2ecd2e061bb52fc9184391d994538304cee91727cff327a2";
+      sha512 = "961a2a2cd6b70bfc919859ffeb4153ee5539da05b56ced84c00b7cbc23ddbd8825aaabad2885c325d7a96c16e0a710fd403cf9d4fbf706508cc6d6901bfda3e7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/son/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/son/firefox-66.0.4.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "620e40c8484fee31620a2dd838c484cf971e2d677a21ead71f2043a2f81bd7e1ed2c70c6778922ad337a2fcc87724f919305b78e31ac9880139a68cd924d3bb3";
+      sha512 = "6fba26ac3c298a20ef52a8ecb0ddcc4b6e0d96be10820b0038bc56f5a879642885641939d86de64b516033f3623cb6e6570e9b0b92e0afb5aba08d847c1f4f4e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/sq/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/sq/firefox-66.0.4.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "7b4653a69e11df2a3f0b4e40315fcaccdc8f7de179774a4f1709a85534520d53739b76e34e43da5dc7bff36d8a7db1388a0507242c70a351a14cef081261d15f";
+      sha512 = "0344b6ca43dfa9ac3a17da898177a65d46c600518ca26eb1c01643fbda1afdadd378fc642c21f9ba19e512c2ee31391c4b0cb71086d290fa9275f99e6cd87bc3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/sr/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/sr/firefox-66.0.4.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "5990ee7d8f68705501f81d48b687b5bff33f9be0912f4cf4c0a3ba23acaa22b3168420b5c4dd8d6dd7968f194b7280c9c34f8f24da9d10a80bc3b2a03e00f436";
+      sha512 = "bc75532d2fca3038d8415a6ef5447dd4ef9cc5a189aaaacf2f0bff9802ef79dc42b9083c2b9d0e7c4b019f02e01af5ed6b2ac668a61f66f359312d35a0db3ae1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/sv-SE/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/sv-SE/firefox-66.0.4.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "ad9a81e3c384ef559d30ee537e3d8a966d5b1c118c3185de2e5062a29b1f2b88b9394e0a480cdba8bf02ad60984badfc0329f576c152837ebef47ddbc4c1ffb0";
+      sha512 = "45a183b62ff7d2ae17bd696212cee5babe71e15531fdde486e19505d0104cc5e96360a5c475b42edcbbbd0c754168ea474904bec7bf493befc7bbd4f280a8b5a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/ta/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/ta/firefox-66.0.4.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "ae78e4ddeeb2853ba83dc41c703f63e22d3bd2d58ad53118603f47ead33d656582ca579dee1b4eb4330bd97d605cb14c10e36889e8bb43ebf17d36a165612d3c";
+      sha512 = "e65efaa3d08e3912db2dd164c2cbf1ed686246347da3e5b4fa11de5d7db7f0c6edfed6cc822c64730a309641a5766662a0e1f07e6b3203d139c89eb6de6e197d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/te/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/te/firefox-66.0.4.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "d57fbe1c4f6c8af40c8f55912ef0e1d2f38118737a2fdbec18dd71c97618342b9100d7f6fd884c72191c587f64b1d08f16959b7eb4b6c48d43f755f43cc35fa3";
+      sha512 = "613689c3665c76ab9b05f666b1250f92b5bed37d2cb7d61df2ac6c25ae085853416b2bcc5638f3f4cd2223adb2d585b0d3be84132e9ac038377dcbe08b39b319";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/th/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/th/firefox-66.0.4.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "6eca812c1277cf9859722c38cdd962dd1f9039617cffb48882bad55b4e8cbfc8138ff230ee491d19b042b3c10ee5499720ec494605bd3c266cd2aa29d9b44a70";
+      sha512 = "9123aad2b2a8cf5c09007a042571e884fcdf06d04e2fa71207a8e266257d4b83125d6ef30acafce3d8731856a3e81ac54858dbf8fb7e778a91f188b1338754b3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/tr/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/tr/firefox-66.0.4.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "1cf21e60a8212503d1511b3372e2f9948a6f8e66db8e53fc0d825a4e581afdac173b8518dced34303aca7eb126b9cbd4e0c23c4a1969ca1e68f63f8aede32275";
+      sha512 = "c11a6020364af2924e4970afa09377b34ee6270ec0164afa3e583eab8560b1c3824734556f91c0a77581032fb978a0343cdc86d25e02e186e6e600240346325d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/uk/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/uk/firefox-66.0.4.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "c24711ce6ca420121fe88c90f610a08ec3230a0f323cf5fd80511c65f8188126f31b6e40b1a4b9f9465c7ab72b866879528080018163dcba3769e1f958580257";
+      sha512 = "f67e01de24bcd47b653174c9d72321004cba717148e045f6744b89f1a45423225ac533f32f9ba4082b9dbb9f6b594f96dd7ea819a5f9aa2f6342ba4ca7064330";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/ur/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/ur/firefox-66.0.4.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha512 = "358f004569d6a61d57af6305e6b02d5e30d699002e524bb5b73d72ec42c427c63a8f0a5b1fcb11136140b4ede6dc2d705553d5dbafad9bada1a9b1172b4e9af4";
+      sha512 = "27d6c55ed4b364353318a4585844545affd9cbcccfe119ee2ee925ca2bfa68c9dc14ce8dcc4632e9064ec679b6504800c7821beaaac13079a85fda5914ddbd31";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/uz/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/uz/firefox-66.0.4.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "e0fceb8f52939cbb37df6d5fcbb95d1d50a22f1910c653778381e6c1fec14a3014ec01119e06a958768677a9ad54765d6c4387c9edd9c6ac57d2c37334bf6c2b";
+      sha512 = "fb3f8f95efbc230d4f92efec5ba1e99f3945461962b24d20d635e312facc79a2d62a6ca9eda34bdd516b697beb7b78612b73706ba461b8127abc4bac4db261c6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/vi/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/vi/firefox-66.0.4.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "94c0f9c8df20be53fd6a34388c9be4f3984c437ab270dbc18318e272c234b791911e099dedf9bc6f837ff290e3a2e0a8946078ca830ec24a052044093be2e8b6";
+      sha512 = "db2057f6b203144dd032e4f3c53dfdcea8e339ed71894d21f96b24593254beb0779103234242a0541fb26f913d47a7ad8543ed9a871c2f11f341f051c4dbd0ba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/xh/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/xh/firefox-66.0.4.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "891dd4fb85d28cffe312c6310c9a6cb2a70f3ccc9c07d510553790cca51068bbe07e406ff3a7b33c690e26036a7676ebfef68af2819db3ef6e88ffd0557fc8e0";
+      sha512 = "30574f459a2fa6ed4bfceb276ecd48bafc2ca63ff5dfcc6251f4b003c5c7a1039af30682394b0e93eae4ac42177a4e58caa9cadcbc4c36b7eae0052595bd62ad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/zh-CN/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/zh-CN/firefox-66.0.4.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "188339263557e356ba24b4a78f715e36c2b5a43af3a9e229deebf9e84e01e3673ca5aa73a271db130455be1f0047591c54745968dbeeea0ce071cb38ffe73851";
+      sha512 = "e7278c50c7db235f244f0e32f1a3a5e438462a7a179a38bbf8cacb8dc07cc63d979491b85036ee9baea1d8481a10517005a164c31507649d643bab995f98a1b1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-x86_64/zh-TW/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/zh-TW/firefox-66.0.4.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "52a39dfc7caa53ce70bda4acb1e2c472981df6e457baa143ea3a1a5f6e77f8de1d64663ac7f7a21c56032cf6e9927d191b30a1c615b19a29ca2142e46d736672";
+      sha512 = "4b3024b7b47348261aceb573b905d079eea27b45947069316629a05a8ad9f983bbb835ac46f610bfc2640874403b48b7acd6b4bfd4cfbc602227fcbeca4e9c8a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/ach/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/ach/firefox-66.0.4.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "134b66544e203956007ee47b649ec61adafaadb0e03b0a62c83f16f4efc984ad9c765ba92a46f53f78589f09e224bba731c3322041e2b6d3f46ae6919e66fbfd";
+      sha512 = "721ab206f584a65b0f5ac2e2da9e0b95ef80e66aae01cc65bc736ea672c276dccfac1885c7de5b168432736f00cd8106f85c5a2a5b8a477e2860e9a8dcca8f99";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/af/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/af/firefox-66.0.4.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "71fc9af0dbccb2eace1de118f528430fb5ef26d6ace6ed0f8bfee065c4a5b3049097847f4785bca543f3a77abc64f8dbcb0311069c6120dadf653ab98848af52";
+      sha512 = "e86bc71b580d6cb1c4f52d5f5d248301805a0b3782f822dcc41f590a1be289a6a2b9f42931b56e36df1124ea2de0b2528ed00de54e2de4e915427cc055e461e3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/an/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/an/firefox-66.0.4.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "c7569fc44cb6db5c5f9b2242faadcfad3d7d957d452964ef806547b03cab10776177f05b0a3a308aef09723e7a2c77529fa0ca746a5d72f3a554c8b49ff4e0df";
+      sha512 = "bfbc55e1a0002fdc30dd65f396afe05c7090cec1a54cb13dac0fa2079f2427f54960de4bbe7af93bc3d3dda3bdff84f8760463054e0cf315f151d318e9a2b4ff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/ar/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/ar/firefox-66.0.4.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "d5e5f0be178bf719e465f8b62650b65f731db4b101075ac69b59b4df75e6eb21a3d4b848dc977aef8adff51e39ecdbb67530f575c9e0311ce583e9c072a0868c";
+      sha512 = "e030f962cf81caf576b165c7c76f6bebad317860b788153c5df5f27c8427a0850e3dc2a4877a8de8220f435fb71ca43d3e131253e345b2161ca65bca98b08833";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/as/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/as/firefox-66.0.4.tar.bz2";
       locale = "as";
       arch = "linux-i686";
-      sha512 = "e7667f0705766c544909f512d7ca801ec8ab3c0428f0c5be01dee574ebb4b7ddda15b8a0111a35bb75729fb6f12669ef73cb0dc3479faf54685aa8d644fdc9b4";
+      sha512 = "afd792df04ac43cab4bd837fb7a5139635bc9a2851bade301bfe677882134e25b7aa37a70da9836ca28496dcb7533f005af6806b97f531a3632cdd2e019279da";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/ast/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/ast/firefox-66.0.4.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "b64eb2c9194cc9a62c42efc89086ce3e0dcadf2b8728bbedec31f4f258aa9fb5362a555d4379f70f53d4d14ee1f0574739b901fe510ffb47c8a65cc314447dec";
+      sha512 = "1589d9b31ce8ce47666ca091358acd423452964ef72a45f89e01d20507ea3c7ce85547d5eeba8a7afbd4569ffbb08fb72faa2be7a45749a6ba57a1a887290842";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/az/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/az/firefox-66.0.4.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "8d7674eca828f2cfe22fc954222c43298ee790b00560735ee571c9edc98a719d9c684539c8f2d1f47ff18371b7860de8a7ba33f9154a534ca7918337bcf3dd11";
+      sha512 = "312ecbde1115129d4c5cfd6f5e0ac6e20b13a81ee7cee9e2ee7841e1c4ad81743ab50c3fb0a0d599cdbeb9671fc7410fee7246865db58654982e4c3935dbf266";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/be/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/be/firefox-66.0.4.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "5951d05b4130403436b8667b5286569d341e3499f1f2bffe959ef4eff384b79ead9b276074836c4fee41ed7fb3f36f17efe1bf552f7507cf19b03505d3893353";
+      sha512 = "01f750b21f49806e5cd6227bc4f6eba698c7c1de7cea7bf6998438490ae4fc69641ad9de710f9dd1e7da67b8e43e668f3cca50dd995f9e12c4c5388f743a77ca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/bg/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/bg/firefox-66.0.4.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "8176952179a38572bed2624819e9bfbe271e94c6b60277e19d301e902c21934d1c787acd3b0003027faa0f3b8907b01e52731c38ae80ffffd0deedff86412125";
+      sha512 = "fd950660fe3660f8474c848bdfbf356ea47adba4a25719873cd322ececd3bc8f5f3748dccb0272b1cdfe91778f0c5e18be8bc1253f2192bdb0cda0888da2c49b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/bn-BD/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/bn-BD/firefox-66.0.4.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "98da4add6c85ef6b3f19e7ae1b7b1be340c0d78ce17fd409c919926d75fd06f54607272d0404a4700e482f94cd6ad72937cbe82c7fbc0ef41a862ec885cf9987";
+      sha512 = "9d95cea55725327bfc255cee7b9dc5b32710d8575931feca0c5d2611fa9d9a1c9121283248e11715f594e98ec1e0584454ea4836b2853386dba3c04e1ed764f3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/bn-IN/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/bn-IN/firefox-66.0.4.tar.bz2";
       locale = "bn-IN";
       arch = "linux-i686";
-      sha512 = "3f182c05b584c2d09fef0981340c71e28ad10c41c031aca0dde1f2d217522b1d3e7a3e785c6fa634952bd8a8ad6b401d502ae07065e838a3d0cc59e13d313364";
+      sha512 = "1504f69b631ec7452a6db588190987108c52f805cfe40d50034bb0da9f06bd642cc4e8a78fdf297950156109e1dac33d8a186943b61e89923ee313cfbcacbb84";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/br/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/br/firefox-66.0.4.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "ea9e175c2c06a051e1d01bb2e1d61f1d0f5e75fb8956516f6a4a1ac52c55e5eeed6405771598ae36c69087c7275d5aea3325ae44b477639ea8423a3aaa4ffe2c";
+      sha512 = "6ec57a6f0159d6dbdc9ed1edb5f157bf9833fd1ca626011a3f9bc7387ff5e5c227feadaa2ddc87c134774f6b93cc36cf421f46996125cfbda2b265b7aef3a04c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/bs/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/bs/firefox-66.0.4.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "88344099457ad847be785ccacd930f34ad5e08b0a0594c6719865a0d1ec5a01c5e5f5095dc01ef399aee19494d5108a86e8bcabda642ea966912466863a38715";
+      sha512 = "2d71b24c1c24f52d3930e65a37d8354d826e47dea1eb2c4293094726d76c11258e238e2c71121f7de0c323c5e701f5173decd3857525df944d2a349a528dd603";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/ca/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/ca/firefox-66.0.4.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "e9f0aeb2a3ee8cd118e0afc59909df7ea4f87b737a3786b11841d2e85ee3a61747c525cb2c1a707d480238fc00c128062c2bcbdce6c0249ad1404e06d9d7f1e4";
+      sha512 = "241aa2b588fa66caa21c64e3e0511893bbd3e87d8bd24cb73956eb7bd17e6aeb1248712bf2a2a302a9d9d5131807e0daec7eaeb00c752f6fc66607d9ffc52a33";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/cak/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/cak/firefox-66.0.4.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "21f48505956ac21cb74140f39923364e578c7eedf3fa180a5114c400431476f489bbe14aaebff9003ed7a958e8970fc9c713d52fd3f4388f21152c570ec082b6";
+      sha512 = "1273f8d70a02d4d49260ab97df101136062bdbd70f9b76fb9550dc9fd9097961fecae61832238eab017f00cc7e63c6b096c9452c2f426460a2347e66fec4f6c8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/cs/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/cs/firefox-66.0.4.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "8b89cd378f4705e96547fdaa0693b359c617fcd0d76931d279ac176cace79d12ea4f7644b82e4835575d78b564ec6c00b667f1e98204886e3a2e990756a97de9";
+      sha512 = "de0d30e2621b8d25a701ef1350f9cd75989f436880567541e0c34c90b6010d904aa06cfd4839f13670fce4b98e1a759490ac7b1daa396ad570ff1032c3cf308d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/cy/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/cy/firefox-66.0.4.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "484808fdbaa1ada47b5a05be161c67202c8d82bbd3c8eebff37aed11d5e763679a2236ea74f08286c70602d8a347698f2bbcdc105c3fb9e0cf835600dfd28a26";
+      sha512 = "2b980fb5fd2a3b98af34dcf0f57e0f1e039148d95d452c6c297cdb814eca2327f2887933a89bcf829c38dfa0b1742f166f133f58754af564bebb0416ac2cf396";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/da/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/da/firefox-66.0.4.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "207e10cafb402f2b1de2f2141822e68951f06a30e8ef4fbbc337fc103d826f0af15f5b8790c618dd423e52436c6a07bd9db4759c10297b51e1cd1a3ba3045e96";
+      sha512 = "a2c364a2a77025f7fb2646b110ff765d98f44ad84d0f1a56984048c56e062a7e498a0f8cf6cb1fa4f3e34ba386b20a8b00ef3df3691abb49aaab9e86b869a2d5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/de/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/de/firefox-66.0.4.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "09550ad63b619376708e51b967fcdf0c0a9b0921ee2444cf10b08e8b30264ce45130502fb29e8a70c887f3465aed3d737d9a45b134f16a181f3ae094afd5c717";
+      sha512 = "aa053f108d1b9775529023f7003a5bf72fe0e503ca5fa61f5f966b6034818483912e09df3a5aa72ab0df75fbf3f78407c9410b609dbff8e0be3869ad8995ce9d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/dsb/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/dsb/firefox-66.0.4.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "6ab4b87adb70b3c5f015e4f96b5e932ceca421f552f30acfd9e00d171b428529e8280937eb5b89086eb8389a9ded86b61f45dd2362767b49fb25a11d9b9513ff";
+      sha512 = "670fce6387b3e867873adb71cf37a28016da2bd9826ee718a0196280e8cbd1f7406bdbf91009f9faa8d4c94a55ff5102b73b8fb319407261a3cf8caa5b69e726";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/el/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/el/firefox-66.0.4.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "e80dc8fdc61f1b19260c1eaa0717375402dfeba3b00d6a8e60b4074d260239405958b34902e954063d2877dd026e9b19d74a6e6cacb60e42ee5940ebd1077e60";
+      sha512 = "cce6185101eb4d4044fc6216d1af35ec25e2ad7f4203f671cbce1b1f2968b71d2eded6da45dcfaefe92471046edfb6e9551ac3c0fa2a109966210fdb8c7297e6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/en-CA/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/en-CA/firefox-66.0.4.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha512 = "e832f717ee292430ff5335e1be7cfd4081fba289be7e62a153282bb5fa5f4d37673f994160e436297f542ae40845ff09843632b66b37af2ad392d05c0104088e";
+      sha512 = "24666b9a5c26be2b23c80744bfc3b08f83f02b8f3d6ee392d02d2db6ae16cb555e0e6a65fe08d7942551520798f2b2d0bfab4f607c9ec29f82acbed5b3a8c7be";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/en-GB/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/en-GB/firefox-66.0.4.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "aae266e5e46a33da09d8b656ea7d0112ae4c612216bbf4bdb5db0d0e0b231c7e83ffdc085e34ca996958c0d56c2c03f42988efa783644c1ba249c867cf1aa48b";
+      sha512 = "2e66d24d2ddbbc03b284488c062f5c8b561c647f184b370c621bea67610713ad41ed83ca04e4ee7092e2d4d9916b94b13736c02e7e9eab519a30fe5531120d39";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/en-US/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/en-US/firefox-66.0.4.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "55ec374310abaed9cff7ff17cb4b4848a2ba8b7803846f6a1aefebc14ad8e3c62ffc066bd6c44d9bb208e82d833738df9d5d0a0e19d90a64f4ba1889994637c4";
+      sha512 = "2b0bc9c83c9f8e9b570a5d1936ec3418fcf738ffcfb2dabfb6a8cd153ddfbf47472c6f95a081ef49ae2a6c7153b0f50b4346385470b7e28a90e5586b71e8507e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/en-ZA/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/en-ZA/firefox-66.0.4.tar.bz2";
       locale = "en-ZA";
       arch = "linux-i686";
-      sha512 = "1ca7a97219fc9aeb790046adf4545e20a3aa3a382a74ad4621e0df89584984ecec212492016d680b512dae0341130cc4618f61cfaba86337ba3e0d3deebdff88";
+      sha512 = "c24f3d5ee00fac6285b6551c59c9532a84769cfffc61ae760b19347cac5c98eb35ea9803f89c6aabbf8077a9a844b7bef8528b309f26658891e711ef2a08c6ae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/eo/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/eo/firefox-66.0.4.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "1ae8bf9caf03ffaea1a6f6a071b1d26818e39b0b4e33e75ad4ebca7a2f0b20b8c0450a1f24466edd59b211a1d7f2667c447fb19297e42f4d32e6d676b634696d";
+      sha512 = "060a951a4d997aab308b9bc61daf09c133dea250499d9e1699fc0056c382956918f8700bd5a4f8c2955b0c812a84fd6775569f7d16424d5299a541b0d0152e20";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/es-AR/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/es-AR/firefox-66.0.4.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "0c48e15544335e4d061db1b12e82ef7eaecdd542391c0e5fed91fb74755cfaf6766bdad02b4f70c1c7522eb1cebf684b400db92bc632aae2012a9f9627e04552";
+      sha512 = "1dc63ee6473ee4659e7df21d73e552458075f2e0885f3bfe79264b3f202a6a2ddcd90f81b7a1b8b877467819228db0f5f7245bdb434600e05bdb7d6af8043c1a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/es-CL/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/es-CL/firefox-66.0.4.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "c38c5dd28313333849cd00a8f35a91fb261e3cabc8edc71bb74b3b0152b9375ae915a6c26a7ac2334db9805a6630a394ae14f53e3de048f9808ce07cbb14816e";
+      sha512 = "9d999af584485900e53910c462ae5271cb08dc24c39b89f765a7e393f940e6daa317202e3ebf46d4a03ed5adeeebcaa9390465a954e0bf6816c48ea4a55d05ab";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/es-ES/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/es-ES/firefox-66.0.4.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "b7019e49956fb4038f445e7425e99cd19ee23d12ea32b53d664898acc3c9f23e03168e1d35fd731cf88d3ed98ba0a487c288f457a79721df0c49f0a66f5d32cb";
+      sha512 = "37bd3dfa6a2bf3b2988f889270123a19ea03300e51b85fb1772230d3764c95e17382c996b40124c3df439d40f7fc72f69de006bcf024604ac844444a45179f0c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/es-MX/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/es-MX/firefox-66.0.4.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "ee4abe8b333f3de4b70d0ecc9d76c040d4b268b0c797eca6eb0eee89cb3950310b73bc0d07117aadbb386c7e3957d0aad97089cd6d352c385a5849f426bacfd5";
+      sha512 = "3ff7427884ed23efda07d5448e3236456a44edaec2584d2c693cc9ab8e9ea27f715e7c6a0b7ff84d79376ee36e81d63ca80fb467f481595cd64f919cabada830";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/et/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/et/firefox-66.0.4.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "238c68efd328ec4fbd679a573da18cd48ac3db6553e31ad49f3d0a08392b6fbfe907d9b4b996764d1f346fee66c9ce660af4fc8c2dd8fb87f8734c688b9aeb74";
+      sha512 = "624f2d1095f92c1e6fb88355801f5b95820f3c43dcad5243247aff49e6a83193a704c377ff44a9ee94edd7c9d1ee7c735da3b6250868433aabc0c3274f320e3b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/eu/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/eu/firefox-66.0.4.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "30e5ba2be30b4db009bb88461b7425efe3a7c1f8b292c3a47ddcd6d82f85e69a2b283c54c50905be4b5d4941f788b4a2ff1878430d7f6918a13080c6e8d2116f";
+      sha512 = "432fbcffe82a8122aba1298fac1f9e1f93902cc7f8c8b9782074cbf57026d34013a5b77a3b110397a97281adfd7e07fd2e6b99a10114017af2813c7b4ce8c653";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/fa/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/fa/firefox-66.0.4.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "a00b712dd49e0ee6bac17f67619c92ccc6774de7e9e078f5d95a38ad0bc6b8a16405cced536d111043fc0cffdaab420d5d12694f452a8839fc750b8a06b38622";
+      sha512 = "ec7856b3d8c3f16db39d6e4c0378815f10a0eea4d566cb2351bc6a5dd38493e6d965c32da6431a9ecdb30cf31acf86d877ff3d694f43fc46ebae14dd36c2e40c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/ff/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/ff/firefox-66.0.4.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "008a099bf92ee2e1911717e470de41b563d1db63ab165df70140a287e4accba7ecbfed08e9f155696eca24d82b5e3710a51deae00b9cb3ebe2c154cec52b55bf";
+      sha512 = "9f811b0ebcf1a25ebdd2d44b0b8cc185a5a6a01df79f788689410353f76c55144b5ba74a2efb896c7ebcdceddd24c1aff109580fe4360d6ac011597ab5955cae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/fi/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/fi/firefox-66.0.4.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "7107756f54bb5f388ddb88f3bfaf0f24302f66e47864a68f66596960f7d2d344aa10a8af674a681ec1cec7af4d554365cfab18a9bb7c341cc953d4bb7f0385c6";
+      sha512 = "7a26244a21b13bdc54fc4c14fcf547f8302d38f73f8385c424fe79480acab1ee43720544a7137bcb2a0b6cdbb1ba8335ec5b723773128eb6825e9e3bbf0b30ed";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/fr/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/fr/firefox-66.0.4.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "b5124721aef078386a4c9dac9dda7fc7cbbb7aa35f4797e6689c74db39d18b23eb92d87b29a2e5ba718944c7bcb80cd26f33248091a0f99be854566f68377b7d";
+      sha512 = "b97ada588c37af74b3fe6a11190e4408fadc1a63b1760986ea258c493460840cafc30d46660c85e11f74946f1a5cb87149535926d286e2e537a21b7d7cdfa229";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/fy-NL/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/fy-NL/firefox-66.0.4.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "9cd219aaffda54d2b6807b7825557d91651861a3fb2d99c33623f04450d799d029311a7cbeca3062b372e59c50f0b0ba169a38a0a87c676b57ebb3b6b70c11fe";
+      sha512 = "3fb3465d10169182e9e34b2216b8f7cfeef421f9c45fe72b965b92220b828dff68acf88e755cab0f2c831acb1c0bd207345b7646c83895d4e448ffce0bb7fad9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/ga-IE/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/ga-IE/firefox-66.0.4.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "6044ace615e3133677cdf53c6fbc1b4b9f02d57363fd6f9b802a4501da92a604a539689dec774339b4590f17f3e05a28dcd1ae1c306d76fe75b4ebf18a0310f7";
+      sha512 = "be5f150e10bb4205b8fde5a78fd4860cf45b1367334020f90c5e1e2c2b65bbb8911b19b0b63310f1152bdc1857bd465d2a168147e16673fce3105e87182422fa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/gd/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/gd/firefox-66.0.4.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "eb8bec22155e74d2e8da88741ffe596174000ab92859d7f06ae00c6280a0f564c1cc03d06312ef1960d182b61543c88ad5fefac977cac2456a2002bd22a13eab";
+      sha512 = "95a6522ef83ea8da6a36c23bcf49e1d6f2b4a5be0c0aaba3e9cbeae0e716d6f5a78c4d3461a1fb799a21a96c04510fcf25fcfa5203e8101536e7d4c365ee8bf1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/gl/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/gl/firefox-66.0.4.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "e98597c41cc48fce17c0698afcd694bcb772d62671de6bba4db8afff8c02ae2c11627a4b6a17f719bf86f5425783e3c7ef94124c49732447e356b67f35b97b37";
+      sha512 = "e1e3506d962c06bad43fcd295434035d6312a4d686663a33a043740123b28ec4040d6d1bc7581eac742c6193974ba3aeafd0867307f2c28d321363e6a907b97a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/gn/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/gn/firefox-66.0.4.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "7f89a5cceafca50806a61ef748319fb2897ba71993b99a8e0fa951a6e1d0f04af4c75d4cd18a2061f6a56fb66fde391382fb4b11e3509f9ab227c48ddcc53fd9";
+      sha512 = "56063c52c71cc117ff1984da22c03bc8c2f1b53b1a063f62864a05dbd3e5bab79c156307b8be5c7d7cdf9254048e1a27fec8112656c4677b0ab068d2dd658559";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/gu-IN/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/gu-IN/firefox-66.0.4.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "4a50e5397349d68a1d3c9d1595873b16d4bfb8c28bc588bccba4d9f7a804374fb2094cac8584ee62cc415d4cfb22e1af42820ce0d3a8642d985910785888900c";
+      sha512 = "4400ebe78e80b8c776f7af169c9e99c83624db188e2de98626371052999b7d52b265b0a09152f3acdda85040abc029cb9ae790ff8d4d6562b111c6fef8387aa4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/he/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/he/firefox-66.0.4.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "98cdc96eed8b3d56a4b23ea7b5ef044d385b01635c4da76a36284e69f1feb2426c370af907e81121a4ad9baeb7899f98ac76ad477a6e74f1fcb6333a35fc635d";
+      sha512 = "16453b5aae26b4bb7153a915810fd66549c8e8c6d880686d90c5340822e757a01479978de0ce63b48e66979456ad20c508da5c70c7d2411daefb556e29321ffa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/hi-IN/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/hi-IN/firefox-66.0.4.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "96d4388edb544b9dfaae47ffc87d426f9a3e13a9eddcbf6d83e60f8d0bd7b9bc0565c2ff8c610881c4853a7739d3aff9d64ccad8dddc27d2ea6588a077441d6d";
+      sha512 = "acc1843b76699c68a1f6328829a339f303bac8f1eb3a66eb9355422bff6782928de6e4693ebf51b6e3d8337dee6c6ac34d7935b7ae7cde6fef8b297130115e28";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/hr/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/hr/firefox-66.0.4.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "4f1e2112d4771ac198a6739ebbd4738e8977a84b740e8737569afec5570d36aaebcdfde4da54e818c2782c6f31d785c84114be9e33a6d17db480ef5c9955c62c";
+      sha512 = "4606e21fe491959585254135cecd629ee39adedb2c576fcc597a385a103b7c774f84a141e060c84cfb3c3560359c63a014bee7ed76cfe17b18bbd86458fde8f1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/hsb/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/hsb/firefox-66.0.4.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "27e284f211b9f3f76fb7bca2db5ae92ba336df2df838b4566ad7b7a538229911717f8a7d3321264d5034a7cbb57df4283b13742a2aa45b7357efce8365551640";
+      sha512 = "20ce433e45c16af0ca6d4fb9bcc85c2072b95a7058f4b4f9aba486259278ad9077c02fe9daccc0ab43772a716728a026e6c7224ff243aa095a35a62a8f848ca8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/hu/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/hu/firefox-66.0.4.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "08dced3a7979fa7692e9bf4d5070925fe06ec7af1b261d56f36e55a068bbc994e881540eb7830abd418c44895edde460fb43beea84753e5d96ee35f224ba60ec";
+      sha512 = "9984c6a996e1aec493cac5722166c20f7bf91812ef805c065bb32dd6e01b0e4950074f50698174341d2fd98bf583d2fefb033918f9243da32cacbceb6c2be66d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/hy-AM/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/hy-AM/firefox-66.0.4.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "6ad25162a877f821ea0a4aa37ff92e89c45b1dcca03324d79950aac451afe8d3acdd86f0eba20f9bbd058ab260b4d64e6ceb6e5d1698893d05611c6759274e14";
+      sha512 = "6e295f3c4d2dd1d8ccb20a6a95aaa90f6b56f2aca0f56e88ddf2b5d944e83f7950883e6a78e8585a35ecf938e6ad3c2a9861bb90b7f243f9d9a95ae0a3611797";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/ia/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/ia/firefox-66.0.4.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha512 = "fbaf8495d07d270bb1c80afbe47820193e3aaa52f396b281fc0a3a468e987d1d24abfcf9ba02aff58d9719cb97d96f5a4b0ad016acd79aa8097e88b737bb3179";
+      sha512 = "a6ea1f8c4ed980696afde549df4f2e8811f33c3a26990ee594328fe8ff2b85da690ff2562c4589adfc6c96a8df2826b4ecb45a1f66abe37fe63befc7c1ac83f4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/id/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/id/firefox-66.0.4.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "8cbda23ddfb9a62c3e19f24ff036c0f569c0de3c9598932ee8c63f89252f1c0f71d61fecbd270164952236a6a9a86724d1ab86eff644a31e6c0c46fe94f4b11e";
+      sha512 = "525778a18d1a10658f68acd5765ec256c94a0b380cebb9f71ab5bfbf860985dce1d075abca8a230bd10f45536d10e1274718bf475d6b371befaeffdc3f66c12c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/is/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/is/firefox-66.0.4.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "302951a92d245bb25600cf7a791087398aca5e053ed50ed3008c5da9f24cc049c34be0bde5cc4d8d54a272fe5c85b8c29d067563c33c7a03b2466bebf805233c";
+      sha512 = "d6495199e2c2327c5b0347b9b4d41e7e83522c0e67202080b71bbb804eff012cee9949e0376dae274b090e64308a26ec73d040ac13bfa8e694cac4419c312b38";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/it/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/it/firefox-66.0.4.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "4eb888408e72385ea976b2b6f6fec3304cac26780724d570e715625a5a1c04c38c34349256ee8011a643301c3f1075a9cac407c3e3f44a18de30b555a34c8ed1";
+      sha512 = "06a82828e9df605cfde798e15e68179adcf6d7fd8483668bbad5d6671a587a1c44e1adfbb737ef333d86a47afe251fe83ff3cc79286c3a92ab9cb28f9346ca7d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/ja/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/ja/firefox-66.0.4.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "87d0c8b7d8ec1cdc085d911b8af9a29ecafd4dbc0717e333ecc59af1bfd245cde5f76a42686d58ab7b688bad33e76e1771c47746a1cff5fc8351cda7bfc1819d";
+      sha512 = "7419ac401b72896e66e92230fe54da3b88dccb900fa208e1d4786284fb64284c3979592d3c0815bb4ea7a6c50850920b27d6bf08b134ce7adc60096556f94a85";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/ka/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/ka/firefox-66.0.4.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "63f1e3b1160d7baad2522a833dc817343fe208c347941c73eb67764a337894edb67c81eb1e9751475e0e36d4654f3cc2f17e15f1d2a1fe0d2a0a166fb7db354b";
+      sha512 = "1664333a9c32f312d2f4e781b277549921f30efef1012de640fc62368c9806dfed3bf37fc6e25315e4dfb571e8fe1cd5032ddf5b6a54904277c59cd52aa40efe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/kab/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/kab/firefox-66.0.4.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "bda5d6e27e1e4346b0fefeca8242d1d5300116242c2387fcd1c0a38bdd413e3b8fdb9bee91778be58988eacd1dcb7273a152e8ab43b624cccf5f0c92115f4c4f";
+      sha512 = "7bbad72a2a2da61446a45de9333f97749ac07019959889cb4e2c78f3a014d478db8e3f1f054e934d32604b8ff1aab6fc5e59a6dfb7ac30456cd5c5bb0b9637d7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/kk/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/kk/firefox-66.0.4.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "ccdc808818e5f9e27260125c8d8015730593b64afab1905c1e17e047263215b3163049186e21f511752aa5adcae085311d7d4bcda657b92d3ccf640f2b210975";
+      sha512 = "714e6d78307b2bc33ed90414943dc3e8090b3a0a63d0a6f1266dad2bd9b155848cf747b2685d376af8c4d34a1d520ac3ecb8da7b7e72de70f80c726aee555de9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/km/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/km/firefox-66.0.4.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "8d384412ae5af3b73f175c27606e44e5c030f9438aea914b6ff2509fd42bdfe54469a5d5a6e0bb6363b74664bb185e24e2187fdf4013f6d5f7c49ac2a75236dd";
+      sha512 = "eac3ba4d9ea03506bae726a2ced74b1e37bb58c29a03529ffcd6cf595a6c2ce7feef29cd289aa1b650e399e046065bf7b93e5506f92b2b332ef6ab5d5ae89591";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/kn/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/kn/firefox-66.0.4.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "9d20cdb789ff63e6f25862d7d4342d170c47979353b605bf7fff1d58dc0244f7f9d13fcd1020a9f0934d72aea2b5571a08b2781cc0efd8bdbc923b75e1c30600";
+      sha512 = "9741d335f170871bba7f731caf01604341800b706144ba050a0f352e15602dbfe7b2db42930f92828615aec8afd2b432f6857474f757ba940d0292487673a0b7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/ko/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/ko/firefox-66.0.4.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "a1bd8b36e95342539b0ec4d8c624ba3a38a9b39b683f74d474a1c5420e3693aed3660122d1593dae95efd9fc1d938281728920b64b06d353d029926eda901d3e";
+      sha512 = "3c4fa714cf1de96927af3578a2da83898ff86b5ca9f4499a266e1300c24b0a75b88e718630e269e94302ad7ffa62f8dba1a5c13d5aa807129857451d8d8a04df";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/lij/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/lij/firefox-66.0.4.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "5e1a9ccc0e2265e5f79dc2f5f315567deab1840051ed16b5d78009bc4c0c8a7a70841828c816877a50ea73baa51bef00bfa987107218a7ca137cd2fe6ec57a66";
+      sha512 = "31f708c82116d359100bdcd3d5750311dd387160808d64718b102a9e6b35125ceb971c7c5c530a584d206e312ca85db5a1626314ab8d573ff0d48e2e2ccc65e5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/lt/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/lt/firefox-66.0.4.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "1b5b1bdf7c360622f2e1727674349f142bb2912aa4d94de24722c3c3ea2e304a0c6a9ace091e455939441fc03f6b84cb77064eb0e86aabc083f0f4b090e0117e";
+      sha512 = "9413359590c85b26b2fbf141a9ac5d4e1ec27c4b64c8bed3ea9cee40567ba1a84c9757f16499c53d96643f50ee53fc9194d06688f1e3deaf6866b77f0651e45b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/lv/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/lv/firefox-66.0.4.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "aeb4de3b3eecf08a627512d6c73755150d8cdcd00ef9f9d834b9de72e6e21e0df6b0fe2f248919e7c6219a4eb3e6b63dddd60da08742af0297264f3da655a580";
+      sha512 = "0746866b601275a4b937175a7176de6f13dec8fa88dcdad40bbb5c5aa6bbebebc61162baeefed0269ff6af75854095a704e3df62779eb2c8e581e82cb2038e5c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/mai/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/mai/firefox-66.0.4.tar.bz2";
       locale = "mai";
       arch = "linux-i686";
-      sha512 = "27c2e1581a08fcd530acc8728543304f5ffddbadde8855dc241dcf3c4374dacf5092ce32f90a0147540d832d4c3221416d9c9d8741bf3df75918fbae5c1bafdf";
+      sha512 = "103c1b5c978a8c2f5295e24c346eb95c4ecc3187cfe6e2d0ab74654683dca13751fe1aa58456732130249a1edd921fea2e0843aee6de82b62524b5ed03a34512";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/mk/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/mk/firefox-66.0.4.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "968bc246c79685aec397dea83aba70be43db5198849a868366fbbb201b032cf48cdbfab1dcf8472dc34d43269f9f89969e0142391a1404eb514a4c002afc41b3";
+      sha512 = "b408418432f7c2ea8aea58e1138dba61c00f0a8d6564df0cd14ae03050bfd8ba17e9654adb6cd835dcb798f26db1884fc89920ed43974c1fb92c79b39c3001ac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/ml/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/ml/firefox-66.0.4.tar.bz2";
       locale = "ml";
       arch = "linux-i686";
-      sha512 = "06915e32d05ba2c2e51afa0b93da0347c4e9a2d1e13fe07f63b3e923332e693155046d27c3cbf653c1f4e2c0803e9d44a92c2c7d6c51e57d68aaf0928829f1a1";
+      sha512 = "5c58a55345930e9a136bace10466a534f5b9c2365edf6bafcc47c9797461c7b98f836a8b8d2390a5a9239b6d4e96b7213a600fe64099f80e9874ff1dcb1ebcad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/mr/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/mr/firefox-66.0.4.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "db3d3a4f508596fdd52337101521b4adc4ad9ef65f076afac0eb35060e8def5dfdeb8cb2294e80ad6bde8c8d38b8e7302985fec191d5aaa78889c0a4058d9a9f";
+      sha512 = "d6ed0fe10c705a06ec1a361634fad2498107b8c9ff47f2360c6acc11ac745ccde738a014af22bf171022198ce8dd32eea53062642a49587764e99975f4147425";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/ms/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/ms/firefox-66.0.4.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "f0dec83a8e4df4702c48519d00588b8fcc437c6c4f2314e4e2479045b0b610193e06744fb2ef53239840f73efc641c5ed4c542c572e5c1a2efd3906f91109da5";
+      sha512 = "0112e5cc8b176c32e10ac2725f47bed95e49176cb81ded0e6f2b324eb9f6dc487ce073a92a5fd5c25b66a5401389c1959366905846ee7bccc8280dd6b0e94e31";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/my/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/my/firefox-66.0.4.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha512 = "82091b20acb72e105384cf203c26752667535cb9741484599904a3fcf995730cde7e4fae644671a5a43a75cf1c426fe0b4a4e4a8cb47e5649414dbf340f04a28";
+      sha512 = "32837f4f0f733b133171cd730b4d5f67ce8abe4cfdf7d5763ef431f605ec7d2032437c2d41be16c7133ab8e6ffbb5e3050be769a1c90ea88faba32e32fa8cec9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/nb-NO/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/nb-NO/firefox-66.0.4.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "5ea64b98cf0941a00c884ae02727858a3a4d1bb81f1b926f39f4cab30340d889b6a7250bfa615b806964baab46a97ab379fcc32eb27ccfe120c474d38da1e00b";
+      sha512 = "2a4bf96f5f55da8fd6ef7393f99c52b6b99fb75944813189ccf7d30524686b3d6beb14bd6d7854fcc323acad3b17629e5b9b4e9c05dd0f1bf29001c0c9db8274";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/ne-NP/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/ne-NP/firefox-66.0.4.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha512 = "ec88e2fcb98afae35bc9fba6bd9c835e0eb47c9ee65c5147c49ecd1a5c7e3a4303a31f24cd1cfcdd0483282ac5a277dc31a1c31f1a6af16ea87d98f72b1c683e";
+      sha512 = "db675367e97d4ca0c46f066cc53bdc9265763a0c3492a06db8fdee0f27d2166374c703445b5d286ae5ad1edff2939ac27705af5f484f9dcc82e75b154d2a4905";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/nl/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/nl/firefox-66.0.4.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "3c63b8d51d900fcf1d84dc2df5ff60d80180aa57ab6b51748c3e6c493aa5eb76dba394f57c6563272346a728a6a432d63b660ed252faadc520732fcec2279c04";
+      sha512 = "2be6093f8a5303cf31a7bd3788c0b87f6525b0fd39f8d867646c5667a0bdbcac54c7bcebc6b0f91531291aff4e9041f6af21a20cd28b9191a1e778a6b3dedc6c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/nn-NO/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/nn-NO/firefox-66.0.4.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "996587a51fea3c960133862dbefa9f6639f3512edf81cbe3740b88a76651753faf7e49fec1b657d039e2f1970137933ed3b3ad3a09f4c9476377282af22b1a6c";
+      sha512 = "f1a50d57284e5e989e96598635fb9a876b1f72049ab2c3b5d4155a23c103bcc814f9551ca8da24e4c4565ba45ed2206e786b2070a51da248c654711911b62fcd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/oc/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/oc/firefox-66.0.4.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha512 = "1e156c39ebd5d74c6327fa09e04046cc2efa013747b574916a203862e5fa19c921f223ab537a91ec613282821c4916a73ae8e61170c709752cf3f12ffede6dfb";
+      sha512 = "2d8c7b92014717126098ccf93cff317c7e119cf05c971bc43890d84adc12201977a64fa8f67c6db6de94a1f446ea00c815164031f72862ff8bfe5188c3c192d1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/or/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/or/firefox-66.0.4.tar.bz2";
       locale = "or";
       arch = "linux-i686";
-      sha512 = "3113556bd37eafeecf562afc068fd8608e387fbbafc7e7d6ece475678c1cb0a025d4ca92de569ea6a78e1f83755bf0aacea6031d36ef67ba43de48d124e8e766";
+      sha512 = "43337f05cd9a3f37ab1c65a0a6d8375d8029dd805d70d9b638fa80941d53abdd1cb8befe0203219f69585300ec4175e0abaaef38d41703ca828600289b102a95";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/pa-IN/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/pa-IN/firefox-66.0.4.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "c74d08d019b0257ade3e6c9bcd9a30d102523cac3740bab5d11a7543181de8623e6b12930e0c57fc3a261a496db886ca1c8225bbb46ea0fcca3ac6ccaa2c34cb";
+      sha512 = "de4794e5ee7b82475d9f1ee03654a606cfdb93e658c289c8e51ed12d5c4f8f5d9506a6693dd9c55dbe80c9a050b8d5ff9e4d587857ef65885a683a669d827269";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/pl/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/pl/firefox-66.0.4.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "54a0666be5524e49e4f3cf11ff19c2cfa66c65524bfbd70ee3cb21428c75f84afc8625a2bc35ffc8a4d8b79074c7b1d0f81770a0bc392ccfd7bf1dfe8805c569";
+      sha512 = "4836a9c7ca7eede61aef652e5a97339aa3c9949a78a7b2de48affaa335777522396555ae23abe11c95b02a1c59fc38ceb932fb9db74b50eb9b852bd3738f62b8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/pt-BR/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/pt-BR/firefox-66.0.4.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "122b4dda0fbe80776b50a6dafda9fe9b5c08a0bf48ceff3bf3ba4c759ced6a09e76dd1b7faabc937233e8efe5a4f37d9ec54c4370531e2ede255463cdc20d4ad";
+      sha512 = "85173013452964e7621ba41588c3376f29bc73eef6dbedb9ef4f0a3ca5ddce831a2c03fd0855df32e1f72f16e544073e1749546e82ce02aae0a057eddd64dfd0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/pt-PT/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/pt-PT/firefox-66.0.4.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "2fb9253e60407d5deeeaafc61919d7cd7caa7b183d8ca000b4070da7c3f7352bc1fbd295fa10a77365afd2c0566257b60ea4d6718f25ed39f282682a0a4c6ae1";
+      sha512 = "f1a4b2d14811e8b6f9617126b03d931665275ea5a59cfa9c9b93fad395d09a6ba309f41ca472b2f0253eb4bd3a12914d1bdd25341d4166b71fc601206a6931ea";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/rm/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/rm/firefox-66.0.4.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "c44d99c714ebeb4303c3344ff5a58041a4c93f8a241271c8fce72c6fe3048cd966709a412d7b589bc540754db16a622a12c81c885cb0fa8c072277b2b32b6c12";
+      sha512 = "4ac10aad3370d83f56ad59a6c971de1e53548782493979ab5f214c7499d0fe0fd86b59fd8a1e717d5e3d27553667e12eadbdefa2e474a5815e74e46af4485727";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/ro/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/ro/firefox-66.0.4.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "53e1343c751a0dbd53fe7a6a53afc54807e7d745f811ce9032d2edd60721e9e01a59a547aadfc9c62aaea9c825da9e02794520a03183318dab7cf08a4969eed0";
+      sha512 = "c85cd47c77c0e1ee4487cc0d0909ae02c20052b9a0784b426f0e7164136ca6eb6be7d87c13dede37fa6b0d4df63ea5198b9313da7af5c28e0adee0a7b7404943";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/ru/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/ru/firefox-66.0.4.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "cfe85e79f0cabac2ef0939cd6001939a0dfd1525b1612bd991101e22078f9e94965ea52ee8fab38a6744cda0ab410d9cc638c706c61717f51f989d5efec241fb";
+      sha512 = "e690662ea7c9fdfc5d721a41241b5f70bf1ab12f4db4bb444b51f25c5f0650977848fb2631b3f0106e5e54cf739a0288fb6e36736560a3170a5d893f6a6e6864";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/si/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/si/firefox-66.0.4.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "0736e18ef2f6c3112cd8a5142f31b45a05cd6f6a6028b5011e35c72b770787bcc69d86e507c1ac292e194f80e041590bf23c981295b7193b4dbc3f576c8d55ab";
+      sha512 = "d1a4f021ed8ef7d55cde9ef2bb1c5e28fb41a0220cd169071a070cd6be11ae2fba7d0f9a6c7d036317c4e7c13b07a041f46bb3e750261c382805bce39e9daab3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/sk/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/sk/firefox-66.0.4.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "525a589b137ff53ed8aac506ae11a62a94e02cd3fb6322a2078523d630fa86fdbfd1e1ebcabd627a2d34a1232666cdb7fb4b265f17199c063eb73cd2499decf1";
+      sha512 = "fe0bd4ac5da78502baa39554aafd0d96f8c214197af0c62e28cd4a2a62940d6a6fe2774668ede43cb1d3ddc9f629d418ad467d1c7723020ec0c22bbed49963f8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/sl/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/sl/firefox-66.0.4.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "805b5cf866b80032467b3a0d825c9a31243de48a0588b966788ae31495bebdb1038ff5c1f342dff86d471786d680c67f1469af70f0058dbb0daabf11633c89ae";
+      sha512 = "e5d46fa3ca8e934a7a3e0ecc1c096f478b7c3e594f12a8991c7181b18e321077768912963de1a48df7aa1a07440cbf23401baf1a84a12149750de3560834d2f0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/son/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/son/firefox-66.0.4.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "c03faa7bfe24157e053694d80a521bde6aa8e79e8c832ebb026b01a95ef84c5e3a87e674b4fb1cd8292f1a9fd7ac9686157909b0e71a81495c98c77692934703";
+      sha512 = "cc79dbc2e5cd5ff682bcc61f6148170688d542fb3d07ac2fad518841ed6d93a722bff9a7ed1ce77a68e7f5f09fc4e1a13f1c7fc9d6458b2ef0a15cecdb15f7ad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/sq/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/sq/firefox-66.0.4.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "27a3d25c9ee414c933a01db42a1c8fc288324b1fd280462e5acb38707b142ff140f0e77d3a1f6bd234cfd12a8b945a36557b2d7b09cde92c77aee591d1c5a4d4";
+      sha512 = "8dd55f612140e10681102d6d4414ac34d12733b4f8c5f253d6a278f5ac3cbdfdec1c14e4384e875e9881fc720ea1c54564de8ac3ac06f2ec5ad2941f7738e72e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/sr/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/sr/firefox-66.0.4.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "e053f3e8c0cdffca1fa2ba875186402906afdbe7196cb2ec926fb1ff749e391d21beef1f4721cec48edf2a230317a1adaf9b3314586f5a2e8cb840e08f52cdc8";
+      sha512 = "fc29bb36ffd38ea5c71d66cc3fa498d2b6fda41a710c45ded72456c236c892855ba7ac8e07ed69c73f12ea2cd82bf7fa6e82a6fad49960feb4f5c36c78154fbd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/sv-SE/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/sv-SE/firefox-66.0.4.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "1027ee7d4454466a7c4b378e8b0410de2059fa166797efedd16f9c71f38f536f2a70a1a32296f0dc2bf71c1710f59379d967e841eae9bf7a6eff5a66e0616f15";
+      sha512 = "1f544109c73fb4c34b964c4df5d9f6da8201689d1038043efd6150bb8a323106a911e4a6f9b7a648497747a1b0df16c2122fce55bbd6eefa72d1e64458e90337";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/ta/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/ta/firefox-66.0.4.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "000303c245dadd0f7d36477d645215d7f8623e693217182e378ecad059ceabf7f5b9d0f8aaf303417c90fb75d4c0c61de0c75e616c90d68ce74d4564aeba0eda";
+      sha512 = "fe9d51b667c8a37caac25a5e236c40e87c3cc3620b630ba0f6169b8ec6b6580e6c5c53d36018fa236919120924ade33a3478f3526b7275f523d7f098e9c309cf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/te/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/te/firefox-66.0.4.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "d720d75fe3f5fee87cb65dc3df64960699bd6b879ec79e94de06a3426481487f44b3b7cc2a727d1110c8de104e3b52efaeda44a942b986add3a9cee293092d01";
+      sha512 = "fffacb5ff18d3c6b78dda7d33d0b05a2e6f55bfa24908a4ac5f970f5e8e44f9f4fe066ee73ea8656907c69390dfe3710b35606c9e8e1e4a7097fd8c004e98699";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/th/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/th/firefox-66.0.4.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "27cfa6611d57bb57d5e1529853c02623ecc6636ef800b7b9854b22495e15e2501a7b4ac6ff0bba0312eea64b1a2cdf7ebcbb2061617253f0f9c012c7ae8f336e";
+      sha512 = "98092b4981db5460d2457e38ce1cb7dcf99abbc455d7c9b5b490e2ba1d91db7a553beaa404b78b02e66d5e4dcb71cc9e521a3f953d84ca495f9c4405e6262d00";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/tr/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/tr/firefox-66.0.4.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "b562ea3e73aeb0d12d14ece571d44a3f86bbe36b7cff9d731918c851c666c1469228c6912d1bf3a740baabd51199cce3ff9a5c246394ed5866c63e90c4984b2b";
+      sha512 = "8d75be55b4baffc17fcb6a15a776c3a9f85c06ac1aade5fa2d859951f3231d36f47c3b32093a0fc70c9a4593b4f6ddeabbe7388e0e648d3b772010ecf10c1f04";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/uk/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/uk/firefox-66.0.4.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "b0183271adf9c4fdb94a5c936d995ef749125e7031de80fad8d92048e8e260068ebc2dc5fa70ad05940bdccfa78b7ea64f067cd5c367232fe8b43c78f1dfe556";
+      sha512 = "009350e490504e907a1667055a1816ee77f87ab9d6e2460a166c3b6ff8a95d71f24c7369b97a3723307dadea82ad6fe345b071d4783769b1abf0ce76c67f6f11";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/ur/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/ur/firefox-66.0.4.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha512 = "497e3c0eab42a1fe8b09182f27f7b17b0dd4e776a60d176bb332eab2b38ef5ea697fbad688e34c182e07a8965a8f8be13dfd212609776a30e7aa4419a755eb30";
+      sha512 = "790596c72c1eb9862d3fdd476ebd859c1d2f9ef756d9c069cdd4004c2df66a8c9b255b054cf50bf5b4c387fc5f6d96e366b60540fd79f5827b23dd0a2304fa7b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/uz/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/uz/firefox-66.0.4.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "b0ca42a5af823f144292bb46191f37dc7abf485c4e5207fc50d6bd1277caf1ef3ac39f15430ee060ad7114d3d9f8d56ca2157729aee5384ab82a2352b97d4769";
+      sha512 = "c3d447f331dc36347f454aab0dbe5ceb4628b5b6cf63ecce009002fc87c2e63bbb55e7310c3c7a070767f38f792ac309a442c3abe4e1a041bd12638852b5e7dc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/vi/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/vi/firefox-66.0.4.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "b6cf7e2d0064b9828e4e030213ee7288749f0ebdc3abb5f480f36e4b13d5d2dbbba3470cc4e6add622fb7198ad99a802081b01dc916247584e728fb8845d20dc";
+      sha512 = "370b456cb442a68e62dca86fb44b5cedc8a9328da5a8b35cd0fecbccc6afa5a82032454961a156e246c87df77799207fb6d53f32ad5a0f3c0ec0c21be5345548";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/xh/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/xh/firefox-66.0.4.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "97c5596455e0ca0cdf24c14c5232da07196b20c52ee860bd2a9cccbbfe2a3a68a781c1efb8ba1a7ed6a840c60493c1a3e0cbacd68e03d2f914445e1dccbed9d7";
+      sha512 = "f126678434aecd25449bbbf4da96eca70a7b9d65000a2073b9b033e4e01aaa68aa4019793180c0400658ebd55fcdf93b58f391c7fe7c588c064dea1c1d2c13df";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/zh-CN/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/zh-CN/firefox-66.0.4.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "298d2c45324c9bae65a1859683120e7b13253e289f8471cde434d3927ad33f0a7cf6ec8c54a3e8254eeb02203551f73db0a331407306f2e8baa889971fe10268";
+      sha512 = "aae684f94b9e567e8b075efea5f910261a752c29904ef658bbf9377884f39a467c359ab703b36867c2090f012b591502612918160ef7a2b2f98958af58f4e8ec";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.3/linux-i686/zh-TW/firefox-66.0.3.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/zh-TW/firefox-66.0.4.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "debd419335edd694ad7fa7f3faf6a2b75e5470ba2ba2777cc6a54d8213d8a4914af113b7670267b9a7de6267c475c3ef9bcaaa2feb596aab728aa6ac68559d2d";
+      sha512 = "8f6329fc2a37ffd296a8e5ad7878f8f2bd7a172b53ea0629147c795aa920d1157001c819de479f62eeae6cc59d2d50e378cc9b9e5f401a1fa31f613af4fc145c";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -72,10 +72,10 @@ rec {
 
   firefox-esr-60 = common rec {
     pname = "firefox-esr";
-    ffversion = "60.6.1esr";
+    ffversion = "60.6.2esr";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${ffversion}/source/firefox-${ffversion}.source.tar.xz";
-      sha512 = "3nl3cisn1sw3y6dxnv0bm143dpp091h1s9j7g73qfx5s6sfxl832lan177ikm00ay7fsly251vi1xz17wwicch1himsmhjisnd3ws51";
+      sha512 = "2gk11kffwmyq3m8dsjc86f7zfagl15msb8byrb4db4w4ssn335wax2p8m221xi4qnzf20fl0p1b30g5z8ivrxx2n19yknnwalazcjzd";
     };
 
     patches = [


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

- Repaired certificate chain to re-enable web extensions that had been disabled

https://www.mozilla.org/en-US/firefox/66.0.4/releasenotes/
https://www.mozilla.org/en-US/firefox/60.6.2/releasenotes/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Tested only `firefox-bin`.

`firefox` is updated by 1f6ddfc7e039e0f1003116b8e9e7110f363e26e2.

---
