### PR TITLE
parinfer-rust: init at 0.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1531,6 +1531,11 @@
     github = "eqyiel";
     name = "Ruben Maher";
   };
+  eraserhd = {
+    email = "jason.m.felice@gmail.com";
+    github = "eraserhd";
+    name = "Jason Felice";
+  };
   ericbmerritt = {
     email = "eric@afiniate.com";
     github = "ericbmerritt";

--- a/pkgs/development/tools/parinfer-rust/default.nix
+++ b/pkgs/development/tools/parinfer-rust/default.nix
@@ -1,0 +1,28 @@
+{ stdenv, rustPlatform, fetchFromGitHub }:
+
+rustPlatform.buildRustPackage rec {
+  name = "parinfer-rust-${version}";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "eraserhd";
+    repo = "parinfer-rust";
+    rev = "v${version}";
+    sha256 = "0w7fcg33k8k16q8wzax44ck8csa2dr7bmwcz1g57dz33vhxi8ajc";
+  };
+
+  cargoSha256 = "17fkzpvfaxixllr9nxx7dnpqxkiighggryxf30j3lafghyrx987f";
+
+  postInstall = ''
+    mkdir -p $out/share/kak/autoload/plugins
+    cp rc/parinfer.kak $out/share/kak/autoload/plugins/
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Infer parentheses for Clojure, Lisp, and Scheme.";
+    homepage = "https://github.com/eraserhd/parinfer-rust";
+    license = licenses.isc;
+    maintainers = with maintainers; [ eraserhd ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9324,6 +9324,8 @@ in
 
   pants = callPackage ../development/tools/build-managers/pants {};
 
+  parinfer-rust = callPackage ../development/tools/parinfer-rust {};
+
   parse-cli-bin = callPackage ../development/tools/parse-cli-bin { };
 
   patchelf = callPackage ../development/tools/misc/patchelf { };


### PR DESCRIPTION
###### Motivation for this change

I'm the maintainer for parinfer-rust and will be relying on nix and NixOS from
my dotfiles repo to configure my environment.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
  **(New package, no dependencies)**
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  **Size: 29328840**
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---