### PR TITLE
graphene: init at 1.8.6 

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -89,11 +89,12 @@ in
   gitlab = handleTest ./gitlab.nix {};
   gitolite = handleTest ./gitolite.nix {};
   gjs = handleTest ./gjs.nix {};
-  google-oslogin = handleTest ./google-oslogin {};
   gnome3 = handleTestOn ["x86_64-linux"] ./gnome3.nix {}; # libsmbios is unsupported on aarch64
   gnome3-gdm = handleTestOn ["x86_64-linux"] ./gnome3-gdm.nix {}; # libsmbios is unsupported on aarch64
   gocd-agent = handleTest ./gocd-agent.nix {};
   gocd-server = handleTest ./gocd-server.nix {};
+  google-oslogin = handleTest ./google-oslogin {};
+  graphene = handleTest ./graphene.nix {};
   grafana = handleTest ./grafana.nix {};
   graphite = handleTest ./graphite.nix {};
   hadoop.hdfs = handleTestOn [ "x86_64-linux" ] ./hadoop/hdfs.nix {};

--- a/nixos/tests/graphene.nix
+++ b/nixos/tests/graphene.nix
@@ -1,0 +1,18 @@
+# run installed tests
+import ./make-test.nix ({ pkgs, ... }:
+
+{
+  name = "graphene";
+
+  meta = {
+    maintainers = pkgs.graphene.meta.maintainers;
+  };
+
+  machine = { pkgs, ... }: {
+    environment.systemPackages = with pkgs; [ gnome-desktop-testing ];
+  };
+
+  testScript = ''
+    $machine->succeed("gnome-desktop-testing-runner -d '${pkgs.graphene.installedTests}/share'");
+  '';
+})

--- a/pkgs/development/libraries/graphene/0001-meson-add-options-for-tests-installation-dirs.patch
+++ b/pkgs/development/libraries/graphene/0001-meson-add-options-for-tests-installation-dirs.patch
@@ -1,0 +1,79 @@
+From c550bf4a41e9f86351b0a65ea3d6c9ab616e27c0 Mon Sep 17 00:00:00 2001
+From: worldofpeace <worldofpeace@protonmail.ch>
+Date: Thu, 16 May 2019 21:15:15 -0400
+Subject: [PATCH] meson: add options for tests installation dirs
+
+---
+ meson_options.txt     |  6 ++++++
+ src/tests/meson.build | 19 ++++++++++++++-----
+ 2 files changed, 20 insertions(+), 5 deletions(-)
+
+diff --git a/meson_options.txt b/meson_options.txt
+index c938805..c1e9e95 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -19,6 +19,12 @@ option('arm_neon', type: 'boolean',
+ option('tests', type: 'boolean',
+        value: true,
+        description: 'Build the test suite (requires GObject)')
++option('installed_test_datadir', type: 'string',
++       value: '',
++       description: 'Installation directory for data files in tests')
++option('installed_test_bindir', type: 'string',
++       value: '',
++       description: 'Installation directory for binary files in tests')
+ option('benchmarks', type: 'boolean',
+        value: true,
+        description: 'Build the benchmarks suite (requires GObject)')
+diff --git a/src/tests/meson.build b/src/tests/meson.build
+index 62129c6..0186400 100644
+--- a/src/tests/meson.build
++++ b/src/tests/meson.build
+@@ -22,8 +22,17 @@ unit_tests = [
+ python = python3.find_python()
+ gen_installed_test = join_paths(meson.current_source_dir(), 'gen-installed-test.py')
+ 
+-installed_test_datadir = join_paths(get_option('prefix'), get_option('datadir'), 'installed-tests', graphene_api_path)
+-installed_test_bindir = join_paths(get_option('prefix'), get_option('libexecdir'), 'installed-tests', graphene_api_path)
++test_suffix = join_paths('installed-tests', graphene_api_path)
++
++test_datadir = join_paths(get_option('installed_test_datadir'), test_suffix)
++if test_datadir == ''
++    test_datadir = join_paths(get_option('prefix'), get_option('datadir'), test_suffix)
++endif
++
++test_bindir = join_paths(get_option('installed_test_bindir'), test_suffix)
++if test_bindir == ''
++    test_bindir = join_paths(get_option('prefix'), get_option('libexecdir'), test_suffix)
++endif
+ 
+ foreach unit: unit_tests
+   wrapper = '@0@.test'.format(unit)
+@@ -32,13 +41,13 @@ foreach unit: unit_tests
+                        command: [
+                          python,
+                          gen_installed_test,
+-                         '--testdir=@0@'.format(installed_test_bindir),
++                         '--testdir=@0@'.format(test_bindir),
+                          '--testname=@0@'.format(unit),
+                          '--outdir=@OUTDIR@',
+                          '--outfile=@0@'.format(wrapper),
+                        ],
+                        install: true,
+-                       install_dir: installed_test_datadir)
++                       install_dir: test_datadir)
+ 
+   exe = executable(unit, unit + '.c',
+                    dependencies: graphene_dep,
+@@ -50,7 +59,7 @@ foreach unit: unit_tests
+                      '-DGLIB_DISABLE_DEPRECATION_WARNINGS',
+                    ],
+                    install: true,
+-                   install_dir: installed_test_bindir)
++                   install_dir: test_bindir)
+ 
+   test(unit, exe, args: [ '--tap', '-k' ])
+ endforeach
+-- 
+2.21.0
+

