### PR TITLE
lz4: fix build on darwin

### DIFF
--- a/pkgs/tools/compression/lz4/default.nix
+++ b/pkgs/tools/compression/lz4/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, valgrind
+{ stdenv, fetchFromGitHub, fetchpatch, valgrind
 , enableStatic ? false, enableShared ? true
 }:
 
@@ -12,6 +12,12 @@ stdenv.mkDerivation rec {
     repo = "lz4";
     owner = "lz4";
   };
+
+  patches = stdenv.lib.optional stdenv.isDarwin (fetchpatch {
+    name = "fix-darwin-detection.patch";
+    url = "https://github.com/lz4/lz4/commit/024216ef7394b6411eeaa5b52d0cec9953a44249.patch";
+    sha256 = "0j0j2pr6pkplxf083hlwl5q4cfp86q3wd8mc64bcfcr7ysc5pzl3";
+  });
 
   outputs = [ "out" "dev" ];
 


### PR DESCRIPTION
###### Motivation for this change
Fix build on darwin by fetching patch from upstream.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
