### PR TITLE
pg_partman: init at 4.1.0

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pg_partman.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_partman.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, postgresql }:
+
+stdenv.mkDerivation rec {
+  pname = "pg_partman";
+  version = "4.1.0";
+
+  buildInputs = [ postgresql ];
+
+  src = fetchFromGitHub {
+    owner  = "pgpartman";
+    repo   = pname;
+    rev    = "refs/tags/v${version}";
+    sha256 = "0bzv92x492jcwzhal9x4vc3vszixscdpxc6yq5rrqld26dhmsp06";
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin    # For buildEnv to setup proper symlinks. See #22653
+    mkdir -p $out/{lib,share/extension}
+
+    cp src/*.so      $out/lib
+    cp updates/*     $out/share/extension
+    cp -r sql/*      $out/share/extension
+    cp *.control     $out/share/extension
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Partition management extension for PostgreSQL";
+    homepage    = https://github.com/pgpartman/pg_partman;
+    maintainers = with maintainers; [ ggpeti ];
+    platforms   = postgresql.meta.platforms;
+    license     = licenses.postgresql;
+  };
+}

--- a/pkgs/servers/sql/postgresql/packages.nix
+++ b/pkgs/servers/sql/postgresql/packages.nix
@@ -38,4 +38,6 @@ self: super: {
     tds_fdw = super.callPackage ./ext/tds_fdw.nix { };
 
     pgrouting = super.callPackage ./ext/pgrouting.nix { };
+
+    pg_partman = super.callPackage ./ext/pg_partman.nix { };
 }


### PR DESCRIPTION
###### Motivation for this change
To add pg_partman, a partition manager extension for Postgres.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
