### PR TITLE
magma: 2.0.2 -> 2.5.0

### DIFF
--- a/pkgs/development/libraries/science/math/magma/default.nix
+++ b/pkgs/development/libraries/science/math/magma/default.nix
@@ -1,23 +1,30 @@
-{ stdenv, fetchurl, cmake, gfortran, cudatoolkit, libpthreadstubs, liblapack }:
+{ stdenv, fetchurl, cmake, gfortran, cudatoolkit, libpthreadstubs, liblapack
+, mklSupport ? false, mkl ? null
+}:
+
+assert !mklSupport || mkl != null;
 
 with stdenv.lib;
 
-let version = "2.0.2";
+let version = "2.5.0";
 
 in stdenv.mkDerivation {
   name = "magma-${version}";
   src = fetchurl {
     url = "https://icl.cs.utk.edu/projectsfiles/magma/downloads/magma-${version}.tar.gz";
-    sha256 = "0w3z6k1npfh0d3r8kpw873f1m7lny29sz2bvvfxzk596d4h083lk";
+    sha256 = "0czspk93cv1fy37zyrrc9k306q4yzfxkhy1y4lj937dx8rz5rm2g";
     name = "magma-${version}.tar.gz";
   };
 
-  buildInputs = [ gfortran cudatoolkit libpthreadstubs liblapack cmake ];
+  buildInputs = [ gfortran cudatoolkit libpthreadstubs cmake ]
+    ++ (if mklSupport then [ mkl ] else [ liblapack ]);
 
   doCheck = false;
-  #checkTarget = "tests";
+
+  MKLROOT = optionalString mklSupport "${mkl}";
 
   enableParallelBuilding=true;
+  buildFlags = [ "magma" "magma_sparse" ];
 
   # MAGMA's default CMake setup does not care about installation. So we copy files directly.
   installPhase = ''
@@ -41,6 +48,6 @@ in stdenv.mkDerivation {
     license = licenses.bsd3;
     homepage = http://icl.cs.utk.edu/magma/index.html;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ ianwookim ];
+    maintainers = with maintainers; [ tbenst ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Without magma, many linalg functions in pytorch are broken on GPU. I also had to update magma to support newer versions of CUDA.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
