### PR TITLE
libpointmatcher: 2016-09-11 -> 1.3.1

### DIFF
--- a/pkgs/development/libraries/libpointmatcher/default.nix
+++ b/pkgs/development/libraries/libpointmatcher/default.nix
@@ -1,17 +1,18 @@
-{stdenv, fetchFromGitHub, cmake, eigen, boost, libnabo}:
+{ stdenv, fetchFromGitHub, cmake, eigen, boost, libnabo }:
 
 stdenv.mkDerivation rec {
-  version = "2016-09-11";
-  name = "libpointmatcher-${version}";
+  pname = "libpointmatcher";
+  version = "1.3.1";
 
   src = fetchFromGitHub {
     owner = "ethz-asl";
-    repo = "libpointmatcher";
-    rev = "75044815d40ff934fe0bb7e05ed8bbf18c06493b";
-    sha256 = "1s7ilvg3lhr1fq8sxw05ydmbd3kl46496jnyxprhnpgvpmvqsbzl";
+    repo = pname;
+    rev = version;
+    sha256 = "0lai6sr3a9dj1j4pgjjyp7mx10wixy5wpvbka8nsc2danj6xhdyd";
   };
 
-  buildInputs = [cmake eigen boost libnabo];
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ eigen boost libnabo ];
 
   enableParallelBuilding = true;
 
@@ -19,11 +20,11 @@ stdenv.mkDerivation rec {
     -DEIGEN_INCLUDE_DIR=${eigen}/include/eigen3
   ";
 
-  checkPhase = ''
-  export LD_LIBRARY_PATH=$PWD
-  ./utest/utest --path ../examples/data/
-  '';
   doCheck = true;
+  checkPhase = ''
+    export LD_LIBRARY_PATH=$PWD
+    ./utest/utest --path ../examples/data/
+  '';
 
   meta = with stdenv.lib; {
     inherit (src.meta) homepage;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fixing a recurring build failure on Hydra

Changelog:
https://github.com/ethz-asl/libpointmatcher/releases/tag/1.3.1
cc @cryptix 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
