### PR TITLE
libertinus: 6.6 -> 6.8

### DIFF
--- a/pkgs/data/fonts/libertinus/default.nix
+++ b/pkgs/data/fonts/libertinus/default.nix
@@ -5,7 +5,7 @@ let
 in fetchFromGitHub rec {
   name = "libertinus-${version}";
 
-  owner  = "libertinus-fonts";
+  owner  = "alif-type";
   repo   = "libertinus";
   rev    = "v${version}";
 
@@ -23,7 +23,7 @@ in fetchFromGitHub rec {
       that started as an OpenType math companion of the Libertine font family,
       but grown as a full fork to address some of the bugs in the fonts.
     '';
-    homepage = https://github.com/libertinus-fonts/libertinus;
+    homepage = https://github.com/alif-type/libertinus;
     license = licenses.ofl;
     maintainers = with maintainers; [ siddharthist ];
     platforms = platforms.all;

--- a/pkgs/data/fonts/libertinus/default.nix
+++ b/pkgs/data/fonts/libertinus/default.nix
@@ -1,11 +1,11 @@
 { lib, fetchFromGitHub }:
 
 let
-  version = "6.6";
+  version = "6.8";
 in fetchFromGitHub rec {
   name = "libertinus-${version}";
 
-  owner  = "khaledhosny";
+  owner  = "libertinus-fonts";
   repo   = "libertinus";
   rev    = "v${version}";
 
@@ -14,7 +14,7 @@ in fetchFromGitHub rec {
     install -m444 -Dt $out/share/fonts/opentype *.otf
     install -m444 -Dt $out/share/doc/${name}    *.txt
   '';
-  sha256 = "11pxb2zwvjlk06zbqrfv2pgwsl4awf68fak1ks4881i8xbl1910m";
+  sha256 = "0iwbw3sw8rcsifpzw72g3cz0a960scv7cib8mwrw53282waqq2gc";
 
   meta = with lib; {
     description = "A fork of the Linux Libertine and Linux Biolinum fonts";
@@ -23,7 +23,7 @@ in fetchFromGitHub rec {
       that started as an OpenType math companion of the Libertine font family,
       but grown as a full fork to address some of the bugs in the fonts.
     '';
-    homepage = https://github.com/khaledhosny/libertinus;
+    homepage = https://github.com/libertinus-fonts/libertinus;
     license = licenses.ofl;
     maintainers = with maintainers; [ siddharthist ];
     platforms = platforms.all;


### PR DESCRIPTION
###### Motivation for this change

Notes:

https://github.com/libertinus-fonts/libertinus/releases/tag/v6.8
https://github.com/libertinus-fonts/libertinus/releases/tag/v6.7

* update repo "owner", moved
* don't try to build since we don't mean to :)
* update for font cleanup PR (thanks!)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---