### PR TITLE
blast: init at 2.10.0

### DIFF
--- a/pkgs/applications/science/biology/blast/default.nix
+++ b/pkgs/applications/science/biology/blast/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, zlib, bzip2, boost168, perl, cpio, gawk, coreutils }:
+{ stdenv, fetchurl, zlib, bzip2, perl, cpio, gawk, coreutils }:
 
 stdenv.mkDerivation rec {
   pname = "blast";
@@ -68,7 +68,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ perl ];
 
-  buildInputs = [ coreutils gawk zlib boost168 bzip2 cpio ];
+  buildInputs = [ coreutils gawk zlib bzip2 cpio ];
   hardeningDisable = [ "format" ];
 
   patches = [ ./no_slash_bin.patch ];
@@ -85,7 +85,8 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  doCheck = true;
+  # Many tests require either network access or locally available databases
+  doCheck = false;
 
   meta = with stdenv.lib; {
     description = ''Basic Local Alignment Search Tool (BLAST) finds regions of

--- a/pkgs/applications/science/biology/blast/default.nix
+++ b/pkgs/applications/science/biology/blast/default.nix
@@ -82,7 +82,6 @@ stdenv.mkDerivation rec {
     patchShebangs $out/bin/update_blastdb.pl
   '';
 
-
   enableParallelBuilding = true;
 
   doCheck = true;

--- a/pkgs/applications/science/biology/blast/default.nix
+++ b/pkgs/applications/science/biology/blast/default.nix
@@ -99,7 +99,10 @@ stdenv.mkDerivation rec {
     similarity between biological sequences'';
     homepage = https://blast.ncbi.nlm.nih.gov/Blast.cgi;
     license = licenses.publicDomain;
-    platforms = platforms.unix;
+
+    # Version 2.10.0 fails on Darwin
+    # See https://github.com/NixOS/nixpkgs/pull/61430
+    platforms = platforms.linux;
     maintainers = with maintainers; [ luispedro ];
   };
 }

--- a/pkgs/applications/science/biology/blast/default.nix
+++ b/pkgs/applications/science/biology/blast/default.nix
@@ -77,17 +77,13 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ perl ];
 
-  buildInputs = [ coreutils gawk zlib bzip2 cpio ]
+  # perl is necessary in buildInputs so that installed perl scripts get patched
+  # correctly
+  buildInputs = [ coreutils perl gawk zlib bzip2 cpio ]
     ++ lib.optionals stdenv.isDarwin [ ApplicationServices ];
   hardeningDisable = [ "format" ];
 
   patches = [ ./no_slash_bin.patch ];
-
-  postInstall = ''
-    patchShebangs $out/bin/get_species_taxids.sh
-    patchShebangs $out/bin/legacy_blast.pl
-    patchShebangs $out/bin/update_blastdb.pl
-  '';
 
   enableParallelBuilding = true;
 

--- a/pkgs/applications/science/biology/blast/default.nix
+++ b/pkgs/applications/science/biology/blast/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "blast";
-  version = "2.9.0";
+  version = "2.10.0";
 
   src = fetchurl {
     url = "ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/${version}/ncbi-blast-${version}+-src.tar.gz";
-    sha256 = "0my2rpd1bln05sxnp4c5wk5j5y6yx56vi38pzicjfhh9g8nwr453";
+    sha256 = "09nry5knj5hhxpn0a5ww1gb1704grd4r1y7adbjl6kqwq37dkk9s";
   };
 
   sourceRoot = "ncbi-blast-${version}+-src/c++";

