### PR TITLE
arandr: Stop crashing when trying to open dialog boxes

### DIFF
--- a/pkgs/tools/X11/arandr/default.nix
+++ b/pkgs/tools/X11/arandr/default.nix
@@ -1,4 +1,7 @@
-{ stdenv, fetchurl, gobject-introspection, gtk3, xrandr, python3Packages }:
+{ stdenv, fetchurl, python3Packages
+, gobject-introspection, gsettings-desktop-schemas, gtk3
+, wrapGAppsHook, xrandr
+}:
 
 let
   inherit (python3Packages) buildPythonApplication docutils pygobject3;
@@ -17,13 +20,13 @@ in buildPythonApplication rec {
   # no tests
   doCheck = false;
 
-  buildInputs = [ docutils ];
-  nativeBuildInputs = [ gobject-introspection gtk3 ];
-  propagatedBuildInputs = [ xrandr pygobject3 ];
+  # hook for gobject-introspection doesn't like strictDeps
+  # https://github.com/NixOS/nixpkgs/issues/56943
+  strictDeps = false;
 
-  makeWrapperArgs = [
-    "--set GI_TYPELIB_PATH $GI_TYPELIB_PATH"
-  ];
+  buildInputs = [ docutils gsettings-desktop-schemas gtk3 ];
+  nativeBuildInputs = [ gobject-introspection wrapGAppsHook ];
+  propagatedBuildInputs = [ xrandr pygobject3 ];
 
   meta = {
     homepage = http://christian.amsuess.com/tools/arandr/;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

arandr crashes if you try to do anything involving a dialog box:
https://github.com/NixOS/nixpkgs/pull/61216#issuecomment-493884859

This _might_ fix it - It worked for me both before and after this change on my nix-on-ubuntu system.

I cargo-culted the `$GSETTINGS_SCHEMAS_PATH` stuff from https://github.com/NixOS/nixpkgs/pull/26614/files , but I'm unsure if the icon stuff needs to come across also.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
