### PR TITLE
libxslt: make ID generation deterministic

### DIFF
--- a/pkgs/development/libraries/libxslt/default.nix
+++ b/pkgs/development/libraries/libxslt/default.nix
@@ -24,6 +24,11 @@ stdenv.mkDerivation rec {
       url = "https://gitlab.gnome.org/GNOME/libxslt/commit/e03553605b45c88f0b4b2980adfbbb8f6fca2fd6.patch";
       sha256 = "0pkpb4837km15zgg6h57bncp66d5lwrlvkr73h0lanywq7zrwhj8";
     })
+    (fetchpatch {
+      name = "0004-Make-generate-id-deterministic.patch";
+      url = "https://salsa.debian.org/xml-sgml-team/libxslt/raw/4318e384be3a4304e5b3c1a73abacaefa54fa3a3/debian/patches/0004-Make-generate-id-deterministic.patch";
+      sha256 = "1abzglnm95ldbpnycirhdb1fcb11wc5lkfvma2f31z4572h6438f";
+    })
   ];
 
   outputs = [ "bin" "dev" "out" "man" "doc" ] ++ stdenv.lib.optional pythonSupport "py";


### PR DESCRIPTION
###### Motivation for this change

ID generation in docbook HTML is non-deterministic [[0]]. This commit
pulls in a patch from Debian's libxslt_1.1.32-2.debian.tar.xz
Also refer to the relevant bugs filed in GNOME [[1]] and Debian [[2]].

This particular change was a result of looking into non-determinism in the `opensc` package's HTML documentation.

I will note there was some concern voiced [[3]] about the quality of the patch.

[0]: https://r13y.com/diff/31b703000e1c2d5a8ef2ef416a450f6e5505baa62ab9d0434fd4d359979562c3-cb7fa3904384d7606b65c421aeb1ab34f97991356c4099571b067586450c0e91.html
[1]: https://bugzilla.gnome.org/show_bug.cgi?id=751621
[2]: https://bugs.debian.org/823857
[3]: https://bugzilla.gnome.org/show_bug.cgi?id=751621#c19

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
