### PR TITLE
[wip] nixos/lxd-container.nix: init

### DIFF
--- a/nixos/modules/virtualisation/lxd-container.nix
+++ b/nixos/modules/virtualisation/lxd-container.nix
@@ -1,0 +1,50 @@
+{ lib, config, pkgs, ... }:
+
+# Partially taken from ../profilers/docker-container.nix
+# TODO: Rework module hierarchy to provide a generic “open container
+# profile.
+
+let
+
+  # Can’t find official documentation for this?
+  # Found some info here:
+  # https://github.com/lxc/lxd/blob/master/doc/image-handling.md#content
+  # But no comprehensive docs. They must be somewhere!
+  metadata = {
+    architecture = pkgs.stdenv.hostPlatform.parsed.cpu.name;
+    creation_date = 0;
+    properties = rec {
+      os = "NixOS";
+      description = "${os} ${lib.trivial.codeName} ${lib.version}";
+      inherit (lib.trivial) release;
+    };
+  };
+
+  pkgs2storeContents = map (x: { object = x; symlink = "none"; });
+
+in {
+  imports = [ ./lxc-container.nix ];
+
+  system.build.tarball = pkgs.callPackage ../../lib/make-system-tarball.nix {
+    contents = [
+      {
+        source = "${config.system.build.toplevel}/.";
+        target = "./rootfs";
+      }
+    ];
+    extraArgs = "--owner=0";
+
+    # Add init script to image
+    storeContents = pkgs2storeContents [
+      config.system.build.toplevel pkgs.stdenv
+    ];
+
+    extraCommands = ''
+      # Some container managers like lxc need these
+      mkdir -p rootfs/proc rootfs/sys rootfs/dev
+
+      cp ${builtins.toFile "metadata.yaml" (lib.generators.toYAML {} metadata)} metadata.yaml
+    '';
+  };
+
+}

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -228,6 +228,12 @@ in rec {
     inherit system;
   });
 
+  # Wrapper around container tarball based on the above.
+  lxdContainer = forAllSystems (system: makeSystemTarball {
+    module = ./modules/virtualisation/lxd-container.nix;
+    inherit system;
+  });
+
   /*
   system_tarball_fuloong2f =
     assert builtins.currentSystem == "mips64-linux";


### PR DESCRIPTION
Fixes #43781

Add an LXD-based container. Based on some documentation found here:

https://github.com/lxc/lxd/blob/master/doc/image-handling.md

It’s very close to the lxc container image, but with the toplevel in
rootfs/ and some meta information in metadata.yaml. I took some basic
info from the NixOS configuration for this. My main use case is
getting a Chrome OS laptop setup with Crostini.

Eventually, I want to try to get this in some image registries like
https://us.images.linuxcontainers.org/, but they don’t appear to have
any process for including new distros. I’ve opened an issue here:

https://github.com/lxc/lxc-ci/issues/38

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
