### PR TITLE
pythonPackages.macropy: init at 1.10b2

### DIFF
--- a/pkgs/development/python-modules/macropy/default.nix
+++ b/pkgs/development/python-modules/macropy/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, python
+, isPy27
+, pinqSupport ? false, sqlalchemy
+, pyxlSupport ? false, pyxl3
+}:
+
+buildPythonPackage rec {
+  # https://github.com/lihaoyi/macropy/issues/94
+  version = "1.1.0b2";
+  pname = "macropy";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "lihaoyi";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1bd2fzpa30ddva3f8lw2sbixxf069idwib8srd64s5v46ricm2cf";
+  };
+
+  # js_snippets extra only works with python2
+  propagatedBuildInputs = [ ]
+    ++ lib.optional pinqSupport sqlalchemy
+    ++ lib.optional pyxlSupport pyxl3;
+
+  checkPhase = ''
+    ${python.interpreter} run_tests.py
+  '';
+
+  meta = with lib; {
+    homepage = https://github.com/lihaoyi/macropy;
+    description = "Macros in Python: quasiquotes, case classes, LINQ and more";
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/pyxl3/default.nix
+++ b/pkgs/development/python-modules/pyxl3/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, unittest2
+, python
+, isPy27
+}:
+
+buildPythonPackage rec {
+  pname = "pyxl3";
+  version = "1.0";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "df413d86664e2d261f67749beffff07eb830ab8c7bbe631d11d4c42f3a5e5fde";
+  };
+
+  checkInputs = [ unittest2 ];
+
+  checkPhase = ''
+     ${python.interpreter} tests/test_basic.py
+  '';
+
+  # tests require weird codec installation
+  # which is not necessary for major use of package
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Python 3 port of pyxl for writing structured and reusable inline HTML";
+    homepage = https://github.com/gvanrossum/pyxl3;
+    license = licenses.asl20;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -492,6 +492,8 @@ in {
 
   logzero = callPackage ../development/python-modules/logzero { };
 
+  macropy = callPackage ../development/python-modules/macropy { };
+
   mail-parser = callPackage ../development/python-modules/mail-parser { };
 
   manhole = callPackage ../development/python-modules/manhole { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4522,6 +4522,8 @@ in {
 
   pysendfile = callPackage ../development/python-modules/pysendfile { };
 
+  pyxl3 = callPackage ../development/python-modules/pyxl3 { };
+
   qpid-python = callPackage ../development/python-modules/qpid-python { };
 
   xattr = callPackage ../development/python-modules/xattr { };


### PR DESCRIPTION
###### Motivation for this change

Use macropy to abuse python syntax

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
