### PR TITLE
bettercap: 2.11 -> 2.24

### DIFF
--- a/pkgs/tools/security/bettercap/default.nix
+++ b/pkgs/tools/security/bettercap/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, buildGoPackage, fetchFromGitHub, pkgconfig, libpcap, libnfnetlink, libnetfilter_queue }:
+{ stdenv, buildGoPackage, fetchFromGitHub, pkgconfig, libpcap, libusb1, libnfnetlink, libnetfilter_queue }:
 
 buildGoPackage rec {
   name = "bettercap-${version}";
-  version = "2.11";
+  version = "2.24";
 
   goPackagePath = "github.com/bettercap/bettercap";
 
@@ -10,11 +10,11 @@ buildGoPackage rec {
     owner = "bettercap";
     repo = "bettercap";
     rev = "v${version}";
-    sha256 = "08hd7hk0jllfhdiky1f5pfsvl1x0bkgv1p4z9qvsksdg9a7qjznw";
+    sha256 = "1f8bzxbcyf0bpyqj6hz4l8dp5xknnb537xy9y5skcznp03i44h55";
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ libpcap libnfnetlink libnetfilter_queue ];
+  buildInputs = [ libpcap libusb1 libnfnetlink libnetfilter_queue ];
 
   goDeps = ./deps.nix;
 

--- a/pkgs/tools/security/bettercap/deps.nix
+++ b/pkgs/tools/security/bettercap/deps.nix
@@ -28,6 +28,15 @@
     };
   }
   {
+    goPackagePath  = "github.com/bettercap/recording";
+    fetch = {
+      type = "git";
+      url = "https://github.com/bettercap/recording";
+      rev =  "3ce1dcf032e391eb321311b34cdf31c6fc9523f5";
+      sha256 = "1arh12iz15anyrqr4q496lpd0gx5nf2cwyr5rv17rawqqz8ydg23";
+    };
+  }
+  {
     goPackagePath  = "github.com/chifflier/nfqueue-go";
     fetch = {
       type = "git";
@@ -142,6 +151,15 @@
       url = "https://github.com/jpillora/go-tld";
       rev =  "4bfc8d9a90b591e101a56265afc2239359fb0810";
       sha256 = "04pv1rwpfq3ip3vn0yfixxczcnv56w1l0z8bp4fjscw1bfqbb4pn";
+    };
+  }
+  {
+    goPackagePath  = "github.com/kr/binarydist";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kr/binarydist";
+      rev =  "190e7de772656c6127fa8e55c6258ed1b7eabcee";
+      sha256 = "1mzzn3vaw4h990knz9wwr7gf8fwznv2claavslr7fhd5h0zyy9ga";
     };
   }
   {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
New release contains bugfixes and additional functionality.

Have used this updated package for a few days without any issues.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
