### PR TITLE
tree-from-tags: init at 1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2927,6 +2927,15 @@
     github = "listx";
     name = "Linus Arver";
   };
+  livnev = {
+    email = "lev@liv.nev.org.uk";
+    github = "livnev";
+    name = "Lev Livnev";
+    keys = [{
+      longkeyid = "rsa2048/0x68FF81E6A7850F49";
+      fingerprint = "74F5 E5CC 19D3 B5CB 608F  6124 68FF 81E6 A785 0F49";
+    }];
+  };
   luis = {
       email = "luis.nixos@gmail.com";
       github = "Luis-Hebendanz";

--- a/pkgs/applications/audio/tree-from-tags/Gemfile
+++ b/pkgs/applications/audio/tree-from-tags/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "taglib-ruby"

--- a/pkgs/applications/audio/tree-from-tags/Gemfile.lock
+++ b/pkgs/applications/audio/tree-from-tags/Gemfile.lock
@@ -1,0 +1,13 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    taglib-ruby (0.7.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  taglib-ruby
+
+BUNDLED WITH
+   1.16.3

--- a/pkgs/applications/audio/tree-from-tags/default.nix
+++ b/pkgs/applications/audio/tree-from-tags/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, bundlerEnv, ruby, fetchFromGitHub }:
+let
+  version = "1.1";
+  gems = bundlerEnv {
+    name = "tree-from-tags-${version}-gems";
+    inherit ruby;
+    gemdir  = ./.;
+  };
+in stdenv.mkDerivation {
+  name = "tree-from-tags-${version}";
+  src = fetchFromGitHub {
+    owner  = "dbrock";
+    repo   = "bongo";
+    rev    = version;
+    sha256 = "1nszph9mn98flyhn1jq3y6mdh6jymjkvj5ng36ql016dj92apvhv";
+  };
+  buildInputs = [ gems ruby ];
+  installPhase = ''
+    mkdir -p $out/{bin,share}
+    cp tree-from-tags.rb $out/share/
+    bin=$out/bin/tree-from-tags
+# we are using bundle exec to start in the bundled environment
+    cat > $bin <<EOF
+#!/bin/sh -e
+exec ${gems}/bin/bundle exec ${ruby}/bin/ruby "$out"/share/tree-from-tags.rb "\$@"
+EOF
+    chmod +x $bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Create file hierarchies from media tags";
+    homepage = https://www.emacswiki.org/emacs/Bongo;
+    platforms = ruby.meta.platforms;
+    maintainers = [ maintainers.livnev maintainers.dbrock ];
+    license = licenses.gpl2Plus;
+  };
+}

--- a/pkgs/applications/audio/tree-from-tags/gemset.nix
+++ b/pkgs/applications/audio/tree-from-tags/gemset.nix
@@ -1,0 +1,10 @@
+{
+  taglib-ruby = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0r8g7zdncc6243d000jn0grc1n70rn9mx16vggy3q7c4wgsa37xi";
+      type = "gem";
+    };
+    version = "0.7.1";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20646,6 +20646,8 @@ in
 
   trayer = callPackage ../applications/window-managers/trayer { };
 
+  tree-from-tags = callPackage ../applications/audio/tree-from-tags { };
+
   tdrop = callPackage ../applications/misc/tdrop { };
 
   tree = callPackage ../tools/system/tree {};


### PR DESCRIPTION
###### Motivation for this change

`tree-from-tags` is a tool for organising tagged audio into a tree, commonly used with `bongo`, a buffer-oriented media player for `emacs`.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @dbrock 