### PR TITLE
nbdime: init at 1.0.6

### DIFF
--- a/pkgs/development/python-modules/nbdime/default.nix
+++ b/pkgs/development/python-modules/nbdime/default.nix
@@ -1,0 +1,69 @@
+{ lib, buildPythonPackage, fetchPypi, callPackage, isPy3k
+, hypothesis
+, setuptools_scm
+, six
+, attrs
+, py
+, setuptools
+, pytestcov
+, pytest-timeout
+, pytest-tornado
+, mock
+, tabulate
+, nbformat
+, jsonschema
+, pytest
+, colorama
+, pygments
+, tornado
+, requests
+, GitPython
+, notebook
+, jinja2
+}:
+
+buildPythonPackage rec {
+  pname = "nbdime";
+  version = "1.0.6";
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "00nywb69kp9i0wl5mczgwqc5db8v70ihr9cjbwqppd2jkx4vf34j";
+  };
+
+  checkInputs = [
+    hypothesis
+    pytestcov
+    pytest-timeout
+    pytest-tornado
+    jsonschema
+    mock
+    tabulate
+    pytest
+  ];
+
+  nativeBuildInputs = [ setuptools_scm ];
+
+  propagatedBuildInputs = [
+    attrs
+    py
+    setuptools
+    six
+    nbformat
+    colorama
+    pygments
+    tornado
+    requests
+    GitPython
+    notebook
+    jinja2
+    ];
+
+  meta = with lib; {
+    homepage = https://github.com/jupyter/nbdime;
+    description = "Tools for diffing and merging of Jupyter notebooks.";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ tbenst ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3968,6 +3968,8 @@ in {
 
   nbmerge = callPackage ../development/python-modules/nbmerge { };
 
+  nbdime = callPackage ../development/python-modules/nbdime { };
+
   nbxmpp = callPackage ../development/python-modules/nbxmpp { };
 
   sleekxmpp = callPackage ../development/python-modules/sleekxmpp { };


### PR DESCRIPTION
###### Motivation for this change

Adds a useful tool for diffing and merging of Jupyter notebooks. Also updated `jsonschema`--had to remove tests as couldn't get them to run due to new test framework based on `tox`. Perhaps @domenkozar has an idea?

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Also not sure if I did this recompilation test correctly...
```
~/c/nixpkgs> nix-shell -p nix-review --run "nix-review wip"
these paths will be fetched (0.08 MiB download, 0.38 MiB unpacked):
  /nix/store/w7xgdpblmq59blg2qzcdj951rgl2h6v0-bash-interactive-4.4-p23-dev
  /nix/store/x9vlpm4wyzzjwjdmcm3sbpbq2lvs8n0r-nix-review-2.0.0
copying path '/nix/store/w7xgdpblmq59blg2qzcdj951rgl2h6v0-bash-interactive-4.4-p23-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/x9vlpm4wyzzjwjdmcm3sbpbq2lvs8n0r-nix-review-2.0.0' from 'https://cache.nixos.org'...
$ git fetch --force https://github.com/NixOS/nixpkgs master:refs/nix-review/0
From https://github.com/NixOS/nixpkgs
 * [new branch]              master     -> refs/nix-review/0
$ git worktree add /home/tyler/.cache/nix-review/rev-5fd27a66239c96ef088c45aa1a7fb40b74cf897e-dirty/nixpkgs efcdac63fee4280cdc276362199503b6acb75df2
Preparing worktree (detached HEAD efcdac63fee)
Checking out files: 100% (18930/18930), done.
HEAD is now at efcdac63fee nixos/pantheon: add geoclue application configuration
$ nix-env -f /home/tyler/.cache/nix-review/rev-5fd27a66239c96ef088c45aa1a7fb40b74cf897e-dirty/nixpkgs -qaP --xml --out-path --show-trace
No diff detected, stopping review...
$ git worktree prune
```
