### PR TITLE
refind: allows building for aarch64

### DIFF
--- a/pkgs/tools/bootloaders/refind/0001-toolchain.patch
+++ b/pkgs/tools/bootloaders/refind/0001-toolchain.patch
@@ -1,0 +1,27 @@
+diff --git a/Make.common b/Make.common
+index 3f0b919..ee365f5 100644
+--- a/Make.common
++++ b/Make.common
+@@ -33,22 +33,6 @@ ARCH            ?= $(HOSTARCH)
+ 
+ # Note: TIANOBASE is defined in master Makefile and exported
+ GENFW           = $(TIANOBASE)/BaseTools/Source/C/bin/GenFw
+-prefix          = /usr/bin/
+-ifeq ($(ARCH),aarch64)
+-  CC            = $(prefix)aarch64-linux-gnu-gcc
+-  AS            = $(prefix)aarch64-linux-gnu-as
+-  LD            = $(prefix)aarch64-linux-gnu-ld
+-  AR            = $(prefix)aarch64-linux-gnu-ar
+-  RANLIB        = $(prefix)aarch64-linux-gnu-ranlib
+-  OBJCOPY       = $(prefix)aarch64-linux-gnu-objcopy
+-else
+-  CC            = $(prefix)gcc
+-  AS            = $(prefix)as
+-  LD            = $(prefix)ld
+-  AR            = $(prefix)ar
+-  RANLIB        = $(prefix)ranlib
+-  OBJCOPY       = $(prefix)objcopy
+-endif
+ 
+ ifeq ($(MAKEWITH),TIANO)
+ # Below file defines TARGET (RELEASE or DEBUG) and TOOL_CHAIN_TAG (GCC44, GCC45, GCC46, or GCC47)

--- a/pkgs/tools/bootloaders/refind/default.nix
+++ b/pkgs/tools/bootloaders/refind/default.nix
@@ -4,6 +4,7 @@ let
   archids = {
     "x86_64-linux" = { hostarch = "x86_64"; efiPlatform = "x64"; };
     "i686-linux" = rec { hostarch = "ia32"; efiPlatform = hostarch; };
+    "aarch64-linux" = rec { hostarch = "aarch64"; efiPlatform = "aa64"; };
   };
 
   inherit
@@ -21,6 +22,10 @@ stdenv.mkDerivation rec {
     sha256 = "1bjd0dl77bc5k6g3kc7s8m57vpbg2zscph9qh84xll9rc10g3fir";
   };
 
+  patches = [
+    ./0001-toolchain.patch
+  ];
+
   buildInputs = [ gnu-efi ];
 
   hardeningDisable = [ "stackprotector" ];
@@ -32,6 +37,7 @@ stdenv.mkDerivation rec {
       "GNUEFILIB=${gnu-efi}/lib"
       "EFICRT0=${gnu-efi}/lib"
       "HOSTARCH=${hostarch}"
+      "ARCH=${hostarch}"
     ];
 
   buildFlags = [ "gnuefi" "fs_gnuefi" ];
@@ -116,7 +122,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = http://refind.sourceforge.net/;
     maintainers = [ maintainers.AndersonTorres ];
-    platforms = [ "i686-linux" "x86_64-linux" ];
+    platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" ];
     license = licenses.gpl3Plus;
   };
 


### PR DESCRIPTION
###### Motivation for this change

AArch64 all the things :)

###### Things done

This was verified with cross-compilation and native build on AArch64. The cross-compiled result was verified to boot on hardware.

- ☑️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ☑️ NixOS
   - 🔲 macOS
   - 🔲 other Linux distributions
- 🔲 Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ☑️ Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- 🔲 Tested execution of all binary files (usually in `./result/bin/`)
- 🔲 Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ☑️ Assured whether relevant documentation is up to date
- ☑️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@GrahamcOfBorg build refind