### PR TITLE
Gnome/3.32.2

### DIFF
--- a/pkgs/desktops/gnome-3/apps/accerciser/default.nix
+++ b/pkgs/desktops/gnome-3/apps/accerciser/default.nix
@@ -1,10 +1,26 @@
-{ stdenv, fetchurl, pkgconfig, gnome3, gtk3, wrapGAppsHook, gobject-introspection
-, itstool, libxml2, python3Packages, at-spi2-core
-, dbus, gettext, libwnck3 }:
+{ stdenv
+, fetchurl
+, pkgconfig
+, gnome3
+, gtk3
+, glib
+, wrapGAppsHook
+, gobject-introspection
+, itstool
+, libxml2
+, python3
+, at-spi2-core
+, dbus
+, gettext
+, libwnck3
+, adwaita-icon-theme
+}:
 
-stdenv.mkDerivation rec {
+ python3.pkgs.buildPythonApplication rec {
   name = "accerciser-${version}";
   version = "3.32.2";
+
+  format = "other";
 
   src = fetchurl {
     url = "mirror://gnome/sources/accerciser/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
@@ -12,16 +28,33 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    pkgconfig wrapGAppsHook itstool gettext
+    gettext
     gobject-introspection # For setup hook
-  ];
-  buildInputs = [
-    gtk3 libxml2 python3Packages.python python3Packages.pyatspi
-    python3Packages.pygobject3 python3Packages.ipython
-    at-spi2-core dbus libwnck3 gnome3.adwaita-icon-theme
+    itstool
+    libxml2
+    pkgconfig
+    dbus
+    wrapGAppsHook
   ];
 
-  wrapPrefixVariables = [ "PYTHONPATH" ];
+  buildInputs = [
+    adwaita-icon-theme
+    at-spi2-core
+    gtk3
+    libwnck3
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    ipython
+    pyatspi
+    pycairo
+    pygobject3
+    xlib
+  ];
+
+  # Strict deps breaks accerciser
+  # and https://github.com/NixOS/nixpkgs/issues/56943
+  strictDeps = false;
 
   passthru = {
     updateScript = gnome3.updateScript {

--- a/pkgs/desktops/gnome-3/apps/accerciser/default.nix
+++ b/pkgs/desktops/gnome-3/apps/accerciser/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "accerciser-${version}";
-  version = "3.32.1";
+  version = "3.32.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/accerciser/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0afzhbig5yw87zyfmid61368jj8l6i7k8gs29x0hv65fz4yiv4h4";
+    sha256 = "05ssj8whzhf98lpcaca7m45h03g0wx0i8jlsrh3yn943mshzidy8";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/apps/evolution/default.nix
+++ b/pkgs/desktops/gnome-3/apps/evolution/default.nix
@@ -7,13 +7,13 @@
 , libcanberra-gtk3, bogofilter, gst_all_1, procps, p11-kit, openldap }:
 
 let
-  version = "3.32.1";
+  version = "3.32.2";
 in stdenv.mkDerivation rec {
   name = "evolution-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/evolution/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0ns76w6vwv5k1nxpaqrizp1pnm89xzfgs60i6cwwfs35zqlmb7iq";
+    sha256 = "1sb60zhdawza33zlp0n3hbd7mq43a4y09jmkphpnxdifypfkar55";
   };
 
   propagatedUserEnvPkgs = [ evolution-data-server ];

--- a/pkgs/desktops/gnome-3/apps/gedit/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gedit/default.nix
@@ -6,11 +6,11 @@
 
 stdenv.mkDerivation rec {
   name = "gedit-${version}";
-  version = "3.32.0";
+  version = "3.32.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gedit/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1lray9vvbcrnhjv5cr5fc4bqfd68km2x79cj50byyqn9cnlf5qn9";
+    sha256 = "1q2rk7fym542c7k3bn2wlnzgy384gxacbifsjny0spbg95gfybvl";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/apps/gnome-boxes/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-boxes/default.nix
@@ -9,13 +9,13 @@
 # TODO: ovirt (optional)
 
 let
-  version = "3.32.0.2";
+  version = "3.32.1";
 in stdenv.mkDerivation rec {
   name = "gnome-boxes-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-boxes/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1239x1bbkn0gxxq82zpvjjr7srla2d5ghi5rqwxnhsab0c2ypswk";
+    sha256 = "159sxii3g4s5pjb4s4i3kc4q162w5vicp4g6wvk1y2yv68bgmcl4";
   };
 
   doCheck = true;

--- a/pkgs/desktops/gnome-3/apps/gnome-calendar/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-calendar/default.nix
@@ -4,13 +4,13 @@
 
 let
   pname = "gnome-calendar";
-  version = "3.32.1";
+  version = "3.32.2";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1wip968nvp1yj34hbpc3wjbrmrgjm1f82ag5ngv90z38953vi9vl";
+    sha256 = "07p73cvzj8idr80npja5yiv9pjfyi6qqfhaz5jwcgqspqbnhnl7k";
   };
 
   passthru = {

--- a/pkgs/desktops/gnome-3/apps/gnome-maps/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-maps/default.nix
@@ -5,13 +5,13 @@
 
 let
   pname = "gnome-maps";
-  version = "3.32.1";
+  version = "3.32.2";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1q15qsp0ca67y4l0x31518cfakrj85x9g0cbcm0wysnbddi1aik0";
+    sha256 = "1yvwzdfxjdgx4478l2i240ssvbr8hm5sg4krc1gw2ps08sgap7yx";
   };
 
   doCheck = true;

--- a/pkgs/desktops/gnome-3/apps/gnome-music/default.nix
+++ b/pkgs/desktops/gnome-3/apps/gnome-music/default.nix
@@ -6,13 +6,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "gnome-music";
-  version = "3.32.1";
+  version = "3.32.2";
 
   format = "other";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "11fdij1jznjsph1q5rkkvdhikzdh2lls921lv2m2di9x7i2xn3h4";
+    sha256 = "0cn7l1d3ayima1w3bxpshijabd7ibhnvqxv2mpvffzizk04ln6hk";
   };
 
   nativeBuildInputs = [ meson ninja gettext itstool pkgconfig libxml2 wrapGAppsHook desktop-file-utils appstream-glib gobject-introspection ];

--- a/pkgs/desktops/gnome-3/apps/polari/default.nix
+++ b/pkgs/desktops/gnome-3/apps/polari/default.nix
@@ -5,13 +5,13 @@
 
 let
   pname = "polari";
-  version = "3.32.1";
+  version = "3.32.2";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0z2dxj1hd798jn79y9a7lkb77lm8l7y5fsqh9g6lbr7pnmg559yk";
+    sha256 = "0h0w9j3y067l911gpj446b3a2w1i2vzr1w2a7cz7i5rhn6qkf2sp";
   };
 
   propagatedUserEnvPkgs = [ telepathy-idle telepathy-logger ];

--- a/pkgs/desktops/gnome-3/apps/seahorse/default.nix
+++ b/pkgs/desktops/gnome-3/apps/seahorse/default.nix
@@ -6,11 +6,11 @@
 
 stdenv.mkDerivation rec {
   pname = "seahorse";
-  version = "3.32.1";
+  version = "3.32.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1nh2gahiixj661a3l008yhidx952q50fqgdckg8l0d237wnwp7f6";
+    sha256 = "0d8zdzmlz7fjv9xl20zl4ckidf465mvdjnbpxy3k08y9iw423q4x";
   };
 
   doCheck = true;

--- a/pkgs/desktops/gnome-3/core/gjs/default.nix
+++ b/pkgs/desktops/gnome-3/core/gjs/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "gjs-${version}";
-  version = "1.56.1";
+  version = "1.56.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gjs/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0wylq6r0c0gf558hridlyly84vb03qzdrfph21z8dbqy8l7g2937";
+    sha256 = "1b5321krn89p3f7s2ik6gpfnc61apzljhlnbqky8c88f7n6832ac";
   };
 
   passthru = {

--- a/pkgs/desktops/gnome-3/core/gnome-shell/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-shell/default.nix
@@ -14,11 +14,11 @@ let
 
 in stdenv.mkDerivation rec {
   name = "gnome-shell-${version}";
-  version = "3.32.1";
+  version = "3.32.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-shell/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1pb00af3w4wivdhcvdy59z2xlxasg90bcm5a9ck0p5lf97adwx08";
+    sha256 = "0anlkdnqsp5fqvmg95rqjpp1ifcx5xzsvwcrdsvb1cqzbh6inmp5";
   };
 
   LANG = "en_US.UTF-8";

--- a/pkgs/desktops/gnome-3/core/gnome-software/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-software/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-software-${version}";
-  version = "3.32.1";
+  version = "3.32.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-software/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0xxhvyqfwlcyvlqc36rpcili00dpwy8b5c5klaqccn5qrc87rl38";
+    sha256 = "12kw5vyg8jy0xiq1shfh4ksar2dpyzcdxbyx8lrp9494d606nrlx";
   };
 
   patches = [

--- a/pkgs/desktops/gnome-3/core/gnome-terminal/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-terminal/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-terminal-${version}";
-  version = "3.32.1";
+  version = "3.32.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-terminal/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "0i613844gf5dmzpvwiy68lg8walhj4zr88scacp2qwpqs870si8x";
+    sha256 = "0shhpnagasyp1kxgjczfrivcxbgrrl3y8lzvp1z101m67h4jp6km";
   };
 
   buildInputs = [

--- a/pkgs/desktops/gnome-3/core/gnome-user-docs/default.nix
+++ b/pkgs/desktops/gnome-3/core/gnome-user-docs/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-user-docs-${version}";
-  version = "3.32.1";
+  version = "3.32.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-user-docs/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "09g6fi9b1xpk0fnp6wgh350v1x318mrf20j4bfarww25vrj6irrw";
+    sha256 = "1ny7cwkyskrykzsrabjnlc9jsdl4kdk73smwxas6ddmca02hpm7c";
   };
 
   passthru = {

--- a/pkgs/desktops/gnome-3/core/mutter/default.nix
+++ b/pkgs/desktops/gnome-3/core/mutter/default.nix
@@ -11,11 +11,11 @@
 
 stdenv.mkDerivation rec {
   pname = "mutter";
-  version = "3.32.1";
+  version = "3.32.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/mutter/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "1q74lrb08vy0ynxbssqyxvbzf9252xgf9l6jxr9g4q0gmvpq402j";
+    sha256 = "1h577i2ap7dpfy1jg101jvc6nzccc0csgvd55ahydlr8f94frcva";
   };
 
   mesonFlags = [

--- a/pkgs/desktops/gnome-3/core/nautilus/default.nix
+++ b/pkgs/desktops/gnome-3/core/nautilus/default.nix
@@ -7,13 +7,13 @@
 
 let
   pname = "nautilus";
-  version = "3.32.0";
+  version = "3.32.1";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1pnh32fal7dkwadga5savg1nv0zqnbakhk0hxr5726087i6y6ii2";
+    sha256 = "0vmrvimv4183l3ij4kv0ir2c9rfzk7gh3xc2pa4wkqq9kn7h6m7s";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome-3/core/simple-scan/default.nix
+++ b/pkgs/desktops/gnome-3/core/simple-scan/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "simple-scan-${version}";
-  version = "3.32.2";
+  version = "3.32.2.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/simple-scan/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "12r5hacwpf0gzca3p73xpmx3dksa1kx50nlj6w4nw8jfqzjlkq1k";
+    sha256 = "0xqb642bsd2hddsm4bd199vyq8jcipdlxm0br3mjlc5vjcxgkxyp";
   };
 
   buildInputs = [

--- a/pkgs/desktops/gnome-3/core/yelp-tools/default.nix
+++ b/pkgs/desktops/gnome-3/core/yelp-tools/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   name = "yelp-tools-${version}";
-  version = "3.32.0";
+  version = "3.32.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/yelp-tools/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "037fd6xpy3zab7j5p7c0vfc6c3nk6qs0prvz1hbilzc31p8l1pdz";
+    sha256 = "1qrn8ss3wc601w8j0ziicgmgic0yh01az6611n3jgd7wll9c79wr";
   };
 
   passthru = {

--- a/pkgs/desktops/gnome-3/core/yelp/default.nix
+++ b/pkgs/desktops/gnome-3/core/yelp/default.nix
@@ -5,11 +5,11 @@
 
 stdenv.mkDerivation rec {
   name = "yelp-${version}";
-  version = "3.32.1";
+  version = "3.32.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/yelp/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "159ayfyswn9yh7g5hjs6lphh510n6qkyd1cj47hnc3ynnab9hn4r";
+    sha256 = "0yrl96icmmrxvg7sxl519gzg9qb368cmzgrr9ddh181ignkxzx7f";
   };
 
   nativeBuildInputs = [ pkgconfig gettext itstool wrapGAppsHook ];

--- a/pkgs/desktops/gnome-3/games/gnome-mines/default.nix
+++ b/pkgs/desktops/gnome-3/games/gnome-mines/default.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "gnome-mines-${version}";
-  version = "3.32.0";
+  version = "3.32.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-mines/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "13ia8a7bmdnp1281lwp8nvdqqkclvg1n3pw4bbr2dgsrsswfkscj";
+    sha256 = "1nv966wkp2rqxzcdb76bwlbzpjqadcaqzrnkxpzwnvjjr167yx8g";
   };
 
   # gobject-introspection for finding vapi files

--- a/pkgs/desktops/gnome-3/misc/gnome-applets/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gnome-applets/default.nix
@@ -26,13 +26,13 @@
 
 let
   pname = "gnome-applets";
-  version = "3.30.0";
+  version = "3.32.0";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "1cvl32486kqw301wy40l1a1sdhanra7bx4smq0a3lmnl3x01zg43";
+    sha256 = "10kd19ymxl2z65121g90mx96m6vcn2a8a50g6a56prrdjsgbgia1";
   };
 
   nativeBuildInputs = [
@@ -68,7 +68,7 @@ in stdenv.mkDerivation rec {
   doCheck = true;
 
   configureFlags = [
-    "--with-libpanel-applet-dir=$(out)/share/gnome-panel/applets"
+    "--with-libpanel-applet-dir=${placeholder ''out''}/share/gnome-panel/applets"
   ];
 
   passthru = {

--- a/pkgs/desktops/gnome-3/misc/gnome-flashback/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gnome-flashback/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , autoreconfHook
 , fetchurl
-, fetchpatch
 , gettext
 , glib
 , gnome-bluetooth
@@ -29,24 +28,15 @@
 
 let
   pname = "gnome-flashback";
-  version = "3.30.0";
+  version = "3.32.0";
   requiredComponents = wmName: "RequiredComponents=${wmName};gnome-flashback-init;gnome-flashback;gnome-panel;org.gnome.SettingsDaemon.A11ySettings;org.gnome.SettingsDaemon.Clipboard;org.gnome.SettingsDaemon.Color;org.gnome.SettingsDaemon.Datetime;org.gnome.SettingsDaemon.Housekeeping;org.gnome.SettingsDaemon.Keyboard;org.gnome.SettingsDaemon.MediaKeys;org.gnome.SettingsDaemon.Mouse;org.gnome.SettingsDaemon.Power;org.gnome.SettingsDaemon.PrintNotifications;org.gnome.SettingsDaemon.Rfkill;org.gnome.SettingsDaemon.ScreensaverProxy;org.gnome.SettingsDaemon.Sharing;org.gnome.SettingsDaemon.Smartcard;org.gnome.SettingsDaemon.Sound;org.gnome.SettingsDaemon.Wacom;org.gnome.SettingsDaemon.XSettings;";
   gnome-flashback = stdenv.mkDerivation rec {
     name = "${pname}-${version}";
 
     src = fetchurl {
       url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-      sha256 = "18rwql2pi78155l9zp1i50xfi5z8xz2l08m9d81x6qqbfr1nyy57";
+      sha256 = "0jfzr7vdmnxpxqqa38ni1p3c508xhlnxqpmmqshk3rvrf0afqn62";
     };
-
-    patches =[
-      # overrides do not respect gsettingsschemasdir
-      # https://gitlab.gnome.org/GNOME/gnome-flashback/issues/9
-      (fetchpatch {
-       url = https://gitlab.gnome.org/GNOME/gnome-flashback/commit/a55530f58ccd600414a5420b287868ab7d219705.patch;
-       sha256 = "1la94lhhb9zlw7bnbpl6hl26zv3kxbsvgx996mhph720wxg426mh";
-      })
-    ];
 
     # make .desktop Execs absolute
     postPatch = ''

--- a/pkgs/desktops/gnome-3/misc/gnome-panel/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gnome-panel/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , fetchurl
 , autoreconfHook
-, fetchpatch
 , dconf
 , evolution-data-server
 , gdm

--- a/pkgs/desktops/gnome-3/misc/gnome-panel/default.nix
+++ b/pkgs/desktops/gnome-3/misc/gnome-panel/default.nix
@@ -24,7 +24,7 @@
 
 let
   pname = "gnome-panel";
-  version = "3.30.0";
+  version = "3.32.0";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
@@ -32,17 +32,8 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "12q0l7wy6hzl46i7xpvv82ka3bn14z0jg6fhv5xhnk7j9mkbmgqw";
+    sha256 = "0a9zi1jb0b42zd6wx3251cnns9v1w0cbwasmrx9hsj1dsb9pjq3a";
   };
-
-  patches = [
-    # https://github.com/NixOS/nixpkgs/issues/36468
-    # https://gitlab.gnome.org/GNOME/gnome-panel/issues/8
-    (fetchpatch {
-      url = https://gitlab.gnome.org/GNOME/gnome-panel/commit/77be9c3507bd1b5d70d97649b85ec9f47f6c359c.patch;
-      sha256 = "00b1ihnc6hp2g6x1v1njbc6mhsk44izl2wigviibmka2znfk03nv";
-    })
-  ];
 
   # make .desktop Exec absolute
   postPatch = ''

--- a/pkgs/desktops/gnome-3/misc/metacity/default.nix
+++ b/pkgs/desktops/gnome-3/misc/metacity/default.nix
@@ -16,13 +16,13 @@
 
 let
   pname = "metacity";
-  version = "3.30.1";
+  version = "3.32.0";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "12kr472gblx7jxh9rvnamy09bkg29ms2pgc0c3373piqmavi24qg";
+    sha256 = "177dmb1smizfgkddk49n2kr90graj9r6xw5hg3aq0y2qqg6v4rcg";
   };
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change
Mostly 3.32.2 updates with the last five commits being for gnome flashback.
GJS bump in here also.

See commit msg's for NEWS or summary.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
