### PR TITLE
jellyfin: remove assertion if emby enabled: no emby module exists

### DIFF
--- a/nixos/modules/services/misc/jellyfin.nix
+++ b/nixos/modules/services/misc/jellyfin.nix
@@ -48,12 +48,6 @@ in
       jellyfin = {};
     };
 
-    assertions = [
-      {
-        assertion = !config.services.emby.enable;
-        message = "Emby and Jellyfin are incompatible, you cannot enable both";
-      }
-    ];
   };
 
   meta.maintainers = with lib.maintainers; [ minijackson ];


### PR DESCRIPTION
###### Motivation for this change
Jellyfin replaced the emby module, however the used PR expected the emby module to exist, and therefore had an assertion when `!config.services.emby.enable`, which prevents NixOS from rebuilding because there's no emby attribute in config.services.

This commit removes such assertion, allowing jellyfin to be used again.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
