### PR TITLE
python3Packages.seabreeze: init at 0.6.0

### DIFF
--- a/pkgs/development/python-modules/seabreeze/default.nix
+++ b/pkgs/development/python-modules/seabreeze/default.nix
@@ -1,0 +1,42 @@
+{ stdenv
+, fetchFromGitHub
+, buildPythonPackage
+, pyusb
+, numpy
+}:
+
+## Usage
+# In NixOS, simply add the `udev` multiple output to services.udev.packages:
+#   services.udev.packages = [ pkgs.python3Packages.seabreeze.udev ];
+
+buildPythonPackage rec {
+  pname = "seabreeze";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "ap--";
+    repo = "python-seabreeze";
+    rev = "python-seabreeze-v${version}";
+    sha256 = "0bc2s9ic77gz9m40w89snixphxlzib60xa4f49n4zasjrddfz1l8";
+  };
+
+  outputs = [ "out" "udev" ];
+
+  postInstall = ''
+    mkdir -p $udev/lib/udev/rules.d
+    cp misc/10-oceanoptics.rules $udev/lib/udev/rules.d/10-oceanoptics.rules
+  '';
+
+  doCheck = false;
+
+  propagatedBuildInputs = [ pyusb numpy ];
+
+  setupPyBuildFlags = [ "--without-cseabreeze" ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/ap--/python-seabreeze";
+    description = "A python library to access Ocean Optics spectrometers";
+    maintainers = [];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4240,6 +4240,8 @@ in {
 
   seaborn = callPackage ../development/python-modules/seaborn { };
 
+  seabreeze = callPackage ../development/python-modules/seabreeze { };
+
   selenium = callPackage ../development/python-modules/selenium { };
 
   serpy = callPackage ../development/python-modules/serpy { };


### PR DESCRIPTION
###### Motivation for this change
Need to interface with a spectrometer

###### Things done
added a python package 

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
