### PR TITLE
pythonPackages.deeplabcut: init at 2.1.6

### DIFF
--- a/pkgs/applications/science/machine-learning/deeplabcut/default.nix
+++ b/pkgs/applications/science/machine-learning/deeplabcut/default.nix
@@ -1,0 +1,56 @@
+{ lib, writeText
+, wrapGAppsHook
+, gtk3
+, opencv3
+, python37
+, mkl
+ }:
+
+let
+  pythonOverrides = python-self: python-super: {
+    # WARNING: openblas does not work
+    # https://github.com/AlexEMG/DeepLabCut/issues/637#issuecomment-606893058
+
+    # imgaug test stalls...
+    imgaug = python-super.imgaug.overrideAttrs (old:{
+      doInstallCheck = false;
+    });
+
+    opencv3 = python-super.toPythonModule (opencv3.override {
+      enablePython = true;
+      enableFfmpeg = true;
+      pythonPackages = python-self;
+    });
+  };
+
+  python = python37.override {
+    packageOverrides = pythonOverrides;
+  };
+  py = python.pkgs;
+in
+py.toPythonApplication
+  (py.deeplabcut.overridePythonAttrs(old: rec {
+  pname = "deeplabcut-gui";
+
+  script = writeText "deeplabcut"
+    ''
+      #!/usr/bin/env python
+      import deeplabcut
+      deeplabcut.launch_dlc()
+    '';
+
+  postInstall = ''
+    ${old.postInstall}
+    mkdir -p $out/bin
+    cp ${script} $out/bin/deeplabcut
+    chmod +x $out/bin/deeplabcut
+  '';
+
+  buildInputs = [
+    gtk3
+  ];
+
+  nativeBuildInputs = old.nativeBuildInputs ++ [
+    wrapGAppsHook
+  ];
+}))

--- a/pkgs/data/machine-learning/resnet/default.nix
+++ b/pkgs/data/machine-learning/resnet/default.nix
@@ -1,0 +1,37 @@
+{ stdenvNoCC, fetchurl }:
+let
+  srcs = {
+    resnet50 = fetchurl {
+      url = "http://download.tensorflow.org/models/resnet_v1_50_2016_08_28.tar.gz";
+      sha256 = "0wqw22aj5pbrhhbb13nh8r26zkj3dkq1ajrhvx4gczly50jxr84i";
+    };
+    resnet101 = fetchurl {
+      url = "http://download.tensorflow.org/models/resnet_v1_101_2016_08_28.tar.gz";
+      sha256 = "068sl5x9z05j1wagfjwz3yrxnk1r8ikb8wrx931ckrsnbv7kz0ax";
+    };
+    resnet152 = fetchurl {
+      url = "http://download.tensorflow.org/models/resnet_v1_152_2016_08_28.tar.gz";
+      sha256 = "078qf8ajbs7y632fj6jlkfgqjbb53958f3nrnq6rqva8vad596y8";
+    };
+  };
+in
+  stdenvNoCC.mkDerivation rec {
+    pname = "resnet";
+    version = "2016-08-28";
+    buildCommand = ''
+      mkdir -p $out
+      ln -s "${srcs.resnet50}" "$out/${srcs.resnet50.name}"
+      ln -s "${srcs.resnet101}" "$out/${srcs.resnet101.name}"
+      ln -s "${srcs.resnet152}" "$out/${srcs.resnet152.name}"
+    '';
+    meta = with stdenvNoCC.lib; {
+      description = "Pretrained weights for ResNet";
+      longDescription = ''
+        Deep residual networks, or ResNets for short, provided the breakthrough idea of identity mappings in order to enable training of very deep convolutional neural networks on ImageNet. See: Deep Residual Learning for Image Recognition by Kaiming He, Xiangyu Zhang, Shaoqing Ren, and Jian Sun, Dec 2015.
+      '';
+      homepage = "https://github.com/tensorflow/models";
+      license = licenses.asl20;
+      platforms = platforms.all;
+      maintainers = with maintainers; [ tbenst ];
+    };
+  }

