### PR TITLE
kakoune: support for adding plugins

### DIFF
--- a/doc/package-notes.xml
+++ b/doc/package-notes.xml
@@ -325,6 +325,18 @@ packageOverrides = pkgs: {
    elm2nix</link>.
   </para>
  </section>
+ <section xml:id="sec-kakoune">
+  <title>Kakoune</title>
+
+  <para>
+   Kakoune can be built to autoload plugins:
+<programlisting>(kakoune.override {
+  configure = {
+    plugins = with pkgs.kakounePlugins; [ parinfer-rust ];
+  };
+})</programlisting>
+  </para>
+ </section>
  <section xml:id="sec-shell-helpers">
   <title>Interactive shell helpers</title>
 

--- a/pkgs/applications/editors/kakoune/default.nix
+++ b/pkgs/applications/editors/kakoune/default.nix
@@ -3,7 +3,7 @@
 with stdenv.lib;
 
 stdenv.mkDerivation rec {
-  name = "kakoune-${version}";
+  pname = "kakoune-unwrapped";
   version = "2019.01.20";
   src = fetchFromGitHub {
     repo = "kakoune";

--- a/pkgs/applications/editors/kakoune/plugins.nix
+++ b/pkgs/applications/editors/kakoune/plugins.nix
@@ -1,0 +1,5 @@
+{ parinfer-rust }:
+
+{
+  inherit parinfer-rust;
+}

--- a/pkgs/applications/editors/kakoune/wrapper.nix
+++ b/pkgs/applications/editors/kakoune/wrapper.nix
@@ -1,0 +1,44 @@
+{ stdenv, bash }:
+with stdenv.lib;
+
+kakoune:
+
+let
+  getPlugins = { plugins ? [] }: plugins;
+
+  wrapper = { configure ? {} }:
+  stdenv.mkDerivation rec {
+    pname = "kakoune";
+    version = getVersion kakoune;
+
+    src = ./.;
+    buildCommand = ''
+      mkdir -p $out/share/kak
+      for plugin in ${strings.escapeShellArgs (getPlugins configure)}; do
+        if [[ -d $plugin/share/kak/autoload ]]; then
+          find "$plugin/share/kak/autoload" -type f -name '*.kak'| while read rcfile; do
+            printf 'source "%s"\n' "$rcfile"
+          done
+        fi
+      done >>$out/share/kak/plugins.kak
+
+      mkdir -p $out/bin
+      substitute ${src}/wrapper.sh $out/bin/kak \
+        --subst-var-by bash "${bash}" \
+        --subst-var-by kakoune "${kakoune}" \
+        --subst-var-by out "$out"
+      chmod +x $out/bin/kak
+    '';
+
+    preferLocalBuild = true;
+    buildInputs = [ bash kakoune ];
+    passthru = { unwrapped = kakoune; };
+
+    meta = kakoune.meta // {
+      # prefer wrapper over the package
+      priority = (kakoune.meta.priority or 0) - 1;
+      hydraPlatforms = [];
+    };
+  };
+in
+  makeOverridable wrapper

--- a/pkgs/applications/editors/kakoune/wrapper.sh
+++ b/pkgs/applications/editors/kakoune/wrapper.sh
@@ -1,0 +1,30 @@
+#!@bash@/bin/bash
+
+# We use the -E option to load plugins.  This only makes sense when we are
+# starting a new session, so we detect that.  Also, Kakoune can only handle
+# one -E option, so we prepend loading plugins to an existing one.
+args=( "$@" )
+loadPlugins=true
+EValueOffset=-1
+pluginScript='@out@/share/kak/plugins.kak'
+
+for (( i = 0; i < ${#args[@]}; i++ )); do
+    case "${args[i]}" in
+        -n|-c|-l|-p|-clear|-version) loadPlugins=false;;
+        -E)                          EValueOffset=$(( i + 1 ));;
+        --)                          break;;
+    esac
+    case "${args[i]}" in
+        -E|-c|-e|-s|-p|-f|-i|-ui|-debug) i=$(( i + 1 ));;
+    esac
+done
+
+if [[ $loadPlugins = true ]]; then
+    if (( EValueOffset >= 0 )); then
+        args[EValueOffset]="source '$pluginScript'"$'\n'"${args[EValueOffset]}"
+    else
+        args=( "-E" "source '$pluginScript'" "${args[@]}" )
+    fi
+fi
+
+exec @kakoune@/bin/kak "${args[@]}"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3943,7 +3943,10 @@ in
 
   kalibrate-hackrf = callPackage ../applications/radio/kalibrate-hackrf { };
 
-  kakoune = callPackage ../applications/editors/kakoune { };
+  wrapKakoune = callPackage ../applications/editors/kakoune/wrapper.nix { };
+  kakounePlugins = callPackage ../applications/editors/kakoune/plugins.nix { };
+  kakoune-unwrapped = callPackage ../applications/editors/kakoune { };
+  kakoune = wrapKakoune kakoune-unwrapped { };
 
   kbdd = callPackage ../applications/window-managers/kbdd { };
 


### PR DESCRIPTION
###### Motivation for this change

There is a thriving plugin ecosystem for Kakoune now, and it is nice
to add these in our Nix configurations. This was modeled after weechat's
plugins.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

**No binary files to test**
**Closure size: Before: 41,022,312, After: 41,022,312** 

###### Notes

parinfer-rust is useable both standalone and as a Kakoune plugin,
so the plugin file inherits the same definition as pkgs.

I'll make PRs for other plugins if this gets accepted.
[Here](https://github.com/eraserhd/nixpkgs/tree/kak-ansi)'s a tested
branch for the `kak-ansi` plugin.

---