### PR TITLE
nixos/mysql: don't run parts of mysqld.service as root

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1909.xml
+++ b/nixos/doc/manual/release-notes/rl-1909.xml
@@ -95,6 +95,14 @@
    </listitem>
    <listitem>
     <para>
+      The <option>services.mysql.pidDir</option> option was removed, as it was only used by the wordpress
+      apache-httpd service to wait for mysql to have started up.
+      This can be accomplished by either describing a dependency on mysql.service (preferred)
+      or waiting for the (hardcoded) <filename>/run/mysqld/mysql.sock</filename> file to appear.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
       The <option>services.emby.enable</option> module has been removed, see
       <option>services.jellyfin.enable</option> instead for a free software fork of Emby.
 

--- a/nixos/doc/manual/release-notes/rl-1909.xml
+++ b/nixos/doc/manual/release-notes/rl-1909.xml
@@ -161,6 +161,17 @@
       The <literal>hunspellDicts.fr-any</literal> dictionary now ships with <literal>fr_FR.{aff,dic}</literal>
       which is linked to <literal>fr-toutesvariantes.{aff,dic}</literal>.
     </para>
+  </listitem>
+  <listitem>
+    <para>
+      The <literal>mysql</literal> service now runs as <literal>mysql</literal>
+      user. Previously, systemd did execute it as root, and mysql dropped privileges
+      itself.
+      This includes <literal>ExecStartPre=</literal> and
+      <literal>ExecStartPost=</literal> phases.
+      To accomplish that, runtime and data directory setup was delegated to
+      RuntimeDirectory and tmpfiles.
+    </para>
    </listitem>
   </itemizedlist>
  </section>

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -212,6 +212,7 @@ with lib;
     (mkRemovedOptionModule [ "services" "logstash" "enableWeb" ] "The web interface was removed from logstash")
     (mkRemovedOptionModule [ "boot" "zfs" "enableLegacyCrypto" ] "The corresponding package was removed from nixpkgs.")
     (mkRemovedOptionModule [ "services" "winstone" ] "The corresponding package was removed from nixpkgs.")
+    (mkRemovedOptionModule [ "services" "mysql" "pidDir" ] "Don't wait for pidfiles, describe dependencies through systemd")
 
     # ZSH
     (mkRenamedOptionModule [ "programs" "zsh" "enableSyntaxHighlighting" ] [ "programs" "zsh" "syntaxHighlighting" "enable" ])

--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -326,6 +326,8 @@ in
         '';
 
         serviceConfig = {
+          User = cfg.user;
+          Group = "mysql";
           Type = if hasNotify then "notify" else "simple";
           # /run/mysqld needs to be created in addition to pidDir, as they could point to different locations
           RuntimeDirectory = "mysqld";

--- a/nixos/modules/services/web-servers/apache-httpd/wordpress.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/wordpress.nix
@@ -273,7 +273,7 @@ in
     if [ ! -d ${serverInfo.fullConfig.services.mysql.dataDir}/${config.dbName} ]; then
       echo "Need to create the database '${config.dbName}' and grant permissions to user named '${config.dbUser}'."
       # Wait until MySQL is up
-      while [ ! -e ${serverInfo.fullConfig.services.mysql.pidDir}/mysqld.pid ]; do
+      while [ ! -S /run/mysqld/mysqld.sock ]; do
         sleep 1
       done
       ${pkgs.mysql}/bin/mysql -e 'CREATE DATABASE ${config.dbName};'


### PR DESCRIPTION
Also don't use `RuntimeDirectory=mysqld`, which translates to
`/run/mysqld`, which is `cfg.pidDir`, but only if `cfg.pidDir` isn't set
to something else.

Use `systemd.tmpfiles.rules` to create `dataDir` and `pidDir`, instead
of relying on the deprecated PermissionsStartOnly=yes [0][1] to setup
filesystem structure.

Also group some of the different steps together for better readability.

###### Motivation for this change
[0] https://github.com/systemd/systemd/pull/10802
[1] https://github.com/NixOS/nixpkgs/issues/53852

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
