### PR TITLE
xbill: init at 2.1

### DIFF
--- a/pkgs/games/xbill/default.nix
+++ b/pkgs/games/xbill/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, lib, fetchurl, libX11, libXpm, libXt, motif, ... }:
+
+stdenv.mkDerivation rec {
+  pname = "xbill";
+  version = "2.1";
+
+  buildInputs = [ libX11 libXpm libXt motif ];
+
+  NIX_CFLAGS_LINK = [ "-lXpm" ];
+
+  configureFlags = [
+    "--with-x"
+    "--enable-motif"
+  ];
+
+  src = fetchurl {
+    url = "http://www.xbill.org/download/${pname}-${version}.tar.gz";
+    sha256 = "13b08lli2gvppmvyhy0xs8cbjbkvrn4b87302mx0pxrdrvqzzz8f";
+  };
+
+  meta = with stdenv; {
+    description = "Protect a computer network from getting infected.";
+    homepage = "http://www.xbill.org/";
+    license = lib.licenses.gpl1;
+    maintainers = with lib.maintainers; [ aw ];
+    longDescription = ''
+      Ever get the feeling that nothing is going right? You're a sysadmin,
+      and someone's trying to destroy your computers. The little people
+      running around the screen are trying to infect your computers with
+      Wingdows [TM], a virus cleverly designed to resemble a popular
+      operating system.
+    '';
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6585,6 +6585,8 @@ in
 
   xbanish = callPackage ../tools/X11/xbanish { };
 
+  xbill = callPackage ../games/xbill { };
+
   xbrightness = callPackage ../tools/X11/xbrightness { };
 
   xkbvalidate = callPackage ../tools/X11/xkbvalidate { };


### PR DESCRIPTION
Old game, once more popular than Quake (but not Quake Ⅱ).

From the homepage:

Ever get the feeling that nothing is going right? You're a sysadmin, and
someone's trying to destroy your computers. The little people running
around the screen are trying to infect your computers with Wingdows
[TM], a virus cleverly designed to resemble a popular operating system.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
