### PR TITLE
broadcom_sta: fix build on linux-5.1

### DIFF
--- a/pkgs/os-specific/linux/broadcom-sta/default.nix
+++ b/pkgs/os-specific/linux/broadcom-sta/default.nix
@@ -34,6 +34,7 @@ stdenv.mkDerivation {
     # source: https://aur.archlinux.org/cgit/aur.git/tree/linux412.patch?h=broadcom-wl
     ./linux-4.12.patch
     ./linux-4.15.patch
+    ./linux-5.1.patch
     ./null-pointer-fix.patch
     ./gcc.patch
   ];

--- a/pkgs/os-specific/linux/broadcom-sta/linux-5.1.patch
+++ b/pkgs/os-specific/linux/broadcom-sta/linux-5.1.patch
@@ -1,0 +1,32 @@
+commit bcb06af629a36eb84f9a35ac599ec7e51e2d39fb
+Author: georgewhewell <georgerw@gmail.com>
+Date:   Sat May 18 21:22:37 2019 +0100
+
+    find src -type f -name \'*.c\' -exec sed -i "s/get_ds()/KERNEL_DS/g" {} \;
+
+diff --git a/src/wl/sys/wl_cfg80211_hybrid.c b/src/wl/sys/wl_cfg80211_hybrid.c
+index 7b606e0..51c81bc 100644
+--- a/src/wl/sys/wl_cfg80211_hybrid.c
++++ b/src/wl/sys/wl_cfg80211_hybrid.c
+@@ -450,7 +450,7 @@ wl_dev_ioctl(struct net_device *dev, u32 cmd, void *arg, u32 len)
+ 	ifr.ifr_data = (caddr_t)&ioc;
+ 
+ 	fs = get_fs();
+-	set_fs(get_ds());
++	set_fs(KERNEL_DS);
+ #if defined(WL_USE_NETDEV_OPS)
+ 	err = dev->netdev_ops->ndo_do_ioctl(dev, &ifr, SIOCDEVPRIVATE);
+ #else
+diff --git a/src/wl/sys/wl_iw.c b/src/wl/sys/wl_iw.c
+index c4c610b..9c3c74e 100644
+--- a/src/wl/sys/wl_iw.c
++++ b/src/wl/sys/wl_iw.c
+@@ -117,7 +117,7 @@ dev_wlc_ioctl(
+ 	ifr.ifr_data = (caddr_t) &ioc;
+ 
+ 	fs = get_fs();
+-	set_fs(get_ds());
++	set_fs(KERNEL_DS);
+ #if defined(WL_USE_NETDEV_OPS)
+ 	ret = dev->netdev_ops->ndo_do_ioctl(dev, &ifr, SIOCDEVPRIVATE);
+ #else


### PR DESCRIPTION
###### Motivation for this change
broadcom_sta module no longer compiles under linux 5.1 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
