### PR TITLE
elasticmq-server-bin: init at 0.14.6

### DIFF
--- a/pkgs/servers/elasticmq-server-bin/default.nix
+++ b/pkgs/servers/elasticmq-server-bin/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchurl, jdk, jre, makeWrapper }:
+
+stdenv.mkDerivation rec {
+  pname = "elasticmq-server";
+  version = "0.14.6";
+  name = "${pname}-${version}";
+
+  src = fetchurl {
+    url = "https://s3-eu-west-1.amazonaws.com/softwaremill-public/${name}.jar";
+    sha256 = "1cp2pmkc6gx7gr6109jlcphlky5rr6s1wj528r6hyhzdc01sjhhz";
+  };
+
+  # don't do anything?
+  unpackPhase = "${jdk}/bin/jar xf $src favicon.png";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/elasticmq-server
+
+    cp $src $out/share/elasticmq-server/elasticmq-server.jar
+
+    # TODO: how to add extraArgs? current workaround is to use JAVA_TOOL_OPTIONS environment to specify properties
+    makeWrapper ${jre}/bin/java $out/bin/elasticmq-server \
+      --add-flags "-jar $out/share/elasticmq-server/elasticmq-server.jar"
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/softwaremill/elasticmq";
+    description = "Message queueing system with Java, Scala and Amazon SQS-compatible interfaces";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ peterromfeldhk ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14094,6 +14094,8 @@ in
 
   elasticmq = callPackage ../servers/elasticmq { };
 
+  elasticmq-server-bin = callPackage ../servers/elasticmq-server-bin { };
+
   eventstore = callPackage ../servers/nosql/eventstore {
     Nuget = dotnetPackages.Nuget;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
