### PR TITLE
doge: init at 3.5.0

### DIFF
--- a/pkgs/misc/doge/default.nix
+++ b/pkgs/misc/doge/default.nix
@@ -1,0 +1,18 @@
+{ stdenv , python3Packages }:
+
+python3Packages.buildPythonPackage rec {
+  pname = "doge";
+  version = "3.5.0";
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "0lwdl06lbpnaqqjk8ap9dsags3bzma30z17v0zc7spng1gz8m6xj";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/thiderman/doge;
+    description = "wow very terminal doge";
+    license = licenses.mit;
+    maintainers = with maintainers; [ Gonzih ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15940,6 +15940,8 @@ in
 
   documize-community = callPackage ../servers/documize-community { };
 
+  doge = callPackage ../misc/doge { };
+
   doulos-sil = callPackage ../data/fonts/doulos-sil { };
 
   cabin = callPackage ../data/fonts/cabin { };


### PR DESCRIPTION
###### Motivation for this change
Adding the most important tool without which workflow in terminal is almost impossible.

The `doge` utility.

![doge](https://user-images.githubusercontent.com/266275/57262878-1ee23280-703c-11e9-9973-578911077665.png)


###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
