### PR TITLE
cfitsio: 3.430 -> 3.450

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5401,6 +5401,11 @@
     github = "xaverdh";
     name = "Dominik Xaver Hörl";
   };
+  xbreak = {
+    email = "xbreak@alphaware.se";
+    github = "xbreak";
+    name = "Calle Rosenquist";
+  };
   xeji = {
     email = "xeji@cat3.de";
     github = "xeji";

--- a/pkgs/development/libraries/cfitsio/default.nix
+++ b/pkgs/development/libraries/cfitsio/default.nix
@@ -1,14 +1,22 @@
-{ fetchurl, stdenv }:
+{ fetchurl, stdenv
 
- stdenv.mkDerivation {
-  name = "cfitsio-3.430";
+# Optional dependencies
+, bzip2 ? null }:
+
+stdenv.mkDerivation rec {
+  name = "cfitsio-${version}";
+  version = "3.450";
 
   src = fetchurl {
-    url = "ftp://heasarc.gsfc.nasa.gov/software/fitsio/c/cfitsio3430.tar.gz";
-    sha256 = "07fghxh5fl8nqk3q0dh8rvc83npnm0hisxzcj16a6r7gj5pmp40l";
+    url = "https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio${builtins.replaceStrings ["."] [""] version}.tar.gz";
+    sha256 = "0bmrkw6w65zb0k3mszaaqy1f4zjm2hl7njww74nb5v38wvdi4q5z";
   };
 
+  buildInputs = [ bzip2 ];
+
   patches = [ ./darwin-curl-config.patch ./darwin-rpath-universal.patch ];
+
+  configureFlags = stdenv.lib.optional (bzip2 != null) "--with-bzip2=${bzip2.out}";
 
   # Shared-only build
   buildFlags = "shared";
@@ -27,8 +35,8 @@
          advanced features for manipulating and filtering the information in
          FITS files.
       '';
-    # Permissive BSD-style license.
-    license = "permissive";
+    license = licenses.mit;
+    maintainers = [ maintainers.xbreak ];
     platforms = with platforms; linux ++ darwin;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

- Update cfits version from 3.430 to 3.450. Please also note that this update contains security fixes made in 3.440 ([ChangeLog](https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/docs/changes.txt)).
- Switch src.url to use https (HEASARC will disable FTP as of September 2019, https://heasarc.gsfc.nasa.gov/docs/FTPWarning.html).
- Added optional bzip2 support in derivation (enabled by default as suggested by @c0bw3b). 

###### Changes from Review
- ~~This also includes a fixup of the `cfitsio.pc` file to point to the store path of the bzip2 libraries.~~ Not needed if bzip2.out is used instead.
- Enabled bzip2 support by default.
- Minor cleanup.
- Added myself as maintainer.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions (CentOS 7.4)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] *Tested compilation of all pkgs that depend on this change manually
- [x] Tested compilation with bzip support enabled and manually inspected libraries and pc-file.
- [x] **Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
---
\* I had to manually build some packages due to error cloning builder process (I'm running single user on CentOS without sandboxing).
\** Tested to load fits files with giv

Built ok:
- cfitsio
- gimpPlugins.ufraw
- ufraw
- indilib
- gildas
- gimp-with-plugins
- giv