### PR TITLE
aws-sdk-cpp: fix cross compilation

### DIFF
--- a/pkgs/development/libraries/aws-sdk-cpp/default.nix
+++ b/pkgs/development/libraries/aws-sdk-cpp/default.nix
@@ -37,9 +37,11 @@ stdenv.mkDerivation rec {
     "-DBUILD_DEPS=OFF"
     "-DCMAKE_SKIP_BUILD_RPATH=OFF"
   ] ++ lib.optional (!customMemoryManagement) "-DCUSTOM_MEMORY_MANAGEMENT=0"
-    ++ lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) "-DENABLE_TESTING=OFF"
-    ++ lib.optional (apis != ["*"])
-      "-DBUILD_ONLY=${lib.concatStringsSep ";" apis}";
+  ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    "-DENABLE_TESTING=OFF"
+    "-DCURL_HAS_H2=0"
+  ] ++ lib.optional (apis != ["*"])
+    "-DBUILD_ONLY=${lib.concatStringsSep ";" apis}";
 
   preConfigure =
     ''


### PR DESCRIPTION
###### Motivation for this change

Fix cross compilation of `nix`: `nix build nixpkgs.pkgsCross.aarch64-multiplatform.nix`

```
...
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Updating version info to 1.7.90
-- Custom memory management disabled
-- Performing Test CURL_HAS_H2
CMake Error: TRY_RUN() invoked in cross-compiling mode, please set the following cache variables appropriately:
   CURL_HAS_H2_EXITCODE (advanced)
   CURL_HAS_H2_EXITCODE__TRYRUN_OUTPUT (advanced)
For details see /build/source/build/TryRunResults.cmake
-- Performing Test CURL_HAS_H2 - Failed
-- Configuring incomplete, errors occurred!
See also "/build/source/build/CMakeFiles/CMakeOutput.log".
See also "/build/source/build/CMakeFiles/CMakeError.log".
builder for '/nix/store/wagq7k2fbgkl32alzfh5f4ysgpvsi4jw-aws-sdk-cpp-1.7.90-aarch64-unknown-linux-gnu.drv' failed with exit code 1
cannot build derivation '/nix/store/lkbs04l8a4489pykvfrjj0r4vc8y2k2i-nix-2.2.2-aarch64-unknown-linux-gnu.drv': 1 dependencies couldn't be built
error: build of '/nix/store/lkbs04l8a4489pykvfrjj0r4vc8y2k2i-nix-2.2.2-aarch64-unknown-linux-gnu.drv' failed
```

I think the problem was introduced in https://github.com/aws/aws-sdk-cpp/commit/f024f1df634de8441414ba090d963af71254ebd8.

###### Things done

Provided the expected result of a CMake `try_run` call. I'm really unsure about wether this is supposed to be `0` or `1`. The exit code of the test should be `0` and the [docs](https://cmake.org/cmake/help/latest/command/try_run.html#behavior-when-cross-compiling) say that the variable should be set to the exit code, but it might be better if someone double checked wether this really translates to `-DCURL_HAS_H2=0`.

I did not run the build result, as I have no access to `aarch64` hardware atm.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
