### PR TITLE
perl: get perl in HOST_PATH for patch-shebangs

### DIFF
--- a/pkgs/development/perl-modules/generic/default.nix
+++ b/pkgs/development/perl-modules/generic/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, perl, buildPerl, toPerlModule }:
 
-{ nativeBuildInputs ? [], name, ... } @ attrs:
+{ buildInputs ? [], nativeBuildInputs ? [], name, ... } @ attrs:
 
 toPerlModule(stdenv.mkDerivation (
   (
@@ -36,6 +36,7 @@ toPerlModule(stdenv.mkDerivation (
   {
     name = "perl${perl.version}-${name}";
     builder = ./builder.sh;
+    buildInputs = buildInputs ++ [ perl ];
     nativeBuildInputs = nativeBuildInputs ++ [ (perl.dev or perl) ];
     fullperl = buildPerl;
   }


### PR DESCRIPTION
###### Motivation for this change
Fixes #61520

Regression from https://github.com/NixOS/nixpkgs/commit/a1533dfc414961bb723937c111f5fe0925411f75 https://github.com/NixOS/nixpkgs/commit/61bc03c017f18e2fe54d209ae8ba8a42033b9564

cc @alexarice @volth  @matthewbauer 

##### special thanks to @alexarice for bisecting

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
