### PR TITLE
stdenv, cacert: $NIX_SSL_CERT_FILE changes

### DIFF
--- a/pkgs/data/misc/cacert/setup-hook.sh
+++ b/pkgs/data/misc/cacert/setup-hook.sh
@@ -1,4 +1,6 @@
 cacertHook() {
+    export NIX_SSL_CERT_FILE=@out@/etc/ssl/certs/ca-bundle.crt
+    # left for compatibility
     export SSL_CERT_FILE=@out@/etc/ssl/certs/ca-bundle.crt
 }
 

--- a/pkgs/development/interpreters/gauche/default.nix
+++ b/pkgs/development/interpreters/gauche/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     "--with-iconv=${libiconv}"
     "--with-dbm=gdbm"
     "--with-zlib=${zlib}"
-    "--with-ca-bundle=$SSL_CERT_FILE"
+    "--with-ca-bundle=$NIX_SSL_CERT_FILE"
     # TODO: Enable slib
     #       Current slib in nixpkgs is specialized to Guile
     # "--with-slib=${slibGuile}/lib/slib"

--- a/pkgs/development/tools/pypi2nix/default.nix
+++ b/pkgs/development/tools/pypi2nix/default.nix
@@ -43,7 +43,7 @@ in stdenv.mkDerivation rec {
     mv click-*/click                    $out/pkgs/click
     mv requests-*/requests              $out/pkgs/
 
-    if [ "$IN_NIX_SHELL" != "1" ]; then
+    if [ -z "$IN_NIX_SHELL" ]; then
       if [ -e git-export ]; then
         mv git-export/src/pypi2nix      $out/pkgs/pypi2nix
       else

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -647,12 +647,12 @@ export NIX_BUILD_CORES
 
 
 # Prevent SSL libraries from using certificates in /etc/ssl, unless set explicitly.
-# Leave it in shells for convenience.
-if [ -z "${NIX_SSL_CERT_FILE:-}" ] && [ -z "${IN_NIX_SHELL:-}" ]; then
+# Leave it in impure shells for convenience.
+if [ -z "${NIX_SSL_CERT_FILE:-}" ] && [ "${IN_NIX_SHELL:-}" != "impure" ]; then
   export NIX_SSL_CERT_FILE=/no-cert-file.crt
 fi
 # Another variant left for compatibility.
-if [ -z "${SSL_CERT_FILE:-}" ] && [ -z "${IN_NIX_SHELL:-}" ]; then
+if [ -z "${SSL_CERT_FILE:-}" ] && [ "${IN_NIX_SHELL:-}" != "impure" ]; then
   export SSL_CERT_FILE=/no-cert-file.crt
 fi
 

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -646,9 +646,12 @@ fi
 export NIX_BUILD_CORES
 
 
-# Prevent OpenSSL-based applications from using certificates in
-# /etc/ssl.
+# Prevent SSL libraries from using certificates in /etc/ssl, unless set explicitly.
 # Leave it in shells for convenience.
+if [ -z "${NIX_SSL_CERT_FILE:-}" ] && [ -z "${IN_NIX_SHELL:-}" ]; then
+  export NIX_SSL_CERT_FILE=/no-cert-file.crt
+fi
+# Another variant left for compatibility.
 if [ -z "${SSL_CERT_FILE:-}" ] && [ -z "${IN_NIX_SHELL:-}" ]; then
   export SSL_CERT_FILE=/no-cert-file.crt
 fi


### PR DESCRIPTION
###### Motivation for this change

Some SSL libs don't react to `$SSL_CERT_FILE`.  That actually makes sense to me, as we add this behavior as nixpkgs-specific, so it seems "safer" to use `$NIX_*`.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date: _docs are **still** missing ;-)_
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
