### PR TITLE
Add CRI-O package

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1746,13 +1746,13 @@
     github = "fps";
     name = "Florian Paul Schmidt";
   };
-  
+
   fragamus = {
     email = "innovative.engineer@gmail.com";
     github = "fragamus";
     name = "Michael Gough";
   };
-  
+
   fredeb = {
     email = "im@fredeb.dev";
     github = "fredeeb";
@@ -4396,6 +4396,11 @@
     email = "danielehlers@mindeye.net";
     github = "sargon";
     name = "Daniel Ehlers";
+  };
+  saschagrunert = {
+    email = "mail@saschagrunert.de";
+    github = "saschagrunert";
+    name = "Sascha Grunert";
   };
   sauyon = {
     email = "s@uyon.co";

--- a/pkgs/applications/virtualization/cri-o/default.nix
+++ b/pkgs/applications/virtualization/cri-o/default.nix
@@ -1,0 +1,75 @@
+{ flavor ? ""
+, ldflags ? ""
+, stdenv
+, btrfs-progs
+, buildGoPackage
+, fetchFromGitHub
+, glibc
+, gpgme
+, libapparmor
+, libassuan
+, libgpgerror
+, libseccomp
+, libselinux
+, lvm2
+, pkgconfig
+}:
+
+buildGoPackage rec {
+  project = "cri-o";
+  version = "1.14.1";
+  name = "${project}-${version}${flavor}";
+
+  goPackagePath = "github.com/${project}/${project}";
+
+  src = fetchFromGitHub {
+    owner = "cri-o";
+    repo = "cri-o";
+    rev = "v${version}";
+    sha256 = "1cclxarwabk5zlqysm2dzgsm6qkxyzbnlylr0gs57ppn4ibky3nk";
+  };
+
+  outputs = [ "bin" "out" ];
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ btrfs-progs gpgme libapparmor libassuan libgpgerror
+                 libseccomp libselinux lvm2 ]
+                ++ stdenv.lib.optionals (glibc != null) [ glibc glibc.static ];
+
+  makeFlags = ''BUILDTAGS="apparmor seccomp selinux
+    containers_image_ostree_stub"'';
+
+  buildPhase = ''
+    pushd go/src/${goPackagePath}
+
+    # Build conmon and pause
+    go build -tags ${makeFlags} -o bin/crio-config -buildmode=pie \
+      -ldflags '-s -w ${ldflags}' ${goPackagePath}/cmd/crio-config
+
+    pushd conmon
+    ../bin/crio-config
+    popd
+
+    make -C conmon
+    make -C pause
+
+    # Build the crio binary
+    go build -tags ${makeFlags} -o bin/crio -buildmode=pie \
+      -ldflags '-s -w ${ldflags}' ${goPackagePath}/cmd/crio
+  '';
+  installPhase = ''
+    install -Dm755 bin/crio $bin/bin/crio${flavor}
+
+    mkdir -p $bin/libexec/crio
+    install -Dm755 bin/conmon $bin/libexec/crio/conmon${flavor}
+    install -Dm755 bin/pause $bin/libexec/crio/pause${flavor}
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://cri-o.io;
+    description = ''Open Container Initiative-based implementation of the
+                    Kubernetes Container Runtime Interface'';
+    license = licenses.asl20;
+    maintainers = with maintainers; [ saschagrunert ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
This commits adds the CRI-O package, which includes the `crio` binary as
well as `conmon` and `pause`. The configuration is not part of this
package because it would be included in a service.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] ~~macOS~~ **(won't build on it)**
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date **(not sure if I missed something here)**
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).