### PR TITLE
mkclean: init at 0.8.10

### DIFF
--- a/pkgs/applications/video/mkclean/default.nix
+++ b/pkgs/applications/video/mkclean/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ dos2unix ];
 
   src = fetchurl {
-    url = "mirror://sourceforge/matroska/${pname}.tar.bz2";
+    url = "mirror://sourceforge/matroska/${pname}-${version}.tar.bz2";
     sha256 = "0zbpi4sm68zb20d53kbss93fv4aafhcmz7dsd0zdf01vj1r3wxwn";
   };
 

--- a/pkgs/applications/video/mkclean/default.nix
+++ b/pkgs/applications/video/mkclean/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "mkclean is a command line tool to clean and optimize Matroska (.mkv / .mka / .mks / .mk3d) and WebM (.webm / .weba) files that have already been muxed.";
-    homepage = https://www.matroska.org;
+    homepage = "https://www.matroska.org";
     license = licenses.bsdOriginal;
     maintainers = with maintainers; [ chrisaw ];
     platforms = [ "i686-linux" "x86_64-linux" ];

--- a/pkgs/applications/video/mkclean/default.nix
+++ b/pkgs/applications/video/mkclean/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     description = "mkclean is a command line tool to clean and optimize Matroska (.mkv / .mka / .mks / .mk3d) and WebM (.webm / .weba) files that have already been muxed.";
     homepage = https://www.matroska.org;
-    license = licenses.bsd;
+    license = licenses.bsdOriginal;
     maintainers = with maintainers; [ chrisaw ];
     platforms = [ "i686-linux" "x86_64-linux" ];
   };

--- a/pkgs/applications/video/mkclean/default.nix
+++ b/pkgs/applications/video/mkclean/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   buildPhase = ''
     make -C mkclean
-  '' 
+  '';
 
   installPhase = ''
     mkdir -p $out/{bin,lib}

--- a/pkgs/applications/video/mkclean/default.nix
+++ b/pkgs/applications/video/mkclean/default.nix
@@ -1,4 +1,4 @@
-{fetchurl, stdenv }:
+{ dos2unix, fetchurl, stdenv }:
 
 stdenv.mkDerivation rec {
   pname = "mkclean";
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ dos2unix ];
 
   src = fetchurl {
-    url = "mirror://sourceforge/matroska/${name}.tar.bz2";
+    url = "mirror://sourceforge/matroska/${pname}.tar.bz2";
     sha256 = "0zbpi4sm68zb20d53kbss93fv4aafhcmz7dsd0zdf01vj1r3wxwn";
   };
 

--- a/pkgs/applications/video/mkclean/default.nix
+++ b/pkgs/applications/video/mkclean/default.nix
@@ -1,0 +1,37 @@
+{fetchurl, stdenv }:
+
+stdenv.mkDerivation rec {
+  pname = "mkclean";
+  version = "0.8.10";
+
+  hardeningDisable = [ "format" ];
+  nativeBuildInputs = [ dos2unix ];
+
+  src = fetchurl {
+    url = "mirror://sourceforge/matroska/${name}.tar.bz2";
+    sha256 = "0zbpi4sm68zb20d53kbss93fv4aafhcmz7dsd0zdf01vj1r3wxwn";
+  };
+
+  configurePhase = ''
+    dos2unix ./mkclean/configure.compiled
+    ./mkclean/configure.compiled
+  '';
+
+  buildPhase = ''
+    make -C mkclean
+  '' 
+
+  installPhase = ''
+    mkdir -p $out/{bin,lib}
+    mv release/gcc_linux_*/*.* $out/lib
+    mv release/gcc_linux_*/* $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "mkclean is a command line tool to clean and optimize Matroska (.mkv / .mka / .mks / .mk3d) and WebM (.webm / .weba) files that have already been muxed.";
+    homepage = https://www.matroska.org;
+    license = licenses.bsd;
+    maintainers = with maintainers; [ chrisaw ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4469,6 +4469,8 @@ in
     withMinimal = false;
   };
 
+  mkclean = callPackage ../applications/video/mkclean {};
+
   mkcue = callPackage ../tools/cd-dvd/mkcue { };
 
   mkp224o = callPackage ../tools/security/mkp224o { };


### PR DESCRIPTION
###### Motivation for this change
Add support for the mkclean tool which is very useful for cleaning up and improving the playback success rate of MKV files on platforms like Plex, etc.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
