### PR TITLE
biber: fix shebang

### DIFF
--- a/pkgs/tools/typesetting/biber/default.nix
+++ b/pkgs/tools/typesetting/biber/default.nix
@@ -22,6 +22,8 @@ perlPackages.buildPerlModule rec {
     PerlIOutf8_strict
   ];
 
+  postPatch = "patchShebangs bin";
+
   meta = with stdenv.lib; {
     description = "Backend for BibLaTeX";
     license = with licenses; [ artistic1 gpl1Plus ];


### PR DESCRIPTION
${pkgs.biber}/bin/biber has too long "#!/usr/bin/env perl ..." shebang, change it to "${pkgs.perl}/bin/perl ..." which has no such limit

Fixes #61520
Fixes #61631