### PR TITLE
openexr: fix cross-compilation

### DIFF
--- a/pkgs/development/libraries/openexr/default.nix
+++ b/pkgs/development/libraries/openexr/default.nix
@@ -20,8 +20,7 @@ stdenv.mkDerivation rec {
     ./bootstrap
   '';
 
-  nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ autoconf automake libtool ];
+  nativeBuildInputs = [ pkgconfig autoconf automake libtool ];
   propagatedBuildInputs = [ ilmbase zlib ];
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/openexr/default.nix
+++ b/pkgs/development/libraries/openexr/default.nix
@@ -1,4 +1,9 @@
-{ lib, stdenv, fetchurl, autoconf, automake, libtool, pkgconfig, zlib, ilmbase }:
+{ lib, stdenv, buildPackages, fetchurl, autoconf, automake, libtool, pkgconfig, zlib, ilmbase, }:
+
+let
+  # Doesn't really do anything when not crosscompiling
+  emulator = stdenv.hostPlatform.emulator buildPackages;
+in
 
 stdenv.mkDerivation rec {
   name = "openexr-${version}";
@@ -14,6 +19,22 @@ stdenv.mkDerivation rec {
   ];
 
   outputs = [ "bin" "dev" "out" "doc" ];
+
+  # Needed because there are some generated sources. Solution: just run them under QEMU.
+  postPatch = ''
+    for file in b44ExpLogTable dwaLookups
+    do
+      # Ecape for both sh and Automake
+      emu=${lib.escapeShellArg (lib.replaceStrings ["$"] ["$$"] emulator)}
+      before="./$file > $file.h"
+      after="$emu $before"
+      substituteInPlace IlmImf/Makefile.am \
+        --replace "$before" "$after"
+    done
+
+    # Make sure the patch succeeded
+    [[ $(grep "$emu" IlmImf/Makefile.am | wc -l) = 2 ]]
+  '';
 
   preConfigure = ''
     patchShebangs ./bootstrap


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - They seem to work, but I'm not sure what exactly they do, so I haven't tested them very thoroughly
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
