### PR TITLE
maintainer-list: add my gpg key info (@dtzWill), fix email

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1354,9 +1354,13 @@
     name = "David Sferruzza";
   };
   dtzWill = {
-    email = "nix@wdtz.org";
+    email = "w@wdtz.org";
     github = "dtzWill";
     name = "Will Dietz";
+    keys = [{
+      longkeyid = "rsa4096/0xFD42C7D0D41494C8";
+      fingerprint = "389A 78CB CD88 5E0C 4701  DEB9 FD42 C7D0 D414 94C8";
+    }];
   };
   dxf = {
     email = "dingxiangfei2009@gmail.com";


### PR DESCRIPTION
Apparently I have zero commits under nix@wdtz.org,
so change my address to match my commits and key.

###### Motivation for this change

Touchup my maintainer entry to reflect
the email I use for commits, add gpg info.

---