### PR TITLE
cnstrokeorder: init at 0.0.4.7

### DIFF
--- a/pkgs/data/fonts/cnstrokeorder/default.nix
+++ b/pkgs/data/fonts/cnstrokeorder/default.nix
@@ -1,0 +1,26 @@
+{ lib, fetchurl }:
+
+let
+  version = "0.0.4.7";
+in fetchurl {
+  name = "cnstrokeorder-${version}";
+
+  url = "http://rtega.be/chmn/CNstrokeorder-${version}.ttf";
+
+  recursiveHash = true;
+  downloadToTemp = true;
+
+  postFetch = ''
+    install -D $downloadedFile $out/share/fonts/truetype/CNstrokeorder-${version}.ttf
+  '';
+
+  sha256 = "0cizgfdgbq9av5c8234mysr2q54iw9pkxrmq5ga8gv32hxhl5bx4";
+
+  meta = with lib; {
+    description = "Chinese font that shows stroke order for HSK 1-4";
+    homepage = "http://rtega.be/chmn/index.php?subpage=68";
+    license = [ licenses.arphicpl ];
+    maintainers = with maintainers; [ johnazoidberg ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16022,6 +16022,8 @@ in
 
   cherry = callPackage ../data/fonts/cherry { };
 
+  cnstrokeorder = callPackage ../data/fonts/cnstrokeorder {};
+
   comfortaa = callPackage ../data/fonts/comfortaa {};
 
   comic-neue = callPackage ../data/fonts/comic-neue { };


### PR DESCRIPTION
###### Motivation for this change
I saw #61659 and thought it'd be cool to have the same for proper Mandarin characters.

###### Things done

Builds fine and displays nicely in LibreOffice Writer.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).