### PR TITLE
nixos/geoclue2: don't run as root

### DIFF
--- a/nixos/modules/services/desktops/geoclue2.nix
+++ b/nixos/modules/services/desktops/geoclue2.nix
@@ -188,6 +188,19 @@ in
 
     systemd.packages = [ package ];
 
+    users.users.geoclue = {
+      isSystemUser = true;
+      home = "/var/lib/geoclue";
+      group = "geoclue";
+      description = "Geoinformation service";
+    };
+
+    users.groups.geoclue = {};
+
+    systemd.tmpfiles.rules = [
+      "d /var/lib/geoclue 0755 geoclue geoclue"
+    ];
+
     # restart geoclue service when the configuration changes
     systemd.services."geoclue".restartTriggers = [
       config.environment.etc."geoclue/geoclue.conf".source

--- a/pkgs/development/libraries/geoclue/default.nix
+++ b/pkgs/development/libraries/geoclue/default.nix
@@ -42,6 +42,7 @@ stdenv.mkDerivation rec {
     "-Ddemo-agent=${if withDemoAgent then "true" else "false"}"
     "--sysconfdir=/etc"
     "-Dsysconfdir_install=${placeholder "out"}/etc"
+    "-Ddbus-srv-user=geoclue"
   ] ++ optionals stdenv.isDarwin [
     "-D3g-source=false"
     "-Dcdma-source=false"


### PR DESCRIPTION
###### Motivation for this change
Don't have this service use the root user.
Followup from https://github.com/NixOS/nixpkgs/pull/61612#issue-279733258

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
