### PR TITLE
wf-recorder: unstable-2019-04-21 -> 0.1

### DIFF
--- a/pkgs/applications/video/wf-recorder/default.nix
+++ b/pkgs/applications/video/wf-recorder/default.nix
@@ -1,14 +1,16 @@
-{ stdenv, fetchFromGitHub, meson, ninja, pkgconfig, wayland, wayland-protocols, ffmpeg, x264, libpulseaudio }:
+{ stdenv, fetchFromGitHub, meson, ninja, pkgconfig, wayland, wayland-protocols
+, ffmpeg, x264, libpulseaudio
+}:
 
 stdenv.mkDerivation rec {
   pname = "wf-recorder";
-  version = "unstable-2019-04-21";
+  version = "0.1";
 
   src = fetchFromGitHub {
     owner = "ammen99";
     repo = pname;
-    rev = "ddb96690556371007e316577ed1b14f0cb62e13c";
-    sha256 = "04amfd1kyklcj6nmmmf21dz333ykglvhxb3cbzak06v2fxlrp2w3";
+    rev = "v${version}";
+    sha256 = "1rl75r87ijja9mfyrwrsz8r4zvjnhm0103qmgyhq2phlrdpkks5d";
   };
 
   nativeBuildInputs = [ meson ninja pkgconfig ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

https://github.com/ammen99/wf-recorder/compare/ddb96690556371007e316577ed1b14f0cb62e13c...65a29cbdf4c4c3930aa92816edf224f3ce5d385b

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @CrazedProgrammer 