### PR TITLE
termite: 15, minor patch follow-up

### DIFF
--- a/pkgs/applications/misc/termite/default.nix
+++ b/pkgs/applications/misc/termite/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "termite-${version}";
-  version = "14";
+  version = "15";
 
   src = fetchFromGitHub {
     owner = "thestinger";
     repo = "termite";
     rev = "v${version}";
-    sha256 = "0dmz9rpc2fdvcwhcmjnhb48ixn403gxpq03g334d1hgjw2hsyx7x";
+    sha256 = "0hp1x6lj098m3jgna274wv5dv60lnzg22297di68g4hw9djjyd2k";
     fetchSubmodules = true;
   };
 

--- a/pkgs/applications/misc/termite/default.nix
+++ b/pkgs/applications/misc/termite/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, pkgconfig, vte-ng, gtk3, ncurses, wrapGAppsHook }:
+{ stdenv, fetchFromGitHub, fetchpatch, pkgconfig, vte-ng, gtk3, ncurses, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
   name = "termite-${version}";
@@ -14,7 +14,13 @@ stdenv.mkDerivation rec {
 
   # https://github.com/thestinger/termite/pull/516
   patches = [ ./url_regexp_trailing.patch ./add_errno_header.patch
-              ] ++ stdenv.lib.optional stdenv.isDarwin ./remove_ldflags_macos.patch;
+    # Fix off-by-one in select_text() on libvte >= 0.55.0
+    # Expected to be included in next release (16).
+    (fetchpatch {
+      url = "https://github.com/thestinger/termite/commit/7e9a93b421b9596f8980645a46ac2ad5468dac06.patch";
+      sha256 = "0vph2m5919f7w1xnc8i6z0j44clsm1chxkfg7l71nahxyfw5yh4j";
+    })
+  ] ++ stdenv.lib.optional stdenv.isDarwin ./remove_ldflags_macos.patch;
 
   makeFlags = [ "VERSION=v${version}" "PREFIX=" "DESTDIR=$(out)" ];
 


### PR DESCRIPTION
###### Motivation for this change

https://github.com/thestinger/termite/releases/tag/v15

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---