### PR TITLE
python3Packages.spacy: 2.0.18 -> 2.1.3

### DIFF
--- a/pkgs/development/python-modules/blis/default.nix
+++ b/pkgs/development/python-modules/blis/default.nix
@@ -1,0 +1,38 @@
+{ stdenv
+, lib
+, buildPythonPackage
+, fetchPypi
+, cython
+, hypothesis
+, numpy
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "blis";
+  version = "0.2.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0c5hd0bim9134sk8wb31cqzvi9c380rbl5zwjiwrq8nnix8a2k1d";
+  };
+
+  nativeBuildInputs = [
+    cython
+  ];
+
+
+  checkInputs = [
+    cython
+    hypothesis
+    numpy
+    pytest
+  ];
+
+  meta = with stdenv.lib; {
+    description = "BLAS-like linear algebra library";
+    homepage = https://github.com/explosion/cython-blis;
+    license = licenses.mit;
+    maintainers = with maintainers; [ danieldk ];
+    };
+}

--- a/pkgs/development/python-modules/spacy/default.nix
+++ b/pkgs/development/python-modules/spacy/default.nix
@@ -25,11 +25,11 @@
 
 buildPythonPackage rec {
   pname = "spacy";
-  version = "2.1.3";
+  version = "2.1.4";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "01mmgfn7r288jklz6902xfb5dbih0h29s9p0na12gyj2c7gnvf5i";
+    sha256 = "03m4c59aaqpqr2x5yhv7y37z0vxhmmkfi6dv4cbp9nxsq9wv100d";
   };
 
   prePatch = ''

--- a/pkgs/development/python-modules/spacy/default.nix
+++ b/pkgs/development/python-modules/spacy/default.nix
@@ -17,22 +17,24 @@
 , pathlib
 , msgpack-python
 , msgpack-numpy
+, jsonschema
+, blis
+, wasabi
+, srsly
 }:
 
 buildPythonPackage rec {
   pname = "spacy";
-  version = "2.0.18";
+  version = "2.1.3";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0mybdms7c40jvk8ak180n65anjiyg4c8gkaqwkzicrd1mxq3ngqj";
+    sha256 = "01mmgfn7r288jklz6902xfb5dbih0h29s9p0na12gyj2c7gnvf5i";
   };
 
   prePatch = ''
     substituteInPlace setup.py \
