### PR TITLE
electrum: 3.3.4 -> 3.3.5 (not your typical version bump)

### DIFF
--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -14,13 +14,13 @@ in
 
 python3Packages.buildPythonApplication rec {
   pname = "electrum";
-  version = "3.3.4";
+  version = "3.3.5";
 
   src = fetchFromGitHub {
     owner = "spesmilo";
     repo = "electrum";
     rev = version;
-    sha256 = "0yxdpc602jnd14xz3px85ka0b6db98zwbgfi9a3vj8p1k3mmiwaj";
+    sha256 = "039y0z8v65ffzz6qm9wv9n29l3i2ik59xs6z6mg5pi4f5mjq05jj";
   };
 
   propagatedBuildInputs = with python3Packages; [

--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, python3, python3Packages, zbar, secp256k1 }:
+{ stdenv, fetchurl, python3, python3Packages, zbar, secp256k1 }:
 
 let
   qdarkstyle = python3Packages.buildPythonPackage rec {
@@ -16,11 +16,9 @@ python3Packages.buildPythonApplication rec {
   pname = "electrum";
   version = "3.3.5";
 
-  src = fetchFromGitHub {
-    owner = "spesmilo";
-    repo = "electrum";
-    rev = version;
-    sha256 = "039y0z8v65ffzz6qm9wv9n29l3i2ik59xs6z6mg5pi4f5mjq05jj";
+  src = fetchurl {
+    url = "https://download.electrum.org/${version}/Electrum-${version}.tar.gz";
+    sha256 = "1csj0n96zlajnrs39wsazfj5lmy7v7n77cdz56lr8nkmchh6k9z1";
   };
 
   propagatedBuildInputs = with python3Packages; [

--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -62,7 +62,10 @@ python3Packages.buildPythonApplication rec {
     rm -rf $out/${python3.sitePackages}/nix
 
     substituteInPlace $out/share/applications/electrum.desktop \
-      --replace "Exec=electrum %u" "Exec=$out/bin/electrum %u"
+      --replace 'Exec=sh -c "PATH=\"\\$HOME/.local/bin:\\$PATH\"; electrum %u"' \
+                "Exec=$out/bin/electrum %u" \
+      --replace 'Exec=sh -c "PATH=\"\\$HOME/.local/bin:\\$PATH\"; electrum --testnet %u"' \
+                "Exec=$out/bin/electrum --testnet %u"
   '';
 
   checkInputs = with python3Packages; [ pytest ];

--- a/pkgs/development/python-modules/aiorpcx/default.nix
+++ b/pkgs/development/python-modules/aiorpcx/default.nix
@@ -2,12 +2,12 @@
 
 buildPythonPackage rec {
   pname = "aiorpcx";
-  version = "0.10.5";
+  version = "0.17.0";
 
   src = fetchPypi {
     inherit version;
     pname = "aiorpcX";
-    sha256 = "0c4kan020s09ap5qai7p1syxjz2wk6g9ydhxj6fc35s4103x7b91";
+    sha256 = "14np5r75rs0v45vsv20vbzmnv3qisvm9mdllj1j9s1633cvcik0k";
   };
 
   propagatedBuildInputs = [ attrs ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Bah, see commits for details.

I thought we'd gone down this path before,
but if we did I can't find the PR on github.

Please take a look :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---