### PR TITLE
 gtk-doc: build with meson, etc

### DIFF
--- a/pkgs/development/tools/documentation/gtk-doc/0001-highlight-fix-permission-on-file-style.patch
+++ b/pkgs/development/tools/documentation/gtk-doc/0001-highlight-fix-permission-on-file-style.patch
@@ -1,0 +1,24 @@
+From 95a75c95c5c4e641ce7cda0ded968d66f07f822a Mon Sep 17 00:00:00 2001
+From: worldofpeace <worldofpeace@protonmail.ch>
+Date: Sat, 18 May 2019 14:44:08 -0400
+Subject: [PATCH] highlight: fix permission on file style
+
+---
+ gtkdoc/highlight.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gtkdoc/highlight.py b/gtkdoc/highlight.py
+index 8f6e470..d11c432 100644
+--- a/gtkdoc/highlight.py
++++ b/gtkdoc/highlight.py
+@@ -47,6 +47,6 @@ def highlight_code(code, lang='c'):
+ 
+ 
+ def append_style_defs(css_file_name):
+-    os.chmod(css_file_name, stat.S_IWRITE)
++    os.chmod(css_file_name, 0o664)
+     with open(css_file_name, 'at', newline='\n', encoding='utf-8') as css:
+         css.write(HTML_FORMATTER.get_style_defs())
+-- 
+2.21.0
+

--- a/pkgs/development/tools/documentation/gtk-doc/default.nix
+++ b/pkgs/development/tools/documentation/gtk-doc/default.nix
@@ -27,6 +27,8 @@ stdenv.mkDerivation rec {
 
   patches = [
     passthru.respect_xml_catalog_files_var_patch
+    # https://gitlab.gnome.org/GNOME/gtk-doc/issues/84
+    ./0001-highlight-fix-permission-on-file-style.patch
   ];
 
   outputDevdoc = "out";

--- a/pkgs/development/tools/documentation/gtk-doc/default.nix
+++ b/pkgs/development/tools/documentation/gtk-doc/default.nix
@@ -1,5 +1,15 @@
-{ stdenv, fetchurl, autoreconfHook, pkgconfig, perl, python3, libxml2Python, libxslt, which
-, docbook_xml_dtd_43, docbook_xsl, gnome-doc-utils, gettext, itstool, gnome3
+{ stdenv
+, fetchFromGitLab
+, meson
+, ninja
+, pkgconfig
+, python3
+, libxml2Python
+, docbook_xml_dtd_43
+, docbook_xsl
+, libxslt
+, gettext
+, gnome3
 , withDblatex ? false, dblatex
 }:
 
@@ -7,9 +17,12 @@ stdenv.mkDerivation rec {
   pname = "gtk-doc";
   version = "1.30";
 
-  src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "17h6nwhis66z4dxjrc833wvfl6pqjp81yfx3fq6x7k1qp2749xm4";
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "GNOME";
+    repo = pname;
+    rev = "GTK_DOC_${stdenv.lib.replaceStrings ["."] ["_"] version }";
+    sha256 = "05lr6apj3pd3s59a7k6p45k9ywwrp577ra4pvkhxvb5p7v90c2fi";
   };
 
   patches = [
@@ -18,13 +31,27 @@ stdenv.mkDerivation rec {
 
   outputDevdoc = "out";
 
-  nativeBuildInputs = [ autoreconfHook ];
-  buildInputs =
-    [ pkgconfig perl python3 libxml2Python libxslt docbook_xml_dtd_43 docbook_xsl
-      gnome-doc-utils gettext which itstool
-    ] ++ stdenv.lib.optional withDblatex dblatex;
+  nativeBuildInputs = [
+    gettext
+    meson
+    ninja
+  ];
 
-  configureFlags = [ "--disable-scrollkeeper" ];
+  buildInputs = [
+    docbook_xml_dtd_43
+    docbook_xsl
+    libxslt
+    pkgconfig
+    python3
+    libxml2Python
+  ]
+  ++ stdenv.lib.optional withDblatex dblatex
+  ;
+
+  mesonFlags = [
+    "-Dtests=false"
+    "-Dyelp_manual=false"
+  ];
 
   # Make pygments available for binaries, python.withPackages creates a wrapper
   # but scripts are not allowed in shebangs so we link it into sys.path.

--- a/pkgs/development/tools/documentation/gtk-doc/default.nix
+++ b/pkgs/development/tools/documentation/gtk-doc/default.nix
@@ -26,10 +26,10 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--disable-scrollkeeper" ];
 
-  # Make six available for binaries, python.withPackages creates a wrapper
+  # Make pygments available for binaries, python.withPackages creates a wrapper
   # but scripts are not allowed in shebangs so we link it into sys.path.
   postInstall = ''
-    ln -s ${python3.pkgs.six}/${python3.sitePackages}/* $out/share/gtk-doc/python/
+    ln -s ${python3.pkgs.pygments}/${python3.sitePackages}/* $out/share/gtk-doc/python/
   '';
 
   doCheck = false; # requires a lot of stuff


### PR DESCRIPTION
###### Motivation for this change
Mostly wanted to fix building documentation for `glib` and https://github.com/NixOS/nixpkgs/commit/6f892ad16490156247d9bdadceac8fd5ae874bae fixes what I [noticed](https://github.com/NixOS/nixpkgs/pull/61317#issuecomment-492899556) but it still fails.

See: https://gist.github.com/worldofpeace/7a54fc196ff6ecbe35b11ed2106422ec

Additionally 1.30 added the experimental `gtkdoc-mkhtml2` which needs `anytree` and `lxml`.
I haven't done anything to care for this because adding `anytree` to `gtk-doc` results in one of those
:curly_loop: 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
