### PR TITLE
zuki-themes: 3.32-1 -> 3.32-3

### DIFF
--- a/pkgs/data/themes/zuki/default.nix
+++ b/pkgs/data/themes/zuki/default.nix
@@ -1,24 +1,21 @@
-{ stdenv, fetchFromGitHub, gdk_pixbuf, librsvg, gtk-engine-murrine }:
+{ stdenv, fetchFromGitHub, meson, ninja, sassc, gdk_pixbuf, librsvg, gtk_engines, gtk-engine-murrine }:
 
 stdenv.mkDerivation rec {
   pname = "zuki-themes";
-  version = "3.32-1";
+  version = "3.32-3";
 
   src = fetchFromGitHub {
     owner = "lassekongo83";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0x6ghc7n5y7p0agm2yp7rygz9154f58s891zxzhd07wc2c4mzp0s";
+    sha256 = "1al1fb7pqrcdi4g6llz8ka4sc9hsprv2ba0kkc21r6vajs0qp83n";
   };
 
-  buildInputs = [ gdk_pixbuf librsvg ];
+  nativeBuildInputs = [ meson ninja sassc ];
+
+  buildInputs = [ gdk_pixbuf librsvg gtk_engines ];
 
   propagatedUserEnvPkgs = [ gtk-engine-murrine ];
-
-  installPhase = ''
-    install -dm 755 $out/share/themes
-    cp -a Zuki* $out/share/themes/
-  '';
 
   meta = with stdenv.lib; {
     description = "Themes for GTK3, gnome-shell and more";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update to version [3.32-3](https://github.com/lassekongo83/zuki-themes/releases/tag/v3.32-3).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).