### PR TITLE
sfxr: init at 1.2.1

### DIFF
--- a/pkgs/applications/audio/sfxr/default.nix
+++ b/pkgs/applications/audio/sfxr/default.nix
@@ -1,0 +1,56 @@
+{ stdenv
+, fetchurl
+, pkgconfig
+, desktop-file-utils
+, SDL
+, gtk3
+, gsettings-desktop-schemas
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "sfxr";
+  version = "1.2.1";
+
+  src = fetchurl {
+    url = "http://www.drpetter.se/files/sfxr-sdl-${version}.tar.gz";
+    sha256 = "0dfqgid6wzzyyhc0ha94prxax59wx79hqr25r6if6by9cj4vx4ya";
+  };
+
+  postPatch = ''
+    substituteInPlace Makefile --replace "usr/" ""
+    substituteInPlace sdlkit.h --replace \
+      "/usr/share/sfxr/sfxr.bmp" \
+      "$out/share/sfxr/sfxr.bmp"
+    substituteInPlace main.cpp \
+      --replace \
+      "/usr/share/sfxr/font.tga" \
+      "$out/share/sfxr/font.tga" \
+      --replace \
+      "/usr/share/sfxr/ld48.tga" \
+      "$out/share/sfxr/ld48.tga"
+  '';
+
+  nativeBuildInputs = [
+    pkgconfig
+    desktop-file-utils
+  ];
+
+  buildInputs = [
+    SDL
+    gtk3
+    gsettings-desktop-schemas
+    wrapGAppsHook
+  ];
+
+  makeFlags = [ "DESTDIR=$(out)" ];
+
+  meta = with stdenv.lib; {
+    homepage = "http://www.drpetter.se/project_sfxr.html";
+    description = "A videogame sound effect generator";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fgaz ];
+    platforms = platforms.unix;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19859,6 +19859,8 @@ in
 
   setbfree = callPackage ../applications/audio/setbfree { };
 
+  sfxr = callPackage ../applications/audio/sfxr { };
+
   sfxr-qt = libsForQt5.callPackage ../applications/audio/sfxr-qt { };
 
   shadowfox = callPackage ../tools/networking/shadowfox { };


### PR DESCRIPTION
###### Motivation for this change

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---