### PR TITLE
alttab: init at 1.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4454,6 +4454,11 @@
     github = "sfrijters";
     name = "Stefan Frijters";
   };
+  sgraf = {
+    email = "sgraf1337@gmail.com";
+    github = "sgraf812";
+    name = "Sebastian Graf";
+  };
   shanemikel = {
     email = "shanemikel1@gmail.com";
     github = "shanemikel";

--- a/pkgs/tools/X11/alttab/default.nix
+++ b/pkgs/tools/X11/alttab/default.nix
@@ -1,0 +1,45 @@
+{ stdenv, fetchFromGitHub, autoconf, automake, pkgconfig, ronn, libpng, uthash
+, xorg }:
+
+stdenv.mkDerivation rec {
+  version = "1.4.0";
+
+  pname = "alttab";
+
+  src = fetchFromGitHub {
+    owner = "sagb";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "028ifp54yl3xq5mj2ww9baga8p56nmrx4ypvj8k35akcaxdpyga9";
+  };
+
+  nativeBuildInputs = [ 
+    autoconf
+    automake
+    pkgconfig
+    ronn
+  ];
+
+  preConfigure = "./bootstrap.sh";
+
+  buildInputs = [
+    libpng
+    uthash
+    xorg.libX11
+    xorg.libXft
+    xorg.libXmu
+    xorg.libXpm
+    xorg.libXrandr
+    xorg.libXrender
+  ];
+
+  enableParallelBuild = true;
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/sagb/alttab;
+    description = "X11 window switcher designed for minimalistic window managers or standalone X11 session";
+    license = licenses.gpl3;
+    platforms = platforms.all;
+    maintainers = [ maintainers.sgraf ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -645,6 +645,8 @@ in
 
   altermime = callPackage ../tools/networking/altermime {};
 
+  alttab = callPackage ../tools/X11/alttab { };
+
   amule = callPackage ../tools/networking/p2p/amule { };
 
   amuleDaemon = appendToName "daemon" (amule.override {


### PR DESCRIPTION
###### Motivation for this change

`alttab` is a window switcher for X11, designed for minimalistic window
managers or a standalone X11 session.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
