### PR TITLE
Issue 61250 coreutils disable test on musl

### DIFF
--- a/pkgs/tools/misc/coreutils/avoid-false-positive-in-date-debug-test.patch
+++ b/pkgs/tools/misc/coreutils/avoid-false-positive-in-date-debug-test.patch
@@ -1,0 +1,52 @@
+From 0251229bfd9617e8a35cf9dd7d338d63fff74a0c Mon Sep 17 00:00:00 2001
+From: Assaf Gordon <assafgordon@gmail.com>
+Date: Mon, 13 May 2019 16:37:40 -0600
+Subject: [PATCH] tests: avoid false-positive in date-debug test
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+When debugging an invalid date due to DST switching, the intermediate
+'normalized time' should not be checked - its value can differ between
+systems (e.g. glibc vs musl).
+
+Reported by Niklas Hambüchen in
+https://lists.gnu.org/r/coreutils/2019-05/msg00031.html
+Analyzed by Rich Felker in
+https://lists.gnu.org/r/coreutils/2019-05/msg00039.html
+
+* tests/misc/date-debug.sh: Replace the exact normalized time
+with 'XX:XX:XX' so different values would not trigger test failure.
+---
+ tests/misc/date-debug.sh | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/tests/misc/date-debug.sh b/tests/misc/date-debug.sh
+index aa47f1abb..2ce6f4ce8 100755
+--- a/tests/misc/date-debug.sh
++++ b/tests/misc/date-debug.sh
+@@ -71,7 +71,7 @@ date: input timezone: TZ="America/Edmonton" in date string
+ date: using specified time as starting value: '02:30:00'
+ date: error: invalid date/time value:
+ date:     user provided time: '(Y-M-D) 2006-04-02 02:30:00'
+-date:        normalized time: '(Y-M-D) 2006-04-02 03:30:00'
++date:        normalized time: '(Y-M-D) 2006-04-02 XX:XX:XX'
+ date:                                             --
+ date:      possible reasons:
+ date:        non-existing due to daylight-saving time;
+@@ -81,7 +81,14 @@ date: invalid date 'TZ="America/Edmonton" 2006-04-02 02:30:00'
+ EOF
+ 
+ # date should return 1 (error) for invalid date
+-returns_ 1 date --debug -d "$in2" >out2 2>&1 || fail=1
++returns_ 1 date --debug -d "$in2" >out2-t 2>&1 || fail=1
++
++# The output line of "normalized time" can differ between systems
++# (e.g. glibc vs musl) and should not be checked.
++# See: https://lists.gnu.org/archive/html/coreutils/2019-05/msg00039.html
++sed '/normalized time:/s/ [0-9][0-9]:[0-9][0-9]:[0-9][0-9]/ XX:XX:XX/' \
++    out2-t > out2 || framework_failure_
++
+ compare exp2 out2 || fail=1
+ 
+ ##

--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -25,6 +25,9 @@ stdenv.mkDerivation rec {
   };
 
   patches = optional stdenv.hostPlatform.isCygwin ./coreutils-8.23-4.cygwin.patch
+         # Fix failing test with musl. See https://lists.gnu.org/r/coreutils/2019-05/msg00031.html
+         # To be removed in coreutils-8.32.
+         ++ optional stdenv.hostPlatform.isMusl ./avoid-false-positive-in-date-debug-test.patch
          # Fix compilation in musl-cross environments. To be removed in coreutils-8.32.
          ++ optional stdenv.hostPlatform.isMusl ./coreutils-8.31-musl-cross.patch;
 

--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -54,10 +54,12 @@ stdenv.mkDerivation rec {
     for f in gnulib-tests/{test-chown.c,test-fchownat.c,test-lchown.c}; do
       echo "int main() { return 77; }" > "$f"
     done
-  '' + optionalString (stdenv.hostPlatform.libc == "musl") ''
-    echo "int main() { return 77; }" > gnulib-tests/test-parse-datetime.c
-    echo "int main() { return 77; }" > gnulib-tests/test-getlogin.c
-  '';
+  '' + optionalString (stdenv.hostPlatform.libc == "musl") (lib.concatStringsSep "\n" [
+    ''
+      echo "int main() { return 77; }" > gnulib-tests/test-parse-datetime.c
+      echo "int main() { return 77; }" > gnulib-tests/test-getlogin.c
+    ''
+  ]);
 
   outputs = [ "out" "info" ];
 


### PR DESCRIPTION
###### Motivation for this change

Fixes https://github.com/NixOS/nixpkgs/pull/61250#issuecomment-491642024

CC @matthewbauer @tobim 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
