### PR TITLE
cpcfs: init at 0.85.4

### DIFF
--- a/pkgs/tools/filesystems/cpcfs/default.nix
+++ b/pkgs/tools/filesystems/cpcfs/default.nix
@@ -1,0 +1,41 @@
+{ stdenv, fetchFromGitHub, makeWrapper, ncurses, readline, ronn }:
+
+stdenv.mkDerivation rec {
+
+  pname = "cpcfs";
+  version = "0.85.4";
+  
+  src = fetchFromGitHub {
+    owner = "derikz";
+    repo = "cpcfs";
+    rev = "v${version}";
+    sha256 = "0rfbry0qy8mv746mzk9zdfffkdgq4w7invgb5cszjma2cp83q3i2";
+  };
+
+  sourceRoot = "source/src";
+
+  nativeBuildInputs = [ makeWrapper ncurses readline ronn ];
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace '-ltermcap' '-lncurses' \
+      --replace '-L /usr/lib/termcap' ' '
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    mkdir -p $out/man/man1
+    cp cpcfs $out/bin
+    ronn --roff ../template.doc --pipe > $out/man/man1/cpcfs.1
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Manipulating CPC dsk images and files";
+    homepage = "https://github.com/derikz/cpcfs/" ;
+    license = licenses.bsd2;
+    maintainers = [ maintainers.genesis ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2261,6 +2261,8 @@ in
 
   convoy = callPackage ../tools/filesystems/convoy { };
 
+  cpcfs = callPackage ../tools/filesystems/cpcfs { };
+
   cool-retro-term = libsForQt5.callPackage ../applications/misc/cool-retro-term { };
 
   coreutils = callPackage ../tools/misc/coreutils { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
