### PR TITLE
[blocked] vapoursynth-editor: init at R19

### DIFF
--- a/pkgs/applications/video/mpv/default.nix
+++ b/pkgs/applications/video/mpv/default.nix
@@ -191,7 +191,7 @@ in stdenv.mkDerivation rec {
   + optionalString youtubeSupport ''
       --prefix PATH : "${youtube-dl}/bin" \
   '' + optionalString vapoursynthSupport ''
-      --prefix PYTHONPATH : "${vapoursynth}/lib/${python3.libPrefix}/site-packages:$PYTHONPATH"
+      --prefix PYTHONPATH : "${python3.pkgs.vapoursynth}/lib/${python3.libPrefix}/site-packages:$PYTHONPATH"
   '';
 
   installPhase = ''

--- a/pkgs/development/libraries/vapoursynth/default.nix
+++ b/pkgs/development/libraries/vapoursynth/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pkgconfig, autoreconfHook
+{ stdenv, fetchFromGitHub, pkgconfig, autoreconfHook, makeWrapper
 , zimg, libass, python3, libiconv
 , ApplicationServices, nasm
 , ocrSupport ?  false, tesseract ? null
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     sha256 = "09fj4k75cksx1imivqfyr945swlr8k392kkdgzldwc4404qv82s6";
   };
 
-  nativeBuildInputs = [ pkgconfig autoreconfHook nasm ];
+  nativeBuildInputs = [ pkgconfig autoreconfHook nasm python3 makeWrapper ];
   buildInputs = [
     zimg libass
     (python3.withPackages (ps: with ps; [ sphinx cython ]))
@@ -37,12 +37,22 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  outputs = [ "out" "dev" "python" ];
+
+  postInstall = ''
+    moveToOutput include $dev
+    moveToOutput lib/${python3.libPrefix} $python
+    moveToOutput bin/vspipe $python
+    wrapProgram $python/bin/vspipe \
+        --prefix PYTHONPATH : $(toPythonPath $python)
+  '';
+
   meta = with stdenv.lib; {
     description = "A video processing framework with the future in mind";
     homepage    = http://www.vapoursynth.com/;
     license     = licenses.lgpl21;
     platforms   = platforms.x86_64;
-    maintainers = with maintainers; [ rnhmjoj ];
+    maintainers = with maintainers; [ rnhmjoj tadeokondrak ];
   };
 
 }

--- a/pkgs/development/libraries/vapoursynth/editor.nix
+++ b/pkgs/development/libraries/vapoursynth/editor.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchFromBitbucket, makeWrapper
+, python3, vapoursynth
+, qmake, qtbase, qtwebsockets
+}:
+
+stdenv.mkDerivation rec {
+  pname = "vapoursynth-editor";
+  version = "R19";
+
+  src = fetchFromBitbucket {
+    owner = "mystery_keeper";
+    repo = pname;
+    rev = stdenv.lib.toLower version;
+    sha256 = "1zlaynkkvizf128ln50yvzz3b764f5a0yryp6993s9fkwa7djb6n";
+  };
+
+  nativeBuildInputs = [ qmake makeWrapper python3 ];
+  buildInputs = [ qtbase vapoursynth qtwebsockets ];
+
+  preConfigure = ''
+    cd pro
+  '';
+
+  installPhase = ''
+    cd ../build/release*
+    mkdir -p $out/bin
+    for bin in vsedit{,-job-server{,-watcher}}; do
+        mv $bin $out/bin
+
+        wrapProgram $out/bin/$bin \
+            --prefix PYTHONPATH : $(toPythonPath ${python3.pkgs.vapoursynth}) \
+            --prefix LD_LIBRARY_PATH : ${vapoursynth}/lib
+    done
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Cross-platform editor for VapourSynth scripts";
+    homepage = https://bitbucket.org/mystery_keeper/vapoursynth-editor;
+    license = licenses.mit;
+    maintainers = with maintainers; [ tadeokondrak ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4885,7 +4885,7 @@ in
 
   ola = callPackage ../applications/misc/ola { };
 
-  olive-editor = libsForQt5.callPackage ../applications/video/olive-editor { 
+  olive-editor = libsForQt5.callPackage ../applications/video/olive-editor {
     inherit (darwin.apple_sdk.frameworks) CoreFoundation;
   };
 
@@ -21813,6 +21813,8 @@ in
   };
 
   vapoursynth-mvtools = callPackage ../development/libraries/vapoursynth-mvtools { };
+
+  vapoursynth-editor = libsForQt5.callPackage ../development/libraries/vapoursynth/editor.nix { };
 
   vassal = callPackage ../games/vassal { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5564,6 +5564,10 @@ in {
   flickrapi = callPackage ../development/python-modules/flickrapi { };
 
   aioesphomeapi = callPackage ../development/python-modules/aioesphomeapi { };
+
+  vapoursynth = disabledIf (!pythonAtLeast "3.7") (toPythonModule (pkgs.vapoursynth.override {
+    python3 = python;
+  })).python;
 });
 
 in fix' (extends overrides packages)


### PR DESCRIPTION
depends on #58859, don't merge before (I can't mark a PR as draft after it's made)

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

More vapoursynth changes. This is the most popular (only?) script editor for vapoursynth.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

LD_LIBRARY_PATH is needed since the library is loaded at runtime.