### PR TITLE
pythonPackages.block-io: 1.1.9 -> 1.1.10

### DIFF
--- a/pkgs/development/python-modules/block-io/default.nix
+++ b/pkgs/development/python-modules/block-io/default.nix
@@ -1,20 +1,13 @@
-{ stdenv, fetchPypi, fetchpatch, buildPythonPackage, base58, ecdsa, pycryptodome, requests, six }:
+{ stdenv, fetchPypi, buildPythonPackage, base58, ecdsa, pycryptodome, requests, six }:
 
 buildPythonPackage rec {
   pname = "block-io";
-  version = "1.1.9";
+  version = "1.1.10";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "4909d58b32ab7f93d3cd83fa4bbe4edef42ab7566f016bdb6a405a0d8b1907c9";
+    sha256 = "ba2e750085d9da4d1567932f3f719974fdc3f02649ee0d5c2f85fce592208723";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/BlockIo/block_io-python/commit/8ec0a0cd1afcfcb439d6dc306d8497dd9e4a0993.patch";
-      sha256 = "1i6c153wvkr5ncm3cpn34faxvavz534x5kndwn4adlaxlzq30snn";
-    })
-  ];
 
   propagatedBuildInputs = [
     base58
@@ -23,6 +16,11 @@ buildPythonPackage rec {
     requests
     six
   ];
+
+  preConfigure = ''
+    substituteInPlace setup.py \
+      --replace "ecdsa==0.13" "ecdsa>=0.13"
+  '';
 
   # Tests needs a BlockIO API key to run properly
   # https://github.com/BlockIo/block_io-python/blob/79006bc8974544b70a2d8e9f19c759941d32648e/test.py#L18


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

I had to unfreeze ecdsa which was fixed on 0.13

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
