### PR TITLE
libfprint: added a fork for Lenovo ThinkPad

### DIFF
--- a/nixos/modules/services/security/fprintd.nix
+++ b/nixos/modules/services/security/fprintd.nix
@@ -25,6 +25,16 @@ in
         '';
       };
 
+      package = mkOption {
+        type = types.package;
+        default = pkgs.fprintd;
+        defaultText = "pkgs.fprintd";
+        example = "pkgs.fprintd-thinkpad";
+        description = ''
+          fprintd package to use.
+        '';
+      };
+
     };
 
   };
@@ -38,7 +48,7 @@ in
 
     environment.systemPackages = [ pkgs.fprintd ];
 
-    systemd.packages = [ pkgs.fprintd ];
+    systemd.packages = [ cfg.package ];
 
   };
 

--- a/pkgs/development/libraries/libfprint/default.nix
+++ b/pkgs/development/libraries/libfprint/default.nix
@@ -1,16 +1,29 @@
-{ stdenv, fetchurl, pkgconfig, meson, ninja, libusb, pixman, glib, nss, gtk3
-, coreutils, gtk-doc, docbook_xsl, docbook_xml_dtd_43 }:
+{ thinkpad ? false, stdenv, fetchFromGitHub, fetchurl, pkgconfig, meson, ninja, libusb, pixman, glib, nss, gtk3
+, coreutils, gtk-doc, docbook_xsl, docbook_xml_dtd_43, openssl ? null }:
+
+assert thinkpad -> openssl != null;
 
 stdenv.mkDerivation rec {
-  name = "libfprint-${version}";
+  pname = "libfprint" + stdenv.lib.optionalString thinkpad "-thinkpad";
   version = "0.99.0";
 
-  src = fetchurl {
-    url = "https://gitlab.freedesktop.org/libfprint/libfprint/uploads/82ba3cef5bdf72997df711eacdb13c0f/libfprint-${version}.tar.xz";
-    sha256 = "16r4nl40y0jri57jiqmdz4s87byblx22lbhyvqpljd6mqm5rg187";
-  };
+  src = {
+    libfprint-thinkpad =
+      fetchFromGitHub {
+        owner = "3v1n0";
+        repo = "libfprint";
+        rev = "2e2e3821717e9042e93a995bdbd3d00f2df0be9c";
+        sha256 = "1vps1wrp7hskf13f7jrv0dwry2fcid76x2w463wplngp63cj7b3b";
+      };
+    libfprint = fetchurl {
+      url = "https://gitlab.freedesktop.org/libfprint/libfprint/uploads/82ba3cef5bdf72997df711eacdb13c0f/libfprint-${version}.tar.xz";
+      sha256 = "16r4nl40y0jri57jiqmdz4s87byblx22lbhyvqpljd6mqm5rg187";
+    };
+  }.${pname};
 
-  buildInputs = [ libusb pixman glib nss gtk3 ];
+  buildInputs = [ libusb pixman glib nss gtk3 ]
+    ++ stdenv.lib.optional thinkpad openssl;
+
   nativeBuildInputs = [ pkgconfig meson ninja gtk-doc docbook_xsl docbook_xml_dtd_43 ];
 
   mesonFlags = [ "-Dudev_rules_dir=lib/udev/rules.d" "-Dx11-examples=false" ];

--- a/pkgs/tools/security/fprintd/default.nix
+++ b/pkgs/tools/security/fprintd/default.nix
@@ -1,8 +1,9 @@
-{ stdenv, fetchurl, pkgconfig, intltool
-, libfprint, glib, dbus-glib, polkit, nss, pam, systemd }:
+{ thinkpad ? false
+, stdenv, fetchurl, pkgconfig, intltool, libfprint-thinkpad ? null
+, libfprint ? null, glib, dbus-glib, polkit, nss, pam, systemd }:
 
 stdenv.mkDerivation rec {
-  name = "fprintd-${version}";
+  pname = "fprintd" + stdenv.lib.optionalString thinkpad "-thinkpad";
   version = "0.8.1";
 
   src = fetchurl {
@@ -10,7 +11,10 @@ stdenv.mkDerivation rec {
     sha256 = "124s0g9syvglgsmqnavp2a8c0zcq8cyaph8p8iyvbla11vfizs9l";
   };
 
-  buildInputs = [ libfprint glib dbus-glib polkit nss pam systemd ];
+  buildInputs = [ glib dbus-glib polkit nss pam systemd ]
+    ++ stdenv.lib.optional thinkpad libfprint-thinkpad
+    ++ stdenv.lib.optional (!thinkpad) libfprint;
+
   nativeBuildInputs = [ pkgconfig intltool ];
 
   configureFlags = [ "--with-systemdsystemunitdir=$(out)/lib/systemd/system" "--localstatedir=/var" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11299,6 +11299,9 @@ in
   };
 
   libfprint = callPackage ../development/libraries/libfprint { };
+  libfprint-thinkpad = libfprint.override {
+    thinkpad = true;
+  };
 
   libfpx = callPackage ../development/libraries/libfpx { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2981,6 +2981,9 @@ in
   fprot = callPackage ../tools/security/fprot { };
 
   fprintd = callPackage ../tools/security/fprintd { };
+  fprintd-thinkpad = fprintd.override {
+    thinkpad = true;
+  };
 
   franz = callPackage ../applications/networking/instant-messengers/franz { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Lenovo ThinkPads have a fingerprint sensor with special needs. There's a fork of libfprintd available that supports it.

###### Things done
1. Added `thinkpad` option to `pkgs/development/libraries/libfprint/default.nix`
2. Added `thinkpad` option to `fprintd` (package and service)

Usage:

```
  services.fprintd.package = pkgs.fprintd-thinkpad;
  services.fprintd.enable = true;
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
