### PR TITLE
nginxModules: update nginx modules

### DIFF
--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -132,8 +132,8 @@ in
     src = fetchFromGitHub {
       owner = "openresty";
       repo = "lua-nginx-module";
-      rev = "v0.10.14";
-      sha256 = "1vg6pp9n8z42p6f3jqk15gvdyy7mfvs5ssfbiy83bydjx42fq7g0";
+      rev = "v0.10.15";
+      sha256 = "1j216isp0546hycklbr5wi8mlga5hq170hk7f2sm16sfavlkh5gz";
     };
     inputs = [ pkgs.luajit ];
     preConfigure = ''

--- a/pkgs/servers/http/nginx/modules.nix
+++ b/pkgs/servers/http/nginx/modules.nix
@@ -6,8 +6,8 @@ let
     src = fetchFromGitHub {
       owner = "chobits";
       repo = "ngx_http_proxy_connect_module";
-      rev = "18e2520b361ffebde6c08c8119ecfba113a3b53c";
-      sha256 = "1nyil5n2a97nqsqarvnp4bazw4vnxifqizzw5aank4vi9xlq90b2";
+      rev = "002f8f9ef15562dc3691b977134518ad216d7a90";
+      sha256 = "163wg0xb7w5mwh6wrfarzcgaf6c7gb5qydgpi2wk35k551f7286s";
     };
 
     patches = [
@@ -96,12 +96,8 @@ in
     };
   };
 
-  http_proxy_connect_module_v15 = http_proxy_connect_module_generic "proxy_connect_rewrite_1015" // {
-    supports = with lib.versions; version: major version == "1" && minor version == "15";
-  };
-
-  http_proxy_connect_module_v14 = http_proxy_connect_module_generic "proxy_connect_rewrite_1014" // {
-    supports = with lib.versions; version: major version == "1" && minor version == "14";
+  http_proxy_connect_module_v16 = http_proxy_connect_module_generic "proxy_connect_rewrite_101504" // {
+    supports = with lib.versions; version: major version == "1" && minor version == "16";
   };
 
   ipscrub = {


### PR DESCRIPTION
###### Motivation for this change
Update nginx modules:
 - http_proxy_connect_module to 06.05.2019
 - lua to 0.10.15

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
