### PR TITLE
horst: 5.0 -> 5.1, cleanup a bit

### DIFF
--- a/pkgs/tools/networking/horst/default.nix
+++ b/pkgs/tools/networking/horst/default.nix
@@ -2,25 +2,19 @@
 
 stdenv.mkDerivation rec {
   name = "horst-${version}";
-  version = "5.0";
+  version = "5.1";
 
   src = fetchFromGitHub {
     owner = "br101";
     repo = "horst";
-    rev = "version-${version}";
-    sha256 = "0m7gc6dj816z8wyq5bdkqj7fw6rmxaah84s34ncsaispz2llva1x";
+    rev = "v${version}";
+    sha256 = "140pyv6rlsh4c745w4b59pz3hrarr39qq3mz9z1lsd3avc12nx1a";
   };
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ ncurses libnl ];
 
-  installPhase = ''
-    mkdir -p $out/bin
-    mv horst $out/bin
-
-    mkdir -p $out/man/man1
-    cp horst.1 $out/man/man1
-  '';
+  installFlags = [ "DESTDIR=${placeholder "out"}" ];
 
   meta = with stdenv.lib; {
     description = "Small and lightweight IEEE802.11 wireless LAN analyzer with a text interface";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update!

5.1 is from back in 2017, unrelated to kernel number these days :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---