### PR TITLE
hdf4: fix tests on some machines

### DIFF
--- a/pkgs/tools/misc/hdf4/default.nix
+++ b/pkgs/tools/misc/hdf4/default.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
     export DYLD_LIBRARY_PATH=$(pwd)/bin
   '';
 
-  excludedTests = [
+  excludedTests = stdenv.lib.optionals stdenv.isDarwin [
     "MFHDF_TEST-hdftest"
     "MFHDF_TEST-hdftest-shared"
     "HDP-dumpsds-18"


### PR DESCRIPTION
###### Motivation for this change

The hdf4 package has some problems with tests failing on certain machines. Based on my testing, a particular machine will either fail or pass reliably. I have not seen any transient failures.

I discovered this issue because the Hydra builder ["ike" failed to build this package](https://hydra.nixos.org/build/92714668/nixlog/1) and therefore one of my builders attempted to build it and also failed. The build [previously succeeded on builder "t4a"](https://hydra.nixos.org/build/92341034/nixlog/3). I tested both commits, and both times was able to reproduce the failure, meaning that this is not a regression.

Here are the results of tests on different machines:

| Status | CPU | OS | Cores |
:-------:|-------|-----|-----|
| :heavy_check_mark: | i7-6700HQ | Arch Linux | 8 |
| :heavy_check_mark: | Xeon E5-1620 v2 | NixOS | 8 |
| :x: | Xeon E5-2640 v4 | Ubuntu 18.04 | 40 |
| :x: | Xeon E5-2620 | Ubuntu 18.04 | 24 |
| :x: | Xeon E5-2623 v3 | Fedora 30 | 16 |
| :x: | Xeon E5-2660 v3 | Fedora 29 | 40 |
| :x: | Xeon E5-2623 v3 | Fedora 24 | 16 |

All of these test were done with sandboxing enabled.

###### Things done

Interestingly, the most reliable way I can find to fix the tests is to enable all the tests. The tests that were previously disabled pass on all machines I was able to test, including armv7l and aarch64, and they seem to make the other failing tests pass as well. I was not able to test macOS, but that can be done by ofborg.

I'm not sure what's going on here, but I suspect it fails on machines that have large numbers of cores, maybe due to a race condition.

cc @knedlsepp

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
