### PR TITLE
g2o: build g2o_viewer, libqglviewer: 2.6.3 -> 2.7.1

### DIFF
--- a/pkgs/development/libraries/g2o/default.nix
+++ b/pkgs/development/libraries/g2o/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
   # Removes a reference to gcc that is only used in a debug message
   patches = [ ./remove-compiler-reference.patch ];
 
+  separateDebugInfo = true;
+
   nativeBuildInputs = [ cmake makeWrapper ];
   buildInputs = [ eigen suitesparse libGLU qt5.qtbase libsForQt5.libqglviewer ];
 

--- a/pkgs/development/libraries/g2o/default.nix
+++ b/pkgs/development/libraries/g2o/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv, fetchFromGitHub, cmake, eigen, suitesparse }:
+{ lib, stdenv, fetchFromGitHub, cmake, eigen, suitesparse, libGLU, qt5
+, libsForQt5, makeWrapper }:
 
 stdenv.mkDerivation rec {
   pname = "g2o";
@@ -11,8 +12,31 @@ stdenv.mkDerivation rec {
     sha256 = "1rgrz6zxiinrik3lgwgvsmlww1m2fnpjmvcx1mf62xi1s2ma5w2i";
   };
 
-  nativeBuildInputs = [ cmake ];
-  buildInputs = [ eigen suitesparse ];
+  # Removes a reference to gcc that is only used in a debug message
+  patches = [ ./remove-compiler-reference.patch ];
+
+  nativeBuildInputs = [ cmake makeWrapper ];
+  buildInputs = [ eigen suitesparse libGLU qt5.qtbase libsForQt5.libqglviewer ];
+
+  cmakeFlags = [
+    # Detection script is broken
+    "-DQGLVIEWER_INCLUDE_DIR=${libsForQt5.libqglviewer}/include/QGLViewer"
+    "-DG2O_BUILD_EXAMPLES=OFF"
+  ] ++ lib.optionals stdenv.isx86_64 ([ "-DDO_SSE_AUTODETECT=OFF" ] ++ {
+    "default"        = [ "-DDISABLE_SSE3=ON" "-DDISABLE_SSE4_1=ON" "-DDISABLE_SSE4_2=ON" "-DDISABLE_SSE4_A=ON" ];
+    "westmere"       = [                                                                 "-DDISABLE_SSE4_A=ON" ];
+    "sandybridge"    = [                                                                 "-DDISABLE_SSE4_A=ON" ];
+    "ivybridge"      = [                                                                 "-DDISABLE_SSE4_A=ON" ];
+    "haswell"        = [                                                                 "-DDISABLE_SSE4_A=ON" ];
+    "broadwell"      = [                                                                 "-DDISABLE_SSE4_A=ON" ];
+    "skylake"        = [                                                                 "-DDISABLE_SSE4_A=ON" ];
+    "skylake-avx512" = [                                                                 "-DDISABLE_SSE4_A=ON" ];
+  }.${stdenv.hostPlatform.platform.gcc.arch or "default"});
+
+  postInstall = ''
+    wrapProgram $out/bin/g2o_viewer \
+      --prefix QT_PLUGIN_PATH : "${qt5.qtbase}/${qt5.qtbase.qtPluginPrefix}"
+  '';
 
   meta = {
     description = "A General Framework for Graph Optimization";

--- a/pkgs/development/libraries/g2o/remove-compiler-reference.patch
+++ b/pkgs/development/libraries/g2o/remove-compiler-reference.patch
@@ -1,0 +1,25 @@
+From b9bfed09e4e3c481b7eb36bee1ff4202ccf69dee Mon Sep 17 00:00:00 2001
+From: Ben Wolsieffer <benwolsieffer@gmail.com>
+Date: Fri, 17 May 2019 19:05:36 -0400
+Subject: [PATCH] Remove reference to compiler.
+
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a3f66dd..bb05bd0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -371,7 +371,7 @@ set(G2O_HAVE_CHOLMOD ${CHOLMOD_FOUND})
+ set(G2O_HAVE_CSPARSE ${CSPARSE_FOUND})
+ set(G2O_SHARED_LIBS ${BUILD_SHARED_LIBS})
+ set(G2O_LGPL_SHARED_LIBS ${BUILD_LGPL_SHARED_LIBS})
+-set(G2O_CXX_COMPILER "${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER}")
++set(G2O_CXX_COMPILER "${CMAKE_CXX_COMPILER_ID} unknown")
+ 
+ configure_file(config.h.in "${PROJECT_BINARY_DIR}/g2o/config.h")
+ install(FILES ${PROJECT_BINARY_DIR}/g2o/config.h DESTINATION ${INCLUDES_DESTINATION}/g2o)
+-- 
+2.21.0
+

--- a/pkgs/development/libraries/libqglviewer/default.nix
+++ b/pkgs/development/libraries/libqglviewer/default.nix
@@ -1,25 +1,25 @@
-{ stdenv, fetchurl, qt4, qmake4Hook, AGL }:
+{ stdenv, fetchurl, qmake, qtbase, libGLU, AGL }:
 
 stdenv.mkDerivation rec {
-  name = "libqglviewer-2.6.3";
-  version = "2.6.3";
+  pname = "libqglviewer";
+  version = "2.7.1";
 
   src = fetchurl {
     url = "http://www.libqglviewer.com/src/libQGLViewer-${version}.tar.gz";
-    sha256 = "00jdkyk4wg1356c3ar6nk3hyp494ya3yvshq9m57kfmqpn3inqdy";
+    sha256 = "08f10yk22kjdsvrqhd063gqa8nxnl749c20mwhaxij4f7rzdkixz";
   };
 
-  buildInputs = [ qt4 qmake4Hook ]
+  nativeBuildInputs = [ qmake ];
+  buildInputs = [ qtbase libGLU ]
     ++ stdenv.lib.optional stdenv.isDarwin AGL;
 
-  postPatch =
-    ''
-      cd QGLViewer
-    '';
+  postPatch = ''
+    cd QGLViewer
+  '';
 
   meta = with stdenv.lib; {
     description = "C++ library based on Qt that eases the creation of OpenGL 3D viewers";
-    homepage = http://libqglviewer.com/;
+    homepage = "http://libqglviewer.com";
     license = licenses.gpl2;
     platforms = platforms.all;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11538,10 +11538,6 @@ in
 
   libplist = callPackage ../development/libraries/libplist { };
 
-  libqglviewer = callPackage ../development/libraries/libqglviewer {
-    inherit (darwin.apple_sdk.frameworks) AGL;
-  };
-
   libre = callPackage ../development/libraries/libre {};
   librem = callPackage ../development/libraries/librem {};
 
@@ -12770,6 +12766,10 @@ in
     libopenshot = callPackage ../applications/video/openshot-qt/libopenshot.nix { };
 
     libopenshot-audio = callPackage ../applications/video/openshot-qt/libopenshot-audio.nix { };
+
+    libqglviewer = callPackage ../development/libraries/libqglviewer {
+      inherit (darwin.apple_sdk.frameworks) AGL;
+    };
 
     libqtav = callPackage ../development/libraries/libqtav { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I recently added a basic derivation for `g2o` in #61344, but this package was missing support for the graph viewer application (`g2o_viewer`). It also performed impure CPU feature (SSE) detection.

`g2o_viewer` requires `libqglviewer`, but the version currently in nixpkgs is too old, so this package was updated. This moved it from using Qt4 to using Qt5.

###### Things done

Updated `libqglviewer` to the latest version. It now uses Qt5 so it was moved to `libsForQt5`. There were no users of this package within nixpkgs. I did not add an alias because this change would almost certainly break any out of tree usage anyway due to the Qt upgrade. 

I am not able to test the Darwin build, so it would be helpful if someone could ask ofborg to build it.

I added the `libqglviewer` dependency to `g2o` in order to build `g2o_viewer`. I also added a patch that removes an unnecessary reference to the compiler that was just used in a [debug message](https://github.com/RainerKuemmerle/g2o/blob/master/g2o/apps/g2o_cli/g2o.cpp#L174). Lastly, I added CPU feature tables as done in #59148. This prevents the build from impurely detecting SSE support on the build machine and potentially generating code that cannot run on all supported machines.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
