### PR TITLE
podman: 1.2.0 -> 1.3.0

### DIFF
--- a/pkgs/applications/virtualization/podman/conmon.nix
+++ b/pkgs/applications/virtualization/podman/conmon.nix
@@ -4,13 +4,13 @@ with lib;
 
 stdenv.mkDerivation rec {
   name = "conmon-${version}";
-  version = "unstable-2019-03-19";
-  rev = "84c860029893e2e2dd71d62231f009c9dcd3c0b4";
+  version = "unstable-2019-04-17";
+  rev = "c150bb3474d7575323e245d26c7edad58555de79";
 
   src = fetchFromGitHub {
     owner = "containers";
     repo = "conmon";
-    sha256 = "1ydidl3s7s5rfwk9gx0k80nxcixlilxw61g7x0vqsdy3mkylysv5";
+    sha256 = "1cjxlbkbf1pz2jyn1gflga69c025p1qgb5lfq9pibrxls0zdqza6";
     inherit rev;
   };
 

--- a/pkgs/applications/virtualization/podman/default.nix
+++ b/pkgs/applications/virtualization/podman/default.nix
@@ -1,17 +1,17 @@
 { stdenv, fetchFromGitHub, pkgconfig
-, buildGoPackage, gpgme, lvm2, btrfs-progs, libseccomp
+, buildGoPackage, gpgme, lvm2, btrfs-progs, libseccomp, systemd
 , go-md2man
 }:
 
 buildGoPackage rec {
   name = "podman-${version}";
-  version = "1.2.0";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "containers";
     repo = "libpod";
     rev = "v${version}";
-    sha256 = "1nlll4q62w3i897wraj18pdi5cc91b8gmp360pzyqzzjdm9ag7v6";
+    sha256 = "0lxn9ddqhwyl0a4fcr61qvlbww1fcs4q8sqbswya56a34gjsmcf4";
   };
 
   goPackagePath = "github.com/containers/libpod";
@@ -23,7 +23,7 @@ buildGoPackage rec {
   nativeBuildInputs = [ pkgconfig go-md2man ];
 
   buildInputs = [
-    btrfs-progs libseccomp gpgme lvm2
+    btrfs-progs libseccomp gpgme lvm2 systemd
   ];
 
   buildPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Update podman to latest release
- [release note](default.nix)
- Adds a dependency on systemd (for `sd-journal`)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
