### PR TITLE
qdarkstyle: 2.6.6 -> 2.6.8, use in electrum instead of override

### DIFF
--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -3,16 +3,6 @@
 let
   version = "3.3.5";
 
-  qdarkstyle = python3Packages.buildPythonPackage rec {
-    pname = "QDarkStyle";
-    version = "2.5.4";
-    src = python3Packages.fetchPypi {
-      inherit pname version;
-      sha256 = "1w715m1i5pycfqcpkrggpn0rs9cakx6cm5v8rggcxnf4p0i0kdiy";
-    };
-    doCheck = false; # no tests
-  };
-
   # Not provided in official source releases, which are what upstream signs.
   tests = fetchFromGitHub {
     owner = "spesmilo";

--- a/pkgs/development/python-modules/qdarkstyle/default.nix
+++ b/pkgs/development/python-modules/qdarkstyle/default.nix
@@ -2,12 +2,12 @@
 
 buildPythonPackage rec {
   pname = "qdarkstyle";
-  version = "2.6.6";
+  version = "2.6.8";
 
   src = fetchPypi {
     inherit version;
     pname = "QDarkStyle";
-    sha256 = "1jbvvg36fnbvpzvg4ns7zx5jj8h1xsqdr05v5m98a0a9r8awdx3m";
+    sha256 = "18l2ynq2x8jd380nr47xy947c3qdmhv8nnxnan03y5d51azm8yh3";
   };
 
   # No tests available


### PR DESCRIPTION
###### Motivation for this change

Bump our qdarkstyle to latest, which we can now use with electrum
directly instead of overriding to a pinned version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---