### PR TITLE
gbdk-n: init at unstable-2019-03-14

### DIFF
--- a/pkgs/development/libraries/gbdk-n/default.nix
+++ b/pkgs/development/libraries/gbdk-n/default.nix
@@ -1,0 +1,46 @@
+{ stdenv, fetchFromGitHub, automake, sdcc }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  pname = "gbdk-n";
+  version = "unstable-2019-03-14";
+
+  src = fetchFromGitHub {
+    owner = "andreasjhkarlsson";
+    repo = "gbdk-n";
+    rev = "e7353c42ea6973ffdea1a10bbaadc3c516dd7d98";
+    sha256 = "1dk8lg9ghvws904723gf8rgigf2w00v38vnq26l5ikg240v3r7vg";
+  };
+
+  nativeBuildInputs = [ automake ];
+  buildInputs = [ sdcc ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,lib,obj,include}
+    cp bin/*.sh $out/bin
+    cp lib/* $out/lib
+    cp obj/* $out/obj
+    cp -r include/* $out/include
+
+    runHook postInstall
+  '';
+
+  doCheck = true;
+  checkPhase = ''
+    make examples
+  '';
+  
+  meta = {
+    description = "GBDK is an SDK for gameboy platform";
+    longDescription = ''
+      The Gameboy Development Kit (GBDK) is an SDK for developing applications/games for the gameboy platform.
+    '';
+    homepage = "https://github.com/andreasjhkarlsson/gbdk-n";
+    license = "unknown";
+    maintainers = with maintainers; [ genesis ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3066,6 +3066,8 @@ in
 
   garmintools = callPackage ../development/libraries/garmintools {};
 
+  gbdk-n = callPackage ../development/libraries/gbdk-n {};
+
   gauge = callPackage ../development/tools/gauge { };
 
   gawk = callPackage ../tools/text/gawk {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
