### PR TITLE
Fix Kitty wrapper on MacOS

### DIFF
--- a/pkgs/applications/misc/kitty/default.nix
+++ b/pkgs/applications/misc/kitty/default.nix
@@ -2,7 +2,7 @@
   harfbuzz, fontconfig, pkgconfig, ncurses, imagemagick, xsel,
   libstartup_notification, libX11, libXrandr, libXinerama, libXcursor,
   libxkbcommon, libXi, libXext, wayland-protocols, wayland,
-  which, dbus,
+  which, dbus, fetchpatch,
   Cocoa,
   CoreGraphics,
   Foundation,
@@ -67,6 +67,17 @@ buildPythonApplication rec {
       libstartup_notification = "${libstartup_notification}/lib/libstartup-notification-1.so";
     })
   ] ++ stdenv.lib.optionals stdenv.isDarwin [
+    (fetchpatch {
+      name = "macos-symlink-1";
+      url = https://github.com/kovidgoyal/kitty/commit/bdeec612667f6976109247fe1750b10dda9c24c0.patch;
+      sha256 = "1d18x260w059qag80kgb2cgi2h4rricvqhwpbrw79s8yxzs7jhxk";
+    })
+    (fetchpatch {
+      # fixup of previous patch
+      name = "macos-symlink-2";
+      url = https://github.com/kovidgoyal/kitty/commit/af2c9a49b1ad31e94242295d88598591623fbf11.patch;
+      sha256 = "0k3dmgbvmh66j8k3h8dw6la6ma6f20fng6jjypy982kxvracsnl5";
+    })
     ./macos-10.11.patch
     ./no-lto.patch
     ./no-werror.patch

--- a/pkgs/applications/misc/kitty/default.nix
+++ b/pkgs/applications/misc/kitty/default.nix
@@ -95,7 +95,7 @@ buildPythonApplication rec {
     mkdir -p $out
     ${if stdenv.isDarwin then ''
     mkdir "$out/bin"
-    ln -s ../Applications/kitty.app/Contents/MacOS/kitty "$out/bin/kitty"
+    ln -s ../Applications/kitty.app/Contents/MacOS/kitty-deref-symlink "$out/bin/kitty"
     mkdir "$out/Applications"
     cp -r kitty.app "$out/Applications/kitty.app"
     '' else ''


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Closes https://github.com/NixOS/nixpkgs/issues/61231

Apply https://github.com/kovidgoyal/kitty/commit/bdeec612667f6976109247fe1750b10dda9c24c0 and https://github.com/kovidgoyal/kitty/commit/af2c9a49b1ad31e94242295d88598591623fbf11 as a patch

Refs https://github.com/kovidgoyal/kitty/issues/1539

The patch can be removed once the changes referenced land in a release

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
