### PR TITLE
Update ultrastar creator and manager

### DIFF
--- a/pkgs/development/libraries/audio/libbass/default.nix
+++ b/pkgs/development/libraries/audio/libbass/default.nix
@@ -11,7 +11,7 @@ let
         x86_64-linux = "x64/libbass.so";
       };
       urlpath = "bass${version}-linux.zip";
-      sha256 = "0alxx7knkvzwwifqrmzavafwq53flja7s1ckaabk6p2ir2f0j5cp";
+      sha256 = "1hjxp1akj8367qlglv5rqpwq2dimfz3bkllwq39abavz4sp8smjz";
     };
 
     bass_fx = {
@@ -21,7 +21,7 @@ let
         x86_64-linux = "x64/libbass_fx.so";
       };
       urlpath = "z/0/bass_fx${version}-linux.zip";
-      sha256 = "0j1cbq88j3vnqf2bibcqnfhciz904w48ldgycyh9d8954hwyg22m";
+      sha256 = "1q0g74z7iyhxqps5b3gnnbic8v2jji1r0mkvais57lsx8y21sbin";
     };
   };
 

--- a/pkgs/tools/misc/ultrastar-creator/default.nix
+++ b/pkgs/tools/misc/ultrastar-creator/default.nix
@@ -1,15 +1,20 @@
 { stdenv, fetchFromGitHub
 , qmake, qtbase, pkgconfig, taglib, libbass, libbass_fx }:
 
+# TODO: get rid of (unfree) libbass
+# issue:https://github.com/UltraStar-Deluxe/UltraStar-Creator/issues/3
+# there’s a WIP branch here:
+# https://github.com/UltraStar-Deluxe/UltraStar-Creator/commits/BASS_removed
+
 stdenv.mkDerivation rec {
   name = "ultrastar-creator-${version}";
-  version = "2017-04-12";
+  version = "2019-04-23";
 
   src = fetchFromGitHub {
     owner = "UltraStar-Deluxe";
     repo = "UltraStar-Creator";
-    rev = "ac519a003f8283bfbe5e2d8e9cdff3a3faf97001";
-    sha256 = "00idr8a178gvmylq722n13bli59kpxlsy5d8hlplqn7fih48mnzi";
+    rev = "36583b4e482b68f6aa949e77ef2744776aa587b1";
+    sha256 = "1rzz04l7s7pxj74xam0cxlq569lfpgig35kpbsplq531d4007pc9";
   };
 
   postPatch = with stdenv.lib; ''

--- a/pkgs/tools/misc/ultrastar-manager/default.nix
+++ b/pkgs/tools/misc/ultrastar-manager/default.nix
@@ -2,9 +2,9 @@
 , qtbase, qtmultimedia, taglib, libmediainfo, libzen, libbass }:
 
 let
-  version = "2017-05-24";
-  rev = "eed5dc41c849ab29b2dee37d97852fffdb45e390";
-  sha256 = "1ymdgaffazndg9vhh47qqjr5873ld7j066hycp670r08bm519ysg";
+  version = "2019-04-23";
+  rev = "ef4524e2239ddbb60f26e05bfba1f4f28cb7b54f";
+  sha256 = "0dl2qp686vbs160b3i9qypb7sv37phy2wn21kgzljbk3wnci3yv4";
   buildInputs = [ qtbase qtmultimedia taglib libmediainfo libzen libbass ];
 
   plugins = [


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update broken versions (libbass, qt changed interface)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
