### PR TITLE
ddcci-driver: init at 0.3.2

### DIFF
--- a/pkgs/os-specific/linux/ddcci/default.nix
+++ b/pkgs/os-specific/linux/ddcci/default.nix
@@ -1,0 +1,42 @@
+{ stdenv, fetchFromGitLab, kernel }:
+
+stdenv.mkDerivation rec {
+  pname = "ddcci-driver";
+  version = "0.3.2";
+  name = "${pname}-${kernel.version}-${version}";
+
+  src = fetchFromGitLab {
+    owner = "${pname}-linux";
+    repo = "${pname}-linux";
+    rev = "v${version}";
+    sha256 = "0jl4l3vvxn85cbqr80p6bgyhf2vx9kbadrwx086wkj9ni8k6x5m6";
+  };
+
+  hardeningDisable = [ "pic" ];
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  prePatch = ''
+    substituteInPlace ./ddcci/Makefile \
+      --replace 'SUBDIRS="$(src)"' 'M=$(PWD)' \
+      --replace depmod \#
+    substituteInPlace ./ddcci-backlight/Makefile \
+      --replace 'SUBDIRS="$(src)"' 'M=$(PWD)' \
+      --replace depmod \#
+  '';
+
+  makeFlags = [
+    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "KVER=${kernel.modDirVersion}"
+    "KERNEL_MODLIB=$(out)/lib/modules/${kernel.modDirVersion}"
+    "INCLUDEDIR=$(out)/include"
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Kernel module driver for DDC/CI monitors";
+    homepage = "https://gitlab.com/ddcci-driver-linux/ddcci-driver-linux";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ bricewge ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15240,6 +15240,8 @@ in
 
     cpupower = callPackage ../os-specific/linux/cpupower { };
 
+    ddcci-driver = callPackage ../os-specific/linux/ddcci { };
+
     deepin-anything = callPackage ../os-specific/linux/deepin-anything { };
 
     dpdk = callPackage ../os-specific/linux/dpdk { };


### PR DESCRIPTION
###### Motivation for this change
It adds a linux kernel driver for DDC/CI monitors. With it you can modify the brightness of your external monitor through sysfs, in the same way as with a laptop screen. `acpilight` is the recommended utility to achieve this.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
