### PR TITLE
adom: Replace adom-noteye 1.2.0 with vanilla adom 3.3.3

### DIFF
--- a/pkgs/games/adom/default.nix
+++ b/pkgs/games/adom/default.nix
@@ -1,59 +1,34 @@
-{ stdenv, fetchurl, patchelf, zlib, libmad, libpng12, libcaca, libGLU_combined, alsaLib, libpulseaudio
-, xorg }:
+{ stdenv, fetchurl, autoPatchelfHook
+, ncurses5
+}:
 
-let
-
-  inherit (xorg) libXext libX11;
-
-  lpath = "${stdenv.cc.cc.lib}/lib64:" + stdenv.lib.makeLibraryPath [
-      zlib libmad libpng12 libcaca libXext libX11 libGLU_combined alsaLib libpulseaudio];
-
-in
 stdenv.mkDerivation rec {
-  name = "adom-${version}-noteye";
-  version = "1.2.0_pre23";
+  name = "adom-${version}";
+  version = "3.3.3";
 
   src = fetchurl {
-    url = "http://ancardia.uk.to/download/adom_noteye_linux_ubuntu_64_${version}.tar.gz";
-    sha256 = "0sbn0csaqb9cqi0z5fdwvnymkf84g64csg0s9mm6fzh0sm2mi0hz";
+    url = "https://www.adom.de/home/download/current/adom_linux_ubuntu_64_${version}.tar.gz";
+    sha256 = "493ef76594c1f6a7f38dcf32a76cd107fb71dd12bf917c18fdeaebcac1a353b1";
   };
 
-  buildCommand = ''
-    . $stdenv/setup
+  nativeBuildInputs = [ autoPatchelfHook ];
 
-    unpackPhase
+  buildInputs = [ ncurses5 ];
 
-    mkdir -pv $out
-    cp -r -t $out adom/*
-
-    chmod u+w $out/lib
-    for l in $out/lib/*so* ; do
-      chmod u+w $l
-      ${patchelf}/bin/patchelf \
-        --set-rpath "$out/lib:${lpath}" \
-        $l
-    done
-
-    ${patchelf}/bin/patchelf \
-      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      --set-rpath "$out/lib:${lpath}" \
-      $out/adom
-
-    mkdir $out/bin
-    cat >$out/bin/adom <<EOF
-    #! ${stdenv.shell}
-    (cd $out; exec $out/adom ; )
-    EOF
-    chmod +x $out/bin/adom
+  installPhase = ''
+    mkdir -p $out/bin $out/share
+    cp -a adom $out/bin
+    cp -a docs licenses $out/share
   '';
 
   meta = with stdenv.lib; {
     description = "A rogue-like game with nice graphical interface";
     homepage = http://adom.de/;
     license = licenses.unfreeRedistributable;
-    maintainers = [maintainers.smironov];
+    maintainers = [maintainers.Baughn];
 
-    # Please, notify me (smironov) if you need the x86 version
+    # Please, notify me (Baughn) if you need the x86 version
     platforms = ["x86_64-linux"];
   };
 }
+-------

--- a/pkgs/games/adom/default.nix
+++ b/pkgs/games/adom/default.nix
@@ -31,4 +31,3 @@ stdenv.mkDerivation rec {
     platforms = ["x86_64-linux"];
   };
 }
--------


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The old adom-noteye download site was shut down sometime last year, and I couldn't find a replacement.

This PR entirely replaces the adom derivation with one wrapping vanilla adom, from the official site. In case adom-noteye is still wanted (and can be found), I suggest it should be a separate derivation.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
