### PR TITLE
[r18.09] leptonica: patch multiple CVEs

### DIFF
--- a/pkgs/development/libraries/leptonica/CVE-2018-3836.patch
+++ b/pkgs/development/libraries/leptonica/CVE-2018-3836.patch
@@ -1,0 +1,95 @@
+--- a/src/allheaders.h
++++ b/src/allheaders.h
+@@ -2600,6 +2600,7 @@
+ LEPT_DLL extern char * stringReverse ( const char *src );
+ LEPT_DLL extern char * strtokSafe ( char *cstr, const char *seps, char **psaveptr );
+ LEPT_DLL extern l_int32 stringSplitOnToken ( char *cstr, const char *seps, char **phead, char **ptail );
++LEPT_DLL extern l_int32 stringCheckForChars ( const char *src, const char *chars, l_int32 *pfound );
+ LEPT_DLL extern char * stringRemoveChars ( const char *src, const char *remchars );
+ LEPT_DLL extern l_int32 stringFindSubstr ( const char *src, const char *sub, l_int32 *ploc );
+ LEPT_DLL extern char * stringReplaceSubstr ( const char *src, const char *sub1, const char *sub2, l_int32 *pfound, l_int32 *ploc );
+--- a/src/gplot.c
++++ b/src/gplot.c
+@@ -141,9 +141,10 @@
+             const char  *xlabel,
+             const char  *ylabel)
+ {
+-char   *newroot;
+-char    buf[L_BUF_SIZE];
+-GPLOT  *gplot;
++char    *newroot;
++char     buf[L_BUF_SIZE];
++l_int32  badchar;
++GPLOT   *gplot;
+ 
+     PROCNAME("gplotCreate");
+ 
+@@ -152,6 +153,9 @@
+     if (outformat != GPLOT_PNG && outformat != GPLOT_PS &&
+         outformat != GPLOT_EPS && outformat != GPLOT_LATEX)
+         return (GPLOT *)ERROR_PTR("outformat invalid", procName, NULL);
++    stringCheckForChars(rootname, "`;&|><\"?*", &badchar);
++    if (badchar)  /* danger of command injection */
++        return (GPLOT *)ERROR_PTR("invalid rootname", procName, NULL);
+ 
+     if ((gplot = (GPLOT *)LEPT_CALLOC(1, sizeof(GPLOT))) == NULL)
+         return (GPLOT *)ERROR_PTR("gplot not made", procName, NULL);
+--- a/src/utils2.c
++++ b/src/utils2.c
+@@ -42,6 +42,7 @@
+  *           l_int32    stringSplitOnToken()
+  *
+  *       Find and replace string and array procs
++ *           l_int32    stringCheckForChars()
+  *           char      *stringRemoveChars()
+  *           l_int32    stringFindSubstr()
+  *           char      *stringReplaceSubstr()
+@@ -701,6 +702,48 @@
+ /*--------------------------------------------------------------------*
+  *                       Find and replace procs                       *
+  *--------------------------------------------------------------------*/
++/*!
++ * \brief   stringCheckForChars()
++ *
++ * \param[in]    src      input string; can be of zero length
++ * \param[in]    chars    string of chars to be searched for in %src
++ * \param[out]   pfound   1 if any characters are found; 0 otherwise
++ * \return  0 if OK, 1 on error
++ *
++ * <pre>
++ * Notes:
++ *      (1) This can be used to sanitize an operation by checking for
++ *          special characters that don't belong in a string.
++ * </pre>
++ */
++l_int32
++stringCheckForChars(const char  *src,
++                    const char  *chars,
++                    l_int32     *pfound)
++{
++char     ch;
++l_int32  i, n;
++
++    PROCNAME("stringCheckForChars");
++
++    if (!pfound)
++        return ERROR_INT("&found not defined", procName, 1);
++    *pfound = FALSE;
++    if (!src || !chars)
++        return ERROR_INT("src and chars not both defined", procName, 1);
++
++    n = strlen(src);
++    for (i = 0; i < n; i++) {
++        ch = src[i];
++        if (strchr(chars, ch)) {
++            *pfound = TRUE;
++            break;
++        }
++    }
++    return 0;
++}
++
++
+ /*!
+  * \brief   stringRemoveChars()
+  *

--- a/pkgs/development/libraries/leptonica/default.nix
+++ b/pkgs/development/libraries/leptonica/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchurl, fetchpatch, autoreconfHook, pkgconfig
-, giflib, libjpeg, libpng, libtiff, libwebp, openjpeg, zlib
+, giflib, libjpeg, libpng, libtiff, libwebp, openjpeg, zlib, which, gnuplot
 }:
 
 stdenv.mkDerivation rec {
@@ -11,12 +11,34 @@ stdenv.mkDerivation rec {
     sha256 = "0qpcidvv6igybrrhj0m6j47g642c8sk1qn4dpj82mgd38xx52skl";
   };
 
-  patches = stdenv.lib.singleton (fetchpatch {
-    # configure: Support pkg-config
-    url = "https://github.com/DanBloomberg/leptonica/commit/"
-        + "4476d162cc191a0fefb2ce434153e12bbf188664.patch";
-    sha256 = "1razzp2g49shfaravfqpxm3ivcd1r92lvqysll6nnf6d1wp9865s";
-  });
+  patches = [
+    (fetchpatch {
+      # configure: Support pkg-config
+      url = "https://github.com/DanBloomberg/leptonica/commit/"
+          + "4476d162cc191a0fefb2ce434153e12bbf188664.patch";
+      sha256 = "1razzp2g49shfaravfqpxm3ivcd1r92lvqysll6nnf6d1wp9865s";
+    })
+    # stripped down copy of upstream commit b88c821f8d347bce0aea86d606c710303919f3d2
+    ./CVE-2018-3836.patch
+    (fetchpatch {
+      # CVE-2018-7186
+      url = "https://github.com/DanBloomberg/leptonica/commit/"
+          + "ee301cb2029db8a6289c5295daa42bba7715e99a.patch";
+      sha256 = "0cgb7mvz2px1rg5i80wk1wxxjvzjga617d8q6j7qygkp7jm6495d";
+    })
+    (fetchpatch {
+      # CVE-2018-7247
+      url = "https://github.com/DanBloomberg/leptonica/commit/"
+          + "c1079bb8e77cdd426759e466729917ca37a3ed9f.patch";
+      sha256 = "1z4iac5gwqggh7aa8cvyp6nl9fwd1v7wif26caxc9y5qr3jj34qf";
+    })
+    (fetchpatch {
+      # CVE-2018-7440
+      url = "https://github.com/DanBloomberg/leptonica/commit/"
+          + "49ecb6c2dfd6ed5078c62f4a8eeff03e3beced3b.patch";
+      sha256 = "1hjmva98iaw9xj7prg7aimykyayikcwnk4hk0380007hqb35lqmy";
+    })
+  ];
 
   postPatch = ''
     # Remove the AC_SUBST() macros on *_LIBS, because the *_LIBS variables will
@@ -33,6 +55,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
   buildInputs = [ giflib libjpeg libpng libtiff libwebp openjpeg zlib ];
+
+  checkInputs = [ which gnuplot ];
+  doCheck = true;
 
   meta = {
     description = "Image processing and analysis library";


### PR DESCRIPTION
###### Motivation for this change
Cherrypick of https://github.com/NixOS/nixpkgs/pull/61217 to 18.09. The `k2pdfopt` patch (https://github.com/NixOS/nixpkgs/pull/61302) isn't needed because its custom `leptonica` doesn't mess with the `patches` in 18.09.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
