### PR TITLE
xss-lock: improve locker options passing

### DIFF
--- a/nixos/modules/programs/xss-lock.nix
+++ b/nixos/modules/programs/xss-lock.nix
@@ -8,11 +8,22 @@ in
 {
   options.programs.xss-lock = {
     enable = mkEnableOption "xss-lock";
+
     lockerCommand = mkOption {
       default = "${pkgs.i3lock}/bin/i3lock";
       example = literalExample ''''${pkgs.i3lock-fancy}/bin/i3lock-fancy'';
       type = types.string;
       description = "Locker to be used with xsslock";
+    };
+
+    extraOptions = mkOption {
+      default = [ ];
+      example = literalExample [ "--ignore-sleep" ];
+      type = types.listOf types.str;
+      description = ''
+        Additional command-line arguments to pass to
+        <command>xss-lock</command>.
+      '';
     };
   };
 
@@ -21,7 +32,13 @@ in
       description = "XSS Lock Daemon";
       wantedBy = [ "graphical-session.target" ];
       partOf = [ "graphical-session.target" ];
-      serviceConfig.ExecStart = "${pkgs.xss-lock}/bin/xss-lock ${cfg.lockerCommand}";
+      serviceConfig.ExecStart = with lib;
+        strings.concatStringsSep " " ([
+            "${pkgs.xss-lock}/bin/xss-lock"
+          ] ++ cfg.extraOptions ++ [
+            "--"
+            cfg.lockerCommand
+        ]);
     };
   };
 }

--- a/nixos/modules/programs/xss-lock.nix
+++ b/nixos/modules/programs/xss-lock.nix
@@ -18,7 +18,7 @@ in
 
     extraOptions = mkOption {
       default = [ ];
-      example = literalExample [ "--ignore-sleep" ];
+      example = [ "--ignore-sleep" ];
       type = types.listOf types.str;
       description = ''
         Additional command-line arguments to pass to
@@ -35,7 +35,7 @@ in
       serviceConfig.ExecStart = with lib;
         strings.concatStringsSep " " ([
             "${pkgs.xss-lock}/bin/xss-lock"
-          ] ++ cfg.extraOptions ++ [
+          ] ++ (map escapeShellArg cfg.extraOptions) ++ [
             "--"
             cfg.lockerCommand
         ]);


### PR DESCRIPTION
*Noob alert: This is my first PR to nixpkgs.*

###### Motivation for this change
Currently, command line arguments can't be passed in `locker` easily without workarounds.

```nix
# Doesn't work
programs.xss-lock.lockerCommand = "${pkgs.xlockmore}/bin/xlock -mode ant";
```

This is because xss-lock doesn't recognize these are locker arguments.

```nix
# Works but seems hacky
programs.xss-lock.lockerCommand = "-- ${pkgs.xlockmore}/bin/xlock -mode ant";
```

###### Things done

In short:

- allow locker options without hacks
- add extraOptions

Locker is now separated by `--`. Because of this one can no longer abuse `locker` option to pass arguments to `xss-lock` and therefore new option `extraOptions` was added to pass options to `xss-lock`

**This is a breaking change for configurations which used workaround described**

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
