### PR TITLE
data/fonts: cleanup

### DIFF
--- a/pkgs/data/fonts/agave/default.nix
+++ b/pkgs/data/fonts/agave/default.nix
@@ -1,24 +1,21 @@
-{ stdenv, fetchurl }:
+{ lib, fetchurl }:
 
-stdenv.mkDerivation rec {
+let
   pname = "agave";
   version = "009";
+in fetchurl {
+  name = "${pname}-${version}";
+  url = "https://github.com/agarick/agave/releases/download/v${version}/agave-r.ttf";
 
-  src = fetchurl {
-    url = "https://github.com/agarick/agave/releases/download/v${version}/agave-r.ttf";
-    sha256 = "05766gp2glm1p2vknk1nncxigq28hg8s58kjwsbn8zpwy8ivywpk";
-  };
-
-  sourceRoot = ".";
-
-  unpackPhase = ":";
-  dontBuild = true;
-  installPhase = ''
-    mkdir -p $out/share/fonts/truetype
-    cp $src $out/share/fonts/truetype/
+  downloadToTemp = true;
+  recursiveHash = true;
+  postFetch = ''
+    install -D $downloadedFile $out/share/fonts/truetype/agave-r.ttf
   '';
 
-  meta = with stdenv.lib; {
+  sha256 = "16qvz3zpwiq2nw0gxygva5pssswcia5xp0q6ir5jfkackvqf3fql";
+
+  meta = with lib; {
     description = "truetype monospaced typeface designed for X environments";
     homepage = https://b.agaric.net/page/agave;
     license = licenses.mit;

--- a/pkgs/data/fonts/aileron/default.nix
+++ b/pkgs/data/fonts/aileron/default.nix
@@ -1,4 +1,4 @@
-{ stdenv,  fetchzip }:
+{ lib, fetchzip }:
 
 let
   majorVersion = "0";
@@ -17,7 +17,7 @@ fetchzip rec {
     unzip -j $downloadedFile \*.otf  -d $out/share/fonts/opentype/${pname}
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "http://dotcolon.net/font/${pname}/";
     description = "A helvetica font in nine weights";
     platforms = platforms.all;

--- a/pkgs/data/fonts/andagii/default.nix
+++ b/pkgs/data/fonts/andagii/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let
   version = "1.0.2";
@@ -17,7 +17,7 @@ in fetchzip {
   # There are multiple claims that the font is GPL, so I include the
   # package; but I cannot find the original source, so use it on your
   # own risk Debian claims it is GPL - good enough for me.
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = http://www.i18nguy.com/unicode/unicode-font.html;
     description = "Unicode Plane 1 Osmanya script font";
     maintainers = with maintainers; [ raskin rycee ];

--- a/pkgs/data/fonts/andika/default.nix
+++ b/pkgs/data/fonts/andika/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchzip}:
+{ lib, fetchzip }:
 
 let
   version = "5.000";
@@ -16,7 +16,7 @@ in
 
     sha256 = "1jy9vpcprpd1k48p20wh6jhyn909ibia8lr5i747p41l0s8a7lqy";
 
-    meta = with stdenv.lib; {
+    meta = with lib; {
       homepage = https://software.sil.org/andika;
       description = "A family designed especially for literacy use taking into account the needs of beginning readers";
       longDescription = ''

--- a/pkgs/data/fonts/ankacoder/condensed.nix
+++ b/pkgs/data/fonts/ankacoder/condensed.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let version = "1.100"; in
 fetchzip rec {
@@ -13,7 +13,7 @@ fetchzip rec {
 
   sha256 = "0i80zpr2y9368rg2i6x8jv0g7d03kdyr5h7w9yz7pjd7i9xd8439";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Anka/Coder Condensed font";
     homepage = https://code.google.com/archive/p/anka-coder-fonts;
     license = licenses.ofl;

--- a/pkgs/data/fonts/ankacoder/default.nix
+++ b/pkgs/data/fonts/ankacoder/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let version = "1.100"; in
 fetchzip rec {
@@ -13,7 +13,7 @@ fetchzip rec {
 
   sha256 = "1jqx9micfmiarqh9xp330gl96v3vxbwzz9cmg2vi845n9md4im85";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Anka/Coder fonts";
     homepage = https://code.google.com/archive/p/anka-coder-fonts;
     license = licenses.ofl;

--- a/pkgs/data/fonts/anonymous-pro/default.nix
+++ b/pkgs/data/fonts/anonymous-pro/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let
   version = "1.002";
@@ -13,7 +13,7 @@ in fetchzip rec {
   '';
   sha256 = "05rgzag38qc77b31sm5i2vwwrxbrvwzfsqh3slv11skx36pz337f";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://www.marksimonson.com/fonts/view/anonymous-pro;
     description = "TrueType font set intended for source code";
     longDescription = ''

--- a/pkgs/data/fonts/arkpandora/default.nix
+++ b/pkgs/data/fonts/arkpandora/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl }:
+{ lib, fetchurl }:
 
 let
   version = "2.04";
@@ -21,6 +21,5 @@ in fetchurl {
 
   meta = {
     description = "Font, metrically identical to Arial and Times New Roman";
-    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/data/fonts/arphic/default.nix
+++ b/pkgs/data/fonts/arphic/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, mkfontscale, mkfontdir }:
+{ lib, fetchzip, mkfontscale, mkfontdir }:
 
 let
   version = "0.2.20080216.2";
@@ -18,7 +18,7 @@ in {
 
     sha256 = "0xi5ycm7ydzpn7cqxv1kcj9vd70nr9wn8v27hmibyjc25y2qdmzl";
 
-    meta = with stdenv.lib; {
+    meta = with lib; {
       description = "CJK Unicode font Kai style";
       homepage = https://www.freedesktop.org/wiki/Software/CJKUnifonts/;
 
@@ -43,7 +43,7 @@ in {
 
     sha256 = "16jybvj1cxamm682caj6nsm6l5c60x9mgchp1l2izrw2rvc8x38d";
 
-    meta = with stdenv.lib; {
+    meta = with lib; {
       description = "CJK Unicode font Ming style";
       homepage = https://www.freedesktop.org/wiki/Software/CJKUnifonts/;
 

--- a/pkgs/data/fonts/aurulent-sans/default.nix
+++ b/pkgs/data/fonts/aurulent-sans/default.nix
@@ -1,12 +1,13 @@
-{stdenv, fetchzip}:
+{ lib, fetchFromGitHub }:
 
-fetchzip rec {
+fetchFromGitHub rec {
   name = "aurulent-sans-0.1";
-
-  url = "https://github.com/deepfire/hartke-aurulent-sans/archive/${name}.zip";
+  owner = "deepfire";
+  repo = "hartke-aurulent-sans";
+  rev = name;
   postFetch = ''
     mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
+    tar xf $downloadedFile -C $out/share/fonts --strip=1
   '';
   sha256 = "1l60psfv9x0x9qx9vp1qnhmck7a7kks385m5ycrd3d91irz1j5li";
 
@@ -14,8 +15,8 @@ fetchzip rec {
     description = "Aurulent Sans";
     longDescription = "Aurulent Sans is a humanist sans serif intended to be used as an interface font.";
     homepage = http://delubrum.org/;
-    maintainers = with stdenv.lib.maintainers; [ deepfire ];
-    license = stdenv.lib.licenses.ofl;
-    platforms = stdenv.lib.platforms.all;
+    maintainers = with lib.maintainers; [ deepfire ];
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
   };
 }

--- a/pkgs/data/fonts/b612/default.nix
+++ b/pkgs/data/fonts/b612/default.nix
@@ -1,20 +1,21 @@
-{ stdenv, fetchzip, lib }:
+{ lib, fetchFromGitHub }:
 
 let
   version = "1.008";
   pname = "b612";
-in
-
-fetchzip rec {
+in fetchFromGitHub {
   name = "${pname}-font-${version}";
-  url = "https://github.com/polarsys/b612/archive/${version}.zip";
-  sha256 = "0r3lana1q9w3siv8czb3p9rrb5d9svp628yfbvvmnj7qvjrmfsiq";
+  owner = "polarsys";
+  repo = "b612";
+  rev = version;
   postFetch = ''
+    tar xf $downloadedFile --strip=1
     mkdir -p $out/share/fonts/truetype/${pname}
-    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype/${pname}
+    cp fonts/ttf/*.ttf $out/share/fonts/truetype/${pname}
   '';
+  sha256 = "0r3lana1q9w3siv8czb3p9rrb5d9svp628yfbvvmnj7qvjrmfsiq";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = http://b612-font.com/;
     description = "Highly legible font family for use on aircraft cockpit screens";
     longDescription = ''

--- a/pkgs/data/fonts/babelstone-han/default.nix
+++ b/pkgs/data/fonts/babelstone-han/default.nix
@@ -1,7 +1,7 @@
-{stdenv, fetchzip}:
+{ lib, fetchzip }:
 
 let
-  version = "11.0.3";
+  version = "12.1.4";
 in fetchzip {
   name = "babelstone-han-${version}";
 
@@ -10,9 +10,9 @@ in fetchzip {
     mkdir -p $out/share/fonts/truetype
     unzip $downloadedFile '*.ttf' -d $out/share/fonts/truetype
   '';
-  sha256 = "0c8s21kllyilwivrb8gywq818y67w3zpann34hz36vy0wyiswn1c";
+  sha256 = "1fypwk2i87jfrckvxg9wz4x84z7c6ifgzrjb8fylhac50lzi6kni";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Unicode CJK font with over 36000 Han characters";
     homepage = http://www.babelstone.co.uk/Fonts/Han.html;
 

--- a/pkgs/data/fonts/baekmuk-ttf/default.nix
+++ b/pkgs/data/fonts/baekmuk-ttf/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 fetchzip rec {
   name = "baekmuk-ttf-2.2";
@@ -6,9 +6,8 @@ fetchzip rec {
   url = "http://kldp.net/baekmuk/release/865-${name}.tar.gz";
   postFetch = ''
     tar -xzvf $downloadedFile --strip-components=1
-    mkdir -p $out/share/fonts $out/share/doc/${name}
-    cp ttf/*.ttf  $out/share/fonts
-    cp COPYRIGHT* $out/share/doc/${name}
+    install -m444 -Dt $out/share/fonts        ttf/*.ttf
+    install -m444 -Dt $out/share/doc/${name}  COPYRIGHT*
   '';
   sha256 = "1jgsvack1l14q8lbcv4qhgbswi30mf045k37rl772hzcmx0r206g";
 
@@ -16,7 +15,6 @@ fetchzip rec {
     description = "Korean font";
     homepage = http://kldp.net/projects/baekmuk/;
     license = "BSD-like";
-    platforms = stdenv.lib.platforms.linux;
   };
 }
 

--- a/pkgs/data/fonts/bakoma-ttf/default.nix
+++ b/pkgs/data/fonts/bakoma-ttf/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchzip}:
+{ lib, fetchzip }:
 
 fetchzip {
   name = "bakoma-ttf";
@@ -16,6 +16,5 @@ fetchzip {
   meta = {
     description = "TrueType versions of the Computer Modern and AMS TeX Fonts";
     homepage = http://www.ctan.org/tex-archive/fonts/cm/ps-type1/bakoma/ttf/;
-    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/data/fonts/behdad-fonts/default.nix
+++ b/pkgs/data/fonts/behdad-fonts/default.nix
@@ -1,22 +1,21 @@
-{ stdenv, fetchFromGitHub }:
+{ lib, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
+let
   pname = "behdad-fonts";
   version = "0.0.3";
+in fetchFromGitHub rec {
+  name = "${pname}-${version}";
+  owner = "font-store";
+  repo = "BehdadFont";
+  rev = "v${version}";
 
-  src = fetchFromGitHub {
-    owner = "font-store";
-    repo = "BehdadFont";
-    rev = "v${version}";
-    sha256 = "0rlmyv82qmyy90zvkjnlva44ia7dyhiyk7axbq526v7zip3g79w0";
-  };
-
-  installPhase = ''
-    mkdir -p $out/share/fonts/behdad-fonts
-    cp -v $( find . -name '*.ttf') $out/share/fonts/behdad-fonts
+  postFetch = ''
+    tar xf $downloadedFile --strip=1
+    find . -name '*.ttf' -exec install -m444 -Dt $out/share/fonts/behrad-fonts {} \;
   '';
+  sha256 = "0c57232462cv1jrfn0m2bl7jzcfkacirrdd2qimrc8iqhkz0ajfz";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://github.com/font-store/BehdadFont;
     description = "A Persian/Arabic Open Source Font";
     license = licenses.ofl;

--- a/pkgs/data/fonts/cabin/default.nix
+++ b/pkgs/data/fonts/cabin/default.nix
@@ -1,19 +1,21 @@
-{ stdenv, fetchzip }:
+{ lib, fetchFromGitHub }:
 
-fetchzip rec {
+fetchFromGitHub rec {
   name = "cabin-1.005";
 
-  url = https://github.com/impallari/Cabin/archive/982839c790e9dc57c343972aa34c51ed3b3677fd.zip;
+  owner = "impallari";
+  repo = "Cabin";
+  rev = "982839c790e9dc57c343972aa34c51ed3b3677fd";
 
   postFetch = ''
-    mkdir -p $out/share/{doc,fonts}
-    unzip -j $downloadedFile \*.otf                    -d $out/share/fonts/opentype
-    unzip -j $downloadedFile \*README.md \*FONTLOG.txt -d "$out/share/doc/${name}"
+    tar xf $downloadedFile --strip=1
+    install -m444 -Dt $out/share/fonts/opentype fonts/OTF/*.otf
+    install -m444 -Dt $out/share/doc/${name}    README.md FONTLOG.txt
   '';
 
-  sha256 = "1ax5c2iab48qsk9zn3gjvqaib2lnlm25f1wr0aysf5ngw0y0jkrd";
+  sha256 = "1bl7h217m695jn4rbniialfk573aa44fslp2rjxnhkicakpcm44h";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A humanist sans with 4 weights and true italics";
     longDescription = ''
       The Cabin font family is a humanist sans with 4 weights and true italics,

--- a/pkgs/data/fonts/caladea/default.nix
+++ b/pkgs/data/fonts/caladea/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchzip}:
+{ lib, fetchzip }:
 
 let
   version = "20130214";
@@ -15,7 +15,7 @@ in fetchzip rec {
   '';
   sha256 = "0kwm42ggr8kvcn3554cpmv90xzam1sdncx7x3zs3bzp88mxrnv1z";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     # This font doesn't appear to have any official web site but this
     # one provides some good information and samples.
     homepage = http://openfontlibrary.org/en/font/caladea;

--- a/pkgs/data/fonts/camingo-code/default.nix
+++ b/pkgs/data/fonts/camingo-code/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let
   version = "1.0";
@@ -8,14 +8,12 @@ in fetchzip rec {
   url = https://github.com/chrissimpkins/codeface/releases/download/font-collection/codeface-fonts.zip;
   postFetch = ''
     unzip $downloadedFile
-    mkdir -p $out/share/fonts/truetype
-    mkdir -p $out/share/doc/${name}
-    cp -v fonts/camingo-code/*.ttf $out/share/fonts/truetype/
-    cp -v fonts/camingo-code/*.txt $out/share/doc/${name}/
+    install -m444 -Dt $out/share/fonts/truetype fonts/camingo-code/*.ttf
+    install -m444 -Dt $out/share/doc/${name}    fonts/camingo-code/*.txt
   '';
-  sha256 = "035z2k6lwwy2bysw27pirn3vjxnj2h23nyx8jr213rb2bl0m21x1";
+  sha256 = "16iqjwwa7pnswvcc4w8nglkd0m0fz50qsz96i1kcpqip3nwwvw7y";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://www.myfonts.com/fonts/jan-fromm/camingo-code/;
     description = "A monospaced typeface designed for source-code editors";
     platforms = platforms.all;

--- a/pkgs/data/fonts/carlito/default.nix
+++ b/pkgs/data/fonts/carlito/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchzip}:
+{ lib, fetchzip }:
 
 let
   version = "20130920";
@@ -17,7 +17,7 @@ in fetchzip rec {
 
   sha256 = "0d72zy6kdmxgpi63r3yvi3jh1hb7lvlgv8hgd4ag0x10dz18mbzv";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     # This font doesn't appear to have any official web site but this
     # one provides some good information and samples.
     homepage = http://openfontlibrary.org/en/font/carlito;

--- a/pkgs/data/fonts/charis-sil/default.nix
+++ b/pkgs/data/fonts/charis-sil/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchzip}:
+{ lib, fetchzip }:
 
 let
   version = "5.000";
@@ -16,7 +16,7 @@ in
 
     sha256 = "1a220s8n0flvcdkazqf5g10v6r55s2an308slvvarynpj6l7x27n";
 
-    meta = with stdenv.lib; {
+    meta = with lib; {
       homepage = https://software.sil.org/charis;
       description = "A family of highly readable fonts for broad multilingual use";
       longDescription = ''

--- a/pkgs/data/fonts/clearlyU/default.nix
+++ b/pkgs/data/fonts/clearlyU/default.nix
@@ -7,18 +7,17 @@ stdenv.mkDerivation {
     url = https://www.math.nmsu.edu/~mleisher/Software/cu/cu12-1.9.tgz;
     sha256 = "1xn14jbv3m1khy7ydvad9ydkn7yygdbhjy9wm1v000jzjwr3lv21";
   };
-  
+
   nativeBuildInputs = [ mkfontdir mkfontscale ];
 
-  installPhase =
-    ''
-      mkdir -p $out/share/fonts
-      cp *.bdf $out/share/fonts
-      cd $out/share/fonts
-      mkfontdir 
-      mkfontscale
-    '';
-  
+  installPhase = ''
+    mkdir -p $out/share/fonts
+    cp *.bdf $out/share/fonts
+    cd $out/share/fonts
+    mkfontdir
+    mkfontscale
+  '';
+
   outputHashAlgo = "sha256";
   outputHashMode = "recursive";
   outputHash = "127zrg65s90ksj99kr9hxny40rbxvpai62mf5nqk853hcd1bzpr6";
@@ -26,6 +25,5 @@ stdenv.mkDerivation {
   meta = {
     description = "A Unicode font";
     maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/data/fonts/cm-unicode/default.nix
+++ b/pkgs/data/fonts/cm-unicode/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let
   version = "0.7.0";
@@ -9,15 +9,13 @@ in fetchzip rec {
 
   postFetch = ''
     tar -xJvf $downloadedFile --strip-components=1
-    mkdir -p $out/share/fonts/opentype
-    mkdir -p $out/share/doc/${name}
-    cp -v *.otf $out/share/fonts/opentype/
-    cp -v README FontLog.txt $out/share/doc/${name}
+    install -m444 -Dt $out/share/fonts/opentype *.otf
+    install -m444 -Dt $out/share/doc/${name}    README FontLog.txt
   '';
 
   sha256 = "1rzz7yhqq3lljyqxbg46jfzfd09qgpgx865lijr4sgc94riy1ypn";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = http://canopus.iacp.dvo.ru/~panov/cm-unicode/;
     description = "Computer Modern Unicode fonts";
     maintainers = with maintainers; [ raskin rycee ];

--- a/pkgs/data/fonts/comfortaa/default.nix
+++ b/pkgs/data/fonts/comfortaa/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchzip}:
+{ lib, fetchzip }:
 
 let
   version = "3.001";
@@ -8,13 +8,12 @@ in fetchzip rec {
   url = "https://orig00.deviantart.net/40a3/f/2017/093/d/4/comfortaa___font_by_aajohan-d1qr019.zip";
   postFetch = ''
     mkdir -p $out/share/fonts $out/share/doc
-    unzip -l $downloadedFile
     unzip -j $downloadedFile \*.ttf                        -d $out/share/fonts/truetype
     unzip -j $downloadedFile \*/FONTLOG.txt \*/donate.html -d $out/share/doc/${name}
   '';
   sha256 = "0z7xr0cnn6ghwivrm5b5awq9bzhnay3y99qq6dkdgfkfdsaz0n9h";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = http://aajohan.deviantart.com/art/Comfortaa-font-105395949;
     description = "A clean and modern font suitable for headings and logos";
     license = licenses.ofl;

--- a/pkgs/data/fonts/comic-neue/default.nix
+++ b/pkgs/data/fonts/comic-neue/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let
   version = "2.2";
@@ -19,7 +19,7 @@ in fetchzip rec {
 
   sha256 = "1yypq5aqqzv3q1c6vx5130mi2iwihzzvrawhwqpwsfjl0p25sq9q";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = http://comicneue.com/;
     description = "A casual type face: Make your lemonade stand look like a fortune 500 company";
     longDescription = ''

--- a/pkgs/data/fonts/comic-relief/default.nix
+++ b/pkgs/data/fonts/comic-relief/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchzip}:
+{ lib, fetchzip }:
 
 let
   version = "1.1";
@@ -18,7 +18,7 @@ in fetchzip rec {
 
   sha256 = "0dz0y7w6mq4hcmmxv6fn4mp6jkln9mzr4s96vsg68wrl5b7k9yff";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = http://loudifier.com/comic-relief/;
     description = "A font metric-compatible with Microsoft Comic Sans";
     longDescription = ''

--- a/pkgs/data/fonts/cooper-hewitt/default.nix
+++ b/pkgs/data/fonts/cooper-hewitt/default.nix
@@ -1,6 +1,6 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
-fetchzip rec {
+fetchzip {
   name = "cooper-hewitt-2014-06-09";
 
   url = https://www.cooperhewitt.org/wp-content/uploads/fonts/CooperHewitt-OTF-public.zip;
@@ -12,7 +12,7 @@ fetchzip rec {
 
   sha256 = "01iwqmjvqkc6fmc2r0486vk06s6f51n9wxzl1pf9z48n0igj4gqd";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://www.cooperhewitt.org/open-source-at-cooper-hewitt/cooper-hewitt-the-typeface-by-chester-jenkins/;
     description = "A contemporary sans serif, with characters composed of modified-geometric curves and arches";
     license = licenses.ofl;

--- a/pkgs/data/fonts/corefonts/default.nix
+++ b/pkgs/data/fonts/corefonts/default.nix
@@ -41,12 +41,10 @@ stdenv.mkDerivation {
 
     cabextract --lowercase viewer1.cab
 
-    fontDir=$out/share/fonts/truetype
-    mkdir -p $fontDir
-    cp *.ttf $fontDir
+    install -m444 -Dt $out/share/fonts/truetype *.ttf
 
     # Also put the EULA there to be on the safe side.
-    cp ${eula} $fontDir/eula.html
+    cp ${eula} $out/share/fonts/truetype/eula.html
 
     # Set up no-op font configs to override any aliases set up by
     # other packages.

--- a/pkgs/data/fonts/crimson/default.nix
+++ b/pkgs/data/fonts/crimson/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchzip}:
+{ lib, fetchzip }:
 
 let
   version = "2014.10";
@@ -9,16 +9,13 @@ in fetchzip rec {
 
   postFetch = ''
     tar -xzvf $downloadedFile --strip-components=1
-
-    mkdir -p $out/share/fonts/opentype
-    mkdir -p $out/share/doc/${name}
-    cp -v "Desktop Fonts/OTF/"*.otf $out/share/fonts/opentype
-    cp -v README.md $out/share/doc/${name}
+    install -m444 -Dt $out/share/fonts/opentype "Desktop Fonts/OTF/"*.otf
+    install -m444 -Dt $out/share/doc/${name}    README.md
   '';
 
   sha256 = "0mg65f0ydyfmb43jqr1f34njpd10w8npw15cbb7z0nxmy4nkl842";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://aldusleaf.org/crimson.html;
     description = "A font family inspired by beautiful oldstyle typefaces";
     license = licenses.ofl;

--- a/pkgs/data/fonts/culmus/default.nix
+++ b/pkgs/data/fonts/culmus/default.nix
@@ -1,16 +1,12 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let
   version = "0.133";
-in stdenv.mkDerivation {
+in fetchzip {
   name = "culmus-${version}";
-
-  src = fetchzip {
-    url = "mirror://sourceforge/culmus/culmus/${version}/culmus-${version}.tar.gz";
-    sha256 = "0q80j3vixn364sc23hcy6098rkgy0kb4p91lky6224am1dwn2qmr";
-  };
-
-  installPhase = ''
+  url = "mirror://sourceforge/culmus/culmus/${version}/culmus-${version}.tar.gz";
+  postFetch = ''
+    tar xf $downloadedFile --strip=1
     mkdir -p $out/share/fonts/{truetype,type1}
     cp -v *.pfa $out/share/fonts/type1/
     cp -v *.afm $out/share/fonts/type1/
@@ -19,12 +15,13 @@ in stdenv.mkDerivation {
     cp -v *.otf $out/share/fonts/truetype/
     cp -v fonts.scale-ttf $out/share/fonts/truetype/fonts.scale
   '';
+  sha256 = "0zqqjcrqmbd4389hqz2dwymkkcxjrq9ylyriiv3gbmzl6l1ffk3g";
 
   meta = {
     description = "Culmus Hebrew fonts";
     longDescription = "The Culmus project aims at providing the Hebrew-speaking GNU/Linux and Unix community with a basic collection of Hebrew fonts for X Windows.";
-    platforms = stdenv.lib.platforms.all;
-    license = stdenv.lib.licenses.gpl2;
+    platforms = lib.platforms.all;
+    license = lib.licenses.gpl2;
     homepage = http://culmus.sourceforge.net/;
     downloadPage = http://culmus.sourceforge.net/download.html;
   };

--- a/pkgs/data/fonts/d2coding/default.nix
+++ b/pkgs/data/fonts/d2coding/default.nix
@@ -1,10 +1,10 @@
-{ stdenv, fetchzip, unzip }:
+{ lib, fetchzip, unzip }:
 
 let
   version = "1.3.2";
   pname = "d2codingfont";
 
-in fetchzip rec {
+in fetchzip {
   name = "${pname}-${version}";
   url = "https://github.com/naver/${pname}/releases/download/VER${version}/D2Coding-Ver${version}-20180524.zip";
 
@@ -15,7 +15,7 @@ in fetchzip rec {
 
   sha256 = "1812r82530wzfki7k9cm35fy6k2lvis7j6w0w8svc784949m1wwj";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Monospace font with support for Korean and latin characters";
     longDescription = ''
       D2Coding is a monospace font developed by a Korean IT Company called Naver.

--- a/pkgs/data/fonts/dina-pcf/default.nix
+++ b/pkgs/data/fonts/dina-pcf/default.nix
@@ -60,6 +60,5 @@ stdenv.mkDerivation rec {
     downloadPage = https://www.donationcoder.com/Software/Jibz/Dina/;
     license = licenses.free;
     maintainers = [ maintainers.prikhi ];
-    platforms = platforms.unix;
   };
 }

--- a/pkgs/data/fonts/dina/default.nix
+++ b/pkgs/data/fonts/dina/default.nix
@@ -5,11 +5,13 @@ let
 in fetchzip rec {
   name = "dina-font-${version}";
 
-  url = "http://www.donationcoder.com/Software/Jibz/Dina/downloads/Dina.zip";
+  # `meta.homepage` has no direct download link
+  url = "https://github.com/ProgrammingFonts/ProgrammingFonts/archive/b15ef365146be7eef4a46979cfe157c5aeefb7c0.zip";
 
   postFetch = ''
     mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.bdf -d $out/share/fonts
+    unzip -j $downloadedFile '*/Dina/*.bdf' -d $out/share/fonts
+    chmod u-x $out/share/fonts/*
   '';
 
   sha256 = "02a6hqbq18sw69npylfskriqhvj1nsk65hjjyd05nl913ycc6jl7";
@@ -25,6 +27,5 @@ in fetchzip rec {
     downloadPage = https://www.donationcoder.com/Software/Jibz/Dina/;
     license = licenses.free;
     maintainers = [ maintainers.prikhi ];
-    platforms = platforms.unix;
   };
 }

--- a/pkgs/data/fonts/dosemu-fonts/default.nix
+++ b/pkgs/data/fonts/dosemu-fonts/default.nix
@@ -31,6 +31,5 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Various fonts from the DOSEmu project";
-    platforms = stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/data/fonts/dosis/default.nix
+++ b/pkgs/data/fonts/dosis/default.nix
@@ -1,19 +1,21 @@
-{ stdenv, fetchzip}:
+{ lib, fetchFromGitHub }:
 
-fetchzip rec {
+fetchFromGitHub rec {
   name = "dosis-1.007";
 
-  url = https://github.com/impallari/Dosis/archive/12df1e13e58768f20e0d48ff15651b703f9dd9dc.zip;
+  owner = "impallari";
+  repo = "Dosis";
+  rev = "12df1e13e58768f20e0d48ff15651b703f9dd9dc";
 
   postFetch = ''
-    mkdir -p $out/share/{doc,fonts}
-    unzip -j $downloadedFile \*.otf                    -d $out/share/fonts/opentype
-    unzip -j $downloadedFile \*README.md \*FONTLOG.txt -d "$out/share/doc/${name}"
+    tar xf $downloadedFile --strip=1
+    find . -name '*.otf' -exec install -m444 -Dt $out/share/fonts/opentype {} \;
+    install -m444 -Dt $out/share/doc/${name} README.md FONTLOG.txt
   '';
 
-  sha256 = "11a8jmgaly14l7rm3jxkwwv3ngr8fdlkp70nicjk2rg0nny2cvfq";
+  sha256 = "0vz25w45i8flfvppymr5h83pa2n1r37da20v7691p44018fdsdny";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A very simple, rounded, sans serif family";
     longDescription = ''
       Dosis is a very simple, rounded, sans serif family.

--- a/pkgs/data/fonts/doulos-sil/default.nix
+++ b/pkgs/data/fonts/doulos-sil/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchzip}:
+{ lib, fetchzip }:
 
 let
   version = "5.000";
@@ -16,7 +16,7 @@ in
 
     sha256 = "04a9cr7jbw7d8llcj8xsqp9rp8w6gcgbd9sdwvi02kz7jhqa0vad";
 
-    meta = with stdenv.lib; {
+    meta = with lib; {
       homepage = https://software.sil.org/doulos;
       description = "A font that provides complete support for the International Phonetic Alphabet";
       longDescription = ''

--- a/pkgs/data/fonts/eb-garamond/default.nix
+++ b/pkgs/data/fonts/eb-garamond/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let
   version = "0.016";
@@ -15,7 +15,7 @@ in fetchzip rec {
 
   sha256 = "04jq4mpln85zzbla8ybsjw7vn9qr3r0snmk5zykrm24imq7ripv3";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = http://www.georgduffner.at/ebgaramond/;
     description = "Digitization of the Garamond shown on the Egenolff-Berner specimen";
     maintainers = with maintainers; [ relrod rycee ];

--- a/pkgs/data/fonts/emacs-all-the-icons-fonts/default.nix
+++ b/pkgs/data/fonts/emacs-all-the-icons-fonts/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let
   version = "3.2.0";
@@ -14,7 +14,7 @@ in fetchzip {
 
   sha256 = "0ps8q9nkx67ivgn8na4s012360v36jwr0951rsg7j6dyyw9g41jq";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Icon fonts for emacs all-the-icons";
     longDescription = ''
       The emacs package all-the-icons provides icons to improve

--- a/pkgs/data/fonts/emojione/default.nix
+++ b/pkgs/data/fonts/emojione/default.nix
@@ -29,7 +29,6 @@ stdenv.mkDerivation rec {
     description = "Open source emoji set";
     homepage = http://emojione.com/;
     license = licenses.cc-by-40;
-    platforms = platforms.linux;
     maintainers = with maintainers; [ abbradar ];
   };
 }

--- a/pkgs/data/fonts/encode-sans/default.nix
+++ b/pkgs/data/fonts/encode-sans/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 fetchzip rec {
   name = "encode-sans-1.002";
@@ -13,7 +13,7 @@ fetchzip rec {
 
   sha256 = "16mx894zqlwrhnp4rflgayxhxppmsj6k7haxdngajhb30rlwf08p";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A versatile sans serif font family";
     longDescription = ''
       The Encode Sans family is a versatile workhorse. Featuring a huge range of

--- a/pkgs/data/fonts/eunomia/default.nix
+++ b/pkgs/data/fonts/eunomia/default.nix
@@ -1,4 +1,4 @@
-{ stdenv,  fetchzip }:
+{ lib, fetchzip }:
 
 let
   majorVersion = "0";
@@ -17,7 +17,7 @@ fetchzip rec {
     unzip -j $downloadedFile \*.otf  -d $out/share/fonts/opentype/${pname}
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = http://dotcolon.net/font/eunomia/;
     description = "A futuristic decorative font.";
     platforms = platforms.all;

--- a/pkgs/data/fonts/f5_6/default.nix
+++ b/pkgs/data/fonts/f5_6/default.nix
@@ -1,4 +1,4 @@
-{ stdenv,  fetchzip }:
+{ lib, fetchzip }:
 
 let
   majorVersion = "0";
@@ -17,7 +17,7 @@ fetchzip rec {
     unzip -j $downloadedFile \*.otf  -d $out/share/fonts/opentype/${pname}
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "http://dotcolon.net/font/${pname}/";
     description = "A weighted decorative font.";
     platforms = platforms.all;

--- a/pkgs/data/fonts/fantasque-sans-mono/default.nix
+++ b/pkgs/data/fonts/fantasque-sans-mono/default.nix
@@ -1,9 +1,7 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let
-
   version = "1.7.2";
-
 in
 
 fetchzip rec {
@@ -19,7 +17,7 @@ fetchzip rec {
 
   sha256 = "1fwvbqfrgb539xybwdawvwa8cg4f215kw905rgl9a6p0iwa1nxqk";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://github.com/belluzj/fantasque-sans;
     description = "A font family with a great monospaced variant for programmers";
     license = licenses.ofl;

--- a/pkgs/data/fonts/ferrum/default.nix
+++ b/pkgs/data/fonts/ferrum/default.nix
@@ -1,4 +1,4 @@
-{ stdenv,  fetchzip }:
+{ lib, fetchzip }:
 
 let
   majorVersion = "0";
@@ -17,7 +17,7 @@ fetchzip rec {
     unzip -j $downloadedFile \*.otf  -d $out/share/fonts/opentype/${pname}
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "http://dotcolon.net/font/${pname}/";
     description = "A decorative font.";
     platforms = platforms.all;

--- a/pkgs/data/fonts/fira/default.nix
+++ b/pkgs/data/fonts/fira/default.nix
@@ -1,18 +1,23 @@
-{ stdenv, fetchzip }:
+{ lib, fetchFromGitHub }:
 
-fetchzip rec {
-  name = "fira-4.106";
+let
+  version = "4.106";
+in fetchFromGitHub {
+  name = "fira-${version}";
 
-  url = https://github.com/mozilla/Fira/archive/4.106.zip;
+  owner = "mozilla";
+  repo = "Fira";
+  rev = version;
 
   postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile Fira-4.106/otf/FiraSans\*.otf -d $out/share/fonts/opentype
+    tar xf $downloadedFile --strip=1
+    mkdir -p $out/share/fonts/opentype
+    cp otf/*.otf $out/share/fonts/opentype
   '';
 
   sha256 = "0c97nmihcq0ki7ywj8zn048a2bgrszc61lb9p0djfi65ar52jab4";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://mozilla.github.io/Fira/;
     description = "Sans-serif font for Firefox OS";
     longDescription = ''

--- a/pkgs/data/fonts/fixedsys-excelsior/default.nix
+++ b/pkgs/data/fonts/fixedsys-excelsior/default.nix
@@ -1,33 +1,25 @@
 { stdenv, fetchurl } :
 
-let 
+let
   major = "3";
   minor = "00";
   version = "${major}.${minor}";
-
-in
-
-stdenv.mkDerivation rec {
+in fetchurl rec {
   name = "fixedsys-excelsior-${version}";
 
-  src = fetchurl {
-    url = http://www.fixedsysexcelsior.com/fonts/FSEX300.ttf;
-    sha256 = "6ee0f3573bc5e33e93b616ef6282f49bc0e227a31aa753ac76ed2e3f3d02056d";
-  };
-
-  phases = [ "installPhase" ];
-
-  installPhase = ''
-    mkdir -p $out/share/fonts/truetype/
-    cp $src $out/share/fonts/truetype/${name}.ttf
+  urls = [
+    http://www.fixedsysexcelsior.com/fonts/FSEX300.ttf
+    https://raw.githubusercontent.com/chrissimpkins/codeface/master/fonts/fixed-sys-excelsior/FSEX300.ttf
+    http://tarballs.nixos.org/sha256/6ee0f3573bc5e33e93b616ef6282f49bc0e227a31aa753ac76ed2e3f3d02056d
+  ];
+  downloadToTemp = true;
+  recursiveHash = true;
+  postFetch = ''
+    install -m444 -D $downloadedFile $out/share/fonts/truetype/${name}.ttf
   '';
 
-  outputHashMode = "recursive";
+  sha256 = "32d6f07f1ff08c764357f8478892b2ba5ade23427af99759f34a0ba24bcd2e37";
 
-  outputHashAlgo = "sha256";
-
-  outputHash = "32d6f07f1ff08c764357f8478892b2ba5ade23427af99759f34a0ba24bcd2e37";
-  
   meta = {
     description = "Pan-unicode version of Fixedsys, a classic DOS font.";
     homepage = http://www.fixedsysexcelsior.com/;

--- a/pkgs/data/fonts/font-awesome-5/default.nix
+++ b/pkgs/data/fonts/font-awesome-5/default.nix
@@ -1,20 +1,22 @@
-{ stdenv, fetchzip }:
+{ lib, fetchFromGitHub }:
 
 let
   version = "5.8.2";
-in fetchzip rec {
+in fetchFromGitHub rec {
   name = "font-awesome-${version}";
 
-  url = "https://github.com/FortAwesome/Font-Awesome/archive/${version}.zip";
+  owner = "FortAwesome";
+  repo = "Font-Awesome";
+  rev = version;
 
   postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile "Font-Awesome-${version}/otfs/*.otf" -d $out/share/fonts/opentype
+    tar xf $downloadedFile --strip=1
+    install -m444 -Dt $out/share/fonts/opentype otfs/*.otf
   '';
 
   sha256 = "1h0qhvkfyfs4579jvrk3gwc7dp4i9s46bkj406b493dvmxxhv986";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Font Awesome - OTF font";
     longDescription = ''
       Font Awesome gives you scalable vector icons that can instantly be customized.

--- a/pkgs/data/fonts/fontconfig-penultimate/default.nix
+++ b/pkgs/data/fonts/fontconfig-penultimate/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip
+{ lib, fetchzip
 , version ? "0.3.5"
 , sha256 ? "1gfgl7qimp76q4z0nv55vv57yfs4kscdr329np701k0xnhncwvrk"
 }:
@@ -14,7 +14,7 @@ fetchzip {
     unzip -j $downloadedFile \*.conf -d $out/etc/fonts/conf.d
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://github.com/ttuegel/fontconfig-penultimate;
     description = "Sensible defaults for Fontconfig";
     license = licenses.asl20;

--- a/pkgs/data/fonts/freefont-ttf/default.nix
+++ b/pkgs/data/fonts/freefont-ttf/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchzip}:
+{ lib, fetchzip }:
 
 fetchzip rec {
   name = "freefont-ttf-20120503";
@@ -20,8 +20,8 @@ fetchzip rec {
       10646/Unicode UCS (Universal Character Set).
     '';
     homepage = https://www.gnu.org/software/freefont/;
-    license = stdenv.lib.licenses.gpl3Plus;
-    platforms = stdenv.lib.platforms.all;
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.all;
     maintainers = [];
   };
 }

--- a/pkgs/data/fonts/gandom-fonts/default.nix
+++ b/pkgs/data/fonts/gandom-fonts/default.nix
@@ -1,22 +1,21 @@
-{ stdenv, fetchFromGitHub }:
+{ lib, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
+let
   pname = "gandom-fonts";
   version = "0.6";
+in fetchFromGitHub {
+  name = "${pname}-${version}";
+  owner = "rastikerdar";
+  repo = "gandom-font";
+  rev = "v${version}";
 
-  src = fetchFromGitHub {
-    owner = "rastikerdar";
-    repo = "gandom-font";
-    rev = "v${version}";
-    sha256 = "1pdbqhvcsz6aq3qgarhfd05ip0wmh7bxqkmxrwa0kgxsly6zxz9x";
-  };
-
-  installPhase = ''
-    mkdir -p $out/share/fonts/gandom-fonts
-    cp -v $( find . -name '*.ttf') $out/share/fonts/gandom-fonts
+  postFetch = ''
+    tar xf $downloadedFile --strip=1
+    find . -name '*.ttf' -exec install -m444 -Dt $out/share/fonts/gandom-fonts {} \;
   '';
+  sha256 = "0zsq6s9ziyb5jz0v8aj00dlxd1aly0ibxgszd05dfvykmgz051lc";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://github.com/rastikerdar/gandom-font;
     description = "A Persian (Farsi) Font - فونت (قلم) فارسی گندم";
     license = licenses.ofl;

--- a/pkgs/data/fonts/gdouros/default.nix
+++ b/pkgs/data/fonts/gdouros/default.nix
@@ -1,29 +1,16 @@
-{stdenv, fetchzip, lib}:
+{ fetchzip, lib }:
 
 let
   fonts = {
-    symbola = { version = "9.17"; file = "Symbola.zip"; sha256 = "13z18lxx0py54nns61ihgxacpf1lg9s7g2sbpbnxpllqw7j73iq2";
-                description = "Basic Latin, Greek, Cyrillic and many Symbol blocks of Unicode"; };
-    aegyptus = { version = "6.17"; file = "Aegyptus.zip"; sha256 = "19rkf89msqb076qjdfa75pqrx35c3slj64vxw08zqdvyavq7jc79";
-                 description = "Egyptian Hieroglyphs, Coptic, Meroitic"; };
-    akkadian = { version = "7.17"; file = "AkkadianAssyrian.zip"; sha256 = "1xw2flrwb5r89sk7jd195v3svsb21brf1li2i3pdjcfqxfp5m0g7";
-                 description = "Sumero-Akkadian Cuneiform"; };
-    anatolian = { version = "5.17"; file = "Anatolian.zip"; sha256 = "0dqcyjakc4fy076pjplm6psl8drpwxiwyq97xrf6a3qa098gc0qc";
-                  description = "Anatolian Hieroglyphs"; };
-    maya = { version = "4.17"; file = "Maya.zip"; sha256 = "17s5c23wpqrcq5h6pgssbmzxiv4jvhdh2ssr99j9q6j32a51h9gh";
-             description = "Maya Hieroglyphs"; };
-    unidings = { version = "9.17"; file = "Unidings.zip"; sha256 = "0nzw8mrhk0hbjnl2cgi31b00vmi785win86kiz9d2yzdfz1is6sk";
-                 description = "Glyphs and Icons for blocks of The Unicode Standard"; };
-    musica = { version = "3.17"; file = "Musica.zip"; sha256 = "0mnv61dxzs2npvxgs5l9q81q19xzzi1sn53x5qwpiirkmi6bg5y6";
-               description = "Musical Notation"; };
-    analecta = { version = "5.17"; file = "Analecta.zip"; sha256 = "13npnfscd9mz6vf89qxxbj383njf53a1smqjh0c1w2lvijgak3aj";
-                 description = "Coptic, Gothic, Deseret"; };
-    textfonts = { version = "7.17"; file = "TextfontsFonts.zip"; sha256 = "1ggflqnslp81v8pzmzx6iwi2sa38l9bpivjjci7nvx3y5xynm6wl";
-                 description = "Aroania, Anaktoria, Alexander, Avdira and Asea"; };
-    aegan = { version = "9.17"; file = "AegeanFonts.zip"; sha256 = "0dm2ck3p11bc9izrh7xz3blqfqg1mgsvy4jsgmz9rcs4m74xrhsf";
-              description = "Aegean"; };
-    abydos = { version = "1.23"; file = "AbydosFont.zip"; sha256 = "04r7ysnjjq0nrr3m8lbz8ssyx6xaikqybjqxzl3ziywl9h6nxdj8";
-               description = "AbydosFont"; };
+    aegan     = { version = "10.00"; file = "Aegean.zip";       sha256 = "0k47nhzw4vx771ch3xx8mf6xx5vx0hg0cif5jdlmdaz4h2c3rawz"; description = "Aegean"; };
+    aegyptus  = { version =  "8.00"; file = "Aegyptus.zip";     sha256 = "13h2pi641k9vxgqi9l11mjya10ym9ln54wrkwxx6gxq63zy7y5mj"; description = "Egyptian Hieroglyphs, Coptic, Meroitic"; };
+    akkadian  = { version =  "7.18"; file = "Akkadian.zip";     sha256 = "1bplcvszbdrk85kqipn9lzhr62647wjibz1p8crzjvsw6f9ymxy3"; description = "Sumero-Akkadian Cuneiform"; };
+    assyrian  = { version =  "2.00"; file = "AssyrianFont.zip"; sha256 = "0vdvb24vsnmwzd6bw14akqg0hbvsk8avgnbwk9fkybn1f801475k"; description = "Neo-Assyrian in Unicode with OpenType"; };
+    eemusic   = { version =  "2.00"; file = "EEMusic.zip";      sha256 = "1y9jf105a2b689m7hdjmhhr7z5j0qd2w6dmb3iic9bwaczlrjy7j"; description = "Byzantine Musical Notation in Unicode with OpenType"; };
+    maya      = { version =  "4.18"; file = "Maya.zip";         sha256 = "08z2ch0z2c43fjfg5m4yp3l1dp0cbk7lv5i7wzsr3cr9kr59wpi9"; description = "Maya Hieroglyphs"; };
+    symbola   = { version = "12.00"; file = "Symbola.zip";      sha256 = "1i3xra33xkj32vxs55xs2afrqyc822nk25669x78px5g5qd8gypm"; description = "Basic Latin, Greek, Cyrillic and many Symbol blocks of Unicode"; };
+    textfonts = { version =  "9.00"; file = "Textfonts.zip";    sha256 = "0wzxz4j4fgk81b88d58715n1wvq2mqmpjpk4g5hi3vk77y2zxc4d"; description = "Aroania, Anaktoria, Alexander, Avdira and Asea"; };
+    unidings  = { version =  "9.19"; file = "Unidings.zip";     sha256 = "1bybzgdqhmq75hb12n3pjrsdcpw1a6sgryx464s68jlq4zi44g78"; description = "Glyphs and Icons for blocks of The Unicode Standard"; };
   };
 
   mkpkg = name_: {version, file, sha256, description}: fetchzip rec {
@@ -42,9 +29,8 @@ let
       # In lieu of a license:
       # Fonts in this site are offered free for any use;
       # they may be installed, embedded, opened, edited, modified, regenerated, posted, packaged and redistributed.
-      license = stdenv.lib.licenses.free;
+      license = lib.licenses.free;
       homepage = http://users.teilar.gr/~g1951d/;
-      platforms = stdenv.lib.platforms.unix;
     };
   };
 in

--- a/pkgs/data/fonts/gentium-book-basic/default.nix
+++ b/pkgs/data/fonts/gentium-book-basic/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let
   major = "1";
@@ -11,14 +11,13 @@ in fetchzip rec {
 
   postFetch = ''
     mkdir -p $out/share/{doc,fonts}
-    unzip -l $downloadedFile
     unzip -j $downloadedFile \*.ttf                            -d $out/share/fonts/truetype
     unzip -j $downloadedFile \*/FONTLOG.txt \*/GENTIUM-FAQ.txt -d $out/share/doc/${name}
   '';
 
   sha256 = "0598zr5f7d6ll48pbfbmmkrybhhdks9b2g3m2g67wm40070ffzmd";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://software.sil.org/gentium/;
     description = "A high-quality typeface family for Latin, Cyrillic, and Greek";
     maintainers = with maintainers; [ ];

--- a/pkgs/data/fonts/gentium/default.nix
+++ b/pkgs/data/fonts/gentium/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let
   version = "5.000";
@@ -17,7 +17,7 @@ in fetchzip rec {
 
   sha256 = "1qr2wjdmm93167b0w9cidlf3wwsyjx4838ja9jmm4jkyian5whhp";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://software.sil.org/gentium/;
     description = "A high-quality typeface family for Latin, Cyrillic, and Greek";
     longDescription = ''

--- a/pkgs/data/fonts/go-font/default.nix
+++ b/pkgs/data/fonts/go-font/default.nix
@@ -1,26 +1,22 @@
 { stdenv, fetchgit }:
 
-stdenv.mkDerivation rec {
-  name = "go-font-${version}";
+let
   version = "2017-03-30";
+in (fetchgit {
+  name = "go-font-${version}";
+  url = "https://go.googlesource.com/image";
+  rev = "f03a046406d4d7fbfd4ed29f554da8f6114049fc";
 
-  src = fetchgit {
-    url = "https://go.googlesource.com/image";
-    rev = "f03a046406d4d7fbfd4ed29f554da8f6114049fc";
-    sha256 = "1aq6mnjayks55gd9ahavk6jfydlq5lm4xm0xk4pd5sqa74p5p74d";
-  };
-
-  installPhase = ''
+  postFetch = ''
+    mv $out/* .
     mkdir -p $out/share/fonts/truetype
     mkdir -p $out/share/doc/go-font
     cp font/gofont/ttfs/* $out/share/fonts/truetype
     mv $out/share/fonts/truetype/README $out/share/doc/go-font/LICENSE
   '';
 
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-  outputHash = "10hfm2cpxlx1ng7r2mbvykjhmy131qlgzpdzj7ibg9kr293bcjc0";
-
+  sha256 = "1488426ya2nzmwjas947fx9h5wzxrp9wasn8nkjqf0y0mpd4f1xz";
+}) // {
   meta = with stdenv.lib; {
     homepage = https://blog.golang.org/go-fonts;
     description = "The Go font family";

--- a/pkgs/data/fonts/gohufont/default.nix
+++ b/pkgs/data/fonts/gohufont/default.nix
@@ -67,6 +67,5 @@ stdenv.mkDerivation rec {
     homepage    = http://font.gohu.org/;
     license     = licenses.wtfpl;
     maintainers = with maintainers; [ epitrochoid rnhmjoj ];
-    platforms   = platforms.unix;
   };
 }

--- a/pkgs/data/fonts/gyre/default.nix
+++ b/pkgs/data/fonts/gyre/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchzip}:
+{ lib, fetchzip }:
 
 let
   baseName = "gyre-fonts";
@@ -25,8 +25,8 @@ in fetchzip {
       covering all modern European languages and then some
     '';
     homepage = "http://www.gust.org.pl/projects/e-foundry/tex-gyre/index_html#Readings";
-    license = stdenv.lib.licenses.lppl13c;
-    platforms = stdenv.lib.platforms.all;
-    maintainers = with stdenv.lib.maintainers; [ bergey ];
+    license = lib.licenses.lppl13c;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ bergey ];
   };
 }

--- a/pkgs/data/fonts/hack/default.nix
+++ b/pkgs/data/fonts/hack/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let
   version = "3.003";
@@ -14,7 +14,7 @@ in fetchzip rec {
 
   sha256 = "1l6ih6v7dqali5c7zh6z2xnbf9h2wz0ag6fdgszmqd5lnhw39v6s";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A typeface designed for source code";
     longDescription = ''
       Hack is hand groomed and optically balanced to be a workhorse face for

--- a/pkgs/data/fonts/hanazono/default.nix
+++ b/pkgs/data/fonts/hanazono/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let
   version = "20141012";
@@ -15,7 +15,7 @@ in fetchzip {
 
   sha256 = "0z0fgrjzp0hqqnhfisivciqpxd2br2w2q9mvxkglj44np2q889w2";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Free kanji font containing 96,327 characters";
     homepage = http://fonts.jp/hanazono/;
 

--- a/pkgs/data/fonts/hasklig/default.nix
+++ b/pkgs/data/fonts/hasklig/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchzip}:
+{ lib, fetchzip }:
 
 let
   version = "1.1";
@@ -9,13 +9,12 @@ in fetchzip {
 
   postFetch = ''
     unzip $downloadedFile
-    mkdir -p $out/share/fonts/opentype
-    cp *.otf $out/share/fonts/opentype
+    install -m444 -Dt $out/share/fonts/opentype *.otf
   '';
 
   sha256 = "0xxyx0nkapviqaqmf3b610nq17k20afirvc72l32pfspsbxz8ybq";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://github.com/i-tu/Hasklig;
     description = "A font with ligatures for Haskell code based off Source Code Pro";
     license = licenses.ofl;

--- a/pkgs/data/fonts/helvetica-neue-lt-std/default.nix
+++ b/pkgs/data/fonts/helvetica-neue-lt-std/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let
   version = "2013.06.07"; # date of most recent file in distribution
@@ -28,8 +28,8 @@ in fetchzip rec {
       font. The numbers are well spaced and defined with high accuracy. The
       punctuation marks are heavily detailed as well.
     '';
-    license = stdenv.lib.licenses.unfree;
-    maintainers = [ stdenv.lib.maintainers.romildo ];
-    platforms = stdenv.lib.platforms.all;
+    license = lib.licenses.unfree;
+    maintainers = [ lib.maintainers.romildo ];
+    platforms = lib.platforms.all;
   };
 }

--- a/pkgs/data/fonts/hermit/default.nix
+++ b/pkgs/data/fonts/hermit/default.nix
@@ -1,23 +1,20 @@
-{ stdenv, fetchurl }:
+{ lib, fetchzip }:
 
-stdenv.mkDerivation rec {
+let
   pname = "hermit";
   version = "2.0";
+in fetchzip rec {
+  name = "${pname}-${version}";
 
-  src = fetchurl {
-    url = "https://pcaro.es/d/otf-${pname}-${version}.tar.gz";
-    sha256 = "09rmy3sbf1j1hr8zidighjgqc8kp0wsra115y27vrnlf10ml6jy0";
-  };
+  url = "https://pcaro.es/d/otf-${name}.tar.gz";
 
-  sourceRoot = ".";
-
-  dontBuild = true;
-  installPhase = ''
-    mkdir -p $out/share/fonts/opentype
-    cp *.otf $out/share/fonts/opentype/
+  postFetch = ''
+    tar xf $downloadedFile
+    install -m444 -Dt $out/share/fonts/opentype *.otf
   '';
+  sha256 = "127hnpxicqya7v1wmzxxqafq3aj1n33i4j5ncflbw6gj5g3bizwl";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "monospace font designed to be clear, pragmatic and very readable";
     homepage = https://pcaro.es/p/hermit;
     license = licenses.ofl;

--- a/pkgs/data/fonts/hyperscrypt/default.nix
+++ b/pkgs/data/fonts/hyperscrypt/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, lib }:
+{ fetchzip, lib }:
 
 let
   version = "1.1";
@@ -15,7 +15,7 @@ fetchzip rec {
     unzip -j $downloadedFile \*${pname}.otf -d $out/share/fonts/opentype/${pname}.otf
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = http://velvetyne.fr/fonts/hyper-scrypt/;
     description = "A modern stencil typeface inspired by stained glass technique";
     longDescription = ''

--- a/pkgs/data/fonts/inriafonts/default.nix
+++ b/pkgs/data/fonts/inriafonts/default.nix
@@ -1,26 +1,22 @@
-{ stdenv, fetchFromGitHub }:
+{ lib, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
-
+let
   pname = "inriafonts";
   version = "1.200";
+in fetchFromGitHub rec {
   name = "${pname}-${version}";
-
-src = fetchFromGitHub {
   owner = "BlackFoundry";
   repo = "InriaFonts";
   rev = "v${version}";
-  sha256 = "06775y99lyh6hj5hzvrx56iybdck8a8xfqkipqd5c4cldg0a9hh8";
-};
 
-installPhase = ''
-  mkdir -p $out/share/fonts/truetype
-  cp fonts/*/TTF/*.ttf $out/share/fonts/truetype
-  mkdir -p $out/share/fonts/opentype
-  cp fonts/*/OTF/*.otf $out/share/fonts/opentype
-'';
+  postFetch = ''
+    tar xf $downloadedFile --strip=1
+    install -m444 -Dt $out/share/fonts/truetype fonts/*/TTF/*.ttf
+    install -m444 -Dt $out/share/fonts/opentype fonts/*/OTF/*.otf
+  '';
+  sha256 = "0wrwcyycyzvgvgnlmwi1ncdvwb8f6bbclynd1105rsyxgrz5dd70";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://black-foundry.com/work/inria;
     description = "Inria Sans and Inria Serif";
     longDescription = ''
@@ -32,7 +28,7 @@ installPhase = ''
       typeface with a unapologetically contemporary design as the
       Sans-serif part and a more rational axis and drawing for the
       serif. Both members comes in 3 weights with matching italics.
-      '';
+    '';
     license = licenses.ofl;
     maintainers = with maintainers; [ leenaars ];
     platforms = platforms.all;

--- a/pkgs/data/fonts/inter-ui/default.nix
+++ b/pkgs/data/fonts/inter-ui/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 # XXX: IMPORTANT:
 # For compat, keep this at the last version that used the name "Inter UI"
@@ -18,7 +18,7 @@ in fetchzip {
 
   sha256 = "01d2ql803jrhss6g60djvs08x9xl7z6b3snkn03vqnrajdgifcl4";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://rsms.me/inter/;
     description = "A typeface specially designed for user interfaces";
     license = licenses.ofl;

--- a/pkgs/data/fonts/inter/default.nix
+++ b/pkgs/data/fonts/inter/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let
   version = "3.5";
@@ -14,7 +14,7 @@ in fetchzip {
 
   sha256 = "0zqixzzbb3n1j4jvpjm0hlxc32j53hgq4j078gihjkhgvjhsklf2";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://rsms.me/inter/;
     description = "A typeface specially designed for user interfaces";
     license = licenses.ofl;

--- a/pkgs/data/fonts/ipaexfont/default.nix
+++ b/pkgs/data/fonts/ipaexfont/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
-fetchzip rec {
+fetchzip {
   name = "ipaexfont-003.01";
 
-  url = "http://dl.ipafont.ipa.go.jp/IPAexfont/IPAexfont00301.zip";
+  url = "http://web.archive.org/web/20160616003021/http://dl.ipafont.ipa.go.jp/IPAexfont/IPAexfont00301.zip";
 
   postFetch = ''
     mkdir -p $out/share/fonts
@@ -12,7 +12,7 @@ fetchzip rec {
 
   sha256 = "02a6sj990cnig5lq0m54nmbmfkr3s57jpxl9fiyzrjmigvd1qmhj";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Japanese font package with Mincho and Gothic fonts";
     longDescription = ''
       IPAex font is a Japanese font developed by the Information-technology
@@ -24,6 +24,5 @@ fetchzip rec {
     homepage = http://ipafont.ipa.go.jp/;
     license = licenses.ipa;
     maintainers = with maintainers; [ gebner ];
-    platforms = with platforms; unix;
   };
 }

--- a/pkgs/data/fonts/ipafont/default.nix
+++ b/pkgs/data/fonts/ipafont/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 fetchzip {
   name = "ipafont-003.03";
@@ -20,8 +20,7 @@ fetchzip {
       suitable for both display and printing.
     '';
     homepage = http://ipafont.ipa.go.jp/ipafont/;
-    license = stdenv.lib.licenses.ipa;
-    maintainers = [ stdenv.lib.maintainers.auntie ];
-    platforms = stdenv.lib.platforms.unix;
+    license = lib.licenses.ipa;
+    maintainers = [ lib.maintainers.auntie ];
   };
 }

--- a/pkgs/data/fonts/ir-standard-fonts/default.nix
+++ b/pkgs/data/fonts/ir-standard-fonts/default.nix
@@ -1,22 +1,21 @@
-{ stdenv, fetchFromGitHub }:
+{ lib, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
+let
   pname = "ir-standard-fonts";
-  version= "unstable-2017-01-21";
+  version = "unstable-2017-01-21";
+in fetchFromGitHub rec {
+  name = "${pname}-${version}";
+  owner = "morealaz";
+  repo = pname;
+  rev = "d36727d6c38c23c01b3074565667a2fe231fe18f";
 
-  src = fetchFromGitHub {
-    owner = "morealaz";
-    repo = pname;
-    rev = "d36727d6c38c23c01b3074565667a2fe231fe18f";
-    sha256 = "1ks9q1r1gk2517yfr1fbgrdbgw0w97i4am6jqn5ywpgm2xd03yg1";
-  };
-
-  installPhase = ''
-    mkdir -p $out/share/fonts/ir-standard-fonts
-    cp -v $( find . -name '*.ttf') $out/share/fonts/ir-standard-fonts
+  postFetch = ''
+    tar xf $downloadedFile --strip=1
+    find . -name '*.ttf' -exec install -m444 -Dt $out/share/fonts/ir-standard-fonts {} \;
   '';
+  sha256 = "0i2vzhwk77pm6fx5z5gxl026z9f35rhh3cvl003mry2lcg1x5rhp";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://github.com/morealaz/ir-standard-fonts;
     description = "Iran Supreme Council of Information and Communication Technology (SCICT) standard Persian fonts series";
     # License information is unavailable.

--- a/pkgs/data/fonts/iwona/default.nix
+++ b/pkgs/data/fonts/iwona/default.nix
@@ -1,23 +1,18 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
-stdenv.mkDerivation rec {
-  name = "iwona-${version}";
+let
   version = "0_995";
+in fetchzip {
+  name = "iwona-${version}";
+  url = "http://jmn.pl/pliki/Iwona-otf-${version}.zip";
 
-  src = fetchzip {
-    url = "http://jmn.pl/pliki/Iwona-otf-${version}.zip";
-    sha256 = "1wj5bxbxpz5a8p3rhw708cyjc0lgqji8g0iv6brmmbrrkpb3jq2s";
-  };
-
-  installPhase = ''
-    install -m 444 -D -t $out/share/fonts/opentype/ *.otf
+  postFetch = ''
+    mkdir -p $out/share/fonts/opentype
+    unzip -j $downloadedFile *.otf -d $out/share/fonts/opentype
   '';
+  sha256 = "1dcpn13bd31dw7ir0s722bv3nk136dy6qsab0kznjbzfqd7agswa";
 
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-  outputHash = "1dcpn13bd31dw7ir0s722bv3nk136dy6qsab0kznjbzfqd7agswa";
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A two-element sans-serif typeface, created by Małgorzata Budyta";
     homepage = http://jmn.pl/en/kurier-i-iwona/;
     # "[...] GUST Font License (GFL), which is a free license, legally

--- a/pkgs/data/fonts/junicode/default.nix
+++ b/pkgs/data/fonts/junicode/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 fetchzip {
   name = "junicode-0.7.8";
@@ -15,7 +15,6 @@ fetchzip {
   meta = {
     homepage = http://junicode.sourceforge.net/;
     description = "A Unicode font for medievalists";
-    platforms = stdenv.lib.platforms.unix;
-    license = stdenv.lib.licenses.gpl2Plus;
+    license = lib.licenses.gpl2Plus;
   };
 }

--- a/pkgs/data/fonts/kawkab-mono/default.nix
+++ b/pkgs/data/fonts/kawkab-mono/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchzip}:
+{ lib, fetchzip }:
 
 fetchzip rec {
   name = "kawkab-mono-20151015";
@@ -15,8 +15,7 @@ fetchzip rec {
   meta = {
     description = "An arab fixed-width font";
     homepage = https://makkuk.com/kawkab-mono/;
-    license = stdenv.lib.licenses.ofl;
-    platforms = stdenv.lib.platforms.unix;
+    license = lib.licenses.ofl;
   };
 }
 

--- a/pkgs/data/fonts/kochi-substitute-naga10/default.nix
+++ b/pkgs/data/fonts/kochi-substitute-naga10/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let version = "20030809";
 in
@@ -26,7 +26,7 @@ fetchzip {
       Debian version.
     '';
     homepage = http://sourceforge.jp/projects/efont/;
-    license = stdenv.lib.licenses.unfreeRedistributable;
-    maintainers = [ stdenv.lib.maintainers.auntie ];
+    license = lib.licenses.unfreeRedistributable;
+    maintainers = [ lib.maintainers.auntie ];
   };
 }

--- a/pkgs/data/fonts/kochi-substitute/default.nix
+++ b/pkgs/data/fonts/kochi-substitute/default.nix
@@ -43,6 +43,5 @@ stdenv.mkDerivation {
     homepage = http://sourceforge.jp/projects/efont/;
     license = stdenv.lib.licenses.wadalab;
     maintainers = [ stdenv.lib.maintainers.auntie ];
-    platforms = stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/data/fonts/lalezar-fonts/default.nix
+++ b/pkgs/data/fonts/lalezar-fonts/default.nix
@@ -1,22 +1,22 @@
-{ stdenv, fetchFromGitHub }:
+{ lib, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
+let
   pname = "lalezar-fonts";
   version = "unstable-2017-02-28";
+in fetchFromGitHub {
+  name = "${pname}-${version}";
+  owner = "BornaIz";
+  repo = "Lalezar";
+  rev = "238701c4241f207e92515f845a199be9131c1109";
 
-  src = fetchFromGitHub {
-    owner = "BornaIz";
-    repo = "Lalezar";
-    rev = "238701c4241f207e92515f845a199be9131c1109";
-    sha256 = "1j3zg9qw4ahw52i0i2c69gv5gjc1f4zsdla58kd9visk03qgk77p";
-  };
-
-  installPhase = ''
+  postFetch = ''
+    tar xf $downloadedFile --strip=1
     mkdir -p $out/share/fonts/lalezar-fonts
     cp -v $( find . -name '*.ttf') $out/share/fonts/lalezar-fonts
   '';
+  sha256 = "0jmwhr2dqgj3vn0v26jh6c0id6n3wd6as3bq39xa870zlk7v307b";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://github.com/BornaIz/Lalezar;
     description = "A multi-script display typeface for popular culture";
     license = licenses.ofl;

--- a/pkgs/data/fonts/lato/default.nix
+++ b/pkgs/data/fonts/lato/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 fetchzip {
   name = "lato-2.0";
@@ -12,7 +12,7 @@ fetchzip {
 
   sha256 = "1amwn6vcaggxrd2s4zw21s2pr47zmzdf2xfy4x9lxa2cd9bkhvg5";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = http://www.latofonts.com/;
 
     description = ''

--- a/pkgs/data/fonts/liberastika/default.nix
+++ b/pkgs/data/fonts/liberastika/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchzip}:
+{ lib, fetchzip }:
 
 let
   version = "1.1.5";
@@ -15,7 +15,7 @@ in fetchzip rec {
 
   sha256 = "1a9dvl1pzch2vh8sqyyn1d1wz4n624ffazl6hzlc3s5k5lzrb6jp";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Liberation Sans fork with improved cyrillic support";
     homepage = https://sourceforge.net/projects/lib-ka/;
 

--- a/pkgs/data/fonts/liberation-sans-narrow/default.nix
+++ b/pkgs/data/fonts/liberation-sans-narrow/default.nix
@@ -14,11 +14,8 @@ stdenv.mkDerivation rec {
   buildInputs = [ fontforge pythonPackages.fonttools python ];
 
   installPhase = ''
-    mkdir -p $out/share/fonts/truetype
-    cp -v $(find . -name '*Narrow*.ttf') $out/share/fonts/truetype
-
-    mkdir -p "$out/doc/${pname}-${version}"
-    cp -v AUTHORS ChangeLog COPYING License.txt README "$out/doc/${pname}-${version}" || true
+    find . -name '*Narrow*.ttf' -exec install -m444 -Dt $out/share/fonts/truetype {} \;
+    install -m444 -Dt $out/doc/${pname}-${version} AUTHORS ChangeLog COPYING License.txt README.rst
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/data/fonts/libertinus/default.nix
+++ b/pkgs/data/fonts/libertinus/default.nix
@@ -1,28 +1,22 @@
-{ stdenv, fetchFromGitHub }:
+{ lib, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
-  name = "libertinus-${version}";
+let
   version = "6.6";
+in fetchFromGitHub rec {
+  name = "libertinus-${version}";
 
-  src = fetchFromGitHub {
-    rev    = "v${version}";
-    owner  = "khaledhosny";
-    repo   = "libertinus";
-    sha256 = "0syagjmwy6q1ysncchl9bgyfrm7f6fghj1aipbr6md7l6gafz7ji";
-  };
+  owner  = "khaledhosny";
+  repo   = "libertinus";
+  rev    = "v${version}";
 
-  installPhase = ''
-    mkdir -p $out/share/fonts/opentype/
-    mkdir -p $out/share/doc/${name}/
-    cp *.otf $out/share/fonts/opentype/
-    cp *.txt $out/share/doc/${name}/
+  postFetch = ''
+    tar xf $downloadedFile --strip=1
+    install -m444 -Dt $out/share/fonts/opentype *.otf
+    install -m444 -Dt $out/share/doc/${name}    *.txt
   '';
+  sha256 = "11pxb2zwvjlk06zbqrfv2pgwsl4awf68fak1ks4881i8xbl1910m";
 
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-  outputHash = "11pxb2zwvjlk06zbqrfv2pgwsl4awf68fak1ks4881i8xbl1910m";
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A fork of the Linux Libertine and Linux Biolinum fonts";
     longDescription = ''
       Libertinus fonts is a fork of the Linux Libertine and Linux Biolinum fonts

--- a/pkgs/data/fonts/libre-baskerville/default.nix
+++ b/pkgs/data/fonts/libre-baskerville/default.nix
@@ -1,19 +1,21 @@
-{ stdenv, fetchzip }:
+{ lib, fetchFromGitHub }:
 
-fetchzip rec {
+fetchFromGitHub rec {
   name = "libre-baskerville-1.000";
 
-  url = https://github.com/impallari/Libre-Baskerville/archive/2fba7c8e0a8f53f86efd3d81bc4c63674b0c613f.zip;
+  owner = "impallari";
+  repo = "Libre-Baskerville";
+  rev = "2fba7c8e0a8f53f86efd3d81bc4c63674b0c613f";
 
   postFetch = ''
-    mkdir -p $out/share/{doc,fonts}
-    unzip    -j $downloadedFile \*.ttf                    -d $out/share/fonts/truetype
-    unzip -n -j $downloadedFile \*README.md \*FONTLOG.txt -d "$out/share/doc/${name}"
+    tar xf $downloadedFile --strip=1
+    install -m444 -Dt $out/share/fonts/truetype *.ttf
+    install -m444 -Dt $out/share/doc/${name}    README.md FONTLOG.txt
   '';
 
-  sha256 = "0arlq89b3vmpw3n4wbllsdvqblhz6p09dm19z1cndicmcgk26w2a";
+  sha256 = "1kpji85d1mgwq8b4fh1isznrhsrv32la3wf058rwjmhx5a3l7yaj";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A webfont family optimized for body text";
     longDescription = ''
       Libre Baskerville is a webfont family optimized for body text. It's Based

--- a/pkgs/data/fonts/libre-bodoni/default.nix
+++ b/pkgs/data/fonts/libre-bodoni/default.nix
@@ -1,19 +1,21 @@
-{ stdenv, fetchzip }:
+{ lib, fetchFromGitHub }:
 
-fetchzip rec {
+fetchFromGitHub rec {
   name = "libre-bodoni-2.000";
 
-  url = https://github.com/impallari/Libre-Bodoni/archive/995a40e8d6b95411d660cbc5bb3f726ffd080c7d.zip;
+  owner = "impallari";
+  repo = "Libre-Bodoni";
+  rev = "995a40e8d6b95411d660cbc5bb3f726ffd080c7d";
 
   postFetch = ''
-    mkdir -p $out/share/{doc,fonts}
-    unzip -j $downloadedFile \*/v2000\ -\ initial\ glyphs\ migration/OTF/\*.otf  -d $out/share/fonts/opentype
-    unzip -j $downloadedFile \*README.md \*FONTLOG.txt                           -d "$out/share/doc/${name}"
+    tar xf $downloadedFile --strip=1
+    install -m444 -Dt $out/share/fonts/opentype */v2000\ -\ initial\ glyphs\ migration/OTF/*.otf
+    install -m444 -Dt $out/share/doc/${name}    README.md FONTLOG.txt
   '';
 
-  sha256 = "0pnb1xydpvcl9mkz095f566kz7yj061wbf40rwrbwmk706f6bsiw";
+  sha256 = "0my0i5a7f0d27m6dcdirjmlcnswqqfp8gl3ccxa5f2wkn3qlzkvz";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Bodoni fonts adapted for today's web requirements";
     longDescription = ''
       The Libre Bodoni fonts are based on the 19th century Morris Fuller

--- a/pkgs/data/fonts/libre-franklin/default.nix
+++ b/pkgs/data/fonts/libre-franklin/default.nix
@@ -1,19 +1,21 @@
-{ stdenv, fetchzip }:
+{ lib, fetchFromGitHub }:
 
-fetchzip rec {
+fetchFromGitHub rec {
   name = "libre-franklin-1.014";
 
-  url = https://github.com/impallari/Libre-Franklin/archive/006293f34c47bd752fdcf91807510bc3f91a0bd3.zip;
+  owner = "impallari";
+  repo = "Libre-Franklin";
+  rev = "006293f34c47bd752fdcf91807510bc3f91a0bd3";
 
   postFetch = ''
-    mkdir -p $out/share/{doc,fonts}
-    unzip -j $downloadedFile \*.otf                    -d $out/share/fonts/opentype
-    unzip -j $downloadedFile \*README.md \*FONTLOG.txt -d "$out/share/doc/${name}"
+    tar xf $downloadedFile --strip=1
+    install -m444 -Dt $out/share/fonts/opentype */OTF/*.otf
+    install -m444 -Dt $out/share/doc/${name}    README.md FONTLOG.txt
   '';
 
-  sha256 = "1rkjp8x62cn4alw3lp7m45q34bih81j2hg15kg5c1nciyqq1qz0z";
+  sha256 = "0aq280m01pbirkzga432340aknf2m5ggalw0yddf40sqz7falykf";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A reinterpretation and expansion based on the 1912 Morris Fuller Benton’s classic.";
     homepage = https://github.com/impallari/Libre-Franklin;
     license = licenses.ofl;

--- a/pkgs/data/fonts/lm-math/default.nix
+++ b/pkgs/data/fonts/lm-math/default.nix
@@ -1,26 +1,20 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
-stdenv.mkDerivation rec {
-  name = "latinmodern-math-${version}";
+let
   version = "1.959";
+in fetchzip rec {
+  name = "latinmodern-math-${version}";
 
-  src = fetchzip {
-    url = "www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip";
-    sha256 = "15l3lxjciyjmbh0q6jjvzz16ibk4ij79in9fs47qhrfr2wrddpvs";
-  };
-
-  installPhase = ''
+  url = "http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip";
+  postFetch = ''
     mkdir -p $out/share/fonts/opentype/
     mkdir -p $out/share/doc/${name}/
-    cp otf/*.otf $out/share/fonts/opentype/
-    cp doc/*.txt $out/share/doc/${name}/
+    unzip -f $downloadedFile otf/*.otf -d $out/share/fonts/opentype/
+    unzip -f $downloadedFile doc/*.txt -d $out/share/doc/${name}/
   '';
+  sha256 = "05k145bxgxjh7i9gx1ahigxfpc2v2vwzsy2mc41jvvg51kjr8fnn";
 
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-  outputHash = "05k145bxgxjh7i9gx1ahigxfpc2v2vwzsy2mc41jvvg51kjr8fnn";
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "The Latin Modern Math (LM Math) font completes the modernization of the Computer Modern family of typefaces designed and programmed by Donald E. Knuth.";
     homepage = http://www.gust.org.pl/projects/e-foundry/lm-math;
     # "The Latin Modern Math font is licensed under the GUST Font License (GFL),

--- a/pkgs/data/fonts/lmodern/default.nix
+++ b/pkgs/data/fonts/lmodern/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 fetchzip {
   name = "lmodern-2.004.5";
@@ -21,7 +21,6 @@ fetchzip {
 
   meta = {
     description = "Latin Modern font";
-    platforms = stdenv.lib.platforms.unix;
   };
 }
 

--- a/pkgs/data/fonts/lmodern/lmmath.nix
+++ b/pkgs/data/fonts/lmodern/lmmath.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 fetchzip {
   name = "lmmath-0.903";
@@ -21,7 +21,6 @@ fetchzip {
 
   meta = {
     description = "Latin Modern font";
-    platforms = stdenv.lib.platforms.unix;
   };
 }
 

--- a/pkgs/data/fonts/lobster-two/default.nix
+++ b/pkgs/data/fonts/lobster-two/default.nix
@@ -70,10 +70,11 @@ in
     outputHash = "0if9l8pzwgfnbdjg5yblcy08dwn9yj3wzz29l0fycia46xlzd4ym";
 
     meta = with stdenv.lib; {
-      homepage = http://www.impallari.com/lobstertwo;
+      homepage = https://github.com/librefonts/lobstertwo;
       description = "Script font with many ligatures";
       license = licenses.ofl;
       platforms = platforms.all;
       maintainers = [maintainers.rycee];
+      broken = true; # googlecode.com RIP; can be built from sources
     };
   }

--- a/pkgs/data/fonts/lohit-fonts/default.nix
+++ b/pkgs/data/fonts/lohit-fonts/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, lib }:
+{ fetchzip, lib }:
 let
   fonts = {
     assamese        = { label = "Assamese";          version = "2.91.5"; sha256 = "06cw416kgw0m6883n5ixmpniinsd747rdmacf06z83w1hqwj2js6"; };
@@ -51,7 +51,6 @@ let
       # Set a non-zero priority to allow easy overriding of the
       # fontconfig configuration files.
       priority = 5;
-      platforms = stdenv.lib.platforms.unix;
     };
   };
 

--- a/pkgs/data/fonts/manrope/default.nix
+++ b/pkgs/data/fonts/manrope/default.nix
@@ -1,19 +1,19 @@
-{ stdenv, fetchFromGitHub }:
+{ lib, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
+let
   pname = "manrope";
   version = "3";
-  src = fetchFromGitHub {
-    owner = "sharanda";
-    repo = pname;
-    rev = "3bd68c0c325861e32704470a90dfc1868a5c37e9";
-    sha256 = "1k6nmczbl97b9j2a8vx6a1r3q4gd1c2qydv0y9gn8xyl7x8fcvhs";
-  };
-  dontBuild = true;
-  installPhase = ''
+in fetchFromGitHub {
+  name = "${pname}-${version}";
+  owner = "sharanda";
+  repo = pname;
+  rev = "3bd68c0c325861e32704470a90dfc1868a5c37e9";
+  sha256 = "1h4chkfbp75hrrqqarf28ld4yb7hfrr7q4w5yz96ivg94lbwlnld";
+  postFetch = ''
+    tar xf $downloadedFile --strip=1
     install -Dm644 -t $out/share/fonts/opentype "desktop font"/*
   '';
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Open-source modern sans-serif font family";
     homepage = https://github.com/sharanda/manrope;
     license = licenses.ofl;

--- a/pkgs/data/fonts/marathi-cursive/default.nix
+++ b/pkgs/data/fonts/marathi-cursive/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, p7zip }:
+{ lib, fetchzip, p7zip }:
 
 let
   version = "1.2";
@@ -11,15 +11,13 @@ in fetchzip rec {
     ${p7zip}/bin/7z x $downloadedFile
     cd MarathiCursive
 
-    mkdir -p $out/share/fonts/marathi-cursive
-    cp -v *.otf *.ttf $out/share/fonts/marathi-cursive
-    mkdir -p $out/share/doc/${name}
-    cp -v README *.txt $out/share/doc/${name}
+    install -m444 -Dt $out/share/fonts/marathi-cursive *.otf *.ttf
+    install -m444 -Dt $out/share/doc/${name}           README *.txt
   '';
 
-  sha256 = "0fhz2ixrkm523qlx5pnwyzxgb1cfiiwrhls98xg8a5l3sypn1g8v";
+  sha256 = "0wq4w79x8r5w6ikm9amcmapf0jcdgifs9zf1pbnw3fk4ncz5s551";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://github.com/MihailJP/MarathiCursive;
     description = "Modi script font with Graphite and OpenType support";
     maintainers = with maintainers; [ mathnerd314 ];

--- a/pkgs/data/fonts/material-design-icons/default.nix
+++ b/pkgs/data/fonts/material-design-icons/default.nix
@@ -1,17 +1,15 @@
-{ stdenv, fetchFromGitHub }:
+{ lib, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
-  name = "material-design-icons-${version}";
+let
   version = "3.3.92";
+in fetchFromGitHub {
+  name = "material-design-icons-${version}";
+  owner  = "Templarian";
+  repo   = "MaterialDesign-Webfont";
+  rev    = "v${version}";
 
-  src = fetchFromGitHub {
-    owner  = "Templarian";
-    repo   = "MaterialDesign-Webfont";
-    rev    = "v${version}";
-    sha256 = "0k8pv2nsp3al4i4awx5mv7cscpm8akjn567jl9dwzangcsai0l53";
-  };
-
-  installPhase = ''
+  postFetch = ''
+    tar xf $downloadedFile --strip=1
     mkdir -p $out/share/fonts/{eot,svg,truetype,woff,woff2}
     cp fonts/*.eot $out/share/fonts/eot/
     cp fonts/*.svg $out/share/fonts/svg/
@@ -19,8 +17,9 @@ stdenv.mkDerivation rec {
     cp fonts/*.woff $out/share/fonts/woff/
     cp fonts/*.woff2 $out/share/fonts/woff2/
   '';
+  sha256 = "0dbm4qfd0b91yrw3cv4i377pnm98fgj936nk1m5wlx8mx8jahz48";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "3200+ Material Design Icons from the Community";
     longDescription = ''
       Material Design Icons' growing icon collection allows designers and

--- a/pkgs/data/fonts/material-icons/default.nix
+++ b/pkgs/data/fonts/material-icons/default.nix
@@ -1,22 +1,22 @@
-{ stdenv, fetchFromGitHub }:
+{ lib, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
-  name = "material-icons-${version}";
+let
   version = "3.0.1";
+in fetchFromGitHub {
+  name = "material-icons-${version}";
 
-  src = fetchFromGitHub {
-    owner  = "google";
-    repo   = "material-design-icons";
-    rev    = "${version}";
-    sha256 = "17q5brcqyyc8gbjdgpv38p89s60cwxjlwy2ljnrvas5cj0s62np0";
-  };
+  owner  = "google";
+  repo   = "material-design-icons";
+  rev    = version;
 
-  buildCommand = ''
+  postFetch = ''
+    tar xf $downloadedFile --strip=1
     mkdir -p $out/share/fonts/truetype
-    cp $src/iconfont/*.ttf $out/share/fonts/truetype
+    cp iconfont/*.ttf $out/share/fonts/truetype
   '';
+  sha256 = "1syy6v941lb8nqxhdf7mfx28v05lwrfnq53r3c1ym13x05l9kchp";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "System status icons by Google, featuring material design";
     homepage = https://material.io/icons;
     license = licenses.asl20;

--- a/pkgs/data/fonts/medio/default.nix
+++ b/pkgs/data/fonts/medio/default.nix
@@ -1,4 +1,4 @@
-{ stdenv,  fetchzip }:
+{ lib, fetchzip }:
 
 let
   majorVersion = "0";
@@ -17,7 +17,7 @@ fetchzip rec {
     unzip -j $downloadedFile \*.otf  -d $out/share/fonts/opentype/${pname}
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "http://dotcolon.net/font/${pname}/";
     description = "Serif font designed by Sora Sagano";
     longDescription = ''

--- a/pkgs/data/fonts/migmix/default.nix
+++ b/pkgs/data/fonts/migmix/default.nix
@@ -26,8 +26,7 @@ stdenv.mkDerivation rec {
   unpackPhase = ":";
 
   installPhase = ''
-    mkdir -p $out/share/fonts/truetype/migmix
-    find $srcs -name '*.ttf' | xargs install -m644 --target $out/share/fonts/truetype/migmix
+    find $srcs -name '*.ttf' -exec install -m644 -Dt $out/share/fonts/truetype/migmix {} \;
   '';
 
   outputHashAlgo = "sha256";
@@ -38,7 +37,6 @@ stdenv.mkDerivation rec {
     description = "A high-quality Japanese font based on M+ fonts and IPA fonts";
     homepage = http://mix-mplus-ipa.osdn.jp/migmix;
     license = licenses.ipa;
-    platforms = platforms.unix;
     maintainers = [ maintainers.mikoim ];
   };
 }

--- a/pkgs/data/fonts/migu/default.nix
+++ b/pkgs/data/fonts/migu/default.nix
@@ -37,7 +37,6 @@ stdenv.mkDerivation rec {
     description = "A high-quality Japanese font based on modified M+ fonts and IPA fonts";
     homepage = http://mix-mplus-ipa.osdn.jp/migu/;
     license = licenses.ipa;
-    platforms = platforms.unix;
     maintainers = [ maintainers.mikoim ];
   };
 }

--- a/pkgs/data/fonts/mononoki/default.nix
+++ b/pkgs/data/fonts/mononoki/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let
   version = "1.2";
@@ -14,7 +14,7 @@ in fetchzip {
 
   sha256 = "19y4xg7ilm21h9yynyrwcafdqn05zknpmmjrb37qim6p0cy2glff";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://github.com/madmalik/mononoki;
     description = "A font for programming and code review";
     license = licenses.ofl;

--- a/pkgs/data/fonts/montserrat/default.nix
+++ b/pkgs/data/fonts/montserrat/default.nix
@@ -2,7 +2,7 @@
 #
 # https://aur.archlinux.org/packages/ttf-montserrat/
 
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let
   version = "1.0";
@@ -19,7 +19,7 @@ in fetchzip {
 
   sha256 = "11sdgvhaqg59mq71aqwqp2mb428984hjxy7hd1vasia9kgk8259w";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A geometric sans serif font with extended latin support (Regular, Alternates, Subrayada)";
     homepage    = "https://www.fontspace.com/julieta-ulanovsky/montserrat";
     license     = licenses.ofl;

--- a/pkgs/data/fonts/mph-2b-damase/default.nix
+++ b/pkgs/data/fonts/mph-2b-damase/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchzip}:
+{ lib, fetchzip }:
 
 fetchzip {
   name = "MPH-2B-Damase-2";
@@ -13,6 +13,5 @@ fetchzip {
   sha256 = "0yzf12z6fpbgycqwiz88f39iawdhjabadfa14wxar3nhl9n434ql";
 
   meta = {
-    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/data/fonts/mplus-outline-fonts/default.nix
+++ b/pkgs/data/fonts/mplus-outline-fonts/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let
   version = "063";
@@ -15,7 +15,7 @@ in fetchzip rec {
 
   sha256 = "0d485l2ihxfk039rrrnfviamlbj13cwky0c752m4ikwvgiqiq94y";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "M+ Outline Fonts";
     homepage = http://mplus-fonts.sourceforge.jp/mplus-outline-fonts/index-en.html;
     license = licenses.mit;

--- a/pkgs/data/fonts/mro-unicode/default.nix
+++ b/pkgs/data/fonts/mro-unicode/default.nix
@@ -3,7 +3,7 @@
 fetchzip {
   name = "mro-unicode-2013-05-25";
 
-  url = "https://github.com/phjamr/MroUnicode/raw/master/MroUnicode-Regular.ttf";
+  url = "https://github.com/phjamr/MroUnicode/raw/f297de070f7eba721a47c850e08efc119d3bfbe8/MroUnicode-Regular.ttf";
 
   postFetch = "install -Dm644 $downloadedFile $out/share/fonts/truetype/MroUnicode-Regular.ttf";
 

--- a/pkgs/data/fonts/nahid-fonts/default.nix
+++ b/pkgs/data/fonts/nahid-fonts/default.nix
@@ -1,22 +1,21 @@
-{ stdenv, fetchFromGitHub }:
+{ lib, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
+let
   pname = "nahid-fonts";
   version = "0.3.0";
+in fetchFromGitHub {
+  name = "${pname}-${version}";
+  owner = "rastikerdar";
+  repo = "nahid-font";
+  rev = "v${version}";
 
-  src = fetchFromGitHub {
-    owner = "rastikerdar";
-    repo = "nahid-font";
-    rev = "v${version}";
-    sha256 = "0n42sywi41zin9dilr8vabmcqvmx2f1a8b4yyybs6ms9zb9xdkxg";
-  };
-
-  installPhase = ''
-    mkdir -p $out/share/fonts/nahid-fonts
-    cp -v $( find . -name '*.ttf') $out/share/fonts/nahid-fonts
+  postFetch = ''
+    tar xf $downloadedFile --strip=1
+    find . -name '*.ttf' -exec install -m444 -Dt $out/share/fonts/nahid-fonts {} \;
   '';
+  sha256 = "0df169sibq14j2mj727sq86c00jm1nz8565v85hkvh4zgz2plb7c";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://github.com/rastikerdar/nahid-font;
     description = "A Persian (Farsi) Font - قلم (فونت) فارسی ناهید";
     license = licenses.free;

--- a/pkgs/data/fonts/nanum-gothic-coding/default.nix
+++ b/pkgs/data/fonts/nanum-gothic-coding/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, unzip}:
+{ lib, fetchzip }:
 
 let
   version = "VER2.5";
@@ -15,7 +15,7 @@ in fetchzip rec {
 
   sha256 = "0b3pkhd6xn6393zi0dhj3ah08w1y1ji9fl6584bi0c8lanamf2pc";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A contemporary monospaced sans-serif typeface with a warm touch";
     homepage = https://github.com/naver/nanumfont;
     license = licenses.ofl;

--- a/pkgs/data/fonts/nerdfonts/default.nix
+++ b/pkgs/data/fonts/nerdfonts/default.nix
@@ -30,7 +30,6 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/ryanoasis/nerd-fonts;
     license = licenses.mit;
     maintainers = with maintainers; [ garbas ];
-    platforms = with platforms; unix;
     hydraPlatforms = []; # 'Output limit exceeded' on Hydra
   };
 }

--- a/pkgs/data/fonts/nika-fonts/default.nix
+++ b/pkgs/data/fonts/nika-fonts/default.nix
@@ -1,22 +1,21 @@
-{ stdenv, fetchFromGitHub }:
+{ lib, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
+let
   pname = "nika-fonts";
   version = "1.0.0";
+in fetchFromGitHub rec {
+  name = "${pname}-${version}";
+  owner = "font-store";
+  repo = "NikaFont";
+  rev = "v${version}";
 
-  src = fetchFromGitHub {
-    owner = "font-store";
-    repo = "NikaFont";
-    rev = "v${version}";
-    sha256 = "16dhk87vmjnywl5wqsl9dzp12ddpfk57w08f7811m3ijqadscdwc";
-  };
-
-  installPhase = ''
-    mkdir -p $out/share/fonts/nika-fonts
-    cp -v $( find . -name '*.ttf') $out/share/fonts/nika-fonts
+  postFetch = ''
+    tar xf $downloadedFile --strip=1
+    find . -name '*.ttf' -exec install -m444 -Dt $out/share/fonts/nika-fonts {} \;
   '';
+  sha256 = "1x34b2dqn1dymi1vmj5vrjcy2z8s0f3rr6cniyrz85plvid6x40i";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://github.com/font-store/NikaFont/;
     description = "Persian/Arabic Open Source Font";
     license = licenses.ofl;

--- a/pkgs/data/fonts/norwester/default.nix
+++ b/pkgs/data/fonts/norwester/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let
   version = "1.2";
@@ -15,7 +15,7 @@ in fetchzip rec {
 
   sha256 = "1npsaiiz9g5z6315lnmynwcnrfl37fyxc7w1mhkw1xbzcnv74z4r";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = http://jamiewilson.io/norwester;
     description = "A condensed geometric sans serif by Jamie Wilson";
     maintainers = with maintainers; [ leenaars ];

--- a/pkgs/data/fonts/noto-fonts/tools.nix
+++ b/pkgs/data/fonts/noto-fonts/tools.nix
@@ -27,6 +27,5 @@ pythonPackages.buildPythonPackage rec {
     description = "Noto fonts support tools and scripts plus web site generation";
     license = lib.licenses.asl20;
     homepage = https://github.com/googlei18n/nototools;
-    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/data/fonts/office-code-pro/default.nix
+++ b/pkgs/data/fonts/office-code-pro/default.nix
@@ -1,26 +1,23 @@
-{ stdenv, fetchFromGitHub }:
+{ lib, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
+let
   pname = "office-code-pro";
   version = "1.004";
+in fetchFromGitHub rec {
+  name = "${pname}-${version}";
 
-  src = fetchFromGitHub {
-    owner = "nathco";
-    repo = "Office-Code-Pro";
-    rev = version;
-    sha256 = "0znmjjyn5q83chiafy252bhsmw49r2nx2ls2cmhjp4ihidfr6cmb";
-  };
+  owner = "nathco";
+  repo = "Office-Code-Pro";
+  rev = version;
 
-  installPhase = ''
-    fontDir=$out/share/fonts/opentype
-    docDir=$out/share/doc/${pname}-${version}
-    mkdir -p $fontDir $docDir
-    install -Dm644 README.md $docDir
-    install -t $fontDir -m644 'Fonts/Office Code Pro/OTF/'*.otf
-    install -t $fontDir -m644 'Fonts/Office Code Pro D/OTF/'*.otf
+  postFetch = ''
+    tar xf $downloadedFile --strip=1
+    install -m644 -Dt $out/share/doc/${name} README.md
+    install -m444 -Dt $out/share/fonts/opentype 'Fonts/Office Code Pro/OTF/'*.otf 'Fonts/Office Code Pro D/OTF/'*.otf
   '';
+  sha256 = "1bagwcaicn6q8qkqazz6wb3x30y4apmkga0mkv8fh6890hfhywr9";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A customized version of Source Code Pro";
     longDescription = ''
       Office Code Pro is a customized version of Source Code Pro, the monospaced
@@ -31,6 +28,5 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/nathco/Office-Code-Pro;
     license = licenses.ofl;
     maintainers = [ maintainers.AndersonTorres ];
-    platforms = platforms.unix;
   };
 }

--- a/pkgs/data/fonts/oldsindhi/default.nix
+++ b/pkgs/data/fonts/oldsindhi/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip, p7zip }:
+{ lib, fetchzip, p7zip }:
 
 let
   version = "0.1";
@@ -10,15 +10,13 @@ in fetchzip rec {
   postFetch = ''
     ${p7zip}/bin/7z x $downloadedFile
 
-    mkdir -p $out/share/fonts/truetype
-    mkdir -p $out/share/doc/${name}
-    cp -v OldSindhi/*.ttf $out/share/fonts/truetype/
-    cp -v OldSindhi/README OldSindhi/*.txt $out/share/doc/${name}
+    install -m444 -Dt $out/share/fonts/truetype OldSindhi/*.ttf
+    install -m444 -Dt $out/share/doc/${name}    OldSindhi/README OldSindhi/*.txt
   '';
 
-  sha256 = "1na3lxyz008fji5ln3fqzyr562k6kch1y824byhfs4y0rwwz3f3q";
+  sha256 = "0d4l9cg2vmh2pvnqsla8mgcwvc7wjxzcabhlli6633h3ifj2yp7b";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://github.com/MihailJP/oldsindhi;
     description = "Free Sindhi Khudabadi font";
     maintainers = with maintainers; [ mathnerd314 ];

--- a/pkgs/data/fonts/oldstandard/default.nix
+++ b/pkgs/data/fonts/oldstandard/default.nix
@@ -1,29 +1,21 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
-stdenv.mkDerivation rec {
-  name = "oldstandard-${version}";
+let
   version = "2.2";
+in fetchzip rec {
+  name = "oldstandard-${version}";
 
-  src = fetchzip {
-    stripRoot = false;
-    url = "https://github.com/akryukov/oldstand/releases/download/v${version}/${name}.otf.zip";
-    sha256 = "1hl78jw5szdjq9dhbcv2ln75wpp2lzcxrnfc36z35v5wk4l7jc3h";
-  };
+  url = "https://github.com/akryukov/oldstand/releases/download/v${version}/${name}.otf.zip";
 
-  phases = [ "unpackPhase" "installPhase" ];
-
-  installPhase = ''
-    mkdir -p $out/share/fonts/opentype
-    mkdir -p $out/share/doc/${name}
-    cp -v *.otf $out/share/fonts/opentype/
-    cp -v FONTLOG.txt $out/share/doc/${name}
+  postFetch = ''
+    unzip $downloadedFile
+    install -m444 -Dt $out/share/fonts/opentype *.otf
+    install -m444 -Dt $out/share/doc/${name}    FONTLOG.txt
   '';
 
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-  outputHash = "1qwfsyp51grr56jcnkkmnrnl3r20pmhp9zh9g88kp64m026cah6n";
+  sha256 = "1qwfsyp51grr56jcnkkmnrnl3r20pmhp9zh9g88kp64m026cah6n";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://github.com/akryukov/oldstand;
     description = "An attempt to revive a specific type of Modern style of serif typefaces";
     maintainers = with maintainers; [ raskin rycee ];

--- a/pkgs/data/fonts/open-dyslexic/default.nix
+++ b/pkgs/data/fonts/open-dyslexic/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchzip}:
+{ lib, fetchzip }:
 
 let
   version = "2016-06-23";
@@ -15,7 +15,7 @@ in fetchzip {
 
   sha256 = "1vl8z5rknh2hpr2f0v4b2qgs5kclx5pzyk8al7243k5db82a2cyi";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://opendyslexic.org/;
     description = "Font created to increase readability for readers with dyslexia";
     license = "Bitstream Vera License (https://www.gnome.org/fonts/#Final_Bitstream_Vera_Fonts)";

--- a/pkgs/data/fonts/open-sans/default.nix
+++ b/pkgs/data/fonts/open-sans/default.nix
@@ -1,25 +1,23 @@
-{ stdenv, fetchFromGitLab }:
+{ lib, fetchFromGitLab }:
 
-stdenv.mkDerivation rec {
+let
   pname = "open-sans";
   version = "1.11";
+in fetchFromGitLab rec {
+  name = "${pname}-${version}";
 
-  src = fetchFromGitLab {
-    domain = "salsa.debian.org";
-    owner = "fonts-team";
-    repo = "fonts-open-sans";
-    rev = "debian%2F1.11-1"; # URL-encoded form of "debian/1.11-1" tag
-    sha256 = "077hkvpmk3ghbqyb901w43b2m2a27lh8ddasyx1x7pdwyr2bjjl2";
-  };
-
-  dontBuild = true;
-
-  installPhase = ''
+  domain = "salsa.debian.org";
+  owner = "fonts-team";
+  repo = "fonts-open-sans";
+  rev = "debian%2F1.11-1"; # URL-encoded form of "debian/1.11-1" tag
+  postFetch = ''
+    tar xf $downloadedFile --strip=1
     mkdir -p $out/share/fonts/truetype
     cp *.ttf $out/share/fonts/truetype
   '';
+  sha256 = "146ginwx18z624z582lrnhil8jvi9bjg6843265bgxxrfmf75vhp";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Open Sans fonts";
     longDescription = ''
       Open Sans is a humanist sans serif typeface designed by Steve Matteson,

--- a/pkgs/data/fonts/orbitron/default.nix
+++ b/pkgs/data/fonts/orbitron/default.nix
@@ -1,23 +1,23 @@
-{ stdenv, fetchzip }:
+{ lib, fetchFromGitHub }:
 
 let
   version = "20110526";
-in fetchzip {
+in fetchFromGitHub {
   name = "orbitron-${version}";
 
-  url = https://github.com/theleagueof/orbitron/archive/13e6a52.zip;
+  owner = "theleagueof";
+  repo = "orbitron";
+  rev = "13e6a52";
 
   postFetch = ''
-    otfdir=$out/share/fonts/opentype/orbitron
-    ttfdir=$out/share/fonts/ttf/orbitron
-    mkdir -p $otfdir $ttfdir
-    unzip -j $downloadedFile \*/Orbitron\*.otf -d $otfdir
-    unzip -j $downloadedFile \*/Orbitron\*.ttf -d $ttfdir
+    tar xf $downloadedFile --strip=1
+    install -m444 -Dt $out/share/fonts/opentype/orbitron *.otf
+    install -m444 -Dt $out/share/fonts/ttf/orbitron      *.ttf
   '';
 
   sha256 = "1y9yzvpqs2v3ssnqk2iiglrh8amgsscnk8vmfgnqgqi9f4dhdvnv";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://www.theleagueofmoveabletype.com/orbitron;
     downloadPage = "https://www.theleagueofmoveabletype.com/orbitron/download";
     description = ''

--- a/pkgs/data/fonts/overpass/default.nix
+++ b/pkgs/data/fonts/overpass/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let
   version = "3.0.3";
@@ -14,7 +14,7 @@ in fetchzip rec {
 
   sha256 = "1m6p7rrlyqikjvypp4698sn0lp3a4z0z5al4swblfhg8qaxzv5pg";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = http://overpassfont.org/;
     description = "Font heavily inspired by Highway Gothic";
     license = licenses.ofl;

--- a/pkgs/data/fonts/oxygenfonts/default.nix
+++ b/pkgs/data/fonts/oxygenfonts/default.nix
@@ -1,18 +1,21 @@
-{ stdenv, fetchzip }:
+{ lib, fetchFromGitHub }:
 
-fetchzip rec {
+fetchFromGitHub {
   name = "oxygenfonts-20160824";
 
-  url = https://github.com/vernnobile/oxygenFont/archive/62db0ebe3488c936406685485071a54e3d18473b.zip;
+  owner = "vernnobile";
+  repo = "oxygenFont";
+  rev = "62db0ebe3488c936406685485071a54e3d18473b";
 
   postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile '*/Oxygen-Sans.ttf' '*/Oxygen-Sans-Bold.ttf' '*/OxygenMono-Regular.ttf' -d $out/share/fonts/truetype
+    tar xf $downloadedFile --strip=1
+    mkdir -p $out/share/fonts/truetype
+    cp */Oxygen-Sans.ttf */Oxygen-Sans-Bold.ttf */OxygenMono-Regular.ttf $out/share/fonts/truetype
   '';
 
   sha256 = "17m86p1s7a7d90zqjsr46h5bpmas4vxsgj7kd0j5c8cb7lw92jyf";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Desktop/gui font for integrated use with the KDE desktop";
     longDescription = ''
       Oxygen Font is a font family originally aimed as a desktop/gui

--- a/pkgs/data/fonts/parastoo-fonts/default.nix
+++ b/pkgs/data/fonts/parastoo-fonts/default.nix
@@ -1,22 +1,22 @@
-{ stdenv, fetchFromGitHub }:
+{ lib, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
+let
   pname = "parastoo-fonts";
   version = "1.0.0-alpha5";
+in fetchFromGitHub rec {
+  name = "${pname}-${version}";
 
-  src = fetchFromGitHub {
-    owner = "rastikerdar";
-    repo = "parastoo-font";
-    rev = "v${version}";
-    sha256 = "1nya9cbbs6sgv2w3zyah3lb1kqylf922q3fazh4l7bi6zgm8q680";
-  };
+  owner = "rastikerdar";
+  repo = "parastoo-font";
+  rev = "v${version}";
 
-  installPhase = ''
-    mkdir -p $out/share/fonts/parastoo-fonts
-    cp -v $( find . -name '*.ttf') $out/share/fonts/parastoo-fonts
+  postFetch = ''
+    tar xf $downloadedFile --strip=1
+    find . -name '*.ttf' -exec install -m444 -Dt $out/share/fonts/parastoo-fonts {} \;
   '';
+  sha256 = "10jbii6rskcy4akjl5yfcqv4mfwk3nqnx36l6sbxks43va9l04f4";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://github.com/rastikerdar/parastoo-font;
     description = "A Persian (Farsi) Font - فونت ( قلم ) فارسی پرستو";
     license = licenses.ofl;

--- a/pkgs/data/fonts/paratype-pt/mono.nix
+++ b/pkgs/data/fonts/paratype-pt/mono.nix
@@ -3,7 +3,10 @@
 fetchzip rec {
   name = "paratype-pt-mono";
 
-  url = "http://www.paratype.ru/uni/public/PTMono.zip";
+  url = [
+    https://company.paratype.com/system/attachments/631/original/ptmono.zip
+    http://rus.paratype.ru/system/attachments/631/original/ptmono.zip
+  ];
 
   postFetch = ''
     mkdir -p $out/share/{doc,fonts}
@@ -14,7 +17,7 @@ fetchzip rec {
   sha256 = "07kl82ngby55khvzsvn831ddpc0q8djgz2y6gsjixkyjfdk2xjjm";
 
   meta = with stdenv.lib; {
-    homepage = http://www.paratype.ru/public/; 
+    homepage = http://www.paratype.ru/public/;
     description = "An open Paratype font";
 
     license = "Open Paratype license";

--- a/pkgs/data/fonts/paratype-pt/sans.nix
+++ b/pkgs/data/fonts/paratype-pt/sans.nix
@@ -3,7 +3,10 @@
 fetchzip rec {
   name = "paratype-pt-sans";
 
-  url = "http://www.paratype.ru/uni/public/PTSans.zip";
+  url = [
+    https://company.paratype.com/system/attachments/629/original/ptsans.zip
+    http://rus.paratype.ru/system/attachments/629/original/ptsans.zip
+  ];
 
   postFetch = ''
     mkdir -p $out/share/{doc,fonts}
@@ -14,7 +17,7 @@ fetchzip rec {
   sha256 = "01fkd417gv98jf3a6zyfi9w2dkqsbddy1vacga2672yf0kh1z1r0";
 
   meta = with stdenv.lib; {
-    homepage = http://www.paratype.ru/public/; 
+    homepage = http://www.paratype.ru/public/;
     description = "An open Paratype font";
 
     license = "Open Paratype license";

--- a/pkgs/data/fonts/paratype-pt/serif.nix
+++ b/pkgs/data/fonts/paratype-pt/serif.nix
@@ -3,7 +3,10 @@
 fetchzip rec {
   name = "paratype-pt-serif";
 
-  url = "http://www.paratype.ru/uni/public/PTSerif.zip";
+  url = [
+    https://company.paratype.com/system/attachments/634/original/ptserif.zip
+    http://rus.paratype.ru/system/attachments/634/original/ptserif.zip
+  ];
 
   postFetch = ''
     mkdir -p $out/share/{doc,fonts}
@@ -14,7 +17,7 @@ fetchzip rec {
   sha256 = "1iw5qi4ag3yp1lwmi91lb18gr768bqwl46xskaqnkhr9i9qp0v6d";
 
   meta = with stdenv.lib; {
-    homepage = http://www.paratype.ru/public/; 
+    homepage = http://www.paratype.ru/public/;
     description = "An open Paratype font";
 
     license = "Open Paratype license";

--- a/pkgs/data/fonts/pecita/default.nix
+++ b/pkgs/data/fonts/pecita/default.nix
@@ -1,9 +1,7 @@
-{ stdenv, fetchurl }:
+{ lib, fetchurl }:
 
 let
-
   version = "5.4";
-
 in
 
 fetchurl rec {
@@ -21,7 +19,7 @@ fetchurl rec {
   recursiveHash = true;
   sha256 = "0pwm20f38lcbfkdqkpa2ydpc9kvmdg0ifc4h2dmipsnwbcb5rfwm";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = http://pecita.eu/police-en.php;
     description = "Handwritten font with connected glyphs";
     license = licenses.ofl;

--- a/pkgs/data/fonts/penna/default.nix
+++ b/pkgs/data/fonts/penna/default.nix
@@ -1,4 +1,4 @@
-{ stdenv,  fetchzip }:
+{ lib, fetchzip }:
 
 let
   majorVersion = "0";
@@ -17,7 +17,7 @@ fetchzip rec {
     unzip -j $downloadedFile \*.otf  -d $out/share/fonts/opentype/${pname}
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "http://dotcolon.net/font/${pname}/";
     description = "Geometric sans serif designed by Sora Sagano";
     longDescription = ''

--- a/pkgs/data/fonts/poly/default.nix
+++ b/pkgs/data/fonts/poly/default.nix
@@ -46,6 +46,5 @@ stdenv.mkDerivation rec {
     homepage = http://www.fontsquirrel.com/fonts/poly;
     license = stdenv.lib.licenses.ofl;
     maintainers = with stdenv.lib.maintainers; [ relrod ];
-    platforms = with stdenv.lib.platforms; linux;
   };
 }

--- a/pkgs/data/fonts/powerline-fonts/default.nix
+++ b/pkgs/data/fonts/powerline-fonts/default.nix
@@ -1,30 +1,24 @@
-{ stdenv, fetchzip}:
+{ lib, fetchFromGitHub }:
 
-fetchzip {
+fetchFromGitHub {
   name = "powerline-fonts-2018-11-11";
 
-  url = https://github.com/powerline/fonts/archive/e80e3eba9091dac0655a0a77472e10f53e754bb0.zip;
+  owner = "powerline";
+  repo = "fonts";
+  rev = "e80e3eba9091dac0655a0a77472e10f53e754bb0";
 
   postFetch = ''
-    mkdir -p $out/share/fonts/opentype
-    unzip -j $downloadedFile '*.otf' -d $out/share/fonts/opentype
-
-    mkdir -p $out/share/fonts/truetype
-    unzip -j $downloadedFile '*.ttf' -d $out/share/fonts/truetype
-
-    mkdir -p $out/share/fonts/bdf
-    unzip -j $downloadedFile '*/BDF/*.bdf' -d $out/share/fonts/bdf
-
-    mkdir -p $out/share/fonts/pcf
-    unzip -j $downloadedFile '*/PCF/*.pcf.gz' -d $out/share/fonts/pcf
-
-    mkdir -p $out/share/fonts/psf
-    unzip -j $downloadedFile '*/PSF/*.psf.gz' -d $out/share/fonts/psf
+    tar xf $downloadedFile --strip=1
+    find . -name '*.otf'    -exec install -Dt $out/share/fonts/opentype {} \;
+    find . -name '*.ttf'    -exec install -Dt $out/share/fonts/truetype {} \;
+    find . -name '*.bdf'    -exec install -Dt $out/share/fonts/bdf      {} \;
+    find . -name '*.pcf.gz' -exec install -Dt $out/share/fonts/pcf      {} \;
+    find . -name '*.psf.gz' -exec install -Dt $out/share/fonts/psf      {} \;
   '';
 
   sha256 = "0irifak86gn7hawzgxcy53s22y215mxc2kjncv37h7q44jsqdqww";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://github.com/powerline/fonts;
     description = "Patched fonts for Powerline users";
     longDescription = ''

--- a/pkgs/data/fonts/profont/default.nix
+++ b/pkgs/data/fonts/profont/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 fetchzip rec {
   name = "profont";
 
-  url = "http://tobiasjung.name/downloadfile.php?file=profont-x11.zip";
+  url = "http://web.archive.org/web/20160707013914/http://tobiasjung.name/downloadfile.php?file=profont-x11.zip";
 
   postFetch = ''
     unzip -j $downloadedFile
@@ -19,10 +19,10 @@ fetchzip rec {
 
   sha256 = "1calqmvrfv068w61f614la8mg8szas6m5i9s0lsmwjhb4qwjyxbw";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = http://tobiasjung.name;
     description = "A monospaced font created to be a most readable font for programming";
-    maintainers = with stdenv.lib.maintainers; [ myrl ];
+    maintainers = with lib.maintainers; [ myrl ];
     license = licenses.mit;
     platforms = platforms.all;
   };

--- a/pkgs/data/fonts/public-sans/default.nix
+++ b/pkgs/data/fonts/public-sans/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let
   version = "1.003";
@@ -14,7 +14,7 @@ in fetchzip rec {
 
   sha256 = "02ranwr1bw4n9n1ljw234nzhj2a0hgradniib37nh10maark5wg3";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A strong, neutral, principles-driven, open source typeface for text or display";
     homepage = https://public-sans.digital.gov/;
     license = licenses.ofl;

--- a/pkgs/data/fonts/quattrocento-sans/default.nix
+++ b/pkgs/data/fonts/quattrocento-sans/default.nix
@@ -1,11 +1,11 @@
-{stdenv, fetchzip}:
+{ lib, fetchzip }:
 
 let
   version = "2.0";
 in fetchzip rec {
   name = "quattrocento-sans-${version}";
 
-  url = "http://www.impallari.com/media/releases/quattrocento-sans-v${version}.zip";
+  url = "http://web.archive.org/web/20170709124317/http://www.impallari.com/media/releases/quattrocento-sans-v${version}.zip";
 
   postFetch = ''
     mkdir -p $out/share/{fonts,doc}
@@ -15,7 +15,7 @@ in fetchzip rec {
 
   sha256 = "0g8hnn92ks4y0jbizwj7yfa097lk887wqkqpqjdmc09sd2n44343";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = http://www.impallari.com/quattrocentosans/;
     description = "A classic, elegant and sober sans-serif typeface";
     license = licenses.ofl;

--- a/pkgs/data/fonts/quattrocento/default.nix
+++ b/pkgs/data/fonts/quattrocento/default.nix
@@ -1,11 +1,11 @@
-{stdenv, fetchzip}:
+{ lib, fetchzip }:
 
 let
   version = "1.1";
 in fetchzip rec {
   name = "quattrocento-${version}";
 
-  url = "http://www.impallari.com/media/releases/quattrocento-v${version}.zip";
+  url = "http://web.archive.org/web/20170707001804/http://www.impallari.com/media/releases/quattrocento-v${version}.zip";
 
   postFetch = ''
     mkdir -p $out/share/{fonts,doc}
@@ -15,7 +15,7 @@ in fetchzip rec {
 
   sha256 = "0f8l19y61y20sszn8ni8h9kgl0zy1gyzychg22z5k93ip4h7kfd0";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = http://www.impallari.com/quattrocento/;
     description = "A classic, elegant, sober and strong serif typeface";
     license = licenses.ofl;

--- a/pkgs/data/fonts/raleway/default.nix
+++ b/pkgs/data/fonts/raleway/default.nix
@@ -1,16 +1,18 @@
-{ stdenv, fetchzip }:
+{ lib, fetchFromGitHub }:
 
 let
   version = "2016-08-30";
-in fetchzip {
+in fetchFromGitHub {
   name = "raleway-${version}";
 
-  url = https://github.com/impallari/Raleway/archive/fa27f47b087fc093c6ae11cfdeb3999ac602929a.zip;
+  owner = "impallari";
+  repo = "Raleway";
+  rev = "fa27f47b087fc093c6ae11cfdeb3999ac602929a";
 
   postFetch = ''
-    mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*-Original.otf  -d $out/share/fonts/opentype
-    unzip -j $downloadedFile \*.txt \*.md     -d $out
+    tar xf $downloadedFile --strip=1
+    find . -name "*-Original.otf" -exec install -Dt $out/share/fonts/opentype {} \;
+    cp *.txt *.md -d $out
   '';
 
   sha256 = "16jr7drqg2wib2q48ajlsa7rh1jxjibl1wd4rjndi49vfl463j60";
@@ -33,8 +35,8 @@ in fetchzip {
     '';
 
     homepage = https://github.com/impallari/Raleway;
-    license = stdenv.lib.licenses.ofl;
+    license = lib.licenses.ofl;
 
-    maintainers = with stdenv.lib.maintainers; [ Profpatsch ];
+    maintainers = with lib.maintainers; [ Profpatsch ];
   };
 }

--- a/pkgs/data/fonts/ricty/default.nix
+++ b/pkgs/data/fonts/ricty/default.nix
@@ -31,7 +31,6 @@ stdenv.mkDerivation rec {
     description = "A high-quality Japanese font based on Inconsolata and Migu 1M";
     homepage = https://www.rs.tus.ac.jp/yyusa/ricty.html;
     license = licenses.unfree;
-    platforms = platforms.unix;
     maintainers = [ maintainers.mikoim ];
   };
 }

--- a/pkgs/data/fonts/roboto/default.nix
+++ b/pkgs/data/fonts/roboto/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let
   version = "2.138";
@@ -22,8 +22,8 @@ in fetchzip rec {
       Chrome OS, and the recommended font for Google’s visual language,
       Material Design.
     '';
-    license = stdenv.lib.licenses.asl20;
-    platforms = stdenv.lib.platforms.all;
-    maintainers = [ stdenv.lib.maintainers.romildo ];
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.romildo ];
   };
 }

--- a/pkgs/data/fonts/rounded-mgenplus/default.nix
+++ b/pkgs/data/fonts/rounded-mgenplus/default.nix
@@ -1,33 +1,19 @@
-{ stdenv, fetchurl, p7zip }:
+{ lib, fetchzip, p7zip }:
 
 let
   pname = "rounded-mgenplus";
   version = "20150602";
-
-in
-
-stdenv.mkDerivation rec {
+in fetchzip rec {
   name = "${pname}-${version}";
-  inherit version;
 
-  src = fetchurl {
-    url = "https://osdn.jp/downloads/users/8/8598/${name}.7z";
-    sha256 = "1k15xvzd3s5ppp151wv31wrfq2ri8v96xh7i71i974rxjxj6gspc";
-  };
-
-  nativeBuildInputs = [ p7zip ];
-
-  phases = [ "unpackPhase" "installPhase" ];
-
-  unpackPhase = ''
-    7z x $src
-  '';
-
-  installPhase = ''
+  url = "https://osdn.jp/downloads/users/8/8598/${name}.7z";
+  postFetch = ''
+    ${p7zip}/bin/7z x $downloadedFile
     install -m 444 -D -t $out/share/fonts/${pname} ${pname}-*.ttf
   '';
+  sha256 = "0vwdknagdrl5dqwpb1x5lxkbfgvbx8dpg7cb6yamgz71831l05v1";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A Japanese font based on Rounded M+ and Noto Sans Japanese";
     homepage = http://jikasei.me/font/rounded-mgenplus/;
     license = licenses.ofl;

--- a/pkgs/data/fonts/route159/default.nix
+++ b/pkgs/data/fonts/route159/default.nix
@@ -1,4 +1,4 @@
-{ stdenv,  fetchzip }:
+{ lib, fetchzip }:
 
 let
   majorVersion = "1";
@@ -17,7 +17,7 @@ fetchzip rec {
     unzip -j $downloadedFile \*.otf  -d $out/share/fonts/opentype/${pname}
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "http://dotcolon.net/font/${pname}/";
     description = "A weighted sans serif font";
     platforms = platforms.all;

--- a/pkgs/data/fonts/sahel-fonts/default.nix
+++ b/pkgs/data/fonts/sahel-fonts/default.nix
@@ -1,22 +1,22 @@
-{ stdenv, fetchFromGitHub }:
+{ lib, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
+let
   pname = "sahel-fonts";
   version = "1.0.0-alpha22";
+in fetchFromGitHub rec {
+  name = "${pname}-${version}";
 
-  src = fetchFromGitHub {
-    owner = "rastikerdar";
-    repo = "sahel-font";
-    rev = "v${version}";
-    sha256 = "1kx7byzb5zxspq0i4cvgf4q7sm6xnhdnfyw9zrb1wfmdv3jzaz7p";
-  };
+  owner = "rastikerdar";
+  repo = "sahel-font";
+  rev = "v${version}";
 
-  installPhase = ''
-    mkdir -p $out/share/fonts/sahel-fonts
-    cp -v $( find . -name '*.ttf') $out/share/fonts/sahel-fonts
+  postFetch = ''
+    tar xf $downloadedFile --strip=1
+    find . -name '*.ttf' -exec install -m444 -Dt $out/share/fonts/sahel-fonts {} \;
   '';
+  sha256 = "0vj8ydv50rjanb0favd7rh4r9rv5fl39vqwvzkpgfdcdawn0xjm7";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://github.com/rastikerdar/sahel-font;
     description = "A Persian (farsi) Font - فونت (قلم) فارسی ساحل";
     license = licenses.ofl;

--- a/pkgs/data/fonts/samim-fonts/default.nix
+++ b/pkgs/data/fonts/samim-fonts/default.nix
@@ -1,22 +1,22 @@
-{ stdenv, fetchFromGitHub }:
+{ lib, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
+let
   pname = "samim-fonts";
   version = "3.1.0";
+in fetchFromGitHub rec {
+  name = "${pname}-${version}";
 
-  src = fetchFromGitHub {
-    owner = "rastikerdar";
-    repo = "samim-font";
-    rev = "v${version}";
-    sha256 = "1mp0pgbn9r098ilajwzag7c21shwb13mq61ly9av0mfbpnhkkjqk";
-  };
+  owner = "rastikerdar";
+  repo = "samim-font";
+  rev = "v${version}";
 
-  installPhase = ''
-    mkdir -p $out/share/fonts/samim-fonts
-    cp -v $( find . -name '*.ttf') $out/share/fonts/samim-fonts
+  postFetch = ''
+    tar xf $downloadedFile --strip=1
+    find . -name '*.ttf' -exec install -m444 -Dt $out/share/fonts/samim-fonts {} \;
   '';
+  sha256 = "0mmhncqg48dp0d7l725dv909zswbkk22dlqzcdfh6k6cgk2gn08q";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://github.com/rastikerdar/samim-font;
     description = "A Persian (Farsi) Font - فونت (قلم) فارسی صمیم";
     license = licenses.ofl;

--- a/pkgs/data/fonts/sarasa-gothic/default.nix
+++ b/pkgs/data/fonts/sarasa-gothic/default.nix
@@ -1,25 +1,21 @@
-{ stdenv, fetchurl, p7zip }:
+{ lib, fetchurl, p7zip }:
 
 let
   version = "0.8.0";
-  sha256 = "0zafvzrh4180hmz351f1rvs29n8mfxf0qv6mdl7psf1f066dizs6";
 in fetchurl rec {
-  inherit sha256;
-
   name = "sarasa-gothic-${version}";
 
   url = "https://github.com/be5invis/Sarasa-Gothic/releases/download/v${version}/sarasa-gothic-ttc-${version}.7z";
+  sha256 = "0zafvzrh4180hmz351f1rvs29n8mfxf0qv6mdl7psf1f066dizs6";
 
   recursiveHash = true;
   downloadToTemp = true;
 
   postFetch = ''
-    ${p7zip}/bin/7z x $downloadedFile
-    mkdir -p $out/share/fonts
-    install -m644 *.ttc $out/share/fonts/
+    ${p7zip}/bin/7z x $downloadedFile -o$out/share/fonts
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "SARASA GOTHIC is a Chinese & Japanese programming font based on Iosevka and Source Han Sans";
     homepage = https://github.com/be5invis/Sarasa-Gothic;
     license = licenses.ofl;

--- a/pkgs/data/fonts/scheherazade/default.nix
+++ b/pkgs/data/fonts/scheherazade/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let
   version = "2.100";
@@ -17,7 +17,7 @@ in fetchzip rec {
 
   sha256 = "1g5f5f9gzamkq3kqyf7vbzvl4rdj3wmjf6chdrbxksrm3rnb926z";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://software.sil.org/scheherazade/;
     description = "A font designed in a similar style to traditional Naskh typefaces";
     longDescription = ''

--- a/pkgs/data/fonts/seshat/default.nix
+++ b/pkgs/data/fonts/seshat/default.nix
@@ -1,4 +1,4 @@
-{ stdenv,  fetchzip }:
+{ lib,  fetchzip }:
 
 let
   majorVersion = "0";
@@ -17,7 +17,7 @@ fetchzip rec {
     unzip -j $downloadedFile \*.otf  -d $out/share/fonts/opentype/${pname}
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "http://dotcolon.net/font/${pname}/";
     description = "Roman body font designed for main text by Sora Sagano";
     longDescription = ''

--- a/pkgs/data/fonts/shabnam-fonts/default.nix
+++ b/pkgs/data/fonts/shabnam-fonts/default.nix
@@ -1,22 +1,22 @@
-{ stdenv, fetchFromGitHub }:
+{ lib, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
-  name = "shabnam-fonts";
+let
+  pname = "shabnam-fonts";
   version = "4.0.0";
+in fetchFromGitHub rec {
+  name = "${pname}-${version}";
 
-  src = fetchFromGitHub {
-    owner = "rastikerdar";
-    repo = "shabnam-font";
-    rev = "v${version}";
-    sha256 = "1y4w16if2y12028b9vyc5l5c5bvcglhxacv380ixb8fcc4hfakmb";
-  };
+  owner = "rastikerdar";
+  repo = "shabnam-font";
+  rev = "v${version}";
 
-  installPhase = ''
-    mkdir -p $out/share/fonts/shabnam-fonts
-    cp -v $( find . -name '*.ttf') $out/share/fonts/shabnam-fonts
+  postFetch = ''
+    tar xf $downloadedFile --strip=1
+    find . -name '*.ttf' -exec install -m444 -Dt $out/share/fonts/shabnam-fonts {} \;
   '';
+  sha256 = "0wfyaaj2pq2knz12l7rsc4wc703cbz0r8gkcya5x69p0aixch8ba";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://github.com/rastikerdar/shabnam-font;
     description = "A Persian (Farsi) Font - فونت (قلم) فارسی شبنم";
     license = licenses.ofl;

--- a/pkgs/data/fonts/shrikhand/default.nix
+++ b/pkgs/data/fonts/shrikhand/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let
   version = "2016-03-03";
@@ -11,7 +11,7 @@ in fetchzip {
 
   sha256 = "0s54k9cs1g2yz6lwg5gakqb12vg5qkfdz3pc8mh7mib2s6q926hs";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://jonpinhorn.github.io/shrikhand/;
     description = "A vibrant and playful typeface for both Latin and Gujarati writing systems";
     maintainers = with maintainers; [ sternenseemann ];

--- a/pkgs/data/fonts/siji/default.nix
+++ b/pkgs/data/fonts/siji/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let
   date = "2016-05-13";
@@ -19,8 +19,8 @@ in fetchzip {
   meta = {
     homepage = https://github.com/stark/siji;
     description = "An iconic bitmap font based on Stlarch with additional glyphs";
-    license = stdenv.lib.licenses.gpl2;
-    platforms = stdenv.lib.platforms.all;
-    maintainers = [ stdenv.lib.maintainers.asymmetric ];
+    license = lib.licenses.gpl2;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.asymmetric ];
   };
 }

--- a/pkgs/data/fonts/source-code-pro/default.nix
+++ b/pkgs/data/fonts/source-code-pro/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let
   version = "2.030";
@@ -16,9 +16,9 @@ in fetchzip {
 
   meta = {
     description = "A set of monospaced OpenType fonts designed for coding environments";
-    maintainers = with stdenv.lib.maintainers; [ relrod ];
-    platforms = with stdenv.lib.platforms; all;
+    maintainers = with lib.maintainers; [ relrod ];
+    platforms = with lib.platforms; all;
     homepage = https://adobe-fonts.github.io/source-code-pro/;
-    license = stdenv.lib.licenses.ofl;
+    license = lib.licenses.ofl;
   };
 }

--- a/pkgs/data/fonts/source-han-code-jp/default.nix
+++ b/pkgs/data/fonts/source-han-code-jp/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let
   pname = "source-han-code-jp";
@@ -17,9 +17,9 @@ in fetchzip {
 
   meta = {
     description = "A monospaced Latin font suitable for coding";
-    maintainers = with stdenv.lib.maintainers; [ mt-caret ];
-    platforms = with stdenv.lib.platforms; all;
+    maintainers = with lib.maintainers; [ mt-caret ];
+    platforms = with lib.platforms; all;
     homepage = https://blogs.adobe.com/CCJKType/2015/06/source-han-code-jp.html;
-    license = stdenv.lib.licenses.ofl;
+    license = lib.licenses.ofl;
   };
 }

--- a/pkgs/data/fonts/source-han-sans/default.nix
+++ b/pkgs/data/fonts/source-han-sans/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchzip}:
+{ lib, fetchzip }:
 
 let
   makePackage = {variant, language, region, sha256}: let
@@ -19,9 +19,8 @@ let
     meta = {
       description = "${language} subset of an open source Pan-CJK sans-serif typeface";
       homepage = https://github.com/adobe-fonts/source-han-sans;
-      license = stdenv.lib.licenses.ofl;
-      platforms = stdenv.lib.platforms.unix;
-      maintainers = with stdenv.lib.maintainers; [ taku0 ];
+      license = lib.licenses.ofl;
+      maintainers = with lib.maintainers; [ taku0 ];
     };
   };
 in

--- a/pkgs/data/fonts/source-han-serif/default.nix
+++ b/pkgs/data/fonts/source-han-serif/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchzip}:
+{ lib, fetchzip }:
 
 let
   makePackage = {variant, language, region, sha256}: let
@@ -19,9 +19,8 @@ let
     meta = {
       description = "${language} subset of an open source Pan-CJK serif typeface";
       homepage = https://github.com/adobe-fonts/source-han-sans;
-      license = stdenv.lib.licenses.ofl;
-      platforms = stdenv.lib.platforms.unix;
-      maintainers = with stdenv.lib.maintainers; [ taku0 ];
+      license = lib.licenses.ofl;
+      maintainers = with lib.maintainers; [ taku0 ];
     };
   };
 in

--- a/pkgs/data/fonts/source-sans-pro/default.nix
+++ b/pkgs/data/fonts/source-sans-pro/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 fetchzip {
   name = "source-sans-pro-2.045";
@@ -14,7 +14,7 @@ fetchzip {
 
   sha256 = "0xjdp226ybdcfylbpfsdgnz2bf4pj4qv1wfs6fv22hjxlzqfixf3";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://adobe-fonts.github.io/source-sans-pro/;
     description = "A set of OpenType fonts designed by Adobe for UIs";
     license = licenses.ofl;

--- a/pkgs/data/fonts/source-serif-pro/default.nix
+++ b/pkgs/data/fonts/source-serif-pro/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let
   version = "2.010";
@@ -16,7 +16,7 @@ in fetchzip {
 
   sha256 = "1a3lmqk7hyxpfkb30s9z73lhs823dmq6xr5llp9w23g6bh332x2h";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://adobe-fonts.github.io/source-serif-pro/;
     description = "A set of OpenType fonts to complement Source Sans Pro";
     license = licenses.ofl;

--- a/pkgs/data/fonts/spleen/default.nix
+++ b/pkgs/data/fonts/spleen/default.nix
@@ -1,23 +1,25 @@
-{ stdenv, fetchurl, mkfontdir, mkfontscale }:
+{ lib, fetchurl }:
 
-stdenv.mkDerivation rec {
+let
   pname = "spleen";
   version = "1.0.4";
+in fetchurl rec {
+  name = "${pname}-${version}";
+  url = "https://github.com/fcambus/spleen/releases/download/${version}/spleen-${version}.tar.gz";
 
-  src = fetchurl {
-    url = "https://github.com/fcambus/spleen/releases/download/${version}/spleen-${version}.tar.gz";
-    sha256 = "1x62a5ygn3rpgzbaacz64rp8mn7saymdnxci4l3xasvsjjp60s3g";
-  };
-
-  buildPhase = "gzip -n9 *.pcf";
-  installPhase = ''
+  downloadToTemp = true;
+  recursiveHash = true;
+  postFetch = ''
+    tar xf $downloadedFile --strip=1
     d="$out/share/fonts/X11/misc/spleen"
+    gzip -n9 *.pcf
     install -Dm644 *.pcf.gz  -t $d
     install -Dm644 *.bdf -t $d
     install -m644 fonts.alias-spleen $d/fonts.alias
   '';
+  sha256 = "0jab55h08gy7gpyxqfrfj30iinmknpllh3dp5g7ck5q3qfgdzh7m";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Monospaced bitmap fonts";
     homepage = https://www.cambus.net/spleen-monospaced-bitmap-fonts;
     license = licenses.bsd2;

--- a/pkgs/data/fonts/stix-otf/default.nix
+++ b/pkgs/data/fonts/stix-otf/default.nix
@@ -1,11 +1,11 @@
-{stdenv, fetchzip}:
+{ lib, fetchzip }:
 
 let
   version = "1.1.1";
 in fetchzip rec {
   name = "stix-otf-${version}";
 
-  url = "mirror://sourceforge/stixfonts/STIXv${version}-word.zip";
+  url = "http://ftp.fi.muni.cz/pub/linux/gentoo/distfiles/STIXv${version}-word.zip";
 
   postFetch = ''
     mkdir -p $out/share/fonts
@@ -14,7 +14,7 @@ in fetchzip rec {
 
   sha256 = "04d4qxq3i9fyapsmxk6d9v1xirjam8c74fyxs6n24d3gf2945zmw";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = http://www.stixfonts.org/;
     description = "Fonts for Scientific and Technical Information eXchange";
     license = licenses.ofl;

--- a/pkgs/data/fonts/stix-two/default.nix
+++ b/pkgs/data/fonts/stix-two/default.nix
@@ -5,11 +5,11 @@ let
 in fetchzip {
   name = "stix-two-${version}";
 
-  url = "mirror://sourceforge/stixfonts/Current%20Release/STIXv${version}.zip";
+  url = "https://github.com/stipub/stixfonts/archive/${version}.zip";
 
   postFetch = ''
     mkdir -p $out/share/fonts
-    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
+    unzip -j $downloadedFile '*/OTF/*.otf' -d $out/share/fonts/opentype
   '';
 
   sha256 = "19i30d2xjk52bjj7xva1hnlyh58yd5phas1njcc8ldcz87a1lhql";

--- a/pkgs/data/fonts/sudo/default.nix
+++ b/pkgs/data/fonts/sudo/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let
   version = "0.37";
@@ -11,7 +11,7 @@ in fetchzip rec {
     mkdir -p $out/share/fonts/truetype/
     unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype/
   '';
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Font for programmers and command line users";
     homepage = https://www.kutilek.de/sudo-font/;
     license = licenses.ofl;

--- a/pkgs/data/fonts/tamsyn/default.nix
+++ b/pkgs/data/fonts/tamsyn/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchurl, mkfontdir, mkfontscale }:
 
 let
-  version = "1.11"; 
+  version = "1.11";
 in stdenv.mkDerivation {
   pname = "tamsyn-font";
   inherit version;
@@ -22,7 +22,7 @@ in stdenv.mkDerivation {
     fontDir="$out/share/fonts/tamsyn"
     mkdir -p "$fontDir"
     mv *.pcf "$fontDir"
-    mv *.psf.gz "$fontDir" 
+    mv *.psf.gz "$fontDir"
 
     cd "$fontDir"
     mkfontdir
@@ -38,13 +38,12 @@ in stdenv.mkDerivation {
     longDescription = ''Tamsyn is a monospace bitmap font, primarily aimed at
     programmers. It was derived from Gilles Boccon-Gibod's MonteCarlo. Tamsyn
     font was further inspired by Gohufont, Terminus, Dina, Proggy, Fixedsys, and
-    Consolas. 
+    Consolas.
     '';
     homepage = http://www.fial.com/~scott/tamsyn-font/;
     downloadPage = http://www.fial.com/~scott/tamsyn-font/download;
     license = licenses.free;
     maintainers = [ maintainers.rps ];
-    platforms = platforms.linux;
   };
 }
 

--- a/pkgs/data/fonts/tempora-lgc/default.nix
+++ b/pkgs/data/fonts/tempora-lgc/default.nix
@@ -38,6 +38,5 @@ stdenv.mkDerivation {
     description = ''Tempora font'';
     license = stdenv.lib.licenses.gpl2 ;
     maintainers = [stdenv.lib.maintainers.raskin];
-    platforms = stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/data/fonts/tenderness/default.nix
+++ b/pkgs/data/fonts/tenderness/default.nix
@@ -1,4 +1,4 @@
-{ stdenv,  fetchzip }:
+{ lib, fetchzip }:
 
 let
   majorVersion = "0";
@@ -17,7 +17,7 @@ fetchzip rec {
     unzip -j $downloadedFile \*.otf  -d $out/share/fonts/opentype/${pname}
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = "http://dotcolon.net/font/${pname}/";
     description = "Serif font designed by Sora Sagano with old-style figures";
     platforms = platforms.all;

--- a/pkgs/data/fonts/terminus-font-ttf/default.nix
+++ b/pkgs/data/fonts/terminus-font-ttf/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let
   version = "4.47.0";
@@ -20,7 +20,7 @@ in fetchzip rec {
 
   sha256 = "1mnx3vlnl0r15yzsa4zb9qqab4hpi603gdwhlbw960wg03i3xn8z";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "A clean fixed width TTF font";
     longDescription = ''
       Monospaced bitmap font designed for long work with computers
@@ -29,6 +29,5 @@ in fetchzip rec {
     homepage = http://files.ax86.net/terminus-ttf;
     license = licenses.ofl;
     maintainers = with maintainers; [ okasu ];
-    platforms = platforms.unix;
   };
 }

--- a/pkgs/data/fonts/terminus-font/default.nix
+++ b/pkgs/data/fonts/terminus-font/default.nix
@@ -37,6 +37,5 @@ stdenv.mkDerivation rec {
     homepage = http://terminus-font.sourceforge.net/;
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ astsmtl ];
-    platforms = platforms.linux;
   };
 }

--- a/pkgs/data/fonts/tewi/default.nix
+++ b/pkgs/data/fonts/tewi/default.nix
@@ -46,6 +46,5 @@ stdenv.mkDerivation rec {
       url = "https://www.gnu.org/licenses/gpl-faq.html#FontException";
     };
     maintainers = [ maintainers.fro_ozen ];
-    platforms = platforms.unix;
   };
 }

--- a/pkgs/data/fonts/tex-gyre-math/default.nix
+++ b/pkgs/data/fonts/tex-gyre-math/default.nix
@@ -28,32 +28,30 @@ let
     };
   };
 
-  mkVariant = variant: current:
-    let dotless_version = builtins.replaceStrings ["."] [""] current.version; in
+  mkVariant = variant: {displayName, version, sha256, outputHash}:
+    let dotless_version = builtins.replaceStrings ["."] [""] version; in
     stdenv.mkDerivation rec {
-      name = "tex-gyre-${variant}-math-${current.version}";
-      version = "${current.version}";
+      name = "tex-gyre-${variant}-math-${version}";
+      inherit version;
 
       src = fetchzip {
-        url = "www.gust.org.pl/projects/e-foundry/tg-math/download/texgyre${variant}-math-${dotless_version}.zip";
-        sha256 = current.sha256;
+        url = "http://www.gust.org.pl/projects/e-foundry/tg-math/download/texgyre${variant}-math-${dotless_version}.zip";
+        inherit sha256;
       };
 
       installPhase = ''
-        mkdir -p $out/share/fonts/opentype/
-        mkdir -p $out/share/doc/${name}/
-        cp -v opentype/*.otf $out/share/fonts/opentype/
-        cp -v doc/*.txt $out/share/doc/${name}/
+        install -m444 -Dt $out/share/fonts/opentype opentype/*.otf
+        install -m444 -Dt $out/share/doc/${name}    doc/*.txt
       '';
 
       outputHashAlgo = "sha256";
       outputHashMode = "recursive";
-      outputHash = current.outputHash;
+      inherit outputHash;
 
       meta = with stdenv.lib; {
         longDescription = ''
-          TeX Gyre ${current.displayName} Math is a math companion for the TeX Gyre
-          ${current.displayName} family of fonts (see
+          TeX Gyre ${displayName} Math is a math companion for the TeX Gyre
+          ${displayName} family of fonts (see
           http://www.gust.org.pl/projects/e-foundry/tex-gyre/) in the OpenType format.
         '';
         homepage = http://www.gust.org.pl/projects/e-foundry/tg-math;

--- a/pkgs/data/fonts/tex-gyre/default.nix
+++ b/pkgs/data/fonts/tex-gyre/default.nix
@@ -20,7 +20,7 @@ let
 
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = outputHash;
+    inherit outputHash;
 
     meta = with stdenv.lib; {
       homepage = http://www.gust.org.pl/projects/e-foundry/tex-gyre;

--- a/pkgs/data/fonts/theano/default.nix
+++ b/pkgs/data/fonts/theano/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let
   version = "2.0";
@@ -16,7 +16,7 @@ in fetchzip rec {
 
   sha256 = "1my1symb7k80ys33iphsxvmf6432wx6vjdnxhzhkgrang1rhx1h8";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://github.com/akryukov/theano;
     description = "An old-style font designed from historic samples";
     maintainers = with maintainers; [ raskin rycee ];

--- a/pkgs/data/fonts/tipa/default.nix
+++ b/pkgs/data/fonts/tipa/default.nix
@@ -22,7 +22,6 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Phonetic font for TeX";
-    platforms = stdenv.lib.platforms.unix;
   };
 }
 

--- a/pkgs/data/fonts/tlwg/default.nix
+++ b/pkgs/data/fonts/tlwg/default.nix
@@ -21,7 +21,6 @@ stdenv.mkDerivation rec {
     description = "A collection of Thai scalable fonts available under free licenses";
     homepage = https://linux.thai.net/projects/fonts-tlwg;
     license = with licenses; [ gpl2 publicDomain lppl13c free ];
-    platforms = platforms.unix;
     maintainers = [ maintainers.yrashk ];
   };
 }

--- a/pkgs/data/fonts/ttf-bitstream-vera/default.nix
+++ b/pkgs/data/fonts/ttf-bitstream-vera/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchzip}:
+{ lib, fetchzip }:
 
 fetchzip {
   name = "ttf-bitstream-vera-1.10";
@@ -7,14 +7,11 @@ fetchzip {
 
   postFetch = ''
     tar -xjf $downloadedFile --strip-components=1
-    fontDir=$out/share/fonts/truetype
-    mkdir -p $fontDir
-    cp *.ttf $fontDir
+    install -m444 -Dt $out/share/fonts/truetype *.ttf
   '';
 
   sha256 = "179hal4yi3367jg8rsvqx6h2w4s0kn9zzrv8c47sslyg28g39s4m";
 
   meta = {
-    platforms = stdenv.lib.platforms.unix;
   };
 }

--- a/pkgs/data/fonts/ttf-envy-code-r/default.nix
+++ b/pkgs/data/fonts/ttf-envy-code-r/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let
   pname = "ttf-envy-code-r";
@@ -16,11 +16,10 @@ in fetchzip {
 
   sha256 = "0x0r07nax68cmz7490x2crzzgdg4j8fg63wppcmjqm0230bggq2z";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = http://damieng.com/blog/tag/envy-code-r;
     description = "Free scalable coding font by DamienG";
     license = licenses.unfree;
-    platforms = platforms.unix;
     maintainers = [ maintainers.lyt ];
   };
 }

--- a/pkgs/data/fonts/twemoji-color-font/default.nix
+++ b/pkgs/data/fonts/twemoji-color-font/default.nix
@@ -38,6 +38,5 @@ stdenv.mkDerivation rec {
     downloadPage = "https://github.com/eosrei/twemoji-color-font/releases";
     license = with licenses; [ cc-by-40 mit ];
     maintainers = [ maintainers.fgaz ];
-    platforms = platforms.linux;
   };
 }

--- a/pkgs/data/fonts/ubuntu-font-family/default.nix
+++ b/pkgs/data/fonts/ubuntu-font-family/default.nix
@@ -1,9 +1,9 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 fetchzip rec {
   name = "ubuntu-font-family-0.83";
 
-  url = "http://font.ubuntu.com/download/${name}.zip";
+  url = "https://assets.ubuntu.com/v1/fad7939b-ubuntu-font-family-0.83.zip";
 
   postFetch = ''
     mkdir -p $out/share/fonts
@@ -19,8 +19,8 @@ fetchzip rec {
     contemporary style and contains characteristics unique to
     the Ubuntu brand that convey a precise, reliable and free attitude.";
     homepage = http://font.ubuntu.com/;
-    license = stdenv.lib.licenses.free;
-    platforms = stdenv.lib.platforms.all;
-    maintainers = [ stdenv.lib.maintainers.antono ];
+    license = lib.licenses.free;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.antono ];
   };
 }

--- a/pkgs/data/fonts/ultimate-oldschool-pc-font-pack/default.nix
+++ b/pkgs/data/fonts/ultimate-oldschool-pc-font-pack/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let
   version = "1.0";
@@ -13,10 +13,9 @@ fetchzip rec {
     unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "The Ultimate Oldschool PC Font Pack (TTF Fonts)";
     homepage = "http://int10h.org/oldschool-pc-fonts/";
-    platforms = platforms.unix;
     license = licenses.cc-by-sa-40;
     maintainers = [ maintainers.endgame ];
   };

--- a/pkgs/data/fonts/undefined-medium/default.nix
+++ b/pkgs/data/fonts/undefined-medium/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 fetchzip rec {
   name = "undefined-medium-1.0";
@@ -10,9 +10,9 @@ fetchzip rec {
     unzip -j $downloadedFile ${name}/fonts/otf/\*.otf -d $out/share/fonts/opentype
   '';
 
-  sha256 = "0v3p1g9f1c0d6b9lhrvm1grzivm7ddk7dvn96zl5hdzr2y60y1rw";
+  sha256 = "1wa04jzbffshwcxm705yb5wja8wakn8j7fvim1mlih2z1sqw0njk";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://undefined-medium.com/;
     description = "A pixel grid-based monospace typeface";
     longDescription = ''

--- a/pkgs/data/fonts/uni-vga/default.nix
+++ b/pkgs/data/fonts/uni-vga/default.nix
@@ -20,13 +20,12 @@ stdenv.mkDerivation {
 
   outputHashAlgo = "sha256";
   outputHashMode = "recursive";
-  sha256 = "0rfly7r6blr2ykxlv0f6my2w41vvxcw85chspljd2p1fxlr28jd7";
+  outputHash = "0rfly7r6blr2ykxlv0f6my2w41vvxcw85chspljd2p1fxlr28jd7";
 
   meta = {
     description = "Unicode VGA font";
     maintainers = [stdenv.lib.maintainers.ftrvxmtrx];
     homepage = http://www.inp.nsk.su/~bolkhov/files/fonts/univga/;
     license = stdenv.lib.licenses.mit;
-    platforms = stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/data/fonts/unifont_upper/default.nix
+++ b/pkgs/data/fonts/unifont_upper/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let
   version = "12.1.01";
@@ -11,7 +11,7 @@ in fetchzip rec {
 
   sha256 = "11b14ka2w16vssxdhgq7k9bx7xx0sr36hfi2vzyimmaibasi1r74";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Unicode font for glyphs above the Unicode Basic Multilingual Plane";
     homepage = http://unifoundry.com/unifont.html;
 

--- a/pkgs/data/fonts/vazir-fonts/default.nix
+++ b/pkgs/data/fonts/vazir-fonts/default.nix
@@ -1,23 +1,22 @@
-{ stdenv, fetchFromGitHub }:
+{ lib, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
-  name = "vazir-fonts";
+let
+  pname = "vazir-fonts";
   version = "19.2.0";
+in fetchFromGitHub rec {
+  name = "${pname}-${version}";
 
-  src = fetchFromGitHub {
-    owner = "rastikerdar";
-    repo = "vazir-font";
-    rev = "v${version}";
-    sha256 = "0p96y4q20nhpv7hxca6rncfcb14iqy2vacv0xl55wkwqkm4wvzgr";
-  };
+  owner = "rastikerdar";
+  repo = "vazir-font";
+  rev = "v${version}";
 
-  installPhase = ''
-    mkdir -p $out/share/fonts/vazir-fonts
-    cp -v $( find . -name '*.ttf') $out/share/fonts/vazir-fonts
-
+  postFetch = ''
+    tar xf $downloadedFile --strip=1
+    find . -name '*.ttf' -exec install -m444 -Dt $out/share/fonts/vazir-fonts {} \;
   '';
+  sha256 = "008h095rjrcjhz9h02v6cf3gv64khj21lii4zffgpdlmvfs29f8l";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://github.com/rastikerdar/vazir-font;
     description = "A Persian (Farsi) Font - قلم (فونت) فارسی وزیر";
     license = licenses.ofl;

--- a/pkgs/data/fonts/vdrsymbols/default.nix
+++ b/pkgs/data/fonts/vdrsymbols/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 fetchzip rec {
   name = "vdrsymbols-20100612";
@@ -12,7 +12,7 @@ fetchzip rec {
     install -Dm444 -t "$out/share/fonts/truetype" */*.ttf
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "DejaVu fonts with additional symbols used by VDR";
     homepage = http://andreas.vdr-developer.org/fonts/;
     platforms = platforms.all;

--- a/pkgs/data/fonts/vegur/default.nix
+++ b/pkgs/data/fonts/vegur/default.nix
@@ -1,29 +1,22 @@
-{ stdenv, rpmextract, fetchurl, unzip }:
+{ lib, buildPackages, fetchzip }:
 
-stdenv.mkDerivation rec {
+let
   version = "0.701";
+in fetchzip {
   name = "vegur-font-${version}";
 
   # Upstream doesn't version their URLs.
   # http://dotcolon.net/font/vegur/ → http://dotcolon.net/DL/font/vegur.zip
-  src = fetchurl {
-    url = "http://download.opensuse.org/repositories/M17N:/fonts/SLE_12_SP3/src/dotcolon-vegur-fonts-0.701-1.4.src.rpm";
-    sha256 = "0ra3fds3b352rpzn0015km539c3l2ik2lqd5x6fr65ss9fg2xn34";
-  };
+  url = "http://download.opensuse.org/repositories/M17N:/fonts/SLE_12_SP3/src/dotcolon-vegur-fonts-0.701-1.4.src.rpm";
 
-  nativeBuildInputs = [ rpmextract unzip ];
-
-  unpackPhase = ''
-    rpmextract $src
+  postFetch = ''
+    ${buildPackages.rpmextract}/bin/rpmextract $downloadedFile
     unzip vegur.zip
+    install -m444 -Dt $out/share/fonts/Vegur *.otf
   '';
+  sha256 = "0iisi2scq72lyj7pc1f36fhfjnm676n5byl4zaavhbxpdrbc6d1v";
 
-  installPhase = ''
-    mkdir -p $out/share/fonts/Vegur
-    cp *.otf $out/share/fonts/Vegur
-  '';
-
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = http://dotcolon.net/font/vegur/;
     description = "A humanist sans serif font.";
     platforms = platforms.all;

--- a/pkgs/data/fonts/vista-fonts-chs/default.nix
+++ b/pkgs/data/fonts/vista-fonts-chs/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchzip, cabextract}:
+{ lib, fetchzip, buildPackages }:
 
 # Modified from vista-fonts
 
@@ -8,7 +8,7 @@ fetchzip {
   url = http://download.microsoft.com/download/d/6/e/d6e2ff26-5821-4f35-a18b-78c963b1535d/VistaFont_CHS.EXE;
 
   postFetch = ''
-    ${cabextract}/bin/cabextract --lowercase --filter '*.TTF' $downloadedFile
+    ${buildPackages.cabextract}/bin/cabextract --lowercase --filter '*.TTF' $downloadedFile
 
     mkdir -p $out/share/fonts/truetype
     cp *.ttf $out/share/fonts/truetype
@@ -25,12 +25,12 @@ fetchzip {
   meta = {
     description = "TrueType fonts from Microsoft Windows Vista For Simplified Chinese (Microsoft YaHei)";
     homepage = https://www.microsoft.com/typography/fonts/family.aspx?FID=350;
-    license = stdenv.lib.licenses.unfree;
-    maintainers = [ stdenv.lib.maintainers.ChengCat ];
+    license = lib.licenses.unfree;
+    maintainers = [ lib.maintainers.ChengCat ];
 
     # Set a non-zero priority to allow easy overriding of the
     # fontconfig configuration files.
     priority = 5;
-    platforms = stdenv.lib.platforms.all;
+    platforms = lib.platforms.all;
   };
 }

--- a/pkgs/data/fonts/vista-fonts/default.nix
+++ b/pkgs/data/fonts/vista-fonts/default.nix
@@ -31,6 +31,6 @@ fetchzip {
     # Set a non-zero priority to allow easy overriding of the
     # fontconfig configuration files.
     priority = 5;
-    platforms = stdenv.lib.platforms.unix;
+    broken = true; # source url is 404
   };
 }

--- a/pkgs/data/fonts/weather-icons/default.nix
+++ b/pkgs/data/fonts/weather-icons/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let
   version = "2.0.10";
-in fetchzip rec {
+in fetchzip {
   name = "weather-icons-${version}";
 
   url = "https://github.com/erikflowers/weather-icons/archive/${version}.zip";
@@ -14,7 +14,7 @@ in fetchzip rec {
 
   sha256 = "10zny9987wybq55sm803hrjkp33dq1lgmnxc15kssr8yb81g6qrl";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Weather Icons";
     longDescription = ''
       Weather Icons is the only icon font and CSS with 222 weather themed icons,

--- a/pkgs/data/fonts/wqy-microhei/default.nix
+++ b/pkgs/data/fonts/wqy-microhei/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 fetchzip rec {
   name = "wqy-microhei-0.2.0-beta";
@@ -15,9 +15,9 @@ fetchzip rec {
   meta = {
     description = "A (mainly) Chinese Unicode font";
     homepage = http://wenq.org;
-    license = stdenv.lib.licenses.asl20;
-    maintainers = [ stdenv.lib.maintainers.pkmx ];
-    platforms = stdenv.lib.platforms.all;
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.pkmx ];
+    platforms = lib.platforms.all;
   };
 }
 

--- a/pkgs/data/fonts/wqy-zenhei/default.nix
+++ b/pkgs/data/fonts/wqy-zenhei/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let
   version = "0.9.45";
@@ -18,8 +18,8 @@ in fetchzip rec {
   meta = {
     description = "A (mainly) Chinese Unicode font";
     homepage = http://wenq.org;
-    license = stdenv.lib.licenses.gpl2; # with font embedding exceptions
-    maintainers = [ stdenv.lib.maintainers.pkmx ];
-    platforms = stdenv.lib.platforms.all;
+    license = lib.licenses.gpl2; # with font embedding exceptions
+    maintainers = [ lib.maintainers.pkmx ];
+    platforms = lib.platforms.all;
   };
 }

--- a/pkgs/data/fonts/xkcd-font/default.nix
+++ b/pkgs/data/fonts/xkcd-font/default.nix
@@ -1,24 +1,23 @@
-{ stdenv, fetchFromGitHub }:
+{ lib, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
+let
   pname = "xkcd-font";
   version = "unstable-2017-08-24";
+in fetchFromGitHub rec {
+  name = "${pname}-${version}";
 
-  src = fetchFromGitHub {
-    owner = "ipython";
-    repo = pname;
-    rev = "5632fde618845dba5c22f14adc7b52bf6c52d46d";
-    sha256 = "01wpfc1yp93b37r472mx2b459il5gywnv5sl7pp9afpycb3i4f6l";
-  };
+  owner = "ipython";
+  repo = pname;
+  rev = "5632fde618845dba5c22f14adc7b52bf6c52d46d";
 
-  phases = [ "unpackPhase" "installPhase" ];
-
-  installPhase = ''
+  postFetch = ''
+    tar xf $downloadedFile --strip=1
     install -Dm444 -t $out/share/fonts/opentype/ xkcd/build/xkcd.otf
     install -Dm444 -t $out/share/fonts/truetype/ xkcd-script/font/xkcd-script.ttf
   '';
+  sha256 = "0xhwa53aiz20763jb9nvbr2zq9k6jl69p07dc4b0apwrrwz0jfr1";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "The xkcd font";
     homepage = https://github.com/ipython/xkcd-font;
     license = licenses.cc-by-nc-30;

--- a/pkgs/data/fonts/yanone-kaffeesatz/default.nix
+++ b/pkgs/data/fonts/yanone-kaffeesatz/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchzip}:
+{ lib, fetchzip }:
 
 fetchzip {
   name = "yanone-kaffeesatz-2004";
@@ -14,9 +14,9 @@ fetchzip {
 
   meta = {
     description = "The free font classic";
-    maintainers = with stdenv.lib.maintainers; [ mt-caret ];
-    platforms = with stdenv.lib.platforms; all;
+    maintainers = with lib.maintainers; [ mt-caret ];
+    platforms = with lib.platforms; all;
     homepage = https://yanone.de/fonts/kaffeesatz/;
-    license = stdenv.lib.licenses.ofl;
+    license = lib.licenses.ofl;
   };
 }

--- a/pkgs/data/fonts/zilla-slab/default.nix
+++ b/pkgs/data/fonts/zilla-slab/default.nix
@@ -1,8 +1,7 @@
-{ stdenv, fetchzip }:
+{ lib, fetchzip }:
 
 let
   version = "1.002";
-  hash = "1b1ys28hyjcl4qwbnsyi6527nj01g3d6id9jl23fv6f8fjm4ph0f";
 in fetchzip {
   name = "zilla-slab-${version}";
 
@@ -12,9 +11,9 @@ in fetchzip {
     mkdir -p $out/share/fonts/truetype
     cp -v zilla-slab/ttf/*.ttf $out/share/fonts/truetype/
   '';
-  sha256 = hash;
+  sha256 = "1b1ys28hyjcl4qwbnsyi6527nj01g3d6id9jl23fv6f8fjm4ph0f";
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     homepage = https://github.com/mozilla/zilla-slab;
     description = "Zilla Slab fonts";
     longDescription = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16429,7 +16429,7 @@ in
   stix-two = callPackage ../data/fonts/stix-two { };
 
   inherit (callPackages ../data/fonts/gdouros { })
-    symbola aegyptus akkadian anatolian maya unidings musica analecta textfonts aegan abydos;
+    aegan aegyptus akkadian assyrian eemusic maya symbola textfonts unidings;
 
   iana-etc = callPackage ../data/misc/iana-etc { };
 
@@ -24016,7 +24016,7 @@ in
     stdenv = crossLibcStdenv;
     };
 
-	omnisharp-roslyn = callPackage ../development/tools/omnisharp-roslyn { };
+  omnisharp-roslyn = callPackage ../development/tools/omnisharp-roslyn { };
 
   wasmtime = callPackage ../development/interpreters/wasmtime {};
 


### PR DESCRIPTION
 - [x] make other font derivations fixed-output where applicable
 - [x] fix dead links
 - [x] ```stdenv.lib``` -> ```lib``` where ```stdenv``` is not involved
 - [x] remove ```meta.platforms = [ unix ]``` and ```meta.platforms = [ linux ]``` because the restriction has no sense for data packages