### PR TITLE
dnstracer: 1.9 -> 1.10,  touchup

### DIFF
--- a/pkgs/tools/networking/dnstracer/default.nix
+++ b/pkgs/tools/networking/dnstracer/default.nix
@@ -1,17 +1,24 @@
-{ stdenv, fetchurl, libresolv }:
+{ stdenv, fetchurl, libresolv, perl }:
 
 stdenv.mkDerivation rec {
-  version = "1.9";
-  name = "dnstracer-${version}";
+  version = "1.10";
+  pname = "dnstracer";
 
   src = fetchurl {
-    url = "https://www.mavetju.org/download/${name}.tar.gz";
-    sha256 = "177y58smnq2xhx9lbmj1gria371iv3r1d132l2gjvflkjsphig1f";
+    url = "https://www.mavetju.org/download/${pname}-${version}.tar.bz2";
+    sha256 = "089bmrjnmsga2n0r4xgw4bwbf41xdqsnmabjxhw8lngg2pns1kb4";
   };
 
   outputs = [ "out" "man" ];
 
+  nativeBuildInputs = [ perl /* for pod2man */ ];
+
   setOutputFlags = false;
+
+  installPhase = ''
+    install -Dm755 -t $out/bin dnstracer
+    install -Dm755 -t $man/share/man/man8 dnstracer.8
+  '';
 
   buildInputs = [] ++ stdenv.lib.optionals stdenv.isDarwin [ libresolv ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---