### PR TITLE
bpftool: init at 5.1.1

### DIFF
--- a/pkgs/os-specific/linux/bpftool/default.nix
+++ b/pkgs/os-specific/linux/bpftool/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl
+, libopcodes, libbfd, libelf
+, linuxPackages_latest
+}:
+
+stdenv.mkDerivation rec {
+  pname = "bpftool";
+  inherit (linuxPackages_latest.kernel) version src;
+
+  buildInputs = [ libopcodes libbfd libelf ];
+
+  preConfigure = ''
+    cd tools/bpf/bpftool
+    substituteInPlace ./Makefile \
+      --replace '/usr/local' "$out" \
+      --replace '/usr'       "$out" \
+      --replace '/sbin'      '/bin'
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Debugging/program analysis tool for the eBPF subsystem";
+    license     = [ licenses.gpl2 licenses.bsd2 ];
+    platforms   = platforms.linux;
+    maintainers = with maintainers; [ thoughtpolice ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8816,6 +8816,8 @@ in
   buildkite-agent2 = callPackage ../development/tools/continuous-integration/buildkite-agent/2.x.nix { };
   buildkite-agent3 = callPackage ../development/tools/continuous-integration/buildkite-agent/3.x.nix { };
 
+  bpftool = callPackage ../os-specific/linux/bpftool { };
+
   byacc = callPackage ../development/tools/parsing/byacc { };
 
   cadre = callPackage ../development/tools/cadre { };


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
