### PR TITLE
broadcom-sta: patch for 5.1+

### DIFF
--- a/pkgs/os-specific/linux/broadcom-sta/default.nix
+++ b/pkgs/os-specific/linux/broadcom-sta/default.nix
@@ -34,6 +34,8 @@ stdenv.mkDerivation {
     # source: https://aur.archlinux.org/cgit/aur.git/tree/linux412.patch?h=broadcom-wl
     ./linux-4.12.patch
     ./linux-4.15.patch
+    # source: https://bugs.archlinux.org/task/62604
+    ./linux-5.1.patch
     ./null-pointer-fix.patch
     ./gcc.patch
   ];

--- a/pkgs/os-specific/linux/broadcom-sta/linux-5.1.patch
+++ b/pkgs/os-specific/linux/broadcom-sta/linux-5.1.patch
@@ -1,0 +1,22 @@
+--- a/src/wl/sys/wl_cfg80211_hybrid.c	2015-09-19 00:47:30.000000000 +0200
++++ b/src/wl/sys/wl_cfg80211_hybrid.c	2019-05-11 11:02:12.988391025 +0200
+@@ -450,7 +450,7 @@
+ 	ifr.ifr_data = (caddr_t)&ioc;
+ 
+ 	fs = get_fs();
+-	set_fs(get_ds());
++	set_fs(KERNEL_DS);
+ #if defined(WL_USE_NETDEV_OPS)
+ 	err = dev->netdev_ops->ndo_do_ioctl(dev, &ifr, SIOCDEVPRIVATE);
+ #else
+--- a/src/wl/sys/wl_iw.c	2015-09-19 00:47:30.000000000 +0200
++++ b/src/wl/sys/wl_iw.c	2019-05-11 11:02:50.743413053 +0200
+@@ -117,7 +117,7 @@
+ 	ifr.ifr_data = (caddr_t) &ioc;
+ 
+ 	fs = get_fs();
+-	set_fs(get_ds());
++	set_fs(KERNEL_DS);
+ #if defined(WL_USE_NETDEV_OPS)
+ 	ret = dev->netdev_ops->ndo_do_ioctl(dev, &ifr, SIOCDEVPRIVATE);
+ #else


### PR DESCRIPTION
###### Motivation for this change
The broadcom-sta package wasn't compiling on kernel 5.1.0. It calls a get_ds() function, which was removed. get_ds() was simply defined as KERNEL_DS, so replacing that function call with KERNEL_DS seems to have fixed things. I pulled the patch from archlinux. Here are some relevant bug reports:
https://bugs.gentoo.org/685214
https://bugs.archlinux.org/task/62604

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
