### PR TITLE
bitwarden_rs: 1.8.0 -> 1.9.0

### DIFF
--- a/pkgs/tools/security/bitwarden_rs/default.nix
+++ b/pkgs/tools/security/bitwarden_rs/default.nix
@@ -2,20 +2,21 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "bitwarden_rs";
-  version = "1.8.0";
+  version = "1.9.0";
 
   src = fetchFromGitHub {
     owner = "dani-garcia";
     repo = pname;
     rev = version;
-    sha256 = "0jz9r6ck6sfz4ig95x0ja6g5ikyq6z0xw1zn9zf4kxha4klqqbkx";
+    sha256 = "14c2blzkmdd9s0gpf6b7y141yx9s2v2gmwy5l1lgqjhi3h6jpcqr";
   };
 
-  buildInputs = [ pkgconfig openssl ];
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ openssl ];
 
   RUSTC_BOOTSTRAP = 1;
 
-  cargoSha256 = "02xrz7vq8nan70f07xyf335blfmdc6gaz9sbfjipsi1drgfccf09";
+  cargoSha256 = "038l6alcdc0g4avpbzxgd2k09nr3wrsbry763bq2c77qqgwldj8r";
 
   meta = with lib; {
     description = "An unofficial lightweight implementation of the Bitwarden server API using Rust and SQLite";

--- a/pkgs/tools/security/bitwarden_rs/default.nix
+++ b/pkgs/tools/security/bitwarden_rs/default.nix
@@ -1,4 +1,4 @@
-{ lib, rustPlatform, fetchFromGitHub, pkgconfig, openssl }:
+{ stdenv, rustPlatform, fetchFromGitHub, pkgconfig, openssl, Security, CoreServices }:
 
 rustPlatform.buildRustPackage rec {
   pname = "bitwarden_rs";
@@ -12,13 +12,13 @@ rustPlatform.buildRustPackage rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ openssl ];
+  buildInputs = [ openssl ] ++ stdenv.lib.optionals stdenv.isDarwin [ Security CoreServices ];
 
   RUSTC_BOOTSTRAP = 1;
 
   cargoSha256 = "038l6alcdc0g4avpbzxgd2k09nr3wrsbry763bq2c77qqgwldj8r";
 
-  meta = with lib; {
+  meta = with stdenv.lib; {
     description = "An unofficial lightweight implementation of the Bitwarden server API using Rust and SQLite";
     homepage = https://github.com/dani-garcia/bitwarden_rs;
     license = licenses.gpl3;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -674,7 +674,9 @@ in
 
   bcachefs-tools = callPackage ../tools/filesystems/bcachefs-tools { };
 
-  bitwarden_rs = callPackage ../tools/security/bitwarden_rs { };
+  bitwarden_rs = callPackage ../tools/security/bitwarden_rs {
+    inherit (darwin.apple_sdk.frameworks) Security CoreServices;
+  };
 
   bitwarden_rs-vault = callPackage ../tools/security/bitwarden_rs/vault.nix { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

To go with #60959
cc @msteen @marsam 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
