### PR TITLE
Fix Zathura on Darwin

### DIFF
--- a/pkgs/applications/misc/zathura/core/default.nix
+++ b/pkgs/applications/misc/zathura/core/default.nix
@@ -32,15 +32,15 @@ stdenv.mkDerivation rec {
   ] ++ optional synctexSupport "-Dsynctex=enabled";
 
   nativeBuildInputs = [
-    meson ninja pkgconfig appstream-glib desktop-file-utils python3.pkgs.sphinx
+    meson ninja pkgconfig desktop-file-utils python3.pkgs.sphinx
     gettext makeWrapper libxml2
-  ];
+  ] ++ optional stdenv.isLinux appstream-glib;
 
   buildInputs = [
-    gtk girara libintl libseccomp
-    sqlite glib file librsvg
+    gtk girara libintl sqlite glib file librsvg
   ] ++ optional synctexSupport texlive.bin.core
-    ++ optional stdenv.isDarwin [ gtk-mac-integration ];
+    ++ optional stdenv.isLinux libseccomp
+    ++ optional stdenv.isDarwin gtk-mac-integration;
 
   meta = {
     homepage = https://pwmt.org/projects/zathura/;

--- a/pkgs/applications/misc/zathura/default.nix
+++ b/pkgs/applications/misc/zathura/default.nix
@@ -1,5 +1,5 @@
 { config, pkgs
-, useMupdf ? config.zathura.useMupdf or true
+, useMupdf ? config.zathura.useMupdf or (!pkgs.stdenv.isDarwin)
 , synctexSupport ? true }:
 
 let

--- a/pkgs/applications/misc/zathura/default.nix
+++ b/pkgs/applications/misc/zathura/default.nix
@@ -1,4 +1,5 @@
 { config, pkgs
+# zathura_pdf_mupdf fails to load _opj_create_decompress at runtime on Darwin (https://github.com/NixOS/nixpkgs/pull/61295#issue-277982980)
 , useMupdf ? config.zathura.useMupdf or (!pkgs.stdenv.isDarwin)
 , synctexSupport ? true }:
 

--- a/pkgs/applications/misc/zathura/pdf-mupdf/default.nix
+++ b/pkgs/applications/misc/zathura/pdf-mupdf/default.nix
@@ -21,9 +21,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     zathura_core girara mupdf cairo
-  ] ++ stdenv.lib.optional stdenv.isDarwin [
-    gtk-mac-integration
-  ];
+  ] ++ lib.optional stdenv.isDarwin gtk-mac-integration;
 
   PKG_CONFIG_ZATHURA_PLUGINDIR= "lib/zathura";
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Currently Zathura package cannot be built on Darwin due to incorrect usage of `lib.optional` in `master` derivation, as well as being dependent on Linux-only packages

###### Things done
- Fixed the `lib.optional` usage and made some dependencies Linux-only.
- Opening `pdf`'s using MuPDF on Darwin fails with
```
error: Could not load plugin '/nix/store/27fc303khwdkqkbb3skr7dsrkdmlsld6-zathura-pdf-mupdf-0.3.4/lib/zathura/libpdf-mupdf.dylib' (dlopen(/nix/store/27fc303khwdkqkbb3skr7dsrkdmlsld6-zathura-pdf-mupdf-0.3.4/lib/zathura/libpdf-mupdf.dylib, 2): Symbol not found: _opj_create_decompress
  Referenced from: /nix/store/27fc303khwdkqkbb3skr7dsrkdmlsld6-zathura-pdf-mupdf-0.3.4/lib/zathura/libpdf-mupdf.dylib
  Expected in: flat namespace
 in /nix/store/27fc303khwdkqkbb3skr7dsrkdmlsld6-zathura-pdf-mupdf-0.3.4/lib/zathura/libpdf-mupdf.dylib).
error: Unknown file type: 'com.adobe.pdf'
```
but works with poppler plugin, hence made derivation use poppler `pdf` plugin by default on Darwin.

Note that I tried adding `fixDarwinDylibNames` to `buildInputs` of `openjpeg`, but this did not fix the issue.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
