### PR TITLE
Kube3d

### DIFF
--- a/pkgs/applications/networking/cluster/kube3d/default.nix
+++ b/pkgs/applications/networking/cluster/kube3d/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, buildGoPackage, fetchFromGitHub }:
+
+buildGoPackage rec {
+  pname = "kube3d";
+  version = "1.1.0";
+
+  goPackagePath = "github.com/rancher/k3d";
+
+  src = fetchFromGitHub {
+    owner  = "rancher";
+    repo   = "k3d";
+    rev    = "v${version}";
+    sha256 = "180q7a95znpkhfqcaw3asqrq22r6ppw98qsggp2wfm746mllg5pc";
+  };
+
+  goDeps = ./deps.nix;
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/rancher/k3d";
+    description = "A helper to run k3s (Lightweight Kubernetes. 5 less than k8s) in a docker container";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ kuznero ];
+  };
+}

--- a/pkgs/applications/networking/cluster/kube3d/deps.nix
+++ b/pkgs/applications/networking/cluster/kube3d/deps.nix
@@ -1,0 +1,174 @@
+# file generated from go.mod using vgo2nix (https://github.com/adisbladis/vgo2nix)
+[
+  {
+    goPackagePath = "github.com/Microsoft/go-winio";
+    fetch = {
+      type = "git";
+      url = "https://github.com/Microsoft/go-winio";
+      rev = "v0.4.12";
+      sha256 = "10v2f1xaw2cc97mjqnxzgs9ydpqv71f0ynp1spcywqw97la56zqw";
+    };
+  }
+  {
+    goPackagePath = "github.com/davecgh/go-spew";
+    fetch = {
+      type = "git";
+      url = "https://github.com/davecgh/go-spew";
+      rev = "v1.1.0";
+      sha256 = "0d4jfmak5p6lb7n2r6yvf5p1zcw0l8j74kn55ghvr7zr7b7axm6c";
+    };
+  }
+  {
+    goPackagePath = "github.com/docker/distribution";
+    fetch = {
+      type = "git";
+      url = "https://github.com/docker/distribution";
+      rev = "v2.7.1";
+      sha256 = "1nx8b5a68rn81alp8wkkw6qd5v32mgf0fk23mxm60zdf63qk1nzw";
+    };
+  }
+  {
+    goPackagePath = "github.com/docker/docker";
+    fetch = {
+      type = "git";
+      url = "https://github.com/docker/docker";
+      rev = "v1.13.1";
+      sha256 = "0l9kjibnpwcgk844sibxk9ppyqniw9r0np1mzp95f8f461jb0iar";
+    };
+  }
+  {
+    goPackagePath = "github.com/docker/go-connections";
+    fetch = {
+      type = "git";
+      url = "https://github.com/docker/go-connections";
+      rev = "v0.4.0";
+      sha256 = "0mv6f6b5nljc17dmwmc28hc0y11pqglz7x0d2mjrwdmfxf64hwqq";
+    };
+  }
+  {
+    goPackagePath = "github.com/docker/go-units";
+    fetch = {
+      type = "git";
+      url = "https://github.com/docker/go-units";
+      rev = "v0.3.3";
+      sha256 = "0npxsb3pp89slwf4a73fxm20hykad8xggij6i6hcd5jy19bjrd93";
+    };
+  }
+  {
+    goPackagePath = "github.com/mattn/go-runewidth";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-runewidth";
+      rev = "v0.0.4";
+      sha256 = "00b3ssm7wiqln3k54z2wcnxr3k3c7m1ybyhb9h8ixzbzspld0qzs";
+    };
+  }
+  {
+    goPackagePath = "github.com/mitchellh/go-homedir";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/go-homedir";
+      rev = "v1.1.0";
+      sha256 = "0ydzkipf28hwj2bfxqmwlww47khyk6d152xax4bnyh60f4lq3nx1";
+    };
+  }
+  {
+    goPackagePath = "github.com/olekukonko/tablewriter";
+    fetch = {
+      type = "git";
+      url = "https://github.com/olekukonko/tablewriter";
+      rev = "v0.0.1";
+      sha256 = "0hh95glg7d2md185r03wn52j2r33jc4zil0qvcrs66ka7bdxi7vj";
+    };
+  }
+  {
+    goPackagePath = "github.com/opencontainers/go-digest";
+    fetch = {
+      type = "git";
+      url = "https://github.com/opencontainers/go-digest";
+      rev = "v1.0.0-rc1";
+      sha256 = "01gc7fpn8ax429024p2fcx3yb18axwz5bjf2hqxlii1jbsgw4bh9";
+    };
+  }
+  {
+    goPackagePath = "github.com/pkg/errors";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pkg/errors";
+      rev = "v0.8.1";
+      sha256 = "0g5qcb4d4fd96midz0zdk8b9kz8xkzwfa8kr1cliqbg8sxsy5vd1";
+    };
+  }
+  {
+    goPackagePath = "github.com/pmezard/go-difflib";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pmezard/go-difflib";
+      rev = "v1.0.0";
+      sha256 = "0c1cn55m4rypmscgf0rrb88pn58j3ysvc2d0432dp3c6fqg6cnzw";
+    };
+  }
+  {
+    goPackagePath = "github.com/stretchr/objx";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/objx";
+      rev = "v0.1.0";
+      sha256 = "19ynspzjdynbi85xw06mh8ad5j0qa1vryvxjgvbnyrr8rbm4vd8w";
+    };
+  }
+  {
+    goPackagePath = "github.com/stretchr/testify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/testify";
+      rev = "v1.3.0";
+      sha256 = "0wjchp2c8xbgcbbq32w3kvblk6q6yn533g78nxl6iskq6y95lxsy";
+    };
+  }
+  {
+    goPackagePath = "github.com/urfave/cli";
+    fetch = {
+      type = "git";
+      url = "https://github.com/urfave/cli";
+      rev = "v1.20.0";
+      sha256 = "0y6f4sbzkiiwrxbl15biivj8c7qwxnvm3zl2dd3mw4wzg4x10ygj";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev = "c2843e01d9a2";
+      sha256 = "01xgxbj5r79nmisdvpq48zfy8pzaaj90bn6ngd4nf33j9ar1dp8r";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev = "b630fd6fe46b";
+      sha256 = "0m84kwckmmc0z05kjb4dd43g1g61al32a4z593flpcbaqx8di5sd";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev = "d0b11bdaac8a";
+      sha256 = "18yfsmw622l7gc5sqriv5qmck6903vvhivpzp8i3xfy3z33dybdl";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev = "v0.3.0";
+      sha256 = "0r6x6zjzhr8ksqlpiwm5gdd7s209kwk5p4lw54xjvz10cs3qlq19";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24326,4 +24326,6 @@ in
 
   dapper = callPackage ../development/tools/dapper { };
 
+  kube3d =  callPackage ../applications/networking/cluster/kube3d {};
+
 }


### PR DESCRIPTION
###### Motivation for this change
Add the k3d (https://github.com/rancher/k3d) tool.
The k3d tool spins up a k3s kubernetes cluster.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---