### PR TITLE
opencsg: Darwin support and tidy

### DIFF
--- a/pkgs/development/libraries/opencsg/default.nix
+++ b/pkgs/development/libraries/opencsg/default.nix
@@ -1,5 +1,5 @@
 {stdenv, fetchurl, libGLU_combined, freeglut, glew, libXmu, libXext, libX11
-  }:
+, qmake, GLUT, fixDarwinDylibNames }:
 
 stdenv.mkDerivation rec {
   version = "1.4.2";
@@ -9,27 +9,42 @@ stdenv.mkDerivation rec {
     sha256 = "1ysazynm759gnw1rdhn9xw9nixnzrlzrc462340a6iif79fyqlnr";
   };
 
-  buildInputs = [libGLU_combined freeglut glew libXmu libXext libX11];
+  nativeBuildInputs = [ qmake ]
+    ++ stdenv.lib.optional stdenv.isDarwin fixDarwinDylibNames;
+
+  buildInputs = [ glew ]
+    ++ stdenv.lib.optionals stdenv.isLinux [ libGLU_combined freeglut libXmu libXext libX11 ]
+    ++ stdenv.lib.optional stdenv.isDarwin GLUT;
 
   doCheck = false;
 
+  patches = [ ./fix-pro-files.patch ];
+
   preConfigure = ''
-    sed -i 's/^\(LIBS *=.*\)$/\1 -lX11/' example/Makefile
+    rm example/Makefile src/Makefile
+    qmakeFlags="$qmakeFlags INSTALLDIR=$out"
   '';
 
-  installPhase = ''
-    mkdir -pv "$out/"{bin,share/doc/opencsg}
+  postInstall = ''
+    install -D license.txt "$out/share/doc/opencsg/license.txt"
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+    mkdir -p $out/Applications
+    mv $out/bin/*.app $out/Applications
+    rmdir $out/bin || true
+  '';
 
-    cp example/opencsgexample "$out/bin"
-    cp -r include lib "$out"
-
-    cp license.txt "$out/share/doc/opencsg"
+  postFixup = stdenv.lib.optionalString stdenv.isDarwin ''
+    app=$out/Applications/opencsgexample.app/Contents/MacOS/opencsgexample
+    install_name_tool -change \
+      $(otool -L $app | awk '/opencsg.+dylib/ { print $1 }') \
+      $(otool -D $out/lib/libopencsg.dylib | tail -n 1) \
+      $app
   '';
 
   meta = with stdenv.lib; {
     description = "Constructive Solid Geometry library";
     homepage = http://www.opencsg.org/;
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     maintainers = [ maintainers.raskin ];
     license = licenses.gpl2;
   };

--- a/pkgs/development/libraries/opencsg/fix-pro-files.patch
+++ b/pkgs/development/libraries/opencsg/fix-pro-files.patch
@@ -1,0 +1,21 @@
+diff -ur OpenCSG-1.4.2-pristine/example/example.pro OpenCSG-1.4.2/example/example.pro
+--- OpenCSG-1.4.2-pristine/example/example.pro	2016-09-27 06:11:16.000000000 +0900
++++ OpenCSG-1.4.2/example/example.pro	2019-05-07 10:45:18.785251737 +0900
+@@ -6,7 +6,9 @@
+ INCLUDEPATH += ../include
+ LIBS += -L../lib -lopencsg -lGLEW
+ 
+-INSTALLDIR = /usr/local
++isEmpty(INSTALLDIR) {
++  INSTALLDIR = /usr/local
++}
+ INSTALLS += target
+ target.path = $$INSTALLDIR/bin
+ 
+diff -ur OpenCSG-1.4.2-pristine/opencsg.pro OpenCSG-1.4.2/opencsg.pro
+--- OpenCSG-1.4.2-pristine/opencsg.pro	2016-09-27 06:11:16.000000000 +0900
++++ OpenCSG-1.4.2/opencsg.pro	2019-05-07 10:44:50.578698165 +0900
+@@ -1,2 +1,3 @@
+ TEMPLATE = subdirs
+ SUBDIRS  = src example
++CONFIG   += ordered

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12248,7 +12248,10 @@ in
 
   opencore-amr = callPackage ../development/libraries/opencore-amr { };
 
-  opencsg = callPackage ../development/libraries/opencsg { };
+  opencsg = callPackage ../development/libraries/opencsg {
+    inherit (qt5) qmake;
+    inherit (darwin.apple_sdk.frameworks) GLUT;
+  };
 
   openct = callPackage ../development/libraries/openct { };
 


### PR DESCRIPTION
Regenerate the Makefiles using qmake to set the correct compiler and
use the default installPhase.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Working towards building openscad for Darwin.

The install name handling here is rather unpleasant. The library is ultimately corrected in the fixup phase by the hook, however the example application is already linked by then. Suggestions for improvement welcome.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
