### PR TITLE
Feature/qt clang integration

### DIFF
--- a/pkgs/development/tools/qtcreator/0001-Fix-clang-libcpp-regexp.patch
+++ b/pkgs/development/tools/qtcreator/0001-Fix-clang-libcpp-regexp.patch
@@ -1,0 +1,15 @@
+diff --git a/src/plugins/cpptools/headerpathfilter.cpp b/src/plugins/cpptools/headerpathfilter.cpp
+index b514c46..5f96358 100644
+--- a/src/plugins/cpptools/headerpathfilter.cpp
++++ b/src/plugins/cpptools/headerpathfilter.cpp
+@@ -92,8 +92,8 @@ HeaderPaths::iterator resourceIterator(HeaderPaths &headerPaths, bool isMacOs)
+ {
+     // include/c++, include/g++, libc++\include and libc++abi\include
+     static const QString cppIncludes = R"((.*\/include\/.*(g\+\+|c\+\+).*))"
+-                                       R"(|(.*libc\+\+\/include))"
+-                                       R"(|(.*libc\+\+abi\/include))";
++                                       R"(|(.*libc\+\+.*\/include))"
++                                       R"(|(.*libc\+\+abi.*\/include))";
+     static const QRegularExpression includeRegExp("\\A(" + cppIncludes + ")\\z");
+ 
+     // The same as includeRegExp but also matches /usr/local/include

--- a/pkgs/development/tools/qtcreator/default.nix
+++ b/pkgs/development/tools/qtcreator/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchurl, makeWrapper
-, qtbase, qtquickcontrols, qtscript, qtdeclarative, qmake
+{ stdenv, fetchurl, fetchgit, fetchpatch, makeWrapper
+, qtbase, qtquickcontrols, qtscript, qtdeclarative, qmake, llvmPackages_8
 , withDocumentation ? false
 }:
 
@@ -8,6 +8,17 @@ with stdenv.lib;
 let
   baseVersion = "4.9";
   revision = "1";
+
+  # Fetch clang from qt vendor, this contains submodules like this:
+  # clang<-clang-tools-extra<-clazy. 
+  clang_qt_vendor = llvmPackages_8.clang-unwrapped.overrideAttrs (oldAttrs: rec {
+    src = fetchgit {
+      url = "https://code.qt.io/clang/clang.git";
+      rev = "c12b012bb7465299490cf93c2ae90499a5c417d5";
+      sha256 = "0mgmnazgr19hnd03xcrv7d932j6dpz88nhhx008b0lv4bah9mqm0";
+    };
+    unpackPhase = "";
+  });
 in
 
 stdenv.mkDerivation rec {
@@ -19,9 +30,28 @@ stdenv.mkDerivation rec {
     sha256 = "10ddp1365rf0z4bs7yzc9hajisp3j6mzjshyd0vpi4ki126j5f3r";
   };
 
-  buildInputs = [ qtbase qtscript qtquickcontrols qtdeclarative ];
+  buildInputs = [ qtbase qtscript qtquickcontrols qtdeclarative llvmPackages_8.libclang clang_qt_vendor llvmPackages_8.llvm ];
 
   nativeBuildInputs = [ qmake makeWrapper ];
+
+  # 0001-Fix-clang-libcpp-regexp.patch is for fixing regexp that is used to 
+  # find clang libc++ library include paths. By default it's not covering paths
+  # like libc++-version, which is default name for libc++ folder in nixos.
+  patches = [ ./0001-Fix-clang-libcpp-regexp.patch 
+
+    # Fix clazy plugin name. This plugin was renamed with clang8 
+    # release, and patch didn't make it into 4.9.1 release. Should be removed 
+    # on qtcreator update, if this problem is fixed.
+    (fetchpatch {
+      url = "https://code.qt.io/cgit/qt-creator/qt-creator.git/patch/src/plugins/clangcodemodel/clangeditordocumentprocessor.cpp?id=53c407bc0c87e0b65b537bf26836ddd8e00ead82";
+      sha256 = "1lanp7jg0x8jffajb852q8p4r34facg41l410xsz6s1k91jskbi9";
+    })
+
+    (fetchpatch {
+      url = "https://code.qt.io/cgit/qt-creator/qt-creator.git/patch/src/plugins/clangtools/clangtidyclazyrunner.cpp?id=53c407bc0c87e0b65b537bf26836ddd8e00ead82";
+      sha256 = "1rl0rc2l297lpfhhawvkkmj77zb081hhp0bbi7nnykf3q9ch0clh";
+    })
+  ]; 
 
   doCheck = true;
 
@@ -34,6 +64,20 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     substituteInPlace src/plugins/plugins.pro \
       --replace '$$[QT_INSTALL_QML]/QtQuick/Controls' '${qtquickcontrols}/${qtbase.qtQmlPrefix}/QtQuick/Controls'
+
+    # Fix paths for llvm/clang includes directories.
+    substituteInPlace src/shared/clang/clang_defines.pri \
+      --replace '$$clean_path($${LLVM_LIBDIR}/clang/$${LLVM_VERSION}/include)' '${clang_qt_vendor}/lib/clang/8.0.0/include' \
+      --replace '$$clean_path($${LLVM_BINDIR})' '${clang_qt_vendor}/bin'
+
+    # Fix include path to find clang and clang-c include directories.  
+    substituteInPlace src/plugins/clangtools/clangtools.pro \
+      --replace 'INCLUDEPATH += $$LLVM_INCLUDEPATH' 'INCLUDEPATH += $$LLVM_INCLUDEPATH ${clang_qt_vendor}'
+
+    # Fix paths to libclang library.
+    substituteInPlace src/shared/clang/clang_installation.pri \
+      --replace 'LIBCLANG_LIBS = -L$${LLVM_LIBDIR}' 'LIBCLANG_LIBS = -L${llvmPackages_8.libclang}/lib' \
+      --replace 'LIBCLANG_LIBS += $${CLANG_LIB}' 'LIBCLANG_LIBS += -lclang'
   '';
 
   preBuild = optional withDocumentation ''


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Starting with version 4.7 clang code model is the default method for supporting QOL services as is: 
code completion, syntactic and semantic highlighting, diagnostics with fixits and integrated Clang-Tidy and Clazy checks, follow symbol, outline of symbols, tooltips, renaming of local symbols.

For future releases of qtc clang code model support is esssential need.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- Clang:
  - Built as build dependency from [vendor](https://code.qt.io/cgit/clang/) branches, that's why:
    - Clazy included to build and builds as plugin
    - Clazy and Clang-tidy added to driver, so they may be invoked in runtime as plugins through clang arguments
  - QtCreator:
  - Patched regexp for includes path of clang lib++ (to include paths like libc++-version/include, was libc++/include)
  - Added llvm/libclang dependencies for clang code model
  - Added clang dependencies for runtime analysis. 
  - Added substitutes to clang clang*.pr* for qmake to find llvm/clang libraries and includes
  - Added substitutes to correct clazy plugin name. That changed with clang 8 release. [Bug in archlinux tracker](https://bugs.archlinux.org/task/62221). [Fixed in upstream but didn't make to release](https://code.qt.io/cgit/qt-creator/qt-creator.git/commit/src/plugins/clangtools/clangtidyclazyrunner.cpp?id=53c407bc0c87e0b65b537bf26836ddd8e00ead82).
- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
###### How clang-tools and clang-code-model functionallity was tested
1. Create shell.nix: 
   ```nix
   with import <nixpkgs> {};
   
   {  
       environment = stdenvNoCC.mkDerivation {
       name = "dev_environment";
       buildInputs = [ qt5.full qtcreator cmake gcc8 clang_8 gdb boost libpqxx xterm bashInteractive 
   llvmPackages.libcxx];
     };
   }
   ```
   clang_8 is optional as qtcreator will still find it. 
1. Clone [test project](https://github.com/tfc/nix_cmake_example)
1. Launch nix-shell: `nix-shell -I nixpkgs=../nixpkgs --pure --keep LD_LIBRARY_PATH`
nixpkgs path is path to my nixpkgs fork with this changes.
1. Launch qtcreator: `qtcreator`, if debug of clang-model is needed: `QT_LOGGING_RULES=qtc.clang*=true LIBCLANG_TIMING=1 qtcreator`
1.  In settings create 2 kits: 1 for clang and 1 for gcc,
1. Test that project is successfully building with this kits. And that after opening c++ source file there is no popups with errors.
1. Launch clang tools analysis (In top menu Analysis->Clang-Tidy and Clazy...->Analyze) and check that there is warnings from diagnostic and no errors in application output tab `11:40:47: Clang-Tidy and Clazy finished: Processed 3 files successfully, 0 failed.`.

### Update: 
Rebased and tested on 03 june 2019 - reason is qtcreator was updated to 4.9.1 in master.
### Update2:
As @abbradar adviced, i removed all changes that was made to system clang, added qt vendor clang version as build dependency. After testing all looks good: clang code model working with both clang and gcc compilers set in project kit. Clang-tidy and clazy checks also works like they should.