### PR TITLE
guake: 3.5.0 -> 3.6.3

### DIFF
--- a/pkgs/applications/misc/guake/default.nix
+++ b/pkgs/applications/misc/guake/default.nix
@@ -1,8 +1,8 @@
 { stdenv, fetchFromGitHub, python3, gettext, gobject-introspection, wrapGAppsHook, glibcLocales
-, gtk3, keybinder3, libnotify, libutempter, vte }:
+, gtk3, keybinder3, libnotify, libutempter, vte, libwnck3 }:
 
 let
-  version = "3.5.0";
+  version = "3.6.3";
 in python3.pkgs.buildPythonApplication rec {
   name = "guake-${version}";
   format = "other";
@@ -11,7 +11,7 @@ in python3.pkgs.buildPythonApplication rec {
     owner = "Guake";
     repo = "guake";
     rev = version;
-    sha256 = "0fz0gciw5fpxrp6yyji27l7q8c0r9ljsq6vw584mr70bcl1gzjqx";
+    sha256 = "13ipnmqcyixpa6qv83m0f91za4kar14s5jpib68b32z65x1h0j3b";
   };
 
   # Strict deps breaks guake
@@ -23,7 +23,7 @@ in python3.pkgs.buildPythonApplication rec {
 
   buildInputs = [ gtk3 keybinder3 libnotify python3 vte ];
 
-  propagatedBuildInputs = with python3.pkgs; [ dbus-python pbr pycairo pygobject3 ];
+  propagatedBuildInputs = with python3.pkgs; [ dbus-python pbr pycairo pygobject3 libwnck3 ];
 
   LC_ALL = "en_US.UTF-8"; # fixes weird encoding error, see https://github.com/NixOS/nixpkgs/pull/38642#issuecomment-379727699
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---