### PR TITLE
kubernetes: 1.13.5 -> 1.13.6

### DIFF
--- a/pkgs/applications/networking/cluster/kubernetes/default.nix
+++ b/pkgs/applications/networking/cluster/kubernetes/default.nix
@@ -15,13 +15,13 @@ with lib;
 
 stdenv.mkDerivation rec {
   name = "kubernetes-${version}";
-  version = "1.13.5";
+  version = "1.13.6";
 
   src = fetchFromGitHub {
     owner = "kubernetes";
     repo = "kubernetes";
     rev = "v${version}";
-    sha256 = "06pf4h76zsqs3dsxr57y9sb9sw48nfyw1x2q1725zww61jfz2a6y";
+    sha256 = "02v12x241zkl11qfb8d472kzq3hvsgip1qvg179kf1xwd5cswlxq";
   };
 
   buildInputs = [ removeReferencesTo makeWrapper which go rsync go-bindata ];


### PR DESCRIPTION

###### Motivation for this change
Bump kubernetes revision.

Tests run clean locally:
```
$ nix-build nixos/release.nix -A tests.kubernetes.dns.singlenode -A tests.kubernetes.dns.multinode -A tests.kubernetes.rbac.singlenode -A tests.kubernetes.rbac.multinode
/nix/store/3mir42ixsa0c9jqf3g27nqa2p49ivgaj-vm-test-run-kubernetes-dns-singlenode
/nix/store/nzj809jb8swd0g78h70csrs7kdkpwgp0-vm-test-run-kubernetes-dns-multinode
/nix/store/f8iqn98k7r8m6ll51k0j7hnn4cipwin6-vm-test-run-kubernetes-rbac-singlenode
/nix/store/3mdg3x892z25r3ywp5szn264gs9kd6p7-vm-test-run-kubernetes-rbac-multinode
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
