### PR TITLE
nixos/release-notes: mention length of release support

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1903.xml
+++ b/nixos/doc/manual/release-notes/rl-1903.xml
@@ -3,7 +3,7 @@
          xmlns:xi="http://www.w3.org/2001/XInclude"
          version="5.0"
          xml:id="sec-release-19.03">
- <title>Release 19.03 (“Koi”, 2019/03/??)</title>
+ <title>Release 19.03 (“Koi”, 2019/04/11)</title>
 
  <section xmlns="http://docbook.org/ns/docbook"
          xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -18,6 +18,11 @@
   </para>
 
   <itemizedlist>
+   <listitem>
+    <para>
+     End of support is planned for end of October 2019, handing over to 19.09.
+    </para>
+   </listitem>
    <listitem>
     <para>
      The default Python 3 interpreter is now CPython 3.7 instead of CPython

--- a/nixos/doc/manual/release-notes/rl-1909.xml
+++ b/nixos/doc/manual/release-notes/rl-1909.xml
@@ -19,7 +19,9 @@
 
   <itemizedlist>
    <listitem>
-    <para />
+    <para>
+     End of support is planned for end of April 2020, handing over to 20.03.
+    </para>
    </listitem>
   </itemizedlist>
  </section>


### PR DESCRIPTION
I took the date for 19.03 from the announcement:
https://discourse.nixos.org/t/nixos-19-03-release/2652

- [x] Assured whether relevant documentation is up to date