### PR TITLE
vokoscreen-beta: init at 2.5.8

### DIFF
--- a/pkgs/applications/video/vokoscreen-beta/default.nix
+++ b/pkgs/applications/video/vokoscreen-beta/default.nix
@@ -1,0 +1,54 @@
+{ stdenv, fetchFromGitHub
+, pkgconfig, qtbase, qttools, qmake, qtmultimedia, qtx11extras, alsaLib, libv4l, libXrandr
+, ffmpeg
+}:
+
+stdenv.mkDerivation rec {
+
+  pname = "vokoscreen";
+  version = "2.5.8-beta";
+
+  src = fetchFromGitHub {
+    owner   = "vkohaupt";
+    repo    = "vokoscreen";
+    rev     = "2bf2469803f76a0de4abdd19f3abc3229b259b7e";
+    sha256  = "1a85vbsi53mhzva49smqwcs61c51wv3ic410nvb9is9nlsbifwan";
+  };
+
+  nativeBuildInputs = [ pkgconfig qmake ];
+  buildInputs = [
+    alsaLib
+    libv4l
+    qtbase
+    qtmultimedia
+    qttools
+    qtx11extras
+    libXrandr
+  ];
+
+  patches = [
+    ./ffmpeg-out-of-box.patch
+  ];
+
+  preConfigure = ''
+    sed -i 's/lrelease-qt5/lrelease/g' vokoscreen.pro
+    sed -i 's/TARGET\ =\ vokoscreen/TARGET\ =\ vokoscreen-beta/g' vokoscreen.pro
+  '';
+
+  postConfigure = ''
+    substituteInPlace settings/QvkSettings.cpp --subst-var-by ffmpeg ${ffmpeg}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Simple GUI screencast recorder, using ffmpeg";
+    homepage = "http://linuxecke.volkoh.de/vokoscreen/vokoscreen.html";
+    longDescription = ''
+      vokoscreen is an easy to use screencast creator to record
+      educational videos, live recordings of browser, installation,
+      videoconferences, etc.
+    '';
+    license = licenses.gpl2Plus;
+    maintainers = [ maintainers.league ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/video/vokoscreen-beta/ffmpeg-out-of-box.patch
+++ b/pkgs/applications/video/vokoscreen-beta/ffmpeg-out-of-box.patch
@@ -1,0 +1,24 @@
+diff --git a/settings/QvkSettings.cpp b/settings/QvkSettings.cpp
+index 3008e62..07485bd 100644
+--- a/settings/QvkSettings.cpp
++++ b/settings/QvkSettings.cpp
+@@ -66,17 +66,8 @@ void QvkSettings::readAll()
+       Minimized = settings.value( "Minimized", 0 ).toUInt();
+       MinimizedByStart = settings.value( "MinimizedByStart", 0 ).toUInt();
+       Countdown = settings.value( "Countdown", 0 ).toUInt();
+-      QFile file;
+-      if ( file.exists( qApp->applicationDirPath().append( "/bin/ffmpeg" ) ) == true )
+-      {
+-        vokoscreenWithLibs = true;
+-        Recorder = qApp->applicationDirPath().append( "/bin/ffmpeg" );
+-      }
+-      else
+-      {
+-        vokoscreenWithLibs = false;
+-        Recorder = settings.value( "Recorder", "ffmpeg" ).toString();
+-      }
++      vokoscreenWithLibs = true;
++      Recorder = settings.value( "Recorder", "@ffmpeg@/bin/ffmpeg" ).toString();
+     settings.endGroup();
+     
+     settings.beginGroup( "Videooptions" );

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23566,6 +23566,8 @@ in
 
   vokoscreen = libsForQt5.callPackage ../applications/video/vokoscreen { };
 
+  vokoscreen-beta = libsForQt5.callPackage ../applications/video/vokoscreen-beta { };
+
   vttest = callPackage ../tools/misc/vttest { };
 
   wasm-pack = callPackage ../development/tools/wasm-pack { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Only the stable version of vokoscreen is available, but is missing multiple features that I needed.
I already build and installed it locally and used it multiple times successfully :-)
I guess it could be bundled with the stable version, but this may be more reasonable when the beta and stable version will be maintained continuously.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
