### PR TITLE
givaro: 4.0.4 -> 4.1.0, fflas-ffpack: 2.3.2 -> 2.4.0, linbox: 1.5.2 -> 1.6.0

### DIFF
--- a/pkgs/applications/science/math/sage/sage-src.nix
+++ b/pkgs/applications/science/math/sage/sage-src.nix
@@ -141,6 +141,14 @@ stdenv.mkDerivation rec {
       url = "https://git.sagemath.org/sage.git/patch/?h=8b7dbd0805d02d0e8674a272e161ceb24a637966";
       sha256 = "1c81f13z1w62s06yvp43gz6vkp8mxcs289n6l4gj9xj10slimzff";
     })
+
+    # https://trac.sagemath.org/ticket/26932
+    (fetchSageDiff {
+      name = "givaro-4.1.0_fflas-ffpack-2.4.0_linbox-1.6.0.patch";
+      base = "8.8.beta4";
+      rev = "c11d9cfa23ff9f77681a8f12742f68143eed4504";
+      sha256 = "0xzra7mbgqvahk9v45bjwir2mqz73hrhhy314jq5nxrb35ysdxyi";
+    })
   ];
 
   patches = nixPatches ++ bugfixPatches ++ packageUpgradePatches;

--- a/pkgs/development/libraries/fflas-ffpack/default.nix
+++ b/pkgs/development/libraries/fflas-ffpack/default.nix
@@ -1,27 +1,17 @@
 { stdenv, fetchFromGitHub, autoreconfHook, givaro, pkgconfig, blas
-, fetchpatch
 , gmpxx
 }:
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "fflas-ffpack";
-  version = "2.3.2";
+  version = "2.4.0";
 
   src = fetchFromGitHub {
     owner = "linbox-team";
     repo = "${pname}";
     rev = "v${version}";
-    sha256 = "1cqhassj2dny3gx0iywvmnpq8ca0d6m82xl5rz4mb8gaxr2kwddl";
+    sha256 = "1q1ala88ysz14pb5cn2kskv829nc1qif7zfzjwzhd5nnzwyivmc4";
   };
-
-  patches = [
-    # https://github.com/linbox-team/fflas-ffpack/issues/146
-    (fetchpatch {
-      name = "fix-flaky-test-fgemm-check.patch";
-      url = "https://github.com/linbox-team/fflas-ffpack/commit/d8cd67d91a9535417a5cb193cf1540ad6758a3db.patch";
-      sha256 = "1gnfc616fvnlr0smvz6lb2d445vn8fgv6vqcr6pwm3dj4wa6v3b3";
-    })
-  ];
 
   checkInputs = [
     gmpxx

--- a/pkgs/development/libraries/givaro/default.nix
+++ b/pkgs/development/libraries/givaro/default.nix
@@ -2,12 +2,12 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "givaro";
-  version = "4.0.4";
+  version = "4.1.0";
   src = fetchFromGitHub {
     owner = "linbox-team";
     repo = "${pname}";
     rev = "v${version}";
-    sha256 = "199p8wyj5i63jbnk7j8qbdbfp5rm2lpmcxyk3mdjy9bz7ygx3hhy";
+    sha256 = "1l1172c964hni66mjdmhr7766l5k7y63zs3hgcpr10a8f1nx3iwp";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/linbox/default.nix
+++ b/pkgs/development/libraries/linbox/default.nix
@@ -12,13 +12,13 @@
 stdenv.mkDerivation rec {
   name = "${pname}-${version}";
   pname = "linbox";
-  version = "1.5.2";
+  version = "1.6.0";
 
   src = fetchFromGitHub {
     owner = "linbox-team";
     repo = "${pname}";
     rev = "v${version}";
-    sha256 = "1wfivlwp30mzdy1697w7rzb8caajim50mc8h27k82yipn2qc5n4i";
+    sha256 = "0rmk474hvgkggmhxwa5i52wdnbvipx9n8mpsc41j1c96q4v8fl22";
   };
 
   nativeBuildInputs = [
@@ -49,16 +49,6 @@ stdenv.mkDerivation rec {
   }.${stdenv.hostPlatform.platform.gcc.arch or "default"}
   ++ stdenv.lib.optionals withSage [
     "--enable-sage"
-  ];
-
-  patches = stdenv.lib.optionals withSage [
-    # https://trac.sagemath.org/ticket/24214#comment:39
-    # Will be resolved by
-    # https://github.com/linbox-team/linbox/issues/69
-    (fetchpatch {
-      url = "https://raw.githubusercontent.com/sagemath/sage/a843f48b7a4267e44895a3dfa892c89c85b85611/build/pkgs/linbox/patches/linbox_charpoly_fullCRA.patch";
-      sha256 = "16nxfzfknra3k2yk3xy0k8cq9rmnmsch3dnkb03kx15h0y0jmibk";
-    })
   ];
 
   doCheck = true;


### PR DESCRIPTION

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The three packages are interdependent and need to be updated together,
like the main contributor did for sage:

https://trac.sagemath.org/ticket/24214


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
