### PR TITLE
whatstyle: init at 0.1.7

### DIFF
--- a/pkgs/development/tools/misc/whatstyle/default.nix
+++ b/pkgs/development/tools/misc/whatstyle/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, python3, fetchFromGitHub, clang-unwrapped }:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "whatstyle";
+  version = "0.1.7";
+  src = fetchFromGitHub {
+    owner = "mikr";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "16ak4g149cr764c1lqakiyzmf5s98w8bdc4gk69m8qacimfg3mzm";
+  };
+
+  # Fix references to previous version, to avoid confusion:
+  postPatch = ''
+    substituteInPlace setup.py --replace 0.1.6 ${version}
+    substituteInPlace ${pname}.py --replace 0.1.6 ${version}
+  '';
+
+  checkInputs = [ clang-unwrapped /* clang-format */ ];
+
+  doCheck = false; # 3 or 4 failures depending on version, haven't investigated.
+
+  meta = with stdenv.lib; {
+    description = "Find a code format style that fits given source files";
+    homepage = https://github.com/mikr/whatstyle;
+    license = licenses.mit;
+    maintainers = with maintainers; [ dtzWill ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9705,6 +9705,10 @@ in
 
   vtable-dumper = callPackage ../development/tools/misc/vtable-dumper { };
 
+  whatstyle = callPackage ../development/tools/misc/whatstyle {
+    inherit (llvmPackages) clang-unwrapped;
+  };
+
   watson-ruby = callPackage ../development/tools/misc/watson-ruby {};
 
   xc3sprog = callPackage ../development/tools/misc/xc3sprog { };


### PR DESCRIPTION
###### Motivation for this change

This is a great little tool,
especially for getting a first `.clang-format` for a project
without spending a day of human time fiddling with options.

Nothing stops you from doing so anyway, of course!
Or from packaging a tool to fiddle on your behalf ;).

I couldn't get the tests to pass with the versions of clang I had
available,
but the tool works well in my usage so far regardless.

Perhaps related to wrapping or something,
I didn't investigate it much O:).

Apparently this can be used with other formatters (!!)
but I have not explored that myself.

Please share your experiences if you give it a whirl :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---