### PR TITLE
adafruit-ampy: init at 1.0.7

### DIFF
--- a/pkgs/tools/misc/adafruit-ampy/default.nix
+++ b/pkgs/tools/misc/adafruit-ampy/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, python3 }:
+
+with python3.pkgs;
+
+buildPythonApplication rec {
+  pname = "adafruit-ampy";
+  version = "1.0.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1dz5sksalccv4c3bzk3c1jxpg3s28lwlw8hfwc9dfxhw3a1np3fd";
+  };
+
+  nativeBuildInputs = [ setuptools_scm ];
+  propagatedBuildInputs = [ click python-dotenv pyserial ];
+
+  # No tests
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/pycampers/ampy";
+    license = licenses.mit;
+    description = "Utility to interact with a MicroPython board over a serial connection.";
+    maintainers = with maintainers; [ etu ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -447,6 +447,8 @@ in
 
   actkbd = callPackage ../tools/system/actkbd { };
 
+  adafruit-ampy = callPackage ../tools/misc/adafruit-ampy { };
+
   adlplug = callPackage ../applications/audio/adlplug { };
 
   opnplug = callPackage ../applications/audio/adlplug {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
