### PR TITLE
2019 05 15 patchwork

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4953,6 +4953,11 @@
     github = "the-kenny";
     name = "Moritz Ulrich";
   };
+  thedavidmeister = {
+    email = "thedavidmeister@gmail.com";
+    github = "thedavidmeister";
+    name = "David Meister";
+  };
   thesola10 = {
     email = "thesola10@bobile.fr";
     github = "thesola10";

--- a/pkgs/applications/networking/ssb/patchwork/default.nix
+++ b/pkgs/applications/networking/ssb/patchwork/default.nix
@@ -1,0 +1,46 @@
+{
+ stdenv,
+ appimage-run,
+ fetchurl,
+ runtimeShell,
+ gsettings-desktop-schemas,
+ gtk3,
+ gobject-introspection,
+ wrapGAppsHook,
+}:
+
+stdenv.mkDerivation rec {
+  # latest version that runs without errors
+  # https://github.com/ssbc/patchwork/issues/972
+  version = "3.11.4";
+  pname = "patchwork";
+
+  src = fetchurl {
+    url = "https://github.com/ssbc/patchwork/releases/download/v${version}/Patchwork-${version}-linux-x86_64.AppImage";
+    sha256 = "1blsprpkvm0ws9b96gb36f0rbf8f5jgmw4x6dsb1kswr4ysf591s";
+  };
+
+  nativeBuildInputs = [ wrapGAppsHook ];
+  buildInputs = [ appimage-run gtk3 gsettings-desktop-schemas gobject-introspection ];
+
+  unpackPhase = ":";
+
+  installPhase = ''
+    mkdir -p $out/{bin,share}
+    cp $src $out/share/${pname}
+    echo "#!${runtimeShell}" > $out/bin/${pname}
+    echo "${appimage-run}/bin/appimage-run $out/share/${pname}" >> $out/bin/${pname}
+    chmod +x $out/bin/${pname} $out/share/${pname}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A decentralized messaging and sharing app built on top of Secure Scuttlebutt (SSB).";
+    longDescription = ''
+      sea-slang for gossip - a scuttlebutt is basically a watercooler on a ship.
+    '';
+    homepage = https://www.scuttlebutt.nz/;
+    license = licenses.agpl3;
+    maintainers = with maintainers; [ thedavidmeister ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12905,6 +12905,8 @@ in
 
   lvtk = callPackage ../development/libraries/audio/lvtk { };
 
+  patchwork = callPackage ../applications/networking/ssb/patchwork { };
+
   qradiolink = callPackage ../applications/radio/qradiolink { };
 
   qrupdate = callPackage ../development/libraries/qrupdate { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

same as #59111 with different commit history


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
