### PR TITLE
analog: 6.0.13 -> 6.0.15

### DIFF
--- a/pkgs/tools/admin/analog/default.nix
+++ b/pkgs/tools/admin/analog/default.nix
@@ -1,38 +1,38 @@
-{ stdenv, fetchurl, unzip }:
+{ stdenv, lib, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
+  pname = "analog";
+  version = "6.0.15";
 
-  name = "analog-6.0.13";
-
-  buildInputs = [ unzip ];
-
-  src = fetchurl {
-    url = "http://www.c-amie.co.uk/static/analog/6013/analog-src-6013ce.zip";
-    sha256 = "1njfsclmxk8sn1i07k3qfk8fmsnz7qw9kmydk3bil7qjf4ngmzc6";
+  src = fetchFromGitHub {
+    owner = "c-amie";
+    repo = "analog-ce";
+    rev = version;
+    sha256 = "1clrx2xr3n5zh6gaavvdxkc127hayssxrplrd2qvw70givywza0m";
   };
 
   configurePhase = ''
     sed -i src/anlghead.h \
       -e "s|#define DEFAULTCONFIGFILE .*|#define DEFAULTCONFIGFILE \"$out/etc/analog.cfg\"|g" \
-      -e "s|#define LANGDIR .*|#define LANGDIR \"$out/share/${name}/lang/\"|g"
+      -e "s|#define LANGDIR .*|#define LANGDIR \"$out/share/$pname}/lang/\"|g"
   '';
 
   installPhase = ''
-    mkdir -p $out/bin $out/etc $out/share/doc/${name} $out/share/man/man1 $out/share/${name}
+    mkdir -p $out/bin $out/etc $out/share/doc/$pname $out/share/man/man1 $out/share/$pname
     mv analog $out/bin/
     cp examples/big.cfg $out/etc/analog.cfg
     mv analog.man $out/share/man/man1/analog.1
-    mv docs $out/share/doc/${name}/manual
-    mv how-to $out/share/doc/${name}/
-    mv lang images examples $out/share/${name}/
+    mv docs $out/share/doc/$pname/manual
+    mv how-to $out/share/doc/$pname/
+    mv lang images examples $out/share/$pname/
   '';
 
   meta = {
-    homepage = https://www.c-amie.co.uk/software/analog/;
-    license = stdenv.lib.licenses.gpl2;
+    homepage = "https://www.c-amie.co.uk/software/analog/";
+    license = lib.licenses.gpl2;
     description = "Powerful tool to generate web server statistics";
-    maintainers = [ stdenv.lib.maintainers.peti ];
-    platforms = stdenv.lib.platforms.linux;
+    maintainers = [ lib.maintainers.peti ];
+    platforms = lib.platforms.linux;
   };
 
 }


### PR DESCRIPTION
* Updates src so it can be auto updated.
* Changes output paths to be only the pname, which seems more
  consistent with other packages in nixpkgs
* minor cleanups

###### Motivation for this change

New version

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---