### PR TITLE
nixos/systemd-boot: add support for memtest86 EFI app

### DIFF
--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -33,6 +33,15 @@ initrd {initrd}
 options {kernel_params}
 """
 
+# The boot loader entry for memtest86.
+#
+# TODO: This is hard-coded to use the 64-bit EFI app, but it could probably
+# be updated to use the 32-bit EFI app on 32-bit systems.  The 32-bit EFI
+# app filename is BOOTIA32.efi.
+MEMTEST_BOOT_ENTRY = """title MemTest86
+efi /efi/memtest86/BOOTX64.efi
+"""
+
 def write_loader_conf(profile, generation):
     with open("@efiSysMountPoint@/loader/loader.conf.tmp", 'w') as f:
         if "@timeout@" != "":
@@ -198,6 +207,24 @@ def main():
         write_entry(*gen, machine_id)
         if os.readlink(system_dir(*gen)) == args.default_config:
             write_loader_conf(*gen)
+
+    memtest_entry_file = "@efiSysMountPoint@/loader/entries/memtest86.conf"
+    if os.path.exists(memtest_entry_file):
+        os.unlink(memtest_entry_file)
+    shutil.rmtree("@efiSysMountPoint@/efi/memtest86", ignore_errors=True)
+    if "@memtest86@" != "":
+        mkdir_p("@efiSysMountPoint@/efi/memtest86")
+        for path in glob.iglob("@memtest86@/*"):
+            if os.path.isdir(path):
+                shutil.copytree(path, os.path.join("@efiSysMountPoint@/efi/memtest86", os.path.basename(path)))
+            else:
+                shutil.copy(path, "@efiSysMountPoint@/efi/memtest86/")
+
+        memtest_entry_file = "@efiSysMountPoint@/loader/entries/memtest86.conf"
+        memtest_entry_file_tmp_path = "%s.tmp" % memtest_entry_file
+        with open(memtest_entry_file_tmp_path, 'w') as f:
+            f.write(MEMTEST_BOOT_ENTRY)
+        os.rename(memtest_entry_file_tmp_path, memtest_entry_file)
 
     # Since fat32 provides little recovery facilities after a crash,
     # it can leave the system in an unbootable state, when a crash/outage

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
@@ -25,6 +25,8 @@ let
     inherit (cfg) consoleMode;
 
     inherit (efi) efiSysMountPoint canTouchEfiVariables;
+
+    memtest86 = if cfg.memtest86.enable then pkgs.memtest86-efi else "";
   };
 in {
 
@@ -85,6 +87,19 @@ in {
           </para></listitem>
         </itemizedlist>
       '';
+    };
+
+    memtest86 = {
+      enable = mkOption {
+        default = false;
+        type = types.bool;
+        description = ''
+          Make MemTest86 available from the systemd-boot menu. MemTest86 is a
+          program for testing memory.  MemTest86 is a non-open-source program, so
+          this requires <literal>allowUnfree</literal> to be set to
+          <literal>true</literal>.
+        '';
+      };
     };
   };
 

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
@@ -95,7 +95,7 @@ in {
         type = types.bool;
         description = ''
           Make MemTest86 available from the systemd-boot menu. MemTest86 is a
-          program for testing memory.  MemTest86 is a non-open-source program, so
+          program for testing memory.  MemTest86 is an unfree program, so
           this requires <literal>allowUnfree</literal> to be set to
           <literal>true</literal>.
         '';


### PR DESCRIPTION
This commit adds support for installing the memtest86 EFI app and adding a boot entry for it with systemd-boot.

In order to test this, you can set the following in `/etc/nixos/configuration.nix`:

```nix
{ config, pkgs, ...}:

{
  boot.loader.systemd-boot.memtest86.enable = true;
}
```

This should work as long as you have `boot.loader.systemd-boot.enable` set to `true`.

You'll also need `allowUnfree` set to `true`, since memtest86 is not open source.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I wanted a way to install memtest86 easily from NixOS.  This is a follow-up of #60967.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
