### PR TITLE
compton: 0.1_beta2.5 -> 6.2

### DIFF
--- a/nixos/modules/services/x11/compton.nix
+++ b/nixos/modules/services/x11/compton.nix
@@ -194,11 +194,22 @@ in {
     };
 
     vSync = mkOption {
-      type = types.bool;
+      type = with types; either bool
+        (enum [ "none" "drm" "opengl" "opengl-oml" "opengl-swc" "opengl-mswc" ]);
       default = false;
+      apply = x:
+        let
+          res = x != "none";
+          msg = "The type of services.compton.vSync has changed to bool:"
+                + " interpreting ${x} as ${lib.boolToString res}";
+        in
+          if isBool x then x
+          else warn msg res;
+
       description = ''
         Enable vertical synchronization. Chooses the best method
         (drm, opengl, opengl-oml, opengl-swc, opengl-mswc) automatically.
+        The bool value should be used, the others are just for backwards compatibility.
       '';
     };
 

--- a/nixos/modules/services/x11/compton.nix
+++ b/nixos/modules/services/x11/compton.nix
@@ -37,7 +37,12 @@ let
       # opacity
       active-opacity   = ${cfg.activeOpacity};
       inactive-opacity = ${cfg.inactiveOpacity};
-      menu-opacity     = ${cfg.menuOpacity};
+
+      wintypes:
+      {
+        popup_menu = { opacity = ${cfg.menuOpacity}; }
+        dropdown_menu = { opacity = ${cfg.menuOpacity}; }
+      };
 
       opacity-rule = [
         ${opacityRules}
@@ -45,7 +50,7 @@ let
 
       # other options
       backend = ${toJSON cfg.backend};
-      vsync = ${toJSON cfg.vSync};
+      vsync = ${lib.boolToString cfg.vSync};
       refresh-rate = ${toString cfg.refreshRate};
     '' + cfg.extraOptions);
 
@@ -189,15 +194,11 @@ in {
     };
 
     vSync = mkOption {
-      type = types.enum [
-        "none" "drm" "opengl"
-        "opengl-oml" "opengl-swc" "opengl-mswc"
-      ];
-      default = "none";
-      example = "opengl-swc";
+      type = types.bool;
+      default = false;
       description = ''
-        Enable vertical synchronization using the specified method.
-        See <literal>compton(1)</literal> man page an explanation.
+        Enable vertical synchronization. Chooses the best method
+        (drm, opengl, opengl-oml, opengl-swc, opengl-mswc) automatically.
       '';
     };
 

--- a/pkgs/applications/window-managers/compton/default.nix
+++ b/pkgs/applications/window-managers/compton/default.nix
@@ -97,7 +97,6 @@ let
     NIX_CFLAGS_COMPILE = [ "-fno-strict-aliasing" ];
 
     mesonFlags = [
-      "-Dvsync_drm=true"
       "-Dnew_backends=true"
       "-Dbuild_docs=true"
     ];

--- a/pkgs/applications/window-managers/compton/default.nix
+++ b/pkgs/applications/window-managers/compton/default.nix
@@ -63,7 +63,7 @@ let
 
   gitSource = rec {
     pname = "compton-git";
-    version = "5.1-rc2";
+    version = "6.2";
 
     COMPTON_VERSION = "v${version}";
 
@@ -73,7 +73,7 @@ let
       owner  = "yshui";
       repo   = "compton";
       rev    = COMPTON_VERSION;
-      sha256 = "1qpy76kkhz8gfby842ry7lanvxkjxh4ckclkcjk4xi2wsmbhyp08";
+      sha256 = "03fi9q8zw2qrwpkmy1bnavgfh91ci9in5fdi17g4s5s0n2l7yil7";
     };
 
     buildInputs = [

--- a/pkgs/applications/window-managers/compton/default.nix
+++ b/pkgs/applications/window-managers/compton/default.nix
@@ -3,108 +3,67 @@
 , xorgproto, libxcb ,xcbutilrenderutil, xcbutilimage, pixman, libev
 , dbus, libconfig, libdrm, libGL, pcre, libX11, libXcomposite, libXdamage
 , libXinerama, libXrandr, libXrender, libXext, xwininfo, libxdg_basedir }:
