### PR TITLE
rgbds: 0.2.4 -> 0.3.8

### DIFF
--- a/pkgs/development/compilers/rgbds/default.nix
+++ b/pkgs/development/compilers/rgbds/default.nix
@@ -1,21 +1,35 @@
-{stdenv, fetchFromGitHub, yacc}:
+{stdenv, fetchFromGitHub, bison, flex, pkg-config, libpng}:
+
+# TODO: byacc is the recommended parser generator but due to https://github.com/rednex/rgbds/issues/333
+# it does not work for the moment. We should switch back to byacc as soon as the fix is integrated
+# in a published version.
 
 stdenv.mkDerivation rec {
   name = "rgbds-${version}";
-  version = "0.2.4";
+  version = "0.3.8";
   src = fetchFromGitHub {
-    owner = "bentley";
+    owner = "rednex";
     repo = "rgbds";
     rev = "v${version}";
-    sha256 = "0dwq0p9g1lci8sm12a2rfk0g33z2vr75x78zdf1g84djwbz8ipc6";
+    sha256 = "0db37z886026svhj6qnc3wk56sndbnz1vi41gn2k3bl6ppbnjlpk";
   };
-  nativeBuildInputs = [ yacc ];
+  nativeBuildInputs = [ bison flex pkg-config libpng ];
   installFlags = "PREFIX=\${out}";
 
   meta = with stdenv.lib; {
-    homepage = https://www.anjbe.name/rgbds/;
-    description = "An assembler/linker package that produces Game Boy programs";
-    license = licenses.free;
+    homepage = https://rednex.github.io/rgbds/;
+    description = "A free assembler/linker package for the Game Boy and Game Boy Color";
+    license = licenses.mit;
+    longDescription =
+      ''RGBDS (Rednex Game Boy Development System) is a free assembler/linker package for the Game Boy and Game Boy Color. It consists of:
+
+          - rgbasm (assembler)
+          - rgblink (linker)
+          - rgbfix (checksum/header fixer)
+          - rgbgfx (PNG‐to‐Game Boy graphics converter)
+
+        This is a fork of the original RGBDS which aims to make the programs more like other UNIX tools.
+      '';
     maintainers = with maintainers; [ matthewbauer ];
     platforms = platforms.all;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

- Switch to the new GitHub organization.
- Updated to the latest published version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
