### PR TITLE
gitAndTools.gitstatus: init at 20190506

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -127,6 +127,8 @@ let
 
   gitflow = callPackage ./gitflow { };
 
+  gitstatus = callPackage ./gitstatus { };
+
   grv = callPackage ./grv { };
 
   hub = callPackage ./hub {

--- a/pkgs/applications/version-management/git-and-tools/gitstatus/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/gitstatus/default.nix
@@ -1,0 +1,30 @@
+{callPackage, stdenv, fetchFromGitHub, ...}:
+
+stdenv.mkDerivation rec {
+  pname = "gitstatus";
+  version = "unstable-2019-05-06";
+
+  src = fetchFromGitHub {
+    owner = "romkatv";
+    repo = "gitstatus";
+    rev = "9c791f93c23c04dadfab8b4309a863b62a6ee424";
+    sha256 = "0jbdrgl62x6j920h72n2q6304fb6gdgnmllpv4aa76m13b9qhgq6";
+  };
+
+  buildInputs = [ (callPackage ./romkatv_libgit2.nix {}) ];
+  patchPhase = ''
+    sed -i "s|local daemon.*|local daemon=$out/bin/gitstatusd|" gitstatus.plugin.zsh
+  '';
+  installPhase = ''
+    install -Dm755 gitstatusd $out/bin/gitstatusd
+    install -Dm444 gitstatus.plugin.zsh $out
+  '';
+
+  meta = with stdenv.lib; {
+    description = "10x faster implementation of `git status` command";
+    homepage = https://github.com/romkatv/gitstatus;
+    license = [ licenses.gpl3 ];
+
+    maintainers = [ maintainers.mmlb ];
+  };
+}

--- a/pkgs/applications/version-management/git-and-tools/gitstatus/romkatv_libgit2.nix
+++ b/pkgs/applications/version-management/git-and-tools/gitstatus/romkatv_libgit2.nix
@@ -1,0 +1,19 @@
+{fetchFromGitHub, libgit2_0_27, ...}:
+
+libgit2_0_27.overrideAttrs (oldAttrs: rec {
+  cmakeFlags = oldAttrs.cmakeFlags ++ [
+    "-DUSE_BUNDLED_ZLIB=ON"
+    "-DUSE_ICONV=OFF"
+    "-DBUILD_CLAR=OFF"
+    "-DUSE_SSH=OFF"
+    "-DUSE_HTTPS=OFF"
+    "-DBUILD_SHARED_LIBS=OFF"
+    "-DUSE_EXT_HTTP_PARSER=OFF"
+  ];
+  src = fetchFromGitHub {
+    owner = "romkatv";
+    repo = "libgit2";
+    rev = "aab6c56e6766fa752bef00c745067d875925fc89";
+    sha256 = "1yqqhpi5xi6s86411sixw4yq5c6n2v8pdh447c8b7q5lfc089lvl";
+  };
+})


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
