### PR TITLE
shairport-sync: set sysconfdir to /etc/

### DIFF
--- a/pkgs/servers/shairport-sync/default.nix
+++ b/pkgs/servers/shairport-sync/default.nix
@@ -31,6 +31,7 @@ stdenv.mkDerivation rec {
     "--with-alsa" "--with-pipe" "--with-pa" "--with-stdout"
     "--with-avahi" "--with-ssl=openssl" "--with-soxr"
     "--without-configfiles"
+    "--sysconfdir=/etc"
   ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
since 2.8.5, shairport-sync uses the directory path sysconfdir to
determine where to place the configuration file shairport-sync.conf.

This led to shairport-sync complaining at startup:
> configuration file name "/nix/store/i8gb0hsb2zczdl8g1h73pbcb952585l9-shairport-sync-3.2.2/etc/shairport-sync.conf" can not be resolved.

Looking for a configuration file there doesn't make much sense, as we'd
have to include configuration in the shairport-sync derivation itself.

By setting sysconfdir to /etc/, shairport-sync will try to read its
configuration from /etc/shairport-sync.conf, which is a more sane
default.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
