### PR TITLE
systemd: Don't order systemd-user-sessions.service after network.target

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -28,6 +28,8 @@ stdenv.mkDerivation rec {
     sha256 = "0ldyhfxdy4qlgygvpc92wp0qp6p1c9y3rnm77zwbkga48x60d9i8";
   };
 
+  patches = [ ./user-sessions-not-after-network.patch ];
+
   outputs = [ "out" "lib" "man" "dev" ];
 
   nativeBuildInputs =

--- a/pkgs/os-specific/linux/systemd/user-sessions-not-after-network.patch
+++ b/pkgs/os-specific/linux/systemd/user-sessions-not-after-network.patch
@@ -1,0 +1,13 @@
+diff --git a/units/systemd-user-sessions.service.in b/units/systemd-user-sessions.service.in
+index 6d585eb0a1..4c86ebc37e 100644
+--- a/units/systemd-user-sessions.service.in
++++ b/units/systemd-user-sessions.service.in
+@@ -10,7 +10,7 @@
+ [Unit]
+ Description=Permit User Sessions
+ Documentation=man:systemd-user-sessions.service(8)
+-After=remote-fs.target nss-user-lookup.target network.target
++After=remote-fs.target nss-user-lookup.target
+ 
+ [Service]
+ Type=oneshot


### PR DESCRIPTION
Fix delayed startups waiting for DHCP, see #60900

The startup time issue seems much more annoying to me than the original SSH session issue, so I think we should merge this now. If others disagree, I guess we wait until we have a proper fix for the latter.

###### Motivation for this change
Improve boot times for local NixOS users.

###### Things done

I tested by overriding the package in `configuration.nix`:
```
systemd.package = pkgs.callPackage /home/craig/nixpkgs/pkgs/os-specific/linux/systemd/default.nix {};
```


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