--- a/pkgs/development/libraries/graphene/default.nix
+++ b/pkgs/development/libraries/graphene/default.nix
@@ -1,0 +1,62 @@
+{ stdenv
+, fetchFromGitHub
+, pkgconfig
+, meson
+, ninja
+, python3
+, glib
+, gtk-doc
+, docbook_xsl
+, docbook_xml_dtd_43
+, gobject-introspection
+}:
+
+stdenv.mkDerivation rec {
+  pname = "graphene";
+  version = "1.8.6";
+
+  outputs = [ "out" "devdoc" "installedTests" ];
+
+  src = fetchFromGitHub {
+    owner = "ebassi";
+    repo = pname;
+    rev = version;
+    sha256 = "1hdbdzcz86jrvsq5h954ph9q62m8jr2a5s5acklxhdkfqn5bkbv8";
+  };
+
+  patches = [
+    ./0001-meson-add-options-for-tests-installation-dirs.patch
+  ];
+
+  mesonFlags = [
+    "-Dgtk_doc=true"
+    "-Dinstalled_test_datadir=${placeholder ''installedTests''}/share"
+    "-Dinstalled_test_bindir=${placeholder ''installedTests''}/libexec"
+  ];
+
+  nativeBuildInputs = [
+    docbook_xml_dtd_43
+    docbook_xsl
+    gtk-doc
+    meson
+    ninja
+    pkgconfig
+    python3
+  ];
+
+  buildInputs = [
+    gobject-introspection
+  ];
+
+  checkInputs = [
+    glib
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A thin layer of graphic data types";
+    homepage = "https://ebassi.github.com/graphene";
+    license = licenses.mit;
+    maintainers = with maintainers; [ worldofpeace ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9202,6 +9202,8 @@ in
 
   graphene-hardened-malloc = callPackage ../development/libraries/graphene-hardened-malloc { };
 
+  graphene = callPackage ../development/libraries/graphene { };
+
   gtk-doc = callPackage ../development/tools/documentation/gtk-doc { };
 
   gtkdialog = callPackage ../development/tools/misc/gtkdialog { };


### PR DESCRIPTION
###### Motivation for this change
Pretty sure we'll need this for mutter in GNOME 3.34.

This pr adds:
* this package
* nixos test for installed tests

There's also a patch to add options for which directory the installed test stuff goes.
I probably should try to upstream that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
