### PR TITLE
pythonPackages.i3ipc: 1.5.1 -> 1.6.0

### DIFF
--- a/pkgs/development/python-modules/i3ipc/default.nix
+++ b/pkgs/development/python-modules/i3ipc/default.nix
@@ -5,13 +5,13 @@
 
 buildPythonPackage rec {
   pname = "i3ipc";
-  version = "1.5.1";
+  version = "1.6.0";
 
   src = fetchFromGitHub {
     owner  = "acrisci";
     repo   = "i3ipc-python";
     rev    = "v${version}";
-    sha256 = "06d7g4d7cnh0vp5diavy3x9wz1w5nwdrb7ipc4g1c3a2wc78862d";
+    sha256 = "0sb525wvwcnikjaqzha94xr97r1gjys30csmaj17swlxgyczxvq5";
   };
 
   propagatedBuildInputs = [ enum-compat ];
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   checkPhase = ''${python.interpreter} run-tests.py'';
 
   meta = with stdenv.lib; {
-    description = "An improved Python library to control i3wm";
+    description = "An improved Python library to control i3wm and sway";
     homepage    = https://github.com/acrisci/i3ipc-python;
     license     = licenses.bsd3;
     maintainers = with maintainers; [ vanzef ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
