### PR TITLE
 firefox: 66.0.4 -> 66.0.5, firefox-bin: 66.0.4 -> 66.0.5,  firefox-beta-bin: 67.0b17 -> 670b18 

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix
@@ -1,995 +1,995 @@
 {
-  version = "67.0b17";
+  version = "67.0b18";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/ach/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/ach/firefox-67.0b18.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "d972df8e4c40b1d14c0b72fed8c9d70bf426f753ee83cefb7eae6178c0e0c381eb09e427165f70ad2193af8570f5a1f8388e6934708703e4c3fc568b5a3d067f";
+      sha512 = "0769bc01b1178b1f86d87f6486a0c1131146675ec24d30d8f17ea907302e773addfa0f6e8ea97d753cddc82a9f301ae54d517e0a2327cfa2afc133f93cbe85b9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/af/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/af/firefox-67.0b18.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "5ad9a1a9b11159609f2825ffab6d399e9bfa8e357ddc30080e77016392d8c48af6745d82d20acfa4405ab234b0b1a031ca3f044583089f8c4b128cc9ad5c2403";
+      sha512 = "7fddbc2f09bd49d3617f2226afba0dcb67fc0b15f7e9263940d54fb0c7421917e9a2891da698cb0be9f76402873592975813aec10b7d23c757e7f6d49c495d4e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/an/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/an/firefox-67.0b18.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "48ce5fa046f0a51c117f4b2ac10918daf64f5dc94ab1d920f8e3347b026be9a8ff3d995f4a5483ebce6bd39428de1447f4688794fd742d909f92a6fc1e6bbeac";
+      sha512 = "07e7ce1a59d563dc001672b14d0e0b47f500bba00616482c4b205fe354bd5e7adf3129f33bc8a158a0e6d806c697b7b62828b5bb53c3c16375c123ae0af91944";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/ar/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/ar/firefox-67.0b18.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "724762f7601f9767ecf778c2a59e9d3aa752b6b03b97efbc04db423702e101629f7fc131d499e363e47a831003be4d068ea01712584fd0f698e06d28eebb71b8";
+      sha512 = "8f167e9b15b365941c0b07e0ebc2764a32ca5b593801c0c63bcb29d8c62a917d6e8574d3a8749920de4d522ed9a9f8bf248700711008e753d6fe24e12bf4910d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/as/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/as/firefox-67.0b18.tar.bz2";
       locale = "as";
       arch = "linux-x86_64";
-      sha512 = "5326404fa9ddda83b241a9ef58c53537c099202d8a928037e1f6e332982ef8b94c50d6fdb0f447ceeb3e332f0e45172948af35ef91332783ccbd107e0a6e6d72";
+      sha512 = "3294af7acdcc50fab8632b957ef98536912b2e13a97427e3f3172871873ae992868ede0fb99d795ec4f989058639b0f848998c49bec12668fd187cc364b532b1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/ast/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/ast/firefox-67.0b18.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "bec65c571d211fdfe474bd1e9e18a9b77ba25ee3de940cbc2f605fec1942f8db864b889725bc08f71ebceafc066a6e3c652e81e2d2d79ca53714b0dc53afb12a";
+      sha512 = "27c2f368178e41e3c86ed31a588b6e71eac08ee69c91ff841d2b7e0b7a14547a011a47f7b86113cfa0bc74981310797ba46a1a59095c575a45380f6ac9cc5061";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/az/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/az/firefox-67.0b18.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "433efa4f25262a1ebc64fd30f1cad3f85f05f83448d8ca9900fca4bc0d4344fec0aef54bdc6deed3717c0f32a28f2c5ac4570b9c75c30754dd300f36d298ec0e";
+      sha512 = "f1f23c600e0fe98949e6b23493adb74f2d16bbd107c1b2b9b3e6f639d2148b6782f8599f5516481b432e551867a5de0fdf417f2d6ebd9a537a8408d1bcc418d0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/be/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/be/firefox-67.0b18.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "8aed8545ab84fa77fbb25b7ab1090b5b758a1ebc18e4a2e112cf5e0a063ee6160103a017fd8457b3d90a08648e372037b7cb0699efdee5294b6c233ef8bc0150";
+      sha512 = "ed79c5ea368d3ba5c6a29169c0d4c4070cd2f045db9c8ef5151d8c489a9099baf74346bbf45806b06afa2034647803df8eddd1bdfcbf7bd4afd44ae42c902913";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/bg/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/bg/firefox-67.0b18.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "eb6d929f343ef270d5e46499bcb3180ffe3a110509e5beb6b4d5219dd1031da931a0952a5ae311844a36d637b76f51a5ffdc1486c0ec9ff75015467c5644c6cf";
+      sha512 = "13069aff98bf87c9ee445e4b46d4a43d5f00fd1db13e7ee76863146b90730a644d9beba59df183083ac1b2b7460cbe907d0a13ca5c7d2ef018d9ef41b3058467";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/bn-BD/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/bn-BD/firefox-67.0b18.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "43e5ae1a8e80c6dabc5d39511c8e063b0f05679b9ba45639a6f92faaa6693b1486318275885d7d1b88ca4fa4c21cb82e15ba842a65e2ffdd7b9aca8fae0c1212";
+      sha512 = "b48e45d9591162ef472018895a84633555dc85f6ae9f6920a32668323ebf76b109b4fac04ecaf8852e7b198257b515212a08c3214bfb06ad62d05c59a8ba91b8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/bn-IN/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/bn-IN/firefox-67.0b18.tar.bz2";
       locale = "bn-IN";
       arch = "linux-x86_64";
-      sha512 = "1031278c8243faf19ea043ac3c6f7752391d32e09ddc3a7f6e9a0fe15ef6b59446ba4ccfaeadd4bfe3640996692cb1a9478ecfad39790f4b2e85449bf30873b2";
+      sha512 = "6d25c4ce44528e2f3129005e50cd02613b0204769aea79bf7c99a2fe9842e0a935dea26b98df833374041827906742fdc0ce3ae9b73fc80f3dde0987f4bc6c68";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/br/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/br/firefox-67.0b18.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "6f13c2b96a8e2f39cdeda79b15d7a7ed9cd79c51f3a704a377c41facdd697d60ef7f9e204b6f551b9e674b15badf2f46e7e262e63333c29caeac13661e72ebbb";
+      sha512 = "db331005453e21f24453a1bebed498ea78d2399f4122bdf0ff543a1fb1545067de1016b1edcd19a24749e7d21596b8e27141634da19774d192cb477216fe23e1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/bs/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/bs/firefox-67.0b18.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "8d575ff30881e0c88e8f3e2838a3517001aee4f282e9301312e105759112eeff1807da8cb13590e3f9ca73aea79ccc7e1ae68cc7b082a10c382fa0a1a9adae3b";
+      sha512 = "e46cc4f4eb0f4573185cf1bd76e609e733e3edccddb73746bfa9a6a8c769f6de2a95bcce00212dd25f1b99051d2607cdb7bf568060cf623ca3c5798aa90d0543";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/ca/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/ca/firefox-67.0b18.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "ff303ab168d45abae0cb3096a02b5c1bc4911e9cf95929541a400e05791a75a3ee6a812c0cc41ae541b6507bf20d6e852d40c16c68aaa3708f972d018cc16c26";
+      sha512 = "7bbad716a551a8629bc75d703ec6b3e6cc2f95c0a5514b5d2fb73dbdd8c392a22505425a9b6c24cac8a55fc020803ad31626c68d84d8c5f550bfbfefb0630352";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/cak/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/cak/firefox-67.0b18.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "af88063c276af628561dad2fb65e7466d37e9746d68883a57d1ca212de999b4a11c3836432d1c2fbbff35395c626d922ef6bbb9e9f59e994ba089b182d592daf";
+      sha512 = "4be1b384584b2f8a8a6f4fee65921497def09a554f4d77f50b8ca6b105c3cb17c5601016955bd4c53e7a3fc296572ce144e05eed588ee23d63f667819a88eb92";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/cs/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/cs/firefox-67.0b18.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "0a86c553dc8788f2c04a386db2f76dbe22145ae116020cb7a48b22d89b34d697273c72234fae2674e8614f4ae268839d2e2f4e94a158cb5ebeb2ee303dbe29d1";
+      sha512 = "ecfad56ed401b66ff33461bf47c7fc6901b6373eb8f2c4234d281d19bee9c9fa1fbff6fd4da6e39aeb1f75352db5a256f8b8b0085ee43ae33d609a01a5c0447b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/cy/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/cy/firefox-67.0b18.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "eb73a0889b7398ddcb61314ef82d5b425c7ba3b5d1219b31db7ac6ca138de08eed8814fc9bdbc02dd3029bfbff82d8fdc0b088c5c8bffed7ecb2a62bad2bb586";
+      sha512 = "b23fd53e4d78a75507c86c9de91defdff4726c6a80b0cb9f936afa6005f07bea7bca72b2218f58308b6d8ba2dcc3d9d57a70cea8fcd466671121fea5ea6dc89f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/da/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/da/firefox-67.0b18.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "52c7c6fa1ef0ae41ef17d852e97424783f9683e3d1cc8581cdcfd009fa5be9ece873ca5a7c01ec2690e259109e27adebf8870679f1042261cd6b482e21c61ae4";
+      sha512 = "c0da4c254247e98ef5715f8af5bf63a1b245001f2ecfb86e87698cf97e44e5272c9c8a05d0390c0c82c93789f08204eebd8a56b5cbbc8a2757949088dd53e2b5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/de/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/de/firefox-67.0b18.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "345198ef7025c0dea849a42202d7eb3dbf381eed4735c55a8b08b125afd30a63134999fa62f270d3332bbe3d0c6bf9e201a323f9d67d27616f349b61ef02f33b";
+      sha512 = "5f87241024593383d139a109c3ddd58b59e4ddd94cc86fb6b4d437c2d8005b4c4306b0854260bf0af594c87c990c2e6c9141ee2a3b6dc7f03460aa2e588ee827";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/dsb/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/dsb/firefox-67.0b18.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "d9d704f11e49ddd0f8aa27c596bf41fb14d71884424939b7cd1ba97667adeb9fe14001e89de64b78eeba4837fa06c6b5ede7fdc361bcb97a3a69ffcd71e5ed21";
+      sha512 = "847a524b6f97cca3ced60765b6b7099604e53ef38ee05306479dd692ba7c44a52bfe2192b45b7fcbae741f541d3c3c1c5d0a325f43db5377e9e33b74dda13f82";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/el/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/el/firefox-67.0b18.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "282c08354850521581e234a4b9fdb854549447f837f3fbcffc18153433904f8cd1f9c48b44c3b9d55c5c58d69776e062bdb4abaf30f4a503d8ef80ad4d7b65b4";
+      sha512 = "d3d56f8a43b023dab34672d19fcb4e87ac5d38e325b889c92b44d83bccc89e27ec2db7b99dde400f06b5a3249cf25c253ca16ab2529d0336ff0fde002973982f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/en-CA/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/en-CA/firefox-67.0b18.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha512 = "27a8f4aba3de26de293034a3a8df3d51ade8ce9e873477e3594f512749336c0684493e6d71b0d89793387571cb39b18dc1502c773a9b2e4ee8d0463f1f89dfc9";
+      sha512 = "7908a54de36bb5e846efaae0c767309991aa9767e52b08fbed7ab0dbc63615e54bb9be8ab6c93e62f269641dfbf8e9ca14763db70d0c7a91072c950b9469f7b7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/en-GB/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/en-GB/firefox-67.0b18.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "732b08849d49e82ca94fae502f72401e6ad99d5278412fd8d57917fc09a306b1ee89ac7bf081f6f1354dc412fcd652dd571a082fab60870bb068770b87166964";
+      sha512 = "cfbab51c622b687f7772c3f5532bde334d70714f8917b8dd75f0d4050cf666e506382b758242a7e75eac436b84f77afb98cc7fb32e8f7da5cf55abf32bb7e1e0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/en-US/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/en-US/firefox-67.0b18.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "f7da3e20f0261dcaaff354de5dbc736d1234ee025b7f9bce38738c5b441ac92fb1f237128cc018efb6df3332d691234b63f1f49d0fce420f715c5c2d7e0aa8f9";
+      sha512 = "e49eeba70ff6962f36df3d9c717a2d050d5b3be52d1d859be00f2d2bdeb97568e8c180b82e9d449f159b1da71b6d7d592e4df57b84b199d08807ce11b76c4ae7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/en-ZA/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/en-ZA/firefox-67.0b18.tar.bz2";
       locale = "en-ZA";
       arch = "linux-x86_64";
-      sha512 = "8db395cead672345072a21fd6443fff92c402b697a0456fc2ff486dadc50093721e0123842384d286fb44f3d676fbc2f3ffee4ddbb345b2802bdbf99c542d2b7";
+      sha512 = "5dc8904bef3fd67f1c42467a773061d33de09716751f1d5402872d44c9d7e1a8a65b59ec170cfc769a116bba320a5da71d90e9d0382cdc42fd50e23d09f39806";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/eo/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/eo/firefox-67.0b18.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "a5f7c94f82ce7036b2b2a5c93c292d89c3d85fa0e3f2cadab6b84d44df3002f26028c2a2e2500e2f8c4a172aba031be1326defcfd8240895bcbd2592531a075c";
+      sha512 = "c4d5124e969ba0586e7b3a03786ed662055824548fbbdae70d902086ad4c07634e592813bc6c9de2c160e6a7b7f934b08879507658f4a77b1d92ce59c2ba7def";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/es-AR/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/es-AR/firefox-67.0b18.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "2856e12987c1c381acaa0068fe2bb406485167e6b6021c433db48368cc1e538d09db4bbea0e780ba9cd8991c8167ae0e8c828f2d60b243a62a6ec4fb48d4414a";
+      sha512 = "f9ab7f316f7f1effbe6629251c948a4310a9a4598ceae03b935ca27750d6c70bc9a1302c2eba35a193bd0256ad89724b51a6c5b1ab2782927d96c1ebc7f0e84b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/es-CL/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/es-CL/firefox-67.0b18.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "3a9e01d17859a87e3fa8c2802397a2c79f00cabc5d0d7477f8a8ad0313cf54081612dfca5b8f46193fbd0c6de3dba2981f3c5625c59dc5fbddfe2b9f8f599ffe";
+      sha512 = "563ecffa8ab710b178e853581b09f8c624b7dfaeaf3aff40e46a3a224030691db20cfc58f7d914fea45a4c38136919cb6238b1e9a11351825f427191deb1f665";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/es-ES/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/es-ES/firefox-67.0b18.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "061527b0429505e3137a7e2edeb287a778d5caa03cfbb1f45747625f3d028a09aed5531bef05efebedb8aa7f6812914aad8f2626210d382bf5d8408f932b4505";
+      sha512 = "b8a6958a4aa86961e02f803c3a590bcbdd4d34963ab0afc0f21b42fd28607b654c2d7a9f0bef2723e5ae54b68b0ea4c52fb79c06c4996d06700091da5a759788";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/es-MX/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/es-MX/firefox-67.0b18.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "396003a3c3bf5beced73622df527110b075f715cf33a32b67da96df5d4f1c45276e3bbda4ef9e788c14e425f985594df6621217a245efa2f8c6a0e14e2430a01";
+      sha512 = "a0b5c8250832f4333d437082b7af0ec25fbcd604d863e3c402156a298903a88daed24a99e2ff2298da6dd038d41c46045413dbd9a0ec2c1436036f8b7ed767e3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/et/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/et/firefox-67.0b18.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "6a51caaebf3775ca9749849dd8f21052d5eacdfa4f2f46c52d1a8326584c045c33c61b0c987e6727bbdd8a7e0f7674ec8de471c558d505105fc81b6f70b75631";
+      sha512 = "7d75d902c248ba18ec5ed6d83c54a4ed118e8fc07597609401ca6a7807c45de3c4fc423b1076000d4123990ed845a9f3c2acba619563adb62418f7b1360c248f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/eu/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/eu/firefox-67.0b18.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "2429b5b862c6cacf4153f3893cc3a6a56aa598be27946c73dfc40dc93f03730a91e2cffe0a38a0eb6a82c4a93d5d768f79e3c6ba143c0d2028c0638cd6d15044";
+      sha512 = "e64584b603c6b169f148600d1ff8761bde688eb7159854cd62d684a1764cf14e021f9883540121be31ffd1496eb232a3067e28952f013cba27fbc53bd75769c8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/fa/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/fa/firefox-67.0b18.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "f9a174603892fdda1f003b16dba38cc281ac894fc9de22683184343b12e0813b37ee836b074fb0dd62a9d2a232016d667199a6ae3e8ded72ba8c23ed97e52c63";
+      sha512 = "5c5006a0c43f8f8bf32a08497187e506c8c86454551f78f190014d9b1e63353cacb0de9176b2ef2ee285607eebafa6325a2d3b2ee0a69cf4b3b1f3c940b871e9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/ff/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/ff/firefox-67.0b18.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "4529a6dd05a9c9eb21cbf7f1147e9be52ba4d08d20ad6d3f94c46db8d2195550d31590b617e3f693f181012c1bdc5b6522ec124ea81066361147cd08b9baa06f";
+      sha512 = "ecec561181bd2132d1bcec62fac6571c56028d3a780789c75bde79e18da09a46fa2fcaf6d5066cb0052fefd3a7a7e189a18238896303065034981ba9eb8bf82f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/fi/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/fi/firefox-67.0b18.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "da132dbf65133700558a0d9edbcb2d425120131ce77449914dbbd0785e433ce11f044ac8cd15054f20352716ace145587789433287b9d0249aaaa2216d0be812";
+      sha512 = "39ae1dec658a8acb20110bcfcfdc0ae36918387b49fc2a746ada7318ebdce380de8cf857241af4a4c4114fa8dc9467eccbccaadfd67e9b9ff1ce67959ec69767";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/fr/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/fr/firefox-67.0b18.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "a094a9165c30e0535b1802fd7b7bcd2fd6b11a08e2f27fd9297a327ad37fbbf62f99d614c66b2855e0e64a06355f3239af158115cadab6de548b9bf15498bc25";
+      sha512 = "75319e1be73306b18114df1afe1f6d5c7fcad6a540c253cdadb4e0cd63b03aeba2a0d9eafc06b68ada3cc96b2c515cda6877aa78e0a6534c17fb3c892233bfcd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/fy-NL/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/fy-NL/firefox-67.0b18.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "1d49e5ed376fc526bb71918b94a6abaf25b7661d6209ef09c5a9eb08ff1c2075f2b1a46a8ea7ee8d8b65b6537c0f2aa4edb7ecdffd28180f1f77320a0ab7b541";
+      sha512 = "a6ca5052394d1faf664b664fb06684423831f2eb7b9adaea3cbea0c7e4cd96eb78b3946c00f881ba4e859f12bebbf8f0c6caabd1e128a13b0fc34e7189de8103";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/ga-IE/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/ga-IE/firefox-67.0b18.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "24ea4488586c533afe36676bc674d491c5af2493de722d14bd05882a9af9487916bd45bad83993d2f52cd69085a88b534ce79279ae5163b114ba12b2a248aaf8";
+      sha512 = "c99ee94de278b0cd4b336337888f054d67f009e421008f4ac8232e6ba9376d3e30c56990f78c9da9843f5d3b3319b002a9c0da7711867ac6b9b44f3dc3008adf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/gd/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/gd/firefox-67.0b18.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "614ebe6292caccfd897e53f0397ae4008a26bfc36b11ddee38539073439a7f4fb1d49852afa094d34ef745a91fe7dc7246f09593438803e9f3b8cff7df1434ea";
+      sha512 = "f43331474f95ef8630e0caf2232ffd2cf42191ce5a15afa1edbd983765a1a6bde830ac499e98ae027936019294e5c0a0af1bba85d7f8efb8c280ec3f7a17f10f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/gl/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/gl/firefox-67.0b18.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "2b093e1ba9f07e1dee3d0adb480e96aedd5695e5d9736a1d63f3893bdbfd98037fabe80711b4ebc389331cece2d3b324c802453a5ea049b8fe89499668903527";
+      sha512 = "efdfaa97dac023f99f2adebc2415a8c499f6588ee2282aa57c11f4fda90a50c77dc99f0f3e69be81ef84a7273fe667a034f9d3568713533eddde0747490e5695";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/gn/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/gn/firefox-67.0b18.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "6c6fdc4a10c1c1704bee1b7c014177cac8445813ecb156fd6d9e581ef08d75537f067a61a996a445ca37d10c8fc8b957953ca9f056846c71251f4cd3f4d8c902";
+      sha512 = "98d54c94bec9de4ed3f9a017edfcca02b4c7553991c3e1316f111d29ef541cf92e455197064f83201808ce3c81566189b7d8d8c38bac635c8d41b26bd517f42a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/gu-IN/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/gu-IN/firefox-67.0b18.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "8e4a8f3846edfc12142a7408d9b39e22a5df389c69b3393f9f5a016cf42eaedd687dcda74573f66ef8cfe31ce0b906f32301843053d34b559bd300af5ab51738";
+      sha512 = "aea28693b577eba529100044ba78cc23b560339092262d20422da75def30819dccddf7a129f0f4a51dd2a8af4fd8a8568f0da9be0c9ddef9dfb691cd9680a351";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/he/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/he/firefox-67.0b18.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "dec44691741558f18bac80ae045aa01659d4a08ab43be0a566787cde56fc8f94008a38396633a85aba2c690de21ee26fd4d67ce195fab97b0c988d5950085664";
+      sha512 = "865ce6baf7d69fa366fa809221b981d28600985f21445f4d6bc3061c3de9c04a49bd33dd7551f73faf9e5631f3990f87e834954f08876783e3b35cfe2296dbf1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/hi-IN/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/hi-IN/firefox-67.0b18.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "e774dfeacca10137c074c0b3373992c576cbda7cd6a343b30b454f1cb53cfe946576f9e49901766944d9b8866ced6a17fb694c212dab2b36cf4975a3904bff2f";
+      sha512 = "eb7b15bb932a59eb588976c07316d0541317993b9c7f328b4ff20380ab8dd08d9195a33b34cdca0102ef1e43f71f91b63886ec876f20ce81da9746e5b097942d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/hr/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/hr/firefox-67.0b18.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "6bf935257121d3269ed20e57c7b5f716c0f5c8f139c23dd3297014759a78dcce79655e9f6f15ee23e3d71f28c3fc526412854c0de4ebc7631b9dddd2fa37fc08";
+      sha512 = "15deedecdb9529a8aafcbba5d1db62ee59eacd70828f9af1466c484e0ddffb90a95321efff3ba16eedd3d342e30a215d70ad869f7c21bb95e99629164c6adf78";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/hsb/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/hsb/firefox-67.0b18.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "cebc838cb4462f44af601e3074a28bd284a07d87b7f82a5d10d5a5c244353453fcc76c2eb45433421c1d854d198f4cc8dba48e36b5e681ff84b89b0fb051c37d";
+      sha512 = "ed1d678797765d3927ab7c059a203ec054355f49f805af367e8dad4b5ab2e969f3834f339b8b181d380900bb5f67aedbb5d5fd760a5622372468a848ef04dd06";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/hu/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/hu/firefox-67.0b18.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "d930ab76cf92ebd83cac0a18686aeee759cd30404e8ce9e4a06bf51894accfef67fffe4bf7e9cb6b5fbcbc3c8afcd18f6dcbaaf3c067eb091569081986d41314";
+      sha512 = "d2e4c41799bbdcee19de3c1d8b01998ce025f64987cee56ce6e5382da65a4c2bcdb4699d6c959991fde1e151a76465af2e2ab6d5aae7701c647712ccd5fd4caf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/hy-AM/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/hy-AM/firefox-67.0b18.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "73aa0a4ab5057a3bdafffb8909879fd4eccbc2530f60a31e9e3847b886c47210c981c9896d890925c62cdda2c047e7e5b1553c0d357217d07bfa9ae7d1be9cc8";
+      sha512 = "1bf60d4c87e8a74013620c06e0d9101f968b73300b3a00a146c7d46ca4c161a05e91255e569ec88bff90828b54a95eba27b9a776cb510fa7b45f7e763b2e5aa4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/ia/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/ia/firefox-67.0b18.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha512 = "0e7dbd8d5aab8e5fd797ab2703ada2c4a3f81020c56a3d8d929a390248e863cd3601c828e0da3be6174ab7ce1acd5303d176688e9e6496b51188932ad2a779b1";
+      sha512 = "ae06a4321985fa2c733e49121c936bfdabdbabf31eeb70c03f9c261413613729c28bfa68c39d4a153e3e543348e605ea05efe76c7c0c0d5c3579316a33fe2077";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/id/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/id/firefox-67.0b18.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "a3578b1c7849dae63892020595705e4e70d29bffd4923519084eec702aa143e01a05294d94467a82265c02f811611f36f4ed204ccd3d0c827665076b43fde481";
+      sha512 = "5039ec6545708bb227e0d0ce3d3220c378ee4522969bbf7d2213bb50de8d1ffbbbb21c169acd9187c7dbb5c398466732889a616afcdb9644b5492cbb139f8180";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/is/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/is/firefox-67.0b18.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "aee9291395f1684b71e8053e48650d4357180b269704a09cab7cde819f14a93f7bd4d04844e4170838929e56c0dd6282b2eed37265ba9ada700c83d9300b79e8";
+      sha512 = "254e8b9009ec4573fc49e2725112637e62e9fe5c85861b3f183da39fe20ef8dec8e8c6d3db69f777d0ac587eaecf43e5aad5e76066b36427805bf1c250e12427";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/it/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/it/firefox-67.0b18.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "a06ae957abb7f0bb5a7314a43e0849c4f5cf8520cf4bea2ddc8cfa2d7fbe110c456d6c2a5663726b03ba4a7209e66c18810c8692272d40578ef84aaa14d5d30d";
+      sha512 = "b985e79f40b896ed9544c2a46383286a6b4938363ceb8e58e89afc74f7e35e7c5e6e97abf0582cb6a06a21222b8a6617e3b1a762e71f2ce0bb0bc385bc1a53a1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/ja/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/ja/firefox-67.0b18.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "13ddded4e2449f3c49c249fa123099d34167f5d0caaac13f6f193ceb2625a4d1466b5a31e12c5347a240f84d3672ec17e9d09d9dc9aab317a5eadb15a52892c7";
+      sha512 = "adcd758688288004178f4da7a99511a97f9b71bb8a8721c40b283b50f640e1e0941a7a5e89d5435e3e437a99ab02ad46e0426364637cb28165b5ee953565d11c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/ka/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/ka/firefox-67.0b18.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "4471813a2d15051a87b32f76eafcf5febd0852b7ea009c2ab714d4bc30e2a0882b6d20857db1f339b759b62cb85d211447be0f5981b95edeaa1f250a824c3cb5";
+      sha512 = "9982f01bab9ae08f08faad3e51d3b1f036ae8de41ec3389e6a499d6cd592376844a133a2c847164cfc0044840a5a433115c113b6e9785a6da997172e342c5afd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/kab/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/kab/firefox-67.0b18.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "508166b1d711b0c6106aba0997e13998abeae1b4dec8736c08d86bc1ccf5824d2b097e77890a3219315e99fe544314fc12a5289466f9db5268857f328f339b5e";
+      sha512 = "0f93718bd714a4d72b74442e7429605ccc2fc7dc92c20b9520eb6348b93944401a1541a311779ed6f745aaf57e2b4093fd73c4c0c2546045c7a16a8235fadaad";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/kk/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/kk/firefox-67.0b18.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "e5ac50c7fcb57927fd423029916b50af10b69e0e7810f93d08bab2f3cb5e7d31eed98f82ff74b8319048a491a8dde81d07e77e5a8e66fad2d77b1173db643d4a";
+      sha512 = "032ee445d82cb90afcab1d6c0ae694b6c68c6472ee540fefeff397c8ed27d0e06324d7daf56015dbdbbaca6b0ff850868ede9faaeb7c49958175463dd6c40820";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/km/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/km/firefox-67.0b18.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "2ed715bb8604af685a131bf2950fbdaeb7a1b1dc29444273a0b57dce213cdffe398acc8eebdff124c23068fb553e14e95990ed05253d2dd553e7f4c0facb5444";
+      sha512 = "19cc0593436ebc13da5cb8ca9353855c85feb7d7e8eb62b8b0f8afe9abee757ab19eb85ee78df7b1e608629138712a83d8cf794299dd073ecab5c5baeedac7c2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/kn/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/kn/firefox-67.0b18.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "7c052bd8a16208f485bed9b0e57c31733250208f16845cfb84c4e77a4c491e4e1dbd3ab11e47ebadc18bf00c8fe5a52c596bf858709eb2baf3b79409d8420019";
+      sha512 = "f111dce7f3f7eaf59358e0ad139449d022aa48131a1237806fcff8fa50181ffd8beed9ead2f1a706a99b34ba579e5251a62291b25bf4a05536208b4f5309e86b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/ko/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/ko/firefox-67.0b18.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "d1b5db7b7c1850a9f0ea53fa123a3d5f5d6326e4cb2ea9993d283c6f5a3e372782348a007bbaee5de5793c3434701b7ae3db7796e82a10012a9834cc229fe0e1";
+      sha512 = "7a66013ad733ddde776adde6a0213c5065545d310862c8e1ac9c30ef488689dbd5897bfdbbe25d33acf598e44bd82ba53ecb5f94d0b343a9308f00011f78370d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/lij/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/lij/firefox-67.0b18.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "ef2a3fcbd87cdc10e276981cd1d437863c275e965a659d848e6b8e64586af8d899dc1ea2f77d5ca0fc17805a53727471f4dfaee6fba71c1ec6768217c76129af";
+      sha512 = "8740aeec08ed4d69c95e561a072843fb97c95f14c1d1aaa5dca67c7e5e5e126db33b2d81efdd8b6bcdb373efda4fb3db660aa84bf080f017a7aeb57ecbc46d9a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/lt/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/lt/firefox-67.0b18.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "851e47f24aa4f183629f31263a206fd8ad3eaeb012abcb6fb52a072af5c12023a2097c982968d32772424af53198dc019c82f4db608ef9509855f83313c86223";
+      sha512 = "140e2978c80a3a54295d7235d90f50935df8820cdea9e90283efe9c6e8f028e401e9c51c9111475d08b96c2b25bc359828d7ff13c8f8e4dbbcc914edbfcd548d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/lv/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/lv/firefox-67.0b18.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "ebc5ff84fa5b04b6786b885e12b59b3da1933d53bdb86f5d6dba4cd4b10da4727da1f680e34640b47beb1bc78c50480cdc597ba4be7583be3d378844098b6145";
+      sha512 = "4ef8038cfdfa5b94900a7b9d003f66685250dc2d414ed3ac3b107aa4f93ef75e486cd8918bde06f546a259d317be6a1d21a7d7604410e817aca94a8d5c6026bc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/mai/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/mai/firefox-67.0b18.tar.bz2";
       locale = "mai";
       arch = "linux-x86_64";
-      sha512 = "9f8a4fdebf27122efa3fc4e0a2696805d8a6c57766045cbdb83b976962c407b8bd4011227e4df587b21645549b88357e15e6c63bb62ae6f127e98736444f0bcf";
+      sha512 = "111e20a61d66f2ae901badc6ca60f57214b0bac6dd6e7d962059eb2c0e0fc136f140546f7def96aa7fb36b8bd870a751edf721b0fac4e8af66bc0fa502b91d0e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/mk/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/mk/firefox-67.0b18.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "8b0c2383278098f4bff948a91731e0d547324bd06623a58e7239514322d0a607d6bcd89a50afae72e2c3609cfac08c7276209779992310f21aaaa7cd21a87408";
+      sha512 = "9104e981c567d62f158de38c9eb5a6dd9608482ffff04f203a5d8992ecaddae3bafd7a626fb6dbd46c877717bd7be6330a33b6b59c81d231686346cfc43c1810";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/ml/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/ml/firefox-67.0b18.tar.bz2";
       locale = "ml";
       arch = "linux-x86_64";
-      sha512 = "4b81cbf8f25a51f0812953f2c9b5523c9f18a91e6008c9169e1eb55222f03435be47e5cbfc45ce6707f4ebbcf705d7a283d0fcae3cf42c38c4ed469f0a4a6f59";
+      sha512 = "4cc80a6160b033b5c1aa85961e2a3a26c0f970bc1cebeca3cd75766e4adb70f88be729ca2b95ce32650eefcf993a95a73b47370324aad26c2d6c15904bdc3bd7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/mr/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/mr/firefox-67.0b18.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "bcbb37e15d0474eb591a5d1b3e8821e32e7700462ef50dbe106d4a729ce272d41f2afaa33a8cdc4cff4a6abee5637d72b4e57869f7799c54f1f7d42cb5ea499e";
+      sha512 = "2798883732aecc034228fc44023e0bc4877817c1886ed5bf383cdb70bf57499116b4d7c33b2d04f472d545fb4bb58f0bb870d5ea31ee1eaf556803c90833aaa0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/ms/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/ms/firefox-67.0b18.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "a7e350967cf7d3c884920ff0bd49175727b165cda7f506f16efbd4b6b77f8af92b0861d293a74d008db71c9354c1fe661d081ecc646995f1c594dcc5afc373e5";
+      sha512 = "214adc95917428fd59df2f92e58eae7dd933ae00100ddfcc7a1bfb0beb943531473de19e95c51d37f42f10003abdd438db61bc5ede062300bd58feb493c90b8f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/my/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/my/firefox-67.0b18.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha512 = "a616c86801f0aaf348263d38b9b42836fc39e1f33d1447eb99c834937b0c8af570894577e29b4629e7036282607d42c9c0201607387cd0c4ac4c403fd38e3221";
+      sha512 = "586747badd496571e1260e194d0028596cf535deb1bc2ccb90abf8e38a3ea1b204caeb78704ff3f09dab01a8c2fce656a170e9c281ff661535b5dd2a73920e11";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/nb-NO/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/nb-NO/firefox-67.0b18.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "5e6d123acd2c3779762eea9166dc08a21969d46c454503d7fa1638ec8f2c38f179a430af225d97119049ec318726f0a4950ccc1f81c039d2aac92ea7d0d6ba08";
+      sha512 = "a9e0c2981212d9086c735a1e26aa8dc8b8ab8336742b0dcb55760141cebc60cd69e08f4140f3fa4dd7dc8e6b215fa9e6b822a8f1c02749d84baf33e8797ee2f0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/ne-NP/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/ne-NP/firefox-67.0b18.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha512 = "ff65559f40eb01c7744daef562aaaa9b6f2c12b1b4f76bf8930f4c840eb1bd6802713e04ea3131d20ce9e3b0e8466bebb67b1062a759d03528e54785d8c06a06";
+      sha512 = "b6e5fb0ffdb34eb3e626d83890d447c2948cf9a3f7bacc1d85c25aec2af50cf92c82f09f292c6b48bdd8d181c0855cf0476769d213a5f56b95a00f15a98f65cd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/nl/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/nl/firefox-67.0b18.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "0b0fdab60471cc02f241ae07103c7c18e21708d13911f91f7388f4b71803ebc1e6e7a0db509d06a0523c6e9f775e954955a5d3dc674e2f4ed6f2e294e5c73e48";
+      sha512 = "93abbcb8032f4f8a24a02e41542165cc22c897d8dd83ecf60fe8e6dec88037e2c3fe70756fe45394fc8064275c9adad55c66c2dac2fc3ecff18184c4638def0b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/nn-NO/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/nn-NO/firefox-67.0b18.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "393adf5b39ab77382ddce7bb2b38b87c7c1fa86d9f666c961b9695266a932097316848ebf6ce46847bc8bc2aa05a8cab0ba01f568c31cef33675ffd32fd279d0";
+      sha512 = "61e5fb53bd02424e85d9cfff876cb9159d6f2e2ab24c9d8eb80c0a5ea32214eb6d9c0d7206a343ffd959a785050a3d7ef6918ebd6c31c51cc2bd6a8b275a42c2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/oc/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/oc/firefox-67.0b18.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha512 = "308025f320dcf0d359020cb2b9b560f40a74d6bd167322d1a92bb23c9c17ab9c9f9a07a9df9c1ceb2f7593184ec97234ccec8ee5b51e6979cb8ae90ccae3ae9e";
+      sha512 = "8e0dbe72fcdc44af79d4585120c6db0e7c8dff6f5d44a937cdda99d0f846ec9c0cae770f455295c11c3c9e42affdb725839abc8b62399f925761e6e0808c779d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/or/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/or/firefox-67.0b18.tar.bz2";
       locale = "or";
       arch = "linux-x86_64";
-      sha512 = "12bf952a51a789ca0aaf31dab2f37b3165abb9682e7b4c0629f8afb89b4a97bd02b37757cb9d6d64fccb86fd7dd2a3b6240bf73dde54516372c597024c2048a4";
+      sha512 = "be4c49933b81201de3eccccf1976c3ad19eecf4b6296b78ac13636259cb35c94b6788aba2217924ad7249bf5b879c0fb53ae4ee401595a42321582c81e77b305";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/pa-IN/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/pa-IN/firefox-67.0b18.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "3935ec90834f6b595dcdf16b67b67e98d1698480418dc3e4e7cbff36c7ee3ca67a114f20c1b74d046d3d23466b0a608bbe336998bcaa67e04282b5abc70cce4e";
+      sha512 = "614e98f7ce0b0fafefd2f78585b6a760591b1c30c97301f9b2021450678b0995fa2436dc9e848d869198b8497eea0f5a061ed1cf6c0ce81c3de30e0c2ee9499a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/pl/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/pl/firefox-67.0b18.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "fa7fcafe51a046b19a1de49610d0fdab8f9302eb2ac478aca5fcef936162850313d8830d09de8cacad0836cf93596f3efc3f78900e72b1f9a2a51156246cf7b8";
+      sha512 = "05942bdf2a87295506c798b9ef8e1f3afbbc234247385b5b6ae43b03e5e8d0898de100216b838b8e0715c08ec25673bb66fcd0200c86ae4615eb4dda37d60ab2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/pt-BR/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/pt-BR/firefox-67.0b18.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "ef730208f5aa09e98912397806d055425a85bab2937e2a126c304047e454bd9d051404acccaf125b0df14ddacc432fc48131d7ae9e61613b06b2666466913139";
+      sha512 = "16d53681ac12f1fb9061054b4eb4fcd846517e5600b5825909baf6c973078c3372ea96a02dd0a2220ae738326ba7772c85336aa7adec0f195da68bd8c4e881a9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/pt-PT/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/pt-PT/firefox-67.0b18.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "d9e545f7266643733d05ba3159fe427172030aeac17d53ec786cfdf3b2cecfc6df5723eff2f13b85caa1c1df491718bb7125d6e5de0aa4175f877e9884196b0c";
+      sha512 = "fc9c22cdc6c500de25b3d7a8051bdaebeb78b80c24d191e6c5963d244a17f18505edc29f167ff65259e4ff32a9ff267c4f93b312a8cc23fca23f4198f56c9cb8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/rm/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/rm/firefox-67.0b18.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "262b951c958682009d7568e1c4c4f852f337162a8544f6d43033fa5d35c9b5b65e785d730e7fdd1e5dbae3e2e92dc66b2678a28be255144d9208ed92661e2c65";
+      sha512 = "054291423e1b2fc39248015601724b121c7dc4caad88a43d1fef95bde779dc7aed53ea19517782dda4e2940a4d7562cdd108b07da97b9ccbf0890a3c6aca522d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/ro/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/ro/firefox-67.0b18.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "2638d6ab621b1c12d7a4e6e299c571a44e4572e5a57b35a98db5a21b6d4d66fce29dcfd7cc4cb52bd1b6babf70eb910dd07a0d25ff5f117e1eeee3f552a98603";
+      sha512 = "a5c6e8a29dfffb1ae942e25bfd697e3863942656e81997023f5f36122a09838cbc5b49a2c63643288360162128e638b12cc8f087ad71ea2c167d8c8b19d3fcb1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/ru/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/ru/firefox-67.0b18.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "0833383ac0b1c5845dc90a8e990321d67747bac98b731fcc4e9400806e8584f53bd30626e50235ca8246dbbe2454e06f667d2f3e393bc20b4c4fd2c989ff6fdf";
+      sha512 = "a1fa36b7b829059e472779ff8b6ada126cd662241a9b94237fcb285b3f84f5ca2766a107ddb2fec1fd10f87383082ae9b016bf1dc0c7df04206607320c124420";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/si/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/si/firefox-67.0b18.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "d6e6e57d6e7b3ef80bb2a0574d4cd711669ed6cf026433b672909af2d749918eaddd61bdca2fb6c89c6288595fec50e58fd337507f04935dc88915602d4c2879";
+      sha512 = "00a567b640dffbbcb8cc16070a8466f1915d19b81482ec76bead18aa481b0e9c5ab4822113dd3cd7b27f38e07e260fd49c1e890bc018444728fe35901b0e895b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/sk/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/sk/firefox-67.0b18.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "4cdc735d757551058acc58d70f35589d56a88b172e156634c15cc969fb0165f8512920e256dca2cb34d0a9e33e3438c41962063a6d08a314d8b31a19dde3e09b";
+      sha512 = "b7ff5274e86fb3de19e16eb2239336a6a65f6c74baa516a162a330b44842ce9e674d73d998cfff22b2935a4c72ba60083919d0898664d5ffce8d8fe0ccc16d9b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/sl/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/sl/firefox-67.0b18.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "c413c3242e1d1a9bef75b021dde12ceedbf2ae026ee70186d398ea24ad14d68878cde3ffc34e290b65e5d64dab8b4352931ad9ce71c4d758678c1d416f673653";
+      sha512 = "87b009942bb75273d19bebe713722d21bc0f9d220b386a4bfdd9189f7fecf39a32b4113e788cab9a190b43c6a96187f57fa32d9c34182e99424f4afb03a00302";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/son/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/son/firefox-67.0b18.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "b76ed2e4be73a466e74a30cd5d3eb9fc4d6e963d42a22471da3c657d58026187db0ea7e5f4e8eefebd558209719f6e01e01d0c54af77738214d49edfef5bc85e";
+      sha512 = "bc2c0014e7c141aac7d45ddbf94fa5b82423959a61a501bf92577bcf880f53a812c99e6fedff7dc5b7b0981bc709bb919d4d628ed4d42d26c7e80f2f5be78af9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/sq/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/sq/firefox-67.0b18.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "1dd5462ce9bd3217192f30d9353292f6ed8f9cb032f5591435068961f26c6eb630ec602477d4ae5c87cedb58fbf7a4265f738e5ce14366050c433c4ad5c94184";
+      sha512 = "8f6e87b9de6706d5315709b4644eeb3aa5985ea0b5822e63f401f2c5b961aec01aa2396b844069e7c5198f2f78af84b2f76bf346be5eaba80712c3b7f187dcf1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/sr/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/sr/firefox-67.0b18.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "4dcdc2e145d647a24c0c765afc396b5a54b06a719a2ef7c87b51c8af63d04fbbfcf6801eecffbbce0364cf79577ee25bbdfa62c77fe20a25e5e6ac04ced35965";
+      sha512 = "348477c7fd28d1cb5e567f6700f10e4deb70421b48a9dcdccd78dabe11cdedc80894128992b073848b697146c09ddc4cc7045e632cb1c2fc40bc92c67c9a314f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/sv-SE/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/sv-SE/firefox-67.0b18.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "7873ba8ecf982ce3bda6fb3b6f0c757062c0a15ae73ee848389c8a8864b1555a441daa9227a2532185631b30aeb8dff974ecd17548bc19aad6d194d566bc0618";
+      sha512 = "dcf45d07273b63ac7c2209366db6595204c379b2822b8b9a01c41ac56865bfecf582538f34ae3c25a4253ed22a7b300d18c8b3c90897736bb50c65d403a23b2e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/ta/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/ta/firefox-67.0b18.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "3fc6a0592bf90bab7e1f14a2c3eaa036fabf25715a5bd90fffe31ed853d7fb808c5f2c0082205477de5fa0db9c7f13b9ff4a1cbc18194cf5ecc95272da04e42c";
+      sha512 = "6f70d677c251ece26f00d34ad241963dd5686b64ce85ee13a2b46232f29afa72a8519105e84b583ebcd297cb76e17dca65e4f7f79a8bbd4accbf4efd2a34720f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/te/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/te/firefox-67.0b18.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "ad6dd9e1b1f7f3b87260b771565c93c5a1dd3e3816c0d02e0b3d9a29693be1d933298fb40c388fb6cd0d5088eef2d3673f6a64b95b13bd0b695be8e3a48c3bee";
+      sha512 = "3877da4c91a7ced22828ae4f706ffabab178a4667c61b1a3a771eb2f7fe073b1079edbeb009d1c5039477ecbe29a4e14c501b9cfdf3d8b02052f0d857e8b3e45";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/th/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/th/firefox-67.0b18.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "4bb69801eb42b7e3873311a58478a4ec3b8c645862ef168bc05108386492045a66f8a1f56f7e672748d048afd5a5a3fa98211c2a93a2dd437b85ea304b1ef44b";
+      sha512 = "c3547e34cb5ca350723ab0acae61e683abef0c842c3702602f0867001f02acb6a3aac57595cc0c8e79222336625243aaefcca9b9e2f5550349f934708d489a3a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/tr/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/tr/firefox-67.0b18.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "432da9abab5f9e37ec44526fad6652517148bbcc3df1ba05e0110bd106f546d3d5013643ab692ab7c7632c320a1ef576192fb59e5fe992e006dcb41828269a3b";
+      sha512 = "d044e57778f3b4c83c3a952525e092b5d6726598540a0887050e51797564ef50ce1046692e5b3a33a661360235b41da99c6fcf22c546839e3b8cbbf755a87356";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/uk/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/uk/firefox-67.0b18.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "87aa3f86a456610f621c9fc3f3df91d95681727394d450f3c14a9a97357f4010b25a30a20f3f3f8dae81874351c170bfd03ce98c626792c043d9cf03d2f73789";
+      sha512 = "d9bb511d55a25325a0406e5ea8541f92122db7a1aa3e9d14349d5e215b55b411c3c88f02b329c53ee930eaa352a5e4e107f97b020c18b2cd71f375ac2ccb63a8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/ur/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/ur/firefox-67.0b18.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha512 = "170bc3a3ff6141975fc6e64a4a88246292d3b4856c05f70f1125037f8ed6f46f178fb31e422ef0bc3fc4f90406530a2388123004416bccfb712fbe847e668457";
+      sha512 = "49023c5c550a8098dc19b972a13820afc3e9c4f143df0d3d983f99f94adfaeabdd098bbda2577a94f2449eaa9469289beb092afbfdc08a1b4b6cd7c45be09b23";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/uz/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/uz/firefox-67.0b18.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "db3d18fb95a9db22ab18f53f6990899ea59aab426e968ab29e3dbde45df334fac8b418398df9b6deb9dbdaca6e6a2cb8db4fe892046936fa90761f037ab36c2a";
+      sha512 = "3e47215ed738f4c00c5d891aea775adb21c1a41ebf8a6fb4f94b2dc801816390cb207b064bd8703b4c006fc6dde8ec4c8057eeb203a56d7fa0478c629cb66489";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/vi/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/vi/firefox-67.0b18.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "8d43a6f95ffdc4c6408688736554ffb22033e27f89e862cf9aed6969f18fb3ffc80be6f3d685db2361dca58c0b7446aa4b4f2d32f624a7d00b72275870e7e782";
+      sha512 = "e6ad9cfc80fef308a2365d616b1e2b1949ccee0ecd2bb4cd421a175dab35956146c4e75a7976b9c71e680202811ebddf3af5b99a992185a5c523b90246c41156";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/xh/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/xh/firefox-67.0b18.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "b724fa6cc59f1371bf86b7c3957cb4b37d101f0713ce859008bd78658a35f014a9f2f68a7c5751b3e5cfdb59ee80d0227e24d939ec8eaf62a96fc2fb438b22dd";
+      sha512 = "f3db5f03d9849095d8fd96f1737a0bb727b91ee98668b78e5f068aac0468621f26bc686bf69d07cec2b57023ccb2780bd68e62afed196e1668a90532b8480a2c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/zh-CN/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/zh-CN/firefox-67.0b18.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "2d0d2db1182f4f15d72accb8370012184a8b27525c3d9b7c815709be23dffd04a45cadfbdc31f2f3bd58f8643c2f09b4c59363b7ead23fdebd9e8236ea542725";
+      sha512 = "a562075894b5f1717105e5816ca3901344266e96fb2a0d7957c7dd846bd3315689eb1549ed6604f05708c8feca48740fde1efb6b4553330b1da809ee49cf79c4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-x86_64/zh-TW/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-x86_64/zh-TW/firefox-67.0b18.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "de02dd3b856cedb3575819aa24b91a7303a057d29074ca25de759487192f4dd9c466fe16d2680f0a1f53776a897bc2089de6490f13c546bb163dfe28c8f1ef78";
+      sha512 = "efdefe8171624596f027e1daea7f4872b5faa6247064fb97fb81451c213a021002f32be707d4f92661f5bf9e73dd7190fc0745ec8b6984198549bdcd048d6508";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/ach/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/ach/firefox-67.0b18.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "5e2dc826aa6b0870f9f0ae43ad9ec80d8d73e69b1090f50045a7af4bd9ab9708fe0dd4479248abb1e58b36b4347be101582fe989bb37d7a88f0d1c1af144d58b";
+      sha512 = "443d44cb68f0dffae2e74dc07b583a6edb33499bad2648d134b8205ff96afc395ea433ca1007e832ffff1f2ab9b35ed4cbe7f81d84b9269fce6af06713a4cd90";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/af/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/af/firefox-67.0b18.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "6a39561973ddcc4598303cc4f21ad234fd739ef6b8683380d48c6e865846debcf1b1a85afff271d9c6036ae11fc7bdc1e6b00fa12ab0d9f376145c167bdbd35c";
+      sha512 = "03f9b49f091f25a3f588b388d4ae93786bcc98e015d869829761b50e52b1c13fd0d8cdbacac72763b589fbcde13f563cd84ac661408b80bad1212862393a6430";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/an/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/an/firefox-67.0b18.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "f890a442d07a8f6601dca71f6939be99c2e50729e9488504d47f90543159527778ead5bd94db86bd4551888463e6465abbe8677cce1521c6fa8f2124d4d9e3ef";
+      sha512 = "0b3412d5fa232a32429e75d0b165956b73712abdadab3a04159a8b412f5c40a748d93e2b8494fece5012cc6a020dd2a1c8436f986112eebfbbfa07e0c8f02032";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/ar/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/ar/firefox-67.0b18.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "07b2fcaa4b5a689b3a3faf76d48e774d05635714569d96032c636d89cfa6a3c8c4dba455052556ac4dc053dec481662196b81281a5c27db372191460b97ae458";
+      sha512 = "ef93aee847557e02aa8f630364b80451787fc758e06ed6226d9703c63f9d117e92ab6ec697fe48084e1f7fb50896378f88562049131fc32ca456765aa3890145";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/as/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/as/firefox-67.0b18.tar.bz2";
       locale = "as";
       arch = "linux-i686";
-      sha512 = "72abcb41fb5c2b08cd6b32efe1179566640ce1aa6300cd4b47c5bdfee5862a92b4e848284f0c7793b5029948ce5594f2cf9a592255f9013987cbe67a5900c68f";
+      sha512 = "272958c4f4069ad22836fd15e4ff663e8740b90f34ed816aafb10b2f5da039fc4da7faee1c2ba6e8a6b2de19d19274aea2ff8d495b808bfd1a98684b6edb2f24";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/ast/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/ast/firefox-67.0b18.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "7d2b0b6ebdfaac83ead00682af7f42e870a218a99576a4837e81bf67c2d6fbd4657642f2a4c4a55e7633f88f847e7673423a756b96eac00752c8e5023fc91397";
+      sha512 = "7f48fd4d4da18e6a1cbda39f73d97adf6544ec7a11bacd9b2d433dd526becaa157a70db033531951bc771ffa30c15c9f501bcf80a0ad6a54364c6b919986879e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/az/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/az/firefox-67.0b18.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "c4c3e1fddb8dd682caa5de4714cdcfb9263ae915aa6926fc99c7e27f5e8abc5ba8c45fc4ec8ff3b21f029d8d4d2cc671103a24fccbecd6b4e54841c25c240eb6";
+      sha512 = "554da22b2703c8eefd3c3e8ccff156ff5c2d7f33e7e508b36908e25b5a289157d09a204c84f88312d845e42969ccd874baef7afd08a6f36c9e4e01e4f2c3be7f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/be/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/be/firefox-67.0b18.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "49c16d91f380b611c8e6e898986824f0afa7d7ea24a3460f73788f4e5d0ba60f13c1c2a37018e3690a54693f22662d4b43192c5aceb93bfd20f3aca9fb7ee33f";
+      sha512 = "1b0e39d81b3ced1bedc1e3472504aaf71f2cbbedabe5bd1a6f894a10f94c9941c7452447ba4f1a969de5236a33bed82abc0434d9fbc37c17467887b12c680cc4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/bg/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/bg/firefox-67.0b18.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "4e13b0959bec44ce0a7075611d4687eed3e88cd8e27888678f53bacf5762190ba628890b6c1fbf0b0c910d193a6f5be1d779119bb40ffa39c187e310bcf4d195";
+      sha512 = "4318f2a10487d87de120b49dc01be19dff208c3f3a88897e50ef1fba5a96da038973d2df837881eb54b2cad13a1b68beced5f6a426ff304493192876fab2ae9f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/bn-BD/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/bn-BD/firefox-67.0b18.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "c3ddeee73c35cdf958aded90de953941b0ec9741a7896174a9a39976b76ae45c635fb44dd8db26f080766b61e4d5ad54f1257708d2063ceab4a0890689666332";
+      sha512 = "61743f94bd59c57ff979fffad91e7d0762d7732cda4cd55d861ca52363bf306f818229a69165a0398a2b2e9ce8a70c22112673779233a88e8109b61f2d27160e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/bn-IN/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/bn-IN/firefox-67.0b18.tar.bz2";
       locale = "bn-IN";
       arch = "linux-i686";
-      sha512 = "998a234db5db22ace4509a1d7d651331de2c8c2d79c21e0c9167a2b5200d828913b9e878c2399f4bd139448f5de27d8ca52feb89d5983459f54652c8f4da4d1a";
+      sha512 = "75ad4d61195d148939681038baf3d9922fafa2d8204b72ff7cbf9017b332b3fc8028e8615edd711ad5b1f58b1e8fb9825ea69d772ff1a0c35910c86d35cd0fce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/br/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/br/firefox-67.0b18.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "00bb23f5ca80975dc6d58a06d3d7b30b413525b31dbae8c5abaa65e6dd65c4b0e4f187af0637d28fd0bff6a0508bb90d91d0b3bb55651bf056e06911acddb051";
+      sha512 = "54b7f2aad80e0e0278fa541118ac60df4e129c063a5c28563391f11a8fa5ae0ba51a63d97cebfd4226e47e6f623748f6e6961b5e2e4cd721fffcdeba296b4835";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/bs/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/bs/firefox-67.0b18.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "10d5d9d286d7178ac06953f66383f7eabe677bb73784df0b8e02933d64956a70493e02c7aca099cdc63a80645ec2536ea093637b7c579efc2f4a24a93972afde";
+      sha512 = "04444859798d31fe2c713357c963c46802d42ade7d66cf80893b6b39917b2625f78d5599e3f97a24d9269b2b4e5a90f82d1fb645633e804062a58eb4b79f6bae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/ca/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/ca/firefox-67.0b18.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "b412e2a8facaef2de23f139eac4910572a148dcdbe22429e5c64d4cd1682fbc187dc2a9ef396e9e7a4643b0add3dbd3bff5815397b4877167f0accdfb9c81a11";
+      sha512 = "0f62333715524c65cdee1ccc1da4c345953cf14449143206b64ab5bab98e635b94c23645c40bb4865ba9c9585731aef45cdb1bcc6d3d268667417cc86c366c91";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/cak/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/cak/firefox-67.0b18.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "c62dd0c1cc16619f815fca5240b1bb219cb973a1e47e75f0a47a34e2be739ea2ff1fa3b4b1822486ca4d6c0538f799a2ab3368b2582d005ff6f2bffa742321e9";
+      sha512 = "867a1ee75564bffa889f0ef10974459f6dacb07cd6ecadb622a129f846f0987d8cf16e47a9010d73260cc2525f141cb96dac52a498797f1da3bc9f6d7624a4bf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/cs/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/cs/firefox-67.0b18.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "a724da1110e2597097b09d446d96594858ca6aa6e8e02f536be14e74c19aca434fed261d9ca217f69e9b15b54067da2afe6b395f0fd3f44bd024c6ad0c5b1ab6";
+      sha512 = "ca44584f699432276a7d8aa578d0c4c76a8cfd046e82f053f62f194681829382e2695f8a1b851de2fc9482969e7975dcf05dea58c92bf505b1fc71c57c7b6360";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/cy/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/cy/firefox-67.0b18.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "1e68b3351165aae7acee53356b9d765f1b8022b6775d340b33b196ecc7b2608961e970f33db8ac25310c0e98ce2e556bb69840b7078f89ed1f34c64d2af3be26";
+      sha512 = "a68a618fd33012596ad5c511c6b7ce3a218599b60c55ff8efd4d5cdcb8962efe4fda0366e6b0e8c9b44d71954184a334b6baee6896d0d7cb0960a08d41ad14b4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/da/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/da/firefox-67.0b18.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "d571516feedb549fa6fee78b4d2705daf1225c41cffd821526530b78e059f9f58a4e37e6302113425a1ccfdf6e3af88bc380b075099431a98715b1f5781d046b";
+      sha512 = "d69efae3267554ffeb065f012acf7e63beb584ca17070b80d6fb91a2767b03cda4b86d1291a2c2211d7e7ecb867e316a52e7c17e841c1fcf2e0757571ad4df6f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/de/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/de/firefox-67.0b18.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "711e30fe39a81084e59fb98a1256829dd3d6614da0486a6a0a7483c5b21d596438610be69bcb1da46978d26a86d7b60d2445cd70f7b16483be346293f10a03c2";
+      sha512 = "0cf2675d8fb544cd896b21e0dfe211b22c43bd418a9f51bf2c63be8d29aebf9220b852465d18af009e48b5ef8f08ec7b14e53a650562f1c24e2e08b045daf792";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/dsb/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/dsb/firefox-67.0b18.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "bac01c4ca713a17061bcaded973bea11c1fe4b960cb7dad7684389fb96d83ed5cc12c744fdf88677d38e1f4593059bfeccbf2e84bd165c261af4ab611556f8a9";
+      sha512 = "a0fdefea46c4339720c1cbeadde59359b8cdb07093061daa9527c98d41d972bc4d16a5882ef57322f4ceed46528c7b62820440541c2d2b96d93dc24a070e4cf9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/el/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/el/firefox-67.0b18.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "7d36c4eebd58c5630456b596cfc4069f4601c3e07238b1b7fc0d10b5a02c295626f4af263c274edba110c36bc48a0b1f4b351ddd7914cb077775a7b37bff62f7";
+      sha512 = "1cedb34a76f1a6f98f62569784534f642de01997dc8507bf83ae3ddc5e195ee02d4848cc7d9605dad7681413373fe52811d610e917cf995c5d80ee883df58021";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/en-CA/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/en-CA/firefox-67.0b18.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha512 = "281fd337e5d99892c29177a51b99fa5f6c872190119dbba5a340cc6255398c0b233f9c6281365c1ab466a26c0d0b22ea9ecfa19cd7de166de45213e908092732";
+      sha512 = "44504283554c88cfd80b8a662e795e0405fbe1c0fc009f2ed4da5f036ccb40abfc9f5769de658e9c89d6c8a89a5adaec53541f50c3ea1018ecd5cabba43c8b17";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/en-GB/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/en-GB/firefox-67.0b18.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "c03d75936de0f53e31782a869626120a363bfa334273f0a262d85c207927391eb7ad036805d1abcfa3cc372284c1c9badc61a6ec1a71ad00d8332834c934b226";
+      sha512 = "40d2985c60333d6d95cba75efd0ca20bfc9e9c81434df050db08e6934f31a9d141eb63a1417b3ce2f9b01d71c5a299126fd7d95c34e64edd83dbe9d853c05b50";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/en-US/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/en-US/firefox-67.0b18.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "db51834187e4892436b2351c85b29559fa55d461d285785555f6c5525ee3af3bfac2db24db7a9fb67c46cb27d3832eac362b859c10dd9ab5e3f6af29f6a8bd51";
+      sha512 = "083aff8bc27d00ebb3331f81f14429bf105cb16d4ac9464d9e275e7ffcf5983c7144a7f9001e6f766c668f79a9d80fd147455cb55099c87c92a4b2ed3807d1f5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/en-ZA/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/en-ZA/firefox-67.0b18.tar.bz2";
       locale = "en-ZA";
       arch = "linux-i686";
-      sha512 = "f4d8a9b3f1e00835f7799cae363ea14e7753d0f85170af7833ba04a08c1764603fbee6bff79bc3cc70bb71490efec89632a7715681cfb5b9ad8c790841281b12";
+      sha512 = "cef07a63302a00869837d3e526f7cc5b6518f2ea49932cd66e788912bc8e71460cef265b73c3fff64ae35c5eeb9585323f605679b816d817e4569fd1b6073772";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/eo/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/eo/firefox-67.0b18.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "cb51153857c23854270a74b51e321e3d769e724c995b55f008d5849d0dab79b7b4fc5b488b50ef77a9c11c0c9f4eda39e6dab038ddb0e3d8ecb2c26a7e95a26e";
+      sha512 = "37c35c893cdcdc2dda103ebcd4bceca4097a999070ec3db76288b00080f71e4b39c6914760bf42f1ded50c193e56261ad1563c2a5c006c66703b7c3065190394";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/es-AR/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/es-AR/firefox-67.0b18.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "dde46c908755ee912df15d4d95e52636ca8d5009626215c434e637ba22f895765017e94a55b344ea44850629f7bf6a5b39c63dedd9e82b830141ea0375d2e4f9";
+      sha512 = "e2975c93edd8fbe942ac4072514fd786446d1c1e4dac39c3cc7222377006acfd6e037763018b81c428b80290da0d7c685620719cb40e85e6941a4e759574068d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/es-CL/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/es-CL/firefox-67.0b18.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "d7580e5675af69576a327341c8b8572b1eaca977d074842a8681f1aa6082a819c43001effec7255b3c067790c14e97027df3e014a70c9f7784b44b7f22f39fad";
+      sha512 = "5aadba2d88bcbad41750cce4ca43d1cd9ced8177c4bb86ef7c85302cde7ae5900cc5c015b11889e80011c0a9ffac839f9d68859ba298d88ed4117e62645992ca";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/es-ES/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/es-ES/firefox-67.0b18.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "cb861d7a75cbf7a1fd6b0761a7f8afb3dd5a6f85567e65ba3e888a41a916340b9a41d5815518180b0feca4bdf7b95fac3b8f205395a9d0bb8ea1b0550bb1fac4";
+      sha512 = "a8a68383ddcccb81123228a60006a59e3ab260c53508a44d0360c56bd1bf28ae920893d5c3c8886ab2d223a7cb92f98d4e19e6eb17d75d2e1de2bb6e4090d082";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/es-MX/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/es-MX/firefox-67.0b18.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "354c649e408ae15ff00b5e88accb7d52979706886ed3ba1bf4fd7790cca2b23405c34aeffe35d5476824c15e5f4c6c1123a59f43392c3a8d9fb8108364e36625";
+      sha512 = "0324d91ebbfad06b5c9a51d8d4a4b0312d28b52d180c463bbdb2ccd282983d5734a9299a0e6ac4e6b7688dba24c623c0c61600609c0846b60a0edb340393daf6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/et/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/et/firefox-67.0b18.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "25a14e88b3a87f8833bd820e9f438eddda6eb4b17faf3f6f09da56b7c649ab91295cf37394fa01f9ab94ca8770aea70fe707bc7ee5f613bc6dc3617ab831af79";
+      sha512 = "a2a21987984ea4883cb514aed741d95fc0fd612ad00d137353d5576da0f3741eff7e280f520613f9ddad0dd573e9c7b91ad5394030ca4ff8a6f9209fa607234b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/eu/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/eu/firefox-67.0b18.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "885cabd74befb02d056c1295d761fd46a03e59670eff7a7ad31f6248dc02f8ade924a39b664e2708483d97dd00b958a53c1a035bbecd92445d9633f07d28b905";
+      sha512 = "20a4902349677d58f9ebe2b3c8ffd356a11e5cf6cb7cf3a7389a77e1da1c2697963c6d77c3c2724b0946665b02166b5741f9a48372c6dd687028751ab3f87116";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/fa/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/fa/firefox-67.0b18.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "9c79a05157471141caa88513ccedbc522b85d26faa52d63e9c4650720fce19f6e83ab91e333e4b249cf1cc0945a04f5cb1d6c3e313e34b8984f53306a603f687";
+      sha512 = "53a61213b2c6e652804ceb53b810421635e9cd392e8b3150389a067045275d2affb827732bf6717e32414cae76cb1eac360291d5863b785a31fe5a14701fb73f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/ff/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/ff/firefox-67.0b18.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "8769ac72f4ab9136930af41ea2d7964bf2bc615e0a6d7ffbbc9396875f2ea0ab709e14493adfcbcf602a700f656a7eb03c67bc75adc78379c4170799e38a490b";
+      sha512 = "4427caa3218b20dc0ef5ea349f40c41606e6cd57b536b0a48dc590e8a2e48c6516a2e5fb930745aa28a17bf835107f65a8a0e586b401d5b717199ef8cbecd387";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/fi/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/fi/firefox-67.0b18.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "b677a46820fffdebef4d7b9b2a7d50cba76f0f371dfa27aa7f2c9aa954d075467eae9936a6d2edb47eb726e57a251fc30c481c2d95e493e32815c7cb315a8a37";
+      sha512 = "08cfd6ad90c88e5daf264241c9c40f89930d0c7e84a8c33e8333741ebb139e681b3d7b3ddde972aa0ce325a686bb75b56e524a0259ea9ae696a926f052dff84f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/fr/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/fr/firefox-67.0b18.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "dc6433a9ee7667af7feb9eb4445477f0c9cbfdd34f906c9b9218b465b8d743a309b831309312587b3c259ff986e4d48204e23a3729d3157fe9287db0599070e1";
+      sha512 = "50b63fcd9a60a32964769d766927b913b0b5c3812ebe88738aa2d0420b448d5aefdc374a1b030c230644ac2e89faddbfba1b50006eb277c109ed36c81ac436c6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/fy-NL/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/fy-NL/firefox-67.0b18.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "0e79e794d88a257dd7390d1adde4c3af0968242c6fad464742f97710f248a385aeca70eb6a2b1772c91bcadf7e02187fc914e1223b2f0fcda55ad7e842bf2560";
+      sha512 = "616b766e2c3e564dbd0e4eeab9544be322aca47de9ba44444dbed96274c291e6bcb155a2be11aa2d6b43a296422ce84ea5143425b174b73283870eb2b78e3c55";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/ga-IE/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/ga-IE/firefox-67.0b18.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "9776f8ab91dbe9ed43cd446eaafcd2da329092921d99126812d8c15dea9f475880e2e404e8bc27c77e7558562dd5b552a570837321f8d044058151766a53c918";
+      sha512 = "a00b961fb0d3f832209d5c33147102907599abae9c10b5062c038863f2162b5d93fe48b918e958890a273c9a449bd223e22d7adabe2c60a092246d6fda150e59";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/gd/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/gd/firefox-67.0b18.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "158ce665efb91a69deebbc3370080546420a06e093f68e3eaf8a5c6200d59837e3eea7f5395e674209db1c25859488cf43f6f8a2767b7bf0751bc2d68eaada99";
+      sha512 = "cf8bb3ab406e4893a3f7f09789c95b51d1e7d745dc5fbf30e809827340ae056b6bbcf5c6c8e224a7492001ea182ad6354ca0702a81496a3b543531dca92d2ba8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/gl/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/gl/firefox-67.0b18.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "d5e9f7ef9e8392ac7bf0a927763466b60d3467f54570682775d8cad1f6f974e4c8f1c3332c1425c1f5c2d4f60f51db4745c9c0cca9c4753475f546935574ea1d";
+      sha512 = "77e143d6ce058654b9e4a92bf1a1d9dffd37339d85733d5785885ce51d32328f525140f9a9409f6f1532146514715fe0fbc750077a384f9156ca07e994864530";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/gn/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/gn/firefox-67.0b18.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "5dde85bd2efbe5750b57e66bba184927c0732a60118ec11069f6d3d89991576b9f12bbeabb8336968a0413756dc35a68407d425b3c5943b0b11f4371ff5aa181";
+      sha512 = "baf483e6285268c50d07b75ee358cddabf2ac99a502fe5c8524e71ff5ce1e9982df0ff641877ca54a8074c39ff7e964ce0d82dd7970fbc674994806abe23cc3b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/gu-IN/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/gu-IN/firefox-67.0b18.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "221b561822058f1fe6669ff1f0f5503b7196e0411d543d76a5e21bc334cab08d74bf521e8fa927d3b7d2fa3ed9a9f56846962569cfe45db9a85e1ffbe77def20";
+      sha512 = "771bc1ddedd8147b3e2cabbf0bade2f241542886533661e3a006c86cbeb922517a1a417ae80d31710461c8b4e5899b2e745eb1fa3fdaa69e32f498a9b5ac848d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/he/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/he/firefox-67.0b18.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "99c46906fd8b57472044fb4d6ba2e624b960afeb6eff9a6c5886e65607af15d5a62b5d1a01d8937e2f1faa67486bcd4d17b4e2b5c6ec983388b872aacfb2e084";
+      sha512 = "e52d6a321d1fb8e39ab376cbfb8d0e75e820ec543950a4d21e3b01b3a5fd33e1f5e017d002c608b3f19edb50cbad8c949b50121b29b70d3557a6ae5d0c4bb96f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/hi-IN/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/hi-IN/firefox-67.0b18.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "7c78e9e84151a6db4f2c4b00116ec3c4cdf9caa167009c9360ed068d4afd24f323277c6b8bb40facb62dd6046f3481efadb00f8b249046c57ac156dea4d121cf";
+      sha512 = "fa37e7332b45f518b9d1ca8287da80a6b558788f97f256539e21b83c09a6569344eeb3ec9e766b0fee7ee33a91247ff59ae639b83f3713f110c2ac993dadb7f9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/hr/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/hr/firefox-67.0b18.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "206935a83387f77a4fc85e98dd81532e9a7f373cab4895a8e71dbdc0b5794452a91870a38daf1155700e92b413bfe1ca4ddb854299a86ca8f409bf51df4962d4";
+      sha512 = "fe56b9438ce09381cbb4865e8bfe051ac0397414f15f0da7374de8d82a1f6f0bc13d8152d8d3543674bf01b1d6fd948981c6e95c19f84cfab94f33f482be7124";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/hsb/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/hsb/firefox-67.0b18.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "241c87157f15a71b51bd74cae7cabc8b19a7046e1ec287031705c6f288cd568d6225b9119f539963622950b15b1dda3f7031034946f407ab15d070655d5a7287";
+      sha512 = "24565e1079f23217165c5dbcb9c30d4317b9a5e8d71f9956a22d643326229f519ef93b7d1c2e676a94f95f7c80df133d73d6b6d527adefe371f89767563c9aaa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/hu/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/hu/firefox-67.0b18.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "2683ab21084ddcbf86da7ac9390679e65aec30e2fa513d20f230bb23b3f0e21489d991e7dab1b781ab2e927d37eb18528fd29973f02170f5811752cdff53884c";
+      sha512 = "67e13a7752d7f9078ac1827e93bbcfe2175bc328b3e45cfd30acdc153d73d1acd18fc318ef6cbebdf12b9c4f482df89f5b6d88ac3144f2ad2128e9f0224783ac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/hy-AM/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/hy-AM/firefox-67.0b18.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "b81f1238f396e88a02e55f5dc0c1b2bbd51d247a5ff7b918f88fde8b2464e31fb08aab108dd07e5c8abe4f27330f82971c73d685f927044138abc818e3967b76";
+      sha512 = "d9ee9e6ace7d15c619e5e25ed443c0da9cd338a2ae255c85bcf31f990c92a26e3b447c21b510efcbdaabf3604877166c0c67d86c336704990a8b6cbc10b999af";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/ia/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/ia/firefox-67.0b18.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha512 = "2c9ee27f81d5662c61ef0e293be5568f53f5e5f0e3f7f6e6247de23e13d9dec5bde3ee93c141e8c11863aecf3ccc7d8000f88b4f1ab72cfc048162afc465268c";
+      sha512 = "3f2b35311ad2fe946c6b761f73f2e4c4004a0ecadaefd6888a83d6ed16d79e1a1bf069c15cdecfc9b7207b49b0247f1567d640d73eea445ab0b6c7153ec6d315";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/id/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/id/firefox-67.0b18.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "53c0c4572bab7b8fba5f3fe4ecfe2fbca02fcf344b9a451a921eb0397b3c0af264e9d70191489dc70d3f3aa853f87189c45c3cbd26b31560dd737920c46254cb";
+      sha512 = "86c35a9637ef56b7b3e848f455b40b0d857a18c32298c7260f69716bf7ec4270ec00690f5f23ed3baa61eecd0422f23500de48ee81764a893db84fd123733433";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/is/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/is/firefox-67.0b18.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "6a71af26f4d21d82d1d0e272f48f2b0c4a7e52a4d1e3ff93f7f45fa5b63d7e50a09155ca7adc38860454044a4eb6b929fb24ac7ff036e09e8661ba2006e1ea20";
+      sha512 = "4c8731b2fe7206efc1ab6717805bccbb50dd528abe0ef7d60921066985f30ff1dcd4c370e5f2513e9e5ada2df13f7bcb127bfc893ccbcb671268af3d13691d65";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/it/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/it/firefox-67.0b18.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "f29ad5e27344aabdf39f1d592cbd0a458cf63c073ee1e3f01bdb4cde665b885f479e7fcf286301e80f1c31468fe9d171ce63a684b734bfce32fa1a71c8384e62";
+      sha512 = "0da9b1924421e704fcc0ec768e82acf743f6c444122c24bd48f633d0694e017b54814d776dc42593267c967f3825c2f4dbcfcb209660d3df27f9dd405c850e49";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/ja/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/ja/firefox-67.0b18.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "b9d9e8eedda1273302c5568ea0c39ba1eaac0960351136d1761d75cd182e57bd80c10cd790cd4a1832fd9224f56dacf1829ad45ee932038f22518b8132c37170";
+      sha512 = "5bbfc6a34dc66f685060358aba485b1dbfd0b6f5f25bef8239c500d00990a66aa8db9e67d3652ab84441da4aa0f8417d5b6c61a305afd9dd8dfe199735bc51c5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/ka/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/ka/firefox-67.0b18.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "8dcac75ea5303cb47b86e259d381b7e2b4d947460fd9fe57fd236334bf4afd969e4cce2bee5690d619c3905417ec5f0a6791b48954cdd3c124d181dd28fed6d0";
+      sha512 = "68b484fa06079cc723327771251000e6096c2bc8e323aee3a8cf10c3991b803afdc8dc7d12e282eb9635fb1a81e90b5fe777b592d7865a525b78ee845e6b0174";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/kab/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/kab/firefox-67.0b18.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "a1fd847e02ac23f4355eac80609ec892dd6957c769c1fa3a6659c0e5ff8f8e9ba23830ecfbc7833ec1a514f32f7325aeb854b74a0b69f402e6f92c3c3ffc9aa4";
+      sha512 = "f8bbc287251129c314d459750b28cd6287582e48f8fe6fce0fa5bd55ede6ede9ca9312e04e44ce973535f750a8989675993115f796de67b2fae8416d0252cd15";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/kk/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/kk/firefox-67.0b18.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "ef11e019b1f24d65fe086ee1ef6eaffe662d4d879e57ad1028d0a4ed3d91d5d3821e61929887735eeaeedda53a16b133e4a26c1289f109b6dc161cc0b9b8d737";
+      sha512 = "0b45fd12636de2709e45419348e18ff38b69a54be9f7fae8590e6468ebaa2608c0c493432ea639b0c7417ffc44cb6354314b0b89642f7f97705d063f9934a6f5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/km/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/km/firefox-67.0b18.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "97f5d8e017528b61a5a33f54ebe46cdae993bad7de5b31bd5e023d9fbcce4fc55673a5cc4dca3488dabe2fabd73f137d38ec7b606dd2968c1269ded59c761223";
+      sha512 = "a3f2f417b1f00e5def74ef2851a96e75db1d71952c74b3715646210720da7cd5a182ba9c25fdbc36f82ecc197ed598116d91a004e5946184c02108e2d33708d3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/kn/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/kn/firefox-67.0b18.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "61500f9fe70f3c9cc3d96cf923cb8cc38602535d9a7018a375ed6d3e197d2ede9bf7e43af61e6fa6ea6ee0344464440bbd50b89e03d1d498cbab4af60e3179d8";
+      sha512 = "bdeb06aa7a025117f8f8dad65db32b42fae8b2d221354cf72c3e04eb54cf94ceec0954679e93847aeee5da01431f76b52f8eb6a7ab9e5c3d232b69c5b17f0605";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/ko/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/ko/firefox-67.0b18.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "b21506b419fa8107c9536fc2d769ae3a22904291376849df6f37db04508ec9cf0fdf826ca59b6087aae084456b74eaa641bc5f52ffdf92b3af5a1e5e08dd01e6";
+      sha512 = "ddc3f9091d9e01f81eb0c8a07f125c7f757f2110efca5eba5967dff550211bf81e8e89153ae4b8e76d53c4187b25791e580cf0845788c55c1b65242a80712fe4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/lij/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/lij/firefox-67.0b18.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "7d190979e6d3b1064a7e8377fbeb35d48ea2558eec730b6486aa4a8e710cceae612de374ad6353d13168849b856a588fc4275e5fb4448d8c7a888925c68d4219";
+      sha512 = "7ea1e6cd38910148e6e2593d975bceaadeb3a2c6fe66ba9199bbeac5be7fc4943213fc81077970e81df1fb8ca7168becb3e77c56bfe51ce38aa17a02237af8d0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/lt/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/lt/firefox-67.0b18.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "56d160ff01f238bbfde59aec30711ae2a5cedd5997b2989da35d91716742ce467671909905e3fc323227fc819e420af927c294e7057b698255d3e01bfa524aab";
+      sha512 = "a8dcfa87273f1330e5321dbff06fcf82f6a4164f7b0c2ff9926b211d1b151a9991be1f0904d587b7755583db457299c67d81417af75bce7b1e1056508b652e47";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/lv/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/lv/firefox-67.0b18.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "c814420be7fc181e5ee7f0b8ef56f7aa2506a5de5f6a7586befbfcb2442869998193f6412a54b2dcb4d0bf52094e539c5270d35ed1709b70187643ba476ea262";
+      sha512 = "f4c7d14014d0c4d9f22f90d0bd01c2bf720a36e5f19463f57c7f6f76693e45e06297613fc1486ebea2637637bc0ce50ceba2ba88cd2f1f77aff3c25155363986";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/mai/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/mai/firefox-67.0b18.tar.bz2";
       locale = "mai";
       arch = "linux-i686";
-      sha512 = "c0a44bfca4c3db9ba7cea0e1249b8983d322d0414b03fa868f72437961ed98afca2ae91c7ba0cc13137ea182f14d709906b080d7e41b82f4dbb49ea73190ae40";
+      sha512 = "06b5c4c32654e88b3b6c1c67708142453cb0da9e85ce287f11a693f88577d7f614b56204437ea0ac4811fc4145d36ab78822bc3b9d72c3d71551ab75d6860db0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/mk/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/mk/firefox-67.0b18.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "f3533ae65afeb45d3bfa8f6b4ce59083f9853a2e803e90a9cfdcbcb0ba58a30b0c6b231b5262366a3f9f337a92aaf7d8534b7ebfc8fa4ff617c1799c6a05d0e9";
+      sha512 = "f6ba1d2dcfc7f2b0a4f70c6f86b8ffc1a3becec61cf17780c52bfe03350b0f1cdbaa48bea7a1fc5f0ca58353c8f57386472d34b04257e8bd2131383df7855006";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/ml/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/ml/firefox-67.0b18.tar.bz2";
       locale = "ml";
       arch = "linux-i686";
-      sha512 = "3214165c93f40c6add58de638d956f98bbc76051d57eb8251bdfed97dd0409d6167cde18b63cc2ef787756e5f62807ce0ef01f749e4b8312e265b648bd8ba55d";
+      sha512 = "c40d68315d5c6118f2c0a61cad7118427186e558aa8cf9a89443f73d4ac012598988a87a03547e366142eb0d7a8ee776e965a07efdc2d44611c51dc9cba5469e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/mr/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/mr/firefox-67.0b18.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "330dfe55f9713c9353208e008b96565df738aa9d31d0b247e8a3566a190e8c117d2a75ab9ce2bcbf47d69bed1a527d9e39262838b8264cb896821bd16037503d";
+      sha512 = "603980ce2bc2e3b13019e2de439136479b3b650a76d0cec91f8699fedf8651fa3e872662160d19d022bd90597e59982f0f0ad2ba4cf0a738bf5292b15c4c22a0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/ms/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/ms/firefox-67.0b18.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "75150905e1f61c75ff61f2b98a14e21c3b2a8366cc8e22871166efb0796e55ad7b77eaed3f12089a481ff219218c60d964f1a62f6582954e43aa761c348d8792";
+      sha512 = "62698a95379733edd5f63abe8e9f110d5bb853272d0b8bd4b40228251a8055464520a9e1b13975dddae88a624edf8dab2a9c751ac3f5fab4df4bdd30064a2fe7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/my/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/my/firefox-67.0b18.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha512 = "1ac0e5ad914680e2936918702dd29325119172ec9959f4108b1da6f36eae05c50b10ad48f3faf433321b0d5706950d5006b0d47f5f310097bf7f3ff81f05e870";
+      sha512 = "1bde440109a874ea1eb9ea7db01bce2338f810985fc5b5d059c8f558f9ee1fb2bdbdeee2dbd7fe7b788e31895ecd9c32c036d1ab9dabcce850ce49abf9f7da53";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/nb-NO/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/nb-NO/firefox-67.0b18.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "3d22b6109d20e08b81d36d41e41c7f864f360f6f66dc440ca30e996ea52c7bbcd8d1ef7ff38318ea443843d0cc3ac8f0e94fe53d1dac9ae09a5cbc595b08ce6a";
+      sha512 = "7196b732947ccd0e94022f6687a885d5af1c1613b605fec82bcf97eaf8cfdd170f22963ca446277d884eada376e3ff0f4e79da9effc712547fef56adefaee62a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/ne-NP/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/ne-NP/firefox-67.0b18.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha512 = "b2ddc6467914af5e816bf5acbce901e63a9d21a1f47d6125c30fda4ef555c2a386fc2258ea613a8fd277e5cfd7db0a917159307268595cdcf67a8c473f5260da";
+      sha512 = "27220f803c33302a9b8636a77324934e94cd2ae395c43bea25cecd977966d2198be99ca5d9f9714109e00349bc66de6391d7b7aa1649d2e0530d8d4f3726718c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/nl/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/nl/firefox-67.0b18.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "79525094158eed262d1d269368cc3cc3248efbc7b667cf2b6c455de6c14533fd0fe5a6536f1b8e78baa804bee6244a46ccd7e5a261cfa20fe61f2985d52847bb";
+      sha512 = "c46f47170d990d7711d7cfa7d3f7b7d03a1dce021a8c7d20dad1f36db5af7f0d5071eb33689bc7f55b89074d11963190f31abf26387fc4bcaa28a6e3403c88bc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/nn-NO/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/nn-NO/firefox-67.0b18.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "78c8b082f84c1120994a21e231bfc97d76f785f675a3098f225a4213ffccd34ca2a3beed45520286bf9edfaa70a924873225e162328ed04c40cde1e8f0eed486";
+      sha512 = "4769f386b959ec8229d3d6574fc93327d90be06129ae433906fa1d36af7dd03d3d5288ec81af3097a7eefdd8bc7574d035e279b6e4c923415038fb8e6ee779be";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/oc/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/oc/firefox-67.0b18.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha512 = "be2f575c2c009700a3da80db3769d1e8383fce60b55a59768752fa4b637d4985c380d63a38a1c348a3f8141f28cdaa4efdacd28b6cafdcc62ae683b7bee978e7";
+      sha512 = "d44203376cc4e58f7cd5241d7e14e970dccf0465b9b156e5004dbdf56440b7e5b713a45a15d8a5d0100acffebc804fdfd1fb45a61439b7e7f9b0c17f8f413d1e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/or/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/or/firefox-67.0b18.tar.bz2";
       locale = "or";
       arch = "linux-i686";
-      sha512 = "93c59d7953133c827ac0bfee3687b7464234928beb2a903ccea62a483423408db1750500f028b5fe7e4136c08179936de5b24fe5e0a76b931eda21a76eeac039";
+      sha512 = "6e4b49731a4fe471af22734ce48e67751d7ff5999db8e55b74d5e18d176d7e8d354b150897b6863e2913703d5d43211fc90e48c986f57112622f5ef820182cd5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/pa-IN/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/pa-IN/firefox-67.0b18.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "c451fd5e76bf9ea7533df6b52e08c61e9ec5632588d45a491ae755d980476e946f951b85f08e03f071c4ed67e969dc06fe2aeb603bd997afa04ab14653d4b37d";
+      sha512 = "09ecc51e3cd84c20dca84ddbabc89ee98201d2de3630ee3b07f1a03838624a2392023ac0912566d9e1d3422f3c641698485cccc0310519643dbb067742b9b739";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/pl/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/pl/firefox-67.0b18.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "b957cb08156642c30b2c8158875309eac6e3e30cd9738c30f433125206c3a9798d3325e436a55d34cf8c4559b88b5c6e4e86b64ce71fff136e48bf8db90d636b";
+      sha512 = "818b35596e13654b8705af0fc731e0219e304b34693e48006c508e5e516e3a7b0d89db32b514d51a04bec569e88ea86b1239edcf304bd99bed34811a0fe33473";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/pt-BR/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/pt-BR/firefox-67.0b18.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "6fea1a12942e05b9023a55e6f30e7b1661106c4007a0c4b0fd2a2f97f8a280b681176937c4534acb756fdf69fd5ad7cf33b78edc5709928926d2ad42aca632bd";
+      sha512 = "047eb09354fa50676378c7e3082dadbcc71088c0d25398e1e6bb25f0d44fe26b9aa025b222970e9bb33d9fb0f48f60639c28024c95ae47624389d311f62753ce";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/pt-PT/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/pt-PT/firefox-67.0b18.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "4f2a416dbab14767b83361b303d5d2eaecae8397a6729acf3274be7f6b9ec739b0312f94f1116afa7bccb5773fb7512360f4f8a403ff81c511a129a1c1d46b23";
+      sha512 = "0674dd63e12bbc5169817557d1fa9ada97d1202cbd97b8fb36595f234adb2716b6f79c6b7cc1aaa48e9513e8c6fab042852483fb3222ec868a655d43c5315d81";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/rm/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/rm/firefox-67.0b18.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "3eec49e997ee34e6f79475cd1c3224ace06d030f1c62df8e58b89cd83ffd2ab365a284932c08f9b8e49314a91d3f1d03c137cfab94729a5215a8dc824401ce5b";
+      sha512 = "18ba376b1e1edfe731428d486f9789fdfc0a2fc7fffdc0717431ee3ed60f737e3166309aa9c28f7ceb321a7410ea7c160a85368458b3d7f7e366ab81fb48b802";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/ro/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/ro/firefox-67.0b18.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "9662eaf290ec38500decf8d474ea3d635d4a4c6df4125d4a36aca9635f02d80129d5a92ece301ed1c0bd4d6990432479825b6575c5bbe40d9b93ab09de7fbba5";
+      sha512 = "46b6b7fd59e6c5367e95a5d5c5891f9339043faf1ec2518242ece74dffceb8582b46289534978e7bf39e8c2bc61e0d011ba3f1adc5d34022b7f857e5b25f237d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/ru/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/ru/firefox-67.0b18.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "a0840386db86e383f6397fb440a86efe623eea56e5b9246c0c2219b50864269ef35238a1028dad5b858a1ebc347a44b588150e1140679292d7f8e43b42b4b216";
+      sha512 = "1e8df6f7cd3902d6536a5e9355a300dd8a75a97036f58495967a30ce18086bd9610bfd173df57c4a34cd6a1c64e0786d94400da312806a2430493e684c1d6fe6";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/si/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/si/firefox-67.0b18.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "3a55e60a4f8baf1d0df17d1317da7b5cfe5bb7e5fc7be512599c9ea566434c8ec98d7e55ad51c3709f46ca01a96b5322b54e44e8814f9f11633a20e4a1a8d83d";
+      sha512 = "06871c8e05dcee61c3d2e1431fe051e5cf70b2d623fa0e07ca94ec3a6d6b85699585c41bc9d978e33297b1547bc2132c09fedf5160084f911de93fd01cbeaabe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/sk/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/sk/firefox-67.0b18.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "df88f7d9667717c8922e6cd575ebae714246d99252b7f65b3d12c4d1dc9717fa06ecb89b6cd07bd37c8b5a3744d4c5380a7e78847398c42f112c07853ee5724d";
+      sha512 = "6f46bfc89960fe7f35c3498ad144a1195c2c32085b7c4b96bf73cf25734a46dbfdc17b555f3adb53942a96dd87995fec5ad911e22e7202859d8aff4f7410c96e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/sl/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/sl/firefox-67.0b18.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "add245941b10147cdd7888dd2183c72b43bd36e5a57bd28234ae8ff45c239b20242599a07aaf499947118cf613df483188f945381c43590864752b0178eaa8e0";
+      sha512 = "bcf428d707e38bd783fbbed5c21a43cc171840fa24e0a382b56945168ad19aebf07dfa6b5ea7090a767e10043d89277556d577e404775fd466badc9722fa46db";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/son/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/son/firefox-67.0b18.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "95a1e1c4a749aa0a8107771db090a628e3980eda4562f413d9417ae71b812a23cc5e9210c93e5aa1e3422503360213bf8168a9f2ddea0e83e06b3a8caf5d9f66";
+      sha512 = "22ab850e4c4dc0af44830dca37323d758f7350f55c15d50dff5acd5d44402059a24d5cde697812b46e7eeeb92c9e75a5e2acca0582769191b96d1161692394d3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/sq/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/sq/firefox-67.0b18.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "59f9898e8ea2a9d1c9cae3f3fb9b7ae20144b38656efcf9095cb4e534cb5b92d6aae695a37fb21bb2196300ed01a3896b7ad9dcd4a6d3e5c68dcaa1d43931070";
+      sha512 = "46a3a290094740d45f50a43b6f680889da5134cb158a81776c253fecfd61fe36a0a6c3d6be717e4aa4f97deacee9aa53808210676562086f7b43bf40f0fd8f1a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/sr/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/sr/firefox-67.0b18.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "da5ca0f67e6b452eb128fde6fc6e0657cd296e2d4fa2e3fb9aeae88563ac0e2cd91a85915d3c758a558795c92a849fdc2d22bc7a650fa785a08fe624bab0c452";
+      sha512 = "8d3cf3a5269ae6c4455048ba6b659c01de2897809c10811e602dd755b742034d10aec16ff5cc9e2c4c8222764938c5335693f33d8ba8b4f9a749700c43f52d4f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/sv-SE/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/sv-SE/firefox-67.0b18.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "4d5cc5cda0f85653a8234af9b674b8c334ca7561d3cd4f69245830d3d31e8f1f7ff30fe0615ce154ddaf0d50db2e717192826b850b19dff7aaf71869e401f436";
+      sha512 = "3391a5258315f095fe4d560f6c2cd8e70af8cdd6b062e2559ba3955abb162814a15907d8a9fef933d7af39b3a5b7f7a1fb1e531edf7a6e1b5ae1b96d4adadfd8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/ta/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/ta/firefox-67.0b18.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "d106704886b39d6a4dbe0a98a5fe465edeb975346d28659fe866ed8afa23e7416276ec11b17965171a5cc3f3ffadc4a58beeaeaa0ee8d879783c301dff5ce488";
+      sha512 = "85c58141e9a871dda3807b4d4e0d8b4f98a18fc963953afa44efb0f755cc60d793a6ddc0d8add21136fb5f98c83bf033cbd62ee3fb1f70465127ecc47c5932b9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/te/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/te/firefox-67.0b18.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "c28dd4b81e4583aa79a7c8e389813ee3c7e66ce27435fbf4203dfd7b9924eaa88f4509ef879cf64303b155fcf95bb595e74130d1fcfce0396326ca8710f65e3a";
+      sha512 = "7fbd1c13721120550fc755f7b277b145c3f6a23a176407cdea7b0cd36ceb1af8ee4986d74bec056e7d9ca823550964785f93d2e906a26968b3e45bb51ac72920";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/th/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/th/firefox-67.0b18.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "750ec351b5164c1036e6099d8150e234f8507acf759ad5a94d90f5cbb75bb2e1a81c1728dc1c4167f66bcac4ed0c9eb436e58507b0ff1cb2024970582dcc1dc2";
+      sha512 = "ebaa8f5c8b4504a5a69d4687cac4ef3c9adb51043331bb099535558b4255f506f9a30909df98b0f8f6345370e2c86b217e4d59abad69e88cbaea8c3bf05f12cb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/tr/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/tr/firefox-67.0b18.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "eaed8385e18fe63b481e2a4cd8bad587cbd77187aa5979b6153ff444554aa3ab844181b651344f111854c7cd605006ce2c43b124f75dc7ca30698adfd222f8b9";
+      sha512 = "fa0d0cbfc24876a0bccafa7d2b1264a92d94d5fcc394e2fe87fca0f4ee28bb7157c20a55cef88cc30d01a9163c353f9013c122ce4072647cf4922b4a0958093a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/uk/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/uk/firefox-67.0b18.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "674c50f7ce0b29dbca906db85acec63a57a313b3057971f9927ab8a08af346e4f4375b55c3711d59bf77507a3e713b497e78fd98737c3520f56ed918d2a417f3";
+      sha512 = "5f0ac76a263df2c9424897994a65843e5b83a7f6a31cf67cd87ba42f78526566cb1ab0d8253c9292dfd8633c153de4f9f1c2094794e6cd008eda22ce3d121605";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/ur/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/ur/firefox-67.0b18.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha512 = "4a5ae461d3f43ca4596ce3e82d56ba6558c971b32e3bb7ca035fc6e4871097c09f3341b27e2e4bf2eb06df31b3b2eb53f82d7b807225611288be05333db07870";
+      sha512 = "46b0f84deed0859b03aa5418e73b15fdb925f424dc2aaa37b48697a6ddb2d22c2cd1f98d8bb8252dfee80a070a2099f29c0898b79b6cd91dd1fcce2f65418472";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/uz/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/uz/firefox-67.0b18.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "236f58c13709566f9cdaae2b8b03742f85616a917fbbe6c75cfe662f19d10cd60ad16bee8e454a8e9233f3b80184e4a037a91850763d9572935af56572db6c44";
+      sha512 = "9faba9b67cc972f0e60e2fff63a4808bd0836ae5467dc400dfaa82d9249dcc7091014180d04750ff94c4d7b5645fa18ff11a950297b6598d731726093a920dc1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/vi/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/vi/firefox-67.0b18.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "1969f62165a73c88004dda2e173732c9b7d133edcfc313e1713d9b5c24cb6a5db19bb287d693a1f77cfc9fc28bd3c7ff8449051df09392f00d023add981d4529";
+      sha512 = "40ab917e85d5e625bbf29c6e89c2ef816306c22f00b84e3296523ee50ca3de44a6e3a09623225ae3b2a435c098639c828026b38e1fa987cfb6f1d46747170baf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/xh/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/xh/firefox-67.0b18.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "b4406d3c5ba0ff5088f91a8df30087a3029eb0f36a659e08666cbb55dfe1461b69501d2c95d22dcbb534551c7df0d8330d226883d24c3458e3bbe5e2c481d27b";
+      sha512 = "da5e9e56e4016650602a28e28ec0a58e00ed1f42392ef410274abb33c4b5fb71732b6810ad61cf172b618cdefbbf943386601e114dfc9564723b3446be1ea1ac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/zh-CN/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/zh-CN/firefox-67.0b18.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "0c0a4d87d4b973a79da290692375358a6cfc06758be48a84b0c56f39875d3488e845f6473ce432b2e2841023d6cd7655551d13d0a464b533b3bde7efa96e912f";
+      sha512 = "94315e64a5f757b90a06d94a6bc750e16a66828b6bdfc0ecc7a0dba34c68dd0c1c93a6150ece78c58a372276daa7a700609de9477e807eaba395038ca99e0583";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b17/linux-i686/zh-TW/firefox-67.0b17.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/67.0b18/linux-i686/zh-TW/firefox-67.0b18.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "46539cc0cdae004ea69c792aa7f9f158994fbbf3a28f2db43efc5a6a9337f59d6a0507fa94db3a6e4bf451ceb4234841c9e3417b21b399eada809b9ca4511489";
+      sha512 = "81c8b294c88985bcbd8bcb73767a5f4dc0cc767e16177a548222727f66316fabff379f0c74e4087bb5d4d6dd19ae59314dcc1a43e13328b9279750f1cb87e4f3";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,995 +1,995 @@
 {
-  version = "66.0.4";
+  version = "66.0.5";
   sources = [
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/ach/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/ach/firefox-66.0.5.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha512 = "789ecf57dbca48a149a19d60e1a25ae5c1aff21d7ee4dd8e1cd40674f0ec29f891b7e90981e48dc69dc930212b7345ee0ec09f47e09cc8492112d2454fe4f5ad";
+      sha512 = "81dd4f3df0953e6234484bf0f55973123336e374ee38e0ca7c1aae3dc12e66aefb18c985be7e98578c857c6d2cd86d5319ac9aa2170b4df7eb47fe8fc7373b08";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/af/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/af/firefox-66.0.5.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha512 = "2bc27408660e583abc67b78b05e88c2d8c75a71979bb286609b68d978ccacb2e5edc35494ede290389587b80e6ba3a27cc6bb8f1853fc58e8f138b873b36e2b0";
+      sha512 = "87cc2d6c5aa0c5a8eeb910af6780144111f81fcfbdf4aecffcc046b5317669d29329347920117256f2442e8b08b11fb9886c7f9558647db9847637b07aac272f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/an/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/an/firefox-66.0.5.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha512 = "4d3b215c6517633e130a02fa468f92f93e366b645865699729cb4eb4d93fa638ad3a7dc9b15d927cf871412e9e4aef352e882d3804477c6b0d378b47445f325a";
+      sha512 = "b15896cb8c138b444b779362a38bac2defaf012818696d303025dc1e1dda7efd57032ebab254d393d8fef31356a525dff87aa65d60dd65198cd0e47bd87c27f2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/ar/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/ar/firefox-66.0.5.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "931322aefdc370f4618d4a595d750840e2d9b573e870531bee97832a878e0ce4787947c09d06ab7d27319ae5e2e56a5a2e1f35a41ab91fe160f843eaa749e22d";
+      sha512 = "d7f6e90064ce4fe123922f786c9395706c12ef1093b34ce60564255325fa14da9c46c24344a45f27a2e6e1b606f1e8bf6c5891c278763e3f4f70566c3b128970";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/as/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/as/firefox-66.0.5.tar.bz2";
       locale = "as";
       arch = "linux-x86_64";
-      sha512 = "8b7ca252fb388aa6e29385e78e90f66b377ba1e0bff05f185e7b42aef38eda2bd833a24921cb3d497d68aac3e1b36604d9b9019af3e0a5c8dd6e074c134455f7";
+      sha512 = "ef2eb62a16e865a6f0ec796dc17a91da99b5643326a102019a55d3c477d68b62a566d0c73feb5aa1c23347bc7f358e1b6d116608945e03e4136baa6ade97d763";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/ast/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/ast/firefox-66.0.5.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "42f9447742379e80ec51c9604f002689598b66c6eb6948bd45c276aec6a61390a024aa11256263a4de358d9c219d80d0a784427bf446d63740529cd440d21263";
+      sha512 = "fd5a01a343911f5d0cf4afafb0994cd236ce5f477a020272e56222eb216efb27b610a6aea26273c76b3947f62538d613d4af0a0d5ee16f6c985aa7b637dc4832";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/az/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/az/firefox-66.0.5.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha512 = "1a27ceb32a711ae960c9637a3557a962142ec959590602a09459af46777477d0320283f6aa1c54015a73dacd3928297b5a1864a0237aa5bc6c48a50ccc7c1636";
+      sha512 = "2674b4404da94eceb54bb91208d622adbd0c433691e6bf09b93b784c112f77c5b6a7f655000a8a1ae6b2957c96637ba2b61fcb18d4a028a70c8ea6b4c82f7c72";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/be/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/be/firefox-66.0.5.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "f7b8ed7aa47d67d5d71e0887f66e89697add0af6a1de04bdc80d07c6c0c6f0adfcfdf2e1e6bc6194bd624ee8e442f0f0901b550b4621d40340e1e6c37b12f777";
+      sha512 = "b79bdfc175ac65bbf13a50eccbcd47587d05e1a7e937eaa91598f546c2ef33b99c5b9b5ff14cb155add7602132dce98ee298764c40c27e72c221f3d64a3ed7d7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/bg/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/bg/firefox-66.0.5.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "70066e04e0f1d5a55c09d19668c05123ebcfde74cbba0b1d685c23d48832ba8865576af4cdcaccfa587dd90c7e4cc8477d7397102482933f7fd98bad13260dca";
+      sha512 = "206aa03f0299af698149d93eba7b232835d5471e60ccc6bbedfc1566e0375a88e8bcd8da882f80b500fad9e850c1ff6657eddce499abf6ac976b1fb0eed77e4d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/bn-BD/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/bn-BD/firefox-66.0.5.tar.bz2";
       locale = "bn-BD";
       arch = "linux-x86_64";
-      sha512 = "2f31746734cab6b027c7f1503629bdfeb25c6ed8f1d597fbef7bccb0ba67ff02705e3bae74b4c9598bea7063b9e2819fadd582145e6eb81381820935ecacef5a";
+      sha512 = "54f8f199008519e57d474f49ad8b28163fea3ea158a94fec2c437ce81336059ba8fdc70cc080c79667dd8172aa89152e0bea08a67a2f140628682d66c0da07c7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/bn-IN/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/bn-IN/firefox-66.0.5.tar.bz2";
       locale = "bn-IN";
       arch = "linux-x86_64";
-      sha512 = "e80862cc2f26b76f7d77404ac693acd9086ff1169cebfbe28775c4199f79907503e034142e522f81fad67c2ae273513c969f4c4fe073ef87e8c619b5a55da950";
+      sha512 = "e78887887b3793bcc659f9dff24661aa5175f4c614797c47fd7063e36b668c865cc61e65ad0b040cccd499ae99d41aae215c86f43f837149fc612ce7c02ea908";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/br/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/br/firefox-66.0.5.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "e7602765bbd77f1e525579f4e20bb151d9201d072b323f9d3625aefe53808159faa4bf22b9ed9f57d85df75aff2a0246b6482d5880d5d9b5ba114e5f815fb3ba";
+      sha512 = "da4e0af68be8aa38db212beb0a6d9f4de14571fa32ddd28d47a439626111ac0fedcfc7976250e03a40aff626522840731a1febc3718fba5cde08f02cbc045e1b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/bs/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/bs/firefox-66.0.5.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha512 = "ec5852bcbefaafd13879256e6c6d58ade9a825204f5bbbf01297e0c19de48ee72b47fe1dd26c9f00d4df8605563e8cdb9cfa314c1134bd17d5d4cb80f55b997b";
+      sha512 = "68d1a09118c0a81dca3edcd3eb0e36384fcb370c708956c84681b6f41a084256df2c463a8539fde497a34015cdb4523c340bd34080e433b7eb71e66db35c89ac";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/ca/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/ca/firefox-66.0.5.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "7f119a513b64a61ba8f23adda7c8f3681fcdd66ce945bf9060ee4b0cfd2ec8550d55e820b177f896f2f5d43b538ffff10ebd1b2bd5840fc6ab026a7b2e93e3f9";
+      sha512 = "f76264197f35bb8feba8905600fd4cffa9561e17bfcc811a880a81c25a9a9c12bed29db9e4c53c99ddcc8796f45fb83003301df2cafac93eda582ca6ad92334f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/cak/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/cak/firefox-66.0.5.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha512 = "52d73516f4e268410fa0bc0ddbde9cd8c1c70721aed1d28a750e98b2bb8ccfa425082ced20691c4f3074cefe2c7427e9b7ca931bdbf9100249b2aa385a5659b6";
+      sha512 = "779e3e776877aa1116bfb9c21276f6e1b2b9813c854b38894a2c4beec39a52d15ba3ace536a58011216defb729c4a26a6d80becbae967b0ddd2126d9ef8056a7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/cs/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/cs/firefox-66.0.5.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "583e6f3682e9126310b11e8ae515dc2a550291b9f6069ac8fbf568d8f0696e896d9b3a410d2ef13a1475e793214674d21e2c357b4acd5908ac6043c259b043d9";
+      sha512 = "bf4d60effd3628602be7ebae080bc429e6d0795ab2c4bc4e703e0a1d92b1cd4885dd3af10f22e939dbfd8d83cb1b79c90cad424fd2bafa976f9bb9dc3ec78c94";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/cy/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/cy/firefox-66.0.5.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "9deea20b92d1e8e48bbd0288959ffe8f9795221b4d57d1f2e92b0f6de65caa180684b5ea2354cc442bdd5941722be160b95a455ed7464a683906310459000d0e";
+      sha512 = "f485f1e307db31a6382542a2ed4c103483342bee05790661db1f12d11585d029793096f6e0d881388f317d54878ba10dd7f6703b488e80417d1af4b3f83771a5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/da/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/da/firefox-66.0.5.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "95b0e4aed159fe34cf925174f3ec20a14b296c27541f1aa2b369243261d305751415805321d02259512a18cc422bf0272f3b92d8918f03ccb65a9ff084315061";
+      sha512 = "6870622105879e703072153b0fd8b5e00b1e5621270fa187d0795675e69e39943e3232404d8702defe6844f75335292615d7c5f128fb3881eb027a90d3fb9710";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/de/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/de/firefox-66.0.5.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "dd21fa81e0e85188bcc61519bb4549bbfcb433f88677b79b91da5c3796df985e60b1dc1fec391a70813d61f1a902dd0eb69815c5d81d96a0937373b491d70cbd";
+      sha512 = "58a9ca0b2faa54193854f5467d9efd989be71560afcd32f013bcfdc01a8f51a24d54850bb02527c58a1c39f698b66144af899f6820ad867edc725a7c0399442f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/dsb/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/dsb/firefox-66.0.5.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "c7fcbf4e008f6c2ad9bfb5c37a57f257011a2eef811e5bfc28cdc05812283db5a69aa0167651dfe9df5dfec2aac74ba128d9bfc396ddda1475630b89e46cc6cf";
+      sha512 = "8ebe982a0f7d0520654093af62ba62e2d9415ea1bc3ea1f12f14d64c15d4db70f64abee3ea9141a875cf487f72287fffaa2085e66b610a01bc40b0ad2c944efb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/el/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/el/firefox-66.0.5.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "889e9e88105d12523b0394d4ea8ff2dae753f560c624b2feff3a8c48640052e3dd871446b9b0b9832998d909f2c9cb5dbc0e03f3b099b940bf50779a9db44eed";
+      sha512 = "cafe8a9933947fbd7acea7234ced4ff7061a3e2136e5fa5789fea64aba96b1731e3a1e7120f4dec1dd0353763435089354998e2d151b1a884ef927a799edd1d4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/en-CA/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/en-CA/firefox-66.0.5.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha512 = "30e54bab160ec76f15c7d44b8ba8840204e297fc3cddd74cf35cb86c9a0677a54548feb3a4b6ab899b10abba142635faaa68888a6cc53ba0f6f9ee401338cb3b";
+      sha512 = "ffdda6e16d9b43c23aebd5e876296f9dcfdf3cfc54577e4031ca25d004aad53ba63057e2875840fb054f8fe080532361c1fc613382ca23a521aeb844e1626dbb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/en-GB/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/en-GB/firefox-66.0.5.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "2c9548a80d26ab338e662c4a2ccd02185afd6bb07812fb4d2118f0acac01dd32f759efcf6921942f6b7db144f293193554ed5678a9762220c9a7e997d9eaca1d";
+      sha512 = "69351e93fffcf3279abc7b23a81c262b1e804cbec7da3b55b3a62a3062a59dfc6894fe41975bb9f70bba01364f0d5bd86f0659b82f9bd9b9ce8a14b66cb24506";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/en-US/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/en-US/firefox-66.0.5.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "938d9efd9a344ed755f26a2864d813f848f07907ecd795d74edb352ff44fc7cbf85d6d4bfd496a85a3bb6fb2ea1b14847705c627b40f1af53b49301708c3c1be";
+      sha512 = "7cbb43a8c1ffe1884c551421bc32f8e48239200af62800e8ff5b18d461b1ddd7b5d0c9afe0e262f98112bbde2949fedc740209e957bcee0b2c30a19e17bd5428";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/en-ZA/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/en-ZA/firefox-66.0.5.tar.bz2";
       locale = "en-ZA";
       arch = "linux-x86_64";
-      sha512 = "2dac84bbed983f8638a9a9e92c217bec73b026eca7d66f585934ce4a89f21bd55b69804df00a61c9613de0c9e5fd331dacc01f3b08f36cf4489b86c85b05d688";
+      sha512 = "8bf0583385c31dc6cf3d4df7790d06790a9387f59c54f18f30d3df05cc110bda2fefa6764d732c90e7f6eab4e42e594230da966acf1ebae078710f99793919d2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/eo/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/eo/firefox-66.0.5.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha512 = "82b4fc79e2fd0aa29e88570ed3b44967ea888a7df70c74fadacd929d7b64e86aac2abb7b92362fc607c858de5c8619c63267e7ceff951617517569df06accfe2";
+      sha512 = "2a72aed4c755f463dcb97549d7f9fd644ce1bc0e259eff7bfe5b43148a5cca32315779121fc1d02c189961d7aa6953d62bd7f56c6925a321d1081765f11b2b11";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/es-AR/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/es-AR/firefox-66.0.5.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "78fba3adce26eaaafb72a08a953ee8801c401b650a39c9ae4cac872a86456813976db0c7e98b4255b4b02525c1fca3f3ecb5df8f8d678cb60e29edf5e9d2e103";
+      sha512 = "f5b297e47bc51811e2096f9cf60686b0732a6f7eabde581ecc585b192341724e5656d251b7da545d99dce840b2aca2692c5e6b4eef4796b58e791dd59709c12b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/es-CL/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/es-CL/firefox-66.0.5.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha512 = "3f59b8a28afc1255cece3534e639d4a9bbd48f4bdcdaf836b5c5a459d55599c3cdf84c8af45b30b9496f95afad11afa51364b2b0acf9cd08c561dc2f132347e2";
+      sha512 = "94ba91ab326ccd20ac60da18429e9a787de3e97057eabc24ef38e6ba44066108eb18e8d58f2148a8b7a28b47aee65b12673b51b1a3eb8f733af199ef0b865c4d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/es-ES/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/es-ES/firefox-66.0.5.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "7a01d61bfabf1bdbe9e485ce2cde726ccd3e937e8b951ae2b3cbbd1d7976cc010ac82202fda51f07cef5f0895ce5b53db506bf5d949967f2232c999b52b2d713";
+      sha512 = "f40a14cc05855ca16efeed2c78a4342c1f6439f6f380e42ceb47433e1cc9088e17a91b656ce098d02d6b92b927bf33c0288f2bf2941d99e10b9e536ee71108aa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/es-MX/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/es-MX/firefox-66.0.5.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha512 = "6e1849aa7c85b099a61c616bea86f3b809c7ea464b85291415f590d7ea4953005db7ae2fa15417cad9ca0a6d66b17fc3447bca31d3579ce6573609580cde3cb7";
+      sha512 = "dd3ca519b32a1951844a0bc54690be59a9843000873091a830df54fb8cc92b866fe448a5216d253a3118d533baac672e3c56464cceb5d3b920b5b6c51a3b5163";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/et/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/et/firefox-66.0.5.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "2c119e3902073a150d3df9e1d458b155529a2c747f2c96508dd90a0efa73df0fccf7c36ca7e8438dbbc9e463567195d20ba9e4bc1b9a908b13aa4e6a43ef58ff";
+      sha512 = "5dffa53a49117d2f0c6442ce343c08c5f5764535273ab85f7e603736fac25795fa672113384de47b649d7214c84af3d249ef1e9ffb43db7d81e51e59184f8322";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/eu/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/eu/firefox-66.0.5.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "cc82250530f1a869ce578f05d76e835588e01b359a19748d1d418b9a0b16770878518fb492fe79108b1ade4c8b9ed780b61a6e414b89a1b259aed5eb73510b40";
+      sha512 = "f401b7084044c346343c52dee074ecc3478dde92cf9ee9f624749e88ab2ae5c9f70b7a979129e84172d785a81228edddb9023351b61d6c74c2ab1137843f67f1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/fa/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/fa/firefox-66.0.5.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha512 = "bf990360a952060ee71f8f761ea893401775f317d3e1409444d26eeb3f7ed8f641b70226db1549ecac4550cabe8c19308fda99f494560c660afef4a886d27d3e";
+      sha512 = "af65c1415f5fd26cf0b14dce1855266a2e295817405abac6402f20f7a409466e7d7dc06a9233b5cb9064f9ba5e954246db20ceea0f0bbed4d42e93cda77e22a4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/ff/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/ff/firefox-66.0.5.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha512 = "22213c96652c3f1dedf400281dfcec1aeda20661e8f9e24cc32d62585b70e3d09a2dd2537f09918a6a9550799162ae196a62158a2e1613f9ec23ea9191f3cd35";
+      sha512 = "6440b9db16a365f44064da652ea4b36b9976794896e062d627e200d6781d35fbbc98ac6d148c45de38788b204005ecdb0857fe2e02cb7240536c00e5ca3fd8a2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/fi/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/fi/firefox-66.0.5.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "3b82fd86b0116eb36da8fc2ccebffce4bdb00ce549bd69264a7a837374241bf02f24b2196a4d2e80dd9b82a24674f74ec8035d3f6f252878d28ab9dda028545a";
+      sha512 = "756a89e20d96e548b27570a907595b9aac701df8ad9262f5c82ddbd25d508e07b603f8d24769d756e83e6e4e9076144bdf39f66ba4f1983dc447646d0eb88b9b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/fr/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/fr/firefox-66.0.5.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "db70c00d7c60083ca8880cf324f1f510d5ae66399b76790d6689e668aa6e7380ea263f0f5ab18a0ebdbcdb8ec66e1921b4a56540971cf2c641cc026293aeb885";
+      sha512 = "2c26924902510167d88e660fb5236e6738defa5cf5600daf1cf9267e7ea05541109d5e736b7f78e311b2e31e53216ac22d9236f91a51498c40e376fa1a4d9387";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/fy-NL/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/fy-NL/firefox-66.0.5.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "14dea2ad6c8da49716adef7d20efe88933dc69ec7566c07c948c296d145b4b24268c0e08f0123605451699efbd758a3af2229c23d301c8b122cd99596624ff63";
+      sha512 = "e45b45c0b84504c978906dab3057c9213301767efc4e63c760ebd4d8b44b59ad72fe486877216f6062a592ca173a13fa5341ffaa1106763a43c215201b390079";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/ga-IE/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/ga-IE/firefox-66.0.5.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "70110fa27b8cda7b0ffaf52f2931000d886be4763741ca71eb7ccd6b58ee1a0e1e82735599ed19519b4719dee0ef9d0bdcfb599ebbceb7663013f2d5e26bc848";
+      sha512 = "3e2ec6aa813351add3292f8d646761a5ba0c371f0017a965b0b815c9d6324bcdba42f3b585cd9df4a187f1f0b40d3a78dbd6357b4d46406550ce6dc52111be34";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/gd/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/gd/firefox-66.0.5.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "063f8ef3adfa83637fe15f89ad7b7baf0d9ebc7a54fd743f4b88637f4a29db925d459612c480205744136e6f99f84ff2aa755a58ac89877cce0ac0f93bca5d9f";
+      sha512 = "1aa9d0bb86c56182c28efa5f92dbf58dcbc83bbc187bb942f5e418e75d586fd1742568ce5ac5871133cb0703f83ec2b49f1337dffd327aaade3359e740b50fa3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/gl/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/gl/firefox-66.0.5.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "79161f599ba4a916d8bd61b761067dbc3ae05ac4eb0345c941c87aabb826c5a41ce2f3d60dc91062d4e579826120c585e28e2b4364209852966267abdd3ec767";
+      sha512 = "121f5f6c384283cf9002cf4f1bceed611e28d1afa837e2d19cbc18a0d6a7ca291c5d7b75d110005369cc491023bf84632f0919ff359ccd12ffdc449e4d1a0cd5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/gn/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/gn/firefox-66.0.5.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha512 = "5a9bde18ffc4f15875dccbff737122d199125e32f3805e904bde0e3b1eced173ababe00b3170f97b140e08861d27a63cc2aa9345231ab12e34785e17e390d3a5";
+      sha512 = "66ec624b0b903a215659ef34828fe83cf64e7d43cf264624deae0a37aed9a0980be850ddeacddd8ac71b27ec6d1e635f43ff1f75e5c7ff13848220a27a23df4a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/gu-IN/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/gu-IN/firefox-66.0.5.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha512 = "4ab7a824d4da3c1cc5b5eadeb35132a0322c61f86d5c475e0632a0964ea529d3255313501186138848718f33b2ee62bce30952ca5418e7fce784c1e218f80452";
+      sha512 = "7438de7c95068a4c84b57b49b86652641ef176f88c715789067f2e33edf35defc4776f2b891f1cce2813889fb4c03fe1c26110564f02c82326cf48cfde728af7";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/he/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/he/firefox-66.0.5.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "b552d54f6ae9ba1f565f7ffe86b68eb916a6f53566e8cb05b1a1a7e39ccc8cf38b941c11b25e07fdab9baee8c31f55f1611153609e873b15c36e00ef32ca9871";
+      sha512 = "4d6675d21ebcafd60fc27971676d9f1d87823fd0f6f384746b7e5ed9ee1c4a3080cd1b93a7481846f2955f12c3648ddb18424749a1a2d11eb56e74232f9bf7dd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/hi-IN/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/hi-IN/firefox-66.0.5.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha512 = "aa39f47e5b56544ba826173048b60fb79723c0af2c93155ee7ec632741795c40cb38b445ca896543b0af2ad0307b2f5c4786b42be1cff992c240298e8786b9d0";
+      sha512 = "fca993dafb56b59235a7935dd19e2241f3a4c81bf1d395beb971cdd4c4d3f2550c90a76920e55d5ace09c900599b48fd7f9a318fdf4e70f0ef26c7f937f0b3ae";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/hr/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/hr/firefox-66.0.5.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "9e4256069c4c094a04df85c899b00d27e5cff171c827c4946973c1f9f58d9fe158dae2f021dcc8e85aeca2ec9baf7ed11d5c8091b7c4705ce3dbeccb089b02c9";
+      sha512 = "ea3fafeabb46eb2c674c4dbd53bc1f98badc09ee7cc99f2deee75e2f377c02d79c2c881361500424db5baf10afc016c074b8a0b91420e1769dd5e71dc39cab85";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/hsb/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/hsb/firefox-66.0.5.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "65285b9abdb550dade0705ae530af879cabf9eb0953bf91c5e7485035eff20b4d97134f2ea280c8e7087aba3a6f9fa0f4b30443eb418aad400fe2ac110c56745";
+      sha512 = "493379fdc37e29079c3561f26c5c211ebd4a68a5d7055e5089d0c25347d1f38252b5145f76a910868f5edb820d02d46c682a6226c97fe674ba2b37dc4ee4e39b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/hu/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/hu/firefox-66.0.5.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "ecfec8847285c14238605f12e29ae9e7fa0540162e08678bd35f20ec135c631df06e1c5cdd31349ab338491443a473b88e5f10bf5528299d4c655a787c94c5fe";
+      sha512 = "983dd20160987e94cc311fface93c64b8e8aa99373b0ddd09154e909504376173027f7eb05a96fc205c3e1668743e05001081bb0708c3a5ece02f95009f6ba35";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/hy-AM/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/hy-AM/firefox-66.0.5.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "e1b4e51a9bdd5b7a41fcad703ec674bc6b602edd94849be310889286bbc22948fcd6370da99c0481f2f4781077856e9766997431f3fe77f0b3d80194e36d76d4";
+      sha512 = "fb8759786a313692a7de408bf377614264b5af657ea9ce95bc7195e4075196c69801267913d1a2f980420785b9e04899d81231b8f00729c73037f9d22b9a6914";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/ia/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/ia/firefox-66.0.5.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha512 = "084e8b0238b1ddc4c441cc8579f28315fdbd0e997eb7a9ea8413a3140a10366fa16b8a0c3e0c03312196af03b12015d498961a4b7673c82c8163b39d702f1ff7";
+      sha512 = "1c7b9e314276e9e0e94de008ac928c2a8dba0fbe4255176643f9f7aaf0e4f7a2edf597656a0b656b94741b55300b850943cfca51d1e2437f84dcd6ed2884c11d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/id/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/id/firefox-66.0.5.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "50e18367cd9cf31d9d3df3e31cc78c696e5578d7840c71af55935fed645b149b61c8843ae2f4bf25e2a9389b4ad8da9cb16b587c5c9fd912872e8baf4ade4f22";
+      sha512 = "52f31c787ced6ee5fb68f910f565d6890c24cb06f396a7cf60f9dd4832959468dda4ab1f65b874b46331a251679cffa507fefdb55803f531b41cdcdf848d4eda";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/is/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/is/firefox-66.0.5.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "fd4c9ae4081afafc51285bdce826e92329e8d506a71f649a73bbb2786532cb7929b7577e24f9ca92caee9d6bdb88783a842c55c2c446aae57663fcb6d563815a";
+      sha512 = "5571678c28173936303163ebd780663a9902fb2c82df684fbc935b45dbd81b82654981de5ca8ddf2c803190c3df173d9edf7a5fff6faa23932bae0d084a1543a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/it/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/it/firefox-66.0.5.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "070ebcbe345b96292d06f10d209144629344cf1b48070465f82ef6d974c648c83fd587a5d629b9fcecfac6c6dfe1e3c5cae4ff25d11518b5536f931bc6675da5";
+      sha512 = "ecd3509595c0f9229202b3cf45d50bc5902c1e63a8064cca77f0eb559ca6270fc49497448c2dd24ad775c0e229963c6aa76c6bb07736751a318f4c365839e276";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/ja/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/ja/firefox-66.0.5.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "58842ab79b1aeff66c40fdb5a27cae809ed4082799301f1f718d695b46b389cf1b6416c26a5b05043778fdb6a7260e85a0080ed3dacc50da74350019643455d9";
+      sha512 = "a56268e5cd7f4d9eb598dfaeef7f9fe56e98aa0a0552f17fbf2c4e4eda4f64298f400d03d89bec27cb001db65aa4b91abf9aac0952f43c22e95f0c320ccb0f74";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/ka/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/ka/firefox-66.0.5.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha512 = "dffd3ca8e7530c0f563d7b8309956553b448da98bf6e9fa3ecc8492fa49485287432bb72127285edf6d80c52760dfaed8dc65ed6a48ebc5a4857b80c5e9728c9";
+      sha512 = "c57e5c9034989a5ef6fe6fde7f179dce7a8b78fff442a0d3db93138d6678f9b4a74a8d5d51db16953a729b48b0b7530d29cec41f6cb1dad27677a759fa78036f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/kab/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/kab/firefox-66.0.5.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "5e87256a8230356a382a4bea207d370e2d4939ae7f1e88ecd1a0afcd004d498e941be648ff12c4fb5912f009e6b192212a44dcc4b563d935699f82842fc16022";
+      sha512 = "6b1241dd610794867f58289a7149038cc2a8f5bdd17f20bea99ef7dcf3da2a683079bceb37abca6d21a6d2c90e3406ea406f50670b189135cc656180c13a627e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/kk/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/kk/firefox-66.0.5.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "f3a73bfab3e2f69fe366e73860eda64c94da004877a1ded9aa6c6b89d3d48d4dc3daf918036a811cce4a37c2ee2addebbe61f47c6379316a60980316c8c02c1f";
+      sha512 = "7c0f4cf4cfc0894ba9bf48c29a8b27266c637d7d7a293465a048eab1cba6ab9668b8f274521dd670425a02282e073c148cccf7e265910f4f034b8edc1b704bc9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/km/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/km/firefox-66.0.5.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha512 = "cc669ef1e7139ca3561557acbace0455c59c2333d375298d969ab22dd0663425791e3296729e98f514754fba9c119b15f8817835c9d053fb0fdd327baec184e6";
+      sha512 = "c5aa21d97b88099065b571f007ddb6b50f86b16d82d2ae699387b3618e47fd847bcfeb34e18d2c7d1a7dc402a5cc99885610169abc41fb5941b3fb0e959e8a7f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/kn/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/kn/firefox-66.0.5.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha512 = "b067a1850687a5194c57f1fe1b1ebc875e39d567162454fff8522c2c1c02d6ac7bdd7c23053e66c19552ac7239e95118eca3e93cbf5e74d9e400d61caa80a337";
+      sha512 = "ed574cdf851b071437bd21f68293db4c3dcbc6f259651c25617a64719e36dc34f22d43a3aaafd08439d8ca2f52ccc5f78a109f52de0c26a061e5fbc197990172";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/ko/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/ko/firefox-66.0.5.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "43571dce5bcb5cd9c44cb6974cf7224e9d03bb9dd546d9b494e2e4126e6b91c3ff0fe7118fd2ddd2cdb3d1bfb96c4433c935d7af52c387cf03f33363f995a062";
+      sha512 = "2602dfe1c534f688247ee3b14d80ccc75d43060203e965fb6a28e659031ebf9c10621aaccc25cec62663f3b52198579a8d9db1be406d2cc99d54d1125177ee04";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/lij/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/lij/firefox-66.0.5.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha512 = "a8163716dd01731d8914d4f711466277e97107c4d62230319a85d251ac68e04a05554c402d3d29ce5a1d00ad69ecd285c0fe4412ce52e905f3a6c6cc9d8cbc98";
+      sha512 = "1e3a78df80e259d0aa52d13ad3a47b65bf37ab4cc456b3704991726230bfcdb5429bd727f8631127f878975535154acf3b8f4b32b97ff815f3fd8efbd2d24761";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/lt/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/lt/firefox-66.0.5.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "ebcc5d3f6eb5c458d27fbf8fefefda113cb6dc78eb6e6b243396aaa85bd7891f5d8aaa8978a81e40653cc73bb6fcdb16839a97f769e437f6c4a9d512ad1cfd48";
+      sha512 = "3ab5e09f5af356428b835fcb9e9e7c7a1fd710460fe42072bb67b3007efb3bc2d24d8013c96474763245d7bf806f762679e8053d73d20b6fd2b01f5b3f529f86";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/lv/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/lv/firefox-66.0.5.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha512 = "6573e17058ca50a28751a62ccf87ba0542df55b53c4398a09d0752181cc442e57e967d060d3533af394dee4f122ee784d6ee6168ed2dca08855617121bc4a60e";
+      sha512 = "4f87af9f69d52f13424f481d8ef4109f74ab361c7056daf9b81581076b55b8ffd1b2f96fe8c6cbadf16418292e8c49d3149199401a4da519d1c1c29d6c6edff9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/mai/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/mai/firefox-66.0.5.tar.bz2";
       locale = "mai";
       arch = "linux-x86_64";
-      sha512 = "1e92c29312c635f195a6f52c869f4b4593d9284a8e00c768bfc4490a69c09c69e604d514178e26a1f067a7348088e0022f7c4659c4193ac775261f402e72418a";
+      sha512 = "06e3072e5b94767a3c42da911a322ca1a0c403b69cbec216b3fc82d1182403ee074f3b595b45aee834d0e0267567cf0adb97e99246e0aea233f6512f39b50bbe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/mk/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/mk/firefox-66.0.5.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha512 = "493d4ee0450a1a7c54aea2a2541d681a7b18be6f45fe2e9b97d41761e625cfaff4977ddb464dfb6587eb844c23bfcac04015da69d0f19b05b4afcbd42dbfd26c";
+      sha512 = "b42ddc552556bf32f3f11897174f452a23f812877219bf0624cd0ced1f2adba1fd8d6ec8e7dc0c5127a22ee25728c7f73ed6cf7c876373f2e26735e1871bbc78";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/ml/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/ml/firefox-66.0.5.tar.bz2";
       locale = "ml";
       arch = "linux-x86_64";
-      sha512 = "d00043f5b87edf4dbee22289c031a30d9b9b5d4b95ad63bb07c3196270da5fb2e14cc1ee853edc0f4d1de976f4da8f84a92f70fb319135bb6d2a5af21ea5d4b2";
+      sha512 = "1842099651174a2adcd42cec08e9250fa00fe8e2c80044ee170f9ed411757a44224876ea270f4b491e81ba99dded91d07747a7043d3d43141d4d31bffb4dfc29";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/mr/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/mr/firefox-66.0.5.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha512 = "ed41f4a7e8fed7fe60ee35406a5aea0050e8a3d687a0d4d97fbeb0b34e3593adec6d1b43e6e585e8cd94ee07213341c324289da264503a9c340d26e9cbd6b38f";
+      sha512 = "74b439a4742da28e1c5d34b3b4d7c8896c6910cf6a6088bd06b79fc881b98bfb2fe9a6f4d6f9a41acb7950dbe5e334f40a9e978c964edea7a34b510bcb971502";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/ms/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/ms/firefox-66.0.5.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "043d73907bee6e333cdd6d1e905cf61d0ff8f78953027dc09f2a845171e5d25c671d529cf2d16aec7b2aa39961482d13ae7c91e3e9cff664aab69f5e8f291a72";
+      sha512 = "798d306eaa895e6d673851865df7dd2ec3a4f2cecb3d88d432de9ca710b8c67b00a75a070e5c736c0d86f2bd785fee515cc8f33a22a23ebdf593586fba7825d4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/my/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/my/firefox-66.0.5.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha512 = "6e3d55ac4dcef62548f309df30853f8ee317d2bea1a1d774af4908e1abccf3cb31cc5dd2406829097b043412a40b8b81c8a87fe9433518e0d811b43a878f99cf";
+      sha512 = "2ea262c2c96bc20ff8814880d25783ec6dd5ad8cf0abdadf0e4892ec49caaa1eaed05680404ccb74b3a0b482ab0593992c25a77037b39f8f081a6ce90eac57bb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/nb-NO/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/nb-NO/firefox-66.0.5.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "681935d216c8607ea0f84cce21c1c88251eef0ed4e057f16faa6e485e9bbedc62ab05f1c31dbafc356c2923ec5b6b3d4fb3d74454647917c11896ed1a44f4e63";
+      sha512 = "f49e4d833f29352aaa61c41f400edbb121675ca7bad615a3a65c8676283ee91f89cb505384722ae5326f3e8311dc3ca6330e86652ad09b3df11aa6f31b109f22";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/ne-NP/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/ne-NP/firefox-66.0.5.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha512 = "8790899e58535c921b156b89cfaba61dc2d201d84faae066c0c89ab6b39aa6dd961125398ef139571f3ccfdf8c8ea0d1b8287e95bc0f90686569220909572b6c";
+      sha512 = "fa2da86e5751731b4d76b20d2c4e7e4313ef029184580c8298a66fd5f7b203508a3174db7733bfb4859eb146b9ed6b0699490210114b995ba0eb62ab85af29d1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/nl/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/nl/firefox-66.0.5.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "cdc216a01b1953a313d8d353ca58150c46905dda9019007f04be93459054e57868e7a325792c9a5e5d0d83a3b6a577d60848739bfa908114e4c2189d1fac9978";
+      sha512 = "8aefd6428b710df898cb9e637367a2d3ade3370821630230afca1241367eb30a3cbbb23d4dd6c816c19e6804766e8e84c00c7e3002dd91d80cae9c6b5c003523";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/nn-NO/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/nn-NO/firefox-66.0.5.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "79fffbf0c1bfff145461427fb7fd3bd3805e197311b7bbf9915bc5f07ddfb8a66d2348637afbb74d25d70acd536b27464069d0536f0a471476620a76b4e188b3";
+      sha512 = "e1ee61f29b915ecfc514981d79be115bb55981cd28a10f7c268f4e3a8cfb80524c409950a3b38c16988ccdbe5eeb333ccf3833cbfc5b3243f08809ac79dbc0c3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/oc/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/oc/firefox-66.0.5.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha512 = "39ace895dbbaf995fe48e7120ba2f400ec5c412b21cd4b6857fdf3ac86857db5b875459d6e4772269b24824ca7f7de1f13d2085b9ac5d6ded930d1afaef724e4";
+      sha512 = "802d59c2d9a037140d22e62cc06a122c41bdc0120c54be6654de0237344ca6865d1741fd852e3391fbd508015c9fb4c98d4bab46b028d1867b61dc9eb900b60d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/or/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/or/firefox-66.0.5.tar.bz2";
       locale = "or";
       arch = "linux-x86_64";
-      sha512 = "028650991e5d17e2626532e29470151a81258748a1f59da216dced05b2f9923fcf8b2b008e3385e954fc2b787e4b4db28703817726dffe1ee10f286acf03da86";
+      sha512 = "c97a7812ae5992f5832c3c3e456e30f166134f09b086257e78414a1e790d19a2a5a8871eaa2fd66b0efa30881397bc29e207f5840dff891a27a1e86bb26d8ff9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/pa-IN/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/pa-IN/firefox-66.0.5.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha512 = "53c0c9c88a89d6613199da6a9912920a77cbbba87e5a324ccd3d52129cdc76c48cf26842c2b173308ed64d2bfda2b2019ce4ebccf0ff4ee2003db240a020beb4";
+      sha512 = "6044da60b8aafda769622d9069ce10916818f1a266e9457d5373043a8d58210a822e0091450a613967d2278f2817ce24daccbc1414c963113265f36602e34e64";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/pl/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/pl/firefox-66.0.5.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "afbfaa5e03fd9559cbaf5d26427fffaafc51abf3ee7e7161cf1d33150a6729d598acae52990a452a628d6df7ecbb37910e1ce121472f169826ea698ad4a4cb58";
+      sha512 = "59cd02ad97118540b52aa981167604e82c5ea74af22665be63e7dc3e01a8a13856810c293d04125d015306445dc5693b5fabebd62bdb04db4dda09b05db81078";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/pt-BR/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/pt-BR/firefox-66.0.5.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "46c152920c7f8cc36d845429a9e4c9213a114a965a79c069bd16214c104e29bdcdc014b8629d428a6cfd735327c89659f12dc4e84eb572c0663579a9b19bb858";
+      sha512 = "987f650e38aab5d59f4c84da3830524ff0e141102649476fda04349b3960ac4142e9731a46da6457ecbcba00e402eaa5c0c6ae78189c9b223bd0133b823c887f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/pt-PT/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/pt-PT/firefox-66.0.5.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "f8052357068416fb3ee87547cb7714c3d59a719bba6e943158560e212062708e8a4bda202d3519f0b2f7fe0933d77edc7030694fb9a40d3269164c17ad46836e";
+      sha512 = "06ce2ff205d1e14174d9dbd07f39122b093380c22fe74661321a734882e9232138bdbaddefad598c9344dea8bd61e81ed2c0bcbd2d09df616a05486635e99ffe";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/rm/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/rm/firefox-66.0.5.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "942bec7f8a913fe6f259c1c38af0773268776514453e741e455e0af3c9c2ea0fdca0926557b39e6f65dfe73867fa9de0ecd3c97a1876521651d82b7811e01c50";
+      sha512 = "75f5b24fa0ab6b069a25ca568e2ad70373762e03353c7340e4fd849803360229f5dd8cdf79bb71a04c047bcaa63cbbddfef71b35d9bcad3f8d8492fbe6b88847";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/ro/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/ro/firefox-66.0.5.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "16fc97cc0b16eb7bed5d0fa14f4584caf0a082b322cb59260eb5a1e7303d94d42e055db5c9b192d15e4ea3b515c3e38e6b6f7a421f2a97abdc7821264669f342";
+      sha512 = "acc557c9634f09e206478e4cdff36e7af4a70c6ae25dc9c92f15143b4239bf20291a0e977c13f98137457e97601e164a0e1ee8ebef387acedb1f2e1cbc2429b9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/ru/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/ru/firefox-66.0.5.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "85b0f38dc56ceaca5ef633beb5303eea41b59112a9d96d839f681da46e41deb9c77b05fed578c6fa431eeb71b5af3117e2d6697f2636ba7bb373c17e5690f65f";
+      sha512 = "d5c0e11d622eb0f5681b78cff605437bbf12570f8c282ef8cd8fee405c06f7a42a402d27f784b4574828a0ba320cba4849b56c0f639c2879682e0cdeb6a05d76";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/si/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/si/firefox-66.0.5.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "e0aa9a503f830bc26f85df5ba952405df73e1b53bebe24198b0400d683f4194a4ca7fca26d89789c6ff347b954dc5e4c99ac2eb07f328985a61ba636f93b24c2";
+      sha512 = "75ff287200ff05afb435604987ab56a6177f86954c1233e2d91a24c9529205af9b891b771aee02c21ff09adccb90d49bbf33c1452d5921d4664ac3575d69578f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/sk/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/sk/firefox-66.0.5.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "231a8c4751839709a65133e7f643a8150468fe9b0760cce308895da47ea1e032f54848cda6ebac27813be3cdce09392e32c6cb1d08471f5e96db0349da592318";
+      sha512 = "485d0ec3d88c3f4afbfc8e1a7171b463d8596efd85e24a17e1da71df747b48680087532d8cd0d86bd653d6e0a3ecf2ad0566527c1448a6cd13d4958c2ad8e582";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/sl/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/sl/firefox-66.0.5.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "961a2a2cd6b70bfc919859ffeb4153ee5539da05b56ced84c00b7cbc23ddbd8825aaabad2885c325d7a96c16e0a710fd403cf9d4fbf706508cc6d6901bfda3e7";
+      sha512 = "3453d03f4b43889409230ac85918c41b2c4b28b17a88ebc6e3028e943ac840ec13529759f01b55beb69b47870eeaef54130b4407300bb7bac5ecebb9d9267459";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/son/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/son/firefox-66.0.5.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha512 = "6fba26ac3c298a20ef52a8ecb0ddcc4b6e0d96be10820b0038bc56f5a879642885641939d86de64b516033f3623cb6e6570e9b0b92e0afb5aba08d847c1f4f4e";
+      sha512 = "2585dc5818fe8fd188876319aaada09cc570e2731b70a8948d733f49e878f081a999a27e8a069c2fefd89ecc78d994b8e16b00758d606bd8a6a326e70f09de32";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/sq/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/sq/firefox-66.0.5.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "0344b6ca43dfa9ac3a17da898177a65d46c600518ca26eb1c01643fbda1afdadd378fc642c21f9ba19e512c2ee31391c4b0cb71086d290fa9275f99e6cd87bc3";
+      sha512 = "bb1ac7b25f80a7ebb58e989710751c168014ab4c40681078b64df26ed224908acf6d0248d1fed9bc95d8719faa78624c45636da30a79916083a60ed2a118d75f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/sr/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/sr/firefox-66.0.5.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "bc75532d2fca3038d8415a6ef5447dd4ef9cc5a189aaaacf2f0bff9802ef79dc42b9083c2b9d0e7c4b019f02e01af5ed6b2ac668a61f66f359312d35a0db3ae1";
+      sha512 = "6dd2728d54df09705d6ea4c3e8191a125f0ebc547450fae8fa24fc3430afb654d72992b91267f1bfda5f11ae89b5f653c0536ecffdc019a228111cfa530199f8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/sv-SE/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/sv-SE/firefox-66.0.5.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "45a183b62ff7d2ae17bd696212cee5babe71e15531fdde486e19505d0104cc5e96360a5c475b42edcbbbd0c754168ea474904bec7bf493befc7bbd4f280a8b5a";
+      sha512 = "086cf49b5cd6e60661e1b89eb0a1ccc33365bdba7e52e04432256be4975f27d58fd4d3996a27c0f63200d4d925328c5de898df7a5071200162545e7fdae6b962";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/ta/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/ta/firefox-66.0.5.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha512 = "e65efaa3d08e3912db2dd164c2cbf1ed686246347da3e5b4fa11de5d7db7f0c6edfed6cc822c64730a309641a5766662a0e1f07e6b3203d139c89eb6de6e197d";
+      sha512 = "f00490d45844a44dca5fe498771fe9490c56ab7861a93128eb6d55f09a4e9d77266023e0c6fadf1d121aae0916966c21bae30d9126e46a8d4f8d33c23f16671a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/te/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/te/firefox-66.0.5.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha512 = "613689c3665c76ab9b05f666b1250f92b5bed37d2cb7d61df2ac6c25ae085853416b2bcc5638f3f4cd2223adb2d585b0d3be84132e9ac038377dcbe08b39b319";
+      sha512 = "ad10c5e4086d50e793639ab3c0cb7a066c5bf2627530e54a1954d15efe1ede3df900b968a545c3796b16b3a78176a668b2067bec09c230fb48da3d3b9c0144e1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/th/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/th/firefox-66.0.5.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha512 = "9123aad2b2a8cf5c09007a042571e884fcdf06d04e2fa71207a8e266257d4b83125d6ef30acafce3d8731856a3e81ac54858dbf8fb7e778a91f188b1338754b3";
+      sha512 = "423f4aac98e178b832b99724d34e48ef4d552c8fa8e0a3e7df60732ce13ae4245a510305309507cbf86d0ce74ca06d81001b3b033912ccfdcb138960848cf038";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/tr/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/tr/firefox-66.0.5.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "c11a6020364af2924e4970afa09377b34ee6270ec0164afa3e583eab8560b1c3824734556f91c0a77581032fb978a0343cdc86d25e02e186e6e600240346325d";
+      sha512 = "8f0a5ebd69b011ab3c8507ac7e7211d41a449c0b49c63a484b7b79159e46696407cd8f96387b043aa4c223a4021d5f282a6b19e95fced18ce1cbbb494fc47118";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/uk/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/uk/firefox-66.0.5.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "f67e01de24bcd47b653174c9d72321004cba717148e045f6744b89f1a45423225ac533f32f9ba4082b9dbb9f6b594f96dd7ea819a5f9aa2f6342ba4ca7064330";
+      sha512 = "2b9e0678eae4dd1e920b3faeb3484441afe0327dd7a1dd42ab0f89ce6b105e2f2856a62789a02f90b6e81ccec1d295116b73b469dd6eb734dd929b5409915043";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/ur/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/ur/firefox-66.0.5.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha512 = "27d6c55ed4b364353318a4585844545affd9cbcccfe119ee2ee925ca2bfa68c9dc14ce8dcc4632e9064ec679b6504800c7821beaaac13079a85fda5914ddbd31";
+      sha512 = "68676c3387141a73060702899e7eb2c1ae6bde43124f844a5909140e9b5b180d4ef226bb1785265f406aeefffc7ad3b56c89fab12d2e92e41f0cf0e08b7ae691";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/uz/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/uz/firefox-66.0.5.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha512 = "fb3f8f95efbc230d4f92efec5ba1e99f3945461962b24d20d635e312facc79a2d62a6ca9eda34bdd516b697beb7b78612b73706ba461b8127abc4bac4db261c6";
+      sha512 = "4f146ecb3c9428e6da96c8731df491693bdfa3aafbd3d898aa349e025baccca43514e831d97a54d195c610fec5e12d3cb3ab8763fc5a1e6c2cb210e5de86ab1f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/vi/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/vi/firefox-66.0.5.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "db2057f6b203144dd032e4f3c53dfdcea8e339ed71894d21f96b24593254beb0779103234242a0541fb26f913d47a7ad8543ed9a871c2f11f341f051c4dbd0ba";
+      sha512 = "3cb5572bce606f8ba96e3fb40abe943dd1a5b809619ed4c72d9f645deb3af9e2da198cf1c6f8625447c5c63d4d3cfdf7a093a6a8d6ab58edc179c9763ccf942f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/xh/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/xh/firefox-66.0.5.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha512 = "30574f459a2fa6ed4bfceb276ecd48bafc2ca63ff5dfcc6251f4b003c5c7a1039af30682394b0e93eae4ac42177a4e58caa9cadcbc4c36b7eae0052595bd62ad";
+      sha512 = "13d182190781c091de4055a3758dca2c35ca070a570fb48714585caf1e9306f81b98d95fd321675b9c946eac09f5256bcce396dfd9dcbd3c0749a528ce08b300";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/zh-CN/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/zh-CN/firefox-66.0.5.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "e7278c50c7db235f244f0e32f1a3a5e438462a7a179a38bbf8cacb8dc07cc63d979491b85036ee9baea1d8481a10517005a164c31507649d643bab995f98a1b1";
+      sha512 = "28e1149f5cbfbd81871a4bc817f6ff1fa01d91ca63625431568abad1851373f402fb93cac8458cadf66bba7fd616c7488cc2703b524fec0e803a474c3c70fc5c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-x86_64/zh-TW/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-x86_64/zh-TW/firefox-66.0.5.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "4b3024b7b47348261aceb573b905d079eea27b45947069316629a05a8ad9f983bbb835ac46f610bfc2640874403b48b7acd6b4bfd4cfbc602227fcbeca4e9c8a";
+      sha512 = "0c6a7a431c2d1ba3d3b437f56c68914aeaa405e90c05530f996a1448266d0dab1193921c11291b8eecc32f194e24bbd2744ccd8502f36ba8de074ab6ddb7b605";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/ach/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/ach/firefox-66.0.5.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha512 = "721ab206f584a65b0f5ac2e2da9e0b95ef80e66aae01cc65bc736ea672c276dccfac1885c7de5b168432736f00cd8106f85c5a2a5b8a477e2860e9a8dcca8f99";
+      sha512 = "143bde45ba31f2ffe4784f05d9b78a58644f6e8dcf85c12261cb542346352130bcd7c7cc3fb8fbb537af096902f8594ff90731fb680673bcf3902ea7e8fca165";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/af/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/af/firefox-66.0.5.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha512 = "e86bc71b580d6cb1c4f52d5f5d248301805a0b3782f822dcc41f590a1be289a6a2b9f42931b56e36df1124ea2de0b2528ed00de54e2de4e915427cc055e461e3";
+      sha512 = "93b15d2721533f3b3b2a1338119adc663785b82e3a48549c5700be522c03a00fb46e8413b31c2ea39180cf8b2b7b4a3a7c766daf1687dc389a9bb314b744aa0b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/an/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/an/firefox-66.0.5.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha512 = "bfbc55e1a0002fdc30dd65f396afe05c7090cec1a54cb13dac0fa2079f2427f54960de4bbe7af93bc3d3dda3bdff84f8760463054e0cf315f151d318e9a2b4ff";
+      sha512 = "61c2b6e8a028a6af70d047d35fbd14b25d87b41d3651456f4e4ce151560e1d8618654d31ace7a99eeaae6c7e6fa438782a2ba3826476bdf07664a6fe11ab8040";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/ar/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/ar/firefox-66.0.5.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "e030f962cf81caf576b165c7c76f6bebad317860b788153c5df5f27c8427a0850e3dc2a4877a8de8220f435fb71ca43d3e131253e345b2161ca65bca98b08833";
+      sha512 = "5d41aacd05ef2c548e12f8f8ac9c9e514b55be400a1de82709b27edf3a0a31778a40ac01e63d170b423c56f4a9a177d7f4ccf511311c1f140aaaa259eb6b3273";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/as/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/as/firefox-66.0.5.tar.bz2";
       locale = "as";
       arch = "linux-i686";
-      sha512 = "afd792df04ac43cab4bd837fb7a5139635bc9a2851bade301bfe677882134e25b7aa37a70da9836ca28496dcb7533f005af6806b97f531a3632cdd2e019279da";
+      sha512 = "8e92abcaa8bc2b891446551db5377066a4ff25dfa76e5f940e5f0141388a3d1ae5ec57c350a45d655ad573da28d99f465721621291a049d93bdcc20f8799b434";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/ast/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/ast/firefox-66.0.5.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "1589d9b31ce8ce47666ca091358acd423452964ef72a45f89e01d20507ea3c7ce85547d5eeba8a7afbd4569ffbb08fb72faa2be7a45749a6ba57a1a887290842";
+      sha512 = "661508f7d31d3795eeb0859289b45eb9efae70afe714153beef4dd9af8a981aec74cd2a31207cff95420b2ff2485b8ccf6bd104e9269efc08710cda1ad9e0f43";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/az/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/az/firefox-66.0.5.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha512 = "312ecbde1115129d4c5cfd6f5e0ac6e20b13a81ee7cee9e2ee7841e1c4ad81743ab50c3fb0a0d599cdbeb9671fc7410fee7246865db58654982e4c3935dbf266";
+      sha512 = "518cda92119d08b6853e55a2897444cb180ba21f6a1d5800667612dc56dea3f025ae6dbdd3f950d07c9fc7efd5ef3a4a0c5ad1de40734bf4d4e7b70c0bae0889";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/be/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/be/firefox-66.0.5.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "01f750b21f49806e5cd6227bc4f6eba698c7c1de7cea7bf6998438490ae4fc69641ad9de710f9dd1e7da67b8e43e668f3cca50dd995f9e12c4c5388f743a77ca";
+      sha512 = "36d328eaf96c904b04265c9f66eb009e9a7842a1d4848bf6135b46442b91aaeffeddf5595fe6cbaf53c6c9fa9ade1beb01726da08cdccd0444e8182bc61b74b8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/bg/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/bg/firefox-66.0.5.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "fd950660fe3660f8474c848bdfbf356ea47adba4a25719873cd322ececd3bc8f5f3748dccb0272b1cdfe91778f0c5e18be8bc1253f2192bdb0cda0888da2c49b";
+      sha512 = "387e8771aaa032eb51f6db15be9feb897db813674f7f8444e13fee82cfa2ad108470d684056b4c858c22e35b91e08cff7f514aa36157dc3879df3c93bbfaaa48";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/bn-BD/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/bn-BD/firefox-66.0.5.tar.bz2";
       locale = "bn-BD";
       arch = "linux-i686";
-      sha512 = "9d95cea55725327bfc255cee7b9dc5b32710d8575931feca0c5d2611fa9d9a1c9121283248e11715f594e98ec1e0584454ea4836b2853386dba3c04e1ed764f3";
+      sha512 = "70549261581856bb220473da33f605401a329cafc63ffae697cd2dca149e4a55d2440539e97e5f9dd1c781c9c39daeacfe8027219dbcb6d8dce81aca5a50c737";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/bn-IN/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/bn-IN/firefox-66.0.5.tar.bz2";
       locale = "bn-IN";
       arch = "linux-i686";
-      sha512 = "1504f69b631ec7452a6db588190987108c52f805cfe40d50034bb0da9f06bd642cc4e8a78fdf297950156109e1dac33d8a186943b61e89923ee313cfbcacbb84";
+      sha512 = "a9129a26e2c923c8484a3b1b1a20b5330cad29f127222482b771a216a93bca88d3fa33e42fb8c39edad61c61939be04f362888b09d483fda60b5c97923abd828";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/br/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/br/firefox-66.0.5.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "6ec57a6f0159d6dbdc9ed1edb5f157bf9833fd1ca626011a3f9bc7387ff5e5c227feadaa2ddc87c134774f6b93cc36cf421f46996125cfbda2b265b7aef3a04c";
+      sha512 = "f809eea506327ccfdd9d816d7c0133e90154ce5b4c7209748fd9439bae2b28a265087804fea7a1ad7c5ee810b41b922e196150e4fb7b5b8ef6138420313262e4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/bs/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/bs/firefox-66.0.5.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha512 = "2d71b24c1c24f52d3930e65a37d8354d826e47dea1eb2c4293094726d76c11258e238e2c71121f7de0c323c5e701f5173decd3857525df944d2a349a528dd603";
+      sha512 = "12973bb2dea8bb8c2c046e45e63b4b34d0a49d067703274cc32fbb9ecb44a8919361743269ffbbc7bc7716bb20f3696721c4aca41b45fca68160e308e3934a10";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/ca/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/ca/firefox-66.0.5.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "241aa2b588fa66caa21c64e3e0511893bbd3e87d8bd24cb73956eb7bd17e6aeb1248712bf2a2a302a9d9d5131807e0daec7eaeb00c752f6fc66607d9ffc52a33";
+      sha512 = "25dc6fb35330d637912656f9f1f813c6fe742c6f603b879e236340e073c056207ef59c395f2aa6d6a3aaad2ea1b1f8aba97602597b272af0695143ca3181e64f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/cak/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/cak/firefox-66.0.5.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha512 = "1273f8d70a02d4d49260ab97df101136062bdbd70f9b76fb9550dc9fd9097961fecae61832238eab017f00cc7e63c6b096c9452c2f426460a2347e66fec4f6c8";
+      sha512 = "0f9888724bbc7157a9838db6f58ff57c93c527042806c3697d8ce996c4d059cf47daceee6a39e79f1a4e01d8ea4c0a1101808e5eb2d99c5fd1092833e4df55dd";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/cs/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/cs/firefox-66.0.5.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "de0d30e2621b8d25a701ef1350f9cd75989f436880567541e0c34c90b6010d904aa06cfd4839f13670fce4b98e1a759490ac7b1daa396ad570ff1032c3cf308d";
+      sha512 = "3c9284275d4fac7697ffe0790ba8b7cde71f3297f78ac5467261f47d588ab620ca370cc349ddb8683febade9a4b761acc79236b7b1bacd18e819324ffdf61964";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/cy/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/cy/firefox-66.0.5.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "2b980fb5fd2a3b98af34dcf0f57e0f1e039148d95d452c6c297cdb814eca2327f2887933a89bcf829c38dfa0b1742f166f133f58754af564bebb0416ac2cf396";
+      sha512 = "e3047c59c710ca0f189c61089caa86fc844514ed8653cec9e64f5ec1ce81466890c5e565fe6790dd6d7388d8e5c48847eec54d42431045fd1a1de056544e50f3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/da/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/da/firefox-66.0.5.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "a2c364a2a77025f7fb2646b110ff765d98f44ad84d0f1a56984048c56e062a7e498a0f8cf6cb1fa4f3e34ba386b20a8b00ef3df3691abb49aaab9e86b869a2d5";
+      sha512 = "689e8bc5b0b93658da2e5b873d799b2f3f1548ef67f4c082a07d79918f6c7900b0aa00c84a115279de9a5e2d8f2fe083bd14476b111d589a610c539612d3beb5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/de/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/de/firefox-66.0.5.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "aa053f108d1b9775529023f7003a5bf72fe0e503ca5fa61f5f966b6034818483912e09df3a5aa72ab0df75fbf3f78407c9410b609dbff8e0be3869ad8995ce9d";
+      sha512 = "c4a17564458794710f52eac0e3e7e5fa3416fb278bd1113270b70f877dfe105f802a5de611d0e0ab5d0d8888dcf6d5856211a34a8315a039cad7516effaf8eba";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/dsb/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/dsb/firefox-66.0.5.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "670fce6387b3e867873adb71cf37a28016da2bd9826ee718a0196280e8cbd1f7406bdbf91009f9faa8d4c94a55ff5102b73b8fb319407261a3cf8caa5b69e726";
+      sha512 = "6e52744b4d65ebe711dde2c7f5e92243858d1218f18eba1e47b6bfd5600668fbd36ab3edd0a0780b6682354c7df5a2d3d0202263a0768dfb7be1f3469e1a21bb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/el/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/el/firefox-66.0.5.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "cce6185101eb4d4044fc6216d1af35ec25e2ad7f4203f671cbce1b1f2968b71d2eded6da45dcfaefe92471046edfb6e9551ac3c0fa2a109966210fdb8c7297e6";
+      sha512 = "b0fabda2a20c3a9b0e957987ef4c859049988cd959331f83510b13c52752867722fb6fe99c6e4fb18a54f9ca965d34947bdb3aed6ad007ed41ce98c68297735f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/en-CA/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/en-CA/firefox-66.0.5.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha512 = "24666b9a5c26be2b23c80744bfc3b08f83f02b8f3d6ee392d02d2db6ae16cb555e0e6a65fe08d7942551520798f2b2d0bfab4f607c9ec29f82acbed5b3a8c7be";
+      sha512 = "3a3952783b22490762054b0fc6bb73d15f5c4faf1d208abaa8f74ef6ca9b829594fe9b2e1c57a02df840eaf640dea09c399e62a93a2481e6f35c3271443ea1eb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/en-GB/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/en-GB/firefox-66.0.5.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "2e66d24d2ddbbc03b284488c062f5c8b561c647f184b370c621bea67610713ad41ed83ca04e4ee7092e2d4d9916b94b13736c02e7e9eab519a30fe5531120d39";
+      sha512 = "64dceee7bab4580299ab32aafa835ab0cc0ebc8f9326e3b933b1d74b2ee35ed4a95ed0d896c38cc0ca880f5ac48f52019b910e9e1ca50d9eefc17e5043f808a0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/en-US/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/en-US/firefox-66.0.5.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "2b0bc9c83c9f8e9b570a5d1936ec3418fcf738ffcfb2dabfb6a8cd153ddfbf47472c6f95a081ef49ae2a6c7153b0f50b4346385470b7e28a90e5586b71e8507e";
+      sha512 = "0c0579498ec84c12e2c90ca98c79021e888de449d031ca4e27c7b969934fb5d63b997153947b4121eed7046fd42f264865d6a3cf40b4543fe3a2f7880fb0ef4d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/en-ZA/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/en-ZA/firefox-66.0.5.tar.bz2";
       locale = "en-ZA";
       arch = "linux-i686";
-      sha512 = "c24f3d5ee00fac6285b6551c59c9532a84769cfffc61ae760b19347cac5c98eb35ea9803f89c6aabbf8077a9a844b7bef8528b309f26658891e711ef2a08c6ae";
+      sha512 = "fe1331634800d62ec69cb1e1db48377280590a0629f6099af2e5671102fa277409a8e682139494ca57618c2cdc2d8f1a4721b6b495d10b1d775ac22c22756b4a";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/eo/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/eo/firefox-66.0.5.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha512 = "060a951a4d997aab308b9bc61daf09c133dea250499d9e1699fc0056c382956918f8700bd5a4f8c2955b0c812a84fd6775569f7d16424d5299a541b0d0152e20";
+      sha512 = "bd5fba6465a78e821ad1bc15e63cbc4a5cc3c3bd9b9e44e9cabec05d0443d68cfbd4571963b5aa01c9124c1828f493f48d043c18acd6b6db1b5d9d339e696693";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/es-AR/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/es-AR/firefox-66.0.5.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "1dc63ee6473ee4659e7df21d73e552458075f2e0885f3bfe79264b3f202a6a2ddcd90f81b7a1b8b877467819228db0f5f7245bdb434600e05bdb7d6af8043c1a";
+      sha512 = "d0be25abc28e79ac615852aa04b71800d07bef55f1f279540bfe198546ee6f0483dd4e06a9f23215c816eb4ee15d79730178dd54a2aef8d1ed5077c2d35df470";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/es-CL/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/es-CL/firefox-66.0.5.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha512 = "9d999af584485900e53910c462ae5271cb08dc24c39b89f765a7e393f940e6daa317202e3ebf46d4a03ed5adeeebcaa9390465a954e0bf6816c48ea4a55d05ab";
+      sha512 = "636fbde6dbf8244652f4ded0423b708567817684aad648ad682371b37d70694444355398eab933626782d5ffe2274cebd7db4c24587580b7d5edd213b9170bd5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/es-ES/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/es-ES/firefox-66.0.5.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "37bd3dfa6a2bf3b2988f889270123a19ea03300e51b85fb1772230d3764c95e17382c996b40124c3df439d40f7fc72f69de006bcf024604ac844444a45179f0c";
+      sha512 = "6c786ca9432d8bc5453b3558c0863953457f1f32f4204cf39250628f6fee50050b1abdc0d0478600f497d3f082e1cd9f5a280db0202240c3f66dff2870afb9c3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/es-MX/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/es-MX/firefox-66.0.5.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha512 = "3ff7427884ed23efda07d5448e3236456a44edaec2584d2c693cc9ab8e9ea27f715e7c6a0b7ff84d79376ee36e81d63ca80fb467f481595cd64f919cabada830";
+      sha512 = "10bd832885031e67caf6495543bfee9d9e1e9f5e75c6dc34aa81d2f9f33fb89a52c2fac78e3c15ec8e2fa09fa1e43cf07035a2e0ea9e9a8d8ec21343b9ace36b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/et/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/et/firefox-66.0.5.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "624f2d1095f92c1e6fb88355801f5b95820f3c43dcad5243247aff49e6a83193a704c377ff44a9ee94edd7c9d1ee7c735da3b6250868433aabc0c3274f320e3b";
+      sha512 = "1d3019bd7ee02ceca29b4c48a9f41c89b9836e6fac0d1025ebab2a8faa4bad5274c13eb81a1a919d490ee92400d2dad480dcf7405a2a3094273179256d9165d1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/eu/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/eu/firefox-66.0.5.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "432fbcffe82a8122aba1298fac1f9e1f93902cc7f8c8b9782074cbf57026d34013a5b77a3b110397a97281adfd7e07fd2e6b99a10114017af2813c7b4ce8c653";
+      sha512 = "c6e8c5e9d0b41d51b948a3b3a4a20502392ead14e45ac8c559bbf9313a9d6d55f33f1eb6162918020d7786db334b7193e00a4661c44fc7a3c3b7121c4e708fb1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/fa/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/fa/firefox-66.0.5.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha512 = "ec7856b3d8c3f16db39d6e4c0378815f10a0eea4d566cb2351bc6a5dd38493e6d965c32da6431a9ecdb30cf31acf86d877ff3d694f43fc46ebae14dd36c2e40c";
+      sha512 = "6a0b16e81d926f9b52d1f160215e78d4ffac272dff5043433c372f902ac6c031006ad8367baaa815da766f703541804ee088fdc1d4184995f3ce5448860baf6e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/ff/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/ff/firefox-66.0.5.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha512 = "9f811b0ebcf1a25ebdd2d44b0b8cc185a5a6a01df79f788689410353f76c55144b5ba74a2efb896c7ebcdceddd24c1aff109580fe4360d6ac011597ab5955cae";
+      sha512 = "65092d8889426a7966af531d0cb6df2cb7588cdd0bf8d79102772b0cb48759d2f611d2d7cefce7de85cb799fc5b65fe6fe80b3b10eb00e53328fb14758a01072";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/fi/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/fi/firefox-66.0.5.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "7a26244a21b13bdc54fc4c14fcf547f8302d38f73f8385c424fe79480acab1ee43720544a7137bcb2a0b6cdbb1ba8335ec5b723773128eb6825e9e3bbf0b30ed";
+      sha512 = "3e69f8af10b5061ac183a53c674a1964c3840b3532e521c2c31acbb9d665ff6fc25f82c90c1c23aa08bbe152628404a3916a786b7fff0c693e3e9cd0f6baaaaf";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/fr/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/fr/firefox-66.0.5.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "b97ada588c37af74b3fe6a11190e4408fadc1a63b1760986ea258c493460840cafc30d46660c85e11f74946f1a5cb87149535926d286e2e537a21b7d7cdfa229";
+      sha512 = "40e919128406b91d86a64c7f1860750b17e3947d8bb58ac0b6b308d3b2f87ee946d58d250c2e735ecc0dabad844e67bab63ff7a41401da2a852f0f56ee28a1ff";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/fy-NL/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/fy-NL/firefox-66.0.5.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "3fb3465d10169182e9e34b2216b8f7cfeef421f9c45fe72b965b92220b828dff68acf88e755cab0f2c831acb1c0bd207345b7646c83895d4e448ffce0bb7fad9";
+      sha512 = "24ae60db18847e9bb877d512c6d30b14fa31c855b9ea82dbc86c7febb5f80fd0bdb1badf4ac1cd78f287f1a0571a07b85a207020d3441bd0c9454e9d917ca12b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/ga-IE/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/ga-IE/firefox-66.0.5.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "be5f150e10bb4205b8fde5a78fd4860cf45b1367334020f90c5e1e2c2b65bbb8911b19b0b63310f1152bdc1857bd465d2a168147e16673fce3105e87182422fa";
+      sha512 = "6f44ba5cbb8430533f1e3ff2d1b7dc2c3eb869f54eba387bbc9b57b4f14d0dbd5dd8491190febaf76899c54805274484a993724b556ffa728129eef7a4b7b974";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/gd/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/gd/firefox-66.0.5.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "95a6522ef83ea8da6a36c23bcf49e1d6f2b4a5be0c0aaba3e9cbeae0e716d6f5a78c4d3461a1fb799a21a96c04510fcf25fcfa5203e8101536e7d4c365ee8bf1";
+      sha512 = "e9691ce54fe3a0f9c90a90ce5ec9b6fc9c070bd55b3e852e9e586fe60d7358c9bb0c86ca2f0e0e305fce8df6c1ccd9e190923ecc8d9ff1125a2075c1986ceb81";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/gl/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/gl/firefox-66.0.5.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "e1e3506d962c06bad43fcd295434035d6312a4d686663a33a043740123b28ec4040d6d1bc7581eac742c6193974ba3aeafd0867307f2c28d321363e6a907b97a";
+      sha512 = "27954989bb8d11c984a621b17a4468be77f481916974a63e4dd7ab38f43db8352c5d77dc200dd97cf5b6ab7d169e9960c9d202500492914c8b24ecc8bd2d6c4f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/gn/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/gn/firefox-66.0.5.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha512 = "56063c52c71cc117ff1984da22c03bc8c2f1b53b1a063f62864a05dbd3e5bab79c156307b8be5c7d7cdf9254048e1a27fec8112656c4677b0ab068d2dd658559";
+      sha512 = "8d4c7b80cca5cc6d4cf3dbc66e56d62c9055b8b2c6050dfc55a52b1ecc835bf40027d22cca12bfc507491e75c1b29cb7e805f2b340a2943ffc89b0127a608b90";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/gu-IN/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/gu-IN/firefox-66.0.5.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha512 = "4400ebe78e80b8c776f7af169c9e99c83624db188e2de98626371052999b7d52b265b0a09152f3acdda85040abc029cb9ae790ff8d4d6562b111c6fef8387aa4";
+      sha512 = "39e8905fe88f742d0060901dea2070ac8ead2e4e3916628166a5b64fece1a16db42aba347cb4b346d147c95cd14e9e2259abe80749c0f0a8a837ac49ec66057d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/he/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/he/firefox-66.0.5.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "16453b5aae26b4bb7153a915810fd66549c8e8c6d880686d90c5340822e757a01479978de0ce63b48e66979456ad20c508da5c70c7d2411daefb556e29321ffa";
+      sha512 = "24e04866088fda3f66e43d05f71baf07295409714f1a51a4a2dfa419106e543b42ec5be7ce27339a0d65ea8ca084695e97aa4b3226293827aad6674026817119";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/hi-IN/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/hi-IN/firefox-66.0.5.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha512 = "acc1843b76699c68a1f6328829a339f303bac8f1eb3a66eb9355422bff6782928de6e4693ebf51b6e3d8337dee6c6ac34d7935b7ae7cde6fef8b297130115e28";
+      sha512 = "cb580cd596cf6a6f3e0b9fd83e47362732ea8f2de2c9535800172949320562b862b29dc0b653d17ac44959a78b99f2636a5e28a57a00a167bf32c711f9ba32a5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/hr/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/hr/firefox-66.0.5.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "4606e21fe491959585254135cecd629ee39adedb2c576fcc597a385a103b7c774f84a141e060c84cfb3c3560359c63a014bee7ed76cfe17b18bbd86458fde8f1";
+      sha512 = "c319352e29cd1ca0627d7a3332ce9a9afc29a8ec447f921a9ed2a89a4722ac43f21bc353509a15257a139de7e56652a2cf96fbecc38cdb860bf59e7ff3e282a8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/hsb/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/hsb/firefox-66.0.5.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "20ce433e45c16af0ca6d4fb9bcc85c2072b95a7058f4b4f9aba486259278ad9077c02fe9daccc0ab43772a716728a026e6c7224ff243aa095a35a62a8f848ca8";
+      sha512 = "e04c62c9a7fb273f43efc066491fe32a214c5e8bfecc527508b5d1a6ef1db7f09ab045a913593ad98bce8fc2af1f63f1fe695156018181b3b834b7545cd17621";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/hu/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/hu/firefox-66.0.5.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "9984c6a996e1aec493cac5722166c20f7bf91812ef805c065bb32dd6e01b0e4950074f50698174341d2fd98bf583d2fefb033918f9243da32cacbceb6c2be66d";
+      sha512 = "af69a29e22f8d6566c68fde1e661352835ddb3de87ab80e4921ad44a1575af815163744f4814bd761b52075474d8570152b0bcaed753ac9bd9909baa297d6f00";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/hy-AM/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/hy-AM/firefox-66.0.5.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "6e295f3c4d2dd1d8ccb20a6a95aaa90f6b56f2aca0f56e88ddf2b5d944e83f7950883e6a78e8585a35ecf938e6ad3c2a9861bb90b7f243f9d9a95ae0a3611797";
+      sha512 = "9531b16c6f7a369bf435f9449fb898ff8eea1d9d1a6855f56f01fff6fd47176f367b21c26c2757af0874e3a88b948e4d3d14217c92a49a5d4831313a338b1c15";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/ia/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/ia/firefox-66.0.5.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha512 = "a6ea1f8c4ed980696afde549df4f2e8811f33c3a26990ee594328fe8ff2b85da690ff2562c4589adfc6c96a8df2826b4ecb45a1f66abe37fe63befc7c1ac83f4";
+      sha512 = "387466e7e270bd907402a9c323b2766c82fa0f04d252a21513f71acf3f0d159c479b895fcf95e9287ea0a9366fad9e04f5fc67aa65f1ccddb16eae07e3143105";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/id/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/id/firefox-66.0.5.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "525778a18d1a10658f68acd5765ec256c94a0b380cebb9f71ab5bfbf860985dce1d075abca8a230bd10f45536d10e1274718bf475d6b371befaeffdc3f66c12c";
+      sha512 = "c5ba2f9707212fe41180cc1a8fb987b03d7547790639e34457be6b9a921ed9c2502476990f0417122cdacf9a5f8badecee23957856f379dc3284b3fd26847058";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/is/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/is/firefox-66.0.5.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "d6495199e2c2327c5b0347b9b4d41e7e83522c0e67202080b71bbb804eff012cee9949e0376dae274b090e64308a26ec73d040ac13bfa8e694cac4419c312b38";
+      sha512 = "b0c2561628b136736b17f7c52bfff315657310fce0b4445334657ebfc4e6c98e73f21da7df56e4ce4dd0a6b91ad5980eff63684a7c8109b4a00b9a24669ef625";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/it/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/it/firefox-66.0.5.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "06a82828e9df605cfde798e15e68179adcf6d7fd8483668bbad5d6671a587a1c44e1adfbb737ef333d86a47afe251fe83ff3cc79286c3a92ab9cb28f9346ca7d";
+      sha512 = "cdb0bf8b76a0ee92272a3b22061ff79f634bef1b2804ab40c4cdba54458b0458a77ee7dbcd17dab45015b26e8d8704f01ecd8041d8a0c1a0f2f9cd413c89d8df";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/ja/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/ja/firefox-66.0.5.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "7419ac401b72896e66e92230fe54da3b88dccb900fa208e1d4786284fb64284c3979592d3c0815bb4ea7a6c50850920b27d6bf08b134ce7adc60096556f94a85";
+      sha512 = "93be68a0b11c4fc36af01d0399bc177562e5cb41fc7b7aae332bdc57c1606aea6a210c4db8154f47c6aef414be2b6ffdab4c86f0188254dfcf89ae9354f9a9fb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/ka/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/ka/firefox-66.0.5.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha512 = "1664333a9c32f312d2f4e781b277549921f30efef1012de640fc62368c9806dfed3bf37fc6e25315e4dfb571e8fe1cd5032ddf5b6a54904277c59cd52aa40efe";
+      sha512 = "dd30a818619c26b069b3b9da38191df64ac190a5663e49d0826fda79e2ce4123f48274f66bdad64538f6d03350e462cf34961e00a0d80c67e27bdbb152e57e57";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/kab/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/kab/firefox-66.0.5.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "7bbad72a2a2da61446a45de9333f97749ac07019959889cb4e2c78f3a014d478db8e3f1f054e934d32604b8ff1aab6fc5e59a6dfb7ac30456cd5c5bb0b9637d7";
+      sha512 = "266725f1fa6050a9c2a6c7220c42e96a2605319ef7b7a93861f7a1ff05d8f28e5399a12d3091b3aacb653c13162f52cdf327b315da11226901c480cdf4836569";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/kk/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/kk/firefox-66.0.5.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "714e6d78307b2bc33ed90414943dc3e8090b3a0a63d0a6f1266dad2bd9b155848cf747b2685d376af8c4d34a1d520ac3ecb8da7b7e72de70f80c726aee555de9";
+      sha512 = "1dc7a5f8cb76c0fb9c537e197556de5a0996eb11701b759c2c8c0ecd89e58f60f32e75261eb70861ef6a19616bd56e29a33023c31e4b17d2ec9f91acd346f9cb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/km/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/km/firefox-66.0.5.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha512 = "eac3ba4d9ea03506bae726a2ced74b1e37bb58c29a03529ffcd6cf595a6c2ce7feef29cd289aa1b650e399e046065bf7b93e5506f92b2b332ef6ab5d5ae89591";
+      sha512 = "b227eb8dfa16dd2a7686e28e7d62cef1e627b19da6879f43b435d70ff8bc9b60964b9c1427418b71c71cef6e2fd6d26a7ea67e4f9174a4dcba59d50885a6f6fa";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/kn/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/kn/firefox-66.0.5.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha512 = "9741d335f170871bba7f731caf01604341800b706144ba050a0f352e15602dbfe7b2db42930f92828615aec8afd2b432f6857474f757ba940d0292487673a0b7";
+      sha512 = "c89b651540671c085c9b7549946004f0d0377e7fd75d6cd5156e5d4bbf2d1176a717bd062da4eb392928179ff73a87cc1f80c0f703a7f4b8424b78bbb2f29056";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/ko/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/ko/firefox-66.0.5.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "3c4fa714cf1de96927af3578a2da83898ff86b5ca9f4499a266e1300c24b0a75b88e718630e269e94302ad7ffa62f8dba1a5c13d5aa807129857451d8d8a04df";
+      sha512 = "4962394b60da987c7b9945d840a98f3c4b3dc389dbfaeaf71c3194efad94f3e8646948c14383f0c6ab652f926971f1e95bf75d54e521bd13c865e61ec812f395";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/lij/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/lij/firefox-66.0.5.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha512 = "31f708c82116d359100bdcd3d5750311dd387160808d64718b102a9e6b35125ceb971c7c5c530a584d206e312ca85db5a1626314ab8d573ff0d48e2e2ccc65e5";
+      sha512 = "dc08d5d4e973da32b84bde101152b595270cbe610f3f970c844fc278e163ab7caaf3a4edbdfd5b7cab937ca8999eca084b0f5eda40e1a12a1334aaeb1545bc58";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/lt/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/lt/firefox-66.0.5.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "9413359590c85b26b2fbf141a9ac5d4e1ec27c4b64c8bed3ea9cee40567ba1a84c9757f16499c53d96643f50ee53fc9194d06688f1e3deaf6866b77f0651e45b";
+      sha512 = "ecb5e9977295b74c63fb64638da06322603999620bfd396405b5c272f584066b5c17e2f872c4c7c8f53fc62362b56ddf09c6f39ac496c5868339a7d270891d72";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/lv/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/lv/firefox-66.0.5.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha512 = "0746866b601275a4b937175a7176de6f13dec8fa88dcdad40bbb5c5aa6bbebebc61162baeefed0269ff6af75854095a704e3df62779eb2c8e581e82cb2038e5c";
+      sha512 = "f668a35dd04604a07d3b93f83a7731f87d2bb726dda74a6a94bb23e2824117a0c6335a28d7bf05efe154a601472f0662aba5a2d6c38717e0ebbfa649599a7edc";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/mai/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/mai/firefox-66.0.5.tar.bz2";
       locale = "mai";
       arch = "linux-i686";
-      sha512 = "103c1b5c978a8c2f5295e24c346eb95c4ecc3187cfe6e2d0ab74654683dca13751fe1aa58456732130249a1edd921fea2e0843aee6de82b62524b5ed03a34512";
+      sha512 = "ac30950eb86b9583eb1dbf0ef74cbad0942ca227a7a79284cfe9beb7f1d4decad95ce8435c65c3a8120b85259cf98a1ef89ad184b1cb0afbcb69937f2aed781d";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/mk/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/mk/firefox-66.0.5.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha512 = "b408418432f7c2ea8aea58e1138dba61c00f0a8d6564df0cd14ae03050bfd8ba17e9654adb6cd835dcb798f26db1884fc89920ed43974c1fb92c79b39c3001ac";
+      sha512 = "e346090975a9c14782161142f370bc22c6c73abdb80588c9584a2efd8518fe016a764327fbae25e08ced2bb8107a50e256cdc627eceee8abb8eca3cba6993ba8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/ml/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/ml/firefox-66.0.5.tar.bz2";
       locale = "ml";
       arch = "linux-i686";
-      sha512 = "5c58a55345930e9a136bace10466a534f5b9c2365edf6bafcc47c9797461c7b98f836a8b8d2390a5a9239b6d4e96b7213a600fe64099f80e9874ff1dcb1ebcad";
+      sha512 = "2d26c4af2cd67fde5e7e4132f4ab9fde8bc87340adbecd00c006b3064f67f19f7148b557faac6252b78d1446f16899b7336c87ddf9dd739c7cccb0318493a1f9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/mr/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/mr/firefox-66.0.5.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha512 = "d6ed0fe10c705a06ec1a361634fad2498107b8c9ff47f2360c6acc11ac745ccde738a014af22bf171022198ce8dd32eea53062642a49587764e99975f4147425";
+      sha512 = "536180dfa72d2e2c4043dc35e529f7243b13bee79bc3f1727752cb75165258481b16f834043843b7b3480e4a8c4a275b8242a0d4455f85b5d33a67a8e206b098";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/ms/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/ms/firefox-66.0.5.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "0112e5cc8b176c32e10ac2725f47bed95e49176cb81ded0e6f2b324eb9f6dc487ce073a92a5fd5c25b66a5401389c1959366905846ee7bccc8280dd6b0e94e31";
+      sha512 = "b2a619df14d1110910bbf96876c22c2f4d70bcc522a886d801d3ccef5b6a802ff6528e67be7a10e05d5602c397543b59e42f88cec694d721abf0d5270b4da1c3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/my/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/my/firefox-66.0.5.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha512 = "32837f4f0f733b133171cd730b4d5f67ce8abe4cfdf7d5763ef431f605ec7d2032437c2d41be16c7133ab8e6ffbb5e3050be769a1c90ea88faba32e32fa8cec9";
+      sha512 = "e45c96e33c4dd2c1707676bd2240b8c79a51bd3f5b0bb436f1d1639f62288858f6947ecd1c210b17c6000309b514ec1fcdf708824ea0c2783613eebdd9364939";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/nb-NO/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/nb-NO/firefox-66.0.5.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "2a4bf96f5f55da8fd6ef7393f99c52b6b99fb75944813189ccf7d30524686b3d6beb14bd6d7854fcc323acad3b17629e5b9b4e9c05dd0f1bf29001c0c9db8274";
+      sha512 = "3f86e960b3d7eb9309b45b7c7d8110a2421f210b6890af3f5dcc8b4bd9853643d97a03c8f2d3fbb187644ea29ac39219ab17547924d98e20c4e0949e6f9acfb3";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/ne-NP/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/ne-NP/firefox-66.0.5.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha512 = "db675367e97d4ca0c46f066cc53bdc9265763a0c3492a06db8fdee0f27d2166374c703445b5d286ae5ad1edff2939ac27705af5f484f9dcc82e75b154d2a4905";
+      sha512 = "b37cbee88debed4a9fa4dd618efee71052a708cff29b398b8461f35824e6e877fc9b1df1dc856081f8e9ec820c6388a6c875965707955626b2b185a9c44f4e69";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/nl/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/nl/firefox-66.0.5.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "2be6093f8a5303cf31a7bd3788c0b87f6525b0fd39f8d867646c5667a0bdbcac54c7bcebc6b0f91531291aff4e9041f6af21a20cd28b9191a1e778a6b3dedc6c";
+      sha512 = "0e5531ee0ca2765542e84aa88b0756e0ff765e25f2f9f3db9273658f619e13c6eb1e028f2ab573d6b0b4fe3233561445136ef329c75d318aebaf9b581afc41c1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/nn-NO/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/nn-NO/firefox-66.0.5.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "f1a50d57284e5e989e96598635fb9a876b1f72049ab2c3b5d4155a23c103bcc814f9551ca8da24e4c4565ba45ed2206e786b2070a51da248c654711911b62fcd";
+      sha512 = "e9aca83b6acee05063e602f5cca0dc82d04a326591f4d414ac5a3aa16ec6871dabfcf27fbb1e6bafd95fbda96e1c64251ed3eb6aa698830846b8c01e8b0f055f";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/oc/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/oc/firefox-66.0.5.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha512 = "2d8c7b92014717126098ccf93cff317c7e119cf05c971bc43890d84adc12201977a64fa8f67c6db6de94a1f446ea00c815164031f72862ff8bfe5188c3c192d1";
+      sha512 = "45085d11c85f6889056c144eab500a24bef9547be394e5c1834b2d7096b6c1251ec2a502e10b4b51422a6e6033a1fafb21b94330b5e370c5d8acac3aa7f609f0";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/or/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/or/firefox-66.0.5.tar.bz2";
       locale = "or";
       arch = "linux-i686";
-      sha512 = "43337f05cd9a3f37ab1c65a0a6d8375d8029dd805d70d9b638fa80941d53abdd1cb8befe0203219f69585300ec4175e0abaaef38d41703ca828600289b102a95";
+      sha512 = "bcb365e42dcd4d2f426117b39b39a015d3cd0b1667db653a7798fdc261ebbc52499d265b913e76330963b271d7f2fc567e2d58c5afbf6eefde87c890c6685f10";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/pa-IN/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/pa-IN/firefox-66.0.5.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha512 = "de4794e5ee7b82475d9f1ee03654a606cfdb93e658c289c8e51ed12d5c4f8f5d9506a6693dd9c55dbe80c9a050b8d5ff9e4d587857ef65885a683a669d827269";
+      sha512 = "8f9477a044885977707288c8e2bf98858b92a61b6c4e9e98d416521913426bebf2e7d1baa0925187c0e459ec41e94d8ae7b1b26f8953b48189864f408cc573c8";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/pl/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/pl/firefox-66.0.5.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "4836a9c7ca7eede61aef652e5a97339aa3c9949a78a7b2de48affaa335777522396555ae23abe11c95b02a1c59fc38ceb932fb9db74b50eb9b852bd3738f62b8";
+      sha512 = "86fae15a9e8ff7b7a3b7c7ad5ea7b308ed7bf5001547b0ea3a7f251f2bba4e966aeaee28d7cc489c3d9f85a4a7f3660946207d6899915834adb5a178b099a537";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/pt-BR/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/pt-BR/firefox-66.0.5.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "85173013452964e7621ba41588c3376f29bc73eef6dbedb9ef4f0a3ca5ddce831a2c03fd0855df32e1f72f16e544073e1749546e82ce02aae0a057eddd64dfd0";
+      sha512 = "c54dd7d19079d41545fb305b680489e7613154c9800913405f6383e25376c96db6b80a2cf7ad0f356f78f4fd01f1f2d1d183419e78eff1e9a1ea0b0fd9955177";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/pt-PT/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/pt-PT/firefox-66.0.5.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "f1a4b2d14811e8b6f9617126b03d931665275ea5a59cfa9c9b93fad395d09a6ba309f41ca472b2f0253eb4bd3a12914d1bdd25341d4166b71fc601206a6931ea";
+      sha512 = "8c7ee4e79b89a523c0e0378f09f006d883a05bf0b094c3756a366cf1037e59662d9588cdfb064a00cdf22cca8e9d0b51f150b4218764ecb2c101a797a127de9c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/rm/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/rm/firefox-66.0.5.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "4ac10aad3370d83f56ad59a6c971de1e53548782493979ab5f214c7499d0fe0fd86b59fd8a1e717d5e3d27553667e12eadbdefa2e474a5815e74e46af4485727";
+      sha512 = "73ea3ce657b4ca26eaab1239dece228643fe5bd72257f04c7273b88c2b2cf136beb76f692cbda2f799cac82688316a8fff652455d10f0dae27eace99306b7b1c";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/ro/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/ro/firefox-66.0.5.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "c85cd47c77c0e1ee4487cc0d0909ae02c20052b9a0784b426f0e7164136ca6eb6be7d87c13dede37fa6b0d4df63ea5198b9313da7af5c28e0adee0a7b7404943";
+      sha512 = "12ab234921a0b7fb07737248de895a5ca32430715967a9f786d7015384d58ce68bdb555a1074cf99ed76babc61dbb73c6ab45eb0dd6d4124813d84d5db43fc4e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/ru/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/ru/firefox-66.0.5.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "e690662ea7c9fdfc5d721a41241b5f70bf1ab12f4db4bb444b51f25c5f0650977848fb2631b3f0106e5e54cf739a0288fb6e36736560a3170a5d893f6a6e6864";
+      sha512 = "f5a7110b1929aae678a832de494477dbe9d89dfe8fb2a29e2d18b5a7b8c4b4fece2f8863b04e03946c318e1a3a7218ae68afc5b30f0caf39b36f8a648d4ae003";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/si/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/si/firefox-66.0.5.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "d1a4f021ed8ef7d55cde9ef2bb1c5e28fb41a0220cd169071a070cd6be11ae2fba7d0f9a6c7d036317c4e7c13b07a041f46bb3e750261c382805bce39e9daab3";
+      sha512 = "076c13952baa9335a26e04ddb083f76289bb541f23f4d8ee80b0c442b0b23c3fc8bfa50946c9220cc8b6d9dd6afaed1e5cbf1a9995fed26e79b7666796c7dbd9";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/sk/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/sk/firefox-66.0.5.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "fe0bd4ac5da78502baa39554aafd0d96f8c214197af0c62e28cd4a2a62940d6a6fe2774668ede43cb1d3ddc9f629d418ad467d1c7723020ec0c22bbed49963f8";
+      sha512 = "9378267650ec97395fc9b08cc187ae5bfc16da28093202d33c64e230ffa9c7dc939474e3785df1c4f89adc3f8de2d252c3bacd754b8b904b76b5b868e5929ab1";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/sl/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/sl/firefox-66.0.5.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "e5d46fa3ca8e934a7a3e0ecc1c096f478b7c3e594f12a8991c7181b18e321077768912963de1a48df7aa1a07440cbf23401baf1a84a12149750de3560834d2f0";
+      sha512 = "5451e7f5345f5bcbf9d5d9550703f66efb316c3e4e98b5dcbd8baf68846e7ac3b2f99c53364d583dee92dcab63a2d6fdfaf0e85f39a093dc3b1dd6fec8375fd5";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/son/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/son/firefox-66.0.5.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha512 = "cc79dbc2e5cd5ff682bcc61f6148170688d542fb3d07ac2fad518841ed6d93a722bff9a7ed1ce77a68e7f5f09fc4e1a13f1c7fc9d6458b2ef0a15cecdb15f7ad";
+      sha512 = "e552d6884ad981eff2badd8584d79a7b7f561e88cd1bb65f86dc08f162d174b2a05d800255c3e1a3d65c11bd5c54a54177f3c990b954b2d439a70b6f8a15e81e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/sq/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/sq/firefox-66.0.5.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "8dd55f612140e10681102d6d4414ac34d12733b4f8c5f253d6a278f5ac3cbdfdec1c14e4384e875e9881fc720ea1c54564de8ac3ac06f2ec5ad2941f7738e72e";
+      sha512 = "7c5d678e248102949298dc8aae4c3d174b01814e176dc923bcb23e71a49b96f16c167cc736e222a83a7c11de34708308b7d5f6057df71599a51fb353984c5223";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/sr/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/sr/firefox-66.0.5.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "fc29bb36ffd38ea5c71d66cc3fa498d2b6fda41a710c45ded72456c236c892855ba7ac8e07ed69c73f12ea2cd82bf7fa6e82a6fad49960feb4f5c36c78154fbd";
+      sha512 = "07718754558e1023f437fba61dd55b9610dd2f0f3ec15d7c36b56433d162e2699f93b094e50794d15fba74b2c02eada99fdb283de70c73394041180b8e7d7345";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/sv-SE/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/sv-SE/firefox-66.0.5.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "1f544109c73fb4c34b964c4df5d9f6da8201689d1038043efd6150bb8a323106a911e4a6f9b7a648497747a1b0df16c2122fce55bbd6eefa72d1e64458e90337";
+      sha512 = "c2d8bff74fb6537eae2c8e34df58a9233c4df3572cb3d7bb8b68660e4fd6848e23e58709ec4e7ec049c8e43aa40394b6f4b2f89363d91e6879c25ff0c523c27e";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/ta/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/ta/firefox-66.0.5.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha512 = "fe9d51b667c8a37caac25a5e236c40e87c3cc3620b630ba0f6169b8ec6b6580e6c5c53d36018fa236919120924ade33a3478f3526b7275f523d7f098e9c309cf";
+      sha512 = "0fd4b8c94340d341ef2fe70c10b4880a1073972b1b3df3391f92b6084e2cb84ccf9dbf764e26b04007b286106289b94806f6387c353a68ae64bacd4b2ca8eb50";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/te/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/te/firefox-66.0.5.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha512 = "fffacb5ff18d3c6b78dda7d33d0b05a2e6f55bfa24908a4ac5f970f5e8e44f9f4fe066ee73ea8656907c69390dfe3710b35606c9e8e1e4a7097fd8c004e98699";
+      sha512 = "3d1f9f8abe7b0491c0ce6084f6e4bd047fd606de376afe9d811f2ba91593f3e98e3d2f26d27c550c008455e76237a98c4f0847e88c3ed338ce1d495a3380ebbb";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/th/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/th/firefox-66.0.5.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha512 = "98092b4981db5460d2457e38ce1cb7dcf99abbc455d7c9b5b490e2ba1d91db7a553beaa404b78b02e66d5e4dcb71cc9e521a3f953d84ca495f9c4405e6262d00";
+      sha512 = "9f1343de6e161ec1803d56e7a87e1d3fa8b05c16fdb101f19daa8f514456e70645ff0935cbd7ce4a3d3d760b4b1107d28bf0f463509aaf197d7a91adb31c88a2";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/tr/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/tr/firefox-66.0.5.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "8d75be55b4baffc17fcb6a15a776c3a9f85c06ac1aade5fa2d859951f3231d36f47c3b32093a0fc70c9a4593b4f6ddeabbe7388e0e648d3b772010ecf10c1f04";
+      sha512 = "21058f2b49cca57e6146a02e211a0d80a92e3e2bd46445b06a8b5399ec1c2965d7e17d58f7c256ade21ff9399bc7dae1c8eb09555dee84d0e92a37f05e7b3353";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/uk/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/uk/firefox-66.0.5.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "009350e490504e907a1667055a1816ee77f87ab9d6e2460a166c3b6ff8a95d71f24c7369b97a3723307dadea82ad6fe345b071d4783769b1abf0ce76c67f6f11";
+      sha512 = "9d85bfa038ea5ebdda4061fa99e85ac93585f6d781e6a7b9297c189b6bc1e593bf429c2d1cc9344ccc253aef2367aeb840caa20ebf65af067636555fe8c66f57";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/ur/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/ur/firefox-66.0.5.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha512 = "790596c72c1eb9862d3fdd476ebd859c1d2f9ef756d9c069cdd4004c2df66a8c9b255b054cf50bf5b4c387fc5f6d96e366b60540fd79f5827b23dd0a2304fa7b";
+      sha512 = "06a3f2d441756c1506e8307ef8f42257eb37f63eca1378427c59880e9db3de44d85bc39241f1e43970c04dac00c4c4f6b82d7203c48b5b0c113fd1589e8e8639";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/uz/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/uz/firefox-66.0.5.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha512 = "c3d447f331dc36347f454aab0dbe5ceb4628b5b6cf63ecce009002fc87c2e63bbb55e7310c3c7a070767f38f792ac309a442c3abe4e1a041bd12638852b5e7dc";
+      sha512 = "0c6ded8776bcac49035f7fbc73c4a8c5470a081d79b883040ae7b9f60e31ece2c4a2f0baf867b6fdd722b0cbc3f359d1f9aaf75a364edb03b8f01e9946f109ee";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/vi/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/vi/firefox-66.0.5.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "370b456cb442a68e62dca86fb44b5cedc8a9328da5a8b35cd0fecbccc6afa5a82032454961a156e246c87df77799207fb6d53f32ad5a0f3c0ec0c21be5345548";
+      sha512 = "6091c0e48a097408cc2251f0bebce6e77ced9771486c67fc89074490455ca11048b2653d0b934b23c8266730af3fd58fef96a3319af8cbd8c6c83b740fd87bb4";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/xh/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/xh/firefox-66.0.5.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha512 = "f126678434aecd25449bbbf4da96eca70a7b9d65000a2073b9b033e4e01aaa68aa4019793180c0400658ebd55fcdf93b58f391c7fe7c588c064dea1c1d2c13df";
+      sha512 = "18bf62d055408eefccf145cf42d95234d88646b82c2f9d6f8f5107409be23879dac63b1ba0346d8295b114145c95921848de73aa98aee6343deb3bd103f73e46";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/zh-CN/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/zh-CN/firefox-66.0.5.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "aae684f94b9e567e8b075efea5f910261a752c29904ef658bbf9377884f39a467c359ab703b36867c2090f012b591502612918160ef7a2b2f98958af58f4e8ec";
+      sha512 = "e999b37838b09da9f5315ec692543c59a1a801c99560f8830ce1998cbcc6fce92a873a8b628682b176dac580a6f66e89588e2a2cbe7214cea542bf0c7162171b";
     }
-    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.4/linux-i686/zh-TW/firefox-66.0.4.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/firefox/releases/66.0.5/linux-i686/zh-TW/firefox-66.0.5.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "8f6329fc2a37ffd296a8e5ad7878f8f2bd7a172b53ea0629147c795aa920d1157001c819de479f62eeae6cc59d2d50e378cc9b9e5f401a1fa31f613af4fc145c";
+      sha512 = "a66bdf11578fddc740a9dcd4d1bb43c29d27c6c4cd26e896a88050c6bec4a0d5cd9ffc6ab3e48b2ae202b7de9bf11b402436a37001b1d166b7a6a1296e57a998";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -17,10 +17,10 @@ rec {
 
   firefox = common rec {
     pname = "firefox";
-    ffversion = "66.0.4";
+    ffversion = "66.0.5";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${ffversion}/source/firefox-${ffversion}.source.tar.xz";
-      sha512 = "0mz2xrznma3hwb2b36hlv4qmnzbfcfhrxbxqhc8yyqxnc0fm4vxbbzh1pzvghp4182n98l1dignw95v11pfgi3gss7sz1zkiywz47sw";
+      sha512 = "18bcpbwzhc2fi6cqhxhh6jiw5akhzr7qqs6s8irjbvh7q8f3z2n046vrlvpblhbkc2kv1n0s14n49yzv432adqwa9qi8d57jnxyfqkf";
     };
 
     patches = [


### PR DESCRIPTION
###### Motivation for this change

For the firefox attribute the changelog can be seen at https://blog.mozilla.org/addons/2019/05/04/update-regarding-add-ons-in-firefox/comment-page-5/ It is yet another fixup of the certificate issue that started last week.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
