### PR TITLE
treewide: Make all usage of python2Packages explicit

### DIFF
--- a/pkgs/applications/audio/clerk/default.nix
+++ b/pkgs/applications/audio/clerk/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, makeWrapper, rofi, mpc_cli, perl,
-utillinux, pythonPackages, libnotify }:
+utillinux, python2Packages, libnotify }:
 
 stdenv.mkDerivation {
   name = "clerk-2016-10-14";
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
     sha256 = "0y045my65hr3hjyx13jrnyg6g3wb41phqb1m7azc4l6vx6r4124b";
   };
 
-  buildInputs = [ makeWrapper pythonPackages.mpd2 ];
+  buildInputs = [ makeWrapper python2Packages.mpd2 ];
 
   dontBuild = true;
 

--- a/pkgs/applications/audio/gtklick/default.nix
+++ b/pkgs/applications/audio/gtklick/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, pythonPackages, gettext, klick}:
+{ stdenv, fetchurl, python2Packages, gettext, klick}:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   pname = "gtklick";
   version = "0.6.4";
 
@@ -9,7 +9,7 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "7799d884126ccc818678aed79d58057f8cf3528e9f1be771c3fa5b694d9d0137";
   };
 
-  pythonPath = with pythonPackages; [
+  pythonPath = with python2Packages; [
     pyliblo
     pyGtkGlade
   ];

--- a/pkgs/applications/audio/lastfmsubmitd/default.nix
+++ b/pkgs/applications/audio/lastfmsubmitd/default.nix
@@ -1,6 +1,6 @@
-{ lib, fetchurl, pythonPackages }:
+{ lib, fetchurl, python2Packages }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   pname = "lastfmsubmitd";
   version = "1.0.6";
 

--- a/pkgs/applications/audio/mimms/default.nix
+++ b/pkgs/applications/audio/mimms/default.nix
@@ -1,6 +1,6 @@
-{ fetchurl, stdenv, pythonPackages, libmms }:
+{ fetchurl, stdenv, python2Packages, libmms }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   pname = "mimms";
   version = "3.2";
 

--- a/pkgs/applications/audio/mopidy/default.nix
+++ b/pkgs/applications/audio/mopidy/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchFromGitHub, pythonPackages, wrapGAppsHook
+{ stdenv, fetchFromGitHub, python2Packages, wrapGAppsHook
 , gst_all_1, glib-networking, gobject-introspection
 }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   pname = "mopidy";
   version = "2.2.2";
 
@@ -20,7 +20,7 @@ pythonPackages.buildPythonApplication rec {
     glib-networking gobject-introspection
   ];
 
-  propagatedBuildInputs = with pythonPackages; [
+  propagatedBuildInputs = with python2Packages; [
     gst-python pygobject3 pykka tornado_4 requests
   ] ++ stdenv.lib.optional (!stdenv.isDarwin) dbus-python;
 

--- a/pkgs/applications/audio/mopidy/gmusic.nix
+++ b/pkgs/applications/audio/mopidy/gmusic.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, pythonPackages, mopidy }:
+{ stdenv, fetchurl, python2Packages, mopidy }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   pname = "mopidy-gmusic";
   version = "3.0.0";
 
@@ -11,9 +11,9 @@ pythonPackages.buildPythonApplication rec {
 
   propagatedBuildInputs = [
     mopidy
-    pythonPackages.requests
-    pythonPackages.gmusicapi
-    pythonPackages.cachetools
+    python2Packages.requests
+    python2Packages.gmusicapi
+    python2Packages.cachetools
   ];
 
   doCheck = false;

--- a/pkgs/applications/audio/mopidy/iris.nix
+++ b/pkgs/applications/audio/mopidy/iris.nix
@@ -1,10 +1,10 @@
-{ stdenv, pythonPackages, mopidy, mopidy-local-images }:
+{ stdenv, python2Packages, mopidy, mopidy-local-images }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   pname = "Mopidy-Iris";
   version = "3.37.1";
 
-  src = pythonPackages.fetchPypi {
+  src = python2Packages.fetchPypi {
     inherit pname version;
     sha256 = "0qcg456k7av0anymmmnlcn0v4642gbgk0nhic6w9bg9v5m0nj9ll";
   };
@@ -12,7 +12,7 @@ pythonPackages.buildPythonApplication rec {
   propagatedBuildInputs = [
     mopidy
     mopidy-local-images
-  ] ++ (with pythonPackages; [
+  ] ++ (with python2Packages; [
     configobj
     requests
     tornado_4

--- a/pkgs/applications/audio/mopidy/local-images.nix
+++ b/pkgs/applications/audio/mopidy/local-images.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, pythonPackages, mopidy, gobject-introspection }:
+{ stdenv, fetchFromGitHub, python2Packages, mopidy, gobject-introspection }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   pname = "mopidy-local-images";
   version = "1.0.0";
 
@@ -14,13 +14,13 @@ pythonPackages.buildPythonApplication rec {
   buildInputs = [ gobject-introspection ];
 
   checkInputs = [
-    pythonPackages.mock
+    python2Packages.mock
   ];
 
   propagatedBuildInputs = [
     mopidy
-    pythonPackages.pykka
-    pythonPackages.uritools
+    python2Packages.pykka
+    python2Packages.uritools
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/audio/mopidy/local-sqlite.nix
+++ b/pkgs/applications/audio/mopidy/local-sqlite.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, pythonPackages, mopidy }:
+{ stdenv, fetchFromGitHub, python2Packages, mopidy }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   pname = "mopidy-local-sqlite";
   version = "1.0.0";
 
@@ -13,7 +13,7 @@ pythonPackages.buildPythonApplication rec {
 
   propagatedBuildInputs = [
     mopidy
-    pythonPackages.uritools
+    python2Packages.uritools
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/audio/mopidy/moped.nix
+++ b/pkgs/applications/audio/mopidy/moped.nix
@@ -1,10 +1,10 @@
-{ stdenv, pythonPackages, mopidy, glibcLocales }:
+{ stdenv, python2Packages, mopidy, glibcLocales }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   pname = "Mopidy-Moped";
   version = "0.7.1";
 
-  src = pythonPackages.fetchPypi {
+  src = python2Packages.fetchPypi {
     inherit pname version;
     sha256 = "15461174037d87af93dd59a236d4275c5abf71cea0670ffff24a7d0399a8a2e4";
   };

--- a/pkgs/applications/audio/mopidy/mopify.nix
+++ b/pkgs/applications/audio/mopidy/mopify.nix
@@ -1,15 +1,15 @@
-{ stdenv, pythonPackages, mopidy }:
+{ stdenv, python2Packages, mopidy }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   pname = "Mopidy-Mopify";
   version = "1.6.1";
 
-  src = pythonPackages.fetchPypi {
+  src = python2Packages.fetchPypi {
     inherit pname version;
     sha256 = "93ad2b3d38b1450c8f2698bb908b0b077a96b3f64cdd6486519e518132e23a5c";
   };
 
-  propagatedBuildInputs = with pythonPackages; [ mopidy configobj ];
+  propagatedBuildInputs = with python2Packages; [ mopidy configobj ];
 
   # no tests implemented
   doCheck = false;

--- a/pkgs/applications/audio/mopidy/musicbox-webclient.nix
+++ b/pkgs/applications/audio/mopidy/musicbox-webclient.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, pythonPackages, mopidy }:
+{ stdenv, fetchFromGitHub, python2Packages, mopidy }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   pname = "mopidy-musicbox-webclient";
   version = "2.3.0";
 

--- a/pkgs/applications/audio/mopidy/soundcloud.nix
+++ b/pkgs/applications/audio/mopidy/soundcloud.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, pythonPackages, mopidy }:
+{ stdenv, fetchFromGitHub, python2Packages, mopidy }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   pname = "mopidy-soundcloud";
   version = "2.1.0";
 

--- a/pkgs/applications/audio/mopidy/spotify-tunigo.nix
+++ b/pkgs/applications/audio/mopidy/spotify-tunigo.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, pythonPackages, mopidy, mopidy-spotify }:
+{ stdenv, fetchFromGitHub, python2Packages, mopidy, mopidy-spotify }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   pname = "mopidy-spotify-tunigo";
   version = "1.0.0";
 
@@ -11,7 +11,7 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "1jwk0b2iz4z09qynnhcr07w15lx6i1ra09s9lp48vslqcf2fp36x";
   };
 
-  propagatedBuildInputs = [ mopidy mopidy-spotify pythonPackages.tunigo ];
+  propagatedBuildInputs = [ mopidy mopidy-spotify python2Packages.tunigo ];
 
   doCheck = false;
 

--- a/pkgs/applications/audio/mopidy/spotify.nix
+++ b/pkgs/applications/audio/mopidy/spotify.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, pythonPackages, mopidy }:
+{ stdenv, fetchurl, python2Packages, mopidy }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   pname = "mopidy-spotify";
   version = "3.1.0";
 
@@ -9,7 +9,7 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "1mh87w4j0ypvsrnax7kkjgfxfpnw3l290jvfzg56b8qlwf20khjl";
   };
 
-  propagatedBuildInputs = [ mopidy pythonPackages.pyspotify ];
+  propagatedBuildInputs = [ mopidy python2Packages.pyspotify ];
 
   doCheck = false;
 

--- a/pkgs/applications/audio/mopidy/youtube.nix
+++ b/pkgs/applications/audio/mopidy/youtube.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, pythonPackages, mopidy }:
+{ stdenv, fetchFromGitHub, python2Packages, mopidy }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   pname = "mopidy-youtube";
   version = "2.0.2";
 
@@ -11,7 +11,7 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "06r3ikyg2ch5n7fbn3sgj04hk6icpfpk1r856qch41995k3bbfg7";
   };
 
-  propagatedBuildInputs = with pythonPackages; [ mopidy pafy ];
+  propagatedBuildInputs = with python2Packages; [ mopidy pafy ];
 
   doCheck = false;
 

--- a/pkgs/applications/audio/pulseaudio-dlna/default.nix
+++ b/pkgs/applications/audio/pulseaudio-dlna/default.nix
@@ -1,4 +1,4 @@
-{ fetchFromGitHub, stdenv, pythonPackages
+{ fetchFromGitHub, stdenv, python2Packages
 , mp3Support ? true, lame ? null
 , opusSupport ? true, opusTools ? null
 , faacSupport ? false, faac ? null
@@ -14,7 +14,7 @@ assert flacSupport -> flac != null;
 assert soxSupport -> sox != null;
 assert vorbisSupport -> vorbisTools != null;
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   pname = "pulseaudio-dlna";
   version = "2017-11-01";
 
@@ -28,7 +28,7 @@ pythonPackages.buildPythonApplication rec {
   # pulseaudio-dlna has no tests
   doCheck = false;
 
-  propagatedBuildInputs = with pythonPackages; [
+  propagatedBuildInputs = with python2Packages; [
     dbus-python docopt requests setproctitle protobuf psutil futures
     chardet notify2 netifaces pyroute2 pygobject2 lxml zeroconf ]
     ++ stdenv.lib.optional mp3Support lame

--- a/pkgs/applications/audio/split2flac/default.nix
+++ b/pkgs/applications/audio/split2flac/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, makeWrapper
 , shntool, cuetools
 , flac, faac, mp4v2, wavpack, mac
-, imagemagick, libiconv, enca, lame, pythonPackages, vorbis-tools
+, imagemagick, libiconv, enca, lame, python2Packages, vorbis-tools
 , aacgain, mp3gain, vorbisgain
 }:
 
@@ -12,7 +12,7 @@ let
       --prefix PATH : ${stdenv.lib.makeBinPath [
         shntool cuetools
         flac faac mp4v2 wavpack mac
-        imagemagick libiconv enca lame pythonPackages.mutagen vorbis-tools
+        imagemagick libiconv enca lame python2Packages.mutagen vorbis-tools
         aacgain mp3gain vorbisgain
       ]}
   '';

--- a/pkgs/applications/editors/neovim/qt.nix
+++ b/pkgs/applications/editors/neovim/qt.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, cmake, doxygen, makeWrapper
-, msgpack, neovim, pythonPackages, qtbase }:
+, msgpack, neovim, python2Packages, qtbase }:
 
 let
   unwrapped = stdenv.mkDerivation rec {
@@ -20,7 +20,7 @@ let
     buildInputs = [
       neovim.unwrapped # only used to generate help tags at build time
       qtbase
-    ] ++ (with pythonPackages; [
+    ] ++ (with python2Packages; [
       jinja2 python msgpack
     ]);
 

--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -3,7 +3,7 @@
 , bundlerEnv, ruby
 , nodejs
 , nodePackages
-, pythonPackages
+, python2Packages
 , python3Packages
 }:
 with stdenv.lib;
@@ -41,7 +41,7 @@ let
   getDeps = attrname: map (plugin: plugin.${attrname} or (_:[]));
 
   pluginPythonPackages = getDeps "pythonDependencies" requiredPlugins;
-  pythonEnv = pythonPackages.python.withPackages(ps:
+  pythonEnv = python2Packages.python.withPackages(ps:
         [ ps.pynvim ]
         ++ (extraPythonPackagesFun ps)
         ++ (concatMap (f: f ps) pluginPythonPackages));

--- a/pkgs/applications/graphics/cinepaint/default.nix
+++ b/pkgs/applications/graphics/cinepaint/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, cmake, pkgconfig, gtk2, freetype, fontconfig, lcms,
   flex, libtiff, libjpeg, libpng, libexif, zlib, perlPackages, libX11,
-  pythonPackages, gettext, intltool, babl, gegl,
+  python2Packages, gettext, intltool, babl, gegl,
   glib, makedepend, xorgproto, libXmu, openexr,
   libGLU_combined, libXext, libXpm, libXau, libXxf86vm, pixman, libpthreadstubs, fltk } :
 
 let
-  inherit (pythonPackages) python pygtk;
+  inherit (python2Packages) python pygtk;
 in stdenv.mkDerivation rec {
   name = "cinepaint-1.1";
 

--- a/pkgs/applications/graphics/jbrout/default.nix
+++ b/pkgs/applications/graphics/jbrout/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchsvn, pythonPackages, makeWrapper, fbida, which }:
+{ stdenv, fetchsvn, python2Packages, makeWrapper, fbida, which }:
 
 let
-  inherit (pythonPackages) python;
-in pythonPackages.buildPythonApplication rec {
+  inherit (python2Packages) python;
+in python2Packages.buildPythonApplication rec {
   name = "jbrout-${version}";
   version = "338";
 
@@ -31,7 +31,7 @@ in pythonPackages.buildPythonApplication rec {
   '';
 
   buildInputs = [ python makeWrapper which ];
-  propagatedBuildInputs = with pythonPackages; [ pillow lxml pyGtkGlade pyexiv2 fbida ];
+  propagatedBuildInputs = with python2Packages; [ pillow lxml pyGtkGlade pyexiv2 fbida ];
 
   meta = {
     homepage = https://manatlan.com/jbrout/;

--- a/pkgs/applications/graphics/mirage/default.nix
+++ b/pkgs/applications/graphics/mirage/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, pythonPackages, libX11, gettext }:
+{ stdenv, fetchurl, python2Packages, libX11, gettext }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
     name = "mirage-${version}";
     version = "0.9.5.2";
 
@@ -17,7 +17,7 @@ pythonPackages.buildPythonApplication rec {
       sed -i "s@/usr/local/share/locale@$out/share/locale@" mirage.py
     '';
 
-    propagatedBuildInputs = with pythonPackages; [ pygtk pillow ];
+    propagatedBuildInputs = with python2Packages; [ pygtk pillow ];
 
     meta = {
       description = "Simple image viewer written in PyGTK";

--- a/pkgs/applications/graphics/screencloud/default.nix
+++ b/pkgs/applications/graphics/screencloud/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, qt4, quazip, qt-mobility, qxt, pythonPackages }:
+{ stdenv, fetchFromGitHub, cmake, qt4, quazip, qt-mobility, qxt, python2Packages }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     sha256 = "1s0dxa1sa37nvna5nfqdsp294810favj68qb7ghl78qna7zw0cim";
   };
 
-  buildInputs = [ cmake qt4 quazip qt-mobility qxt pythonPackages.python pythonPackages.pycrypto ];
+  buildInputs = [ cmake qt4 quazip qt-mobility qxt python2Packages.python python2Packages.pycrypto ];
 
   patchPhase = ''
     # Required to make the configure script work. Normally, screencloud's
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
   postInstall = ''
     patchShebangs $prefix/opt/screencloud/screencloud.sh
     substituteInPlace "$prefix/opt/screencloud/screencloud.sh" --replace "/opt" "$prefix/opt"
-    sed -i "2 i\export PYTHONPATH=$(toPythonPath ${pythonPackages.pycrypto}):\$PYTHONPATH" "$prefix/opt/screencloud/screencloud.sh"
+    sed -i "2 i\export PYTHONPATH=$(toPythonPath ${python2Packages.pycrypto}):\$PYTHONPATH" "$prefix/opt/screencloud/screencloud.sh"
     mkdir $prefix/bin
     mkdir $prefix/lib
     ln -s $prefix/opt/screencloud/screencloud.sh $prefix/bin/screencloud

--- a/pkgs/applications/misc/batti/default.nix
+++ b/pkgs/applications/misc/batti/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchurl
-, pkgconfig, gettext, pythonPackages
+, pkgconfig, gettext, python2Packages
 , gtk2, gdk_pixbuf, upower
 , makeWrapper }:
 
 let
-  inherit (pythonPackages) dbus-python pygtk python;
+  inherit (python2Packages) dbus-python pygtk python;
 in stdenv.mkDerivation rec {
 
   name = "batti-${version}";

--- a/pkgs/applications/misc/bleachbit/default.nix
+++ b/pkgs/applications/misc/bleachbit/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, pythonPackages, fetchurl, gettext }:
-pythonPackages.buildPythonApplication rec {
+{ stdenv, python2Packages, fetchurl, gettext }:
+python2Packages.buildPythonApplication rec {
   pname = "bleachbit";
   version = "2.2";
 
@@ -22,7 +22,7 @@ pythonPackages.buildPythonApplication rec {
 
   installFlags = [ "prefix=${placeholder "out"}" ];
 
-  propagatedBuildInputs = with pythonPackages; [ pygtk ];
+  propagatedBuildInputs = with python2Packages; [ pygtk ];
 
   meta = {
     homepage = http://bleachbit.sourceforge.net;

--- a/pkgs/applications/misc/cherrytree/default.nix
+++ b/pkgs/applications/misc/cherrytree/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pythonPackages, gettext }:
+{ stdenv, fetchurl, python2Packages, gettext }:
 
 with stdenv.lib;
 stdenv.mkDerivation rec {
@@ -11,10 +11,10 @@ stdenv.mkDerivation rec {
     sha256 = "1ns87xl2sgrf3nha4xkhp0xcxlycqszlp6xdrn95lg6vzm0fa8dg";
   };
 
-  buildInputs = with pythonPackages;
+  buildInputs = with python2Packages;
   [ python gettext wrapPython pygtk dbus-python pygtksourceview ];
 
-  pythonPath = with pythonPackages;
+  pythonPath = with python2Packages;
   [ pygtk dbus-python pygtksourceview ];
 
   patches = [ ./subprocess.patch ];

--- a/pkgs/applications/misc/curabydagoma/default.nix
+++ b/pkgs/applications/misc/curabydagoma/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, runtimeShell, lib, fetchurl, python, pythonPackages, unzip }:
+{ stdenv, runtimeShell, lib, fetchurl, python, python2Packages, unzip }:
 
 # This package uses a precompiled "binary" distribution of CuraByDagoma,
 # distributed by the editor.
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   };
   unpackCmd = "unzip $curSrc && tar zxf CuraByDagoma_amd64.tar.gz";
   nativeBuildInputs = [ unzip ];
-  buildInputs = [ python pythonPackages.pyopengl pythonPackages.wxPython pythonPackages.pyserial pythonPackages.numpy ];
+  buildInputs = [ python python2Packages.pyopengl python2Packages.wxPython python2Packages.pyserial python2Packages.numpy ];
 
   # Compile all pyc files because the included pyc files may be older than the
   # py files. However, Python doesn't realize that because the packages

--- a/pkgs/applications/misc/dockbarx/default.nix
+++ b/pkgs/applications/misc/dockbarx/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, pythonPackages, gnome2, keybinder }:
+{ stdenv, fetchFromGitHub, python2Packages, gnome2, keybinder }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   ver = "0.93";
   name = "dockbarx-${ver}";
 
@@ -24,7 +24,7 @@ pythonPackages.buildPythonApplication rec {
     substituteInPlace dockx_applets/volume-control.py         --replace /usr/share/             $out/share/
   '';
 
-  propagatedBuildInputs = (with pythonPackages; [ pygtk pyxdg dbus-python pillow xlib ])
+  propagatedBuildInputs = (with python2Packages; [ pygtk pyxdg dbus-python pillow xlib ])
     ++ (with gnome2; [ gnome_python gnome_python_desktop ])
     ++ [ keybinder ];
 

--- a/pkgs/applications/misc/dotfiles/default.nix
+++ b/pkgs/applications/misc/dotfiles/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, pythonPackages }:
+{ stdenv, python2Packages }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   pname = "dotfiles";
   name = "${pname}-${version}";
   version = "0.6.4";
 
-  src = pythonPackages.fetchPypi {
+  src = python2Packages.fetchPypi {
     inherit version pname;
     sha256 = "03qis6m9r2qh00sqbgwsm883s4bj1ibwpgk86yh4l235mdw8jywv";
   };
@@ -13,8 +13,8 @@ pythonPackages.buildPythonApplication rec {
   # No tests in archive
   doCheck = false;
 
-  checkInputs = with pythonPackages; [ pytest ];
-  propagatedBuildInputs = with pythonPackages; [ click ];
+  checkInputs = with python2Packages; [ pytest ];
+  propagatedBuildInputs = with python2Packages; [ click ];
 
   meta = with stdenv.lib; {
     description = "Easily manage your dotfiles";

--- a/pkgs/applications/misc/hamster-time-tracker/default.nix
+++ b/pkgs/applications/misc/hamster-time-tracker/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, pythonPackages, docbook2x, libxslt, gnome-doc-utils
+{ stdenv, fetchzip, python2Packages, docbook2x, libxslt, gnome-doc-utils
 , intltool, dbus-glib, gnome_python
 , hicolor-icon-theme
 , wafHook
@@ -9,7 +9,7 @@
 #
 #   WARNING:root:Could not import wnck - workspace tracking will be disabled
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   name = "hamster-time-tracker-1.04";
 
   src = fetchzip {
@@ -23,7 +23,7 @@ pythonPackages.buildPythonApplication rec {
     docbook2x libxslt gnome-doc-utils dbus-glib hicolor-icon-theme
   ];
 
-  propagatedBuildInputs = with pythonPackages; [ pygobject2 pygtk pyxdg gnome_python dbus-python ];
+  propagatedBuildInputs = with python2Packages; [ pygobject2 pygtk pyxdg gnome_python dbus-python ];
 
   postFixup = ''
     wrapPythonProgramsIn $out/lib/hamster-time-tracker "$out $pythonPath"

--- a/pkgs/applications/misc/menumaker/default.nix
+++ b/pkgs/applications/misc/menumaker/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, pythonPackages }:
+{ stdenv, fetchurl, python2Packages }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   name = "menumaker-${version}";
   version = "0.99.10";
 

--- a/pkgs/applications/misc/ocropus/default.nix
+++ b/pkgs/applications/misc/ocropus/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, fetchurl, pythonPackages, curl }:
+{ stdenv, fetchFromGitHub, fetchurl, python2Packages, curl }:
 
 let
   getmodel = name: sha256: {
@@ -17,7 +17,7 @@ let
   ];
 
 in
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   pname = "ocropus";
   version = "1.3.3";
 
@@ -28,7 +28,7 @@ pythonPackages.buildPythonApplication rec {
     owner = "tmbdev";
   };
 
-  propagatedBuildInputs = with pythonPackages; [ curl numpy scipy pillow
+  propagatedBuildInputs = with python2Packages; [ curl numpy scipy pillow
     matplotlib beautifulsoup4 pygtk lxml ];
 
   enableParallelBuilding = true;

--- a/pkgs/applications/misc/pdf-quench/default.nix
+++ b/pkgs/applications/misc/pdf-quench/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, pkgs, pythonPackages, wrapGAppsHook}:
+{ stdenv, fetchFromGitHub, pkgs, python2Packages, wrapGAppsHook}:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   name = "pdf-quench-${version}";
   version = "1.0.5";
 
@@ -18,7 +18,7 @@ pythonPackages.buildPythonApplication rec {
     goocanvas2
     poppler_gi
   ];
-  propagatedBuildInputs = with pythonPackages; [ pygobject3 pypdf2 ];
+  propagatedBuildInputs = with python2Packages; [ pygobject3 pypdf2 ];
 
   format = "other";
   doCheck = false;

--- a/pkgs/applications/misc/pdfdiff/default.nix
+++ b/pkgs/applications/misc/pdfdiff/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, pythonPackages, fetchurl, xpdf }:
+{ stdenv, python2Packages, fetchurl, xpdf }:
 let
-  py = pythonPackages;
+  py = python2Packages;
 in
 py.buildPythonApplication rec {
   name = "pdfdiff-${version}";
@@ -11,7 +11,7 @@ py.buildPythonApplication rec {
     sha256 = "0zxwjjbklz87wkbhkmsvhc7xmv5php7m2a9vm6ydhmhlxsybf836";
   };
 
-  buildInputs = [  pythonPackages.wrapPython ];
+  buildInputs = [  python2Packages.wrapPython ];
 
   doCheck = false;
 
@@ -29,7 +29,7 @@ py.buildPythonApplication rec {
     cp pdfdiff.py $out/bin/pdfdiff
     chmod +x $out/bin/pdfdiff
 
-    substituteInPlace $out/bin/pdfdiff --replace "#!/usr/bin/python" "#!${pythonPackages.python.interpreter}"
+    substituteInPlace $out/bin/pdfdiff --replace "#!/usr/bin/python" "#!${python2Packages.python.interpreter}"
     '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/misc/phwmon/default.nix
+++ b/pkgs/applications/misc/phwmon/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitLab, pythonPackages }:
+{ stdenv, fetchFromGitLab, python2Packages }:
 
 stdenv.mkDerivation rec {
   name = "phwmon-${version}";
@@ -11,11 +11,11 @@ stdenv.mkDerivation rec {
     sha256 = "1hqmsq66y8bqkpvszw84jyk8haxq3cjnz105hlkmp7786vfmkisq";
   };
 
-  nativeBuildInputs = [ pythonPackages.wrapPython ];
+  nativeBuildInputs = [ python2Packages.wrapPython ];
 
-  buildInputs = [ pythonPackages.pygtk pythonPackages.psutil ];
+  buildInputs = [ python2Packages.pygtk python2Packages.psutil ];
 
-  pythonPath = [ pythonPackages.pygtk pythonPackages.psutil ];
+  pythonPath = [ python2Packages.pygtk python2Packages.psutil ];
   
   patchPhase = ''
     substituteInPlace install.sh --replace "/usr/local" "$out"

--- a/pkgs/applications/misc/roxterm/default.nix
+++ b/pkgs/applications/misc/roxterm/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, docbook_xsl, dbus, dbus-glib, expat
 , gsettings-desktop-schemas, gdk_pixbuf, gtk3, hicolor-icon-theme
 , imagemagick, itstool, librsvg, libtool, libxslt, makeWrapper
-, pkgconfig, python, pythonPackages, vte
+, pkgconfig, python, python2Packages, vte
 , wrapGAppsHook}:
 
 # TODO: Still getting following warning.
@@ -22,7 +22,7 @@ in stdenv.mkDerivation rec {
 
   buildInputs =
     [ docbook_xsl expat imagemagick itstool librsvg libtool libxslt
-      makeWrapper python pythonPackages.lockfile dbus dbus-glib
+      makeWrapper python python2Packages.lockfile dbus dbus-glib
       gdk_pixbuf gsettings-desktop-schemas gtk3
       hicolor-icon-theme vte ];
 
@@ -32,7 +32,7 @@ in stdenv.mkDerivation rec {
 
   # Fix up python path so the lockfile library is on it.
   PYTHONPATH = stdenv.lib.makeSearchPathOutput "lib" python.sitePackages [
-    pythonPackages.lockfile
+    python2Packages.lockfile
   ];
 
   buildPhase = ''

--- a/pkgs/applications/misc/weather/default.nix
+++ b/pkgs/applications/misc/weather/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pythonPackages }:
+{ stdenv, fetchurl, python2Packages }:
 
 stdenv.mkDerivation rec {
     version = "2.3";
@@ -9,14 +9,14 @@ stdenv.mkDerivation rec {
         sha256 = "0inij30prqqcmzjwcmfzjjn0ya5klv18qmajgxipz1jr3lpqs546";
     };
 
-    nativeBuildInputs = [ pythonPackages.wrapPython ];
+    nativeBuildInputs = [ python2Packages.wrapPython ];
 
-    buildInputs = [ pythonPackages.python ];
+    buildInputs = [ python2Packages.python ];
 
     phases = [ "unpackPhase" "installPhase" ];
 
     installPhase = ''
-        site_packages=$out/${pythonPackages.python.sitePackages}
+        site_packages=$out/${python2Packages.python.sitePackages}
         mkdir -p $out/{share/{man,weather-util},bin,etc} $site_packages
         cp weather $out/bin/
         cp weather.py $site_packages/

--- a/pkgs/applications/misc/zk-shell/default.nix
+++ b/pkgs/applications/misc/zk-shell/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, pythonPackages }:
+{ stdenv, fetchFromGitHub, python2Packages }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   version = "1.0.0";
   name = "zk-shell-" + version;
 
@@ -11,7 +11,7 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "0zisvvlclsf4sdh7dpqcl1149xbxw6pi1aqcwjbqblgf8m4nm0c7";
   };
 
-  propagatedBuildInputs = (with pythonPackages; [
+  propagatedBuildInputs = (with python2Packages; [
     ansi kazoo nose six tabulate twitter
   ]);
 

--- a/pkgs/applications/networking/cluster/spark/default.nix
+++ b/pkgs/applications/networking/cluster/spark/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, makeWrapper, jre, pythonPackages, coreutils, hadoop
+{ stdenv, fetchzip, makeWrapper, jre, python2Packages, coreutils, hadoop
 , RSupport? true, R
 , mesosSupport ? true, mesos
 , version
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     url    = "mirror://apache/spark/${name}/${name}-bin-without-hadoop.tgz";
   };
 
-  buildInputs = [ makeWrapper jre pythonPackages.python pythonPackages.numpy ]
+  buildInputs = [ makeWrapper jre python2Packages.python python2Packages.numpy ]
     ++ optional RSupport R
     ++ optional mesosSupport mesos;
 
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     export JAVA_HOME="${jre}"
     export SPARK_HOME="$out/lib/${untarDir}"
     export SPARK_DIST_CLASSPATH=$(${hadoop}/bin/hadoop classpath)
-    export PYSPARK_PYTHON="${pythonPackages.python}/bin/${pythonPackages.python.executable}"
+    export PYSPARK_PYTHON="${python2Packages.python}/bin/${python2Packages.python.executable}"
     export PYTHONPATH="\$PYTHONPATH:$PYTHONPATH"
     ${optionalString RSupport
       ''export SPARKR_R_SHELL="${R}/bin/R"

--- a/pkgs/applications/networking/instant-messengers/blink/default.nix
+++ b/pkgs/applications/networking/instant-messengers/blink/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchdarcs, pythonPackages, libvncserver, zlib
+{ stdenv, fetchdarcs, python2Packages, libvncserver, zlib
 , gnutls, libvpx, makeDesktopItem }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   name = "blink-${version}";
   version = "3.0.3";
 
@@ -16,9 +16,9 @@ pythonPackages.buildPythonApplication rec {
     sed -i 's|@out@|'"''${out}"'|g' blink/resources.py
   '';
 
-  propagatedBuildInputs = with pythonPackages; [ pyqt5_with_qtwebkit cjson sipsimple twisted google_api_python_client ];
+  propagatedBuildInputs = with python2Packages; [ pyqt5_with_qtwebkit cjson sipsimple twisted google_api_python_client ];
 
-  buildInputs = [ pythonPackages.cython zlib libvncserver libvpx ];
+  buildInputs = [ python2Packages.cython zlib libvncserver libvpx ];
 
   desktopItem = makeDesktopItem {
     name = "Blink";

--- a/pkgs/applications/networking/instant-messengers/telegram/tdesktop/generic.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/tdesktop/generic.nix
@@ -1,7 +1,7 @@
 { stable, version, sha256Hash, archPatchesRevision, archPatchesHash }:
 
 { mkDerivation, lib, fetchFromGitHub, fetchsvn
-, pkgconfig, pythonPackages, cmake, wrapGAppsHook
+, pkgconfig, python2Packages, cmake, wrapGAppsHook
 , qtbase, qtimageformats, gtk3, libappindicator-gtk3, libnotify, xdg_utils
 , dee, ffmpeg, openalSoft, minizip, libopus, alsaLib, libpulseaudio, range-v3
 }:
@@ -38,7 +38,7 @@ mkDerivation rec {
       --replace '"notify"' '"${libnotify}/lib/libnotify.so"'
   '';
 
-  nativeBuildInputs = [ pkgconfig pythonPackages.gyp cmake wrapGAppsHook ];
+  nativeBuildInputs = [ pkgconfig python2Packages.gyp cmake wrapGAppsHook ];
 
   # We want to run wrapProgram manually (with additional parameters)
   dontWrapGApps = true;

--- a/pkgs/applications/networking/irc/weechat/default.nix
+++ b/pkgs/applications/networking/irc/weechat/default.nix
@@ -6,7 +6,7 @@
 , guileSupport ? true, guile
 , luaSupport ? true, lua5
 , perlSupport ? true, perl, perlPackages
-, pythonSupport ? true, pythonPackages
+, pythonSupport ? true, python2Packages
 , rubySupport ? true, ruby
 , tclSupport ? true, tcl
 , extraBuildInputs ? []
@@ -14,7 +14,7 @@
 }:
 
 let
-  inherit (pythonPackages) python;
+  inherit (python2Packages) python;
   plugins = [
     { name = "perl"; enabled = perlSupport; cmakeFlag = "ENABLE_PERL"; buildInputs = [ perl ]; }
     { name = "tcl"; enabled = tclSupport; cmakeFlag = "ENABLE_TCL"; buildInputs = [ tcl ]; }

--- a/pkgs/applications/networking/irc/weechat/scripts/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/default.nix
@@ -1,8 +1,8 @@
-{ callPackage, luaPackages, pythonPackages }:
+{ callPackage, luaPackages, python2Packages }:
 
 {
   weechat-xmpp = callPackage ./weechat-xmpp {
-    inherit (pythonPackages) pydns;
+    inherit (python2Packages) pydns;
   };
 
   weechat-matrix-bridge = callPackage ./weechat-matrix-bridge {
@@ -10,7 +10,7 @@
   };
 
   wee-slack = callPackage ./wee-slack {
-    inherit pythonPackages;
+    inherit python2Packages;
   };
 
   weechat-autosort = callPackage ./weechat-autosort { };

--- a/pkgs/applications/networking/irc/weechat/wrapper.nix
+++ b/pkgs/applications/networking/irc/weechat/wrapper.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, runCommand, writeScriptBin, buildEnv
-, pythonPackages, perlPackages, runtimeShell
+, python2Packages, perlPackages, runtimeShell
 }:
 
 weechat:
@@ -18,7 +18,7 @@ let
           pluginFile = "${weechat.python}/lib/weechat/plugins/python.so";
           withPackages = pkgsFun: (python // {
             extraEnv = ''
-              export PYTHONHOME="${pythonPackages.python.withPackages pkgsFun}"
+              export PYTHONHOME="${python2Packages.python.withPackages pkgsFun}"
             '';
           });
         };

--- a/pkgs/applications/networking/p2p/soulseekqt/default.nix
+++ b/pkgs/applications/networking/p2p/soulseekqt/default.nix
@@ -5,7 +5,7 @@
 , qtbase, qtmultimedia
 , libjson, libgpgerror
 , libX11, libxcb, libXau, libXdmcp, freetype, libbsd
-, pythonPackages, squashfsTools, desktop-file-utils
+, python2Packages, squashfsTools, desktop-file-utils
 }:
 
 with stdenv.lib;
@@ -31,7 +31,7 @@ in stdenv.mkDerivation rec {
 
   dontBuild = true;
 
-  buildInputs = [ pythonPackages.binwalk squashfsTools desktop-file-utils ];
+  buildInputs = [ python2Packages.binwalk squashfsTools desktop-file-utils ];
 
   # avoid usage of appimage's runner option --appimage-extract 
   unpackCmd = ''

--- a/pkgs/applications/networking/p2p/transmission-remote-cli/default.nix
+++ b/pkgs/applications/networking/p2p/transmission-remote-cli/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pythonPackages }:
+{ stdenv, fetchurl, python2Packages }:
 
 stdenv.mkDerivation rec {
   name = "transmission-remote-cli-${version}";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "1y0hkpcjf6jw9xig8yf484hbhy63nip0pkchx401yxj81m25l4z9";
   };
 
-  buildInputs = with pythonPackages; [ python wrapPython ];
+  buildInputs = with python2Packages; [ python wrapPython ];
 
   installPhase = ''
     install -D transmission-remote-cli $out/bin/transmission-remote-cli

--- a/pkgs/applications/networking/p2p/tribler/default.nix
+++ b/pkgs/applications/networking/p2p/tribler/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pythonPackages, makeWrapper, imagemagick
+{ stdenv, fetchurl, python2Packages, makeWrapper, imagemagick
 , enablePlayer ? true, vlc ? null, qt5 }:
 
 stdenv.mkDerivation rec {
@@ -11,38 +11,38 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    pythonPackages.python
-    pythonPackages.wrapPython
+    python2Packages.python
+    python2Packages.wrapPython
     makeWrapper
     imagemagick
   ];
 
-  pythonPath = [
-    pythonPackages.libtorrentRasterbar
-    pythonPackages.apsw
-    pythonPackages.twisted
-    pythonPackages.netifaces
-    pythonPackages.pycrypto
-    pythonPackages.pyasn1
-    pythonPackages.requests
-    pythonPackages.setuptools
-    pythonPackages.m2crypto
-    pythonPackages.pyqt5
-    pythonPackages.chardet
-    pythonPackages.cherrypy
-    pythonPackages.cryptography
-    pythonPackages.libnacl
-    pythonPackages.configobj
-    pythonPackages.matplotlib
-    pythonPackages.plyvel
-    pythonPackages.decorator
-    pythonPackages.feedparser
-    pythonPackages.service-identity
-    pythonPackages.psutil
-    pythonPackages.meliae
-    pythonPackages.sip
-    pythonPackages.pillow
-    pythonPackages.networkx
+  pythonPath = with python2Packages; [
+    libtorrentRasterbar
+    apsw
+    twisted
+    netifaces
+    pycrypto
+    pyasn1
+    requests
+    setuptools
+    m2crypto
+    pyqt5
+    chardet
+    cherrypy
+    cryptography
+    libnacl
+    configobj
+    matplotlib
+    plyvel
+    decorator
+    feedparser
+    service-identity
+    psutil
+    meliae
+    sip
+    pillow
+    networkx
   ];
 
   postPatch = ''
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
     # Nasty hack; call wrapPythonPrograms to set program_PYTHONPATH.
     wrapPythonPrograms
     cp -prvd ./* $out/
-    makeWrapper ${pythonPackages.python}/bin/python $out/bin/tribler \
+    makeWrapper ${python2Packages.python}/bin/python $out/bin/tribler \
         --set QT_QPA_PLATFORM_PLUGIN_PATH ${qt5.qtbase.bin}/lib/qt-*/plugins/platforms \
         --set _TRIBLERPATH $out \
         --set PYTHONPATH $out:$program_PYTHONPATH \

--- a/pkgs/applications/networking/pyload/default.nix
+++ b/pkgs/applications/networking/pyload/default.nix
@@ -1,11 +1,9 @@
-{ stdenv, fetchFromGitHub, fetchpatch, pythonPackages, gocr, unrar, rhino, spidermonkey }:
+{ stdenv, fetchFromGitHub, fetchpatch, python2Packages, gocr, unrar, rhino, spidermonkey }:
 
 let
-  beautifulsoup = pythonPackages.callPackage ./beautifulsoup.nix {
-    inherit pythonPackages;
-  };
+  beautifulsoup = python2Packages.callPackage ./beautifulsoup.nix { };
 
-in pythonPackages.buildPythonApplication rec {
+in python2Packages.buildPythonApplication rec {
   version = "0.4.9-next";
   name = "pyLoad-" + version;
 
@@ -30,10 +28,10 @@ in pythonPackages.buildPythonApplication rec {
     in [ configParserPatch setupPyPatch ];
 
   buildInputs = [
-    unrar rhino spidermonkey gocr pythonPackages.paver
+    unrar rhino spidermonkey gocr python2Packages.paver
   ];
 
-  propagatedBuildInputs = with pythonPackages; [
+  propagatedBuildInputs = with python2Packages; [
     pycurl jinja2 beaker thrift simplejson pycrypto feedparser tkinter
     beautifulsoup send2trash
   ];

--- a/pkgs/applications/office/gnumeric/default.nix
+++ b/pkgs/applications/office/gnumeric/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchurl, pkgconfig, intltool, perlPackages
-, goffice, gnome3, wrapGAppsHook, gtk3, bison, pythonPackages
+, goffice, gnome3, wrapGAppsHook, gtk3, bison, python2Packages
 , itstool
 }:
 
 let
-  inherit (pythonPackages) python pygobject3;
+  inherit (python2Packages) python pygobject3;
 in stdenv.mkDerivation rec {
   pname = "gnumeric";
   version = "1.12.44";

--- a/pkgs/applications/radio/gnss-sdr/default.nix
+++ b/pkgs/applications/radio/gnss-sdr/default.nix
@@ -9,7 +9,7 @@
 , gnuradio
 , orc
 , pkgconfig
-, pythonPackages
+, python2Packages
 , uhd
 }:
 
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     gnuradio
     orc
     pkgconfig
-    pythonPackages.Mako
+    python2Packages.Mako
 
     # UHD support is optional, but gnuradio is built with it, so there's
     # nothing to be gained by leaving it out.

--- a/pkgs/applications/radio/uhd/default.nix
+++ b/pkgs/applications/radio/uhd/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchFromGitHub, cmake, pkgconfig
-, python, pythonPackages, orc, libusb1, boost }:
+, python, python2Packages, orc, libusb1, boost }:
 
 # You need these udev rules to not have to run as root (copied from
 # ${uhd}/share/uhd/utils/uhd-usrp.rules):
@@ -39,7 +39,7 @@ in stdenv.mkDerivation {
                [ (stdenv.lib.optionalString stdenv.isAarch32 "-DCMAKE_CXX_FLAGS=-Wno-psabi") ];
 
   nativeBuildInputs = [ cmake pkgconfig ];
-  buildInputs = [ python pythonPackages.pyramid_mako orc libusb1 boost ];
+  buildInputs = [ python python2Packages.pyramid_mako orc libusb1 boost ];
 
   # Build only the host software
   preConfigure = "cd host";

--- a/pkgs/applications/science/biology/poretools/default.nix
+++ b/pkgs/applications/science/biology/poretools/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, pythonPackages, fetchFromGitHub }:
+{ stdenv, python2Packages, fetchFromGitHub }:
 
-pythonPackages.buildPythonPackage rec {
+python2Packages.buildPythonPackage rec {
   pname = "poretools";
   version = "unstable-2016-07-10";
   name = "${pname}-${version}";
@@ -12,7 +12,7 @@ pythonPackages.buildPythonPackage rec {
     sha256 = "0bglj833wxpp3cq430p1d3xp085ls221js2y90w7ir2x5ay8l7am";
   };
 
-  propagatedBuildInputs = [pythonPackages.h5py pythonPackages.matplotlib pythonPackages.seaborn pythonPackages.pandas];
+  propagatedBuildInputs = [python2Packages.h5py python2Packages.matplotlib python2Packages.seaborn python2Packages.pandas];
 
   meta = {
     description = "a toolkit for working with nanopore sequencing data from Oxford Nanopore";

--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -4,7 +4,7 @@
 , wrapGAppsHook
 , oceSupport ? true, opencascade
 , ngspiceSupport ? true, libngspice
-, swig, python, pythonPackages
+, swig, python, python2Packages
 , lndir
 }:
 
@@ -46,8 +46,8 @@ in stdenv.mkDerivation rec {
     "-DKICAD_SCRIPTING_WXPYTHON=ON"
     # nix installs wxPython headers in wxPython package, not in wxwidget
     # as assumed. We explicitely set the header location.
-    "-DCMAKE_CXX_FLAGS=-I${pythonPackages.wxPython}/include/wx-3.0"
-    "-DwxPYTHON_INCLUDE_DIRS=${pythonPackages.wxPython}/include/wx-3.0"
+    "-DCMAKE_CXX_FLAGS=-I${python2Packages.wxPython}/include/wx-3.0"
+    "-DwxPYTHON_INCLUDE_DIRS=${python2Packages.wxPython}/include/wx-3.0"
   ] ++ optionals (oceSupport) [ "-DKICAD_USE_OCE=ON" "-DOCE_DIR=${opencascade}" ]
     ++ optional (ngspiceSupport) "-DKICAD_SPICE=ON";
 
@@ -56,11 +56,11 @@ in stdenv.mkDerivation rec {
     doxygen
     pkgconfig
     wrapGAppsHook
-    pythonPackages.wrapPython
+    python2Packages.wrapPython
     lndir
   ];
-  pythonPath = [ pythonPackages.wxPython ];
-  propagatedBuildInputs = [ pythonPackages.wxPython ];
+  pythonPath = [ python2Packages.wxPython ];
+  propagatedBuildInputs = [ python2Packages.wxPython ];
 
   buildInputs = [
     libGLU_combined zlib libX11 wxGTK pcre libXdmcp glew glm libpthreadstubs

--- a/pkgs/applications/science/robotics/gazebo/default.nix
+++ b/pkgs/applications/science/robotics/gazebo/default.nix
@@ -2,7 +2,7 @@
   , boost-build, boost_process
   , xorg_sys_opengl, tbb, ogre, tinyxml-2
   , libtar, glxinfo,  libusb, libxslt, ignition
-  , pythonPackages, utillinux
+  , python2Packages, utillinux
 
   # these deps are hidden; cmake doesn't catch them
   , gazeboSimulator, sdformat ? gazeboSimulator.sdformat, curl, tinyxml, qt4
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
     libxslt
     ignition.math2
     sdformat
-    pythonPackages.pyopengl
+    python2Packages.pyopengl
 
     # TODO: add these hidden deps to cmake configuration & submit upstream
     curl

--- a/pkgs/applications/search/catfish/default.nix
+++ b/pkgs/applications/search/catfish/default.nix
@@ -1,9 +1,9 @@
 { stdenv, fetchurl, file, which, intltool, gobject-introspection,
-  findutils, xdg_utils, gnome3, gtk3, pythonPackages, hicolor-icon-theme,
+  findutils, xdg_utils, gnome3, gtk3, python2Packages, hicolor-icon-theme,
   wrapGAppsHook
 }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   majorver = "1.4";
   minorver = "7";
   version = "${majorver}.${minorver}";
@@ -15,7 +15,7 @@ pythonPackages.buildPythonApplication rec {
   };
 
   nativeBuildInputs = [
-    pythonPackages.distutils_extra
+    python2Packages.distutils_extra
     file
     which
     intltool
@@ -26,15 +26,15 @@ pythonPackages.buildPythonApplication rec {
   buildInputs = [
     gtk3
     gnome3.dconf
-    pythonPackages.pyxdg
-    pythonPackages.ptyprocess
-    pythonPackages.pycairo
+    python2Packages.pyxdg
+    python2Packages.ptyprocess
+    python2Packages.pycairo
     hicolor-icon-theme
   ];
 
   propagatedBuildInputs = [
-    pythonPackages.pygobject3
-    pythonPackages.pexpect
+    python2Packages.pygobject3
+    python2Packages.pexpect
     xdg_utils
     findutils
   ];

--- a/pkgs/applications/version-management/git-and-tools/git-bz/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-bz/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchgit
 , asciidoc, docbook_xml_dtd_45, docbook_xsl, libxslt, makeWrapper, xmlto
-, pythonPackages }:
+, python2Packages }:
 
 stdenv.mkDerivation rec {
   name = "git-bz-${version}";
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     asciidoc docbook_xml_dtd_45 docbook_xsl libxslt makeWrapper xmlto
   ];
   buildInputs = []
-    ++ (with pythonPackages; [ python pysqlite ]);
+    ++ (with python2Packages; [ python pysqlite ]);
 
   postPatch = ''
     patchShebangs configure
@@ -27,8 +27,8 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     wrapProgram $out/bin/git-bz \
-      --prefix PYTHONPATH : "$(toPythonPath "${pythonPackages.pycrypto}")" \
-      --prefix PYTHONPATH : "$(toPythonPath "${pythonPackages.pysqlite}")"
+      --prefix PYTHONPATH : "$(toPythonPath "${python2Packages.pycrypto}")" \
+      --prefix PYTHONPATH : "$(toPythonPath "${python2Packages.pysqlite}")"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/applications/version-management/git-and-tools/git-cola/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-cola/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchFromGitHub, pythonPackages, gettext, git }:
+{ stdenv, fetchFromGitHub, python2Packages, gettext, git }:
 
 let
-  inherit (pythonPackages) buildPythonApplication pyqt5 sip pyinotify;
+  inherit (python2Packages) buildPythonApplication pyqt5 sip pyinotify;
 
 in buildPythonApplication rec {
   name = "git-cola-${version}";

--- a/pkgs/applications/version-management/git-and-tools/git-imerge/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-imerge/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pythonPackages }:
+{ stdenv, fetchFromGitHub, python2Packages }:
 
 stdenv.mkDerivation rec {
   name = "git-imerge-${version}";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0vi1w3f0yk4gqhxj2hzqafqq28rihyhyfnp8x7xzib96j2si14a4";
   };
 
-  buildInputs = [ pythonPackages.python pythonPackages.wrapPython ];
+  buildInputs = [ python2Packages.python python2Packages.wrapPython ];
 
   makeFlags = "PREFIX= DESTDIR=$(out)" ; 
  

--- a/pkgs/applications/version-management/git-crecord/default.nix
+++ b/pkgs/applications/version-management/git-crecord/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, pythonPackages }:
+{ stdenv, fetchFromGitHub, python2Packages }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   name = "git-crecord-${version}";
   version = "20161216.0";
 
@@ -11,7 +11,7 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "0v3y90zi43myyi4k7q3892dcrbyi9dn2q6xgk12nw9db9zil269i";
   };
 
-  propagatedBuildInputs = with pythonPackages; [ docutils ];
+  propagatedBuildInputs = with python2Packages; [ docutils ];
 
   meta = {
     homepage = https://github.com/andrewshadura/git-crecord;

--- a/pkgs/applications/version-management/git-review/default.nix
+++ b/pkgs/applications/version-management/git-review/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, pythonPackages} :
+{ stdenv, fetchFromGitHub, python2Packages} :
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   pname = "git-review";
   version = "1.28.0";
 
@@ -15,7 +15,7 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "1hgw1dkl94m3idv4izc7wf2j7al2c7nnsqywy7g53nzkv9pfv47s";
   };
 
-  propagatedBuildInputs = with pythonPackages; [ pbr requests setuptools ];
+  propagatedBuildInputs = with python2Packages; [ pbr requests setuptools ];
 
   # Don't do tests because they require gerrit which is not packaged
   doCheck = false;

--- a/pkgs/applications/version-management/gitless/default.nix
+++ b/pkgs/applications/version-management/gitless/default.nix
@@ -1,6 +1,6 @@
-{ fetchFromGitHub, pythonPackages, stdenv }:
+{ fetchFromGitHub, python2Packages, stdenv }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   ver = "0.8.6";
   name = "gitless-${ver}";
 
@@ -11,7 +11,7 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "1q6y38f8ap6q1livvfy0pfnjr0l8b68hyhc9r5v87fmdyl7y7y8g";
   };
 
-  propagatedBuildInputs = with pythonPackages; [ sh pygit2 clint ];
+  propagatedBuildInputs = with python2Packages; [ sh pygit2 clint ];
 
   doCheck = false;
 

--- a/pkgs/applications/video/key-mon/default.nix
+++ b/pkgs/applications/video/key-mon/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, gnome2, librsvg, pythonPackages }:
+{ stdenv, fetchurl, gnome2, librsvg, python2Packages }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   name = "key-mon-${version}";
   version = "1.17";
   namePrefix = "";
@@ -11,7 +11,7 @@ pythonPackages.buildPythonApplication rec {
   };
 
   propagatedBuildInputs =
-    [ gnome2.python_rsvg librsvg pythonPackages.pygtk pythonPackages.xlib ];
+    [ gnome2.python_rsvg librsvg python2Packages.pygtk python2Packages.xlib ];
 
   doCheck = false;
 

--- a/pkgs/applications/video/recordmydesktop/gtk.nix
+++ b/pkgs/applications/video/recordmydesktop/gtk.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchsvn, recordmydesktop, autoreconfHook, pkgconfig
-, pythonPackages, jack2, xwininfo }:
+, python2Packages, jack2, xwininfo }:
 
 let
   binPath = lib.makeBinPath [ recordmydesktop jack2 xwininfo ];
@@ -16,11 +16,11 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
 
-  buildInputs = with pythonPackages; [
+  buildInputs = with python2Packages; [
     python pygtk wrapPython
   ];
 
-  pythonPath = with pythonPackages; [ pygtk ];
+  pythonPath = with python2Packages; [ pygtk ];
 
   postInstall = ''
     makeWrapperArgs="--prefix PATH : ${binPath}"

--- a/pkgs/applications/video/recordmydesktop/qt.nix
+++ b/pkgs/applications/video/recordmydesktop/qt.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchsvn, recordmydesktop, autoreconfHook, pkgconfig
-, glib, pythonPackages, qt4, jack2, xwininfo }:
+, glib, python2Packages, qt4, jack2, xwininfo }:
 
 let
   binPath = lib.makeBinPath [ recordmydesktop jack2 xwininfo ];
@@ -16,11 +16,11 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
 
-  buildInputs = [ glib qt4 ] ++ (with pythonPackages; [
+  buildInputs = [ glib qt4 ] ++ (with python2Packages; [
     python wrapPython pyqt4
   ]);
 
-  pythonPath = with pythonPackages; [ pyqt4 ];
+  pythonPath = with python2Packages; [ pyqt4 ];
 
   postInstall = ''
     makeWrapperArgs="--prefix PATH : ${binPath}"

--- a/pkgs/data/fonts/liberation-sans-narrow/default.nix
+++ b/pkgs/data/fonts/liberation-sans-narrow/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, fontforge, pythonPackages, python }:
+{ stdenv, fetchFromGitHub, fontforge, python2Packages, python }:
 
 stdenv.mkDerivation rec {
   pname = "liberation-sans-narrow";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "1qw554jbdnqkg6pjjl4cqkgsalq3398kzvww2naw30vykcz752bm";
   };
 
-  buildInputs = [ fontforge pythonPackages.fonttools python ];
+  buildInputs = [ fontforge python2Packages.fonttools python ];
 
   installPhase = ''
     mkdir -p $out/share/fonts/truetype

--- a/pkgs/data/fonts/noto-fonts/default.nix
+++ b/pkgs/data/fonts/noto-fonts/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, fetchFromGitHub, optipng, cairo, pythonPackages, pkgconfig, pngquant, which, imagemagick }:
+{ stdenv, fetchzip, fetchFromGitHub, optipng, cairo, python2Packages, pkgconfig, pngquant, which, imagemagick }:
 
 let
   mkNoto = { name, weights, sha256, }:
@@ -101,7 +101,7 @@ rec {
 
     buildInputs = [ cairo ];
     nativeBuildInputs = [ pngquant optipng which cairo pkgconfig imagemagick ]
-                     ++ (with pythonPackages; [ python fonttools nototools ]);
+                     ++ (with python2Packages; [ python fonttools nototools ]);
 
     postPatch = ''
       sed -i 's,^PNGQUANT :=.*,PNGQUANT := ${pngquant}/bin/pngquant,' Makefile

--- a/pkgs/desktops/deepin/dtkcore/default.nix
+++ b/pkgs/desktops/deepin/dtkcore/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pkgconfig, qmake, gsettings-qt, pythonPackages, deepin }:
+{ stdenv, fetchFromGitHub, pkgconfig, qmake, gsettings-qt, python2Packages, deepin }:
 
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkgconfig
     qmake
-    pythonPackages.wrapPython
+    python2Packages.wrapPython
     deepin.setupHook
   ];
 

--- a/pkgs/desktops/xfce/panel-plugins/xfce4-dockbarx-plugin.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-dockbarx-plugin.nix
@@ -1,5 +1,5 @@
 { stdenv, pkgconfig, fetchFromGitHub, python2, bash, vala
-, dockbarx, gtk2, xfce, pythonPackages, wafHook }:
+, dockbarx, gtk2, xfce, python2Packages, wafHook }:
 
 stdenv.mkDerivation rec {
   ver = "0.5";
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   pythonPath = [ dockbarx ];
 
   nativeBuildInputs = [ pkgconfig wafHook ];
-  buildInputs = [ python2 vala gtk2 pythonPackages.wrapPython ]
+  buildInputs = [ python2 vala gtk2 python2Packages.wrapPython ]
     ++ (with xfce; [ libxfce4util xfce4-panel xfconf xfce4-dev-tools ])
     ++ pythonPath;
 

--- a/pkgs/development/compilers/seexpr/default.nix
+++ b/pkgs/development/compilers/seexpr/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, cmake, libpng, zlib, qt4,
-bison, flex, libGLU, pythonPackages
+bison, flex, libGLU, python2Packages
 }:
 
 stdenv.mkDerivation rec {
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "0a44k56jf6dl36fwgg4zpc252wq5lf9cblg74mp73k82hxw439l4";
   };
 
-  buildInputs = [ cmake libGLU libpng zlib qt4 pythonPackages.pyqt4 bison flex ];
+  buildInputs = [ cmake libGLU libpng zlib qt4 python2Packages.pyqt4 bison flex ];
   meta = with stdenv.lib; {
     description = "Embeddable expression evaluation engine from Disney Animation";
     homepage = https://www.disneyanimation.com/technology/seexpr.html;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -757,7 +757,7 @@ self: super: {
         postPatch = ''
           substituteInPlace conf.py --replace "'.md': CommonMarkParser," ""
         '';
-        nativeBuildInputs = with pkgs.buildPackages.pythonPackages; [ sphinx recommonmark sphinx_rtd_theme ];
+        nativeBuildInputs = with pkgs.buildPackages.python2Packages; [ sphinx recommonmark sphinx_rtd_theme ];
         makeFlags = "html";
         installPhase = ''
           mv _build/html $out

--- a/pkgs/development/interpreters/hy/default.nix
+++ b/pkgs/development/interpreters/hy/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, fetchpatch, pythonPackages }:
+{ stdenv, fetchurl, fetchpatch, python2Packages }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   name = "hy-${version}";
   version = "0.16.0";
 
@@ -18,7 +18,7 @@ pythonPackages.buildPythonApplication rec {
     })
   ];
 
-  propagatedBuildInputs = with pythonPackages; [
+  propagatedBuildInputs = with python2Packages; [
     appdirs
     astor
     clint

--- a/pkgs/development/interpreters/renpy/default.nix
+++ b/pkgs/development/interpreters/renpy/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, fetchurl, pythonPackages, pkgconfig, SDL2
+{ stdenv, fetchurl, python2Packages, pkgconfig, SDL2
 , libpng, ffmpeg, freetype, glew, libGLU_combined, fribidi, zlib
 , glib
 }:
 
-with pythonPackages;
+with python2Packages;
 
 stdenv.mkDerivation rec {
   name = "renpy-${version}";

--- a/pkgs/development/libraries/farstream/default.nix
+++ b/pkgs/development/libraries/farstream/default.nix
@@ -1,10 +1,10 @@
-{ stdenv, fetchurl, libnice, pkgconfig, pythonPackages, gstreamer, gst-plugins-base
+{ stdenv, fetchurl, libnice, pkgconfig, python2Packages, gstreamer, gst-plugins-base
 , gst-python, gupnp-igd, gobject-introspection
 , gst-plugins-good, gst-plugins-bad, gst-libav
 }:
 
 let
-  inherit (pythonPackages) python pygobject2;
+  inherit (python2Packages) python pygobject2;
 in stdenv.mkDerivation rec {
   name = "farstream-0.2.8";
 

--- a/pkgs/development/libraries/gdal/gdal-1_11.nix
+++ b/pkgs/development/libraries/gdal/gdal-1_11.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, unzip, libjpeg, libtiff, zlib
-, postgresql, mysql57, libgeotiff, python, pythonPackages, proj, geos, openssl
+, postgresql, mysql57, libgeotiff, python, python2Packages, proj, geos, openssl
 , libpng }:
 
 stdenv.mkDerivation rec {
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "0hphxzvy23v3vqxx1y22hhhg4cypihrb8555y12nb4mrhzlw7zfl";
   };
 
-  buildInputs = [ unzip libjpeg libtiff libpng python pythonPackages.numpy proj openssl ];
+  buildInputs = [ unzip libjpeg libtiff libpng python python2Packages.numpy proj openssl ];
 
   patches = [
     # This ensures that the python package is installed into gdal's prefix,

--- a/pkgs/development/libraries/libgpod/default.nix
+++ b/pkgs/development/libraries/libgpod/default.nix
@@ -1,11 +1,11 @@
 {stdenv, lib, fetchurl, gettext, perlPackages, intltool, pkgconfig, glib,
   libxml2, sqlite, zlib, sg3_utils, gdk_pixbuf, taglib,
-  libimobiledevice, pythonPackages, mutagen,
+  libimobiledevice, python2Packages, mutagen,
   monoSupport ? false, mono, gtk-sharp-2_0
 }:
 
 let
-  inherit (pythonPackages) python pygobject2;
+  inherit (python2Packages) python pygobject2;
 in stdenv.mkDerivation rec {
   name = "libgpod-0.8.3";
   src = fetchurl {

--- a/pkgs/development/libraries/libindicate/default.nix
+++ b/pkgs/development/libraries/libindicate/default.nix
@@ -4,14 +4,14 @@
 , pkgconfig, autoconf
 , glib, dbus-glib, libdbusmenu
 , gtkVersion ? "3", gtk2 ? null, gtk3 ? null
-, pythonPackages, gobject-introspection, vala, gnome-doc-utils
+, python2Packages, gobject-introspection, vala, gnome-doc-utils
 , monoSupport ? false, mono ? null, gtk-sharp-2_0 ? null
  }:
 
 with lib;
 
 let
-  inherit (pythonPackages) python pygobject2 pygtk;
+  inherit (python2Packages) python pygobject2 pygtk;
 in stdenv.mkDerivation rec {
   name = let postfix = if gtkVersion == "2" && monoSupport then "sharp" else "gtk${gtkVersion}";
           in "libindicate-${postfix}-${version}";

--- a/pkgs/development/libraries/libvirt-glib/default.nix
+++ b/pkgs/development/libraries/libvirt-glib/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchurl, pkgconfig, libvirt, glib, libxml2, intltool, libtool, yajl
-, nettle, libgcrypt, pythonPackages, gobject-introspection, libcap_ng, numactl
+, nettle, libgcrypt, python2Packages, gobject-introspection, libcap_ng, numactl
 , xen, libapparmor, vala
 }:
 
 let
-  inherit (pythonPackages) python pygobject2;
+  inherit (python2Packages) python pygobject2;
 in stdenv.mkDerivation rec {
   name = "libvirt-glib-2.0.0";
 

--- a/pkgs/development/libraries/ndn-cxx/default.nix
+++ b/pkgs/development/libraries/ndn-cxx/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, openssl, doxygen
-, boost, sqlite, pkgconfig, python, pythonPackages, wafHook }:
+, boost, sqlite, pkgconfig, python, python2Packages, wafHook }:
 let
   version = "0.6.3";
 in
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
     sha256 = "076jhrjigisqz5n8dgxwd5fhimg69zhm834m7w9yvf9afgzrr50h";
   };
   nativeBuildInputs = [ pkgconfig wafHook ];
-  buildInputs = [ openssl doxygen boost sqlite python pythonPackages.sphinx];
+  buildInputs = [ openssl doxygen boost sqlite python python2Packages.sphinx];
   wafConfigureFlags = [
     "--with-openssl=${openssl.dev}"
     "--boost-includes=${boost.dev}/include"

--- a/pkgs/development/libraries/subunit/default.nix
+++ b/pkgs/development/libraries/subunit/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, check, cppunit, perl, pythonPackages }:
+{ stdenv, fetchurl, pkgconfig, check, cppunit, perl, python2Packages }:
 
 # NOTE: for subunit python library see pkgs/top-level/python-packages.nix
 
@@ -12,9 +12,9 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ check cppunit perl pythonPackages.wrapPython ];
+  buildInputs = [ check cppunit perl python2Packages.wrapPython ];
 
-  propagatedBuildInputs = with pythonPackages; [ testtools testscenarios ];
+  propagatedBuildInputs = with python2Packages; [ testtools testscenarios ];
 
   postFixup = "wrapPythonPrograms";
 

--- a/pkgs/development/tools/analysis/cpplint/default.nix
+++ b/pkgs/development/tools/analysis/cpplint/default.nix
@@ -1,6 +1,6 @@
-{ lib, pythonPackages, fetchFromGitHub }:
+{ lib, python2Packages, fetchFromGitHub }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   pname = "cpplint";
   version = "1.3.0";
 

--- a/pkgs/development/tools/build-managers/pants/default.nix
+++ b/pkgs/development/tools/build-managers/pants/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, pythonPackages }:
+{ stdenv, python2Packages }:
 
 with stdenv.lib;
-with pythonPackages;
+with python2Packages;
 
 buildPythonApplication rec {
   pname = "pantsbuild.pants";

--- a/pkgs/development/tools/castxml/default.nix
+++ b/pkgs/development/tools/castxml/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub
-, pythonPackages
+, python2Packages
 , cmake
 , llvmPackages
 , withMan ? true
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     cmake
     llvmPackages.clang-unwrapped
     llvmPackages.llvm
-  ] ++ stdenv.lib.optionals withMan [ pythonPackages.sphinx ];
+  ] ++ stdenv.lib.optionals withMan [ python2Packages.sphinx ];
 
   propagatedbuildInputs = [ llvmPackages.libclang ];
 

--- a/pkgs/development/tools/database/pyrseas/default.nix
+++ b/pkgs/development/tools/database/pyrseas/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, pythonPackages, fetchFromGitHub }:
+{ stdenv, python2Packages, fetchFromGitHub }:
 
 let
-  pgdbconn = pythonPackages.buildPythonPackage rec {
+  pgdbconn = python2Packages.buildPythonPackage rec {
     pname = "pgdbconn";
     version = "0.8.0";
     src = fetchFromGitHub {
@@ -13,13 +13,13 @@ let
     # The tests are impure (they try to access a PostgreSQL server)
     doCheck = false;
     propagatedBuildInputs = [
-      pythonPackages.psycopg2
-      pythonPackages.pytest
+      python2Packages.psycopg2
+      python2Packages.pytest
     ];
   };
 in
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   pname = "pyrseas";
   version = "0.8.0";
   src = fetchFromGitHub {
@@ -31,9 +31,9 @@ pythonPackages.buildPythonApplication rec {
   # The tests are impure (they try to access a PostgreSQL server)
   doCheck = false;
   propagatedBuildInputs = [
-    pythonPackages.psycopg2
-    pythonPackages.pytest
-    pythonPackages.pyyaml
+    python2Packages.psycopg2
+    python2Packages.pytest
+    python2Packages.pyyaml
     pgdbconn
   ];
   meta = {

--- a/pkgs/development/tools/devpi-client/default.nix
+++ b/pkgs/development/tools/devpi-client/default.nix
@@ -1,22 +1,22 @@
 { stdenv
-, pythonPackages
+, python2Packages
 , glibcLocales
 , devpi-server
 , git
 , mercurial
 } :
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   name = "${pname}-${version}";
   pname = "devpi-client";
   version = "4.1.0";
 
-  src = pythonPackages.fetchPypi {
+  src = python2Packages.fetchPypi {
     inherit pname version;
     sha256 = "0f5jkvxx9fl8v5vwbwmplqhjsdfgiib7j3zvn0zxd8krvi2s38fq";
   };
 
-  checkInputs = with pythonPackages; [
+  checkInputs = with python2Packages; [
                     pytest pytest-flakes webtest mock
                     devpi-server tox
                     sphinx wheel git mercurial detox
@@ -34,8 +34,8 @@ pythonPackages.buildPythonApplication rec {
   '';
 
   LC_ALL = "en_US.UTF-8";
-  buildInputs = with pythonPackages; [ glibcLocales pkginfo check-manifest ];
-  propagatedBuildInputs = with pythonPackages; [ py devpi-common pluggy setuptools ];
+  buildInputs = with python2Packages; [ glibcLocales pkginfo check-manifest ];
+  propagatedBuildInputs = with python2Packages; [ py devpi-common pluggy setuptools ];
 
   meta = with stdenv.lib; {
     homepage = http://doc.devpi.net;

--- a/pkgs/development/tools/devpi-server/default.nix
+++ b/pkgs/development/tools/devpi-server/default.nix
@@ -1,18 +1,18 @@
- { stdenv, pythonPackages, nginx }:
+ { stdenv, python2Packages, nginx }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   name = "${pname}-${version}";
   pname = "devpi-server";
   version = "4.4.0";
 
-  src = pythonPackages.fetchPypi {
+  src = python2Packages.fetchPypi {
     inherit pname version;
     sha256 = "0y77kcnk26pfid8vsw07v2k61x9sdl6wbmxg5qxnz3vd7703xpkl";
   };
 
-  propagatedBuildInputs = with pythonPackages;
+  propagatedBuildInputs = with python2Packages;
     [ devpi-common execnet itsdangerous pluggy waitress pyramid passlib ];
-  checkInputs = with pythonPackages; [ nginx webtest pytest beautifulsoup4 pytest-timeout mock pyyaml ];
+  checkInputs = with python2Packages; [ nginx webtest pytest beautifulsoup4 pytest-timeout mock pyyaml ];
   preCheck = ''
     # These tests pass with pytest 3.3.2 but not with pytest 3.4.0.
     sed -i 's/test_basic/noop/' test_devpi_server/test_log.py

--- a/pkgs/development/tools/grabserial/default.nix
+++ b/pkgs/development/tools/grabserial/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchgit, pythonPackages }:
+{ stdenv, fetchgit, python2Packages }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
 
   name = "grabserial-1.9.3";
   namePrefix = "";
@@ -11,7 +11,7 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "043r2p5jw0ymx8ka1d39q1ap39i7sliq5f4w3yr1n53lzshjmc5g";
   };
 
-  propagatedBuildInputs = [ pythonPackages.pyserial ];
+  propagatedBuildInputs = [ python2Packages.pyserial ];
 
   meta = {
     description = "Python based serial dump and timing program";

--- a/pkgs/development/tools/misc/blackmagic/default.nix
+++ b/pkgs/development/tools/misc/blackmagic/default.nix
@@ -1,6 +1,6 @@
 { stdenv, lib, fetchFromGitHub
 , gcc-arm-embedded, binutils-arm-embedded, libftdi
-, python, pythonPackages
+, python, python2Packages
 }:
 
 with lib;
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     libftdi
     python
-    pythonPackages.intelhex
+    python2Packages.intelhex
   ];
 
   postPatch = ''

--- a/pkgs/development/tools/misc/global/default.nix
+++ b/pkgs/development/tools/misc/global/default.nix
@@ -1,5 +1,5 @@
 { fetchurl, stdenv, libtool, makeWrapper
-, coreutils, ctags, ncurses, pythonPackages, sqlite, universal-ctags
+, coreutils, ctags, ncurses, python2Packages, sqlite, universal-ctags
 }:
 
 stdenv.mkDerivation rec {
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ncurses ];
 
-  propagatedBuildInputs = [ pythonPackages.pygments ];
+  propagatedBuildInputs = [ python2Packages.pygments ];
 
   configureFlags = [
     "--with-ltdl-include=${libtool}/include"
@@ -34,9 +34,9 @@ stdenv.mkDerivation rec {
     cp -v *.el "$out/share/emacs/site-lisp"
 
     wrapProgram $out/bin/gtags \
-      --prefix PYTHONPATH : "$(toPythonPath ${pythonPackages.pygments})"
+      --prefix PYTHONPATH : "$(toPythonPath ${python2Packages.pygments})"
     wrapProgram $out/bin/global \
-      --prefix PYTHONPATH : "$(toPythonPath ${pythonPackages.pygments})"
+      --prefix PYTHONPATH : "$(toPythonPath ${python2Packages.pygments})"
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/development/tools/misc/kconfig-frontends/default.nix
+++ b/pkgs/development/tools/misc/kconfig-frontends/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, bison, flex, gperf, ncurses, pythonPackages }:
+{ stdenv, fetchurl, pkgconfig, bison, flex, gperf, ncurses, python2Packages }:
 
 stdenv.mkDerivation rec {
   basename = "kconfig-frontends";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ bison flex gperf ncurses pythonPackages.python pythonPackages.wrapPython ];
+  buildInputs = [ bison flex gperf ncurses python2Packages.python python2Packages.wrapPython ];
 
   configureFlags = [
     "--enable-frontends=conf,mconf,nconf"

--- a/pkgs/development/tools/misc/universal-ctags/default.nix
+++ b/pkgs/development/tools/misc/universal-ctags/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, perl, pythonPackages, libiconv }:
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, perl, python2Packages, libiconv }:
 
 stdenv.mkDerivation rec {
   name = "universal-ctags-${version}";
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
     sha256 = "1f67hy8c2yr9z4ydsqd7wg8iagzn01qjw2ccx6g8mngv3i3jz9mv";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig pythonPackages.docutils ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig python2Packages.docutils ];
   buildInputs = stdenv.lib.optional stdenv.isDarwin libiconv;
 
   # to generate makefile.in

--- a/pkgs/development/tools/reno/default.nix
+++ b/pkgs/development/tools/reno/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, pythonPackages }:
+{ stdenv, fetchurl, python2Packages }:
 
-with pythonPackages; buildPythonApplication rec {
+with python2Packages; buildPythonApplication rec {
   name = "reno-${version}";
   version = "2.3.2";
 

--- a/pkgs/development/tools/winpdb/default.nix
+++ b/pkgs/development/tools/winpdb/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, pythonPackages, makeDesktopItem }:
+{ stdenv, fetchurl, python2Packages, makeDesktopItem }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   name = "winpdb-1.4.8";
   namePrefix = "";
 
@@ -9,7 +9,7 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "0vkpd24r40j928vc04c721innv0168sbllg97v4zw10adm24d8fs";
   };
 
-  propagatedBuildInputs = [ pythonPackages.wxPython ];
+  propagatedBuildInputs = [ python2Packages.wxPython ];
 
   desktopItem = makeDesktopItem {
     name = "winpdb";

--- a/pkgs/development/tools/ydiff/default.nix
+++ b/pkgs/development/tools/ydiff/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, lib, pythonPackages, python3Packages, less, patchutils, git
+{ stdenv, lib, python2Packages, python3Packages, less, patchutils, git
 , subversion, coreutils, which }:
 
-with pythonPackages;
+with python2Packages;
 
 buildPythonApplication rec {
   pname = "ydiff";

--- a/pkgs/misc/drivers/hplip/3.16.11.nix
+++ b/pkgs/misc/drivers/hplip/3.16.11.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, substituteAll
 , pkgconfig
-, cups, libjpeg, libusb1, pythonPackages, sane-backends, dbus, usbutils
+, cups, libjpeg, libusb1, python2Packages, sane-backends, dbus, usbutils
 , net_snmp, openssl, nettools
 , bash, coreutils, utillinux
 , qtSupport ? true
@@ -44,7 +44,7 @@ in
 assert withPlugin -> builtins.elem hplipArch pluginArches
   || throw "HPLIP plugin not supported on ${stdenv.hostPlatform.system}";
 
-pythonPackages.buildPythonApplication {
+python2Packages.buildPythonApplication {
   inherit name src;
   format = "other";
 
@@ -62,7 +62,7 @@ pythonPackages.buildPythonApplication {
     pkgconfig
   ];
 
-  pythonPath = with pythonPackages; [
+  pythonPath = with python2Packages; [
     dbus
     pillow
     pygobject2

--- a/pkgs/misc/drivers/hplip/default.nix
+++ b/pkgs/misc/drivers/hplip/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchurl, substituteAll
 , pkgconfig
-, cups, zlib, libjpeg, libusb1, pythonPackages, sane-backends
+, cups, zlib, libjpeg, libusb1, python2Packages, sane-backends
 , dbus, file, ghostscript, usbutils
 , net_snmp, openssl, perl, nettools
 , bash, coreutils, utillinux
@@ -46,7 +46,7 @@ in
 assert withPlugin -> builtins.elem hplipArch pluginArches
   || throw "HPLIP plugin not supported on ${stdenv.hostPlatform.system}";
 
-pythonPackages.buildPythonApplication {
+python2Packages.buildPythonApplication {
   inherit name src;
   format = "other";
 
@@ -68,7 +68,7 @@ pythonPackages.buildPythonApplication {
     pkgconfig
   ];
 
-  pythonPath = with pythonPackages; [
+  pythonPath = with python2Packages; [
     dbus
     pillow
     pygobject2

--- a/pkgs/misc/gnuk/generic.nix
+++ b/pkgs/misc/gnuk/generic.nix
@@ -1,5 +1,5 @@
 { stdenv, gcc-arm-embedded, binutils-arm-embedded, makeWrapper
-, python, pythonPackages
+, python, python2Packages
 
 # Extra options
 , device ? "fsij", vid ? "234b", pid ? "0000"
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
   inherit src;
 
   nativeBuildInputs = [ gcc-arm-embedded binutils-arm-embedded makeWrapper ];
-  buildInputs = [ python ] ++ (with pythonPackages; [ pyusb colorama ]);
+  buildInputs = [ python ] ++ (with python2Packages; [ pyusb colorama ]);
 
   configurePhase = ''
     cd src

--- a/pkgs/misc/solfege/default.nix
+++ b/pkgs/misc/solfege/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchurl, pkgconfig, pythonPackages, gettext, texinfo
+{ stdenv, fetchurl, pkgconfig, python2Packages, gettext, texinfo
 , ghostscript, librsvg, gdk_pixbuf, txt2man, timidity, mpg123
 , alsaUtils, vorbis-tools, csound, lilypond
 , makeWrapper
 }:
 
 let
-  inherit (pythonPackages) python pygtk;
+  inherit (python2Packages) python pygtk;
 in stdenv.mkDerivation rec {
   name = "solfege-3.22.2";
 

--- a/pkgs/os-specific/linux/pam_usb/default.nix
+++ b/pkgs/os-specific/linux/pam_usb/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, makeWrapper, dbus, libxml2, pam, pkgconfig, pmount, pythonPackages, writeScript, runtimeShell }:
+{ stdenv, fetchurl, makeWrapper, dbus, libxml2, pam, pkgconfig, pmount, python2Packages, writeScript, runtimeShell }:
 
 let
 
@@ -29,7 +29,7 @@ let
 
   pmountBin = useSetUID pmount "/bin/pmount";
   pumountBin = useSetUID pmount "/bin/pumount";
-  inherit (pythonPackages) python dbus-python;
+  inherit (python2Packages) python dbus-python;
 in
 
 stdenv.mkDerivation rec {

--- a/pkgs/os-specific/linux/speedometer/default.nix
+++ b/pkgs/os-specific/linux/speedometer/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, lib, fetchurl, pythonPackages }:
+{ stdenv, lib, fetchurl, python2Packages }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   name = "speedometer-${version}";
   version = "2.8";
 
@@ -9,7 +9,7 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "060bikv3gwr203jbdmvawsfhc0yq0bg1m42dk8czx1nqvwvgv6fm";
   };
 
-  propagatedBuildInputs = [ pythonPackages.urwid ];
+  propagatedBuildInputs = [ python2Packages.urwid ];
 
   postPatch = ''
     sed -i "/'entry_points': {/d" setup.py

--- a/pkgs/servers/couchpotato/default.nix
+++ b/pkgs/servers/couchpotato/default.nix
@@ -1,6 +1,6 @@
-{ fetchurl, pythonPackages, lib }:
+{ fetchurl, python2Packages, lib }:
 
-with pythonPackages;
+with python2Packages;
 
 buildPythonApplication rec {
   name = "couchpotato-${version}";

--- a/pkgs/servers/kippo/default.nix
+++ b/pkgs/servers/kippo/default.nix
@@ -25,14 +25,14 @@
 #
 # Use this package at your own risk.
 
-{stdenv, fetchurl, pythonPackages }:
+{stdenv, fetchurl, python2Packages }:
 
 let
 
-  twisted_13 = pythonPackages.buildPythonPackage rec {
+  twisted_13 = python2Packages.buildPythonPackage rec {
     # NOTE: When updating please check if new versions still cause issues
     # to packages like carbon (http://stackoverflow.com/questions/19894708/cant-start-carbon-12-04-python-error-importerror-cannot-import-name-daem)
-    disabled = pythonPackages.isPy3k;
+    disabled = python2Packages.isPy3k;
 
     name = "Twisted-13.2.0";
     src = fetchurl {
@@ -40,7 +40,7 @@ let
       sha256 = "1wrcqv5lvgwk2aq83qb2s2ng2vx14hbjjk2gc30cg6h1iiipal89";
     };
 
-    propagatedBuildInputs = with pythonPackages; [ zope_interface ];
+    propagatedBuildInputs = with python2Packages; [ zope_interface ];
 
     # Generate Twisted's plug-in cache.  Twited users must do it as well.  See
     # http://twistedmatrix.com/documents/current/core/howto/plugin.html#auto3
@@ -66,7 +66,7 @@ in stdenv.mkDerivation rec {
       url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/kippo/${name}.tar.gz";
       sha256 = "0rd2mk36d02qd24z8s4xyy64fy54rzpar4379iq4dcjwg7l7f63d";
     };
-    buildInputs = with pythonPackages; [ pycrypto pyasn1 twisted_13 ];
+    buildInputs = with python2Packages; [ pycrypto pyasn1 twisted_13 ];
     installPhase = ''
         substituteInPlace ./kippo.tac --replace "kippo.cfg" "$out/src/kippo.cfg"
         substituteInPlace ./kippo.cfg --replace "log_path = log" "log_path = /var/log/kippo" \

--- a/pkgs/servers/neard/default.nix
+++ b/pkgs/servers/neard/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, autoreconfHook, pkgconfig, systemd, glib, dbus, libnl, pythonPackages }:
+{ stdenv, fetchurl, autoreconfHook, pkgconfig, systemd, glib, dbus, libnl, python2Packages }:
 
 stdenv.mkDerivation rec {
   name = "neard-0.16";
@@ -9,8 +9,8 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
-  buildInputs = [ systemd glib dbus libnl pythonPackages.python pythonPackages.wrapPython ];
-  pythonPath = [ pythonPackages.pygobject2 pythonPackages.dbus-python pythonPackages.pygtk ];
+  buildInputs = [ systemd glib dbus libnl python2Packages.python python2Packages.wrapPython ];
+  pythonPath = [ python2Packages.pygobject2 python2Packages.dbus-python python2Packages.pygtk ];
 
   configureFlags = [ "--disable-debug" "--enable-tools" "--enable-ese" "--with-systemdsystemunitdir=$out/lib/systemd/system" ];
 

--- a/pkgs/servers/radicale/1.x.nix
+++ b/pkgs/servers/radicale/1.x.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, pythonPackages }:
+{ stdenv, fetchurl, python2Packages }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   name = "radicale-${version}";
   version = "1.1.6";
 
@@ -9,13 +9,13 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "0ay90nj6fmr2aq8imi0mbjl4m2rzq7a83ikj8qs9gxsylj71j1y0";
   };
 
-  propagatedBuildInputs = stdenv.lib.optionals (!pythonPackages.isPy3k) [
-    pythonPackages.flup
-    pythonPackages.ldap
-    pythonPackages.sqlalchemy
+  propagatedBuildInputs = stdenv.lib.optionals (!python2Packages.isPy3k) [
+    python2Packages.flup
+    python2Packages.ldap
+    python2Packages.sqlalchemy
   ];
 
-  doCheck = !pythonPackages.isPy3k;
+  doCheck = !python2Packages.isPy3k;
 
   meta = with stdenv.lib; {
     homepage = http://www.radicale.org/;

--- a/pkgs/servers/xmpp/pyIRCt/default.nix
+++ b/pkgs/servers/xmpp/pyIRCt/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, xmpppy, pythonIRClib, python, pythonPackages, runtimeShell } :
+{ stdenv, fetchurl, xmpppy, pythonIRClib, python, python2Packages, runtimeShell } :
 
 stdenv.mkDerivation rec {
   name = "pyIRCt-${version}";
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
     sha256 = "0gbc0dvj1p3088b6x315yjrlwnc5vvzp0var36wlf9z60ghvk8yb";
   };
 
-  buildInputs = [ pythonPackages.wrapPython ];
+  buildInputs = [ python2Packages.wrapPython ];
 
   pythonPath = [
     xmpppy pythonIRClib

--- a/pkgs/servers/xmpp/pyMAILt/default.nix
+++ b/pkgs/servers/xmpp/pyMAILt/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, python, xmpppy, pythonPackages, fetchcvs, runtimeShell } :
+{ stdenv, python, xmpppy, python2Packages, fetchcvs, runtimeShell } :
 
 stdenv.mkDerivation rec {
   name = "pyMAILt-${version}";
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 	};
 
   pythonPath = [ xmpppy ];
-  buildInputs = [ pythonPackages.wrapPython ];
+  buildInputs = [ python2Packages.wrapPython ];
 
   /* doConfigure should be removed if not needed */
   installPhase = ''

--- a/pkgs/tools/X11/oblogout/default.nix
+++ b/pkgs/tools/X11/oblogout/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, intltool, file, pythonPackages, cairo }:
+{ stdenv, fetchFromGitHub, intltool, file, python2Packages, cairo }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   name = "oblogout-unstable-${version}";
   version = "2009-11-18";
 
@@ -11,16 +11,16 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "0nj87q94idb5ki4wnb2xipfgc6k6clr3rmm4xxh46b58z4zhhbmj";
   };
 
-  nativeBuildInputs = [ intltool file pythonPackages.distutils_extra ];
+  nativeBuildInputs = [ intltool file python2Packages.distutils_extra ];
 
   buildInputs = [ cairo ];
 
-  propagatedBuildInputs = [ pythonPackages.pygtk pythonPackages.pillow pythonPackages.dbus-python ];
+  propagatedBuildInputs = [ python2Packages.pygtk python2Packages.pillow python2Packages.dbus-python ];
 
   patches = [ ./oblogout-0.3-fixes.patch ];
 
   postPatch = ''
-    substituteInPlace data/oblogout --replace sys.prefix \"$out/${pythonPackages.python.sitePackages}\"
+    substituteInPlace data/oblogout --replace sys.prefix \"$out/${python2Packages.python.sitePackages}\"
     substituteInPlace oblogout/__init__.py --replace sys.prefix \"$out\"
     mkdir -p $out/share/doc
     cp -a README $out/share/doc

--- a/pkgs/tools/X11/winswitch/default.nix
+++ b/pkgs/tools/X11/winswitch/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchurl, pythonPackages
+{ stdenv, fetchurl, python2Packages
 , which, xpra, xmodmap }:
 
 let
-  base = pythonPackages.buildPythonApplication rec {
+  base = python2Packages.buildPythonApplication rec {
     name = "winswitch-${version}";
     namePrefix = "";
     version = "0.12.23";
@@ -12,7 +12,7 @@ let
       sha256 = "1m0akjcdlsgng426rwvzlcl76kjm993icj0pggvha40cizig1yd9";
     };
 
-    propagatedBuildInputs = with pythonPackages; [
+    propagatedBuildInputs = with python2Packages; [
       pygtk twisted pycrypto pyasn1 which xpra xmodmap
     ];
 

--- a/pkgs/tools/admin/salt/default.nix
+++ b/pkgs/tools/admin/salt/default.nix
@@ -1,21 +1,21 @@
 {
-  stdenv, pythonPackages, openssl,
+  stdenv, python2Packages, openssl,
 
   # Many Salt modules require various Python modules to be installed,
   # passing them in this array enables Salt to find them.
   extraInputs ? []
 }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   pname = "salt";
   version = "2019.2.0";
 
-  src = pythonPackages.fetchPypi {
+  src = python2Packages.fetchPypi {
     inherit pname version;
     sha256 = "1kgn3lway0zwwysyzpphv05j4xgxk92dk4rv1vybr2527wmvp5an";
   };
 
-  propagatedBuildInputs = with pythonPackages; [
+  propagatedBuildInputs = with python2Packages; [
     jinja2
     markupsafe
     msgpack
@@ -24,7 +24,7 @@ pythonPackages.buildPythonApplication rec {
     pyzmq
     requests
     tornado_4
-  ] ++ stdenv.lib.optional (!pythonPackages.isPy3k) [
+  ] ++ stdenv.lib.optional (!python2Packages.isPy3k) [
     futures
   ] ++ extraInputs;
 

--- a/pkgs/tools/admin/salt/pepper/default.nix
+++ b/pkgs/tools/admin/salt/pepper/default.nix
@@ -1,18 +1,18 @@
 { lib
-, pythonPackages
+, python2Packages
 , salt
 }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   pname = "salt-pepper";
   version = "0.7.5";
-  src = pythonPackages.fetchPypi {
+  src = python2Packages.fetchPypi {
     inherit pname version;
     sha256 = "1wh6yidwdk8jvjpr5g3azhqgsk24c5rlzmw6l86dmi0mpvmxm94w";
   };
 
-  buildInputs = with pythonPackages; [ setuptools setuptools_scm salt ];
-  checkInputs = with pythonPackages; [
+  buildInputs = with python2Packages; [ setuptools setuptools_scm salt ];
+  checkInputs = with python2Packages; [
     pytest mock pyzmq pytest-rerunfailures pytestcov cherrypy tornado_4
   ];
 

--- a/pkgs/tools/admin/vncdo/default.nix
+++ b/pkgs/tools/admin/vncdo/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub
-, pythonPackages
+, python2Packages
 }:
-pythonPackages.buildPythonPackage rec {
+python2Packages.buildPythonPackage rec {
   pname = "vncdo";
   version = "0.11.2";
   name = "${pname}-${version}";
@@ -13,7 +13,7 @@ pythonPackages.buildPythonPackage rec {
     sha256 = "0k03b09ipsz8vp362x7sx7z68mxgqw9qzvkii2f8j9vx2y79rjsh";
   };
 
-  propagatedBuildInputs = with pythonPackages; [
+  propagatedBuildInputs = with python2Packages; [
     pillow
     twisted
     pexpect

--- a/pkgs/tools/audio/mpdris2/default.nix
+++ b/pkgs/tools/audio/mpdris2/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, autoreconfHook, intltool
-, pythonPackages
+, python2Packages
 }:
 
 stdenv.mkDerivation rec {
@@ -17,9 +17,9 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [ intltool pythonPackages.wrapPython ];
-  propagatedBuildInputs = with pythonPackages; [ python pygtk dbus-python  ];
-  pythonPath = with pythonPackages; [ mpd pygtk dbus-python notify mutagen ];
+  buildInputs = [ intltool python2Packages.wrapPython ];
+  propagatedBuildInputs = with python2Packages; [ python pygtk dbus-python  ];
+  pythonPath = with python2Packages; [ mpd pygtk dbus-python notify mutagen ];
   postInstall = "wrapPythonPrograms";
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/backup/wal-e/default.nix
+++ b/pkgs/tools/backup/wal-e/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, pythonPackages, lzop, postgresql, pv }:
+{ stdenv, fetchurl, python2Packages, lzop, postgresql, pv }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   name = "wal-e-${version}";
   version = "0.6.10";
 
@@ -15,8 +15,8 @@ pythonPackages.buildPythonApplication rec {
   doCheck = false;
 
   propagatedBuildInputs = [
-    pythonPackages.boto
-    pythonPackages.gevent
+    python2Packages.boto
+    python2Packages.gevent
     postgresql
     lzop
     pv

--- a/pkgs/tools/compression/dtrx/default.nix
+++ b/pkgs/tools/compression/dtrx/default.nix
@@ -1,4 +1,4 @@
-{stdenv, lib, fetchurl, pythonPackages
+{stdenv, lib, fetchurl, python2Packages
 , gnutar, unzip, lhasa, rpm, binutils, cpio, gzip, p7zip, cabextract, unrar, unshield
 , bzip2, xz, lzip
 # unzip is handled by p7zip
@@ -11,7 +11,7 @@ let
   ++ lib.optional (unrarSupport) unrar
   ++ [ bzip2 xz lzip ]);
 
-in pythonPackages.buildPythonApplication rec {
+in python2Packages.buildPythonApplication rec {
   name = "dtrx-${version}";
   version = "7.1";
 

--- a/pkgs/tools/filesystems/bees/default.nix
+++ b/pkgs/tools/filesystems/bees/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, runCommand, makeWrapper, fetchFromGitHub, bash, btrfs-progs, coreutils, pythonPackages, utillinux }:
+{ stdenv, runCommand, makeWrapper, fetchFromGitHub, bash, btrfs-progs, coreutils, python2Packages, utillinux }:
 
 let
 
@@ -22,7 +22,7 @@ let
     ];
 
     nativeBuildInputs = [
-      pythonPackages.markdown   # documentation build
+      python2Packages.markdown   # documentation build
     ];
 
     preBuild = ''

--- a/pkgs/tools/filesystems/mergerfs/tools.nix
+++ b/pkgs/tools/filesystems/mergerfs/tools.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, coreutils, makeWrapper
-, rsync, python3, pythonPackages }:
+, rsync, python3, python2Packages }:
 
 stdenv.mkDerivation rec {
   name = "mergerfs-tools-${version}";
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   postInstall = with stdenv.lib; ''
     wrapProgram $out/bin/mergerfs.balance --prefix PATH : ${makeBinPath [ rsync ]}
     wrapProgram $out/bin/mergerfs.dup --prefix PATH : ${makeBinPath [ rsync ]}
-    wrapProgram $out/bin/mergerfs.mktrash --prefix PATH : ${makeBinPath [ pythonPackages.xattr ]}
+    wrapProgram $out/bin/mergerfs.mktrash --prefix PATH : ${makeBinPath [ python2Packages.xattr ]}
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/misc/i3minator/default.nix
+++ b/pkgs/tools/misc/i3minator/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, pythonPackages, glibcLocales }:
+{ stdenv, fetchFromGitHub, python2Packages, glibcLocales }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   name = "i3minator-${version}";
   version = "0.0.4";
 
@@ -13,7 +13,7 @@ pythonPackages.buildPythonApplication rec {
 
   LC_ALL = "en_US.UTF-8";
   buildInputs = [ glibcLocales ];
-  propagatedBuildInputs = [ pythonPackages.pyyaml pythonPackages.i3-py ];
+  propagatedBuildInputs = [ python2Packages.pyyaml python2Packages.i3-py ];
 
   # No tests
   doCheck = false;

--- a/pkgs/tools/misc/ntfy/default.nix
+++ b/pkgs/tools/misc/ntfy/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, pythonPackages, fetchFromGitHub }:
+{ stdenv, python2Packages, fetchFromGitHub }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   pname = "ntfy";
   version = "2.7.0";
 
@@ -11,11 +11,11 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "09f02cn4i1l2aksb3azwfb70axqhn7d0d0vl2r6640hqr74nc1cv";
   };
 
-  checkInputs = with pythonPackages; [
+  checkInputs = with python2Packages; [
     mock
   ];
 
-  propagatedBuildInputs = with pythonPackages; [
+  propagatedBuildInputs = with python2Packages; [
     requests ruamel_yaml appdirs
     sleekxmpp dns
     emoji
@@ -25,7 +25,7 @@ pythonPackages.buildPythonApplication rec {
   ];
 
   checkPhase = ''
-    HOME=$(mktemp -d) ${pythonPackages.python.interpreter} setup.py test
+    HOME=$(mktemp -d) ${python2Packages.python.interpreter} setup.py test
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/tools/misc/togglesg-download/default.nix
+++ b/pkgs/tools/misc/togglesg-download/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, lib, fetchFromGitHub, pythonPackages, makeWrapper, ffmpeg_3 }:
+{ stdenv, lib, fetchFromGitHub, python2Packages, makeWrapper, ffmpeg_3 }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
 
   name = "togglesg-download-git-${version}";
   version = "2017-12-07";

--- a/pkgs/tools/misc/venus/default.nix
+++ b/pkgs/tools/misc/venus/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, python, pythonPackages, libxslt, libxml2, makeWrapper }:
+{ stdenv, fetchurl, python, python2Packages, libxslt, libxml2, makeWrapper }:
 
 let
   rev = "9de21094a8cf565bdfcf75688e121a5ad1f5397b";
@@ -29,14 +29,14 @@ stdenv.mkDerivation rec {
   checkPhase = "python runtests.py";
 
   buildInputs = [ python libxslt
-    libxml2 pythonPackages.genshi pythonPackages.lxml makeWrapper ];
+    libxml2 python2Packages.genshi python2Packages.lxml makeWrapper ];
 
   installPhase = ''
     mkdir -p $out/bin
     cp -R ./* $out/
     ln -s $out/planet.py $out/bin/venus-planet
     wrapProgram $out/planet.py \
-        --prefix PYTHONPATH : $PYTHONPATH:${pythonPackages.lxml}/lib/${python.libPrefix}/site-packages:${pythonPackages.genshi}/lib/${python.libPrefix}/site-packages
+        --prefix PYTHONPATH : $PYTHONPATH:${python2Packages.lxml}/lib/${python.libPrefix}/site-packages:${python2Packages.genshi}/lib/${python.libPrefix}/site-packages
     python runtests.py
   '';
 

--- a/pkgs/tools/misc/xflux/gui.nix
+++ b/pkgs/tools/misc/xflux/gui.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchFromGitHub, pythonPackages
+{ stdenv, fetchFromGitHub, python2Packages
 , gnome_python
 , libappindicator-gtk2, xflux, librsvg, wrapGAppsHook
 }:
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   name = "xflux-gui-${version}";
   version = "1.1.10";
 
@@ -13,7 +13,7 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "1k67qg9y4c0n9ih0syx81ixbdl2x89gd4arwh71316cshskn0rc8";
   };
 
-  propagatedBuildInputs = with pythonPackages; [
+  propagatedBuildInputs = with python2Packages; [
     pexpect
     pyGtkGlade
     pygobject2
@@ -33,7 +33,7 @@ pythonPackages.buildPythonApplication rec {
   postFixup = ''
     wrapGAppsHook
     wrapPythonPrograms
-    patchPythonScript $out/${pythonPackages.python.sitePackages}/fluxgui/fluxapp.py
+    patchPythonScript $out/${python2Packages.python.sitePackages}/fluxgui/fluxapp.py
   '';
 
   meta = {

--- a/pkgs/tools/misc/yle-dl/default.nix
+++ b/pkgs/tools/misc/yle-dl/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, rtmpdump, php, pythonPackages, ffmpeg }:
+{ stdenv, fetchFromGitHub, rtmpdump, php, python2Packages, ffmpeg }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   name = "yle-dl-${version}";
   version = "2.31";
 
@@ -11,11 +11,11 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "0k93p9csyjm0w33diwl5s22kzs3g78jl3n9k8nxxpqrybfjl912f";
   };
 
-  propagatedBuildInputs = with pythonPackages; [ lxml pyamf pycrypto requests future ffmpeg ];
+  propagatedBuildInputs = with python2Packages; [ lxml pyamf pycrypto requests future ffmpeg ];
   pythonPath = [ rtmpdump php ];
 
   doCheck = false; # tests require network access
-  checkInputs = with pythonPackages; [ pytest pytestrunner ];
+  checkInputs = with python2Packages; [ pytest pytestrunner ];
 
   meta = with stdenv.lib; {
     description = "Downloads videos from Yle (Finnish Broadcasting Company) servers";

--- a/pkgs/tools/networking/carddav-util/default.nix
+++ b/pkgs/tools/networking/carddav-util/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, python, pythonPackages, makeWrapper }:
+{ stdenv, fetchgit, python, python2Packages, makeWrapper }:
 
 stdenv.mkDerivation rec {
 
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [makeWrapper];
 
-  propagatedBuildInputs = with pythonPackages; [ requests vobject lxml ];
+  propagatedBuildInputs = with python2Packages; [ requests vobject lxml ];
 
   doCheck = false; # no test
 

--- a/pkgs/tools/networking/connman/connman-notify/default.nix
+++ b/pkgs/tools/networking/connman/connman-notify/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pythonPackages, makeWrapper }:
+{ stdenv, fetchFromGitHub, python2Packages, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "connman-notify-${version}";
@@ -14,11 +14,11 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ makeWrapper ];
 
   buildInputs = [
-    pythonPackages.python
-    pythonPackages.dbus-python
-    pythonPackages.pygobject2
-    pythonPackages.pygtk
-    pythonPackages.notify
+    python2Packages.python
+    python2Packages.dbus-python
+    python2Packages.pygobject2
+    python2Packages.pygtk
+    python2Packages.notify
   ];
 
   installPhase = ''

--- a/pkgs/tools/networking/gmvault/default.nix
+++ b/pkgs/tools/networking/gmvault/default.nix
@@ -1,6 +1,6 @@
-{ pkgs, fetchurl, pythonPackages }:
+{ pkgs, fetchurl, python2Packages }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   version = "1.9.1";
   name = "gmvault-${version}";
 
@@ -12,7 +12,7 @@ pythonPackages.buildPythonApplication rec {
 
   doCheck = false;
 
-  propagatedBuildInputs = with pythonPackages; [ gdata IMAPClient Logbook chardet ];
+  propagatedBuildInputs = with python2Packages; [ gdata IMAPClient Logbook chardet ];
 
   startScript = ./gmvault.py;
 

--- a/pkgs/tools/networking/http-prompt/default.nix
+++ b/pkgs/tools/networking/http-prompt/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, pythonPackages, httpie }:
+{ stdenv, fetchFromGitHub, python2Packages, httpie }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   pname = "http-prompt";
   version = "1.0.0";
   name = "${pname}-${version}";
@@ -12,7 +12,7 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "0kngz2izcqjphbrdkg489p0xmf65xjc8ki1a2szcc8sgwc7z74xy";
   };
 
-  propagatedBuildInputs = with pythonPackages; [
+  propagatedBuildInputs = with python2Packages; [
     click
     httpie
     parsimonious

--- a/pkgs/tools/networking/httpie/default.nix
+++ b/pkgs/tools/networking/httpie/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, pythonPackages }:
+{ stdenv, fetchurl, python2Packages }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   name = "httpie-1.0.2";
 
   src = fetchurl {
@@ -8,7 +8,7 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "1ax22jh5lpjywpj7lsl072wdhr1pxiqzmxhyph5diwxxzs2nqrzw";
   };
 
-  propagatedBuildInputs = with pythonPackages; [ pygments requests ];
+  propagatedBuildInputs = with python2Packages; [ pygments requests ];
 
   doCheck = false;
 

--- a/pkgs/tools/networking/httpstat/default.nix
+++ b/pkgs/tools/networking/httpstat/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, curl, pythonPackages, glibcLocales }:
+{ stdenv, fetchFromGitHub, curl, python2Packages, glibcLocales }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
     name = "${pname}-${version}";
     pname = "httpstat";
     version = "1.2.1";

--- a/pkgs/tools/networking/ipgrep/default.nix
+++ b/pkgs/tools/networking/ipgrep/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, pythonPackages, makeWrapper }:
+{ stdenv, fetchFromGitHub, python2Packages, makeWrapper }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   version = "1.0";
   pname = "ipgrep";
 
@@ -17,7 +17,7 @@ pythonPackages.buildPythonApplication rec {
       --replace "'scripts': []" "'scripts': { '${pname}.py' }"
   '';
 
-  propagatedBuildInputs = with pythonPackages; [
+  propagatedBuildInputs = with python2Packages; [
     pycares
     urllib3
     requests

--- a/pkgs/tools/networking/nyx/default.nix
+++ b/pkgs/tools/networking/nyx/default.nix
@@ -1,6 +1,6 @@
-{ lib, pythonPackages }:
+{ lib, python2Packages }:
 
-with pythonPackages;
+with python2Packages;
 
 buildPythonApplication rec {
   pname = "nyx";

--- a/pkgs/tools/networking/p2p/tahoe-lafs/default.nix
+++ b/pkgs/tools/networking/p2p/tahoe-lafs/default.nix
@@ -1,11 +1,11 @@
-{ fetchurl, lib, unzip, nettools, pythonPackages, texinfo }:
+{ fetchurl, lib, unzip, nettools, python2Packages, texinfo }:
 
 # FAILURES: The "running build_ext" phase fails to compile Twisted
 # plugins, because it tries to write them into Twisted's (immutable)
 # store path. The problem appears to be non-fatal, but there's probably
 # some loss of functionality because of it.
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   version = "1.13.0";
   name = "tahoe-lafs-${version}";
   namePrefix = "";
@@ -48,16 +48,16 @@ pythonPackages.buildPythonApplication rec {
     )
   '';
 
-  nativeBuildInputs = with pythonPackages; [ sphinx texinfo ];
+  nativeBuildInputs = with python2Packages; [ sphinx texinfo ];
 
   # The `backup' command requires `sqlite3'.
-  propagatedBuildInputs = with pythonPackages; [
+  propagatedBuildInputs = with python2Packages; [
     twisted foolscap nevow simplejson zfec pycryptopp darcsver
     setuptoolsTrial setuptoolsDarcs pycrypto pyasn1 zope_interface
     service-identity pyyaml magic-wormhole treq
   ];
 
-  checkInputs = with pythonPackages; [ mock hypothesis twisted ];
+  checkInputs = with python2Packages; [ mock hypothesis twisted ];
 
   # Install the documentation.
   postInstall = ''

--- a/pkgs/tools/networking/photon/default.nix
+++ b/pkgs/tools/networking/photon/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, pythonPackages, fetchurl, makeWrapper }:
+{ stdenv, python2Packages, fetchurl, makeWrapper }:
 
-with pythonPackages;
+with python2Packages;
 buildPythonApplication rec {
   pname = "photon";
   version = "1.0.7";

--- a/pkgs/tools/networking/pssh/default.nix
+++ b/pkgs/tools/networking/pssh/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, pythonPackages, openssh, rsync }:
+{ stdenv, fetchFromGitHub, python2Packages, openssh, rsync }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   name = "pssh-${version}";
   version = "2.3.1";
 

--- a/pkgs/tools/networking/yrd/default.nix
+++ b/pkgs/tools/networking/yrd/default.nix
@@ -1,11 +1,11 @@
-{ stdenv, fetchFromGitHub, pythonPackages }:
+{ stdenv, fetchFromGitHub, python2Packages }:
 
 let
   pname = "yrd";
   version = "0.5.3";
   sha256 = "1yx1hr8z4cvlb3yi24dwafs0nxq41k4q477jc9q24w61a0g662ps";
 
-in pythonPackages.buildPythonApplication {
+in python2Packages.buildPythonApplication {
   name = "${pname}-${version}";
 
   src = fetchFromGitHub {
@@ -15,7 +15,7 @@ in pythonPackages.buildPythonApplication {
     inherit sha256;
   };
 
-  propagatedBuildInputs = with pythonPackages; [ argh ];
+  propagatedBuildInputs = with python2Packages; [ argh ];
 
   meta = with stdenv.lib; {
     description = "Cjdns swiss army knife";

--- a/pkgs/tools/package-management/python2nix/default.nix
+++ b/pkgs/tools/package-management/python2nix/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, pythonPackages }:
+{ stdenv, fetchFromGitHub, python2Packages }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   name = "python2nix-20140927";
  
   src = fetchFromGitHub {
@@ -10,7 +10,7 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "022gr0gw6azfi3iq4ggb3fhkw2jljs6n5rncn45hb5liwakigj8i";
   };
 
-  propagatedBuildInputs = with pythonPackages; [ requests pip setuptools ];
+  propagatedBuildInputs = with python2Packages; [ requests pip setuptools ];
 
   meta = with stdenv.lib; {
     maintainers = [ maintainers.domenkozar ];

--- a/pkgs/tools/security/diceware/default.nix
+++ b/pkgs/tools/security/diceware/default.nix
@@ -1,8 +1,8 @@
 { lib
-, pythonPackages
+, python2Packages
 }:
 
-with pythonPackages;
+with python2Packages;
 
 buildPythonApplication rec {
   pname = "diceware";

--- a/pkgs/tools/security/enpass/default.nix
+++ b/pkgs/tools/security/enpass/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, dpkg, xorg
 , glib, libGLU_combined, libpulseaudio, zlib, dbus, fontconfig, freetype
 , gtk3, pango
-, makeWrapper , python, pythonPackages, lib
+, makeWrapper , python, python2Packages, lib
 , lsof, curl, libuuid, cups, mesa_drivers
 }:
 
@@ -84,7 +84,7 @@ let
       name = "enpass-update-script";
       SCRIPT =./update_script.py;
 
-      buildInputs = with pythonPackages; [python requests pathlib2 six attrs ];
+      buildInputs = with python2Packages; [python requests pathlib2 six attrs ];
       shellHook = ''
       exec python $SCRIPT --target pkgs/tools/security/enpass/data.json --repo ${baseUrl}
       '';

--- a/pkgs/tools/security/fail2ban/default.nix
+++ b/pkgs/tools/security/fail2ban/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchFromGitHub, python, pythonPackages, gamin }:
+{ stdenv, fetchFromGitHub, python, python2Packages, gamin }:
 
 let version = "0.10.4"; in
 
-pythonPackages.buildPythonApplication {
+python2Packages.buildPythonApplication {
   name = "fail2ban-${version}";
 
   src = fetchFromGitHub {
@@ -13,7 +13,7 @@ pythonPackages.buildPythonApplication {
   };
 
   propagatedBuildInputs = [ gamin ]
-    ++ (stdenv.lib.optional stdenv.isLinux pythonPackages.systemd);
+    ++ (stdenv.lib.optional stdenv.isLinux python2Packages.systemd);
 
   preConfigure = ''
     for i in config/action.d/sendmail*.conf; do

--- a/pkgs/tools/security/hash-slinger/default.nix
+++ b/pkgs/tools/security/hash-slinger/default.nix
@@ -1,7 +1,7 @@
-{ stdenv, fetchFromGitHub, pythonPackages, unbound, libreswan }:
+{ stdenv, fetchFromGitHub, python2Packages, unbound, libreswan }:
 
 let
-  inherit (pythonPackages) python;
+  inherit (python2Packages) python;
 in stdenv.mkDerivation rec {
   pname    = "hash-slinger";
   name    = "${pname}-${version}";
@@ -14,10 +14,10 @@ in stdenv.mkDerivation rec {
     sha256 = "05wn744ydclpnpyah6yfjqlfjlasrrhzj48lqmm5a91nyps5yqyn";
   };
 
-  pythonPath = with pythonPackages; [ dnspython m2crypto ipaddr python-gnupg
+  pythonPath = with python2Packages; [ dnspython m2crypto ipaddr python-gnupg
                                       pyunbound ];
 
-  buildInputs = [ pythonPackages.wrapPython ];
+  buildInputs = [ python2Packages.wrapPython ];
   propagatedBuildInputs = [ unbound libreswan ] ++ pythonPath;
   propagatedUserEnvPkgs = [ unbound libreswan ];
 
@@ -27,7 +27,7 @@ in stdenv.mkDerivation rec {
     substituteInPlace ipseckey \
       --replace "/usr/sbin/ipsec" "${libreswan}/sbin/ipsec"
     substituteInPlace tlsa \
-      --replace "/var/lib/unbound/root" "${pythonPackages.pyunbound}/etc/pyunbound/root"
+      --replace "/var/lib/unbound/root" "${python2Packages.pyunbound}/etc/pyunbound/root"
     patchShebangs *
     '';
 

--- a/pkgs/tools/security/john/default.nix
+++ b/pkgs/tools/security/john/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, openssl, nss, nspr, kerberos, gmp, zlib, libpcap, re2
-, gcc, pythonPackages, perl, perlPackages, makeWrapper
+, gcc, python2Packages, perl, perlPackages, makeWrapper
 }:
 
 with stdenv.lib;
@@ -35,8 +35,8 @@ stdenv.mkDerivation rec {
   '';
   configureFlags = [ "--disable-native-macro" ];
 
-  buildInputs = [ openssl nss nspr kerberos gmp zlib libpcap re2 gcc pythonPackages.wrapPython perl makeWrapper ];
-  propagatedBuildInputs = (with pythonPackages; [ dpkt scapy lxml ]) ++ # For pcap2john.py
+  buildInputs = [ openssl nss nspr kerberos gmp zlib libpcap re2 gcc python2Packages.wrapPython perl makeWrapper ];
+  propagatedBuildInputs = (with python2Packages; [ dpkt scapy lxml ]) ++ # For pcap2john.py
                           (with perlPackages; [ DigestMD4 DigestSHA1 GetoptLong # For pass_gen.pl
                                                 perlldap ]); # For sha-dump.pl
                           # TODO: Get dependencies for radius2john.pl and lion2john-alt.pl

--- a/pkgs/tools/security/onioncircuits/default.nix
+++ b/pkgs/tools/security/onioncircuits/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchgit, pythonPackages, intltool, gtk3, gobject-introspection, gnome3 }:
+{ stdenv, fetchgit, python2Packages, intltool, gtk3, gobject-introspection, gnome3 }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   name = "onioncircuits-${version}";
   version = "0.5";
 
@@ -12,7 +12,7 @@ pythonPackages.buildPythonApplication rec {
 
   nativeBuildInputs = [ intltool ];
   buildInputs = [ intltool gtk3 gobject-introspection ];
-  propagatedBuildInputs =  with pythonPackages; [ stem distutils_extra pygobject3 ];
+  propagatedBuildInputs =  with python2Packages; [ stem distutils_extra pygobject3 ];
 
   postFixup = ''
     wrapProgram "$out/bin/onioncircuits" \

--- a/pkgs/tools/security/pius/default.nix
+++ b/pkgs/tools/security/pius/default.nix
@@ -1,7 +1,7 @@
-{ fetchFromGitHub, stdenv, pythonPackages, gnupg, perl }:
+{ fetchFromGitHub, stdenv, python2Packages, gnupg, perl }:
 
 let version = "2.2.7"; in
-pythonPackages.buildPythonApplication {
+python2Packages.buildPythonApplication {
   name = "pius-${version}";
   namePrefix = "";
 
@@ -19,7 +19,7 @@ pythonPackages.buildPythonApplication {
   '';
 
   nativeBuildInputs = [ perl ];
-  propagatedBuildInputs = with pythonPackages; [ six ];
+  propagatedBuildInputs = with python2Packages; [ six ];
 
   meta = {
     homepage = https://www.phildev.net/pius/;

--- a/pkgs/tools/security/trufflehog/default.nix
+++ b/pkgs/tools/security/trufflehog/default.nix
@@ -1,20 +1,20 @@
-{ lib, pythonPackages }:
+{ lib, python2Packages }:
 
 let
-  truffleHogRegexes = pythonPackages.buildPythonPackage rec {
+  truffleHogRegexes = python2Packages.buildPythonPackage rec {
     pname = "truffleHogRegexes";
     version = "0.0.4";
-    src = pythonPackages.fetchPypi {
+    src = python2Packages.fetchPypi {
       inherit pname version;
       sha256 = "09vrscbb4h4w01gmamlzghxx6cvrqdscylrbdcnbjsd05xl7zh4z";
     };
   };
 in
-  pythonPackages.buildPythonApplication rec {
+  python2Packages.buildPythonApplication rec {
     pname = "truffleHog";
     version = "2.0.97";
 
-    src = pythonPackages.fetchPypi {
+    src = python2Packages.fetchPypi {
       inherit pname version;
       sha256 = "034kpv1p4m90286slvc6d4mlrzaf0b5jbd4qaj87hj65wbpcpg8r";
     };
@@ -24,7 +24,7 @@ in
       substituteInPlace setup.py --replace "GitPython ==" "GitPython >= "
     '';
 
-    propagatedBuildInputs = [ pythonPackages.GitPython truffleHogRegexes ];
+    propagatedBuildInputs = [ python2Packages.GitPython truffleHogRegexes ];
 
     # Test cases run git clone and require network access
     doCheck = false;

--- a/pkgs/tools/security/volatility/default.nix
+++ b/pkgs/tools/security/volatility/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, pythonPackages }:
+{ stdenv, fetchurl, python2Packages }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   version = "2.6";
   name = "volatility-${version}";
 
@@ -11,7 +11,7 @@ pythonPackages.buildPythonApplication rec {
 
   doCheck = false;
 
-  propagatedBuildInputs = [ pythonPackages.pycrypto pythonPackages.distorm3 ];
+  propagatedBuildInputs = [ python2Packages.pycrypto python2Packages.distorm3 ];
 
   meta = with stdenv.lib; {
     homepage = https://www.volatilityfoundation.org/;

--- a/pkgs/tools/system/evemu/default.nix
+++ b/pkgs/tools/system/evemu/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, autoreconfHook, pkgconfig, pythonPackages
+{ stdenv, fetchgit, autoreconfHook, pkgconfig, python2Packages
 , libevdev
 }:
 
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig autoreconfHook ];
 
-  buildInputs = [ pythonPackages.python pythonPackages.evdev libevdev ];
+  buildInputs = [ python2Packages.python python2Packages.evdev libevdev ];
 
   meta = with stdenv.lib; {
     description = "Records and replays device descriptions and events to emulate input devices through the kernel's input system";

--- a/pkgs/tools/system/honcho/default.nix
+++ b/pkgs/tools/system/honcho/default.nix
@@ -1,12 +1,12 @@
-{ stdenv, fetchFromGitHub, pythonPackages }:
+{ stdenv, fetchFromGitHub, python2Packages }:
 
 let
-  inherit (pythonPackages) python;
+  inherit (python2Packages) python;
   pname = "honcho";
 
 in
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   name = "${pname}-${version}";
   version = "1.0.1";
   namePrefix = "";
@@ -18,7 +18,7 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "11bd87474qpif20xdcn0ra1idj5k16ka51i658wfpxwc6nzsn92b";
   };
 
-  checkInputs = with pythonPackages; [ jinja2 pytest mock coverage ];
+  checkInputs = with python2Packages; [ jinja2 pytest mock coverage ];
 
   buildPhase = ''
     ${python.interpreter} setup.py build

--- a/pkgs/tools/system/osquery/default.nix
+++ b/pkgs/tools/system/osquery/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, pkgconfig, cmake, pythonPackages
+{ stdenv, lib, fetchFromGitHub, pkgconfig, cmake, python2Packages
 , udev, audit, aws-sdk-cpp, cryptsetup, lvm2, libgcrypt, libarchive
 , libgpgerror, libuuid, iptables, dpkg, lzma, bzip2, rpm
 , beecrypt, augeas, libxml2, sleuthkit, yara, lldpd, google-gflags
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
   patches = [ ./misc.patch ];
 
   nativeBuildInputs = [
-    pkgconfig cmake pythonPackages.python pythonPackages.jinja2 doxygen fpm
+    pkgconfig cmake python2Packages.python python2Packages.jinja2 doxygen fpm
   ];
 
   NIX_LDFLAGS = [

--- a/pkgs/tools/system/ps_mem/default.nix
+++ b/pkgs/tools/system/ps_mem/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, pythonPackages, fetchFromGitHub }:
+{ stdenv, python2Packages, fetchFromGitHub }:
 
 let
   version = "3.12";
   pname = "ps_mem";
-in pythonPackages.buildPythonApplication rec {
+in python2Packages.buildPythonApplication rec {
   name = "${pname}-${version}";
 
   src = fetchFromGitHub {

--- a/pkgs/tools/system/rsyslog/default.nix
+++ b/pkgs/tools/system/rsyslog/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, autoreconfHook, libestr, json_c, zlib, pythonPackages, fastJson
+{ stdenv, fetchurl, pkgconfig, autoreconfHook, libestr, json_c, zlib, python2Packages, fastJson
 , libkrb5 ? null, systemd ? null, jemalloc ? null, mysql ? null, postgresql ? null
 , libdbi ? null, net_snmp ? null, libuuid ? null, curl ? null, gnutls ? null
 , libgcrypt ? null, liblognorm ? null, openssl ? null, librelp ? null, libksi ? null
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig autoreconfHook ];
   buildInputs = [
-    fastJson libestr json_c zlib pythonPackages.docutils libkrb5 jemalloc
+    fastJson libestr json_c zlib python2Packages.docutils libkrb5 jemalloc
     postgresql libdbi net_snmp libuuid curl gnutls libgcrypt liblognorm openssl
     librelp libgt libksi liblogging libnet hadoop rdkafka libmongo-client czmq
     rabbitmq-c hiredis mongoc

--- a/pkgs/tools/system/s-tui/default.nix
+++ b/pkgs/tools/system/s-tui/default.nix
@@ -1,16 +1,16 @@
-{ stdenv, pythonPackages }:
+{ stdenv, python2Packages }:
 
-pythonPackages.buildPythonPackage rec {
+python2Packages.buildPythonPackage rec {
   name = "${pname}-${version}";
   pname = "s-tui";
   version = "0.8.3";
 
-  src = pythonPackages.fetchPypi {
+  src = python2Packages.fetchPypi {
     inherit pname version;
     sha256 = "00lsh2v4i8rwfyjyxx5lijd6rnk9smcfffhzg5sv94ijpcnh216m";
   };
 
-  propagatedBuildInputs = with pythonPackages; [
+  propagatedBuildInputs = with python2Packages; [
     urwid
     psutil
   ];

--- a/pkgs/tools/text/icdiff/default.nix
+++ b/pkgs/tools/text/icdiff/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchFromGitHub, pythonPackages }:
+{ stdenv, fetchFromGitHub, python2Packages }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   name = "icdiff-${version}";
   version = "1.9.4";
 

--- a/pkgs/tools/text/markdown-pp/default.nix
+++ b/pkgs/tools/text/markdown-pp/default.nix
@@ -1,6 +1,6 @@
-{ fetchFromGitHub, pythonPackages, stdenv }:
+{ fetchFromGitHub, python2Packages, stdenv }:
 
-with pythonPackages;
+with python2Packages;
 buildPythonApplication rec {
   pname = "MarkdownPP";
   version = "1.4";

--- a/pkgs/tools/text/rst2html5/default.nix
+++ b/pkgs/tools/text/rst2html5/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, pythonPackages }:
+{ stdenv, fetchurl, python2Packages }:
 
-pythonPackages.buildPythonPackage rec {
+python2Packages.buildPythonPackage rec {
 
   name = "${pname}-${version}";
   pname = "rst2html5";
@@ -11,7 +11,7 @@ pythonPackages.buildPythonPackage rec {
     sha256 = "d044589d30eeaf7336986078b7bd175510fd649a212b01a457d7806b279e6c73";
   };
 
-  propagatedBuildInputs = with pythonPackages;
+  propagatedBuildInputs = with python2Packages;
   [ docutils genshi pygments beautifulsoup4 ];
 
   meta = with stdenv.lib;{

--- a/pkgs/tools/text/shocco/default.nix
+++ b/pkgs/tools/text/shocco/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, perlPackages, pythonPackages }:
+{ stdenv, fetchFromGitHub, perlPackages, python2Packages }:
 
 stdenv.mkDerivation rec {
   name = "shocco-${version}";
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     substituteInPlace configure --replace PATH= NIRVANA=
   '';
 
-  buildInputs = [ perlPackages.TextMarkdown pythonPackages.pygments ];
+  buildInputs = [ perlPackages.TextMarkdown python2Packages.pygments ];
 
   meta = with stdenv.lib; {
     description = "A quick-and-dirty, literate-programming-style documentation generator for / in POSIX shell";

--- a/pkgs/tools/text/yaml-merge/default.nix
+++ b/pkgs/tools/text/yaml-merge/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pythonPackages }:
+{ stdenv, fetchFromGitHub, python2Packages }:
 
 stdenv.mkDerivation rec {
   name= "yaml-merge-2016-02-16";
@@ -10,8 +10,8 @@ stdenv.mkDerivation rec {
     sha256 = "0mwda2shk43i6f22l379fcdchmb07fm7nf4i2ii7fk3ihkhb8dgp";
   };
 
-  pythonPath = with pythonPackages; [ pyyaml ];
-  nativeBuildInputs = [ pythonPackages.wrapPython ];
+  pythonPath = with python2Packages; [ pyyaml ];
+  nativeBuildInputs = [ python2Packages.wrapPython ];
 
   installPhase = ''
     install -Dm755 yaml-merge.py $out/bin/yaml-merge

--- a/pkgs/tools/typesetting/odpdown/default.nix
+++ b/pkgs/tools/typesetting/odpdown/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, pythonPackages, libreoffice }:
+{ stdenv, fetchurl, python2Packages, libreoffice }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
 
   name = "odpdown-${version}";
   version = "0.4.1";
@@ -10,9 +10,9 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "005eecc73c65b9d4c09532547940718a7b308cd565f62a213dfa040827d4d565";
   };
 
-  propagatedBuildInputs = with pythonPackages; [ libreoffice lpod lxml mistune pillow pygments ];
+  propagatedBuildInputs = with python2Packages; [ libreoffice lpod lxml mistune pillow pygments ];
 
-  checkInputs = with pythonPackages; [
+  checkInputs = with python2Packages; [
     nose
   ];
 

--- a/pkgs/tools/video/vnc2flv/default.nix
+++ b/pkgs/tools/video/vnc2flv/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchurl, pythonPackages }:
+{ stdenv, fetchurl, python2Packages }:
 
-pythonPackages.buildPythonApplication rec {
+python2Packages.buildPythonApplication rec {
   name = "vnc2flv-20100207";
   namePrefix = "";
 

--- a/pkgs/tools/virtualization/cloud-init/default.nix
+++ b/pkgs/tools/virtualization/cloud-init/default.nix
@@ -1,8 +1,8 @@
-{ lib, pythonPackages, fetchurl, cloud-utils }:
+{ lib, python2Packages, fetchurl, cloud-utils }:
 
 let version = "0.7.9";
 
-in pythonPackages.buildPythonApplication rec {
+in python2Packages.buildPythonApplication rec {
   name = "cloud-init-${version}";
   namePrefix = "";
 
@@ -28,10 +28,10 @@ in pythonPackages.buildPythonApplication rec {
     sed -i s/argparse// requirements.txt
     '';
 
-  propagatedBuildInputs = with pythonPackages; [ cheetah jinja2 prettytable
+  propagatedBuildInputs = with python2Packages; [ cheetah jinja2 prettytable
     oauthlib pyserial configobj pyyaml requests jsonpatch ];
 
-  checkInputs = with pythonPackages; [ contextlib2 httpretty mock unittest2 ];
+  checkInputs = with python2Packages; [ contextlib2 httpretty mock unittest2 ];
 
   doCheck = false;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -621,7 +621,7 @@ in
 
   aws-rotate-key = callPackage ../tools/admin/aws-rotate-key { };
 
-  aws_shell = pythonPackages.callPackage ../tools/admin/aws_shell { };
+  aws_shell = python2Packages.callPackage ../tools/admin/aws_shell { };
 
   aws-sam-cli = callPackage ../development/tools/aws-sam-cli { };
 
@@ -726,7 +726,7 @@ in
 
   dgsh = callPackage ../shells/dgsh { };
 
-  dkimpy = with pythonPackages; toPythonApplication dkimpy;
+  dkimpy = with python2Packages; toPythonApplication dkimpy;
 
   dpt-rp1-py = callPackage ../tools/misc/dpt-rp1-py { };
 
@@ -876,7 +876,7 @@ in
 
   aria2 = callPackage ../tools/networking/aria2 {
     inherit (darwin.apple_sdk.frameworks) Security;
-    inherit (pythonPackages) sphinx;
+    inherit (python2Packages) sphinx;
   };
   aria = aria2;
 
@@ -1622,7 +1622,7 @@ in
 
   kisslicer = callPackage ../tools/misc/kisslicer { };
 
-  klaus = with pythonPackages; toPythonApplication klaus;
+  klaus = with python2Packages; toPythonApplication klaus;
 
   lcdproc = callPackage ../servers/monitoring/lcdproc { };
 
@@ -1654,7 +1654,7 @@ in
 
   lynis = callPackage ../tools/security/lynis { };
 
-  mathics = pythonPackages.mathics;
+  mathics = python2Packages.mathics;
 
   masscan = callPackage ../tools/security/masscan {
     stdenv = gccStdenv;
@@ -1951,7 +1951,7 @@ in
   };
 
   bud = callPackage ../tools/networking/bud {
-    inherit (pythonPackages) gyp;
+    inherit (python2Packages) gyp;
   };
 
   bup = callPackage ../tools/backup/bup { };
@@ -2153,7 +2153,7 @@ in
   skk-dicts = callPackage ../tools/inputmethods/skk/skk-dicts { };
 
   libkkc-data = callPackage ../data/misc/libkkc-data {
-    inherit (pythonPackages) marisa;
+    inherit (python2Packages) marisa;
   };
 
   libkkc = callPackage ../tools/inputmethods/libkkc { };
@@ -2445,7 +2445,7 @@ in
   diffutils = callPackage ../tools/text/diffutils { };
 
   dir2opus = callPackage ../tools/audio/dir2opus {
-    inherit (pythonPackages) mutagen python wrapPython;
+    inherit (python2Packages) mutagen python wrapPython;
   };
 
   picotts = callPackage ../tools/audio/picotts { };
@@ -2605,7 +2605,7 @@ in
   uudeview = callPackage ../tools/misc/uudeview { };
 
   uutils-coreutils = callPackage ../tools/misc/uutils-coreutils {
-    inherit (pythonPackages) sphinx;
+    inherit (python2Packages) sphinx;
   };
 
   wallutils = callPackage ../tools/graphics/wallutils { };
@@ -2710,7 +2710,7 @@ in
   epsxe = callPackage ../misc/emulators/epsxe { };
 
   escrotum = callPackage ../tools/graphics/escrotum {
-    inherit (pythonPackages) buildPythonApplication pygtk numpy;
+    inherit (python2Packages) buildPythonApplication pygtk numpy;
   };
 
   ethtool = callPackage ../tools/misc/ethtool { };
@@ -5086,7 +5086,7 @@ in
   jbig2enc = callPackage ../tools/graphics/jbig2enc { };
 
   pdfread = callPackage ../tools/graphics/pdfread {
-    inherit (pythonPackages) pillow;
+    inherit (python2Packages) pillow;
   };
 
   briss = callPackage ../tools/graphics/briss { };
@@ -5304,7 +5304,7 @@ in
 
   pwndbg = python3Packages.callPackage ../development/tools/misc/pwndbg { };
 
-  pycangjie = pythonPackages.pycangjie;
+  pycangjie = python2Packages.pycangjie;
 
   pydb = callPackage ../development/tools/pydb { };
 
@@ -5312,9 +5312,9 @@ in
 
   pygmentex = callPackage ../tools/typesetting/pygmentex { };
 
-  pythonIRClib = pythonPackages.pythonIRClib;
+  pythonIRClib = python2Packages.pythonIRClib;
 
-  pythonSexy = pythonPackages.libsexy;
+  pythonSexy = python2Packages.libsexy;
 
   pytrainer = callPackage ../applications/misc/pytrainer { };
 
@@ -5392,7 +5392,7 @@ in
 
   radvd = callPackage ../tools/networking/radvd { };
 
-  rainbowstream = pythonPackages.rainbowstream;
+  rainbowstream = python2Packages.rainbowstream;
 
   rambox = callPackage ../applications/networking/instant-messengers/rambox { };
 
@@ -5509,7 +5509,7 @@ in
   rkrlv2 = callPackage ../applications/audio/rkrlv2 {};
 
   rmlint = callPackage ../tools/misc/rmlint {
-    inherit (pythonPackages) sphinx;
+    inherit (python2Packages) sphinx;
   };
 
   rng-tools = callPackage ../tools/security/rng-tools { };
@@ -6394,7 +6394,7 @@ in
 
   waifu2x-converter-cpp = callPackage ../tools/graphics/waifu2x-converter-cpp { };
 
-  wakatime = pythonPackages.callPackage ../tools/misc/wakatime { };
+  wakatime = python2Packages.callPackage ../tools/misc/wakatime { };
 
   weather = callPackage ../applications/misc/weather { };
 
@@ -6725,7 +6725,7 @@ in
     w3m = w3m-batch;
   };
 
-  xmpppy = pythonPackages.xmpppy;
+  xmpppy = python2Packages.xmpppy;
 
   xiccd = callPackage ../tools/misc/xiccd { };
 
@@ -8214,12 +8214,12 @@ in
     stdenv = if stdenv.cc.isClang then llvmPackages_5.stdenv else stdenv;
   };
 
-  me_cleaner = pythonPackages.callPackage ../tools/misc/me_cleaner { };
+  me_cleaner = python2Packages.callPackage ../tools/misc/me_cleaner { };
 
   mesos = callPackage ../applications/networking/cluster/mesos {
     sasl = cyrus_sasl;
-    inherit (pythonPackages) python boto setuptools wrapPython;
-    pythonProtobuf = pythonPackages.protobuf;
+    inherit (python2Packages) python boto setuptools wrapPython;
+    pythonProtobuf = python2Packages.protobuf;
     perf = linuxPackages.perf;
   };
 
@@ -8859,7 +8859,7 @@ in
 
   conan = callPackage ../development/tools/build-managers/conan { };
 
-  cookiecutter = pythonPackages.cookiecutter;
+  cookiecutter = python2Packages.cookiecutter;
 
   corundum = callPackage ../development/tools/corundum { };
 
@@ -9006,7 +9006,7 @@ in
 
   doit = callPackage ../development/tools/build-managers/doit { };
 
-  dot2tex = pythonPackages.dot2tex;
+  dot2tex = python2Packages.dot2tex;
 
   doxygen = callPackage ../development/tools/documentation/doxygen {
     qt4 = null;
@@ -9081,7 +9081,7 @@ in
 
   jdepend = callPackage ../development/tools/analysis/jdepend { };
 
-  fedpkg = pythonPackages.callPackage ../development/tools/fedpkg { };
+  fedpkg = python2Packages.callPackage ../development/tools/fedpkg { };
 
   flex_2_5_35 = callPackage ../development/tools/parsing/flex/2.5.35.nix { };
   flex = callPackage ../development/tools/parsing/flex { };
@@ -9207,7 +9207,7 @@ in
 
   jenkins = callPackage ../development/tools/continuous-integration/jenkins { };
 
-  jenkins-job-builder = pythonPackages.jenkins-job-builder;
+  jenkins-job-builder = python2Packages.jenkins-job-builder;
 
   kafkacat = callPackage ../development/tools/kafkacat { };
 
@@ -9403,7 +9403,7 @@ in
 
   pprof = callPackage ../development/tools/profiling/pprof { };
 
-  pyprof2calltree = pythonPackages.callPackage ../development/tools/profiling/pyprof2calltree { };
+  pyprof2calltree = python2Packages.callPackage ../development/tools/profiling/pyprof2calltree { };
 
   prelink = callPackage ../development/tools/misc/prelink { };
 
@@ -10090,7 +10090,9 @@ in
 
   easyloggingpp = callPackage ../development/libraries/easyloggingpp {};
 
-  eccodes = callPackage ../development/libraries/eccodes { };
+  eccodes = callPackage ../development/libraries/eccodes {
+    pythonPackages = python2Packages;
+  };
 
   eclib = callPackage ../development/libraries/eclib {};
 
@@ -10140,7 +10142,7 @@ in
     inherit (gst_all_1)
       gstreamer gst-plugins-base gst-plugins-good gst-plugins-bad
       gst-libav;
-    inherit (pythonPackages) gst-python;
+    inherit (python2Packages) gst-python;
   };
 
   fcgi = callPackage ../development/libraries/fcgi { };
@@ -10344,7 +10346,9 @@ in
     libXpm = null;
   };
 
-  gdal = callPackage ../development/libraries/gdal { };
+  gdal = callPackage ../development/libraries/gdal {
+    pythonPackages = python2Packages;
+  };
 
   gdal_1_11 = callPackage ../development/libraries/gdal/gdal-1_11.nix { };
 
@@ -10508,7 +10512,9 @@ in
 
   grab-site = callPackage ../tools/backup/grab-site { };
 
-  grib-api = callPackage ../development/libraries/grib-api { };
+  grib-api = callPackage ../development/libraries/grib-api {
+    pythonPackages = python2Packages;
+  };
 
   grpc = callPackage ../development/libraries/grpc { };
 
@@ -11373,7 +11379,7 @@ in
   libgpiod = callPackage ../development/libraries/libgpiod { };
 
   libgpod = callPackage ../development/libraries/libgpod {
-    inherit (pkgs.pythonPackages) mutagen;
+    inherit (pkgs.python2Packages) mutagen;
   };
 
   libgssglue = callPackage ../development/libraries/libgssglue { };
@@ -12172,7 +12178,7 @@ in
 
   muparser = callPackage ../development/libraries/muparser { };
 
-  mygpoclient = pythonPackages.mygpoclient;
+  mygpoclient = python2Packages.mygpoclient;
 
   mygui = callPackage ../development/libraries/mygui {
     ogre = ogre1_9;
@@ -12316,11 +12322,13 @@ in
   opencv = callPackage ../development/libraries/opencv {
     inherit (darwin) cf-private;
     inherit (darwin.apple_sdk.frameworks) Cocoa QTKit;
+    pythonPackages = python2Packages;
   };
 
   opencv3 = callPackage ../development/libraries/opencv/3.x.nix {
     inherit (darwin) cf-private;
     inherit (darwin.apple_sdk.frameworks) AVFoundation Cocoa QTKit VideoDecodeAcceleration;
+    pythonPackages = python2Packages;
   };
 
   opencv3WithoutCuda = opencv3.override {
@@ -12330,6 +12338,7 @@ in
   opencv4 = callPackage ../development/libraries/opencv/4.x.nix {
     inherit (darwin) cf-private;
     inherit (darwin.apple_sdk.frameworks) AVFoundation Cocoa QTKit VideoDecodeAcceleration;
+    pythonPackages = python2Packages;
   };
 
   openexr = callPackage ../development/libraries/openexr { };
@@ -13095,7 +13104,7 @@ in
 
   spice = callPackage ../development/libraries/spice {
     celt = celt_0_5_1;
-    inherit (pythonPackages) pyparsing;
+    inherit (python2Packages) pyparsing;
   };
 
   spice-gtk = callPackage ../development/libraries/spice-gtk { };
@@ -13258,7 +13267,7 @@ in
   theft = callPackage ../development/libraries/theft { };
 
   thrift = callPackage ../development/libraries/thrift {
-    inherit (pythonPackages) twisted;
+    inherit (python2Packages) twisted;
   };
 
   tidyp = callPackage ../development/libraries/tidyp { };
@@ -14487,7 +14496,7 @@ in
 
   qpid-cpp = callPackage ../servers/amqp/qpid-cpp {
     boost = boost155;
-    inherit (pythonPackages) buildPythonPackage qpid-python;
+    inherit (python2Packages) buildPythonPackage qpid-python;
   };
 
   quagga = callPackage ../servers/quagga { };
@@ -16569,7 +16578,7 @@ in
   aacgain = callPackage ../applications/audio/aacgain { };
 
   abcde = callPackage ../applications/audio/abcde {
-    inherit (pythonPackages) eyeD3;
+    inherit (python2Packages) eyeD3;
   };
 
   abiword = callPackage ../applications/office/abiword { };
@@ -16936,7 +16945,7 @@ in
   };
 
   chirp = callPackage ../applications/radio/chirp {
-    inherit (pythonPackages) pyserial pygtk;
+    inherit (python2Packages) pyserial pygtk;
   };
 
   browsh = callPackage ../applications/networking/browsers/browsh { };
@@ -17466,7 +17475,7 @@ in
 
     external = {
       inherit (haskellPackages) ghc-mod structured-haskell-mode Agda hindent;
-      inherit (pythonPackages) elpy;
+      inherit (python2Packages) elpy;
       inherit
         autoconf automake git libffi libpng pkgconfig poppler rtags w3m zlib
         substituteAll rustPlatform;
@@ -17707,7 +17716,7 @@ in
 
   gthumb = callPackage ../applications/graphics/gthumb { };
 
-  gtimelog = pythonPackages.gtimelog;
+  gtimelog = python2Packages.gtimelog;
 
   inherit (gnome3) gucharmap;
 
@@ -20162,7 +20171,7 @@ in
 
   telepathy-idle = callPackage ../applications/networking/instant-messengers/telepathy/idle {};
 
-  termdown = (newScope pythonPackages) ../applications/misc/termdown { };
+  termdown = (newScope python2Packages) ../applications/misc/termdown { };
 
   terminal-notifier = callPackage ../applications/misc/terminal-notifier {};
 
@@ -20264,7 +20273,7 @@ in
   torch-repl = lib.setName "torch-repl" torchPackages.trepl;
 
   torchat = callPackage ../applications/networking/instant-messengers/torchat {
-    inherit (pythonPackages) wrapPython wxPython;
+    inherit (python2Packages) wrapPython wxPython;
   };
 
   torrential = callPackage ../applications/networking/p2p/torrential { };
@@ -20322,7 +20331,7 @@ in
 
   umurmur = callPackage ../applications/networking/umurmur { };
 
-  udocker = pythonPackages.callPackage ../tools/virtualization/udocker { };
+  udocker = python2Packages.callPackage ../tools/virtualization/udocker { };
 
   unigine-valley = callPackage ../applications/graphics/unigine-valley { };
 
@@ -21176,7 +21185,7 @@ in
     opencv3 = opencv3WithoutCuda;
   };
 
-  displaycal = (newScope pythonPackages) ../applications/graphics/displaycal {};
+  displaycal = (newScope python2Packages) ../applications/graphics/displaycal {};
 
   drumkv1 = callPackage ../applications/audio/drumkv1 { };
 
@@ -21343,7 +21352,7 @@ in
   icbm3d = callPackage ../games/icbm3d { };
 
   ingen = callPackage ../applications/audio/ingen {
-    inherit (pythonPackages) rdflib;
+    inherit (python2Packages) rdflib;
   };
 
   instead = callPackage ../games/instead {
@@ -22276,7 +22285,7 @@ in
   nauty = callPackage ../applications/science/math/nauty {};
 
   or-tools = callPackage ../development/libraries/science/math/or-tools {
-    pythonProtobuf = pythonPackages.protobuf;
+    pythonProtobuf = python2Packages.protobuf;
   };
 
   rubiks = callPackage ../development/libraries/science/math/rubiks { };
@@ -23295,7 +23304,7 @@ in
 
   nix-script = callPackage ../tools/nix/nix-script {};
 
-  nix-template-rpm = callPackage ../build-support/templaterpm { inherit (pythonPackages) python toposort; };
+  nix-template-rpm = callPackage ../build-support/templaterpm { inherit (python2Packages) python toposort; };
 
   nix-top = callPackage ../tools/package-management/nix-top { };
 
@@ -23490,7 +23499,7 @@ in
 
   satysfi = callPackage ../tools/typesetting/satysfi { };
 
-  sc-controller = pythonPackages.callPackage ../misc/drivers/sc-controller {
+  sc-controller = python2Packages.callPackage ../misc/drivers/sc-controller {
     inherit libusb1; # Shadow python.pkgs.libusb1.
   };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This is in preparation for Python2 going EOL in 2020.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
