### PR TITLE
rtl8812au: fix build with Linux >= 5.0

### DIFF
--- a/pkgs/os-specific/linux/rtl8812au/default.nix
+++ b/pkgs/os-specific/linux/rtl8812au/default.nix
@@ -7,8 +7,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "zebulon2";
     repo = "rtl8812au-driver-5.2.20";
-    rev = "2dad788f5d71d50df4f692b67a4428967ba3d42c";
-    sha256 = "17pn73j2xqya0g8f86hn1jyf9x9wp52md05yrg1md58ixsbh1kz3";
+    rev = "ac063a4b1a87855e10f6cd1f358aaccbeee9b9c1";
+    sha256 = "1cmsv22q4k6p2wzm73k60kxbjhcgx4hqr0x3djvqrlv4rzz75l92";
   };
 
   nativeBuildInputs = [ bc ];


### PR DESCRIPTION
###### Motivation for this change

Current version in nixpkgs doesn't build with newer linux kernels. This grabs the latest commit in the repo with fixes. Tested builds fine with `linuxPackages_latest.rtl8812au`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
