### PR TITLE
youtube-dl: build the lazy_extractors module to improve startup time

### DIFF
--- a/pkgs/tools/misc/youtube-dl/default.nix
+++ b/pkgs/tools/misc/youtube-dl/default.nix
@@ -42,6 +42,10 @@ buildPythonPackage rec {
         ++ lib.optional phantomjsSupport phantomjs2;
     in [ ''--prefix PATH : "${lib.makeBinPath packagesToBinPath}"'' ];
 
+  setupPyBuildFlags = [
+    "build_lazy_extractors"
+  ];
+
   postInstall = ''
     mkdir -p $out/share/zsh/site-functions
     cp youtube-dl.zsh $out/share/zsh/site-functions/_youtube-dl


### PR DESCRIPTION
###### Motivation for this change

`youtube-dl` [imports every extractor](https://github.com/ytdl-org/youtube-dl/blob/71ebd35d5003cfc5f4c8518249e03e1da0e620b4/youtube_dl/extractor/__init__.py#L9) it has unless the `youtube_dl/extractor/lazy_extractors.py` module is built.

This updates nixpkgs' youtube-dl to build the module, improving startup time.

Testing on an Intel 4790K / NVMe drive:

before:

```
# time youtube-dl --help > /dev/null
youtube-dl --help > /dev/null  0.26s user 0.06s system 100% cpu 0.322 total

# strace youtube-dl 'https://www.youtube.com/watch?v=nJ9IdzcQMoc' 2>&1 | grep extractor/ | grep \.pyc | wc -l
789
```

after:

```
# time youtube-dl --help > /dev/null
youtube-dl --help > /dev/null  0.13s user 0.05s system 100% cpu 0.182 total

# strace youtube-dl 'https://www.youtube.com/watch?v=nJ9IdzcQMoc' 2>&1 | grep extractor/ | grep \.pyc | wc -l
6
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
