### PR TITLE
Sylk: init at 2.1.0

### DIFF
--- a/pkgs/applications/networking/Sylk/default.nix
+++ b/pkgs/applications/networking/Sylk/default.nix
@@ -1,0 +1,32 @@
+{ appimageTools, fetchurl, lib, gsettings-desktop-schemas, gtk3 }:
+
+let
+  pname = "Sylk";
+  version = "2.1.0";
+in
+
+appimageTools.wrapType2 rec {
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "http://download.ag-projects.com/Sylk/Sylk-${version}-x86_64.AppImage";
+    sha256 = "1ifi8qr6f84dcssxhv5ar1s48nsqxiv2j1blc82248hmq5is24mf";
+  };
+
+  profile = ''
+    export LC_ALL=C.UTF-8
+    export XDG_DATA_DIRS=${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}:$XDG_DATA_DIRS
+  '';
+
+  multiPkgs = null; # no 32bit needed
+  extraPkgs = appimageTools.defaultFhsEnvArgs.multiPkgs;
+  extraInstallCommands = "mv $out/bin/{${name},${pname}}";
+
+  meta = with lib; {
+    description = "Sylk WebRTC client";
+    homepage = "http://sylkserver.com/";
+    license = licenses.agpl3Plus;
+    maintainers = with maintainers; [ zimbatm ];
+    platforms = [ "i386-linux" "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6023,6 +6023,8 @@ in
 
   systrayhelper = callPackage ../tools/misc/systrayhelper {};
 
+  Sylk = callPackage ../applications/networking/Sylk {};
+
   otter-browser = qt5.callPackage ../applications/networking/browsers/otter {};
 
   privoxy = callPackage ../tools/networking/privoxy {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This package is part of the NLNet  / PET Zero funding grant

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
