### PR TITLE
ocamlPackages.cairo2: 0.6 -> 0.6.1; ocamlPackages.lablgtk3: 3.0.beta5 -> 3.0.beta6

### DIFF
--- a/pkgs/development/ocaml-modules/cairo2/default.nix
+++ b/pkgs/development/ocaml-modules/cairo2/default.nix
@@ -4,11 +4,11 @@
 
 buildDunePackage rec {
   pname = "cairo2";
-  version = "0.6";
+  version = "0.6.1";
 
   src = fetchurl {
     url = "https://github.com/Chris00/ocaml-cairo/releases/download/${version}/cairo2-${version}.tbz";
-    sha256 = "1k2q7ipmddqnd2clybj4qb5xwzzrnl2fxnd6kv60dlzgya18lchs";
+    sha256 = "1ik4qf4b9443sliq2z7x9acd40rmzvyzjh3bh98wvjklxbb84a9i";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/development/ocaml-modules/lablgtk3/default.nix
+++ b/pkgs/development/ocaml-modules/lablgtk3/default.nix
@@ -1,16 +1,14 @@
-{ lib, fetchFromGitHub, pkgconfig, buildDunePackage, gtk3, cairo2 }:
+{ lib, fetchurl, pkgconfig, buildDunePackage, gtk3, cairo2 }:
 
 buildDunePackage rec {
-  version = "3.0.beta5";
+  version = "3.0.beta6";
   pname = "lablgtk3";
 
   minimumOCamlVersion = "4.05";
 
-  src = fetchFromGitHub {
-    owner = "garrigue";
-    repo = "lablgtk";
-    rev = version;
-    sha256 = "05n3pjy4496gbgxwbypfm2462njv6dgmvkcv26az53ianpwa4vzz";
+  src = fetchurl {
+    url = "https://github.com/garrigue/lablgtk/releases/download/${version}/lablgtk3-${version}.tbz";
+    sha256 = "1jni5cbp54qs7y0dc5zkm28v2brpfwy5miighv7cy0nmmxrsq520";
   };
 
   nativeBuildInputs = [ pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

Fixes and improvements:
https://github.com/Chris00/ocaml-cairo/releases/tag/0.6.1
https://github.com/garrigue/lablgtk/releases/tag/3.0.beta6

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
