### PR TITLE
leptonica: enable tests on non-darwin

### DIFF
--- a/pkgs/development/libraries/leptonica/default.nix
+++ b/pkgs/development/libraries/leptonica/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchurl, fetchpatch, autoreconfHook, pkgconfig
 , giflib, libjpeg, libpng, libtiff, libwebp, openjpeg, zlib
+, gnuplot
 }:
 
 stdenv.mkDerivation rec {
@@ -13,6 +14,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
   buildInputs = [ giflib libjpeg libpng libtiff libwebp openjpeg zlib ];
+
+  checkInputs = [ gnuplot ];
+  doCheck = !stdenv.isDarwin;
 
   meta = {
     description = "Image processing and analysis library";


### PR DESCRIPTION
###### Motivation for this change
Enable tests for `leptonica` - 1.78.0's tests don't seem to behave themselves at all on darwin though, so exclude that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
