### PR TITLE
awesome: add optional gtk3 support (port to 19.03 branch)

### DIFF
--- a/pkgs/applications/window-managers/awesome/default.nix
+++ b/pkgs/applications/window-managers/awesome/default.nix
@@ -5,7 +5,11 @@
 , xmlto, docbook_xml_dtd_45, docbook_xsl, findXMLCatalogs
 , libxkbcommon, xcbutilxrm, hicolor-icon-theme
 , asciidoctor
+, gtk3Support ? false, gtk3 ? null
 }:
+
+# needed for beautiful.gtk to work
+assert gtk3Support -> gtk3 != null;
 
 with luaPackages; stdenv.mkDerivation rec {
   name = "awesome-${version}";
@@ -36,7 +40,8 @@ with luaPackages; stdenv.mkDerivation rec {
                   xorg.libXau xorg.libXdmcp xorg.libxcb xorg.libxshmfence
                   xorg.xcbutil xorg.xcbutilimage xorg.xcbutilkeysyms
                   xorg.xcbutilrenderutil xorg.xcbutilwm libxkbcommon
-                  xcbutilxrm ];
+                  xcbutilxrm ]
+                  ++ stdenv.lib.optional gtk3Support gtk3;
 
   #cmakeFlags = "-DGENERATE_MANPAGES=ON";
   cmakeFlags = "-DOVERRIDE_VERSION=${version}";
@@ -48,7 +53,7 @@ with luaPackages; stdenv.mkDerivation rec {
   LUA_PATH  = "${lgi}/share/lua/${lua.luaversion}/?.lua;;";
 
   postInstall = ''
-    # Don't use wrapProgram or or the wrapper will duplicate the --search
+    # Don't use wrapProgram or the wrapper will duplicate the --search
     # arguments every restart
     mv "$out/bin/awesome" "$out/bin/.awesome-wrapped"
     makeWrapper "$out/bin/.awesome-wrapped" "$out/bin/awesome" \


### PR DESCRIPTION
Porting https://github.com/NixOS/nixpkgs/pull/61161 to `release-19.03` Cc @rasendubi .
See also https://github.com/NixOS/nixpkgs/pull/61161#issuecomment-491638098

Add optional gtk3 support to Awesome so that the `beautiful.gtk` module can be
used.

The `beautiful.gtk` uses `lgi` to obtain Gtk via gobject-introspect:

    return require('lgi').Gtk

Since the current build does not include the typelib files needed, the above
call fails.

It turns out that both `gtk3` and `atk` (Accessibility toolkit) are needed, so
this commit adds them as optional build inputs.

Setting `gtk3Support` to `true` e.g. in an overlay will make `beautiful.gtk`
work at the cost of an increased closure size (currently 99.6M vs 223.4M).
