### PR TITLE
sqlitebrowser: 3.10.1 -> 3.11.2

### DIFF
--- a/pkgs/development/tools/database/sqlitebrowser/default.nix
+++ b/pkgs/development/tools/database/sqlitebrowser/default.nix
@@ -1,37 +1,31 @@
 { mkDerivation, lib, fetchFromGitHub, cmake, antlr
-, qtbase, qttools, qscintilla, sqlite }:
+, qtbase, qttools, sqlite }:
 
 mkDerivation rec {
-  version = "3.10.1";
-  name = "sqlitebrowser-${version}";
+  version = "3.11.2";
+  pname = "sqlitebrowser";
 
   src = fetchFromGitHub {
-    repo   = "sqlitebrowser";
-    owner  = "sqlitebrowser";
+    repo   = pname;
+    owner  = pname;
     rev    = "v${version}";
-    sha256 = "1brzam8yv6sbdmbqsp7vglhd6wlx49g2ap8llr271zrkld4k3kar";
+    sha256 = "0ydd5fg76d5d23byac1f7f8mzx3brmd0cnnkd58qpmlzi7p9hcvx";
   };
 
-  buildInputs = [ qtbase qscintilla sqlite ];
+  buildInputs = [ qtbase sqlite ];
 
   nativeBuildInputs = [ cmake antlr qttools ];
+
+  # Use internal `qscintilla` rather than our package to fix the build
+  # (https://github.com/sqlitebrowser/sqlitebrowser/issues/1348#issuecomment-374170936).
+  # This can probably be removed when https://github.com/NixOS/nixpkgs/pull/56034 is merged.
+  cmakeFlags = [ "-DFORCE_INTERNAL_QSCINTILLA=ON" ];
 
   NIX_LDFLAGS = [
     "-lQt5PrintSupport"
   ];
 
   enableParallelBuilding = true;
-
-  # We have to patch out Test and PrintSupport to make this work with Qt 5.9
-  # It can go when the application supports 5.9
-  postPatch = ''
-    substituteInPlace CMakeLists.txt \
-      --replace Test         "" \
-      --replace PrintSupport ""
-
-    substituteInPlace libs/qcustomplot-source/CMakeLists.txt \
-      --replace PrintSupport ""
-  '';
 
   meta = with lib; {
     description = "DB Browser for SQLite";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The latest releases of `sqlitebrowser` contain several new features like
a dark mode, improved CSV import/export and a lot of new bugfixes:

https://github.com/sqlitebrowser/sqlitebrowser/releases/tag/v3.11.2
https://github.com/sqlitebrowser/sqlitebrowser/releases/tag/v3.11.1
https://github.com/sqlitebrowser/sqlitebrowser/releases/tag/v3.11.0

Also some minor changes were applied to the package definition:

* Using the `pname`/`version` convention now.
* Use internal `qscintilla` rather than our package to fix the build
  (https://github.com/sqlitebrowser/sqlitebrowser/issues/1348#issuecomment-374170936).
  This can probably be removed when https://github.com/NixOS/nixpkgs/pull/56034 is merged.
* Dropped patch which removed Test and Print support as QT 5.12 is now
  used to build the application.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
