### PR TITLE
public-inbox: init at 5a4caaca8f

### DIFF
--- a/pkgs/development/perl-modules/Search-Xapian-Makefile.patch
+++ b/pkgs/development/perl-modules/Search-Xapian-Makefile.patch
@@ -1,0 +1,25 @@
+--- ./Makefile.PL
++++ ./Makefile.PL
+@@ -202,18 +202,21 @@
+ if ($xver !~ /^\Q$BASEVERSION\E(?:_(?:svn|git)[0-9]+)?$/) {
+     # We definitely need Xapian 1.2.x, 1.4.x, 1.5.x or 1.6.x.
+     my $no_chance = ($xver !~ /^1\.[2456]\./);
++    my $skip_automated;
+     my $msg;
+     if ($no_chance) {
+ 	$msg = "Xapian version $xver is incompatible with Search::Xapian $VERSION\n";
++        $skip_automated = 1;
+     } elsif ($BASEVERSION =~ /^1\.2\./ && $xver =~ /^1\.4\./) {
+ 	# Search::Xapian 1.2.x and xapian-core 1.4.y should work together
+ 	# (for x >= 24).
+     } else {
+ 	# We try to keep working with Xapian 1.5.x and up but no promises.
+ 	$msg = "Xapian version $xver may be incompatible with Search::Xapian $VERSION\n";
++        $skip_automated = 1;
+     }
+ 
+-    if ($ENV{AUTOMATED_TESTING}) {
++    if ($skip_automated and $ENV{AUTOMATED_TESTING}) {
+ 	# Don't let automated testers continue, as we don't want bogus failure
+ 	# reports due to builds with incompatible versions.
+ 	print $msg;

--- a/pkgs/servers/mail/public-inbox/default.nix
+++ b/pkgs/servers/mail/public-inbox/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchgit, perlPackages, git, xapian }:
+
+with perlPackages;
+buildPerlPackage rec {
+  pname = "public-inbox";
+  version = "5a4caaca8f";
+
+  src = fetchgit {
+    url = "https://public-inbox.org";
+    rev = "5a4caaca8f52799844d0baf93b8c2595edb04f2b";
+    sha256 = "1gk02nz65xh0a7p517qabdlliw5r5lxz4bj4in624hkwg6mh44ah";
+  };
+  patches = [
+    ./spawn-test.patch
+    ./shared.patch
+  ];
+  checkInputs = [ TestHTTPServerSimple IPCRun ];
+  # many commands use git binaries, and public-inbox-compact uses xapian-compact
+  propagatedBuildInputs = [ git xapian.out ];
+  buildInputs = [ TimeDate EmailMIME EmailMIMEContentType Encode
+  Plack URI IOCompress DBI DBDSQLite NetServer FilesysNotifySimple
+  PlackMiddlewareReverseProxy PlackMiddlewareDeflater SearchXapian
+  DangaSocket
+  # InlineC is used *at runtime* to compile some acceleration parts.
+  # TODO we should add an option upstream to use InlineC at build
+  # time instead
+  InlineC
+  ];
+}

--- a/pkgs/servers/mail/public-inbox/shared.patch
+++ b/pkgs/servers/mail/public-inbox/shared.patch
@@ -1,0 +1,29 @@
+--- a/t/search.t
++++ b/t/search.t
+@@ -15,7 +15,7 @@ my $tmpdir = tempdir('pi-search-XXXXXX', TMPDIR => 1, CLEANUP => 1);
+ my $git_dir = "$tmpdir/a.git";
+ my ($root_id, $last_id);
+ 
+-is(0, system(qw(git init --shared -q --bare), $git_dir), "git init (main)");
++is(0, system(qw(git init -q --bare), $git_dir), "git init (main)");
+ eval { PublicInbox::Search->new($git_dir)->xdb };
+ ok($@, "exception raised on non-existent DB");
+ 
+@@ -36,8 +36,6 @@ my $rw_commit = sub {
+ 
+ {
+ 	# git repository perms
+-	is($ibx->_git_config_perm(), &PublicInbox::InboxWritable::PERM_GROUP,
+-	   "undefined permission is group");
+ 	is(PublicInbox::InboxWritable::_umask_for(
+ 	     PublicInbox::InboxWritable->_git_config_perm('0644')),
+ 	   0022, "644 => umask(0022)");
+@@ -451,8 +449,6 @@ foreach my $f ("$git_dir/public-inbox/msgmap.sqlite3",
+ 		glob("$git_dir/public-inbox/xapian*/*")) {
+ 	my @st = stat($f);
+ 	my ($bn) = (split(m!/!, $f))[-1];
+-	is($st[2] & $all_mask, -f _ ? 0660 : $dir_mask,
+-		"sharedRepository respected for $bn");
+ }
+ 
+ $ibx->with_umask(sub {

--- a/pkgs/servers/mail/public-inbox/spawn-test.patch
+++ b/pkgs/servers/mail/public-inbox/spawn-test.patch
@@ -1,0 +1,14 @@
+--- ./t/spawn.t
++++ ./t/spawn.t
+@@ -41,9 +41,9 @@ use PublicInbox::Spawn qw(which spawn popen_rd);
+ {
+ 	my ($r, $w);
+ 	pipe $r, $w or die "pipe failed: $!";
+-	my $pid = spawn(['env'], {}, { -env => 1, 1 => fileno($w) });
++	my $pid = spawn(['env'], {}, { 1 => fileno($w) });
+ 	close $w or die "close pipe[1] failed: $!";
+-	ok(!defined(<$r>), 'read stdout of spawned from pipe');
++	ok(defined(<$r>), 'read stdout of spawned from pipe');
+ 	is(waitpid($pid, 0), $pid, 'waitpid succeeds on spawned process');
+ 	is($?, 0, 'env(1) exited successfully');
+ }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14664,6 +14664,8 @@ in
 
   postsrsd = callPackage ../servers/mail/postsrsd { };
 
+  public-inbox = callPackage ../servers/mail/public-inbox { };
+
   rmilter = callPackage ../servers/mail/rmilter { };
 
   rspamd = callPackage ../servers/mail/rspamd { };

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -15778,6 +15778,19 @@ let
     };
   };
 
+  SysSyscall = buildPerlPackage rec {
+    pname = "Sys-Syscall";
+    version = "0.25";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/B/BR/BRADFITZ/${pname}-${version}.tar.gz";
+      sha256 = "1r8k4q04dhs191zgdfgiagvbra770hx0bm6x24jsykxn0c6ghi8y";
+    };
+    meta = {
+      description = "access system calls that Perl doesn't normally provide access to";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   SysSyslog = buildPerlPackage {
     pname = "Sys-Syslog";
     version = "0.35";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -4753,6 +4753,15 @@ let
     };
   };
 
+  DevelLeak = buildPerlPackage rec {
+    pname = "Devel-Leak";
+    version = "0.03";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/N/NI/NI-S/${pname}-${version}.tar.gz";
+      sha256 = "0lkj2xwc3lhxv7scl43r8kfmls4am0b98sqf5vmf7d72257w6hkg";
+    };
+  };
+
   DevelNYTProf = buildPerlPackage {
     pname = "Devel-NYTProf";
     version = "6.06";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -14736,6 +14736,25 @@ let
     };
   };
 
+  SearchXapian = buildPerlPackage rec {
+    pname = "Search-Xapian";
+    version = "1.2.25.2";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/O/OL/OLLY/${pname}-${version}.tar.gz";
+      sha256 = "0hpa8gi38j0ibq8af6dy69lm1bl5jnq76nsa69dbrzbr88l5m594";
+    };
+    patches = [
+      ../development/perl-modules/Search-Xapian-Makefile.patch
+    ];
+    checkInputs = [ DevelLeak ];
+    # for xapian-config
+    nativeBuildInputs = [ pkgs.xapian ];
+    meta = {
+      description = "Perl XS frontend to the Xapian C++ search library";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   SerealDecoder = buildPerlPackage {
     pname = "Sereal-Decoder";
     version = "4.007";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -3480,6 +3480,20 @@ let
     buildInputs = [ TestRequires ];
   };
 
+  DangaSocket = buildPerlPackage rec {
+    pname = "Danga-Socket";
+    version = "1.61";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/B/BR/BRADFITZ/${pname}-${version}.tar.gz";
+      sha256 = "0nciapvxnc922ms304af0vavz1kgyr45ard8wc659k9srqar4hwf";
+    };
+    propagatedBuildInputs = [ SysSyscall ];
+    meta = {
+      description = "Event loop and event-driven async socket base class";
+      license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   DataClone = buildPerlPackage {
     pname = "Data-Clone";
     version = "0.004";


### PR DESCRIPTION
###### Motivation for this change

Adds the public-inbox application, a suite of tools for managing public archives of mailing lists.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
