### PR TITLE
pythonPackages.zxcvbn-python: 4.4.24 -> 4.4.27

### DIFF
--- a/pkgs/development/python-modules/zxcvbn-python/default.nix
+++ b/pkgs/development/python-modules/zxcvbn-python/default.nix
@@ -1,20 +1,20 @@
-{ lib
-, buildPythonPackage
-, fetchPypi
-}:
+{ lib, buildPythonPackage, fetchFromGitHub
+, pytest_3 }:
 
 buildPythonPackage rec {
   pname = "zxcvbn-python";
-  version = "4.4.24";
+  version = "4.4.27";
 
-
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "900b28cc5e96be4091d8778f19f222832890264e338765a1c1c09fca2db64b2d";
+  src = fetchFromGitHub {
+    owner = "dwolfhub";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0w0sx9ssjks8da973cdv5xi87yjsf038jqxmzj2y26xvpyjsg2v2";
   };
 
-  # No tests in archive
-  doCheck = false;
+  checkInputs = [
+    pytest_3
+  ];
 
   meta = {
     description = "Python implementation of Dropbox's realistic password strength estimator, zxcvbn";


### PR DESCRIPTION
Couldn't get `4.4.27` using `fetchPypi`.
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
