### PR TITLE
aws-c-common: 0.3.4 -> 0.3.9.

### DIFF
--- a/pkgs/development/libraries/aws-c-common/default.nix
+++ b/pkgs/development/libraries/aws-c-common/default.nix
@@ -2,18 +2,16 @@
 
 stdenv.mkDerivation rec {
   pname = "aws-c-common";
-  version = "0.3.4";
+  version = "0.3.9";
 
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1z02ndb9jjn0p5bcc49pq0d8c0q2pq33dlszw77l76jkhrfx0921";
+    sha256 = "04wrmrw83vypqzsq88b2q8kp5sfbv0qsci3bcxw0c2mfxqk8358n";
   };
 
   nativeBuildInputs = [ cmake ];
-
-  buildInputs = lib.optional stdenv.hostPlatform.isMusl libexecinfo;
 
   NIX_CFLAGS_COMPILE = lib.optionals stdenv.isDarwin [
     "-Wno-nullability-extension"


### PR DESCRIPTION
Also remove conditional adding of `libexecinfo` for musl; see #56106.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
