### PR TITLE
openscad: Darwin support and tidy

### DIFF
--- a/pkgs/applications/graphics/openscad/default.nix
+++ b/pkgs/applications/graphics/openscad/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, qt5, libsForQt5
 , bison, flex, eigen, boost, libGLU_combined, glew, opencsg, cgal
-, mpfr, gmp, glib, pkgconfig, harfbuzz, gettext
+, mpfr, gmp, glib, pkgconfig, harfbuzz, gettext, freetype, fontconfig
 }:
 
 stdenv.mkDerivation rec {
@@ -18,11 +18,13 @@ stdenv.mkDerivation rec {
     sha256 = "1y63yqyd0v255liik4ff5ak6mj86d8d76w436x76hs5dk6jgpmfb";
   };
 
+  nativeBuildInputs = [ bison flex pkgconfig ];
+
   buildInputs = [
-    bison flex eigen boost libGLU_combined glew opencsg cgal mpfr gmp glib
-    pkgconfig harfbuzz gettext
-  ]
-    ++ (with qt5; [qtbase qmake])
+    eigen boost glew opencsg cgal mpfr gmp glib
+    harfbuzz gettext freetype fontconfig
+  ] ++ stdenv.lib.optional stdenv.isLinux libGLU_combined
+    ++ (with qt5; [qtbase qmake] ++ stdenv.lib.optional stdenv.isDarwin qtmacextras)
     ++ (with libsForQt5; [qscintilla])
   ;
 
@@ -32,6 +34,17 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = false; # true by default due to qmake
 
   doCheck = false;
+
+  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
+    mkdir $out/Applications
+    mv $out/bin/*.app $out/Applications
+    rmdir $out/bin || true
+
+    mv --target-directory=$out/Applications/OpenSCAD.app/Contents/Resources \
+      $out/share/openscad/{examples,color-schemes,locale,libraries,fonts}
+
+    rmdir $out/share/openscad
+  '';
 
   meta = {
     description = "3D parametric model compiler";
@@ -48,7 +61,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = http://openscad.org/;
     license = stdenv.lib.licenses.gpl2;
-    platforms = stdenv.lib.platforms.linux;
+    platforms = stdenv.lib.platforms.unix;
     maintainers = with stdenv.lib.maintainers;
       [ bjornfor raskin the-kenny ];
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Darwin support

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
