### PR TITLE
opensc: fix cross compilation

### DIFF
--- a/pkgs/development/libraries/libassuan/default.nix
+++ b/pkgs/development/libraries/libassuan/default.nix
@@ -1,4 +1,4 @@
-{ fetchurl, stdenv, gettext, pth, libgpgerror, buildPackages }:
+{ fetchurl, stdenv, gettext, npth, libgpgerror, buildPackages }:
 
 stdenv.mkDerivation rec {
   pname = "libassuan";
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   outputBin = "dev"; # libassuan-config
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
-  buildInputs = [ pth gettext ];
+  buildInputs = [ npth gettext ];
 
   configureFlags = [
     "--with-libgpg-error-prefix=${libgpgerror.dev}"

--- a/pkgs/development/libraries/libassuan/default.nix
+++ b/pkgs/development/libraries/libassuan/default.nix
@@ -37,5 +37,6 @@ stdenv.mkDerivation rec {
     homepage = http://gnupg.org;
     license = licenses.lgpl2Plus;
     platforms = platforms.all;
+    maintainers = [ maintainers.erictapen ];
   };
 }

--- a/pkgs/tools/security/opensc/default.nix
+++ b/pkgs/tools/security/opensc/default.nix
@@ -58,5 +58,6 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/OpenSC/OpenSC/wiki;
     license = licenses.lgpl21Plus;
     platforms = platforms.all;
+    maintainers = [ maintainers.erictapen ];
   };
 }

--- a/pkgs/tools/security/opensc/default.nix
+++ b/pkgs/tools/security/opensc/default.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, zlib, readline, openssl
 , libiconv, pcsclite, libassuan, libXt
 , docbook_xsl, libxslt, docbook_xml_dtd_412
-, Carbon, PCSC
+, Carbon, PCSC, buildPackages
 , withApplePCSC ? stdenv.isDarwin
 }:
 
@@ -16,9 +16,9 @@ stdenv.mkDerivation rec {
     sha256 = "10575gb9l38cskq7swyjp0907wlziyxg4ppq33ndz319dsx69d87";
   };
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig autoreconfHook ];
   buildInputs = [
-    autoreconfHook zlib readline openssl libassuan
+    zlib readline openssl libassuan
     libXt libxslt libiconv docbook_xml_dtd_412
   ]
   ++ stdenv.lib.optional stdenv.isDarwin Carbon
@@ -43,6 +43,8 @@ stdenv.mkDerivation rec {
       else
         "${stdenv.lib.getLib pcsclite}/lib/libpcsclite${stdenv.hostPlatform.extensions.sharedLibrary}"
       }"
+    (stdenv.lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform)
+      "XSLTPROC=${buildPackages.libxslt}/bin/xsltproc")
   ];
 
   PCSC_CFLAGS = stdenv.lib.optionalString withApplePCSC


### PR DESCRIPTION
###### Motivation for this change

Fix cross compilation for `opensc`:

```
nix build nixpkgs.pkgsCross.aarch64-multiplatform.opensc
```

###### Things done

For `libassuan` use `npth` instead of `pth`.

- `pth` fails to cross-compile atm and the fix seemed to difficult for me.
- `npth` [claims](https://www.gnupg.org/software/npth/index.html) to be compatible with GNU pth.
- The latest [release](https://www.gnu.org/software/pth/) of `pth` is from 2006, while `npth` is from 2018.
- Also `libassuan` as well as `npth` are developed by the GnuPG project, so I think that change would be safe.

Also added myself as maintainer as there was none.

For `opensc`:

- Added myself as maintainer as there was none.
- Move `autoreconfHook` into `nativeBuidInputs`.
- Specify path for `xsltproc`.

The latter fixes the following problem:

```terminal
$ nix build nixpkgs.pkgsCross.aarch64-multiplatform.opensc
error: build of '/nix/store/fgf3blzqa02xhkq0azhrdh7fzzbsk7lp-opensc-0.19.0-aarch64-unknown-linux-gnu.drv' on 'ssh://root@192.168.0.101' failed: builder for '/nix/store/fgf3blzqa02xhkq0azhrdh7fzzbsk7lp-opensc-0.19.0-aarch64-unknown-linux-gnu.drv' failed with exit code 1
builder for '/nix/store/fgf3blzqa02xhkq0azhrdh7fzzbsk7lp-opensc-0.19.0-aarch64-unknown-linux-gnu.drv' failed with exit
code 1; last 10 log lines:
  checking for winscard.h... yes
  checking pcsclite.h usability... yes
  checking pcsclite.h presence... no
  configure: WARNING: pcsclite.h: accepted by the compiler, rejected by the preprocessor!
  configure: WARNING: pcsclite.h: proceeding with the compiler's result
  checking for pcsclite.h... yes
  completion detect
  checking for bash-completion >= 2.0... no
  checking XSLTPROC requirement... configure: error: Missing XSLTPROC
  builder for '/nix/store/fgf3blzqa02xhkq0azhrdh7fzzbsk7lp-opensc-0.19.0-aarch64-unknown-linux-gnu.drv' failed with exit code 1
[0 built (1 failed), 0.0 MiB DL]
error: build of '/nix/store/fgf3blzqa02xhkq0azhrdh7fzzbsk7lp-opensc-0.19.0-aarch64-unknown-linux-gnu.drv' failed
```
@GrahamcOfBorg build opensc pkgsCross.aarch64-multiplatform.opensc

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
