### PR TITLE
haskell: add a callStack2nix function

### DIFF
--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -360,10 +360,39 @@ in package-set { inherit pkgs stdenv callPackage; } self // {
     # environment.  However, callStack2nix should not be used if you want to
     # hack on the PureScript compiler itself.
     #
-    # TODO: Currently this doesn't work for stack.yaml files that have extra-deps
-    # that come from places other than Hackage.  This is due to an unfortunate
-    # interaction between stack2nix and cabal2nix.  In theory, this should be able
-    # to be fixed.
+    # WARNING: Currently this doesn't work for stack.yaml files that have
+    # extra-deps that are specified as git repos, HTTP(S) URLs, etc.
+    #
+    # An example non-working stack.yaml file would look like the following:
+    #
+    #   resolver: lts-13.17
+    #   packages:
+    #     - .
+    #   extra-deps:
+    #     - git: 'https://github.com/ekmett/lens.git'
+    #       commit: '867f1ff48d2576b4d7cf50d1f971ce5496650a47'
+    #     - http://hackage.haskell.org/package/conduit-1.3.1.1/conduit-1.3.1.1.tar.gz
+    #
+    # This stack.yaml will not work with callStack2nix because the lens and
+    # conduit extra-deps are specified as a git repo and HTTP URL.
+    #
+    # The following is a similar stack.yaml file that will work with
+    # callStack2nix:
+    #
+    #   resolver: lts-13.17
+    #   packages:
+    #     - .
+    #   extra-deps:
+    #     - lens-4.17.1
+    #     - conduit-1.3.1.1
+    #
+    # This stack.yaml will work, because all the extra-deps are specified as
+    # packages on Hackage.
+    #
+    # This is due to an unfortunate interaction between stack2nix and
+    # cabal2nix.  See
+    # https://github.com/NixOS/nixpkgs/pull/61067#discussion_r282447134
+    # for the technical details.
     callStack2nix =
       { # The source for the Haskell package that contains a stack.yaml file.
         src

--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -315,6 +315,245 @@ in package-set { inherit pkgs stdenv callPackage; } self // {
           else "${ghcEnv}/lib/${ghcCommand}-${ghc.version}";
       });
 
