### PR TITLE
certbot: 0.31.0 -> ... -> 0.35.0

### DIFF
--- a/pkgs/tools/admin/certbot/default.nix
+++ b/pkgs/tools/admin/certbot/default.nix
@@ -41,7 +41,7 @@ python3Packages.buildPythonApplication rec {
   '';
 
   checkInputs = with python3Packages; [ pytest pyyaml ];
-  doCheck = false /* integration tests want 'docker', not sure how to disable */ && !stdenv.isDarwin; # On Hydra Darwin tests fail with "Too many open files".
+  doCheck = false /* integration tests want 'docker', not sure how to disable */;
 
   meta = with stdenv.lib; {
     homepage = src.meta.homepage;

--- a/pkgs/tools/admin/certbot/default.nix
+++ b/pkgs/tools/admin/certbot/default.nix
@@ -2,13 +2,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "certbot";
-  version = "0.34.2";
+  version = "0.35.0";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "0658awigjxih5j0snrs8iwazhviw9ivq6pib7sy0939haigqf32f";
+    sha256 = "1phrh07w22hkgn7cxm19ksgsnk6xrv96w5rc0ihvsnigwhlfb4ln";
   };
 
   propagatedBuildInputs = with python3Packages; [

--- a/pkgs/tools/admin/certbot/default.nix
+++ b/pkgs/tools/admin/certbot/default.nix
@@ -2,13 +2,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "certbot";
-  version = "0.31.0";
+  version = "0.34.2";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "0rwjxmkpicyc9a5janvj1lfi430nq6ha94nyfgp11ds9fyydbh1s";
+    sha256 = "0658awigjxih5j0snrs8iwazhviw9ivq6pib7sy0939haigqf32f";
   };
 
   propagatedBuildInputs = with python3Packages; [
@@ -40,7 +40,8 @@ python3Packages.buildPythonApplication rec {
     done
   '';
 
-  doCheck = !stdenv.isDarwin; # On Hydra Darwin tests fail with "Too many open files".
+  checkInputs = with python3Packages; [ pytest pyyaml ];
+  doCheck = false /* integration tests want 'docker', not sure how to disable */ && !stdenv.isDarwin; # On Hydra Darwin tests fail with "Too many open files".
 
   meta = with stdenv.lib; {
     homepage = src.meta.homepage;


### PR DESCRIPTION
###### Motivation for this change

Whoops, I guess I haven't been sending these for a while :3.

Tests disabled because they require docker (integration testing),
dunno if there's a way to run non-docker tests or such, suggestions
welcome :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---