### PR TITLE
slack: Generalize theming

### DIFF
--- a/pkgs/applications/networking/instant-messengers/slack/dark-theme.nix
+++ b/pkgs/applications/networking/instant-messengers/slack/dark-theme.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchurl }:
+
+let
+  rev = "56d2007b5ba9f1628a44af6edf5dbdf74cf92278";
+  sha256 = "1v264mpf9ddiz8zb7fcyjwy1a2yr5f4xs520gf63kl9378v721da";
+  version = "2019-03-15";
+in stdenv.mkDerivation {
+  inherit version;
+
+  name = "slack-theme-black";
+  src = fetchurl {
+    url = "https://raw.githubusercontent.com/laCour/slack-night-mode/${rev}/css/raw/black.css";
+    inherit sha256;
+  };
+
+  unpackPhase = "true";
+
+  buildCommand = ''
+    mkdir $out
+    cp $src $out/theme.css
+  '';
+}

--- a/pkgs/applications/networking/instant-messengers/slack/default.nix
+++ b/pkgs/applications/networking/instant-messengers/slack/default.nix
@@ -1,9 +1,7 @@
-{ stdenv, fetchurl, dpkg, makeWrapper , alsaLib, atk, cairo,
+{ theme ? null, stdenv, fetchurl, dpkg, makeWrapper , alsaLib, atk, cairo,
 cups, curl, dbus, expat, fontconfig, freetype, glib , gnome2, gtk3, gdk_pixbuf,
 libappindicator-gtk3, libnotify, libxcb, nspr, nss, pango , systemd, xorg,
-at-spi2-atk, libuuid,
-darkMode ? false,
-darkModeCssUrl ? "https://cdn.rawgit.com/laCour/slack-night-mode/master/css/raw/black.css"
+at-spi2-atk, libuuid
 }:
 
 let
@@ -94,12 +92,12 @@ in stdenv.mkDerivation {
     substituteInPlace $out/share/applications/slack.desktop \
       --replace /usr/bin/ $out/bin/ \
       --replace /usr/share/ $out/share/
-  '' + stdenv.lib.optionalString darkMode ''
+  '' + stdenv.lib.optionalString (theme != null) ''
     cat <<EOF >> $out/lib/slack/resources/app.asar.unpacked/src/static/ssb-interop.js
     document.addEventListener('DOMContentLoaded', function() {
     let tt__customCss = ".menu ul li a:not(.inline_menu_link) {color: #fff !important;}"
     $.ajax({
-        url: '${darkModeCssUrl}',
+        url: '${theme}/theme.css',
         success: function(css) {
             \$("<style></style>").appendTo('head').html(css + tt__customCss);
             \$("<style></style>").appendTo('head').html('#reply_container.upload_in_threads .inline_message_input_container {background: padding-box #545454}');

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18371,7 +18371,8 @@ in
   leftwm = callPackage ../applications/window-managers/leftwm { };
 
   slack = callPackage ../applications/networking/instant-messengers/slack { };
-  slack-dark = pkgs.slack.override { darkMode = true; };
+  slack-theme-black = callPackage ../applications/networking/instant-messengers/slack/dark-theme.nix { };
+  slack-dark = pkgs.slack.override { theme = slack-theme-black; };
 
   slack-cli = callPackage ../tools/networking/slack-cli { };
 


### PR DESCRIPTION
Split out dark theme
Fixes #61155

###### Motivation for this change
#61155 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
