### PR TITLE
passff-host: 1.0.2 -> 1.2.1

### DIFF
--- a/pkgs/tools/security/passff-host/default.nix
+++ b/pkgs/tools/security/passff-host/default.nix
@@ -2,23 +2,20 @@
 
 stdenv.mkDerivation rec {
   name = "passff-host-${version}";
-  version = "1.0.2";
+  version = "1.2.1";
 
   src = fetchFromGitHub {
     owner = "passff";
     repo = "passff-host";
     rev = version;
-    sha256 = "1zks34rg9i8vphjrj1h80y5rijadx33z911qxa7pslf7ahmjqdv3";
+    sha256 = "0ydfwvhgnw5c3ydx2gn5d7ys9g7cxlck57vfddpv6ix890v21451";
   };
 
   buildInputs = [ python3 ];
 
   patchPhase = ''
-    sed -i 's#COMMAND      = "pass"#COMMAND = "${pass}/bin/pass"#' src/passff.py
+    sed -i 's#COMMAND = "pass"#COMMAND = "${pass}/bin/pass"#' src/passff.py
   '';
-
-  preBuild = "cd src";
-  postBuild = "cd ..";
 
   installPhase = ''
     install -D bin/testing/passff.py $out/share/passff-host/passff.py


### PR DESCRIPTION
###### Motivation for this change

Version 1.0.2 displays an error message with the current Firefox plugin if the otp plugin is enabled.

###### Things done


- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
