### PR TITLE
nexus: 3.15.0-01 -> 3.16.1-02

### DIFF
--- a/pkgs/development/tools/repository-managers/nexus/default.nix
+++ b/pkgs/development/tools/repository-managers/nexus/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "nexus-${version}";
-  version = "3.15.0-01";
+  version = "3.16.1-02";
 
   src = fetchurl {
     url = "https://sonatype-download.global.ssl.fastly.net/nexus/3/nexus-${version}-unix.tar.gz";
-    sha256 = "0akizdljcjl1nh25k01wxvp5wp4i2jphsj0hh5rqbd0fk1pjivkv";
+    sha256 = "0nfcpsb7byykiwrdz01c99a6hr5ww2d4471spzpgs9i64kbjj7ln";
   };
 
   sourceRoot = name;

--- a/pkgs/development/tools/repository-managers/nexus/nexus-bin.patch
+++ b/pkgs/development/tools/repository-managers/nexus/nexus-bin.patch
@@ -1,15 +1,17 @@
---- nexus-3.5.1-02/bin/nexus	2017-08-18 17:51:08.000000000 +0200
-+++ nexus	2017-08-31 12:41:01.271475645 +0200
-@@ -72,7 +72,7 @@
+diff --git a/bin/nexus b/bin/nexus
+index d06cb44..37c606e 100755
+--- a/bin/nexus
++++ b/bin/nexus
+@@ -88,7 +88,7 @@ create_db_entry() {
    fi
    db_new_file=${db_file}_new
    if [ -f "$db_file" ]; then
--    awk '$1 != "'"$test_dir"'" {print $0}' $db_file > $db_new_file
-+    awk '$1 != "'"$test_dir"'" {print $scriptname}' $db_file > $db_new_file
+-    awk '$2 != "'"$test_dir"'" {print $0}' $db_file > $db_new_file
++    awk '$2 != "'"$test_dir"'" {print $scriptname}' $db_file > $db_new_file
      rm "$db_file"
      mv "$db_new_file" "$db_file"
    fi
-@@ -236,7 +236,7 @@
+@@ -246,7 +246,7 @@ read_vmoptions() {
  
  unpack_file() {
    if [ -f "$1" ]; then
@@ -18,32 +20,24 @@
      bin/unpack200 -r "$1" "$jar_file"
  
      if [ $? -ne 0 ]; then
-@@ -360,8 +360,14 @@
+@@ -377,9 +377,14 @@ fi
  
  old_pwd=`pwd`
  
 -progname=`basename "$0"`
 -linkdir=`dirname "$0"`
 +scriptname=$0
-+
+ 
 +if [ ! -z "$ALTERNATIVE_NAME" ]; then
 +  scriptname=`dirname "$0"`"/"$ALTERNATIVE_NAME
 +fi
 +
 +progname=`basename "$scriptname"`
 +linkdir=`dirname "$scriptname"`
- 
  cd "$linkdir"
  prg="$progname"
-@@ -522,7 +528,6 @@
  
- $INSTALL4J_JAVA_PREFIX nohup "$app_java_home/bin/java" -server -Dinstall4j.jvmDir="$app_java_home" -Dexe4j.moduleName="$prg_dir/$progname" "-XX:+UnlockDiagnosticVMOptions" "-Dinstall4j.launcherId=245" "-Dinstall4j.swt=false" "$vmov_1" "$vmov_2" "$vmov_3" "$vmov_4" "$vmov_5" $INSTALL4J_ADD_VM_PARAMS -classpath "$local_classpath" com.install4j.runtime.launcher.UnixLauncher start 9d17dc87 "" "" org.sonatype.nexus.karaf.NexusMain  > /dev/null 2>&1 &
- 
--
-     ;;
-     start-launchd)
-         echo "Starting nexus"
-@@ -569,7 +574,7 @@
+@@ -590,7 +595,7 @@ return_code=$?
  
      ;;
      *)


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

New upstream release with some minor improvements:
https://help.sonatype.com/repomanager3/release-notes/2019-release-notes#id-2019ReleaseNotes-RepositoryManager3.16.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
