### PR TITLE
chit: init at 0.1.12

### DIFF
--- a/pkgs/development/tools/chit/default.nix
+++ b/pkgs/development/tools/chit/default.nix
@@ -1,0 +1,47 @@
+{ stdenv, fetchFromGitHub, rustPlatform, pkgconfig, openssl
+, darwin
+}:
+
+with rustPlatform;
+
+buildRustPackage rec {
+  pname = "chit";
+  version = "0.1.12";
+
+  src = fetchFromGitHub {
+    owner = "peterheesterman";
+    repo = pname;
+    rev = version;
+    sha256 = "17g2p07zhf4n4pjmws0ssfy2mrn0v933ih0vnlr1z2cv9mx8srsl";
+  };
+
+  cargoSha256 = "1jqnnf4jgjpm1i310hda15423nxfw9frgpmc2kbrs66qcsj7avaw";
+
+  nativeBuildInputs = stdenv.lib.optionals stdenv.isLinux [ pkgconfig ];
+  buildInputs = []
+  ++ stdenv.lib.optionals stdenv.isLinux [ openssl ]
+  ++ stdenv.lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ CoreFoundation CoreServices Security ])
+  ;
+
+  # Tests require network access
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Crate help in terminal: A tool for looking up details about rust crates without going to crates.io";
+    longDescription = ''
+      Chit helps answer these questions:
+
+      * Who wrote this crate? What else did they write?
+      * What alternatives are there?
+      * How old is this crate?
+      * What versions are there? When did they come out?
+      * What are the downloads over time?
+      * Should i use this crate?
+      * How mature is it?
+    '';
+    homepage = https://github.com/peterheesterman/chit;
+    license = licenses.mit;
+    maintainers = [ maintainers.lilyball ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2032,6 +2032,8 @@ in
 
   checkinstall = callPackage ../tools/package-management/checkinstall { };
 
+  chit = callPackage ../development/tools/chit { };
+
   chkrootkit = callPackage ../tools/security/chkrootkit { };
 
   chrony = callPackage ../tools/networking/chrony { };


### PR DESCRIPTION
###### Motivation for this change
New package [chit](https://github.com/peterheesterman/chit), which is a tool for help with Rust development.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS (with sandboxing)
   - [X] macOS (without sandboxing)
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---