### PR TITLE
idsk: unstable-2018-02-11 -> 0.19

### DIFF
--- a/pkgs/tools/filesystems/idsk/default.nix
+++ b/pkgs/tools/filesystems/idsk/default.nix
@@ -2,23 +2,14 @@
 
 stdenv.mkDerivation rec {
 
-  repo = "idsk";
-  version = "unstable-2018-02-11";
-  rev = "1846729ac3432aa8c2c0525be45cfff8a513e007";
-  name = "${repo}-${version}";
-
-  meta = with stdenv.lib; {
-    description = "Manipulating CPC dsk images and files";
-    homepage = https://github.com/cpcsdk/idsk ;
-    license = "unknown";
-    maintainers = [ maintainers.genesis ];
-    platforms = platforms.linux;
-  };
+  pname = "idsk";
+  version = "0.19";
 
   src = fetchFromGitHub {
-    inherit rev repo;
+    repo = "idsk";
     owner = "cpcsdk";
-    sha256 = "0d891lvf2nc8bys8kyf69k54rf3jlwqrcczbff8xi0w4wsiy5ckv";
+    rev = "v${version}";
+    sha256 = "0b4my5cz5kbzh4n65jr721piha6zixaxmfiss2zidip978k9rb6f";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -27,4 +18,12 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin
     cp iDSK $out/bin
   '';
+
+  meta = with stdenv.lib; {
+    description = "Manipulating CPC dsk images and files";
+    homepage = "https://github.com/cpcsdk/idsk" ;
+    license = licenses.mit;
+    maintainers = [ maintainers.genesis ];
+    platforms = platforms.linux;
+  };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

fix homepage , license ( https://github.com/cpcsdk/idsk/issues/6 ) and release !

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
