### PR TITLE
hydra: 2019-03-18 -> 2019-05-06

### DIFF
--- a/pkgs/development/tools/misc/hydra/default.nix
+++ b/pkgs/development/tools/misc/hydra/default.nix
@@ -13,12 +13,6 @@ if lib.versions.major nix.version == "1"
 else
 
 let
-  isGreaterNix20 = with lib.versions;
-    let
-      inherit (nix) version;
-      inherit (lib) toInt;
-    in major version == "2" && toInt (minor version) >= 1 || toInt (major version) > 2;
-
   perlDeps = buildEnv {
     name = "hydra-perl-deps";
     paths = with perlPackages;
@@ -74,16 +68,16 @@ let
       ];
   };
 in releaseTools.nixBuild rec {
-  name = "hydra-${version}";
-  version = "2019-03-18";
+  pname = "hydra";
+  version = "2019-05-06";
 
   inherit stdenv;
 
   src = fetchFromGitHub {
     owner = "NixOS";
-    repo = "hydra";
-    rev = "0721f6623ffb5a4b6a77b499af4eee7d6e4dd6a7";
-    sha256 = "0b2g2bnbaqpwxx8p81i4gpl4y16i57z5pnjm90fpd0jxnkij3pcg";
+    repo = pname;
+    rev = "ff64583d07f046e378a6be596ec0ce7a9e2b7472";
+    sha256 = "0w88q0saz7si22z3ryim6vdrv9qkwn6l25xfmiapvh5qrnrrdcb9";
   };
 
   buildInputs =
@@ -93,7 +87,8 @@ in releaseTools.nixBuild rec {
       perlDeps perl nix
       postgresql # for running the tests
       nlohmann_json
-    ] ++ lib.optionals isGreaterNix20 [ boost ];
+      boost
+    ];
 
   hydraPath = lib.makeBinPath (
     [ sqlite subversion openssh nix coreutils findutils pixz
@@ -102,15 +97,7 @@ in releaseTools.nixBuild rec {
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
 
-  # adds a patch which ensures compatibility with the API of Nix 2.0.
-  # it has been reverted in https://github.com/NixOS/hydra/commit/162d671c48a418bd10a8a171ca36787ef3695a44,
-  # for Nix 2.1/unstable compatibility. Reapplying helps if Nix 2.0 is used to keep the build functional.
-  patches = lib.optionals (!isGreaterNix20) [
-    (fetchpatch {
-      url = "https://github.com/NixOS/hydra/commit/08de434bdd0b0a22abc2081be6064a6c846d3920.patch";
-      sha256 = "0kz77njp5ynn9l81g3q8zrryvnsr06nk3iw0a60187wxqzf5fmf8";
-    })
-  ] ++ [
+  patches = [
     (fetchpatch {
       url = "https://github.com/NixOS/hydra/pull/648/commits/4171ab4c4fd576c516dc03ba64d1c7945f769af0.patch";
       sha256 = "1fxa2459kdws6qc419dv4084c1ssmys7kqg4ic7n643kybamsgrx";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

As Hydra doesn't have a release model, we have to pin git revs for our
package. The current state provides some new fixes and features like a status
plugin for GitLab.

As Nix 2.0 isn't bundled in `master` and `release-19.03` and we don't
support Nix 1.11 for Hydra, I figured that the Nix version checks could
be dropped and boost can always be used as build input.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
