### PR TITLE
android-file-transfer: fix hash of version 3.8

### DIFF
--- a/pkgs/tools/filesystems/android-file-transfer/default.nix
+++ b/pkgs/tools/filesystems/android-file-transfer/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     owner = "whoozle";
     repo = "android-file-transfer-linux";
     rev = "v${version}";
-    sha256 = "0a388pqc0azgn0wy85wb1mjk3b5zb6vcr58l4warwfzhca400zn0";
+    sha256 = "0sym33a0ccdka2cpzv003n2xniid70z0gkjxx93gd2bajkgs9ggc";
   };
 
   nativeBuildInputs = [ cmake readline pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change
Fix the hash which was accidentally left unchanged in the update to version 3.8 (8857abb3b687be2bbf5381d7cb65b2d01426be16).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
