### PR TITLE
kdiff3: 1.7.x -> 1.8.1

### DIFF
--- a/pkgs/tools/text/kdiff3/default.nix
+++ b/pkgs/tools/text/kdiff3/default.nix
@@ -6,11 +6,11 @@
 
 mkDerivation rec {
   pname = "kdiff3";
-  version = "1.8";
+  version = "1.8.1";
 
   src = fetchurl {
     url = "https://download.kde.org/stable/${pname}/${pname}-${version}.tar.xz";
-    sha256 = "083pz5c1w7l9h4sb8zz8a763yph5sk3mxnhpdykz1rrggy9f8p54";
+    sha256 = "0vj3rw5w0kry2c1y8gv6hniam417w7k3ydb1dkf5xwr4iprw0xvq";
   };
 
   nativeBuildInputs = [ extra-cmake-modules kdoctools wrapGAppsHook ];

--- a/pkgs/tools/text/kdiff3/default.nix
+++ b/pkgs/tools/text/kdiff3/default.nix
@@ -1,34 +1,17 @@
 {
-  mkDerivation, lib, fetchgit, fetchpatch,
+  mkDerivation, lib, fetchurl,
   extra-cmake-modules, kdoctools, wrapGAppsHook,
   kcrash, kconfig, kinit, kparts
 }:
 
 mkDerivation rec {
-  name = "kdiff3-${version}";
-  version = "1.7.0-2017-02-19";
+  pname = "kdiff3";
+  version = "1.8";
 
-  src = fetchgit {
-    # gitlab is outdated
-    url = https://anongit.kde.org/scratch/thomasfischer/kdiff3.git;
-    sha256 = "0znlk9m844a6qsskbd898w4yk48dkg5bkqlkd5abvyrk1jipzyy8";
-    rev = "0d2ac328164e3cbe2db35875d3df3a86187ae84f";
+  src = fetchurl {
+    url = "https://download.kde.org/stable/${pname}/${pname}-${version}.tar.xz";
+    sha256 = "083pz5c1w7l9h4sb8zz8a763yph5sk3mxnhpdykz1rrggy9f8p54";
   };
-
-  setSourceRoot = ''sourceRoot="$(echo */kdiff3/)"'';
-
-  patches = [
-    (fetchpatch {
-      name = "git-mergetool.diff"; # see https://gitlab.com/tfischer/kdiff3/merge_requests/2
-      url = "https://gitlab.com/vcunat/kdiff3/commit/6106126216.patch";
-      sha256 = "16xqc24y8bg8gzkdbwapiwi68rzqnkpz4hgn586mi01ngig2fd7y";
-    })
-  ];
-  patchFlags = "-p 2";
-
-  postPatch = ''
-    sed -re "s/(p\\[[^]]+] *== *)('([^']|\\\\')+')/\\1QChar(\\2)/g" -i src/diff.cpp
-  '';
 
   nativeBuildInputs = [ extra-cmake-modules kdoctools wrapGAppsHook ];
 


### PR DESCRIPTION
Drop git-diff patch, really hope it's not still outstanding
(and it doesn't apply).
cc @vcunat (who filed linked upstream issue)


<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---