### PR TITLE
Fix ldc

### DIFF
--- a/pkgs/development/compilers/dmd/default.nix
+++ b/pkgs/development/compilers/dmd/default.nix
@@ -103,8 +103,7 @@ stdenv.mkDerivation rec {
 
   checkPhase = ''
     cd dmd
-    # https://github.com/NixOS/nixpkgs/pull/55998#issuecomment-465871846
-    #make -j$NIX_BUILD_CORES -C test -f Makefile PIC=1 CC=$CXX DMD=${pathToDmd} BUILD=release SHELL=$SHELL
+    make -j$NIX_BUILD_CORES -C test -f Makefile PIC=1 CC=$CXX DMD=${pathToDmd} BUILD=release SHELL=$SHELL
     cd ../druntime
     make -j$NIX_BUILD_CORES -f posix.mak unittest PIC=1 DMD=${pathToDmd} BUILD=release
     cd ../phobos

--- a/pkgs/development/compilers/ldc/default.nix
+++ b/pkgs/development/compilers/ldc/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, cmake, ninja, llvm, llvm_8, curl, tzdata
+{ stdenv, fetchurl, cmake, ninja, llvm_5, llvm_8, curl, tzdata
 , python, libconfig, lit, gdb, unzip, darwin, bash
 , callPackage, makeWrapper, targetPackages
 , bootstrapVersion ? false
@@ -83,7 +83,7 @@ stdenv.mkDerivation rec {
   ++ stdenv.lib.optional (!bootstrapVersion && stdenv.hostPlatform.isDarwin) [
     # https://github.com/NixOS/nixpkgs/issues/57120
     # https://github.com/NixOS/nixpkgs/pull/59197#issuecomment-481972515
-    llvm
+    llvm_5
   ]
 
   ++ stdenv.lib.optional (!bootstrapVersion && !stdenv.hostPlatform.isDarwin) [
@@ -96,7 +96,7 @@ stdenv.mkDerivation rec {
   ]
 
   ++ stdenv.lib.optional (bootstrapVersion) [
-    libconfig llvm
+    libconfig llvm_5
   ]
 
   ++ stdenv.lib.optional stdenv.hostPlatform.isDarwin (with darwin.apple_sdk.frameworks; [
@@ -150,7 +150,7 @@ stdenv.mkDerivation rec {
   else
     "";
 
-  doCheck = !bootstrapVersion && !stdenv.isDarwin;
+  doCheck = !bootstrapVersion;
 
   checkPhase = stdenv.lib.optionalString doCheck ''
     # Build default lib test runners


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This fixes the ldc build. https://github.com/NixOS/nixpkgs/issues/61316
Also enabled the dmd testsuite for the dmd package because #56744 fixed that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