+    # This uses stack2nix to create a .nix file corresponding to a Haskell
+    # package set for a Stack project.  This .nix file can either be copied
+    # into your project and used as-is, or it can be used directly with the
+    # callStack2nixPkgSet function.
+    #
+    # This function is meant for easily creating a package set for building a
+    # Stack-based project.
+    #
+    # Here's an example of how to use this:
+    #
+    #   haskellPackages.callStack2nix {
+    #     name = "purescript";
+    #     src = fetchFromGitHub {
+    #       owner = "purescript";
+    #       repo = "purescript";
+    #       rev = "v0.12.4";
+    #       sha256 = "0lgfmqrn2j1fipgghxrccd9n5f8sw1ncc7fb25201z6x3klzy7bb";
+    #     };
+    #     sha256 = "1in80b914h46hsscdvkmfz0042181lxy2cj522gzyc36l4qq560w";
+    #     hackageSnapshotTimestamp = "2019-05-06T00:00:00Z";
+    #     compiler = haskell.compiler.ghc864;
+    #   };
+    #
+    # This creates a .nix file containing a Haskell package set with Haskell
+    # package versions determined by the LTS used to build PureScript.  This
+    # example is using LTS-13.12 (which is determined by the stack.yaml file in
+    # the purescript repo).
+    #
+    # See the callStack2nixPkgSet for how to import and build this resulting
+    # package set.
+    #
+    # In general, this function won't be used within nixpkgs, but instead
+    # by end-users who want an easy way to build a stack-based project with nix.
+    #
+    # This produces a fixed-output derivation.  See the comment on the sha256
+    # argument for a little more info about this.  This means that
+    # callStack2nix is suited for building Haskell tools, but not suited for
+    # interactive development on Haskell projects.
+    #
+    # For instance, with the PureScript example above, callStack2nix is
+    # convenient to use if you're working on a frontend project written in
+    # PureScript, and you need the PureScript compiler available in your
+    # environment.  However, callStack2nix should not be used if you want to
+    # hack on the PureScript compiler itself.
+    #
+    # TODO: Currently this doesn't work for stack.yaml files that have extra-deps
+    # that come from places other than Hackage.  This is due to an unfortunate
+    # interaction between stack2nix and cabal2nix.  In theory, this should be able
+    # to be fixed.
+    callStack2nix =
+      { # The source for the Haskell package that contains a stack.yaml file.
+        src
+      , # Hash for the .nix file that is produced by stack2nix.
+        #
+        # It is not possible to know this before running stack2nix.  You are
+        # suggested to first run this with a known incorrect sha256 hash, like
+        # "a24341d51da6db9f9f0edcdefe185dbd7726888ec4e230855fb9871de7c07717".
+        # Nix will complain that the hash is incorrect and will tell you the
+        # correct hash.  Then you should fill in the correct hash and run
+        # the derivation again.
+        #
+        # Since the derivation produced by callStack2nix is a fixed-output
+        # derivation, you must be sure to update the sha256 if you update
+        # src, hackageSnapshotTimestamp, compiler, etc.  If you only update
+        # src (or hackageSnapshotTimestamp, etc) and don't update sha256, nix
+        # won't realize that it should re-run callStack2nix.
+        sha256
+      , # A time stamp specifying a Hackage snapshot version.  In order to
+        # make the output of stack2nix reproducible, stack2nix must always
+        # look at the same state of Hackage.  This is needed because the
+        # packages on Hackage are not actually immutable.
+        #
+        # example: "2019-04-16T00:00:00Z"
+        #
+        # TODO: It should be possible to use stack2nix to figure out what
+        # resolver a package is using (like lts-13.7), then automatically
+        # take the release date of the resolver as the
+        # hackageSnapshotTimestamp.
+        hackageSnapshotTimestamp
+      , # Which GHC to use for stack2nix.  This needs to the GHC version
+        # used the resolver in the stack.yaml file.
+        #
+        # example: haskell.compiler.ghc865
+        compiler
+      , # The name for the package.  This is only used to create the
+        # derivation name for the produced .nix file.  It should either
+        # be a string, or null.
+        #
+        # example: "purescript"
+        name ? null
+      , stack2nix ? buildPackages.haskellPackages.stack2nix_0_2_3
+      , cabal-install ? buildPackages.cabal-install
+      , stdenv ? pkgs.stdenv
+      , cacert ? pkgs.cacert
+      , git ? pkgs.git
+      , iana-etc ? pkgs.iana-etc
+      , libredirect ? pkgs.libredirect
+      , doCheck ? true
+      , doHaddock ? true
+      , doBenchmark ? false
+      }:
+      assert builtins.isString hackageSnapshotTimestamp;
+      stdenv.mkDerivation {
+        name = "stack2nix${if isNull name then "" else "-for-" + name}.nix";
+
+        nativeBuildInputs = [
+          cabal-install
+          cacert
+          compiler
+          git
+          iana-etc
+          libredirect
+          stack2nix
+        ];
+
+        phases = ["installPhase"];
+
+        LANG = "en_US.UTF-8";
+
+        outputHashMode = "flat";
+        outputHashAlgo = "sha256";
+        outputHash = sha256;
+
+        # Certificates need to be overridden for git and Haskell packages.
+        GIT_SSL_CAINFO = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+        NIX_SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+        SYSTEM_CERTIFICATE_PATH = "${cacert}/etc/ssl/certs";
+
+        installPhase = ''
+          # Make sure /etc/protocols is available because the libraries stack
+          # depends on use it.
+          export NIX_REDIRECTS=/etc/protocols=${iana-etc}/etc/protocols
+          export LD_PRELOAD=${libredirect}/lib/libredirect.so
+
+          # Set $HOME because stack needs it.
+          export HOME="$TMP"
+
+          # Make a temporary directory.  stack2nix uses stack internally.
+          # stack creates a .stack-work/ directory inside the source code
+          # directory it is trying to build.  Since the source code directory
+          # we are using is in /nix/store and not writable, we copy the
+          # source code to a temporary directory so that stack is able to
+          # create a .stack-work/ directory inside of it.
+          #
+          # Below, the temporary source directory is replaced with the path
+          # to the actual source directory from /nix/store. The name of the
+          # temporary source directory needs to be long enough so it is
+          # reliably unique.
+          temp_src_dir=$(mktemp -d stack2nix-temp.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX)
+          cp --no-target-directory -r ${src} $temp_src_dir
+          chmod -R ugo+rwx $temp_src_dir
+
+          # Make sure .stack-work doesn't already exist in the source directory.
+          rm -rf $temp_src_dir/.stack-work
+
+          stack2nix \
+            ${pkgs.lib.optionalString doCheck "--test"} \
+            ${pkgs.lib.optionalString doHaddock "--haddock"} \
+            ${pkgs.lib.optionalString doBenchmark "--bench"} \
+            -o $out \
+            --hackage-snapshot ${hackageSnapshotTimestamp} \
+            --verbose \
+            --no-ensure-executables \
+            $temp_src_dir
+
+          # stack2nix creates the output nix file with a reference to the
+          # temporary source directory from above.  We need to replace this
+          # with the actual source directory from /nix/store.
+          substituteInPlace $out --replace "$temp_src_dir" "${src}"
+        '';
+      };
+
+    # This uses stack2nix to create a Haskell package set for a Stack project.
+    # This package set contains all the Haskell packages defined in the Stack
+    # project.
+    #
+    # This function is meant for easily building a Stack-based project with
+    # nix.
+    #
+    # Here's an example of how to use this:
+    #
+    #   let
+    #     purescriptPkgSet = haskellPackages.callStack2nixPkgSet {
+    #       name = "purescript";
+    #       src = fetchFromGitHub {
+    #         owner = "purescript";
+    #         repo = "purescript";
+    #         rev = "v0.12.4";
+    #         sha256 = "0lgfmqrn2j1fipgghxrccd9n5f8sw1ncc7fb25201z6x3klzy7bb";
+    #       };
+    #       sha256 = "1in80b914h46hsscdvkmfz0042181lxy2cj522gzyc36l4qq560w";
+    #       hackageSnapshotTimestamp = "2019-05-06T00:00:00Z";
+    #       haskellPackagesCompiler = haskell.packages.ghc864;
+    #     };
+    #   in purescriptPkgSet.purescript
+    #
+    # This is an example of building the PureScript compiler.
+    #
+    # This purescriptPkgSet is a normal Haskell package set (similar to
+    # haskellPackages) that contains all the packages defined in the
+    # stackage resolver from the stack.yaml file in the PureScript repo.
+    # It contains packages like purescript, aeson, protolude, etc.
+    #
+    # If you want to override some of the packages used to build PureScript,
+    # you can do it the same way you'd normally override Haskell packages.
+    #
+    # See the callStack2nix function for some of the limitations of this
+    # approach.
+    callStack2nixPkgSet =
+      { # callStack2nix produces a derivation that takes a nix package set
+        # as an argument.  This pkgs argument is passed to that derivation.
+        # By default, it uses the nixpkgs that contains this function.
+        pkgs ? pkgs
+      , # Which Haskell package set to use for stack2nix.  This needs to the GHC
+        # version used in the resolver in the stack.yaml file.  This is passed to
+        # the derivation created from stack2nix and overridden with the Haskell
+        # package versions from the generated .nix file.
+        #
+        # example: haskell.packages.ghc865
+        haskellPackagesCompiler
+      , # Additional arguments are the same as those for the callStack2nix
+        # function.
+        ...
+      }@args:
+      let
+        callStack2nixArgs =
+          builtins.removeAttrs args ["pkgs" "haskellPackagesCompiler"] // {
+            compiler = haskellPackagesCompiler.ghc;
+          };
+
+        pkgSetNixFileDrv = self.callStack2nix callStack2nixArgs;
+
+        pkgSet = import pkgSetNixFileDrv {
+          inherit pkgs;
+          compiler = haskellPackagesCompiler;
+        };
+
+      in pkgSet;
+
     ghc = ghc // {
       withPackages = self.ghcWithPackages;
       withHoogle = self.ghcWithHoogle;


