### PR TITLE
upower: 0.99.9 -> 0.99.10

### DIFF
--- a/pkgs/os-specific/linux/upower/default.nix
+++ b/pkgs/os-specific/linux/upower/default.nix
@@ -1,41 +1,64 @@
-{ stdenv, fetchurl, pkgconfig, dbus-glib
-, intltool, libxslt, docbook_xsl, udev, libgudev, libusb1
-, useSystemd ? true, systemd, gobject-introspection
+{ stdenv
+, fetchurl
+, pkgconfig
+, dbus-glib
+, intltool
+, libxslt
+, docbook_xsl
+, udev
+, libgudev
+, libusb1
+, gobject-introspection
+, useSystemd ? true, systemd
 }:
 
 stdenv.mkDerivation rec {
-  name = "upower-0.99.9";
+  pname = "upower";
+  version = "0.99.10";
 
   src = fetchurl {
-    url = https://gitlab.freedesktop.org/upower/upower/uploads/2282c7c0e53fb31816b824c9d1f547e8/upower-0.99.9.tar.xz;
-    sha256 = "046ix7j7hmb7ycv8v54668kjsrgjhzwxn299c1d87vdnkd38kfh1";
+    url = https://gitlab.freedesktop.org/upower/upower/uploads/c438511024b9bc5a904f8775cfc8e4c4/upower-0.99.10.tar.xz;
+    sha256 = "17d2bclv5fgma2y3g8bsn9pdvspn1zrzismzdnzfivc0f2wm28k4";
   };
 
-  buildInputs =
-    [ dbus-glib intltool libxslt docbook_xsl udev libgudev libusb1 gobject-introspection ]
-    ++ stdenv.lib.optional useSystemd systemd;
+  nativeBuildInputs = [
+    pkgconfig
+  ];
 
-  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [
+    dbus-glib
+    intltool
+    libxslt
+    docbook_xsl
+    udev
+    libgudev
+    libusb1
+    gobject-introspection
+  ]
+  ++ stdenv.lib.optional useSystemd systemd
+  ;
 
-  configureFlags =
-    [ "--with-backend=linux" "--localstatedir=/var"
-    ]
-    ++ stdenv.lib.optional useSystemd
-    [ "--with-systemdsystemunitdir=$(out)/etc/systemd/system"
-      "--with-systemdutildir=$(out)/lib/systemd"
-      "--with-udevrulesdir=$(out)/lib/udev/rules.d"
-    ];
-
-  NIX_CFLAGS_LINK = "-lgcc_s";
+  configureFlags = [
+    "--with-backend=linux"
+    "--localstatedir=/var"
+  ]
+  ++ stdenv.lib.optional useSystemd [
+    "--with-systemdsystemunitdir=${placeholder ''out''}/etc/systemd/system"
+    "--with-systemdutildir=${placeholder ''out''}/lib/systemd"
+    "--with-udevrulesdir=${placeholder ''out''}/lib/udev/rules.d"
+  ]
+  ;
 
   doCheck = false; # fails with "env: './linux/integration-test': No such file or directory"
 
-  installFlags = "historydir=$(TMPDIR)/foo";
+  installFlags = [
+    "historydir=$(TMPDIR)/foo"
+  ];
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = https://upower.freedesktop.org/;
     description = "A D-Bus service for power management";
-    platforms = stdenv.lib.platforms.linux;
-    license = stdenv.lib.licenses.gpl2Plus;
+    platforms = platforms.linux;
+    license = licenses.gpl2Plus;
   };
 }


### PR DESCRIPTION
Using placeholder and drop the NIX_CFLAGS_LINK.

https://gitlab.freedesktop.org/upower/upower/blob/UPOWER_0_99_10/NEWS

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
