### PR TITLE
krita: fixed missing python path

### DIFF
--- a/pkgs/applications/graphics/krita/default.nix
+++ b/pkgs/applications/graphics/krita/default.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, lib, stdenv, fetchurl, cmake, extra-cmake-modules
+{ mkDerivation, lib, stdenv, makeWrapper, fetchurl, cmake, extra-cmake-modules
 , karchive, kconfig, kwidgetsaddons, kcompletion, kcoreaddons
 , kguiaddons, ki18n, kitemmodels, kitemviews, kwindowsystem
 , kio, kcrash
@@ -25,7 +25,7 @@ mkDerivation rec {
     sha256 = "0h2rplc76r82b8smk61zci1ijj9xkjmf20pdqa8fc2lz4zicjxh4";
   };
 
-  nativeBuildInputs = [ cmake extra-cmake-modules python3Packages.sip ];
+  nativeBuildInputs = [ cmake extra-cmake-modules python3Packages.sip makeWrapper ];
 
   buildInputs = [
     karchive kconfig kwidgetsaddons kcompletion kcoreaddons kguiaddons
@@ -43,6 +43,12 @@ mkDerivation rec {
     "-DPYQT_SIP_DIR_OVERRIDE=${python3Packages.pyqt5}/share/sip/PyQt5"
     "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
   ];
+
+  postInstall = ''
+    for i in $out/bin/*; do
+      wrapProgram $i --prefix PYTHONPATH : "$PYTHONPATH"
+    done
+  '';
 
   meta = with lib; {
     description = "A free and open source painting application";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fixes [#56042](https://github.com/NixOS/nixpkgs/issues/56042).
Krita no longer complains about not finding PyQt5 and sip (and in consequence no longer segfaults on exit).
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'sip'
krita.scripting: "Traceback (most recent call last):"
krita.scripting: "  File \"/nix/store/0a81gj7kskr0nbpd90x93n08xk8snw75-krita-4.1.8/lib/krita-python-libs/krita/__init__.py\", line 7, in <module>"
krita.scripting: "    from .api import *"
krita.scripting: "  File \"/nix/store/0a81gj7kskr0nbpd90x93n08xk8snw75-krita-4.1.8/lib/krita-python-libs/krita/api.py\", line 28, in <module>"
krita.scripting: "    from PyKrita.krita import *"
krita.scripting: "ModuleNotFoundError: No module named 'PyQt5'"
krita.scripting: "Could not import krita"
```

###### Things done
Added a pythonpath wrapper for the krita and kritarunner binaries.
See the postInstall phase of [pyqt5](https://github.com/NixOS/nixpkgs/blob/d27643bc0ae06ed52a5d88aa875d79d1da9ffcb1/pkgs/development/python-modules/pyqt/5.x.nix).
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Things to do/consider
- [x] PyQt5 could be added to pythonpath instead of softlinking it... Are there any guidelines on how such things should be handled?
- [x] Krita still complains about missing icons, ~~we should probably add them~~ it's actually not [relevant](https://kde-bugs-dist.kde.narkive.com/jSF4GX3w/krita-bug-392108-new-qml-failed-to-get-image-from-provider)
- [ ] By default krita expects the font Source Sans Pro to be installed, I'm not sure if it should be included in the package though
- [x] Run some krita python scripts. (only quickly confirmed that Tools -> Scripts -> Scripter works)
---
