### PR TITLE
g2o: init at 2019-04-07

### DIFF
--- a/pkgs/development/libraries/g2o/default.nix
+++ b/pkgs/development/libraries/g2o/default.nix
@@ -1,0 +1,24 @@
+{ lib, stdenv, fetchFromGitHub, cmake, eigen, suitesparse }:
+
+stdenv.mkDerivation rec {
+  pname = "g2o";
+  version = "unstable-2019-04-07";
+
+  src = fetchFromGitHub {
+    owner = "RainerKuemmerle";
+    repo = pname;
+    rev = "9b41a4ea5ade8e1250b9c1b279f3a9c098811b5a";
+    sha256 = "1rgrz6zxiinrik3lgwgvsmlww1m2fnpjmvcx1mf62xi1s2ma5w2i";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ eigen suitesparse ];
+
+  meta = {
+    description = "A General Framework for Graph Optimization";
+    homepage = "https://github.com/RainerKuemmerle/g2o";
+    license = with lib.licenses; [ bsd3 lgpl3 gpl3 ];
+    maintainers = with lib.maintainers; [ lopsided98 ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1525,6 +1525,8 @@ in
 
   fzy = callPackage ../tools/misc/fzy { };
 
+  g2o = callPackage ../development/libraries/g2o { };
+
   gbsplay = callPackage ../applications/audio/gbsplay { };
 
   gdrivefs = python27Packages.gdrivefs;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I use this package.

###### Things done

Add g2o using the latest git revision. g2o does not have regular releases. It has a commit from 2017 tagged as a release, but this was added arbitrarily because someone wanted a release (https://github.com/RainerKuemmerle/g2o/issues/194), so I thought it was better to just use the latest version.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
