### PR TITLE
calcurse: fix python3 wrapper

### DIFF
--- a/pkgs/applications/misc/calcurse/default.nix
+++ b/pkgs/applications/misc/calcurse/default.nix
@@ -9,17 +9,13 @@ stdenv.mkDerivation rec {
     sha256 = "0vw2xi6a2lrhrb8n55zq9lv4mzxhby4xdf3hmi1vlfpyrpdwkjzd";
   };
 
-  buildInputs = [ ncurses gettext python3 ];
+  buildInputs = [ ncurses gettext python3 python3Packages.wrapPython ];
   nativeBuildInputs = [ makeWrapper ];
 
-  # Build Python environment with httplib2 for calcurse-caldav
-  pythonEnv = python3Packages.python.buildEnv.override {
-    extraLibs = [ python3Packages.httplib2 ];
-  };
-  propagatedBuildInputs = [ pythonEnv ];
-
   postInstall = ''
-    substituteInPlace $out/bin/calcurse-caldav --replace /usr/bin/python3 ${pythonEnv}/bin/python3
+    patchShebangs .
+    buildPythonPath ${python3Packages.httplib2}
+    patchPythonScript $out/bin/calcurse-caldav
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The current Python wrapper for `httplib2` breaks when running e.g.
`./result/bin/calcurse-caldav` with the following error:

```
Traceback (most recent call last):
  File "./result/bin/calcurse-caldav", line 6, in <module>
    import httplib2
ModuleNotFoundError: No module named 'httplib2'
```

The easiest workaround is to use the `wrapPython` tool to properly patch
library path inside the script.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
