### PR TITLE
android-file-transfer: 3.7 -> 3.8

### DIFF
--- a/pkgs/tools/filesystems/android-file-transfer/default.nix
+++ b/pkgs/tools/filesystems/android-file-transfer/default.nix
@@ -1,22 +1,19 @@
-{ lib, stdenv, fetchFromGitHub, cmake, fuse, readline, pkgconfig, qtbase }:
+{ stdenv, fetchFromGitHub, cmake, fuse, readline, pkgconfig, qtbase }:
 
 stdenv.mkDerivation rec {
-  name = "android-file-transfer-${version}";
-  version = "3.7";
+  pname = "android-file-transfer";
+  version = "3.8";
+
   src = fetchFromGitHub {
     owner = "whoozle";
     repo = "android-file-transfer-linux";
     rev = "v${version}";
     sha256 = "0a388pqc0azgn0wy85wb1mjk3b5zb6vcr58l4warwfzhca400zn0";
   };
-  buildInputs = [ cmake fuse readline pkgconfig qtbase ];
-  buildPhase = ''
-    cmake .
-    make
-  '';
-  installPhase = ''
-    make install
-  '';
+
+  nativeBuildInputs = [ cmake readline pkgconfig ];
+  buildInputs = [ fuse qtbase ];
+
   meta = with stdenv.lib; {
     description = "Reliable MTP client with minimalistic UI";
     homepage = https://whoozle.github.io/android-file-transfer-linux/;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

https://github.com/whoozle/android-file-transfer-linux/releases/tag/v3.8

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @xaverdh