### PR TITLE
kanji-stroke-order-font: init at 4.002

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4001,6 +4001,11 @@
     github = "Ptival";
     name = "Valentin Robert";
   };
+  ptrhlm = {
+    email = "ptrhlm0@gmail.com";
+    github = "ptrhlm";
+    name = "Piotr Halama";
+  };
   puffnfresh = {
     email = "brian@brianmckenna.org";
     github = "puffnfresh";

--- a/pkgs/data/fonts/kanji-stroke-order-font/default.nix
+++ b/pkgs/data/fonts/kanji-stroke-order-font/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchzip }:
+
+let
+  version = "4.002";
+in fetchzip {
+  name = "kanji-stroke-order-font-${version}";
+
+  url = "https://sites.google.com/site/nihilistorguk/KanjiStrokeOrders_v${version}.zip?attredirects=0";
+
+  postFetch = ''
+    mkdir -p $out/share/fonts/kanji-stroke-order $out/share/doc/kanji-stroke-order
+    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/kanji-stroke-order
+    unzip -j $downloadedFile \*.txt -d $out/share/doc/kanji-stroke-order
+  '';
+
+  sha256 = "194ylkx5p7r1461wnnd3hisv5dz1xl07fyxmg8gv47zcwvdmwkc0";
+
+  meta = with stdenv.lib; {
+    description = "Font containing stroke order diagrams for over 6500 kanji, 180 kana and other characters";
+    homepage = "https://sites.google.com/site/nihilistorguk/";
+
+    license = [ licenses.bsd3 ];
+    maintainers = with maintainers; [ ptrhlm ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16223,6 +16223,8 @@ in
 
   junicode = callPackage ../data/fonts/junicode { };
 
+  kanji-stroke-order-font = callPackage ../data/fonts/kanji-stroke-order-font {};
+
   kawkab-mono-font = callPackage ../data/fonts/kawkab-mono {};
 
   kochi-substitute = callPackage ../data/fonts/kochi-substitute {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This pull request adds font with Japanese kanji characters, annotated with stroke order.
The font is used for learning Japanese, for example with Anki flashcards.

Additionally, I added myself to maintainer list in order to maintain this package (I'm not sure if I should - if not, I'll remove that commit).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
