### PR TITLE
bind: 9.12.4-P1 -> 9.14.2

### DIFF
--- a/pkgs/servers/dns/bind/default.nix
+++ b/pkgs/servers/dns/bind/default.nix
@@ -8,30 +8,22 @@
 assert enableSeccomp -> libseccomp != null;
 assert enablePython -> python3 != null;
 
-let version = "9.12.4-P1"; in
+let version = "9.14.2"; in
 
 stdenv.mkDerivation rec {
   name = "bind-${version}";
 
   src = fetchurl {
     url = "https://ftp.isc.org/isc/bind9/${version}/${name}.tar.gz";
-    sha256 = "1if7zc5gzrfd28csc63v9bjwrc0rgvm1x9yx058946hc5gp5lyp2";
+    sha256 = "033zqajnj5ys45g899132xkhh9f0hsh76ffv7302wl166xbjfh0f";
   };
 
   outputs = [ "out" "lib" "dev" "man" "dnsutils" "host" ];
 
-  patches = [ ./dont-keep-configure-flags.patch ./remove-mkdir-var.patch ] ++
-    [
-      # Workaround for missing atomic operations on aarch64. Upstream added the
-      # below patch after the release. Can probably be dropped with the next
-      # version.
-      (fetchpatch {
-        name = "client-atomics-as-refcount.patch";
-        url = https://gitlab.isc.org/isc-projects/bind9/commit/d72f436b7d7c697b262968c48c2d7643069ab17f.diff;
-        sha256 = "0sidlab9wcv21751fbq3h9m4wy6hk7frag9ar2jndw8rn3axr2qy";
-      })
-    ] ++
-    stdenv.lib.optional stdenv.isDarwin ./darwin-openssl-linking-fix.patch;
+  patches = [
+    ./dont-keep-configure-flags.patch
+    ./remove-mkdir-var.patch
+  ] ++ stdenv.lib.optional stdenv.isDarwin ./darwin-openssl-linking-fix.patch;
 
   nativeBuildInputs = [ perl ];
   buildInputs = [ libtool libxml2 openssl ]

--- a/pkgs/servers/dns/bind/dont-keep-configure-flags.patch
+++ b/pkgs/servers/dns/bind/dont-keep-configure-flags.patch
@@ -1,8 +1,8 @@
 diff --git a/bin/named/include/named/globals.h b/bin/named/include/named/globals.h
-index 388dc97..3c6135c 100644
+index b8e356b..cbe6c94 100644
 --- a/bin/named/include/named/globals.h
 +++ b/bin/named/include/named/globals.h
-@@ -65,7 +65,9 @@ EXTERN const char *		named_g_version		INIT(VERSION);
+@@ -68,7 +68,9 @@ EXTERN const char *		named_g_version		INIT(VERSION);
  EXTERN const char *		named_g_product		INIT(PRODUCT);
  EXTERN const char *		named_g_description	INIT(DESCRIPTION);
  EXTERN const char *		named_g_srcid		INIT(SRCID);
@@ -13,21 +13,21 @@ index 388dc97..3c6135c 100644
  EXTERN in_port_t		named_g_port		INIT(0);
  EXTERN isc_dscp_t		named_g_dscp		INIT(-1);
 diff --git a/bin/named/main.c b/bin/named/main.c
-index 4fb0566..60d56cd 100644
+index 62d9ce3..342abdc 100644
 --- a/bin/named/main.c
 +++ b/bin/named/main.c
-@@ -672,8 +672,10 @@ parse_command_line(int argc, char *argv[]) {
- 			       (*named_g_description != '\0') ? " " : "",
- 			       named_g_description, named_g_srcid);
- 			printf("running on %s\n", named_os_uname());
-+			#if 0
- 			printf("built by %s with %s\n",
- 			       named_g_builder, named_g_configargs);
-+			#endif
+@@ -459,8 +459,10 @@ printversion(bool verbose) {
+ 	}
+ 
+ 	printf("running on %s\n", named_os_uname());
++#if 0
+ 	printf("built by %s with %s\n",
+ 	       named_g_builder, named_g_configargs);
++#endif
  #ifdef __clang__
- 			printf("compiled by CLANG %s\n", __VERSION__);
+ 	printf("compiled by CLANG %s\n", __VERSION__);
  #else
-@@ -1075,9 +1077,11 @@ setup(void) {
+@@ -1001,9 +1003,11 @@ setup(void) {
  		      NAMED_LOGMODULE_MAIN, ISC_LOG_NOTICE,
  		      "running on %s", named_os_uname());
  


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

9.12 is EOL as of May 2019.

9.14.2 release notes (which appear to extend those for 9.14.1):

https://ftp.isc.org/isc/bind9/9.14.2/RELEASE-NOTES-bind-9.14.2.html

Please check the security fixes and prioritize this as appropriate.

NixOS tests should be checked of course :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---