### PR TITLE
zmap: init at 2.1.1

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -144,6 +144,7 @@
   ./programs/xonsh.nix
   ./programs/xss-lock.nix
   ./programs/yabar.nix
+  ./programs/zmap.nix
   ./programs/zsh/oh-my-zsh.nix
   ./programs/zsh/zsh.nix
   ./programs/zsh/zsh-autoenv.nix

--- a/nixos/modules/programs/zmap.nix
+++ b/nixos/modules/programs/zmap.nix
@@ -1,0 +1,18 @@
+{ pkgs, config, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.zmap;
+in {
+  options.programs.zmap = {
+    enable = mkEnableOption "ZMap";
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.zmap ];
+
+    environment.etc."zmap/blacklist.conf".source = "${pkgs.zmap}/etc/zmap/blacklist.conf";
+    environment.etc."zmap/zmap.conf".source = "${pkgs.zmap}/etc/zmap.conf";
+  };
+}

--- a/pkgs/development/tools/parsing/byacc/default.nix
+++ b/pkgs/development/tools/parsing/byacc/default.nix
@@ -12,7 +12,15 @@ stdenv.mkDerivation rec {
     sha256 = "173l9yai5yndbyn8nzdl6q11wv4x959bd0w392i82nfsqcz0pfsv";
   };
 
+  configureFlags = [
+    "--program-transform-name='s,^,b,'"
+  ];
+
   doCheck = true;
+
+  postInstall = ''
+    ln -s $out/bin/byacc $out/bin/yacc
+  '';
 
   meta = with stdenv.lib; {
     description = "Berkeley YACC";

--- a/pkgs/tools/security/zmap/default.nix
+++ b/pkgs/tools/security/zmap/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, cmake, pkgconfig, libjson, json_c, gengetopt, flex, byacc, gmp
+, libpcap
+}:
+
+stdenv.mkDerivation rec {
+  pname = "zmap";
+  version = "2.1.1";
+
+  src = fetchFromGitHub {
+    owner = "zmap";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0yaahaiawkjk020hvsb8pndbrk8k10wxkfba1irp12a4sj6rywcs";
+  };
+
+  cmakeFlags = [ "-DRESPECT_INSTALL_PREFIX_CONFIG=ON" ];
+  dontUseCmakeBuildDir = true;
+
+  nativeBuildInputs = [ cmake pkgconfig gengetopt flex byacc ];
+  buildInputs = [ libjson json_c gmp libpcap ];
+
+  outputs = [ "out" "man" ];
+
+  meta = with stdenv.lib; {
+    homepage = https://zmap.io/;
+    license = licenses.asl20;
+    description = "Fast single packet network scanner designed for Internet-wide network surveys";
+    maintainers = with maintainers; [ ma27 ];
+    platforms = platforms.unix;
+    broken = stdenv.isDarwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6811,6 +6811,8 @@ in
 
   zxing = callPackage ../tools/graphics/zxing {};
 
+  zmap = callPackage ../tools/security/zmap { };
+
 
   ### SHELLS
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
zmap[1] is a fast network scanner for the IPv4 address space. This is
the main package of the ZMap projects, there are further one that will
be packaged soon.

[1]: https://zmap.io/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
