### PR TITLE
adom: Rewrite derivation, add ascii-only variant

### DIFF
--- a/pkgs/games/adom/default.nix
+++ b/pkgs/games/adom/default.nix
@@ -65,6 +65,7 @@ let
       cd $out/share/adom; exec adom
       EOF
       chmod +x $out/bin/adom
+      runHook postInstall
     '';
 
     meta = with stdenv.lib; {

--- a/pkgs/games/adom/default.nix
+++ b/pkgs/games/adom/default.nix
@@ -1,59 +1,81 @@
-{ stdenv, fetchurl, patchelf, zlib, libmad, libpng12, libcaca, libGLU_combined, alsaLib, libpulseaudio
-, xorg }:
+{ stdenv, fetchurl, autoPatchelfHook, system, lib
+# Used by the ASCII build.
+, ncurses5
+# Used by the graphical build only.
+, SDL2, SDL2_image, SDL2_net, SDL2_mixer, SDL2_ttf
+, luajit
+}:
 
 let
-
-  inherit (xorg) libXext libX11;
-
-  lpath = "${stdenv.cc.cc.lib}/lib64:" + stdenv.lib.makeLibraryPath [
-      zlib libmad libpng12 libcaca libXext libX11 libGLU_combined alsaLib libpulseaudio];
-
-in
-stdenv.mkDerivation rec {
-  name = "adom-${version}-noteye";
-  version = "1.2.0_pre23";
-
-  src = fetchurl {
-    url = "http://ancardia.uk.to/download/adom_noteye_linux_ubuntu_64_${version}.tar.gz";
-    sha256 = "0sbn0csaqb9cqi0z5fdwvnymkf84g64csg0s9mm6fzh0sm2mi0hz";
+  version = "3.3.3";
+  sources = {
+    ascii = {
+      x86_64-linux = fetchurl {
+        url = "https://www.adom.de/home/download/current/adom_linux_ubuntu_64_${version}.tar.gz";
+        sha256 = "493ef76594c1f6a7f38dcf32a76cd107fb71dd12bf917c18fdeaebcac1a353b1";
+      };
+      i686-linux = fetchurl {
+        url = "https://www.adom.de/home/download/current/adom_linux_ubuntu_32_${version}.tar.gz";
+        sha256 = "0fayy4vz4zk45i77j5nb1jx7rkl65jyfdp2wy0y9sv9p980yz0q3";
+      };
+    };
+    graphical = {
+      x86_64-linux = fetchurl {
+        url = "https://www.indiedb.com/downloads/mirror/173928/115/4eb8407f7ab0e4143212c289acfbe735/";
+        sha256 = "047q472rrr2xwkq76431i4acbfic1q9d01x45y49bbp58fsgvkgd";
+      };
+      i686-linux = fetchurl {
+        url = "https://www.indiedb.com/downloads/mirror/173927/100/af42faf2994ef88e844fb630894f80c8";
+        sha256 = "08dn1504qjwznwmzh4304igbv8fx9azw8rq70724pv9if72yja77";
+      };
+    };
   };
 
-  buildCommand = ''
-    . $stdenv/setup
+  mkAdom = type: stdenv.mkDerivation {
+    name = "adom-${type}-${version}";
 
-    unpackPhase
+    src = sources.${type}.${system};
 
-    mkdir -pv $out
-    cp -r -t $out adom/*
+    nativeBuildInputs = [ autoPatchelfHook ];
 
-    chmod u+w $out/lib
-    for l in $out/lib/*so* ; do
-      chmod u+w $l
-      ${patchelf}/bin/patchelf \
-        --set-rpath "$out/lib:${lpath}" \
-        $l
-    done
+    buildInputs = [ ncurses5 ] ++ lib.optional (type == "graphical") [ 
+      SDL2 SDL2_image SDL2_net SDL2_mixer SDL2_ttf
+      luajit
+    ];
 
-    ${patchelf}/bin/patchelf \
-      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      --set-rpath "$out/lib:${lpath}" \
-      $out/adom
+    unpackPhase = ''
+      tar xzf $src
+      cd adom
+    '';
 
-    mkdir $out/bin
-    cat >$out/bin/adom <<EOF
-    #! ${stdenv.shell}
-    (cd $out; exec $out/adom ; )
-    EOF
-    chmod +x $out/bin/adom
-  '';
+    installPhase = ''
+      mkdir -p $out/share/adom $out/bin
+      cp -a * $out/share/adom
 
-  meta = with stdenv.lib; {
-    description = "A rogue-like game with nice graphical interface";
-    homepage = http://adom.de/;
-    license = licenses.unfreeRedistributable;
-    maintainers = [maintainers.smironov];
+      # Graphical build only.
+      if [[ -d lib ]]; then
+        rm $out/share/adom/lib/*
+        cp lib/{libstdc++,libnoteye}* $out/share/adom/lib/
+        addAutoPatchelfSearchPath $out/share/adom/lib
+      fi
 
-    # Please, notify me (smironov) if you need the x86 version
-    platforms = ["x86_64-linux"];
+      cat >$out/bin/adom <<EOF
+      #! ${stdenv.shell}
+      cd $out/share/adom; exec adom
+      EOF
+      chmod +x $out/bin/adom
+    '';
+
+    meta = with stdenv.lib; {
+      description = "A rogue-like game with nice graphical interface";
+      homepage = http://adom.de/;
+      license = licenses.unfreeRedistributable;
+      maintainers = [maintainers.Baughn];
+
+      platforms = platforms.linux;
+    };
   };
+in {
+  adom-ascii = mkAdom "ascii";
+  adom-graphical = mkAdom "graphical";
 }

--- a/pkgs/games/adom/default.nix
+++ b/pkgs/games/adom/default.nix
@@ -49,6 +49,7 @@ let
     '';
 
     installPhase = ''
+      runHook preInstall
       mkdir -p $out/share/adom $out/bin
       cp -a * $out/share/adom
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20491,7 +20491,9 @@ in
 
   _90secondportraits = callPackage ../games/90secondportraits { love = love_0_10; };
 
-  adom = callPackage ../games/adom { };
+  adom = (callPackage ../games/adom { }).adom-graphical;
+
+  adom-ascii = (callPackage ../games/adom { }).adom-ascii;
 
   airstrike = callPackage ../games/airstrike { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The mirror currently used for ADOM has died.

This PR points at the new one that's linked from adom.de. In addition I added a derivation for the (much smaller) ascii-only variant, updated the derivation to use autoPatchElf, and added a hypothetically-functional i686 version. I unfortunately cannot test that, as some of the dependencies fail when cross-compiling.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
