### PR TITLE
unison: fix building on macOS with enableX11 = false

### DIFF
--- a/pkgs/applications/networking/sync/unison/default.nix
+++ b/pkgs/applications/networking/sync/unison/default.nix
@@ -20,8 +20,10 @@ stdenv.mkDerivation (rec {
   echo -e '\ninstall:\n\tcp $(FSMONITOR)$(EXEC_EXT) $(INSTALLDIR)' >> src/fsmonitor/linux/Makefile
   '';
 
-  makeFlags = "INSTALLDIR=$(out)/bin/" + (if enableX11 then " UISTYLE=gtk2" else "")
-    + (if ! ocaml.nativeCompilers then " NATIVE=false" else "");
+  makeFlags = [
+    "INSTALLDIR=$(out)/bin/"
+    "UISTYLE=${if enableX11 then "gtk2" else "text"}"
+  ] ++ stdenv.lib.optional (!ocaml.nativeCompilers) "NATIVE=false";
 
   preInstall = "mkdir -p $out/bin";
 


### PR DESCRIPTION
###### Motivation for this change
If `UISTYLE` is not specified, Unison tries to auto-detect the UI style based on the available environment. On macOS this apparently means using `UISTYLE=mac`, it can't actually build this way in Nix. On other platforms this change shouldn't affect anything as it should be detecting `text` if lablgtk2 isn't available.

Without this change, `unison` fails to build on macOS when `config.unison.enableX11 = false`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @viric