### PR TITLE
awesome: refactor LUA_PATH env var and don't expose it at runtime (19.03 branch)

### DIFF
--- a/pkgs/applications/window-managers/awesome/default.nix
+++ b/pkgs/applications/window-managers/awesome/default.nix
@@ -42,17 +42,17 @@ with luaPackages; stdenv.mkDerivation rec {
   cmakeFlags = "-DOVERRIDE_VERSION=${version}";
 
   GI_TYPELIB_PATH = "${pango.out}/lib/girepository-1.0";
+  # LUA_CPATH and LUA_PATH are used only for *building*, see the --search flags
+  # below for how awesome finds the libraries it needs at runtime.
   LUA_CPATH = "${lgi}/lib/lua/${lua.luaversion}/?.so";
-  LUA_PATH  = "?.lua;${lgi}/share/lua/${lua.luaversion}/?.lua;${lgi}/share/lua/${lua.luaversion}/lgi/?.lua";
+  LUA_PATH  = "${lgi}/share/lua/${lua.luaversion}/?.lua;;";
 
   postInstall = ''
     wrapProgram $out/bin/awesome \
       --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
       --add-flags '--search ${lgi}/lib/lua/${lua.luaversion}' \
       --add-flags '--search ${lgi}/share/lua/${lua.luaversion}' \
-      --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH" \
-      --prefix LUA_PATH ';'  "${lgi}/share/lua/${lua.luaversion}/?.lua;${lgi}/share/lua/${lua.luaversion}/lgi/?.lua" \
-      --prefix LUA_CPATH ';' "${lgi}/lib/lua/${lua.luaversion}/?.so"
+      --prefix GI_TYPELIB_PATH : "$GI_TYPELIB_PATH"
 
     wrapProgram $out/bin/awesome-client \
       --prefix PATH : "${which}/bin"


### PR DESCRIPTION
Cherry-picked  c973e15fb6f to fix #60232 in the 19.03 branch. Hope this is the right way to do it. Thanks.

This commit partly reinstates changes from 5465d6f that had been somehow
reverted in 17d3eb2.  Also, a comment has been added in the hope that future
changes won't do the same.

Additionally, refactor the LUA_PATH env var to ensure that the internal lgi lua
files can't be required explicitly and to avoid possible name clashes (this
fixes issue #60232).

Finally, rather than using prepending `?.lua` append `;;` to LUA_PATH. Quoting
@psychon:

> This is interpreted by Lua as "add the default search path here" (which does
> indeed contain ?.lua, but also contains more).

Testing done:

- Build with `nix-build -I /path/to/repo -A awesome`
- Start an X session with xterm only
- Start xephyr, e.g. `Xephyr :1 -name xephyr -screen 512x384 -ac -br -noreset &`
- Run awesome like `DISPLAY=:1.0 ./result/bin/awesome`. Additionally, add
  `--search` options to expose lua modules that have a name clash with lgi's
  internal ones (see #60232 for more details) and `require` them in `rc.lua` to
  prove that they are loaded correctly

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
