### PR TITLE
spl: fix build with linux 5.1

### DIFF
--- a/pkgs/os-specific/linux/spl/default.nix
+++ b/pkgs/os-specific/linux/spl/default.nix
@@ -21,6 +21,11 @@ stdenv.mkDerivation rec {
 
   patches = [ ./install_prefix.patch ];
 
+  # Backported fix for 0.7.13 to build with 5.1, please remove when updating to 0.7.14
+  postPatch = optionalString (versionAtLeast kernel.version "5.1") ''
+    sed -i 's/get_ds()/KERNEL_DS/g' module/spl/spl-vnode.c
+  '';
+
   nativeBuildInputs = [ autoreconfHook ] ++ kernel.moduleBuildDependencies;
 
   hardeningDisable = [ "fortify" "stackprotector" "pic" ];


### PR DESCRIPTION
Upstream issue: https://github.com/zfsonlinux/zfs/issues/8697
Upstream fix (zfs repo): 782dfae3218b5f2029ce78722b999cb04e8ef001

This can't be applied cleanly as a patch, since spl has been moved
into the zfs repo since 0.7.13.

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc maintainers @fpletz @wizeman @globin