### PR TITLE
[WIP] libdispatch: update to 10.12.6

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/default.nix
@@ -28,6 +28,7 @@ let
       dtrace        = "209.50.12";
       libpthread    = "218.60.3";
       hfs           = "366.70.1";
+      libdispatch   = "703.50.37";
     };
     "osx-10.11.6" = {
       PowerManagement = "572.50.1";
@@ -219,7 +220,7 @@ let
       Libc_old        = applePackage "Libc/825_40_1.nix" "osx-10.8.5"      "0xsx1im52gwlmcrv4lnhhhn9dyk5ci6g27k6yvibn9vj8fzjxwcf" {};
     };
     libclosure      = applePackage "libclosure"        "osx-10.11.6"     "1zqy1zvra46cmqv6vsf1mcsz3a76r9bky145phfwh4ab6y15vjpq" {};
-    libdispatch     = applePackage "libdispatch"       "osx-10.10.5"     "0jsfbzp87lwk9snlby0hd4zvj7j894p5q3cw0wdx9ny1mcp3kdcj" {};
+    libdispatch     = applePackage "libdispatch"       "osx-10.12.6"     "0h7cl6m167qvklfx5h8c3vzmp9k2dpkgh4i6h7wdmgr37wrkibvv" {};
     libiconv        = applePackage "libiconv"          "osx-10.12.6"     "1gg5h6z8sk851bhv87vyxzs54jmqz6lh57ny8j4s51j7srja0nly" {};
     Libinfo         = applePackage "Libinfo"           "osx-10.11.6"     "0qjgkd4y8sjvwjzv5wwyzkb61pg8wwg95bkp721dgzv119dqhr8x" {};
     Libm            = applePackage "Libm"              "osx-10.7.4"      "02sd82ig2jvvyyfschmb4gpz6psnizri8sh6i982v341x6y4ysl7" {};

--- a/pkgs/os-specific/darwin/apple-source-releases/libdispatch/default.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libdispatch/default.nix
@@ -6,11 +6,10 @@ appleDerivation {
   installPhase = ''
     mkdir -p $out/include/dispatch $out/include/os
 
-    # Move these headers so CF can find <os/voucher_private.h>
-    mv private/voucher*.h  $out/include/os
-    cp -r private/*.h  $out/include/dispatch
+    cp os/voucher*.h  $out/include/os
+    cp private/*.h  $out/include/dispatch
 
-    cp -r dispatch/*.h $out/include/dispatch
-    cp -r os/object*.h  $out/include/os
+    cp dispatch/*.h $out/include/dispatch
+    cp os/object*.h  $out/include/os
   '';
 }


### PR DESCRIPTION
Waiting for it to build, but hopefully it fixes #61596 🤞. <!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
