### PR TITLE
tridactyl-native: init at 1.14.9

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -8,6 +8,7 @@
 , google_talk_plugin, fribid, gnome3/*.gnome-shell*/
 , esteidfirefoxplugin
 , browserpass, chrome-gnome-shell, uget-integrator, plasma-browser-integration, bukubrow
+, tridactyl-native
 , udev
 , kerberos
 }:
@@ -67,6 +68,7 @@ let
         ([ ]
           ++ lib.optional (cfg.enableBrowserpass or false) (lib.getBin browserpass)
           ++ lib.optional (cfg.enableBukubrow or false) bukubrow
+          ++ lib.optional (cfg.enableTridactylNative or false) tridactyl-native
           ++ lib.optional (cfg.enableGnomeExtensions or false) chrome-gnome-shell
           ++ lib.optional (cfg.enableUgetIntegrator or false) uget-integrator
           ++ lib.optional (cfg.enablePlasmaBrowserIntegration or false) plasma-browser-integration

--- a/pkgs/tools/networking/tridactyl-native/default.nix
+++ b/pkgs/tools/networking/tridactyl-native/default.nix
@@ -1,0 +1,44 @@
+{ stdenv
+, fetchFromGitHub
+, python3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tridactyl-native";
+  # this is actually the version of tridactyl itself; the native messenger will
+  # probably not change with every tridactyl version
+  version = "1.14.9";
+
+  src = fetchFromGitHub {
+    owner = "tridactyl";
+    repo = "tridactyl";
+    rev = version;
+    sha256 = "0d80c744qfv6jd03cmdp3p71xaj8lq8jzsa2m24jxv9q4ks2dcmj";
+  };
+  sourceRoot = "source/native";
+
+  nativeBuildInputs = [
+    python3.pkgs.wrapPython
+  ];
+
+  buildPhase = ''
+    sed -i -e "s|REPLACE_ME_WITH_SED|$out/share/tridactyl/native_main.py|" "tridactyl.json"
+  '';
+
+  installPhase = ''
+    mkdir -p "$out/lib/mozilla/native-messaging-hosts"
+    cp tridactyl.json "$out/lib/mozilla/native-messaging-hosts/"
+
+    mkdir -p "$out/share/tridactyl"
+    cp native_main.py "$out/share/tridactyl"
+    wrapPythonProgramsIn "$out/share/tridactyl"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Tridactyl native messaging host application";
+    homepage = https://github.com/tridactyl/tridactyl;
+    license = licenses.asl20;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ timokau ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2619,6 +2619,8 @@ in
 
   teamocil = callPackage ../tools/misc/teamocil { };
 
+  tridactyl-native = callPackage ../tools/networking/tridactyl-native { };
+
   uudeview = callPackage ../tools/misc/uudeview { };
 
   uutils-coreutils = callPackage ../tools/misc/uutils-coreutils {


### PR DESCRIPTION
###### Motivation for this change

[Tridactyl](https://github.com/tridactyl/tridactyl) requires a native messenger plugin for many of its features (like reading an rc file or shelling out). I'd like to be able to install that declaratively.

@Infinisil can you review this? I know near to nothing about firefox in nixpkgs and I basically copied what bukubrow does.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
