### PR TITLE
python3Packages.pyaxmlparser: 0.3.13 -> 0.3.15

### DIFF
--- a/pkgs/development/python-modules/pyaxmlparser/default.nix
+++ b/pkgs/development/python-modules/pyaxmlparser/default.nix
@@ -1,7 +1,7 @@
 { buildPythonPackage, stdenv, lxml, click, fetchFromGitHub, pytest, isPy3k }:
 
 buildPythonPackage rec {
-  version = "0.3.13";
+  version = "0.3.15";
   pname = "pyaxmlparser";
 
   # the PyPI tarball doesn't ship tests.
@@ -9,7 +9,7 @@ buildPythonPackage rec {
     owner = "appknox";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0jfjhxc6b57npsidknxmhj1x813scg47aaw90ybyr90fpdz5rlwk";
+    sha256 = "0p4x21rg8h7alrg2zk6rbgc3fj77fiyky4zzvziz2bp5jpx1pvzp";
   };
 
   disabled = !isPy3k;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Minor bugfix releases with several improvements and more checks for APK
files to parse.

https://github.com/appknox/pyaxmlparser/compare/v0.3.13...v0.3.15

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
