### PR TITLE
shell-hist: init at 0.1.0

### DIFF
--- a/pkgs/tools/misc/shell-hist/default.nix
+++ b/pkgs/tools/misc/shell-hist/default.nix
@@ -1,0 +1,23 @@
+{ lib, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage {
+  pname = "shell-hist";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "jamesmunns";
+    repo = "shell-hist";
+    rev = "158de8c3908b49530ecd76bf6e65c210f351ef82";
+    sha256 = "0kc128xnnp1d56if70vfv0w3qnwhljhbnvzwwb7hfm3x2m0vqrqf";
+  };
+
+  cargoSha256 = "1nqnkzwqk879qy1261g1gds668xz6islhzq7chzhilaqpmvf6039";
+
+  meta = with lib; {
+    description = "Inspect your shell history";
+    homepage = "https://github.com/jamesmunns/shell-hist";
+    license = with licenses; [ mit /* or */ asl20 ];
+    maintainers = [ maintainers.spacekookie ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1760,6 +1760,8 @@ in
 
   shab = callPackage ../tools/text/shab { };
 
+  shell-hist = callPackage ../tools/misc/shell-hist { };
+
   simg2img = callPackage ../tools/filesystems/simg2img { };
 
   snipes = callPackage ../games/snipes { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
