### PR TITLE
chunkwm: init at 0.4.9

### DIFF
--- a/pkgs/os-specific/darwin/chunkwm/default.nix
+++ b/pkgs/os-specific/darwin/chunkwm/default.nix
@@ -1,0 +1,36 @@
+{ stdenv, fetchzip, Carbon, Cocoa, ScriptingBridge }:
+
+stdenv.mkDerivation rec {
+  name = "chunkwm-${version}";
+  version = "0.4.9";
+  src = fetchzip {
+    url = "http://github.com/koekeishiya/chunkwm/archive/v${version}.tar.gz";
+    sha256 = "0w8q92q97fdvbwc3qb5w44jn4vi3m65ssdvjp5hh6b7llr17vspl";
+  };
+
+  buildInputs = [ Carbon Cocoa ScriptingBridge ];
+  outputs = [ "bin" "out" ];
+
+  buildPhase = ''
+    for d in . src/chunkc src/plugins/*; do
+        pushd $d
+        buildPhase
+        popd
+    done
+  '';
+
+  installPhase = ''
+    mkdir -p $bin/bin $out/bin $out/lib/chunkwm/plugins
+    cp src/chunkc/bin/chunkc $bin/bin/chunkc
+    cp bin/chunkwm $out/bin
+    cp plugins/*.so $out/lib/chunkwm/plugins
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Tiling window manager for macOS based on plugin architecture";
+    homepage = https://github.com/koekeishiya/chunkwm;
+    platforms = platforms.darwin;
+    maintainers = with maintainers; [ lnl7 ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -822,6 +822,10 @@ in
 
   kwakd = callPackage ../servers/kwakd { };
 
+  chunkwm = callPackage ../os-specific/darwin/chunkwm {
+    inherit (darwin.apple_sdk.frameworks) Carbon Cocoa ScriptingBridge;
+  };
+
   kwm = callPackage ../os-specific/darwin/kwm { };
 
   khd = callPackage ../os-specific/darwin/khd {


### PR DESCRIPTION
###### Things done

We can build this now that nixpkgs uses 10.12 headers.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
