### PR TITLE
Pass CARGO_HOME on more invocations of cargo

### DIFF
--- a/pkgs/build-support/rust/default.nix
+++ b/pkgs/build-support/rust/default.nix
@@ -97,6 +97,7 @@ in stdenv.mkDerivation (args // {
 
     (
     set -x
+    export CARGO_HOME=$(pwd)
     env \
       "CC_${stdenv.buildPlatform.config}"="${ccForBuild}" \
       "CXX_${stdenv.buildPlatform.config}"="${cxxForBuild}" \
@@ -121,6 +122,7 @@ in stdenv.mkDerivation (args // {
   checkPhase = args.checkPhase or ''
     runHook preCheck
     echo "Running cargo test"
+    export CARGO_HOME=$(pwd)
     cargo test
     runHook postCheck
   '';


### PR DESCRIPTION
Fixes #61192.

###### Motivation for this change

Although this failure only occurs when using Cargo nightly, which isn't actually packaged here yet, this will eventually become a problem when nightly becomes stable.

I'm not really sure that this is the right place for this change. Is the existing absence of `CARGO_HOME` meant to flush out reproducibility failures when cargo tries to download a package? Or was it just because previously `cargo` didn't need to do anything in the build or test phases so it wasn't necessary?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
