### PR TITLE
pythonPackages.httpretty: fix build on aarch64

### DIFF
--- a/pkgs/development/python-modules/httpretty/default.nix
+++ b/pkgs/development/python-modules/httpretty/default.nix
@@ -6,6 +6,7 @@
 , httplib2
 , sure
 , nose
+, nose-exclude
 , coverage
 , certifi
 , urllib3
@@ -24,18 +25,20 @@ buildPythonPackage rec {
     sha256 = "01b52d45077e702eda491f4fe75328d3468fd886aed5dcc530003e7b2b5939dc";
   };
 
-  checkInputs = [ nose sure coverage mock rednose
-  # Following not declared in setup.py
-    nose-randomly requests tornado httplib2
-  ];
   propagatedBuildInputs = [ six ];
+
+  checkInputs = [ nose sure coverage mock rednose
+    # Following not declared in setup.py
+    nose-randomly requests tornado httplib2 nose-exclude
+  ];
 
   __darwinAllowLocalNetworking = true;
 
+  NOSE_EXCLUDE = stdenv.lib.optionalString (stdenv.isAarch64) "tests.functional.test_httplib2.test_callback_response";
+
   meta = with stdenv.lib; {
-    homepage = "https://falcao.it/HTTPretty/";
+    homepage = "https://httpretty.readthedocs.org/";
     description = "HTTP client request mocking tool";
     license = licenses.mit;
   };
-
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
_tests.functional.test_httplib2.test_callback_response_ keeps failing on Hydra
\+ update meta.homepage

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
