### PR TITLE
partitionmanager,kpmcore: 3.3.{0,1} -> 4.1.0

### DIFF
--- a/pkgs/development/libraries/kpmcore/default.nix
+++ b/pkgs/development/libraries/kpmcore/default.nix
@@ -20,6 +20,7 @@ in stdenv.mkDerivation rec {
     smartmontools
     parted # we only need the library
 
+    kdeFrameworks.kauth
     kdeFrameworks.kio
 
     utillinux # needs blkid (note that this is not provided by utillinux-compat)

--- a/pkgs/development/libraries/kpmcore/default.nix
+++ b/pkgs/development/libraries/kpmcore/default.nix
@@ -8,11 +8,11 @@ let
 
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
-  version = "3.3.0";
+  version = "4.0.0";
 
   src = fetchurl {
     url = "mirror://kde/stable/${pname}/${version}/src/${name}.tar.xz";
-    sha256 = "0s6v0jfrhjg31ri5p6h9n4w29jvasf5dj954j3vfpzl91lygmmmq";
+    sha256 = "0vfz9pr9n6p9hs3d9cm8yirp9mkw76nhnin55v3bwsb34p549w6p";
   };
 
   buildInputs = [

--- a/pkgs/development/libraries/kpmcore/default.nix
+++ b/pkgs/development/libraries/kpmcore/default.nix
@@ -8,11 +8,11 @@ let
 
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
-  version = "4.0.0";
+  version = "4.1.0";
 
   src = fetchurl {
     url = "mirror://kde/stable/${pname}/${version}/src/${name}.tar.xz";
-    sha256 = "0vfz9pr9n6p9hs3d9cm8yirp9mkw76nhnin55v3bwsb34p549w6p";
+    sha256 = "0jsig7algmab9h0fb09my0axjqzw83zgscamhzl8931lribs6idm";
   };
 
   buildInputs = [

--- a/pkgs/development/libraries/kpmcore/default.nix
+++ b/pkgs/development/libraries/kpmcore/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchurl, extra-cmake-modules
-, qtbase, kdeFrameworks
-, libatasmart, parted
+, qtbase, qca-qt5, kdeFrameworks
+, smartmontools, parted
 , utillinux }:
 
 let
@@ -16,8 +16,8 @@ in stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    qtbase
-    libatasmart
+    qtbase qca-qt5
+    smartmontools
     parted # we only need the library
 
     kdeFrameworks.kio

--- a/pkgs/tools/misc/partition-manager/default.nix
+++ b/pkgs/tools/misc/partition-manager/default.nix
@@ -8,11 +8,11 @@ let
   pname = "partitionmanager";
 in mkDerivation rec {
   name = "${pname}-${version}";
-  version = "4.0.0";
+  version = "4.1.0";
 
   src = fetchurl {
     url = "mirror://kde/stable/${pname}/${version}/src/${name}.tar.xz";
-    sha256 = "1q8kqi05qv932spln8bh7n739ivq6pra2pgz67zl2dmdknpysrvr";
+    sha256 = "1d1mawaq4npw8kdny4210wslzgsikj9wbkhr5did6k45ghij07nn";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/tools/misc/partition-manager/default.nix
+++ b/pkgs/tools/misc/partition-manager/default.nix
@@ -8,11 +8,11 @@ let
   pname = "partitionmanager";
 in mkDerivation rec {
   name = "${pname}-${version}";
-  version = "3.3.1";
+  version = "4.0.0";
 
   src = fetchurl {
     url = "mirror://kde/stable/${pname}/${version}/src/${name}.tar.xz";
-    sha256 = "0jhggb4xksb0k0mj752n6pz0xmccnbzlp984xydqbz3hkigra1si";
+    sha256 = "1q8kqi05qv932spln8bh7n739ivq6pra2pgz67zl2dmdknpysrvr";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/tools/misc/partition-manager/default.nix
+++ b/pkgs/tools/misc/partition-manager/default.nix
@@ -1,7 +1,7 @@
 { mkDerivation, fetchurl, lib
-, extra-cmake-modules, kdoctools, wrapGAppsHook, wrapQtAppsHook
-, kconfig, kcrash, kinit, kpmcore
-, eject, libatasmart , utillinux, qtbase
+, extra-cmake-modules, kdoctools, wrapGAppsHook
+, kconfig, kcrash, kinit, kpmcore, kauth
+, eject, smartmontools, utillinux, qtbase
 }:
 
 let
@@ -17,11 +17,11 @@ in mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [ extra-cmake-modules kdoctools wrapGAppsHook wrapQtAppsHook ];
+  nativeBuildInputs = [ extra-cmake-modules kdoctools wrapGAppsHook ];
 
   # refer to kpmcore for the use of eject
-  buildInputs = [ eject libatasmart utillinux ];
-  propagatedBuildInputs = [ kconfig kcrash kinit kpmcore ];
+  buildInputs = [ eject smartmontools utillinux ];
+  propagatedBuildInputs = [ kauth kconfig kcrash kinit kpmcore ];
 
   meta = with lib; {
     description = "KDE Partition Manager";


### PR DESCRIPTION

###### Motivation for this change

https://stikonas.eu/wordpress/2019/05/02/kde-partition-manager-4-0/

I've had some trouble with the permissions/auth situation,
even running it as root doesn't seem to work?

This may be my environment, but should hold off merging until
someone reports the updated versions are working for them
or I sort out what's going on locally :).

---

2020:

* bump further to 4.1.0
* no longer need to pin to "newer" utillinux, version in-tree is sufficient (newer than the pin anyway)
* Drop `wrapQtAppsHook` since qt's `mkDerivation` is already used
  (not sure the use of both `wrapGAppsHook` and qt wrapper hook will work properly as-is but double-including seems unhelpful regardless)

Still issues running w/o sudo, not sure what that's about.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---