--- a/pkgs/development/python-modules/deeplabcut/default.nix
+++ b/pkgs/development/python-modules/deeplabcut/default.nix
@@ -1,0 +1,150 @@
+{ lib, buildPythonPackage, fetchFromGitHub, fetchzip, fetchurl
+, tensorflow
+, setuptools_scm
+, gzip
+, gnutar
+, certifi
+, chardet
+, click
+, easydict
+, ffmpeg
+, h5py
+, imageio
+, imageio-ffmpeg
+, imgaug
+, intel-openmp
+, ipython
+, matplotlib
+, moviepy
+, numpy
+, opencv3
+, pandas
+, patsy
+, pillow
+, pudb
+, python
+, python-prctl
+, py
+, pyyaml
+, requests
+, resnet
+, ruamel_yaml
+, setuptools
+, scikitimage
+, scikitlearn
+, scipy
+, six
+, statsmodels
+, tables
+, tensorpack
+, tqdm
+, tkinter
+, wheel
+, wxPython_4_0
+, wrapGAppsHook
+, xvfb_run
+}:
+
+buildPythonPackage rec {
+  pname = "deeplabcut";
+  version = "2.1.6.4";
+
+  # pypi does not contain tests, using github sources instead
+  src = fetchFromGitHub {
+    owner = "AlexEMG";
+    repo = "DeepLabCut";
+    rev = "v${version}";
+    sha256 = "056lbzbixlah2xkimi6lvrhv660jsby933nmwajqs8x5rjkqici1";
+  };
+
+  nativeBuildInputs = [
+    setuptools_scm
+    wrapGAppsHook
+  ];
+
+  buildInputs = [ 
+    ffmpeg
+  ];
+  
+  propagatedBuildInputs = [
+    certifi
+    chardet
+    click
+    easydict
+    h5py
+    imageio
+    imageio-ffmpeg
+    imgaug
+    intel-openmp
+    ipython
+    matplotlib
+    moviepy
+    numpy
+    opencv3
+    pandas
+    patsy
+    pillow
+    pyyaml
+    python-prctl
+    requests
+    ruamel_yaml
+    setuptools
+    scikitimage
+    scikitlearn
+    scipy
+    six
+    statsmodels
+    tables
+    tensorpack
+    tensorflow
+    tqdm
+    tkinter
+    wheel
+    wxPython_4_0
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "numpy==1.16.4" "numpy" \
+      --replace "h5py~=2.7" "h5py" \
+      --replace "matplotlib==3.0.3" "matplotlib" \
+      --replace "'opencv-python~=3.4'," "" \
+      --replace "ruamel.yaml~=0.15" "ruamel.yaml"
+
+    # we skip tensorpack tests for now due to https://github.com/AlexEMG/DeepLabCut/issues/637#issuecomment-606868137
+    substituteInPlace examples/testscript.py --replace \
+      'print("CREATING TRAININGSET for shuffle 2")' \
+      'exit(0)'
+  '';
+  
+  checkInputs = [
+    py
+    xvfb_run
+  ];
+
+  checkPhase = ''
+    cd examples
+    xvfb-run ${python.interpreter} testscript.py
+  '';
+
+  defaultLocale = "en_US.UTF-8";
+
+  postInstall = ''
+    mkdir -p resnet/resnet50
+    mkdir -p resnet/resnet101
+    mkdir -p resnet/resnet152
+    tar -xf ${resnet}/resnet_v1_50_2016_08_28.tar.gz -C resnet/resnet50/
+    tar -xf ${resnet}/resnet_v1_101_2016_08_28.tar.gz -C resnet/resnet101/
+    tar -xf ${resnet}/resnet_v1_152_2016_08_28.tar.gz -C resnet/resnet152/
+    mv resnet/resnet50/* $out/${python.sitePackages}/deeplabcut/pose_estimation_tensorflow/models/pretrained/
+    mv resnet/resnet101/* $out/${python.sitePackages}/deeplabcut/pose_estimation_tensorflow/models/pretrained/
+    mv resnet/resnet152/* $out/${python.sitePackages}/deeplabcut/pose_estimation_tensorflow/models/pretrained/
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/AlexEMG/DeepLabCut";
+    maintainers = with maintainers; [ tbenst ];
+    description = "Markerless tracking of user-defined features with deep learning";
+    license = licenses.lgpl3;
+  };
+}

--- a/pkgs/development/python-modules/imageio-ffmpeg/default.nix
+++ b/pkgs/development/python-modules/imageio-ffmpeg/default.nix
@@ -1,22 +1,69 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
+, fetchurl
 , isPy3k
+, numpy
+, ffmpeg
+, pytest
+, psutil
 }:
 
 buildPythonPackage rec {
   pname = "imageio-ffmpeg";
-  version = "0.3.0";
+  version = "0.4.1";
 
-  src = fetchPypi {
-    sha256 = "1hnn00xz9jyksnx1g0r1icv6ynbdnxq4cfnmb58ikg6ymi20al18";
-    inherit pname version;
+  # pypi does not contain tests, using github sources instead
+  src = fetchFromGitHub {
+    owner = "imageio";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0yv47kn0ng58638dkl75ih6dfba6bsl5kh49n7m8pg35063pwcbx";
   };
+
+  test_url1 = fetchurl {
+    url = "https://raw.githubusercontent.com/imageio/imageio-binaries/master/images/cockatoo.mp4";
+    sha256 = "19cayf0dxw7xmqzjf7q2sdh4ajxni8c2ip6j2vi8djl8lbskbpjz";
+  };
+
+  test_url2 = fetchurl {
+    url = "https://raw.githubusercontent.com/imageio/imageio-binaries/master/images/realshort.mp4";
+    sha256 = "067ygc924iv8d5bm9w1y9317n0mcd2px8ahpl6g3ni9h44n5rcx8";
+  };
+
+  buildInputs = [
+    ffmpeg
+  ];
 
   disabled = !isPy3k;
 
-  # No test infrastructure in repository.
-  doCheck = false;
+  patchPhase = ''
+    substituteInPlace imageio_ffmpeg/_utils.py  --replace \
+      'os.getenv("IMAGEIO_FFMPEG_EXE", None)' \
+      '"${ffmpeg}/bin/ffmpeg"'
+    substituteInPlace tests/testutils.py  --replace \
+      'os.path.join(test_dir, "cockatoo.mp4")' \
+      '"${test_url1}"'
+    substituteInPlace tests/testutils.py  --replace \
+      'os.path.join(test_dir, "realshort.mp4")' \
+      '"${test_url1}"'
+    substituteInPlace tests/testutils.py  --replace \
+      'os.path.join(test_dir, "test.mp4")' \
+      '"test.mp4"'
+    substituteInPlace tests/testutils.py  --replace \
+      'have_downloaded = False' \
+      'have_downloaded = True'
+  '';
+
+  checkPhase = ''
+    for f in tests/test*.py; do echo ========== $f ==========; python $f; done
+  '';
+
+  checkInputs = [
+    numpy
+    pytest
+    psutil
+  ];
 
   meta = with lib; {
     description = "FFMPEG wrapper for Python";

--- a/pkgs/development/python-modules/imageio/default.nix
+++ b/pkgs/development/python-modules/imageio/default.nix
@@ -5,7 +5,7 @@
 , pillow
 , psutil
 , imageio-ffmpeg
-, pytest
+, pytestCheckHook
 , numpy
 , isPy3k
 , ffmpeg_3
@@ -22,21 +22,30 @@ buildPythonPackage rec {
     inherit pname version;
   };
 
-  checkInputs = [ pytest psutil ] ++ stdenv.lib.optionals isPy3k [
+  checkInputs = [
+    psutil
+    pytestCheckHook
+  ] ++ stdenv.lib.optionals isPy3k [
     imageio-ffmpeg ffmpeg_3
-    ];
+  ];
+
   propagatedBuildInputs = [ numpy pillow ] ++ stdenv.lib.optionals (!isPy3k) [
     futures
     enum34
     pathlib
   ];
 
-  checkPhase = ''
+  dontUseSetuptoolsCheck = true;
+
+  preCheck = ''
     export IMAGEIO_USERDIR="$TMP"
     export IMAGEIO_NO_INTERNET="true"
     export HOME="$(mktemp -d)"
-    py.test
   '';
+
+  disabledTests = [
+    "test_get_exe_env"
+  ];
 
   # For some reason, importing imageio also imports xml on Nix, see
   # https://github.com/imageio/imageio/issues/395

--- a/pkgs/development/python-modules/imgaug/default.nix
+++ b/pkgs/development/python-modules/imgaug/default.nix
@@ -4,7 +4,7 @@
 , imagecorruptions
 , numpy
 , opencv3
-, pytest
+, pytestCheckHook
 , scikitimage
 , scipy
 , shapely
@@ -43,11 +43,16 @@ buildPythonPackage rec {
     six
   ];
 
-  checkPhase = ''
-     pytest ./test
-  '';
+  # checkPhase = ''
+  #    pytest
+  # '';
 
-  checkInputs = [ opencv3 pytest ];
+  pytestFlagsArray = [ 
+    # imagecorruptions not currently in nixpkgs
+    "--ignore=test/augmenters/test_imgcorruptlike.py"
+  ];
+
+  checkInputs = [ pytestCheckHook ];
 
   meta = with stdenv.lib; {
     homepage = "https://github.com/aleju/imgaug";

--- a/pkgs/development/python-modules/intel-openmp/default.nix
+++ b/pkgs/development/python-modules/intel-openmp/default.nix
@@ -1,0 +1,29 @@
+{ lib, pkgs, buildPythonPackage, fetchPypi, isPy3k
+, numpy
+}:
+buildPythonPackage rec {
+  pname = "intel-openmp";
+  version = "2020.0.133";
+  format = "wheel";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "intel_openmp";
+    format = "wheel";
+    platform = "manylinux1_x86_64";
+    python = "py2.py3";
+    sha256 = "cb9a12b0a1cb3f9c44a75959f687e548dc642a9470be3c63f73bccf291b8dcc8";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+  ];
+
+  meta = {
+    homepage = "https://software.intel.com/en-us/articles/empowering-science-with-high-performance-python";
+    description = "Intel OpenMP Runtime Library";
+    platforms = [ "x86_64-linux" ];
+    license = lib.licenses.issl;
+    maintainers = with lib.maintainers; [ tbenst ];
+  };
+}

--- a/pkgs/development/python-modules/tensorpack/default.nix
+++ b/pkgs/development/python-modules/tensorpack/default.nix
@@ -1,0 +1,68 @@
+{ lib, buildPythonPackage, setuptools_scm, fetchFromGitHub, isPy3k
+, fetchurl
+, numpy
+, bash
+, six
+, termcolor
+, tabulate
+, tqdm
+, lmdb
+, msgpack
+, pkgs
+, msgpack-numpy
+, pyzmq
+, psutil
+, scikitimage
+, flake8
+, tensorflow
+, opencv3
+}:
+
+buildPythonPackage rec {
+  pname = "tensorpack";
+  version = "0.10";
+  disabled=!isPy3k;
+
+  src = fetchFromGitHub {
+      owner = pname;
+      repo = pname;
+      rev = "v${version}";
+      sha256 = "046nj1y8rl0zsp6q2x7vbhnphq21xbyyjpndi8f2rv9hx9nbxyjv";
+  };
+
+  nativeBuildInputs = [ setuptools_scm ];
+
+  propagatedBuildInputs = [
+    numpy
+    opencv3
+    six
+    termcolor
+    tabulate
+    tqdm
+    lmdb
+    msgpack
+    msgpack-numpy
+    pyzmq
+    psutil
+  ];
+  
+  checkInputs = [
+    scikitimage
+    flake8
+    tensorflow
+  ];
+
+  checkPhase = ''
+    mkdir mnist_data
+    export TENSORPACK_DATASET="$(pwd)"
+    ln -s ${pkgs.mnist}/* mnist_data/
+    bash tests/run-tests.sh
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/tensorpack/tensorpack";
+    maintainers = with maintainers; [ tbenst ];
+    description = "A neural network training interface based on TensorFlow";
+    license = licenses.asl20;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24650,6 +24650,8 @@ in
 
   dcm2niix = callPackage ../applications/science/biology/dcm2niix { };
 
+  deeplabcut = callPackage ../applications/science/machine-learning/deeplabcut { };
+
   deeptools = callPackage ../applications/science/biology/deeptools { python = python3; };
 
   delly = callPackage ../applications/science/biology/delly { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14514,6 +14514,8 @@ in
 
   resolv_wrapper = callPackage ../development/libraries/resolv_wrapper { };
 
+  resnet = callPackage ../data/machine-learning/resnet { };
+
   rhino = callPackage ../development/libraries/java/rhino {
     javac = jdk;
     jvm = jre;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2338,6 +2338,8 @@ in {
 
   curtsies = callPackage ../development/python-modules/curtsies { };
 
+  deeplabcut = callPackage ../development/python-modules/deeplabcut { };
+
   envs = callPackage ../development/python-modules/envs { };
 
   etelemetry = callPackage ../development/python-modules/etelemetry { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2354,6 +2354,8 @@ in {
   }));
 
   impacket = callPackage ../development/python-modules/impacket { };
+  
+  intel-openmp = callPackage ../development/python-modules/intel-openmp { };
 
   jsonlines = callPackage ../development/python-modules/jsonlines { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7019,6 +7019,8 @@ in {
 
   tensorly = callPackage ../development/python-modules/tensorly { };
 
+  tensorpack = callPackage ../development/python-modules/tensorpack { };
+
   tflearn = callPackage ../development/python-modules/tflearn { };
 
   simpleai = callPackage ../development/python-modules/simpleai { };


### PR DESCRIPTION
###### Motivation for this change
add deeplabcut, and fix derivation for wxPython40, which is broken and unlisted: https://github.com/NixOS/nixpkgs/issues/54235. Now working thanks to help from Phoenix team https://github.com/wxWidgets/Phoenix/issues/1162  and  @deliciouslytyped  

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
Resolves: #54235