### PR TITLE
saleae-logic: 1.2.28 -> 1.2.18

### DIFF
--- a/pkgs/development/tools/misc/saleae-logic/default.nix
+++ b/pkgs/development/tools/misc/saleae-logic/default.nix
@@ -26,13 +26,13 @@ assert stdenv.hostPlatform.system == "x86_64-linux";
 
 stdenv.mkDerivation rec {
   pname = "saleae-logic";
-  version = "1.2.28";
+  version = "1.2.18";
   name = "${pname}-${version}";
 
   src = fetchurl {
     name = "saleae-logic-${version}-64bit.zip";
     url = "http://downloads.saleae.com/logic/${version}/Logic%20${version}%20(64-bit).zip";
-    sha256 = "0apq8hmn39k0ads4xy8iyy9rp8bvia60mh7a944rk1gjpqv227g5";
+    sha256 = "0lhair2vsg8sjvzicvfcjfmvy30q7i01xj4z02iqh7pgzpb025h8";
   };
 
   desktopItem = makeDesktopItem {


### PR DESCRIPTION
Yes, this is a downgrade. The .28 version is beta software, whereas .18
is the latest stable version. Ref. https://github.com/NixOS/nixpkgs/pull/53844

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Have latest stable version, but not beta software.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
