### PR TITLE
pythonPackages.funcsigs: fix tests on pypy3

### DIFF
--- a/pkgs/development/python-modules/funcsigs/default.nix
+++ b/pkgs/development/python-modules/funcsigs/default.nix
@@ -1,5 +1,6 @@
 { stdenv, buildPythonPackage, fetchPypi
-, unittest2 }:
+, isPyPy, isPy3k, unittest2
+}:
 
 buildPythonPackage rec {
   pname = "funcsigs";
@@ -11,6 +12,9 @@ buildPythonPackage rec {
   };
 
   buildInputs = [ unittest2 ];
+
+  # https://github.com/testing-cabal/funcsigs/issues/10
+  patches = stdenv.lib.optional (isPyPy && isPy3k) [ ./fix-pypy3-tests.patch ];
 
   meta = with stdenv.lib; {
     description = "Python function signatures from PEP362 for Python 2.6, 2.7 and 3.2+";

--- a/pkgs/development/python-modules/funcsigs/fix-pypy3-tests.patch
+++ b/pkgs/development/python-modules/funcsigs/fix-pypy3-tests.patch
@@ -1,0 +1,94 @@
+diff --git a/tests/test_inspect.py b/tests/test_inspect.py
+index 98d6592..3a2a1f2 100644
+--- a/tests/test_inspect.py
++++ b/tests/test_inspect.py
+@@ -8,6 +8,7 @@ import unittest2 as unittest
+ 
+ import funcsigs as inspect
+ 
++import platform
+ 
+ class TestSignatureObject(unittest.TestCase):
+     @staticmethod
+@@ -409,7 +410,7 @@ def test_signature_on_decorated(self):
+                       Ellipsis))
+ """)
+ 
+-    if sys.version_info[0] > 2:
++    if sys.version_info[0] > 2 and platform.python_implementation() != "PyPy":
+         exec("""
+ def test_signature_on_class(self):
+     class C:
+@@ -493,41 +494,44 @@ def test_signature_on_class(self):
+                       Ellipsis))
+ """)
+ 
+-    def test_signature_on_callable_objects(self):
+-        class Foo(object):
+-            def __call__(self, a):
+-                pass
++    if platform.python_implementation() != "PyPy":
++        exec("""
++def test_signature_on_callable_objects(self):
++    class Foo(object):
++        def __call__(self, a):
++            pass
+ 
+-        self.assertEqual(self.signature(Foo()),
+-                         ((('a', Ellipsis, Ellipsis, "positional_or_keyword"),),
+-                          Ellipsis))
++    self.assertEqual(self.signature(Foo()),
++                     ((('a', Ellipsis, Ellipsis, "positional_or_keyword"),),
++                      Ellipsis))
+ 
+-        class Spam(object):
+-            pass
+-        with self.assertRaisesRegex(TypeError, "is not a callable object"):
+-            inspect.signature(Spam())
++    class Spam(object):
++        pass
++    with self.assertRaisesRegex(TypeError, "is not a callable object"):
++        inspect.signature(Spam())
+ 
+-        class Bar(Spam, Foo):
+-            pass
++    class Bar(Spam, Foo):
++        pass
+ 
+-        self.assertEqual(self.signature(Bar()),
+-                         ((('a', Ellipsis, Ellipsis, "positional_or_keyword"),),
+-                          Ellipsis))
++    self.assertEqual(self.signature(Bar()),
++                     ((('a', Ellipsis, Ellipsis, "positional_or_keyword"),),
++                      Ellipsis))
+ 
+-        class ToFail(object):
+-            __call__ = type
+-        with self.assertRaisesRegex(ValueError, "not supported by signature"):
+-            inspect.signature(ToFail())
++    class ToFail(object):
++        __call__ = type
++    with self.assertRaisesRegex(ValueError, "not supported by signature"):
++        inspect.signature(ToFail())
+ 
+-        if sys.version_info[0] < 3:
+-            return
++    if sys.version_info[0] < 3:
++        return
+ 
+-        class Wrapped(object):
+-            pass
+-        Wrapped.__wrapped__ = lambda a: None
+-        self.assertEqual(self.signature(Wrapped),
+-                         ((('a', Ellipsis, Ellipsis, "positional_or_keyword"),),
+-                          Ellipsis))
++    class Wrapped(object):
++        pass
++    Wrapped.__wrapped__ = lambda a: None
++    self.assertEqual(self.signature(Wrapped),
++                     ((('a', Ellipsis, Ellipsis, "positional_or_keyword"),),
++                      Ellipsis))
++""")
+ 
+     def test_signature_on_lambdas(self):
+         self.assertEqual(self.signature((lambda a=10: a)),


### PR DESCRIPTION
###### Motivation for this change

This package has a spurious test failure on PyPy3, which was reported
upstream a while ago: https://github.com/testing-cabal/funcsigs/issues/10

This is fixed thanks to the included patch, which was authored and is
also used by the Gentoo Python team.

With this, packages like 'pytest' and 'click' now work under PyPy3.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
