### PR TITLE
[19.03] rednose: disable test suite

### DIFF
--- a/pkgs/development/python-modules/rednose/default.nix
+++ b/pkgs/development/python-modules/rednose/default.nix
@@ -13,9 +13,9 @@ buildPythonPackage rec {
     substituteInPlace setup.py --replace "six==1.10.0" "six>=1.10.0"
   '';
 
-  # Do not test on Python 2 darwin because the tests suite gets stuck
-  # https://github.com/JBKahn/rednose/issues/23
-  doCheck = !(stdenv.isDarwin && isPy27);
+  # Do not test on Python 2 because the tests suite gets stuck
+  # https://github.com/NixOS/nixpkgs/issues/60786
+  doCheck = !(isPy27);
 
   checkInputs = [ six ];
   propagatedBuildInputs = [ nose colorama termstyle ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

Building nixops fails because the python test suite gets stuck. The test suite had previously been disabled for Darwin because of a similar error. So now I disabled it entirely because I was also getting an error on a Debian Linux system.

Occured during testing of https://github.com/fort-nix/nix-bitcoin/pull/48

###### Motivation for this change

Backport of #60805
/cc @FRidh 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
