### PR TITLE
pythonPackages.pyopenssl: add support for building with openssl 1.1.x

### DIFF
--- a/pkgs/development/python-modules/pyopenssl/default.nix
+++ b/pkgs/development/python-modules/pyopenssl/default.nix
@@ -32,12 +32,25 @@ let
     "test_set_notBefore"
   ];
 
+  # these tests are extremely tightly wed to the exact output of the openssl cli tool,
+  # including exact punctuation.
+  failingOpenSSL_1_1Tests = [
+    "test_dump_certificate"
+    "test_dump_privatekey_text"
+    "test_dump_certificate_request"
+    "test_export_text"
+  ];
+
   disabledTests = [
     # https://github.com/pyca/pyopenssl/issues/692
     # These tests, we disable always.
     "test_set_default_verify_paths"
     "test_fallback_default_verify_paths"
-  ] ++ (optionals (hasPrefix "libressl" openssl.meta.name) failingLibresslTests);
+  ] ++ (
+    optionals (hasPrefix "libressl" openssl.meta.name) failingLibresslTests
+  ) ++ (
+    optionals (versionAtLeast (getVersion openssl.name) "1.1") failingOpenSSL_1_1Tests
+  );
 
   # Compose the final string expression, including the "-k" and the single quotes.
   testExpression = optionalString (disabledTests != [])


### PR DESCRIPTION
###### Motivation for this change
Because sometimes you need to use `openssl` 1.1 features.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
