### PR TITLE
Package some DNS security tools

### DIFF
--- a/pkgs/tools/security/dnsenum/default.nix
+++ b/pkgs/tools/security/dnsenum/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, fetchFromGitHub, makeWrapper, perl, perlPackages }:
+
+stdenv.mkDerivation rec {
+  pname = "dnsenum";
+  version = "1.2.4.2";
+
+  src = fetchFromGitHub {
+    owner = "fwaeytens";
+    repo = pname;
+    rev = version;
+    sha256 = "1bg1ljv6klic13wq4r53bg6inhc74kqwm3w210865b1v1n8wj60v";
+  };
+
+  propagatedBuildInputs = with perlPackages; [
+    perl NetDNS NetIP NetNetmask StringRandom XMLWriter NetWhoisIP WWWMechanize
+  ];
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    install -vD dnsenum.pl $out/bin/dnsenum
+    install -vD dns.txt -t $out/share
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/fwaeytens/dnsenum";
+    description = "A tool to enumerate DNS information";
+    maintainers = with maintainers; [ c0bw3b globin ];
+    license = licenses.gpl2Plus;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/tools/security/dnsrecon/default.nix
+++ b/pkgs/tools/security/dnsrecon/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, fetchFromGitHub, python3 }:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "dnsrecon";
+  version = "0.9.1";
+
+  src = fetchFromGitHub {
+    owner = "darkoperator";
+    repo = pname;
+    rev = version;
+    sha256 = "1ysf8wx287psfk89r0i2vgnrjvxdj44s6nhf6sva59jbwvr9lghy";
+  };
+
+  format = "other";
+
+  pythonPath = with python3.pkgs; [
+    dns netaddr lxml
+  ];
+
+  postPatch = ''
+    substituteInPlace dnsrecon.py \
+      --replace "namelist.txt" "../share/namelist.txt" \
+      --replace "0.9.0" "${version}"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -vD dnsrecon.py $out/bin/dnsrecon
+    install -vD namelist.txt subdomains-*.txt -t $out/share
+    install -vd $out/${python3.sitePackages}/
+    cp -R lib tools msf_plugin $out/${python3.sitePackages}
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "DNS Enumeration Script";
+    homepage = "https://github.com/darkoperator/dnsrecon";
+    license = licenses.gpl2;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ c0bw3b globin ];
+  };
+}

--- a/pkgs/tools/security/fierce/default.nix
+++ b/pkgs/tools/security/fierce/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchFromGitHub, python3 }:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "fierce";
+  version = "1.3.0";
+
+  src = fetchFromGitHub {
+    owner = "mschwager";
+    repo = pname;
+    rev = version;
+    sha256 = "0cdp9rpabazyfnks30rsf3qfdi40z1bkspxk4ds9bm82kpq33jxy";
+  };
+
+  propagatedBuildInputs = [ python3.pkgs.dns ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/mschwager/fierce";
+    description = "DNS reconnaissance tool for locating non-contiguous IP space";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ c0bw3b globin ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/tools/security/theharvester/default.nix
+++ b/pkgs/tools/security/theharvester/default.nix
@@ -1,21 +1,20 @@
-{ stdenv, makeWrapper, python2Packages, fetchFromGitHub }:
+{ stdenv, fetchFromGitHub, makeWrapper, python3Packages }:
 
 stdenv.mkDerivation rec {
   pname = "theHarvester";
-  version = "2.7.1";
-  name = "${pname}-${version}";
+  version = "3.0.6";
 
   src = fetchFromGitHub {
     owner = "laramies";
-    repo = "${pname}";
-    rev = "25553762d2d93a39083593adb08a34d5f5142c60";
-    sha256 = "0gnm598y6paz0knwvdv1cx0w6ngdbbpzkdark3q5vs66yajv24w4";
+    repo = pname;
+    rev = version;
+    sha256 = "0f33a7sfb5ih21yp1wspb03fxsls1m14yizgrw0srfirm2a6aa0c";
   };
 
   nativeBuildInputs = [ makeWrapper ];
 
   # add dependencies
-  propagatedBuildInputs = [ python2Packages.requests ];
+  propagatedBuildInputs = with python3Packages; [ requests beautifulsoup4 plotly ];
 
   installPhase = ''
     # create dirs

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2879,6 +2879,8 @@ in
 
   fltrdr = callPackage ../tools/misc/fltrdr { stdenv = gcc8Stdenv; };
 
+  fierce = callPackage ../tools/security/fierce { };
+
   figlet = callPackage ../tools/misc/figlet { };
 
   file = callPackage ../tools/misc/file {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2437,6 +2437,8 @@ in
 
   dnscrypt-wrapper = callPackage ../tools/networking/dnscrypt-wrapper { };
 
+  dnsenum = callPackage ../tools/security/dnsenum { };
+
   dnsmasq = callPackage ../tools/networking/dnsmasq { };
 
   dnsperf = callPackage ../tools/networking/dnsperf { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2443,6 +2443,8 @@ in
 
   dnsperf = callPackage ../tools/networking/dnsperf { };
 
+  dnsrecon = callPackage ../tools/security/dnsrecon { };
+
   dnstop = callPackage ../tools/networking/dnstop { };
 
   dhcp = callPackage ../tools/networking/dhcp { };

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -14141,6 +14141,14 @@ let
     };
   };
 
+  StringRandom = buildPerlModule rec {
+    name = "String-Random-0.30";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/${name}.tar.gz";
+      sha256 = "06xdpyjc53al0a4ib2lw1m388v41z97hzqbdkd00w3nmjsdrn4w1";
+    };
+  };
+
   StringRewritePrefix = buildPerlPackage {
     name = "String-RewritePrefix-0.007";
     src = fetchurl {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -11426,6 +11426,18 @@ let
     };
   };
 
+  NetNetmask = buildPerlPackage rec {
+    name = "Net-Netmask-1.9104";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/J/JM/JMASLAK/${name}.tar.gz";
+      sha256 = "17li2svymz49az35xl6galp4b9qcnb985gzklhikkvkn9da6rz3y";
+    };
+    buildInputs = [ Test2Suite TestUseAllModules ];
+    meta = {
+      description = "Parse, manipulate and lookup IP network blocks";
+    };
+  };
+
   NetOAuth = buildPerlModule {
     name = "Net-OAuth-0.28";
     src = fetchurl {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -11658,6 +11658,22 @@ let
     };
   };
 
+  NetWhoisIP = buildPerlPackage rec {
+    name = "Net-Whois-IP-1.19";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/B/BS/BSCHMITZ/${name}.tar.gz";
+      sha256 = "08kj2h9qiyfvv3jfz619xl796j93cslg7d96919mnrnjy6hdz6zh";
+    };
+
+    propagatedBuildInputs = [ RegexpIPv6 LWPProtocolhttps ];
+    doCheck = false;
+
+    # https://rt.cpan.org/Public/Bug/Display.html?id=99377
+    postPatch = ''
+      substituteInPlace IP.pm --replace " AutoLoader" ""
+    '';
+  };
+
   NetWorks = buildPerlPackage {
     name = "Net-Works-0.22";
     src = fetchurl {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Refresh of #30542
And I'd like to have these tools available from nixpkgs

cc @globin @treemo 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
