### PR TITLE
geoclue: 2.5.2 -> 2.5.3

### DIFF
--- a/pkgs/development/libraries/geoclue/add-option-for-installation-sysconfdir.patch
+++ b/pkgs/development/libraries/geoclue/add-option-for-installation-sysconfdir.patch
@@ -1,5 +1,5 @@
 diff --git a/data/meson.build b/data/meson.build
-index f826864..8b8a25e 100644
+index c189753..12c10cb 100644
 --- a/data/meson.build
 +++ b/data/meson.build
 @@ -7,7 +7,7 @@ if get_option('enable-backend')
@@ -11,7 +11,16 @@ index f826864..8b8a25e 100644
      configure_file(output: 'geoclue.conf',
                     input: 'geoclue.conf.in',
                     configuration: conf,
-@@ -26,7 +26,7 @@ if get_option('enable-backend')
+@@ -16,7 +16,7 @@ if get_option('enable-backend')
+     conf = configuration_data()
+     conf.set('libexecdir', libexecdir)
+     conf.set('dbus_srv_user', get_option('dbus-srv-user'))
+-    conf.set('sysconfdir', sysconfdir)
++    conf.set('sysconfdir', sysconfdir_install)
+ 
+     service_dir = join_paths(datadir, 'dbus-1', 'system-services')
+     configure_file(output: 'org.freedesktop.GeoClue2.service',
+@@ -33,7 +33,7 @@ if get_option('enable-backend')
      # DBus Service policy file
      dbus_service_dir = get_option('dbus-sys-dir')
      if dbus_service_dir == ''
@@ -21,10 +30,10 @@ index f826864..8b8a25e 100644
      configure_file(output: 'org.freedesktop.GeoClue2.conf',
                     input: 'org.freedesktop.GeoClue2.conf.in',
 diff --git a/demo/meson.build b/demo/meson.build
-index 99c094f..a29ca96 100644
+index 1427fbe..2623f16 100644
 --- a/demo/meson.build
 +++ b/demo/meson.build
-@@ -56,7 +56,7 @@ if get_option('demo-agent')
+@@ -54,7 +54,7 @@ if get_option('demo-agent')
                                     install_dir: desktop_dir)
  
      # Also install in the autostart directory.
@@ -34,7 +43,7 @@ index 99c094f..a29ca96 100644
                               desktop_file.full_path(),
                               autostart_dir)
 diff --git a/meson.build b/meson.build
-index d738ef6..c794a1d 100644
+index fde6fa3..39b7b0a 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -12,7 +12,11 @@ gclue_api_version='2.0'
@@ -50,8 +59,8 @@ index d738ef6..c794a1d 100644
  localedir = join_paths(datadir, 'locale')
  
  header_dir = 'libgeoclue-' + gclue_api_version
-@@ -29,7 +33,7 @@ conf.set_quoted('PACKAGE_URL', 'http://www.freedesktop.org/wiki/Software/GeoClue
- conf.set_quoted('PACKAGE_BUGREPORT', 'http://bugs.freedesktop.org/enter_bug.cgi?product=GeoClue')
+@@ -29,7 +33,7 @@ conf.set_quoted('PACKAGE_URL', 'https://gitlab.freedesktop.org/geoclue/geoclue/w
+ conf.set_quoted('PACKAGE_BUGREPORT', 'https://gitlab.freedesktop.org/geoclue/geoclue/issues/new')
  conf.set_quoted('TEST_SRCDIR', meson.source_root() + '/data/')
  conf.set_quoted('LOCALEDIR', localedir)
 -conf.set_quoted('SYSCONFDIR', sysconfdir)

--- a/pkgs/development/libraries/geoclue/default.nix
+++ b/pkgs/development/libraries/geoclue/default.nix
@@ -7,14 +7,14 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "geoclue";
-  version = "2.5.2";
+  version = "2.5.3";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = pname;
     repo = pname;
     rev = version;
-    sha256 = "1zk6n28q030a9v03whad928b9zwq16d30ch369qv2c0994axdr5p";
+    sha256 = "1wbpi74dw3p7izxwd57irz2i1g55r7wzl5h2yf0ns0hgq2njdfsg";
   };
 
   patches = [


### PR DESCRIPTION
Updated patch as needed.

https://gitlab.freedesktop.org/geoclue/geoclue/tags/2.5.3

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
The usual. This isn't runtime tested yet.

I noticed that we can specify what [user to run the dbus service under](https://gitlab.freedesktop.org/geoclue/geoclue/blob/2.5.3/meson_options.txt#L34) so after this is merged I'm going to pr a change to the nixos module so we can use a `geoclue` user and not `root`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
