### PR TITLE
scons: Fix a wrapping issue which overrides your PATH

### DIFF
--- a/pkgs/development/tools/build-managers/scons/common.nix
+++ b/pkgs/development/tools/build-managers/scons/common.nix
@@ -16,6 +16,13 @@ in python2Packages.buildPythonApplication {
 
   setupHook = ./setup-hook.sh;
 
+  # If your PATH contains a python.withPackages interpreter and as part of your
+  # SConstruct build you want to launch a python script in a subprocess, which
+  # should run with '#!/usr/bin/env python', then it would be problematic to have
+  # scons wrapped with an additional PATH pointing to a different python
+  # interpreter. None of your withPackages-packages would be importable.
+  dontWrapPythonPrograms = true;
+
   meta = with stdenv.lib; {
     homepage = http://scons.org/;
     description = "An improved, cross-platform substitute for Make";


### PR DESCRIPTION
This fixes the following situation:
If your PATH contains a python.withPackages interpreter and as part of
your SConstruct build you want to launch a python script in a
subprocess, which should run with '#!/usr/bin/env python', then it would
be problematic to have scons wrapped with an additional PATH pointing to
a different python interpreter. None of your withPackages-packages would
be importable.

In a sidenote: this will also remove the PYTHONNOUSERSITE argument. I'm not yet sure if this behavior is good or bad. So to whoever will be reviewing this, I'm especially interested in this part of the PR.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
