### PR TITLE
Avoid collisions between essential packages

### DIFF
--- a/pkgs/os-specific/linux/procps-ng/default.nix
+++ b/pkgs/os-specific/linux/procps-ng/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = https://gitlab.com/procps-ng/procps;
     description = "Utilities that give information about processes using the /proc filesystem";
-    priority = 10; # less than coreutils, which also provides "kill" and "uptime"
+    priority = 11; # less than coreutils, which also provides "kill" and "uptime"
     license = lib.licenses.gpl2;
     platforms = lib.platforms.unix;
     maintainers = [ lib.maintainers.typetetris ];

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -220,6 +220,7 @@ in stdenv.mkDerivation rec {
     description = "A system and service manager for Linux";
     license = licenses.lgpl21Plus;
     platforms = platforms.linux;
+    priority = 10;
     maintainers = [ maintainers.eelco ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Fix remaining collision between essential packages.
See issue #55886.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
