### PR TITLE
public-sans: init at 1.002

### DIFF
--- a/pkgs/data/fonts/public-sans/default.nix
+++ b/pkgs/data/fonts/public-sans/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchzip }:
+
+let
+  version = "1.002";
+in fetchzip rec {
+  name = "public-sans-${version}";
+
+  url = "https://github.com/uswds/public-sans/releases/download/v${version}/public-sans-v${version}.zip";
+
+  postFetch = ''
+    mkdir -p $out/share
+    unzip $downloadedFile fonts/{otf,variable}/\*.\[ot\]tf -d $out/share/
+  '';
+
+  sha256 = "1j792i6350sp63l04jww5rpnsfz9zkj97rd378yxnpnwf2a8nv4k";
+
+  meta = with stdenv.lib; {
+    description = "A strong, neutral, principles-driven, open source typeface for text or display";
+    homepage = https://public-sans.digital.gov/;
+    license = licenses.ofl;
+    maintainers = with maintainers; [ dtzWill ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16286,6 +16286,8 @@ in
 
   proggyfonts = callPackage ../data/fonts/proggyfonts { };
 
+  public-sans  = callPackage ../data/fonts/public-sans { };
+
   qogir-theme = callPackage ../data/themes/qogir { };
 
   route159 = callPackage ../data/fonts/route159 { };


### PR DESCRIPTION
###### Motivation for this change

Open font! :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---