### PR TITLE
lightdm: 1.28.0 -> 1.30.0

### DIFF
--- a/pkgs/applications/display-managers/lightdm/default.nix
+++ b/pkgs/applications/display-managers/lightdm/default.nix
@@ -9,7 +9,7 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "lightdm";
-  version = "1.28.0";
+  version = "1.30.0";
 
   outputs = [ "out" "dev" ];
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     owner = "CanonicalLtd";
     repo = pname;
     rev = version;
-    sha256 = "1mmqy1jdvgc0h0h9gli7n4vdv5p8m5019qjr5ni4h73iz6mjdj2b";
+    sha256 = "0i1yygmjbkdjnqdl9jn8zsa1mfs2l19qc4k2capd8q1ndhnjm2dx";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Waiting on rebuild all day :P,
so marking draft to make it clear
it hasn't had usual baseline of testing :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---