### PR TITLE
libsass: add patch for CVE-2018-19827

### DIFF
--- a/pkgs/development/libraries/libsass/default.nix
+++ b/pkgs/development/libraries/libsass/default.nix
@@ -9,6 +9,14 @@ stdenv.mkDerivation rec {
     sha256 = "0w6v1xa00jvfyk4b29ir7dfkhiq72anz015gg580bi7x3n7saz28";
   };
 
+  patches = [
+    (fetchpatch {
+      name = "CVE-2018-19827.patch";
+      url = "https://github.com/sass/libsass/commit/67a3f4ff9b790ed016197e6da4ef4e1d4c9da09f.patch";
+      sha256 = "0ix12x9plmpgs3xda2fjdcykca687h16qfwqr57i5qphjr9vp33l";
+    })
+  ];
+
   preConfigure = ''
     export LIBSASS_VERSION=${version}
   '';


### PR DESCRIPTION
###### Motivation for this change
Of the 4 open CVEs against `libsass` (https://github.com/NixOS/nixpkgs/issues/60842), **one** of them _does_ have an apply-able patch available for it, so we should probably add that. Better than nothing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
