### PR TITLE
sloccount: Wrap shell scripts

### DIFF
--- a/pkgs/development/tools/misc/sloccount/default.nix
+++ b/pkgs/development/tools/misc/sloccount/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, perl }:
+{ fetchurl, stdenv, perl, makeWrapper }:
 
 stdenv.mkDerivation rec {
   name = "sloccount-2.26";
@@ -8,6 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0ayiwfjdh1946asah861ah9269s5xkc8p5fv1wnxs9znyaxs4zzs";
   };
 
+  nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ perl ];
 
   # Make sure the Flex-generated files are newer than the `.l' files, so that
@@ -39,6 +40,13 @@ stdenv.mkDerivation rec {
     mkdir -p "$out/share/man/man1"
     mkdir -p "$out/share/doc"
   '';
+
+  postInstall = ''
+    for w in "$out/bin"/*; do
+      isScript "$w" || continue
+      wrapProgram "$w" --prefix PATH : "$out/bin"
+    done
+    '';
 
   meta = {
     description = "Set of tools for counting physical Source Lines of Code (SLOC)";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

`sloccount` scripts are not wrapped so invoking `sloccount` fails because it doesn't find its companion scripts and binaries:
```
$ sloccount .
/nix/store/ankhdwbyalcvh3xm3kswzm57wyy9cysm-sloccount-2.26/bin/sloccount: line 215: make_filelists: command not found
```
I avoid wrapping the compiled binaries (`c_count`, `java_count` and `jsp_count` for example) because they don't seem to need it. I can change this to wrap everything as well if it's preferable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions (CentOS 7.4 single user)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] *Tested execution of a number of scripts and binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

\* I also ran `sloccount` on the sloccount provided "testcode" as well, which exercises a number of languages,  without problems.

---
