### PR TITLE
iputils: 20190324 -> 20190515

### DIFF
--- a/pkgs/os-specific/linux/iputils/default.nix
+++ b/pkgs/os-specific/linux/iputils/default.nix
@@ -6,7 +6,7 @@
 with stdenv.lib;
 
 let
-  time = "20190324";
+  time = "20190515";
   # ninfod probably could build on cross, but the Makefile doesn't pass --host
   # etc to the sub configure...
   withNinfod = stdenv.hostPlatform == stdenv.buildPlatform;
@@ -21,19 +21,19 @@ in stdenv.mkDerivation {
     owner = "iputils";
     repo = "iputils";
     rev = "s${time}";
-    sha256 = "0b755gv3370c0rrphx14mrsqjb396zqnsm9lsws842a4k4zrqmvi";
+    sha256 = "1k2wzgk0d47d1g9k8c1a5l24ml8h8xxz1vrs0vfbyxr7qghdhn4i";
   };
 
   # ninfod cannot be build with nettle yet:
   patches =
     [ ./build-ninfod-with-openssl.patch
-      (fetchpatch { # tracepath: fix musl build, again
-        url = "https://github.com/iputils/iputils/commit/c9aca1b53324bcd1b5a2de5c645813f80eccd016.patch";
-        sha256 = "0faqgkqbi57cyx1zgzzy6xgd24xr0iawix7mjs47j92ra9gw90cz";
+      (fetchpatch { # build-sys/doc: Fix the dependency on xsltproc
+        url = "https://github.com/iputils/iputils/commit/3b013f271931c3fe771e5a2c591f35d617de90f3.patch";
+        sha256 = "0ilhlgiqdflry7km3ik8i4h1yymm5f5zmwyl5r029q7x1p8kinfw";
       })
-      (fetchpatch { # doc: Use namespace correctly
-        url = "https://github.com/iputils/iputils/commit/c503834519d21973323980850431101f90e663ef.patch";
-        sha256 = "1yp6b6403ddccbhfzsb36cscxd36d4xb8syc1g02a18xkswiwf09";
+      (fetchpatch { # build-sys: Make setcap really optional
+        url = "https://github.com/iputils/iputils/commit/473be6467f995865244e7e68b2fa587a4ee79551.patch";
+        sha256 = "0781147qaf0jwa177jbmh474r8hqs0jwgi5vgx9csb43jzdm8hqf";
       })
     ];
 
@@ -41,13 +41,14 @@ in stdenv.mkDerivation {
     [ "-DUSE_CRYPTO=nettle"
       "-DBUILD_RARPD=true"
       "-DBUILD_TRACEROUTE6=true"
+      "-DNO_SETCAP_OR_SUID=true"
       "-Dsystemdunitdir=etc/systemd/system"
     ]
     ++ optional (!withNinfod) "-DBUILD_NINFOD=false"
     # Disable idn usage w/musl (https://github.com/iputils/iputils/pull/111):
     ++ optional stdenv.hostPlatform.isMusl "-DUSE_IDN=false";
 
-  nativeBuildInputs = [ meson ninja pkgconfig gettext libxslt.bin docbook_xsl_ns libcap ];
+  nativeBuildInputs = [ meson ninja pkgconfig gettext libxslt.bin docbook_xsl_ns ];
   buildInputs = [ libcap nettle systemd ]
     ++ optional (!stdenv.hostPlatform.isMusl) libidn2
     ++ optional withNinfod openssl; # TODO: Build with nettle


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
