### PR TITLE
openra: 20181215 -> 20190314 + updated other engine releases and mods

### DIFF
--- a/pkgs/games/openra/common.nix
+++ b/pkgs/games/openra/common.nix
@@ -3,7 +3,7 @@
 */
 { stdenv, makeSetupHook, curl, unzip, dos2unix, pkgconfig, makeWrapper
 , lua, mono, dotnetPackages, python
-, libGL, openal, SDL2
+, libGL, freetype, openal, SDL2
 , zenity
 }:
 
@@ -11,7 +11,7 @@ with stdenv.lib;
 
 let
   path = makeBinPath ([ mono python ] ++ optional (zenity != null) zenity);
-  rpath = makeLibraryPath [ lua openal SDL2 ];
+  rpath = makeLibraryPath [ lua freetype openal SDL2 ];
   mkdirp = makeSetupHook { } ./mkdirp.sh;
 
 in {
@@ -54,10 +54,7 @@ in {
       StyleCopMSBuild
       StyleCopPlusMSBuild
     ] ++ [
-      lua
       libGL
-      openal
-      SDL2
     ];
 
     # TODO: Test if this is correct.

--- a/pkgs/games/openra/engines.nix
+++ b/pkgs/games/openra/engines.nix
@@ -22,20 +22,20 @@ let
 
 in {
   release = name: (buildUpstreamOpenRAEngine rec {
-    version = "20181215";
+    version = "20190314";
     rev = "${name}-${version}";
-    sha256 = "0p0izykjnz7pz02g2khp7msqa00jhjsrzk9y0g29dirmdv75qa4r";
+    sha256 = "15pvn5cx3g0nzbrgpsfz8dngad5wkzp5dz25ydzn8bmxafiijvcr";
   } name);
 
   playtest = name: (buildUpstreamOpenRAEngine rec {
-    version = "20190106";
+    version = "20190302";
     rev = "${name}-${version}";
-    sha256 = "0ps9x379plrrj1hnj4fpr26lc46mzgxknv5imxi0bmrh5y4781ql";
+    sha256 = "1vqvfk2p2lpk3m0d3rpvj34i8cmk3mfc7w4cn4llqd9zp4kk9pya";
   } name);
 
   bleed = buildUpstreamOpenRAEngine {
-    version = "9c9cad1";
-    rev = "9c9cad1a15c3a34dc2a61b305e4a9a735381a5f8";
-    sha256 = "0100p7wrnnlvkmy581m0gbyg3cvi4i1w3lzx2gq91ndz1sbm8nd2";
+    version = "8ee1102";
+    rev = "8ee11028d72cde7556b31d45f556b40be65b4b70";
+    sha256 = "19fjzwgmfdf832c6b1x885kaiyck03kpiba0qpsxvps04i7b3vj4";
   };
 }

--- a/pkgs/games/openra/mod-launch-game.sh
+++ b/pkgs/games/openra/mod-launch-game.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 show_error() {
   if command -v zenity > /dev/null; then
     zenity --no-wrap --no-markup --error --title "OpenRA - @title@" --text "$1" 2>/dev/null
@@ -12,7 +12,7 @@ cd "@out@/lib/openra-@name@"
 
 # Check for missing assets
 assetsError='@assetsError@'
-if [ -n "$assetsError" -a ! -d "$HOME/.openra/Content/@name@" ]; then
+if [[ -n "$assetsError" && ! -d "$HOME/.openra/Content/@name@" ]]; then
   show_error "$assetsError"
 fi
 
@@ -20,6 +20,6 @@ fi
 mono --debug OpenRA.Game.exe Game.Mod=@name@ Engine.LaunchPath="@out@/bin/openra-@name@" Engine.ModSearchPaths="@out@/lib/openra-@name@/mods" "$@"
 
 # Show a crash dialog if something went wrong
-if [ $? -ne 0 -a $? -ne 1 ]; then
+if (( $? != 0 && $? != 1 )); then
   show_error $'OpenRA - @title@ has encountered a fatal error.\nPlease refer to the crash logs for more information.\n\nLog files are located in ~/.openra/Logs'
 fi

--- a/pkgs/games/openra/mods.nix
+++ b/pkgs/games/openra/mods.nix
@@ -60,23 +60,23 @@ in {
   };
 
   dr = buildOpenRAMod rec {
-    version = "266.git.920b476";
+    version = "324.git.ffcd6ba";
     title = "Dark Reign";
     description = "A re-imagination of the original Command & Conquer: ${title} game";
     homepage = https://github.com/drogoganor/DarkReign;
     src = fetchFromGitHub {
       owner = "drogoganor";
       repo = "DarkReign";
-      rev = "920b476be1b7751db087f1f7acd504b8a048d1e2";
-      sha256 = "11ir4pnichrnv4z9532fp9g166jl8fvy5kk03a2fgxssp3g40zz2";
+      rev = "ffcd6ba72979e5f77508136ed7b0efc13e4b100e";
+      sha256 = "07g4qw909649s3i1yhw75613mpwfka05jana5mpp5smhnf0pkack";
     };
     engine = {
       version = "DarkReign";
       src = fetchFromGitHub {
         owner = "drogoganor";
         repo = "OpenRA" ;
-        rev = "e08b75c2add30439228ea3dd61d6be60d1800329";
-        sha256 = "125vf962p69ajrh5pxgfwsi0ksczqwvlw5kn2fvffiwvh8d5in23";
+        rev = "f91d3f2603bbf51afaa89357e4defcdc36138102";
+        sha256 = "05g900ri6q0zrkrk8rmjaz576vjggmi2y6jm0xz3cwli54prn11w";
         name = "engine";
         inherit extraPostFetch;
       };
@@ -161,15 +161,15 @@ in {
   };
 
   ra2 = buildOpenRAMod rec {
-    version = "881.git.b37f4f9";
+    version = "903.git.2f7c700";
     title = "Red Alert 2";
     description = "Re-imagination of the original Command & Conquer: ${title} game";
     homepage = https://github.com/OpenRA/ra2;
     src = fetchFromGitHub {
       owner = "OpenRA";
       repo = "ra2";
-      rev = "b37f4f9f07404127062d9061966e9cc89dd86445";
-      sha256 = "1jiww66ma3qdk9hzyvhbcaa5h4p2mxxk22kvrw92ckpxy0bqba3h";
+      rev = "2f7c700d6d63c0625e7158ef3098221fa6741569";
+      sha256 = "11vnzwczn47wjfrq6y7z9q234p27ihdrcl5p87i6h2xnrpwi8b6m";
     };
     engine = rec {
       version = "release-20180923";
@@ -189,23 +189,23 @@ in {
   };
 
   raclassic = buildOpenRAMod {
-    version = "181.git.8240890";
+    version = "183.git.c76c13e";
     title = "Red Alert Classic";
     description = "A modernization of the original Command & Conquer: Red Alert game";
     homepage = https://github.com/OpenRA/raclassic;
     src = fetchFromGitHub {
       owner = "OpenRA";
       repo = "raclassic";
-      rev = "8240890b32191ce34241c22158b8a79e8c380879";
-      sha256 = "0dznyb6qa4n3ab87g1c4bihfc2nx53k6z0kajc7ynjdnwzvx69ww";
+      rev = "c76c13e9f0912a66ddebae8d05573632b19736b2";
+      sha256 = "1cnr3ccvrkjlv8kkdcglcfh133yy0fkva9agwgvc7wlj9n5ydl4g";
     };
     engine = rec {
-      version = "playtest-20190106";
+      version = "release-20190314";
       src = fetchFromGitHub {
         owner = "OpenRA";
         repo = "OpenRA" ;
         rev = version;
-        sha256 = "0ps9x379plrrj1hnj4fpr26lc46mzgxknv5imxi0bmrh5y4781ql";
+        sha256 = "15pvn5cx3g0nzbrgpsfz8dngad5wkzp5dz25ydzn8bmxafiijvcr";
         name = "engine";
         inherit extraPostFetch;
       };
@@ -242,24 +242,24 @@ in {
   };
 
   sp = unsafeBuildOpenRAMod {
-    version = "176.git.fc89ae8";
+    version = "221.git.ac000cc";
     title = "Shattered Paradise";
     description = "Re-imagination of the original Command & Conquer: Tiberian Sun game";
     homepage = https://github.com/ABrandau/OpenRAModSDK;
     src = fetchFromGitHub {
       owner = "ABrandau";
       repo = "OpenRAModSDK";
-      rev = "fc89ae8a10e0f765ac735f923e01aa24dd20e8d2";
-      sha256 = "0xyxhipmjlld0kp23fwsdwnspr7fci0mdnjd60gcsh34c7m0341p";
+      rev = "ac000cc15377cdf6d3c2b72c737d692aa0ed8bcd";
+      sha256 = "16mzs5wcxj9nlpcyx2c87idsqpbm40lx0rznsccclnlb3hiwqas9";
     };
     engine = {
-      version = "SP-Bleed-Branch";
+      version = "SP-22-04-19";
       mods = [ "as" "ts" ];
       src = fetchFromGitHub {
         owner = "ABrandau";
         repo = "OpenRA" ;
-        rev = "d3545c0b751aea2105748eddaab5919313e35314";
-        sha256 = "1jsldl6vnf3r9dzppdm4z7kqbrzkidda5k74wc809i8c4jjnq9rq";
+        rev = "bb0930008a57c07f3002421023f6b446e3e3af69";
+        sha256 = "1jvgpbf56hd02ikhklv49br4d1jiv5hphc5kl79qnjlaacnj222x";
         name = "engine";
         inherit extraPostFetch;
       };
@@ -315,23 +315,23 @@ in {
   };
 
   yr = unsafeBuildOpenRAMod rec {
-    version = "118.git.c26bf14";
+    version = "199.git.5b8b952";
     homepage = https://github.com/cookgreen/yr;
     title = "Yuri's Revenge";
     description = "Re-imagination of the original Command & Conquer: ${title} game";
     src = fetchFromGitHub {
       owner = "cookgreen";
       repo = "yr";
-      rev = "c26bf14155d040edf33c6c5eb3677517d07b39f8";
-      sha256 = "15k6gv4rx3490n0cs9q7ah7q31z89v0pddsw6nqv0fhcahhvq1bc";
+      rev = "5b8b952dbe21f194a6d00485f20e215ce8362712";
+      sha256 = "0hxzrqnz5d7qj1jjr20imiyih62x1cnmndf75nnil4c4sj82f9a6";
     };
     engine = rec {
-      version = "release-20180923";
+      version = "release-20190314";
       src = fetchFromGitHub {
         owner = "OpenRA";
         repo = "OpenRA" ;
         rev = version;
-        sha256 = "1pgi3zaq9fwwdq6yh19bwxscslqgabjxkvl9bcn1a5agy4bfbqk5";
+        sha256 = "15pvn5cx3g0nzbrgpsfz8dngad5wkzp5dz25ydzn8bmxafiijvcr";
         name = "engine";
         inherit extraPostFetch;
       };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Updated the OpenRA engine releases and updated the mods for which the bleeding edge versions were known to work. Both the updated engine releases and mods have been checked to build and run, although they have not been thoroughly tested (e.g. full play through), because doing so would take too much time.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
