### PR TITLE
xmind: 7.5-update1 -> 8-update8

### DIFF
--- a/pkgs/applications/misc/xmind/java-env-config-fixes.patch
+++ b/pkgs/applications/misc/xmind/java-env-config-fixes.patch
@@ -1,0 +1,40 @@
+diff --git a/XMind_amd64/XMind.ini b/XMind_amd64/XMind.ini
+index bdd8a37..5f35daf 100644
+--- a/XMind_amd64/XMind.ini
++++ b/XMind_amd64/XMind.ini
+@@ -1,11 +1,11 @@
+ -configuration
+-./configuration
++@user.home/.xmind/configuration-cathy_linux_64
+ -data
+-../workspace
++@user.home/.xmind/workspace-cathy
+ -startup
+-../plugins/org.eclipse.equinox.launcher_1.3.200.v20160318-1642.jar
++plugins/org.eclipse.equinox.launcher_1.3.200.v20160318-1642.jar
+ --launcher.library
+-../plugins/org.eclipse.equinox.launcher.gtk.linux.x86_64_1.1.400.v20160518-1444
++plugins/org.eclipse.equinox.launcher.gtk.linux.x86_64_1.1.400.v20160518-1444
+ --launcher.defaultAction
+ openFile
+ --launcher.GTK_version
+diff --git a/XMind_i386/XMind.ini b/XMind_i386/XMind.ini
+index 4ed3225..1d74258 100644
+--- a/XMind_i386/XMind.ini
++++ b/XMind_i386/XMind.ini
+@@ -1,11 +1,11 @@
+ -configuration
+-./configuration
++@user.home/.xmind/configuration-cathy_linux_64
+ -data
+-../workspace
++@user.home/.xmind/workspace-cathy
+ -startup
+-../plugins/org.eclipse.equinox.launcher_1.3.200.v20160318-1642.jar
++plugins/org.eclipse.equinox.launcher_1.3.200.v20160318-1642.jar
+ --launcher.library
+-../plugins/org.eclipse.equinox.launcher.gtk.linux.x86_1.1.400.v20160518-1444
++plugins/org.eclipse.equinox.launcher.gtk.linux.x86_1.1.400.v20160518-1444
+ --launcher.defaultAction
+ openFile
+ --launcher.GTK_version


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The latest version of XMind doesn't support a prebuilt debian package
anymore, hence a manual installation of the ZIP is needed. The new
configuration for the Java GUI had to be patched as it relied on several
paths in the ZIP that won't work anymore in a Nix-based environment.

Additionally the following changes were made:

* Manual creation of a desktop item and an icon (we're using the one
  from AUR for now). Those files were available in the old `.deb`, but
  that isn't supported for the latest XMind version.

* Created a patch fro `XMind.ini` to use writable paths in $HOME and fix
  the path to the plugins in the store path.

* Created a custom startup script which ensures the creation of
  `$HOME/.xmind` and copies the relevant files from the store path into
  it. Such a behavior was available in the old `.deb` as well, but not
  anymore with the new ZIP.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
