### PR TITLE
jellyfin: add bundled libraries to LD_LIBRARY_PATH

### DIFF
--- a/pkgs/servers/jellyfin/default.nix
+++ b/pkgs/servers/jellyfin/default.nix
@@ -1,6 +1,22 @@
-{ stdenv, fetchurl, unzip, sqlite, makeWrapper, dotnet-sdk, ffmpeg }:
+{ stdenv, lib, fetchurl, unzip, sqlite, makeWrapper, dotnet-sdk, ffmpeg,
+  fontconfig, freetype }:
 
-stdenv.mkDerivation rec {
+let
+  os = if stdenv.isDarwin then "osx" else "linux";
+  arch =
+    with stdenv.hostPlatform;
+    if isx86_32 then "x86"
+    else if isx86_64 then "x64"
+    else if isAarch32 then "arm"
+    else if isAarch64 then "arm64"
+    else lib.warn "Unsupported architecture, some image processing features might be unavailable" "unknown";
+  musl = lib.optionalString stdenv.hostPlatform.isMusl
+    (if (arch != "x64")
+      then lib.warn "Some image processing features might be unavailable for non x86-64 with Musl" "musl-"
+      else "musl-");
+  runtimeDir = "${os}-${musl}${arch}";
+
+in stdenv.mkDerivation rec {
   pname = "jellyfin";
   version = "10.3.2";
 
@@ -28,8 +44,8 @@ stdenv.mkDerivation rec {
 
     makeWrapper "${dotnet-sdk}/bin/dotnet" $out/bin/jellyfin \
       --prefix LD_LIBRARY_PATH : "${stdenv.lib.makeLibraryPath [
-        sqlite
-      ]}" \
+        sqlite fontconfig freetype stdenv.cc.cc.lib
+      ]}:$out/opt/jellyfin/runtimes/${runtimeDir}/native/" \
       --add-flags "$out/opt/jellyfin/jellyfin.dll --ffmpeg ${ffmpeg}/bin/ffmpeg"
   '';
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

- Jellyfin uses the Skia library to do some image processing.
- Jellyfin bundles the library.

Without this, we have this error:

```
[10:51:42] [INF] Skia not available. Will fallback to NullIMageEncoder. {0}
System.DllNotFoundException: Unable to load shared library 'libSkiaSharp' or one of its dependencies. In order to help diagnose loading problems, consider setting the LD_DEBUG environment variable: liblibSkiaSharp: cannot open shared >
   at SkiaSharp.SkiaApi.sk_color_premultiply(SKColor color)
   at SkiaSharp.SKPMColor.PreMultiply(SKColor color)
   at Jellyfin.Drawing.Skia.SkiaEncoder.LogVersion()
   at Jellyfin.Server.Program.GetImageEncoder(IFileSystem fileSystem, IApplicationPaths appPaths, ILocalizationManager localizationManager)
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
