### PR TITLE
redhat-official-fonts: init at 2.2.0

### DIFF
--- a/pkgs/data/fonts/redhat-official/default.nix
+++ b/pkgs/data/fonts/redhat-official/default.nix
@@ -1,0 +1,22 @@
+{ lib, fetchzip }:
+
+let version = "2.2.0"; in
+fetchzip rec {
+  name = "redhat-official-${version}";
+  url = "https://github.com/RedHatOfficial/RedHatFont/archive/${version}.zip";
+
+  postFetch = ''
+    mkdir -p $out/share/fonts/opentype
+    unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
+  '';
+
+  sha256 = "0yb6shgq6jrv3kq9faky66qpdbv4g580c3jl942844grwyngymyj";
+
+  meta = with lib; {
+    homepage = https://github.com/RedHatOfficial/RedHatFont;
+    description = "Red Hat's Open Source Fonts - Red Hat Display and Red Hat Text";
+    license = licenses.ofl;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16420,6 +16420,8 @@ in
 
   qogir-theme = callPackage ../data/themes/qogir { };
 
+  redhat-official-fonts = callPackage ../data/fonts/redhat-official { };
+
   route159 = callPackage ../data/fonts/route159 { };
 
   sampradaya = callPackage ../data/fonts/sampradaya { };


### PR DESCRIPTION
###### Motivation for this change

Add for use by all! :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---