### PR TITLE
devd: init at 0.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -762,6 +762,11 @@
     github = "brian-dawn";
     name = "Brian Dawn";
   };
+  brianhicks = {
+    email = "brian@brianthicks.com";
+    github = "BrianHicks";
+    name = "Brian Hicks";
+  };
   bricewge = {
     email = "bricewge@gmail.com";
     github = "bricewge";

--- a/pkgs/development/tools/devd/default.nix
+++ b/pkgs/development/tools/devd/default.nix
@@ -1,0 +1,22 @@
+{ buildGoPackage, fetchFromGitHub, stdenv }:
+
+buildGoPackage rec {
+  pname = "devd";
+  version = "0.9";
+  src = fetchFromGitHub {
+    owner = "cortesi";
+    repo = "devd";
+    rev = "v${version}";
+    sha256 = "1b02fj821k68q7xl48wc194iinqw9jiavzfl136hlzvg4m07p1wf";
+  };
+  goPackagePath = "github.com/cortesi/devd";
+  subPackages = [ "cmd/devd" ];
+  goDeps = ./deps.nix;
+  meta = with stdenv.lib; {
+    description = "A local webserver for developers";
+    homepage = https://github.com/cortesi/devd;
+    license = licenses.mit;
+    maintainers = with maintainers; [ brianhicks ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/tools/devd/deps.nix
+++ b/pkgs/development/tools/devd/deps.nix
@@ -1,0 +1,201 @@
+# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
+[
+  {
+    goPackagePath  = "github.com/GeertJohan/go.rice";
+    fetch = {
+      type = "git";
+      url = "https://github.com/GeertJohan/go.rice";
+      rev =  "c02ca9a983da5807ddf7d796784928f5be4afd09";
+      sha256 = "1wzi3fprizg29dd4b4bmwz49x154k8cry9d7c08441y1i8w895yw";
+    };
+  }
+  {
+    goPackagePath  = "github.com/alecthomas/template";
+    fetch = {
+      type = "git";
+      url = "https://github.com/alecthomas/template";
+      rev =  "a0175ee3bccc567396460bf5acd36800cb10c49c";
+      sha256 = "0qjgvvh26vk1cyfq9fadyhfgdj36f1iapbmr5xp6zqipldz8ffxj";
+    };
+  }
+  {
+    goPackagePath  = "github.com/alecthomas/units";
+    fetch = {
+      type = "git";
+      url = "https://github.com/alecthomas/units";
+      rev =  "2efee857e7cfd4f3d0138cc3cbb1b4966962b93a";
+      sha256 = "1j65b91qb9sbrml9cpabfrcf07wmgzzghrl7809hjjhrmbzri5bl";
+    };
+  }
+  {
+    goPackagePath  = "github.com/bmatcuk/doublestar";
+    fetch = {
+      type = "git";
+      url = "https://github.com/bmatcuk/doublestar";
+      rev =  "85a78806aa1b4707d1dbace9be592cf1ece91ab3";
+      sha256 = "01fd5j142pgsj5gfba43646aa6vd09fzvjhhik2r30nj4lsyy3z8";
+    };
+  }
+  {
+    goPackagePath  = "github.com/cortesi/moddwatch";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cortesi/moddwatch";
+      rev =  "0a1e0881aa8823d4dbec04c5b65a32a33f467e46";
+      sha256 = "0f9gi2vvrhsbbvfqzlx2dcgn389qj1h77rvh2iffqhnsn3cxf5fr";
+    };
+  }
+  {
+    goPackagePath  = "github.com/cortesi/termlog";
+    fetch = {
+      type = "git";
+      url = "https://github.com/cortesi/termlog";
+      rev =  "87cefd5ac843f65364f70a1fd2477bb6437690e8";
+      sha256 = "1mygv1bv6dkm5p1wsvzrsyq771k6apdcxlyfqdp5ay8vl75jxvmb";
+    };
+  }
+  {
+    goPackagePath  = "github.com/daaku/go.zipexe";
+    fetch = {
+      type = "git";
+      url = "https://github.com/daaku/go.zipexe";
+      rev =  "a5fe2436ffcb3236e175e5149162b41cd28bd27d";
+      sha256 = "0vi5pskhifb6zw78w2j97qbhs09zmrlk4b48mybgk5b3sswp6510";
+    };
+  }
+  {
+    goPackagePath  = "github.com/dustin/go-humanize";
+    fetch = {
+      type = "git";
+      url = "https://github.com/dustin/go-humanize";
+      rev =  "9f541cc9db5d55bce703bd99987c9d5cb8eea45e";
+      sha256 = "1kqf1kavdyvjk7f8kx62pnm7fbypn9z1vbf8v2qdh3y7z7a0cbl3";
+    };
+  }
+  {
+    goPackagePath  = "github.com/fatih/color";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fatih/color";
+      rev =  "3f9d52f7176a6927daacff70a3e8d1dc2025c53e";
+      sha256 = "165ww24x6ba47ji4j14mp3f006ksnmi53ws9280pgd2zcw91nbn8";
+    };
+  }
+  {
+    goPackagePath  = "github.com/goji/httpauth";
+    fetch = {
+      type = "git";
+      url = "https://github.com/goji/httpauth";
+      rev =  "2da839ab0f4df05a6db5eb277995589dadbd4fb9";
+      sha256 = "0rcz1qxdbc2gw0gaj81kag94k98izs9vmhcp5mzs7979s7q4kym1";
+    };
+  }
+  {
+    goPackagePath  = "github.com/gorilla/websocket";
+    fetch = {
+      type = "git";
+      url = "https://github.com/gorilla/websocket";
+      rev =  "66b9c49e59c6c48f0ffce28c2d8b8a5678502c6d";
+      sha256 = "00i4vb31nsfkzzk7swvx3i75r2d960js3dri1875vypk3v2s0pzk";
+    };
+  }
+  {
+    goPackagePath  = "github.com/juju/ratelimit";
+    fetch = {
+      type = "git";
+      url = "https://github.com/juju/ratelimit";
+      rev =  "59fac5042749a5afb9af70e813da1dd5474f0167";
+      sha256 = "0ppwvwbh9jdpdk4f9924vw373cpfz5g5ad10c707p22a984vanrz";
+    };
+  }
+  {
+    goPackagePath  = "github.com/kardianos/osext";
+    fetch = {
+      type = "git";
+      url = "https://github.com/kardianos/osext";
+      rev =  "ae77be60afb1dcacde03767a8c37337fad28ac14";
+      sha256 = "056dkgxrqjj5r18bnc3knlpgdz5p3yvp12y4y978hnsfhwaqvbjz";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mattn/go-colorable";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-colorable";
+      rev =  "167de6bfdfba052fa6b2d3664c8f5272e23c9072";
+      sha256 = "1nwjmsppsjicr7anq8na6md7b1z84l9ppnlr045hhxjvbkqwalvx";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mattn/go-isatty";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mattn/go-isatty";
+      rev =  "6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c";
+      sha256 = "0zs92j2cqaw9j8qx1sdxpv3ap0rgbs0vrvi72m40mg8aa36gd39w";
+    };
+  }
+  {
+    goPackagePath  = "github.com/mitchellh/go-homedir";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/go-homedir";
+      rev =  "ae18d6b8b3205b561c79e8e5f69bff09736185f4";
+      sha256 = "0f0z0aa4wivk4z1y503dmnw0k0g0g403dly8i4q263gfshs82sbq";
+    };
+  }
+  {
+    goPackagePath  = "github.com/rjeczalik/notify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/rjeczalik/notify";
+      rev =  "629144ba06a1c6af28c1e42c228e3d42594ce081";
+      sha256 = "0745w0mdr9xfr4rxw4pfr1sl8apc7wr7mvfykdl4wslq3mdj8a91";
+    };
+  }
+  {
+    goPackagePath  = "github.com/toqueteos/webbrowser";
+    fetch = {
+      type = "git";
+      url = "https://github.com/toqueteos/webbrowser";
+      rev =  "43eedf9c266f511c55ef7eace9ee549e269b54b4";
+      sha256 = "0wa8xv0gh9iq3dlwb48dx8w2awrsarqa900hszan8gaxgag7x7ih";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev =  "505ab145d0a99da450461ae2c1a9f6cd10d1f447";
+      sha256 = "1vbsvcvmjz6c00p5vf8ls533p52fx2y3gy6v4k5qrdlzl4wf0i5s";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev =  "927f97764cc334a6575f4b7a1584a147864d5723";
+      sha256 = "0np7b766gb92vbm514yhdl7cjmqvn0dxdxskd84aas2ri1fkpgw5";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev =  "b4a75ba826a64a70990f11a225237acd6ef35c9f";
+      sha256 = "0kzrd2wywkcq35iakbzplqyma4bvf2ng3mzi7917kxcbdq3fflrj";
+    };
+  }
+  {
+    goPackagePath  = "gopkg.in/alecthomas/kingpin.v2";
+    fetch = {
+      type = "git";
+      url = "https://github.com/alecthomas/kingpin";
+      rev =  "947dcec5ba9c011838740e680966fd7087a71d0d";
+      sha256 = "0mndnv3hdngr3bxp7yxfd47cas4prv98sqw534mx7vp38gd88n5r";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9002,6 +9002,8 @@ in
 
   dejagnu = callPackage ../development/tools/misc/dejagnu { };
 
+  devd = callPackage ../development/tools/devd { };
+
   devtodo = callPackage ../development/tools/devtodo { };
 
   dfeet = callPackage ../development/tools/misc/d-feet { };


### PR DESCRIPTION
###### Motivation for this change

I notice we have `modd`, but not `devd`, but I'd like to use it, so this adds it!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"` **(it says there was no diff detected)**
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
