### PR TITLE
awesome: add optional gtk3 support

### DIFF
--- a/pkgs/applications/window-managers/awesome/default.nix
+++ b/pkgs/applications/window-managers/awesome/default.nix
@@ -6,7 +6,11 @@
 , libxkbcommon, xcbutilxrm, hicolor-icon-theme
 , asciidoctor
 , fontsConf
+, gtk3Support ? false, gtk3 ? null
 }:
+
+# needed for beautiful.gtk to work
+assert gtk3Support -> gtk3 != null;
 
 with luaPackages; stdenv.mkDerivation rec {
   name = "awesome-${version}";
@@ -42,7 +46,8 @@ with luaPackages; stdenv.mkDerivation rec {
                   xorg.libXau xorg.libXdmcp xorg.libxcb xorg.libxshmfence
                   xorg.xcbutil xorg.xcbutilimage xorg.xcbutilkeysyms
                   xorg.xcbutilrenderutil xorg.xcbutilwm libxkbcommon
-                  xcbutilxrm ];
+                  xcbutilxrm ]
+                  ++ stdenv.lib.optional gtk3Support gtk3;
 
   #cmakeFlags = "-DGENERATE_MANPAGES=ON";
   cmakeFlags = "-DOVERRIDE_VERSION=${version}";
@@ -54,7 +59,7 @@ with luaPackages; stdenv.mkDerivation rec {
   LUA_PATH  = "${lgi}/share/lua/${lua.luaversion}/?.lua;;";
 
   postInstall = ''
-    # Don't use wrapProgram or or the wrapper will duplicate the --search
+    # Don't use wrapProgram or the wrapper will duplicate the --search
     # arguments every restart
     mv "$out/bin/awesome" "$out/bin/.awesome-wrapped"
     makeWrapper "$out/bin/.awesome-wrapped" "$out/bin/awesome" \


### PR DESCRIPTION
###### Motivation for this change

Add optional gtk3 support to Awesome so that the `beautiful.gtk` module can be
used.

The `beautiful.gtk` uses `lgi` to obtain Gtk via gobject-introspect:

    return require('lgi').Gtk

Since the current build does not include the typelib files needed, the above
call fails.

It turns out that both `gtk3` and `atk` (Accessibility toolkit) are needed, so
this commit adds them as optional build inputs.

Setting `gtk3Support` to `true` e.g. in an overlay will make `beautiful.gtk`
work at the cost of an increased closure size (currently 99.6M vs 223.4M).

Fixes https://github.com/NixOS/nixpkgs/issues/60538


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([`nix.useSandbox`](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