-      --replace "regex==" "regex>=" \
-      --replace "plac<1.0.0,>=0.9.6" "plac>=0.9.6" \
-      --replace "wheel>=0.32.0,<0.33.0" "wheel>=0.32.0"
+      --replace "plac<1.0.0,>=0.9.6" "plac>=0.9.6"
   '';
 
   propagatedBuildInputs = [
@@ -49,6 +51,10 @@ buildPythonPackage rec {
    ftfy
    msgpack-python
    msgpack-numpy
+   jsonschema
+   blis
+   wasabi
+   srsly
   ] ++ lib.optional (pythonOlder "3.4") pathlib;
 
   checkInputs = [

--- a/pkgs/development/python-modules/spacy/models.json
+++ b/pkgs/development/python-modules/spacy/models.json
@@ -1,78 +1,96 @@
 [{
+  "pname": "de_core_news_md",
+  "version": "2.1.0",
+  "sha256": "0q1flyrp2n8ja11kdlw6x1k0gll0r096pxy8ba4xv15hjng2zay1",
+  "license": "cc-by-sa-40"
+},
+{
   "pname": "de_core_news_sm",
-  "version": "2.0.0",
-  "sha256": "13fs4f46qg9mlxd9ynmh81gxizm11kfq3g52pk8d2m7wp89xfc6a",
+  "version": "2.1.0",
+  "sha256": "0fj4dqa915i6niyskxmw2318fxzjhgdjhjx79h9cpp4mxw719w95",
+  "license": "cc-by-sa-40"
+},
+{
+  "pname": "el_core_news_md",
+  "version": "2.1.0",
+  "sha256": "1rgy9hlb92amhlbwkd91yh87xssqj2a1ign0wm59aai69rb79q3s",
+  "license": "cc-by-sa-40"
+},
+{
+  "pname": "el_core_news_sm",
+  "version": "2.1.0",
+  "sha256": "07n7qg0nnzg5gjq7vs72j9qc6z4zjx65qsrrj0hjhiihk3ps378z",
   "license": "cc-by-sa-40"
 },
 {
   "pname": "en_core_web_lg",
-  "version": "2.0.0",
-  "sha256": "1r33l02jrkzjn78nd0bzzzd6rwjlz7qfgs3bg5yr2ki6q0m7qxvw",
+  "version": "2.1.0",
+  "sha256": "0ywcczd9nsxmpfwknxa7z54h566bwi7chq0jzx3sqk2a6lva4q52",
   "license": "cc-by-sa-40"
 },
 {
   "pname": "en_core_web_md",
-  "version": "2.0.0",
-  "sha256": "1b5g5gma1gzm8ffj0pgli1pllccx5jpjvb7a19n7c8bfswpifxzc",
+  "version": "2.1.0",
+  "sha256": "10vgq1xd6dpdl7xdssgf0kywbq7xpxp79yqc2vcnl3c4axfpwk5q",
   "license": "cc-by-sa-40"
 },
 {
   "pname": "en_core_web_sm",
-  "version": "2.0.0",
-  "sha256": "161298pl6kzc0cgf2g7ji84xbqv8ayrgsrmmg0hxiflwghfj77cx",
+  "version": "2.1.0",
+  "sha256": "1wg5a7nxq82sfmnc3j5xfr8il65rprmcx2h36va5dvydm1h6icad",
   "license": "cc-by-sa-40"
 },
 {
   "pname": "en_vectors_web_lg",
-  "version": "2.0.0",
-  "sha256": "15qfd8vzdv56x41fzghy7k5x1c8ql92ds70r37b6a8hkb87z9byw",
+  "version": "2.1.0",
+  "sha256": "1sq41pr70215f2s8k35x5ni4w0i4xhbzbfg3iyxgbp1b35gizg94",
   "license": "cc-by-sa-40"
 },
 {
   "pname": "es_core_news_md",
-  "version": "2.0.0",
-  "sha256": "03056qz866r641q4nagymw6pc78qnn5vdvcp7p1ph2cvxh7081kp",
+  "version": "2.1.0",
+  "sha256": "02v7hm711r9ma8p5yk057z7hm2pcvpfjgnjszc697d0ymfn4avby",
   "license": "cc-by-sa-40"
 },
 {
   "pname": "es_core_news_sm",
-  "version": "2.0.0",
-  "sha256": "1b91lcmw2kyqmcrxlfq7m5vlj1a57i3bb9a5h4y31smjgzmsr81s",
+  "version": "2.1.0",
+  "sha256": "1smyyb1gqp090sailqdqp5v5ww4kf99a3hcd9d9rdhn1wgsv28dh",
   "license": "cc-by-sa-40"
 },
 {
   "pname": "fr_core_news_md",
-  "version": "2.0.0",
-  "sha256": "06kva46l1nw819bidzj2vks69ap1a9fa7rnvpd28l3z2haci38ls",
+  "version": "2.1.0",
+  "sha256": "0n94ja7y4jbvz0k0x5bij2dypy11ikvgpd9dav0m0hw1wpqgls1i",
   "license": "cc-by-sa-40"
 },
 {
   "pname": "fr_core_news_sm",
-  "version": "2.0.0",
-  "sha256": "1zlhm9646g3cwcv4cs33160f3v8gxmzdr02x8hx7jpw1fbnmc5mx",
+  "version": "2.1.0",
+  "sha256": "1czr40y5sqs0n2dd4s37kc2xawkh2nsj41wvmsx48bw0aksb1n75",
   "license": "cc-by-sa-40"
 },
 {
   "pname": "it_core_news_sm",
-  "version": "2.0.0",
-  "sha256": "0fs68rdq19migb3x3hb510b96aabibsi01adlk1fipll1x48msaz",
+  "version": "2.1.0",
+  "sha256": "1i8dm703mf1l39jwis3mn5mb9azpx6bsimh66iriax94612x64mb",
   "license": "cc-by-sa-40"
 },
 {
   "pname": "nl_core_news_sm",
-  "version": "2.0.0",
-  "sha256": "0n5x61jp8rdxa3ki250ipbd68rjpp9li6xwbx3fbzycpngffwy8z",
+  "version": "2.1.0",
+  "sha256": "0ywyn7jprsfr10bvwnm3qk270raxm9s9rvzyp1cp7ca037ab633y",
   "license": "cc-by-sa-40"
 },
 {
   "pname": "pt_core_news_sm",
-  "version": "2.0.0",
-  "sha256": "1sg500b3f3qnx1ga32hbq9p4qfynqhpdzhlmdjrxgqw8i58ys23g",
+  "version": "2.1.0",
+  "sha256": "0vigc9x7158sdqxjgcxgvp6458k5936jlmlp2qdmlmzxr5wmfrbc",
   "license": "cc-by-sa-40"
 },
 {
   "pname": "xx_ent_wiki_sm",
-  "version": "2.0.0",
-  "sha256": "0mc3mm6nfjp31wbjysdj2x72akyi52hgprm1g54djxfypm3pmn35",
+  "version": "2.1.0",
+  "sha256": "19sfsxwjqdzlfm43gb4hbyj0hgqcfhcfxwdib4g5i1pcfx1v3pf4",
   "license": "cc-by-sa-40"
 }]

--- a/pkgs/development/python-modules/srsly/default.nix
+++ b/pkgs/development/python-modules/srsly/default.nix
@@ -1,0 +1,41 @@
+{ stdenv
+, lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, mock
+, numpy
+, pathlib
+, pytest
+, pytz
+}:
+
+buildPythonPackage rec {
+  pname = "srsly";
+  version = "0.0.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0apgm8znc3k79ifja16fvxsxwgpy3n2fvbp7iwf9szizzpjscylp";
+  };
+
+  propagatedBuildInputs = lib.optional (pythonOlder "3.4") pathlib;
+
+  checkInputs = [
+    mock
+    numpy
+    pytest
+    pytz
+  ];
+
+  # TypeError: cannot serialize '_io.BufferedRandom' object
+  # Possibly because of sandbox restrictions.
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Modern high-performance serialization utilities for Python";
+    homepage = https://github.com/explosion/srsly;
+    license = licenses.mit;
+    maintainers = with maintainers; [ danieldk ];
+  };
+}

