### PR TITLE
chit: 0.1.12 -> 0.1.13

### DIFF
--- a/pkgs/development/tools/chit/default.nix
+++ b/pkgs/development/tools/chit/default.nix
@@ -6,13 +6,13 @@ with rustPlatform;
 
 buildRustPackage rec {
   pname = "chit";
-  version = "0.1.12";
+  version = "0.1.13";
 
   src = fetchFromGitHub {
     owner = "peterheesterman";
     repo = pname;
     rev = version;
-    sha256 = "17g2p07zhf4n4pjmws0ssfy2mrn0v933ih0vnlr1z2cv9mx8srsl";
+    sha256 = "1qp5ad83lvfz9l4ihz1l500p8bgf7q0z1k4f3i13nd5n7i3ksdjc";
   };
 
   cargoSha256 = "1jqnnf4jgjpm1i310hda15423nxfw9frgpmc2kbrs66qcsj7avaw";
@@ -22,9 +22,6 @@ buildRustPackage rec {
   ++ stdenv.lib.optionals stdenv.isLinux [ openssl ]
   ++ stdenv.lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ CoreFoundation CoreServices Security ])
   ;
-
-  # Tests require network access
-  doCheck = false;
 
   meta = with stdenv.lib; {
     description = "Crate help in terminal: A tool for looking up details about rust crates without going to crates.io";


### PR DESCRIPTION
###### Motivation for this change
https://github.com/peterheesterman/chit/releases/tag/0.1.13

Re-enable tests as the one that required network access has been fixed.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS (with sandboxing)
   - [X] macOS (without sandboxing)
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---