### PR TITLE
neo.map: fix URL

### DIFF
--- a/pkgs/os-specific/linux/kbd/keymaps.nix
+++ b/pkgs/os-specific/linux/kbd/keymaps.nix
@@ -23,8 +23,9 @@
     version = "2476";
 
     src = fetchurl {
-      name = "neo.map";
-      url = "https://svn.neo-layout.org/linux/console/neo.map?r=${version}";
+      pname = "neo.map";
+      url = "https://raw.githubusercontent.com/neo-layout/neo-layout/"
+          + "a0dee06fed824abfad658b7f10e6d907b270be0a/linux/console/neo.map";
       sha256 = "19mfrd31vzpsjiwc7pshxm0b0sz5dd17xrz6k079cy4im1vf0r4g";
     };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

Current URL is no longer available, due to the migration from svn to github.

Occurred during testing of https://github.com/fort-nix/nix-bitcoin/pull/48

###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/60201 seems to have stalled. This PR commits @samsonan-it's fix and @teto's & @matthiasbeyer's suggested changes.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
