### PR TITLE
git-repo-updater: init at 0.5

### DIFF
--- a/pkgs/development/tools/git-repo-updater/default.nix
+++ b/pkgs/development/tools/git-repo-updater/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonApplication, fetchPypi
+, colorama, GitPython }:
+
+buildPythonApplication rec {
+  pname = "gitup";
+  version = "0.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "11ilz9i2yxrbipyjzpfkj7drx9wkrn3phvd1a60jivphbqdldpgf";
+  };
+
+  propagatedBuildInputs = [ colorama GitPython ];
+
+  meta = with lib; {
+    description = "Easily update multiple Git repositories at once";
+    homepage = "https://github.com/earwig/git-repo-updater";
+    license = licenses.mit;
+    maintainers = [ maintainers.bdesham ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -770,6 +770,8 @@ in
 
   git-fire = callPackage ../tools/misc/git-fire { };
 
+  git-repo-updater = python3Packages.callPackage ../development/tools/git-repo-updater { };
+
   git-town = callPackage ../tools/misc/git-town { };
 
   github-changelog-generator = callPackage ../development/tools/github-changelog-generator { };


### PR DESCRIPTION
###### Motivation for this change

Adds git-repo-updater, a Python script that fetches all available remotes and fast-forwards your local branches (whenever possible) in multiple Git repos. The executable is called `gitup`.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions (Ubuntu)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).