### PR TITLE
simgrid: 3.21 -> 3.22.2

### DIFF
--- a/pkgs/applications/science/misc/simgrid/default.nix
+++ b/pkgs/applications/science/misc/simgrid/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchgit, cmake, perl, python3, boost, valgrind
+{ stdenv, fetchFromGitLab, cmake, perl, python3, boost, valgrind
 # Optional requirements
 # Lua 5.3 needed and not available now
 #, luaSupport ? false, lua5
@@ -17,13 +17,16 @@ let
 in
 
 stdenv.mkDerivation rec {
-  name = "simgrid-${version}";
+  pname = "simgrid";
   version = "3.22.2";
+  name = "${pname}-${version}";
 
-  src = fetchgit {
-    url = "https://framagit.org/simgrid/simgrid.git";
+  src = fetchFromGitLab {
+    domain = "framagit.org";
+    owner = pname;
+    repo = pname;
     rev = "v${version}";
-    sha256 = "13gm9c66dvlnz3dnzv688h1063ngz96d3pflj102x38kz4akbhms";
+    sha256 = "02zzivp3k7n2yvlr79p9kapzxpxq9x4x7jf2vrkpkwnssv4f9b4p";
   };
 
   nativeBuildInputs = [ cmake perl python3 boost valgrind ]

--- a/pkgs/applications/science/misc/simgrid/default.nix
+++ b/pkgs/applications/science/misc/simgrid/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, perl, python3, boost, valgrind
+{ stdenv, fetchgit, cmake, perl, python3, boost, valgrind
 # Optional requirements
 # Lua 5.3 needed and not available now
 #, luaSupport ? false, lua5
@@ -18,13 +18,12 @@ in
 
 stdenv.mkDerivation rec {
   name = "simgrid-${version}";
-  version = "3.21";
+  version = "3.22.2";
 
-  src = fetchFromGitHub {
-    owner = "simgrid";
-    repo = "simgrid";
-    rev = "v${replaceChars ["."] ["_"] version}";
-    sha256 = "1v0dwlww2wl56ms8lvg5zwffzbmz3sjzpkqc73f714mrc9g02bxs";
+  src = fetchgit {
+    url = "https://framagit.org/simgrid/simgrid.git";
+    rev = "v${version}";
+    sha256 = "13gm9c66dvlnz3dnzv688h1063ngz96d3pflj102x38kz4akbhms";
   };
 
   nativeBuildInputs = [ cmake perl python3 boost valgrind ]
@@ -52,7 +51,7 @@ stdenv.mkDerivation rec {
   # - lua53:  for enable_lua
   #
   # For more information see:
-  # http://simgrid.gforge.inria.fr/simgrid/latest/doc/install.html#install_cmake_list
+  # https://simgrid.org/doc/3.22/Installing_SimGrid.html#simgrid-compilation-options)
   cmakeFlags= ''
     -Denable_documentation=${optionOnOff buildDocumentation}
     -Denable_java=${optionOnOff buildJavaBindings}
@@ -87,6 +86,7 @@ stdenv.mkDerivation rec {
   checkPhase = ''
     runHook preCheck
 
+    make tests -j $NIX_BUILD_CORES
     ctest -j $NIX_BUILD_CORES --output-on-failure -E smpi-replay-multiple
 
     runHook postCheck

--- a/pkgs/applications/science/misc/simgrid/default.nix
+++ b/pkgs/applications/science/misc/simgrid/default.nix
@@ -86,13 +86,11 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  checkPhase = ''
-    runHook preCheck
-
-    make tests -j $NIX_BUILD_CORES
-    ctest -j $NIX_BUILD_CORES --output-on-failure -E smpi-replay-multiple
-
-    runHook postCheck
+  # Prevent the execution of tests known to fail.
+  preCheck = ''
+    cat <<EOW >CTestCustom.cmake
+    SET(CTEST_CUSTOM_TESTS_IGNORE smpi-replay-multiple)
+    EOW
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/applications/science/misc/simgrid/default.nix
+++ b/pkgs/applications/science/misc/simgrid/default.nix
@@ -19,7 +19,6 @@ in
 stdenv.mkDerivation rec {
   pname = "simgrid";
   version = "3.22.2";
-  name = "${pname}-${version}";
 
   src = fetchFromGitLab {
     domain = "framagit.org";


### PR DESCRIPTION



###### Motivation for this change
Keep nixpkgs's SimGrid up-to-date.

This commit does the following.
- Update git repository. The SimGrid team uses Framagit more than GitHub now, and intermediate releases (as this one, 3.22.2) are not available on GitHub.
- In checkPhase, explicitly compile test binaries thanks to `make tests`. This is now required as calling `make` without parameter no longer build test binaries.
- Fix broken documentation link.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distribution (Arch + Nix)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