+stdenv.mkDerivation rec {
+  pname = "compton";
+  version = "6.2";
 
-let
-  common = source: stdenv.mkDerivation (source // rec {
-    name = "${source.pname}-${source.version}";
+  COMPTON_VERSION = "v${version}";
 
-    nativeBuildInputs = (source.nativeBuildInputs or []) ++ [
-      pkgconfig
-      asciidoc
-      docbook_xml_dtd_45
-      docbook_xsl
-      makeWrapper
-    ];
-
-    installFlags = [ "PREFIX=$(out)" ];
-
-    postInstall = ''
-      wrapProgram $out/bin/compton-trans \
-        --prefix PATH : ${lib.makeBinPath [ xwininfo ]}
-    '';
-
-    meta = with lib; {
-      description = "A fork of XCompMgr, a sample compositing manager for X servers";
-      longDescription = ''
-        A fork of XCompMgr, which is a sample compositing manager for X
-        servers supporting the XFIXES, DAMAGE, RENDER, and COMPOSITE
-        extensions. It enables basic eye-candy effects. This fork adds
-        additional features, such as additional effects, and a fork at a
-        well-defined and proper place.
-      '';
-      license = licenses.mit;
-      maintainers = with maintainers; [ ertes enzime twey ];
-      platforms = platforms.linux;
-    };
-  });
-
-  stableSource = rec {
-    pname = "compton";
-    version = "0.1_beta2.5";
-
-    COMPTON_VERSION = version;
-
-    buildInputs = [
-      dbus libX11 libXcomposite libXdamage libXrender libXrandr libXext
-      libXinerama libdrm pcre libxml2 libxslt libconfig libGL
-    ];
-
-    src = fetchFromGitHub {
-      owner = "chjj";
-      repo = "compton";
-      rev = "b7f43ee67a1d2d08239a2eb67b7f50fe51a592a8";
-      sha256 = "1p7ayzvm3c63q42na5frznq3rlr1lby2pdgbvzm1zl07wagqss18";
-    };
-
-    meta = {
-      homepage = https://github.com/chjj/compton/;
-    };
+  src = fetchFromGitHub {
+    owner  = "yshui";
+    repo   = "compton";
+    rev    = COMPTON_VERSION;
+    sha256 = "03fi9q8zw2qrwpkmy1bnavgfh91ci9in5fdi17g4s5s0n2l7yil7";
   };
 
-  gitSource = rec {
-    pname = "compton-git";
-    version = "6.2";
+  nativeBuildInputs = [
+    meson ninja
+    pkgconfig
+    asciidoc
+    docbook_xml_dtd_45
+    docbook_xsl
+    makeWrapper
+  ];
 
-    COMPTON_VERSION = "v${version}";
+  buildInputs = [
+    dbus libX11 libXext
+    xorgproto
+    libXinerama libdrm pcre libxml2 libxslt libconfig libGL
+    libxcb xcbutilrenderutil xcbutilimage
+    pixman libev
+    libxdg_basedir
+  ];
 
-    nativeBuildInputs = [ meson ninja ];
+  NIX_CFLAGS_COMPILE = [ "-fno-strict-aliasing" ];
 
-    src = fetchFromGitHub {
-      owner  = "yshui";
-      repo   = "compton";
-      rev    = COMPTON_VERSION;
-      sha256 = "03fi9q8zw2qrwpkmy1bnavgfh91ci9in5fdi17g4s5s0n2l7yil7";
-    };
+  mesonFlags = [
+    "-Dbuild_docs=true"
+  ];
 
-    buildInputs = [
-      dbus libX11 libXext
-      xorgproto
-      libXinerama libdrm pcre libxml2 libxslt libconfig libGL
-      # Removed:
-      # libXcomposite libXdamage libXrender libXrandr
+  preBuild = ''
+    git() { echo "v${version}"; }
+    export -f git
+  '';
 
-      # New:
-      libxcb xcbutilrenderutil xcbutilimage
-      pixman libev
-      libxdg_basedir
-    ];
+  installFlags = [ "PREFIX=$(out)" ];
 
-    preBuild = ''
-      git() { echo "v${version}"; }
-      export -f git
+  postInstall = ''
+    wrapProgram $out/bin/compton-trans \
+      --prefix PATH : ${lib.makeBinPath [ xwininfo ]}
+  '';
+
+  meta = with lib; {
+    description = "A fork of XCompMgr, a sample compositing manager for X servers";
+    longDescription = ''
+      A fork of XCompMgr, which is a sample compositing manager for X
+      servers supporting the XFIXES, DAMAGE, RENDER, and COMPOSITE
+      extensions. It enables basic eye-candy effects. This fork adds
+      additional features, such as additional effects, and a fork at a
+      well-defined and proper place.
     '';
-
-    NIX_CFLAGS_COMPILE = [ "-fno-strict-aliasing" ];
-
-    mesonFlags = [
-      "-Dbuild_docs=true"
-    ];
-
-    meta = {
-      homepage = https://github.com/yshui/compton/;
-    };
+    license = licenses.mit;
+    homepage = "https://github.com/yshui/compton";
+    maintainers = with maintainers; [ ertes enzime twey ];
+    platforms = platforms.linux;
   };
-in {
-  compton = common stableSource;
-  compton-git = common gitSource;
 }

--- a/pkgs/applications/window-managers/compton/default.nix
+++ b/pkgs/applications/window-managers/compton/default.nix
@@ -97,7 +97,6 @@ let
     NIX_CFLAGS_COMPILE = [ "-fno-strict-aliasing" ];
 
     mesonFlags = [
-      "-Dnew_backends=true"
       "-Dbuild_docs=true"
     ];
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -59,6 +59,7 @@ mapAliases ({
   clawsMail = claws-mail; # added 2016-04-29
   clutter_gtk = clutter-gtk; # added 2018-02-25
   conkerorWrapper = conkeror; # added 2015-01
+  compton-git = compton; # added 2019-05-20
   conntrack_tools = conntrack-tools; # added 2018-05
   cool-old-term = cool-retro-term; # added 2015-01-31
   cupsBjnp = cups-bjnp; # added 2016-01-02

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20850,7 +20850,7 @@ in
 
   inherit (xorg) xcompmgr;
 
-  inherit (callPackage ../applications/window-managers/compton {}) compton compton-git;
+  compton = callPackage ../applications/window-managers/compton {};
 
   xdaliclock = callPackage ../tools/misc/xdaliclock {};
 


### PR DESCRIPTION
###### Motivation for this change
Many new releases:
- https://github.com/yshui/compton/releases/tag/v5.1
- https://github.com/yshui/compton/releases/tree/v6
- https://github.com/yshui/compton/releases/tree/v6.2

Maintainers: @ertes @enzime @twey

###### Things done

I'm using it with the NixOS module and its default settings. Seems fine so far, running all day today.

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).