### PR TITLE
cargo-make: init at 0.19.1

### DIFF
--- a/pkgs/development/tools/rust/cargo-make/default.nix
+++ b/pkgs/development/tools/rust/cargo-make/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchurl, runCommand, fetchFromGitHub, rustPlatform, Security }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-make";
+  version = "0.19.1";
+
+  src =
+    let
+      source = fetchFromGitHub {
+        owner = "sagiegurari";
+        repo = pname;
+        rev = version;
+        sha256 = "1bv5gv5zd9h0yw7wb28r0c4z9wqa6n7ac4ipd855apwz1v7sm9n3";
+      };
+      cargo-lock = fetchurl {
+        url = "https://gist.githubusercontent.com/xrelkd/e4c9c7738b21f284d97cb7b1d181317d/raw/8a12a07cafeff4ef4a01983f5243dd8c95d10c48/cargo-make-0.19.1-Cargo.lock";
+        sha256 = "0v2hygkpsyjcpzrgyzl5mah0y8gmprfbnz7kn4hh6zfhz2lhqqwm";
+      };
+    in
+    runCommand "cargo-make-src" {} ''
+      cp -R ${source} $out
+      chmod +w $out
+      cp ${cargo-lock} $out/Cargo.lock
+    '';
+
+  buildInputs = stdenv.lib.optionals stdenv.isDarwin [ Security ];
+
+  cargoSha256 = "0j7gyg6l428gypjpfgdz082vz8m86cx1wy2r47az3sc3skl6dhkq";
+
+  # Some tests fail because they need network access.
+  # However, Travis ensures a proper build.
+  # See also:
+  #   https://travis-ci.org/sagiegurari/cargo-make
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "A Rust task runner and build tool";
+    homepage = https://github.com/sagiegurari/cargo-make;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ xrelkd ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4889,7 +4889,7 @@ in
 
   ola = callPackage ../applications/misc/ola { };
 
-  olive-editor = libsForQt5.callPackage ../applications/video/olive-editor { 
+  olive-editor = libsForQt5.callPackage ../applications/video/olive-editor {
     inherit (darwin.apple_sdk.frameworks) CoreFoundation;
   };
 
@@ -7943,6 +7943,9 @@ in
   cargo-bloat = callPackage ../development/tools/rust/cargo-bloat { };
   cargo-expand = callPackage ../development/tools/rust/cargo-expand { };
   cargo-fuzz = callPackage ../development/tools/rust/cargo-fuzz { };
+  cargo-make = callPackage ../development/tools/rust/cargo-make {
+    inherit (darwin.apple_sdk.frameworks) Security;
+  };
   cargo-sweep = callPackage ../development/tools/rust/cargo-sweep { };
   cargo-xbuild = callPackage ../development/tools/rust/cargo-xbuild { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

`cargo-make` is a Rust runner and build tool.

https://sagiegurari.github.io/cargo-make/
https://github.com/sagiegurari/cargo-make


**Note**: 
`doCheck` is set as `false`.
Some tests fail because they need network access. However, Travis ensures a proper build.
     https://travis-ci.org/sagiegurari/cargo-make/jobs/530738212
     https://travis-ci.org/sagiegurari/cargo-make/jobs/530738213
     https://travis-ci.org/sagiegurari/cargo-make/jobs/530738214

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
