### PR TITLE
Backport "elk5: 5.6.9 -> 5.6.16 & elk6: 6.7.1 -> 6.7.2 & elasticsearchPlugins fix" to release-19.03

### DIFF
--- a/pkgs/development/tools/misc/kibana/5.x.nix
+++ b/pkgs/development/tools/misc/kibana/5.x.nix
@@ -11,9 +11,9 @@ let
   elasticArch = archOverrides."${arch}" or arch;
   plat = elemAt info 1;
   shas = {
-    "x86_64-linux"  = "1rg4j5jm8mkscrwlbx5qk3qjnblyr8z9x5npvyi73zm0ism0gv4j";
-    "i686-linux"    = "14swgx9sf23pns2pj30yyhd0p0rnykdimdrnj8rb0r1pqszw57qx";
-    "x86_64-darwin" = "10l13r47nx74xicnjgb56nvgvx2al1zx1p8f09pjldaa2gjlll2k";
+    "x86_64-linux"  = "0hzr47hyw54b9j4c33n6f6n3pala6kjhyvinfszgikbghyhb7fsa";
+    "i686-linux"    = "0bka4h31cw10ii4pfygc81pwc3wr32pzw3v4k4bi8rnqbk280fmn";
+    "x86_64-darwin" = "0jqc2g89rqkla0alqxr14sh4pccfn514jrwr7mkjivxdapygh1ll";
   };
 in stdenv.mkDerivation rec {
   name = "kibana-${version}";

--- a/pkgs/development/tools/misc/kibana/6.x.nix
+++ b/pkgs/development/tools/misc/kibana/6.x.nix
@@ -19,12 +19,12 @@ let
   shas =
     if enableUnfree
     then {
-      "x86_64-linux"  = "039ll00kvrp881cyybb04z90cw68j7p5cspgdxh0bky9lyi9qpwb";
-      "x86_64-darwin" = "0qrakrihcjwn9dic77b0k9ja3zf6nbz534v76xid9gv20md5dds3";
+      "x86_64-linux"  = "1i3zmzxihplwd8n994lfxhhgygdg3qxjqgrj1difa8w3vss0zbfn";
+      "x86_64-darwin" = "09a96ms9id77infxd9xxfs6r7j01mn0rz5yw3g9sl92j9ri7r52c";
     }
     else {
-      "x86_64-linux"  = "1v1fbmfkbnlx043z3yx02gaqqy63bj2ymvcby66n4qq0vlpahvwx";
-      "x86_64-darwin" = "1y4q7a2b9arln94d6sj547qkv3258jlgcz9b342fh6khlbpfjb8c";
+      "x86_64-linux"  = "166rhxr0qlv1yarj2mg1c3b8mxvhl70jhz53azq7ic6laj55q7fk";
+      "x86_64-darwin" = "0ngngkbl036p2mzwhp8qafi3aqzk398a218w12srfqny5n630vdk";
     };
 
 in stdenv.mkDerivation rec {

--- a/pkgs/misc/logging/beats/5.x.nix
+++ b/pkgs/misc/logging/beats/5.x.nix
@@ -8,7 +8,7 @@ let beat = package : extraArgs : buildGoPackage (rec {
         owner = "elastic";
         repo = "beats";
         rev = "v${version}";
-        sha256 = "00g90i58c6gnyzszsx7y75vn1350hrkzrsb50xx700jqg9ii8yin";
+        sha256 = "0sslcwjdf7zb9xj2c98jid3rb09l96m22k3af48gppimxg1lkh9b";
       };
 
       goPackagePath = "github.com/elastic/beats";

--- a/pkgs/misc/logging/beats/6.x.nix
+++ b/pkgs/misc/logging/beats/6.x.nix
@@ -8,7 +8,7 @@ let beat = package : extraArgs : buildGoPackage (rec {
         owner = "elastic";
         repo = "beats";
         rev = "v${version}";
-        sha256 = "0n1sjngc82b7wysw5aaiqvllq4c8rx2jj7khw4vrypc40f8ahjs5";
+        sha256 = "0if08dxibdnqpsxs8f6hvw147j0j8bavhcm11scn28j9id65absq";
       };
 
       goPackagePath = "github.com/elastic/beats";

--- a/pkgs/servers/search/elasticsearch/5.x.nix
+++ b/pkgs/servers/search/elasticsearch/5.x.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://artifacts.elastic.co/downloads/elasticsearch/${name}.tar.gz";
-    sha256 = "0sm99m4m4mmigj6ll22kyaw7zkp1s2i0mhzx15fzidnybdnlifb4";
+    sha256 = "0zy7awb2cm2fk3c7zc7v8b8pl0jw49awqwpa1jvilmvx6dcml0vb";
   };
 
   patches = [ ./es-home-5.x.patch ./es-classpath-5.x.patch ];

--- a/pkgs/servers/search/elasticsearch/6.x.nix
+++ b/pkgs/servers/search/elasticsearch/6.x.nix
@@ -19,8 +19,8 @@ stdenv.mkDerivation (rec {
     url = "https://artifacts.elastic.co/downloads/elasticsearch/${name}.tar.gz";
     sha256 =
       if enableUnfree
-      then "1qh6iz3qhw8zcvxfss5w3h89zarwvk6dp5bbbag7c30kh94gkqvv"
-      else "13v8qpslanfn5w81qvbg0aqh510yfbl3x59kisvdkz9ifhjbcavi";
+      then "1a88yyl0x4bsx92m3wjsz1fgm76gbfdzcd4bzp2x652rha667vfh"
+      else "04fa0fk25d5yxcjdj0bwqvdrswgwj31fwjvbq4gpg66c6bqwzcn6";
   };
 
   patches = [ ./es-home-6.x.patch ];

--- a/pkgs/servers/search/elasticsearch/plugins.nix
+++ b/pkgs/servers/search/elasticsearch/plugins.nix
@@ -1,12 +1,18 @@
-{ pkgs,  stdenv, fetchurl, unzip, elasticsearch-oss, javaPackages, elk6Version }:
+{ pkgs, lib, stdenv, fetchurl, unzip, javaPackages, elasticsearch }:
 
 let
+  esVersion = elasticsearch.version;
+
+  majorVersion = lib.head (builtins.splitVersion esVersion);
+
   esPlugin = a@{
     pluginName,
     installPhase ? ''
       mkdir -p $out/config
       mkdir -p $out/plugins
-      ES_HOME=$out ${elasticsearch-oss}/bin/elasticsearch-plugin install --batch -v file://$src
+      ln -s ${elasticsearch}/lib $out/lib
+      ES_HOME=$out ${elasticsearch}/bin/elasticsearch-plugin install --batch -v file://$src
+      rm $out/lib
     '',
     ...
   }:
@@ -15,37 +21,41 @@ let
       unpackPhase = "true";
       buildInputs = [ unzip ];
       meta = a.meta // {
-        platforms = elasticsearch-oss.meta.platforms;
+        platforms = elasticsearch.meta.platforms;
         maintainers = (a.meta.maintainers or []) ++ (with stdenv.lib.maintainers; [ offline ]);
       };
     });
 in {
 
-  elasticsearch_analysis_lemmagen = esPlugin rec {
+  analysis-lemmagen = esPlugin rec {
     name = "elasticsearch-analysis-lemmagen-${version}";
     pluginName = "elasticsearch-analysis-lemmagen";
-    version = "6.7.1"; # elk6Version;
+    version = esVersion;
     src = fetchurl {
-      url = "https://github.com/vhyza/elasticsearch-analysis-lemmagen/releases/download/v${version}/${name}-plugin.zip";
-      sha256 = "0mf8lpf40bjpzfj9lkhrg7c3xinzvg7aby3vd6h92g9i676xs8ri";
+      url = "https://github.com/vhyza/${pluginName}/releases/download/v${version}/${name}-plugin.zip";
+      sha256 =
+        if version == "7.0.1" then "155zj9zw81msx976c952nk926ndav1zqhmy2xih6nr82qf0p71hm"
+        else if version == "6.7.2" then "1r176ncjbilkmri2c5rdxh5xqsrn77m1f0p98zs47czwlqh230iq"
+        else throw "unsupported version ${version} for plugin ${pluginName}";
     };
     meta = with stdenv.lib; {
       homepage = https://github.com/vhyza/elasticsearch-analysis-lemmagen;
       description = "LemmaGen Analysis plugin provides jLemmaGen lemmatizer as Elasticsearch token filter";
       license = licenses.asl20;
-      # TODO: remove the following when there's a release compatible with elasticsearch-6.7.2.
-      # See: https://github.com/vhyza/elasticsearch-analysis-lemmagen/issues/14
-      broken = true;
     };
   };
 
   discovery-ec2 = esPlugin rec {
     name = "elasticsearch-discovery-ec2-${version}";
     pluginName = "discovery-ec2";
-    version = "${elk6Version}";
+    version = esVersion;
     src = pkgs.fetchurl {
-      url = "https://artifacts.elastic.co/downloads/elasticsearch-plugins/discovery-ec2/discovery-ec2-${elk6Version}.zip";
-      sha256 = "1p0cdz3lfksfd2kvlcj0syxhbx27mimsaw8q4kgjpjjjwqayg523";
+      url = "https://artifacts.elastic.co/downloads/elasticsearch-plugins/${pluginName}/${pluginName}-${version}.zip";
+      sha256 =
+        if version == "7.0.1" then "0nrvralh4fygs0ys2ikg3x08jdyh9276d5w7yfncbbi0xrg9hk6g"
+        else if version == "6.7.2" then "1p0cdz3lfksfd2kvlcj0syxhbx27mimsaw8q4kgjpjjjwqayg523"
+        else if version == "5.6.16" then "1300pfmnlpfm1hh2jgas8j2kqjqiqkxhr8czshj9lx0wl4ciknin"
+        else throw "unsupported version ${version} for plugin ${pluginName}";
     };
     meta = with stdenv.lib; {
       homepage = https://github.com/elastic/elasticsearch/tree/master/plugins/discovery-ec2;
@@ -54,17 +64,65 @@ in {
     };
   };
 
-  search_guard = esPlugin rec {
-    name = "elastic-search-guard-${version}";
+  repository-s3 = esPlugin rec {
+    name = "elasticsearch-repository-s3-${version}";
+    pluginName = "repository-s3";
+    version = esVersion;
+    src = pkgs.fetchurl {
+      url = "https://artifacts.elastic.co/downloads/elasticsearch-plugins/${pluginName}/${pluginName}-${esVersion}.zip";
+      sha256 =
+        if version == "7.0.1" then "17bf8m1q92j5yhgldckl4hlsfv6qgwwqdc1da9kzgidgky7jwkbc"
+        else if version == "6.7.2" then "1l353zfyv3qziz8xkann9cbzx4wj5s14wnknfw351j6vgdq26l12"
+        else if version == "5.6.16" then "0k3li5xv1270ygb9lqk6ji3nngngl2im3z38k08nd627vxdrzij2"
+        else throw "unsupported version ${version} for plugin ${pluginName}";
+    };
+    meta = with stdenv.lib; {
+      homepage = https://github.com/elastic/elasticsearch/tree/master/plugins/repository-s3;
+      description = "The S3 repository plugin adds support for using AWS S3 as a repository for Snapshot/Restore.";
+      license = licenses.asl20;
+    };
+  };
+
+  repository-gcs = esPlugin rec {
+    name = "elasticsearch-repository-gcs-${version}";
+    pluginName = "repository-gcs";
+    version = esVersion;
+    src = pkgs.fetchurl {
+      url = "https://artifacts.elastic.co/downloads/elasticsearch-plugins/${pluginName}/${pluginName}-${esVersion}.zip";
+      sha256 =
+        if version == "7.0.1" then "0a3rc2gggsj7xfncil1s53dmq799lcm82h0yncs94jnb182sbmzc"
+        else if version == "6.7.2" then "0afccbvb7x6y3nrwmal09vpgxyz4lar6lffw4mngalcppsk8irvv"
+        else if version == "5.6.16" then "0hwqx4yhdn4c0ccdpvgrg30ag8hy3mgxgk7h7pibdmzvy7qw7501"
+        else throw "unsupported version ${version} for plugin ${pluginName}";
+    };
+    meta = with stdenv.lib; {
+      homepage = https://github.com/elastic/elasticsearch/tree/master/plugins/repository-gcs;
+      description = "The GCS repository plugin adds support for using Google Cloud Storage as a repository for Snapshot/Restore.";
+      license = licenses.asl20;
+    };
+  };
+
+  search-guard = let
+    majorVersion = lib.head (builtins.splitVersion esVersion);
+  in esPlugin rec {
+    name = "elasticsearch-search-guard-${version}";
     pluginName = "search-guard";
-    version = "${elk6Version}-25.1";
-    src = fetchurl rec {
-      url = "mirror://maven/com/floragunn/search-guard-6/${version}/search-guard-6-${version}.zip";
-      sha256 = "119r1zibi0z40mfxrpkx0zzay0yz6c7syqmmw8i2681wmz4nksda";
+    version =
+      if esVersion == "7.0.1" then "${esVersion}-35.0.0"
+      else if esVersion == "6.7.2" then "${esVersion}-25.1"
+      else if esVersion == "5.6.16" then "${esVersion}-19.3"
+      else throw "unsupported version ${esVersion} for plugin ${pluginName}";
+    src = fetchurl {
+      url = "mirror://maven/com/floragunn/${pluginName}-${majorVersion}/${version}/${pluginName}-${majorVersion}-${version}.zip";
+      sha256 =
+        if version == "7.0.1-35.0.0" then "0wsiqq7j7ph9g2vhhvjmwrh5a2q1wzlysgr75gc35zcvqz6cq8ha"
+        else if version == "6.7.2-25.1" then "119r1zibi0z40mfxrpkx0zzay0yz6c7syqmmw8i2681wmz4nksda"
+        else if version == "5.6.16-19.3" then "1q70anihh89c53fnk8wlq9z5dx094j0f9a0y0v2zsqx18lz9ikmx"
+        else throw "unsupported version ${version} for plugin ${pluginName}";
     };
     meta = with stdenv.lib; {
       homepage = https://github.com/floragunncom/search-guard;
-      description = "Plugin to fetch data from JDBC sources for indexing into Elasticsearch";
+      description = "Elasticsearch plugin that offers encryption, authentication, and authorisation. ";
       license = licenses.asl20;
     };
   };

--- a/pkgs/servers/search/elasticsearch/plugins.nix
+++ b/pkgs/servers/search/elasticsearch/plugins.nix
@@ -24,7 +24,7 @@ in {
   elasticsearch_analysis_lemmagen = esPlugin rec {
     name = "elasticsearch-analysis-lemmagen-${version}";
     pluginName = "elasticsearch-analysis-lemmagen";
-    version = "${elk6Version}";
+    version = "6.7.1"; # elk6Version;
     src = fetchurl {
       url = "https://github.com/vhyza/elasticsearch-analysis-lemmagen/releases/download/v${version}/${name}-plugin.zip";
       sha256 = "0mf8lpf40bjpzfj9lkhrg7c3xinzvg7aby3vd6h92g9i676xs8ri";
@@ -33,6 +33,9 @@ in {
       homepage = https://github.com/vhyza/elasticsearch-analysis-lemmagen;
       description = "LemmaGen Analysis plugin provides jLemmaGen lemmatizer as Elasticsearch token filter";
       license = licenses.asl20;
+      # TODO: remove the following when there's a release compatible with elasticsearch-6.7.2.
+      # See: https://github.com/vhyza/elasticsearch-analysis-lemmagen/issues/14
+      broken = true;
     };
   };
 
@@ -42,7 +45,7 @@ in {
     version = "${elk6Version}";
     src = pkgs.fetchurl {
       url = "https://artifacts.elastic.co/downloads/elasticsearch-plugins/discovery-ec2/discovery-ec2-${elk6Version}.zip";
-      sha256 = "05z4vmi29fzfqzid7fdh6h6pjwgd1dz1mhhjgjz9plpvpzymjiln";
+      sha256 = "1p0cdz3lfksfd2kvlcj0syxhbx27mimsaw8q4kgjpjjjwqayg523";
     };
     meta = with stdenv.lib; {
       homepage = https://github.com/elastic/elasticsearch/tree/master/plugins/discovery-ec2;
@@ -54,10 +57,10 @@ in {
   search_guard = esPlugin rec {
     name = "elastic-search-guard-${version}";
     pluginName = "search-guard";
-    version = "${elk6Version}-24.3";
+    version = "${elk6Version}-25.1";
     src = fetchurl rec {
       url = "mirror://maven/com/floragunn/search-guard-6/${version}/search-guard-6-${version}.zip";
-      sha256 = "17gif45fbi4vj9qrzv075fkr7d2sp0naa5bjjj9gvfgqyl2flj7g";
+      sha256 = "119r1zibi0z40mfxrpkx0zzay0yz6c7syqmmw8i2681wmz4nksda";
     };
     meta = with stdenv.lib; {
       homepage = https://github.com/floragunncom/search-guard;

--- a/pkgs/servers/search/elasticsearch/plugins.nix
+++ b/pkgs/servers/search/elasticsearch/plugins.nix
@@ -25,7 +25,10 @@ let
         maintainers = (a.meta.maintainers or []) ++ (with stdenv.lib.maintainers; [ offline ]);
       };
     });
-in {
+in rec {
+
+  # The following alias is for backwards compatibility with 19.03.
+  elasticsearch_analysis_lemmagen = analysis-lemmagen;
 
   analysis-lemmagen = esPlugin rec {
     name = "elasticsearch-analysis-lemmagen-${version}";

--- a/pkgs/tools/misc/logstash/5.x.nix
+++ b/pkgs/tools/misc/logstash/5.x.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://artifacts.elastic.co/downloads/logstash/${name}.tar.gz";
-    sha256 = "0qcq4c4nysdscbjrikhw653xwbi4dwscynjzyndsp8l21vl81x7p";
+    sha256 = "0sax9p2bwjdrcvkm1mgvljdjn2qkyjd5i8rzajdn3n98gqin1la0";
   };
 
   dontBuild         = true;

--- a/pkgs/tools/misc/logstash/6.x.nix
+++ b/pkgs/tools/misc/logstash/6.x.nix
@@ -16,8 +16,8 @@ stdenv.mkDerivation rec {
     url = "https://artifacts.elastic.co/downloads/logstash/${name}.tar.gz";
     sha256 =
       if enableUnfree
-      then "18j2n6gnhfjmb6skhhrzs0d1zwa1aj9jv37rqvg4w3fimnm8p0sh"
-      else "181x8y6izrh587a6d1qipgj8wk71v4fggypkzjkns4my00nki42y";
+      then "178shgxwc9kw9w9vwsvwxp8m8r6lssaw1i32vvmx9na01b4w5m4p"
+      else "0gyq97qsg7fys9cc5yj4kpcf3xxvdd5qgzal368yg9swps37g5yj";
   };
 
   dontBuild         = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2519,7 +2519,7 @@ in
   evemu = callPackage ../tools/system/evemu { };
 
   # The latest version used by elasticsearch, logstash, kibana and the the beats from elastic.
-  elk5Version = "5.6.9";
+  elk5Version = "5.6.16";
   elk6Version = "6.7.1";
   elk7Version = "7.0.1";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2536,8 +2536,19 @@ in
   elasticsearch-oss = elasticsearch6-oss;
 
   elasticsearchPlugins = recurseIntoAttrs (
-    callPackage ../servers/search/elasticsearch/plugins.nix { }
+    callPackage ../servers/search/elasticsearch/plugins.nix {
+      elasticsearch = elasticsearch-oss;
+    }
   );
+  elasticsearch5Plugins = elasticsearchPlugins.override {
+    elasticsearch = elasticsearch5;
+  };
+  elasticsearch6Plugins = elasticsearchPlugins.override {
+    elasticsearch = elasticsearch6-oss;
+  };
+  elasticsearch7Plugins = elasticsearchPlugins.override {
+    elasticsearch = elasticsearch7-oss;
+  };
 
   elasticsearch-curator = with (python3.override {
     packageOverrides = self: super: {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2520,7 +2520,7 @@ in
 
   # The latest version used by elasticsearch, logstash, kibana and the the beats from elastic.
   elk5Version = "5.6.16";
-  elk6Version = "6.7.1";
+  elk6Version = "6.7.2";
   elk7Version = "7.0.1";
 
   elasticsearch5 = callPackage ../servers/search/elasticsearch/5.x.nix { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This backports the bug-fix releases for the ELK stack (https://github.com/NixOS/nixpkgs/pull/61255) to 19.03. 

This also backports Jaka's fixes for the `elasticsearchPlugins` (https://github.com/NixOS/nixpkgs/pull/61045) with an additional commit that adds the old `elasticsearchPlugins.elasticsearch_analysis_lemmagen` attribute to keep compatibility with 19.03.

CC @offlinehacker 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
