### PR TITLE
python-packages: Set pythonPackages attr in pythonPackages scope

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -130,6 +130,9 @@ in {
 
   wrapPython = callPackage ../development/interpreters/python/wrap-python.nix {inherit python; inherit (pkgs) makeSetupHook makeWrapper; };
 
+  # Dont take pythonPackages from "global" pkgs scope to avoid mixing python versions
+  pythonPackages = self;
+
   # specials
 
   recursivePthLoader = callPackage ../development/python-modules/recursive-pth-loader { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
If we don't set this we are mixing python versions in the same package.
Any package called from `python-packages.nix` using `pythonPackages` directly as an argument is currently wrong.

Before:
```
nix-repl> python3Packages.bugseverywhere.buildInputs
[ «derivation /nix/store/csd0d2j3vgl5dnag6afi5q92xb64rv7z-python2.7-Jinja2-2.10.1.drv» «derivation /nix/store/gsj389hprxlr8a39b0ccszagirirf1lv-python2.7-cherrypy-17.4.1.drv» «derivation /nix/store/ysmd4wdkbi9gd6bw2ha92hwrd2k2xlnh-python2.7-bootstrapped-pip-19.0.3.drv» ]
```

After:
```
nix-repl> python3Packages.bugseverywhere.buildInputs
[ «derivation /nix/store/m0mfx1i98ciby8mx8xjva98kinhqkj6r-python3.7-Jinja2-2.10.1.drv» «derivation /nix/store/2gqd0sbiwqmin2814ja83pnyal8pq86a-python3.7-cherrypy-18.1.1.drv» «derivation /nix/store/0rq8n7xq2ksxiq2y2d844i9516p0rd41-python3.7-bootstrapped-pip-19.0.3.drv» ]
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