### PR DESCRIPTION
`callStack2nix` is a function similar to `callCabal2nix`, but instead of just creating a .nix file for a single Haskell package, it creates a whole overlay based on an Stackage LTS resolver.

This makes it very easy to build a Stack-based Haskell project with Nix.

`callStack2nix` uses the `stack2nix` tool to produce a `.nix` file as output.  You can see an example of what one of these files look like in the `stack2nix` repo:

https://raw.githubusercontent.com/input-output-hk/stack2nix/1143ceb8b395478d4e5bc8d2b0b0dee19e2f140a/stack2nix.nix

There is another function, `callStack2nixPkgSet`, that actually does the import-from-derivation so that the package set produced from `callStack2nix` is usable.

There is an example in the documentation, but here is a another example:

```nix
let
  src = fetchFromGitHub {
    owner = "chrisdone";
    repo = "intero";
    rev = "8da81244783fbf03afb49660423c875f2e874fba";
    sha256 = "17vibxapzp4wf0dfc56x98wsf3wy98ghj5h10nyf7xcfwy6k0rja";
  };

  interoPkgSet = haskellPackages.callStack2nixPkgSet {
    name = "intero";
    inherit src;
    sha256 = "163mmyl1c718g3i5r7djr4x2m07id190zb3pjl69flh0wyxwzzzc";
    hackageSnapshotTimestamp = "2019-04-16T00:00:00Z";
    haskellPackagesCompiler = pkgs.haskell.packages.ghc822;
    doCheck = false;
    doHaddock = false;
  };

in

interoPkgSet.intero
```

This example demonstrates using `callStack2nixPkgSet` to easily build the [intero](https://github.com/chrisdone/intero) tool.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I wanted an easy way to build a stack-based Haskell project with nix.

Every once in a while it comes up on the issue tracker or IRC that someone wants an easy way to build a Stack-based Haskell project with nix, and there is currently no way to do this.  I think it would be nice to have a short-and-sweet method for doing this in nixpkgs.

There are a few alternatives (like using `stack2nix` by hand to generate a package set, using `haskell.nix`, etc), but they all require more work and additional understanding to use.

Pinging @peti. I opened this as a PR against `master`, because it doesn't really affect any of the other Haskell stuff, but I can always rebase it against the `haskell-updates` branch if this is easier.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
