### PR TITLE
doc/stdenv: put note about remote builds with breakpointHook into a <note>

### DIFF
--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -2643,9 +2643,7 @@ addEnvHooks "$hostOffset" myBashFunction
        At <filename>/var/lib/cntr</filename> the sandboxed filesystem is
        mounted. All commands and files of the system are still accessible
        within the shell. To execute commands from the sandbox use the cntr exec
-       subcommand. Note that <command>cntr</command> also needs to be executed
-       on the machine that is doing the build, which might not be the case when
-       remote builders are enabled. <command>cntr</command> is only supported
+       subcommand. <command>cntr</command> is only supported
        on Linux-based platforms. To use it first add <literal>cntr</literal> to
        your <literal>environment.systemPackages</literal> on NixOS or
        alternatively to the root user on non-NixOS systems. Then in the package
@@ -2657,6 +2655,16 @@ addEnvHooks "$hostOffset" myBashFunction
        When a build failure happens there will be an instruction printed that
        shows how to attach with <literal>cntr</literal> to the build sandbox.
       </para>
+      <note>
+       <title>Caution with remote builds</title>
+       <para>
+        This won't work with remote builds as the build environment is on
+        a different machine and can't be accessed by <command>cntr</command>.
+        Remote builds can be turned off by setting <literal>--option builders ''</literal>
+        for <command>nix-build</command> or <literal>--builders ''</literal> for
+        <command>nix build</command>.
+       </para>
+      </note>
      </listitem>
     </varlistentry>
     <varlistentry>


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

With remote builds, the sandbox can't be accessed by `cntr` as it is on
a different machine. I decided to document this in the manual as it took
me admittedly too much time to figure this out.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
