### PR TITLE
qscintilla: fix dylib names on Darwin

### DIFF
--- a/pkgs/development/libraries/qscintilla/default.nix
+++ b/pkgs/development/libraries/qscintilla/default.nix
@@ -1,6 +1,7 @@
 { stdenv, lib, fetchurl, unzip
 , qt4 ? null, qmake4Hook ? null
 , withQt5 ? false, qtbase ? null, qtmacextras ? null, qmake ? null
+, fixDarwinDylibNames
 }:
 
 # Fix Xcode 8 compilation problem
@@ -22,7 +23,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ (if withQt5 then qtbase else qt4) ]
     ++ lib.optional (withQt5 && stdenv.isDarwin) qtmacextras;
   nativeBuildInputs = [ unzip ]
-    ++ (if withQt5 then [ qmake ] else [ qmake4Hook ]);
+    ++ (if withQt5 then [ qmake ] else [ qmake4Hook ])
+    ++ lib.optional stdenv.isDarwin fixDarwinDylibNames;
 
 
   patches = lib.optional (stdenv.isDarwin && withQt5) [ xcodePatch ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

On Darwin dylibs are intended to have their install names set to their absolute path. Without an absolute path, applications using these libraries will have invalid references embedded, and will be unable to locate the libraries at runtime.

Before
```
$ otool -D $(nix-build channel:nixos-unstable -A qscintilla)/lib/libqscintilla2.dylib | tail -n 1
libqscintilla2.12.dylib
```

After
```
$ otool -D $(nix-build . -A qscintilla)/lib/libqscintilla2.dylib | tail -n 1
/nix/store/n72ds0cqcnpkq9066lxjas2k814j4i79-qscintilla-qt4-2.9.4/lib/libqscintilla2.12.0.2.dylib
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---