### PR TITLE
libnice: 0.1.15 -> 0.1.16

### DIFF
--- a/pkgs/development/libraries/libnice/default.nix
+++ b/pkgs/development/libraries/libnice/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchurl, fetchpatch, meson, ninja, pkgconfig, python3, gobject-introspection, gtk-doc, docbook_xsl, docbook_xml_dtd_412, glib, gupnp-igd, gst_all_1, gnutls }:
 
 stdenv.mkDerivation rec {
-  name = "libnice-0.1.15";
+  name = "libnice-0.1.16";
 
   outputs = [ "bin" "out" "dev" "devdoc" ];
 
   src = fetchurl {
     url = "https://nice.freedesktop.org/releases/${name}.tar.gz";
-    sha256 = "1nl7fn07f4i513s9c1s1ic3rki8rm2d000wsf6f4157mb0zhya7p";
+    sha256 = "1pzgxq0qrqlrhd78qnvpfgp8bl5c4znqh599ljaybpcldw37idh6";
   };
 
   patches = [

--- a/pkgs/development/libraries/libnice/default.nix
+++ b/pkgs/development/libraries/libnice/default.nix
@@ -18,19 +18,6 @@ stdenv.mkDerivation rec {
       url = https://gitlab.freedesktop.org/libnice/libnice/commit/d470c4bf4f2449f7842df26ca1ce1efb63452bc6.patch;
       sha256 = "0z74vizf92flfw1m83p7yz824vfykmnm0xbnk748bnnyq186i6mg";
     })
-
-    # Fix test-different-number-streams
-    # https://gitlab.freedesktop.org/libnice/libnice/merge_requests/36
-    (fetchpatch {
-      url = https://gitlab.freedesktop.org/libnice/libnice/commit/a38c2adfc4bed2a69dc02568417f0926dd555b9a.patch;
-      sha256 = "1rh4z4iknrimmm3b3v8ln8vl3dsqi91g4vf0dl85348kvnf0sv6z";
-    })
-    # Fix test-gstreamer
-    # https://gitlab.freedesktop.org/libnice/libnice/merge_requests/35
-    (fetchpatch {
-      url = https://gitlab.freedesktop.org/libnice/libnice/commit/02de1fa1956105b09d9db4fd6331452b0ff0b8a2.patch;
-      sha256 = "12dymq1v20wj5n1cway4n3y8fkra1ffnpj5w7pbz38i612b82qw0";
-    })
   ];
 
   nativeBuildInputs = [ meson ninja pkgconfig python3 gobject-introspection gtk-doc docbook_xsl docbook_xml_dtd_412 ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---