--- a/pkgs/development/python-modules/thinc/default.nix
+++ b/pkgs/development/python-modules/thinc/default.nix
@@ -21,15 +21,18 @@
 , mock
 , wrapt
 , dill
+, blis
+, srsly
+, wasabi
 }:
 
 buildPythonPackage rec {
   pname = "thinc";
-  version = "6.12.1";
+  version = "7.0.4";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1kkp8b3xcs3yn3ia5sxrh086c9xv27s2khdxd17abdypxxa99ich";
+    sha256 = "14v8ygjrkj63dwd4pi490ld6i2d8n8wzcf15hnacjjfwij93pa1q";
   };
 
   buildInputs = lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
@@ -37,6 +40,7 @@ buildPythonPackage rec {
   ]);
 
   propagatedBuildInputs = [
+   blis
    cython
    cymem
    msgpack-numpy
@@ -48,8 +52,10 @@ buildPythonPackage rec {
    cytoolz
    plac
    six
+   srsly
    wrapt
    dill
+   wasabi
   ] ++ lib.optional (pythonOlder "3.4") pathlib;
 
 
@@ -61,12 +67,7 @@ buildPythonPackage rec {
 
   prePatch = ''
     substituteInPlace setup.py \
-      --replace "pathlib==1.0.1" "pathlib>=1.0.0,<2.0.0" \
-      --replace "plac>=0.9.6,<1.0.0" "plac>=0.9.6" \
-      --replace "msgpack-numpy<0.4.4" "msgpack-numpy" \
-      --replace "wheel>=0.32.0,<0.33.0" "wheel" \
-      --replace "wrapt>=1.10.0,<1.11.0" "wrapt" \
-      --replace "msgpack>=0.5.6,<0.6.0" "msgpack"
+      --replace "plac>=0.9.6,<1.0.0" "plac>=0.9.6"
   '';
 
   # Cannot find cython modules.

--- a/pkgs/development/python-modules/wasabi/default.nix
+++ b/pkgs/development/python-modules/wasabi/default.nix
@@ -1,0 +1,30 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "wasabi";
+  version = "0.2.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0xxjc9bvvcaz1qq1jyhcxyl2v39jz8d8dz4zhpfbc7dz53kq6b7r";
+  };
+
+  checkInputs = [
+    pytest
+  ];
+
+  checkPhase = ''
+    pytest wasabi/tests
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A lightweight console printing and formatting toolkit";
+    homepage = https://github.com/ines/wasabi;
+    license = licenses.mit;
+    maintainers = with maintainers; [ danieldk ];
+    };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5431,6 +5431,8 @@ in {
 
   thinc = callPackage ../development/python-modules/thinc { };
 
+  wasabi = callPackage ../development/python-modules/wasabi { };
+
   yahooweather = callPackage ../development/python-modules/yahooweather { };
 
   spacy = callPackage ../development/python-modules/spacy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5429,6 +5429,8 @@ in {
 
   backports_weakref = callPackage ../development/python-modules/backports_weakref { };
 
+  blis = callPackage ../development/python-modules/blis { };
+
   srsly = callPackage ../development/python-modules/srsly { };
 
   thinc = callPackage ../development/python-modules/thinc { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5429,6 +5429,8 @@ in {
 
   backports_weakref = callPackage ../development/python-modules/backports_weakref { };
 
+  srsly = callPackage ../development/python-modules/srsly { };
+
   thinc = callPackage ../development/python-modules/thinc { };
 
   wasabi = callPackage ../development/python-modules/wasabi { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Changes:

https://github.com/explosion/spaCy/releases

The most important change since 2.0.x is support for ELMo/BERT-like pretraining, but there are many other changes that improve spaCy across the board.

Since spaCy has quite many dependencies (that seem to be specific to spaCy), I have bundled all the necessary changes together in this PR, namely:

* Add the wasabi wheel
* Add the srsly wheel
* Add the blis wheel
* Update thinc 7.0.4

The last commit updates all the models to version 2.1.0, which also adds medium/small models for Greek and a medium-size model for German.

Tested using the analysis example from the spaCy webpage with the English small model.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
