### PR TITLE
rtl8192eu: update at 4.4.1

### DIFF
--- a/pkgs/os-specific/linux/rtl8192eu/default.nix
+++ b/pkgs/os-specific/linux/rtl8192eu/default.nix
@@ -11,8 +11,8 @@ in stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "Mange";
     repo = "rtl8192eu-linux-driver";
-    rev = "4094004";
-    sha256 = "0rgcsp8bd5i5ik9b35qipdhq0xd8pva8kdijixxfaxm4vw6kbrvr";
+    rev = "0a7199b";
+    sha256 = "0xxb8z7fd997ny53bgmf95hyqsmwjplbj6fry0rf65k9x9nggx71";
   };
 
   hardeningDisable = [ "pic" ];

--- a/pkgs/os-specific/linux/rtl8192eu/default.nix
+++ b/pkgs/os-specific/linux/rtl8192eu/default.nix
@@ -6,7 +6,7 @@ let modDestDir = "$out/lib/modules/${kernel.modDirVersion}/kernel/drivers/net/wi
 
 in stdenv.mkDerivation rec {
   name = "rtl8192eu-${kernel.version}-${version}";
-  version = "4.4.1";
+  version = "4.4.1.20190319";
 
   src = fetchFromGitHub {
     owner = "Mange";


### PR DESCRIPTION
###### Motivation for this change
Latest commit in rtl8192eu module github repo contains fixes for compiling with 5.0 and 5.1 kernels so I've just updated git hash codes
###### Things done
Updated git commit hashes to checkout latest rtl8192eu kernel module source code

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
