### PR TITLE
pypyPackages: enable sure (without checkPhase)

### DIFF
--- a/pkgs/development/python-modules/sure/default.nix
+++ b/pkgs/development/python-modules/sure/default.nix
@@ -10,12 +10,13 @@
 buildPythonPackage rec {
   pname = "sure";
   version = "1.4.11";
-  disabled = isPyPy;
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "3c8d5271fb18e2c69e2613af1ad400d8df090f1456081635bd3171847303cdaa";
   };
+
+  doCheck = !isPyPy;
 
   buildInputs = [ rednose ];
   propagatedBuildInputs = [ six mock ];


### PR DESCRIPTION
sure 1.4.6 added support for pypy 3, which the previous 1.2.x version
didn't support, but this wasn't fixed in the update from
12d4cc12ac4f53f38db19a4e8e78ebc7ba2ee042.

However, just fixing this results in a test failure; it looks like it's
a simple change in the internals of how PyPy throws some error messages,
but is otherwise benign, but hasn't been caught upstream yet.

```
======================================================================
FAIL: test_old_api.test_that_contains_none
that('foobar').contains(None)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/build/sure-1.4.11/sure/old.py", line 129, in raises
    self._src(*self._callable_args, **self._callable_kw)
  File "/build/sure-1.4.11/tests/test_old_api.py", line 548, in
assertions
    assert that(b'foobar' if PY2 else 'foobar').contains(None)
  File "/build/sure-1.4.11/sure/old.py", line 437, in contains
    assert what in self._src, '%r should be in %r' % (what, self._src)
TypeError: Can't convert 'NoneType' object to str implicitly

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File
"/nix/store/rmz3gqbdhb32zpsbn183lmd4ysajv88m-pypy3.5-nose-1.3.7/site-packages/nose/case.py",
line 197, in runTest
    self.test(*self.arg)
  File "/build/sure-1.4.11/tests/test_old_api.py", line 554, in
test_that_contains_none
    error_msg
  File "/build/sure-1.4.11/sure/old.py", line 153, in raises
    msg, err))
AssertionError: <function test_that_contains_none.<locals>.assertions at
0x0000000001f09420> raised TypeError, but the exception message does not
                    match.

EXPECTED:
'NoneType' does not have the buffer interface

GOT:
Can't convert 'NoneType' object to str implicitly
----------------------------------------------------------------------
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
