### PR TITLE
demoit: unstable-2019-03-29 -> unstable-2019-05-10

### DIFF
--- a/pkgs/servers/demoit/default.nix
+++ b/pkgs/servers/demoit/default.nix
@@ -12,7 +12,7 @@ buildGoPackage rec {
     owner = "dgageot";
     repo = "demoit";
     rev = "c1d4780620ebf083cb4a81b83c80e7547ff7bc23";
-    sha256 = "03h0ad3v9xfigrppbcxiykzgcrv3dnarm7m1vixi2j4n1340f7q6";
+    sha256 = "0l0pw0kzgnrk6a6f4ls3s82icjp7q9djbaxwfpjswbcfdzrsk4p2";
   };
 
   meta = with stdenv.lib; {

--- a/pkgs/servers/demoit/default.nix
+++ b/pkgs/servers/demoit/default.nix
@@ -5,14 +5,14 @@
 
 buildGoPackage rec {
   pname = "demoit";
-  version = "unstable-2019-03-29";
+  version = "unstable-2019-05-10";
   goPackagePath = "github.com/dgageot/demoit";
 
   src = fetchFromGitHub {
     owner = "dgageot";
     repo = "demoit";
-    rev = "ec70fbdf5a5e92fa1c06d8f039f7d388e0237ba2";
-    sha256 = "01584cxlnrc928sw7ldmi0sm7gixmwnawy3c5hd79rqkw8r0gbk0";
+    rev = "c1d4780620ebf083cb4a81b83c80e7547ff7bc23";
+    sha256 = "03h0ad3v9xfigrppbcxiykzgcrv3dnarm7m1vixi2j4n1340f7q6";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION

###### Motivation for this change

Update demoit package

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
