### PR TITLE
virtualbox: python2 -> python3

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -5,7 +5,7 @@
 , alsaLib, curl, libvpx, nettools, dbus
 , makeself, perl
 , javaBindings ? false, jdk ? null
-, pythonBindings ? false, python2 ? null
+, pythonBindings ? false, python3 ? null
 , extensionPack ? null, fakeroot ? null
 , pulseSupport ? config.pulseaudio or stdenv.isLinux, libpulseaudio ? null
 , enableHardening ? false
@@ -17,7 +17,7 @@
 with stdenv.lib;
 
 let
-  python = python2;
+  python = python3;
   buildType = "release";
   # Remember to change the extpackRev and version in extpack.nix and
   # guest-additions/default.nix as well.


### PR DESCRIPTION

###### Motivation for this change

I wasn't thrilled to see python2 in my system's runtime closure, so I fixed its only reference.

[Also python2 is almost dead.](https://pythonclock.org/)

I ran all the NixOS tests for Virtualbox on x86_64-linux, and they all passed.