### PR TITLE
x264: 20170731-2245 -> 20190517-2245; add myself as maintainer

### DIFF
--- a/pkgs/development/libraries/x264/default.nix
+++ b/pkgs/development/libraries/x264/default.nix
@@ -1,36 +1,37 @@
-{stdenv, fetchurl, yasm, enable10bit ? false}:
+{ stdenv, fetchurl, nasm }:
 
 stdenv.mkDerivation rec {
-  version = "20170731-2245";
-  name = "x264-${version}";
+  pname = "x264";
+  version = "20190517-2245";
 
   src = fetchurl {
     url = "https://download.videolan.org/x264/snapshots/x264-snapshot-${version}-stable.tar.bz2";
-    sha256 = "01sgk1ps4qfifdnblwa3fxnd8ah6n6zbmfc1sy09cgqcdgzxgj0z";
+    sha256 = "1xv41z04km3rf374xk3ny7v8ibr211ph0j5am0909ln63mphc48f";
   };
 
-  patchPhase = ''
-    sed -i s,/bin/bash,${stdenv.shell}, configure version.sh
+  postPatch = ''
+    patchShebangs .
   '';
 
-  outputs = [ "out" "lib" ]; # leaving 52 kB of headers
+  enableParallelBuilding = true;
+
+  outputs = [ "out" "lib" "dev" ];
 
   preConfigure = ''
-    # `AS' is set to the binutils assembler, but we need yasm
+    # `AS' is set to the binutils assembler, but we need nasm
     unset AS
   '';
 
   configureFlags = [ "--enable-shared" ]
-    ++ stdenv.lib.optional (!stdenv.isi686) "--enable-pic"
-    ++ stdenv.lib.optional (enable10bit) "--bit-depth=10";
+    ++ stdenv.lib.optional (!stdenv.isi686) "--enable-pic";
 
-  buildInputs = [ yasm ];
+  nativeBuildInputs = [ nasm ];
 
   meta = with stdenv.lib; {
     description = "Library for encoding H264/AVC video streams";
     homepage    = http://www.videolan.org/developers/x264.html;
     license     = licenses.gpl2;
     platforms   = platforms.unix;
-    maintainers = [ maintainers.spwhitt ];
+    maintainers = with maintainers; [ spwhitt tadeokondrak ];
   };
 }


### PR DESCRIPTION
- yasm has been replaced by nasm
- both 10-bit and 8-bit are in the same binary now

- patchPhase replaced with postPatch to allow patching with overrides
- enableParallelBuilding enabled, long build and doesn't seem to cause
issues
- dev output added

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Was using this, noticed it hadn't been updated in a long time.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
