### PR TITLE
u-boot: 2018.09 -> 2019.04 (+ ATF update and boards)

### DIFF
--- a/pkgs/misc/arm-trusted-firmware/default.nix
+++ b/pkgs/misc/arm-trusted-firmware/default.nix
@@ -6,7 +6,7 @@ let
             , platform
             , extraMakeFlags ? []
             , extraMeta ? {}
-            , version ? "2.0"
+            , version ? "2.1"
             , ... } @ args:
            stdenv.mkDerivation (rec {
 
@@ -17,7 +17,7 @@ let
       owner = "ARM-software";
       repo = "arm-trusted-firmware";
       rev = "refs/tags/v${version}";
-      sha256 = "087pkwa6slxff0aiz3v42gww007nww97bl1p96fvvs7rr1y14gjx";
+      sha256 = "1gy5qskrjy8n3kxdcm1dx8b45l5b75n0pm8pq80wl6xic1ycy24r";
     };
 
     depsBuildBuild = [ buildPackages.stdenv.cc ];

--- a/pkgs/misc/arm-trusted-firmware/default.nix
+++ b/pkgs/misc/arm-trusted-firmware/default.nix
@@ -57,15 +57,7 @@ in rec {
   inherit buildArmTrustedFirmware;
 
   armTrustedFirmwareAllwinner = buildArmTrustedFirmware rec {
-    version = "1.0";
-    src = fetchFromGitHub {
-      owner = "apritzel";
-      repo = "arm-trusted-firmware";
-      # Branch: `allwinner`
-      rev = "91f2402d941036a0db092d5375d0535c270b9121";
-      sha256 = "0lbipkxb01w97r6ah8wdbwxir3013rp249fcqhlzh2gjwhp5l1ys";
-    };
-    platform = "sun50iw1p1";
+    platform = "sun50i_a64";
     extraMeta.platforms = ["aarch64-linux"];
     filesToInstall = ["build/${platform}/release/bl31.bin"];
   };

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -4,7 +4,7 @@
 }:
 
 let
-  buildUBoot = { version ? "2018.09"
+  buildUBoot = { version ? "2019.04"
             , filesToInstall
             , installDir ? "$out"
             , defconfig
@@ -20,7 +20,7 @@ let
 
     src = fetchurl {
       url = "ftp://ftp.denx.de/pub/u-boot/u-boot-${version}.tar.bz2";
-      sha256 = "0s122kyz1svvs2yjzj4j9qravl3ra4vn0fjqgski7rlczqyg56w3";
+      sha256 = "1vwv4bgbl7fjcm073zrphn17hnz5h5h778f88ivdsgbb2lnpgdvn";
     };
 
     patches = [

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -195,6 +195,13 @@ in rec {
     filesToInstall = ["u-boot-sunxi-with-spl.bin"];
   };
 
+  ubootPine64LTS = buildUBoot rec {
+    defconfig = "pine64-lts_defconfig";
+    extraMeta.platforms = ["aarch64-linux"];
+    BL31 = "${armTrustedFirmwareAllwinner}/bl31.bin";
+    filesToInstall = ["u-boot-sunxi-with-spl.bin"];
+  };
+
   ubootQemuAarch64 = buildUBoot rec {
     defconfig = "qemu_arm64_defconfig";
     extraMeta.platforms = ["aarch64-linux"];

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -202,6 +202,13 @@ in rec {
     filesToInstall = ["u-boot-sunxi-with-spl.bin"];
   };
 
+  ubootPinebook = buildUBoot rec {
+    defconfig = "pinebook_defconfig";
+    extraMeta.platforms = ["aarch64-linux"];
+    BL31 = "${armTrustedFirmwareAllwinner}/bl31.bin";
+    filesToInstall = ["u-boot-sunxi-with-spl.bin"];
+  };
+
   ubootQemuAarch64 = buildUBoot rec {
     defconfig = "qemu_arm64_defconfig";
     extraMeta.platforms = ["aarch64-linux"];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15881,6 +15881,7 @@ in
     ubootOrangePiZeroPlus2H5
     ubootPcduino3Nano
     ubootPine64
+    ubootPine64LTS
     ubootQemuAarch64
     ubootQemuArm
     ubootRaspberryPi

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15882,6 +15882,7 @@ in
     ubootPcduino3Nano
     ubootPine64
     ubootPine64LTS
+    ubootPinebook
     ubootQemuAarch64
     ubootQemuArm
     ubootRaspberryPi


### PR DESCRIPTION
###### Motivation for this change

 * Updates u-boot
 * Adds new boards derivatives of Sopine (Pine64LTS, Pinebook)
 * Updates ATF from 2.0 to 2.1
 * Updates Allwinner ATF to upstream, otherwise Pinebook GFX init won't work in u-boot

* * *

For the changelog:

 * [2019.04 Announcement](https://lists.denx.de/pipermail/u-boot/2019-April/364431.html)
 * [rc4](https://lists.denx.de/pipermail/u-boot/2019-March/362174.html)
 * [rc3](https://lists.denx.de/pipermail/u-boot/2019-March/360728.html)
 * [rc2](https://lists.denx.de/pipermail/u-boot/2019-February/359463.html)
 * [rc1](https://lists.denx.de/pipermail/u-boot/2019-February/357902.html)
 * [2019.01 Announcement](https://lists.denx.de/pipermail/u-boot/2019-January/354598.html)
 * [rc3](https://lists.denx.de/pipermail/u-boot/2019-January/353882.html)
 * [rc2](https://lists.denx.de/pipermail/u-boot/2018-December/352385.html)
 * [rc1](https://lists.denx.de/pipermail/u-boot/2018-December/350498.html)
 * [2018.11 Announcement](https://lists.denx.de/pipermail/u-boot/2018-November/347424.html)
 * [rc2](https://lists.denx.de/pipermail/u-boot/2018-October/344567.html)
 * [rc1](https://lists.denx.de/pipermail/u-boot/2018-October/342659.html)

(Looks like we're not having real changelogs anymore with version updates :/)

###### Things done

- ✔️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Also, boot fine on my Pinebook (new 11" 1080p).
