### PR TITLE
howl: 0.5.3 -> 0.6

### DIFF
--- a/pkgs/applications/editors/howl/default.nix
+++ b/pkgs/applications/editors/howl/default.nix
@@ -4,12 +4,12 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "howl-${version}";
-  version = "0.5.3";
+  version = "0.6";
 
   # Use the release tarball containing pre-downloaded dependencies sources
   src = fetchurl {
-    url = "https://github.com/howl-editor/howl/releases/download/0.5.3/howl-0.5.3.tgz";
-    sha256 = "0gnc8vr5h8mwapbcqc1zr9la62rb633awyqgy8q7pwjpiy85a03v";
+    url = "https://github.com/howl-editor/howl/releases/download/${version}/howl-${version}.tgz";
+    sha256 = "1qc58l3rkr37cj6vhf8c7bnwbz93nscyraz7jxqwjq6k4gj0cjw3";
   };
 
   sourceRoot = "./howl-${version}/src";


### PR DESCRIPTION
###### Motivation for this change

This upgrades the `howl` package to the latest version.
Changes have been successfully tested.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
