### PR TITLE
[19.03] Avoid collisions between essential packages

### DIFF
--- a/nixos/modules/config/system-path.nix
+++ b/nixos/modules/config/system-path.nix
@@ -7,7 +7,7 @@ with lib;
 
 let
 
-  requiredPackages = map lib.lowPrio
+  requiredPackages = map (pkg: setPrio ((pkg.meta.priority or 5) + 3) pkg)
     [ config.nix.package
       pkgs.acl
       pkgs.attr

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -327,6 +327,7 @@ stdenv.mkDerivation {
     { description =
         stdenv.lib.attrByPath ["meta" "description"] "System binary utilities" bintools_
         + " (wrapper script)";
+      priority = 10;
   } // optionalAttrs useMacosReexportHack {
     platforms = stdenv.lib.platforms.darwin;
   };

--- a/pkgs/os-specific/darwin/binutils/default.nix
+++ b/pkgs/os-specific/darwin/binutils/default.nix
@@ -52,4 +52,8 @@ stdenv.mkDerivation {
   passthru = {
     inherit targetPrefix;
   };
+
+  meta = {
+    maintainers = with stdenv.lib.maintainers; [ matthewbauer ];
+  };
 }

--- a/pkgs/os-specific/darwin/binutils/default.nix
+++ b/pkgs/os-specific/darwin/binutils/default.nix
@@ -55,5 +55,6 @@ stdenv.mkDerivation {
 
   meta = {
     maintainers = with stdenv.lib.maintainers; [ matthewbauer ];
+    priority = 10;
   };
 }

--- a/pkgs/os-specific/linux/procps-ng/default.nix
+++ b/pkgs/os-specific/linux/procps-ng/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = https://gitlab.com/procps-ng/procps;
     description = "Utilities that give information about processes using the /proc filesystem";
-    priority = 10; # less than coreutils, which also provides "kill" and "uptime"
+    priority = 11; # less than coreutils, which also provides "kill" and "uptime"
     license = lib.licenses.gpl2;
     platforms = lib.platforms.unix;
     maintainers = [ lib.maintainers.typetetris ];

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -220,6 +220,7 @@ in stdenv.mkDerivation rec {
     description = "A system and service manager for Linux";
     license = licenses.lgpl21Plus;
     platforms = platforms.linux;
+    priority = 10;
     maintainers = [ maintainers.eelco ];
   };
 }

--- a/pkgs/tools/archivers/gnutar/default.nix
+++ b/pkgs/tools/archivers/gnutar/default.nix
@@ -62,5 +62,7 @@ stdenv.mkDerivation rec {
 
     maintainers = [ ];
     platforms = stdenv.lib.platforms.all;
+
+    priority = 10;
   };
 }

--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -123,6 +123,8 @@ stdenv.mkDerivation rec {
 
     platforms = platforms.unix ++ platforms.windows;
 
+    priority = 10;
+
     maintainers = [ maintainers.eelco ];
   };
 

--- a/pkgs/top-level/unix-tools.nix
+++ b/pkgs/top-level/unix-tools.nix
@@ -20,7 +20,10 @@ let
       bin = "${getBin provider}/bin/${cmd}";
       manpage = "${getOutput "man" provider}/share/man/man1/${cmd}.1.gz";
     in runCommand "${cmd}-${version}" {
-      meta.platforms = map (n: { kernel.name = n; }) (attrNames providers);
+      meta = {
+        priority = 10;
+        platforms = map (n: { kernel.name = n; }) (attrNames providers);
+      };
       passthru = { inherit provider; };
       preferLocalBuild = true;
     } ''


### PR DESCRIPTION
###### Motivation for this change
Backport #61138 to 19.03. This should finally close #55886.

###### Things done
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files
- [ ] Determined the impact on package closure size
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
