### PR TITLE
mp3cat init at 0.5

### DIFF
--- a/pkgs/tools/audio/mp3cat/default.nix
+++ b/pkgs/tools/audio/mp3cat/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "mp3cat";
+  version = "0.5";
+
+  src = fetchFromGitHub {
+    owner = "tomclegg";
+    repo = pname;
+    rev = version;
+    sha256 = "0n6hjg2wgd06m561zc3ib5w2m3pwpf74njv2b2w4sqqh5md2ymfr";
+  };
+
+  makeFlags = [
+    "PREFIX=${placeholder ''out''}"
+  ];
+
+  installTargets = [
+    "install_bin"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A command line program which concatenates MP3 files";
+    longDescription = ''
+      A command line program which concatenates MP3 files, mp3cat
+      only outputs MP3 frames with valid headers, even if there is extra garbage
+      in its input stream
+    '';
+    homepage = https://github.com/tomclegg/mp3cat;
+    license = licenses.gpl2;
+    maintainers = [ maintainers.omnipotententity ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1680,6 +1680,8 @@ in
 
   mp3blaster = callPackage ../applications/audio/mp3blaster { };
 
+  mp3cat = callPackage ../tools/audio/mp3cat {};
+
   mp3fs = callPackage ../tools/filesystems/mp3fs { };
 
   mpdas = callPackage ../tools/audio/mpdas { };


### PR DESCRIPTION
Adding package mp3cat, a command line mp3 utility which will concatenate
multiple mp3 files, and keep only the audio frames, discarding headers
and so on.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

It's a reasonably useful single use utility.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
