### PR TITLE
nvidia-x11: Add patches for kernel 5.1.

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -31,6 +31,10 @@ rec {
     sha256_64bit = "1cg7927g5ml1rwgpydlrjzr55gza5dfkqkch29bbarpzd7dh0mf4";
     settingsSha256 = "150c64wbijwyq032ircl1b78q0gwdvfq35gxaqw00d3ac2hjwpsg";
     persistencedSha256 = "07wh6v8c2si0zwy9j60yzrdn1b1pm0vr9kfvql3jkyjqfn4np44z";
+
+    # https://github.com/NixOS/nixpkgs/issues/61165
+    patches = lib.optionals (stdenv.lib.versionAtLeast kernel.version "5.1")
+      [ ./vm_fault_t.patch ./drm_probe_helper.patch ];
   };
 
   # Last one supporting x86

--- a/pkgs/os-specific/linux/nvidia-x11/drm_probe_helper.patch
+++ b/pkgs/os-specific/linux/nvidia-x11/drm_probe_helper.patch
@@ -1,0 +1,53 @@
+diff -urN old/kernel/conftest.sh new/kernel/conftest.sh
+--- old/kernel/conftest.sh	2019-05-10 19:56:54.556379817 +0200
++++ new/kernel/conftest.sh	2019-05-10 20:35:07.945055354 +0200
+@@ -107,6 +107,7 @@
+     FILES="$FILES drm/drm_drv.h"
+     FILES="$FILES drm/drm_framebuffer.h"
+     FILES="$FILES drm/drm_connector.h"
++    FILES="$FILES drm/drm_probe_helper.h"
+     FILES="$FILES generated/autoconf.h"
+     FILES="$FILES generated/compile.h"
+     FILES="$FILES generated/utsrelease.h"
+diff -urN old/kernel/nvidia-drm/nvidia-drm-drv.c new/kernel/nvidia-drm/nvidia-drm-drv.c
+--- old/kernel/nvidia-drm/nvidia-drm-drv.c	2019-05-10 19:56:54.544379770 +0200
++++ new/kernel/nvidia-drm/nvidia-drm-drv.c	2019-05-10 20:35:48.760211841 +0200
+@@ -55,6 +55,10 @@
+ #include <drm/drm_atomic_helper.h>
+ #endif
+ 
++#if defined(NV_DRM_DRM_PROBE_HELPER_H_PRESENT)
++#include <drm/drm_probe_helper.h>
++#endif
++
+ static struct nv_drm_device *dev_list = NULL;
+ 
+ #if defined(NV_DRM_ATOMIC_MODESET_AVAILABLE)
+diff -urN old/kernel/nvidia-drm/nvidia-drm-encoder.c new/kernel/nvidia-drm/nvidia-drm-encoder.c
+--- old/kernel/nvidia-drm/nvidia-drm-encoder.c	2019-05-10 19:56:54.544379770 +0200
++++ new/kernel/nvidia-drm/nvidia-drm-encoder.c	2019-05-10 20:49:10.018182041 +0200
+@@ -36,6 +36,10 @@
+ #include <drm/drm_atomic.h>
+ #include <drm/drm_atomic_helper.h>
+ 
++#if defined(NV_DRM_DRM_PROBE_HELPER_H_PRESENT)
++#include <drm/drm_probe_helper.h>
++#endif
++
+ static void nv_drm_encoder_destroy(struct drm_encoder *encoder)
+ {
+     struct nv_drm_encoder *nv_encoder = to_nv_encoder(encoder);
+diff -urN old/kernel/nvidia-drm/nvidia-drm-connector.c new/kernel/nvidia-drm/nvidia-drm-connector.c
+--- old/kernel/nvidia-drm/nvidia-drm-connector.c	2019-05-10 19:56:54.544379770 +0200
++++ new/kernel/nvidia-drm/nvidia-drm-connector.c	2019-05-10 20:51:11.163839290 +0200
+@@ -35,6 +35,10 @@
+ #include <drm/drm_atomic.h>
+ #include <drm/drm_atomic_helper.h>
+ 
++#if defined(NV_DRM_DRM_PROBE_HELPER_H_PRESENT)
++#include <drm/drm_probe_helper.h>
++#endif
++
+ static void nv_drm_connector_destroy(struct drm_connector *connector)
+ {
+     struct nv_drm_connector *nv_connector = to_nv_connector(connector);

--- a/pkgs/os-specific/linux/nvidia-x11/vm_fault_t.patch
+++ b/pkgs/os-specific/linux/nvidia-x11/vm_fault_t.patch
@@ -1,0 +1,137 @@
+diff -urN old/kernel/common/inc/nv-mm.h new/kernel/common/inc/nv-mm.h
+--- old/kernel/common/inc/nv-mm.h	2019-05-10 19:56:54.543379766 +0200
++++ new/kernel/common/inc/nv-mm.h	2019-05-10 20:14:00.985871563 +0200
+@@ -209,4 +209,11 @@
+     }
+ #endif // NV_VM_FAULT_PRESENT
+ 
++#if defined(NV_VM_OPS_VM_FAULT_T_RET)
++#include <linux/mm.h>
++typedef vm_fault_t nv_vm_fault_t;
++#else
++typedef int nv_vm_fault_t;
++#endif
++
+ #endif // __NV_MM_H__
+diff -urN old/kernel/conftest.sh new/kernel/conftest.sh
+--- old/kernel/conftest.sh	2019-05-10 19:56:54.556379817 +0200
++++ new/kernel/conftest.sh	2019-05-10 20:23:39.998142596 +0200
+@@ -2647,6 +2647,17 @@
+             compile_check_conftest "$CODE" "NV_VM_OPS_FAULT_REMOVED_VMA_ARG" "" "types"
+         ;;
+ 
++        vm_ops_vm_fault_t_ret)
++            # Determine if the return type of vm_ops functions is vm_fault_t.
++            CODE="
++            #include <linux/mm.h>
++            void conftest_vm_ops_vm_fault_t_ret(void) {
++                vm_fault_t fault;
++            }"
++
++            compile_check_conftest "$CODE" "NV_VM_OPS_VM_FAULT_T_RET" "" "types"
++        ;;
++
+         pnv_npu2_init_context)
+             #
+             # Determine if the pnv_npu2_init_context() function is
+diff -urN old/kernel/nvidia-drm/nvidia-drm-gem-nvkms-memory.c new/kernel/nvidia-drm/nvidia-drm-gem-nvkms-memory.c
+--- old/kernel/nvidia-drm/nvidia-drm-gem-nvkms-memory.c	2019-05-10 19:56:54.544379770 +0200
++++ new/kernel/nvidia-drm/nvidia-drm-gem-nvkms-memory.c	2019-05-10 20:25:50.956755143 +0200
+@@ -330,7 +330,7 @@
+ 
+ /* XXX Move these vma operations to os layer */
+ 
+-static int __nv_drm_vma_fault(struct vm_area_struct *vma,
++static nv_vm_fault_t __nv_drm_vma_fault(struct vm_area_struct *vma,
+                               struct vm_fault *vmf)
+ {
+     unsigned long address = nv_page_fault_va(vmf);
+@@ -338,7 +338,7 @@
+     struct nv_drm_gem_nvkms_memory *nv_nvkms_memory = to_nv_nvkms_memory(
+         to_nv_gem_object(gem));
+     unsigned long page_offset, pfn;
+-    int ret = -EINVAL;
++    nv_vm_fault_t ret;
+ 
+     pfn = (unsigned long)(uintptr_t)nv_nvkms_memory->pPhysicalAddress;
+     pfn >>= PAGE_SHIFT;
+@@ -377,12 +377,12 @@
+  */
+ 
+ #if defined(NV_VM_OPS_FAULT_REMOVED_VMA_ARG)
+-static int nv_drm_vma_fault(struct vm_fault *vmf)
++static nv_vm_fault_t nv_drm_vma_fault(struct vm_fault *vmf)
+ {
+     return __nv_drm_vma_fault(vmf->vma, vmf);
+ }
+ #else
+-static int nv_drm_vma_fault(struct vm_area_struct *vma,
++static nv_vm_fault_t nv_drm_vma_fault(struct vm_area_struct *vma,
+                                 struct vm_fault *vmf)
+ {
+     return __nv_drm_vma_fault(vma, vmf);
+diff -urN old/kernel/nvidia-drm/nvidia-drm.Kbuild new/kernel/nvidia-drm/nvidia-drm.Kbuild
+--- old/kernel/nvidia-drm/nvidia-drm.Kbuild	2019-05-10 19:56:54.544379770 +0200
++++ new/kernel/nvidia-drm/nvidia-drm.Kbuild	2019-05-10 20:02:36.840632933 +0200
+@@ -81,6 +81,7 @@
+ NV_CONFTEST_TYPE_COMPILE_TESTS += vm_fault_has_address
+ NV_CONFTEST_TYPE_COMPILE_TESTS += vm_fault_present
+ NV_CONFTEST_TYPE_COMPILE_TESTS += vm_ops_fault_removed_vma_arg
++NV_CONFTEST_TYPE_COMPILE_TESTS += vm_ops_vm_fault_t_ret
+ NV_CONFTEST_TYPE_COMPILE_TESTS += kref_has_refcount_of_type_refcount_t
+ NV_CONFTEST_TYPE_COMPILE_TESTS += drm_atomic_helper_crtc_destroy_state_has_crtc_arg
+ NV_CONFTEST_TYPE_COMPILE_TESTS += drm_crtc_helper_funcs_has_atomic_enable
+diff -urN old/kernel/nvidia-uvm/nvidia-uvm.Kbuild new/kernel/nvidia-uvm/nvidia-uvm.Kbuild
+--- old/kernel/nvidia-uvm/nvidia-uvm.Kbuild	2019-05-10 19:56:54.549379790 +0200
++++ new/kernel/nvidia-uvm/nvidia-uvm.Kbuild	2019-05-10 20:02:57.198703444 +0200
+@@ -112,4 +112,5 @@
+ NV_CONFTEST_TYPE_COMPILE_TESTS += vm_fault_has_address
+ NV_CONFTEST_TYPE_COMPILE_TESTS += vm_fault_present
+ NV_CONFTEST_TYPE_COMPILE_TESTS += vm_ops_fault_removed_vma_arg
++NV_CONFTEST_TYPE_COMPILE_TESTS += vm_ops_vm_fault_t_ret
+ NV_CONFTEST_TYPE_COMPILE_TESTS += node_states_n_memory
+diff -urN old/kernel/nvidia-uvm/uvm8.c new/kernel/nvidia-uvm/uvm8.c
+--- old/kernel/nvidia-uvm/uvm8.c	2019-05-10 19:56:54.552379801 +0200
++++ new/kernel/nvidia-uvm/uvm8.c	2019-05-10 20:15:16.193233998 +0200
+@@ -36,6 +36,7 @@
+ #include "uvm_linux_ioctl.h"
+ #include "uvm8_hmm.h"
+ #include "uvm8_mem.h"
++#include "nv-mm.h"
+ 
+ static struct cdev g_uvm_cdev;
+ 
+@@ -166,13 +167,13 @@
+ // If a fault handler is not set, paths like handle_pte_fault in older kernels
+ // assume the memory is anonymous. That would make debugging this failure harder
+ // so we force it to fail instead.
+-static int uvm_vm_fault_sigbus(struct vm_area_struct *vma, struct vm_fault *vmf)
++static nv_vm_fault_t uvm_vm_fault_sigbus(struct vm_area_struct *vma, struct vm_fault *vmf)
+ {
+     UVM_DBG_PRINT_RL("Fault to address 0x%lx in disabled vma\n", nv_page_fault_va(vmf));
+     return VM_FAULT_SIGBUS;
+ }
+ 
+-static int uvm_vm_fault_sigbus_wrapper(struct vm_fault *vmf)
++static nv_vm_fault_t uvm_vm_fault_sigbus_wrapper(struct vm_fault *vmf)
+ {
+ #if defined(NV_VM_OPS_FAULT_REMOVED_VMA_ARG)
+     return uvm_vm_fault_sigbus(vmf->vma, vmf);
+@@ -390,7 +391,7 @@
+         uvm_record_unlock_mmap_sem_write(&current->mm->mmap_sem);
+ }
+ 
+-static int uvm_vm_fault(struct vm_area_struct *vma, struct vm_fault *vmf)
++static nv_vm_fault_t uvm_vm_fault(struct vm_area_struct *vma, struct vm_fault *vmf)
+ {
+     uvm_va_space_t *va_space = uvm_va_space_get(vma->vm_file);
+     uvm_va_block_t *va_block;
+@@ -507,7 +508,7 @@
+     }
+ }
+ 
+-static int uvm_vm_fault_wrapper(struct vm_fault *vmf)
++static nv_vm_fault_t uvm_vm_fault_wrapper(struct vm_fault *vmf)
+ {
+ #if defined(NV_VM_OPS_FAULT_REMOVED_VMA_ARG)
+     return uvm_vm_fault(vmf->vma, vmf);


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/61165

Produced this on my own based on the errors and kernel changes:

https://github.com/torvalds/linux/commit/3d3539018d2cbd12e5af4a132636ee7fd8d43ef0
This is an intentional breaking change forcing drivers to acknowledge that the
return type of vm_vault handlers has changed to vm_fault_t and that VM_FAULT_*
must be returned. The driver only needs to be fixed to actually return vm_fault_t,
it already returns VM_FAULT_* values.

https://github.com/torvalds/linux/commit/fcd70cd36b9bf697122538c9e38e8cf954b2342b
Some DRM helper functions were moved to a separate header.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Drivers do not build with kernel 5.1.

###### Things done
Builds without warning/errors and runs without obvious problem on my system with kernel 5.1. Plasma desktop with compositing and some random WebGL samples work fine. I think a few more people should test it.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
