### PR TITLE
elasticsearch-curator: 5.6.0 -> 5.7.6 & upgrades of dependencies (based on staging)

### DIFF
--- a/pkgs/development/libraries/libbytesize/default.nix
+++ b/pkgs/development/libraries/libbytesize/default.nix
@@ -1,10 +1,10 @@
 { stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, gettext
 , gtk-doc, libxslt, docbook_xml_dtd_43, docbook_xsl
-, python3, pcre, gmp, mpfr
+, python3, pcre2, gmp, mpfr
 }:
 
 let
-  version = "1.4";
+  version = "2.0";
 in stdenv.mkDerivation rec {
   name = "libbytesize-${version}";
 
@@ -12,14 +12,14 @@ in stdenv.mkDerivation rec {
     owner = "storaged-project";
     repo = "libbytesize";
     rev = version;
-    sha256 = "1yxlc0f960rhqmh3fs3p0hvw0y2cikplgc27zsz6rn4h5dlrfmi2";
+    sha256 = "0m950idlyv6mbkhr8ngnda5l5wwb5lzs4wn4kxl73cvdlcvklmwj";
   };
 
   outputs = [ "out" "dev" "devdoc" ];
 
   nativeBuildInputs = [ autoreconfHook pkgconfig gettext gtk-doc libxslt docbook_xml_dtd_43 docbook_xsl python3 ];
 
-  buildInputs = [ pcre gmp mpfr ];
+  buildInputs = [ pcre2 gmp mpfr ];
 
   meta = with stdenv.lib; {
     description = "A tiny library providing a C “class” for working with arbitrary big sizes in bytes";

--- a/pkgs/development/python-modules/boto3/default.nix
+++ b/pkgs/development/python-modules/boto3/default.nix
@@ -13,11 +13,11 @@
 
 buildPythonPackage rec {
   pname =  "boto3";
-  version = "1.9.96"; # N.B: if you change this, change botocore too
+  version = "1.9.150"; # N.B: if you change this, change botocore too
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "c103241394d396ee08548b03d5d1f0f89a7ad1dfa7ccca88a47131f329cca093";
+    sha256 = "1j0dldqn2yxykzrib4yiir28vk45mn4d43smvpg55dnz9lr1lap3";
   };
 
   propagatedBuildInputs = [ botocore jmespath s3transfer ] ++ lib.optionals (!isPy3k) [ futures ];

--- a/pkgs/development/python-modules/botocore/default.nix
+++ b/pkgs/development/python-modules/botocore/default.nix
@@ -12,11 +12,11 @@
 
 buildPythonPackage rec {
   pname = "botocore";
-  version = "1.12.96"; # N.B: if you change this, change boto3 and awscli to a matching version
+  version = "1.12.150"; # N.B: if you change this, change boto3 and awscli to a matching version
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "55c1594041e6716847d5a8b38181e3cc44e245edbf4598ae2b99e3040073b2cf";
+    sha256 = "1xrbl9dfb65wpz7rq5n4j2qvb591z1ny5d1s6rn813ws96pl8bpq";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/certifi/default.nix
+++ b/pkgs/development/python-modules/certifi/default.nix
@@ -5,11 +5,11 @@
 
 buildPythonPackage rec {
   pname = "certifi";
-  version = "2018.11.29";
+  version = "2019.3.9";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1dvccavd2fzq4j37w0sznylp92ps14zi6gvlxzm23in0yhzciya7";
+    sha256 = "1bnpw7hrf9i1l9gfxjnzi45hkrvzz0pyn9ia8m4mw7sxhgb08qdj";
   };
 
   meta = {

--- a/pkgs/development/python-modules/elasticsearch-curator/default.nix
+++ b/pkgs/development/python-modules/elasticsearch-curator/default.nix
@@ -17,11 +17,11 @@
 
 buildPythonPackage rec {
   pname   = "elasticsearch-curator";
-  version = "5.6.0";
+  version = "5.7.6";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0r4p229233ivprxnvp33hilkgczijmyvi33wivxhhj6q3kkywpyq";
+    sha256 = "0a6q7jcqwcqf8cv76lzldf90hnj2x8gha754x515dq10zsi9sjms";
   };
 
   # The test hangs so we disable it.

--- a/pkgs/development/python-modules/elasticsearch-dsl/default.nix
+++ b/pkgs/development/python-modules/elasticsearch-dsl/default.nix
@@ -11,11 +11,11 @@
 
 buildPythonPackage rec {
   pname = "elasticsearch-dsl";
-  version = "6.3.1";
+  version = "7.0.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1gh8a0shqi105k325hgwb9avrpdjh0mc6mxwfg9ba7g6lssb702z";
+    sha256 = "08kgpcf6lp8gjan6dvdx35340i4yqa77klapk8j7165svfjc5v9a";
   };
 
   propagatedBuildInputs = [ elasticsearch python-dateutil six ]

--- a/pkgs/development/python-modules/elasticsearch/default.nix
+++ b/pkgs/development/python-modules/elasticsearch/default.nix
@@ -7,11 +7,11 @@
 
 buildPythonPackage (rec {
   pname = "elasticsearch";
-  version = "6.3.1";
+  version = "7.0.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "aada5cfdc4a543c47098eb3aca6663848ef5d04b4324935ced441debc11ec98b";
+    sha256 = "0ax00k6xi7g419azjdn8g19zad304xmxw62pcfp3njawqnlnwp24";
   };
 
   # Check is disabled because running them destroy the content of the local cluster!

--- a/pkgs/tools/admin/awscli/default.nix
+++ b/pkgs/tools/admin/awscli/default.nix
@@ -33,11 +33,11 @@ let
 
 in py.pkgs.buildPythonApplication rec {
   pname = "awscli";
-  version = "1.16.106"; # N.B: if you change this, change botocore to a matching version too
+  version = "1.16.160"; # N.B: if you change this, change botocore to a matching version too
 
   src = py.pkgs.fetchPypi {
     inherit pname version;
-    sha256 = "169810cb895ac8608747e81480aebd2712f654ad2e49e1f1315f34d6052d5e2d";
+    sha256 = "0w6frr2d4b5cas9kgd0fpn97mrx6ki9amqc0qr876cwnmgn2631x";
   };
 
   # No tests included

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2706,6 +2706,13 @@ in
           sha256 = "f15516df478d5a56180fbf80e68f206010e6d160fc39fa508b65e035fd75130b";
         };
       });
+      pyyaml = super.pyyaml.overridePythonAttrs (oldAttrs: rec {
+        version = "3.12";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "1aqjl8dk9amd4zr99n8v2qxzgmr2hdvqfma4zh7a41rj6336c9sr";
+        };
+      });
     };
   }).pkgs; toPythonApplication elasticsearch-curator;
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

https://github.com/elastic/curator/releases

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
