### PR TITLE
bat: 0.10.0 -> 0.11.0

### DIFF
--- a/pkgs/tools/misc/bat/default.nix
+++ b/pkgs/tools/misc/bat/default.nix
@@ -3,18 +3,18 @@
 }:
 
 rustPlatform.buildRustPackage rec {
-  name    = "bat-${version}";
-  version = "0.10.0";
+  pname   = "bat";
+  version = "0.11.0";
 
   src = fetchFromGitHub {
     owner  = "sharkdp";
-    repo   = "bat";
+    repo   = pname;
     rev    = "v${version}";
-    sha256 = "1q22lbyrwh58vhznpjpkiaa8v4qv6a3a8lrxzaypd8wg78p9dca6";
+    sha256 = "0yyvlplskjvxb2cspqsvfsnahd5m0s83psrp777ng0wc0kr1adbw";
     fetchSubmodules = true;
   };
 
-  cargoSha256 = "0npj2rf4vr45gq3qwqq6kqnv9dh58v5lpx0gsmy2qrq44dxb75rq";
+  cargoSha256 = "078n31c0isvxvna0s1m12xv4bkh15rb2nixfyg4c501mlkalb517";
 
   nativeBuildInputs = [ cmake pkgconfig zlib ];
 
@@ -22,13 +22,14 @@ rustPlatform.buildRustPackage rec {
 
   postInstall = ''
     install -m 444 -Dt $out/share/man/man1 doc/bat.1
+    install -m 444 -Dt $out/share/fish/vendor_completions.d assets/completions/bat.fish
   '';
 
   meta = with stdenv.lib; {
     description = "A cat(1) clone with syntax highlighting and Git integration";
     homepage    = https://github.com/sharkdp/bat;
     license     = with licenses; [ asl20 /* or */ mit ];
-    maintainers = with maintainers; [ dywedir ];
-    platforms   = platforms.linux ++ platforms.darwin;
+    maintainers = with maintainers; [ dywedir lilyball ];
+    platforms   = platforms.all;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
https://github.com/sharkdp/bat/releases/tag/v0.11.0

Also add myself as a maintainer, and set platforms to `all`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS (with sandboxing)
   - [X] macOS (without sandboxing)
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

CC @dywedir