### PR TITLE
uutils-coreutils: 2018-09-30 -> 2019-05-03

### DIFF
--- a/pkgs/tools/misc/uutils-coreutils/default.nix
+++ b/pkgs/tools/misc/uutils-coreutils/default.nix
@@ -1,18 +1,18 @@
 { stdenv, fetchFromGitHub, rustPlatform, cargo, cmake, sphinx, lib, prefix ? "uutils-" }:
 
 rustPlatform.buildRustPackage {
-  name = "uutils-coreutils-2018-09-30";
+  name = "uutils-coreutils-2019-05-03";
   src = fetchFromGitHub {
     owner = "uutils";
     repo = "coreutils";
-    rev = "a161b7e803aef08455ae0547dccd9210e38a4574";
-    sha256 = "19j40cma7rz6yf5j6nyid8qslbcmrnxdk6by53hflal2qx3g555z";
+    rev = "036dd812958ace22d973acf7b370f58072049dac";
+    sha256 = "0d9w3iiphhsk7l5l34682wayp90rgq5a3d94l3qdvhcqkfmpg727";
   };
 
   # too many impure/platform-dependent tests
   doCheck = false;
 
-  cargoSha256 = "1a9k7i4829plkxgsflmpji3mrw2i1vln6jsnhxmkl14h554yi5j4";
+  cargoSha256 = "0qnpx2xhckb45q8cgn0xh31dg5k73hqp5mz5zg3micmg7as4b621";
 
   makeFlags =
     [ "CARGO=${cargo}/bin/cargo" "PREFIX=$(out)" "PROFILE=release" "INSTALLDIR_MAN=$(out)/share/man/man1" ]


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

There's still no new release, but since there are ~120 commits since
August with several dependency bumps and improvements regarding the
compatibility with the GNU coreutils.

The full diff can be viewed here:
https://github.com/uutils/coreutils/compare/a161b7e803aef08455ae0547dccd9210e38a4574...036dd812958ace22d973acf7b370f58072049dac

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