--- a/pkgs/applications/science/biology/blast/default.nix
+++ b/pkgs/applications/science/biology/blast/default.nix
@@ -46,7 +46,8 @@ stdenv.mkDerivation rec {
             --replace /bin/echo ${coreutils}/bin/echo
     done
     for mk in src/build-system/Makefile.meta_p \
-        src/build-system/Makefile.rules_with_autodep.in; do
+        src/build-system/Makefile.rules_with_autodep.in \
+        src/build-system/Makefile.protobuf.in ; do
 
         substituteInPlace $mk \
             --replace /bin/mv ${coreutils}/bin/mv

--- a/pkgs/applications/science/biology/blast/default.nix
+++ b/pkgs/applications/science/biology/blast/default.nix
@@ -83,6 +83,10 @@ stdenv.mkDerivation rec {
     ++ lib.optionals stdenv.isDarwin [ ApplicationServices ];
   hardeningDisable = [ "format" ];
 
+  postInstall = ''
+    substituteInPlace $out/bin/get_species_taxids.sh \
+        --replace /bin/rm ${coreutils}/bin/rm
+  '';
   patches = [ ./no_slash_bin.patch ];
 
   enableParallelBuilding = true;

--- a/pkgs/applications/science/biology/blast/default.nix
+++ b/pkgs/applications/science/biology/blast/default.nix
@@ -1,0 +1,98 @@
+{ stdenv, fetchurl, zlib, bzip2, boost, perl, cpio, gawk, coreutils }:
+
+stdenv.mkDerivation rec {
+  pname = "blast";
+  version = "2.9.0";
+
+  src = fetchurl {
+    url = "ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/${version}/ncbi-blast-${version}+-src.tar.gz";
+    sha256 = "0my2rpd1bln05sxnp4c5wk5j5y6yx56vi38pzicjfhh9g8nwr453";
+  };
+
+  sourceRoot = "ncbi-blast-${version}+-src/c++";
+  
+  configureFlags = [ "--without-makefile-auto-update" ];
+  preConfigure = ''
+    export NCBICXX_RECONF_POLICY=warn
+    export PWD=$(pwd)
+    export HOME=$PWD
+
+    # The configure scripts wants to set AR="ar cr" unless it is already set in
+    # the environment. Because stdenv sets AR="ar", the result is a bad call to
+    # the assembler later in the process. Thus, we need to unset AR
+    unset AR
+
+    for awks in scripts/common/impl/is_log_interesting.awk \
+        scripts/common/impl/report_duplicates.awk; do
+
+        substituteInPlace $awks \
+              --replace /usr/bin/awk ${gawk}/bin/awk
+    done
+
+    for mk in src/build-system/Makefile.meta.in \
+        src/build-system/helpers/run_with_lock.c ; do
+
+        substituteInPlace $mk \
+        --replace /bin/rm ${coreutils}/bin/rm
+    done
+
+    for mk in src/build-system/Makefile.meta.gmake=no \
+        src/build-system/Makefile.meta_l \
+        src/build-system/Makefile.meta_r \
+        src/build-system/Makefile.requirements \
+        src/build-system/Makefile.rules_with_autodep.in; do
+
+        substituteInPlace $mk \
+            --replace /bin/echo ${coreutils}/bin/echo
+    done
+    for mk in src/build-system/Makefile.meta_p \
+        src/build-system/Makefile.rules_with_autodep.in; do
+
+        substituteInPlace $mk \
+            --replace /bin/mv ${coreutils}/bin/mv
+    done
+
+
+    substituteInPlace src/build-system/configure \
+        --replace /bin/pwd ${coreutils}/bin/pwd \
+        --replace /bin/ln ${coreutils}/bin/ln
+
+    substituteInPlace src/build-system/configure.ac \
+        --replace /bin/pwd ${coreutils}/bin/pwd \
+        --replace /bin/ln ${coreutils}/bin/ln
+
+    substituteInPlace src/build-system/Makefile.meta_l \
+        --replace /bin/date ${coreutils}/bin/date
+  '';
+
+  nativeBuildInputs = [ perl ];
+
+  buildInputs = [ coreutils gawk zlib boost bzip2 cpio ];
+  hardeningDisable = [ "format" ];
+
+  patches = [ ./no_slash_bin.patch ];
+
+  postInstall = ''
+    # BLAST installs some unit test binaries, but several of them cannot be run
+    # without the corresponding test databases, so clean up
+    rm -f $out/bin/*_unit_test
+
+    patchShebangs $out/bin/get_species_taxids.sh
+    patchShebangs $out/bin/legacy_blast.pl
+    patchShebangs $out/bin/update_blastdb.pl
+  '';
+
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = ''Basic Local Alignment Search Tool (BLAST) finds regions of
+    similarity between biological sequences'';
+    homepage = https://blast.ncbi.nlm.nih.gov/Blast.cgi;
+    license = licenses.publicDomain;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ luispedro ];
+  };
+}

--- a/pkgs/applications/science/biology/blast/default.nix
+++ b/pkgs/applications/science/biology/blast/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, zlib, bzip2, boost, perl, cpio, gawk, coreutils }:
+{ stdenv, fetchurl, zlib, bzip2, boost168, perl, cpio, gawk, coreutils }:
 
 stdenv.mkDerivation rec {
   pname = "blast";
@@ -68,7 +68,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ perl ];
 
-  buildInputs = [ coreutils gawk zlib boost bzip2 cpio ];
+  buildInputs = [ coreutils gawk zlib boost168 bzip2 cpio ];
   hardeningDisable = [ "format" ];
 
   patches = [ ./no_slash_bin.patch ];

--- a/pkgs/applications/science/biology/blast/no_slash_bin.patch
+++ b/pkgs/applications/science/biology/blast/no_slash_bin.patch
@@ -1,0 +1,195 @@
+diff -u --recursive ncbi-blast-2.9.0+-src/scripts/common/impl/collect_outside_libs.sh ncbi-blast-2.9.0+-src.patched/scripts/common/impl/collect_outside_libs.sh
+--- ncbi-blast-2.9.0+-src/scripts/common/impl/collect_outside_libs.sh	2014-08-01 22:01:17.000000000 +0800
++++ ncbi-blast-2.9.0+-src.patched/scripts/common/impl/collect_outside_libs.sh	2019-05-15 12:40:44.145239480 +0800
+@@ -1,8 +1,5 @@
+ #!/bin/sh
+ set -e
+-PATH=/bin:/usr/bin
+-export PATH
+-unset CDPATH
+ 
+ base=$1
+ search=`echo ${2-$LD_LIBRARY_PATH} | tr : ' '`
+diff -u --recursive ncbi-blast-2.9.0+-src/scripts/common/impl/create_flat_tuneups.sh ncbi-blast-2.9.0+-src.patched/scripts/common/impl/create_flat_tuneups.sh
+--- ncbi-blast-2.9.0+-src/scripts/common/impl/create_flat_tuneups.sh	2011-08-17 02:55:10.000000000 +0800
++++ ncbi-blast-2.9.0+-src.patched/scripts/common/impl/create_flat_tuneups.sh	2019-05-15 12:40:48.449276574 +0800
+@@ -1,9 +1,6 @@
+ #!/bin/sh
+ id='$Id: create_flat_tuneups.sh 331412 2011-08-16 18:55:10Z ucko $'
+ 
+-PATH=/bin:/usr/bin
+-export PATH
+-
+ exec > auto_flat_tuneups.mk
+ 
+ cat <<EOF
+diff -u --recursive ncbi-blast-2.9.0+-src/scripts/common/impl/get_lock.sh ncbi-blast-2.9.0+-src.patched/scripts/common/impl/get_lock.sh
+--- ncbi-blast-2.9.0+-src/scripts/common/impl/get_lock.sh	2011-08-20 04:12:28.000000000 +0800
++++ ncbi-blast-2.9.0+-src.patched/scripts/common/impl/get_lock.sh	2019-05-15 12:40:52.901315000 +0800
+@@ -1,7 +1,5 @@
+ #!/bin/sh
+ 
+-PATH=/bin:/usr/bin
+-export PATH
+ 
+ dir=$1.lock
+ 
+diff -u --recursive ncbi-blast-2.9.0+-src/scripts/common/impl/if_diff.sh ncbi-blast-2.9.0+-src.patched/scripts/common/impl/if_diff.sh
+--- ncbi-blast-2.9.0+-src/scripts/common/impl/if_diff.sh	2014-07-30 22:06:45.000000000 +0800
++++ ncbi-blast-2.9.0+-src.patched/scripts/common/impl/if_diff.sh	2019-05-15 12:42:57.298410841 +0800
+@@ -4,9 +4,6 @@
+ # Author:  Denis Vakatov (vakatov@ncbi.nlm.nih.gov)
+ #################################
+ 
+-orig_PATH=$PATH
+-PATH=/bin:/usr/bin
+-
+ script_name=`basename $0`
+ script_args="$*"
+ 
+@@ -16,7 +13,7 @@
+ base_action=`basename "$action"`
+ case "$base_action" in
+   cp | cp\ * | ln | ln\ * )
+-      action=/bin/$base_action
++      action=$base_action
+       rm="rm -f"
+       ;;
+   * )
+@@ -58,10 +55,8 @@
+   shift
+   cmd="$* $dest_file"
+   test "$quiet" = yes || echo "$cmd"
+-  PATH=$orig_PATH
+   "$@" "$dest"
+   status=$?
+-  PATH=/bin:/usr/bin
+   return $status
+ }
+ 
+@@ -74,7 +69,7 @@
+   case "$base_action" in
+     ln | ln\ -f )
+       test "$quiet" = yes || echo "failed; trying \"cp -p ...\" instead"
+-      cmd="/bin/cp -p $src_file $dest_file"
++      cmd="cp -p $src_file $dest_file"
+       ExecHelper "$dest_file" /bin/cp -p "$src_file"  ||
+       Usage "\"$cmd\" failed"
+       ;;
+diff -u --recursive ncbi-blast-2.9.0+-src/scripts/common/impl/make_lock_map.sh ncbi-blast-2.9.0+-src.patched/scripts/common/impl/make_lock_map.sh
+--- ncbi-blast-2.9.0+-src/scripts/common/impl/make_lock_map.sh	2011-11-17 04:43:52.000000000 +0800
++++ ncbi-blast-2.9.0+-src.patched/scripts/common/impl/make_lock_map.sh	2019-05-15 12:40:56.769348434 +0800
+@@ -1,8 +1,6 @@
+ #!/bin/sh
+ # $Id: make_lock_map.sh 344587 2011-11-16 20:43:52Z ucko $
+ 
+-PATH=/bin:/usr/bin
+-export PATH
+ 
+ act=false
+ cache_dir='.#SRC-cache'
+diff -u --recursive ncbi-blast-2.9.0+-src/scripts/common/impl/run_with_lock.sh ncbi-blast-2.9.0+-src.patched/scripts/common/impl/run_with_lock.sh
+--- ncbi-blast-2.9.0+-src/scripts/common/impl/run_with_lock.sh	2015-10-29 22:36:05.000000000 +0800
++++ ncbi-blast-2.9.0+-src.patched/scripts/common/impl/run_with_lock.sh	2019-05-15 12:41:53.401842849 +0800
+@@ -1,10 +1,6 @@
+ #!/bin/sh
+ # $Id: run_with_lock.sh 483249 2015-10-29 14:36:05Z ucko $
+ 
+-orig_PATH=$PATH
+-PATH=/bin:/usr/bin
+-export PATH
+-
+ base=
+ logfile=
+ map=
+@@ -23,7 +19,7 @@
+ : ${base:=`basename "$1"`}
+ 
+ clean_up () {
+-    /bin/rm -rf "$base.lock"
++    rm -rf "$base.lock"
+ }
+ 
+ case $0 in
+@@ -45,7 +41,7 @@
+     trap "clean_up; exit $error_status" 1 2 15
+     if [ -n "$logfile" ]; then
+         status_file=$base.lock/status
+-        (PATH=$orig_PATH; export PATH; "$@"; echo $? > "$status_file") 2>&1 \
++        ("$@"; echo $? > "$status_file") 2>&1 \
+             | tee "$logfile.new"
+         # Emulate egrep -q to avoid having to move from under scripts.
+         if [ ! -f "$logfile" ]  \
+@@ -58,8 +54,6 @@
+             status=1
+         fi
+     else
+-        PATH=$orig_PATH
+-        export PATH
+         "$@"
+         status=$?
+     fi
+diff -u --recursive ncbi-blast-2.9.0+-src/scripts/common/impl/strip_for_install.sh ncbi-blast-2.9.0+-src.patched/scripts/common/impl/strip_for_install.sh
+--- ncbi-blast-2.9.0+-src/scripts/common/impl/strip_for_install.sh	2013-09-24 03:06:51.000000000 +0800
++++ ncbi-blast-2.9.0+-src.patched/scripts/common/impl/strip_for_install.sh	2019-05-15 12:40:13.272975092 +0800
+@@ -1,8 +1,5 @@
+ #!/bin/sh
+ 
+-PATH=/bin:/usr/bin:/usr/ccs/bin
+-export PATH
+-
+ case "$1" in
+     --dirs )
+         shift
+--- ncbi-blast-2.9.0+-src/scripts/common/impl/update_configurable.sh	2017-07-13 22:53:24.000000000 +0800
++++ ncbi-blast-2.9.0+-src.patched/scripts/common/impl/update_configurable.sh	2019-05-15 15:03:35.861276083 +0800
+@@ -1,6 +1,4 @@
+ #!/bin/sh
+-PATH=/bin:/usr/bin
+-export PATH
+ 
+ script_name=`basename $0`
+ script_dir=`dirname $0`
+--- ncbi-blast-2.9.0+-src/src/build-system/Makefile.mk.in	2019-01-04 01:38:37.000000000 +0800
++++ ncbi-blast-2.9.0+-src.patched/src/build-system/Makefile.mk.in	2019-05-15 15:14:41.749416495 +0800
+@@ -50,12 +50,12 @@
+ 
+ ### Auxiliary commands, filters
+ 
+-RM       = /bin/rm -f
+-RMDIR    = /bin/rm -rf
+-COPY     = /bin/cp -p
++RM       = rm -f
++RMDIR    = rm -rf
++COPY     = cp -p
+ BINCOPY  = @BINCOPY@
+ TOUCH    = @TOUCH@
+-MKDIR    = /bin/mkdir
++MKDIR    = mkdir
+ BINTOUCH = $(TOUCH)
+ LN_S     = @LN_S@
+ GREP     = @GREP@
+--- ncbi-blast-2.9.0+-src/src/build-system/Makefile.protobuf.in	2018-08-10 02:31:01.000000000 +0800
++++ ncbi-blast-2.9.0+-src.patched/src/build-system/Makefile.protobuf.in	2019-05-15 15:22:53.159858809 +0800
+@@ -63,7 +63,7 @@
+ 
+ $(INCLUDEDIR)/%.pb.h: %.pb.cc # not .h, to avoid duplicate protoc runs
+ 	$(MKDIR) -p $(INCLUDEDIR)
+-	/bin/mv -f $*.pb.h $@
++	mv -f $*.pb.h $@
+ 
+ $(INCLUDEDIR)/%.pb.hpp: $(INCLUDEDIR)/%.pb.h
+ 	@echo '#warning "*.pb.hpp headers are deprecated,"' > $@.tmp
+--- ncbi-blast-2.9.0+-src/src/build-system/configure	2019-03-05 00:49:08.000000000 +0800
++++ ncbi-blast-2.9.0+-src.patched/src/build-system/configure	2019-05-15 16:55:40.711795042 +0800
+@@ -10417,10 +10417,6 @@
+ echo "${ECHO_T}no, using $LN_S" >&6; }
+ fi
+ 
+-case "$LN_S" in
+-    /*) ;;
+-    * ) LN_S=/bin/$LN_S ;;
+-esac
+ 
+ if test -n "$ac_tool_prefix"; then
+   # Extract the first word of "${ac_tool_prefix}ranlib", so it can be a program name with args.

--- a/pkgs/applications/science/biology/blast/no_slash_bin.patch
+++ b/pkgs/applications/science/biology/blast/no_slash_bin.patch
@@ -169,17 +169,6 @@ diff -u --recursive ncbi-blast-2.9.0+-src/scripts/common/impl/strip_for_install.
  BINTOUCH = $(TOUCH)
  LN_S     = @LN_S@
  GREP     = @GREP@
---- ncbi-blast-2.9.0+-src/src/build-system/Makefile.protobuf.in	2018-08-10 02:31:01.000000000 +0800
-+++ ncbi-blast-2.9.0+-src.patched/src/build-system/Makefile.protobuf.in	2019-05-15 15:22:53.159858809 +0800
-@@ -63,7 +63,7 @@
- 
- $(INCLUDEDIR)/%.pb.h: %.pb.cc # not .h, to avoid duplicate protoc runs
- 	$(MKDIR) -p $(INCLUDEDIR)
--	/bin/mv -f $*.pb.h $@
-+	mv -f $*.pb.h $@
- 
- $(INCLUDEDIR)/%.pb.hpp: $(INCLUDEDIR)/%.pb.h
- 	@echo '#warning "*.pb.hpp headers are deprecated,"' > $@.tmp
 --- ncbi-blast-2.9.0+-src/src/build-system/configure	2019-03-05 00:49:08.000000000 +0800
 +++ ncbi-blast-2.9.0+-src.patched/src/build-system/configure	2019-05-15 16:55:40.711795042 +0800
 @@ -10417,10 +10417,6 @@

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23652,7 +23652,9 @@ in
 
   bftools = callPackage ../applications/science/biology/bftools { };
 
-  blast = callPackage ../applications/science/biology/blast { };
+  blast = callPackage ../applications/science/biology/blast { 
+    inherit (darwin.apple_sdk.frameworks) ApplicationServices; 
+  };
 
   cd-hit = callPackage ../applications/science/biology/cd-hit { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23652,6 +23652,8 @@ in
 
   bftools = callPackage ../applications/science/biology/bftools { };
 
+  blast = callPackage ../applications/science/biology/blast { };
+
   cd-hit = callPackage ../applications/science/biology/cd-hit { };
 
   cmtk = callPackage ../applications/science/biology/cmtk { };


### PR DESCRIPTION
###### Motivation for this change

BLAST is one of the basic bioinformatics packages

###### Things done


- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
