### PR TITLE
perlPackages: update

### DIFF
--- a/pkgs/development/perl-modules/generic/default.nix
+++ b/pkgs/development/perl-modules/generic/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, perl, buildPerl, toPerlModule }:
 
-{ nativeBuildInputs ? [], name, ... } @ attrs:
+{ nativeBuildInputs ? [], ... } @ attrs:
 
 toPerlModule(stdenv.mkDerivation (
   (
@@ -27,14 +27,14 @@ toPerlModule(stdenv.mkDerivation (
     # https://metacpan.org/pod/release/XSAWYERX/perl-5.26.0/pod/perldelta.pod#Removal-of-the-current-directory-%28%22.%22%29-from-@INC
     PERL_USE_UNSAFE_INC = "1";
 
-    meta.homepage = "https://metacpan.org/release/${(builtins.parseDrvName name).name}";
+    meta.homepage = "https://metacpan.org/release/${attrs.pname or (builtins.parseDrvName attrs.name).name}"; # TODO: phase-out `attrs.name`
     meta.platforms = perl.meta.platforms;
   }
   attrs
   )
   //
   {
-    name = "perl${perl.version}-${name}";
+    name = "perl${perl.version}-${attrs.name or "${attrs.pname}-${attrs.version}"}"; # TODO: phase-out `attrs.name`
     builder = ./builder.sh;
     nativeBuildInputs = nativeBuildInputs ++ [ (perl.dev or perl) ];
     fullperl = buildPerl;

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -12706,13 +12706,14 @@ let
   };
 
   PPI = buildPerlPackage rec {
-    name = "PPI-1.236";
+    pname = "PPI";
+    version = "1.264";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MITHALDU/${name}.tar.gz";
-      sha256 = "c6674b349c0b7d9a6d668e789a5e5215477d88ed4c8203aa69a2a50085308aec";
+      url = mirror://cpan/authors/id/M/MI/MITHALDU/PPI-1.264.tar.gz;
+      sha256 = "bbfdb5b94e0741c35f7fd1f30f12d9d2cc878b1a30f6be10716d105cfe9eb904";
     };
-    buildInputs = [ ClassInspector FileRemove TestDeep TestObject TestSubCalls ];
-    propagatedBuildInputs = [ Clone IOString ListMoreUtils ParamsUtil TaskWeaken ];
+    buildInputs = [ ClassInspector TestDeep TestNoWarnings TestObject TestSubCalls ];
+    propagatedBuildInputs = [ Clone IOString ParamsUtil TaskWeaken ];
 
     # Remove test that fails due to unexpected shebang after
     # patchShebang.

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -15984,10 +15984,11 @@ let
   };
 
   TestSimple13 = buildPerlPackage rec {
-    name = "Test-Simple-1.302162";
+    pname = "Test-Simple";
+    version = "1.302164";
     src = fetchurl {
-      url = mirror://cpan/authors/id/E/EX/EXODIST/Test-Simple-1.302162.tar.gz;
-      sha256 = "73a0197c3d735e060881da509f4c5fa76c4cbf7dbabd4297d3cf5f5feed31fc4";
+      url = mirror://cpan/authors/id/E/EX/EXODIST/Test-Simple-1.302164.tar.gz;
+      sha256 = "50277b613f09cd52eb87b02c69ce0517b80080be8a8d80e1eda609479b0d6615";
     };
     meta = {
       description = "Basic utilities for writing tests";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -11605,10 +11605,11 @@ let
   };
 
   NetSSLeay = buildPerlPackage rec {
-    name = "Net-SSLeay-1.85";
+    pname = "Net-SSLeay";
+    version = "1.88";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIKEM/${name}.tar.gz";
-      sha256 = "1j5h4ycm8538397l204d2d5fkm9595aj174pj7bkpbhwzfwqi0cx";
+      url = mirror://cpan/authors/id/C/CH/CHRISN/Net-SSLeay-1.88.tar.gz;
+      sha256 = "1pfgh4h3szcpvqlcimc60pjbk9zwls99x5863sva0wc47i4dl010";
     };
     buildInputs = [ pkgs.openssl ];
     doCheck = false; # Test performs network access.

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -1078,10 +1078,11 @@ let
   };
 
   CanaryStability = buildPerlPackage rec {
-    name = "Canary-Stability-2012";
+    pname = "Canary-Stability";
+    version = "2013";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/${name}.tar.gz";
-      sha256 = "fd240b111d834dbae9630c59b42fae2145ca35addc1965ea311edf0d07817107";
+      url = mirror://cpan/authors/id/M/ML/MLEHMANN/Canary-Stability-2013.tar.gz;
+      sha256 = "a5c91c62cf95fcb868f60eab5c832908f6905221013fea2bce3ff57046d7b6ea";
     };
     meta = {
       license = stdenv.lib.licenses.gpl1Plus;

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -8080,10 +8080,11 @@ let
   };
 
   InlineC = buildPerlPackage rec {
-    name = "Inline-C-0.80";
+    pname = "Inline-C";
+    version = "0.81";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TI/TINITA/${name}.tar.gz";
-      sha256 = "35f5ff188f56b9c8a5ec342e2ff3a2d248ddbc91eead80d9361697914d5adbe3";
+      url = mirror://cpan/authors/id/T/TI/TINITA/Inline-C-0.81.tar.gz;
+      sha256 = "f185258d9050d7f79b4f00f12625cc469c2f700ff62d3e831cb18d80d2c87aac";
     };
     buildInputs = [ FileCopyRecursive FileShareDirInstall TestWarn YAMLLibYAML ];
     propagatedBuildInputs = [ Inline ParseRecDescent Pegex ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -764,10 +764,11 @@ let
   };
 
   BC = buildPerlPackage rec {
-    name = "B-C-1.55";
+    pname = "B-C";
+    version = "1.57";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RU/RURBAN/${name}.tar.gz";
-      sha256 = "001bc3mxv1zkg1ynqpv3fbn1v3h3bqihg0pp19z4gfvrsrkns8q9";
+      url = mirror://cpan/authors/id/R/RU/RURBAN/B-C-1.57.tar.gz;
+      sha256 = "1zs9a4gl63icja055kncgyny6xk1nsk6payfbzczkba3sc8sclh4";
     };
     propagatedBuildInputs = [ BFlags IPCRun Opcodes ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -16284,11 +16284,12 @@ let
   };
 
   TextBibTeX = buildPerlModule rec {
-    name = "Text-BibTeX-0.87";
+    pname = "Text-BibTeX";
+    version = "0.88";
     buildInputs = [ CaptureTiny ConfigAutoConf ExtUtilsLibBuilder ];
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AM/AMBS/${name}.tar.gz";
-      sha256 = "1qhm0fin3j6nqpzlk0xy1lx6bzcrhb7fr82rjgkcq0wgmw91mqax";
+      url = mirror://cpan/authors/id/A/AM/AMBS/Text-BibTeX-0.88.tar.gz;
+      sha256 = "0b7lmjvfmypps1nw6nsdikgaakm0n0g4186glaqazg5xd1p5h55h";
     };
     perlPreHook = "export LD=$CC";
     perlPostHook = stdenv.lib.optionalString stdenv.isDarwin ''

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -1295,10 +1295,11 @@ let
   };
 
   CatalystManual = buildPerlPackage rec {
-    name = "Catalyst-Manual-5.9009";
+    pname = "Catalyst-Manual";
+    version = "5.9010";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/${name}.tar.gz";
-      sha256 = "1z6l0vdjxzisqgb5w447m3m73sfvkhwm7qw2l1dpcdng3zaypllh";
+      url = mirror://cpan/authors/id/H/HA/HAARG/Catalyst-Manual-5.9010.tar.gz;
+      sha256 = "1xg2m6d76xl0a76vq0v4yv25458d6df00k5xq1ab2z8mzvwbm4ah";
     };
     meta = {
       description = "The Catalyst developer's manual";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -4029,10 +4029,11 @@ let
   };
 
   DevelPPPort = buildPerlPackage rec {
-    name = "Devel-PPPort-3.45";
+    pname = "Devel-PPPort";
+    version = "3.51";
     src = fetchurl {
-      url = mirror://cpan/authors/id/A/AT/ATOOMIC/Devel-PPPort-3.45.tar.gz;
-      sha256 = "171dcfb3abd964081986634b79c53108f0825c47f95f915eb7cdb3309f7d04f0";
+      url = mirror://cpan/authors/id/E/ET/ETHER/Devel-PPPort-3.51.tar.gz;
+      sha256 = "4502fb60827286663a931f26f497be0ac2a9f36cfaa73d7632c7525a9dfb53bc";
     };
     meta = {
       description = "Perl/Pollution/Portability";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -113,10 +113,11 @@ let
     };
   };
 
-  AlgorithmDiff = let version = "1.1903"; in buildPerlPackage {
+  AlgorithmDiff = buildPerlPackage {
     pname = "Algorithm-Diff";
+    version = "1.1903";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TY/TYEMQ/Algorithm-Diff-${version}.tar.gz";
+      url = mirror://cpan/authors/id/T/TY/TYEMQ/Algorithm-Diff-1.1903.tar.gz;
       sha256 = "0l8pk7ziz72d022hsn4xldhhb9f5649j5cgpjdibch0xng24ms1h";
     };
     buildInputs = [ pkgs.unzip ];
@@ -189,7 +190,7 @@ let
     pname = "Alien-Tidyp";
     version = "1.4.7";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KM/KMX/Alien-Tidyp-v${version}.tar.gz";
+      url = mirror://cpan/authors/id/K/KM/KMX/Alien-Tidyp-v1.4.7.tar.gz;
       sha256 = "0raapwp4155lqag1kzhsd20z4if10hav9wx4d7mc1xpvf7dcnr5r";
     };
 
@@ -476,7 +477,8 @@ let
   };
 
   AppSt = buildPerlPackage rec {
-    name = "App-St-1.1.4";
+    pname = "App-St";
+    version = "1.1.4";
     src = fetchurl {
       url = https://github.com/nferraz/st/archive/v1.1.4.tar.gz;
       sha256 = "1f4bqm4jiazcxgzzja1i48671za96621k0s3ln87cdacgvv1can0";
@@ -2384,11 +2386,10 @@ let
   };
 
   ClassStdFast = buildPerlModule rec {
-    name = "${pname}-${version}";
     pname = "Class-Std-Fast";
     version = "0.0.8";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AC/ACID/${pname}-v${version}.tar.gz";
+      url = mirror://cpan/authors/id/A/AC/ACID/Class-Std-Fast-v0.0.8.tar.gz;
       sha256 = "1057rz95jsr66gam472i4zdv04v7bmzph3m3jwq1hwx3qrikgm0v";
     };
     propagatedBuildInputs = [ ClassStd ];
@@ -3378,10 +3379,11 @@ let
     };
   };
 
-  Curses = let version = "1.36"; in buildPerlPackage {
+  Curses = buildPerlPackage {
     pname = "Curses";
+    version = "1.36";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GI/GIRAFFED/Curses-${version}.tar.gz";
+      url = mirror://cpan/authors/id/G/GI/GIRAFFED/Curses-1.36.tar.gz;
       sha256 = "0r6xd9wr0c25rr28zixhqipak575zqsfb7r7f2693i9il1dpj554";
     };
     propagatedBuildInputs = [ pkgs.ncurses ];
@@ -7385,7 +7387,7 @@ let
   };
 
   ham = buildPerlPackage rec {
-    name = "ham-unstable-${version}";
+    pname = "ham-unstable";
     version = "2019-01-22";
 
     src = fetchFromGitHub {
@@ -8425,10 +8427,10 @@ let
   };
 
   IOPager = buildPerlPackage rec {
-    version = "0.40";
     pname = "IO-Pager";
+    version = "0.40";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JP/JPIERCE/IO-Pager-${version}.tgz";
+      url = mirror://cpan/authors/id/J/JP/JPIERCE/IO-Pager-0.40.tgz;
       sha256 = "1vzdypsr7vkj8nnda9ccrksci6pqj5awwmi89l7x3mbpq36gad87";
     };
     propagatedBuildInputs = [ pkgs.more FileWhich ]; # `more` used in tests
@@ -8648,11 +8650,11 @@ let
   };
 
   ImageExifTool = buildPerlPackage rec {
-    name = "Image-ExifTool-${version}";
+    pname = "Image-ExifTool";
     version = "11.30";
 
     src = fetchurl {
-      url = "https://www.sno.phy.queensu.ca/~phil/exiftool/${name}.tar.gz";
+      url = https://www.sno.phy.queensu.ca/~phil/exiftool/Image-ExifTool-11.30.tar.gz;
       sha256 = "0vkjb2c1a3jdlq8rx1jywx4p3f1bmgjn7rzfwx6dxgij2lx76lrs";
     };
 
@@ -9845,9 +9847,10 @@ let
   maatkit = callPackage ../development/perl-modules/maatkit { };
 
   MacPasteboard = buildPerlPackage rec {
-    name = "Mac-Pasteboard-0.009";
+    pname = "Mac-Pasteboard";
+    version = "0.009";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/W/WY/WYANT/${name}.tar.gz";
+      url = mirror://cpan/authors/id/W/WY/WYANT/Mac-Pasteboard-0.009.tar.gz;
       sha256 = "85b1d5e9630973b997c3c1634e2df964d6a8d6cb57d9abe1f7093385cf26cf54";
     };
     meta = with stdenv.lib; {
@@ -9872,11 +9875,11 @@ let
     };
   };
 
-  MailMaildir = buildPerlPackage rec {
+  MailMaildir = buildPerlPackage {
+    pname = "Mail-Maildir";
     version = "1.0.0";
-    name = "Mail-Maildir-${version}";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Z/ZE/ZEROALTI/Mail-Maildir-100/${name}.tar.bz2";
+      url = mirror://cpan/authors/id/Z/ZE/ZEROALTI/Mail-Maildir-100/Mail-Maildir-1.0.0.tar.bz2;
       sha256 = "1krkqfps6q3ifrhi9450l5gm9199qyfcm6vidllr0dv65kdaqpj4";
     };
   };
@@ -10005,10 +10008,10 @@ let
   };
 
   MailSPF = buildPerlPackage rec {
-    name = "Mail-SPF-v2.9.0";
-    #src = /root/nixops/Mail-SPF-v2.9.0;
+    pname = "Mail-SPF";
+    version = "2.9.0";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JM/JMEHNLE/mail-spf/${name}.tar.gz";
+      url = "mirror://cpan/authors/id/J/JM/JMEHNLE/mail-spf/Mail-SPF-v2.9.0.tar.gz";
       sha256 = "61cb5915f1c7acc7a931ffc1bfc1291bdfac555e2a46eb2391b995ea9ecb6162";
     };
     # remove this patch patches = [ ../development/perl-modules/Mail-SPF.patch ];
@@ -10386,10 +10389,11 @@ let
   };
 
   MHonArc = buildPerlPackage rec {
-    name = "MHonArc-2.6.18";
+    pname = "MHonArc";
+    version = "2.6.18";
 
     src = fetchurl {
-      url    = "http://dcssrv1.oit.uci.edu/indiv/ehood/release/MHonArc/tar/${name}.tar.gz";
+      url    = "http://dcssrv1.oit.uci.edu/indiv/ehood/release/MHonArc/tar/MHonArc-2.6.18.tar.gz";
       sha256 = "1xmf26dfwr8achprc3n1pxgl0mkiyr6pf25wq3dqgzqkghrrsxa2";
     };
     outputs = [ "out" "dev" ]; # no "devdoc"
@@ -10418,9 +10422,10 @@ let
   };
 
   mimeConstruct = buildPerlPackage rec {
-    name = "mime-construct-1.11";
+    pname = "mime-construct";
+    version = "1.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RO/ROSCH/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RO/ROSCH/mime-construct-1.11.tar.gz;
       sha256 = "00wk9950i9q6qwp1vdq9xdddgk54lqd0bhcq2hnijh8xnmhvpmsc";
     };
     outputs = [ "out" ];
@@ -10699,10 +10704,11 @@ let
     };
   };
 
-  ModuleImplementation = let version = "0.09"; in buildPerlPackage {
+  ModuleImplementation = buildPerlPackage {
     pname = "Module-Implementation";
+    version = "0.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/Module-Implementation-${version}.tar.gz";
+      url = mirror://cpan/authors/id/D/DR/DROLSKY/Module-Implementation-0.09.tar.gz;
       sha256 = "0vfngw4dbryihqhi7g9ks360hyw8wnpy3hpkzyg0q4y2y091lpy1";
     };
     buildInputs = [ TestFatal TestRequires ];
@@ -10729,10 +10735,11 @@ let
     propagatedBuildInputs = [ BUtils ];
   };
 
-  ModuleInstall = let version = "1.19"; in buildPerlPackage {
+  ModuleInstall = buildPerlPackage {
     pname = "Module-Install";
+    version = "1.19";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/Module-Install-${version}.tar.gz";
+      url = mirror://cpan/authors/id/E/ET/ETHER/Module-Install-1.19.tar.gz;
       sha256 = "06q12cm97yh4p7qbm0a2p96996ii6ss59qy57z0f7f9svy6sflqs";
     };
     propagatedBuildInputs = [ FileRemove ModuleBuild ModuleScanDeps YAMLTiny ];
@@ -10870,10 +10877,11 @@ let
     };
   };
 
-  ModuleScanDeps = let version = "1.27"; in buildPerlPackage {
+  ModuleScanDeps = buildPerlPackage {
     pname = "Module-ScanDeps";
+    version = "1.27";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RS/RSCHUPP/Module-ScanDeps-${version}.tar.gz";
+      url = mirror://cpan/authors/id/R/RS/RSCHUPP/Module-ScanDeps-1.27.tar.gz;
       sha256 = "0j6r9r99x5p0i6fv06i44wpsvjxj32amjkiqf6pmqpj80jff2k7f";
     };
     buildInputs = [ TestRequires ];
@@ -11930,7 +11938,7 @@ let
   };
 
   MozillaLdap = buildPerlPackage rec {
-    name = "Mozilla-Ldap-${version}";
+    pname = "Mozilla-Ldap";
     version = "1.5.3";
     USE_OPENLDAP = 1;
     LDAPSDKDIR = pkgs.openldap.dev;
@@ -12054,7 +12062,8 @@ let
   };
 
   NetAmazonEC2 = buildPerlPackage rec {
-    name = "Net-Amazon-EC2-0.14-stanaka-bc66577e13";
+    pname = "Net-Amazon-EC2";
+    version = "0.14-stanaka-bc66577e13";
     src = fetchFromGitHub {
       owner = "stanaka";
       repo = "net-amazon-ec2";
@@ -13188,11 +13197,12 @@ let
   };
 
   PerconaToolkit = buildPerlPackage rec {
-    name = "Percona-Toolkit-3.0.12";
+    pname = "Percona-Toolkit";
+    version = "3.0.12";
     src = fetchFromGitHub {
       owner = "percona";
       repo = "percona-toolkit";
-      rev = "3.0.12";
+      rev = version;
       sha256 = "0xk4h4dzl80kf97lbx0nznx9ajrb6kkg7k3iwca3rj6f3rqggv9y";
     };
     outputs = [ "out" ];
@@ -13576,7 +13586,8 @@ let
   };
 
   Po4a = buildPerlPackage rec {
-    name = "po4a-0.47";
+    pname = "po4a";
+    version = "0.47";
     src = fetchurl {
       url = "https://alioth.debian.org/frs/download.php/file/4142/po4a-0.47.tar.gz";
       sha256 = "5010e1b7df1115cbd475f46587fc05fefc97301f9bba0c2f15106005ca017507";
@@ -14715,7 +14726,8 @@ let
   };
 
   SGMLSpm = buildPerlPackage {
-    name = "SGMLSpm-1.1";
+    pname = "SGMLSpm";
+    version = "1.1";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RA/RAAB/SGMLSpm-1.1.tar.gz;
       sha256 = "1gdjf3mcz2bxir0l9iljxiz6qqqg3a9gg23y5wjg538w552r432m";
@@ -15015,10 +15027,11 @@ let
     };
   };
 
-  Starman = let version = "0.4014"; in buildPerlModule {
+  Starman = buildPerlModule {
     pname = "Starman";
+    version = "0.4014";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Starman-${version}.tar.gz";
+      url = mirror://cpan/authors/id/M/MI/MIYAGAWA/Starman-0.4014.tar.gz;
       sha256 = "1sbb5rb3vs82rlh1fjkgkcmj5pj62b4y9si4ihh45sl9m8c2qxx5";
     };
     buildInputs = [ LWP ModuleBuildTiny TestRequires TestTCP ];
@@ -15304,10 +15317,11 @@ let
     };
   };
 
-  StringUtil = let version = "1.26"; in buildPerlModule {
+  StringUtil = buildPerlModule {
     pname = "String-Util";
+    version = "1.26";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIKO/String-Util-${version}.tar.gz";
+      url = mirror://cpan/authors/id/M/MI/MIKO/String-Util-1.26.tar.gz;
       sha256 = "0bgs6fsc0gcj9qa1k98nwjp4xbkl3ckz71rz3qhmav0lgkrr96pl";
     };
     meta = {
@@ -15320,7 +15334,7 @@ let
   };
 
   strip-nondeterminism = buildPerlPackage rec {
-    name = "strip-nondeterminism-${version}";
+    pname = "strip-nondeterminism";
     version = "1.0.0";
 
     outputs = [ "out" "dev" ]; # no "devdoc"
@@ -15621,9 +15635,10 @@ let
   };
 
   SysCPU = buildPerlPackage rec {
-    name = "Sys-CPU-0.61";
+    pname = "Sys-CPU";
+    version = "0.61";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MZ/MZSANFORD/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MZ/MZSANFORD/Sys-CPU-0.61.tar.gz;
       sha256 = "1r6976bs86j7zp51m5vh42xlyah951jgdlkimv202413kjvqc2i5";
     };
     buildInputs = stdenv.lib.optional stdenv.isDarwin pkgs.darwin.apple_sdk.frameworks.Carbon;
@@ -15682,8 +15697,8 @@ let
   };
 
   SysVirt = buildPerlModule rec {
+    pname = "Sys-Virt";
     version = "4.10.0";
-    name = "Sys-Virt-${version}";
     src = assert version == pkgs.libvirt.version; pkgs.fetchgit {
       url = git://libvirt.org/libvirt-perl.git;
       rev = "v${version}";
@@ -18643,9 +18658,10 @@ let
   };
 
   vidir = buildPerlPackage rec {
-    name = "vidir-0.040";
+    pname = "App-vidir";
+    version = "0.040-woldrich";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/W/WO/WOLDRICH/App-${name}-woldrich.tar.gz";
+      url = mirror://cpan/authors/id/W/WO/WOLDRICH/App-vidir-0.040-woldrich.tar.gz;
       sha256 = "0c97yx33pyhskbmwpqbwlkxr85awd6kg1baibvqkarhhvc8v7l0h";
     };
     # NB: This preInstall a workaround for a problem that is fixed in HEAD.
@@ -18782,13 +18798,13 @@ let
   };
 
   WWWYoutubeViewer = buildPerlPackage rec {
-    name = "WWW-YoutubeViewer-${version}";
+    pname = "WWW-YoutubeViewer";
     version = "3.3.0";
 
     src = fetchFromGitHub {
       owner  = "trizen";
       repo   = "youtube-viewer";
-      rev    = "${version}";
+      rev    = version;
       sha256 = "15xyrwv08fw8jmpydwzks26ipxnzliwddgyjcfqiaj0p7lwlhmx1";
     };
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -15001,10 +15001,11 @@ let
   };
 
   Test2Suite = buildPerlPackage rec {
-    name = "Test2-Suite-0.000119";
+    pname = "Test2-Suite";
+    version = "0.000121";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/EX/EXODIST/${name}.tar.gz";
-      sha256 = "fd48764118acf1c30057f58f0af90696b194fbc5b637c77e08672e949c101e74";
+      url = mirror://cpan/authors/id/E/EX/EXODIST/Test2-Suite-0.000121.tar.gz;
+      sha256 = "e3fa3eaf9e7cb01dd11dc421aa5af329db6e3b988788af550bfb50be90fe2911";
     };
     propagatedBuildInputs = [ ModulePluggable ScopeGuard SubInfo TermTable TestSimple13 ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -5612,10 +5612,11 @@ let
   };
 
   FFICheckLib = buildPerlPackage {
-    name = "FFI-CheckLib-0.23";
+    pname = "FFI-CheckLib";
+    version = "0.24";
     src = fetchurl {
-      url = mirror://cpan/authors/id/P/PL/PLICEASE/FFI-CheckLib-0.23.tar.gz;
-      sha256 = "0rjivas0rsp7d5599cjcxss80zfj7a5b8did771dlw7h2p5apisf";
+      url = mirror://cpan/authors/id/P/PL/PLICEASE/FFI-CheckLib-0.24.tar.gz;
+      sha256 = "1ixklyh6c7szz5pgggww3wzxyci46cv6b1162csn8kgjf9vnwwlk";
     };
     buildInputs = [ Test2Suite ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -494,10 +494,11 @@ let
   };
 
   ArrayDiff = buildPerlPackage rec {
-     name = "Array-Diff-0.07";
+     pname = "Array-Diff";
+     version = "0.09";
      src = fetchurl {
-       url = mirror://cpan/authors/id/T/TY/TYPESTER/Array-Diff-0.07.tar.gz;
-       sha256 = "0il3izx45wkh71fli2hvaq32jyin95k8x3qrnwby2x2c6yix7rvq";
+       url = mirror://cpan/authors/id/N/NE/NEILB/Array-Diff-0.09.tar.gz;
+       sha256 = "0xsh8k312spzl90xds075qprcaz4r0b93g1bgi9l3rv1k0p3j1l0";
      };
      propagatedBuildInputs = [ AlgorithmDiff ClassAccessor ];
      meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -14753,10 +14753,11 @@ let
   };
 
   TemplateToolkit = buildPerlPackage rec {
-    name = "Template-Toolkit-2.28";
+    pname = "Template-Toolkit";
+    version = "2.29";
     src = fetchurl {
-      url = mirror://cpan/authors/id/A/AT/ATOOMIC/Template-Toolkit-2.28.tar.gz;
-      sha256 = "1msxg3j1hx5wsc7vr81x5gs9gdbn4y0x6cvyj3pq4dgi1603dbvi";
+      url = mirror://cpan/authors/id/A/AT/ATOOMIC/Template-Toolkit-2.29.tar.gz;
+      sha256 = "0ya7c49q2rd2gdjf28y60iq8wsr2afphsy1labyhbf0zyhfdgp9b";
     };
     propagatedBuildInputs = [ AppConfig ];
     doCheck = !stdenv.isDarwin;

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -3658,10 +3658,11 @@ let
   };
 
   DateTime = buildPerlPackage rec {
-    name = "DateTime-1.50";
+    pname = "DateTime";
+    version = "1.51";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/${name}.tar.gz";
-      sha256 = "165iqk1xvhs5j0kzsipa7aqycx3h37wqsl2r4jl104yqvmqhqszd";
+      url = mirror://cpan/authors/id/D/DR/DROLSKY/DateTime-1.51.tar.gz;
+      sha256 = "1ibfq6acz1ih28vl613yygbb3r2d8ykx6di669vajhvswl6xl8ny";
     };
     buildInputs = [ CPANMetaCheck TestFatal TestWarnings ];
     propagatedBuildInputs = [ DateTimeLocale DateTimeTimeZone ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -16320,10 +16320,11 @@ let
   };
 
   TextCSV = buildPerlPackage rec {
-    name = "Text-CSV-1.99";
+    pname = "Text-CSV";
+    version = "2.00";
     src = fetchurl {
-      url = mirror://cpan/authors/id/I/IS/ISHIGAKI/Text-CSV-1.99.tar.gz;
-      sha256 = "e74ec039b12cc51d346bf1d814af7db8a05cb0a98340e7547a21646da8668cd2";
+      url = mirror://cpan/authors/id/I/IS/ISHIGAKI/Text-CSV-2.00.tar.gz;
+      sha256 = "8ccbd9195805222d995844114d0e595bb24ce188f85284dbf256080311cbb2c2";
     };
     meta = {
       description = "Comma-separated values manipulator (using XS or PurePerl)";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -9021,10 +9021,11 @@ let
   };
 
   LWP = buildPerlPackage rec {
-    name = "libwww-perl-6.38";
+    pname = "libwww-perl";
+    version = "6.39";
     src = fetchurl {
-      url = mirror://cpan/authors/id/O/OA/OALDERS/libwww-perl-6.38.tar.gz;
-      sha256 = "a8e0849b8d2798fc45a2a5f2fe45c96cbbad5baf3bcbe64a3bf85f210e78708c";
+      url = mirror://cpan/authors/id/O/OA/OALDERS/libwww-perl-6.39.tar.gz;
+      sha256 = "9a8d7747938aa75d7d524c71574ae7f99ca66a5dac8255a7f7759f373e7774d5";
     };
     propagatedBuildInputs = [ FileListing HTMLParser HTTPCookies HTTPDaemon HTTPNegotiate NetHTTP TryTiny WWWRobotRules ];
     # support cross-compilation by avoiding using `has_module` which does not work in miniperl (it requires B native module)

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -4003,10 +4003,11 @@ let
   };
 
   DevelPatchPerl = buildPerlPackage rec {
-    name = "Devel-PatchPerl-1.56";
+    pname = "Devel-PatchPerl";
+    version = "1.58";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BI/BINGOS/${name}.tar.gz";
-      sha256 = "1b97a6b82qh1dsv13rgxyiv4lffp360crgc9wiq3pyj0zr13nfc2";
+      url = mirror://cpan/authors/id/B/BI/BINGOS/Devel-PatchPerl-1.58.tar.gz;
+      sha256 = "1b7x5aj95fbanm8hm5p81mv8b3axhfkx60ab3mws3pf66453q83r";
     };
     propagatedBuildInputs = [ Filepushd ModulePluggable ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -6805,10 +6805,11 @@ let
   };
 
   Gtk3 = buildPerlPackage rec {
-    name = "Gtk3-0.034";
+    pname = "Gtk3";
+    version = "0.035";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/X/XA/XAOC/${name}.tar.gz";
-      sha256 = "0baxyhlzdf7avka40h1niiir8vz4nilqkiwh876i0hv0f8xj3nqa";
+      url = mirror://cpan/authors/id/X/XA/XAOC/Gtk3-0.035.tar.gz;
+      sha256 = "1zhr4ixjb93rjnxsbrjc3fg86qkx1fj4w21yg5q4swjvm6fxdfcg";
     };
     propagatedBuildInputs = [ pkgs.gtk3 CairoGObject GlibObjectIntrospection ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -9414,10 +9414,11 @@ let
   };
 
   MathClipper = buildPerlModule rec {
-    name = "Math-Clipper-1.27";
+    pname = "Math-Clipper";
+    version = "1.28";
     src = fetchurl {
-      url = mirror://cpan/authors/id/S/SH/SHELDRAKE/Math-Clipper-1.27.tar.gz;
-      sha256 = "0di8frcxa8laa5s0x4vkr2mp9abv2a099c3x4gsdpnbijj10j6dn";
+      url = mirror://cpan/authors/id/S/SH/SHELDRAKE/Math-Clipper-1.28.tar.gz;
+      sha256 = "19rlv7s00r7rkcri01f71jbdfpdq8rlhhgb3f948pjljb0jqcxvn";
     };
     nativeBuildInputs = [ pkgs.ld-is-cc-hook ];
     buildInputs = [ ExtUtilsCppGuess ExtUtilsTypemapsDefault ExtUtilsXSpp ModuleBuildWithXSpp TestDeep ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -9330,10 +9330,11 @@ let
   };
 
   MailTransport = buildPerlPackage rec {
-     name = "Mail-Transport-3.003";
+     pname = "Mail-Transport";
+     version = "3.004";
      src = fetchurl {
-       url = mirror://cpan/authors/id/M/MA/MARKOV/Mail-Transport-3.003.tar.gz;
-       sha256 = "0lb1awpk2wcnn5wg663982jl45x9fdn8ikxscayscxa16rim116p";
+       url = mirror://cpan/authors/id/M/MA/MARKOV/Mail-Transport-3.004.tar.gz;
+       sha256 = "049xsjxfn00v5znmrg7vgyafy5wzxxa901hq2g083s0pyq4mlcfg";
      };
      propagatedBuildInputs = [ MailMessage ];
      meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -14993,12 +14993,13 @@ let
   };
 
   Test2PluginNoWarnings = buildPerlPackage rec {
-     name = "Test2-Plugin-NoWarnings-0.06";
+     pname = "Test2-Plugin-NoWarnings";
+     version = "0.07";
      src = fetchurl {
-       url = mirror://cpan/authors/id/D/DR/DROLSKY/Test2-Plugin-NoWarnings-0.06.tar.gz;
-       sha256 = "002qk6qsm0l6r2kaxywvc38w0yf0mlavgywq8li076pn6kcw3242";
+       url = mirror://cpan/authors/id/D/DR/DROLSKY/Test2-Plugin-NoWarnings-0.07.tar.gz;
+       sha256 = "1sxqcbklmpxpkysq3wbivs77n3c8mvasvfa38dzmyqz04ifaf7gz";
      };
-     buildInputs = [ IPCRun3 Test2Suite ];
+     buildInputs = [ CaptureTiny IPCRun3 Test2Suite ];
      meta = {
        description = "Fail if tests warn";
        license = with stdenv.lib.licenses; [ artistic2 ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -129,10 +129,11 @@ let
   };
 
   AlienBuild = buildPerlPackage {
-    name = "Alien-Build-1.65";
+    pname = "Alien-Build";
+    version = "1.69";
     src = fetchurl {
-      url = mirror://cpan/authors/id/P/PL/PLICEASE/Alien-Build-1.65.tar.gz;
-      sha256 = "1xvwh6r2aawilpxl8zdqb8yy3skj56nkps3h5xz6spkv4ggzzm4a";
+      url = mirror://cpan/authors/id/P/PL/PLICEASE/Alien-Build-1.69.tar.gz;
+      sha256 = "1p121lm6qyy93kva0ncyi4w3hf5vzh9zl60a3a2rifg777sj10q8";
     };
     propagatedBuildInputs = [ CaptureTiny FFICheckLib FileWhich Filechdir PathTiny PkgConfig ];
     buildInputs = [ DevelHide Test2Suite ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -9181,11 +9181,11 @@ let
   };
 
   MailBox = buildPerlPackage rec {
-    version = "3.006";
-    name = "Mail-Box-${version}";
+    version = "3.007";
+    pname = "Mail-Box";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MARKOV/${name}.tar.gz";
-      sha256 = "1fm17z13jq7ff2f4ynnajdzzdqa4sb0kx5nfy9fvb0nzw49qd502";
+      url = mirror://cpan/authors/id/M/MA/MARKOV/Mail-Box-3.007.tar.gz;
+      sha256 = "1rqn9d6sjinbnl8a9ia4rqfmp899ad89y9h9hpzvmr8jxni7i19s";
     };
 
     doCheck = false;

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -3379,11 +3379,12 @@ let
     };
   };
 
-  DataPage = buildPerlModule {
-    name = "Data-Page-2.02";
+  DataPage = buildPerlPackage {
+    pname = "Data-Page";
+    version = "2.03";
     src = fetchurl {
-      url = mirror://cpan/authors/id/L/LB/LBROCARD/Data-Page-2.02.tar.gz;
-      sha256 = "1hvi92c4h2angryc6pngw7gbm3ysc2jfmyxk2wh9ia4vdwpbs554";
+      url = mirror://cpan/authors/id/E/ET/ETHER/Data-Page-2.03.tar.gz;
+      sha256 = "12rxrr2b11qjk0c437cisw2kfqkafw1awcng09cv6yhzglb55yif";
     };
     propagatedBuildInputs = [ ClassAccessorChained ];
     buildInputs = [ TestException ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -4534,6 +4534,20 @@ let
     };
   };
 
+  DirManifest = buildPerlModule {
+    pname = "Dir-Manifest";
+    version = "0.0.5";
+    src = fetchurl {
+      url = mirror://cpan/authors/id/S/SH/SHLOMIF/Dir-Manifest-0.0.5.tar.gz;
+      sha256 = "07c52qgn2ih16gwwk7hvpkhkzq69387bcrjamba3m0008vy2bp0i";
+    };
+    propagatedBuildInputs = [ Moo PathTiny ];
+    meta = {
+      description = "treat a directory and a manifest file as a hash/dictionary of keys to texts or blobs";
+      license = with stdenv.lib.licenses; [ mit ];
+    };
+  };
+
   DistCheckConflicts = buildPerlPackage rec {
     name = "Dist-CheckConflicts-0.11";
     src = fetchurl {
@@ -6300,13 +6314,14 @@ let
   };
 
   GamesSolitaireVerify = buildPerlModule {
-    name = "Games-Solitaire-Verify-0.2000";
+    pname = "Games-Solitaire-Verify";
+    version = "0.2100";
     src = fetchurl {
-      url = mirror://cpan/authors/id/S/SH/SHLOMIF/Games-Solitaire-Verify-0.2000.tar.gz;
-      sha256 = "dc87a348a2cacfadfb8205ff3fdbc138f475126bef175bc806ec9454285c2165";
+      url = mirror://cpan/authors/id/S/SH/SHLOMIF/Games-Solitaire-Verify-0.2100.tar.gz;
+      sha256 = "123ba559cfc6898f91d4c397f525f77339756f17eb26469a75fcfaf3b4fbeca8";
     };
-    buildInputs = [ PathTiny TestDifferences ];
-    propagatedBuildInputs = [ ClassXSAccessor ExceptionClass ListMoreUtils ];
+    buildInputs = [ DirManifest TestDifferences ];
+    propagatedBuildInputs = [ ClassXSAccessor ExceptionClass ListMoreUtils PathTiny ];
     meta = {
       description = "Verify solutions for solitaire games";
       license = stdenv.lib.licenses.mit;

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -16919,10 +16919,11 @@ let
   };
 
   TimeDuration = buildPerlPackage rec {
-    name = "Time-Duration-1.20";
+    pname = "Time-Duration";
+    version = "1.21";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/${name}.tar.gz";
-      sha256 = "1f5vkid4pl5iq3hal01hk1zjbbzrqpx4m1djawbp93l152shb0j5";
+      url = mirror://cpan/authors/id/N/NE/NEILB/Time-Duration-1.21.tar.gz;
+      sha256 = "1f59z2svfydxgd1gzrb5k3hl6d432kzmskk7jhv2dyb5hyx0wd7y";
     };
     meta = {
       description = "Rounded or exact English expression of durations";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -1690,10 +1690,11 @@ let
   };
 
   CGI = buildPerlPackage rec {
-    name = "CGI-4.42";
+    pname = "CGI";
+    version = "4.43";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEEJO/${name}.tar.gz";
-      sha256 = "11d308e7dad2312d65747a7fdec5d0c22024c28df5e882e829ca1553482024e7";
+      url = mirror://cpan/authors/id/L/LE/LEEJO/CGI-4.43.tar.gz;
+      sha256 = "14b94f9df6e48fc26ebc4fa1e01a7b534cbc1611028a49028f9ac9d8ca27b734";
     };
     buildInputs = [ TestDeep TestNoWarnings TestWarn ];
     propagatedBuildInputs = [ HTMLParser ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -3907,10 +3907,11 @@ let
   };
 
   DateTimeTimeZone = buildPerlPackage rec {
-    name = "DateTime-TimeZone-2.34";
+    pname = "DateTime-TimeZone";
+    version = "2.35";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/${name}.tar.gz";
-      sha256 = "dee1111c06f2aa705f803bc4f3d93b50df566d864a1a8bf31b55dfaf2b3de809";
+      url = mirror://cpan/authors/id/D/DR/DROLSKY/DateTime-TimeZone-2.35.tar.gz;
+      sha256 = "79fadc0f24b6b23ffb560524544d9d200902578bf9e0943b9aa8fc5077ca8b02";
     };
     buildInputs = [ TestFatal TestRequires ];
     propagatedBuildInputs = [ ClassSingleton ParamsValidationCompiler Specio namespaceautoclean ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -17938,10 +17938,11 @@ let
   };
 
   YAML = buildPerlPackage rec {
-    name = "YAML-1.27";
+    pname = "YAML";
+    version = "1.29";
     src = fetchurl {
-      url = mirror://cpan/authors/id/T/TI/TINITA/YAML-1.27.tar.gz;
-      sha256 = "1yc2yqjyrcdlhp209f3a63f9xx6v5klisli25fv221yy43la34n9";
+      url = mirror://cpan/authors/id/T/TI/TINITA/YAML-1.29.tar.gz;
+      sha256 = "0gl5ssvrdajlbc85cy6z873n9cwlssk5q8z97a31vyiikhw5fp4w";
     };
 
     buildInputs = [ TestBase TestDeep TestYAML ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -5472,10 +5472,11 @@ let
   };
 
   ExtUtilsMakeMaker = buildPerlPackage {
-    name = "ExtUtils-MakeMaker-7.34";
+    pname = "ExtUtils-MakeMaker";
+    version = "7.36";
     src = fetchurl {
-      url = mirror://cpan/authors/id/B/BI/BINGOS/ExtUtils-MakeMaker-7.34.tar.gz;
-      sha256 = "95f1eb44de480d00b28d031b574ec868f7aeeee199eb5abe5666f6bcbbf68480";
+      url = mirror://cpan/authors/id/B/BI/BINGOS/ExtUtils-MakeMaker-7.36.tar.gz;
+      sha256 = "06cef6429315cdc6afa9b2dc6fbdfa33538b6f68c827f441294621858e28c558";
     };
     meta = {
       description = "Create a module Makefile";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -2805,10 +2805,11 @@ let
   };
 
   CPANPerlReleases = buildPerlPackage rec {
-    name = "CPAN-Perl-Releases-3.94";
+    pname = "CPAN-Perl-Releases";
+    version = "4.00";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BI/BINGOS/${name}.tar.gz";
-      sha256 = "12g3mdl8lziz218a5rlflhbd295paqfqq5f9ylkdr00pnss5jfnp";
+      url = mirror://cpan/authors/id/B/BI/BINGOS/CPAN-Perl-Releases-4.00.tar.gz;
+      sha256 = "0p640z97p1pswqaidla8s2fd7yw4l5i0wp181sd6bg0ai4hz5a2m";
     };
     meta = {
       homepage = https://github.com/bingos/cpan-perl-releases;

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -10171,10 +10171,11 @@ let
   };
 
   Mojolicious = buildPerlPackage rec {
-    name = "Mojolicious-8.14";
+    pname = "Mojolicious";
+    version = "8.15";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SR/SRI/${name}.tar.gz";
-      sha256 = "0dammdx51cyqn2b35yihk85gz1blgw85w6jv6h04cv4cdahph59q";
+      url = mirror://cpan/authors/id/S/SR/SRI/Mojolicious-8.15.tar.gz;
+      sha256 = "1nzcfz86abgif16c4m9k178y6wpavws0l17jc54584zjwhijnl68";
     };
     meta = {
       homepage = https://mojolicious.org;

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -70,9 +70,10 @@ let
 
 
   ack = buildPerlPackage rec {
-    name = "ack-2.28";
+    pname = "ack";
+    version = "2.28";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PETDANCE/${name}.tar.gz";
+      url = mirror://cpan/authors/id/P/PE/PETDANCE/ack-2.28.tar.gz;
       sha256 = "16zgn96v1qkibpj5lic571zjl07y8x55v5xql3x7bvlsmgqcnvla";
     };
     outputs = ["out" "man"];
@@ -90,7 +91,8 @@ let
   };
 
   AlgorithmAnnotate = buildPerlPackage {
-    name = "Algorithm-Annotate-0.10";
+    pname = "Algorithm-Annotate";
+    version = "0.10";
     src = fetchurl {
       url = mirror://cpan/authors/id/C/CL/CLKAO/Algorithm-Annotate-0.10.tar.gz;
       sha256 = "1y92k4nqkscfwpriv8q7c90rjfj85lvwq1k96niv2glk8d37dcf9";
@@ -99,9 +101,10 @@ let
   };
 
   AlgorithmC3 = buildPerlPackage rec {
-    name = "Algorithm-C3-0.10";
+    pname = "Algorithm-C3";
+    version = "0.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/${name}.tar.gz";
+      url = mirror://cpan/authors/id/H/HA/HAARG/Algorithm-C3-0.10.tar.gz;
       sha256 = "01hlcaxndls86bl92rkd3fvf9pfa3inxqaimv88bxs95803kmkss";
     };
     meta = {
@@ -111,7 +114,7 @@ let
   };
 
   AlgorithmDiff = let version = "1.1903"; in buildPerlPackage {
-    name = "Algorithm-Diff-${version}";
+    pname = "Algorithm-Diff";
     src = fetchurl {
       url = "mirror://cpan/authors/id/T/TY/TYEMQ/Algorithm-Diff-${version}.tar.gz";
       sha256 = "0l8pk7ziz72d022hsn4xldhhb9f5649j5cgpjdibch0xng24ms1h";
@@ -120,7 +123,8 @@ let
   };
 
   AlgorithmMerge = buildPerlPackage rec {
-    name = "Algorithm-Merge-0.08";
+    pname = "Algorithm-Merge";
+    version = "0.08";
     src = fetchurl {
       url = mirror://cpan/authors/id/J/JS/JSMITH/Algorithm-Merge-0.08.tar.gz;
       sha256 = "1kqn13wd0lfjrf6h19b9kgdqqwp7k2d9yfq5i0wvii0xi8jqh1lw";
@@ -144,7 +148,8 @@ let
   };
 
   AlienGMP = buildPerlPackage {
-    name = "Alien-GMP-1.14";
+    pname = "Alien-GMP";
+    version = "1.14";
     src = fetchurl {
       url = mirror://cpan/authors/id/P/PL/PLICEASE/Alien-GMP-1.14.tar.gz;
       sha256 = "116vvh1b0d1ykkklqgfxfn89g3bw90a4cj3qrvsnkw1kk5cmn60a";
@@ -158,16 +163,18 @@ let
   };
 
   aliased = buildPerlModule rec {
-    name = "aliased-0.34";
+    pname = "aliased";
+    version = "0.34";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/E/ET/ETHER/aliased-0.34.tar.gz;
       sha256 = "1syyqzy462501kn5ma9gl6xbmcahqcn4qpafhsmpz0nd0x2m4l63";
     };
     buildInputs = [ ModuleBuildTiny ];
   };
 
   asa = buildPerlPackage rec {
-     name = "asa-1.03";
+     pname = "asa";
+     version = "1.03";
      src = fetchurl {
        url = mirror://cpan/authors/id/A/AD/ADAMK/asa-1.03.tar.gz;
        sha256 = "1w97m0gf3n9av61d0qcw7d1i1rac4gm0fd2ba5wyh53df9d7p0i2";
@@ -179,7 +186,7 @@ let
   };
 
   AlienTidyp = buildPerlModule rec {
-    name = "Alien-Tidyp-${version}";
+    pname = "Alien-Tidyp";
     version = "1.4.7";
     src = fetchurl {
       url = "mirror://cpan/authors/id/K/KM/KMX/Alien-Tidyp-v${version}.tar.gz";
@@ -192,9 +199,10 @@ let
   };
 
   AlienWxWidgets = buildPerlModule rec {
-    name = "Alien-wxWidgets-0.69";
+    pname = "Alien-wxWidgets";
+    version = "0.69";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MD/MDOOTSON/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MD/MDOOTSON/Alien-wxWidgets-0.69.tar.gz;
       sha256 = "0jg2dmkzhj03f6b0vmv597yryfw9cclsdn9ynvvlrzzgpd5lw8jk";
     };
     propagatedBuildInputs = [ pkgs.pkgconfig pkgs.gtk2 pkgs.wxGTK30 ModulePluggable ];
@@ -202,9 +210,10 @@ let
   };
 
   AnyEvent = buildPerlPackage rec {
-    name = "AnyEvent-7.15";
+    pname = "AnyEvent";
+    version = "7.15";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/ML/MLEHMANN/AnyEvent-7.15.tar.gz;
       sha256 = "111db2335c71f789edaec271126b3810356691eb1214dd3f67b527a88ec9e354";
     };
     buildInputs = [ CanaryStability ];
@@ -214,9 +223,10 @@ let
   };
 
   AnyEventCacheDNS = buildPerlModule rec {
-    name = "AnyEvent-CacheDNS-0.08";
+    pname = "AnyEvent-CacheDNS";
+    version = "0.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PO/POTYL/${name}.tar.gz";
+      url = mirror://cpan/authors/id/P/PO/POTYL/AnyEvent-CacheDNS-0.08.tar.gz;
       sha256 = "41c1faf183b61806b55889ceea1237750c1f61b9ce2735fdf33dc05536712dae";
     };
     propagatedBuildInputs = [ AnyEvent ];
@@ -229,18 +239,20 @@ let
   };
 
   AnyEventHTTP = buildPerlPackage rec {
-    name = "AnyEvent-HTTP-2.24";
+    pname = "AnyEvent-HTTP";
+    version = "2.24";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/ML/MLEHMANN/AnyEvent-HTTP-2.24.tar.gz;
       sha256 = "0358a542baa45403d81c0a70e43e79c044ddfa1371161d043f002acef63121dd";
     };
     propagatedBuildInputs = [ AnyEvent commonsense ];
   };
 
   AnyEventI3 = buildPerlPackage rec {
-    name = "AnyEvent-I3-0.17";
+    pname = "AnyEvent-I3";
+    version = "0.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MS/MSTPLBG/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MS/MSTPLBG/AnyEvent-I3-0.17.tar.gz;
       sha256 = "5382c984c9f138395f29f0c00af81aa0c8f4b765582055c73ede4b13f04a6d63";
     };
     propagatedBuildInputs = [ AnyEvent JSONXS ];
@@ -251,9 +263,10 @@ let
   };
 
   AnyEventRabbitMQ = buildPerlPackage rec {
-    name = "AnyEvent-RabbitMQ-1.19";
+    pname = "AnyEvent-RabbitMQ";
+    version = "1.19";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DL/DLAMBLEY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DL/DLAMBLEY/AnyEvent-RabbitMQ-1.19.tar.gz;
       sha256 = "a440ec2fa5a4018ad44739baaa9601cc460ad497282e89110ba8e3cf23312f0a";
     };
     buildInputs = [ TestException ];
@@ -265,18 +278,20 @@ let
   };
 
   AnyMoose = buildPerlPackage rec {
-    name = "Any-Moose-0.27";
+    pname = "Any-Moose";
+    version = "0.27";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/E/ET/ETHER/Any-Moose-0.27.tar.gz;
       sha256 = "0dc55mpayrixwx8dwql0vj0jalg4rlb3k64rprc84bl0z8vkx9m8";
     };
     propagatedBuildInputs = [ Moose Mouse ];
   };
 
   ApacheAuthCookie = buildPerlPackage rec {
-    name = "Apache-AuthCookie-3.27";
+    pname = "Apache-AuthCookie";
+    version = "3.27";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MS/MSCHOUT/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MS/MSCHOUT/Apache-AuthCookie-3.27.tar.gz;
       sha256 = "58daeb3e44c681ff88f8fb00e4aabaa7a40cbee73dbdb84fcf6c285b15d357bd";
     };
     buildInputs = [ ApacheTest ];
@@ -294,9 +309,10 @@ let
   };
 
   ApacheLogFormatCompiler = buildPerlModule rec {
-    name = "Apache-LogFormat-Compiler-0.35";
+    pname = "Apache-LogFormat-Compiler";
+    version = "0.35";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KA/KAZEBURO/${name}.tar.gz";
+      url = mirror://cpan/authors/id/K/KA/KAZEBURO/Apache-LogFormat-Compiler-0.35.tar.gz;
       sha256 = "06i70ydxk2wa2rcqn16842kra2qz3jwk0vk1abq8lah4180c0m0n";
     };
     buildInputs = [ HTTPMessage ModuleBuildTiny TestMockTime TestRequires TryTiny URI ];
@@ -311,7 +327,8 @@ let
   };
 
   ApacheSession = buildPerlModule {
-    name = "Apache-Session-1.93";
+    pname = "Apache-Session";
+    version = "1.93";
     src = fetchurl {
       url = mirror://cpan/authors/id/C/CH/CHORNY/Apache-Session-1.93.tar.gz;
       sha256 = "8e5a4882ac8ec657d1018d74d3ba37854e2688a41ddd0e1d73955ea59f276e8d";
@@ -324,7 +341,8 @@ let
   };
 
   ApacheTest = buildPerlPackage {
-    name = "Apache-Test-1.40";
+    pname = "Apache-Test";
+    version = "1.40";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SH/SHAY/Apache-Test-1.40.tar.gz;
       sha256 = "0h5fsi0is6nhclsd3wwkkqx2hfgl3bpdazxycafm9sqxr3qkgx9w";
@@ -337,7 +355,8 @@ let
   };
 
   AppCLI = buildPerlPackage {
-    name = "App-CLI-0.50";
+    pname = "App-CLI";
+    version = "0.50";
     src = fetchurl {
       url = mirror://cpan/authors/id/P/PT/PTC/App-CLI-0.50.tar.gz;
       sha256 = "0ick5agl02rx2pjfxl97d0f9qksy8pjn0asmwm3gn6dm7a1zblsi";
@@ -347,9 +366,10 @@ let
   };
 
   AppCmd = buildPerlPackage rec {
-    name = "App-Cmd-0.331";
+    pname = "App-Cmd";
+    version = "0.331";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RJ/RJBS/App-Cmd-0.331.tar.gz;
       sha256 = "4a5d3df0006bd278880d01f4957aaa652a8f91fe8f66e93adf70fba0c3ecb680";
     };
     buildInputs = [ TestFatal ];
@@ -362,9 +382,10 @@ let
   };
 
   AppConfig = buildPerlPackage rec {
-    name = "AppConfig-1.71";
+    pname = "AppConfig";
+    version = "1.71";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/${name}.tar.gz";
+      url = mirror://cpan/authors/id/N/NE/NEILB/AppConfig-1.71.tar.gz;
       sha256 = "03vvi3mk4833mx2c6dkm9zhvakf02mb2b7wz9pk9xc7c4mq04xqi";
     };
     meta = {
@@ -374,7 +395,8 @@ let
   };
 
   AppFatPacker = buildPerlPackage rec {
-     name = "App-FatPacker-0.010008";
+     pname = "App-FatPacker";
+     version = "0.010008";
      src = fetchurl {
        url = mirror://cpan/authors/id/M/MS/MSTROUT/App-FatPacker-0.010008.tar.gz;
        sha256 = "1kzcbpsf1p7ww45d9fl2w0nfn5jj5pz0r0c649c1lrj5r1nv778j";
@@ -386,9 +408,10 @@ let
   };
 
   Appcpanminus = buildPerlPackage rec {
-    name = "App-cpanminus-1.7044";
+    pname = "App-cpanminus";
+    version = "1.7044";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7044.tar.gz;
       sha256 = "9b60767fe40752ef7a9d3f13f19060a63389a5c23acc3e9827e19b75500f81f3";
     };
     meta = {
@@ -399,9 +422,10 @@ let
   };
 
   Appperlbrew = buildPerlModule rec {
-    name = "App-perlbrew-0.86";
+    pname = "App-perlbrew";
+    version = "0.86";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GU/GUGOD/${name}.tar.gz";
+      url = mirror://cpan/authors/id/G/GU/GUGOD/App-perlbrew-0.86.tar.gz;
       sha256 = "11qh94am7fghizmjaf5c7w868svjbv9g4ffirykj8qa6q40zdspp";
     };
     buildInputs = [ pkgs.curl FileWhich IOAll ModuleBuildTiny PathClass TestException TestNoWarnings TestOutput TestSpec TestTempDirTiny ];
@@ -420,7 +444,8 @@ let
   };
 
   ArchiveAnyLite = buildPerlPackage rec {
-     name = "Archive-Any-Lite-0.11";
+     pname = "Archive-Any-Lite";
+     version = "0.11";
      src = fetchurl {
        url = mirror://cpan/authors/id/I/IS/ISHIGAKI/Archive-Any-Lite-0.11.tar.gz;
        sha256 = "0w2i50fd81ip674zmnrb15nadw162fdpiw4rampbd94k74jqih8m";
@@ -435,9 +460,9 @@ let
 
   AppSqitch = buildPerlModule rec {
     version = "0.9999";
-    name = "App-Sqitch-${version}";
+    pname = "App-Sqitch";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DW/DWHEELER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DW/DWHEELER/App-Sqitch-0.9999.tar.gz;
       sha256 = "f5bfa80206738ab8a70358a3b0557661c7459e11ec07dece23ecafa1f34372b3";
     };
     buildInputs = [ CaptureTiny IOPager TestDeep TestDir TestException TestFile TestFileContents TestMockModule TestNoWarnings TestWarn ];
@@ -469,7 +494,8 @@ let
   };
 
   AttributeParamsValidate = buildPerlPackage {
-    name = "Attribute-Params-Validate-1.21";
+    pname = "Attribute-Params-Validate";
+    version = "1.21";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DR/DROLSKY/Attribute-Params-Validate-1.21.tar.gz;
       sha256 = "586b939ceffdb37188b7c461dd1a8f9f35695184c8703b05c35f6d508c8090f5";
@@ -484,7 +510,8 @@ let
   };
 
   ArrayCompare = buildPerlModule rec {
-    name = "Array-Compare-3.0.2";
+    pname = "Array-Compare";
+    version = "3.0.2";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DA/DAVECROSS/Array-Compare-v3.0.2.tar.gz;
       sha256 = "0ci8pb6nh73rmmwd8fvg6n2064v8nbraqyg1axsncfi28nfz522s";
@@ -509,9 +536,10 @@ let
   };
 
   ArrayFIFO = buildPerlPackage rec {
-    name = "Array-FIFO-0.13";
+    pname = "Array-FIFO";
+    version = "0.13";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DB/DBURKE/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DB/DBURKE/Array-FIFO-0.13.tar.gz;
       sha256 = "be2aeb5f5a9af1a96f0033508a569ca93ad19ad15dc7c6b998e6d7bc740c66f7";
     };
     buildInputs = [ TestDeep TestSpec TestTrap ];
@@ -524,9 +552,10 @@ let
   };
 
   ArchiveCpio = buildPerlPackage rec {
-    name = "Archive-Cpio-0.10";
+    pname = "Archive-Cpio";
+    version = "0.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PI/PIXEL/${name}.tar.gz";
+      url = mirror://cpan/authors/id/P/PI/PIXEL/Archive-Cpio-0.10.tar.gz;
       sha256 = "246fb31669764e78336b2191134122e07c44f2d82dc4f37d552ab28f8668bed3";
     };
     meta = {
@@ -537,9 +566,10 @@ let
   };
 
   ArchiveExtract = buildPerlPackage rec {
-    name = "Archive-Extract-0.80";
+    pname = "Archive-Extract";
+    version = "0.80";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BI/BINGOS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/B/BI/BINGOS/Archive-Extract-0.80.tar.gz;
       sha256 = "25cbc2d5626c14d39a0b5e4fe8383941e085c9a7e0aa873d86e81b6e709025f4";
     };
     meta = {
@@ -549,9 +579,10 @@ let
   };
 
   ArchiveTar = buildPerlPackage rec {
-    name = "Archive-Tar-2.32";
+    pname = "Archive-Tar";
+    version = "2.32";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BI/BINGOS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/B/BI/BINGOS/Archive-Tar-2.32.tar.gz;
       sha256 = "92783780731ab0c9247adf43e70f4801e8317e3915ea87e38b85c8f734e8fca2";
     };
     meta = {
@@ -561,7 +592,8 @@ let
   };
 
   ArchiveTarWrapper = buildPerlPackage rec {
-     name = "Archive-Tar-Wrapper-0.36";
+     pname = "Archive-Tar-Wrapper";
+     version = "0.36";
      src = fetchurl {
        url = mirror://cpan/authors/id/A/AR/ARFREITAS/Archive-Tar-Wrapper-0.36.tar.gz;
        sha256 = "1s7i93qbimwygv07x5963vv90m09g2iiacnl3986smw4rpi5apwg";
@@ -574,7 +606,8 @@ let
   };
 
   ArchiveZip = buildPerlPackage {
-    name = "Archive-Zip-1.64";
+    pname = "Archive-Zip";
+    version = "1.64";
     src = fetchurl {
       url = mirror://cpan/authors/id/P/PH/PHRED/Archive-Zip-1.64.tar.gz;
       sha256 = "0zfinh8nx3rxzscp57vq3w8hihpdb0zs67vvalykcf402kr88pyy";
@@ -587,9 +620,10 @@ let
   };
 
   AudioScan = buildPerlPackage rec {
-    name = "Audio-Scan-1.01";
+    pname = "Audio-Scan";
+    version = "1.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AG/AGRUNDMA/${name}.tar.gz";
+      url = mirror://cpan/authors/id/A/AG/AGRUNDMA/Audio-Scan-1.01.tar.gz;
       sha256 = "0jk3djnk6yf0jsjh8qk3mj8bkx4avp6i4czcpr5xrbf7f41744l3";
     };
     buildInputs = [ pkgs.zlib TestWarn ];
@@ -602,9 +636,10 @@ let
   };
 
   AuthenDecHpwd = buildPerlModule rec {
-    name = "Authen-DecHpwd-2.007";
+    pname = "Authen-DecHpwd";
+    version = "2.007";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Z/ZE/ZEFRAM/${name}.tar.gz";
+      url = mirror://cpan/authors/id/Z/ZE/ZEFRAM/Authen-DecHpwd-2.007.tar.gz;
       sha256 = "f43a93bb02b41f7327d92f9e963b69505f67350a52e8f50796f98afc4fb3f177";
     };
     propagatedBuildInputs = [ DataInteger DigestCRC ScalarString ];
@@ -615,7 +650,8 @@ let
   };
 
   AuthenHtpasswd = buildPerlPackage rec {
-    name = "Authen-Htpasswd-0.171";
+    pname = "Authen-Htpasswd";
+    version = "0.171";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MS/MSTROUT/Authen-Htpasswd-0.171.tar.gz;
       sha256 = "0rw06hwpxg388d26l0jvirczx304f768ijvc20l4b2ll7xzg9ymm";
@@ -628,9 +664,10 @@ let
   };
 
   AuthenModAuthPubTkt = buildPerlPackage rec {
-    name = "Authen-ModAuthPubTkt-0.1.1";
+    pname = "Authen-ModAuthPubTkt";
+    version = "0.1.1";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AG/AGORDON/${name}.tar.gz";
+      url = mirror://cpan/authors/id/A/AG/AGORDON/Authen-ModAuthPubTkt-0.1.1.tar.gz;
       sha256 = "7996e1a42c51216003ccf03c4b5250286b4c55684257971851f5ece9161dc7dd";
     };
     propagatedBuildInputs = [ pkgs.openssl IPCRun3 ];
@@ -644,9 +681,10 @@ let
   };
 
   AuthenPassphrase = buildPerlModule rec {
-    name = "Authen-Passphrase-0.008";
+    pname = "Authen-Passphrase";
+    version = "0.008";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Z/ZE/ZEFRAM/${name}.tar.gz";
+      url = mirror://cpan/authors/id/Z/ZE/ZEFRAM/Authen-Passphrase-0.008.tar.gz;
       sha256 = "55db4520617d859d88c0ee54965da815b7226d792b8cdc8debf92073559e0463";
     };
     propagatedBuildInputs = [ AuthenDecHpwd CryptDES CryptEksblowfish CryptMySQL CryptPasswdMD5 CryptUnixCryptXS DataEntropy DigestMD4 ModuleRuntime ];
@@ -657,7 +695,8 @@ let
   };
 
   AuthenRadius = buildPerlPackage rec {
-    name = "Authen-Radius-0.29";
+    pname = "Authen-Radius";
+    version = "0.29";
     src = fetchurl {
       url = mirror://cpan/authors/id/P/PO/PORTAONE/Authen-Radius-0.29.tar.gz;
       sha256 = "7fb3425546b2f518e4a07edb3bcb55672454fe8e13bece58de2dc43885afb079";
@@ -671,9 +710,10 @@ let
   };
 
   AuthenSASL = buildPerlPackage rec {
-    name = "Authen-SASL-2.16";
+    pname = "Authen-SASL";
+    version = "2.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GB/GBARR/${name}.tar.gz";
+      url = mirror://cpan/authors/id/G/GB/GBARR/Authen-SASL-2.16.tar.gz;
       sha256 = "02afhlrdq5hh5g8b32fa79fqq5i76qzwfqqvfi9zi57h31szl536";
     };
     propagatedBuildInputs = [ DigestHMAC ];
@@ -684,9 +724,10 @@ let
   };
 
   AuthenSimple = buildPerlPackage rec {
-    name = "Authen-Simple-0.5";
+    pname = "Authen-Simple";
+    version = "0.5";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CH/CHANSEN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/C/CH/CHANSEN/Authen-Simple-0.5.tar.gz;
       sha256 = "02cddab47f8bf1a1cbd4c9bf8d258f6d05111499c33f8315e7244812f72613aa";
     };
     propagatedBuildInputs = [ ClassAccessor ClassDataInheritable CryptPasswdMD5 ParamsValidate ];
@@ -697,7 +738,8 @@ let
   };
 
   AuthenSimplePasswd = buildPerlModule rec {
-     name = "Authen-Simple-Passwd-0.6";
+     pname = "Authen-Simple-Passwd";
+     version = "0.6";
      src = fetchurl {
        url = mirror://cpan/authors/id/C/CH/CHANSEN/Authen-Simple-Passwd-0.6.tar.gz;
        sha256 = "1ckl2ry9r5nb1rcn1ik2l5b5pp1i3g4bmllsmzb0zpwy4lvbqmfg";
@@ -710,7 +752,8 @@ let
   };
 
   autobox = buildPerlPackage rec {
-    name = "autobox-3.0.1";
+    pname = "autobox";
+    version = "3.0.1";
     src = fetchurl {
       url = mirror://cpan/authors/id/C/CH/CHOCOLATE/autobox-v3.0.1.tar.gz;
       sha256 = "c303b7fccfaa1ff4d4c429ab3f15e5ca2a77554ef8c9fc3b8c62ba859e874c98";
@@ -724,9 +767,10 @@ let
   };
 
   Autodia = buildPerlPackage rec {
-    name = "Autodia-2.14";
+    pname = "Autodia";
+    version = "2.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TE/TEEJAY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/T/TE/TEEJAY/Autodia-2.14.tar.gz;
       sha256 = "08pl5y18nsvy8ihfzdsbd8rz6a8al09wqfna07zdjfdyib42b0dc";
     };
     propagatedBuildInputs = [ TemplateToolkit XMLSimple ];
@@ -753,9 +797,10 @@ let
   };
 
   autovivification = buildPerlPackage rec {
-    name = "autovivification-0.18";
+    pname = "autovivification";
+    version = "0.18";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/V/VP/VPIT/${name}.tar.gz";
+      url = mirror://cpan/authors/id/V/VP/VPIT/autovivification-0.18.tar.gz;
       sha256 = "01giacr2sx6b9bgfz6aqw7ndcnf08j8n6kwhm7880a94hmb9g69d";
     };
     meta = {
@@ -781,9 +826,10 @@ let
   };
 
   BFlags = buildPerlPackage rec {
-    name = "B-Flags-0.17";
+    pname = "B-Flags";
+    version = "0.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RU/RURBAN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RU/RURBAN/B-Flags-0.17.tar.gz;
       sha256 = "1chhgkaw2h3qniz71dykynggqp0r6b6mi2f4nh4x3ghm2g89gny1";
     };
     meta = {
@@ -794,9 +840,10 @@ let
   BerkeleyDB = callPackage ../development/perl-modules/BerkeleyDB { };
 
   BHooksEndOfScope = buildPerlPackage rec {
-    name = "B-Hooks-EndOfScope-0.24";
+    pname = "B-Hooks-EndOfScope";
+    version = "0.24";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/E/ET/ETHER/B-Hooks-EndOfScope-0.24.tar.gz;
       sha256 = "1imcqxp23yc80a7p0h56sja9glbrh4qyhgzljqd4g9habpz3vah3";
     };
     propagatedBuildInputs = [ ModuleImplementation SubExporterProgressive ];
@@ -807,7 +854,8 @@ let
   };
 
   BHooksOPCheck = buildPerlPackage {
-    name = "B-Hooks-OP-Check-0.22";
+    pname = "B-Hooks-OP-Check";
+    version = "0.22";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/B-Hooks-OP-Check-0.22.tar.gz;
       sha256 = "1kfdv25gn6yik8jrwik4ajp99gi44s6idcvyyrzhiycyynzd3df7";
@@ -820,9 +868,10 @@ let
   };
 
   bignum = buildPerlPackage rec {
-    name = "bignum-0.51";
+    pname = "bignum";
+    version = "0.51";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PJ/PJACKLAM/${name}.tar.gz";
+      url = mirror://cpan/authors/id/P/PJ/PJACKLAM/bignum-0.51.tar.gz;
       sha256 = "8ac0f6efe0b6f24804690e53908bdc5346613667f1c0590d8cf808ec090e9c47";
     };
     meta = {
@@ -833,7 +882,8 @@ let
   };
 
   BitVector = buildPerlPackage {
-    name = "Bit-Vector-7.4";
+    pname = "Bit-Vector";
+    version = "7.4";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/ST/STBEY/Bit-Vector-7.4.tar.gz;
       sha256 = "09m96p8c0ipgz42li2ywdgy0vxb57mb5nf59j9gw7yzc3xkslv9w";
@@ -842,9 +892,10 @@ let
   };
 
   BKeywords = buildPerlPackage rec {
-    name = "B-Keywords-1.20";
+    pname = "B-Keywords";
+    version = "1.20";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RU/RURBAN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RU/RURBAN/B-Keywords-1.20.tar.gz;
       sha256 = "12jvx5gnypqxal4valkf9lidba9nz7kjk2wvm07q3hkmdqxw1zk0";
     };
     meta = {
@@ -854,9 +905,10 @@ let
   };
 
   boolean = buildPerlPackage rec {
-    name = "boolean-0.46";
+    pname = "boolean";
+    version = "0.46";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IN/INGY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/I/IN/INGY/boolean-0.46.tar.gz;
       sha256 = "95c088085c3e83bf680fe6ce16d8264ec26310490f7d1680e416ea7a118f156a";
     };
     meta = {
@@ -867,9 +919,10 @@ let
   };
 
   BoostGeometryUtils = buildPerlModule rec {
-    name = "Boost-Geometry-Utils-0.15";
+    pname = "Boost-Geometry-Utils";
+    version = "0.15";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AA/AAR/${name}.tar.gz";
+      url = mirror://cpan/authors/id/A/AA/AAR/Boost-Geometry-Utils-0.15.tar.gz;
       sha256 = "1jnihz3029x51a455nxa0jx2z125x38q3vkkggsgdlrvawzxsm00";
     };
     patches = [
@@ -881,7 +934,8 @@ let
   };
 
   BSDResource = buildPerlPackage rec {
-    name = "BSD-Resource-1.2911";
+    pname = "BSD-Resource";
+    version = "1.2911";
     src = fetchurl {
       url = mirror://cpan/authors/id/J/JH/JHI/BSD-Resource-1.2911.tar.gz;
       sha256 = "0g8c7825ng2m0yz5sy6838rvfdl8j3vm29524wjgf66ccfhgn74x";
@@ -894,7 +948,8 @@ let
   };
 
   BUtils = buildPerlPackage rec {
-     name = "B-Utils-0.27";
+     pname = "B-Utils";
+     version = "0.27";
      src = fetchurl {
        url = mirror://cpan/authors/id/E/ET/ETHER/B-Utils-0.27.tar.gz;
        sha256 = "1spzhmk3z6c4blmra3kn84nq20fira2b3vjg86m0j085lgv56zzr";
@@ -908,7 +963,8 @@ let
   };
 
   BusinessHours = buildPerlPackage rec {
-    name = "Business-Hours-0.13";
+    pname = "Business-Hours";
+    version = "0.13";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BP/BPS/Business-Hours-0.13.tar.gz;
       sha256 = "1hiybixagj3i1hsnfr134jgs9wv4azkwq6kijr9zlkxqzczzw1x8";
@@ -920,9 +976,10 @@ let
   };
 
   BusinessISBN = buildPerlPackage rec {
-    name = "Business-ISBN-3.004";
+    pname = "Business-ISBN";
+    version = "3.004";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BD/BDFOY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/B/BD/BDFOY/Business-ISBN-3.004.tar.gz;
       sha256 = "07l3zfv8hagv37i3clvj5a1zc2jarr5phg80c93ks35zaz6llx9i";
     };
     propagatedBuildInputs = [ BusinessISBNData ];
@@ -933,9 +990,10 @@ let
   };
 
   BusinessISBNData = buildPerlPackage rec {
-    name = "Business-ISBN-Data-20140910.003";
+    pname = "Business-ISBN-Data";
+    version = "20140910.003";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BD/BDFOY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/B/BD/BDFOY/Business-ISBN-Data-20140910.003.tar.gz;
       sha256 = "1jc5jrjwkr6pqga7998zkgw0yrxgb5n1y7lzgddawxibkf608mn7";
     };
     meta = {
@@ -945,9 +1003,10 @@ let
   };
 
   BusinessISMN = buildPerlPackage rec {
-    name = "Business-ISMN-1.201";
+    pname = "Business-ISMN";
+    version = "1.201";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BD/BDFOY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/B/BD/BDFOY/Business-ISMN-1.201.tar.gz;
       sha256 = "1cpcfyaz1fl6fnm076jx2jsphw147wj6aszj2yzqrgsncjhk2cja";
     };
     propagatedBuildInputs = [ TieCycle ];
@@ -958,7 +1017,8 @@ let
   };
 
   BusinessISSN = buildPerlPackage {
-    name = "Business-ISSN-1.003";
+    pname = "Business-ISSN";
+    version = "1.003";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BD/BDFOY/Business-ISSN-1.003.tar.gz;
       sha256 = "1272456c19937a24bc5f9a0db9dc447043591137719ee4dc955a63be544b99d1";
@@ -970,7 +1030,8 @@ let
   };
 
   CacheCache = buildPerlPackage rec {
-    name = "Cache-Cache-1.08";
+    pname = "Cache-Cache";
+    version = "1.08";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RJ/RJBS/Cache-Cache-1.08.tar.gz;
       sha256 = "1s6i670dc3yb6ngvdk48y6szdk5n1f4icdcjv2vi1l2xp9fzviyj";
@@ -980,7 +1041,8 @@ let
   };
 
   CacheFastMmap = buildPerlPackage rec {
-    name = "Cache-FastMmap-1.48";
+    pname = "Cache-FastMmap";
+    version = "1.48";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RO/ROBM/Cache-FastMmap-1.48.tar.gz;
       sha256 = "118y5lxwa092zrii7mcwnqypff7424w1dpgfkg8zlnz7h2mmnd9c";
@@ -988,7 +1050,8 @@ let
   };
 
   CacheMemcached = buildPerlPackage rec {
-    name = "Cache-Memcached-1.30";
+    pname = "Cache-Memcached";
+    version = "1.30";
     src = fetchurl {
       url =
       mirror://cpan/authors/id/D/DO/DORMANDO/Cache-Memcached-1.30.tar.gz;
@@ -998,7 +1061,8 @@ let
   };
 
   CacheMemcachedFast = buildPerlPackage {
-    name = "Cache-Memcached-Fast-0.25";
+    pname = "Cache-Memcached-Fast";
+    version = "0.25";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RA/RAZ/Cache-Memcached-Fast-0.25.tar.gz;
       sha256 = "0ijw5hlzas1aprp3s6wzabch426m1d8cvp1wn9qphrn4jj82aakq";
@@ -1010,7 +1074,8 @@ let
   };
 
   CacheMemory = buildPerlModule {
-    name = "Cache-2.11";
+    pname = "Cache";
+    version = "2.11";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SH/SHLOMIF/Cache-2.11.tar.gz;
       sha256 = "14m513f4g02daklmnvdm7vqh3w3ick65wvmvqnmnc4cqfybdilp1";
@@ -1020,7 +1085,8 @@ let
   };
 
   CacheSimpleTimedExpiry = buildPerlPackage {
-    name = "Cache-Simple-TimedExpiry-0.27";
+    pname = "Cache-Simple-TimedExpiry";
+    version = "0.27";
     src = fetchurl {
       url = mirror://cpan/authors/id/J/JE/JESSE/Cache-Simple-TimedExpiry-0.27.tar.gz;
       sha256 = "4e78b7e4dd231b5571a48cd0ee1b63953f5e34790c9d020e1595a7c7d0abbe49";
@@ -1032,9 +1098,10 @@ let
   };
 
   Cairo = buildPerlPackage rec {
-    name = "Cairo-1.106";
+    pname = "Cairo";
+    version = "1.106";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/X/XA/XAOC/${name}.tar.gz";
+      url = mirror://cpan/authors/id/X/XA/XAOC/Cairo-1.106.tar.gz;
       sha256 = "1i25kks408c54k2zxskvg54l5k3qadzm8n72ffga9jy7ic0h6j76";
     };
     buildInputs = [ pkgs.cairo ];
@@ -1047,9 +1114,10 @@ let
   };
 
   CairoGObject = buildPerlPackage rec {
-    name = "Cairo-GObject-1.004";
+    pname = "Cairo-GObject";
+    version = "1.004";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/X/XA/XAOC/${name}.tar.gz";
+      url = mirror://cpan/authors/id/X/XA/XAOC/Cairo-GObject-1.004.tar.gz;
       sha256 = "1m896j0xdfhldsx8abf10cc16ll1fm9wbav42dpzal9fh07d9f9v";
     };
     buildInputs = [ pkgs.cairo ];
@@ -1061,16 +1129,18 @@ let
   };
 
   cam_pdf = buildPerlModule rec {
-    name = "CAM-PDF-1.60";
+    pname = "CAM-PDF";
+    version = "1.60";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CD/CDOLAN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/C/CD/CDOLAN/CAM-PDF-1.60.tar.gz;
       sha256 = "12dv5ssf3y7yjz9mrrqnfzx8nf4ydk1qijf5fx59495671zzqsp7";
     };
     propagatedBuildInputs = [ CryptRC4 TextPDF ];
   };
 
   capitalization = buildPerlPackage rec {
-     name = "capitalization-0.03";
+     pname = "capitalization";
+     version = "0.03";
      src = fetchurl {
        url = mirror://cpan/authors/id/M/MI/MIYAGAWA/capitalization-0.03.tar.gz;
        sha256 = "0g7fpckydzxsf8mjkfbyj0pv42dzym4hwbizqahnh7wlfbaicdgi";
@@ -1093,7 +1163,8 @@ let
   };
 
   CaptchaReCAPTCHA = buildPerlPackage rec {
-    name = "Captcha-reCaptcha-0.99";
+    pname = "Captcha-reCaptcha";
+    version = "0.99";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SU/SUNNYP/Captcha-reCaptcha-0.99.tar.gz;
       sha256 = "14j3lk6fhfzda5d3d7z6f373ng3fzxazzwpjyziysrhic1v3b4mq";
@@ -1102,9 +1173,10 @@ let
   };
 
   CaptureTiny = buildPerlPackage rec {
-    name = "Capture-Tiny-0.48";
+    pname = "Capture-Tiny";
+    version = "0.48";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DA/DAGOLDEN/Capture-Tiny-0.48.tar.gz;
       sha256 = "069yrikrrb4vqzc3hrkkfj96apsh7q0hg8lhihq97lxshwz128vc";
     };
     meta = {
@@ -1114,9 +1186,10 @@ let
   };
 
   CarpAlways = buildPerlPackage rec {
-    name = "Carp-Always-0.16";
+    pname = "Carp-Always";
+    version = "0.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FE/FERREIRA/${name}.tar.gz";
+      url = mirror://cpan/authors/id/F/FE/FERREIRA/Carp-Always-0.16.tar.gz;
       sha256 = "1wb6b0qjga7kvn4p8df6k4g1pl2yzaqiln1713xidh3i454i3alq";
     };
     meta = {
@@ -1127,7 +1200,8 @@ let
   };
 
   CarpAssert = buildPerlPackage {
-    name = "Carp-Assert-0.21";
+    pname = "Carp-Assert";
+    version = "0.21";
     src = fetchurl {
       url = mirror://cpan/authors/id/N/NE/NEILB/Carp-Assert-0.21.tar.gz;
       sha256 = "0km5fc6r6whxh6h5yd7g1j0bi96sgk0gkda6cardicrw9qmqwkwj";
@@ -1137,7 +1211,8 @@ let
   };
 
   CarpAssertMore = buildPerlPackage {
-    name = "Carp-Assert-More-1.16";
+    pname = "Carp-Assert-More";
+    version = "1.16";
     src = fetchurl {
       url = mirror://cpan/authors/id/P/PE/PETDANCE/Carp-Assert-More-1.16.tar.gz;
       sha256 = "1x9jd6s3lq97na6gz7g0zaq62l8z297xsfpdj2v42p3ijpfirl4f";
@@ -1150,7 +1225,8 @@ let
   };
 
   CarpClan = buildPerlPackage {
-    name = "Carp-Clan-6.07";
+    pname = "Carp-Clan";
+    version = "6.07";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/Carp-Clan-6.07.tar.gz;
       sha256 = "0gaa4ygd9q8lp2fn5d9s7miiwxz92a2lqs7j6smwmifq6w3mc20a";
@@ -1162,9 +1238,10 @@ let
   };
 
   CatalystActionRenderView = buildPerlPackage rec {
-    name = "Catalyst-Action-RenderView-0.16";
+    pname = "Catalyst-Action-RenderView";
+    version = "0.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BO/BOBTFISH/${name}.tar.gz";
+      url = mirror://cpan/authors/id/B/BO/BOBTFISH/Catalyst-Action-RenderView-0.16.tar.gz;
       sha256 = "8565203950a057d43ecd64e9593715d565c2fbd8b02c91f43c53b2111acd3948";
     };
     propagatedBuildInputs = [ CatalystRuntime DataVisitor ];
@@ -1176,7 +1253,8 @@ let
   };
 
   CatalystActionREST = buildPerlPackage rec {
-    name = "Catalyst-Action-REST-1.21";
+    pname = "Catalyst-Action-REST";
+    version = "1.21";
     src = fetchurl {
       url = mirror://cpan/authors/id/J/JJ/JJNAPIORK/Catalyst-Action-REST-1.21.tar.gz;
       sha256 = "ccf81bba5200d3a0ad6901f923af173a3d4416618aea08a6938baaffdef4cb20";
@@ -1190,7 +1268,8 @@ let
   };
 
   CatalystAuthenticationCredentialHTTP = buildPerlModule {
-    name = "Catalyst-Authentication-Credential-HTTP-1.018";
+    pname = "Catalyst-Authentication-Credential-HTTP";
+    version = "1.018";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/Catalyst-Authentication-Credential-HTTP-1.018.tar.gz;
       sha256 = "0ad5clfiyllnf37an99n139cxhhxf5g5rh8cxashsjv4xrnq38bg";
@@ -1204,7 +1283,8 @@ let
   };
 
   CatalystAuthenticationStoreHtpasswd = buildPerlModule rec {
-    name = "Catalyst-Authentication-Store-Htpasswd-1.006";
+    pname = "Catalyst-Authentication-Store-Htpasswd";
+    version = "1.006";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/Catalyst-Authentication-Store-Htpasswd-1.006.tar.gz;
       sha256 = "0kw0w2g1qmym896bgnqr1bfhvgb6xja39mv10701ipp8fmi8bzf7";
@@ -1214,7 +1294,8 @@ let
   };
 
   CatalystAuthenticationStoreDBIxClass = buildPerlPackage {
-    name = "Catalyst-Authentication-Store-DBIx-Class-0.1506";
+    pname = "Catalyst-Authentication-Store-DBIx-Class";
+    version = "0.1506";
     src = fetchurl {
       url = mirror://cpan/authors/id/I/IL/ILMARI/Catalyst-Authentication-Store-DBIx-Class-0.1506.tar.gz;
       sha256 = "0i5ja7690fs9nhxcij6lw51j804sm8s06m5mvk1n8pi8jljrymvw";
@@ -1228,9 +1309,10 @@ let
   };
 
   CatalystComponentInstancePerContext = buildPerlPackage rec {
-    name = "Catalyst-Component-InstancePerContext-0.001001";
+    pname = "Catalyst-Component-InstancePerContext";
+    version = "0.001001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GR/GRODITI/${name}.tar.gz";
+      url = mirror://cpan/authors/id/G/GR/GRODITI/Catalyst-Component-InstancePerContext-0.001001.tar.gz;
       sha256 = "7f63f930e1e613f15955c9e6d73873675c50c0a3bc2a61a034733361ed26d271";
     };
     propagatedBuildInputs = [ CatalystRuntime ];
@@ -1241,7 +1323,8 @@ let
   };
 
   CatalystControllerHTMLFormFu = buildPerlPackage rec {
-    name = "Catalyst-Controller-HTML-FormFu-2.04";
+    pname = "Catalyst-Controller-HTML-FormFu";
+    version = "2.04";
     src = fetchurl {
       url = mirror://cpan/authors/id/N/NI/NIGELM/Catalyst-Controller-HTML-FormFu-2.04.tar.gz;
       sha256 = "f13fb9b3b3b00b35f06abc31614461c8d7346fbe07fb569c71e8d586e5eb5ddc";
@@ -1256,9 +1339,10 @@ let
   };
 
   CatalystControllerPOD = buildPerlModule rec {
-    name = "Catalyst-Controller-POD-1.0.0";
+    pname = "Catalyst-Controller-POD";
+    version = "1.0.0";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PERLER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/P/PE/PERLER/Catalyst-Controller-POD-1.0.0.tar.gz;
       sha256 = "ee2a4bb3ed78baa1464335408f284345b6ba0ef6576ad7bfbd7b656c788a39f9";
     };
     buildInputs = [ ModuleInstall TestLongString TestWWWMechanize TestWWWMechanizeCatalyst ];
@@ -1270,9 +1354,10 @@ let
   };
 
   CatalystDevel = buildPerlPackage rec {
-    name = "Catalyst-Devel-1.39";
+    pname = "Catalyst-Devel";
+    version = "1.39";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IL/ILMARI/${name}.tar.gz";
+      url = mirror://cpan/authors/id/I/IL/ILMARI/Catalyst-Devel-1.39.tar.gz;
       sha256 = "bce371ba801c7d79eff3257e0af907cf62f140de968f0d63bf55be37d702a58a";
     };
     buildInputs = [ TestFatal ];
@@ -1285,9 +1370,10 @@ let
   };
 
   CatalystDispatchTypeRegex = buildPerlModule rec {
-    name = "Catalyst-DispatchType-Regex-5.90035";
+    pname = "Catalyst-DispatchType-Regex";
+    version = "5.90035";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MG/MGRIMES/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MG/MGRIMES/Catalyst-DispatchType-Regex-5.90035.tar.gz;
       sha256 = "06jq1lmpq88rmp9zik5gqczg234xac0hiyc3l698iif7zsgcyb80";
     };
     propagatedBuildInputs = [ CatalystRuntime ];
@@ -1311,7 +1397,8 @@ let
   };
 
   CatalystModelDBICSchema = buildPerlPackage {
-    name = "Catalyst-Model-DBIC-Schema-0.65";
+    pname = "Catalyst-Model-DBIC-Schema";
+    version = "0.65";
     src = fetchurl {
       url = mirror://cpan/authors/id/G/GB/GBJK/Catalyst-Model-DBIC-Schema-0.65.tar.gz;
       sha256 = "26a911ef5ef7ffc81b6ce65c3156f71fb35083c456ad27e6d82d2dc02493eeea";
@@ -1325,7 +1412,8 @@ let
   };
 
   CatalystRuntime = buildPerlPackage rec {
-    name = "Catalyst-Runtime-5.90124";
+    pname = "Catalyst-Runtime";
+    version = "5.90124";
     src = fetchurl {
       url = mirror://cpan/authors/id/J/JJ/JJNAPIORK/Catalyst-Runtime-5.90124.tar.gz;
       sha256 = "2a60cbe7c1f6fec25f0e7fd3f66273386d73edb625748cc0d8c4f20e62983e00";
@@ -1340,9 +1428,10 @@ let
   };
 
   CatalystPluginAccessLog = buildPerlPackage rec {
-    name = "Catalyst-Plugin-AccessLog-1.10";
+    pname = "Catalyst-Plugin-AccessLog";
+    version = "1.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AR/ARODLAND/${name}.tar.gz";
+      url = mirror://cpan/authors/id/A/AR/ARODLAND/Catalyst-Plugin-AccessLog-1.10.tar.gz;
       sha256 = "873db8e4e72a994e3e17aeb53d2b837e6d524b4b8b0f3539f262135c88cc2120";
     };
     propagatedBuildInputs = [ CatalystRuntime DateTime ];
@@ -1353,9 +1442,10 @@ let
   };
 
   CatalystPluginAuthentication = buildPerlPackage rec {
-    name = "Catalyst-Plugin-Authentication-0.10023";
+    pname = "Catalyst-Plugin-Authentication";
+    version = "0.10023";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BO/BOBTFISH/${name}.tar.gz";
+      url = mirror://cpan/authors/id/B/BO/BOBTFISH/Catalyst-Plugin-Authentication-0.10023.tar.gz;
       sha256 = "0v6hb4r1wv3djrnqvnjcn3xx1scgqzx8nyjdg9lfc1ybvamrl0rn";
     };
     buildInputs = [ TestException ];
@@ -1367,9 +1457,10 @@ let
   };
 
   CatalystPluginAuthorizationACL = buildPerlPackage rec {
-    name = "Catalyst-Plugin-Authorization-ACL-0.16";
+    pname = "Catalyst-Plugin-Authorization-ACL";
+    version = "0.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RK/RKITOVER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RK/RKITOVER/Catalyst-Plugin-Authorization-ACL-0.16.tar.gz;
       sha256 = "0z4328rr6l9xi45hyv6q9pwwamp0864q6skcp29jrz9f919ycdra";
     };
     propagatedBuildInputs = [ CatalystRuntime ClassThrowable ];
@@ -1377,7 +1468,8 @@ let
   };
 
   CatalystPluginAuthorizationRoles = buildPerlPackage {
-    name = "Catalyst-Plugin-Authorization-Roles-0.09";
+    pname = "Catalyst-Plugin-Authorization-Roles";
+    version = "0.09";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BO/BOBTFISH/Catalyst-Plugin-Authorization-Roles-0.09.tar.gz;
       sha256 = "0l83lkwmq0lngwh8b1rv3r719pn8w1gdbyhjqm74rnd0wbjl8h7f";
@@ -1391,7 +1483,8 @@ let
   };
 
   CatalystPluginCache = buildPerlPackage {
-    name = "Catalyst-Plugin-Cache-0.12";
+    pname = "Catalyst-Plugin-Cache";
+    version = "0.12";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BO/BOBTFISH/Catalyst-Plugin-Cache-0.12.tar.gz;
       sha256 = "1q23aipvrl888h06ldr4mmjbykz0j4rqwipxg1jv094kki2fspr9";
@@ -1405,7 +1498,8 @@ let
   };
 
   CatalystPluginCacheHTTP = buildPerlPackage {
-    name = "Catalyst-Plugin-Cache-HTTP-0.001000";
+    pname = "Catalyst-Plugin-Cache-HTTP";
+    version = "0.001000";
     src = fetchurl {
       url = mirror://cpan/authors/id/G/GR/GRAF/Catalyst-Plugin-Cache-HTTP-0.001000.tar.gz;
       sha256 = "0v5iphbq4csc4r6wkvxnqlh97p8g0yhjky9qqmsdyqczn87agbba";
@@ -1419,7 +1513,8 @@ let
   };
 
   CatalystPluginCaptcha = buildPerlPackage {
-    name = "Catalyst-Plugin-Captcha-0.04";
+    pname = "Catalyst-Plugin-Captcha";
+    version = "0.04";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DI/DIEGOK/Catalyst-Plugin-Captcha-0.04.tar.gz;
       sha256 = "0llyj3v5nx9cx46jdbbvxf1lc9s9cxq5ml22xmx3wkb201r5qgaa";
@@ -1431,18 +1526,20 @@ let
   };
 
   CatalystPluginConfigLoader = buildPerlPackage rec {
-    name = "Catalyst-Plugin-ConfigLoader-0.34";
+    pname = "Catalyst-Plugin-ConfigLoader";
+    version = "0.34";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BO/BOBTFISH/${name}.tar.gz";
+      url = mirror://cpan/authors/id/B/BO/BOBTFISH/Catalyst-Plugin-ConfigLoader-0.34.tar.gz;
       sha256 = "19j7p4v7mbx6wrmpvmrnd974apx7hdl2s095ga3b9zcbdrl77h5q";
     };
     propagatedBuildInputs = [ CatalystRuntime ConfigAny DataVisitor ];
   };
 
   CatalystPluginFormValidator = buildPerlPackage rec {
-    name = "Catalyst-Plugin-FormValidator-0.094";
+    pname = "Catalyst-Plugin-FormValidator";
+    version = "0.094";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DH/DHOSS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DH/DHOSS/Catalyst-Plugin-FormValidator-0.094.tar.gz;
       sha256 = "5834f11bf5c9f4b5d336d65c7ce6639b76ce7bfe7a2875eb048d7ea1c82ce05a";
     };
     propagatedBuildInputs = [ CatalystRuntime DataFormValidator ];
@@ -1453,9 +1550,10 @@ let
   };
 
   CatalystPluginFormValidatorSimple = buildPerlPackage rec {
-    name = "Catalyst-Plugin-FormValidator-Simple-0.15";
+    pname = "Catalyst-Plugin-FormValidator-Simple";
+    version = "0.15";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DH/DHOSS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DH/DHOSS/Catalyst-Plugin-FormValidator-Simple-0.15.tar.gz;
       sha256 = "486c6a0e8f410fd017279f4804ab9e35ba46321d33a0a9721fe1e08a391de7a0";
     };
     propagatedBuildInputs = [ CatalystPluginFormValidator FormValidatorSimple ];
@@ -1465,9 +1563,10 @@ let
   };
 
   CatalystPluginLogHandler = buildPerlModule rec {
-    name = "Catalyst-Plugin-Log-Handler-0.08";
+    pname = "Catalyst-Plugin-Log-Handler";
+    version = "0.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEPE/${name}.tar.gz";
+      url = mirror://cpan/authors/id/P/PE/PEPE/Catalyst-Plugin-Log-Handler-0.08.tar.gz;
       sha256 = "0db3c3a57b4ee3d789ba5129890e2858913fef00d8185bdc9c5d7fde31e043ef";
     };
     propagatedBuildInputs = [ ClassAccessor LogHandler MROCompat ];
@@ -1478,9 +1577,10 @@ let
   };
 
   CatalystPluginSession = buildPerlPackage rec {
-    name = "Catalyst-Plugin-Session-0.41";
+    pname = "Catalyst-Plugin-Session";
+    version = "0.41";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JJ/JJNAPIORK/${name}.tar.gz";
+      url = mirror://cpan/authors/id/J/JJ/JJNAPIORK/Catalyst-Plugin-Session-0.41.tar.gz;
       sha256 = "0a451997zc2vjx7rvndgx1ldbrpic8sfbddyvncynh0zr8bhlqc5";
     };
     buildInputs = [ TestDeep TestException TestWWWMechanizePSGI ];
@@ -1492,9 +1592,10 @@ let
   };
 
   CatalystPluginSessionDynamicExpiry = buildPerlPackage rec {
-    name = "Catalyst-Plugin-Session-DynamicExpiry-0.04";
+    pname = "Catalyst-Plugin-Session-DynamicExpiry";
+    version = "0.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BO/BOBTFISH/${name}.tar.gz";
+      url = mirror://cpan/authors/id/B/BO/BOBTFISH/Catalyst-Plugin-Session-DynamicExpiry-0.04.tar.gz;
       sha256 = "7707c56734cdb1512f733dc400fadf6f4c53cb217b58207857824dad6780a079";
     };
     propagatedBuildInputs = [ CatalystPluginSession ];
@@ -1505,16 +1606,18 @@ let
   };
 
   CatalystPluginSessionStateCookie = buildPerlPackage rec {
-    name = "Catalyst-Plugin-Session-State-Cookie-0.17";
+    pname = "Catalyst-Plugin-Session-State-Cookie";
+    version = "0.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MS/MSTROUT/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MS/MSTROUT/Catalyst-Plugin-Session-State-Cookie-0.17.tar.gz;
       sha256 = "1rvxbfnpf9x2pc2zgpazlcgdlr2dijmxgmcs0m5nazs0w6xikssb";
     };
     propagatedBuildInputs = [ CatalystPluginSession ];
   };
 
   CatalystPluginSessionStoreFastMmap = buildPerlPackage rec {
-    name = "Catalyst-Plugin-Session-Store-FastMmap-0.16";
+    pname = "Catalyst-Plugin-Session-Store-FastMmap";
+    version = "0.16";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BO/BOBTFISH/Catalyst-Plugin-Session-Store-FastMmap-0.16.tar.gz;
       sha256 = "0x3j6zv3wr41jlwr6yb2jpmcx019ibyn11y8653ffnwhpzbpzsxs";
@@ -1523,9 +1626,10 @@ let
   };
 
   CatalystPluginSessionStoreFile = buildPerlPackage rec {
-    name = "Catalyst-Plugin-Session-Store-File-0.18";
+    pname = "Catalyst-Plugin-Session-Store-File";
+    version = "0.18";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FL/FLORA/${name}.tar.gz";
+      url = mirror://cpan/authors/id/F/FL/FLORA/Catalyst-Plugin-Session-Store-File-0.18.tar.gz;
       sha256 = "54738e3ce76f8be8b66947092d28973c73d79d1ee19b5d92b057552f8ff09b4f";
     };
     propagatedBuildInputs = [ CacheCache CatalystPluginSession ClassDataInheritable ];
@@ -1536,7 +1640,8 @@ let
   };
 
   CatalystPluginStackTrace = buildPerlPackage {
-    name = "Catalyst-Plugin-StackTrace-0.12";
+    pname = "Catalyst-Plugin-StackTrace";
+    version = "0.12";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BO/BOBTFISH/Catalyst-Plugin-StackTrace-0.12.tar.gz;
       sha256 = "1b2ksz74cpigxqzf63rddar3vfmnbpwpdcbs11v0ml89pb8ar79j";
@@ -1549,7 +1654,8 @@ let
   };
 
   CatalystPluginStaticSimple = buildPerlPackage rec {
-    name = "Catalyst-Plugin-Static-Simple-0.36";
+    pname = "Catalyst-Plugin-Static-Simple";
+    version = "0.36";
     src = fetchurl {
       url = mirror://cpan/authors/id/I/IL/ILMARI/Catalyst-Plugin-Static-Simple-0.36.tar.gz;
       sha256 = "0m4l627p2fvzr4i6sgdxhdvsx4wpa6qmaibsbxlg5x5yjs7k7drn";
@@ -1563,9 +1669,10 @@ let
   };
 
   CatalystPluginStatusMessage = buildPerlPackage rec {
-    name = "Catalyst-Plugin-StatusMessage-1.002000";
+    pname = "Catalyst-Plugin-StatusMessage";
+    version = "1.002000";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HK/HKCLARK/${name}.tar.gz";
+      url = mirror://cpan/authors/id/H/HK/HKCLARK/Catalyst-Plugin-StatusMessage-1.002000.tar.gz;
       sha256 = "649c894ab16f9f48ada8f9cc599a7ecbb8891ab3761ff6fd510520c6de407c1f";
     };
     propagatedBuildInputs = [ CatalystRuntime strictures ];
@@ -1576,9 +1683,10 @@ let
   };
 
   CatalystViewCSV = buildPerlPackage rec {
-    name = "Catalyst-View-CSV-1.7";
+    pname = "Catalyst-View-CSV";
+    version = "1.7";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MC/MCB/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MC/MCB/Catalyst-View-CSV-1.7.tar.gz;
       sha256 = "e41326b6099891f244b432921ed10096ac619f32b8c4f8b41633313bd54662db";
     };
     buildInputs = [ CatalystActionRenderView CatalystModelDBICSchema CatalystPluginConfigLoader CatalystXComponentTraits ConfigGeneral DBDSQLite DBIxClass TestException ];
@@ -1590,9 +1698,10 @@ let
   };
 
   CatalystViewDownload = buildPerlPackage rec {
-    name = "Catalyst-View-Download-0.09";
+    pname = "Catalyst-View-Download";
+    version = "0.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GA/GAUDEON/${name}.tar.gz";
+      url = mirror://cpan/authors/id/G/GA/GAUDEON/Catalyst-View-Download-0.09.tar.gz;
       sha256 = "1qgq6y9iwfbhbkbgpw9czang2ami6z8jk1zlagrzdisy4igqzkvs";
     };
     buildInputs = [ CatalystRuntime TestLongString TestSimple13 TestWWWMechanize TestWWWMechanizeCatalyst TextCSV XMLSimple ];
@@ -1616,9 +1725,10 @@ let
   };
 
   CatalystViewTT = buildPerlPackage rec {
-    name = "Catalyst-View-TT-0.44";
+    pname = "Catalyst-View-TT";
+    version = "0.44";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/E/ET/ETHER/Catalyst-View-TT-0.44.tar.gz;
       sha256 = "06d1zg4nbb6kcyjbnyxrkf8z4zlscxr8650d94f7187jygfl8rvh";
     };
     propagatedBuildInputs = [ CatalystRuntime ClassAccessor TemplateTimer ];
@@ -1629,25 +1739,28 @@ let
   };
 
   CatalystXComponentTraits = buildPerlPackage rec {
-    name = "CatalystX-Component-Traits-0.19";
+    pname = "CatalystX-Component-Traits";
+    version = "0.19";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RK/RKITOVER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RK/RKITOVER/CatalystX-Component-Traits-0.19.tar.gz;
       sha256 = "0iq4ci8m6g2c4g01fvdl568y7pjz28f3widk986v3pyhr7ll8j88";
     };
     propagatedBuildInputs = [ CatalystRuntime MooseXTraitsPluggable ];
   };
 
   CatalystXRoleApplicator = buildPerlPackage rec {
-    name = "CatalystX-RoleApplicator-0.005";
+    pname = "CatalystX-RoleApplicator";
+    version = "0.005";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HD/HDP/${name}.tar.gz";
+      url = mirror://cpan/authors/id/H/HD/HDP/CatalystX-RoleApplicator-0.005.tar.gz;
       sha256 = "0vwaapxn8g5hs2xp63c4dwv9jmapmji4272fakssvgc9frklg3p2";
     };
     propagatedBuildInputs = [ CatalystRuntime MooseXRelatedClassRoles ];
   };
 
   CatalystTraitForRequestProxyBase = buildPerlPackage {
-    name = "Catalyst-TraitFor-Request-ProxyBase-0.000005";
+    pname = "Catalyst-TraitFor-Request-ProxyBase";
+    version = "0.000005";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BO/BOBTFISH/Catalyst-TraitFor-Request-ProxyBase-0.000005.tar.gz;
       sha256 = "a7bf0faa7e12ca5df625d9f5fc710f11bfd16ba5385837e48d42b3d286c9710a";
@@ -1661,7 +1774,8 @@ let
   };
 
   CatalystXScriptServerStarman = buildPerlPackage {
-    name = "CatalystX-Script-Server-Starman-0.03";
+    pname = "CatalystX-Script-Server-Starman";
+    version = "0.03";
     src = fetchurl {
       url = mirror://cpan/authors/id/A/AB/ABRAXXA/CatalystX-Script-Server-Starman-0.03.tar.gz;
       sha256 = "08jvibq4v8xjj0c3cr93h0w8w0c88ajwjn37xjy7ygxl9krlffp6";
@@ -1679,9 +1793,10 @@ let
   };
 
   CDDB_get = buildPerlPackage rec {
-    name = "CDDB_get-2.28";
+    pname = "CDDB_get";
+    version = "2.28";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FO/FONKIE/${name}.tar.gz";
+      url = mirror://cpan/authors/id/F/FO/FONKIE/CDDB_get-2.28.tar.gz;
       sha256 = "1jfrwvfasylcafbvb0jjm94ad4v6k99a7rf5i4qwzhg4m0gvmk5x";
     };
     meta = {
@@ -1707,7 +1822,8 @@ let
   };
 
   CGICompile = buildPerlModule rec {
-     name = "CGI-Compile-0.22";
+     pname = "CGI-Compile";
+     version = "0.22";
      src = fetchurl {
        url = mirror://cpan/authors/id/M/MI/MIYAGAWA/CGI-Compile-0.22.tar.gz;
        sha256 = "1bycbdgbsn88kavy0q8p2i7vn6lf3xk1y7v2rdl32gkrdff4w2gm";
@@ -1722,15 +1838,17 @@ let
   };
 
   CGICookieXS = buildPerlPackage rec {
-    name = "CGI-Cookie-XS-0.18";
+    pname = "CGI-Cookie-XS";
+    version = "0.18";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AG/AGENT/${name}.tar.gz";
+      url = mirror://cpan/authors/id/A/AG/AGENT/CGI-Cookie-XS-0.18.tar.gz;
       sha256 = "1iixvnm0l1q24vdlnayb4vd8fns2bdlhm6zb7fpi884ppm5cp6a6";
     };
   };
 
   CGIEmulatePSGI = buildPerlPackage {
-    name = "CGI-Emulate-PSGI-0.23";
+    pname = "CGI-Emulate-PSGI";
+    version = "0.23";
     src = fetchurl {
       url = mirror://cpan/authors/id/T/TO/TOKUHIROM/CGI-Emulate-PSGI-0.23.tar.gz;
       sha256 = "dd5b6c353f08fba100dae09904284f7f73f8328d31f6a67b2c136fad728d158b";
@@ -1745,7 +1863,8 @@ let
   };
 
   CGIExpand = buildPerlPackage {
-    name = "CGI-Expand-2.05";
+    pname = "CGI-Expand";
+    version = "2.05";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BO/BOWMANBS/CGI-Expand-2.05.tar.gz;
       sha256 = "1ad48nd067j5irjampxpw3zvzpg8wpnpan6szkdc5h64wccd30kf";
@@ -1757,7 +1876,8 @@ let
   };
 
   CGIFast = buildPerlPackage {
-    name = "CGI-Fast-2.15";
+    pname = "CGI-Fast";
+    version = "2.15";
     src = fetchurl {
       url = mirror://cpan/authors/id/L/LE/LEEJO/CGI-Fast-2.15.tar.gz;
       sha256 = "e5342df3dc593edfb724c7afe850b1a0ee753f4d733f5193e037b04633dfeece";
@@ -1770,7 +1890,8 @@ let
   };
 
   CGIFormBuilder = buildPerlPackage rec {
-    name = "CGI-FormBuilder-3.10";
+    pname = "CGI-FormBuilder";
+    version = "3.10";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BI/BIGPRESH/CGI-FormBuilder-3.10.tar.gz;
       sha256 = "163ixq9kninqq094z2rnkg9pv3bcmvjphlww4vksfrzhq3h9pjdf";
@@ -1780,9 +1901,10 @@ let
   };
 
   CGIMinimal = buildPerlModule rec {
-    name = "CGI-Minimal-1.29";
+    pname = "CGI-Minimal";
+    version = "1.29";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SN/SNOWHARE/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SN/SNOWHARE/CGI-Minimal-1.29.tar.gz;
       sha256 = "36c785ffacf5cdee4f1a7219ca1848b7e1700bdd71cd9116e1f00545ec88475d";
     };
     meta = {
@@ -1792,7 +1914,8 @@ let
   };
 
   CGIPSGI = buildPerlPackage {
-    name = "CGI-PSGI-0.15";
+    pname = "CGI-PSGI";
+    version = "0.15";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MI/MIYAGAWA/CGI-PSGI-0.15.tar.gz;
       sha256 = "c50dcb10bf8486a9843baed032ad89d879ff2f41c993342dead62f947a598d91";
@@ -1805,16 +1928,18 @@ let
   };
 
   CGISession = buildPerlModule rec {
-    name = "CGI-Session-4.48";
+    pname = "CGI-Session";
+    version = "4.48";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MARKSTOS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MA/MARKSTOS/CGI-Session-4.48.tar.gz;
       sha256 = "1xsl2pz1jrh127pq0b01yffnj4mnp9nvkp88h5mndrscq9hn8xa6";
     };
     propagatedBuildInputs = [ CGI ];
   };
 
   CGISimple = buildPerlModule rec {
-    name = "CGI-Simple-1.21";
+    pname = "CGI-Simple";
+    version = "1.21";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MA/MANWAR/CGI-Simple-1.21.tar.gz;
       sha256 = "1wzc2igs4khmj7zfahvs87c24p9ks8hnqhhsyviyiix53xx2y6sg";
@@ -1828,7 +1953,8 @@ let
   };
 
   CGIStruct = buildPerlPackage {
-    name = "CGI-Struct-1.21";
+    pname = "CGI-Struct";
+    version = "1.21";
     src = fetchurl {
       url = mirror://cpan/authors/id/F/FU/FULLERMD/CGI-Struct-1.21.tar.gz;
       sha256 = "d13d8da7fdcd6d906054e4760fc28a718aec91bd3cf067a58927fb7cb1c09d6c";
@@ -1841,9 +1967,10 @@ let
   };
 
   CHI = buildPerlPackage rec {
-    name = "CHI-0.60";
+    pname = "CHI";
+    version = "0.60";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JS/JSWARTZ/${name}.tar.gz";
+      url = mirror://cpan/authors/id/J/JS/JSWARTZ/CHI-0.60.tar.gz;
       sha256 = "c7f1a2b3570a8fede484e933f89ba1729e0abd05935791d146c522dd120ee851";
     };
     preConfigure = ''
@@ -1859,7 +1986,8 @@ let
   };
 
   Chart = buildPerlPackage rec {
-    name = "Chart-2.4.10";
+    pname = "Chart";
+    version = "2.4.10";
     src = fetchurl {
       url = mirror://cpan/authors/id/C/CH/CHARTGRP/Chart-2.4.10.tar.gz;
       sha256 = "84bd99a1a0ce72477b15e35881e6120398bb3f553aeeb5e8d72b088520e4f6bf";
@@ -1872,7 +2000,8 @@ let
   };
 
   ClassAccessor = buildPerlPackage {
-    name = "Class-Accessor-0.51";
+    pname = "Class-Accessor";
+    version = "0.51";
     src = fetchurl {
       url = mirror://cpan/authors/id/K/KA/KASEI/Class-Accessor-0.51.tar.gz;
       sha256 = "07215zzr4ydf49832vn54i3gf2q5b97lydkv8j56wb2svvjs64mz";
@@ -1883,7 +2012,8 @@ let
   };
 
   ClassAccessorChained = buildPerlModule {
-    name = "Class-Accessor-Chained-0.01";
+    pname = "Class-Accessor-Chained";
+    version = "0.01";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RC/RCLAMP/Class-Accessor-Chained-0.01.tar.gz;
       sha256 = "1lilrjy1s0q5hyr0888kf0ifxjyl2iyk4vxil4jsv0sgh39lkgx5";
@@ -1892,7 +2022,8 @@ let
   };
 
   ClassAccessorGrouped = buildPerlPackage {
-    name = "Class-Accessor-Grouped-0.10014";
+    pname = "Class-Accessor-Grouped";
+    version = "0.10014";
     src = fetchurl {
       url = mirror://cpan/authors/id/H/HA/HAARG/Class-Accessor-Grouped-0.10014.tar.gz;
       sha256 = "35d5b03efc09f67f3a3155c9624126c3e162c8e3ca98ff826db358533a44c4bb";
@@ -1906,7 +2037,8 @@ let
   };
 
   ClassAccessorLite = buildPerlPackage {
-    name = "Class-Accessor-Lite-0.08";
+    pname = "Class-Accessor-Lite";
+    version = "0.08";
     src = fetchurl {
       url = mirror://cpan/authors/id/K/KA/KAZUHO/Class-Accessor-Lite-0.08.tar.gz;
       sha256 = "75b3b8ec8efe687677b63f0a10eef966e01f60735c56656ce75cbb44caba335a";
@@ -1918,9 +2050,10 @@ let
   };
 
   ClassAutouse = buildPerlPackage rec {
-    name = "Class-Autouse-2.01";
+    pname = "Class-Autouse";
+    version = "2.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AD/ADAMK/${name}.tar.gz";
+      url = mirror://cpan/authors/id/A/AD/ADAMK/Class-Autouse-2.01.tar.gz;
       sha256 = "c05b3236c05719d819c20db0fdeb6d0954747e43d7a738294eed7fbcf36ecf1b";
     };
     meta = {
@@ -1930,7 +2063,8 @@ let
   };
 
   ClassBase = buildPerlPackage rec {
-    name = "Class-Base-0.09";
+    pname = "Class-Base";
+    version = "0.09";
     src = fetchurl {
       url = mirror://cpan/authors/id/Y/YA/YANICK/Class-Base-0.09.tar.gz;
       sha256 = "117dmsrb30a09zlrv919fb5h5rg8r4asa24i99k04n2habgbv9g1";
@@ -1939,9 +2073,10 @@ let
   };
 
   ClassC3 = buildPerlPackage rec {
-    name = "Class-C3-0.34";
+    pname = "Class-C3";
+    version = "0.34";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/${name}.tar.gz";
+      url = mirror://cpan/authors/id/H/HA/HAARG/Class-C3-0.34.tar.gz;
       sha256 = "1dcibc31v5jwmi6hsdzi7c5ag1sb4wp3kxkibc889qrdj7jm12sd";
     };
     propagatedBuildInputs = [ AlgorithmC3 ];
@@ -1952,9 +2087,10 @@ let
   };
 
   ClassC3AdoptNEXT = buildPerlModule rec {
-    name = "Class-C3-Adopt-NEXT-0.14";
+    pname = "Class-C3-Adopt-NEXT";
+    version = "0.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/E/ET/ETHER/Class-C3-Adopt-NEXT-0.14.tar.gz;
       sha256 = "1xsbydmiskpa1qbmnf6n39cb83nlb432xgkad9kfhxnvm8jn4rw5";
     };
     buildInputs = [ ModuleBuildTiny TestException ];
@@ -1966,7 +2102,8 @@ let
   };
 
   ClassC3Componentised = buildPerlPackage {
-    name = "Class-C3-Componentised-1.001002";
+    pname = "Class-C3-Componentised";
+    version = "1.001002";
     src = fetchurl {
       url = mirror://cpan/authors/id/H/HA/HAARG/Class-C3-Componentised-1.001002.tar.gz;
       sha256 = "14wn1g45z3b5apqq7dcai5drk01hfyqydsd2m6hsxzhyvi3b2l9h";
@@ -1979,7 +2116,8 @@ let
   };
 
   ClassClassgenclassgen = buildPerlPackage {
-    name = "Class-Classgen-classgen-3.03";
+    pname = "Class-Classgen-classgen";
+    version = "3.03";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MS/MSCHLUE/Class-Classgen-classgen-3.03.tar.gz;
       sha256 = "9b65d41b991538992e816b32cc4fa9b4a4a0bb3e9c10e7eebeff82658dbbc8f6";
@@ -1987,7 +2125,8 @@ let
   };
 
   ClassContainer = buildPerlModule {
-    name = "Class-Container-0.13";
+    pname = "Class-Container";
+    version = "0.13";
     src = fetchurl {
       url = mirror://cpan/authors/id/K/KW/KWILLIAMS/Class-Container-0.13.tar.gz;
       sha256 = "f5d495b1dfb826d5c0c45d03b4d0e6b6047cbb06cdbf6be15fd4dc902aeeb70b";
@@ -2000,7 +2139,8 @@ let
   };
 
   ClassDataAccessor = buildPerlPackage {
-    name = "Class-Data-Accessor-0.04004";
+    pname = "Class-Data-Accessor";
+    version = "0.04004";
     src = fetchurl {
       url = mirror://cpan/authors/id/C/CL/CLACO/Class-Data-Accessor-0.04004.tar.gz;
       sha256 = "0578m3rplk41059rkkjy1009xrmrdivjnv8yxadwwdk1vzidc8n1";
@@ -2008,7 +2148,8 @@ let
   };
 
   ClassDataInheritable = buildPerlPackage {
-    name = "Class-Data-Inheritable-0.08";
+    pname = "Class-Data-Inheritable";
+    version = "0.08";
     src = fetchurl {
       url = mirror://cpan/authors/id/T/TM/TMTM/Class-Data-Inheritable-0.08.tar.gz;
       sha256 = "0jpi38wy5xh6p1mg2cbyjjw76vgbccqp46685r27w8hmxb7gwrwr";
@@ -2016,9 +2157,10 @@ let
   };
 
   ClassEHierarchy = buildPerlPackage rec {
-    name = "Class-EHierarchy-2.00";
+    pname = "Class-EHierarchy";
+    version = "2.00";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CO/CORLISS/Class-EHierarchy/${name}.tar.gz";
+      url = mirror://cpan/authors/id/C/CO/CORLISS/Class-EHierarchy/Class-EHierarchy-2.00.tar.gz;
       sha256 = "8498baaf7539eaa3422c6fe1055a0fc9a0c02e94dad0c63405373528e622bacb";
     };
     meta = {
@@ -2029,7 +2171,8 @@ let
   };
 
   ClassFactory = buildPerlPackage {
-    name = "Class-Factory-1.06";
+    pname = "Class-Factory";
+    version = "1.06";
     src = fetchurl {
       url = mirror://cpan/authors/id/P/PH/PHRED/Class-Factory-1.06.tar.gz;
       sha256 = "c37a2d269eb935f36a23e113480ae0946fa7c12a12781396a1226c8e435f30f5";
@@ -2037,9 +2180,10 @@ let
   };
 
   ClassFactoryUtil = buildPerlModule rec {
-    name = "Class-Factory-Util-1.7";
+    pname = "Class-Factory-Util";
+    version = "1.7";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DR/DROLSKY/Class-Factory-Util-1.7.tar.gz;
       sha256 = "09ifd6v0c94vr20n9yr1dxgcp7hyscqq851szdip7y24bd26nlbc";
     };
     meta = {
@@ -2049,7 +2193,8 @@ let
   };
 
   ClassInspector = buildPerlPackage {
-    name = "Class-Inspector-1.34";
+    pname = "Class-Inspector";
+    version = "1.34";
     src = fetchurl {
       url = mirror://cpan/authors/id/P/PL/PLICEASE/Class-Inspector-1.34.tar.gz;
       sha256 = "1n7h3jzwdz5a8gmz515xfr7ic82dl5sbdrk5d2fskiycngf8d6py";
@@ -2061,7 +2206,8 @@ let
   };
 
   ClassISA = buildPerlPackage {
-    name = "Class-ISA-0.36";
+    pname = "Class-ISA";
+    version = "0.36";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SM/SMUELLER/Class-ISA-0.36.tar.gz;
       sha256 = "0r5r574i6wgxm8zsq4bc34d0dzprrh6h6mpp1nhlks1qk97g65l8";
@@ -2069,7 +2215,8 @@ let
   };
 
   ClassIterator = buildPerlPackage {
-    name = "Class-Iterator-0.3";
+    pname = "Class-Iterator";
+    version = "0.3";
     src = fetchurl {
       url = mirror://cpan/authors/id/T/TE/TEXMEC/Class-Iterator-0.3.tar.gz;
       sha256 = "db1ba87ca9107f161fe9c1e9e7e267c0026defc26fe3e73bcad8ab8ffc18ef9d";
@@ -2079,9 +2226,10 @@ let
   };
 
   ClassMakeMethods = buildPerlPackage rec {
-    name = "Class-MakeMethods-1.01";
+    pname = "Class-MakeMethods";
+    version = "1.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/EV/EVO/${name}.tar.gz";
+      url = mirror://cpan/authors/id/E/EV/EVO/Class-MakeMethods-1.01.tar.gz;
       sha256 = "0ricb0mn0i06ngfhq5y035yx8i7ahlx83yyqwixqmv6hg4p79b5c";
     };
     preConfigure = ''
@@ -2091,9 +2239,10 @@ let
   };
 
   ClassMethodMaker = buildPerlPackage rec {
-    name = "Class-MethodMaker-2.24";
+    pname = "Class-MethodMaker";
+    version = "2.24";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SC/SCHWIGON/class-methodmaker/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SC/SCHWIGON/class-methodmaker/Class-MethodMaker-2.24.tar.gz;
       sha256 = "0a03i4k3a33qqwhykhz5k437ld5mag2vq52vvsy03gbynb65ivsy";
     };
     # Remove unnecessary, non-autoconf, configure script.
@@ -2105,9 +2254,10 @@ let
   };
 
   ClassMethodModifiers = buildPerlPackage rec {
-    name = "Class-Method-Modifiers-2.12";
+    pname = "Class-Method-Modifiers";
+    version = "2.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/E/ET/ETHER/Class-Method-Modifiers-2.12.tar.gz;
       sha256 = "1j3swa212wh14dq5r6zjarm2lzpx6mrdfplpjy65px8b09ri0k74";
     };
     buildInputs = [ TestFatal TestRequires ];
@@ -2119,9 +2269,10 @@ let
   };
 
   ClassMix = buildPerlModule rec {
-    name = "Class-Mix-0.006";
+    pname = "Class-Mix";
+    version = "0.006";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Z/ZE/ZEFRAM/${name}.tar.gz";
+      url = mirror://cpan/authors/id/Z/ZE/ZEFRAM/Class-Mix-0.006.tar.gz;
       sha256 = "8747f643893914f8c44979f1716d0c1ec8a41394796555447944e860f1ff7c0b";
     };
     propagatedBuildInputs = [ ParamsClassify ];
@@ -2132,9 +2283,10 @@ let
   };
 
   ClassReturnValue = buildPerlPackage rec {
-    name = "Class-ReturnValue-0.55";
+    pname = "Class-ReturnValue";
+    version = "0.55";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JE/JESSE/${name}.tar.gz";
+      url = mirror://cpan/authors/id/J/JE/JESSE/Class-ReturnValue-0.55.tar.gz;
       sha256 = "ed3836885d78f734ccd7a98550ec422a616df7c31310c1b7b1f6459f5fb0e4bd";
     };
     propagatedBuildInputs = [ DevelStackTrace ];
@@ -2145,23 +2297,26 @@ let
   };
 
   ClassSingleton = buildPerlPackage rec {
-    name = "Class-Singleton-1.5";
+    pname = "Class-Singleton";
+    version = "1.5";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHAY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SH/SHAY/Class-Singleton-1.5.tar.gz;
       sha256 = "0y7ngrjf551bjgmijp5rsidbkq6c8hb5lmy2jcqq0fify020s8iq";
     };
   };
 
   ClassThrowable = buildPerlPackage rec {
-    name = "Class-Throwable-0.13";
+    pname = "Class-Throwable";
+    version = "0.13";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KM/KMX/${name}.tar.gz";
+      url = mirror://cpan/authors/id/K/KM/KMX/Class-Throwable-0.13.tar.gz;
       sha256 = "1kmwzdxvp9ca2z44vl0ygkfygdbxqkilzjd8vqhc4vdmvbh136nw";
     };
   };
 
   ClassTiny = buildPerlPackage rec {
-     name = "Class-Tiny-1.006";
+     pname = "Class-Tiny";
+     version = "1.006";
      src = fetchurl {
        url = mirror://cpan/authors/id/D/DA/DAGOLDEN/Class-Tiny-1.006.tar.gz;
        sha256 = "0knbi1agcfc9d7fca0szvxr6335pb22pc5n648q1vrcba8qvvz1f";
@@ -2174,9 +2329,10 @@ let
   };
 
   ClassLoad = buildPerlPackage rec {
-    name = "Class-Load-0.25";
+    pname = "Class-Load";
+    version = "0.25";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/E/ET/ETHER/Class-Load-0.25.tar.gz;
       sha256 = "2a48fa779b5297e56156380e8b32637c6c58decb4f4a7f3c7350523e11275f8f";
     };
     buildInputs = [ TestFatal TestNeeds ];
@@ -2189,9 +2345,10 @@ let
   };
 
   ClassLoadXS = buildPerlPackage rec {
-    name = "Class-Load-XS-0.10";
+    pname = "Class-Load-XS";
+    version = "0.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/E/ET/ETHER/Class-Load-XS-0.10.tar.gz;
       sha256 = "5bc22cf536ebfd2564c5bdaf42f0d8a4cee3d1930fc8b44b7d4a42038622add1";
     };
     buildInputs = [ TestFatal TestNeeds ];
@@ -2204,7 +2361,8 @@ let
   };
 
   ClassObservable = buildPerlPackage {
-    name = "Class-Observable-1.04";
+    pname = "Class-Observable";
+    version = "1.04";
     src = fetchurl {
       url = mirror://cpan/authors/id/C/CW/CWINTERS/Class-Observable-1.04.tar.gz;
       sha256 = "3ef18733a0f03c113f3bcf8ac50476e09ca1fe6234f4aaacaa24dfca95168094";
@@ -2213,7 +2371,8 @@ let
   };
 
   ClassStd = buildPerlModule {
-    name = "Class-Std-0.013";
+    pname = "Class-Std";
+    version = "0.013";
     src = fetchurl {
       url = mirror://cpan/authors/id/C/CH/CHORNY/Class-Std-0.013.tar.gz;
       sha256 = "bcd6d82f6c8af0fe069fced7dd165a4795b0b6e92351c7d4e5a1ab9a14fc35c6";
@@ -2241,9 +2400,10 @@ let
   };
 
   ClassUnload = buildPerlPackage rec {
-    name = "Class-Unload-0.11";
+    pname = "Class-Unload";
+    version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IL/ILMARI/${name}.tar.gz";
+      url = mirror://cpan/authors/id/I/IL/ILMARI/Class-Unload-0.11.tar.gz;
       sha256 = "0pqa98z3ij6a3v9wkmvc8b410kv30y0xxqf0i6if3lp4lx3rgqjj";
     };
     propagatedBuildInputs = [ ClassInspector ];
@@ -2251,9 +2411,10 @@ let
   };
 
   ClassVirtual = buildPerlPackage rec {
-    name = "Class-Virtual-0.08";
+    pname = "Class-Virtual";
+    version = "0.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MS/MSCHWERN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MS/MSCHWERN/Class-Virtual-0.08.tar.gz;
       sha256 = "c6499b42d3b4e5c6488a5e82fbc28698e6c9860165072dddfa6749355a9cfbb2";
     };
     propagatedBuildInputs = [ CarpAssert ClassDataInheritable ClassISA ];
@@ -2264,7 +2425,8 @@ let
   };
 
   ClassXSAccessor = buildPerlPackage {
-    name = "Class-XSAccessor-1.19";
+    pname = "Class-XSAccessor";
+    version = "1.19";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SM/SMUELLER/Class-XSAccessor-1.19.tar.gz;
       sha256 = "1wm6013il899jnm0vn50a7iv9v6r4nqywbqzj0csyf8jbwwnpicr";
@@ -2276,7 +2438,8 @@ let
   };
 
   Clipboard = buildPerlModule {
-    name = "Clipboard-0.20";
+    pname = "Clipboard";
+    version = "0.20";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SH/SHLOMIF/Clipboard-0.20.tar.gz;
       sha256 = "3f7d0a8eafec57072f9574dfd552e1cb8db26c09079c50dbef38f3c97ce25f60";
@@ -2295,9 +2458,10 @@ let
 
 
   Clone = buildPerlPackage rec {
-    name = "Clone-0.41";
+    pname = "Clone";
+    version = "0.41";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GA/GARU/${name}.tar.gz";
+      url = mirror://cpan/authors/id/G/GA/GARU/Clone-0.41.tar.gz;
       sha256 = "060mlm31lacirpnp5fl9jqk4m9cl07vjlh89k83qk25wykf5dh78";
     };
     meta = {
@@ -2307,7 +2471,8 @@ let
   };
 
   CloneChoose = buildPerlPackage rec {
-     name = "Clone-Choose-0.010";
+     pname = "Clone-Choose";
+     version = "0.010";
      src = fetchurl {
        url = mirror://cpan/authors/id/H/HE/HERMES/Clone-Choose-0.010.tar.gz;
        sha256 = "0cin2bjn5z8xhm9v4j7pwlkx88jnvz8al0njdjwyvs6fb0glh8sn";
@@ -2320,7 +2485,8 @@ let
   };
 
   ClonePP = buildPerlPackage rec {
-     name = "Clone-PP-1.07";
+     pname = "Clone-PP";
+     version = "1.07";
      src = fetchurl {
        url = mirror://cpan/authors/id/N/NE/NEILB/Clone-PP-1.07.tar.gz;
        sha256 = "15dkhqvih6rx9dnngfwwljcm9s8afb0nbyl2vdvhd8frnw4y31dz";
@@ -2331,7 +2497,8 @@ let
   };
 
   CodeTidyAll = buildPerlPackage rec {
-     name = "Code-TidyAll-0.73";
+     pname = "Code-TidyAll";
+     version = "0.73";
      src = fetchurl {
        url = mirror://cpan/authors/id/D/DR/DROLSKY/Code-TidyAll-0.73.tar.gz;
        sha256 = "1fvw73q5vj5b12y9jj9mmwl0dipdjlvpsw5rzvldr4csicrpiz6q";
@@ -2345,7 +2512,8 @@ let
   };
 
   CodeTidyAllPluginPerlAlignMooseAttributes = buildPerlPackage rec {
-     name = "Code-TidyAll-Plugin-Perl-AlignMooseAttributes-0.01";
+     pname = "Code-TidyAll-Plugin-Perl-AlignMooseAttributes";
+     version = "0.01";
      src = fetchurl {
        url = mirror://cpan/authors/id/J/JS/JSWARTZ/Code-TidyAll-Plugin-Perl-AlignMooseAttributes-0.01.tar.gz;
        sha256 = "1r8w5kfm17j1dyrrsjhwww423zzdzhx1i3d3brl32wzhasgf47cd";
@@ -2358,9 +2526,10 @@ let
   };
 
   commonsense = buildPerlPackage rec {
-    name = "common-sense-3.74";
+    pname = "common-sense";
+    version = "3.74";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/ML/MLEHMANN/common-sense-3.74.tar.gz;
       sha256 = "1wxv2s0hbjkrnssvxvsds0k213awg5pgdlrpkr6xkpnimc17s7vp";
     };
     meta = {
@@ -2370,7 +2539,8 @@ let
   };
 
   CompressBzip2 = buildPerlPackage {
-    name = "Compress-Bzip2-2.26";
+    pname = "Compress-Bzip2";
+    version = "2.26";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RU/RURBAN/Compress-Bzip2-2.26.tar.gz;
       sha256 = "5132f0c5f377a54d77ee36d332aa0ece585c22a40f2c31f2619e40262f5c4f0c";
@@ -2382,9 +2552,10 @@ let
   };
 
   CompressRawBzip2 = buildPerlPackage rec {
-    name = "Compress-Raw-Bzip2-2.086";
+    pname = "Compress-Raw-Bzip2";
+    version = "2.086";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PM/PMQS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/P/PM/PMQS/Compress-Raw-Bzip2-2.086.tar.gz;
       sha256 = "16gkm5m5hr8129h93r0liyyqffvh820wrlvxal8cn8bdcx59bls6";
     };
 
@@ -2402,15 +2573,17 @@ let
   CompressRawZlib = callPackage ../development/perl-modules/Compress-Raw-Zlib { };
 
   CompressUnLZMA = buildPerlPackage rec {
-    name = "Compress-unLZMA-0.05";
+    pname = "Compress-unLZMA";
+    version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FE/FERREIRA/${name}.tar.gz";
+      url = mirror://cpan/authors/id/F/FE/FERREIRA/Compress-unLZMA-0.05.tar.gz;
       sha256 = "1f0pcpcjjj60whqc5sc5jd0dd7z3si4fnp268w4ykmcjini03s2d";
     };
   };
 
   ConfigAny = buildPerlPackage rec {
-    name = "Config-Any-0.32";
+    pname = "Config-Any";
+    version = "0.32";
     src = fetchurl {
       url = mirror://cpan/authors/id/H/HA/HAARG/Config-Any-0.32.tar.gz;
       sha256 = "0l31sg7dwh4dwwnql42hp7arkhcm15bhsgfg4i6xvbjzy9f2mnk8";
@@ -2423,7 +2596,8 @@ let
   };
 
   ConfigAutoConf = buildPerlPackage rec {
-    name = "Config-AutoConf-0.317";
+    pname = "Config-AutoConf";
+    version = "0.317";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RE/REHSACK/Config-AutoConf-0.317.tar.gz;
       sha256 = "1qcwib4yaml5z2283qy5khjcydyibklsnk8zrk9wzdzc5wnv5r01";
@@ -2436,9 +2610,10 @@ let
   };
 
   ConfigGeneral = buildPerlPackage rec {
-    name = "Config-General-2.63";
+    pname = "Config-General";
+    version = "2.63";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TL/TLINDEN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/T/TL/TLINDEN/Config-General-2.63.tar.gz;
       sha256 = "1bbg3wp0xcpj04cmm86j1x0j5968jqi5s2c87qs7dgmap1vzk6qa";
     };
     meta = {
@@ -2447,7 +2622,8 @@ let
   };
 
   ConfigGitLike = buildPerlPackage {
-    name = "Config-GitLike-1.17";
+    pname = "Config-GitLike";
+    version = "1.17";
     src = fetchurl {
       url = mirror://cpan/authors/id/A/AL/ALEXMV/Config-GitLike-1.17.tar.gz;
       sha256 = "674a07b814fdcf9d323088d093245bcd066aaee24ec0914cb4decc9a943de54e";
@@ -2461,9 +2637,10 @@ let
   };
 
   ConfigGrammar = buildPerlPackage rec {
-    name = "Config-Grammar-1.13";
+    pname = "Config-Grammar";
+    version = "1.13";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DS/DSCHWEI/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DS/DSCHWEI/Config-Grammar-1.13.tar.gz;
       sha256 = "a8b3a3a2c9c8c43b92dc401bf2709d6514f15b467fd4f72c48d356335771d6e3";
     };
     meta = {
@@ -2474,9 +2651,10 @@ let
   };
 
   ConfigINI = buildPerlPackage rec {
-    name = "Config-INI-0.025";
+    pname = "Config-INI";
+    version = "0.025";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RJ/RJBS/Config-INI-0.025.tar.gz;
       sha256 = "628bf76d5b91f89dde22d4813ec033026ebf71b772bb61ccda909da00c869732";
     };
     propagatedBuildInputs = [ MixinLinewise ];
@@ -2488,7 +2666,8 @@ let
   };
 
   ConfigIdentity = buildPerlPackage rec {
-     name = "Config-Identity-0.0019";
+     pname = "Config-Identity";
+     version = "0.0019";
      src = fetchurl {
        url = mirror://cpan/authors/id/D/DA/DAGOLDEN/Config-Identity-0.0019.tar.gz;
        sha256 = "1a0jx12pxwpbnkww4xg4lav8j6ls89hrdimhj4a697k56zdhnli9";
@@ -2503,9 +2682,10 @@ let
   };
 
   ConfigIniFiles = buildPerlModule rec {
-    name = "Config-IniFiles-3.000002";
+    pname = "Config-IniFiles";
+    version = "3.000002";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SH/SHLOMIF/Config-IniFiles-3.000002.tar.gz;
       sha256 = "d92ed6ed2db98d5addf732c96d2a9c15d9f878c7e8b355bb7a5c1668e3f8ba09";
     };
     propagatedBuildInputs = [ IOStringy ];
@@ -2517,7 +2697,8 @@ let
   };
 
   ConfigMerge = buildPerlPackage {
-    name = "Config-Merge-1.04";
+    pname = "Config-Merge";
+    version = "1.04";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DR/DRTECH/Config-Merge-1.04.tar.gz;
       sha256 = "a932477b43ae5fb04a16f071a891da7bd2086c10c680592f2888fa9d9972cccf";
@@ -2531,7 +2712,8 @@ let
   };
 
   ConfigMVP = buildPerlPackage {
-    name = "Config-MVP-2.200011";
+    pname = "Config-MVP";
+    version = "2.200011";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RJ/RJBS/Config-MVP-2.200011.tar.gz;
       sha256 = "23c95666fc43c4adaebcc093b1b56091efc2a6aa2d75366a216d18eda96ad716";
@@ -2546,9 +2728,10 @@ let
   };
 
   ConfigMVPReaderINI = buildPerlPackage rec {
-    name = "Config-MVP-Reader-INI-2.101463";
+    pname = "Config-MVP-Reader-INI";
+    version = "2.101463";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RJ/RJBS/Config-MVP-Reader-INI-2.101463.tar.gz;
       sha256 = "0iflnsh0sgihff3ra8sr7awiiscmqvrp1anaskkwksqi6yzidab9";
     };
     propagatedBuildInputs = [ ConfigINI ConfigMVP ];
@@ -2560,7 +2743,8 @@ let
   };
 
   ConfigStd = buildPerlModule {
-    name = "Config-Std-0.903";
+    pname = "Config-Std";
+    version = "0.903";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BR/BRICKER/Config-Std-0.903.tar.gz;
       sha256 = "b7709ff663bd279d264ab9c2f51e9e9588479a3367a8c4cfc18659c2a11480fe";
@@ -2572,15 +2756,17 @@ let
   };
 
   ConfigTiny = buildPerlPackage rec {
-    name = "Config-Tiny-2.23";
+    pname = "Config-Tiny";
+    version = "2.23";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RS/RSAVAGE/${name}.tgz";
+      url = mirror://cpan/authors/id/R/RS/RSAVAGE/Config-Tiny-2.23.tgz;
       sha256 = "037524cpx962cjdgcp1m8sd30s43g3zvwfn4hmjvq322xpind2ls";
     };
   };
 
   ConfigVersioned = buildPerlPackage {
-    name = "Config-Versioned-1.01";
+    pname = "Config-Versioned";
+    version = "1.01";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MR/MRSCOTTY/Config-Versioned-1.01.tar.gz;
       sha256 = "bc9a4ae3738bd89f86a07bca673627ca3c92ba969737cd6dbc7ab7ad17cd2348";
@@ -2594,9 +2780,10 @@ let
   };
 
   Connector = buildPerlPackage rec {
-    name = "Connector-1.26";
+    pname = "Connector";
+    version = "1.26";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MR/MRSCOTTY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MR/MRSCOTTY/Connector-1.26.tar.gz;
       sha256 = "9852c2b43a8201996530deb1d3aa7fda18abe1ce24c80fbdebd7981cd2f05c45";
     };
     buildInputs = [ ConfigMerge ConfigStd ConfigVersioned DBDSQLite DBI ProcSafeExec TemplateToolkit YAML ];
@@ -2613,7 +2800,8 @@ let
   };
 
   ConstFast = buildPerlModule rec {
-     name = "Const-Fast-0.014";
+     pname = "Const-Fast";
+     version = "0.014";
      src = fetchurl {
        url = mirror://cpan/authors/id/L/LE/LEONT/Const-Fast-0.014.tar.gz;
        sha256 = "1nwlldgrx86yn7y6a53cqgvzm2ircsvxg1addahlcy6510x9a1gq";
@@ -2627,15 +2815,17 @@ let
   };
 
   ConvertASN1 = buildPerlPackage rec {
-    name = "Convert-ASN1-0.27";
+    pname = "Convert-ASN1";
+    version = "0.27";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GB/GBARR/${name}.tar.gz";
+      url = mirror://cpan/authors/id/G/GB/GBARR/Convert-ASN1-0.27.tar.gz;
       sha256 = "12nmsca6hzgxq57sx7dp8yq6zxqhl41z5a6018877sf5w25ag93l";
     };
   };
 
   ConvertColor = buildPerlModule {
-    name = "Convert-Color-0.11";
+    pname = "Convert-Color";
+    version = "0.11";
     src = fetchurl {
       url = mirror://cpan/authors/id/P/PE/PEVANS/Convert-Color-0.11.tar.gz;
       sha256 = "b41217c72931034ba4417d7a9e1e2999f04580d4e6b31c70993fedccc2440d38";
@@ -2649,7 +2839,8 @@ let
   };
 
   constantboolean = buildPerlModule {
-    name = "constant-boolean-0.02";
+    pname = "constant-boolean";
+    version = "0.02";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DE/DEXTER/constant-boolean-0.02.tar.gz;
       sha256 = "1s8gxfg4xqp543aqanv5lbp64vqqyw6ic4x3fm4imkk1h3amjb6d";
@@ -2658,7 +2849,8 @@ let
   };
 
   curry = buildPerlPackage rec {
-     name = "curry-1.001000";
+     pname = "curry";
+     version = "1.001000";
      src = fetchurl {
        url = mirror://cpan/authors/id/M/MS/MSTROUT/curry-1.001000.tar.gz;
        sha256 = "1m2n3w67cskh8ic6vf6ik0fmap9zma875kr5rhyznr1041wn064b";
@@ -2670,15 +2862,17 @@ let
   };
 
   constant-defer = buildPerlPackage rec {
-    name = "constant-defer-6";
+    pname = "constant-defer";
+    version = "6";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KR/KRYDE/${name}.tar.gz";
+      url = mirror://cpan/authors/id/K/KR/KRYDE/constant-defer-6.tar.gz;
       sha256 = "1ykgk0rd05p7kyrdxbv047fj7r0b4ix9ibpkzxp6h8nak0qjc8bv";
     };
   };
 
   ContextPreserve = buildPerlPackage rec {
-    name = "Context-Preserve-0.03";
+    pname = "Context-Preserve";
+    version = "0.03";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/Context-Preserve-0.03.tar.gz;
       sha256 = "07zxgmb11bn4zj3w9g1zwbb9iv4jyk5q7hc0nv59knvv5i64m489";
@@ -2687,9 +2881,10 @@ let
   };
 
   CookieBaker = buildPerlModule rec {
-    name = "Cookie-Baker-0.10";
+    pname = "Cookie-Baker";
+    version = "0.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KA/KAZEBURO/${name}.tar.gz";
+      url = mirror://cpan/authors/id/K/KA/KAZEBURO/Cookie-Baker-0.10.tar.gz;
       sha256 = "b42bad15b12da4cdc5c90c902faf3ad484281a42203fa4e7652866434f6fa4dd";
     };
     buildInputs = [ ModuleBuildTiny TestTime ];
@@ -2702,16 +2897,18 @@ let
   };
 
   CookieXS = buildPerlPackage rec {
-    name = "Cookie-XS-0.11";
+    pname = "Cookie-XS";
+    version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AG/AGENT/${name}.tar.gz";
+      url = mirror://cpan/authors/id/A/AG/AGENT/Cookie-XS-0.11.tar.gz;
       sha256 = "1616rcn2qn1cwiv3rxb8mq5fmwxpj4gya1lxxxq2w952h03p3fd3";
     };
     propagatedBuildInputs = [ CGICookieXS ];
   };
 
   Coro = buildPerlPackage rec {
-     name = "Coro-6.54";
+     pname = "Coro";
+     version = "6.54";
      src = fetchurl {
        url = mirror://cpan/authors/id/M/ML/MLEHMANN/Coro-6.54.tar.gz;
        sha256 = "0a00b351m7fxm39vfk726wpva2xx8qxlx5nv4yjgkbqap502ld2m";
@@ -2723,7 +2920,8 @@ let
   };
 
   Corona = buildPerlPackage rec {
-     name = "Corona-0.1004";
+     pname = "Corona";
+     version = "0.1004";
      src = fetchurl {
        url = mirror://cpan/authors/id/M/MI/MIYAGAWA/Corona-0.1004.tar.gz;
        sha256 = "0g5gpma3998rn61qfjv5csv2nrdi4sc84ipkb4k6synyhfgd3xgz";
@@ -2737,9 +2935,10 @@ let
   };
 
   CPAN = buildPerlPackage rec {
-    name = "CPAN-2.26";
+    pname = "CPAN";
+    version = "2.26";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AN/ANDK/${name}.tar.gz";
+      url = mirror://cpan/authors/id/A/AN/ANDK/CPAN-2.26.tar.gz;
       sha256 = "0db80ce17c374affa71534033bcac94a213912d6b35f5379e263ae3d7c98ae5c";
     };
     propagatedBuildInputs = [ ArchiveZip CPANChecksums CPANPerlReleases Expect FileHomeDir LWP LogLog4perl ModuleBuild TermReadKey YAML YAMLLibYAML YAMLSyck ];
@@ -2750,9 +2949,10 @@ let
   };
 
   CpanelJSONXS = buildPerlPackage rec {
-    name = "Cpanel-JSON-XS-4.11";
+    pname = "Cpanel-JSON-XS";
+    version = "4.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RU/RURBAN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RU/RURBAN/Cpanel-JSON-XS-4.11.tar.gz;
       sha256 = "08d17df7d373868a154bfa687f54fa06e0691836af8470fb29d538215d82bc78";
     };
     meta = {
@@ -2762,9 +2962,10 @@ let
   };
 
   CPANChanges = buildPerlPackage rec {
-    name = "CPAN-Changes-0.400002";
+    pname = "CPAN-Changes";
+    version = "0.400002";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/${name}.tar.gz";
+      url = mirror://cpan/authors/id/H/HA/HAARG/CPAN-Changes-0.400002.tar.gz;
       sha256 = "01eedea90d07468cb58e4a50bfa3bb1d4eeda9073596add1118fc359153abe8d";
     };
     meta = {
@@ -2774,7 +2975,8 @@ let
   };
 
   CPANChecksums = buildPerlPackage {
-    name = "CPAN-Checksums-2.12";
+    pname = "CPAN-Checksums";
+    version = "2.12";
     src = fetchurl {
       url = mirror://cpan/authors/id/A/AN/ANDK/CPAN-Checksums-2.12.tar.gz;
       sha256 = "0f1dbpp4638jfdfwrywjmz88na5wzw4fdsmm2r7gh1x0s6r0yq4r";
@@ -2786,7 +2988,8 @@ let
   };
 
   CPANDistnameInfo = buildPerlPackage rec {
-     name = "CPAN-DistnameInfo-0.12";
+     pname = "CPAN-DistnameInfo";
+     version = "0.12";
      src = fetchurl {
        url = mirror://cpan/authors/id/G/GB/GBARR/CPAN-DistnameInfo-0.12.tar.gz;
        sha256 = "0d94kx596w7k328cvq4y96z1gz12hdhn3z1mklkbrb7fyzlzn91g";
@@ -2798,9 +3001,10 @@ let
   };
 
   CPANMetaCheck = buildPerlPackage rec {
-    name = "CPAN-Meta-Check-0.014";
+    pname = "CPAN-Meta-Check";
+    version = "0.014";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/${name}.tar.gz";
+      url = mirror://cpan/authors/id/L/LE/LEONT/CPAN-Meta-Check-0.014.tar.gz;
       sha256 = "07rmdbz1rbnb7w33vswn1wixlyh947sqr93xrvcph1hwzhmmg818";
     };
     buildInputs = [ TestDeep ];
@@ -2825,9 +3029,10 @@ let
   };
 
   CPANPLUS = buildPerlPackage rec {
-    name = "CPANPLUS-0.9176";
+    pname = "CPANPLUS";
+    version = "0.9176";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BI/BINGOS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/B/BI/BINGOS/CPANPLUS-0.9176.tar.gz;
       sha256 = "09fypxwd13fraarq6qznmw04n1zh2f2ykdz037jmzm4m2ic8n8xc";
     };
     propagatedBuildInputs = [ ArchiveExtract ModulePluggable ObjectAccessor PackageConstants TermUI ];
@@ -2839,9 +3044,10 @@ let
   };
 
   CPANUploader = buildPerlPackage rec {
-    name = "CPAN-Uploader-0.103013";
+    pname = "CPAN-Uploader";
+    version = "0.103013";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RJ/RJBS/CPAN-Uploader-0.103013.tar.gz;
       sha256 = "07k8ia8gvj9mrz7a2lckgd3vxjsahfr43lgrb85474dkhz94f5pq";
     };
     propagatedBuildInputs = [ FileHomeDir GetoptLongDescriptive LWPProtocolHttps TermReadKey ];
@@ -2853,23 +3059,26 @@ let
   };
 
   CryptBlowfish = buildPerlPackage rec {
-    name = "Crypt-Blowfish-2.14";
+    pname = "Crypt-Blowfish";
+    version = "2.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DP/DPARIS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DP/DPARIS/Crypt-Blowfish-2.14.tar.gz;
       sha256 = "1cb7g8cyfs9alrfdykxhs8m6azj091fmcycz6p5vkxbbzcgl7cs6";
     };
   };
 
   CryptCBC = buildPerlPackage rec {
-    name = "Crypt-CBC-2.33";
+    pname = "Crypt-CBC";
+    version = "2.33";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LD/LDS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/L/LD/LDS/Crypt-CBC-2.33.tar.gz;
       sha256 = "0ig698lmpjz7fslnznxm0609lvlnvf4f3s370082nzycnqhxww3a";
     };
   };
 
   CryptCurve25519 = buildPerlPackage {
-    name = "Crypt-Curve25519-0.06";
+    pname = "Crypt-Curve25519";
+    version = "0.06";
     src = fetchurl {
       url = mirror://cpan/authors/id/A/AJ/AJGB/Crypt-Curve25519-0.06.tar.gz;
       sha256 = "1ir0gfxm8i7r9zyfs2zvil5jgwirl7j6cb9cm1p2kjpfnhyp0j4z";
@@ -2881,26 +3090,29 @@ let
   };
 
   CryptDES = buildPerlPackage rec {
-    name = "Crypt-DES-2.07";
+    pname = "Crypt-DES";
+    version = "2.07";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DP/DPARIS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DP/DPARIS/Crypt-DES-2.07.tar.gz;
       sha256 = "1rypxlhpd1jc0c327aghgl9y6ls47drmpvn0a40b4k3vhfsypc9d";
     };
   };
 
   CryptDH = buildPerlPackage rec {
-    name = "Crypt-DH-0.07";
+    pname = "Crypt-DH";
+    version = "0.07";
     src = fetchurl {
-      url    = "mirror://cpan/authors/id/M/MI/MITHALDU/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MI/MITHALDU/Crypt-DH-0.07.tar.gz;
       sha256 = "0pvzlgwpx8fzdy64ki15155vhsj30i9zxmw6i4p7irh17d1g7368";
     };
     propagatedBuildInputs = [ MathBigIntGMP ];
   };
 
   CryptDHGMP = buildPerlPackage rec {
-    name = "Crypt-DH-GMP-0.00012";
+    pname = "Crypt-DH-GMP";
+    version = "0.00012";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DM/DMAKI/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DM/DMAKI/Crypt-DH-GMP-0.00012.tar.gz;
       sha256 = "0f5gdprcql4kwzgxl2s6ngcfg1jl45lzcqh7dkv5bkwlwmxa9rsi";
     };
     buildInputs = [ pkgs.gmp DevelChecklib TestRequires ];
@@ -2909,16 +3121,18 @@ let
   };
 
   CryptEksblowfish = buildPerlModule rec {
-    name = "Crypt-Eksblowfish-0.009";
+    pname = "Crypt-Eksblowfish";
+    version = "0.009";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Z/ZE/ZEFRAM/${name}.tar.gz";
+      url = mirror://cpan/authors/id/Z/ZE/ZEFRAM/Crypt-Eksblowfish-0.009.tar.gz;
       sha256 = "3cc7126d5841107237a9be2dc5c7fbc167cf3c4b4ce34678a8448b850757014c";
     };
     propagatedBuildInputs = [ ClassMix ];
   };
 
   CryptIDEA = buildPerlPackage {
-    name = "Crypt-IDEA-1.10";
+    pname = "Crypt-IDEA";
+    version = "1.10";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DP/DPARIS/Crypt-IDEA-1.10.tar.gz;
       sha256 = "0690lzlyjqgmnb94dq7dm5n6pgybg10fkpgfycgzr814370pig9k";
@@ -2926,9 +3140,10 @@ let
   };
 
   CryptJWT = buildPerlPackage rec {
-    name = "Crypt-JWT-0.024";
+    pname = "Crypt-JWT";
+    version = "0.024";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIK/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MI/MIK/Crypt-JWT-0.024.tar.gz;
       sha256 = "4fcb81992fa61c0dbeb7c3582e887a92746aca76a42609091d986350e91892c5";
     };
     propagatedBuildInputs = [ CryptX JSONMaybeXS ];
@@ -2939,7 +3154,8 @@ let
   };
 
   CryptPasswdMD5 = buildPerlModule {
-    name = "Crypt-PasswdMD5-1.40";
+    pname = "Crypt-PasswdMD5";
+    version = "1.40";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RS/RSAVAGE/Crypt-PasswdMD5-1.40.tgz;
       sha256 = "0j0r74f18nk63phddzqbf7wqma2ci4p4bxvrwrxsy0aklbp6lzdp";
@@ -2947,7 +3163,8 @@ let
   };
 
   CryptPKCS10 = buildPerlModule {
-    name = "Crypt-PKCS10-2.001";
+    pname = "Crypt-PKCS10";
+    version = "2.001";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MR/MRSCOTTY/Crypt-PKCS10-2.001.tar.gz;
       sha256 = "f7945b76a2d8f4d8ecf627b2eb8ea4f41d001e6a915efe82e71d6b97fea3ffa9";
@@ -2960,7 +3177,8 @@ let
   };
 
   CryptRandomSource = buildPerlModule {
-    name = "Crypt-Random-Source-0.14";
+    pname = "Crypt-Random-Source";
+    version = "0.14";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/Crypt-Random-Source-0.14.tar.gz;
       sha256 = "1rpdds3sy5l1fhngnkrsgwsmwd54wpicx3i9ds69blcskwkcwkpc";
@@ -2974,15 +3192,17 @@ let
   };
 
   CryptRC4 = buildPerlPackage rec {
-    name = "Crypt-RC4-2.02";
+    pname = "Crypt-RC4";
+    version = "2.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SI/SIFUKURT/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SI/SIFUKURT/Crypt-RC4-2.02.tar.gz;
       sha256 = "1sp099cws0q225h6j4y68hmfd1lnv5877gihjs40f8n2ddf45i2y";
     };
   };
 
   CryptRandPasswd = buildPerlPackage {
-    name = "Crypt-RandPasswd-0.06";
+    pname = "Crypt-RandPasswd";
+    version = "0.06";
     src = fetchurl {
       url = mirror://cpan/authors/id/N/NE/NEILB/Crypt-RandPasswd-0.06.tar.gz;
       sha256 = "0ca8544371wp4vvqsa19lnhl02hczpkbwkgsgm65ziwwim3r1gdi";
@@ -2990,32 +3210,36 @@ let
   };
 
   CryptMySQL = buildPerlModule rec {
-    name = "Crypt-MySQL-0.04";
+    pname = "Crypt-MySQL";
+    version = "0.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IK/IKEBE/${name}.tar.gz";
+      url = mirror://cpan/authors/id/I/IK/IKEBE/Crypt-MySQL-0.04.tar.gz;
       sha256 = "93ebdfaaefcfe9ab683f0121c85f24475d8197f0bcec46018219e4111434dde3";
     };
     propagatedBuildInputs = [ DigestSHA1 ];
   };
 
   CryptRijndael = buildPerlPackage rec {
-    name = "Crypt-Rijndael-1.13";
+    pname = "Crypt-Rijndael";
+    version = "1.13";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/${name}.tar.gz";
+      url = mirror://cpan/authors/id/L/LE/LEONT/Crypt-Rijndael-1.13.tar.gz;
       sha256 = "0ki16vkgzvzyjdx6mmvjfpngyvhf7cis46pymy6dr8z0vyk0jwnd";
     };
   };
 
   CryptUnixCryptXS = buildPerlPackage rec {
-    name = "Crypt-UnixCrypt_XS-0.11";
+    pname = "Crypt-UnixCrypt_XS";
+    version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BO/BORISZ/${name}.tar.gz";
+      url = mirror://cpan/authors/id/B/BO/BORISZ/Crypt-UnixCrypt_XS-0.11.tar.gz;
       sha256 = "1ajg3x6kwxy4x9p3nw1j36qjxpjvdpi9wkca5gfd86y9q8939sv2";
     };
   };
 
   CryptSmbHash = buildPerlPackage rec {
-    name = "Crypt-SmbHash-0.12";
+    pname = "Crypt-SmbHash";
+    version = "0.12";
     src = fetchurl {
       url = "mirror://cpan/authors/id/B/BJ/BJKUIT/Crypt-SmbHash-0.12.tar.gz";
       sha256 = "0dxivcqmabkhpz5xzph6rzl8fvq9xjy26b2ci77pv5gsmdzari38";
@@ -3023,9 +3247,10 @@ let
   };
 
   CryptOpenSSLAES = buildPerlPackage rec {
-    name = "Crypt-OpenSSL-AES-0.02";
+    pname = "Crypt-OpenSSL-AES";
+    version = "0.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TT/TTAR/${name}.tar.gz";
+      url = mirror://cpan/authors/id/T/TT/TTAR/Crypt-OpenSSL-AES-0.02.tar.gz;
       sha256 = "b66fab514edf97fc32f58da257582704a210c2b35e297d5c31b7fa2ffd08e908";
     };
     NIX_CFLAGS_COMPILE = "-I${pkgs.openssl.dev}/include";
@@ -3037,7 +3262,8 @@ let
   };
 
   CryptOpenSSLBignum = buildPerlPackage rec {
-    name = "Crypt-OpenSSL-Bignum-0.09";
+    pname = "Crypt-OpenSSL-Bignum";
+    version = "0.09";
     src = fetchurl {
       url = mirror://cpan/authors/id/K/KM/KMX/Crypt-OpenSSL-Bignum-0.09.tar.gz;
       sha256 = "1p22znbajq91lbk2k3yg12ig7hy5b4vy8igxwqkmbm4nhgxp4ki3";
@@ -3047,7 +3273,8 @@ let
   };
 
   CryptOpenSSLGuess = buildPerlPackage rec {
-     name = "Crypt-OpenSSL-Guess-0.11";
+     pname = "Crypt-OpenSSL-Guess";
+     version = "0.11";
      src = fetchurl {
        url = mirror://cpan/authors/id/A/AK/AKIYM/Crypt-OpenSSL-Guess-0.11.tar.gz;
        sha256 = "0rvi9l4ljcbhwwvspq019nfq2h2v746dk355h2nwnlmqikiihsxa";
@@ -3060,9 +3287,10 @@ let
   };
 
   CryptOpenSSLRandom = buildPerlPackage rec {
-    name = "Crypt-OpenSSL-Random-0.15";
+    pname = "Crypt-OpenSSL-Random";
+    version = "0.15";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RU/RURBAN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RU/RURBAN/Crypt-OpenSSL-Random-0.15.tar.gz;
       sha256 = "1x6ffps8q7mnawmcfq740llzy7i10g3319vap0wiw4d33fm6z1zh";
     };
     NIX_CFLAGS_COMPILE = "-I${pkgs.openssl.dev}/include";
@@ -3071,7 +3299,8 @@ let
   };
 
   CryptOpenSSLRSA = buildPerlPackage rec {
-    name = "Crypt-OpenSSL-RSA-0.31";
+    pname = "Crypt-OpenSSL-RSA";
+    version = "0.31";
     src = fetchurl {
       url = mirror://cpan/authors/id/T/TO/TODDR/Crypt-OpenSSL-RSA-0.31.tar.gz;
       sha256 = "4173403ad4cf76732192099f833fbfbf3cd8104e0246b3844187ae384d2c5436";
@@ -3083,9 +3312,10 @@ let
   };
 
   CryptEd25519 = buildPerlPackage rec {
-    name = "Crypt-Ed25519-1.04";
+    pname = "Crypt-Ed25519";
+    version = "1.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/ML/MLEHMANN/Crypt-Ed25519-1.04.tar.gz;
       sha256 = "1jwh6b8b2ppvzxaljz287zakj4q3ip4zq121i23iwh26wxhlll2q";
     };
 
@@ -3100,9 +3330,10 @@ let
   };
 
   CryptSSLeay = buildPerlPackage rec {
-    name = "Crypt-SSLeay-0.72";
+    pname = "Crypt-SSLeay";
+    version = "0.72";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NA/NANIS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/N/NA/NANIS/Crypt-SSLeay-0.72.tar.gz;
       sha256 = "1s7zm6ph37kg8jzaxnhi4ff4snxl7mi5h14arxbri0kp6s0lzlzm";
     };
     makeMakerFlags = "--libpath=${pkgs.openssl.out}/lib --incpath=${pkgs.openssl.dev}/include";
@@ -3111,16 +3342,18 @@ let
   };
 
   CSSDOM = buildPerlPackage rec {
-    name = "CSS-DOM-0.17";
+    pname = "CSS-DOM";
+    version = "0.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SP/SPROUT/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SP/SPROUT/CSS-DOM-0.17.tar.gz;
       sha256 = "09phb6c9czpcp9imq06khm54kspsx6hnvfrjxramx663ygmpifb5";
     };
     propagatedBuildInputs = [ Clone ];
   };
 
   CSSMinifierXP = buildPerlModule rec {
-    name = "CSS-Minifier-XS-0.09";
+    pname = "CSS-Minifier-XS";
+    version = "0.09";
     src = fetchurl {
       url = mirror://cpan/authors/id/G/GT/GTERMARS/CSS-Minifier-XS-0.09.tar.gz;
       sha256 = "1myswrmh0sqp5xjpp03x45z8arfmgkjx0srl3r6kjsyzl1zrk9l8";
@@ -3132,7 +3365,8 @@ let
   };
 
   CSSSquish = buildPerlPackage {
-    name = "CSS-Squish-0.10";
+    pname = "CSS-Squish";
+    version = "0.10";
     src = fetchurl {
       url = mirror://cpan/authors/id/T/TS/TSIBLEY/CSS-Squish-0.10.tar.gz;
       sha256 = "65fc0d69acd1fa33d9a4c3b09cce0fbd737d747b1fcc4e9d87ebd91050cbcb4e";
@@ -3145,7 +3379,7 @@ let
   };
 
   Curses = let version = "1.36"; in buildPerlPackage {
-    name = "Curses-${version}";
+    pname = "Curses";
     src = fetchurl {
       url = "mirror://cpan/authors/id/G/GI/GIRAFFED/Curses-${version}.tar.gz";
       sha256 = "0r6xd9wr0c25rr28zixhqipak575zqsfb7r7f2693i9il1dpj554";
@@ -3160,9 +3394,10 @@ let
   };
 
   CursesUI = buildPerlPackage rec {
-    name = "Curses-UI-0.9609";
+    pname = "Curses-UI";
+    version = "0.9609";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MD/MDXI/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MD/MDXI/Curses-UI-0.9609.tar.gz;
       sha256 = "1bqf4h8z70f78nzqq5yj4ahvsbhxxal6bc2g301l9qdn2fjjgf0a";
     };
     meta = {
@@ -3173,9 +3408,10 @@ let
   };
 
   CryptX = buildPerlPackage rec {
-    name = "CryptX-0.063";
+    pname = "CryptX";
+    version = "0.063";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIK/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MI/MIK/CryptX-0.063.tar.gz;
       sha256 = "6cfc672e0e56d56cf849caf0b929ed94f87cb4e6be5c20757ca3d3dbe5569595";
     };
     meta = {
@@ -3185,9 +3421,10 @@ let
   };
 
   CwdGuard = buildPerlModule rec {
-    name = "Cwd-Guard-0.05";
+    pname = "Cwd-Guard";
+    version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KA/KAZEBURO/${name}.tar.gz";
+      url = mirror://cpan/authors/id/K/KA/KAZEBURO/Cwd-Guard-0.05.tar.gz;
       sha256 = "0xwf4rmii55k3lp19mpbh00mbgby7rxdk2lk84148bjhp6i7rz3s";
     };
     meta = {
@@ -3198,7 +3435,8 @@ let
   };
 
   DataClone = buildPerlPackage {
-    name = "Data-Clone-0.004";
+    pname = "Data-Clone";
+    version = "0.004";
     src = fetchurl {
       url = mirror://cpan/authors/id/G/GF/GFUJI/Data-Clone-0.004.tar.gz;
       sha256 = "0g1qhi5qyk4fp0pwyaw90vxiyyn8las0i8ghzrnr4srai1wy3r9g";
@@ -3211,18 +3449,20 @@ let
   };
 
   DataCompare = buildPerlPackage rec {
-    name = "Data-Compare-1.25";
+    pname = "Data-Compare";
+    version = "1.25";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DC/DCANTRELL/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DC/DCANTRELL/Data-Compare-1.25.tar.gz;
       sha256 = "0wzasidg9yjcfsi2gdiaw6726ikqda7n24n0v2ngpaazakdkcjqx";
     };
     propagatedBuildInputs = [ FileFindRule ];
   };
 
   DataDump = buildPerlPackage rec {
-    name = "Data-Dump-1.23";
+    pname = "Data-Dump";
+    version = "1.23";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GA/GAAS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/G/GA/GAAS/Data-Dump-1.23.tar.gz;
       sha256 = "0r9ba52b7p8nnn6nw0ygm06lygi8g68piri78jmlqyrqy5gb0lxg";
     };
     meta = {
@@ -3232,7 +3472,8 @@ let
   };
 
   DataDumper = buildPerlPackage rec {
-    name = "Data-Dumper-2.173";
+    pname = "Data-Dumper";
+    version = "2.173";
     src = fetchurl {
       url = mirror://cpan/authors/id/X/XS/XSAWYERX/Data-Dumper-2.173.tar.gz;
       sha256 = "697608b39330988e519131be667ff47168aaaaf99f06bd2095d5b46ad05d76fa";
@@ -3244,9 +3485,10 @@ let
   };
 
   DataDumperConcise = buildPerlPackage rec {
-    name = "Data-Dumper-Concise-2.023";
+    pname = "Data-Dumper-Concise";
+    version = "2.023";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/E/ET/ETHER/Data-Dumper-Concise-2.023.tar.gz;
       sha256 = "a6c22f113caf31137590def1b7028a7e718eface3228272d0672c25e035d5853";
     };
     meta = {
@@ -3256,26 +3498,29 @@ let
   };
 
   DataEntropy = buildPerlModule rec {
-    name = "Data-Entropy-0.007";
+    pname = "Data-Entropy";
+    version = "0.007";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Z/ZE/ZEFRAM/${name}.tar.gz";
+      url = mirror://cpan/authors/id/Z/ZE/ZEFRAM/Data-Entropy-0.007.tar.gz;
       sha256 = "2611c4a1a3038594d79ea4ed14d9e15a9af8f77105f51667795fe4f8a53427e4";
     };
     propagatedBuildInputs = [ CryptRijndael DataFloat HTTPLite ParamsClassify ];
   };
 
   DataFloat = buildPerlModule rec {
-    name = "Data-Float-0.013";
+    pname = "Data-Float";
+    version = "0.013";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Z/ZE/ZEFRAM/${name}.tar.gz";
+      url = mirror://cpan/authors/id/Z/ZE/ZEFRAM/Data-Float-0.013.tar.gz;
       sha256 = "e2b1523d858930b8bbdbd196f08235f5e678b84919ba87712e26313b9c27518a";
     };
   };
 
   DataFormValidator = buildPerlPackage rec {
-    name = "Data-FormValidator-4.88";
+    pname = "Data-FormValidator";
+    version = "4.88";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DF/DFARRELL/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DF/DFARRELL/Data-FormValidator-4.88.tar.gz;
       sha256 = "c1a539f91c92cbcd8a8d83597ec9a7643fcd8ccf5a94e15382c3765289170066";
     };
     propagatedBuildInputs = [ DateCalc EmailValid FileMMagic ImageSize MIMETypes RegexpCommon ];
@@ -3287,9 +3532,10 @@ let
   };
 
   DataGUID = buildPerlPackage rec {
-    name = "Data-GUID-0.049";
+    pname = "Data-GUID";
+    version = "0.049";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RJ/RJBS/Data-GUID-0.049.tar.gz;
       sha256 = "0yx7d4qwsr9n85gslip0y3mdwr5fkncfbwxz7si2a17x95yl7bxq";
     };
     propagatedBuildInputs = [ DataUUID SubExporter ];
@@ -3301,7 +3547,8 @@ let
   };
 
   DataHexDump = buildPerlPackage {
-    name = "Data-HexDump-0.02";
+    pname = "Data-HexDump";
+    version = "0.02";
     src = fetchurl {
       url = mirror://cpan/authors/id/F/FT/FTASSIN/Data-HexDump-0.02.tar.gz;
       sha256 = "1a9d843e7f667c1c6f77c67af5d77e7462ff23b41937cb17454d03535cd9be70";
@@ -3313,9 +3560,10 @@ let
   };
 
   DataHexdumper = buildPerlPackage rec {
-    name = "Data-Hexdumper-3.0001";
+    pname = "Data-Hexdumper";
+    version = "3.0001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DC/DCANTRELL/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DC/DCANTRELL/Data-Hexdumper-3.0001.tar.gz;
       sha256 = "f9243cbe8affed5045fe4df505726a7a7289471e30c51ac065b3ed6ce0d1a604";
     };
     meta = {
@@ -3325,7 +3573,8 @@ let
   };
 
   DataHierarchy = buildPerlPackage {
-    name = "Data-Hierarchy-0.34";
+    pname = "Data-Hierarchy";
+    version = "0.34";
     src = fetchurl {
       url = mirror://cpan/authors/id/C/CL/CLKAO/Data-Hierarchy-0.34.tar.gz;
       sha256 = "1vfrkygdaq0k7006i83jwavg9wgszfcyzbl9b7fp37z2acmyda5k";
@@ -3334,7 +3583,8 @@ let
   };
 
   DataICal = buildPerlPackage {
-    name = "Data-ICal-0.22";
+    pname = "Data-ICal";
+    version = "0.22";
     src = fetchurl {
       url = mirror://cpan/authors/id/A/AL/ALEXMV/Data-ICal-0.22.tar.gz;
       sha256 = "8ae9d20af244e5a6f606c7325e9d145dd0002676a178357af860a5e156925720";
@@ -3348,7 +3598,8 @@ let
   };
 
   DataIEEE754 = buildPerlPackage {
-    name = "Data-IEEE754-0.02";
+    pname = "Data-IEEE754";
+    version = "0.02";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MA/MAXMIND/Data-IEEE754-0.02.tar.gz;
       sha256 = "07b73dlxd0qmxgkkrpa2xr61y18v3adlf1qgnl9k90kj8q9spx66";
@@ -3361,15 +3612,17 @@ let
   };
 
   DataInteger = buildPerlModule rec {
-    name = "Data-Integer-0.006";
+    pname = "Data-Integer";
+    version = "0.006";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Z/ZE/ZEFRAM/${name}.tar.gz";
+      url = mirror://cpan/authors/id/Z/ZE/ZEFRAM/Data-Integer-0.006.tar.gz;
       sha256 = "0m53zxhx9sn49yqh7azlpyy9m65g54v8cd2ha98y77337gg7xdv3";
     };
   };
 
   DataOptList = buildPerlPackage {
-    name = "Data-OptList-0.110";
+    pname = "Data-OptList";
+    version = "0.110";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RJ/RJBS/Data-OptList-0.110.tar.gz;
       sha256 = "1hzmgr2imdg1fc3hmwx0d56fhsdfyrgmgx7jb4jkyiv6575ifq9n";
@@ -3394,7 +3647,8 @@ let
   };
 
   DataPagePageset = buildPerlModule rec {
-    name = "Data-Page-Pageset-1.02";
+    pname = "Data-Page-Pageset";
+    version = "1.02";
     src = fetchurl {
       url = mirror://cpan/authors/id/C/CH/CHUNZI/Data-Page-Pageset-1.02.tar.gz;
       sha256 = "142isi8la383dbjxj7lfgcbmmrpzwckcc4wma6rdl8ryajsipb6f";
@@ -3407,7 +3661,8 @@ let
   };
 
   DataPassword = buildPerlPackage {
-    name = "Data-Password-1.12";
+    pname = "Data-Password";
+    version = "1.12";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RA/RAZINF/Data-Password-1.12.tar.gz;
       sha256 = "830cde81741ff384385412e16faba55745a54a7cc019dd23d7ed4f05d551a961";
@@ -3415,9 +3670,10 @@ let
   };
 
   DataPerl = buildPerlPackage rec {
-    name = "Data-Perl-0.002009";
+    pname = "Data-Perl";
+    version = "0.002009";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MATTP/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MA/MATTP/Data-Perl-0.002009.tar.gz;
       sha256 = "b62b2225870c2c3b16fb78c429f8729ddb8ed0e342f4209ec3c261b764c36f8b";
     };
     buildInputs = [ TestDeep TestFatal TestOutput ];
@@ -3430,7 +3686,8 @@ let
   };
 
   DataPrinter = buildPerlPackage {
-    name = "Data-Printer-0.40";
+    pname = "Data-Printer";
+    version = "0.40";
     src = fetchurl {
       url = mirror://cpan/authors/id/G/GA/GARU/Data-Printer-0.40.tar.gz;
       sha256 = "0njjh8zp5afc4602jrnmg89icj7gfsil6i955ypcqxc2gl830sb0";
@@ -3443,9 +3700,10 @@ let
   };
 
   DataSection = buildPerlPackage rec {
-    name = "Data-Section-0.200007";
+    pname = "Data-Section";
+    version = "0.200007";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RJ/RJBS/Data-Section-0.200007.tar.gz;
       sha256 = "1pmlxca0a8sv2jjwvhwgqavq6iwys6kf457lby4anjp3f1dpx4yd";
     };
     propagatedBuildInputs = [ MROCompat SubExporter ];
@@ -3458,7 +3716,8 @@ let
   };
 
   DataSerializer = buildPerlModule {
-    name = "Data-Serializer-0.60";
+    pname = "Data-Serializer";
+    version = "0.60";
     src = fetchurl {
       url = mirror://cpan/authors/id/N/NE/NEELY/Data-Serializer-0.60.tar.gz;
       sha256 = "0ca4s811l7f2bqkx7vnyxbpp4f0qska89g2pvsfb3k0bhhbk0jdk";
@@ -3470,7 +3729,8 @@ let
   };
 
   DataSpreadPagination = buildPerlPackage {
-    name = "Data-SpreadPagination-0.1.2";
+    pname = "Data-SpreadPagination";
+    version = "0.1.2";
     src = fetchurl {
       url = mirror://cpan/authors/id/K/KN/KNEW/Data-SpreadPagination-0.1.2.tar.gz;
       sha256 = "74ebfd847132c38cc9e835e14e82c43f1809a95cbc98bb84d1f7ce2e4ef487e3";
@@ -3482,7 +3742,8 @@ let
   };
 
   DataStreamBulk = buildPerlPackage {
-    name = "Data-Stream-Bulk-0.11";
+    pname = "Data-Stream-Bulk";
+    version = "0.11";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DO/DOY/Data-Stream-Bulk-0.11.tar.gz;
       sha256 = "06e08432a6b97705606c925709b99129ad926516e477d58e4461e4b3d9f30917";
@@ -3496,9 +3757,10 @@ let
   };
 
   DataStructureUtil = buildPerlPackage rec {
-    name = "Data-Structure-Util-0.16";
+    pname = "Data-Structure-Util";
+    version = "0.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AN/ANDYA/${name}.tar.gz";
+      url = mirror://cpan/authors/id/A/AN/ANDYA/Data-Structure-Util-0.16.tar.gz;
       sha256 = "9cd42a13e65cb15f3a76296eb9a134da220168ec747c568d331a50ae7a2ddbc6";
     };
     buildInputs = [ TestPod ];
@@ -3509,7 +3771,8 @@ let
   };
 
   DataTaxi = buildPerlPackage {
-    name = "Data-Taxi-0.96";
+    pname = "Data-Taxi";
+    version = "0.96";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MI/MIKO/Data-Taxi-0.96.tar.gz;
       sha256 = "0y4wls4jlwd6prvd77szymddhq9sfj06kaqnk4frlvd0zh83djxb";
@@ -3518,17 +3781,19 @@ let
   };
 
   DataUniqid = buildPerlPackage rec {
-    name = "Data-Uniqid-0.12";
+    pname = "Data-Uniqid";
+    version = "0.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MW/MWX/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MW/MWX/Data-Uniqid-0.12.tar.gz;
       sha256 = "b6919ba49b9fe98bfdf3e8accae7b9b7f78dc9e71ebbd0b7fef7a45d99324ccb";
     };
   };
 
   DataURIEncode = buildPerlPackage rec {
-    name = "Data-URIEncode-0.11";
+    pname = "Data-URIEncode";
+    version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RH/RHANDOM/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RH/RHANDOM/Data-URIEncode-0.11.tar.gz;
       sha256 = "51c9efbf8423853616eaa24841e4d1996b2db0036900617fb1dbc76c75a1f360";
     };
     meta = {
@@ -3537,7 +3802,8 @@ let
   };
 
   DataUUID = buildPerlPackage rec {
-    name = "Data-UUID-1.224";
+    pname = "Data-UUID";
+    version = "1.224";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RJ/RJBS/Data-UUID-1.224.tar.gz;
       sha256 = "0z7l3fc710v830n1krgrp7wzfispi5s0h10cyk65xvxv09sw2n69";
@@ -3545,7 +3811,8 @@ let
   };
 
   DataUUIDMT = buildPerlPackage {
-    name = "Data-UUID-MT-1.001";
+    pname = "Data-UUID-MT";
+    version = "1.001";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DA/DAGOLDEN/Data-UUID-MT-1.001.tar.gz;
       sha256 = "0bb7qibq1c5lhaihxa1sck9pb744p8c7172jgx5zh4c32ac4nk1h";
@@ -3559,9 +3826,10 @@ let
   };
 
   DataValidateDomain = buildPerlPackage rec {
-    name = "Data-Validate-Domain-0.14";
+    pname = "Data-Validate-Domain";
+    version = "0.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DR/DROLSKY/Data-Validate-Domain-0.14.tar.gz;
       sha256 = "4470f253b8d2720a4dd3fa3ae550995417c2269f3be7ff030e01afa04a3a9421";
     };
     buildInputs = [ Test2Suite ];
@@ -3573,9 +3841,10 @@ let
   };
 
   DataValidateIP = buildPerlPackage rec {
-    name = "Data-Validate-IP-0.27";
+    pname = "Data-Validate-IP";
+    version = "0.27";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DR/DROLSKY/Data-Validate-IP-0.27.tar.gz;
       sha256 = "e1aa92235dcb9c6fd9b6c8cda184d1af73537cc77f4f83a0f88207a8bfbfb7d6";
     };
     buildInputs = [ TestRequires ];
@@ -3587,9 +3856,10 @@ let
   };
 
   DataValidateURI = buildPerlPackage rec {
-    name = "Data-Validate-URI-0.07";
+    pname = "Data-Validate-URI";
+    version = "0.07";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SO/SONNEN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SO/SONNEN/Data-Validate-URI-0.07.tar.gz;
       sha256 = "f06418d2a4603913d1b6ce52b167dd13e787e13bf2be325a065df7d408f79c60";
     };
     propagatedBuildInputs = [ DataValidateDomain DataValidateIP ];
@@ -3600,9 +3870,10 @@ let
   };
 
   DataVisitor = buildPerlPackage rec {
-    name = "Data-Visitor-0.30";
+    pname = "Data-Visitor";
+    version = "0.30";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DO/DOY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DO/DOY/Data-Visitor-0.30.tar.gz;
       sha256 = "0m7d1505af9z2hj5aw020grcmjjlvnkjpvjam457d7k5qfy4m8lf";
     };
     buildInputs = [ TestRequires ];
@@ -3610,7 +3881,8 @@ let
   };
 
   DateCalc = buildPerlPackage {
-    name = "Date-Calc-6.4";
+    pname = "Date-Calc";
+    version = "6.4";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/ST/STBEY/Date-Calc-6.4.tar.gz;
       sha256 = "1barz0jgdaan3jm7ciphs5n3ahwkl42imprs3y8c1dwpwyr3gqbw";
@@ -3620,7 +3892,8 @@ let
   };
 
   DateExtract = buildPerlPackage {
-    name = "Date-Extract-0.06";
+    pname = "Date-Extract";
+    version = "0.06";
     src = fetchurl {
       url = mirror://cpan/authors/id/A/AL/ALEXMV/Date-Extract-0.06.tar.gz;
       sha256 = "bc7658d5c50c3525ec0efcb55236a5de2d5d4fc06fc147fa3929c8f0953cda2b";
@@ -3630,9 +3903,10 @@ let
   };
 
   DateManip = buildPerlPackage rec {
-    name = "Date-Manip-6.76";
+    pname = "Date-Manip";
+    version = "6.76";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SB/SBECK/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SB/SBECK/Date-Manip-6.76.tar.gz;
       sha256 = "1a33mpkx7qqb9nqxyh2kkb596d8xq6jw0ljrd4xrwiz30f6cg1qw";
     };
     # for some reason, parsing /etc/localtime does not work anymore - make sure that the fallback "/bin/date +%Z" will work
@@ -3647,7 +3921,8 @@ let
   };
 
   DateSimple = buildPerlPackage {
-    name = "Date-Simple-3.03";
+    pname = "Date-Simple";
+    version = "3.03";
     src = fetchurl {
       url = mirror://cpan/authors/id/I/IZ/IZUT/Date-Simple-3.03.tar.gz;
       sha256 = "29a1926314ce1681a312d6155c29590c771ddacf91b7485873ce449ef209dd04";
@@ -3673,7 +3948,8 @@ let
   };
 
   DateTimeCalendarJulian = buildPerlPackage rec {
-    name = "DateTime-Calendar-Julian-0.100";
+    pname = "DateTime-Calendar-Julian";
+    version = "0.100";
     src = fetchurl {
       url = mirror://cpan/authors/id/W/WY/WYANT/DateTime-Calendar-Julian-0.100.tar.gz;
       sha256 = "0gbw7rh706qk5jlmmz3yzsm0ilzp39kyar28g4j6d57my8cwaipx";
@@ -3686,9 +3962,10 @@ let
   };
 
   DateTimeEventICal = buildPerlPackage rec {
-    name = "DateTime-Event-ICal-0.13";
+    pname = "DateTime-Event-ICal";
+    version = "0.13";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FG/FGLOCK/${name}.tar.gz";
+      url = mirror://cpan/authors/id/F/FG/FGLOCK/DateTime-Event-ICal-0.13.tar.gz;
       sha256 = "1skmykxbrf98ldi72d5s1v6228gfdr5iy4y0gpl0xwswxy247njk";
     };
     propagatedBuildInputs = [ DateTimeEventRecurrence ];
@@ -3699,7 +3976,8 @@ let
   };
 
   DateTimeEventRecurrence = buildPerlPackage {
-    name = "DateTime-Event-Recurrence-0.19";
+    pname = "DateTime-Event-Recurrence";
+    version = "0.19";
     src = fetchurl {
       url = mirror://cpan/authors/id/F/FG/FGLOCK/DateTime-Event-Recurrence-0.19.tar.gz;
       sha256 = "f9408789a461107766ca1a232bb3ec1e702eec7ca8167401ea6ec3f4b6d0b5a5";
@@ -3708,7 +3986,8 @@ let
   };
 
   DateTimeFormatBuilder = buildPerlPackage {
-    name = "DateTime-Format-Builder-0.82";
+    pname = "DateTime-Format-Builder";
+    version = "0.82";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DR/DROLSKY/DateTime-Format-Builder-0.82.tar.gz;
       sha256 = "383faeb22b992c77ca65a5257992dd2f6db91a7db73ea4601c512e1c6c2e1ca3";
@@ -3721,7 +4000,8 @@ let
   };
 
   DateTimeFormatDateParse = buildPerlModule {
-    name = "DateTime-Format-DateParse-0.05";
+    pname = "DateTime-Format-DateParse";
+    version = "0.05";
     src = fetchurl {
       url = mirror://cpan/authors/id/J/JH/JHOBLITT/DateTime-Format-DateParse-0.05.tar.gz;
       sha256 = "f6eca4c8be66ce9992ee150932f8fcf07809fd3d1664caf200b8a5fd3a7e5ebc";
@@ -3734,7 +4014,8 @@ let
   };
 
   DateTimeFormatFlexible = buildPerlPackage {
-    name = "DateTime-Format-Flexible-0.31";
+    pname = "DateTime-Format-Flexible";
+    version = "0.31";
     src = fetchurl {
       url = mirror://cpan/authors/id/T/TH/THINC/DateTime-Format-Flexible-0.31.tar.gz;
       sha256 = "0daf62fe4af0b336d45e367143a580b5a34912a679eef788d54c4d5ad685c2d1";
@@ -3748,9 +4029,10 @@ let
   };
 
   DateTimeFormatHTTP = buildPerlModule rec {
-    name = "DateTime-Format-HTTP-0.42";
+    pname = "DateTime-Format-HTTP";
+    version = "0.42";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CK/CKRAS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/C/CK/CKRAS/DateTime-Format-HTTP-0.42.tar.gz;
       sha256 = "0h6qqdg1yzqkdxp7hqlp0qa7d1y64nilgimxs79dys2ryjfpcknh";
     };
     propagatedBuildInputs = [ DateTime HTTPDate ];
@@ -3761,7 +4043,8 @@ let
   };
 
   DateTimeFormatICal = buildPerlModule {
-    name = "DateTime-Format-ICal-0.09";
+    pname = "DateTime-Format-ICal";
+    version = "0.09";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DR/DROLSKY/DateTime-Format-ICal-0.09.tar.gz;
       sha256 = "8b09f6539f5e9c0df0e6135031699ed4ef9eef8165fc80aefeecc817ef997c33";
@@ -3774,7 +4057,8 @@ let
   };
 
   DateTimeFormatISO8601 = buildPerlModule {
-    name = "DateTime-Format-ISO8601-0.08";
+    pname = "DateTime-Format-ISO8601";
+    version = "0.08";
     src = fetchurl {
       url = mirror://cpan/authors/id/J/JH/JHOBLITT/DateTime-Format-ISO8601-0.08.tar.gz;
       sha256 = "1syccqd5jlwms8v78ksnf68xijzl97jky5vbwhnyhxi5gvgfx8xk";
@@ -3787,7 +4071,8 @@ let
   };
 
   DateTimeFormatMail = buildPerlPackage {
-    name = "DateTime-Format-Mail-0.403";
+    pname = "DateTime-Format-Mail";
+    version = "0.403";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BO/BOOK/DateTime-Format-Mail-0.403.tar.gz;
       sha256 = "8df8e35c4477388ff5c7ce8b3e8b6ae4ed30209c7a5051d41737bd14d755fcb0";
@@ -3800,7 +4085,8 @@ let
   };
 
   DateTimeFormatNatural = buildPerlModule {
-    name = "DateTime-Format-Natural-1.07";
+    pname = "DateTime-Format-Natural";
+    version = "1.07";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SC/SCHUBIGER/DateTime-Format-Natural-1.07.tar.gz;
       sha256 = "1df12c7bf1nchaniak1rd2x18mckp4ymc0bgkbnvphhd1p08bzvx";
@@ -3814,9 +4100,10 @@ let
   };
 
   DateTimeFormatMySQL = buildPerlModule rec {
-    name = "DateTime-Format-MySQL-0.06";
+    pname = "DateTime-Format-MySQL";
+    version = "0.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/X/XM/XMIKEW/${name}.tar.gz";
+      url = mirror://cpan/authors/id/X/XM/XMIKEW/DateTime-Format-MySQL-0.06.tar.gz;
       sha256 = "07cgz60gxvrv7xqvngyll60pa8cx93h3jyx9kc9wdkn95qbd864q";
     };
     propagatedBuildInputs = [ DateTimeFormatBuilder ];
@@ -3827,7 +4114,8 @@ let
   };
 
   DateTimeFormatPg = buildPerlModule {
-    name = "DateTime-Format-Pg-0.16013";
+    pname = "DateTime-Format-Pg";
+    version = "0.16013";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DM/DMAKI/DateTime-Format-Pg-0.16013.tar.gz;
       sha256 = "16siw0f3a0ilzv5fnfas5s9n92drjy271yf6qvmmpm0vwnjjx1kz";
@@ -3841,9 +4129,10 @@ let
   };
 
   DateTimeFormatStrptime = buildPerlPackage rec {
-    name = "DateTime-Format-Strptime-1.76";
+    pname = "DateTime-Format-Strptime";
+    version = "1.76";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DR/DROLSKY/DateTime-Format-Strptime-1.76.tar.gz;
       sha256 = "593c26466ed7a3d2cefe9215f1619666c5116bd3a551e0aa74b64a6353fcb50d";
     };
     buildInputs = [ TestFatal TestWarnings ];
@@ -3855,9 +4144,10 @@ let
   };
 
   DateTimeFormatSQLite = buildPerlPackage rec {
-    name = "DateTime-Format-SQLite-0.11";
+    pname = "DateTime-Format-SQLite";
+    version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CF/CFAERBER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/C/CF/CFAERBER/DateTime-Format-SQLite-0.11.tar.gz;
       sha256 = "cc1f4e0ae1d39b0d4c3dddccfd7423c77c67a70950c4b5ecabf8ca553ab294b4";
     };
     propagatedBuildInputs = [ DateTimeFormatBuilder ];
@@ -3868,7 +4158,8 @@ let
   };
 
   DateTimeFormatW3CDTF = buildPerlPackage {
-    name = "DateTime-Format-W3CDTF-0.07";
+    pname = "DateTime-Format-W3CDTF";
+    version = "0.07";
     src = fetchurl {
       url = mirror://cpan/authors/id/G/GW/GWILLIAMS/DateTime-Format-W3CDTF-0.07.tar.gz;
       sha256 = "69a02b661bbf1daa14a4813cb6786eaa66dbdf2743f0b3f458e30234c3a26268";
@@ -3881,9 +4172,10 @@ let
   };
 
   DateTimeLocale = buildPerlPackage rec {
-    name = "DateTime-Locale-1.24";
+    pname = "DateTime-Locale";
+    version = "1.24";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DR/DROLSKY/DateTime-Locale-1.24.tar.gz;
       sha256 = "d03aaa33126a13b1fe6591b9838f0a07395f1fea12b6e304566d7e39a5e5fb82";
     };
     buildInputs = [ CPANMetaCheck FileShareDirInstall IPCSystemSimple TestFatal TestFileShareDir TestRequires TestWarnings ];
@@ -3895,9 +4187,10 @@ let
   };
 
   DateTimeSet = buildPerlModule rec {
-    name = "DateTime-Set-0.3900";
+    pname = "DateTime-Set";
+    version = "0.3900";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FG/FGLOCK/${name}.tar.gz";
+      url = mirror://cpan/authors/id/F/FG/FGLOCK/DateTime-Set-0.3900.tar.gz;
       sha256 = "94f41c3924aafde4ef7fa6b58e0595d4038d8ac5ffd62ba111b13c5f4dbc0946";
     };
     propagatedBuildInputs = [ DateTime ParamsValidate SetInfinite ];
@@ -3923,7 +4216,8 @@ let
   };
 
   DateTimeXEasy = buildPerlPackage {
-    name = "DateTimeX-Easy-0.089";
+    pname = "DateTimeX-Easy";
+    version = "0.089";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RO/ROKR/DateTimeX-Easy-0.089.tar.gz;
       sha256 = "17e6d202e7ac6049523048e97bb8f195e3c79208570da1504f4313584e487a79";
@@ -3938,7 +4232,8 @@ let
   };
 
   DebugShowStuff = buildPerlModule {
-    name = "Debug-ShowStuff-1.16";
+    pname = "Debug-ShowStuff";
+    version = "1.16";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MI/MIKO/Debug-ShowStuff-1.16.tar.gz;
       sha256 = "1drcrnji3yrd0s3xb69bxnqa51s19c13w68vhvjad3nvswn5vpd4";
@@ -3951,7 +4246,8 @@ let
   };
 
   DevelCaller = buildPerlPackage {
-    name = "Devel-Caller-2.06";
+    pname = "Devel-Caller";
+    version = "2.06";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RC/RCLAMP/Devel-Caller-2.06.tar.gz;
       sha256 = "1pxpimifzmnjnvf4icclx77myc15ahh0k56sj1djad1855mawwva";
@@ -3964,7 +4260,8 @@ let
   };
 
   DevelCheckBin = buildPerlPackage rec {
-     name = "Devel-CheckBin-0.04";
+     pname = "Devel-CheckBin";
+     version = "0.04";
      src = fetchurl {
        url = mirror://cpan/authors/id/T/TO/TOKUHIROM/Devel-CheckBin-0.04.tar.gz;
        sha256 = "1r735yzgvsxkj4m6ks34xva5m21cfzp9qiis2d4ivv99kjskszqm";
@@ -3977,7 +4274,8 @@ let
   };
 
   DevelCheckCompiler = buildPerlModule rec {
-     name = "Devel-CheckCompiler-0.07";
+     pname = "Devel-CheckCompiler";
+     version = "0.07";
      src = fetchurl {
        url = mirror://cpan/authors/id/S/SY/SYOHEX/Devel-CheckCompiler-0.07.tar.gz;
        sha256 = "1db973a4dbyknjxq608hywil5ai6vplnayshqxrd7m5qnjbpd2vn";
@@ -3991,18 +4289,20 @@ let
   };
 
   DevelChecklib = buildPerlPackage rec {
-    name = "Devel-CheckLib-1.13";
+    pname = "Devel-CheckLib";
+    version = "1.13";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MATTN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MA/MATTN/Devel-CheckLib-1.13.tar.gz;
       sha256 = "1a19qkwxwz3wqb16cdabymfbf9kiydiifw90nd5srpq5hy8gvb94";
     };
     buildInputs = [ IOCaptureOutput MockConfig ];
   };
 
   DevelCheckOS = buildPerlPackage rec {
-    name = "Devel-CheckOS-1.81";
+    pname = "Devel-CheckOS";
+    version = "1.81";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DC/DCANTRELL/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DC/DCANTRELL/Devel-CheckOS-1.81.tar.gz;
       sha256 = "f3c17b56b79283b62616f938d36c57adc9df06bfaa295ff98be21e9014a23b10";
     };
     propagatedBuildInputs = [ DataCompare ];
@@ -4024,7 +4324,8 @@ let
   };
 
   DevelRefcount = buildPerlModule {
-    name = "Devel-Refcount-0.10";
+    pname = "Devel-Refcount";
+    version = "0.10";
     src = fetchurl {
       url = mirror://cpan/authors/id/P/PE/PEVANS/Devel-Refcount-0.10.tar.gz;
       sha256 = "0jnaraqkigyinhwz4nqk1ndq7ssjizr98nd1dd183a6icdlx8m5n";
@@ -4050,7 +4351,8 @@ let
   };
 
   DevelTrace = buildPerlPackage {
-    name = "Devel-Trace-0.12";
+    pname = "Devel-Trace";
+    version = "0.12";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MJ/MJD/Devel-Trace-0.12.tar.gz;
       sha256 = "0s1q1a05gk3xvwqkya3k05vqjk13rvb489g0frprhzpzfvvwl0gm";
@@ -4062,7 +4364,8 @@ let
   };
 
   DBDMock = buildPerlModule {
-    name = "DBD-Mock-1.45";
+    pname = "DBD-Mock";
+    version = "1.45";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DI/DICHI/DBD-Mock/DBD-Mock-1.45.tar.gz;
       sha256 = "40a80c37b31ef14536b58b4a8b483e65953b00b8fa7397817c7eb76d540bd00f";
@@ -4084,10 +4387,10 @@ let
   DBFile = callPackage ../development/perl-modules/DB_File { };
 
   DBI = buildPerlPackage rec {
-    name = "DBI-${version}";
+    pname = "DBI";
     version = "1.642";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TI/TIMB/${name}.tar.gz";
+      url = mirror://cpan/authors/id/T/TI/TIMB/DBI-1.642.tar.gz;
       sha256 = "3f2025023a56286cebd15cb495e36ccd9b456c3cc229bf2ce1f69e9ebfc27f5d";
     };
     postInstall = stdenv.lib.optionalString (perl ? crossVersion) ''
@@ -4136,9 +4439,10 @@ let
   };
 
   DBIxClass = buildPerlPackage rec {
-    name = "DBIx-Class-0.082841";
+    pname = "DBIx-Class";
+    version = "0.082841";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RI/RIBASUSHI/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RI/RIBASUSHI/DBIx-Class-0.082841.tar.gz;
       sha256 = "d705f85825aced299020534349778537524526d64f524217ca362787f683c3bd";
     };
     buildInputs = [ DBDSQLite TestDeep TestException TestWarn ];
@@ -4151,9 +4455,10 @@ let
   };
 
   DBIxClassCandy = buildPerlPackage rec {
-    name = "DBIx-Class-Candy-0.005003";
+    pname = "DBIx-Class-Candy";
+    version = "0.005003";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FR/FREW/${name}.tar.gz";
+      url = mirror://cpan/authors/id/F/FR/FREW/DBIx-Class-Candy-0.005003.tar.gz;
       sha256 = "b8a229a7b15f559095d4561cf8220460128541ba7fc3545ed35869923d46565c";
     };
     buildInputs = [ TestDeep TestFatal ];
@@ -4166,7 +4471,8 @@ let
   };
 
   DBIxClassCursorCached = buildPerlPackage {
-    name = "DBIx-Class-Cursor-Cached-1.001004";
+    pname = "DBIx-Class-Cursor-Cached";
+    version = "1.001004";
     src = fetchurl {
       url = mirror://cpan/authors/id/A/AR/ARCANEZ/DBIx-Class-Cursor-Cached-1.001004.tar.gz;
       sha256 = "09b2jahn2x12qm4f7qm1jzsxbz7qn1czp6a3fnl5l2i3l4r5421p";
@@ -4180,18 +4486,20 @@ let
   };
 
   DBIxClassHTMLWidget = buildPerlPackage rec {
-    name = "DBIx-Class-HTMLWidget-0.16";
+    pname = "DBIx-Class-HTMLWidget";
+    version = "0.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AN/ANDREMAR/${name}.tar.gz";
+      url = mirror://cpan/authors/id/A/AN/ANDREMAR/DBIx-Class-HTMLWidget-0.16.tar.gz;
       sha256 = "05zhniyzl31nq410ywhxm0vmvac53h7ax42hjs9mmpvf45ipahj1";
     };
     propagatedBuildInputs = [ DBIxClass HTMLWidget ];
   };
 
   DBIxClassHelpers = buildPerlPackage rec {
-    name = "DBIx-Class-Helpers-2.033004";
+    pname = "DBIx-Class-Helpers";
+    version = "2.033004";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FR/FREW/${name}.tar.gz";
+      url = mirror://cpan/authors/id/F/FR/FREW/DBIx-Class-Helpers-2.033004.tar.gz;
       sha256 = "14bc7adda3b30867311717faa11a4534bceda3061229dc2533647c1906d8784c";
     };
     buildInputs = [ DBDSQLite DateTimeFormatSQLite TestDeep TestFatal TestRoo aliased ];
@@ -4204,9 +4512,10 @@ let
   };
 
   DBIxClassIntrospectableM2M = buildPerlPackage rec {
-    name = "DBIx-Class-IntrospectableM2M-0.001002";
+    pname = "DBIx-Class-IntrospectableM2M";
+    version = "0.001002";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IL/ILMARI/${name}.tar.gz";
+      url = mirror://cpan/authors/id/I/IL/ILMARI/DBIx-Class-IntrospectableM2M-0.001002.tar.gz;
       sha256 = "c6baafb4241693fdb34b29ebd906993add364bf31aafa4462f3e062204cc87f0";
     };
     propagatedBuildInputs = [ DBIxClass ];
@@ -4217,9 +4526,10 @@ let
   };
 
   DBIxClassSchemaLoader = buildPerlPackage rec {
-    name = "DBIx-Class-Schema-Loader-0.07049";
+    pname = "DBIx-Class-Schema-Loader";
+    version = "0.07049";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IL/ILMARI/${name}.tar.gz";
+      url = mirror://cpan/authors/id/I/IL/ILMARI/DBIx-Class-Schema-Loader-0.07049.tar.gz;
       sha256 = "e869cdde1378cfebccf229b0cde58d2746dc6080b75f56d072aa5f1fce76a764";
     };
     buildInputs = [ DBDSQLite TestDeep TestDifferences TestException TestWarn ];
@@ -4231,9 +4541,10 @@ let
   };
 
   DBIxConnector = buildPerlModule rec {
-    name = "DBIx-Connector-0.56";
+    pname = "DBIx-Connector";
+    version = "0.56";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DW/DWHEELER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DW/DWHEELER/DBIx-Connector-0.56.tar.gz;
       sha256 = "57c08d2c1951486cb95cfb83f518f462a3dbf20d353f3eee4f46af44fa19c359";
     };
     buildInputs = [ TestMockModule ];
@@ -4245,7 +4556,8 @@ let
   };
 
   DBIxDBSchema = buildPerlPackage {
-    name = "DBIx-DBSchema-0.45";
+    pname = "DBIx-DBSchema";
+    version = "0.45";
     src = fetchurl {
       url = mirror://cpan/authors/id/I/IV/IVAN/DBIx-DBSchema-0.45.tar.gz;
       sha256 = "7a2a978fb6d9feaa3e4b109c71c963b26a008a2d130c5876ecf24c5a72338a1d";
@@ -4263,7 +4575,8 @@ let
   };
 
   DBIxSearchBuilder = buildPerlPackage {
-    name = "DBIx-SearchBuilder-1.67";
+    pname = "DBIx-SearchBuilder";
+    version = "1.67";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BP/BPS/DBIx-SearchBuilder-1.67.tar.gz;
       sha256 = "453179c22a61af573e502c8396f3f28daea03dfdc162094b90f9b3c331d563da";
@@ -4277,7 +4590,8 @@ let
   };
 
   DBIxSimple = buildPerlPackage {
-    name = "DBIx-Simple-1.37";
+    pname = "DBIx-Simple";
+    version = "1.37";
     src = fetchurl {
       url = mirror://cpan/authors/id/J/JU/JUERD/DBIx-Simple-1.37.tar.gz;
       sha256 = "46d311aa2ce08907401c56119658426dbb044c5a40de73d9a7b79bf50390cae3";
@@ -4289,7 +4603,8 @@ let
   };
 
   DataBinary = buildPerlPackage {
-    name = "Data-Binary-0.01";
+    pname = "Data-Binary";
+    version = "0.01";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SN/SNKWATT/Data-Binary-0.01.tar.gz;
       sha256 = "0wwdrgkz4yqpzdmfvid63v5v10b9hwdsg15jvks0hwdc23ga48a8";
@@ -4301,9 +4616,10 @@ let
   };
 
   DBIxIntrospector = buildPerlPackage rec {
-    name = "DBIx-Introspector-0.001005";
+    pname = "DBIx-Introspector";
+    version = "0.001005";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FR/FREW/${name}.tar.gz";
+      url = mirror://cpan/authors/id/F/FR/FREW/DBIx-Introspector-0.001005.tar.gz;
       sha256 = "0fp6h71xv4pgb8l815rs6ad4camzhjqf64s1sf7zmhchqqn4vacn";
     };
 
@@ -4312,7 +4628,8 @@ let
   };
 
   DevelCycle = buildPerlPackage {
-    name = "Devel-Cycle-1.12";
+    pname = "Devel-Cycle";
+    version = "1.12";
     src = fetchurl {
       url = mirror://cpan/authors/id/L/LD/LDS/Devel-Cycle-1.12.tar.gz;
       sha256 = "1hhb77kz3dys8yaik452j22cm3510zald2mpvfyv5clqv326aczx";
@@ -4323,9 +4640,10 @@ let
   };
 
   DevelDeclare = buildPerlPackage rec {
-    name = "Devel-Declare-0.006019";
+    pname = "Devel-Declare";
+    version = "0.006019";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/E/ET/ETHER/Devel-Declare-0.006019.tar.gz;
       sha256 = "ac719dc289cbf53fbb3b090ccd3a55a9d207f24e09480423c96f7185af131808";
     };
     buildInputs = [ ExtUtilsDepends TestRequires ];
@@ -4337,9 +4655,10 @@ let
   };
 
   DevelFindPerl = buildPerlPackage rec {
-    name = "Devel-FindPerl-0.015";
+    pname = "Devel-FindPerl";
+    version = "0.015";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/${name}.tar.gz";
+      url = mirror://cpan/authors/id/L/LE/LEONT/Devel-FindPerl-0.015.tar.gz;
       sha256 = "1z1xfj3178w632mqddyklk355a19bsgzkilznrng3rvg4bfbfxaj";
     };
     meta = {
@@ -4349,9 +4668,10 @@ let
   };
 
   DevelGlobalDestruction = buildPerlPackage rec {
-    name = "Devel-GlobalDestruction-0.14";
+    pname = "Devel-GlobalDestruction";
+    version = "0.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/${name}.tar.gz";
+      url = mirror://cpan/authors/id/H/HA/HAARG/Devel-GlobalDestruction-0.14.tar.gz;
       sha256 = "1aslj6myylsvzr0vpqry1cmmvzbmpbdcl4v9zrl18ccik7rabf1l";
     };
     propagatedBuildInputs = [ SubExporterProgressive ];
@@ -4361,7 +4681,8 @@ let
   };
 
   DevelGlobalPhase = buildPerlPackage rec {
-     name = "Devel-GlobalPhase-0.003003";
+     pname = "Devel-GlobalPhase";
+     version = "0.003003";
      src = fetchurl {
        url = mirror://cpan/authors/id/H/HA/HAARG/Devel-GlobalPhase-0.003003.tar.gz;
        sha256 = "1x9jzy3l7gwikj57swzl94qsq03j9na9h1m69azzs7d7ghph58wd";
@@ -4373,17 +4694,19 @@ let
   };
 
   DevelHide = buildPerlPackage rec {
-    name = "Devel-Hide-0.0010";
+    pname = "Devel-Hide";
+    version = "0.0010";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FE/FERREIRA/${name}.tar.gz";
+      url = mirror://cpan/authors/id/F/FE/FERREIRA/Devel-Hide-0.0010.tar.gz;
       sha256 = "10jyv9nmv513hs75rls5yx2xn82513xnnhjir3dxiwgb1ykfyvvm";
     };
   };
 
   DevelNYTProf = buildPerlPackage rec {
-    name = "Devel-NYTProf-6.06";
+    pname = "Devel-NYTProf";
+    version = "6.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TI/TIMB/${name}.tar.gz";
+      url = mirror://cpan/authors/id/T/TI/TIMB/Devel-NYTProf-6.06.tar.gz;
       sha256 = "a14227ca79f1750b92cc7b8b0a5806c92abc4964a21a7fb100bd4907d6c4be55";
     };
     propagatedBuildInputs = [ FileWhich JSONMaybeXS ];
@@ -4396,7 +4719,8 @@ let
   };
 
   DevelOverloadInfo = buildPerlPackage rec {
-     name = "Devel-OverloadInfo-0.005";
+     pname = "Devel-OverloadInfo";
+     version = "0.005";
      src = fetchurl {
        url = mirror://cpan/authors/id/I/IL/ILMARI/Devel-OverloadInfo-0.005.tar.gz;
        sha256 = "1rx6g8pyhi7lx6z130b7vlf8syzrq92w9ky8mpw4d6bwlkzy5zcb";
@@ -4410,7 +4734,8 @@ let
   };
 
   DevelPartialDump = buildPerlPackage {
-    name = "Devel-PartialDump-0.20";
+    pname = "Devel-PartialDump";
+    version = "0.20";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/Devel-PartialDump-0.20.tar.gz;
       sha256 = "01yrsdpn9ns9iwwc92bhjn2605b7ys7i3198gjb935lsllzgzw5f";
@@ -4420,7 +4745,8 @@ let
   };
 
   DevelStackTrace = buildPerlPackage {
-    name = "Devel-StackTrace-2.03";
+    pname = "Devel-StackTrace";
+    version = "2.03";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DR/DROLSKY/Devel-StackTrace-2.03.tar.gz;
       sha256 = "7618cd4ebe24e254c17085f4b418784ab503cb4cb3baf8f48a7be894e59ba848";
@@ -4432,7 +4758,8 @@ let
   };
 
   DevelStackTraceAsHTML = buildPerlPackage {
-    name = "Devel-StackTrace-AsHTML-0.15";
+    pname = "Devel-StackTrace-AsHTML";
+    version = "0.15";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MI/MIYAGAWA/Devel-StackTrace-AsHTML-0.15.tar.gz;
       sha256 = "0iri5nb2lb76qv5l9z0vjpfrq5j2fyclkd64kh020bvy37idp0v2";
@@ -4445,9 +4772,10 @@ let
   };
 
   DevelSymdump = buildPerlPackage rec {
-    name = "Devel-Symdump-2.18";
+    pname = "Devel-Symdump";
+    version = "2.18";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AN/ANDK/${name}.tar.gz";
+      url = mirror://cpan/authors/id/A/AN/ANDK/Devel-Symdump-2.18.tar.gz;
       sha256 = "826f81a107f5592a2516766ed43beb47e10cc83edc9ea48090b02a36040776c0";
     };
     meta = {
@@ -4457,9 +4785,10 @@ let
   };
 
   DigestCRC = buildPerlPackage rec {
-    name = "Digest-CRC-0.22.2";
+    pname = "Digest-CRC";
+    version = "0.22.2";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OL/OLIMAUL/${name}.tar.gz";
+      url = mirror://cpan/authors/id/O/OL/OLIMAUL/Digest-CRC-0.22.2.tar.gz;
       sha256 = "112b50f7fbc6f6baf5d4584ee97f542ced6c9ec03a3147f7902c84b8b26778cb";
     };
     meta = {
@@ -4469,7 +4798,8 @@ let
   };
 
   DigestHMAC = buildPerlPackage {
-    name = "Digest-HMAC-1.03";
+    pname = "Digest-HMAC";
+    version = "1.03";
     src = fetchurl {
       url = mirror://cpan/authors/id/G/GA/GAAS/Digest-HMAC-1.03.tar.gz;
       sha256 = "0naavabbm1c9zgn325ndy66da4insdw9l3mrxwxdfi7i7xnjrirv";
@@ -4481,9 +4811,10 @@ let
   };
 
   DigestJHash = buildPerlPackage rec {
-    name = "Digest-JHash-0.10";
+    pname = "Digest-JHash";
+    version = "0.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SH/SHLOMIF/Digest-JHash-0.10.tar.gz;
       sha256 = "c746cf0a861a004090263cd54d7728d0c7595a0cf90cbbfd8409b396ee3b0063";
     };
     meta = {
@@ -4493,15 +4824,17 @@ let
   };
 
   DigestMD4 = buildPerlPackage rec {
-    name = "Digest-MD4-1.9";
+    pname = "Digest-MD4";
+    version = "1.9";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIKEM/DigestMD4/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MI/MIKEM/DigestMD4/Digest-MD4-1.9.tar.gz;
       sha256 = "19ma1hmvgiznq95ngzvm6v4dfxc9zmi69k8iyfcg6w14lfxi0lb6";
     };
   };
 
   DigestMD5File = buildPerlPackage {
-    name = "Digest-MD5-File-0.08";
+    pname = "Digest-MD5-File";
+    version = "0.08";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DM/DMUEY/Digest-MD5-File-0.08.tar.gz;
       sha256 = "060jzf45dlwysw5wsm7av1wvpl06xgk415kwwpvv89r6wda3md5d";
@@ -4513,9 +4846,10 @@ let
   };
 
   DigestPerlMD5 = buildPerlPackage rec {
-    name = "Digest-Perl-MD5-1.9";
+    pname = "Digest-Perl-MD5";
+    version = "1.9";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DE/DELTA/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DE/DELTA/Digest-Perl-MD5-1.9.tar.gz;
       sha256 = "7100cba1710f45fb0e907d8b1a7bd8caef35c64acd31d7f225aff5affeecd9b1";
     };
     meta = {
@@ -4525,7 +4859,8 @@ let
   };
 
   DigestSHA1 = buildPerlPackage {
-    name = "Digest-SHA1-2.13";
+    pname = "Digest-SHA1";
+    version = "2.13";
     src = fetchurl {
       url = mirror://cpan/authors/id/G/GA/GAAS/Digest-SHA1-2.13.tar.gz;
       sha256 = "1k23p5pjk42vvzg8xcn4iwdii47i0qm4awdzgbmz08bl331dmhb8";
@@ -4551,9 +4886,10 @@ let
   };
 
   DistCheckConflicts = buildPerlPackage rec {
-    name = "Dist-CheckConflicts-0.11";
+    pname = "Dist-CheckConflicts";
+    version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DO/DOY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DO/DOY/Dist-CheckConflicts-0.11.tar.gz;
       sha256 = "1i7dr9jpdiy2nijl2p4q5zg2q2s9ckbj2hs4kmnnckf9hsb4p17a";
     };
     buildInputs = [ TestFatal ];
@@ -4565,7 +4901,8 @@ let
   };
 
   DistZilla = buildPerlPackage {
-    name = "Dist-Zilla-6.012";
+    pname = "Dist-Zilla";
+    version = "6.012";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RJ/RJBS/Dist-Zilla-6.012.tar.gz;
       sha256 = "0w1hhvxcdf52ln940f8i37adv2gp7l8ryf2nm6m7haynyrsk0n37";
@@ -4581,7 +4918,8 @@ let
   };
 
   DistZillaPluginBundleTestingMania = buildPerlModule {
-    name = "Dist-Zilla-PluginBundle-TestingMania-0.25";
+    pname = "Dist-Zilla-PluginBundle-TestingMania";
+    version = "0.25";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DO/DOHERTY/Dist-Zilla-PluginBundle-TestingMania-0.25.tar.gz;
       sha256 = "072rsilh88xnk18ldbr8d0svji72r79sabyird6xc3ql1z0b42sy";
@@ -4596,7 +4934,8 @@ let
   };
 
   DistZillaPluginCheckChangeLog = buildPerlPackage {
-    name = "Dist-Zilla-Plugin-CheckChangeLog-0.05";
+    pname = "Dist-Zilla-Plugin-CheckChangeLog";
+    version = "0.05";
     src = fetchurl {
       url = mirror://cpan/authors/id/F/FA/FAYLAND/Dist-Zilla-Plugin-CheckChangeLog-0.05.tar.gz;
       sha256 = "b0b34d6d70b56f1944d03c5f0dc3b8f6f24474c816d07b657a116c692c2e052a";
@@ -4610,7 +4949,8 @@ let
   };
 
   DistZillaPluginMojibakeTests = buildPerlPackage {
-    name = "Dist-Zilla-Plugin-MojibakeTests-0.8";
+    pname = "Dist-Zilla-Plugin-MojibakeTests";
+    version = "0.8";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SY/SYP/Dist-Zilla-Plugin-MojibakeTests-0.8.tar.gz;
       sha256 = "f1fff547ea24a8f7a483406a72ed6c4058d746d9dae963725502ddba025ab380";
@@ -4625,7 +4965,8 @@ let
   };
 
   DistZillaPluginPodWeaver = buildPerlPackage {
-    name = "Dist-Zilla-Plugin-PodWeaver-4.008";
+    pname = "Dist-Zilla-Plugin-PodWeaver";
+    version = "4.008";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RJ/RJBS/Dist-Zilla-Plugin-PodWeaver-4.008.tar.gz;
       sha256 = "0ff1i26s54z292j8w8vm3gw3p7w1yq35wi8g978c84ia7y1y7n8z";
@@ -4639,7 +4980,8 @@ let
   };
 
   DistZillaPluginReadmeAnyFromPod = buildPerlPackage {
-    name = "Dist-Zilla-Plugin-ReadmeAnyFromPod-0.163250";
+    pname = "Dist-Zilla-Plugin-ReadmeAnyFromPod";
+    version = "0.163250";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RT/RTHOMPSON/Dist-Zilla-Plugin-ReadmeAnyFromPod-0.163250.tar.gz;
       sha256 = "d44f2799922f78b2a7961ed89123e11bdd77abfe85ba2040d82b80ad72ed13bc";
@@ -4654,7 +4996,8 @@ let
   };
 
   DistZillaPluginReadmeMarkdownFromPod = buildPerlPackage {
-    name = "Dist-Zilla-Plugin-ReadmeMarkdownFromPod-0.141140";
+    pname = "Dist-Zilla-Plugin-ReadmeMarkdownFromPod";
+    version = "0.141140";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RT/RTHOMPSON/Dist-Zilla-Plugin-ReadmeMarkdownFromPod-0.141140.tar.gz;
       sha256 = "9caad7b366ea59119ad73cdd99dcdd53f877a515bd0164fc28b339c01739a801";
@@ -4669,9 +5012,10 @@ let
   };
 
   DistZillaPluginTestCPANChanges = buildPerlPackage rec {
-    name = "Dist-Zilla-Plugin-Test-CPAN-Changes-0.012";
+    pname = "Dist-Zilla-Plugin-Test-CPAN-Changes";
+    version = "0.012";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DO/DOHERTY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DO/DOHERTY/Dist-Zilla-Plugin-Test-CPAN-Changes-0.012.tar.gz;
       sha256 = "215b3a5c3c58c8bab0ea27130441bbdaec737eecc00f0670937f608bdbf64806";
     };
     buildInputs = [ CPANChanges TestDeep ];
@@ -4683,7 +5027,8 @@ let
   };
 
   DistZillaPluginTestCPANMetaJSON = buildPerlModule {
-    name = "Dist-Zilla-Plugin-Test-CPAN-Meta-JSON-0.004";
+    pname = "Dist-Zilla-Plugin-Test-CPAN-Meta-JSON";
+    version = "0.004";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DO/DOHERTY/Dist-Zilla-Plugin-Test-CPAN-Meta-JSON-0.004.tar.gz;
       sha256 = "0a573e1d5640374e6ee4d56d4fb94a3c67d4e75d52b3ddeae70cfa6450e1af22";
@@ -4698,9 +5043,10 @@ let
   };
 
   DistZillaPluginTestCompile = buildPerlModule rec {
-    name = "Dist-Zilla-Plugin-Test-Compile-2.058";
+    pname = "Dist-Zilla-Plugin-Test-Compile";
+    version = "2.058";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/E/ET/ETHER/Dist-Zilla-Plugin-Test-Compile-2.058.tar.gz;
       sha256 = "d0cf93e525f102eca0f7f3967124d2e59d0a212f738ce54c1ddd91dda268d88a";
     };
     buildInputs = [ CPANMetaCheck ModuleBuildTiny TestDeep TestMinimumVersion TestWarnings ];
@@ -4713,7 +5059,8 @@ let
   };
 
   DistZillaPluginTestDistManifest = buildPerlModule {
-    name = "Dist-Zilla-Plugin-Test-DistManifest-2.000005";
+    pname = "Dist-Zilla-Plugin-Test-DistManifest";
+    version = "2.000005";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DO/DOHERTY/Dist-Zilla-Plugin-Test-DistManifest-2.000005.tar.gz;
       sha256 = "4f0af27bb38745d2dec7d941bcf749e6d7fbeaf8e7bcf8a79a1310a9639b0f65";
@@ -4727,7 +5074,8 @@ let
   };
 
   DistZillaPluginTestEOL = buildPerlModule {
-    name = "Dist-Zilla-Plugin-Test-EOL-0.19";
+    pname = "Dist-Zilla-Plugin-Test-EOL";
+    version = "0.19";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/Dist-Zilla-Plugin-Test-EOL-0.19.tar.gz;
       sha256 = "0f23g931azz1k41xdfxw7kayy4snhw4qdr9ysknk5k1cl33mkfd2";
@@ -4741,7 +5089,8 @@ let
   };
 
   DistZillaPluginTestKwalitee = buildPerlModule {
-    name = "Dist-Zilla-Plugin-Test-Kwalitee-2.12";
+    pname = "Dist-Zilla-Plugin-Test-Kwalitee";
+    version = "2.12";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/Dist-Zilla-Plugin-Test-Kwalitee-2.12.tar.gz;
       sha256 = "bddbcfcc75e8eb2d2d9c8611552f00cdc1b051f0f00798623b8692ff5030af2f";
@@ -4755,7 +5104,8 @@ let
   };
 
   DistZillaPluginTestMinimumVersion = buildPerlPackage {
-    name = "Dist-Zilla-Plugin-Test-MinimumVersion-2.000008";
+    pname = "Dist-Zilla-Plugin-Test-MinimumVersion";
+    version = "2.000008";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DO/DOHERTY/Dist-Zilla-Plugin-Test-MinimumVersion-2.000008.tar.gz;
       sha256 = "d924ce79aaaa1885510ca6ecfcb4d8bc250fb6995bc96627f1536cb589e3b660";
@@ -4769,7 +5119,8 @@ let
   };
 
   DistZillaPluginTestNoTabs = buildPerlModule rec {
-     name = "Dist-Zilla-Plugin-Test-NoTabs-0.15";
+     pname = "Dist-Zilla-Plugin-Test-NoTabs";
+     version = "0.15";
      src = fetchurl {
        url = mirror://cpan/authors/id/E/ET/ETHER/Dist-Zilla-Plugin-Test-NoTabs-0.15.tar.gz;
        sha256 = "196hchmn8y591533v3p7kl75nlhpaygbfdiw2iqbnab9j510qq8v";
@@ -4784,7 +5135,8 @@ let
   };
 
   DistZillaPluginTestPerlCritic = buildPerlModule {
-    name = "Dist-Zilla-Plugin-Test-Perl-Critic-3.001";
+    pname = "Dist-Zilla-Plugin-Test-Perl-Critic";
+    version = "3.001";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/Dist-Zilla-Plugin-Test-Perl-Critic-3.001.tar.gz;
       sha256 = "9250b59d5dc1ae4c6893ba783bd3f05131b14ff9e91afb4555314f55268a3825";
@@ -4798,9 +5150,10 @@ let
   };
 
   DistZillaPluginTestPodLinkCheck = buildPerlPackage rec {
-    name = "Dist-Zilla-Plugin-Test-Pod-LinkCheck-1.004";
+    pname = "Dist-Zilla-Plugin-Test-Pod-LinkCheck";
+    version = "1.004";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RW/RWSTAUNER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RW/RWSTAUNER/Dist-Zilla-Plugin-Test-Pod-LinkCheck-1.004.tar.gz;
       sha256 = "325d236da0940388d2aa86ec5c1326516b4ad45adef8e7a4f83bb91d5ee15490";
     };
 #    buildInputs = [ TestPodLinkCheck ];
@@ -4813,7 +5166,8 @@ let
   };
 
   DistZillaPluginTestPortability = buildPerlModule {
-    name = "Dist-Zilla-Plugin-Test-Portability-2.001000";
+    pname = "Dist-Zilla-Plugin-Test-Portability";
+    version = "2.001000";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/Dist-Zilla-Plugin-Test-Portability-2.001000.tar.gz;
       sha256 = "e08ff5bd9e24cf9503055330148913808d91a3dfe320a2bdf8b0fc638719b179";
@@ -4827,7 +5181,8 @@ let
   };
 
   DistZillaPluginTestSynopsis = buildPerlPackage {
-    name = "Dist-Zilla-Plugin-Test-Synopsis-2.000007";
+    pname = "Dist-Zilla-Plugin-Test-Synopsis";
+    version = "2.000007";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DO/DOHERTY/Dist-Zilla-Plugin-Test-Synopsis-2.000007.tar.gz;
       sha256 = "e7d5e2530cd8a5bb5aadf3e1669a653aaa96e32cad7bd6b9caba6b425ceab563";
@@ -4841,7 +5196,8 @@ let
   };
 
   DistZillaPluginTestUnusedVars = buildPerlModule {
-    name = "Dist-Zilla-Plugin-Test-UnusedVars-2.000007";
+    pname = "Dist-Zilla-Plugin-Test-UnusedVars";
+    version = "2.000007";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DO/DOHERTY/Dist-Zilla-Plugin-Test-UnusedVars-2.000007.tar.gz;
       sha256 = "ea0199a3a0043213ddc132508b9ed9b131ef717735b8f93d78291191d04b43c2";
@@ -4855,7 +5211,8 @@ let
   };
 
   DistZillaPluginTestVersion = buildPerlPackage {
-    name = "Dist-Zilla-Plugin-Test-Version-1.09";
+    pname = "Dist-Zilla-Plugin-Test-Version";
+    version = "1.09";
     src = fetchurl {
       url = mirror://cpan/authors/id/P/PL/PLICEASE/Dist-Zilla-Plugin-Test-Version-1.09.tar.gz;
       sha256 = "7240508731bc1bf6dfad7701ec65450a18ef9245a521ab26ebd6acb39a9ebe17";
@@ -4869,7 +5226,8 @@ let
   };
 
   DistZillaRoleFileWatcher = buildPerlModule rec {
-     name = "Dist-Zilla-Role-FileWatcher-0.006";
+     pname = "Dist-Zilla-Role-FileWatcher";
+     version = "0.006";
      src = fetchurl {
        url = mirror://cpan/authors/id/E/ET/ETHER/Dist-Zilla-Role-FileWatcher-0.006.tar.gz;
        sha256 = "15jfpr257xxp27gz156npgpj7kh2dchzgfmvzivi5bvdb2wl8fpy";
@@ -4884,7 +5242,8 @@ let
   };
 
   Dumbbench = buildPerlPackage {
-    name = "Dumbbench-0.111";
+    pname = "Dumbbench";
+    version = "0.111";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BD/BDFOY/Dumbbench-0.111.tar.gz;
       sha256 = "1ixjb9y9d0k1vd4mzbi4sgvr99ay4z9jkgychf0r5gbjsskkq7fk";
@@ -4898,9 +5257,10 @@ let
   };
 
   EmailAbstract = buildPerlPackage rec {
-    name = "Email-Abstract-3.008";
+    pname = "Email-Abstract";
+    version = "3.008";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RJ/RJBS/Email-Abstract-3.008.tar.gz;
       sha256 = "fc7169acb6c43df7f005e7ef6ad08ee8ca6eb6796b5d1604593c997337cc8240";
     };
     propagatedBuildInputs = [ EmailSimple MROCompat ModulePluggable ];
@@ -4912,7 +5272,8 @@ let
   };
 
   EmailAddress = buildPerlPackage {
-    name = "Email-Address-1.912";
+    pname = "Email-Address";
+    version = "1.912";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RJ/RJBS/Email-Address-1.912.tar.gz;
       sha256 = "1vzr0vx4zsw4zbc9xdffc31wnkc1raqmyfiyws06fbyck197i8qg";
@@ -4924,7 +5285,8 @@ let
   };
 
   EmailAddressList = buildPerlPackage {
-    name = "Email-Address-List-0.06";
+    pname = "Email-Address-List";
+    version = "0.06";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BP/BPS/Email-Address-List-0.06.tar.gz;
       sha256 = "305b94c778011cee70d9f21514d92e985fa9dccbb84c64798f0c1f0b24eb870e";
@@ -4938,7 +5300,8 @@ let
   };
 
   EmailAddressXS = buildPerlPackage rec {
-     name = "Email-Address-XS-1.04";
+     pname = "Email-Address-XS";
+     version = "1.04";
      src = fetchurl {
        url = mirror://cpan/authors/id/P/PA/PALI/Email-Address-XS-1.04.tar.gz;
        sha256 = "0gjrrl81z3sfwavgx5kwjd87gj44mlnbbqsm3dgdv1xllw26spwr";
@@ -4950,9 +5313,10 @@ let
   };
 
   EmailDateFormat = buildPerlPackage rec {
-    name = "Email-Date-Format-1.005";
+    pname = "Email-Date-Format";
+    version = "1.005";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RJ/RJBS/Email-Date-Format-1.005.tar.gz;
       sha256 = "579c617e303b9d874411c7b61b46b59d36f815718625074ae6832e7bb9db5104";
     };
     meta = {
@@ -4963,7 +5327,8 @@ let
   };
 
   EmailReply = buildPerlPackage rec {
-    name = "Email-Reply-1.204";
+    pname = "Email-Reply";
+    version = "1.204";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RJ/RJBS/Email-Reply-1.204.tar.gz;
       sha256 = "ba4fd80ac5017d6d132e0358c786b0ecd1c7adcbeee5c19fb3da2964791a56f0";
@@ -4976,7 +5341,8 @@ let
   };
 
   EmailMessageID = buildPerlPackage {
-    name = "Email-MessageID-1.406";
+    pname = "Email-MessageID";
+    version = "1.406";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RJ/RJBS/Email-MessageID-1.406.tar.gz;
       sha256 = "1f22sdnfq169qw1l0lg7y74pmiam7j9v95bggjnf3q4mygdmshpc";
@@ -4988,9 +5354,10 @@ let
   };
 
   EmailMIME = buildPerlPackage rec {
-    name = "Email-MIME-1.946";
+    pname = "Email-MIME";
+    version = "1.946";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RJ/RJBS/Email-MIME-1.946.tar.gz;
       sha256 = "68ee79023165d77bec99a2e12ef89ad4e12501e6c321f6822053dc4f411c337c";
     };
     propagatedBuildInputs = [ EmailAddressXS EmailMIMEContentType EmailMIMEEncodings EmailMessageID EmailSimple MIMETypes ModuleRuntime ];
@@ -5002,7 +5369,8 @@ let
   };
 
   EmailMIMEAttachmentStripper = buildPerlPackage rec {
-    name = "Email-MIME-Attachment-Stripper-1.317";
+    pname = "Email-MIME-Attachment-Stripper";
+    version = "1.317";
     buildInputs = [ CaptureTiny ];
     propagatedBuildInputs = [ EmailAbstract EmailMIME ];
 
@@ -5017,9 +5385,10 @@ let
   };
 
   EmailMIMEContentType = buildPerlPackage rec {
-    name = "Email-MIME-ContentType-1.022";
+    pname = "Email-MIME-ContentType";
+    version = "1.022";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RJ/RJBS/Email-MIME-ContentType-1.022.tar.gz;
       sha256 = "9abb7280b0da62a855ae5528b14deb94341a84e721af0a7e5a2adc3534ec5310";
     };
     meta = {
@@ -5030,9 +5399,10 @@ let
   };
 
   EmailMIMEEncodings = buildPerlPackage rec {
-    name = "Email-MIME-Encodings-1.315";
+    pname = "Email-MIME-Encodings";
+    version = "1.315";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RJ/RJBS/Email-MIME-Encodings-1.315.tar.gz;
       sha256 = "4c71045507b31ec853dd60152b40e33ba3741779c0f49bb143b50cf8d243ab5c";
     };
     buildInputs = [ CaptureTiny ];
@@ -5044,9 +5414,10 @@ let
   };
 
   EmailSend = buildPerlPackage rec {
-    name = "Email-Send-2.201";
+    pname = "Email-Send";
+    version = "2.201";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RJ/RJBS/Email-Send-2.201.tar.gz;
       sha256 = "4bbec933558d7cc9b8152bad86dd313de277a21a89b4ea83d84e61587e95dbc6";
     };
     propagatedBuildInputs = [ EmailAbstract EmailAddress ReturnValue ];
@@ -5059,10 +5430,10 @@ let
   };
 
   EmailOutlookMessage = buildPerlModule rec {
-    name = "Email-Outlook-Message-${version}";
+    pname = "Email-Outlook-Message";
     version = "0.919";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MV/MVZ/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MV/MVZ/Email-Outlook-Message-0.919.tar.gz;
       sha256 = "0fb1gymqa8nlj540dmbb1rhs2b0ln3y9ippbgj0miswcw92iaayb";
     };
     propagatedBuildInputs = [ EmailMIME EmailSender IOAll IOString OLEStorage_Lite ];
@@ -5075,9 +5446,10 @@ let
   };
 
   EmailSender = buildPerlPackage rec {
-    name = "Email-Sender-1.300031";
+    pname = "Email-Sender";
+    version = "1.300031";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RJ/RJBS/Email-Sender-1.300031.tar.gz;
       sha256 = "c412372938510283d8c850127895e09c2b670f892e1c3992fd54c0c1a9064f14";
     };
     buildInputs = [ CaptureTiny ];
@@ -5090,9 +5462,10 @@ let
   };
 
   EmailSimple = buildPerlPackage rec {
-    name = "Email-Simple-2.216";
+    pname = "Email-Simple";
+    version = "2.216";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RJ/RJBS/Email-Simple-2.216.tar.gz;
       sha256 = "d85f63cd1088d11311103676a8cf498fff564a201b538de52cd753b5e5ca8bd4";
     };
     propagatedBuildInputs = [ EmailDateFormat ];
@@ -5104,9 +5477,10 @@ let
   };
 
   EmailValid = buildPerlPackage rec {
-    name = "Email-Valid-1.202";
+    pname = "Email-Valid";
+    version = "1.202";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RJ/RJBS/Email-Valid-1.202.tar.gz;
       sha256 = "18hkmhddzbd23s6ak64d4j6q8ijykjyp5nxbr2hfcq1acsdhh8fh";
     };
     propagatedBuildInputs = [ IOCaptureOutput MailTools NetDNS NetDomainTLD ];
@@ -5114,9 +5488,10 @@ let
   };
 
   EmailValidLoose = buildPerlPackage rec {
-    name = "Email-Valid-Loose-0.05";
+    pname = "Email-Valid-Loose";
+    version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MI/MIYAGAWA/Email-Valid-Loose-0.05.tar.gz;
       sha256 = "e718e76eddee240251c999e139c8cbe6f2cc80192da5af875cbd12fa8ab93a59";
     };
     propagatedBuildInputs = [ EmailValid ];
@@ -5126,9 +5501,10 @@ let
   };
 
   Encode = buildPerlPackage rec {
-    name = "Encode-3.01";
+    pname = "Encode";
+    version = "3.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DANKOGAI/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DA/DANKOGAI/Encode-3.01.tar.gz;
       sha256 = "d4555f570491648dbbd602bce7966672834b4c8f45acaa6757de474fca3a4d87";
     };
     meta = {
@@ -5138,9 +5514,10 @@ let
   };
 
   EncodeDetect = buildPerlModule rec {
-    name = "Encode-Detect-1.01";
+    pname = "Encode-Detect";
+    version = "1.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JG/JGMYERS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/J/JG/JGMYERS/Encode-Detect-1.01.tar.gz;
       sha256 = "834d893aa7db6ce3f158afbd0e432d6ed15a276e0940db0a74be13fd9c4bbbf1";
     };
     nativeBuildInputs = [ pkgs.ld-is-cc-hook ];
@@ -5152,7 +5529,8 @@ let
 
 
   EncodeEUCJPASCII = buildPerlPackage {
-    name = "Encode-EUCJPASCII-0.03";
+    pname = "Encode-EUCJPASCII";
+    version = "0.03";
     src = fetchurl {
       url = mirror://cpan/authors/id/N/NE/NEZUMI/Encode-EUCJPASCII-0.03.tar.gz;
       sha256 = "f998d34d55fd9c82cf910786a0448d1edfa60bf68e2c2306724ca67c629de861";
@@ -5165,7 +5543,8 @@ let
   };
 
   EncodeHanExtra = buildPerlPackage {
-    name = "Encode-HanExtra-0.23";
+    pname = "Encode-HanExtra";
+    version = "0.23";
     src = fetchurl {
       url = mirror://cpan/authors/id/A/AU/AUDREYT/Encode-HanExtra-0.23.tar.gz;
       sha256 = "1fd4b06cada70858003af153f94c863b3b95f2e3d03ba18d0451a81d51db443a";
@@ -5177,7 +5556,8 @@ let
   };
 
   EncodeJIS2K = buildPerlPackage {
-    name = "Encode-JIS2K-0.03";
+    pname = "Encode-JIS2K";
+    version = "0.03";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DA/DANKOGAI/Encode-JIS2K-0.03.tar.gz;
       sha256 = "1ec84d72db39deb4dad6fca95acfcc21033f45a24d347c20f9a1a696896c35cc";
@@ -5188,7 +5568,8 @@ let
   };
 
   EncodeLocale = buildPerlPackage rec {
-    name = "Encode-Locale-1.05";
+    pname = "Encode-Locale";
+    version = "1.05";
     src = fetchurl {
       url = mirror://cpan/authors/id/G/GA/GAAS/Encode-Locale-1.05.tar.gz;
       sha256 = "176fa02771f542a4efb1dbc2a4c928e8f4391bf4078473bd6040d8f11adb0ec1";
@@ -5205,7 +5586,8 @@ let
   };
 
   EncodeNewlines = buildPerlPackage rec {
-     name = "Encode-Newlines-0.05";
+     pname = "Encode-Newlines";
+     version = "0.05";
      src = fetchurl {
        url = mirror://cpan/authors/id/N/NE/NEILB/Encode-Newlines-0.05.tar.gz;
        sha256 = "1gipd3wnma28w5gjbzycfkpi6chksy14lhxkp4hwizf8r351zcrl";
@@ -5218,9 +5600,10 @@ let
   };
 
   enum = buildPerlPackage rec {
-    name = "enum-1.11";
+    pname = "enum";
+    version = "1.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/${name}.tar.gz";
+      url = mirror://cpan/authors/id/N/NE/NEILB/enum-1.11.tar.gz;
       sha256 = "d2f36b5015f1e35f640159867b60bf5d5cd66b56cd5e42d33f531be68e5eee35";
     };
     meta = {
@@ -5229,7 +5612,8 @@ let
   };
 
   Env = buildPerlPackage {
-    name = "Env-1.04";
+    pname = "Env";
+    version = "1.04";
     src = fetchurl {
       url = mirror://cpan/authors/id/F/FL/FLORA/Env-1.04.tar.gz;
       sha256 = "d94a3d412df246afdc31a2199cbd8ae915167a3f4684f7b7014ce1200251ebb0";
@@ -5241,7 +5625,8 @@ let
   };
 
   EnvPath = buildPerlPackage {
-    name = "Env-Path-0.19";
+    pname = "Env-Path";
+    version = "0.19";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DS/DSB/Env-Path-0.19.tar.gz;
       sha256 = "1qhmj15a66h90pjl2dgnxsb9jj3b1r5mpvnr87cafcl8g69z0jr4";
@@ -5249,17 +5634,19 @@ let
   };
 
   Error = buildPerlModule rec {
-    name = "Error-0.17027";
+    pname = "Error";
+    version = "0.17027";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SH/SHLOMIF/Error-0.17027.tar.gz;
       sha256 = "1gnkxf12dq2w1jmjpllp5f30ya4nll01jv2sfi24386zfn1arch7";
     };
   };
 
   EV = buildPerlPackage rec {
-    name = "EV-4.25";
+    pname = "EV";
+    version = "4.25";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/ML/MLEHMANN/EV-4.25.tar.gz;
       sha256 = "2e65c8e8f2358599f9a48f766cc1b3ad0eaf2e6cef416adc8ad9cddc3f329c6a";
     };
     buildInputs = [ CanaryStability ];
@@ -5270,7 +5657,8 @@ let
   };
 
   EvalClosure = buildPerlPackage {
-    name = "Eval-Closure-0.14";
+    pname = "Eval-Closure";
+    version = "0.14";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DO/DOY/Eval-Closure-0.14.tar.gz;
       sha256 = "1bcc47r6zm3hfr6ccsrs72kgwxm3wkk07mgnpsaxi67cypr482ga";
@@ -5283,9 +5671,10 @@ let
   };
 
   ExceptionBase = buildPerlModule rec {
-    name = "Exception-Base-0.2501";
+    pname = "Exception-Base";
+    version = "0.2501";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DE/DEXTER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DE/DEXTER/Exception-Base-0.2501.tar.gz;
       sha256 = "5723dd78f4ac0b4d262a05ea46af663ea00d8096b2e9c0a43515c210760e1e75";
     };
     buildInputs = [ TestUnitLite ];
@@ -5296,16 +5685,18 @@ let
   };
 
   ExceptionClass = buildPerlPackage rec {
-    name = "Exception-Class-1.44";
+    pname = "Exception-Class";
+    version = "1.44";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DR/DROLSKY/Exception-Class-1.44.tar.gz;
       sha256 = "03gf4cdgrjnljgrlxkvbh2cahsyzn0zsh2zcli7b1lrqn7wgpwrk";
     };
     propagatedBuildInputs = [ ClassDataInheritable DevelStackTrace ];
   };
 
   ExceptionDied = buildPerlModule {
-    name = "Exception-Died-0.06";
+    pname = "Exception-Died";
+    version = "0.06";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DE/DEXTER/Exception-Died-0.06.tar.gz;
       sha256 = "1dcajw2m3x5m76fpi3fvy9fjkmfrd171pnx087i5fkgx5ay41i1m";
@@ -5315,7 +5706,8 @@ let
   };
 
   ExceptionWarning = buildPerlModule {
-    name = "Exception-Warning-0.0401";
+    pname = "Exception-Warning";
+    version = "0.0401";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DE/DEXTER/Exception-Warning-0.0401.tar.gz;
       sha256 = "1a6k3sbhkxmz00wrmhv70f9kxjf7fklp1y6mnprfvcdmrsk9qdkv";
@@ -5325,7 +5717,8 @@ let
   };
 
   ExporterDeclare = buildPerlModule {
-    name = "Exporter-Declare-0.114";
+    pname = "Exporter-Declare";
+    version = "0.114";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/EX/EXODIST/Exporter-Declare-0.114.tar.gz;
       sha256 = "4bd70d6ca76f6f6ba7e4c618d4ac93b8593a58f1233ccbe18b10f5f204f1d4e4";
@@ -5340,7 +5733,8 @@ let
   };
 
   ExporterLite = buildPerlPackage {
-    name = "Exporter-Lite-0.08";
+    pname = "Exporter-Lite";
+    version = "0.08";
     src = fetchurl {
       url = mirror://cpan/authors/id/N/NE/NEILB/Exporter-Lite-0.08.tar.gz;
       sha256 = "1hns15imih8z2h6zv3m1wwmv9fiysacsb52y94v6zf2cmw4kjny0";
@@ -5351,7 +5745,8 @@ let
   };
 
   ExporterTiny = buildPerlPackage {
-    name = "Exporter-Tiny-1.002001";
+    pname = "Exporter-Tiny";
+    version = "1.002001";
     src = fetchurl {
       url = mirror://cpan/authors/id/T/TO/TOBYINK/Exporter-Tiny-1.002001.tar.gz;
       sha256 = "a82c334c02ce4b0f9ea77c67bf77738f76a9b8aa4bae5c7209d1c76453d3c48d";
@@ -5363,7 +5758,8 @@ let
   };
 
   ExtUtilsCBuilder = buildPerlPackage {
-    name = "ExtUtils-CBuilder-0.280231";
+    pname = "ExtUtils-CBuilder";
+    version = "0.280231";
     src = fetchurl {
       url = mirror://cpan/authors/id/A/AM/AMBS/ExtUtils-CBuilder-0.280231.tar.gz;
       sha256 = "1szfbq3vw9q3h3pff23p9pzfj21rkcmbljhdnl5w2s04r932brz6";
@@ -5376,7 +5772,8 @@ let
   };
 
   Expect = buildPerlPackage {
-    name = "Expect-1.35";
+    pname = "Expect";
+    version = "1.35";
     src = fetchurl {
       url = mirror://cpan/authors/id/J/JA/JACOBY/Expect-1.35.tar.gz;
       sha256 = "09d92761421decd495853103379165a99efbf452c720f30277602cf23679fd06";
@@ -5389,9 +5786,10 @@ let
   };
 
   ExtUtilsCChecker = buildPerlModule rec {
-    name = "ExtUtils-CChecker-0.10";
+    pname = "ExtUtils-CChecker";
+    version = "0.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/P/PE/PEVANS/ExtUtils-CChecker-0.10.tar.gz;
       sha256 = "50bfe76870fc1510f56bae4fa2dce0165d9ac4af4e7320d6b8fda14dfea4be0b";
     };
     buildInputs = [ TestFatal ];
@@ -5402,7 +5800,8 @@ let
   };
 
   ExtUtilsConfig = buildPerlPackage {
-    name = "ExtUtils-Config-0.008";
+    pname = "ExtUtils-Config";
+    version = "0.008";
     src = fetchurl {
       url = mirror://cpan/authors/id/L/LE/LEONT/ExtUtils-Config-0.008.tar.gz;
       sha256 = "ae5104f634650dce8a79b7ed13fb59d67a39c213a6776cfdaa3ee749e62f1a8c";
@@ -5414,7 +5813,8 @@ let
   };
 
   ExtUtilsConstant = buildPerlPackage {
-    name = "ExtUtils-Constant-0.25";
+    pname = "ExtUtils-Constant";
+    version = "0.25";
     src = fetchurl {
       url = mirror://cpan/authors/id/N/NW/NWCLARK/ExtUtils-Constant-0.25.tar.gz;
       sha256 = "6933d0e963b62281ef7561068e6aecac8c4ac2b476b2bba09ab0b90fbac9d757";
@@ -5422,7 +5822,8 @@ let
   };
 
   ExtUtilsCppGuess = buildPerlPackage rec {
-    name = "ExtUtils-CppGuess-0.19";
+    pname = "ExtUtils-CppGuess";
+    version = "0.19";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETJ/ExtUtils-CppGuess-0.19.tar.gz;
       sha256 = "1lva59kq447wbpc5nnr0zvr6gczxrmi0r7l9r2kqx132nsx33ijc";
@@ -5433,7 +5834,8 @@ let
   };
 
   ExtUtilsDepends = buildPerlPackage {
-    name = "ExtUtils-Depends-0.8000";
+    pname = "ExtUtils-Depends";
+    version = "0.8000";
     src = fetchurl {
       url = mirror://cpan/authors/id/X/XA/XAOC/ExtUtils-Depends-0.8000.tar.gz;
       sha256 = "165y1cjirbq64w39svkz82cb5jjqkjm8f4c0wqi2lk6050hzf3vq";
@@ -5444,7 +5846,8 @@ let
   };
 
   ExtUtilsHelpers = buildPerlPackage {
-    name = "ExtUtils-Helpers-0.026";
+    pname = "ExtUtils-Helpers";
+    version = "0.026";
     src = fetchurl {
       url = mirror://cpan/authors/id/L/LE/LEONT/ExtUtils-Helpers-0.026.tar.gz;
       sha256 = "05ilqcj1rg5izr09dsqmy5di4fvq6ph4k0chxks7qmd4j1kip46y";
@@ -5456,7 +5859,8 @@ let
   };
 
   ExtUtilsInstall = buildPerlPackage {
-    name = "ExtUtils-Install-2.14";
+    pname = "ExtUtils-Install";
+    version = "2.14";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BI/BINGOS/ExtUtils-Install-2.14.tar.gz;
       sha256 = "35412305cbae979aac3b6e2c70cb301ae461979a1d848a8a043f74518eb96aea";
@@ -5468,7 +5872,8 @@ let
   };
 
   ExtUtilsInstallPaths = buildPerlPackage {
-    name = "ExtUtils-InstallPaths-0.012";
+    pname = "ExtUtils-InstallPaths";
+    version = "0.012";
     src = fetchurl {
       url = mirror://cpan/authors/id/L/LE/LEONT/ExtUtils-InstallPaths-0.012.tar.gz;
       sha256 = "1v9lshfhm9ck4p0v77arj5f7haj1mmkqal62lgzzvcds6wq5www4";
@@ -5481,9 +5886,10 @@ let
   };
 
   ExtUtilsLibBuilder = buildPerlModule rec {
-    name = "ExtUtils-LibBuilder-0.08";
+    pname = "ExtUtils-LibBuilder";
+    version = "0.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AM/AMBS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/A/AM/AMBS/ExtUtils-LibBuilder-0.08.tar.gz;
       sha256 = "1lmmfcjxvsvhn4f3v2lyylgr8dzcf5j7mnd1pkq3jc75dph724f5";
     };
     perlPreHook = "export LD=$CC";
@@ -5507,7 +5913,8 @@ let
   };
 
   ExtUtilsMakeMakerCPANfile = buildPerlPackage rec {
-     name = "ExtUtils-MakeMaker-CPANfile-0.09";
+     pname = "ExtUtils-MakeMaker-CPANfile";
+     version = "0.09";
      src = fetchurl {
        url = mirror://cpan/authors/id/I/IS/ISHIGAKI/ExtUtils-MakeMaker-CPANfile-0.09.tar.gz;
        sha256 = "0xg2z100vjhcndwaz9m3mmi90rb8h5pggpvlj1b0i8dhsh3pc1rc";
@@ -5520,7 +5927,8 @@ let
   };
 
   ExtUtilsManifest = buildPerlPackage rec {
-    name = "ExtUtils-Manifest-1.72";
+    pname = "ExtUtils-Manifest";
+    version = "1.72";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/ExtUtils-Manifest-1.72.tar.gz;
       sha256 = "0pml5pfdk34nj9fa8m4f0qp1rh1yv0d54xagvxzjvvwq9w3q14kr";
@@ -5528,9 +5936,10 @@ let
   };
 
   ExtUtilsPkgConfig = buildPerlPackage rec {
-    name = "ExtUtils-PkgConfig-1.16";
+    pname = "ExtUtils-PkgConfig";
+    version = "1.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/X/XA/XAOC/${name}.tar.gz";
+      url = mirror://cpan/authors/id/X/XA/XAOC/ExtUtils-PkgConfig-1.16.tar.gz;
       sha256 = "bbeaced995d7d8d10cfc51a3a5a66da41ceb2bc04fedcab50e10e6300e801c6e";
     };
     propagatedBuildInputs = [ pkgs.pkgconfig ];
@@ -5553,7 +5962,8 @@ let
   #
   # [1] https://metacpan.org/pod/release/SMUELLER/ExtUtils-Typemap-1.00/lib/ExtUtils/Typemap.pm:
   ExtUtilsTypemap = buildPerlPackage rec {
-    name = "ExtUtils-Typemap-1.00";
+    pname = "ExtUtils-Typemap";
+    version = "1.00";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SM/SMUELLER/ExtUtils-Typemap-1.00.tar.gz;
       sha256 = "1iqz0xlscg655gnwb2h1wrjj70llblps1zznl29qn1mv5mvibc5i";
@@ -5561,7 +5971,8 @@ let
   };
 
   ExtUtilsTypemapsDefault = buildPerlModule rec {
-    name = "ExtUtils-Typemaps-Default-1.05";
+    pname = "ExtUtils-Typemaps-Default";
+    version = "1.05";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SM/SMUELLER/ExtUtils-Typemaps-Default-1.05.tar.gz;
       sha256 = "1phmha0ks95kvzl00r1kgnd5hvg7qb1q9jmzjmw01p5zgs1zbyix";
@@ -5569,7 +5980,8 @@ let
   };
 
   ExtUtilsXSBuilder = buildPerlPackage {
-    name = "ExtUtils-XSBuilder-0.28";
+    pname = "ExtUtils-XSBuilder";
+    version = "0.28";
     src = fetchurl {
       url = mirror://cpan/authors/id/G/GR/GRICHTER/ExtUtils-XSBuilder-0.28.tar.gz;
       sha256 = "8cced386e3d544c5ec2deb3aed055b72ebcfc2ea9a6c807da87c4245272fe80a";
@@ -5578,7 +5990,8 @@ let
   };
 
   ExtUtilsXSpp = buildPerlModule rec {
-    name = "ExtUtils-XSpp-0.18";
+    pname = "ExtUtils-XSpp";
+    version = "0.18";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SM/SMUELLER/ExtUtils-XSpp-0.18.tar.gz;
       sha256 = "1zx84f93lkymqz7qa4d63gzlnhnkxm5i3gvsrwkvvqr9cxjasxli";
@@ -5587,7 +6000,8 @@ let
   };
 
   FatalException = buildPerlModule {
-    name = "Fatal-Exception-0.05";
+    pname = "Fatal-Exception";
+    version = "0.05";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DE/DEXTER/Fatal-Exception-0.05.tar.gz;
       sha256 = "0kzfwc44vpxla3j637kfmnwmv57g6x4899ijqb4ljamk7whms298";
@@ -5597,7 +6011,8 @@ let
   };
 
   FCGI = buildPerlPackage rec {
-    name = "FCGI-0.78";
+    pname = "FCGI";
+    version = "0.78";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/FCGI-0.78.tar.gz;
       sha256 = "1cxavhzg4gyw4gl9kirpbdimjr8gk1rjc3pqs3xrnh1gjybld5xa";
@@ -5605,7 +6020,8 @@ let
   };
 
   FCGIClient = buildPerlModule rec {
-     name = "FCGI-Client-0.09";
+     pname = "FCGI-Client";
+     version = "0.09";
      src = fetchurl {
        url = mirror://cpan/authors/id/T/TO/TOKUHIROM/FCGI-Client-0.09.tar.gz;
        sha256 = "1s11casbv0jmkcl5dk8i2vhfy1nc8rg43d3bg923zassrq4wndym";
@@ -5619,7 +6035,8 @@ let
   };
 
   FCGIProcManager = buildPerlPackage {
-    name = "FCGI-ProcManager-0.28";
+    pname = "FCGI-ProcManager";
+    version = "0.28";
     src = fetchurl {
       url = mirror://cpan/authors/id/A/AR/ARODLAND/FCGI-ProcManager-0.28.tar.gz;
       sha256 = "e1c958c042427a175e051e0008f2025e8ec80613d3c7750597bf8e529b04420e";
@@ -5644,7 +6061,8 @@ let
   };
 
   FennecLite = buildPerlModule {
-    name = "Fennec-Lite-0.004";
+    pname = "Fennec-Lite";
+    version = "0.004";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/EX/EXODIST/Fennec-Lite-0.004.tar.gz;
       sha256 = "dce28e3932762c2ff92aa52d90405c06e898e81cb7b164ccae8966ae77f1dcab";
@@ -5657,7 +6075,8 @@ let
   };
 
   FileChangeNotify = buildPerlPackage {
-    name = "File-ChangeNotify-0.31";
+    pname = "File-ChangeNotify";
+    version = "0.31";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DR/DROLSKY/File-ChangeNotify-0.31.tar.gz;
       sha256 = "192bdb1ce76266c6a694a8e962d039e3adeeb829b6ac1e23f5057f2b506392bd";
@@ -5671,16 +6090,17 @@ let
   };
 
   Filechdir = buildPerlPackage rec {
-    name = "File-chdir-0.1010";
+    pname = "File-chdir";
+    version = "0.1010";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DA/DAGOLDEN/File-chdir-0.1010.tar.gz;
       sha256 = "009b8p2fzj4nhl03fpkhrn0rsh7myxqbrf69iqpzd86p1gs23hgg";
     };
   };
 
   FileBaseDir = buildPerlModule rec {
     version = "0.08";
-    name = "File-BaseDir-${version}";
+    pname = "File-BaseDir";
     src = fetchurl {
       url = mirror://cpan/authors/id/K/KI/KIMRYAN/File-BaseDir-0.08.tar.gz;
       sha256 = "c065fcd3e2f22ae769937bcc971b91f80294d5009fac140bfba83bf7d35305e3";
@@ -5694,9 +6114,10 @@ let
   };
 
   FileBOM = buildPerlModule rec {
-    name = "File-BOM-0.16";
+    pname = "File-BOM";
+    version = "0.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MATTLAW/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MA/MATTLAW/File-BOM-0.16.tar.gz;
       sha256 = "97091a72bb1d3a7b5cac1dfb5372962b6f8055729189d0f3fd2c959c8ff374cf";
     };
     buildInputs = [ TestException ];
@@ -5708,7 +6129,8 @@ let
   };
 
   FileCheckTree = buildPerlPackage {
-    name = "File-CheckTree-4.42";
+    pname = "File-CheckTree";
+    version = "4.42";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RJ/RJBS/File-CheckTree-4.42.tar.gz;
       sha256 = "66fb417f8ff8a5e5b7ea25606156e70e204861c59fa8c3831925b4dd3f155f8a";
@@ -5720,16 +6142,18 @@ let
   };
 
   FileCopyRecursive = buildPerlPackage rec {
-    name = "File-Copy-Recursive-0.44";
+    pname = "File-Copy-Recursive";
+    version = "0.44";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DM/DMUEY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DM/DMUEY/File-Copy-Recursive-0.44.tar.gz;
       sha256 = "1r3frbl61kr7ig9bzd60fka772cd504v3kx9kgnwvcy1inss06df";
     };
     buildInputs = [ PathTiny TestDeep TestFatal TestFile TestWarnings ];
   };
 
   FileCopyRecursiveReduced = buildPerlPackage rec {
-     name = "File-Copy-Recursive-Reduced-0.006";
+     pname = "File-Copy-Recursive-Reduced";
+     version = "0.006";
      src = fetchurl {
        url = mirror://cpan/authors/id/J/JK/JKEENAN/File-Copy-Recursive-Reduced-0.006.tar.gz;
        sha256 = "0b3yf33bahaf4ipfqipn8y5z4296k3vgzzsqbhh5ahwzls9zj676";
@@ -5744,7 +6168,7 @@ let
 
   FileDesktopEntry = buildPerlPackage rec {
     version = "0.22";
-    name = "File-DesktopEntry-${version}";
+    pname = "File-DesktopEntry";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MI/MICHIELB/File-DesktopEntry-0.22.tar.gz;
       sha256 = "169c01e3dae2f629767bec1a9f1cdbd6ec6d713d1501e0b2786e4dd1235635b8";
@@ -5753,7 +6177,8 @@ let
   };
 
   FileFindIterator = buildPerlPackage {
-    name = "File-Find-Iterator-0.4";
+    pname = "File-Find-Iterator";
+    version = "0.4";
     src = fetchurl {
       url = mirror://cpan/authors/id/T/TE/TEXMEC/File-Find-Iterator-0.4.tar.gz;
       sha256 = "a2b87ab9756a2e5bb674adbd39937663ed20c28c716bf5a1095a3ca44d54ab2c";
@@ -5764,7 +6189,8 @@ let
   };
 
   FileFindObject = buildPerlModule rec {
-    name = "File-Find-Object-0.3.2";
+    pname = "File-Find-Object";
+    version = "0.3.2";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SH/SHLOMIF/File-Find-Object-v0.3.2.tar.gz;
       sha256 = "7c467b6b7752bff46b7b8b84c9aabeac45bbfdab1e2224108a2e2170adb9f2b7";
@@ -5777,9 +6203,10 @@ let
   };
 
   FileFindObjectRule = buildPerlModule rec {
-    name = "File-Find-Object-Rule-0.0310";
+    pname = "File-Find-Object-Rule";
+    version = "0.0310";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SH/SHLOMIF/File-Find-Object-Rule-0.0310.tar.gz;
       sha256 = "f1f1820ff44042f6b30e4d6be1db860b9e743b1a9836070ea656ad9829e4eca5";
     };
     propagatedBuildInputs = [ FileFindObject NumberCompare TextGlob ];
@@ -5791,16 +6218,18 @@ let
   };
 
   FileFindRule = buildPerlPackage rec {
-    name = "File-Find-Rule-0.34";
+    pname = "File-Find-Rule";
+    version = "0.34";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RC/RCLAMP/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RC/RCLAMP/File-Find-Rule-0.34.tar.gz;
       sha256 = "1znachnhmi1w5pdqx8dzgfa892jb7x8ivrdy4pzjj7zb6g61cvvy";
     };
     propagatedBuildInputs = [ NumberCompare TextGlob ];
   };
 
   FileFindRulePerl = buildPerlPackage {
-    name = "File-Find-Rule-Perl-1.15";
+    pname = "File-Find-Rule-Perl";
+    version = "1.15";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/File-Find-Rule-Perl-1.15.tar.gz;
       sha256 = "9a48433f86e08ce18e03526e2982de52162eb909d19735460f07eefcaf463ea6";
@@ -5813,9 +6242,10 @@ let
   };
 
   FileFinder = buildPerlPackage rec {
-    name = "File-Finder-0.53";
+    pname = "File-Finder";
+    version = "0.53";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/ME/MERLYN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/ME/MERLYN/File-Finder-0.53.tar.gz;
       sha256 = "2ecbc19ac67a9e635c872a807a8d3eaaff5babc054f15a191d47cdfc5f176a74";
     };
     propagatedBuildInputs = [ TextGlob ];
@@ -5825,7 +6255,8 @@ let
   };
 
   FileFnMatch = buildPerlPackage rec {
-    name = "File-FnMatch-0.02";
+    pname = "File-FnMatch";
+    version = "0.02";
     src = fetchurl {
       url = "mirror://cpan/authors/id/M/MJ/MJP/File-FnMatch-0.02.tar.gz";
       sha256 = "05p9m7kpmjv8bmmbs5chb5fqyshcgmskbbzq5c9qpskbx2w5894n";
@@ -5838,9 +6269,10 @@ let
   };
 
   FileHandleUnget = buildPerlPackage rec {
-    name = "FileHandle-Unget-0.1634";
+    pname = "FileHandle-Unget";
+    version = "0.1634";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DC/DCOPPIT/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DC/DCOPPIT/FileHandle-Unget-0.1634.tar.gz;
       sha256 = "380f34ad3ce5e9ec661d4c468bb3392231c162317d4172df378146b42aab1785";
     };
     buildInputs = [ FileSlurper TestCompile UNIVERSALrequire URI ];
@@ -5853,7 +6285,8 @@ let
   };
 
   FileHomeDir = buildPerlPackage {
-    name = "File-HomeDir-1.004";
+    pname = "File-HomeDir";
+    version = "1.004";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RE/REHSACK/File-HomeDir-1.004.tar.gz;
       sha256 = "45f67e2bb5e60a7970d080e8f02079732e5a8dfc0c7c3cbdb29abfb3f9f791ad";
@@ -5868,18 +6301,20 @@ let
   };
 
   FileKeePass = buildPerlPackage rec {
-    name = "File-KeePass-2.03";
+    pname = "File-KeePass";
+    version = "2.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RH/RHANDOM/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RH/RHANDOM/File-KeePass-2.03.tar.gz;
       sha256 = "c30c688027a52ff4f58cd69d6d8ef35472a7cf106d4ce94eb73a796ba7c7ffa7";
     };
     propagatedBuildInputs = [ CryptRijndael ];
   };
 
   Filelchown = buildPerlModule rec {
-    name = "File-lchown-0.02";
+    pname = "File-lchown";
+    version = "0.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PEVANS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/P/PE/PEVANS/File-lchown-0.02.tar.gz;
       sha256 = "a02fbf285406a8a4d9399284f032f2d55c56975154c2e1674bd109837b8096ec";
     };
     buildInputs = [ ExtUtilsCChecker ];
@@ -5890,9 +6325,10 @@ let
   };
 
   FileLibMagic = buildPerlPackage rec {
-    name = "File-LibMagic-1.16";
+    pname = "File-LibMagic";
+    version = "1.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DR/DROLSKY/File-LibMagic-1.16.tar.gz;
       sha256 = "c8a695fac1454f52e18e2e1b624c0647cf117326014023dda69fa3e1a5f33d60";
     };
     buildInputs = [ pkgs.file TestFatal ];
@@ -5908,7 +6344,8 @@ let
   };
 
   FileListing = buildPerlPackage rec {
-    name = "File-Listing-6.04";
+    pname = "File-Listing";
+    version = "6.04";
     src = fetchurl {
       url = mirror://cpan/authors/id/G/GA/GAAS/File-Listing-6.04.tar.gz;
       sha256 = "1xcwjlnxaiwwpn41a5yi6nz95ywh3szq5chdxiwj36kqsvy5000y";
@@ -5917,7 +6354,8 @@ let
   };
 
   FileMimeInfo = buildPerlPackage rec {
-    name = "File-MimeInfo-0.29";
+    pname = "File-MimeInfo";
+    version = "0.29";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MI/MICHIELB/File-MimeInfo-0.29.tar.gz;
       sha256 = "1sh8r6vczyz08zm8vfsjmkg6a165wch54akjdrd1vbifcmwjg5pi";
@@ -5927,9 +6365,10 @@ let
   };
 
   FileMMagic = buildPerlPackage rec {
-    name = "File-MMagic-1.30";
+    pname = "File-MMagic";
+    version = "1.30";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KN/KNOK/${name}.tar.gz";
+      url = mirror://cpan/authors/id/K/KN/KNOK/File-MMagic-1.30.tar.gz;
       sha256 = "cf0c1b1eb29705c02d97c2913648009c0be42ce93ec24b36c696bf2d4f5ebd7e";
     };
     meta = {
@@ -5939,9 +6378,10 @@ let
   };
 
   FileModified = buildPerlPackage rec {
-    name = "File-Modified-0.10";
+    pname = "File-Modified";
+    version = "0.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/${name}.tar.gz";
+      url = mirror://cpan/authors/id/N/NE/NEILB/File-Modified-0.10.tar.gz;
       sha256 = "6b50b1aab6ec6998a017f6403c2735b3bc1e1cf46187bd134d7eb6df3fc45144";
     };
     meta = {
@@ -5952,15 +6392,17 @@ let
   };
 
   FileNext = buildPerlPackage rec {
-    name = "File-Next-1.16";
+    pname = "File-Next";
+    version = "1.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PETDANCE/${name}.tar.gz";
+      url = mirror://cpan/authors/id/P/PE/PETDANCE/File-Next-1.16.tar.gz;
       sha256 = "0nfp84p63a5xm6iwlckh3f6cy9bdpjw5fazplskhnb8k5ifg4rb9";
     };
   };
 
   FileNFSLock = buildPerlPackage {
-    name = "File-NFSLock-1.29";
+    pname = "File-NFSLock";
+    version = "1.29";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BB/BBB/File-NFSLock-1.29.tar.gz;
       sha256 = "0dzssj15faz9cn1w3xi7jwm64gyjyazapv4bkgglw5l1njcibm31";
@@ -5968,7 +6410,8 @@ let
   };
 
   FilePath = buildPerlPackage rec {
-    name = "File-Path-2.16";
+    pname = "File-Path";
+    version = "2.16";
     src = fetchurl {
       url = mirror://cpan/authors/id/J/JK/JKEENAN/File-Path-2.16.tar.gz;
       sha256 = "21f7d69b59c381f459c5f0bf697d512109bd911f12ca33270b70ca9a9ef6fa05";
@@ -5980,9 +6423,10 @@ let
   };
 
   FilePid = buildPerlPackage rec {
-    name = "File-Pid-1.01";
+    pname = "File-Pid";
+    version = "1.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CW/CWEST/${name}.tar.gz";
+      url = mirror://cpan/authors/id/C/CW/CWEST/File-Pid-1.01.tar.gz;
       sha256 = "bafeee8fdc96eb06306a0c58bbdb7209b6de45f850e75fdc6b16db576e05e422";
     };
     propagatedBuildInputs = [ ClassAccessor ];
@@ -5994,7 +6438,8 @@ let
   };
 
   Filepushd = buildPerlPackage {
-    name = "File-pushd-1.016";
+    pname = "File-pushd";
+    version = "1.016";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DA/DAGOLDEN/File-pushd-1.016.tar.gz;
       sha256 = "d73a7f09442983b098260df3df7a832a5f660773a313ca273fa8b56665f97cdc";
@@ -6006,9 +6451,10 @@ let
   };
 
   FileReadBackwards = buildPerlPackage rec {
-    name = "File-ReadBackwards-1.05";
+    pname = "File-ReadBackwards";
+    version = "1.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/U/UR/URI/${name}.tar.gz";
+      url = mirror://cpan/authors/id/U/UR/URI/File-ReadBackwards-1.05.tar.gz;
       sha256 = "82b261af87507cc3e7e66899c457104ebc8d1c09fb85c53f67c1f90f70f18d6e";
     };
     meta = {
@@ -6018,7 +6464,8 @@ let
   };
 
   FileRemove = buildPerlModule rec {
-    name = "File-Remove-1.58";
+    pname = "File-Remove";
+    version = "1.58";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SH/SHLOMIF/File-Remove-1.58.tar.gz;
       sha256 = "1n6h5w3sp2bs4cfrifdx2z15cfpb4r536179mx1a12xbmj1yrxl1";
@@ -6026,7 +6473,8 @@ let
   };
 
   FileShare = buildPerlPackage {
-    name = "File-Share-0.25";
+    pname = "File-Share";
+    version = "0.25";
     src = fetchurl {
       url = mirror://cpan/authors/id/I/IN/INGY/File-Share-0.25.tar.gz;
       sha256 = "0w3h800qqcf1sn79h84zngnn788rg2jx4jjb70l44f6419p2b7cf";
@@ -6040,7 +6488,8 @@ let
   };
 
   FileShareDir = buildPerlPackage {
-    name = "File-ShareDir-1.116";
+    pname = "File-ShareDir";
+    version = "1.116";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RE/REHSACK/File-ShareDir-1.116.tar.gz;
       sha256 = "0a43rfb0a1fpxh4d2dayarkdxw4cx9a2krkk87zmcilcz7yhpnar";
@@ -6054,7 +6503,8 @@ let
   };
 
   FileShareDirInstall = buildPerlPackage {
-    name = "File-ShareDir-Install-0.13";
+    pname = "File-ShareDir-Install";
+    version = "0.13";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/File-ShareDir-Install-0.13.tar.gz;
       sha256 = "1yc0wlkav2l2wr36a53n4mnhsy2zv29z5nm14mygxgjwv7qgvgj5";
@@ -6066,9 +6516,10 @@ let
   };
 
   FilesysDf = buildPerlPackage rec {
-    name = "Filesys-Df-0.92";
+    pname = "Filesys-Df";
+    version = "0.92";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IG/IGUTHRIE/${name}.tar.gz";
+      url = mirror://cpan/authors/id/I/IG/IGUTHRIE/Filesys-Df-0.92.tar.gz;
       sha256 = "fe89cbb427e0e05f1cd97c2dd6d3866ac6b21bc7a85734ede159bdc35479552a";
     };
     meta = {
@@ -6078,7 +6529,8 @@ let
   };
 
   FilesysNotifySimple = buildPerlPackage {
-    name = "Filesys-Notify-Simple-0.13";
+    pname = "Filesys-Notify-Simple";
+    version = "0.13";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MI/MIYAGAWA/Filesys-Notify-Simple-0.13.tar.gz;
       sha256 = "18jv96k1pf8wqf4vn2ahs7dv44lc9cyqj0bja9z17qici3dx7qxd";
@@ -6091,9 +6543,10 @@ let
   };
 
   FilesysDiskUsage = buildPerlPackage rec {
-    name = "Filesys-DiskUsage-0.12";
+    pname = "Filesys-DiskUsage";
+    version = "0.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MANWAR/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MA/MANWAR/Filesys-DiskUsage-0.12.tar.gz;
       sha256 = "e8afee07014df5868f9a2784e041c82c3c8c38550f4cd48bec56d0d6c4997273";
     };
     buildInputs = [ TestWarn ];
@@ -6104,7 +6557,8 @@ let
   };
 
   FileSlurp = buildPerlPackage {
-    name = "File-Slurp-9999.27";
+    pname = "File-Slurp";
+    version = "9999.27";
     src = fetchurl {
       url = mirror://cpan/authors/id/C/CA/CAPOEIRAB/File-Slurp-9999.27.tar.gz;
       sha256 = "1x233kj1qifvii7j8d4wzarwhj5z11vnpxsqvdm98dsccr7qi79s";
@@ -6116,9 +6570,10 @@ let
   };
 
   FileSlurper = buildPerlPackage rec {
-    name = "File-Slurper-0.012";
+    pname = "File-Slurper";
+    version = "0.012";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/${name}.tar.gz";
+      url = mirror://cpan/authors/id/L/LE/LEONT/File-Slurper-0.012.tar.gz;
       sha256 = "4efb2ea416b110a1bda6f8133549cc6ea3676402e3caf7529fce0313250aa578";
     };
     buildInputs = [ TestWarnings ];
@@ -6129,9 +6584,10 @@ let
   };
 
   FileSlurpTiny = buildPerlPackage rec {
-    name = "File-Slurp-Tiny-0.004";
+    pname = "File-Slurp-Tiny";
+    version = "0.004";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/${name}.tar.gz";
+      url = mirror://cpan/authors/id/L/LE/LEONT/File-Slurp-Tiny-0.004.tar.gz;
       sha256 = "452995beeabf0e923e65fdc627a725dbb12c9e10c00d8018c16d10ba62757f1e";
     };
     meta = {
@@ -6141,9 +6597,10 @@ let
   };
 
   FileTail = buildPerlPackage rec {
-    name = "File-Tail-1.3";
+    pname = "File-Tail";
+    version = "1.3";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MG/MGRABNAR/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MG/MGRABNAR/File-Tail-1.3.tar.gz;
       sha256 = "1ixg6kn4h330xfw3xgvqcbzfc3v2wlzjim9803jflhvfhf0rzl16";
     };
     meta = {
@@ -6154,7 +6611,8 @@ let
   };
 
   FileTemp = buildPerlPackage {
-    name = "File-Temp-0.2309";
+    pname = "File-Temp";
+    version = "0.2309";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/File-Temp-0.2309.tar.gz;
       sha256 = "0pr3wrxrk93wy7dz9gsb1sgl77icrs8rh2mah6wms5cdi2ll5ch1";
@@ -6167,9 +6625,10 @@ let
   };
 
   FileTouch = buildPerlPackage rec {
-    name = "File-Touch-0.11";
+    pname = "File-Touch";
+    version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/${name}.tar.gz";
+      url = mirror://cpan/authors/id/N/NE/NEILB/File-Touch-0.11.tar.gz;
       sha256 = "e379a5ff89420cf39906e5ceff309b8ce958f99f9c3e57ad52b5002a3982d93c";
     };
     meta = {
@@ -6181,7 +6640,8 @@ let
   };
 
   FileType = buildPerlModule {
-    name = "File-Type-0.22";
+    pname = "File-Type";
+    version = "0.22";
     src = fetchurl {
       url = mirror://cpan/authors/id/P/PM/PMISON/File-Type-0.22.tar.gz;
       sha256 = "0hfkaafp6wb0nw19x47wc6wc9mwlw8s2rxiii3ylvzapxxgxjp6k";
@@ -6193,9 +6653,10 @@ let
   };
 
   FileUtil = buildPerlModule rec {
-    name = "File-Util-4.161950";
+    pname = "File-Util";
+    version = "4.161950";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TOMMY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/T/TO/TOMMY/File-Util-4.161950.tar.gz;
       sha256 = "88507b19da580d595b5c25fe6ba75bbd6096b4359e389ead067a216f766c20ee";
     };
     buildInputs = [ TestNoWarnings ];
@@ -6207,9 +6668,10 @@ let
   };
 
   FileWhich = buildPerlPackage rec {
-    name = "File-Which-1.23";
+    pname = "File-Which";
+    version = "1.23";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/${name}.tar.gz";
+      url = mirror://cpan/authors/id/P/PL/PLICEASE/File-Which-1.23.tar.gz;
       sha256 = "b79dc2244b2d97b6f27167fc3b7799ef61a179040f3abd76ce1e0a3b0bc4e078";
     };
     meta = {
@@ -6220,7 +6682,8 @@ let
   };
 
   FileZglob = buildPerlPackage rec {
-     name = "File-Zglob-0.11";
+     pname = "File-Zglob";
+     version = "0.11";
      src = fetchurl {
        url = mirror://cpan/authors/id/T/TO/TOKUHIROM/File-Zglob-0.11.tar.gz;
        sha256 = "16v61rn0yimpv5kp6b20z2f1c93n5kpsyjvr0gq4w2dc43gfvc8w";
@@ -6232,7 +6695,8 @@ let
   };
 
   Filter = buildPerlPackage {
-    name = "Filter-1.59";
+    pname = "Filter";
+    version = "1.59";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RU/RURBAN/Filter-1.59.tar.gz;
       sha256 = "b4babfad4e0566a9a61199735f6e622a60d3274122752304f18f623412bf4e5a";
@@ -6244,9 +6708,10 @@ let
   };
 
   FinanceQuote = buildPerlPackage rec {
-    name = "Finance-Quote-1.47";
+    pname = "Finance-Quote";
+    version = "1.47";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/EC/ECOCODE/${name}.tar.gz";
+      url = mirror://cpan/authors/id/E/EC/ECOCODE/Finance-Quote-1.47.tar.gz;
       sha256 = "0gzbq85738f299jaw4nj3ljnka380j2y6yspmyl71rgfypqjvbr7";
     };
     propagatedBuildInputs = [ CGI DateTime HTMLTableExtract JSON LWPProtocolHttps ];
@@ -6258,17 +6723,19 @@ let
   };
 
   FontAFM = buildPerlPackage rec {
-    name = "Font-AFM-1.20";
+    pname = "Font-AFM";
+    version = "1.20";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GA/GAAS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/G/GA/GAAS/Font-AFM-1.20.tar.gz;
       sha256 = "32671166da32596a0f6baacd0c1233825a60acaf25805d79c81a3f18d6088bc1";
     };
   };
 
   FontTTF = buildPerlPackage rec {
-    name = "Font-TTF-1.06";
+    pname = "Font-TTF";
+    version = "1.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BH/BHALLISSY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/B/BH/BHALLISSY/Font-TTF-1.06.tar.gz;
       sha256 = "4b697d444259759ea02d2c442c9bffe5ffe14c9214084a01f743693a944cc293";
     };
     meta = {
@@ -6279,7 +6746,8 @@ let
   };
 
   ForksSuper = buildPerlPackage {
-    name = "Forks-Super-0.97";
+    pname = "Forks-Super";
+    version = "0.97";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MO/MOB/Forks-Super-0.97.tar.gz;
       sha256 = "0kias11b4zchxy5x9ns2wwjzvzxlzsbap8sq587z9micw5bl7nrk";
@@ -6293,9 +6761,10 @@ let
   };
 
   FormValidatorSimple = buildPerlPackage rec {
-    name = "FormValidator-Simple-0.29";
+    pname = "FormValidator-Simple";
+    version = "0.29";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LY/LYOKATO/${name}.tar.gz";
+      url = mirror://cpan/authors/id/L/LY/LYOKATO/FormValidator-Simple-0.29.tar.gz;
       sha256 = "fc3a63dc54b962d74586070176adaf5be869f09b561bb30f5fd32ef531792666";
     };
     propagatedBuildInputs = [ ClassAccessor ClassDataAccessor DateCalc DateTimeFormatStrptime EmailValidLoose ListMoreUtils TieIxHash UNIVERSALrequire YAML ];
@@ -6307,7 +6776,8 @@ let
   };
 
   FreezeThaw = buildPerlPackage {
-    name = "FreezeThaw-0.5001";
+    pname = "FreezeThaw";
+    version = "0.5001";
     src = fetchurl {
       url = mirror://cpan/authors/id/I/IL/ILYAZ/modules/FreezeThaw-0.5001.tar.gz;
       sha256 = "0h8gakd6b9770n2xhld1hhqghdar3hrq2js4mgiwxy86j4r0hpiw";
@@ -6331,7 +6801,8 @@ let
   };
 
   GD = buildPerlPackage rec {
-    name = "GD-2.71";
+    pname = "GD";
+    version = "2.71";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RU/RURBAN/GD-2.71.tar.gz;
       sha256 = "1ivskdb4nwy7ky37369hwkfxp11fkp6ri5k7qlf2dmra7f3y86s5";
@@ -6346,7 +6817,8 @@ let
   };
 
   GDGraph = buildPerlPackage rec {
-    name = "GDGraph-1.54";
+    pname = "GDGraph";
+    version = "1.54";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RU/RUZ/GDGraph-1.54.tar.gz;
       sha256 = "0kzsdc07ycxjainmz0dnsclb15w2j1y7g8b5mcb7vhannq85qvxr";
@@ -6360,7 +6832,8 @@ let
   };
 
   GDSecurityImage = buildPerlPackage {
-    name = "GD-SecurityImage-1.75";
+    pname = "GD-SecurityImage";
+    version = "1.75";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BU/BURAK/GD-SecurityImage-1.75.tar.gz;
       sha256 = "19lf1kzdavrkkx3f900jnpynr55d5kjd2sdmwpfir5dsmkcj9pix";
@@ -6373,7 +6846,8 @@ let
   };
 
   GDText = buildPerlPackage rec {
-    name = "GDTextUtil-0.86";
+    pname = "GDTextUtil";
+    version = "0.86";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MV/MVERB/GDTextUtil-0.86.tar.gz;
       sha256 = "1g0nc7fz4d672ag7brlrrcz7ibm98x49qs75bq9z957ybkwcnvl8";
@@ -6385,9 +6859,10 @@ let
   };
 
   GeoIP = buildPerlPackage rec {
-    name = "Geo-IP-1.51";
+    pname = "Geo-IP";
+    version = "1.51";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MAXMIND/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MA/MAXMIND/Geo-IP-1.51.tar.gz;
       sha256 = "1fka8fr7fw6sh3xa9glhs1zjg3s2gfkhi7n7da1l2m2wblqj0c0n";
     };
     makeMakerFlags = "LIBS=-L${pkgs.geoip}/lib INC=-I${pkgs.geoip}/include";
@@ -6395,7 +6870,8 @@ let
   };
 
   GeoIP2 = buildPerlPackage {
-    name = "GeoIP2-2.006001";
+    pname = "GeoIP2";
+    version = "2.006001";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MA/MAXMIND/GeoIP2-2.006001.tar.gz;
       sha256 = "05pb8bj2dkfcn8z56f8dcs76x65xcn05fywm7vifmfh39qgkmm62";
@@ -6409,9 +6885,10 @@ let
   };
 
   GetoptArgvFile = buildPerlPackage rec {
-    name = "Getopt-ArgvFile-1.11";
+    pname = "Getopt-ArgvFile";
+    version = "1.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JS/JSTENZEL/${name}.tar.gz";
+      url = mirror://cpan/authors/id/J/JS/JSTENZEL/Getopt-ArgvFile-1.11.tar.gz;
       sha256 = "3709aa513ce6fd71d1a55a02e34d2f090017d5350a9bd447005653c9b0835b22";
     };
     meta = {
@@ -6421,17 +6898,19 @@ let
   };
 
   GetoptLong = buildPerlPackage rec {
-    name = "Getopt-Long-2.50";
+    pname = "Getopt-Long";
+    version = "2.50";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JV/JV/${name}.tar.gz";
+      url = mirror://cpan/authors/id/J/JV/JV/Getopt-Long-2.50.tar.gz;
       sha256 = "0rsb7ri8210xv09mnxykw5asbcqivd0v38x0z4jkis3k5gdim210";
     };
   };
 
   GetoptLongDescriptive = buildPerlPackage rec {
-    name = "Getopt-Long-Descriptive-0.102";
+    pname = "Getopt-Long-Descriptive";
+    version = "0.102";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RJ/RJBS/Getopt-Long-Descriptive-0.102.tar.gz;
       sha256 = "9ad4b98f294aa0515cc3150a1ae878d39e470762b78d8bd9df055eba9dea2846";
     };
     buildInputs = [ CPANMetaCheck TestFatal TestWarnings ];
@@ -6444,17 +6923,19 @@ let
   };
 
   GetoptTabular = buildPerlPackage rec {
-    name = "Getopt-Tabular-0.3";
+    pname = "Getopt-Tabular";
+    version = "0.3";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GW/GWARD/${name}.tar.gz";
+      url = mirror://cpan/authors/id/G/GW/GWARD/Getopt-Tabular-0.3.tar.gz;
       sha256 = "0xskl9lcj07sdfx5dkma5wvhhgf5xlsq0khgh8kk34dm6dv0dpwv";
     };
   };
 
   Git = buildPerlPackage rec {
-    name = "Git-0.42";
+    pname = "Git";
+    version = "0.42";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MS/MSOUTH/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MS/MSOUTH/Git-0.42.tar.gz;
       sha256 = "9469a9f398f3a2bf2b0500566ee41d3ff6fae460412a137185767a1cc4783a6d";
     };
     propagatedBuildInputs = [ Error ];
@@ -6466,9 +6947,10 @@ let
   };
 
   GitPurePerl = buildPerlPackage rec {
-    name = "Git-PurePerl-0.53";
+    pname = "Git-PurePerl";
+    version = "0.53";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BR/BROQ/${name}.tar.gz";
+      url = mirror://cpan/authors/id/B/BR/BROQ/Git-PurePerl-0.53.tar.gz;
       sha256 = "987c74366cc4c37ee084050f985fa254359c89c12507f5b8bfc6607de538d5a8";
     };
     buildInputs = [ Testutf8 ];
@@ -6481,9 +6963,10 @@ let
   };
 
   GitRepository = buildPerlPackage rec {
-    name = "Git-Repository-1.323";
+    pname = "Git-Repository";
+    version = "1.323";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BO/BOOK/${name}.tar.gz";
+      url = mirror://cpan/authors/id/B/BO/BOOK/Git-Repository-1.323.tar.gz;
       sha256 = "966575fcecc9f56ab8739ea451b3825e278bc9179d785a20a9ae52473f33683e";
     };
     buildInputs = [ TestRequiresGit ];
@@ -6495,9 +6978,10 @@ let
   };
 
   GitVersionCompare = buildPerlPackage rec {
-    name = "Git-Version-Compare-1.004";
+    pname = "Git-Version-Compare";
+    version = "1.004";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BO/BOOK/${name}.tar.gz";
+      url = mirror://cpan/authors/id/B/BO/BOOK/Git-Version-Compare-1.004.tar.gz;
       sha256 = "63e8264ed351cb2371b47852a72366214164b5f3fad9dbd68309c7fc63d06491";
     };
     buildInputs = [ TestNoWarnings ];
@@ -6508,9 +6992,10 @@ let
   };
 
   Glib = buildPerlPackage rec {
-    name = "Glib-1.329";
+    pname = "Glib";
+    version = "1.329";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/X/XA/XAOC/${name}.tar.gz";
+      url = mirror://cpan/authors/id/X/XA/XAOC/Glib-1.329.tar.gz;
       sha256 = "0d9ak0zknz81lv3cqkzr2mxdic6g5rrbb87skqc4jj48rz4f2k3v";
     };
     buildInputs = [ pkgs.glib ];
@@ -6524,9 +7009,10 @@ let
   };
 
   GlibObjectIntrospection = buildPerlPackage rec {
-    name = "Glib-Object-Introspection-0.047";
+    pname = "Glib-Object-Introspection";
+    version = "0.047";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/X/XA/XAOC/${name}.tar.gz";
+      url = mirror://cpan/authors/id/X/XA/XAOC/Glib-Object-Introspection-0.047.tar.gz;
       sha256 = "1sk32pcv4ik3sniqbjrz8nlw7f2a76l87wx1rwdjypv6h9pjnrnk";
     };
     propagatedBuildInputs = [ pkgs.gobject-introspection Glib ];
@@ -6537,9 +7023,10 @@ let
   };
 
   Gnome2 = buildPerlPackage rec {
-    name = "Gnome2-1.047";
+    pname = "Gnome2";
+    version = "1.047";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/X/XA/XAOC/${name}.tar.gz";
+      url = mirror://cpan/authors/id/X/XA/XAOC/Gnome2-1.047.tar.gz;
       sha256 = "ccc85c5dc3c14f915ed1a186d238681d83fef3d17eed1c20001499ff56b6390c";
     };
     buildInputs = [ ExtUtilsDepends ExtUtilsPkgConfig Glib Gnome2Canvas Gnome2VFS Gtk2 ];
@@ -6552,9 +7039,10 @@ let
   };
 
   Gnome2Canvas = buildPerlPackage rec {
-    name = "Gnome2-Canvas-1.002";
+    pname = "Gnome2-Canvas";
+    version = "1.002";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TS/TSCH/${name}.tar.gz";
+      url = mirror://cpan/authors/id/T/TS/TSCH/Gnome2-Canvas-1.002.tar.gz;
       sha256 = "47a34204cd5f3a0ef5c8b9e1c9c96f41740edab7e9abf1d0560fa8666ba1916e";
     };
     buildInputs = [ pkgs.gnome2.libgnomecanvas ];
@@ -6565,9 +7053,10 @@ let
   };
 
   Gnome2VFS = buildPerlPackage rec {
-    name = "Gnome2-VFS-1.083";
+    pname = "Gnome2-VFS";
+    version = "1.083";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/X/XA/XAOC/${name}.tar.gz";
+      url = mirror://cpan/authors/id/X/XA/XAOC/Gnome2-VFS-1.083.tar.gz;
       sha256 = "eca974669df4e7f21b4fcedb96c8a328422369c68b8c2cd99b9ce9cc5d7a7979";
     };
     propagatedBuildInputs = [ pkgs.gnome2.gnome_vfs Glib ];
@@ -6578,9 +7067,10 @@ let
   };
 
   Gnome2Wnck = buildPerlPackage rec {
-    name = "Gnome2-Wnck-0.16";
+    pname = "Gnome2-Wnck";
+    version = "0.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TS/TSCH/${name}.tar.gz";
+      url = mirror://cpan/authors/id/T/TS/TSCH/Gnome2-Wnck-0.16.tar.gz;
       sha256 = "604a8ece88ac29f132d59b0caac27657ec31371c1606a4698a2160e88ac586e5";
     };
     buildInputs = [ pkgs.libwnck pkgs.glib pkgs.gtk2 ];
@@ -6592,7 +7082,8 @@ let
   };
 
   GnuPG = buildPerlPackage {
-    name = "GnuPG-0.19";
+    pname = "GnuPG";
+    version = "0.19";
     src = fetchurl {
       url = mirror://cpan/authors/id/Y/YA/YANICK/GnuPG-0.19.tar.gz;
       sha256 = "af53f2d3f63297e046676eae14a76296afdd2910e09723b6b113708622b7989b";
@@ -6601,9 +7092,10 @@ let
   };
 
   GnuPGInterface = buildPerlPackage rec {
-    name = "GnuPG-Interface-0.52";
+    pname = "GnuPG-Interface";
+    version = "0.52";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AL/ALEXMV/${name}.tar.gz";
+      url = mirror://cpan/authors/id/A/AL/ALEXMV/GnuPG-Interface-0.52.tar.gz;
       sha256 = "247a9f5a88bb6745281c00d0f7d5d94e8599a92396849fd9571356dda047fd35";
     };
     buildInputs = [ pkgs.which pkgs.gnupg1compat ];
@@ -6616,7 +7108,8 @@ let
   };
 
   GoferTransporthttp = buildPerlPackage {
-    name = "GoferTransport-http-1.017";
+    pname = "GoferTransport-http";
+    version = "1.017";
     src = fetchurl {
       url = mirror://cpan/authors/id/T/TI/TIMB/GoferTransport-http-1.017.tar.gz;
       sha256 = "f73effe3ea7afa1907ce8977c87387abb0d4404f85a724ae2637b29a73154a9b";
@@ -6629,9 +7122,10 @@ let
   };
 
   GooCanvas = buildPerlPackage rec {
-    name = "Goo-Canvas-0.06";
+    pname = "Goo-Canvas";
+    version = "0.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Y/YE/YEWENBIN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/Y/YE/YEWENBIN/Goo-Canvas-0.06.tar.gz;
       sha256 = "0c588c507eed5e62d12ed1cc1e491c6ff3a1f59c4fb3d435e14214b37ab39251";
     };
     propagatedBuildInputs = [ pkgs.goocanvas pkgs.gtk2 Gtk2 Pango ];
@@ -6642,9 +7136,10 @@ let
   };
 
   GooCanvas2 = buildPerlPackage rec {
-    name = "GooCanvas2-0.06";
+    pname = "GooCanvas2";
+    version = "0.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PERLMAX/${name}.tar.gz";
+      url = mirror://cpan/authors/id/P/PE/PERLMAX/GooCanvas2-0.06.tar.gz;
       sha256 = "0l1vsvyv9hjxhsxrahq4h64axh7qmk50kiz2spa3s1hr7s3qfk72";
     };
     buildInputs = [ pkgs.gtk3 ];
@@ -6656,9 +7151,10 @@ let
   };
 
   GoogleProtocolBuffers = buildPerlPackage rec {
-    name = "Google-ProtocolBuffers-0.12";
+    pname = "Google-ProtocolBuffers";
+    version = "0.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SA/SAXJAZMAN/protobuf/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SA/SAXJAZMAN/protobuf/Google-ProtocolBuffers-0.12.tar.gz;
       sha256 = "0wad56n12h9yhnrq1m1z3jna1ch3mg3mqj41wkfi49ws1g34k15k";
     };
     propagatedBuildInputs = [ ClassAccessor ParseRecDescent ];
@@ -6671,17 +7167,19 @@ let
   };
 
   Graph = buildPerlPackage rec {
-    name = "Graph-0.9704";
+    pname = "Graph";
+    version = "0.9704";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JH/JHI/${name}.tar.gz";
+      url = mirror://cpan/authors/id/J/JH/JHI/Graph-0.9704.tar.gz;
       sha256 = "099a1gca0wj5zs0cffncjqp2mjrdlk9i6325ks89ml72gfq8wpij";
     };
   };
 
   GraphViz = buildPerlPackage rec {
-    name = "GraphViz-2.24";
+    pname = "GraphViz";
+    version = "2.24";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RS/RSAVAGE/${name}.tgz";
+      url = mirror://cpan/authors/id/R/RS/RSAVAGE/GraphViz-2.24.tgz;
       sha256 = "1bgm4a8kan53r30qiknr4kasvhar1khf7vq064l1inzfrp2glpnr";
     };
 
@@ -6696,9 +7194,10 @@ let
   };
 
   grepmail = buildPerlPackage rec {
-    name = "grepmail-5.3111";
+    pname = "grepmail";
+    version = "5.3111";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DC/DCOPPIT/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DC/DCOPPIT/grepmail-5.3111.tar.gz;
       sha256 = "d0984e3f7a1be17ae014575f70c1678151a5bcc9622185dc5a052cb63271a761";
     };
     buildInputs = [ FileHomeDir FileSlurper TestCompile UNIVERSALrequire URI ];
@@ -6713,7 +7212,8 @@ let
   };
 
   GrowlGNTP = buildPerlModule rec {
-    name = "Growl-GNTP-0.21";
+    pname = "Growl-GNTP";
+    version = "0.21";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MA/MATTN/Growl-GNTP-0.21.tar.gz;
       sha256 = "0gq8ypam6ifp8f3s2mf5d6sw53m7h3ki1zfahh2p41kl8a77yy98";
@@ -6723,9 +7223,10 @@ let
   };
 
   GSSAPI = buildPerlPackage rec {
-    name = "GSSAPI-0.28";
+    pname = "GSSAPI";
+    version = "0.28";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AG/AGROLMS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/A/AG/AGROLMS/GSSAPI-0.28.tar.gz;
       sha256 = "1mkhwxjjlhr58pd770i9gnf7zy7jj092iv6jfbnb8bvnc5xjr3vx";
     };
     propagatedBuildInputs = [ pkgs.krb5Full.dev ];
@@ -6738,9 +7239,10 @@ let
   };
 
   Gtk2 = buildPerlPackage rec {
-    name = "Gtk2-1.24992";
+    pname = "Gtk2";
+    version = "1.24992";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/X/XA/XAOC/${name}.tar.gz";
+      url = mirror://cpan/authors/id/X/XA/XAOC/Gtk2-1.24992.tar.gz;
       sha256 = "1044rj3wbfmgaif2jb0k28m2aczli6ai2n5yvn6pr7zjyw16kvd2";
     };
     buildInputs = [ pkgs.gtk2 Cairo ExtUtilsDepends ExtUtilsPkgConfig Glib Pango ];
@@ -6753,9 +7255,10 @@ let
   };
 
   Gtk2GladeXML = buildPerlPackage rec {
-    name = "Gtk2-GladeXML-1.007";
+    pname = "Gtk2-GladeXML";
+    version = "1.007";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TS/TSCH/${name}.tar.gz";
+      url = mirror://cpan/authors/id/T/TS/TSCH/Gtk2-GladeXML-1.007.tar.gz;
       sha256 = "50240a2bddbda807c8f8070de941823b7bf3d288a13be6d0d6563320b42c445a";
     };
     propagatedBuildInputs = [ pkgs.gnome2.libglade pkgs.gtk2 Gtk2 Pango ];
@@ -6766,9 +7269,10 @@ let
   };
 
   Gtk2TrayIcon = buildPerlPackage rec {
-    name = "Gtk2-TrayIcon-0.06";
+    pname = "Gtk2-TrayIcon";
+    version = "0.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BO/BORUP/${name}.tar.gz";
+      url = mirror://cpan/authors/id/B/BO/BORUP/Gtk2-TrayIcon-0.06.tar.gz;
       sha256 = "cbb7632b75d7f41554dfe8ee9063dbfd1d8522291077c65d0d82e9ceb5e94ae2";
     };
     propagatedBuildInputs = [ pkgs.gtk2 Gtk2 Pango ];
@@ -6778,9 +7282,10 @@ let
   };
 
   Gtk2AppIndicator = buildPerlPackage rec {
-    name = "Gtk2-AppIndicator-0.15";
+    pname = "Gtk2-AppIndicator";
+    version = "0.15";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OE/OESTERHOL/${name}.tar.gz";
+      url = mirror://cpan/authors/id/O/OE/OESTERHOL/Gtk2-AppIndicator-0.15.tar.gz;
       sha256 = "a25cb071e214fb89b4450aa4605031eae89b7961e149b0d6e8f491c19c14a90a";
     };
     propagatedBuildInputs = [ pkgs.libappindicator-gtk2 pkgs.libdbusmenu-gtk2 pkgs.gtk2 pkgs.pkgconfig Gtk2 ];
@@ -6794,9 +7299,10 @@ let
   };
 
   Gtk2ImageView = buildPerlPackage rec {
-    name = "Gtk2-ImageView-0.05";
+    pname = "Gtk2-ImageView";
+    version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RA/RATCLIFFE/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RA/RATCLIFFE/Gtk2-ImageView-0.05.tar.gz;
       sha256 = "087186c3693acf196451cf59cc8b7f5cf9a7b05abe20d32dcbcba0822953fb80";
     };
     buildInputs = [ pkgs.gtkimageview pkgs.gtk2 ];
@@ -6812,9 +7318,10 @@ let
   };
 
   Gtk2Unique = buildPerlPackage rec {
-    name = "Gtk2-Unique-0.05";
+    pname = "Gtk2-Unique";
+    version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PO/POTYL/${name}.tar.gz";
+      url = mirror://cpan/authors/id/P/PO/POTYL/Gtk2-Unique-0.05.tar.gz;
       sha256 = "ae8dfb0f6844ddaa2ce7b5b44553419490c8e83c24fd35c431406a58f6be0f4f";
     };
     propagatedBuildInputs = [ pkgs.libunique pkgs.gtk2 Gtk2 Pango ];
@@ -6839,9 +7346,10 @@ let
   };
 
   Gtk3SimpleList = buildPerlPackage rec {
-    name = "Gtk3-SimpleList-0.18";
+    pname = "Gtk3-SimpleList";
+    version = "0.18";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TV/TVIGNAUD/${name}.tar.gz";
+      url = mirror://cpan/authors/id/T/TV/TVIGNAUD/Gtk3-SimpleList-0.18.tar.gz;
       sha256 = "09azmc7miyvw7q21rz8cxw16zbd5i1j5hpakxy376f5vmhqqjyhp";
     };
     meta = {
@@ -6852,17 +7360,19 @@ let
   };
 
   Guard = buildPerlPackage rec {
-    name = "Guard-1.023";
+    pname = "Guard";
+    version = "1.023";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/ML/MLEHMANN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/ML/MLEHMANN/Guard-1.023.tar.gz;
       sha256 = "34c4ddf91fc93d1090d86da14df706d175b1610c67372c01e12ce9555d4dd1dc";
     };
   };
 
   HashDiff = buildPerlPackage rec {
-    name = "Hash-Diff-0.010";
+    pname = "Hash-Diff";
+    version = "0.010";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BO/BOLAV/${name}.tar.gz";
+      url = mirror://cpan/authors/id/B/BO/BOLAV/Hash-Diff-0.010.tar.gz;
       sha256 = "1ig0l859gq00k0r9l85274r2lbvwl7wsndcy52c0m3y9isilm6mw";
     };
     propagatedBuildInputs = [ HashMerge ];
@@ -6916,7 +7426,8 @@ let
   };
 
   HashFlatten = buildPerlPackage rec {
-    name = "Hash-Flatten-1.19";
+    pname = "Hash-Flatten";
+    version = "1.19";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BB/BBC/Hash-Flatten-1.19.tar.gz;
       sha256 = "162b9qgkr19f97w4pic6igyk3zd0sbnrhl3s8530fikciffw9ikh";
@@ -6926,9 +7437,10 @@ let
   };
 
   HashMerge = buildPerlPackage rec {
-    name = "Hash-Merge-0.300";
+    pname = "Hash-Merge";
+    version = "0.300";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RE/REHSACK/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RE/REHSACK/Hash-Merge-0.300.tar.gz;
       sha256 = "0h3wfnpv5d4d3f9xzmwkchay6251nhzngdv3f6xia56mj4hxabs0";
     };
     propagatedBuildInputs = [ CloneChoose ];
@@ -6939,7 +7451,8 @@ let
   };
 
   HashMergeSimple = buildPerlPackage {
-    name = "Hash-Merge-Simple-0.051";
+    pname = "Hash-Merge-Simple";
+    version = "0.051";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RO/ROKR/Hash-Merge-Simple-0.051.tar.gz;
       sha256 = "1c56327873d2f04d5722777f044863d968910466997740d55a754071c6287b73";
@@ -6953,9 +7466,10 @@ let
   };
 
   HashMoreUtils = buildPerlPackage rec {
-    name = "Hash-MoreUtils-0.06";
+    pname = "Hash-MoreUtils";
+    version = "0.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RE/REHSACK/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RE/REHSACK/Hash-MoreUtils-0.06.tar.gz;
       sha256 = "db9a8fb867d50753c380889a5e54075651b5e08c9b3b721cb7220c0883547de8";
     };
     meta = {
@@ -6965,7 +7479,8 @@ let
   };
 
   HashMultiValue = buildPerlPackage {
-    name = "Hash-MultiValue-0.16";
+    pname = "Hash-MultiValue";
+    version = "0.16";
     src = fetchurl {
       url = mirror://cpan/authors/id/A/AR/ARISTOTLE/Hash-MultiValue-0.16.tar.gz;
       sha256 = "1x3k7h542xnigz0b8vsfiq580p5r325wi5b8mxppiqk8mbvis636";
@@ -6977,7 +7492,8 @@ let
   };
 
   HashUtilFieldHashCompat = buildPerlPackage {
-    name = "Hash-Util-FieldHash-Compat-0.11";
+    pname = "Hash-Util-FieldHash-Compat";
+    version = "0.11";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/Hash-Util-FieldHash-Compat-0.11.tar.gz;
       sha256 = "06vlygjyk7rkkw0di3252mma141w801qn3xk40aa2yskbfklcbk4";
@@ -6985,7 +7501,8 @@ let
   };
 
   HeapFibonacci = buildPerlPackage {
-    name = "Heap-0.80";
+    pname = "Heap";
+    version = "0.80";
     src = fetchurl {
       url = mirror://cpan/authors/id/J/JM/JMM/Heap-0.80.tar.gz;
       sha256 = "1plv2djbyhvkdcw2ic54rdqb745cwksxckgzvw7ssxiir7rjknnc";
@@ -6993,9 +7510,10 @@ let
   };
 
   HookLexWrap = buildPerlPackage rec {
-    name = "Hook-LexWrap-0.26";
+    pname = "Hook-LexWrap";
+    version = "0.26";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/E/ET/ETHER/Hook-LexWrap-0.26.tar.gz;
       sha256 = "b60bdc5f98f94f9294b06adef82b1d996da192d5f183f9f434b610fd1137ec2d";
     };
     buildInputs = [ pkgs.unzip ];
@@ -7007,9 +7525,10 @@ let
   };
 
   HTMLClean = buildPerlPackage rec {
-    name = "HTML-Clean-0.8";
+    pname = "HTML-Clean";
+    version = "0.8";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LI/LINDNER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/L/LI/LINDNER/HTML-Clean-0.8.tar.gz;
       sha256 = "1h0dzxx034hpshxlpsxhxh051d1p79cjgp4q5kg68kgx7aian85c";
     };
     meta = {
@@ -7019,7 +7538,8 @@ let
   };
 
   HTMLElementExtended = buildPerlPackage {
-    name = "HTML-Element-Extended-1.18";
+    pname = "HTML-Element-Extended";
+    version = "1.18";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MS/MSISK/HTML-Element-Extended-1.18.tar.gz;
       sha256 = "f3ef1af108f27fef15ebec66479f251ce08aa49bd00b0462c9c80c86b4b6b32b";
@@ -7028,9 +7548,10 @@ let
   };
 
   HTMLEscape = buildPerlModule rec {
-    name = "HTML-Escape-1.10";
+    pname = "HTML-Escape";
+    version = "1.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TOKUHIROM/${name}.tar.gz";
+      url = mirror://cpan/authors/id/T/TO/TOKUHIROM/HTML-Escape-1.10.tar.gz;
       sha256 = "b1cbac4157ad8dedac6914e1628855e05b8dc885a4007d2e4df8177c6a9b70fb";
     };
     buildInputs = [ ModuleBuildPluggablePPPort TestRequires ];
@@ -7042,7 +7563,8 @@ let
   };
 
   HTMLFromANSI = buildPerlPackage {
-    name = "HTML-FromANSI-2.03";
+    pname = "HTML-FromANSI";
+    version = "2.03";
     src = fetchurl {
       url = mirror://cpan/authors/id/N/NU/NUFFIN/HTML-FromANSI-2.03.tar.gz;
       sha256 = "21776345ed701b2c04c7b09380af943f9984cc7f99624087aea45db5fc09c359";
@@ -7053,7 +7575,8 @@ let
   };
 
   HTMLForm = buildPerlPackage {
-    name = "HTML-Form-6.04";
+    pname = "HTML-Form";
+    version = "6.04";
     src = fetchurl {
       url = mirror://cpan/authors/id/O/OA/OALDERS/HTML-Form-6.04.tar.gz;
       sha256 = "100090bdsr5kapv8h0wxzwlzfbfqn57rq9gzrvg9i6hvnsl5gmcw";
@@ -7066,7 +7589,8 @@ let
   };
 
   HTMLFormatter = buildPerlPackage {
-    name = "HTML-Formatter-2.16";
+    pname = "HTML-Formatter";
+    version = "2.16";
     src = fetchurl {
       url = mirror://cpan/authors/id/N/NI/NIGELM/HTML-Formatter-2.16.tar.gz;
       sha256 = "cb0a0dd8aa5e8ba9ca214ce451bf4df33aa09c13e907e8d3082ddafeb30151cc";
@@ -7080,7 +7604,8 @@ let
   };
 
   HTMLFormatTextWithLinks = buildPerlModule {
-    name = "HTML-FormatText-WithLinks-0.15";
+    pname = "HTML-FormatText-WithLinks";
+    version = "0.15";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/ST/STRUAN/HTML-FormatText-WithLinks-0.15.tar.gz;
       sha256 = "7fcc1ab79eb58fb97d43e5bdd14e21791a250a204998918c62d6a171131833b1";
@@ -7093,7 +7618,8 @@ let
   };
 
   HTMLFormatTextWithLinksAndTables = buildPerlPackage {
-    name = "HTML-FormatText-WithLinks-AndTables-0.07";
+    pname = "HTML-FormatText-WithLinks-AndTables";
+    version = "0.07";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DA/DALEEVANS/HTML-FormatText-WithLinks-AndTables-0.07.tar.gz;
       sha256 = "809ee2f11705706b33c54312b5c7bee674838f2beaaedaf8cb945e702aae39b6";
@@ -7106,7 +7632,8 @@ let
   };
 
   HTMLFormFu = buildPerlPackage rec {
-    name = "HTML-FormFu-2.07";
+    pname = "HTML-FormFu";
+    version = "2.07";
     src = fetchurl {
       url = mirror://cpan/authors/id/C/CF/CFRANKS/HTML-FormFu-2.07.tar.gz;
       sha256 = "0cpbcrip95rvihc7i8dywca6lx9ws67ch1hjx6vgnm47g9zh2bsg";
@@ -7120,7 +7647,8 @@ let
   };
 
   HTMLFormFuMultiForm = buildPerlPackage rec {
-     name = "HTML-FormFu-MultiForm-1.03";
+     pname = "HTML-FormFu-MultiForm";
+     version = "1.03";
      src = fetchurl {
        url = mirror://cpan/authors/id/N/NI/NIGELM/HTML-FormFu-MultiForm-1.03.tar.gz;
        sha256 = "17qm94hwhn6jyhd2am4gqxq7yrlhv3jv0ayx17df95mqdgbhrw1n";
@@ -7134,7 +7662,8 @@ let
   };
 
   HTMLFormHandler = buildPerlPackage {
-    name = "HTML-FormHandler-0.40068";
+    pname = "HTML-FormHandler";
+    version = "0.40068";
     src = fetchurl {
       url = mirror://cpan/authors/id/G/GS/GSHANK/HTML-FormHandler-0.40068.tar.gz;
       sha256 = "09z8rpb3avdd8984rm6j6gd2igbzjz9rc0ycig654mqjlgfphyzb";
@@ -7150,7 +7679,8 @@ let
   };
 
   HTMLMason = buildPerlPackage {
-    name = "HTML-Mason-1.58";
+    pname = "HTML-Mason";
+    version = "1.58";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DR/DROLSKY/HTML-Mason-1.58.tar.gz;
       sha256 = "81dc9b199f0f3b3473c97ba0ebee4b9535cd633d4e9c1ca3818615dc03dff948";
@@ -7164,7 +7694,8 @@ let
   };
 
   HTMLMasonPSGIHandler = buildPerlPackage {
-    name = "HTML-Mason-PSGIHandler-0.53";
+    pname = "HTML-Mason-PSGIHandler";
+    version = "0.53";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RU/RUZ/HTML-Mason-PSGIHandler-0.53.tar.gz;
       sha256 = "eafd7c7655dfa8261df3446b931a283d30306877b83ac4671c49cff74ea7f00b";
@@ -7178,9 +7709,10 @@ let
   };
 
   HTMLParser = buildPerlPackage rec {
-    name = "HTML-Parser-3.72";
+    pname = "HTML-Parser";
+    version = "3.72";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GA/GAAS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/G/GA/GAAS/HTML-Parser-3.72.tar.gz;
       sha256 = "12v05ywlnsi9lc17z32k9jxx3sj1viy7y1wpl7n4az76v7hwfa7c";
     };
     propagatedBuildInputs = [ HTMLTagset ];
@@ -7191,9 +7723,10 @@ let
   };
 
   HTMLTagCloud = buildPerlModule rec {
-    name = "HTML-TagCloud-0.38";
+    pname = "HTML-TagCloud";
+    version = "0.38";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RO/ROBERTSD/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RO/ROBERTSD/HTML-TagCloud-0.38.tar.gz;
       sha256 = "05bhnrwwlwd6cj3cn91zw5r99xddvy142bznid26p1pg5m3rk029";
     };
     meta = {
@@ -7203,7 +7736,8 @@ let
   };
 
   HTMLQuoted = buildPerlPackage {
-    name = "HTML-Quoted-0.04";
+    pname = "HTML-Quoted";
+    version = "0.04";
     src = fetchurl {
       url = mirror://cpan/authors/id/T/TS/TSIBLEY/HTML-Quoted-0.04.tar.gz;
       sha256 = "8b41f313fdc1812f02f6f6c37d58f212c84fdcf7827f7fd4b030907f39dc650c";
@@ -7216,7 +7750,8 @@ let
   };
 
   HTMLRewriteAttributes = buildPerlPackage {
-    name = "HTML-RewriteAttributes-0.05";
+    pname = "HTML-RewriteAttributes";
+    version = "0.05";
     src = fetchurl {
       url = mirror://cpan/authors/id/T/TS/TSIBLEY/HTML-RewriteAttributes-0.05.tar.gz;
       sha256 = "1808ec7cdf40d2708575fe6155a88f103b17fec77973a5831c2f24c250e7a58c";
@@ -7229,7 +7764,8 @@ let
   };
 
   HTMLSelectorXPath = buildPerlPackage {
-    name = "HTML-Selector-XPath-0.25";
+    pname = "HTML-Selector-XPath";
+    version = "0.25";
     src = fetchurl {
       url = mirror://cpan/authors/id/C/CO/CORION/HTML-Selector-XPath-0.25.tar.gz;
       sha256 = "1qbad8ayffpx7wj76ip05p6rh9p1lkir6qknpl76zy679ghlsp8s";
@@ -7238,7 +7774,8 @@ let
   };
 
   HTMLScrubber = buildPerlPackage rec {
-    name = "HTML-Scrubber-0.17";
+    pname = "HTML-Scrubber";
+    version = "0.17";
     src = fetchurl {
       url = mirror://cpan/authors/id/N/NI/NIGELM/HTML-Scrubber-0.17.tar.gz;
       sha256 = "06p7w4zd42b2yh541mlzyqj40lwmvvn3fyqi8big4mf34la7m2jm";
@@ -7248,16 +7785,18 @@ let
   };
 
   HTMLTableExtract = buildPerlPackage rec {
-    name = "HTML-TableExtract-2.13";
+    pname = "HTML-TableExtract";
+    version = "2.13";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MS/MSISK/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MS/MSISK/HTML-TableExtract-2.13.tar.gz;
       sha256 = "01jimmss3q68a89696wmclvqwb2ybz6xgabpnbp6mm6jcni82z8a";
     };
     propagatedBuildInputs = [ HTMLElementExtended ];
   };
 
   HTMLTagset = buildPerlPackage rec {
-    name = "HTML-Tagset-3.20";
+    pname = "HTML-Tagset";
+    version = "3.20";
     src = fetchurl {
       url = mirror://cpan/authors/id/P/PE/PETDANCE/HTML-Tagset-3.20.tar.gz;
       sha256 = "1qh8249wgr4v9vgghq77zh1d2zs176bir223a8gh3k9nksn7vcdd";
@@ -7265,7 +7804,8 @@ let
   };
 
   HTMLTemplate = buildPerlPackage rec {
-    name = "HTML-Template-2.97";
+    pname = "HTML-Template";
+    version = "2.97";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SA/SAMTREGAR/HTML-Template-2.97.tar.gz;
       sha256 = "17qjw8swj2q4b1ic285pndgrkmvpsqw0j68nhqzpk1daydhsyiv5";
@@ -7275,9 +7815,10 @@ let
   };
 
   HTMLTidy = buildPerlPackage rec {
-    name = "HTML-Tidy-1.60";
+    pname = "HTML-Tidy";
+    version = "1.60";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PETDANCE/${name}.tar.gz";
+      url = mirror://cpan/authors/id/P/PE/PETDANCE/HTML-Tidy-1.60.tar.gz;
       sha256 = "1iyp2fd6j75cn1xvcwl2lxr8qpjxssy2360cyqn6g3kzd1fzdyxw";
     };
 
@@ -7289,9 +7830,10 @@ let
   };
 
   HTMLTiny = buildPerlPackage rec {
-    name = "HTML-Tiny-1.05";
+    pname = "HTML-Tiny";
+    version = "1.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AN/ANDYA/${name}.tar.gz";
+      url = mirror://cpan/authors/id/A/AN/ANDYA/HTML-Tiny-1.05.tar.gz;
       sha256 = "d7cdc9d5985e2e44ceba10b756acf1e0d3a1b3ee3b516e5b54adb850fe79fda3";
     };
     meta = {
@@ -7301,16 +7843,18 @@ let
   };
 
   HTMLTokeParserSimple = buildPerlModule rec {
-    name = "HTML-TokeParser-Simple-3.16";
+    pname = "HTML-TokeParser-Simple";
+    version = "3.16";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OV/OVID/${name}.tar.gz";
+      url = mirror://cpan/authors/id/O/OV/OVID/HTML-TokeParser-Simple-3.16.tar.gz;
       sha256 = "17aa1v62sp8ycxcicwhankmj4brs6nnfclk9z7mf1rird1f164gd";
     };
     propagatedBuildInputs = [ HTMLParser SubOverride ];
   };
 
   HTMLTree = buildPerlModule {
-    name = "HTML-Tree-5.07";
+    pname = "HTML-Tree";
+    version = "5.07";
     src = fetchurl {
       url = mirror://cpan/authors/id/K/KE/KENTNL/HTML-Tree-5.07.tar.gz;
       sha256 = "1gyvm4qlwm9y6hczkpnrdfl303ggbybr0nqxdjw09hii8yw4sdzh";
@@ -7324,7 +7868,8 @@ let
   };
 
   HTMLTreeBuilderXPath = buildPerlPackage {
-    name = "HTML-TreeBuilder-XPath-0.14";
+    pname = "HTML-TreeBuilder-XPath";
+    version = "0.14";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MI/MIROD/HTML-TreeBuilder-XPath-0.14.tar.gz;
       sha256 = "1wx4i1scng20n405fp3a4vrwvvq9bvbmg977wnd5j2ja8jrbvsr5";
@@ -7337,7 +7882,8 @@ let
   };
 
   HTMLWidget = buildPerlPackage {
-    name = "HTML-Widget-1.11";
+    pname = "HTML-Widget";
+    version = "1.11";
     src = fetchurl {
       url = mirror://cpan/authors/id/C/CF/CFRANKS/HTML-Widget-1.11.tar.gz;
       sha256 = "02w21rd30cza094m5xs9clzw8ayigbhg2ddzl6jycp4jam0dyhmy";
@@ -7348,9 +7894,10 @@ let
   };
 
   HTTPBody = buildPerlPackage rec {
-    name = "HTTP-Body-1.22";
+    pname = "HTTP-Body";
+    version = "1.22";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GE/GETTY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/G/GE/GETTY/HTTP-Body-1.22.tar.gz;
       sha256 = "fc0d2c585b3bd1532d92609965d589e0c87cd380e7cca42fb9ad0a1311227297";
     };
     buildInputs = [ TestDeep ];
@@ -7362,7 +7909,8 @@ let
   };
 
   HTTPCookies = buildPerlPackage {
-    name = "HTTP-Cookies-6.04";
+    pname = "HTTP-Cookies";
+    version = "6.04";
     src = fetchurl {
       url = mirror://cpan/authors/id/O/OA/OALDERS/HTTP-Cookies-6.04.tar.gz;
       sha256 = "1m0kxcirbvbkrm2c59p1bkbvzlcdymg8fdpa7wlxijlx0xwz1iqc";
@@ -7375,7 +7923,8 @@ let
   };
 
   HTTPDaemon = buildPerlPackage {
-    name = "HTTP-Daemon-6.01";
+    pname = "HTTP-Daemon";
+    version = "6.01";
     src = fetchurl {
       url = mirror://cpan/authors/id/G/GA/GAAS/HTTP-Daemon-6.01.tar.gz;
       sha256 = "1hmd2isrkilf0q0nkxms1q64kikjmcw9imbvrjgky6kh89vqdza3";
@@ -7388,7 +7937,8 @@ let
   };
 
   HTTPDate = buildPerlPackage {
-    name = "HTTP-Date-6.02";
+    pname = "HTTP-Date";
+    version = "6.02";
     src = fetchurl {
       url = mirror://cpan/authors/id/G/GA/GAAS/HTTP-Date-6.02.tar.gz;
       sha256 = "0cz357kafhhzw7w59iyi0wvhw7rlh5g1lh38230ckw7rl0fr9fg8";
@@ -7400,7 +7950,8 @@ let
   };
 
   HTTPEntityParser = buildPerlModule rec {
-     name = "HTTP-Entity-Parser-0.21";
+     pname = "HTTP-Entity-Parser";
+     version = "0.21";
      src = fetchurl {
        url = mirror://cpan/authors/id/K/KA/KAZEBURO/HTTP-Entity-Parser-0.21.tar.gz;
        sha256 = "1n7qhyscllialds5jsk1k8x2vmfbjvisa3342as5x15hpm13wkf1";
@@ -7415,7 +7966,8 @@ let
   };
 
   HTTPDAV = buildPerlPackage rec {
-    name = "HTTP-DAV-0.49";
+    pname = "HTTP-DAV";
+    version = "0.49";
     src = fetchurl {
       url = mirror://cpan/authors/id/C/CO/COSIMO/HTTP-DAV-0.49.tar.gz;
       sha256 = "0z4mgb8mc6l5nfsm3ihndjqgpk43q39x1kq9hryy6v8hxkwrscrk";
@@ -7427,17 +7979,19 @@ let
   };
 
   HTTPHeaderParserXS = buildPerlPackage rec {
-    name = "HTTP-HeaderParser-XS-0.20";
+    pname = "HTTP-HeaderParser-XS";
+    version = "0.20";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MARKSMITH/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MA/MARKSMITH/HTTP-HeaderParser-XS-0.20.tar.gz;
       sha256 = "1vs6sw431nnlnbdy6jii9vqlz30ndlfwdpdgm8a1m6fqngzhzq59";
     };
   };
 
   HTTPHeadersFast = buildPerlModule rec {
-    name = "HTTP-Headers-Fast-0.22";
+    pname = "HTTP-Headers-Fast";
+    version = "0.22";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TOKUHIROM/${name}.tar.gz";
+      url = mirror://cpan/authors/id/T/TO/TOKUHIROM/HTTP-Headers-Fast-0.22.tar.gz;
       sha256 = "cc431db68496dd884db4bc0c0b7112c1f4a4f1dc68c4f5a3caa757a1e7481b48";
     };
     buildInputs = [ ModuleBuildTiny TestRequires ];
@@ -7450,18 +8004,20 @@ let
   };
 
   HTTPLite = buildPerlPackage rec {
-    name = "HTTP-Lite-2.44";
+    pname = "HTTP-Lite";
+    version = "2.44";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/${name}.tar.gz";
+      url = mirror://cpan/authors/id/N/NE/NEILB/HTTP-Lite-2.44.tar.gz;
       sha256 = "0z77nflj8zdcfg70kc93glq5kmd6qxn2nf7h70x4xhfg25wkvr1q";
     };
     buildInputs = [ CGI ];
   };
 
   HTTPMessage = buildPerlPackage rec {
-    name = "HTTP-Message-6.18";
+    pname = "HTTP-Message";
+    version = "6.18";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OA/OALDERS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/O/OA/OALDERS/HTTP-Message-6.18.tar.gz;
       sha256 = "d060d170d388b694c58c14f4d13ed908a2807f0e581146cef45726641d809112";
     };
     buildInputs = [ TryTiny ];
@@ -7474,7 +8030,8 @@ let
   };
 
   HTTPMultiPartParser = buildPerlPackage rec {
-     name = "HTTP-MultiPartParser-0.02";
+     pname = "HTTP-MultiPartParser";
+     version = "0.02";
      src = fetchurl {
        url = mirror://cpan/authors/id/C/CH/CHANSEN/HTTP-MultiPartParser-0.02.tar.gz;
        sha256 = "04hbs0b1lzv2c8dqfcc9qjm5akh25fn40903is36zlalkwaxmpay";
@@ -7487,7 +8044,8 @@ let
   };
 
   HTTPNegotiate = buildPerlPackage {
-    name = "HTTP-Negotiate-6.01";
+    pname = "HTTP-Negotiate";
+    version = "6.01";
     src = fetchurl {
       url = mirror://cpan/authors/id/G/GA/GAAS/HTTP-Negotiate-6.01.tar.gz;
       sha256 = "05p053vjs5g91v5cmjnny7a3xzddz5k7vnjw81wfh01ilqg9qwhw";
@@ -7500,17 +8058,19 @@ let
   };
 
   HTTPParserXS = buildPerlPackage rec {
-    name = "HTTP-Parser-XS-0.17";
+    pname = "HTTP-Parser-XS";
+    version = "0.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KA/KAZUHO/${name}.tar.gz";
+      url = mirror://cpan/authors/id/K/KA/KAZUHO/HTTP-Parser-XS-0.17.tar.gz;
       sha256 = "02d84xq1mm53c7jl33qyb7v5w4372vydp74z6qj0vc96wcrnhkkr";
     };
   };
 
   HTTPProxy = buildPerlPackage rec {
-    name = "HTTP-Proxy-0.304";
+    pname = "HTTP-Proxy";
+    version = "0.304";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BO/BOOK/${name}.tar.gz";
+      url = mirror://cpan/authors/id/B/BO/BOOK/HTTP-Proxy-0.304.tar.gz;
       sha256 = "b05290534ec73625c21a0565fc35170890dab163843d95331c292c23f504c69d";
     };
     propagatedBuildInputs = [ LWP ];
@@ -7523,7 +8083,8 @@ let
   };
 
   HTTPRequestAsCGI = buildPerlPackage rec {
-    name = "HTTP-Request-AsCGI-1.2";
+    pname = "HTTP-Request-AsCGI";
+    version = "1.2";
     src = fetchurl {
       url = mirror://cpan/authors/id/F/FL/FLORA/HTTP-Request-AsCGI-1.2.tar.gz;
       sha256 = "1smwmiarwcgq7vjdblnb6ldi2x1s5sk5p15p7xvm5byiqq3znnwl";
@@ -7532,7 +8093,8 @@ let
   };
 
   HTTPResponseEncoding = buildPerlPackage {
-    name = "HTTP-Response-Encoding-0.06";
+    pname = "HTTP-Response-Encoding";
+    version = "0.06";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DA/DANKOGAI/HTTP-Response-Encoding-0.06.tar.gz;
       sha256 = "1am8lis8107s5npca1xgazdy5sknknzcqyhdmc220s4a4f77n5hh";
@@ -7545,7 +8107,8 @@ let
   };
 
   HTTPServerSimple = buildPerlPackage {
-    name = "HTTP-Server-Simple-0.52";
+    pname = "HTTP-Server-Simple";
+    version = "0.52";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BP/BPS/HTTP-Server-Simple-0.52.tar.gz;
       sha256 = "0k6bg7k6mjixfzxdkkdrhqvaqmdhjszx0zsk8g0bimiby6j9z4yq";
@@ -7558,9 +8121,10 @@ let
   };
 
   HTTPServerSimpleAuthen = buildPerlPackage rec {
-    name = "HTTP-Server-Simple-Authen-0.04";
+    pname = "HTTP-Server-Simple-Authen";
+    version = "0.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MI/MIYAGAWA/HTTP-Server-Simple-Authen-0.04.tar.gz;
       sha256 = "2dddc8ab9dc8986980151e4ba836a6bbf091f45cf195be1768ebdb4a993ed59b";
     };
     propagatedBuildInputs = [ AuthenSimple HTTPServerSimple ];
@@ -7570,7 +8134,8 @@ let
   };
 
   HTTPServerSimpleMason = buildPerlPackage {
-    name = "HTTP-Server-Simple-Mason-0.14";
+    pname = "HTTP-Server-Simple-Mason";
+    version = "0.14";
     src = fetchurl {
       url = mirror://cpan/authors/id/J/JE/JESSE/HTTP-Server-Simple-Mason-0.14.tar.gz;
       sha256 = "b7a49d8e6e55bff0b1f0278d951685466b143243b6f9e59e071f5472ca2a025a";
@@ -7583,7 +8148,8 @@ let
   };
 
   HTTPServerSimplePSGI = buildPerlPackage rec {
-     name = "HTTP-Server-Simple-PSGI-0.16";
+     pname = "HTTP-Server-Simple-PSGI";
+     version = "0.16";
      src = fetchurl {
        url = mirror://cpan/authors/id/M/MI/MIYAGAWA/HTTP-Server-Simple-PSGI-0.16.tar.gz;
        sha256 = "1fhx2glycd66m4l4m1gja81ixq8nh4r5g9wjhhkrffq4af2cnz2z";
@@ -7597,9 +8163,10 @@ let
   };
 
   iCalParser = buildPerlPackage rec {
-    name = "iCal-Parser-1.21";
+    pname = "iCal-Parser";
+    version = "1.21";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RI/RIXED/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RI/RIXED/iCal-Parser-1.21.tar.gz;
       sha256 = "0d7939a644a8e67017ec7239d3d9604f3986bb9a4ff80be68fe7299ebfd2270c";
     };
     propagatedBuildInputs = [ DateTimeFormatICal FreezeThaw IOString TextvFileasData ];
@@ -7609,9 +8176,10 @@ let
   };
 
   Imager = buildPerlPackage rec {
-    name = "Imager-1.011";
+    pname = "Imager";
+    version = "1.011";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TONYC/${name}.tar.gz";
+      url = mirror://cpan/authors/id/T/TO/TONYC/Imager-1.011.tar.gz;
       sha256 = "a3aea2f0c172c2c094baeced4a3bdaa9f54e3e85c97eea2e5f8f994ba2beedfc";
     };
     buildInputs = [ pkgs.freetype pkgs.fontconfig pkgs.libjpeg pkgs.libpng ];
@@ -7624,9 +8192,10 @@ let
   };
 
   ImageInfo = buildPerlPackage rec {
-    name = "Image-Info-1.41";
+    pname = "Image-Info";
+    version = "1.41";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SR/SREZIC/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SR/SREZIC/Image-Info-1.41.tar.gz;
       sha256 = "c546d27414686660dbc3cd8501537128c5285a8db0faf742c2dc12b9a29ba3db";
     };
     propagatedBuildInputs = [ IOStringy ];
@@ -7637,9 +8206,10 @@ let
   };
 
   ImageSane = buildPerlPackage rec {
-    name = "Image-Sane-0.14";
+    pname = "Image-Sane";
+    version = "0.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RA/RATCLIFFE/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RA/RATCLIFFE/Image-Sane-0.14.tar.gz;
       sha256 = "a4b027c9b7650291f1acb0eb93861a7fc45aef4e08f6726843f174fa113c8ba5";
     };
     buildInputs = [ pkgs.sane-backends ExtUtilsDepends ExtUtilsPkgConfig TestRequires TryTiny ];
@@ -7651,9 +8221,10 @@ let
   };
 
   ImageScale = buildPerlPackage rec {
-    name = "Image-Scale-0.14";
+    pname = "Image-Scale";
+    version = "0.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AG/AGRUNDMA/${name}.tar.gz";
+      url = mirror://cpan/authors/id/A/AG/AGRUNDMA/Image-Scale-0.14.tar.gz;
       sha256 = "f09c5f0663b87738365ac2819e186b909abeb9ed85d83bc15ee76872c947cdf8";
     };
     buildInputs = [ pkgs.libpng pkgs.libjpeg TestNoWarnings ];
@@ -7666,9 +8237,10 @@ let
   };
 
   ImageSize = buildPerlPackage rec {
-    name = "Image-Size-3.300";
+    pname = "Image-Size";
+    version = "3.300";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJRAY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RJ/RJRAY/Image-Size-3.300.tar.gz;
       sha256 = "0sq2kwdph55h4adx50fmy86brjkkv8grsw33xrhf1k9icpwb3jak";
     };
     buildInputs = [ ModuleBuild ];
@@ -7679,7 +8251,8 @@ let
   };
 
   IMAPClient = buildPerlPackage {
-    name = "IMAP-Client-0.13";
+    pname = "IMAP-Client";
+    version = "0.13";
     src = fetchurl {
       url = mirror://cpan/authors/id/C/CO/CONTEB/IMAP-Client-0.13.tar.gz;
       sha256 = "15fa4hpw2rqg2iadyz10rnv99hns78wph5qlh3257a3mbfjjyyla";
@@ -7688,9 +8261,10 @@ let
   };
 
   Importer = buildPerlPackage rec {
-    name = "Importer-0.025";
+    pname = "Importer";
+    version = "0.025";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/EX/EXODIST/${name}.tar.gz";
+      url = mirror://cpan/authors/id/E/EX/EXODIST/Importer-0.025.tar.gz;
       sha256 = "0745138c487d74033d0cbeb36f06595036dc7e688f1a5dbec9cc2fa799e13946";
     };
     meta = {
@@ -7700,7 +8274,8 @@ let
   };
 
   ImportInto = buildPerlPackage {
-    name = "Import-Into-1.002005";
+    pname = "Import-Into";
+    version = "1.002005";
     src = fetchurl {
       url = mirror://cpan/authors/id/H/HA/HAARG/Import-Into-1.002005.tar.gz;
       sha256 = "0rq5kz7c270q33jq6hnrv3xgkvajsc62ilqq7fs40av6zfipg7mx";
@@ -7713,7 +8288,8 @@ let
   };
 
   IO = buildPerlPackage {
-    name = "IO-1.39";
+    pname = "IO";
+    version = "1.39";
     src = fetchurl {
       url = mirror://cpan/authors/id/T/TO/TODDR/IO-1.39.tar.gz;
       sha256 = "4f0502e7f123ac824188eb8873038aaf2ddcc29f8babc1a0b2e1cd34b55a1fca";
@@ -7726,7 +8302,8 @@ let
   };
 
   IOAll = buildPerlPackage {
-    name = "IO-All-0.87";
+    pname = "IO-All";
+    version = "0.87";
     src = fetchurl {
       url = mirror://cpan/authors/id/F/FR/FREW/IO-All-0.87.tar.gz;
       sha256 = "0nsd9knlbd7if2v6zwj4q978axq0w5hk8ymp61z14a821hjivqjl";
@@ -7739,9 +8316,10 @@ let
   };
 
   IOCapture = buildPerlPackage rec {
-    name = "IO-Capture-0.05";
+    pname = "IO-Capture";
+    version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RE/REYNOLDS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RE/REYNOLDS/IO-Capture-0.05.tar.gz;
       sha256 = "c2c15a254ca74fb8c57d25d7b6cbcaff77a3b4fb5695423f1f80bb423abffea9";
     };
     meta = {
@@ -7750,9 +8328,10 @@ let
   };
 
   IOCaptureOutput = buildPerlPackage rec {
-    name = "IO-CaptureOutput-1.1104";
+    pname = "IO-CaptureOutput";
+    version = "1.1104";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DA/DAGOLDEN/IO-CaptureOutput-1.1104.tar.gz;
       sha256 = "fcc732fcb438f97a72b30e8c7796484bef2562e374553b207028e2fbf73f8330";
     };
     meta = {
@@ -7763,9 +8342,10 @@ let
   };
 
   IOCompress = buildPerlPackage rec {
-    name = "IO-Compress-2.086";
+    pname = "IO-Compress";
+    version = "2.086";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PM/PMQS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/P/PM/PMQS/IO-Compress-2.086.tar.gz;
       sha256 = "110a229aa02b701f9820f5e0c2e9c30db342ea241b2d01c03703ea4922b1ab53";
     };
     propagatedBuildInputs = [ CompressRawBzip2 CompressRawZlib ];
@@ -7778,7 +8358,8 @@ let
   };
 
   IODigest = buildPerlPackage {
-    name = "IO-Digest-0.11";
+    pname = "IO-Digest";
+    version = "0.11";
     src = fetchurl {
       url = mirror://cpan/authors/id/C/CL/CLKAO/IO-Digest-0.11.tar.gz;
       sha256 = "14kz7z4xw179aya3116wxac29l4y2wmwrba087lya4v2gxdgiz4g";
@@ -7787,7 +8368,8 @@ let
   };
 
   IOHTML = buildPerlPackage {
-    name = "IO-HTML-1.001";
+    pname = "IO-HTML";
+    version = "1.001";
     src = fetchurl {
       url = mirror://cpan/authors/id/C/CJ/CJM/IO-HTML-1.001.tar.gz;
       sha256 = "ea78d2d743794adc028bc9589538eb867174b4e165d7d8b5f63486e6b828e7e0";
@@ -7799,7 +8381,8 @@ let
   };
 
   IOHandleUtil = buildPerlModule rec {
-     name = "IO-Handle-Util-0.02";
+     pname = "IO-Handle-Util";
+     version = "0.02";
      src = fetchurl {
        url = mirror://cpan/authors/id/E/ET/ETHER/IO-Handle-Util-0.02.tar.gz;
        sha256 = "1vncvsx53iiw1yy3drlk44hzx2pk5cial0h74djf9i6s2flndfcd";
@@ -7811,7 +8394,8 @@ let
   };
 
   IOInteractive = buildPerlPackage {
-    name = "IO-Interactive-1.022";
+    pname = "IO-Interactive";
+    version = "1.022";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BD/BDFOY/IO-Interactive-1.022.tar.gz;
       sha256 = "0ed53b8ae93ae877e98e0d89b7b429e29ccd1ee4c28e952c4ea9aa73d01febdc";
@@ -7823,7 +8407,8 @@ let
   };
 
   IOLockedFile = buildPerlPackage rec {
-    name = "IO-LockedFile-0.23";
+    pname = "IO-LockedFile";
+    version = "0.23";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RA/RANI/IO-LockedFile-0.23.tar.gz;
       sha256 = "1dgq8zfkaszisdb5hz8jgcl0xc3qpv7bbv562l31xgpiddm7xnxi";
@@ -7831,7 +8416,8 @@ let
   };
 
   IOMultiplex = buildPerlPackage {
-    name = "IO-Multiplex-1.16";
+    pname = "IO-Multiplex";
+    version = "1.16";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BB/BBB/IO-Multiplex-1.16.tar.gz;
       sha256 = "74d22c44b5ad2e7190e2786e8a17d74bbf4cef89b4d1157ba33598b5a2720dad";
@@ -7840,7 +8426,7 @@ let
 
   IOPager = buildPerlPackage rec {
     version = "0.40";
-    name = "IO-Pager-${version}";
+    pname = "IO-Pager";
     src = fetchurl {
       url = "mirror://cpan/authors/id/J/JP/JPIERCE/IO-Pager-${version}.tgz";
       sha256 = "1vzdypsr7vkj8nnda9ccrksci6pqj5awwmi89l7x3mbpq36gad87";
@@ -7849,7 +8435,8 @@ let
   };
 
   IOPrompt = buildPerlModule {
-    name = "IO-Prompt-0.997004";
+    pname = "IO-Prompt";
+    version = "0.997004";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DC/DCONWAY/IO-Prompt-0.997004.tar.gz;
       sha256 = "f17bb305ee6ac8b5b203e6d826eb940c4f3f6d6f4bfe719c3b3a225f46f58615";
@@ -7862,7 +8449,8 @@ let
   };
 
   IOSessionData = buildPerlPackage {
-    name = "IO-SessionData-1.03";
+    pname = "IO-SessionData";
+    version = "1.03";
     src = fetchurl {
       url = mirror://cpan/authors/id/P/PH/PHRED/IO-SessionData-1.03.tar.gz;
       sha256 = "1p9d77pqy9a8dbgw7h7vmmkg0rlckk19dchd4c8gvcyv7qm73934";
@@ -7874,9 +8462,10 @@ let
   };
 
   IOSocketInet6 = buildPerlModule rec {
-    name = "IO-Socket-INET6-2.72";
+    pname = "IO-Socket-INET6";
+    version = "2.72";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SH/SHLOMIF/IO-Socket-INET6-2.72.tar.gz;
       sha256 = "1fqypz6qa5rw2d5y2zq7f49frwra0aln13nhq5gi514j2zx21q45";
     };
     propagatedBuildInputs = [ Socket6 ];
@@ -7884,9 +8473,10 @@ let
   };
 
   IOSocketSSL = buildPerlPackage rec {
-    name = "IO-Socket-SSL-2.066";
+    pname = "IO-Socket-SSL";
+    version = "2.066";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SU/SULLR/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SU/SULLR/IO-Socket-SSL-2.066.tar.gz;
       sha256 = "0d47064781a545304d5dcea5dfcee3acc2e95a32e1b4884d80505cde8ee6ebcd";
     };
     propagatedBuildInputs = [ MozillaCA NetSSLeay ];
@@ -7904,9 +8494,10 @@ let
   };
 
   IOSocketTimeout = buildPerlModule rec {
-    name = "IO-Socket-Timeout-0.32";
+    pname = "IO-Socket-Timeout";
+    version = "0.32";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAMS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DA/DAMS/IO-Socket-Timeout-0.32.tar.gz;
       sha256 = "edf915d6cc66bee43503aa6dc2b373366f38eaff701582183dad10cb8adf2972";
     };
     buildInputs = [ ModuleBuildTiny TestSharedFork TestTCP ];
@@ -7918,23 +8509,26 @@ let
   };
 
   IOString = buildPerlPackage rec {
-    name = "IO-String-1.08";
+    pname = "IO-String";
+    version = "1.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GA/GAAS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/G/GA/GAAS/IO-String-1.08.tar.gz;
       sha256 = "2a3f4ad8442d9070780e58ef43722d19d1ee21a803bf7c8206877a10482de5a0";
     };
   };
 
   IOStringy = buildPerlPackage rec {
-    name = "IO-stringy-2.111";
+    pname = "IO-stringy";
+    version = "2.111";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DS/DSKOLL/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DS/DSKOLL/IO-stringy-2.111.tar.gz;
       sha256 = "178rpx0ym5l2m9mdmpnr92ziscvchm541w94fd7ygi6311kgsrwc";
     };
   };
 
   IOTee = buildPerlPackage rec {
-    name = "IO-Tee-0.65";
+    pname = "IO-Tee";
+    version = "0.65";
     src = fetchurl {
       url = mirror://cpan/authors/id/N/NE/NEILB/IO-Tee-0.65.tar.gz;
       sha256 = "04hc94fk6qlazrarcznw2d8wiqw289js4za0czw65296kc8csgf6";
@@ -7942,7 +8536,8 @@ let
   };
 
   IOTieCombine = buildPerlPackage {
-    name = "IO-TieCombine-1.005";
+    pname = "IO-TieCombine";
+    version = "1.005";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RJ/RJBS/IO-TieCombine-1.005.tar.gz;
       sha256 = "1bv9ampayf4bvyxg4ivy18l8k79jvq55x6gl68b2fg8b62w4sba0";
@@ -7955,18 +8550,20 @@ let
   };
 
   IOTty = buildPerlPackage rec {
-    name = "IO-Tty-1.12";
+    pname = "IO-Tty";
+    version = "1.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TODDR/${name}.tar.gz";
+      url = mirror://cpan/authors/id/T/TO/TODDR/IO-Tty-1.12.tar.gz;
       sha256 = "0399anjy3bc0w8xzsc3qx5vcyqryc9gc52lc7wh7i49hsdq8gvx2";
     };
     doCheck = !stdenv.isDarwin;  # openpty fails in the sandbox
   };
 
   IPCountry = buildPerlPackage rec {
-    name = "IP-Country-2.28";
+    pname = "IP-Country";
+    version = "2.28";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NW/NWETTERS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/N/NW/NWETTERS/IP-Country-2.28.tar.gz;
       sha256 = "88db833a5ab22ed06cb53d6f205725e3b5371b254596053738885e91fa105f75";
     };
     propagatedBuildInputs = [ GeographyCountries ];
@@ -7977,9 +8574,10 @@ let
   };
 
   GeographyCountries = buildPerlPackage rec {
-    name = "Geography-Countries-2009041301";
+    pname = "Geography-Countries";
+    version = "2009041301";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AB/ABIGAIL/${name}.tar.gz";
+      url = mirror://cpan/authors/id/A/AB/ABIGAIL/Geography-Countries-2009041301.tar.gz;
       sha256 = "48c42e40e8281ba7c981743a854c48e6def2d51eb0925ea6c96e25c74497f20f";
     };
     meta = {
@@ -7990,7 +8588,8 @@ let
 
 
   IPCRun = buildPerlPackage {
-    name = "IPC-Run-20180523.0";
+    pname = "IPC-Run";
+    version = "20180523.0";
     src = fetchurl {
       url = mirror://cpan/authors/id/T/TO/TODDR/IPC-Run-20180523.0.tar.gz;
       sha256 = "0bvckcs1629ifqfb68xkapd4a74fd5qbg6z9qs8i6rx4z3nxfl1q";
@@ -8005,15 +8604,17 @@ let
   };
 
   IPCRun3 = buildPerlPackage rec {
-    name = "IPC-Run3-0.048";
+    pname = "IPC-Run3";
+    version = "0.048";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RJ/RJBS/IPC-Run3-0.048.tar.gz;
       sha256 = "0r9m8q78bg7yycpixd7738jm40yz71p2q7inm766kzsw3g6c709x";
     };
   };
 
   IPCShareLite = buildPerlPackage rec {
-    name = "IPC-ShareLite-0.17";
+    pname = "IPC-ShareLite";
+    version = "0.17";
     src = fetchurl {
       url = mirror://cpan/authors/id/A/AN/ANDYA/IPC-ShareLite-0.17.tar.gz;
       sha256 = "1gz7dbwxrzbzdsjv11kb49jlf9q6lci2va6is0hnavd93nwhdm0l";
@@ -8021,7 +8622,8 @@ let
   };
 
   IPCSystemSimple = buildPerlPackage {
-    name = "IPC-System-Simple-1.25";
+    pname = "IPC-System-Simple";
+    version = "1.25";
     src = fetchurl {
       url = mirror://cpan/authors/id/P/PJ/PJF/IPC-System-Simple-1.25.tar.gz;
       sha256 = "f1b6aa1dfab886e8e4ea825f46a1cbb26038ef3e727fef5d84444aa8035a4d3b";
@@ -8033,7 +8635,8 @@ let
   };
 
   IPCSysV = buildPerlPackage {
-    name = "IPC-SysV-2.07";
+    pname = "IPC-SysV";
+    version = "2.07";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MH/MHX/IPC-SysV-2.07.tar.gz;
       sha256 = "d01a367af771d35e3b11a21366ad6405f8d28e8cbca4c0cf08ab78bf157d052d";
@@ -8118,7 +8721,8 @@ let
   };
 
   InlineJava = buildPerlPackage rec {
-    name = "Inline-Java-0.66";
+    pname = "Inline-Java";
+    version = "0.66";
 
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETJ/Inline-Java-0.66.tar.gz;
@@ -8148,15 +8752,17 @@ let
   };
 
   IPCSignal = buildPerlPackage rec {
-    name = "IPC-Signal-1.00";
+    pname = "IPC-Signal";
+    version = "1.00";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RO/ROSCH/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RO/ROSCH/IPC-Signal-1.00.tar.gz;
       sha256 = "1l3g0zrcwf2whwjhbpwdcridb7c77mydwxvfykqg1h6hqb4gj8bw";
     };
   };
 
   JavaScriptMinifierXS = buildPerlModule rec {
-    name = "JavaScript-Minifier-XS-0.11";
+    pname = "JavaScript-Minifier-XS";
+    version = "0.11";
     src = fetchurl {
       url = mirror://cpan/authors/id/G/GT/GTERMARS/JavaScript-Minifier-XS-0.11.tar.gz;
       sha256 = "1vlyhckpjbrg2v4dy9szsxxl0q44n0y1xl763mg2y2ym9g5144hm";
@@ -8168,7 +8774,8 @@ let
   };
 
   JavaScriptValueEscape = buildPerlModule rec {
-     name = "JavaScript-Value-Escape-0.07";
+     pname = "JavaScript-Value-Escape";
+     version = "0.07";
      src = fetchurl {
        url = mirror://cpan/authors/id/K/KA/KAZEBURO/JavaScript-Value-Escape-0.07.tar.gz;
        sha256 = "1p5365lvnax8kbcfrj169lx05af3i3qi5wg5x9mizqgd10vxmjws";
@@ -8181,7 +8788,8 @@ let
   };
 
   JSON = buildPerlPackage {
-    name = "JSON-4.02";
+    pname = "JSON";
+    version = "4.02";
     src = fetchurl {
       url = mirror://cpan/authors/id/I/IS/ISHIGAKI/JSON-4.02.tar.gz;
       sha256 = "0z32x2lijij28c9fhmzgxc41i9nw24fyvd2a8ajs5zw9b9sqhjj4";
@@ -8198,7 +8806,8 @@ let
   };
 
   JSONAny = buildPerlPackage {
-    name = "JSON-Any-1.39";
+    pname = "JSON-Any";
+    version = "1.39";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/JSON-Any-1.39.tar.gz;
       sha256 = "1hspg6khjb38syn59cysnapc1q77qgavfym3fqr6l2kiydf7ajdf";
@@ -8211,7 +8820,8 @@ let
   };
 
   JSONMaybeXS = buildPerlPackage rec {
-    name = "JSON-MaybeXS-1.004000";
+    pname = "JSON-MaybeXS";
+    version = "1.004000";
     src = fetchurl {
       url = mirror://cpan/authors/id/H/HA/HAARG/JSON-MaybeXS-1.004000.tar.gz;
       sha256 = "09m1w03as6n0a00pzvaldkhm494yaf5n0g3j2cwwfx24iwpa1gar";
@@ -8223,7 +8833,8 @@ let
   };
 
   JSONPP = buildPerlPackage rec {
-    name = "JSON-PP-4.02";
+    pname = "JSON-PP";
+    version = "4.02";
     src = fetchurl {
       url = mirror://cpan/authors/id/I/IS/ISHIGAKI/JSON-PP-4.02.tar.gz;
       sha256 = "11wlh4clq0cddiamh1ipps3fh9ly01j4pcdh8f4nw7912bw7pimc";
@@ -8235,7 +8846,8 @@ let
   };
 
   JSONPPCompat5006 = buildPerlPackage {
-    name = "JSON-PP-Compat5006-1.09";
+    pname = "JSON-PP-Compat5006";
+    version = "1.09";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MA/MAKAMAKA/JSON-PP-Compat5006-1.09.tar.gz;
       sha256 = "197030df52635f9bbe25af10742eea5bd74971473118c11311fcabcb62e3716a";
@@ -8247,9 +8859,10 @@ let
   };
 
  JSONWebToken = buildPerlModule rec {
-    name = "JSON-WebToken-0.10";
+    pname = "JSON-WebToken";
+    version = "0.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/X/XA/XAICRON/${name}.tar.gz";
+      url = mirror://cpan/authors/id/X/XA/XAICRON/JSON-WebToken-0.10.tar.gz;
       sha256 = "77c182a98528f1714d82afc548d5b3b4dc93e67069128bb9b9413f24cf07248b";
     };
     buildInputs = [ TestMockGuard TestRequires ];
@@ -8262,7 +8875,8 @@ let
   };
 
   JSONXS = buildPerlPackage {
-    name = "JSON-XS-4.02";
+    pname = "JSON-XS";
+    version = "4.02";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/ML/MLEHMANN/JSON-XS-4.02.tar.gz;
       sha256 = "05ngmpc0smlfzgyhyagd5gza8g93r8hik858kmr186h770higbd5";
@@ -8272,9 +8886,10 @@ let
   };
 
   JSONXSVersionOneAndTwo = buildPerlPackage rec {
-    name = "JSON-XS-VersionOneAndTwo-0.31";
+    pname = "JSON-XS-VersionOneAndTwo";
+    version = "0.31";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LB/LBROCARD/${name}.tar.gz";
+      url = mirror://cpan/authors/id/L/LB/LBROCARD/JSON-XS-VersionOneAndTwo-0.31.tar.gz;
       sha256 = "e6092c4d961fae777acf7fe99fb3cd6e5b710fec85765a6b90417480e4c94a34";
     };
     propagatedBuildInputs = [ JSONXS ];
@@ -8285,15 +8900,16 @@ let
 
   Later = buildPerlPackage rec {
     version = "0.21";
-    name = "Object-Realize-Later-${version}";
+    pname = "Object-Realize-Later";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MARKOV/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MA/MARKOV/Object-Realize-Later-0.21.tar.gz;
       sha256 = "1nfqssld7pcdw9sj4mkfnh75w51wl14i1h7npj9fld4fri09cywg";
     };
   };
 
   libapreq2 = buildPerlPackage {
-    name = "libapreq2-2.13";
+    pname = "libapreq2";
+    version = "2.13";
     src = fetchurl {
       url = mirror://cpan/authors/id/I/IS/ISAAC/libapreq2-2.13.tar.gz;
       sha256 = "5731e6833b32d88e4a5c690e45ddf20fcf969ce3da666c5627d775e92da0cf6e";
@@ -8327,7 +8943,8 @@ let
       # install the apache module
       # https://computergod.typepad.com/home/2007/06/webgui_and_suse.html
       # NOTE: if using the apache module you must use "apreq" as the module name, not "apreq2"
-      # services.httpd.extraModules = [ { name = "apreq"; path = "''${pkgs.perlPackages.libapreq2}/modules/mod_apreq2.so"; } ];
+      # services.httpd.extraModules = [ { pname = "libapreq2";
+ version = "2.13"; path = "''${pkgs.perlPackages.libapreq2}/modules/mod_apreq2.so"; } ];
       pushd module
       make install DESTDIR=$out
       cp -r $out/${pkgs.apacheHttpd.out}/modules $out/
@@ -8342,7 +8959,8 @@ let
   };
 
   libintl_perl = buildPerlPackage rec {
-    name = "libintl-perl-1.31";
+    pname = "libintl-perl";
+    version = "1.31";
     src = fetchurl {
       url = mirror://cpan/authors/id/G/GU/GUIDO/libintl-perl-1.31.tar.gz;
       sha256 = "1afandrl44mq9c32r57xr489gkfswdgc97h8x86k98dz1byv3l6a";
@@ -8350,7 +8968,8 @@ let
   };
 
   libnet = buildPerlPackage {
-    name = "libnet-3.11";
+    pname = "libnet";
+    version = "3.11";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SH/SHAY/libnet-3.11.tar.gz;
       sha256 = "1lsj3a2vbryh85mbb6yddyb2zjv5vs88fdj5x3v7fp2ndr6ixarg";
@@ -8362,7 +8981,8 @@ let
   };
 
   librelative = buildPerlPackage rec {
-     name = "lib-relative-1.000";
+     pname = "lib-relative";
+     version = "1.000";
      src = fetchurl {
        url = mirror://cpan/authors/id/D/DB/DBOOK/lib-relative-1.000.tar.gz;
        sha256 = "1mvcdl87d3kyrdx4y6x79k3n5qdd1x5m1hp8lwjxvgfqbw0cgq6z";
@@ -8375,16 +8995,18 @@ let
   };
 
   libxml_perl = buildPerlPackage rec {
-    name = "libxml-perl-0.08";
+    pname = "libxml-perl";
+    version = "0.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KM/KMACLEOD/${name}.tar.gz";
+      url = mirror://cpan/authors/id/K/KM/KMACLEOD/libxml-perl-0.08.tar.gz;
       sha256 = "1jy9af0ljyzj7wakqli0437zb2vrbplqj4xhab7bfj2xgfdhawa5";
     };
     propagatedBuildInputs = [ XMLParser ];
   };
 
   LinguaENFindNumber = buildPerlPackage {
-    name = "Lingua-EN-FindNumber-1.32";
+    pname = "Lingua-EN-FindNumber";
+    version = "1.32";
     src = fetchurl {
       url = mirror://cpan/authors/id/N/NE/NEILB/Lingua-EN-FindNumber-1.32.tar.gz;
       sha256 = "1d176d1c863fb9844bd19d2c2a4e68a0ed73da158f724a89405b90db7e8dbd04";
@@ -8411,9 +9033,10 @@ let
   };
 
   LinguaENInflectNumber = buildPerlPackage rec {
-    name = "Lingua-EN-Inflect-Number-1.12";
+    pname = "Lingua-EN-Inflect-Number";
+    version = "1.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/${name}.tar.gz";
+      url = mirror://cpan/authors/id/N/NE/NEILB/Lingua-EN-Inflect-Number-1.12.tar.gz;
       sha256 = "66fb33838512746f5c597e80264fea66643f7f26570ec2f9205b6135ad67acbf";
     };
     propagatedBuildInputs = [ LinguaENInflect ];
@@ -8425,9 +9048,10 @@ let
   };
 
   LinguaENInflectPhrase = buildPerlPackage rec {
-    name = "Lingua-EN-Inflect-Phrase-0.20";
+    pname = "Lingua-EN-Inflect-Phrase";
+    version = "0.20";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RK/RKITOVER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RK/RKITOVER/Lingua-EN-Inflect-Phrase-0.20.tar.gz;
       sha256 = "55058911a99f1755de3eb449a99ffbeb92d88c01ff5dc60511a24679050ddea8";
     };
     buildInputs = [ TestNoWarnings ];
@@ -8439,7 +9063,8 @@ let
   };
 
   LinguaENNumberIsOrdinal = buildPerlPackage {
-    name = "Lingua-EN-Number-IsOrdinal-0.05";
+    pname = "Lingua-EN-Number-IsOrdinal";
+    version = "0.05";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RK/RKITOVER/Lingua-EN-Number-IsOrdinal-0.05.tar.gz;
       sha256 = "28d5695400c0f4e2bd209793cb74f6da2b9257356aacb2947c603425e09618d6";
@@ -8453,7 +9078,8 @@ let
   };
 
   LinguaENTagger = buildPerlPackage {
-    name = "Lingua-EN-Tagger-0.30";
+    pname = "Lingua-EN-Tagger";
+    version = "0.30";
     src = fetchurl {
       url = mirror://cpan/authors/id/A/AC/ACOBURN/Lingua-EN-Tagger-0.30.tar.gz;
       sha256 = "0nrnkvsf9f0a7lp82sanmy89ms2nqq1lvjqicvsagsvzp513bl5b";
@@ -8466,7 +9092,8 @@ let
   };
 
   LinguaENWords2Nums = buildPerlPackage {
-    name = "Lingua-EN-Words2Nums-0.18";
+    pname = "Lingua-EN-Words2Nums";
+    version = "0.18";
     src = fetchurl {
       url = mirror://cpan/authors/id/J/JO/JOEY/Lingua-EN-Words2Nums-0.18.tar.gz;
       sha256 = "686556797cd2a4eaa066f19bbf03ab25c06278292c9ead2f187dfd9031ea1d85";
@@ -8477,7 +9104,8 @@ let
   };
 
   LinguaPTStemmer = buildPerlPackage rec {
-     name = "Lingua-PT-Stemmer-0.02";
+     pname = "Lingua-PT-Stemmer";
+     version = "0.02";
      src = fetchurl {
        url = mirror://cpan/authors/id/N/NE/NEILB/Lingua-PT-Stemmer-0.02.tar.gz;
        sha256 = "17c48sfbgwd2ivlgf59sr6jdhwa3aim8750f8pyzz7xpi8gz0var";
@@ -8490,7 +9118,8 @@ let
   };
 
   LinguaStem = buildPerlModule rec {
-    name = "Lingua-Stem-0.84";
+    pname = "Lingua-Stem";
+    version = "0.84";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SN/SNOWHARE/Lingua-Stem-0.84.tar.gz;
       sha256 = "12avh2mnnc7llmmshrr5bgb473fvydxnlqrqbl2815mf2dp4pxcg";
@@ -8500,7 +9129,8 @@ let
   };
 
   LinguaStemFr = buildPerlPackage rec {
-     name = "Lingua-Stem-Fr-0.02";
+     pname = "Lingua-Stem-Fr";
+     version = "0.02";
      src = fetchurl {
        url = mirror://cpan/authors/id/S/SD/SDP/Lingua-Stem-Fr-0.02.tar.gz;
        sha256 = "0vyrspwzaqjxm5mqshf4wvwa3938mkajd1918d9ii2l9m2rn8kwx";
@@ -8510,7 +9140,8 @@ let
   };
 
   LinguaStemIt = buildPerlPackage rec {
-     name = "Lingua-Stem-It-0.02";
+     pname = "Lingua-Stem-It";
+     version = "0.02";
      src = fetchurl {
        url = mirror://cpan/authors/id/A/AC/ACALPINI/Lingua-Stem-It-0.02.tar.gz;
        sha256 = "1207r183s5hlh4mfwa6p46vzm0dhvrs2dnss5s41a0gyfkxp7riq";
@@ -8520,7 +9151,8 @@ let
   };
 
   LinguaStemRu = buildPerlPackage rec {
-     name = "Lingua-Stem-Ru-0.04";
+     pname = "Lingua-Stem-Ru";
+     version = "0.04";
      src = fetchurl {
        url = mirror://cpan/authors/id/N/NE/NEILB/Lingua-Stem-Ru-0.04.tar.gz;
        sha256 = "0a2jmdz7jn32qj5hyiw5kbv8fvlpmws8i00a6xcbkzb48yvwww0j";
@@ -8533,7 +9165,8 @@ let
   };
 
   LinguaStemSnowballDa = buildPerlPackage rec {
-     name = "Lingua-Stem-Snowball-Da-1.01";
+     pname = "Lingua-Stem-Snowball-Da";
+     version = "1.01";
      src = fetchurl {
        url = mirror://cpan/authors/id/C/CI/CINE/Lingua-Stem-Snowball-Da-1.01.tar.gz;
        sha256 = "0mm0m7glm1s6i9f6a78jslw6wh573208arxhq93yriqmw17bwf9f";
@@ -8543,18 +9176,20 @@ let
   };
 
   LinguaTranslit = buildPerlPackage rec {
-    name = "Lingua-Translit-0.28";
+    pname = "Lingua-Translit";
+    version = "0.28";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AL/ALINKE/${name}.tar.gz";
+      url = mirror://cpan/authors/id/A/AL/ALINKE/Lingua-Translit-0.28.tar.gz;
       sha256 = "113f91d8fc2c630437153a49fb7a52b023af8f6278ed96c070b1f60824b8eae1";
     };
     doCheck = false;
   };
 
   LinuxACL = buildPerlPackage rec {
-    name = "Linux-ACL-0.05";
+    pname = "Linux-ACL";
+    version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NA/NAZAROV/${name}.tar.gz";
+      url = mirror://cpan/authors/id/N/NA/NAZAROV/Linux-ACL-0.05.tar.gz;
       sha256 = "312940c1f60f47c4fc93fa0a9d2a626425faa837040c8c2f1ad58ee09f62f371";
     };
     buildInputs = [ pkgs.acl ];
@@ -8567,9 +9202,10 @@ let
   };
 
   LinuxDesktopFiles = buildPerlModule rec {
-    name = "Linux-DesktopFiles-0.25";
+    pname = "Linux-DesktopFiles";
+    version = "0.25";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TR/TRIZEN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/T/TR/TRIZEN/Linux-DesktopFiles-0.25.tar.gz;
       sha256 = "60377a74fba90fa465200ee1c7430dbdde69d454d85f9ee101c039803a07e5f5";
     };
     meta = {
@@ -8580,7 +9216,8 @@ let
   };
 
   LinuxDistribution = buildPerlModule {
-    name = "Linux-Distribution-0.23";
+    pname = "Linux-Distribution";
+    version = "0.23";
     src = fetchurl {
       url = mirror://cpan/authors/id/C/CH/CHORNY/Linux-Distribution-0.23.tar.gz;
       sha256 = "603e27da607b3e872a669d7a66d75982f0969153eab2d4b20c341347b4ebda5f";
@@ -8595,9 +9232,10 @@ let
   };
 
   LinuxFD = buildPerlModule rec {
-    name = "Linux-FD-0.011";
+    pname = "Linux-FD";
+    version = "0.011";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/${name}.tar.gz";
+      url = mirror://cpan/authors/id/L/LE/LEONT/Linux-FD-0.011.tar.gz;
       sha256 = "6bb579d47644cb0ed35626ff77e909ae69063073c6ac09aa0614fef00fa37356";
     };
     buildInputs = [ TestException ];
@@ -8609,7 +9247,8 @@ let
   };
 
   LinuxInotify2 = buildPerlPackage rec {
-    name = "Linux-Inotify2-2.1";
+    pname = "Linux-Inotify2";
+    version = "2.1";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/ML/MLEHMANN/Linux-Inotify2-2.1.tar.gz;
       sha256 = "0w7jyq5pjy28s0ck34gy1vfbr069lhcn579bz0fh29h071sbcrbj";
@@ -8618,7 +9257,8 @@ let
   };
 
   ListAllUtils = buildPerlPackage {
-    name = "List-AllUtils-0.15";
+    pname = "List-AllUtils";
+    version = "0.15";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DR/DROLSKY/List-AllUtils-0.15.tar.gz;
       sha256 = "3711fac729321d3aad8356a756fd9272094f227aa048866a3751f9d8ea6cc95d";
@@ -8631,7 +9271,8 @@ let
   };
 
   ListBinarySearch = buildPerlPackage {
-    name = "List-BinarySearch-0.25";
+    pname = "List-BinarySearch";
+    version = "0.25";
     src = pkgs.fetchurl {
       url = mirror://cpan/authors/id/D/DA/DAVIDO/List-BinarySearch-0.25.tar.gz;
       sha256 = "0ap8y9rsjxg75887klgij90mf459f8dwy0dbx1g06h30pmqk04f8";
@@ -8639,9 +9280,10 @@ let
   };
 
   ListCompare = buildPerlPackage rec {
-    name = "List-Compare-0.53";
+    pname = "List-Compare";
+    version = "0.53";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JK/JKEENAN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/J/JK/JKEENAN/List-Compare-0.53.tar.gz;
       sha256 = "fdbf4ff67b3135d44475fef7fcac0cd4706407d5720d26dca914860eb10f8550";
     };
     buildInputs = [ IOCaptureOutput ];
@@ -8653,9 +9295,10 @@ let
   };
 
   ListMoreUtils = buildPerlPackage rec {
-    name = "List-MoreUtils-0.428";
+    pname = "List-MoreUtils";
+    version = "0.428";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RE/REHSACK/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RE/REHSACK/List-MoreUtils-0.428.tar.gz;
       sha256 = "713e0945d5f16e62d81d5f3da2b6a7b14a4ce439f6d3a7de74df1fd166476cc2";
     };
     propagatedBuildInputs = [ ExporterTiny ListMoreUtilsXS ];
@@ -8667,7 +9310,8 @@ let
   };
 
   ListMoreUtilsXS = buildPerlPackage rec {
-     name = "List-MoreUtils-XS-0.428";
+     pname = "List-MoreUtils-XS";
+     version = "0.428";
      src = fetchurl {
        url = mirror://cpan/authors/id/R/RE/REHSACK/List-MoreUtils-XS-0.428.tar.gz;
        sha256 = "0bfndmnkqaaf3gffprak143bzplxd69c368jxgr7rzlx88hyd7wx";
@@ -8682,9 +9326,10 @@ let
   };
 
   ListSomeUtils = buildPerlPackage rec {
-    name = "List-SomeUtils-0.56";
+    pname = "List-SomeUtils";
+    version = "0.56";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DR/DROLSKY/List-SomeUtils-0.56.tar.gz;
       sha256 = "eaa7d99ce86380c0389876474c8eb84acc0a6bfeef1b0fc23a292592de6f89f7";
     };
     buildInputs = [ TestLeakTrace ];
@@ -8696,7 +9341,8 @@ let
   };
 
   ListUtilsBy = buildPerlModule rec {
-    name = "List-UtilsBy-0.11";
+    pname = "List-UtilsBy";
+    version = "0.11";
     src = fetchurl {
       url = mirror://cpan/authors/id/P/PE/PEVANS/List-UtilsBy-0.11.tar.gz;
       sha256 = "0nkpylkqccxanr8wc7j9wg6jdrizybjjd6p8q3jbh7f29cxz9pgs";
@@ -8704,7 +9350,8 @@ let
   };
 
   LocaleCodes = buildPerlPackage {
-    name = "Locale-Codes-3.60";
+    pname = "Locale-Codes";
+    version = "3.60";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SB/SBECK/Locale-Codes-3.60.tar.gz;
       sha256 = "32829bc49d927335de6994f3cfd55c5e693881602564c2aa966fe86740371194";
@@ -8716,7 +9363,8 @@ let
   };
 
   LocaleGettext = buildPerlPackage {
-    name = "gettext-1.07";
+    pname = "gettext";
+    version = "1.07";
     buildInputs = [ pkgs.gettext ];
     src = fetchurl {
       url = mirror://cpan/authors/id/P/PV/PVANDRY/gettext-1.07.tar.gz;
@@ -8726,7 +9374,8 @@ let
   };
 
   LocaleMOFile = buildPerlPackage rec {
-     name = "Locale-MO-File-0.09";
+     pname = "Locale-MO-File";
+     version = "0.09";
      src = fetchurl {
        url = mirror://cpan/authors/id/S/ST/STEFFENW/Locale-MO-File-0.09.tar.gz;
        sha256 = "0gsaaqimsh5bdhns2v67j1nvb178hx2536lxmr971cwxy31ns0wp";
@@ -8740,7 +9389,8 @@ let
   };
 
   LocaleMaketextFuzzy = buildPerlPackage {
-    name = "Locale-Maketext-Fuzzy-0.11";
+    pname = "Locale-Maketext-Fuzzy";
+    version = "0.11";
     src = fetchurl {
       url = mirror://cpan/authors/id/A/AU/AUDREYT/Locale-Maketext-Fuzzy-0.11.tar.gz;
       sha256 = "3785171ceb78cc7671319a3a6d8ced9b190e097dfcd9b2a9ebc804cd1a282f96";
@@ -8752,7 +9402,8 @@ let
   };
 
   LocaleMaketextLexicon = buildPerlPackage {
-    name = "Locale-Maketext-Lexicon-1.00";
+    pname = "Locale-Maketext-Lexicon";
+    version = "1.00";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DR/DRTECH/Locale-Maketext-Lexicon-1.00.tar.gz;
       sha256 = "b73f6b04a58d3f0e38ebf2115a4c1532f1a4eef6fac5c6a2a449e4e14c1ddc7c";
@@ -8764,7 +9415,8 @@ let
   };
 
   LocaleMsgfmt = buildPerlPackage {
-    name = "Locale-Msgfmt-0.15";
+    pname = "Locale-Msgfmt";
+    version = "0.15";
     src = fetchurl {
       url = mirror://cpan/authors/id/A/AZ/AZAWAWI/Locale-Msgfmt-0.15.tar.gz;
       sha256 = "c3276831cbeecf58be02081bcc180bd348daa35da21a7737b7b038a59f643ab4";
@@ -8776,7 +9428,8 @@ let
   };
 
   LocalePO = buildPerlPackage {
-    name = "Locale-PO-0.27";
+    pname = "Locale-PO";
+    version = "0.27";
     src = fetchurl {
       url = mirror://cpan/authors/id/C/CO/COSIMO/Locale-PO-0.27.tar.gz;
       sha256 = "3c994a4b63e6e4e836c6f79a93f51921cab77c90c9753fe0f8b5429220d516b9";
@@ -8788,7 +9441,8 @@ let
   };
 
   LocaleTextDomainOO = buildPerlPackage rec {
-     name = "Locale-TextDomain-OO-1.036";
+     pname = "Locale-TextDomain-OO";
+     version = "1.036";
      src = fetchurl {
        url = mirror://cpan/authors/id/S/ST/STEFFENW/Locale-TextDomain-OO-1.036.tar.gz;
        sha256 = "0f0fajq4k1sgyywsb7qypsf6xa1sxjx4agm8l8z2284nm3hq65xm";
@@ -8802,7 +9456,8 @@ let
   };
 
   LocaleTextDomainOOUtil = buildPerlPackage rec {
-     name = "Locale-TextDomain-OO-Util-4.002";
+     pname = "Locale-TextDomain-OO-Util";
+     version = "4.002";
      src = fetchurl {
        url = mirror://cpan/authors/id/S/ST/STEFFENW/Locale-TextDomain-OO-Util-4.002.tar.gz;
        sha256 = "1826pl11vr9p7zv7vqs7kcd8y5218086l90dw8lw0xzdcmzs0prw";
@@ -8816,7 +9471,8 @@ let
   };
 
   LocaleUtilsPlaceholderBabelFish = buildPerlPackage rec {
-     name = "Locale-Utils-PlaceholderBabelFish-0.006";
+     pname = "Locale-Utils-PlaceholderBabelFish";
+     version = "0.006";
      src = fetchurl {
        url = mirror://cpan/authors/id/S/ST/STEFFENW/Locale-Utils-PlaceholderBabelFish-0.006.tar.gz;
        sha256 = "1k54njj8xz19c8bjb0iln1mnfq55j3pvbff7samyrab3k59h071f";
@@ -8830,7 +9486,8 @@ let
   };
 
   LocaleUtilsPlaceholderMaketext = buildPerlPackage rec {
-     name = "Locale-Utils-PlaceholderMaketext-1.005";
+     pname = "Locale-Utils-PlaceholderMaketext";
+     version = "1.005";
      src = fetchurl {
        url = mirror://cpan/authors/id/S/ST/STEFFENW/Locale-Utils-PlaceholderMaketext-1.005.tar.gz;
        sha256 = "1srlbp8sfnzhndgh9s4d8bglpzw0vb8gnab9r8r8sggkv15n0a2h";
@@ -8844,7 +9501,8 @@ let
   };
 
   LocaleUtilsPlaceholderNamed = buildPerlPackage rec {
-     name = "Locale-Utils-PlaceholderNamed-1.004";
+     pname = "Locale-Utils-PlaceholderNamed";
+     version = "1.004";
      src = fetchurl {
        url = mirror://cpan/authors/id/S/ST/STEFFENW/Locale-Utils-PlaceholderNamed-1.004.tar.gz;
        sha256 = "1gd68lm5w5c6ndcilx91rn84zviqyrk3fx92jjx5khxm76i8xmvg";
@@ -8858,9 +9516,10 @@ let
   };
 
   locallib = buildPerlPackage rec {
-    name = "local-lib-2.000024";
+    pname = "local-lib";
+    version = "2.000024";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/${name}.tar.gz";
+      url = mirror://cpan/authors/id/H/HA/HAARG/local-lib-2.000024.tar.gz;
       sha256 = "01cav7m6qc1x96wna1viiw6n212f94ks7cik4vj1a1lasixr36rf";
     };
     meta = {
@@ -8871,7 +9530,8 @@ let
   };
 
   LockFileSimple = buildPerlPackage rec {
-    name = "LockFile-Simple-0.208";
+    pname = "LockFile-Simple";
+    version = "0.208";
     src = fetchurl {
       url = "mirror://cpan/authors/id/S/SC/SCHWIGON/lockfile-simple/LockFile-Simple-0.208.tar.gz";
       sha256 = "18pk5a030dsg1h6wd8c47wl8pzrpyh9zi9h2c9gs9855nab7iis5";
@@ -8879,9 +9539,10 @@ let
   };
 
   LogAny = buildPerlPackage rec {
-    name = "Log-Any-1.707";
+    pname = "Log-Any";
+    version = "1.707";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PR/PREACTION/${name}.tar.gz";
+      url = mirror://cpan/authors/id/P/PR/PREACTION/Log-Any-1.707.tar.gz;
       sha256 = "74510f8cbee12637462e7c6020c8943d447a1e8e149a256f8168ee47562c65f1";
     };
     # Syslog test fails.
@@ -8894,9 +9555,10 @@ let
   };
 
   LogContextual = buildPerlPackage rec {
-    name = "Log-Contextual-0.008001";
+    pname = "Log-Contextual";
+    version = "0.008001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FR/FREW/${name}.tar.gz";
+      url = mirror://cpan/authors/id/F/FR/FREW/Log-Contextual-0.008001.tar.gz;
       sha256 = "b93cbcfbb8796d51c836e3b00243cda5630808c152c14eee5f20ca09c9451993";
     };
     buildInputs = [ TestFatal ];
@@ -8909,7 +9571,8 @@ let
   };
 
   LogDispatch = buildPerlPackage {
-    name = "Log-Dispatch-2.68";
+    pname = "Log-Dispatch";
+    version = "2.68";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DR/DROLSKY/Log-Dispatch-2.68.tar.gz;
       sha256 = "1bxd3bhrn1h2q9f8r65z3101a32nl2kdb7l40bxg4vbsk4wk0ynh";
@@ -8923,9 +9586,10 @@ let
   };
 
   LogHandler = buildPerlModule rec {
-    name = "Log-Handler-0.88";
+    pname = "Log-Handler";
+    version = "0.88";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BL/BLOONIX/${name}.tar.gz";
+      url = mirror://cpan/authors/id/B/BL/BLOONIX/Log-Handler-0.88.tar.gz;
       sha256 = "45bf540ab2138ed3ff93afc205b0516dc75755b86acdcc5e75c41347833c293d";
     };
     propagatedBuildInputs = [ ParamsValidate ];
@@ -8936,7 +9600,8 @@ let
   };
 
   LogMessage = buildPerlPackage {
-    name = "Log-Message-0.08";
+    pname = "Log-Message";
+    version = "0.08";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BI/BINGOS/Log-Message-0.08.tar.gz;
       sha256 = "bd697dd62aaf26d118e9f0a0813429deb1c544e4501559879b61fcbdfe99fe46";
@@ -8948,7 +9613,8 @@ let
   };
 
   LogMessageSimple = buildPerlPackage rec {
-     name = "Log-Message-Simple-0.10";
+     pname = "Log-Message-Simple";
+     version = "0.10";
      src = fetchurl {
        url = mirror://cpan/authors/id/B/BI/BINGOS/Log-Message-Simple-0.10.tar.gz;
        sha256 = "15nxi935nfrf8dkdrgvcrf2qlai4pbz03yj8sja0n9mcq2jd24ma";
@@ -8961,7 +9627,8 @@ let
   };
 
   LogTrace = buildPerlPackage rec {
-    name = "Log-Trace-1.070";
+    pname = "Log-Trace";
+    version = "1.070";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BB/BBC/Log-Trace-1.070.tar.gz;
       sha256 = "1qrnxn9b05cqyw1286djllnj8wzys10754glxx6z5hihxxc85jwy";
@@ -8969,7 +9636,8 @@ let
   };
 
   MCE = buildPerlPackage rec {
-     name = "MCE-1.838";
+     pname = "MCE";
+     version = "1.838";
      src = fetchurl {
        url = mirror://cpan/authors/id/M/MA/MARIOROY/MCE-1.838.tar.gz;
        sha256 = "1xg63kd2la5zh7cvapv1l1wsxjallj4xv5l15bdp8jl3vvffwdhi";
@@ -8982,9 +9650,10 @@ let
   };
 
   LogLog4perl = buildPerlPackage rec {
-    name = "Log-Log4perl-1.49";
+    pname = "Log-Log4perl";
+    version = "1.49";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MS/MSCHILLI/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MS/MSCHILLI/Log-Log4perl-1.49.tar.gz;
       sha256 = "b739187f519146cb6bebcfc427c64b1f4138b35c5f4c96f46a21ed4a43872e16";
     };
     meta = {
@@ -8995,7 +9664,8 @@ let
   };
 
   LogDispatchArray = buildPerlPackage {
-    name = "Log-Dispatch-Array-1.003";
+    pname = "Log-Dispatch-Array";
+    version = "1.003";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RJ/RJBS/Log-Dispatch-Array-1.003.tar.gz;
       sha256 = "0dvzp0gsh17jqg02460ndchyapr1haahndq1p9v6mwkv5wf9680c";
@@ -9010,9 +9680,10 @@ let
   };
 
   LogDispatchouli = buildPerlPackage rec {
-    name = "Log-Dispatchouli-2.017";
+    pname = "Log-Dispatchouli";
+    version = "2.017";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RJ/RJBS/Log-Dispatchouli-2.017.tar.gz;
       sha256 = "99f8341c8d4f8f46a673b1ff1a6edc96165d75af96ddcb6d99fa227f9af4dfbf";
     };
     buildInputs = [ TestDeep TestFatal ];
@@ -9025,9 +9696,10 @@ let
   };
 
   LogLogLite = buildPerlPackage rec {
-    name = "Log-LogLite-0.82";
+    pname = "Log-LogLite";
+    version = "0.82";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RA/RANI/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RA/RANI/Log-LogLite-0.82.tar.gz;
       sha256 = "0sqsa4750wvhw4cjmxpxqg30i1jjcddadccflisrdb23qn5zn285";
     };
     propagatedBuildInputs = [ IOLockedFile ];
@@ -9058,9 +9730,10 @@ let
   };
 
   LWPAuthenOAuth = buildPerlPackage rec {
-    name = "LWP-Authen-OAuth-1.02";
+    pname = "LWP-Authen-OAuth";
+    version = "1.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TI/TIMBRODY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/T/TI/TIMBRODY/LWP-Authen-OAuth-1.02.tar.gz;
       sha256 = "e78e0bd7de8002cfb4760073258d555ef55b2c27c07a94b3d8a2166a17fd96bc";
     };
     propagatedBuildInputs = [ LWP ];
@@ -9071,7 +9744,8 @@ let
   };
 
   LWPMediaTypes = buildPerlPackage {
-    name = "LWP-MediaTypes-6.04";
+    pname = "LWP-MediaTypes";
+    version = "6.04";
     src = fetchurl {
       url = mirror://cpan/authors/id/O/OA/OALDERS/LWP-MediaTypes-6.04.tar.gz;
       sha256 = "1n8rg6csv3dsvymg06cmxipimr6cb1g9r903ghm1qsmiv89cl6wg";
@@ -9084,7 +9758,8 @@ let
   };
 
   LWPProtocolConnect = buildPerlPackage {
-    name = "LWP-Protocol-connect-6.09";
+    pname = "LWP-Protocol-connect";
+    version = "6.09";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BE/BENNING/LWP-Protocol-connect-6.09.tar.gz;
       sha256 = "9f252394775e23aa42c3176611e5930638ab528d5190110b4731aa5b0bf35a15";
@@ -9098,7 +9773,8 @@ let
   };
 
   LWPProtocolHttps = buildPerlPackage rec {
-    name = "LWP-Protocol-https-6.07";
+    pname = "LWP-Protocol-https";
+    version = "6.07";
     src = fetchurl {
       url = mirror://cpan/authors/id/O/OA/OALDERS/LWP-Protocol-https-6.07.tar.gz;
       sha256 = "1rxrpwylfw1afah0nk96kgkwjbl2p1a7lwx50iipg8c4rx3cjb2j";
@@ -9114,7 +9790,8 @@ let
   };
 
   LWPProtocolhttp10 = buildPerlPackage rec {
-     name = "LWP-Protocol-http10-6.03";
+     pname = "LWP-Protocol-http10";
+     version = "6.03";
      src = fetchurl {
        url = mirror://cpan/authors/id/G/GA/GAAS/LWP-Protocol-http10-6.03.tar.gz;
        sha256 = "1lxq40qfwfai9ryhzhsdnycc4189c8kfl43rf7qq34fmz48skzzk";
@@ -9127,7 +9804,8 @@ let
   };
 
   LWPUserAgentDetermined = buildPerlPackage {
-    name = "LWP-UserAgent-Determined-1.07";
+    pname = "LWP-UserAgent-Determined";
+    version = "1.07";
     src = fetchurl {
       url = mirror://cpan/authors/id/A/AL/ALEXMV/LWP-UserAgent-Determined-1.07.tar.gz;
       sha256 = "06d8d50e8cd3692a11cb4fb44a2f84e5476a98f0e2e6a4a0dfce9f67e55ddb53";
@@ -9139,7 +9817,8 @@ let
   };
 
   LWPUserAgentMockable = buildPerlModule {
-    name = "LWP-UserAgent-Mockable-1.18";
+    pname = "LWP-UserAgent-Mockable";
+    version = "1.18";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MJ/MJEMMESON/LWP-UserAgent-Mockable-1.18.tar.gz;
       sha256 = "0923ahl22c0gdzrihj7dqnrawia9hmcl462asf4ry8d5wd84z1i5";
@@ -9153,9 +9832,10 @@ let
   };
 
   LWPxParanoidAgent = buildPerlPackage rec {
-    name = "LWPx-ParanoidAgent-1.12";
+    pname = "LWPx-ParanoidAgent";
+    version = "1.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SA/SAXJAZMAN/lwp/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SA/SAXJAZMAN/lwp/LWPx-ParanoidAgent-1.12.tar.gz;
       sha256 = "0gfhw3jbs25yya2dryv8xvyn9myngcfcmsybj7gkq62fnznil16c";
     };
     doCheck = false; # 3 tests fail, probably because they try to connect to the network
@@ -9179,7 +9859,8 @@ let
   };
 
   MailAuthenticationResults = buildPerlPackage {
-    name = "Mail-AuthenticationResults-1.20180923";
+    pname = "Mail-AuthenticationResults";
+    version = "1.20180923";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MB/MBRADSHAW/Mail-AuthenticationResults-1.20180923.tar.gz;
       sha256 = "1g1wym9vcbhldwvi4w5pl0fhd4jh2icj975awf4wr5xmkli9mxbz";
@@ -9214,9 +9895,10 @@ let
   };
 
   MailMboxMessageParser = buildPerlPackage rec {
-    name = "Mail-Mbox-MessageParser-1.5111";
+    pname = "Mail-Mbox-MessageParser";
+    version = "1.5111";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DC/DCOPPIT/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DC/DCOPPIT/Mail-Mbox-MessageParser-1.5111.tar.gz;
       sha256 = "5723c0aa9cc10bab9ed1e3bfd9d5c95f7159e71c1a475414eb1af1dee3a46237";
     };
     buildInputs = [ FileSlurper TestCompile TestPod TestPodCoverage TextDiff UNIVERSALrequire URI ];
@@ -9230,7 +9912,8 @@ let
   };
 
   MailMessage = buildPerlPackage rec {
-     name = "Mail-Message-3.008";
+     pname = "Mail-Message";
+     version = "3.008";
      src = fetchurl {
        url = mirror://cpan/authors/id/M/MA/MARKOV/Mail-Message-3.008.tar.gz;
        sha256 = "1k3d996r2aqqzbv0xx5y88blpy9rp14lhd9vzjc1hjnrl7gij63f";
@@ -9243,7 +9926,8 @@ let
   };
 
   MailDKIM = buildPerlPackage rec {
-    name = "Mail-DKIM-0.55";
+    pname = "Mail-DKIM";
+    version = "0.55";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MB/MBRADSHAW/Mail-DKIM-0.55.tar.gz;
       sha256 = "18nsh1ff6fkns4xk3y2ixmzmadgggydj11qkzj6nlnq2hzqxsafz";
@@ -9254,7 +9938,8 @@ let
   };
 
   MailIMAPClient = buildPerlPackage {
-    name = "Mail-IMAPClient-3.42";
+    pname = "Mail-IMAPClient";
+    version = "3.42";
     src = fetchurl {
       url = mirror://cpan/authors/id/P/PL/PLOBBES/Mail-IMAPClient-3.42.tar.gz;
       sha256 = "0znf035ikaxyfishv507qq6g691xvbnziqlcwfikkj2l1kan88hw";
@@ -9263,9 +9948,10 @@ let
   };
 
   MailPOP3Client = buildPerlPackage rec {
-    name = "Mail-POP3Client-2.19";
+    pname = "Mail-POP3Client";
+    version = "2.19";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SD/SDOWD/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SD/SDOWD/Mail-POP3Client-2.19.tar.gz;
       sha256 = "1142d6247a93cb86b23ed8835553bb2d227ff8213ee2743e4155bb93f47acb59";
     };
     meta = {
@@ -9275,7 +9961,8 @@ let
   };
 
   MailRFC822Address = buildPerlPackage {
-    name = "Mail-RFC822-Address-0.3";
+    pname = "Mail-RFC822-Address";
+    version = "0.3";
     src = fetchurl {
       url = mirror://cpan/authors/id/P/PD/PDWARREN/Mail-RFC822-Address-0.3.tar.gz;
       sha256 = "351ef4104ecb675ecae69008243fae8243d1a7e53c681eeb759e7b781684c8a7";
@@ -9283,9 +9970,10 @@ let
   };
 
   MailSender = buildPerlPackage rec {
-    name = "Mail-Sender-0.903";
+    pname = "Mail-Sender";
+    version = "0.903";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CA/CAPOEIRAB/${name}.tar.gz";
+      url = mirror://cpan/authors/id/C/CA/CAPOEIRAB/Mail-Sender-0.903.tar.gz;
       sha256 = "4413eb49f520a8318151811ccb05a8d542973aada20aa503ad32f9ffc98a39bf";
     };
     meta = {
@@ -9296,7 +9984,8 @@ let
   };
 
   MailSendmail = buildPerlPackage rec {
-    name = "Mail-Sendmail-0.80";
+    pname = "Mail-Sendmail";
+    version = "0.80";
     src = fetchurl {
       url = "mirror://cpan/authors/id/N/NE/NEILB/Mail-Sendmail-0.80.tar.gz";
       sha256 = "1r38qbkj7jwj8cqy1rnqzkk81psxi08b1aiq392817f3bk5ri2jv";
@@ -9338,9 +10027,10 @@ let
 
 
   MailTools = buildPerlPackage rec {
-    name = "MailTools-2.20";
+    pname = "MailTools";
+    version = "2.20";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MARKOV/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MA/MARKOV/MailTools-2.20.tar.gz;
       sha256 = "15iizg2x1w7ca0r8rn3wwhp7w160ljvf55prspljwd6cm7vhcmpm";
     };
     propagatedBuildInputs = [ TimeDate ];
@@ -9365,7 +10055,8 @@ let
   };
 
   MathLibm = buildPerlPackage rec {
-    name = "Math-Libm-1.00";
+    pname = "Math-Libm";
+    version = "1.00";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DS/DSLEWART/Math-Libm-1.00.tar.gz;
       sha256 = "0xn2a950mzzs5q1c4q98ckysn9dz20x7r35g02zvk35chgr0klxz";
@@ -9373,9 +10064,10 @@ let
   };
 
   MathCalcUnits = buildPerlPackage rec {
-    name = "Math-Calc-Units-1.07";
+    pname = "Math-Calc-Units";
+    version = "1.07";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SF/SFINK/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SF/SFINK/Math-Calc-Units-1.07.tar.gz;
       sha256 = "13wgbxv2fmigdj0vf7nwkq1y2q07jgfj8wdrpqkywfxv4zdwzqv1";
     };
     meta = {
@@ -9385,9 +10077,10 @@ let
   };
 
   MathBigInt = buildPerlPackage rec {
-    name = "Math-BigInt-1.999816";
+    pname = "Math-BigInt";
+    version = "1.999816";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PJ/PJACKLAM/${name}.tar.gz";
+      url = mirror://cpan/authors/id/P/PJ/PJACKLAM/Math-BigInt-1.999816.tar.gz;
       sha256 = "95a5a1f636a23f66d400d40bffb0d24ad50df00e6e3c7359c9e645c375f40a89";
     };
     meta = {
@@ -9397,9 +10090,10 @@ let
   };
 
   MathBigIntGMP = buildPerlPackage rec {
-    name = "Math-BigInt-GMP-1.6006";
+    pname = "Math-BigInt-GMP";
+    version = "1.6006";
     src = fetchurl {
-      url    = "mirror://cpan/authors/id/P/PJ/PJACKLAM/${name}.tar.gz";
+      url = mirror://cpan/authors/id/P/PJ/PJACKLAM/Math-BigInt-GMP-1.6006.tar.gz;
       sha256 = "10dg3h5jgc30pb2800x8brz2ijicrpash0rwjahp82xnvysi1hhf";
     };
     buildInputs = [ pkgs.gmp ];
@@ -9410,7 +10104,8 @@ let
   };
 
   MathBigIntLite = buildPerlPackage rec {
-     name = "Math-BigInt-Lite-0.18";
+     pname = "Math-BigInt-Lite";
+     version = "0.18";
      src = fetchurl {
        url = mirror://cpan/authors/id/P/PJ/PJACKLAM/Math-BigInt-Lite-0.18.tar.gz;
        sha256 = "1m97jkh26nrji6mjdwhwlq9bcdn8qlw3vimik8bs2hw80syi70j4";
@@ -9422,9 +10117,10 @@ let
   };
 
   MathBigRat = buildPerlPackage rec {
-    name = "Math-BigRat-0.2614";
+    pname = "Math-BigRat";
+    version = "0.2614";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PJ/PJACKLAM/${name}.tar.gz";
+      url = mirror://cpan/authors/id/P/PJ/PJACKLAM/Math-BigRat-0.2614.tar.gz;
       sha256 = "cea6c20afc6c10a3dc3b62a71df3f842dce13898443bd827242ff3f09f1f3d59";
     };
     meta = {
@@ -9445,7 +10141,8 @@ let
   };
 
   MathConvexHullMonotoneChain = buildPerlPackage rec {
-    name = "Math-ConvexHull-MonotoneChain-0.01";
+    pname = "Math-ConvexHull-MonotoneChain";
+    version = "0.01";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SM/SMUELLER/Math-ConvexHull-MonotoneChain-0.01.tar.gz;
       sha256 = "1xcl7cz62ydddji9qzs4xsfxss484jqjlj4iixa4aci611cw92r8";
@@ -9453,7 +10150,8 @@ let
   };
 
   MathGMP = buildPerlPackage {
-    name = "Math-GMP-2.19";
+    pname = "Math-GMP";
+    version = "2.19";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SH/SHLOMIF/Math-GMP-2.19.tar.gz;
       sha256 = "1c07521m4d38hy2yx21hkwz22n2672bvrc4i21ldc68h85qy1q8i";
@@ -9468,7 +10166,8 @@ let
   };
 
   MathGeometryVoronoi = buildPerlPackage rec {
-    name = "Math-Geometry-Voronoi-1.3";
+    pname = "Math-Geometry-Voronoi";
+    version = "1.3";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SA/SAMTREGAR/Math-Geometry-Voronoi-1.3.tar.gz;
       sha256 = "0b206k2q5cznld45cjhgm0as0clc9hk135ds8qafbkl3k175w1vj";
@@ -9477,7 +10176,8 @@ let
   };
 
   MathInt128 = buildPerlPackage {
-    name = "Math-Int128-0.22";
+    pname = "Math-Int128";
+    version = "0.22";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SA/SALVA/Math-Int128-0.22.tar.gz;
       sha256 = "1g0ra7ldv4fz3kqqg45dlrfavi2abfmlhf0py5ank1jk2x0clc56";
@@ -9490,7 +10190,8 @@ let
   };
 
   MathInt64 = buildPerlPackage {
-    name = "Math-Int64-0.54";
+    pname = "Math-Int64";
+    version = "0.54";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SA/SALVA/Math-Int64-0.54.tar.gz;
       sha256 = "0lfkc0cry65lnsi28gjyz2kvdkanbhhpc0pyrswsczj3k3k53z6w";
@@ -9502,9 +10203,10 @@ let
   };
 
   MathPlanePath = buildPerlPackage rec {
-    name = "Math-PlanePath-126";
+    pname = "Math-PlanePath";
+    version = "126";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KR/KRYDE/${name}.tar.gz";
+      url = mirror://cpan/authors/id/K/KR/KRYDE/Math-PlanePath-126.tar.gz;
       sha256 = "014gr79gg992paas6v1glciyycqp2hg7pg4y03kgfbxz1slc6zhq";
     };
     propagatedBuildInputs = [ MathLibm constant-defer ];
@@ -9512,7 +10214,8 @@ let
   };
 
   MathRandomISAAC = buildPerlPackage {
-    name = "Math-Random-ISAAC-1.004";
+    pname = "Math-Random-ISAAC";
+    version = "1.004";
     src = fetchurl {
       url = mirror://cpan/authors/id/J/JA/JAWNSY/Math-Random-ISAAC-1.004.tar.gz;
       sha256 = "0z1b3xbb3xz71h25fg6jgsccra7migq7s0vawx2rfzi0pwpz0wr7";
@@ -9525,7 +10228,8 @@ let
   };
 
   MathRandomMTAuto = buildPerlPackage {
-    name = "Math-Random-MT-Auto-6.23";
+    pname = "Math-Random-MT-Auto";
+    version = "6.23";
     src = fetchurl {
       url = mirror://cpan/authors/id/J/JD/JDHEDDEN/Math-Random-MT-Auto-6.23.tar.gz;
       sha256 = "04v3fxbqg6bs7dpljw64v62jqb10l2xdrln4l3slz5k266nvbg2q";
@@ -9538,7 +10242,8 @@ let
   };
 
   MathRandomSecure = buildPerlPackage {
-    name = "Math-Random-Secure-0.080001";
+    pname = "Math-Random-Secure";
+    version = "0.080001";
     src = fetchurl {
       url = mirror://cpan/authors/id/F/FR/FREW/Math-Random-Secure-0.080001.tar.gz;
       sha256 = "0dgbf4ncll4kmgkyb9fsaxn0vf2smc9dmwqzgh3259zc2zla995z";
@@ -9552,7 +10257,8 @@ let
   };
 
   MathRound = buildPerlPackage rec {
-    name = "Math-Round-0.07";
+    pname = "Math-Round";
+    version = "0.07";
     src = fetchurl {
       url = mirror://cpan/authors/id/G/GR/GROMMEL/Math-Round-0.07.tar.gz;
       sha256 = "09wkvqj4hfq9y0fimri967rmhnq90dc2wf20lhlmqjp5hsd359vk";
@@ -9560,7 +10266,8 @@ let
   };
 
   MathVecStat = buildPerlPackage rec {
-    name = "Math-VecStat-0.08";
+    pname = "Math-VecStat";
+    version = "0.08";
     src = fetchurl {
       url = mirror://cpan/authors/id/A/AS/ASPINELLI/Math-VecStat-0.08.tar.gz;
       sha256 = "03bdcl9pn2bc9b50c50nhnr7m9wafylnb3v21zlch98h9c78x6j0";
@@ -9568,7 +10275,8 @@ let
   };
 
   MaxMindDBCommon = buildPerlPackage {
-    name = "MaxMind-DB-Common-0.040001";
+    pname = "MaxMind-DB-Common";
+    version = "0.040001";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MA/MAXMIND/MaxMind-DB-Common-0.040001.tar.gz;
       sha256 = "1mqvnabskhyvi2f10f602gisfk39ws51ky55lixd0033sd5xzikb";
@@ -9581,7 +10289,8 @@ let
   };
 
   MaxMindDBReader = buildPerlPackage {
-    name = "MaxMind-DB-Reader-1.000013";
+    pname = "MaxMind-DB-Reader";
+    version = "1.000013";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MA/MAXMIND/MaxMind-DB-Reader-1.000013.tar.gz;
       sha256 = "0w7dmfhpibazrh75bdr7vmpji83fzldsy0zjvhg3cwadr4f35kmq";
@@ -9595,7 +10304,8 @@ let
   };
 
   MaxMindDBReaderXS = buildPerlModule {
-    name = "MaxMind-DB-Reader-XS-1.000007";
+    pname = "MaxMind-DB-Reader-XS";
+    version = "1.000007";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MA/MAXMIND/MaxMind-DB-Reader-XS-1.000007.tar.gz;
       sha256 = "1wg1x1pqamapfhn6rbffqipncgs15k99q34agdamv76i6782ny8r";
@@ -9609,7 +10319,8 @@ let
   };
 
   MaxMindDBWriter = buildPerlModule {
-    name = "MaxMind-DB-Writer-0.300003";
+    pname = "MaxMind-DB-Writer";
+    version = "0.300003";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MA/MAXMIND/MaxMind-DB-Writer-0.300003.tar.gz;
       sha256 = "0gpbrlmxjl45k0wg5v9ghw415hd0fns9fk8ncxzlfyjzjsxgalxs";
@@ -9624,7 +10335,8 @@ let
   };
 
   Memoize = buildPerlPackage {
-    name = "Memoize-1.03";
+    pname = "Memoize";
+    version = "1.03";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MJ/MJD/Memoize-1.03.tgz;
       sha256 = "5239cc5f644a50b0de9ffeaa51fa9991eb06ecb1bf4678873e3ab89af9c0daf3";
@@ -9632,7 +10344,8 @@ let
   };
 
   MemoizeExpireLRU = buildPerlPackage rec {
-     name = "Memoize-ExpireLRU-0.56";
+     pname = "Memoize-ExpireLRU";
+     version = "0.56";
      src = fetchurl {
        url = mirror://cpan/authors/id/N/NE/NEILB/Memoize-ExpireLRU-0.56.tar.gz;
        sha256 = "1xnp3jqabl4il5kfadlqimbxhzsbm7gpwrgw0m5s5fdsrc0n70zf";
@@ -9645,7 +10358,8 @@ let
   };
 
   MetaBuilder = buildPerlModule {
-    name = "Meta-Builder-0.004";
+    pname = "Meta-Builder";
+    version = "0.004";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/EX/EXODIST/Meta-Builder-0.004.tar.gz;
       sha256 = "acb499aa7206eb9db21eb85357a74521bfe3bdae4a6416d50a7c75b939cf56fe";
@@ -9658,7 +10372,8 @@ let
   };
 
   MethodSignaturesSimple = buildPerlPackage {
-    name = "Method-Signatures-Simple-1.07";
+    pname = "Method-Signatures-Simple";
+    version = "1.07";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RH/RHESA/Method-Signatures-Simple-1.07.tar.gz;
       sha256 = "1p6sf6iyyn73pc89mfr65bzxvbw1ibcsp4j10iv8ik3p353pvkf8";
@@ -9690,7 +10405,8 @@ let
   };
 
   MIMECharset = buildPerlPackage {
-    name = "MIME-Charset-1.012.2";
+    pname = "MIME-Charset";
+    version = "1.012.2";
     src = fetchurl {
       url = mirror://cpan/authors/id/N/NE/NEZUMI/MIME-Charset-1.012.2.tar.gz;
       sha256 = "878c779c0256c591666bd06c0cde4c0d7820eeeb98fd1183082aee9a1e7b1d13";
@@ -9712,9 +10428,10 @@ let
   };
 
   MIMELite = buildPerlPackage rec {
-    name = "MIME-Lite-3.030";
+    pname = "MIME-Lite";
+    version = "3.030";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RJ/RJBS/MIME-Lite-3.030.tar.gz;
       sha256 = "8f39901bc580bc3dce69e10415305e4435ff90264c63d29f707b4566460be962";
     };
     propagatedBuildInputs = [ EmailDateFormat ];
@@ -9725,7 +10442,8 @@ let
   };
 
   MIMETools = buildPerlPackage rec {
-    name = "MIME-tools-5.509";
+    pname = "MIME-tools";
+    version = "5.509";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DS/DSKOLL/MIME-tools-5.509.tar.gz;
       sha256 = "0wv9rzx5j1wjm01c3dg48qk9wlbm6iyf91j536idk09xj869ymv4";
@@ -9739,9 +10457,10 @@ let
   };
 
   MIMETypes = buildPerlPackage rec {
-    name = "MIME-Types-2.17";
+    pname = "MIME-Types";
+    version = "2.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MARKOV/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MA/MARKOV/MIME-Types-2.17.tar.gz;
       sha256 = "1xlg7q6h8zyb8534sy0iqn90py18kilg419q6051bwqz5zadfkp0";
     };
     meta = {
@@ -9751,9 +10470,10 @@ let
   };
 
   MixinLinewise = buildPerlPackage rec {
-    name = "Mixin-Linewise-0.108";
+    pname = "Mixin-Linewise";
+    version = "0.108";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RJ/RJBS/Mixin-Linewise-0.108.tar.gz;
       sha256 = "7df20678474c0973930a472b0c55e3f8e85b7790b68ab18ef618f9c453c8aef2";
     };
     propagatedBuildInputs = [ PerlIOutf8_strict SubExporter ];
@@ -9765,9 +10485,10 @@ let
   };
 
   MLDBM = buildPerlModule rec {
-    name = "MLDBM-2.05";
+    pname = "MLDBM";
+    version = "2.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CH/CHORNY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/C/CH/CHORNY/MLDBM-2.05.tar.gz;
       sha256 = "586880ed0c20801abbf6734747e13e0203edefece6ebc4f20ddb5059f02a17a2";
     };
     meta = {
@@ -9779,7 +10500,8 @@ let
   MNI-Perllib = callPackage ../development/perl-modules/MNI {};
 
   Mo = buildPerlPackage rec {
-     name = "Mo-0.40";
+     pname = "Mo";
+     version = "0.40";
      src = fetchurl {
        url = mirror://cpan/authors/id/T/TI/TINITA/Mo-0.40.tar.gz;
        sha256 = "1fff81awg9agfawf3wxx0gpf6vgav8w920rmxsbjg30z75943lli";
@@ -9792,7 +10514,8 @@ let
   };
 
   MockConfig = buildPerlPackage rec {
-     name = "Mock-Config-0.03";
+     pname = "Mock-Config";
+     version = "0.03";
      src = fetchurl {
        url = mirror://cpan/authors/id/R/RU/RURBAN/Mock-Config-0.03.tar.gz;
        sha256 = "06q0xkg5cwdwafzmb9rkaa305ddv7vli9gpm6n9jnkyaaxbk9f55";
@@ -9804,7 +10527,8 @@ let
   };
 
   ModernPerl = buildPerlPackage {
-    name = "Modern-Perl-1.20181021";
+    pname = "Modern-Perl";
+    version = "1.20181021";
 
     src = fetchurl {
       url = mirror://cpan/authors/id/C/CH/CHROMATIC/Modern-Perl-1.20181021.tar.gz;
@@ -9818,9 +10542,10 @@ let
   };
 
   ModuleBuild = buildPerlPackage rec {
-    name = "Module-Build-0.4229";
+    pname = "Module-Build";
+    version = "0.4229";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/${name}.tar.gz";
+      url = mirror://cpan/authors/id/L/LE/LEONT/Module-Build-0.4229.tar.gz;
       sha256 = "064c03wxia7jz0i578awj4srykj0nnigm4p5r0dv0559rnk93r0z";
     };
     meta = {
@@ -9830,7 +10555,8 @@ let
   };
 
   ModuleBuildDeprecated = buildPerlModule {
-    name = "Module-Build-Deprecated-0.4210";
+    pname = "Module-Build-Deprecated";
+    version = "0.4210";
     src = fetchurl {
       url = mirror://cpan/authors/id/L/LE/LEONT/Module-Build-Deprecated-0.4210.tar.gz;
       sha256 = "be089313fc238ee2183473aca8c86b55fb3cf44797312cbe9b892d6362621703";
@@ -9843,9 +10569,10 @@ let
   };
 
   ModuleBuildPluggable = buildPerlModule rec {
-    name = "Module-Build-Pluggable-0.10";
+    pname = "Module-Build-Pluggable";
+    version = "0.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TOKUHIROM/${name}.tar.gz";
+      url = mirror://cpan/authors/id/T/TO/TOKUHIROM/Module-Build-Pluggable-0.10.tar.gz;
       sha256 = "e5bb2acb117792c984628812acb0fec376cb970caee8ede57535e04d762b0e40";
     };
     propagatedBuildInputs = [ ClassAccessorLite ClassMethodModifiers DataOptList ];
@@ -9858,9 +10585,10 @@ let
   };
 
   ModuleBuildPluggablePPPort = buildPerlModule rec {
-    name = "Module-Build-Pluggable-PPPort-0.04";
+    pname = "Module-Build-Pluggable-PPPort";
+    version = "0.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TOKUHIROM/${name}.tar.gz";
+      url = mirror://cpan/authors/id/T/TO/TOKUHIROM/Module-Build-Pluggable-PPPort-0.04.tar.gz;
       sha256 = "44084ba3d8815f343bd391585ac5d8339a4807ce5c0dd84c98db8f310b64c0ea";
     };
     buildInputs = [ TestRequires TestSharedFork ];
@@ -9872,7 +10600,8 @@ let
   };
 
   ModuleBuildTiny = buildPerlModule {
-    name = "Module-Build-Tiny-0.039";
+    pname = "Module-Build-Tiny";
+    version = "0.039";
     src = fetchurl {
       url = mirror://cpan/authors/id/L/LE/LEONT/Module-Build-Tiny-0.039.tar.gz;
       sha256 = "7d580ff6ace0cbe555bf36b86dc8ea232581530cbeaaea09bccb57b55797f11c";
@@ -9886,18 +10615,20 @@ let
   };
 
   ModuleBuildWithXSpp = buildPerlModule rec {
-    name = "Module-Build-WithXSpp-0.14";
+    pname = "Module-Build-WithXSpp";
+    version = "0.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SM/SMUELLER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SM/SMUELLER/Module-Build-WithXSpp-0.14.tar.gz;
       sha256 = "0d39fjg9c0n820bk3fb50vvlwhdny4hdl69xmlyzql5xzp4cicsk";
     };
     propagatedBuildInputs = [ ExtUtilsCppGuess ExtUtilsXSpp ];
   };
 
   ModuleBuildXSUtil = buildPerlModule rec {
-    name = "Module-Build-XSUtil-0.19";
+    pname = "Module-Build-XSUtil";
+    version = "0.19";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HI/HIDEAKIO/${name}.tar.gz";
+      url = mirror://cpan/authors/id/H/HI/HIDEAKIO/Module-Build-XSUtil-0.19.tar.gz;
       sha256 = "004ly9xxjlsbrr2vhxsa1n84z3034gxrzr7z0wl45szd8v1v6qwh";
     };
     buildInputs = [ CaptureTiny CwdGuard FileCopyRecursiveReduced ];
@@ -9910,7 +10641,8 @@ let
   };
 
   ModuleCPANTSAnalyse = buildPerlPackage rec {
-     name = "Module-CPANTS-Analyse-1.00";
+     pname = "Module-CPANTS-Analyse";
+     version = "1.00";
      src = fetchurl {
        url = mirror://cpan/authors/id/I/IS/ISHIGAKI/Module-CPANTS-Analyse-1.00.tar.gz;
        sha256 = "0r77g2h0d3p81scf294x5qkvi76hzwvbfji0m86abidjav5jk6a2";
@@ -9925,7 +10657,8 @@ let
   };
 
   ModuleCPANfile = buildPerlPackage rec {
-     name = "Module-CPANfile-1.1004";
+     pname = "Module-CPANfile";
+     version = "1.1004";
      src = fetchurl {
        url = mirror://cpan/authors/id/M/MI/MIYAGAWA/Module-CPANfile-1.1004.tar.gz;
        sha256 = "08a9a5mybf0llwlfvk7n0q7az6lrrzgzwc3432mcwbb4k8pbxvw8";
@@ -9939,7 +10672,8 @@ let
   };
 
   ModuleExtractUse = buildPerlModule rec {
-     name = "Module-ExtractUse-0.343";
+     pname = "Module-ExtractUse";
+     version = "0.343";
      src = fetchurl {
        url = mirror://cpan/authors/id/D/DO/DOMM/Module-ExtractUse-0.343.tar.gz;
        sha256 = "00hcggwnqk953s4zbvkcabd5mfidg60hawlqsw6146in91dlclj8";
@@ -9953,7 +10687,8 @@ let
   };
 
   ModuleFind = buildPerlPackage {
-    name = "Module-Find-0.13";
+    pname = "Module-Find";
+    version = "0.13";
     src = fetchurl {
       url = mirror://cpan/authors/id/C/CR/CRENZ/Module-Find-0.13.tar.gz;
       sha256 = "0s45y5lvd9k89g7lds83c0bn1p29c13hfsbrd7x64jfaf8h8cisa";
@@ -9965,7 +10700,7 @@ let
   };
 
   ModuleImplementation = let version = "0.09"; in buildPerlPackage {
-    name = "Module-Implementation-${version}";
+    pname = "Module-Implementation";
     src = fetchurl {
       url = "mirror://cpan/authors/id/D/DR/DROLSKY/Module-Implementation-${version}.tar.gz";
       sha256 = "0vfngw4dbryihqhi7g9ks360hyw8wnpy3hpkzyg0q4y2y091lpy1";
@@ -9980,7 +10715,8 @@ let
   };
 
   ModuleInfo = buildPerlPackage rec {
-    name = "Module-Info-0.37";
+    pname = "Module-Info";
+    version = "0.37";
     src = fetchurl {
       url = mirror://cpan/authors/id/N/NE/NEILB/Module-Info-0.37.tar.gz;
       sha256 = "0j143hqxgdkdpj5qssppq72gjr0n73c4f7is6wgrrcchjx905a4f";
@@ -9994,7 +10730,7 @@ let
   };
 
   ModuleInstall = let version = "1.19"; in buildPerlPackage {
-    name = "Module-Install-${version}";
+    pname = "Module-Install";
     src = fetchurl {
       url = "mirror://cpan/authors/id/E/ET/ETHER/Module-Install-${version}.tar.gz";
       sha256 = "06q12cm97yh4p7qbm0a2p96996ii6ss59qy57z0f7f9svy6sflqs";
@@ -10007,7 +10743,8 @@ let
   };
 
   ModuleInstallAuthorRequires = buildPerlPackage {
-    name = "Module-Install-AuthorRequires-0.02";
+    pname = "Module-Install-AuthorRequires";
+    version = "0.02";
     src = fetchurl {
       url = mirror://cpan/authors/id/F/FL/FLORA/Module-Install-AuthorRequires-0.02.tar.gz;
       sha256 = "1v2ciw75dj5y8lh10d1vrhwmjx266gpqavr8m21jlpblgm9j2qyc";
@@ -10020,7 +10757,8 @@ let
   };
 
   ModuleInstallAuthorTests = buildPerlPackage {
-    name = "Module-Install-AuthorTests-0.002";
+    pname = "Module-Install-AuthorTests";
+    version = "0.002";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RJ/RJBS/Module-Install-AuthorTests-0.002.tar.gz;
       sha256 = "121dyggy38316xss06v1zkwx4b59gl7b00c5q99xyzimwqnp49a0";
@@ -10033,7 +10771,8 @@ let
   };
 
   ModuleManifest = buildPerlPackage {
-    name = "Module-Manifest-1.09";
+    pname = "Module-Manifest";
+    version = "1.09";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/Module-Manifest-1.09.tar.gz;
       sha256 = "a395f80ff15ea0e66fd6c453844b6787ed4a875a3cd8df9f7e29280250bd539b";
@@ -10047,9 +10786,10 @@ let
   };
 
   ModulePath = buildPerlPackage rec {
-    name = "Module-Path-0.19";
+    pname = "Module-Path";
+    version = "0.19";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/${name}.tar.gz";
+      url = mirror://cpan/authors/id/N/NE/NEILB/Module-Path-0.19.tar.gz;
       sha256 = "b33179ce4dd73dfcde7d46808804b9ffbb11db0245fe455a7d001747562feaca";
     };
     buildInputs = [ DevelFindPerl ];
@@ -10061,9 +10801,10 @@ let
   };
 
   ModulePluggable = buildPerlPackage rec {
-    name = "Module-Pluggable-5.2";
+    pname = "Module-Pluggable";
+    version = "5.2";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SI/SIMONW/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SI/SIMONW/Module-Pluggable-5.2.tar.gz;
       sha256 = "b3f2ad45e4fd10b3fb90d912d78d8b795ab295480db56dc64e86b9fa75c5a6df";
     };
     patches = [
@@ -10078,7 +10819,8 @@ let
   };
 
   ModulePluggableFast = buildPerlPackage {
-    name = "Module-Pluggable-Fast-0.19";
+    pname = "Module-Pluggable-Fast";
+    version = "0.19";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MR/MRAMBERG/Module-Pluggable-Fast-0.19.tar.gz;
       sha256 = "0pq758wlasmh77xyd2xh75m5b2x14s8pnsv63g5356gib1q5gj08";
@@ -10087,7 +10829,8 @@ let
   };
 
   ModuleRefresh = buildPerlPackage {
-    name = "Module-Refresh-0.17";
+    pname = "Module-Refresh";
+    version = "0.17";
     src = fetchurl {
       url = mirror://cpan/authors/id/A/AL/ALEXMV/Module-Refresh-0.17.tar.gz;
       sha256 = "6b30a6ceddc6512ab4490c16372ecf309a259f2ca147d622e478ac54e08511c3";
@@ -10100,7 +10843,8 @@ let
   };
 
   ModuleRuntime = buildPerlModule {
-    name = "Module-Runtime-0.016";
+    pname = "Module-Runtime";
+    version = "0.016";
     src = fetchurl {
       url = mirror://cpan/authors/id/Z/ZE/ZEFRAM/Module-Runtime-0.016.tar.gz;
       sha256 = "097hy2czwkxlppri32m599ph0xfvfsbf0a5y23a4fdc38v32wc38";
@@ -10112,7 +10856,8 @@ let
   };
 
   ModuleRuntimeConflicts = buildPerlPackage {
-    name = "Module-Runtime-Conflicts-0.003";
+    pname = "Module-Runtime-Conflicts";
+    version = "0.003";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/Module-Runtime-Conflicts-0.003.tar.gz;
       sha256 = "707cdc75038c70fe91779b888ac050f128565d3967ba96680e1b1c7cc9733875";
@@ -10126,7 +10871,7 @@ let
   };
 
   ModuleScanDeps = let version = "1.27"; in buildPerlPackage {
-    name = "Module-ScanDeps-${version}";
+    pname = "Module-ScanDeps";
     src = fetchurl {
       url = "mirror://cpan/authors/id/R/RS/RSCHUPP/Module-ScanDeps-${version}.tar.gz";
       sha256 = "0j6r9r99x5p0i6fv06i44wpsvjxj32amjkiqf6pmqpj80jff2k7f";
@@ -10140,7 +10885,8 @@ let
   };
 
   ModuleSignature = buildPerlPackage {
-    name = "Module-Signature-0.83";
+    pname = "Module-Signature";
+    version = "0.83";
     src = fetchurl {
       url = mirror://cpan/authors/id/A/AU/AUDREYT/Module-Signature-0.83.tar.gz;
       sha256 = "3c15f3845a85d2a76a81253be53cb0f716465a3f696eb9c50e92eef34e9601cb";
@@ -10153,7 +10899,8 @@ let
   };
 
   ModuleUtil = buildPerlModule {
-    name = "Module-Util-1.09";
+    pname = "Module-Util";
+    version = "1.09";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MA/MATTLAW/Module-Util-1.09.tar.gz;
       sha256 = "6cfbcb6a45064446ec8aa0ee1a7dddc420b54469303344187aef84d2c7f3e2c6";
@@ -10165,7 +10912,8 @@ let
   };
 
   ModuleVersions = buildPerlPackage {
-    name = "Module-Versions-0.02";
+    pname = "Module-Versions";
+    version = "0.02";
     src = fetchurl {
       url = mirror://cpan/authors/id/T/TH/THW/Module-Versions-0.02.zip;
       sha256 = "0g7qs6vqg91xpwg1cdy91m3kh9m1zbkzyz1qsy453b572xdscf0d";
@@ -10174,7 +10922,8 @@ let
   };
 
   ModuleVersionsReport = buildPerlPackage {
-    name = "Module-Versions-Report-1.06";
+    pname = "Module-Versions-Report";
+    version = "1.06";
     src = fetchurl {
       url = mirror://cpan/authors/id/J/JE/JESSE/Module-Versions-Report-1.06.tar.gz;
       sha256 = "a3261d0d84b17678d8c4fd55eb0f892f5144d81ca53ea9a38d75d1a00ad9796a";
@@ -10186,7 +10935,8 @@ let
   };
 
   mod_perl2 = buildPerlPackage {
-    name = "mod_perl-2.0.10";
+    pname = "mod_perl";
+    version = "2.0.10";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SH/SHAY/mod_perl-2.0.10.tar.gz;
       sha256 = "0r1bhzwl5gr0202r6448943hjxsickzn55kdmb7dzad39vnq7kyi";
@@ -10216,9 +10966,10 @@ let
   };
 
   MojoliciousPluginStatus = buildPerlPackage rec {
-    name = "Mojolicious-Plugin-Status-1.0";
+    pname = "Mojolicious-Plugin-Status";
+    version = "1.0";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SR/SRI/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SR/SRI/Mojolicious-Plugin-Status-1.0.tar.gz;
       sha256 = "14ypg679dk9yvgq67mp7lzs131cxhbgcmrpx5f4ddqcrs1bzq5rb";
     };
     propagatedBuildInputs = [ BSDResource IPCShareLite Mojolicious Sereal ];
@@ -10231,9 +10982,10 @@ let
   };
 
   MojoIOLoopForkCall = buildPerlModule rec {
-    name = "Mojo-IOLoop-ForkCall-0.20";
+    pname = "Mojo-IOLoop-ForkCall";
+    version = "0.20";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JB/JBERGER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/J/JB/JBERGER/Mojo-IOLoop-ForkCall-0.20.tar.gz;
       sha256 = "2b9962244c25a71e4757356fb3e1237cf869e26d1c27215115ba7b057a81f1a6";
     };
     propagatedBuildInputs = [ IOPipely Mojolicious ];
@@ -10244,9 +10996,10 @@ let
   };
 
   MonitoringPlugin = buildPerlPackage rec {
-    name = "Monitoring-Plugin-0.40";
+    pname = "Monitoring-Plugin";
+    version = "0.40";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NI/NIERLEIN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/N/NI/NIERLEIN/Monitoring-Plugin-0.40.tar.gz;
       sha256 = "0vr3wwdn3zs246qwi04bqk8jir6l88j5m59jk97hmfyj4xz6pfpq";
     };
     propagatedBuildInputs = [ ClassAccessor ConfigTiny MathCalcUnits ParamsValidate ];
@@ -10260,9 +11013,10 @@ let
   };
 
   IOPipely = buildPerlPackage rec {
-    name = "IO-Pipely-0.005";
+    pname = "IO-Pipely";
+    version = "0.005";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RC/RCAPUTO/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RC/RCAPUTO/IO-Pipely-0.005.tar.gz;
       sha256 = "e33b6cf5cb2b46ee308513f51e623987a50a89901e81bf19701dce35179f2e74";
     };
     meta = {
@@ -10272,9 +11026,10 @@ let
   };
 
   Moo = buildPerlPackage rec {
-    name = "Moo-2.003004";
+    pname = "Moo";
+    version = "2.003004";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/${name}.tar.gz";
+      url = mirror://cpan/authors/id/H/HA/HAARG/Moo-2.003004.tar.gz;
       sha256 = "f8bbb625f8e963eabe05cff9048fdd72bdd26777404ff2c40bc690f558be91e1";
     };
     buildInputs = [ TestFatal ];
@@ -10286,7 +11041,8 @@ let
   };
 
   Moose = buildPerlPackage {
-    name = "Moose-2.2011";
+    pname = "Moose";
+    version = "2.2011";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/Moose-2.2011.tar.gz;
       sha256 = "973d0a35d9f39bf93bbc5206c25f5ec3651f96356f082d31873c0ac9a5c1cd82";
@@ -10305,9 +11061,10 @@ let
   };
 
   MooXHandlesVia = buildPerlPackage rec {
-    name = "MooX-HandlesVia-0.001008";
+    pname = "MooX-HandlesVia";
+    version = "0.001008";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MATTP/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MA/MATTP/MooX-HandlesVia-0.001008.tar.gz;
       sha256 = "b0946f23b3537763b8a96b8a83afcdaa64fce4b45235e98064845729acccfe8c";
     };
     buildInputs = [ MooXTypesMooseLike TestException TestFatal ];
@@ -10319,7 +11076,8 @@ let
   };
 
   MooXLocalePassthrough = buildPerlPackage rec {
-     name = "MooX-Locale-Passthrough-0.001";
+     pname = "MooX-Locale-Passthrough";
+     version = "0.001";
      src = fetchurl {
        url = mirror://cpan/authors/id/R/RE/REHSACK/MooX-Locale-Passthrough-0.001.tar.gz;
        sha256 = "04h5xhqdvydd4xk9ckb6a79chn0ygf915ix55vg1snmba9z841bs";
@@ -10332,7 +11090,8 @@ let
   };
 
   MooXLocaleTextDomainOO = buildPerlPackage rec {
-     name = "MooX-Locale-TextDomain-OO-0.001";
+     pname = "MooX-Locale-TextDomain-OO";
+     version = "0.001";
      src = fetchurl {
        url = mirror://cpan/authors/id/R/RE/REHSACK/MooX-Locale-TextDomain-OO-0.001.tar.gz;
        sha256 = "0g8pwj45ccqrzvs9cqyhw29nm68vai1vj46ad39rajnqzp7m53jv";
@@ -10345,7 +11104,8 @@ let
   };
 
   MooXOptions = buildPerlPackage rec {
-     name = "MooX-Options-4.103";
+     pname = "MooX-Options";
+     version = "4.103";
      src = fetchurl {
        url = mirror://cpan/authors/id/R/RE/REHSACK/MooX-Options-4.103.tar.gz;
        sha256 = "0v9j0wxx4f6z6lrmdqf2k084b2c2f2jbvh86pwib0vgjz1sdbyad";
@@ -10359,7 +11119,8 @@ let
   };
 
   MooXSingleton = buildPerlModule rec {
-     name = "MooX-Singleton-1.20";
+     pname = "MooX-Singleton";
+     version = "1.20";
      src = fetchurl {
        url = mirror://cpan/authors/id/A/AJ/AJGB/MooX-Singleton-1.20.tar.gz;
        sha256 = "03i1wfag279ldjjkwi9gvpfs8fgi05my47icq5ggi66yzxpn5mzp";
@@ -10373,7 +11134,8 @@ let
   };
 
   MooXStrictConstructor = buildPerlPackage rec {
-     name = "MooX-StrictConstructor-0.010";
+     pname = "MooX-StrictConstructor";
+     version = "0.010";
      src = fetchurl {
        url = mirror://cpan/authors/id/H/HA/HARTZELL/MooX-StrictConstructor-0.010.tar.gz;
        sha256 = "0vvjgz7xbfmf69yav7sxsxmvklqv835xvh7h47w0apxmlkm9fjgr";
@@ -10387,9 +11149,10 @@ let
   };
 
   MooXTypesMooseLike = buildPerlPackage rec {
-    name = "MooX-Types-MooseLike-0.29";
+    pname = "MooX-Types-MooseLike";
+    version = "0.29";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MATEU/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MA/MATEU/MooX-Types-MooseLike-0.29.tar.gz;
       sha256 = "1d6jg9x3p7gm2r0xmbcag374a44gf5pcga2swvxhlhzakfm80dqx";
     };
     propagatedBuildInputs = [ ModuleRuntime ];
@@ -10397,9 +11160,10 @@ let
   };
 
   MooXTypesMooseLikeNumeric = buildPerlPackage rec {
-    name = "MooX-Types-MooseLike-Numeric-1.03";
+    pname = "MooX-Types-MooseLike-Numeric";
+    version = "1.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MATEU/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MA/MATEU/MooX-Types-MooseLike-Numeric-1.03.tar.gz;
       sha256 = "16adeb617b963d010179922c2e4e8762df77c75232e17320b459868c4970c44b";
     };
     buildInputs = [ Moo TestFatal ];
@@ -10411,7 +11175,8 @@ let
   };
 
   MooseAutobox = buildPerlModule {
-    name = "Moose-Autobox-0.16";
+    pname = "Moose-Autobox";
+    version = "0.16";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/Moose-Autobox-0.16.tar.gz;
       sha256 = "0mbhd0p7gf6qdhaylldl0ahq59zghs0vd5n1iqcbfkj8ryj1sh4j";
@@ -10425,7 +11190,8 @@ let
   };
 
   MooseXABC = buildPerlPackage {
-    name = "MooseX-ABC-0.06";
+    pname = "MooseX-ABC";
+    version = "0.06";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DO/DOY/MooseX-ABC-0.06.tar.gz;
       sha256 = "1sky0dpi22wrymmkjmqba4k966zn7vrbpx918wn2nmg48swyrgjf";
@@ -10439,9 +11205,10 @@ let
   };
 
   MooseXAliases = buildPerlPackage rec {
-    name = "MooseX-Aliases-0.11";
+    pname = "MooseX-Aliases";
+    version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DO/DOY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DO/DOY/MooseX-Aliases-0.11.tar.gz;
       sha256 = "0j07zqczjfmng3md6nkha7560i786d0cp3gdmrx49hr64jbhz1f4";
     };
     buildInputs = [ TestFatal ];
@@ -10449,9 +11216,10 @@ let
   };
 
   MooseXAppCmd = buildPerlModule rec {
-    name = "MooseX-App-Cmd-0.32";
+    pname = "MooseX-App-Cmd";
+    version = "0.32";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/E/ET/ETHER/MooseX-App-Cmd-0.32.tar.gz;
       sha256 = "2e3bbf7283a4bee72d91d26eb204436030992bbe55cbd35ec33a546f16f973ff";
     };
     buildInputs = [ ModuleBuildTiny MooseXConfigFromFile TestOutput YAML ];
@@ -10464,9 +11232,10 @@ let
   };
 
   MooX = buildPerlPackage rec {
-    name = "MooX-0.101";
+    pname = "MooX";
+    version = "0.101";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GE/GETTY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/G/GE/GETTY/MooX-0.101.tar.gz;
       sha256 = "2ff91a656e78aae0aca42293829d7a7e5acb9bf22b0401635b2ab6c870de32d5";
     };
     propagatedBuildInputs = [ DataOptList ImportInto Moo ];
@@ -10478,7 +11247,8 @@ let
   };
 
   MooXCmd = buildPerlPackage rec {
-     name = "MooX-Cmd-0.017";
+     pname = "MooX-Cmd";
+     version = "0.017";
      src = fetchurl {
        url = mirror://cpan/authors/id/R/RE/REHSACK/MooX-Cmd-0.017.tar.gz;
        sha256 = "1xbhmq07v9z371ygkyghva9aryhc22kwbzn5qwkp72c0ma6z4gwl";
@@ -10492,7 +11262,8 @@ let
   };
 
   MooXlate = buildPerlPackage {
-    name = "MooX-late-0.015";
+    pname = "MooX-late";
+    version = "0.015";
     src = fetchurl {
       url = mirror://cpan/authors/id/T/TO/TOBYINK/MooX-late-0.015.tar.gz;
       sha256 = "175326af3076fa8698669f289fad1322724978cddaf40ea04e600fcd7f6afbbf";
@@ -10506,7 +11277,8 @@ let
   };
 
   MouseXSimpleConfig = buildPerlPackage {
-    name = "MouseX-SimpleConfig-0.11";
+    pname = "MouseX-SimpleConfig";
+    version = "0.11";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MJ/MJGARDNER/MouseX-SimpleConfig-0.11.tar.gz;
       sha256 = "257f384091d33d340373a6153947039c698dc449d1ef989335644fc3d2da0069";
@@ -10519,7 +11291,8 @@ let
   };
 
   TestUseAllModules = buildPerlPackage {
-    name = "Test-UseAllModules-0.17";
+    pname = "Test-UseAllModules";
+    version = "0.17";
     src = fetchurl {
       url = mirror://cpan/authors/id/I/IS/ISHIGAKI/Test-UseAllModules-0.17.tar.gz;
       sha256 = "a71f2fe8b96ab8bfc2760aa1d3135ea049a5b20dcb105457b769a1195c7a2509";
@@ -10531,7 +11304,8 @@ let
   };
 
   MouseXTypesPathClass = buildPerlPackage {
-    name = "MouseX-Types-Path-Class-0.07";
+    pname = "MouseX-Types-Path-Class";
+    version = "0.07";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MA/MASAKI/MouseX-Types-Path-Class-0.07.tar.gz;
       sha256 = "228d4b4f3f0ed9547278691d0b7c5fe53d90874a69df709a49703c6af87c09de";
@@ -10545,7 +11319,8 @@ let
   };
 
   MouseXTypes = buildPerlPackage {
-    name = "MouseX-Types-0.06";
+    pname = "MouseX-Types";
+    version = "0.06";
     src = fetchurl {
       url = mirror://cpan/authors/id/G/GF/GFUJI/MouseX-Types-0.06.tar.gz;
       sha256 = "77288441fdadd15beeec9a0813ece8aec1542f1d8ceaaec14755b3f316fbcf8b";
@@ -10559,7 +11334,8 @@ let
   };
 
   MouseXConfigFromFile = buildPerlPackage {
-    name = "MouseX-ConfigFromFile-0.05";
+    pname = "MouseX-ConfigFromFile";
+    version = "0.05";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MA/MASAKI/MouseX-ConfigFromFile-0.05.tar.gz;
       sha256 = "921b31cb13fc1f982a602f8e23815b7add23a224257e43790e287504ce879534";
@@ -10573,9 +11349,10 @@ let
   };
 
   MouseXGetopt = buildPerlModule rec {
-    name = "MouseX-Getopt-0.38";
+    pname = "MouseX-Getopt";
+    version = "0.38";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GF/GFUJI/${name}.tar.gz";
+      url = mirror://cpan/authors/id/G/GF/GFUJI/MouseX-Getopt-0.38.tar.gz;
       sha256 = "de3ea8ef452dd9501ea8c4eda8744b7224602602b04692607edd7d62b79f038f";
     };
     buildInputs = [ ModuleBuildTiny MouseXConfigFromFile MouseXSimpleConfig TestException TestWarn ];
@@ -10588,7 +11365,8 @@ let
   };
 
   MooseXAttributeChained = buildPerlModule rec {
-    name = "MooseX-Attribute-Chained-1.0.3";
+    pname = "MooseX-Attribute-Chained";
+    version = "1.0.3";
     src = fetchurl {
       url = mirror://cpan/authors/id/T/TO/TOMHUKINS/MooseX-Attribute-Chained-1.0.3.tar.gz;
       sha256 = "0kjydmkxh8hpkbbmsgd5wrkhgq7w69lgfg6lx4s5g2xpqfkqmqz7";
@@ -10597,7 +11375,8 @@ let
   };
 
   MooseXAttributeHelpers = buildPerlPackage {
-    name = "MooseX-AttributeHelpers-0.23";
+    pname = "MooseX-AttributeHelpers";
+    version = "0.23";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DR/DROLSKY/MooseX-AttributeHelpers-0.23.tar.gz;
       sha256 = "3f63f60d94d840a309d9137f78605e15f07c977fd15a4f4b55bd47b65ed52be1";
@@ -10612,7 +11391,8 @@ let
   };
 
   MooseXClone = buildPerlModule {
-    name = "MooseX-Clone-0.06";
+    pname = "MooseX-Clone";
+    version = "0.06";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/MooseX-Clone-0.06.tar.gz;
       sha256 = "19wd74dihybnz1lbbsqn0clwxzb6y0aa0i25a8zhajz7p5fq5myb";
@@ -10622,9 +11402,10 @@ let
   };
 
   MooseXConfigFromFile = buildPerlModule rec {
-    name = "MooseX-ConfigFromFile-0.14";
+    pname = "MooseX-ConfigFromFile";
+    version = "0.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/E/ET/ETHER/MooseX-ConfigFromFile-0.14.tar.gz;
       sha256 = "9ad343cd9f86d714be9b54b9c68a443d8acc6501b6ad6b15e9ca0130b2e96f08";
     };
     buildInputs = [ ModuleBuildTiny TestDeep TestFatal TestRequires TestWithoutModule ];
@@ -10637,9 +11418,10 @@ let
   };
 
   MooseXDaemonize = buildPerlModule rec {
-    name = "MooseX-Daemonize-0.21";
+    pname = "MooseX-Daemonize";
+    version = "0.21";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/E/ET/ETHER/MooseX-Daemonize-0.21.tar.gz;
       sha256 = "111f391221d00f8b09cdcc6c806ab114324cf7f529d12f627fb97d054da42225";
     };
     buildInputs = [ DevelCheckOS ModuleBuildTiny TestFatal ];
@@ -10652,7 +11434,8 @@ let
   };
 
   MooseXEmulateClassAccessorFast = buildPerlPackage {
-    name = "MooseX-Emulate-Class-Accessor-Fast-0.009032";
+    pname = "MooseX-Emulate-Class-Accessor-Fast";
+    version = "0.009032";
     src = fetchurl {
       url = mirror://cpan/authors/id/H/HA/HAARG/MooseX-Emulate-Class-Accessor-Fast-0.009032.tar.gz;
       sha256 = "153r30nggcyyx7ai15dbnba2h5145f8jdsh6wj54298d3zpvgvl2";
@@ -10666,9 +11449,10 @@ let
   };
 
   MooseXGetopt = buildPerlModule rec {
-    name = "MooseX-Getopt-0.74";
+    pname = "MooseX-Getopt";
+    version = "0.74";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/E/ET/ETHER/MooseX-Getopt-0.74.tar.gz;
       sha256 = "1de0df3b431ebe9f3563bdf4569eacd7e07e865a8397f2a990d0cb57d4cb2c24";
     };
     buildInputs = [ ModuleBuildTiny MooseXStrictConstructor PathTiny TestDeep TestFatal TestNeeds TestTrap TestWarnings ];
@@ -10681,7 +11465,8 @@ let
   };
 
   MooseXHasOptions = buildPerlPackage {
-    name = "MooseX-Has-Options-0.003";
+    pname = "MooseX-Has-Options";
+    version = "0.003";
     src = fetchurl {
       url = mirror://cpan/authors/id/P/PS/PSHANGOV/MooseX-Has-Options-0.003.tar.gz;
       sha256 = "07c21cf8ed500b272020ff8da19f194728bb414e0012a2f0cc54ef2ef6222a68";
@@ -10696,7 +11481,8 @@ let
   };
 
   MooseXHasSugar = buildPerlPackage {
-    name = "MooseX-Has-Sugar-1.000006";
+    pname = "MooseX-Has-Sugar";
+    version = "1.000006";
     src = fetchurl {
       url = mirror://cpan/authors/id/K/KE/KENTNL/MooseX-Has-Sugar-1.000006.tar.gz;
       sha256 = "efeed3ddb3a8ea18f416d485f3c2b0427145d267e63368c651d488eaa8c28d09";
@@ -10711,7 +11497,8 @@ let
   };
 
   MooseXLazyRequire = buildPerlModule {
-    name = "MooseX-LazyRequire-0.11";
+    pname = "MooseX-LazyRequire";
+    version = "0.11";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/MooseX-LazyRequire-0.11.tar.gz;
       sha256 = "ef620c1e019daf9cf3f23a943d25a94c91e93ab312bcd63be2e9740ec0b94288";
@@ -10726,7 +11513,8 @@ let
   };
 
   MooseXMarkAsMethods = buildPerlPackage {
-    name = "MooseX-MarkAsMethods-0.15";
+    pname = "MooseX-MarkAsMethods";
+    version = "0.15";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RS/RSRCHBOY/MooseX-MarkAsMethods-0.15.tar.gz;
       sha256 = "1y3yxwcjjajm66pvca54cv9fax7a6dy36xqr92x7vzyhfqrw3v69";
@@ -10739,7 +11527,8 @@ let
   };
 
   MooseXMethodAttributes = buildPerlPackage {
-    name = "MooseX-MethodAttributes-0.31";
+    pname = "MooseX-MethodAttributes";
+    version = "0.31";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/MooseX-MethodAttributes-0.31.tar.gz;
       sha256 = "1whd10w7bm3dwaj7gpgw40bci9vvb2zmxs4349ifji91hvinwqck";
@@ -10754,7 +11543,8 @@ let
   };
 
   MooseXNonMoose = buildPerlPackage {
-    name = "MooseX-NonMoose-0.26";
+    pname = "MooseX-NonMoose";
+    version = "0.26";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DO/DOY/MooseX-NonMoose-0.26.tar.gz;
       sha256 = "0zdaiphc45s5xj0ax5mkijf5d8v6w6yccb3zplgj6f30y7n55gnb";
@@ -10768,7 +11558,8 @@ let
   };
 
   MooseXOneArgNew = buildPerlPackage {
-    name = "MooseX-OneArgNew-0.005";
+    pname = "MooseX-OneArgNew";
+    version = "0.005";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RJ/RJBS/MooseX-OneArgNew-0.005.tar.gz;
       sha256 = "0gqhqdkwsnxmni0xv43iplplgp6g55khdwc5117j9i569r3wykvy";
@@ -10782,7 +11573,8 @@ let
   };
 
   MooseXRelatedClassRoles = buildPerlPackage rec {
-    name = "MooseX-RelatedClassRoles-0.004";
+    pname = "MooseX-RelatedClassRoles";
+    version = "0.004";
     src = fetchurl {
       url = mirror://cpan/authors/id/H/HD/HDP/MooseX-RelatedClassRoles-0.004.tar.gz;
       sha256 = "17vynkf6m5d039qkr4in1c9lflr8hnwp1fgzdwhj4q6jglipmnrh";
@@ -10791,7 +11583,8 @@ let
   };
 
   MooseXParamsValidate = buildPerlPackage {
-    name = "MooseX-Params-Validate-0.21";
+    pname = "MooseX-Params-Validate";
+    version = "0.21";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DR/DROLSKY/MooseX-Params-Validate-0.21.tar.gz;
       sha256 = "1n9ry6gnskkp9ir6s7d5jirn3mh14ydgpmwqz6wcp6d9md358ac8";
@@ -10805,7 +11598,8 @@ let
   };
 
   MooseXRoleParameterized = buildPerlModule {
-    name = "MooseX-Role-Parameterized-1.10";
+    pname = "MooseX-Role-Parameterized";
+    version = "1.10";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/MooseX-Role-Parameterized-1.10.tar.gz;
       sha256 = "0plx25n80mv9qwhix52z79md0qil616nbcryk2f4216kghpw2ij8";
@@ -10820,9 +11614,10 @@ let
   };
 
   MooseXRoleWithOverloading = buildPerlPackage rec {
-    name = "MooseX-Role-WithOverloading-0.17";
+    pname = "MooseX-Role-WithOverloading";
+    version = "0.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/E/ET/ETHER/MooseX-Role-WithOverloading-0.17.tar.gz;
       sha256 = "0rb8k0dp1a55bm2pr6r0vsi5msvjl1dslfidxp1gj80j7zbrbc4j";
     };
     propagatedBuildInputs = [ Moose aliased namespaceautoclean ];
@@ -10833,9 +11628,10 @@ let
   };
 
   MooseXRunnable = buildPerlModule rec {
-    name = "MooseX-Runnable-0.10";
+    pname = "MooseX-Runnable";
+    version = "0.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/E/ET/ETHER/MooseX-Runnable-0.10.tar.gz;
       sha256 = "40d8fd1b5524ae965965a1f144d7a0a0c850594c524402b2319b24d5c4af1199";
     };
     buildInputs = [ ModuleBuildTiny TestFatal TestSimple13 TestTableDriven ];
@@ -10848,7 +11644,8 @@ let
   };
 
   MooseXSemiAffordanceAccessor = buildPerlPackage rec {
-    name = "MooseX-SemiAffordanceAccessor-0.10";
+    pname = "MooseX-SemiAffordanceAccessor";
+    version = "0.10";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DR/DROLSKY/MooseX-SemiAffordanceAccessor-0.10.tar.gz;
       sha256 = "1mdil9ckgmgr78z59p8wfa35ixn5855ndzx14y01dvfxpiv5gf55";
@@ -10857,7 +11654,8 @@ let
   };
 
   MooseXSetOnce = buildPerlPackage rec {
-    name = "MooseX-SetOnce-0.200002";
+    pname = "MooseX-SetOnce";
+    version = "0.200002";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RJ/RJBS/MooseX-SetOnce-0.200002.tar.gz;
       sha256 = "0ndnl8dj7nh8lvckl6r3jw31d0dmq30qf2pqkgcz0lykzjvhdvfb";
@@ -10867,7 +11665,8 @@ let
   };
 
   MooseXSingleton = buildPerlModule rec {
-    name = "MooseX-Singleton-0.30";
+    pname = "MooseX-Singleton";
+    version = "0.30";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/MooseX-Singleton-0.30.tar.gz;
       sha256 = "0hb5s1chsgbx2nlb0f112mdh2v1zwww8f4i3gvfvcghx3grv5135";
@@ -10877,7 +11676,8 @@ let
   };
 
   MooseXStrictConstructor = buildPerlPackage {
-    name = "MooseX-StrictConstructor-0.21";
+    pname = "MooseX-StrictConstructor";
+    version = "0.21";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DR/DROLSKY/MooseX-StrictConstructor-0.21.tar.gz;
       sha256 = "c72a5ae9583706ccdec71d401dcb3054013a7536b750df1436613d858ea2920d";
@@ -10891,9 +11691,10 @@ let
   };
 
   MooseXTraits = buildPerlModule rec {
-    name = "MooseX-Traits-0.13";
+    pname = "MooseX-Traits";
+    version = "0.13";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/E/ET/ETHER/MooseX-Traits-0.13.tar.gz;
       sha256 = "74afe0c4faf4e3b97c57f289437caa60becca34cd5821f489dd4cc9da4fbe29a";
     };
     buildInputs = [ ModuleBuildTiny MooseXRoleParameterized TestFatal TestRequires TestSimple13 ];
@@ -10906,9 +11707,10 @@ let
   };
 
   MooseXTraitsPluggable = buildPerlPackage rec {
-    name = "MooseX-Traits-Pluggable-0.12";
+    pname = "MooseX-Traits-Pluggable";
+    version = "0.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RK/RKITOVER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RK/RKITOVER/MooseX-Traits-Pluggable-0.12.tar.gz;
       sha256 = "1jjqmcidy4kdgp5yffqqwxrsab62mbhbpvnzdy1rpwnb1savg5mb";
     };
     buildInputs = [ TestException ];
@@ -10916,9 +11718,10 @@ let
   };
 
   MooseXTypes = buildPerlModule rec {
-    name = "MooseX-Types-0.50";
+    pname = "MooseX-Types";
+    version = "0.50";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/E/ET/ETHER/MooseX-Types-0.50.tar.gz;
       sha256 = "9cd87b3492cbf0be9d2df9317b2adf9fc30663770e69906654bea3f41b17cb08";
     };
     buildInputs = [ ModuleBuildTiny TestFatal TestRequires ];
@@ -10931,9 +11734,10 @@ let
   };
 
   MooseXTypesCommon = buildPerlModule rec {
-    name = "MooseX-Types-Common-0.001014";
+    pname = "MooseX-Types-Common";
+    version = "0.001014";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/E/ET/ETHER/MooseX-Types-Common-0.001014.tar.gz;
       sha256 = "ef93718b6d2f240d50b5c3acb1a74b4c2a191869651470001a82be1f35d0ef0f";
     };
     buildInputs = [ ModuleBuildTiny TestDeep TestWarnings ];
@@ -10946,9 +11750,10 @@ let
   };
 
   MooseXTypesDateTime = buildPerlModule rec {
-    name = "MooseX-Types-DateTime-0.13";
+    pname = "MooseX-Types-DateTime";
+    version = "0.13";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/E/ET/ETHER/MooseX-Types-DateTime-0.13.tar.gz;
       sha256 = "b89fa26636f6a17eaa3868b4514340472b68bbdc2161a1d79a22a1bf5b1d39c6";
     };
     buildInputs = [ ModuleBuildTiny TestFatal TestSimple13 ];
@@ -10961,9 +11766,10 @@ let
   };
 
   MooseXTypesDateTimeMoreCoercions = buildPerlModule rec {
-    name = "MooseX-Types-DateTime-MoreCoercions-0.15";
+    pname = "MooseX-Types-DateTime-MoreCoercions";
+    version = "0.15";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/E/ET/ETHER/MooseX-Types-DateTime-MoreCoercions-0.15.tar.gz;
       sha256 = "21bb3a597719888edb6ceaa132418d5cf92ecb92a50cce37b94259a55e0e3796";
     };
     buildInputs = [ ModuleBuildTiny TestFatal TestSimple13 ];
@@ -10976,7 +11782,8 @@ let
   };
 
   MooseXTypesLoadableClass = buildPerlModule {
-    name = "MooseX-Types-LoadableClass-0.015";
+    pname = "MooseX-Types-LoadableClass";
+    version = "0.015";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/MooseX-Types-LoadableClass-0.015.tar.gz;
       sha256 = "e037d3778253dcf92946435715bada0e6449c0a2808fa3ff32a965064d5a3bf4";
@@ -10991,7 +11798,8 @@ let
   };
 
   MooseXTypesPathClass = buildPerlModule {
-    name = "MooseX-Types-Path-Class-0.09";
+    pname = "MooseX-Types-Path-Class";
+    version = "0.09";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/MooseX-Types-Path-Class-0.09.tar.gz;
       sha256 = "0zpgwzxj6d9k2lbg6v6zd1bcbzjz2h336rm816krbblq6ssvm177";
@@ -11005,7 +11813,8 @@ let
   };
 
   MooseXTypesPathTiny = buildPerlModule {
-    name = "MooseX-Types-Path-Tiny-0.012";
+    pname = "MooseX-Types-Path-Tiny";
+    version = "0.012";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/MooseX-Types-Path-Tiny-0.012.tar.gz;
       sha256 = "19eede02dd654e70f73e34cd7af0063765173bcaefeeff1bdbe21318ecfd9158";
@@ -11020,7 +11829,8 @@ let
   };
 
   MooseXTypesPerl = buildPerlPackage {
-    name = "MooseX-Types-Perl-0.101343";
+    pname = "MooseX-Types-Perl";
+    version = "0.101343";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RJ/RJBS/MooseX-Types-Perl-0.101343.tar.gz;
       sha256 = "0nijy676q27bvjb8swxrb1j4lq2xq8jbqkaxs1l9q81k7jpvx17h";
@@ -11033,7 +11843,8 @@ let
   };
 
   MooseXTypesStringlike = buildPerlPackage {
-    name = "MooseX-Types-Stringlike-0.003";
+    pname = "MooseX-Types-Stringlike";
+    version = "0.003";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DA/DAGOLDEN/MooseX-Types-Stringlike-0.003.tar.gz;
       sha256 = "06fgamdiz0n7cgghb8ycjd5mcidj8w769zs2gws6z6jjbkn4kqrf";
@@ -11047,7 +11858,8 @@ let
   };
 
   MooseXTypesStructured = buildPerlModule {
-    name = "MooseX-Types-Structured-0.36";
+    pname = "MooseX-Types-Structured";
+    version = "0.36";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/MooseX-Types-Structured-0.36.tar.gz;
       sha256 = "0mrxc00sid7526c6brrnjr6288468sszic3wazij71v3z59bdka3";
@@ -11061,9 +11873,10 @@ let
   };
 
   MooseXTypesURI = buildPerlModule rec {
-    name = "MooseX-Types-URI-0.08";
+    pname = "MooseX-Types-URI";
+    version = "0.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/E/ET/ETHER/MooseX-Types-URI-0.08.tar.gz;
       sha256 = "d310d20fa361fe2dff758236df87949cc7bf98e5cf3a7c79115365eccde6ccc1";
     };
     buildInputs = [ ModuleBuildTiny TestSimple13 ];
@@ -11076,7 +11889,8 @@ let
   };
 
   Mouse = buildPerlModule rec {
-    name = "Mouse-2.5.6";
+    pname = "Mouse";
+    version = "2.5.6";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SK/SKAJI/Mouse-v2.5.6.tar.gz;
       sha256 = "1j3048ip691j91rdig6wrlg6i4jdzhszxmz5pi2g7n355rl2w00l";
@@ -11088,9 +11902,10 @@ let
   };
 
   MouseXNativeTraits = buildPerlPackage rec {
-    name = "MouseX-NativeTraits-1.09";
+    pname = "MouseX-NativeTraits";
+    version = "1.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GF/GFUJI/${name}.tar.gz";
+      url = mirror://cpan/authors/id/G/GF/GFUJI/MouseX-NativeTraits-1.09.tar.gz;
       sha256 = "0pnbchkxfz9fwa8sniyjqp0mz75b3k2fafq9r09znbbh51dbz9gq";
     };
     buildInputs = [ AnyMoose TestFatal ];
@@ -11102,9 +11917,10 @@ let
   };
 
   MozillaCA = buildPerlPackage rec {
-    name = "Mozilla-CA-20180117";
+    pname = "Mozilla-CA";
+    version = "20180117";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AB/ABH/${name}.tar.gz";
+      url = mirror://cpan/authors/id/A/AB/ABH/Mozilla-CA-20180117.tar.gz;
       sha256 = "f2cc9fbe119f756313f321e0d9f1fac0859f8f154ac9d75b1a264c1afdf4e406";
     };
     meta = {
@@ -11130,7 +11946,8 @@ let
   };
 
   MROCompat = buildPerlPackage {
-    name = "MRO-Compat-0.13";
+    pname = "MRO-Compat";
+    version = "0.13";
     src = fetchurl {
       url = mirror://cpan/authors/id/H/HA/HAARG/MRO-Compat-0.13.tar.gz;
       sha256 = "1y547lr6zccf7919vx01v22zsajy528psanhg5aqschrrin3nb4a";
@@ -11142,9 +11959,10 @@ let
   };
 
   MusicBrainzDiscID = buildPerlModule rec {
-    name = "MusicBrainz-DiscID-0.03";
+    pname = "MusicBrainz-DiscID";
+    version = "0.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NJ/NJH/${name}.tar.gz";
+      url = mirror://cpan/authors/id/N/NJ/NJH/MusicBrainz-DiscID-0.03.tar.gz;
       sha256 = "0fjph2q3yp0aa87gckv3391s47m13wbyylj7jb7vqx7hv0pzj0jh";
     };
     # Build.PL in this package uses which to find pkg-config -- make it use path instead
@@ -11155,9 +11973,10 @@ let
   };
 
   MusicBrainz = buildPerlModule rec {
-    name = "WebService-MusicBrainz-1.0.5";
+    pname = "WebService-MusicBrainz";
+    version = "1.0.5";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BF/BFAIST/${name}.tar.gz";
+      url = mirror://cpan/authors/id/B/BF/BFAIST/WebService-MusicBrainz-1.0.5.tar.gz;
       sha256 = "16chs1l58cf000d5kalkyph3p31ci73p1rlyx98mfv10d2cq6fsj";
     };
     propagatedBuildInputs = [ Mojolicious ];
@@ -11165,9 +11984,10 @@ let
   };
 
   namespaceautoclean = buildPerlPackage rec {
-    name = "namespace-autoclean-0.28";
+    pname = "namespace-autoclean";
+    version = "0.28";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/E/ET/ETHER/namespace-autoclean-0.28.tar.gz;
       sha256 = "cd410a1681add521a28805da2e138d44f0d542407b50999252a147e553c26c39";
     };
     buildInputs = [ TestRequires ];
@@ -11180,9 +12000,10 @@ let
   };
 
   namespaceclean = buildPerlPackage rec {
-    name = "namespace-clean-0.27";
+    pname = "namespace-clean";
+    version = "0.27";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RI/RIBASUSHI/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RI/RIBASUSHI/namespace-clean-0.27.tar.gz;
       sha256 = "8a10a83c3e183dc78f9e7b7aa4d09b47c11fb4e7d3a33b9a12912fd22e31af9d";
     };
     propagatedBuildInputs = [ BHooksEndOfScope PackageStash ];
@@ -11193,9 +12014,10 @@ let
   };
 
   NetIdent = buildPerlPackage rec {
-    name = "Net-Ident-1.24";
+    pname = "Net-Ident";
+    version = "1.24";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TODDR/${name}.tar.gz";
+      url = mirror://cpan/authors/id/T/TO/TODDR/Net-Ident-1.24.tar.gz;
       sha256 = "5f5f1142185a67b87406a3fb31f221564f61838a70ef4c07284a66c55e82ad05";
     };
     meta = {
@@ -11206,9 +12028,10 @@ let
   };
 
   NetAddrIP = buildPerlPackage rec {
-    name = "NetAddr-IP-4.079";
+    pname = "NetAddr-IP";
+    version = "4.079";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIKER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MI/MIKER/NetAddr-IP-4.079.tar.gz;
       sha256 = "ec5a82dfb7028bcd28bb3d569f95d87dd4166cc19867f2184ed3a59f6d6ca0e7";
     };
     meta = {
@@ -11218,7 +12041,8 @@ let
   };
 
   NetAmazonAWSSign = buildPerlPackage {
-    name = "Net-Amazon-AWSSign-0.12";
+    pname = "Net-Amazon-AWSSign";
+    version = "0.12";
     src = fetchurl {
       url = mirror://cpan/authors/id/N/NA/NATON/Net-Amazon-AWSSign-0.12.tar.gz;
       sha256 = "0gpdjz5095hd3y1xhnbv45m6q2shw0c9r7spj1jvb8hy7dmhq10x";
@@ -11252,9 +12076,10 @@ let
   };
 
   NetAmazonMechanicalTurk = buildPerlModule rec {
-    name = "Net-Amazon-MechanicalTurk-1.02";
+    pname = "Net-Amazon-MechanicalTurk";
+    version = "1.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MT/MTURK/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MT/MTURK/Net-Amazon-MechanicalTurk-1.02.tar.gz;
       sha256 = "13hgggfchhp4m3l2rn3d1v6g6ccwmwf9xiyc9izv5570930mw2cd";
     };
     patches =
@@ -11264,7 +12089,8 @@ let
   };
 
   NetAmazonS3 = buildPerlPackage rec {
-    name = "Net-Amazon-S3-0.86";
+    pname = "Net-Amazon-S3";
+    version = "0.86";
     src = fetchurl {
       url = mirror://cpan/authors/id/L/LL/LLAP/Net-Amazon-S3-0.86.tar.gz;
       sha256 = "6301e683a19b1302a234a1689d7c7f7e7102b3e86f4de428b8cc1cd975f0c38a";
@@ -11278,7 +12104,8 @@ let
   };
 
   NetAmazonS3Policy = buildPerlModule {
-    name = "Net-Amazon-S3-Policy-0.1.6";
+    pname = "Net-Amazon-S3-Policy";
+    version = "0.1.6";
     src = fetchurl {
       url = mirror://cpan/authors/id/P/PO/POLETTIX/Net-Amazon-S3-Policy-0.1.6.tar.gz;
       sha256 = "056rhq6vsdpwi2grbmxj8341qjrz0258civpnhs78j37129nxcfj";
@@ -11291,7 +12118,8 @@ let
   };
 
   NetAMQP = buildPerlModule {
-    name = "Net-AMQP-0.06";
+    pname = "Net-AMQP";
+    version = "0.06";
     src = fetchurl {
       url = mirror://cpan/authors/id/C/CH/CHIPS/Net-AMQP-0.06.tar.gz;
       sha256 = "0b2ba7de2cd7ddd5fe102a2e2ae7aeba21eaab1078bf3bfd3c5a722937256380";
@@ -11306,7 +12134,8 @@ let
   };
 
   NetCIDR = buildPerlPackage {
-    name = "Net-CIDR-0.20";
+    pname = "Net-CIDR";
+    version = "0.20";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MR/MRSAM/Net-CIDR-0.20.tar.gz;
       sha256 = "c75edc6818bb360d71c139169fd64ad65c35fff6d2b9fac7b9f9e6c467f187b5";
@@ -11319,9 +12148,10 @@ let
   };
 
   NetCIDRLite = buildPerlPackage rec {
-    name = "Net-CIDR-Lite-0.21";
+    pname = "Net-CIDR-Lite";
+    version = "0.21";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DO/DOUGW/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DO/DOUGW/Net-CIDR-Lite-0.21.tar.gz;
       sha256 = "cfa125e8a2aef9259bc3a44e07cbdfb7894b64d22e7c0cee92aee2f5c7915093";
     };
     meta = {
@@ -11330,7 +12160,8 @@ let
   };
 
   NetCoverArtArchive = buildPerlPackage {
-    name = "Net-CoverArtArchive-1.02";
+    pname = "Net-CoverArtArchive";
+    version = "1.02";
     src = fetchurl {
       url = mirror://cpan/authors/id/C/CY/CYCLES/Net-CoverArtArchive-1.02.tar.gz;
       sha256 = "1lfx8lrjgb3s11fcm243jp5sghngd9svkgmg7xmssmj34q4f49ap";
@@ -11345,9 +12176,10 @@ let
   };
 
   NetDBus = buildPerlPackage rec {
-    name = "Net-DBus-1.1.0";
+    pname = "Net-DBus";
+    version = "1.1.0";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DANBERR/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DA/DANBERR/Net-DBus-1.1.0.tar.gz;
       sha256 = "8391696db9e96c374b72984c0bad9c7d1c9f3b4efe68f9ddf429a77548e0e269";
     };
     nativeBuildInputs = [ pkgs.buildPackages.pkgconfig ];
@@ -11361,9 +12193,10 @@ let
   };
 
   NetDNS = buildPerlPackage rec {
-    name = "Net-DNS-1.20";
+    pname = "Net-DNS";
+    version = "1.20";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NL/NLNETLABS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/N/NL/NLNETLABS/Net-DNS-1.20.tar.gz;
       sha256 = "7fd9692b687253baa8f2eb639f1dd7ff9c77fddd67167dc59b400bd25e4ce01b";
     };
     propagatedBuildInputs = [ DigestHMAC ];
@@ -11375,7 +12208,8 @@ let
   };
 
   NetDNSResolverMock = buildPerlPackage rec {
-     name = "Net-DNS-Resolver-Mock-1.20171219";
+     pname = "Net-DNS-Resolver-Mock";
+     version = "1.20171219";
      src = fetchurl {
        url = mirror://cpan/authors/id/M/MB/MBRADSHAW/Net-DNS-Resolver-Mock-1.20171219.tar.gz;
        sha256 = "0m3rxpkv1b9121srvbqkrgzg4m8mnydiydqv34in1i1ixwrl6jn9";
@@ -11388,9 +12222,10 @@ let
   };
 
   NetDomainTLD = buildPerlPackage rec {
-    name = "Net-Domain-TLD-1.75";
+    pname = "Net-Domain-TLD";
+    version = "1.75";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AL/ALEXP/${name}.tar.gz";
+      url = mirror://cpan/authors/id/A/AL/ALEXP/Net-Domain-TLD-1.75.tar.gz;
       sha256 = "4c37f811184d68ac4179d48c10ea31922dd5fca2c1bffcdcd95c5a2a3b4002ee";
     };
     meta = {
@@ -11400,7 +12235,8 @@ let
   };
 
   NetFastCGI = buildPerlPackage rec {
-     name = "Net-FastCGI-0.14";
+     pname = "Net-FastCGI";
+     version = "0.14";
      src = fetchurl {
        url = mirror://cpan/authors/id/C/CH/CHANSEN/Net-FastCGI-0.14.tar.gz;
        sha256 = "0sjrnlzci21sci5m52zz0x9bf889j67i6vnhrjlypsfm9w5914qi";
@@ -11413,9 +12249,10 @@ let
   };
 
   NetHTTP = buildPerlPackage rec {
-    name = "Net-HTTP-6.18";
+    pname = "Net-HTTP";
+    version = "6.18";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OA/OALDERS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/O/OA/OALDERS/Net-HTTP-6.18.tar.gz;
       sha256 = "7e42df2db7adce3e0eb4f78b88c450f453f5380f120fd5411232e03374ba951c";
     };
     propagatedBuildInputs = [ URI ];
@@ -11429,7 +12266,8 @@ let
   };
 
   NetIDNEncode = buildPerlModule {
-    name = "Net-IDN-Encode-2.500";
+    pname = "Net-IDN-Encode";
+    version = "2.500";
     src = fetchurl {
       url = mirror://cpan/authors/id/C/CF/CFAERBER/Net-IDN-Encode-2.500.tar.gz;
       sha256 = "1aiy7adirk3wpwlczd8sldi9k1dray0jrg1lbcrcw97zwcrkciam";
@@ -11441,9 +12279,10 @@ let
   };
 
   NetIMAPClient = buildPerlPackage rec {
-    name = "Net-IMAP-Client-0.9505";
+    pname = "Net-IMAP-Client";
+    version = "0.9505";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GA/GANGLION/${name}.tar.gz";
+      url = mirror://cpan/authors/id/G/GA/GANGLION/Net-IMAP-Client-0.9505.tar.gz;
       sha256 = "d3f6a608b85e09a8080a67a9933837aae6f2cd0e8ee39df3380123dc5e3de912";
     };
     propagatedBuildInputs = [ IOSocketSSL ListMoreUtils ];
@@ -11453,7 +12292,8 @@ let
   };
 
   NetIP = buildPerlPackage {
-    name = "Net-IP-1.26";
+    pname = "Net-IP";
+    version = "1.26";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MA/MANU/Net-IP-1.26.tar.gz;
       sha256 = "0ffn2xqqbkfi7v303sp5dwgbv36jah3vg8r4nxhxfiv60vric3q4";
@@ -11464,7 +12304,8 @@ let
   };
 
   NetOAuth = buildPerlModule {
-    name = "Net-OAuth-0.28";
+    pname = "Net-OAuth";
+    version = "0.28";
     src = fetchurl {
       url = mirror://cpan/authors/id/K/KG/KGRENNAN/Net-OAuth-0.28.tar.gz;
       sha256 = "0k4h4a5048h7qgyx25ih64x0l4airx8a6d9gjq08wmxcl2fk3z3v";
@@ -11478,16 +12319,18 @@ let
   };
 
   NetPatricia = buildPerlPackage rec {
-    name = "Net-Patricia-1.22";
+    pname = "Net-Patricia";
+    version = "1.22";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GR/GRUBER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/G/GR/GRUBER/Net-Patricia-1.22.tar.gz;
       sha256 = "70835a926e1c5a8d0324c72fffee82eeb7ec6c141dee04fd446820b64f71c552";
     };
     propagatedBuildInputs = [ NetCIDRLite Socket6 ];
   };
 
   NetPing = buildPerlPackage {
-    name = "Net-Ping-2.72";
+    pname = "Net-Ping";
+    version = "2.72";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RU/RURBAN/Net-Ping-2.72.tar.gz;
       sha256 = "555af602f54229cd81fef7da1a81516800f3155c6dc4d07dc71be1de3253dd6a";
@@ -11498,7 +12341,8 @@ let
   };
 
   NetDNSResolverProgrammable = buildPerlPackage rec {
-    name = "Net-DNS-Resolver-Programmable-0.009";
+    pname = "Net-DNS-Resolver-Programmable";
+    version = "0.009";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BI/BIGPRESH/Net-DNS-Resolver-Programmable-0.009.tar.gz;
       sha256 = "8080a2ab776629585911af1179bdb7c4dc2bebfd4b5efd77b11d1dac62454bf8";
@@ -11511,9 +12355,10 @@ let
   };
 
   NetSCP = buildPerlPackage rec {
-    name = "Net-SCP-0.08.reprise";
+    pname = "Net-SCP";
+    version = "0.08.reprise";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IV/IVAN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/I/IV/IVAN/Net-SCP-0.08.reprise.tar.gz;
       sha256 = "88a9b2df69e769e5855a408b19f61915b82e8fe070ab5cf4d525dd3b8bbe31c1";
     };
     propagatedBuildInputs = [ pkgs.openssl ];
@@ -11528,7 +12373,8 @@ let
   };
 
   NetServer = buildPerlPackage {
-    name = "Net-Server-2.009";
+    pname = "Net-Server";
+    version = "2.009";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RH/RHANDOM/Net-Server-2.009.tar.gz;
       sha256 = "0gw1k9gcw7habbkxvsfa2gz34brlbwcidk6khgsf1qjm0dbccrw2";
@@ -11540,9 +12386,10 @@ let
   };
 
   NetSFTPForeign = buildPerlPackage rec {
-    name = "Net-SFTP-Foreign-1.90";
+    pname = "Net-SFTP-Foreign";
+    version = "1.90";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SA/SALVA/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SA/SALVA/Net-SFTP-Foreign-1.90.tar.gz;
       sha256 = "d1eafb34f669ab6de675058292778ba2e0e42ecafd59abb1128ba31d62a0419d";
     };
     propagatedBuildInputs = [ pkgs.openssl ];
@@ -11556,7 +12403,8 @@ let
   };
 
   NetServerCoro = buildPerlPackage rec {
-     name = "Net-Server-Coro-1.3";
+     pname = "Net-Server-Coro";
+     version = "1.3";
      src = fetchurl {
        url = mirror://cpan/authors/id/A/AL/ALEXMV/Net-Server-Coro-1.3.tar.gz;
        sha256 = "11pvfxsi0q37kd17z597wb8r9dv3r96fiagq57kc746k1lmp06hy";
@@ -11569,7 +12417,8 @@ let
   };
 
   NetSMTPSSL = buildPerlPackage {
-    name = "Net-SMTP-SSL-1.04";
+    pname = "Net-SMTP-SSL";
+    version = "1.04";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RJ/RJBS/Net-SMTP-SSL-1.04.tar.gz;
       sha256 = "001a6dcfahf7kkyirqkc8jd4fh4fkal7n7vm9c4dblqrvmdc8abv";
@@ -11578,7 +12427,8 @@ let
   };
 
   NetSMTPTLS = buildPerlPackage {
-    name = "Net-SMTP-TLS-0.12";
+    pname = "Net-SMTP-TLS";
+    version = "0.12";
     src = fetchurl {
       url = mirror://cpan/authors/id/A/AW/AWESTHOLM/Net-SMTP-TLS-0.12.tar.gz;
       sha256 = "19g48kabj22v66jbf69q78xplhi7r1y2kdbddfwh4xy3g9k75rzg";
@@ -11587,7 +12437,8 @@ let
   };
 
   NetSMTPTLSButMaintained = buildPerlPackage {
-    name = "Net-SMTP-TLS-ButMaintained-0.24";
+    pname = "Net-SMTP-TLS-ButMaintained";
+    version = "0.24";
     src = fetchurl {
       url = mirror://cpan/authors/id/F/FA/FAYLAND/Net-SMTP-TLS-ButMaintained-0.24.tar.gz;
       sha256 = "0vi5cv7f9i96hgp3q3jpxzn1ysn802kh5xc304f8b7apf67w15bb";
@@ -11596,7 +12447,8 @@ let
   };
 
   NetSNMP = buildPerlModule rec {
-    name = "Net-SNMP-6.0.1";
+    pname = "Net-SNMP";
+    version = "6.0.1";
     src = fetchurl {
       url = "mirror://cpan/authors/id/D/DT/DTOWN/Net-SNMP-v6.0.1.tar.gz";
       sha256 = "0hdpn1cw52x8cw24m9ayzpf4rwarm0khygn1sv3wvwxkrg0pphql";
@@ -11605,9 +12457,10 @@ let
   };
 
   NetSSH = buildPerlPackage rec {
-    name = "Net-SSH-0.09";
+    pname = "Net-SSH";
+    version = "0.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IV/IVAN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/I/IV/IVAN/Net-SSH-0.09.tar.gz;
       sha256 = "7c71c7c3cbe953234dfe25bcc1ad7edb0e1f5a0578601f5523bc6070262a3817";
     };
     propagatedBuildInputs = [ pkgs.openssl ];
@@ -11621,7 +12474,8 @@ let
   };
 
   NetSSHPerl = buildPerlPackage rec {
-    name = "Net-SSH-Perl-2.14";
+    pname = "Net-SSH-Perl";
+    version = "2.14";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SC/SCHWIGON/Net-SSH-Perl-2.14.tar.gz;
       sha256 = "2b5d1bb13590b5870116704e7f1dce9a9823c4f80ff5461b97bb26a317393017";
@@ -11657,7 +12511,8 @@ let
   };
 
   NetStatsd = buildPerlPackage {
-    name = "Net-Statsd-0.12";
+    pname = "Net-Statsd";
+    version = "0.12";
     src = fetchurl {
       url = mirror://cpan/authors/id/C/CO/COSIMO/Net-Statsd-0.12.tar.gz;
       sha256 = "63e453603da165bc6d1c4ca0b55eda3d2204f040c59304a47782c5aa7886565c";
@@ -11669,7 +12524,8 @@ let
   };
 
   NetTelnet = buildPerlPackage {
-    name = "Net-Telnet-3.04";
+    pname = "Net-Telnet";
+    version = "3.04";
     src = fetchurl {
       url = mirror://cpan/authors/id/J/JR/JROGERS/Net-Telnet-3.04.tar.gz;
       sha256 = "e64d567a4e16295ecba949368e7a6b8b5ae2a16b3ad682121d9b007dc5d2a37a";
@@ -11681,7 +12537,8 @@ let
   };
 
   NetTwitterLite = buildPerlModule {
-    name = "Net-Twitter-Lite-0.12008";
+    pname = "Net-Twitter-Lite";
+    version = "0.12008";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MM/MMIMS/Net-Twitter-Lite-0.12008.tar.gz;
       sha256 = "13j69a6nqq8mh5b4qk021db55rkfnk1ppwk0rpg68b1z58gvxsmj";
@@ -11697,7 +12554,8 @@ let
   };
 
   NetWorks = buildPerlPackage {
-    name = "Net-Works-0.22";
+    pname = "Net-Works";
+    version = "0.22";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MA/MAXMIND/Net-Works-0.22.tar.gz;
       sha256 = "1zz91vn1kdxljnlwllf4dzdsm4v6pja5694vf8l4w66azcyv5j8a";
@@ -11711,25 +12569,28 @@ let
   };
 
   NumberBytesHuman = buildPerlPackage rec {
-    name = "Number-Bytes-Human-0.11";
+    pname = "Number-Bytes-Human";
+    version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FE/FERREIRA/${name}.tar.gz";
+      url = mirror://cpan/authors/id/F/FE/FERREIRA/Number-Bytes-Human-0.11.tar.gz;
       sha256 = "0b3gprpbcrdwc2gqalpys5m2ngilh5injhww8y0gf3dln14rrisz";
     };
   };
 
   NumberCompare = buildPerlPackage rec {
-    name = "Number-Compare-0.03";
+    pname = "Number-Compare";
+    version = "0.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RC/RCLAMP/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RC/RCLAMP/Number-Compare-0.03.tar.gz;
       sha256 = "09q8i0mxvr7q9vajwlgawsi0hlpc119gnhq4hc933d03x0vkfac3";
     };
   };
 
   NumberFormat = buildPerlPackage rec {
-    name = "Number-Format-1.75";
+    pname = "Number-Format";
+    version = "1.75";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/W/WR/WRW/${name}.tar.gz";
+      url = mirror://cpan/authors/id/W/WR/WRW/Number-Format-1.75.tar.gz;
       sha256 = "82d659cb16461764fd44d11a9ce9e6a4f5e8767dc1069eb03467c6e55de257f3";
     };
     meta = {
@@ -11739,7 +12600,8 @@ let
   };
 
   NumberMisc = buildPerlModule rec {
-     name = "Number-Misc-1.2";
+     pname = "Number-Misc";
+     version = "1.2";
      src = fetchurl {
        url = mirror://cpan/authors/id/M/MI/MIKO/Number-Misc-1.2.tar.gz;
        sha256 = "1n4ivj4ydplanwbxn3jbsfyfcl91ngn2d0addzqrq1hac26bdfbp";
@@ -11751,7 +12613,8 @@ let
   };
 
   NumberWithError = buildPerlPackage {
-    name = "Number-WithError-1.01";
+    pname = "Number-WithError";
+    version = "1.01";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SM/SMUELLER/Number-WithError-1.01.tar.gz;
       sha256 = "0m7my372rcj2d3j8xvhqdlhnnvxqabasvpvvhdkyli3qgrra1xnz";
@@ -11765,9 +12628,10 @@ let
   };
 
   NTLM = buildPerlPackage rec {
-    name = "NTLM-1.09";
+    pname = "NTLM";
+    version = "1.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NB/NBEBOUT/${name}.tar.gz";
+      url = mirror://cpan/authors/id/N/NB/NBEBOUT/NTLM-1.09.tar.gz;
       sha256 = "c823e30cda76bc15636e584302c960e2b5eeef9517c2448f7454498893151f85";
     };
     propagatedBuildInputs = [ DigestHMAC ];
@@ -11778,7 +12642,8 @@ let
   };
 
   ObjectAccessor = buildPerlPackage {
-    name = "Object-Accessor-0.48";
+    pname = "Object-Accessor";
+    version = "0.48";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BI/BINGOS/Object-Accessor-0.48.tar.gz;
       sha256 = "76cb824a27b6b4e560409fcf6fd5b3bfbbd38b72f1f3d37ed0b54bd9c0baeade";
@@ -11790,7 +12655,8 @@ let
   };
 
   ObjectInsideOut = buildPerlModule {
-    name = "Object-InsideOut-4.05";
+    pname = "Object-InsideOut";
+    version = "4.05";
     src = fetchurl {
       url = mirror://cpan/authors/id/J/JD/JDHEDDEN/Object-InsideOut-4.05.tar.gz;
       sha256 = "1i6aif37ji91nsyncp5d0d3q29clf009sxdn1rz38917hai6rzcx";
@@ -11803,7 +12669,8 @@ let
   };
 
   ObjectSignature = buildPerlPackage {
-    name = "Object-Signature-1.08";
+    pname = "Object-Signature";
+    version = "1.08";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/Object-Signature-1.08.tar.gz;
       sha256 = "12k90c19ly93ib1p6sm3k7sbnr2h5dbywkdmnff2ngm99p4m68c4";
@@ -11815,9 +12682,10 @@ let
   };
 
   OLEStorage_Lite = buildPerlPackage rec {
-    name = "OLE-Storage_Lite-0.19";
+    pname = "OLE-Storage_Lite";
+    version = "0.19";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JM/JMCNAMARA/${name}.tar.gz";
+      url = mirror://cpan/authors/id/J/JM/JMCNAMARA/OLE-Storage_Lite-0.19.tar.gz;
       sha256 = "179cxwqxb0f9dpx8954nvwjmggxxi5ndnang41yav1dx6mf0abp7";
     };
     meta = {
@@ -11827,7 +12695,8 @@ let
   };
 
   Opcodes = buildPerlPackage {
-    name = "Opcodes-0.14";
+    pname = "Opcodes";
+    version = "0.14";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RU/RURBAN/Opcodes-0.14.tar.gz;
       sha256 = "7f7365447e4d1c5b87b43091448f0488e67c9f036b26c022a5409cd73d343893";
@@ -11839,9 +12708,10 @@ let
   };
 
   OpenGL = buildPerlPackage rec {
-    name = "OpenGL-0.70";
+    pname = "OpenGL";
+    version = "0.70";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CH/CHM/${name}.tar.gz";
+      url = mirror://cpan/authors/id/C/CH/CHM/OpenGL-0.70.tar.gz;
       sha256 = "1q3lz168q081iwl9jg21fbzhp9la79gav9mv6nmh2jab83s2l3mj";
     };
 
@@ -11863,18 +12733,20 @@ let
   };
 
   NetOpenIDCommon = buildPerlPackage rec {
-    name = "Net-OpenID-Common-1.20";
+    pname = "Net-OpenID-Common";
+    version = "1.20";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/W/WR/WROG/${name}.tar.gz";
+      url = mirror://cpan/authors/id/W/WR/WROG/Net-OpenID-Common-1.20.tar.gz;
       sha256 = "1jdbkp18ka2m4akjp9b0dbw2lqnzgwpq435cnh6hwwa79bbrfkmb";
     };
     propagatedBuildInputs = [ CryptDHGMP XMLSimple ];
   };
 
   NetOpenIDConsumer = buildPerlPackage rec {
-    name = "Net-OpenID-Consumer-1.18";
+    pname = "Net-OpenID-Consumer";
+    version = "1.18";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/W/WR/WROG/${name}.tar.gz";
+      url = mirror://cpan/authors/id/W/WR/WROG/Net-OpenID-Consumer-1.18.tar.gz;
       sha256 = "0f2g6sczvbpyjmy14pabmrj0d48hlsndqswrvmqk1161wxpkh70f";
     };
     propagatedBuildInputs = [ JSON NetOpenIDCommon ];
@@ -11882,9 +12754,10 @@ let
   };
 
   NetOpenSSH = buildPerlPackage rec {
-    name = "Net-OpenSSH-0.78";
+    pname = "Net-OpenSSH";
+    version = "0.78";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SA/SALVA/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SA/SALVA/Net-OpenSSH-0.78.tar.gz;
       sha256 = "8f10844542a2824389decdb8edec7561d8199dc5f0250e849a0bb56f7aee880c";
     };
     meta = {
@@ -11894,9 +12767,10 @@ let
   };
 
   NetZooKeeper = buildPerlPackage rec {
-    name = "Net-ZooKeeper-0.41";
+    pname = "Net-ZooKeeper";
+    version = "0.41";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MAF/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MA/MAF/Net-ZooKeeper-0.41.tar.gz;
       sha256 = "91c177f30f82302eaf3173356eef05c21bc82163df752acb469177bd14a72db9";
     };
     buildInputs = [ pkgs.zookeeper_mt ];
@@ -11912,7 +12786,8 @@ let
   };
 
   PackageConstants = buildPerlPackage {
-    name = "Package-Constants-0.06";
+    pname = "Package-Constants";
+    version = "0.06";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BI/BINGOS/Package-Constants-0.06.tar.gz;
       sha256 = "0b58be78706ccc4e4bd9bbad41767470427fd7b2cfad749489de101f85bc5df5";
@@ -11924,9 +12799,10 @@ let
   };
 
   PackageDeprecationManager = buildPerlPackage rec {
-    name = "Package-DeprecationManager-0.17";
+    pname = "Package-DeprecationManager";
+    version = "0.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DR/DROLSKY/Package-DeprecationManager-0.17.tar.gz;
       sha256 = "1d743ada482b5c9871d894966e87d4c20edc96931bb949fb2638b000ddd6684b";
     };
     buildInputs = [ TestFatal TestWarnings ];
@@ -11938,7 +12814,8 @@ let
   };
 
   PatchReader = buildPerlPackage rec {
-    name = "PatchReader-0.9.6";
+    pname = "PatchReader";
+    version = "0.9.6";
     src = fetchurl {
       url = mirror://cpan/authors/id/T/TM/TMANNERM/PatchReader-0.9.6.tar.gz;
       sha256 = "b8de37460347bb5474dc01916ccb31dd2fe0cd92242c4a32d730e8eb087c323c";
@@ -11950,7 +12827,8 @@ let
   };
 
   PackageStash = buildPerlPackage {
-    name = "Package-Stash-0.38";
+    pname = "Package-Stash";
+    version = "0.38";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/Package-Stash-0.38.tar.gz;
       sha256 = "c58ee8844df2dda38e3bf66fdf443439aaefaef1a33940edf2055f0afd223a7f";
@@ -11964,7 +12842,8 @@ let
   };
 
   PackageStashXS = buildPerlPackage {
-    name = "Package-Stash-XS-0.29";
+    pname = "Package-Stash-XS";
+    version = "0.29";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/Package-Stash-XS-0.29.tar.gz;
       sha256 = "1akqk10qxwk798qppajqbczwmhy4cs9g0lg961m3vq218slnnryk";
@@ -11977,9 +12856,10 @@ let
   };
 
   Pango = buildPerlPackage rec {
-    name = "Pango-1.227";
+    pname = "Pango";
+    version = "1.227";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/X/XA/XAOC/${name}.tar.gz";
+      url = mirror://cpan/authors/id/X/XA/XAOC/Pango-1.227.tar.gz;
       sha256 = "0wdcidnfnb6nm79fzfs39ivawj3x8m98a147fmcxgv1zvwia9c1l";
     };
     buildInputs = [ pkgs.pango ];
@@ -11992,9 +12872,10 @@ let
   };
 
   ParallelForkManager = buildPerlPackage rec {
-    name = "Parallel-ForkManager-2.02";
+    pname = "Parallel-ForkManager";
+    version = "2.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Y/YA/YANICK/${name}.tar.gz";
+      url = mirror://cpan/authors/id/Y/YA/YANICK/Parallel-ForkManager-2.02.tar.gz;
       sha256 = "c1b2970a8bb666c3de7caac4a8f4dbcc043ab819bbc337692ec7bf27adae4404";
     };
     buildInputs = [ TestWarn ];
@@ -12007,7 +12888,8 @@ let
   };
 
   ParallelPrefork = buildPerlPackage {
-    name = "Parallel-Prefork-0.18";
+    pname = "Parallel-Prefork";
+    version = "0.18";
     src = fetchurl {
       url = mirror://cpan/authors/id/K/KA/KAZUHO/Parallel-Prefork-0.18.tar.gz;
       sha256 = "f1c1f48f1ae147a58bc88f9cb2f570d6bb15ea4c0d589abd4c3084ddc961596e";
@@ -12021,7 +12903,8 @@ let
   };
 
   ParamsClassify = buildPerlModule rec {
-    name = "Params-Classify-0.015";
+    pname = "Params-Classify";
+    version = "0.015";
     src = fetchurl {
       url = mirror://cpan/authors/id/Z/ZE/ZEFRAM/Params-Classify-0.015.tar.gz;
       sha256 = "052r198xyrsv8wz21gijdigz2cgnidsa37nvyfzdiz4rv1fc33ir";
@@ -12029,7 +12912,8 @@ let
   };
 
   ParamsUtil = buildPerlPackage {
-    name = "Params-Util-1.07";
+    pname = "Params-Util";
+    version = "1.07";
     src = fetchurl {
       url = mirror://cpan/authors/id/A/AD/ADAMK/Params-Util-1.07.tar.gz;
       sha256 = "0v67sx93yhn7xa0nh9mnbf8mixf54czk6wzrjsp6dzzr5hzyrw9h";
@@ -12041,9 +12925,10 @@ let
   };
 
   ParamsValidate = buildPerlModule rec {
-    name = "Params-Validate-1.29";
+    pname = "Params-Validate";
+    version = "1.29";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DR/DROLSKY/Params-Validate-1.29.tar.gz;
       sha256 = "49a68dfb430bea028042479111d19068e08095e5a467e320b7ab7bde3d729733";
     };
     buildInputs = [ TestFatal TestRequires ];
@@ -12056,7 +12941,8 @@ let
   };
 
   ParamsValidationCompiler = buildPerlPackage rec {
-     name = "Params-ValidationCompiler-0.30";
+     pname = "Params-ValidationCompiler";
+     version = "0.30";
      src = fetchurl {
        url = mirror://cpan/authors/id/D/DR/DROLSKY/Params-ValidationCompiler-0.30.tar.gz;
        sha256 = "1jqn1l4m4i341g14kmjsf3a1kn7vv6z89cix0xjjgr1v70iywnyw";
@@ -12070,9 +12956,10 @@ let
   };
 
   Paranoid = buildPerlPackage rec {
-    name = "Paranoid-2.07";
+    pname = "Paranoid";
+    version = "2.07";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CO/CORLISS/Paranoid/${name}.tar.gz";
+      url = mirror://cpan/authors/id/C/CO/CORLISS/Paranoid/Paranoid-2.07.tar.gz;
       sha256 = "b55cfd8c6d5f181e218efd012f711a50cd14e4dbc8804650b95477178f43b7fc";
     };
     patches = [ ../development/perl-modules/Paranoid-blessed-path.patch ];
@@ -12089,7 +12976,8 @@ let
   };
 
   PARDist = buildPerlPackage {
-    name = "PAR-Dist-0.49";
+    pname = "PAR-Dist";
+    version = "0.49";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RS/RSCHUPP/PAR-Dist-0.49.tar.gz;
       sha256 = "078ycyn8pw3rba4k3qwcqrqfcym5c1pivymwa0bvs9sab45j4iwy";
@@ -12100,7 +12988,8 @@ let
   };
 
   PAUSEPermissions = buildPerlPackage rec {
-     name = "PAUSE-Permissions-0.17";
+     pname = "PAUSE-Permissions";
+     version = "0.17";
      src = fetchurl {
        url = mirror://cpan/authors/id/N/NE/NEILB/PAUSE-Permissions-0.17.tar.gz;
        sha256 = "021ink414w4mdk6rd54cc1f23kfqg0zk4njx4ngr0bw3wc6r4kks";
@@ -12115,7 +13004,8 @@ let
   };
 
   Parent = buildPerlPackage {
-    name = "parent-0.237";
+    pname = "parent";
+    version = "0.237";
     src = fetchurl {
       url = mirror://cpan/authors/id/C/CO/CORION/parent-0.237.tar.gz;
       sha256 = "1bnaadzf51g6zrpq6pvvgds2cc9d4w1vck7sapkd3hb5hmjdk28h";
@@ -12123,9 +13013,10 @@ let
   };
 
   ParseDebControl = buildPerlPackage rec {
-    name = "Parse-DebControl-2.005";
+    pname = "Parse-DebControl";
+    version = "2.005";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JA/JAYBONCI/${name}.tar.gz";
+      url = mirror://cpan/authors/id/J/JA/JAYBONCI/Parse-DebControl-2.005.tar.gz;
       sha256 = "0ad78qri4sg9agghqdm83xsjgks94yvffs23kppy7mqjy8gwwjxn";
     };
     propagatedBuildInputs = [ IOStringy LWP ];
@@ -12135,7 +13026,8 @@ let
   };
 
   ParseLocalDistribution = buildPerlPackage rec {
-     name = "Parse-LocalDistribution-0.19";
+     pname = "Parse-LocalDistribution";
+     version = "0.19";
      src = fetchurl {
        url = mirror://cpan/authors/id/I/IS/ISHIGAKI/Parse-LocalDistribution-0.19.tar.gz;
        sha256 = "17p92nj4k3acrqqjnln1j5x8hbra9jkx5hdcybrq37ld9qnc62vb";
@@ -12149,9 +13041,10 @@ let
   };
 
   ParsePlainConfig = buildPerlPackage rec {
-    name = "Parse-PlainConfig-3.05";
+    pname = "Parse-PlainConfig";
+    version = "3.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CO/CORLISS/Parse-PlainConfig/${name}.tar.gz";
+      url = mirror://cpan/authors/id/C/CO/CORLISS/Parse-PlainConfig/Parse-PlainConfig-3.05.tar.gz;
       sha256 = "6b78a8552398b0d2d7063505c93b3cfed0432c5b2cf6e00b8e51febf411c1efa";
     };
     propagatedBuildInputs = [ ClassEHierarchy Paranoid ];
@@ -12163,7 +13056,8 @@ let
   };
 
   ParsePMFile = buildPerlPackage rec {
-     name = "Parse-PMFile-0.41";
+     pname = "Parse-PMFile";
+     version = "0.41";
      src = fetchurl {
        url = mirror://cpan/authors/id/I/IS/ISHIGAKI/Parse-PMFile-0.41.tar.gz;
        sha256 = "1ffv9msp4xjfaylay2zfqangxhgyr5xk993k5n1k08hh6qagq8df";
@@ -12176,9 +13070,10 @@ let
   };
 
   ParseRecDescent = buildPerlModule rec {
-    name = "Parse-RecDescent-1.967015";
+    pname = "Parse-RecDescent";
+    version = "1.967015";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JT/JTBRAUN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/J/JT/JTBRAUN/Parse-RecDescent-1.967015.tar.gz;
       sha256 = "1943336a4cb54f1788a733f0827c0c55db4310d5eae15e542639c9dd85656e37";
     };
     meta = {
@@ -12188,7 +13083,8 @@ let
   };
 
   ParseSyslog = buildPerlPackage {
-    name = "Parse-Syslog-1.10";
+    pname = "Parse-Syslog";
+    version = "1.10";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DS/DSCHWEI/Parse-Syslog-1.10.tar.gz;
       sha256 = "659a2145441ef36d9835decaf83da308fcd03f49138cb3d90928e8bfc9f139d9";
@@ -12196,7 +13092,8 @@ let
   };
 
   PathClass = buildPerlModule {
-    name = "Path-Class-0.37";
+    pname = "Path-Class";
+    version = "0.37";
     src = fetchurl {
       url = mirror://cpan/authors/id/K/KW/KWILLIAMS/Path-Class-0.37.tar.gz;
       sha256 = "1kj8q8dmd8jci94w5arav59nkp0pkxrkliz4n8n6yf02hsa82iv5";
@@ -12208,7 +13105,8 @@ let
   };
 
   PathTiny = buildPerlPackage {
-    name = "Path-Tiny-0.108";
+    pname = "Path-Tiny";
+    version = "0.108";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DA/DAGOLDEN/Path-Tiny-0.108.tar.gz;
       sha256 = "3c49482be2b3eb7ddd7e73a5b90cff648393f5d5de334ff126ce7a3632723ff5";
@@ -12228,7 +13126,8 @@ let
   };
 
   PathTools = buildPerlPackage {
-    name = "PathTools-3.75";
+    pname = "PathTools";
+    version = "3.75";
     preConfigure = ''
       substituteInPlace Cwd.pm --replace '/usr/bin/pwd' '${pkgs.coreutils}/bin/pwd'
     '';
@@ -12239,7 +13138,8 @@ let
   };
 
   pcscperl = buildPerlPackage {
-    name = "pcsc-perl-1.4.14";
+    pname = "pcsc-perl";
+    version = "1.4.14";
     src = fetchurl {
       url = "mirror://cpan/authors/id/W/WH/WHOM/pcsc-perl-1.4.14.tar.bz2";
       sha256 = "17f6i16jv6ci6459vh6y3sz94vgcvykjjszcl4xsykryakjvf8i7";
@@ -12258,9 +13158,10 @@ let
   };
 
   PDFAPI2 = buildPerlPackage rec {
-    name = "PDF-API2-2.033";
+    pname = "PDF-API2";
+    version = "2.033";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SS/SSIMMS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SS/SSIMMS/PDF-API2-2.033.tar.gz;
       sha256 = "9c0866ec1a3053f73afaca5f5cdbe6925903b4ce606f4bf4ac317731a69d27a0";
     };
     buildInputs = [ TestException TestMemoryCycle ];
@@ -12272,9 +13173,10 @@ let
   };
 
   Pegex = buildPerlPackage rec {
-    name = "Pegex-0.70";
+    pname = "Pegex";
+    version = "0.70";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IN/INGY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/I/IN/INGY/Pegex-0.70.tar.gz;
       sha256 = "fd3521321026048f493a88d43ce4b8e054f5d7acfec6a1db32fcaabe4dfda0fd";
     };
     buildInputs = [ FileShareDirInstall YAMLLibYAML ];
@@ -12304,17 +13206,19 @@ let
   };
 
   Perl5lib = buildPerlPackage rec {
-    name = "perl5lib-1.02";
+    pname = "perl5lib";
+    version = "1.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NO/NOBULL/${name}.tar.gz";
+      url = mirror://cpan/authors/id/N/NO/NOBULL/perl5lib-1.02.tar.gz;
       sha256 = "1b6fgs8wy2a7ff8rr1qdvdghhvlpr1pv760k4i2c8lq1hhjnkf94";
     };
   };
 
   Perlosnames = buildPerlPackage rec {
-    name = "Perl-osnames-0.11";
+    pname = "Perl-osnames";
+    version = "0.11";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PERLANCAR/${name}.tar.gz";
+      url = mirror://cpan/authors/id/P/PE/PERLANCAR/Perl-osnames-0.11.tar.gz;
       sha256 = "fb22a1ed59dc2311f7f1ffca5685d90c0600020467f624f57b4dd3dba5bc659b";
     };
     meta = {
@@ -12324,9 +13228,10 @@ let
   };
 
   PerlCritic = buildPerlModule rec {
-    name = "Perl-Critic-1.132";
+    pname = "Perl-Critic";
+    version = "1.132";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PETDANCE/${name}.tar.gz";
+      url = mirror://cpan/authors/id/P/PE/PETDANCE/Perl-Critic-1.132.tar.gz;
       sha256 = "bcf36e32830373cf1ee35abbe2e20336fbbcad5041c14aad6822ac947be092b1";
     };
     buildInputs = [ TestDeep ];
@@ -12339,17 +13244,19 @@ let
   };
 
   PerlIOeol = buildPerlPackage rec {
-    name = "PerlIO-eol-0.17";
+    pname = "PerlIO-eol";
+    version = "0.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SH/SHLOMIF/PerlIO-eol-0.17.tar.gz;
       sha256 = "1fayp27vcmypqyzcd4003036h3g5zy6jk1ia25frdca58pzcpk6f";
     };
   };
 
   PerlIOutf8_strict = buildPerlPackage rec {
-    name = "PerlIO-utf8_strict-0.007";
+    pname = "PerlIO-utf8_strict";
+    version = "0.007";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/${name}.tar.gz";
+      url = mirror://cpan/authors/id/L/LE/LEONT/PerlIO-utf8_strict-0.007.tar.gz;
       sha256 = "83a33f2fe046cb3ad6afc80790635a423e2c7c6854afacc6998cd46951cc81cb";
     };
     buildInputs = [ TestException ];
@@ -12360,7 +13267,8 @@ let
   };
 
   PerlIOviadynamic = buildPerlPackage {
-    name = "PerlIO-via-dynamic-0.14";
+    pname = "PerlIO-via-dynamic";
+    version = "0.14";
     src = fetchurl {
       url = mirror://cpan/authors/id/A/AL/ALEXMV/PerlIO-via-dynamic-0.14.tar.gz;
       sha256 = "0jbb3xpbqzmr625blvnjszd69l3cwxzi7bhmkj5x48dgv3s7mkca";
@@ -12368,7 +13276,8 @@ let
   };
 
   PerlIOviasymlink = buildPerlPackage {
-    name = "PerlIO-via-symlink-0.05";
+    pname = "PerlIO-via-symlink";
+    version = "0.05";
     src = fetchurl {
       url = mirror://cpan/authors/id/C/CL/CLKAO/PerlIO-via-symlink-0.05.tar.gz;
       sha256 = "0lidddcaz9anddqrpqk4zwm550igv6amdhj86i2jjdka9b1x81s1";
@@ -12384,9 +13293,10 @@ let
   };
 
   PerlIOviaTimeout = buildPerlModule rec {
-    name = "PerlIO-via-Timeout-0.32";
+    pname = "PerlIO-via-Timeout";
+    version = "0.32";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAMS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DA/DAMS/PerlIO-via-Timeout-0.32.tar.gz;
       sha256 = "9278f9ef668850d913d98fa4c0d7e7d667cff3503391f4a4eae73a246f2e7916";
     };
     buildInputs = [ ModuleBuildTiny TestSharedFork TestTCP ];
@@ -12397,9 +13307,10 @@ let
   };
 
   perlldap = buildPerlPackage rec {
-    name = "perl-ldap-0.66";
+    pname = "perl-ldap";
+    version = "0.66";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MARSCHAP/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MA/MARSCHAP/perl-ldap-0.66.tar.gz;
       sha256 = "09263ce6166e80c98d689d41d09995b813389fd069b784601f6dc57f8e2b4102";
     };
     buildInputs = [ TextSoundex ];
@@ -12413,9 +13324,10 @@ let
   };
 
   PerlMagick = buildPerlPackage rec {
-    name = "PerlMagick-6.89-1";
+    pname = "PerlMagick";
+    version = "6.89-1";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JC/JCRISTY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/J/JC/JCRISTY/PerlMagick-6.89-1.tar.gz;
       sha256 = "0n9afy1z5bhf9phrbahnkwhgcmijn8jggpbzwrivw1zhliliiy68";
     };
     buildInputs = [ pkgs.imagemagick ];
@@ -12427,9 +13339,10 @@ let
   };
 
   PerlTidy = buildPerlPackage rec {
-    name = "Perl-Tidy-20181120";
+    pname = "Perl-Tidy";
+    version = "20181120";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHANCOCK/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SH/SHANCOCK/Perl-Tidy-20181120.tar.gz;
       sha256 = "7db0eeb76535a62cbb4e69b6558e0705162d476a654a7a5ec472aa846b8c4569";
     };
     meta = {
@@ -12439,7 +13352,8 @@ let
   };
 
   PHPSerialization = buildPerlPackage {
-    name = "PHP-Serialization-0.34";
+    pname = "PHP-Serialization";
+    version = "0.34";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BO/BOBTFISH/PHP-Serialization-0.34.tar.gz;
       sha256 = "0yphqsgg7zrar2ywk2j2fnjxmi9rq32yf0p5ln8m9fmfx4kd84mr";
@@ -12450,9 +13364,10 @@ let
   };
 
   PkgConfig = buildPerlPackage rec {
-    name = "PkgConfig-0.23026";
+    pname = "PkgConfig";
+    version = "0.23026";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/${name}.tar.gz";
+      url = mirror://cpan/authors/id/P/PL/PLICEASE/PkgConfig-0.23026.tar.gz;
       sha256 = "56c8ad9015af3799b99a21b8790997723406acf479f35d13fe9bf632db2d5c26";
     };
     meta = {
@@ -12463,9 +13378,10 @@ let
   };
 
   Plack = buildPerlPackage rec {
-    name = "Plack-1.0047";
+    pname = "Plack";
+    version = "1.0047";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MI/MIYAGAWA/Plack-1.0047.tar.gz;
       sha256 = "322c93f5acc0a0f0e11fd4a76188f978bdc14338a9f1df3ae535227017046561";
     };
     buildInputs = [ AuthenSimplePasswd CGIEmulatePSGI FileShareDirInstall HTTPRequestAsCGI HTTPServerSimplePSGI IOHandleUtil LWP LWPProtocolhttp10 LogDispatchArray MIMETypes TestMockTimeHiRes TestRequires TestSharedFork TestTCP ];
@@ -12478,7 +13394,8 @@ let
   };
 
   PlackAppProxy = buildPerlPackage rec {
-     name = "Plack-App-Proxy-0.29";
+     pname = "Plack-App-Proxy";
+     version = "0.29";
      src = fetchurl {
        url = mirror://cpan/authors/id/L/LE/LEEDO/Plack-App-Proxy-0.29.tar.gz;
        sha256 = "03x6yb6ykz1ms90jp1s0pq19yplf7wswljvhzqkr16jannfrmah4";
@@ -12492,7 +13409,8 @@ let
   };
 
   PlackMiddlewareAuthDigest = buildPerlModule rec {
-     name = "Plack-Middleware-Auth-Digest-0.05";
+     pname = "Plack-Middleware-Auth-Digest";
+     version = "0.05";
      src = fetchurl {
        url = mirror://cpan/authors/id/M/MI/MIYAGAWA/Plack-Middleware-Auth-Digest-0.05.tar.gz;
        sha256 = "1sqm23kfsl3ac4060zcclc3r86x1vxzhsgvgzg6mxk9njj93zgcs";
@@ -12507,7 +13425,8 @@ let
   };
 
   PlackMiddlewareConsoleLogger = buildPerlModule rec {
-     name = "Plack-Middleware-ConsoleLogger-0.05";
+     pname = "Plack-Middleware-ConsoleLogger";
+     version = "0.05";
      src = fetchurl {
        url = mirror://cpan/authors/id/M/MI/MIYAGAWA/Plack-Middleware-ConsoleLogger-0.05.tar.gz;
        sha256 = "1ngvhwdw9ll4cwnvf0i89ppa9pbyiwng6iba04scrqjda353lrsm";
@@ -12522,9 +13441,10 @@ let
   };
 
   PlackMiddlewareDebug = buildPerlModule rec {
-    name = "Plack-Middleware-Debug-0.17";
+    pname = "Plack-Middleware-Debug";
+    version = "0.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MI/MIYAGAWA/Plack-Middleware-Debug-0.17.tar.gz;
       sha256 = "a30b62f1bb94e641f7b60b5ea5335e140c553b4131ec4003b56db37f47617a26";
     };
     buildInputs = [ ModuleBuildTiny TestRequires ];
@@ -12537,7 +13457,8 @@ let
   };
 
   PlackMiddlewareDeflater = buildPerlPackage rec {
-     name = "Plack-Middleware-Deflater-0.12";
+     pname = "Plack-Middleware-Deflater";
+     version = "0.12";
      src = fetchurl {
        url = mirror://cpan/authors/id/K/KA/KAZEBURO/Plack-Middleware-Deflater-0.12.tar.gz;
        sha256 = "0xf2visi16hgwgyp9q0cjr10ikbn474hjia5mj8mb2scvbkrbni8";
@@ -12551,9 +13472,10 @@ let
   };
 
   PlackMiddlewareFixMissingBodyInRedirect = buildPerlPackage rec {
-    name = "Plack-Middleware-FixMissingBodyInRedirect-0.12";
+    pname = "Plack-Middleware-FixMissingBodyInRedirect";
+    version = "0.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SW/SWEETKID/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SW/SWEETKID/Plack-Middleware-FixMissingBodyInRedirect-0.12.tar.gz;
       sha256 = "6c22d069f5a57ac206d4659b28b8869bb9270640bb955efddd451dcc58cdb391";
     };
     propagatedBuildInputs = [ HTMLParser Plack ];
@@ -12565,7 +13487,8 @@ let
   };
 
   PlackMiddlewareHeader = buildPerlPackage rec {
-     name = "Plack-Middleware-Header-0.04";
+     pname = "Plack-Middleware-Header";
+     version = "0.04";
      src = fetchurl {
        url = mirror://cpan/authors/id/C/CH/CHIBA/Plack-Middleware-Header-0.04.tar.gz;
        sha256 = "0pjxxbnilphn38s3mmv0fmg9q2hm4z02ngp2a1lxblzjfbzvkdjy";
@@ -12578,7 +13501,8 @@ let
   };
 
   PlackMiddlewareMethodOverride = buildPerlPackage rec {
-    name = "Plack-Middleware-MethodOverride-0.20";
+    pname = "Plack-Middleware-MethodOverride";
+    version = "0.20";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MI/MIYAGAWA/Plack-Middleware-MethodOverride-0.20.tar.gz;
       sha256 = "dbfb5a2efb48bfeb01cb3ae1e1c677e155dc7bfe210c7e7f221bae3cb6aab5f1";
@@ -12591,7 +13515,8 @@ let
   };
 
   PlackMiddlewareRemoveRedundantBody = buildPerlPackage {
-    name = "Plack-Middleware-RemoveRedundantBody-0.07";
+    pname = "Plack-Middleware-RemoveRedundantBody";
+    version = "0.07";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SW/SWEETKID/Plack-Middleware-RemoveRedundantBody-0.07.tar.gz;
       sha256 = "64b841d5d74b4c4a595b85749d69297f4f5f5c0829a6e99e0099f05dd69be3c3";
@@ -12605,7 +13530,8 @@ let
   };
 
   PlackMiddlewareReverseProxy = buildPerlPackage {
-    name = "Plack-Middleware-ReverseProxy-0.16";
+    pname = "Plack-Middleware-ReverseProxy";
+    version = "0.16";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MI/MIYAGAWA/Plack-Middleware-ReverseProxy-0.16.tar.gz;
       sha256 = "0a512n62pnk5ayj3zdzyj50iy1qi8nwh6ygks2h7nrh7gp9k2jc7";
@@ -12618,7 +13544,8 @@ let
   };
 
   PlackMiddlewareSession = buildPerlModule rec {
-     name = "Plack-Middleware-Session-0.33";
+     pname = "Plack-Middleware-Session";
+     version = "0.33";
      src = fetchurl {
        url = mirror://cpan/authors/id/M/MI/MIYAGAWA/Plack-Middleware-Session-0.33.tar.gz;
        sha256 = "1vm4a66civdzh7xvl5hy5wn1w8j1vndppwyz8ndh9n4as74s5yag";
@@ -12633,9 +13560,10 @@ let
   };
 
   PlackTestExternalServer = buildPerlPackage rec {
-    name = "Plack-Test-ExternalServer-0.02";
+    pname = "Plack-Test-ExternalServer";
+    version = "0.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/E/ET/ETHER/Plack-Test-ExternalServer-0.02.tar.gz;
       sha256 = "5baf5c57fe0c06412deec9c5abe7952ab8a04f8c47b4bbd8e9e9982268903ed0";
     };
     buildInputs = [ Plack TestSharedFork TestTCP ];
@@ -12678,7 +13606,8 @@ let
   };
 
   POE = buildPerlPackage rec {
-    name = "POE-1.367";
+    pname = "POE";
+    version = "1.367";
     patches = [
       ../development/perl-modules/perl-POE-1.367-pod_linkcheck.patch
       ../development/perl-modules/perl-POE-1.367-pod_no404s.patch
@@ -12715,9 +13644,10 @@ let
   };
 
   POETestLoops = buildPerlPackage rec {
-    name = "POE-Test-Loops-1.360";
+    pname = "POE-Test-Loops";
+    version = "1.360";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RC/RCAPUTO/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RC/RCAPUTO/POE-Test-Loops-1.360.tar.gz;
       sha256 = "0yx4wsljfmdzsiv0ni98x6lw975cm82ahngbwqvzv60wx5pwkl5y";
     };
     meta = {
@@ -12749,7 +13679,8 @@ let
   };
 
   PPIxQuoteLike = buildPerlModule rec {
-    name = "PPIx-QuoteLike-0.006";
+    pname = "PPIx-QuoteLike";
+    version = "0.006";
     src = fetchurl {
       url = mirror://cpan/authors/id/W/WY/WYANT/PPIx-QuoteLike-0.006.tar.gz;
       sha256 = "1gyp3ywnhpv7k3cqdgywpinz7wgqzg38iailcnyiwgl62wib0bsq";
@@ -12762,12 +13693,13 @@ let
   };
 
   PPIxRegexp = buildPerlModule rec {
-    name = "PPIx-Regexp-0.064";
+    pname = "PPIx-Regexp";
+    version = "0.064";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/W/WY/WYANT/${name}.tar.gz";
+      url = mirror://cpan/authors/id/W/WY/WYANT/PPIx-Regexp-0.064.tar.gz;
       sha256 = "8769c634294c941f83b5a7e74a14eda3671c1fa131b8d6416e7fc77f7cd57408";
     };
-    propagatedBuildInputs = [ PPI ];
+    propagatedBuildInputs = [ ListMoreUtils PPI ];
     meta = {
       description = "Parse regular expressions";
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];
@@ -12775,7 +13707,8 @@ let
   };
 
   PPIxUtilities = buildPerlModule {
-    name = "PPIx-Utilities-1.001000";
+    pname = "PPIx-Utilities";
+    version = "1.001000";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/EL/ELLIOTJS/PPIx-Utilities-1.001000.tar.gz;
       sha256 = "03a483386fd6a2c808f09778d44db06b02c3140fb24ba4bf12f851f46d3bcb9b";
@@ -12789,9 +13722,10 @@ let
   };
 
   ProcBackground = buildPerlPackage rec {
-    name = "Proc-Background-1.10";
+    pname = "Proc-Background";
+    version = "1.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BZ/BZAJAC/${name}.tar.gz";
+      url = mirror://cpan/authors/id/B/BZ/BZAJAC/Proc-Background-1.10.tar.gz;
       sha256 = "1ce0dd78c0bb8393a2431b385a27b99fcc623a41ebec57b3cc09cc38cdb708ee";
     };
     meta = {
@@ -12799,7 +13733,8 @@ let
   };
 
   ProcProcessTable = buildPerlPackage {
-    name = "Proc-ProcessTable-0.56";
+    pname = "Proc-ProcessTable";
+    version = "0.56";
     src = fetchurl {
       url = mirror://cpan/authors/id/J/JW/JWB/Proc-ProcessTable-0.56.tar.gz;
       sha256 = "99fb8fd11e4e438399dd362d95b5b2073f1f340e9b3a7f04e76b6c7428170660";
@@ -12811,9 +13746,10 @@ let
   };
 
   ProcFind = buildPerlPackage rec {
-    name = "Proc-Find-0.04";
+    pname = "Proc-Find";
+    version = "0.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PERLANCAR/${name}.tar.gz";
+      url = mirror://cpan/authors/id/P/PE/PERLANCAR/Proc-Find-0.04.tar.gz;
       sha256 = "07d715c2b8644dc6d5b5a36ffcd2f02da017bf86a00027387aa47c53e2347a81";
     };
     buildInputs = [ Perlosnames ];
@@ -12825,7 +13761,8 @@ let
   };
 
   ProcSafeExec = buildPerlPackage {
-    name = "Proc-SafeExec-1.5";
+    pname = "Proc-SafeExec";
+    version = "1.5";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BI/BILBO/Proc-SafeExec-1.5.tar.gz;
       sha256 = "1b4d0908bcac563d34a7e5be61c5da3eee98e4a6c7fa68c2670cc5844b5a2d78";
@@ -12833,9 +13770,10 @@ let
   };
 
   ProcSimple = buildPerlPackage rec {
-    name = "Proc-Simple-1.32";
+    pname = "Proc-Simple";
+    version = "1.32";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MS/MSCHILLI/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MS/MSCHILLI/Proc-Simple-1.32.tar.gz;
       sha256 = "4c8f0a924b19ad78a13da73fe0fb306d32a7b9d10a332c523087fc83a209a8c4";
     };
     meta = {
@@ -12844,7 +13782,8 @@ let
   };
 
   ProcWait3 = buildPerlPackage {
-    name = "Proc-Wait3-0.05";
+    pname = "Proc-Wait3";
+    version = "0.05";
     src = fetchurl {
       url = mirror://cpan/authors/id/C/CT/CTILMES/Proc-Wait3-0.05.tar.gz;
       sha256 = "1a907f5db6933dc2939bbfeffe19eeae7ed39ef1b97a2bc9b723f2f25f81caf3";
@@ -12856,7 +13795,8 @@ let
   };
 
   ProcWaitStat = buildPerlPackage rec {
-    name = "Proc-WaitStat-1.00";
+    pname = "Proc-WaitStat";
+    version = "1.00";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RO/ROSCH/Proc-WaitStat-1.00.tar.gz;
       sha256 = "1g3l8jzx06x4l4p0x7fyn4wvg6plfzl420irwwb9v447wzsn6xfh";
@@ -12865,52 +13805,58 @@ let
   };
 
   ProtocolWebSocket = buildPerlModule rec {
-    name = "Protocol-WebSocket-0.26";
+    pname = "Protocol-WebSocket";
+    version = "0.26";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/V/VT/VTI/${name}.tar.gz";
+      url = mirror://cpan/authors/id/V/VT/VTI/Protocol-WebSocket-0.26.tar.gz;
       sha256 = "08jmazvrmvp8jn15p2n3c1h3f2cbkr07xjzy197jb8x724vx0dsq";
     };
     buildInputs = [ ModuleBuildTiny ];
   };
 
   ProtocolHTTP2 = buildPerlModule rec {
-    name = "Protocol-HTTP2-1.09";
+    pname = "Protocol-HTTP2";
+    version = "1.09";
 
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CR/CRUX/${name}.tar.gz";
+      url = mirror://cpan/authors/id/C/CR/CRUX/Protocol-HTTP2-1.09.tar.gz;
       sha256 = "1bc0ybkqhv81dscgzlbr62w4zqjsidcikmkbjanzn83g2b6ia9nc";
     };
     buildInputs = [ AnyEvent ModuleBuildTiny NetSSLeay TestLeakTrace TestSharedFork TestTCP ];
   };
 
   PSGI = buildPerlPackage rec {
-    name = "PSGI-1.102";
+    pname = "PSGI";
+    version = "1.102";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MI/MIYAGAWA/PSGI-1.102.tar.gz;
       sha256 = "0iqzxs8fv63510knm3zr3jr3ky4x7diwd7y24mlshzci81kl8v55";
     };
   };
 
   PadWalker = buildPerlPackage rec {
-    name = "PadWalker-2.3";
+    pname = "PadWalker";
+    version = "2.3";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RO/ROBIN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RO/ROBIN/PadWalker-2.3.tar.gz;
       sha256 = "2a6c44fb600861e54568e74081a8d1f121f0060076069ceab34b1ae89d6588cf";
     };
   };
 
   Perl6Junction = buildPerlPackage rec {
-    name = "Perl6-Junction-1.60000";
+    pname = "Perl6-Junction";
+    version = "1.60000";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CF/CFRANKS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/C/CF/CFRANKS/Perl6-Junction-1.60000.tar.gz;
       sha256 = "0r3in9pyrm6wfrhcvxbq5w1617x8x5537lxj9hdzks4pa7l7a8yh";
     };
   };
 
   PerlMinimumVersion = buildPerlPackage rec {
-    name = "Perl-MinimumVersion-1.38";
+    pname = "Perl-MinimumVersion";
+    version = "1.38";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/${name}.tar.gz";
+      url = mirror://cpan/authors/id/N/NE/NEILB/Perl-MinimumVersion-1.38.tar.gz;
       sha256 = "478b5824791b87fc74c94a892180682bd06ad2cdf34034b1a4b859273927802a";
     };
     buildInputs = [ TestScript ];
@@ -12923,12 +13869,13 @@ let
   };
 
   PerlPrereqScanner = buildPerlPackage rec {
-    name = "Perl-PrereqScanner-1.023";
+    pname = "Perl-PrereqScanner";
+    version = "1.023";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RJ/RJBS/Perl-PrereqScanner-1.023.tar.gz;
       sha256 = "280a1c4710390865fb9f310a861a34720b28b4cbe50609c841af5cf2d3a2bced";
     };
-    propagatedBuildInputs = [ GetoptLongDescriptive ModulePath Moose PPI StringRewritePrefix namespaceautoclean ];
+    propagatedBuildInputs = [ GetoptLongDescriptive ListMoreUtils ModulePath Moose PPI StringRewritePrefix namespaceautoclean ];
     meta = {
       homepage = https://github.com/rjbs/Perl-PrereqScanner;
       description = "A tool to scan your Perl code for its prerequisites";
@@ -12952,9 +13899,10 @@ let
   };
 
   PerlVersion = buildPerlPackage rec {
-    name = "Perl-Version-1.013";
+    pname = "Perl-Version";
+    version = "1.013";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BD/BDFOY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/B/BD/BDFOY/Perl-Version-1.013.tar.gz;
       sha256 = "1887414d1c8689d864c840114101e043e99d7dd5b9cca69369a60e821e3ad0f7";
     };
     propagatedBuildInputs = [ FileSlurpTiny ];
@@ -12965,7 +13913,8 @@ let
   };
 
   PodChecker = buildPerlPackage {
-    name = "Pod-Checker-1.73";
+    pname = "Pod-Checker";
+    version = "1.73";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MA/MAREKR/Pod-Checker-1.73.tar.gz;
       sha256 = "7dee443b03d80d0735ec50b6d1caf0209c51ab0a97d64050cfc10e1555cb9305";
@@ -12973,16 +13922,18 @@ let
   };
 
   PodCoverage = buildPerlPackage rec {
-    name = "Pod-Coverage-0.23";
+    pname = "Pod-Coverage";
+    version = "0.23";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RC/RCLAMP/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RC/RCLAMP/Pod-Coverage-0.23.tar.gz;
       sha256 = "01xifj83dv492lxixijmg6va02rf3ydlxly0a9slmx22r6qa1drh";
     };
     propagatedBuildInputs = [ DevelSymdump ];
   };
 
   PodCoverageTrustPod = buildPerlPackage {
-    name = "Pod-Coverage-TrustPod-0.100005";
+    pname = "Pod-Coverage-TrustPod";
+    version = "0.100005";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RJ/RJBS/Pod-Coverage-TrustPod-0.100005.tar.gz;
       sha256 = "08bk6lfimr2pwi6c92xg5cw1cxmi5fqhls3yasqzpjnd4if86s3c";
@@ -12996,9 +13947,10 @@ let
   };
 
   PodElemental = buildPerlPackage rec {
-    name = "Pod-Elemental-0.103004";
+    pname = "Pod-Elemental";
+    version = "0.103004";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RJ/RJBS/Pod-Elemental-0.103004.tar.gz;
       sha256 = "43625cde7241fb174ad9c7eb45387fba410dc141d7de2323855eeab3590072c9";
     };
     buildInputs = [ TestDeep TestDifferences ];
@@ -13011,9 +13963,10 @@ let
   };
 
   PodElementalPerlMunger = buildPerlPackage rec {
-    name = "Pod-Elemental-PerlMunger-0.200006";
+    pname = "Pod-Elemental-PerlMunger";
+    version = "0.200006";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RJ/RJBS/Pod-Elemental-PerlMunger-0.200006.tar.gz;
       sha256 = "09fd3b5d53119437a01dced66b42eafdcd53895b3c32a2b0f781f36fda0f665b";
     };
     buildInputs = [ TestDifferences ];
@@ -13026,7 +13979,8 @@ let
   };
 
   PodEventual = buildPerlPackage {
-    name = "Pod-Eventual-0.094001";
+    pname = "Pod-Eventual";
+    version = "0.094001";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RJ/RJBS/Pod-Eventual-0.094001.tar.gz;
       sha256 = "be9fb8910b108e5d1a66f002b659ad22576e88d779b703dff9d15122c3f80834";
@@ -13040,7 +13994,8 @@ let
   };
 
   PodParser = buildPerlPackage {
-    name = "Pod-Parser-1.63";
+    pname = "Pod-Parser";
+    version = "1.63";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MA/MAREKR/Pod-Parser-1.63.tar.gz;
       sha256 = "dbe0b56129975b2f83a02841e8e0ed47be80f060686c66ea37e529d97aa70ccd";
@@ -13052,9 +14007,10 @@ let
   };
 
   PodPOM = buildPerlPackage rec {
-    name = "Pod-POM-2.01";
+    pname = "Pod-POM";
+    version = "2.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/${name}.tar.gz";
+      url = mirror://cpan/authors/id/N/NE/NEILB/Pod-POM-2.01.tar.gz;
       sha256 = "1b50fba9bbdde3ead192beeba0eaddd0c614e3afb1743fa6fff805f57c56f7f4";
     };
     buildInputs = [ FileSlurper TestDifferences TextDiff ];
@@ -13066,9 +14022,10 @@ let
   };
 
   PodPOMViewTOC = buildPerlPackage rec {
-    name = "Pod-POM-View-TOC-0.02";
+    pname = "Pod-POM-View-TOC";
+    version = "0.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PERLER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/P/PE/PERLER/Pod-POM-View-TOC-0.02.tar.gz;
       sha256 = "ccb42272c7503379cb1131394620ee50276d72844e0e80eb4b007a9d58f87623";
     };
     propagatedBuildInputs = [ PodPOM ];
@@ -13079,9 +14036,10 @@ let
   };
 
   PodLaTeX = buildPerlModule rec {
-    name = "Pod-LaTeX-0.61";
+    pname = "Pod-LaTeX";
+    version = "0.61";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TJ/TJENNESS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/T/TJ/TJENNESS/Pod-LaTeX-0.61.tar.gz;
       sha256 = "15a840ea1c8a76cd3c865fbbf2fec33b03615c0daa50f9c800c54e0cf0659d46";
     };
     meta = {
@@ -13092,9 +14050,10 @@ let
   };
 
   podlators = buildPerlPackage rec {
-    name = "podlators-4.10";
+    pname = "podlators";
+    version = "4.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RR/RRA/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RR/RRA/podlators-4.10.tar.gz;
       sha256 = "008b4j41ijrfyyq5nd3y7pqyww6rg49fjg2c6kmpnqrmgs347qqp";
     };
     meta = {
@@ -13104,9 +14063,10 @@ let
   };
 
   podlinkcheck = buildPerlPackage rec {
-    name = "podlinkcheck-15";
+    pname = "podlinkcheck";
+    version = "15";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KR/KRYDE/${name}.tar.gz";
+      url = mirror://cpan/authors/id/K/KR/KRYDE/podlinkcheck-15.tar.gz;
       sha256 = "4e3bebec1bf82dbf850a94ae26a253644cf5806ec41afc74e43e1710a37321db";
     };
     propagatedBuildInputs = [ FileFindIterator FileHomeDir IPCRun constant-defer libintl_perl ];
@@ -13118,7 +14078,8 @@ let
   };
 
   prefork = buildPerlPackage {
-    name = "prefork-1.05";
+    pname = "prefork";
+    version = "1.05";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/prefork-1.05.tar.gz;
       sha256 = "01ckn45ij3nbrsc0yc4wl4z0wndn36jh6247zbycwa1vlvgvr1vd";
@@ -13130,9 +14091,10 @@ let
   };
 
   PodPerldoc = buildPerlPackage rec {
-    name = "Pod-Perldoc-3.28";
+    pname = "Pod-Perldoc";
+    version = "3.28";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MALLEN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MA/MALLEN/Pod-Perldoc-3.28.tar.gz;
       sha256 = "0kf6xwdha8jl0nxv60r2v7xsfnvv6i3gy135xsl40g71p02ychfc";
     };
     meta = {
@@ -13142,7 +14104,8 @@ let
   };
 
   PodPlainer = buildPerlPackage {
-    name = "Pod-Plainer-1.04";
+    pname = "Pod-Plainer";
+    version = "1.04";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RM/RMBARKER/Pod-Plainer-1.04.tar.gz;
       sha256 = "1bbfbf7d1d4871e5a83bab2137e22d089078206815190eb1d5c1260a3499456f";
@@ -13154,7 +14117,8 @@ let
   };
 
   PodMarkdown = buildPerlPackage {
-    name = "Pod-Markdown-3.101";
+    pname = "Pod-Markdown";
+    version = "3.101";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RW/RWSTAUNER/Pod-Markdown-3.101.tar.gz;
       sha256 = "0h7hx4k1c3k00cfnlf226bkxnxaz01705m10vxm9cxh52xn6pzz8";
@@ -13168,7 +14132,8 @@ let
   };
 
   PodMarkdownGithub = buildPerlPackage rec {
-     name = "Pod-Markdown-Github-0.04";
+     pname = "Pod-Markdown-Github";
+     version = "0.04";
      src = fetchurl {
        url = mirror://cpan/authors/id/M/MI/MINIMAL/Pod-Markdown-Github-0.04.tar.gz;
        sha256 = "04y67c50hpf1vb9cwsza3fbj4rshdqa47vi3zcj4kkjckh02yzmk";
@@ -13182,7 +14147,8 @@ let
   };
 
   PodSimple = buildPerlPackage {
-    name = "Pod-Simple-3.35";
+    pname = "Pod-Simple";
+    version = "3.35";
     src = fetchurl {
       url = mirror://cpan/authors/id/K/KH/KHW/Pod-Simple-3.35.tar.gz;
       sha256 = "0gg11ibbc02l2aw0bsv4jx0jax8z0apgfy3p5csqnvhlsb6218cr";
@@ -13190,7 +14156,8 @@ let
   };
 
   PodSpell = buildPerlPackage rec {
-    name = "Pod-Spell-1.20";
+    pname = "Pod-Spell";
+    version = "1.20";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DO/DOLMEN/Pod-Spell-1.20.tar.gz;
       sha256 = "6383f7bfe22bc0d839a08057a0ce780698b046184aea935be4833d94986dd03c";
@@ -13200,7 +14167,8 @@ let
   };
 
   PodStrip = buildPerlModule rec {
-     name = "Pod-Strip-1.02";
+     pname = "Pod-Strip";
+     version = "1.02";
      src = fetchurl {
        url = mirror://cpan/authors/id/D/DO/DOMM/Pod-Strip-1.02.tar.gz;
        sha256 = "1zsjfw2cjq1bd3ppl67fdvrx46vj9lina0c3cv9qgk5clzvaq3fq";
@@ -13212,7 +14180,8 @@ let
   };
 
   PodTidy = buildPerlModule rec {
-     name = "Pod-Tidy-0.10";
+     pname = "Pod-Tidy";
+     version = "0.10";
      src = fetchurl {
        url = mirror://cpan/authors/id/J/JH/JHOBLITT/Pod-Tidy-0.10.tar.gz;
        sha256 = "1gcxjplgksnc5iggi8dzbkbkcryii5wjhypd7fs3kmbwx91y2vl8";
@@ -13226,9 +14195,10 @@ let
   };
 
   PodWeaver = buildPerlPackage rec {
-    name = "Pod-Weaver-4.015";
+    pname = "Pod-Weaver";
+    version = "4.015";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RJ/RJBS/Pod-Weaver-4.015.tar.gz;
       sha256 = "5af25b29a55783e495a9df5ef6293240e2c9ab02764613d79f1ed50b12dec5ae";
     };
     buildInputs = [ PPI SoftwareLicense TestDifferences ];
@@ -13241,7 +14211,8 @@ let
   };
 
   PodWrap = buildPerlModule rec {
-     name = "Pod-Wrap-0.01";
+     pname = "Pod-Wrap";
+     version = "0.01";
      src = fetchurl {
        url = mirror://cpan/authors/id/N/NU/NUFFIN/Pod-Wrap-0.01.tar.gz;
        sha256 = "0qwb5hp26f85xnb3zivf8ccfdplabiyl5sd53c6wgdgvzzicpjjh";
@@ -13252,17 +14223,19 @@ let
   };
 
   ProbePerl = buildPerlPackage rec {
-    name = "Probe-Perl-0.03";
+    pname = "Probe-Perl";
+    version = "0.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KW/KWILLIAMS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/K/KW/KWILLIAMS/Probe-Perl-0.03.tar.gz;
       sha256 = "0c9wiaz0mqqknafr4jdr0g2gdzxnn539182z0icqaqvp5qgd5r6r";
     };
   };
 
   POSIXstrftimeCompiler = buildPerlModule rec {
-    name = "POSIX-strftime-Compiler-0.42";
+    pname = "POSIX-strftime-Compiler";
+    version = "0.42";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KA/KAZEBURO/${name}.tar.gz";
+      url = mirror://cpan/authors/id/K/KA/KAZEBURO/POSIX-strftime-Compiler-0.42.tar.gz;
       sha256 = "26582bdd78b254bcc1c56d0b770fa280e8b8f70957c84dc44572ba4cacb0ac11";
     };
     # We cannot change timezones on the fly.
@@ -13275,9 +14248,10 @@ let
   };
 
   Razor2ClientAgent = buildPerlPackage rec {
-    name = "Razor2-Client-Agent-2.84";
+    pname = "Razor2-Client-Agent";
+    version = "2.84";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TODDR/${name}.tar.gz";
+      url = mirror://cpan/authors/id/T/TO/TODDR/Razor2-Client-Agent-2.84.tar.gz;
       sha256 = "d7c2ed7f347a673b1425e4da7656073d6c52847bc7403bf57e3a404b52f7e501";
     };
     propagatedBuildInputs = [ DigestSHA1 URI ];
@@ -13290,9 +14264,10 @@ let
 
 
   Readonly = buildPerlModule rec {
-    name = "Readonly-2.05";
+    pname = "Readonly";
+    version = "2.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SA/SANKO/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SA/SANKO/Readonly-2.05.tar.gz;
       sha256 = "4b23542491af010d44a5c7c861244738acc74ababae6b8838d354dfb19462b5e";
     };
     buildInputs = [ ModuleBuildTiny ];
@@ -13304,18 +14279,20 @@ let
   };
 
   ReadonlyXS = buildPerlPackage rec {
-    name = "Readonly-XS-1.05";
+    pname = "Readonly-XS";
+    version = "1.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RO/ROODE/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RO/ROODE/Readonly-XS-1.05.tar.gz;
       sha256 = "8ae5c4e85299e5c8bddd1b196f2eea38f00709e0dc0cb60454dc9114ae3fff0d";
     };
     propagatedBuildInputs = [ Readonly ];
   };
 
   Redis = buildPerlModule rec {
-    name = "Redis-1.991";
+    pname = "Redis";
+    version = "1.991";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAMS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DA/DAMS/Redis-1.991.tar.gz;
       sha256 = "f7d1a934fa9360a26e480f896f97be0fd62807f9d9baca65a9aa8d007ff2acaa";
     };
     buildInputs = [ IOString ModuleBuildTiny PodCoverageTrustPod TestCPANMeta TestDeep TestFatal TestSharedFork TestTCP ];
@@ -13328,7 +14305,8 @@ let
   };
 
   RefUtil = buildPerlPackage {
-    name = "Ref-Util-0.204";
+    pname = "Ref-Util";
+    version = "0.204";
     src = fetchurl {
       url = mirror://cpan/authors/id/A/AR/ARC/Ref-Util-0.204.tar.gz;
       sha256 = "1q85y5lzgl8wz5qnz3j6mch2fmllr668h54wszaz6i6gp8ysfps1";
@@ -13340,7 +14318,8 @@ let
   };
 
   RegexpAssemble = buildPerlPackage rec {
-    name = "Regexp-Assemble-0.38";
+    pname = "Regexp-Assemble";
+    version = "0.38";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RS/RSAVAGE/Regexp-Assemble-0.38.tgz;
       sha256 = "0hp4v8mghmpflq9l9fqrkjg4cw0d3ha2nrmnsnzwjwqvmvwyfsx0";
@@ -13348,7 +14327,8 @@ let
   };
 
   RegexpCommon = buildPerlPackage {
-    name = "Regexp-Common-2017060201";
+    pname = "Regexp-Common";
+    version = "2017060201";
     src = fetchurl {
       url = mirror://cpan/authors/id/A/AB/ABIGAIL/Regexp-Common-2017060201.tar.gz;
       sha256 = "ee07853aee06f310e040b6bf1a0199a18d81896d3219b9b35c9630d0eb69089b";
@@ -13360,7 +14340,8 @@ let
   };
 
   RegexpCommonnetCIDR = buildPerlPackage {
-    name = "Regexp-Common-net-CIDR-0.03";
+    pname = "Regexp-Common-net-CIDR";
+    version = "0.03";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BP/BPS/Regexp-Common-net-CIDR-0.03.tar.gz;
       sha256 = "39606a57aab20d4f4468300f2ec3fa2ab557fcc9cb7880ec7c6e07d80162da33";
@@ -13385,7 +14366,8 @@ let
   };
 
   RegexpIPv6 = buildPerlPackage {
-    name = "Regexp-IPv6-0.03";
+    pname = "Regexp-IPv6";
+    version = "0.03";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SA/SALVA/Regexp-IPv6-0.03.tar.gz;
       sha256 = "d542d17d75ce93631de8ba2156da0e0b58a755c409cd4a0d27a3873a26712ce2";
@@ -13393,7 +14375,8 @@ let
   };
 
   RegexpParser = buildPerlPackage {
-    name = "Regexp-Parser-0.22";
+    pname = "Regexp-Parser";
+    version = "0.22";
     src = fetchurl {
       url = mirror://cpan/authors/id/T/TO/TODDR/Regexp-Parser-0.22.tar.gz;
       sha256 = "d6d3c711657a380f1cb24d8b54a1cd20f725f7f54665189e9e67bb0b877109a3";
@@ -13406,7 +14389,8 @@ let
   };
 
   RegexpTrie = buildPerlPackage {
-    name = "Regexp-Trie-0.02";
+    pname = "Regexp-Trie";
+    version = "0.02";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DA/DANKOGAI/Regexp-Trie-0.02.tar.gz;
       sha256 = "1yn5l6x3xyic9jxw9jggqsbggcv7rc8ggj4zbnlz9hfvv17gjazv";
@@ -13416,9 +14400,10 @@ let
   };
 
   RESTClient = buildPerlPackage rec {
-    name = "REST-Client-273";
+    pname = "REST-Client";
+    version = "273";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KK/KKANE/${name}.tar.gz";
+      url = mirror://cpan/authors/id/K/KK/KKANE/REST-Client-273.tar.gz;
       sha256 = "a8652a2214308faff2c68be5ce64c904dcccc5e86be7f32376c1590869d01844";
     };
     propagatedBuildInputs = [ LWPProtocolHttps ];
@@ -13429,7 +14414,8 @@ let
   };
 
   RESTUtils = buildPerlModule {
-    name = "REST-Utils-0.6";
+    pname = "REST-Utils";
+    version = "0.6";
     src = fetchurl {
       url = mirror://cpan/authors/id/J/JA/JALDHAR/REST-Utils-0.6.tar.gz;
       sha256 = "1zdrf3315rp2b8r9dwwj5h93xky7i33iawf4hzszwcddhzflmsfl";
@@ -13443,7 +14429,8 @@ let
   };
 
   RpcXML = buildPerlPackage {
-    name = "RPC-XML-0.80";
+    pname = "RPC-XML";
+    version = "0.80";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RJ/RJRAY/RPC-XML-0.80.tar.gz;
       sha256 = "1xvy9hs7bqsjnk0663kf7zk2qjg0pzv96n6z2wlc2w5bgal7q3ga";
@@ -13453,7 +14440,8 @@ let
   };
 
   ReturnValue = buildPerlPackage {
-    name = "Return-Value-1.666005";
+    pname = "Return-Value";
+    version = "1.666005";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RJ/RJBS/Return-Value-1.666005.tar.gz;
       sha256 = "1b2hfmdl19zi1z3npzv9wf6dh1g0xd88i70b4233ds9icnln08lf";
@@ -13461,7 +14449,8 @@ let
   };
 
   RoleBasic = buildPerlModule {
-    name = "Role-Basic-0.13";
+    pname = "Role-Basic";
+    version = "0.13";
     src = fetchurl {
       url = mirror://cpan/authors/id/O/OV/OVID/Role-Basic-0.13.tar.gz;
       sha256 = "38a0959ef9f193ff76e72c325a9e9211bc4868689bd0e2b005778f53f8b6f36a";
@@ -13473,7 +14462,8 @@ let
   };
 
   RoleHasMessage = buildPerlPackage {
-    name = "Role-HasMessage-0.006";
+    pname = "Role-HasMessage";
+    version = "0.006";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RJ/RJBS/Role-HasMessage-0.006.tar.gz;
       sha256 = "1lylfvarjfy6wy34dfny3032pc6r33mjby5yzzhmxybg8zhdp9pn";
@@ -13486,7 +14476,8 @@ let
   };
 
   RoleIdentifiable = buildPerlPackage {
-    name = "Role-Identifiable-0.007";
+    pname = "Role-Identifiable";
+    version = "0.007";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RJ/RJBS/Role-Identifiable-0.007.tar.gz;
       sha256 = "1bbkj2wqpbfdw1cbm99vg9d94rvzba19m18xhnylaym0l78lc4sn";
@@ -13499,9 +14490,10 @@ let
   };
 
   RoleTiny = buildPerlPackage rec {
-    name = "Role-Tiny-2.000006";
+    pname = "Role-Tiny";
+    version = "2.000006";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/${name}.tar.gz";
+      url = mirror://cpan/authors/id/H/HA/HAARG/Role-Tiny-2.000006.tar.gz;
       sha256 = "cc73418c904a0286ecd8915eac11f5be2a8d1e17ea9cb54c9116b0340cd3e382";
     };
     meta = {
@@ -13511,7 +14503,8 @@ let
   };
 
   RSSParserLite = buildPerlPackage {
-    name = "RSS-Parser-Lite-0.12";
+    pname = "RSS-Parser-Lite";
+    version = "0.12";
     src = fetchurl {
       url = mirror://cpan/authors/id/T/TF/TFPBL/RSS-Parser-Lite-0.12.tar.gz;
       sha256 = "1fcmp4qp7q3xr2mw7clqqwph45icbvgfs2n41gp9zamim2y39p49";
@@ -13521,7 +14514,8 @@ let
   };
 
   RTClientREST = buildPerlModule {
-    name = "RT-Client-REST-0.56";
+    pname = "RT-Client-REST";
+    version = "0.56";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DJ/DJZORT/RT-Client-REST-0.56.tar.gz;
       sha256 = "798baccf11eaecbb7d2d27be0b5e4fa9cb80b34cc51cab12eb7b88facf39fd4b";
@@ -13535,7 +14529,8 @@ let
   };
 
   SafeIsa = buildPerlPackage {
-    name = "Safe-Isa-1.000010";
+    pname = "Safe-Isa";
+    version = "1.000010";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/Safe-Isa-1.000010.tar.gz;
       sha256 = "0sm6p1kw98s7j6n92vvxjqf818xggnmjwci34xjmw7gzl2519x47";
@@ -13547,7 +14542,8 @@ let
   };
 
   ScalarListUtils = buildPerlPackage {
-    name = "Scalar-List-Utils-1.50";
+    pname = "Scalar-List-Utils";
+    version = "1.50";
     src = fetchurl {
       url = mirror://cpan/authors/id/P/PE/PEVANS/Scalar-List-Utils-1.50.tar.gz;
       sha256 = "06aab9c693380190e53be09be7daed20c5d6278f71956989c24cca7782013675";
@@ -13559,24 +14555,27 @@ let
   };
 
   ScalarString = buildPerlModule rec {
-    name = "Scalar-String-0.003";
+    pname = "Scalar-String";
+    version = "0.003";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Z/ZE/ZEFRAM/${name}.tar.gz";
+      url = mirror://cpan/authors/id/Z/ZE/ZEFRAM/Scalar-String-0.003.tar.gz;
       sha256 = "f54a17c9b78713b02cc43adfadf60b49467e7634d31317e8b9e9e97c26d68b52";
     };
   };
 
   SCGI = buildPerlModule rec {
-    name = "SCGI-0.6";
+    pname = "SCGI";
+    version = "0.6";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/V/VI/VIPERCODE/${name}.tar.gz";
+      url = mirror://cpan/authors/id/V/VI/VIPERCODE/SCGI-0.6.tar.gz;
       sha256 = "196rj47mh4fq2vlnw595q391zja5v6qg7s3sy0vy8igfyid8rdsq";
     };
     preConfigure = "export HOME=$(mktemp -d)";
   };
 
   ScopeGuard = buildPerlPackage {
-    name = "Scope-Guard-0.21";
+    pname = "Scope-Guard";
+    version = "0.21";
     src = fetchurl {
       url = mirror://cpan/authors/id/C/CH/CHOCOLATE/Scope-Guard-0.21.tar.gz;
       sha256 = "0y6jfzvxiz8h5yfz701shair0ilypq2mvimd7wn8wi2nbkm1p6wc";
@@ -13588,9 +14587,10 @@ let
   };
 
   ScopeUpper = buildPerlPackage rec {
-    name = "Scope-Upper-0.31";
+    pname = "Scope-Upper";
+    version = "0.31";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/V/VP/VPIT/${name}.tar.gz";
+      url = mirror://cpan/authors/id/V/VP/VPIT/Scope-Upper-0.31.tar.gz;
       sha256 = "cc4d2ce0f185b4867d73b4083991117052a523fd409debf15bdd7e374cc16d8c";
     };
     meta = {
@@ -13600,9 +14600,10 @@ let
   };
 
   SerealDecoder = buildPerlPackage rec {
-    name = "Sereal-Decoder-4.007";
+    pname = "Sereal-Decoder";
+    version = "4.007";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Y/YV/YVES/${name}.tar.gz";
+      url = mirror://cpan/authors/id/Y/YV/YVES/Sereal-Decoder-4.007.tar.gz;
       sha256 = "0jyczxlpn2axgmx5vyjwjvr0myvi0yxnjpp8g7hj4b388j1i2205";
     };
     buildInputs = [ TestDeep TestDifferences TestLongString TestWarn ];
@@ -13616,9 +14617,10 @@ let
   };
 
   SerealEncoder = buildPerlPackage rec {
-    name = "Sereal-Encoder-4.007";
+    pname = "Sereal-Encoder";
+    version = "4.007";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Y/YV/YVES/${name}.tar.gz";
+      url = mirror://cpan/authors/id/Y/YV/YVES/Sereal-Encoder-4.007.tar.gz;
       sha256 = "1dpafqlsir79p9g1j85k7bbn9kckqdb1zdngmmw1r46cizfdsvxz";
     };
     buildInputs = [ SerealDecoder TestDeep TestDifferences TestLongString TestWarn ];
@@ -13631,9 +14633,10 @@ let
   };
 
   Sereal = buildPerlPackage rec {
-    name = "Sereal-4.007";
+    pname = "Sereal";
+    version = "4.007";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Y/YV/YVES/${name}.tar.gz";
+      url = mirror://cpan/authors/id/Y/YV/YVES/Sereal-4.007.tar.gz;
       sha256 = "0ncsfsz9dvqay77hb0gzfx1qsg8xkz50h47q082gqnlf5q3l63j5";
     };
     buildInputs = [ TestLongString TestWarn ];
@@ -13647,9 +14650,10 @@ let
   };
 
   ServerStarter = buildPerlModule rec {
-    name = "Server-Starter-0.34";
+    pname = "Server-Starter";
+    version = "0.34";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KA/KAZUHO/${name}.tar.gz";
+      url = mirror://cpan/authors/id/K/KA/KAZUHO/Server-Starter-0.34.tar.gz;
       sha256 = "96a20d4a1f341655bd1b26df5795d57c5d7498d9bcf8ca9d0d6e2ed743608f78";
     };
     buildInputs = [ TestRequires TestSharedFork TestTCP ];
@@ -13661,7 +14665,8 @@ let
   };
 
   SetInfinite = buildPerlPackage {
-    name = "Set-Infinite-0.65";
+    pname = "Set-Infinite";
+    version = "0.65";
     src = fetchurl {
       url = mirror://cpan/authors/id/F/FG/FGLOCK/Set-Infinite-0.65.tar.gz;
       sha256 = "07bc880734492de40b4a3a8b5a331762f64e69b4629029fd9a9d357b25b87e1f";
@@ -13672,7 +14677,8 @@ let
   };
 
   SetIntSpan = buildPerlPackage rec {
-    name = "Set-IntSpan-1.19";
+    pname = "Set-IntSpan";
+    version = "1.19";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SW/SWMCD/Set-IntSpan-1.19.tar.gz;
       sha256 = "1l6znd40ylzvfwl02rlqzvakv602rmvwgm2xd768fpgc2fdm9dqi";
@@ -13684,9 +14690,10 @@ let
   };
 
   SetObject = buildPerlPackage rec {
-    name = "Set-Object-1.39";
+    pname = "Set-Object";
+    version = "1.39";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RU/RURBAN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RU/RURBAN/Set-Object-1.39.tar.gz;
       sha256 = "5effcfeb104da334f413a20dee9cdc5e874246096c3b282190a5f44453401810";
     };
     meta = {
@@ -13696,7 +14703,8 @@ let
   };
 
   SetScalar = buildPerlPackage {
-    name = "Set-Scalar-1.29";
+    pname = "Set-Scalar";
+    version = "1.29";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DA/DAVIDO/Set-Scalar-1.29.tar.gz;
       sha256 = "07aiqkyi1p22drpcyrrmv7f8qq6fhrxh007achy2vryxyck1bp53";
@@ -13715,7 +14723,8 @@ let
   };
 
   SignalMask = buildPerlPackage {
-    name = "Signal-Mask-0.008";
+    pname = "Signal-Mask";
+    version = "0.008";
     src = fetchurl {
       url = mirror://cpan/authors/id/L/LE/LEONT/Signal-Mask-0.008.tar.gz;
       sha256 = "043d995b6b249d9ebc04c467db31bb7ddc2e55faa08e885bdb050b1f2336b73f";
@@ -13728,7 +14737,8 @@ let
   };
 
   SnowballNorwegian = buildPerlModule rec {
-     name = "Snowball-Norwegian-1.2";
+     pname = "Snowball-Norwegian";
+     version = "1.2";
      src = fetchurl {
        url = mirror://cpan/authors/id/A/AS/ASKSH/Snowball-Norwegian-1.2.tar.gz;
        sha256 = "0675v45bbsh7vr7kpf36xs2q79g02iq1kmfw22h20xdk4rzqvkqx";
@@ -13740,7 +14750,8 @@ let
   };
 
   SnowballSwedish = buildPerlModule rec {
-     name = "Snowball-Swedish-1.2";
+     pname = "Snowball-Swedish";
+     version = "1.2";
      src = fetchurl {
        url = mirror://cpan/authors/id/A/AS/ASKSH/Snowball-Swedish-1.2.tar.gz;
        sha256 = "0agwc12jk5kmabnpsplw3wf4ii5w1zb159cpin44x3srb0sr5apg";
@@ -13752,7 +14763,8 @@ let
   };
 
   SOAPLite = buildPerlPackage {
-    name = "SOAP-Lite-1.27";
+    pname = "SOAP-Lite";
+    version = "1.27";
     src = fetchurl {
       url = mirror://cpan/authors/id/P/PH/PHRED/SOAP-Lite-1.27.tar.gz;
       sha256 = "00fkvmnxiy5mr45rj5qmxmflw0xdkw2gihm48iha2i8smdmi0ng3";
@@ -13766,9 +14778,10 @@ let
   };
 
   Socket6 = buildPerlPackage rec {
-    name = "Socket6-0.29";
+    pname = "Socket6";
+    version = "0.29";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/U/UM/UMEMOTO/${name}.tar.gz";
+      url = mirror://cpan/authors/id/U/UM/UMEMOTO/Socket6-0.29.tar.gz;
       sha256 = "468915fa3a04dcf6574fc957eff495915e24569434970c91ee8e4e1459fc9114";
     };
     setOutputFlags = false;
@@ -13781,9 +14794,10 @@ let
   };
 
   SoftwareLicense = buildPerlPackage rec {
-    name = "Software-License-0.103014";
+    pname = "Software-License";
+    version = "0.103014";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/${name}.tar.gz";
+      url = mirror://cpan/authors/id/L/LE/LEONT/Software-License-0.103014.tar.gz;
       sha256 = "eb45ea602d75006683789fbba57a01c0a1f7037371de95ea54b91577535d1789";
     };
     buildInputs = [ TryTiny ];
@@ -13796,7 +14810,8 @@ let
   };
 
   SoftwareLicenseCCpack = buildPerlPackage rec {
-     name = "Software-License-CCpack-1.11";
+     pname = "Software-License-CCpack";
+     version = "1.11";
      src = fetchurl {
        url = mirror://cpan/authors/id/B/BB/BBYRD/Software-License-CCpack-1.11.tar.gz;
        sha256 = "1cakbn7am8mhalwas5h33l7c6avdqpg42z478p6rav11pim5qksr";
@@ -13811,9 +14826,10 @@ let
   };
 
   SortKey = buildPerlPackage rec {
-    name = "Sort-Key-1.33";
+    pname = "Sort-Key";
+    version = "1.33";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SA/SALVA/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SA/SALVA/Sort-Key-1.33.tar.gz;
       sha256 = "1kqs10s2plj6c96srk0j8d7xj8dxk1704r7mck8rqk09mg7lqspd";
     };
     meta = {
@@ -13823,7 +14839,8 @@ let
   };
 
   SortVersions = buildPerlPackage rec {
-    name = "Sort-Versions-1.62";
+    pname = "Sort-Versions";
+    version = "1.62";
     src = fetchurl {
       url = mirror://cpan/authors/id/N/NE/NEILB/Sort-Versions-1.62.tar.gz;
       sha256 = "1aifzm79ky03gi2lwxyx4mk6yky8x215j0kz4f0jbgkf803k6pxz";
@@ -13831,7 +14848,8 @@ let
   };
 
   Specio = buildPerlPackage rec {
-     name = "Specio-0.43";
+     pname = "Specio";
+     version = "0.43";
      src = fetchurl {
        url = mirror://cpan/authors/id/D/DR/DROLSKY/Specio-0.43.tar.gz;
        sha256 = "07gsm4fssn9v27bnlgcxa7igb7ggrxwgpdqbbryi4134gfzxxl1w";
@@ -13845,7 +14863,8 @@ let
   };
 
   SpecioLibraryPathTiny = buildPerlPackage rec {
-     name = "Specio-Library-Path-Tiny-0.04";
+     pname = "Specio-Library-Path-Tiny";
+     version = "0.04";
      src = fetchurl {
        url = mirror://cpan/authors/id/D/DR/DROLSKY/Specio-Library-Path-Tiny-0.04.tar.gz;
        sha256 = "0cyfx8gigsgisdwynjamh8jkpad23sr8v6a98hq285zmibm16s7g";
@@ -13859,17 +14878,19 @@ let
   };
 
   Spiffy = buildPerlPackage rec {
-    name = "Spiffy-0.46";
+    pname = "Spiffy";
+    version = "0.46";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IN/INGY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/I/IN/INGY/Spiffy-0.46.tar.gz;
       sha256 = "18qxshrjh0ibpzjm2314157mxlibh3smyg64nr4mq990hh564n4g";
     };
   };
 
   SpreadsheetParseExcel = buildPerlPackage rec {
-    name = "Spreadsheet-ParseExcel-0.65";
+    pname = "Spreadsheet-ParseExcel";
+    version = "0.65";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DO/DOUGW/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DO/DOUGW/Spreadsheet-ParseExcel-0.65.tar.gz;
       sha256 = "6ec4cb429bd58d81640fe12116f435c46f51ff1040c68f09cc8b7681c1675bec";
     };
     propagatedBuildInputs = [ CryptRC4 DigestPerlMD5 IOStringy OLEStorage_Lite ];
@@ -13881,9 +14902,10 @@ let
   };
 
   SpreadsheetWriteExcel = buildPerlPackage rec {
-    name = "Spreadsheet-WriteExcel-2.40";
+    pname = "Spreadsheet-WriteExcel";
+    version = "2.40";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JM/JMCNAMARA/${name}.tar.gz";
+      url = mirror://cpan/authors/id/J/JM/JMCNAMARA/Spreadsheet-WriteExcel-2.40.tar.gz;
       sha256 = "e356aad6866cf135731268ee0e979a197443c15a04878e9cf3e80d022ad6c07e";
     };
     propagatedBuildInputs = [ OLEStorage_Lite ParseRecDescent ];
@@ -13894,9 +14916,10 @@ let
   };
 
   SQLAbstract = buildPerlPackage rec {
-    name = "SQL-Abstract-1.86";
+    pname = "SQL-Abstract";
+    version = "1.86";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IL/ILMARI/${name}.tar.gz";
+      url = mirror://cpan/authors/id/I/IL/ILMARI/SQL-Abstract-1.86.tar.gz;
       sha256 = "e7a7f7da5e6fa42f495860e92e9138b8a0964ca7674c95bd6ff1b1ce21aa8cdf";
     };
     buildInputs = [ TestDeep TestException TestWarn ];
@@ -13908,9 +14931,10 @@ let
   };
 
   SQLAbstractLimit = buildPerlModule rec {
-    name = "SQL-Abstract-Limit-0.141";
+    pname = "SQL-Abstract-Limit";
+    version = "0.141";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAVEBAIRD/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DA/DAVEBAIRD/SQL-Abstract-Limit-0.141.tar.gz;
       sha256 = "1qqh89kz065mkgyg5pjcgbf8qcpzfk8vf1lgkbwynknadmv87zqg";
     };
     propagatedBuildInputs = [ DBI SQLAbstract ];
@@ -13918,7 +14942,8 @@ let
   };
 
   SQLSplitStatement = buildPerlPackage rec {
-    name = "SQL-SplitStatement-1.00020";
+    pname = "SQL-SplitStatement";
+    version = "1.00020";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/EM/EMAZEP/SQL-SplitStatement-1.00020.tar.gz;
       sha256 = "0bqg45k4c9qkb2ypynlwhpvzsl4ssfagmsalys18s5c79ps30z7p";
@@ -13928,7 +14953,8 @@ let
   };
 
   SQLTokenizer = buildPerlPackage rec {
-    name = "SQL-Tokenizer-0.24";
+    pname = "SQL-Tokenizer";
+    version = "0.24";
     src = fetchurl {
       url = mirror://cpan/authors/id/I/IZ/IZUT/SQL-Tokenizer-0.24.tar.gz;
       sha256 = "1qa2dfbzdlr5qqdam9yn78z5w3al5r8577x06qan8wv58ay6ka7s";
@@ -13936,9 +14962,10 @@ let
   };
 
   SQLTranslator = buildPerlPackage rec {
-    name = "SQL-Translator-0.11024";
+    pname = "SQL-Translator";
+    version = "0.11024";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IL/ILMARI/${name}.tar.gz";
+      url = mirror://cpan/authors/id/I/IL/ILMARI/SQL-Translator-0.11024.tar.gz;
       sha256 = "5bde9d6f67850089ef35a9296d6f53e5ee8e991438366b71477f3f27c1581bb1";
     };
     buildInputs = [ JSON TestDifferences TestException XMLWriter YAML ];
@@ -13950,7 +14977,8 @@ let
   };
 
   PackageVariant = buildPerlPackage {
-    name = "Package-Variant-1.003002";
+    pname = "Package-Variant";
+    version = "1.003002";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MS/MSTROUT/Package-Variant-1.003002.tar.gz;
       sha256 = "b2ed849d2f4cdd66467512daa3f143266d6df810c5fae9175b252c57bc1536dc";
@@ -13964,15 +14992,17 @@ let
   };
 
   SortNaturally = buildPerlPackage rec {
-    name = "Sort-Naturally-1.03";
+    pname = "Sort-Naturally";
+    version = "1.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BI/BINGOS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/B/BI/BINGOS/Sort-Naturally-1.03.tar.gz;
       sha256 = "eaab1c5c87575a7826089304ab1f8ffa7f18e6cd8b3937623e998e865ec1e746";
     };
   };
 
   Starlet = buildPerlPackage {
-    name = "Starlet-0.31";
+    pname = "Starlet";
+    version = "0.31";
     src = fetchurl {
       url = mirror://cpan/authors/id/K/KA/KAZUHO/Starlet-0.31.tar.gz;
       sha256 = "b9603b8e62880cb4582f6a7939eafec65e6efd3d900f2c7dd342e5f4c68d62d8";
@@ -13986,7 +15016,7 @@ let
   };
 
   Starman = let version = "0.4014"; in buildPerlModule {
-    name = "Starman-${version}";
+    pname = "Starman";
     src = fetchurl {
       url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/Starman-${version}.tar.gz";
       sha256 = "1sbb5rb3vs82rlh1fjkgkcmj5pj62b4y9si4ihh45sl9m8c2qxx5";
@@ -14003,7 +15033,8 @@ let
   };
 
   StatisticsBasic = buildPerlPackage {
-    name = "Statistics-Basic-1.6611";
+    pname = "Statistics-Basic";
+    version = "1.6611";
     src = fetchurl {
       url = mirror://cpan/authors/id/J/JE/JETTERO/Statistics-Basic-1.6611.tar.gz;
       sha256 = "1ywl398z42hz9w1k0waf1caa6agz8jzsjlf4rzs1lgpx2mbcwmb8";
@@ -14015,7 +15046,8 @@ let
   };
 
   StatisticsCaseResampling = buildPerlPackage {
-    name = "Statistics-CaseResampling-0.15";
+    pname = "Statistics-CaseResampling";
+    version = "0.15";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SM/SMUELLER/Statistics-CaseResampling-0.15.tar.gz;
       sha256 = "11whlh2dl7l6wrrnfmpbsg7ldcn316iccl1aaa4j5lqhdyyl6745";
@@ -14026,7 +15058,8 @@ let
   };
 
   StatisticsDescriptive = buildPerlModule {
-    name = "Statistics-Descriptive-3.0702";
+    pname = "Statistics-Descriptive";
+    version = "3.0702";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SH/SHLOMIF/Statistics-Descriptive-3.0702.tar.gz;
       sha256 = "f98a10c625640170cdda408cccc72bdd7f66f8ebe5f59dec1b96185171ef11d0";
@@ -14040,7 +15073,8 @@ let
   };
 
   StatisticsDistributions = buildPerlPackage rec {
-    name = "Statistics-Distributions-1.02";
+    pname = "Statistics-Distributions";
+    version = "1.02";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MI/MIKEK/Statistics-Distributions-1.02.tar.gz;
       sha256 = "1j1kswl98f4i9dn176f9aa3y9bissx2sscga5jm3gjl4pxm3k7zr";
@@ -14048,7 +15082,8 @@ let
   };
 
   StatisticsTTest = buildPerlPackage rec {
-    name = "Statistics-TTest-1.1.0";
+    pname = "Statistics-TTest";
+    version = "1.1.0";
     src = fetchurl {
       url = mirror://cpan/authors/id/Y/YU/YUNFANG/Statistics-TTest-1.1.0.tar.gz;
       sha256 = "0rkifgzm4rappiy669dyi6lyxn2sdqaf0bl6gndlfa67b395kndj";
@@ -14069,7 +15104,8 @@ let
   };
 
   StreamBuffered = buildPerlPackage {
-    name = "Stream-Buffered-0.03";
+    pname = "Stream-Buffered";
+    version = "0.03";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DO/DOY/Stream-Buffered-0.03.tar.gz;
       sha256 = "0fs2n9zw6isfkha2kbqrvl9mwg572x1x0jlfaps0qsyynn846bcv";
@@ -14082,7 +15118,8 @@ let
   };
 
   strictures = buildPerlPackage rec {
-    name = "strictures-2.000006";
+    pname = "strictures";
+    version = "2.000006";
     src = fetchurl {
       url = mirror://cpan/authors/id/H/HA/HAARG/strictures-2.000006.tar.gz;
       sha256 = "0mwd9xqz4n8qfpi5h5581lbm33qhf7agww18h063icnilrs7km89";
@@ -14095,15 +15132,17 @@ let
   };
 
   StringApprox = buildPerlPackage rec {
-    name = "String-Approx-3.28";
+    pname = "String-Approx";
+    version = "3.28";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JH/JHI/${name}.tar.gz";
+      url = mirror://cpan/authors/id/J/JH/JHI/String-Approx-3.28.tar.gz;
       sha256 = "43201e762d8699cb0ac2c0764a5454bdc2306c0771014d6c8fba821480631342";
     };
   };
 
   StringCamelCase = buildPerlPackage rec {
-    name = "String-CamelCase-0.04";
+    pname = "String-CamelCase";
+    version = "0.04";
     src = fetchurl {
       url = mirror://cpan/authors/id/H/HI/HIO/String-CamelCase-0.04.tar.gz;
       sha256 = "1a8i4yzv586svd0pbxls7642vvmyiwzh4x2xyij8gbnfxsydxhw9";
@@ -14111,7 +15150,8 @@ let
   };
 
   StringCRC32 = buildPerlPackage rec {
-    name = "String-CRC32-1.7";
+    pname = "String-CRC32";
+    version = "1.7";
     src = fetchurl {
       url = mirror://cpan/authors/id/L/LE/LEEJO/String-CRC32-1.7.tar.gz;
       sha256 = "1j1bwbxcgxfbgw708rfrni3spwnnmnf717vq9s64nd63jmc4w5lg";
@@ -14119,7 +15159,8 @@ let
   };
 
   StringErrf = buildPerlPackage {
-    name = "String-Errf-0.008";
+    pname = "String-Errf";
+    version = "0.008";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RJ/RJBS/String-Errf-0.008.tar.gz;
       sha256 = "1nyn9s52jgbffrsv0m7rhcx1awjj43n68bfjlap8frdc7mw6y4xf";
@@ -14133,7 +15174,8 @@ let
   };
 
   StringEscape = buildPerlPackage rec {
-    name = "String-Escape-2010.002";
+    pname = "String-Escape";
+    version = "2010.002";
     src = fetchurl {
         url = mirror://cpan/authors/id/E/EV/EVO/String-Escape-2010.002.tar.gz;
         sha256 = "12ls7f7847i4qcikkp3skwraqvjphjiv2zxfhl5d49326f5myr7x";
@@ -14141,9 +15183,10 @@ let
   };
 
   StringFlogger = buildPerlPackage rec {
-    name = "String-Flogger-1.101245";
+    pname = "String-Flogger";
+    version = "1.101245";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RJ/RJBS/String-Flogger-1.101245.tar.gz;
       sha256 = "aa03c08e01f802a358c175c6093c02adf9688659a087a8ddefdc3e9cef72640b";
     };
     propagatedBuildInputs = [ JSONMaybeXS SubExporter ];
@@ -14155,7 +15198,8 @@ let
   };
 
   StringFormat = buildPerlPackage rec {
-    name = "String-Format-1.18";
+    pname = "String-Format";
+    version = "1.18";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SR/SREZIC/String-Format-1.18.tar.gz;
       sha256 = "0y77frxzjifd4sw0j19cc346ysas1mya84rdxaz279lyin7plhcy";
@@ -14163,7 +15207,8 @@ let
   };
 
   StringFormatter = buildPerlPackage {
-    name = "String-Formatter-0.102084";
+    pname = "String-Formatter";
+    version = "0.102084";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RJ/RJBS/String-Formatter-0.102084.tar.gz;
       sha256 = "0mlwm0rirv46gj4h072q8gdync5zxxsxy8p028gdyrhczl942dc3";
@@ -14176,7 +15221,8 @@ let
   };
 
   StringMkPasswd = buildPerlPackage {
-    name = "String-MkPasswd-0.05";
+    pname = "String-MkPasswd";
+    version = "0.05";
     src = fetchurl {
       url = mirror://cpan/authors/id/C/CG/CGRAU/String-MkPasswd-0.05.tar.gz;
       sha256 = "15lvcc8c9hp6mg3jx02wd3b85aphn8yl5db62q3pam04c0sgh42k";
@@ -14184,7 +15230,8 @@ let
   };
 
   StringRewritePrefix = buildPerlPackage {
-    name = "String-RewritePrefix-0.007";
+    pname = "String-RewritePrefix";
+    version = "0.007";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RJ/RJBS/String-RewritePrefix-0.007.tar.gz;
       sha256 = "18nxl1vgkcx0r7ifkmbl9fp73f8ihiqhqqf3vq6sj5b3cgawrfsw";
@@ -14197,7 +15244,8 @@ let
   };
 
   StringShellQuote = buildPerlPackage {
-    name = "String-ShellQuote-1.04";
+    pname = "String-ShellQuote";
+    version = "1.04";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RO/ROSCH/String-ShellQuote-1.04.tar.gz;
       sha256 = "0dfxhr6hxc2majkkrm0qbx3qcbykzpphbj2ms93dc86f7183c1p6";
@@ -14209,7 +15257,8 @@ let
   };
 
   ShellCommand = buildPerlPackage {
-    name = "Shell-Command-0.06";
+    pname = "Shell-Command";
+    version = "0.06";
     src = fetchurl {
       url = mirror://cpan/authors/id/F/FL/FLORA/Shell-Command-0.06.tar.gz;
       sha256 = "1lgc2rb3b5a4lxvbq0cbg08qk0n2i88srxbsz93bwi3razpxxr7k";
@@ -14217,16 +15266,18 @@ let
   };
 
   StringToIdentifierEN = buildPerlPackage rec {
-    name = "String-ToIdentifier-EN-0.12";
+    pname = "String-ToIdentifier-EN";
+    version = "0.12";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RK/RKITOVER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RK/RKITOVER/String-ToIdentifier-EN-0.12.tar.gz;
       sha256 = "12nw7h2yiybhdw0vnnpc7bif8ylhsn6kqf6s39dsrf9h54iq9yrs";
     };
     propagatedBuildInputs = [ LinguaENInflectPhrase TextUnidecode namespaceclean ];
   };
 
   StringTruncate = buildPerlPackage {
-    name = "String-Truncate-1.100602";
+    pname = "String-Truncate";
+    version = "1.100602";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RJ/RJBS/String-Truncate-1.100602.tar.gz;
       sha256 = "0vjz4fd4cvcy12gk5bdha7z73ifmfpmk748khha94dhiq3pd98xa";
@@ -14239,7 +15290,8 @@ let
   };
 
   StringTT = buildPerlPackage {
-    name = "String-TT-0.03";
+    pname = "String-TT";
+    version = "0.03";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BO/BOBTFISH/String-TT-0.03.tar.gz;
       sha256 = "1asjr79wqcl9wk96afxrm1yhpj8lk9bk8kyz78yi5ypr0h55yq7p";
@@ -14253,7 +15305,7 @@ let
   };
 
   StringUtil = let version = "1.26"; in buildPerlModule {
-    name = "String-Util-${version}";
+    pname = "String-Util";
     src = fetchurl {
       url = "mirror://cpan/authors/id/M/MI/MIKO/String-Util-${version}.tar.gz";
       sha256 = "0bgs6fsc0gcj9qa1k98nwjp4xbkl3ckz71rz3qhmav0lgkrr96pl";
@@ -14300,7 +15352,8 @@ let
   };
 
   SubExporter = buildPerlPackage {
-    name = "Sub-Exporter-0.987";
+    pname = "Sub-Exporter";
+    version = "0.987";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RJ/RJBS/Sub-Exporter-0.987.tar.gz;
       sha256 = "1ml3n1ck4ln9qjm2mcgkczj1jb5n1fkscz9c4x23v4db0glb4g2l";
@@ -14314,9 +15367,10 @@ let
   };
 
   SubExporterForMethods = buildPerlPackage rec {
-    name = "Sub-Exporter-ForMethods-0.100052";
+    pname = "Sub-Exporter-ForMethods";
+    version = "0.100052";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RJ/RJBS/Sub-Exporter-ForMethods-0.100052.tar.gz;
       sha256 = "421fbba4f6ffcf13c4335f2c20630d709e6fa659c07545d094dbc5a558ad3006";
     };
     buildInputs = [ namespaceautoclean ];
@@ -14329,7 +15383,8 @@ let
   };
 
   SubExporterGlobExporter = buildPerlPackage {
-    name = "Sub-Exporter-GlobExporter-0.005";
+    pname = "Sub-Exporter-GlobExporter";
+    version = "0.005";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RJ/RJBS/Sub-Exporter-GlobExporter-0.005.tar.gz;
       sha256 = "0qvsvfvfyk69v2ygjnyd5sh3bgbzd6f7k7mgv0zws1yywvpmxi1g";
@@ -14343,7 +15398,8 @@ let
   };
 
   SubExporterProgressive = buildPerlPackage {
-    name = "Sub-Exporter-Progressive-0.001013";
+    pname = "Sub-Exporter-Progressive";
+    version = "0.001013";
     src = fetchurl {
       url = mirror://cpan/authors/id/F/FR/FREW/Sub-Exporter-Progressive-0.001013.tar.gz;
       sha256 = "0mn0x8mkh36rrsr58s1pk4srwxh2hbwss7sv630imnk49navfdfm";
@@ -14355,9 +15411,10 @@ let
   };
 
   SubIdentify = buildPerlPackage rec {
-    name = "Sub-Identify-0.14";
+    pname = "Sub-Identify";
+    version = "0.14";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RG/RGARCIA/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RG/RGARCIA/Sub-Identify-0.14.tar.gz;
       sha256 = "068d272086514dd1e842b6a40b1bedbafee63900e5b08890ef6700039defad6f";
     };
     meta = {
@@ -14367,9 +15424,10 @@ let
   };
 
   SubInfo = buildPerlPackage rec {
-    name = "Sub-Info-0.002";
+    pname = "Sub-Info";
+    version = "0.002";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/EX/EXODIST/${name}.tar.gz";
+      url = mirror://cpan/authors/id/E/EX/EXODIST/Sub-Info-0.002.tar.gz;
       sha256 = "ea3056d696bdeff21a99d340d5570887d39a8cc47bff23adfc82df6758cdd0ea";
     };
     propagatedBuildInputs = [ Importer ];
@@ -14380,7 +15438,8 @@ let
   };
 
   SubInstall = buildPerlPackage {
-    name = "Sub-Install-0.928";
+    pname = "Sub-Install";
+    version = "0.928";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RJ/RJBS/Sub-Install-0.928.tar.gz;
       sha256 = "03zgk1yh128gciyx3q77zxzxg9kf8yy2gm46gdxqi24mcykngrb1";
@@ -14392,9 +15451,10 @@ let
   };
 
   SubName = buildPerlPackage rec {
-    name = "Sub-Name-0.21";
+    pname = "Sub-Name";
+    version = "0.21";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/E/ET/ETHER/Sub-Name-0.21.tar.gz;
       sha256 = "bd32e9dee07047c10ae474c9f17d458b6e9885a6db69474c7a494ccc34c27117";
     };
     buildInputs = [ BC DevelCheckBin ];
@@ -14406,18 +15466,20 @@ let
   };
 
   SubOverride = buildPerlPackage rec {
-    name = "Sub-Override-0.09";
+    pname = "Sub-Override";
+    version = "0.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OV/OVID/${name}.tar.gz";
+      url = mirror://cpan/authors/id/O/OV/OVID/Sub-Override-0.09.tar.gz;
       sha256 = "1d955qn44brkcfif3gi0q2vvvqahny6rax0vr068x5i9yz0ng6lk";
     };
     buildInputs = [ TestFatal ];
   };
 
   SubQuote = buildPerlPackage rec {
-    name = "Sub-Quote-2.006003";
+    pname = "Sub-Quote";
+    version = "2.006003";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/${name}.tar.gz";
+      url = mirror://cpan/authors/id/H/HA/HAARG/Sub-Quote-2.006003.tar.gz;
       sha256 = "be1f3a6f773f351f203cdc8f614803ac492b77d15fd68d5b1f0cd3884be18176";
     };
     buildInputs = [ TestFatal ];
@@ -14428,7 +15490,8 @@ let
   };
 
   SubUplevel = buildPerlPackage {
-    name = "Sub-Uplevel-0.2800";
+    pname = "Sub-Uplevel";
+    version = "0.2800";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DA/DAGOLDEN/Sub-Uplevel-0.2800.tar.gz;
       sha256 = "14z2xjiw931wizcx3mblmby753jspvfm321d6chs907nh0xzdwxl";
@@ -14441,18 +15504,20 @@ let
   };
 
   SVNSimple = buildPerlPackage rec {
-    name = "SVN-Simple-0.28";
+    pname = "SVN-Simple";
+    version = "0.28";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CL/CLKAO/${name}.tar.gz";
+      url = mirror://cpan/authors/id/C/CL/CLKAO/SVN-Simple-0.28.tar.gz;
       sha256 = "1ysgi38zx236cxz539k6d6rw5z0vc70rrglsaf5fk6rnwilw2g6n";
     };
     propagatedBuildInputs = [ (pkgs.subversionClient.override { inherit perl; }) ];
   };
 
   Swim = buildPerlPackage rec {
-    name = "Swim-0.1.46";
+    pname = "Swim";
+    version = "0.1.46";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IN/INGY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/I/IN/INGY/Swim-0.1.46.tar.gz;
       sha256 = "ac747362afec12a0ba30ffdfff8765f80a124dff8ebcb238326fa627e07daae8";
     };
     buildInputs = [ FileShareDirInstall ];
@@ -14465,7 +15530,8 @@ let
   };
 
   Switch = buildPerlPackage rec {
-    name = "Switch-2.17";
+    pname = "Switch";
+    version = "2.17";
     src = fetchurl {
       url = "mirror://cpan/authors/id/C/CH/CHORNY/Switch-2.17.tar.gz";
       sha256 = "0xbdjdgzfj9zwa4j3ipr8bfk7bcici4hk89hq5d27rhg2isljd9i";
@@ -14474,7 +15540,8 @@ let
   };
 
   SymbolGlobalName = buildPerlPackage {
-    name = "Symbol-Global-Name-0.05";
+    pname = "Symbol-Global-Name";
+    version = "0.05";
     src = fetchurl {
       url = mirror://cpan/authors/id/A/AL/ALEXMV/Symbol-Global-Name-0.05.tar.gz;
       sha256 = "0f7623e9d724760aa64040222da1d82f1188586791329261cc60dad1d60d6a92";
@@ -14486,7 +15553,8 @@ let
   };
 
   SymbolUtil = buildPerlModule {
-    name = "Symbol-Util-0.0203";
+    pname = "Symbol-Util";
+    version = "0.0203";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DE/DEXTER/Symbol-Util-0.0203.tar.gz;
       sha256 = "0cnwwrd5d6i80f33s7n2ak90rh4s53ss7q57wndrpkpr4bfn3djm";
@@ -14494,7 +15562,8 @@ let
   };
 
   syntax = buildPerlPackage {
-    name = "syntax-0.004";
+    pname = "syntax";
+    version = "0.004";
     src = fetchurl {
       url = mirror://cpan/authors/id/P/PH/PHAYLON/syntax-0.004.tar.gz;
       sha256 = "fe19b6da8a8f43a5aa2ee571441bc0e339fb156d0081c157a1a24e9812c7d365";
@@ -14508,9 +15577,10 @@ let
   };
 
   SyntaxKeywordJunction = buildPerlPackage rec {
-    name = "Syntax-Keyword-Junction-0.003008";
+    pname = "Syntax-Keyword-Junction";
+    version = "0.003008";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FR/FREW/${name}.tar.gz";
+      url = mirror://cpan/authors/id/F/FR/FREW/Syntax-Keyword-Junction-0.003008.tar.gz;
       sha256 = "8b4975f21b1992a7e6c2df5dcc92b254c61925595eddcdfaf0b1498717aa95ef";
     };
     buildInputs = [ TestRequires ];
@@ -14523,9 +15593,10 @@ let
   };
 
   SysMmap = buildPerlPackage rec {
-    name = "Sys-Mmap-0.19";
+    pname = "Sys-Mmap";
+    version = "0.19";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SW/SWALTERS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SW/SWALTERS/Sys-Mmap-0.19.tar.gz;
       sha256 = "1yh0170xfw3z7n3lynffcb6axv7wi6zb46cx03crj1cvrhjmwa89";
     };
     meta = with stdenv.lib; {
@@ -14536,9 +15607,10 @@ let
   };
 
   SysMemInfo = buildPerlPackage rec {
-    name = "Sys-MemInfo-0.99";
+    pname = "Sys-MemInfo";
+    version = "0.99";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SC/SCRESTO/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SC/SCRESTO/Sys-MemInfo-0.99.tar.gz;
       sha256 = "0786319d3a3a8bae5d727939244bf17e140b714f52734d5e9f627203e4cf3e3b";
     };
     meta = {
@@ -14559,16 +15631,18 @@ let
   };
 
   SysHostnameLong = buildPerlPackage rec {
-    name = "Sys-Hostname-Long-1.5";
+    pname = "Sys-Hostname-Long";
+    version = "1.5";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SC/SCOTT/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SC/SCOTT/Sys-Hostname-Long-1.5.tar.gz;
       sha256 = "1jv5n8jv48c1p8svjsigyxndv1ygsq8wgwj9c7ypx1vaf3rns679";
     };
     doCheck = false; # no `hostname' in stdenv
   };
 
   SysSigAction = buildPerlPackage {
-    name = "Sys-SigAction-0.23";
+    pname = "Sys-SigAction";
+    version = "0.23";
     src = fetchurl {
       url = mirror://cpan/authors/id/L/LB/LBAXTER/Sys-SigAction-0.23.tar.gz;
       sha256 = "c4ef6c9345534031fcbbe2adc347fc7194d47afc945e7a44fac7e9563095d353";
@@ -14581,9 +15655,10 @@ let
   };
 
   SysSyslog = buildPerlPackage rec {
-    name = "Sys-Syslog-0.35";
+    pname = "Sys-Syslog";
+    version = "0.35";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SA/SAPER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SA/SAPER/Sys-Syslog-0.35.tar.gz;
       sha256 = "fe28e47b70b77aaae754385fe1470d174289e7b6908efa247d2e52486516fbb7";
     };
     meta = {
@@ -14593,9 +15668,10 @@ let
   };
 
   SystemCommand = buildPerlPackage rec {
-    name = "System-Command-1.119";
+    pname = "System-Command";
+    version = "1.119";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BO/BOOK/${name}.tar.gz";
+      url = mirror://cpan/authors/id/B/BO/BOOK/System-Command-1.119.tar.gz;
       sha256 = "c8c9fb1e527c52463cab1476500efea70396a0b62bea625d2d6faea994dc46e7";
     };
     propagatedBuildInputs = [ IPCRun ];
@@ -14618,9 +15694,10 @@ let
   };
 
   TAPParserSourceHandlerpgTAP = buildPerlModule rec {
-    name = "TAP-Parser-SourceHandler-pgTAP-3.35";
+    pname = "TAP-Parser-SourceHandler-pgTAP";
+    version = "3.35";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DW/DWHEELER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DW/DWHEELER/TAP-Parser-SourceHandler-pgTAP-3.35.tar.gz;
       sha256 = "1655337l1cyd7q62007wrk87q2gbbwfq9xjy1wgx3hyflxpkkvl4";
     };
     doCheck = !stdenv.isDarwin;
@@ -14631,9 +15708,10 @@ let
   };
 
   TaskCatalystTutorial = buildPerlPackage rec {
-    name = "Task-Catalyst-Tutorial-0.06";
+    pname = "Task-Catalyst-Tutorial";
+    version = "0.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MR/MRAMBERG/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MR/MRAMBERG/Task-Catalyst-Tutorial-0.06.tar.gz;
       sha256 = "75b1b2d96155647842587146cefd0de30943b85195e8e3eca51e0f0b8642d61e";
     };
     propagatedBuildInputs = [ CatalystAuthenticationStoreDBIxClass CatalystControllerHTMLFormFu CatalystDevel CatalystManual CatalystPluginAuthorizationACL CatalystPluginAuthorizationRoles CatalystPluginSessionStateCookie CatalystPluginSessionStoreFastMmap CatalystPluginStackTrace CatalystViewTT ];
@@ -14645,13 +15723,14 @@ let
   };
 
   TaskFreecellSolverTesting = buildPerlModule rec {
-    name = "Task-FreecellSolver-Testing-0.0.11";
+    pname = "Task-FreecellSolver-Testing";
+    version = "0.0.11";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SH/SHLOMIF/Task-FreecellSolver-Testing-v0.0.11.tar.gz;
       sha256 = "a2f73c65d0e5676cf4aae213ba4c3f88bf85f084a2165f1e71e3ce5b19023206";
     };
     buildInputs = [ CodeTidyAll TestDataSplit TestDifferences TestPerlTidy TestRunPluginTrimDisplayedFilenames TestRunValgrind TestTrailingSpace TestTrap ];
-    propagatedBuildInputs = [ EnvPath FileWhich GamesSolitaireVerify InlineC MooX PathTiny StringShellQuote TaskTestRunAllPlugins TemplateToolkit YAMLLibYAML ];
+    propagatedBuildInputs = [ EnvPath FileWhich GamesSolitaireVerify InlineC MooX StringShellQuote TaskTestRunAllPlugins TemplateToolkit YAMLLibYAML ];
     meta = {
       description = "Install the CPAN dependencies of the Freecell Solver test suite";
       license = stdenv.lib.licenses.mit;
@@ -14659,9 +15738,10 @@ let
   };
 
   TaskPlack = buildPerlModule rec {
-    name = "Task-Plack-0.28";
+    pname = "Task-Plack";
+    version = "0.28";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIYAGAWA/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MI/MIYAGAWA/Task-Plack-0.28.tar.gz;
       sha256 = "0ajwkyr9nwn11afi6fz6kx4bi7a3p8awjsldmsakz3sl0s42pmbr";
     };
     propagatedBuildInputs = [ CGICompile CGIEmulatePSGI CGIPSGI Corona FCGI FCGIClient FCGIProcManager HTTPServerSimplePSGI IOHandleUtil NetFastCGI PSGI PlackAppProxy PlackMiddlewareAuthDigest PlackMiddlewareConsoleLogger PlackMiddlewareDebug PlackMiddlewareDeflater PlackMiddlewareHeader PlackMiddlewareReverseProxy PlackMiddlewareSession Starlet Starman Twiggy ];
@@ -14669,9 +15749,10 @@ let
   };
 
   TaskTestRunAllPlugins = buildPerlModule rec {
-    name = "Task-Test-Run-AllPlugins-0.0105";
+    pname = "Task-Test-Run-AllPlugins";
+    version = "0.0105";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SH/SHLOMIF/Task-Test-Run-AllPlugins-0.0105.tar.gz;
       sha256 = "fd43bd053aa884a5abca851f145a0e29898515dcbfc3512f18cd0d86d28eb0a9";
     };
     buildInputs = [ TestRun TestRunCmdLine TestRunPluginAlternateInterpreters TestRunPluginBreakOnFailure TestRunPluginColorFileVerdicts TestRunPluginColorSummary TestRunPluginTrimDisplayedFilenames ];
@@ -14683,7 +15764,8 @@ let
   };
 
   TaskWeaken = buildPerlPackage {
-    name = "Task-Weaken-1.06";
+    pname = "Task-Weaken";
+    version = "1.06";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/Task-Weaken-1.06.tar.gz;
       sha256 = "1gk6rmnp4x50lzr0vfng41khf0f8yzxlm0pad1j69vxskpdzx0r3";
@@ -14695,7 +15777,8 @@ let
   };
 
   TemplatePluginAutoformat = buildPerlPackage {
-    name = "Template-Plugin-Autoformat-2.77";
+    pname = "Template-Plugin-Autoformat";
+    version = "2.77";
     src = fetchurl {
       url = mirror://cpan/authors/id/K/KA/KARMAN/Template-Plugin-Autoformat-2.77.tar.gz;
       sha256 = "bddfb4919f0abb2a2be7a9665333e0d4e098032f0e383dbaf04c4d896c7486ed";
@@ -14709,7 +15792,8 @@ let
   };
 
   TemplatePluginClass = buildPerlPackage {
-    name = "Template-Plugin-Class-0.14";
+    pname = "Template-Plugin-Class";
+    version = "0.14";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RC/RCLAMP/Template-Plugin-Class-0.14.tar.gz;
       sha256 = "1hq7jy6zg1iaslsyi05afz0i944y9jnv3nb4krkxjfmzwy5gw106";
@@ -14718,7 +15802,8 @@ let
   };
 
   TemplatePluginIOAll = buildPerlPackage {
-    name = "Template-Plugin-IO-All-0.01";
+    pname = "Template-Plugin-IO-All";
+    version = "0.01";
     src = fetchurl {
       url = mirror://cpan/authors/id/X/XE/XERN/Template-Plugin-IO-All-0.01.tar.gz;
       sha256 = "1f7445422a21932e09bbef935766e0af6b7cceb088e9d8e030cd7a84bcdc5ee4";
@@ -14732,7 +15817,8 @@ let
   };
 
   TemplatePluginJavaScript = buildPerlPackage {
-    name = "Template-Plugin-JavaScript-0.02";
+    pname = "Template-Plugin-JavaScript";
+    version = "0.02";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MI/MIYAGAWA/Template-Plugin-JavaScript-0.02.tar.gz;
       sha256 = "1mqqqs0dhfr6bp1305j9ns05q4pq1n3f561l6p8848k5ml3dh87a";
@@ -14741,7 +15827,8 @@ let
   };
 
   TemplatePluginJSONEscape = buildPerlPackage {
-    name = "Template-Plugin-JSON-Escape-0.02";
+    pname = "Template-Plugin-JSON-Escape";
+    version = "0.02";
     src = fetchurl {
       url = mirror://cpan/authors/id/N/NA/NANTO/Template-Plugin-JSON-Escape-0.02.tar.gz;
       sha256 = "051a8b1d3bc601d58fc51e246067d36450cfe970278a0456e8ab61940f13cd86";
@@ -14750,7 +15837,8 @@ let
   };
 
   TemplateTimer = buildPerlPackage {
-    name = "Template-Timer-1.00";
+    pname = "Template-Timer";
+    version = "1.00";
     src = fetchurl {
       url = mirror://cpan/authors/id/P/PE/PETDANCE/Template-Timer-1.00.tar.gz;
       sha256 = "1d3pbcx1kz73ncg8s8lx3ifwphz838qy0m40gdar7790cnrlqcdp";
@@ -14763,7 +15851,8 @@ let
   };
 
   TemplateTiny = buildPerlPackage {
-    name = "Template-Tiny-1.12";
+    pname = "Template-Tiny";
+    version = "1.12";
     src = fetchurl {
       url = mirror://cpan/authors/id/A/AD/ADAMK/Template-Tiny-1.12.tar.gz;
       sha256 = "073e062c630b51dfb725cd6485a329155cb72d5c596e8cb698eb67c4566f0a4a";
@@ -14791,7 +15880,8 @@ let
   };
 
    TemplateGD = buildPerlPackage rec {
-    name = "Template-GD-2.66";
+    pname = "Template-GD";
+    version = "2.66";
     src = fetchurl {
       url = mirror://cpan/authors/id/A/AB/ABW/Template-GD-2.66.tar.gz;
       sha256 = "98523c8192f2e8184042e5a2e172bd767ac289dd2e480f35f680dce32160905b";
@@ -14804,7 +15894,8 @@ let
   };
 
   TermEncoding = buildPerlPackage {
-    name = "Term-Encoding-0.03";
+    pname = "Term-Encoding";
+    version = "0.03";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MI/MIYAGAWA/Term-Encoding-0.03.tar.gz;
       sha256 = "95ba9687d735d25a3cbe64508d7894f009c7fa2a1726c3e786e9e21da2251d0b";
@@ -14816,9 +15907,10 @@ let
   };
 
   TermProgressBar = buildPerlPackage rec {
-    name = "Term-ProgressBar-2.22";
+    pname = "Term-ProgressBar";
+    version = "2.22";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MANWAR/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MA/MANWAR/Term-ProgressBar-2.22.tar.gz;
       sha256 = "2642ecca5b0b038c14812bcad3a9611ff7911dc59c9104d220797f837a880c49";
     };
     buildInputs = [ CaptureTiny TestException TestWarnings ];
@@ -14830,7 +15922,8 @@ let
   };
 
   TermProgressBarQuiet = buildPerlPackage {
-    name = "Term-ProgressBar-Quiet-0.31";
+    pname = "Term-ProgressBar-Quiet";
+    version = "0.31";
     src = fetchurl {
       url = mirror://cpan/authors/id/L/LB/LBROCARD/Term-ProgressBar-Quiet-0.31.tar.gz;
       sha256 = "25675292f588bc29d32e710cf3667da9a2a1751e139801770a9fdb18cd2184a6";
@@ -14844,7 +15937,8 @@ let
   };
 
   TermProgressBarSimple = buildPerlPackage {
-    name = "Term-ProgressBar-Simple-0.03";
+    pname = "Term-ProgressBar-Simple";
+    version = "0.03";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/EV/EVDB/Term-ProgressBar-Simple-0.03.tar.gz;
       sha256 = "a20db3c67d5bdfd0c1fab392c6d1c26880a7ee843af602af4f9b53a7043579a6";
@@ -14854,10 +15948,10 @@ let
   };
 
   TermReadKey = buildPerlPackage rec {
-    name = "TermReadKey-${version}";
+    pname = "TermReadKey";
     version = "2.38";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JS/JSTOWE/${name}.tar.gz";
+      url = mirror://cpan/authors/id/J/JS/JSTOWE/TermReadKey-2.38.tar.gz;
       sha256 = "143jlibah1g14bym7sj3gphvqkpj1w4vn7sqc4vc62jpviw5hr2s";
     };
     cross = stdenv.hostPlatform != stdenv.buildPlatform;
@@ -14879,9 +15973,10 @@ let
   };
 
   TermReadLineGnu = buildPerlPackage rec {
-    name = "Term-ReadLine-Gnu-1.36";
+    pname = "Term-ReadLine-Gnu";
+    version = "1.36";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAYASHI/${name}.tar.gz";
+      url = mirror://cpan/authors/id/H/HA/HAYASHI/Term-ReadLine-Gnu-1.36.tar.gz;
       sha256 = "9a08f7a4013c9b865541c10dbba1210779eb9128b961250b746d26702bab6925";
     };
     buildInputs = [ pkgs.readline pkgs.ncurses ];
@@ -14909,7 +16004,8 @@ let
   };
 
   TermReadLineTTYtter = buildPerlPackage rec {
-    name = "Term-ReadLine-TTYtter-1.4";
+    pname = "Term-ReadLine-TTYtter";
+    version = "1.4";
     src = fetchurl {
       url = "mirror://cpan/authors/id/C/CK/CKAISER/Term-ReadLine-TTYtter-1.4.tar.gz";
       sha256 = "14xcqhg1vrwgv65nd2z8xzn0wgb18i17pzkkh8m15cp1rqrk2dxc";
@@ -14924,15 +16020,17 @@ let
   };
 
   TermShellUI = buildPerlPackage rec {
-    name = "Term-ShellUI-0.92";
+    pname = "Term-ShellUI";
+    version = "0.92";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BR/BRONSON/${name}.tar.gz";
+      url = mirror://cpan/authors/id/B/BR/BRONSON/Term-ShellUI-0.92.tar.gz;
       sha256 = "3279c01c76227335eeff09032a40f4b02b285151b3576c04cacd15be05942bdb";
     };
   };
 
   TermSizeAny = buildPerlPackage {
-    name = "Term-Size-Any-0.002";
+    pname = "Term-Size-Any";
+    version = "0.002";
     src = fetchurl {
       url = mirror://cpan/authors/id/F/FE/FERREIRA/Term-Size-Any-0.002.tar.gz;
       sha256 = "64fa5fdb1ae3a823134aaa95aec75354bc17bdd9ca12ba0a7ae34a7e51b3ded2";
@@ -14945,7 +16043,8 @@ let
   };
 
   TermSizePerl = buildPerlPackage {
-    name = "Term-Size-Perl-0.031";
+    pname = "Term-Size-Perl";
+    version = "0.031";
     src = fetchurl {
       url = mirror://cpan/authors/id/F/FE/FERREIRA/Term-Size-Perl-0.031.tar.gz;
       sha256 = "ae9a6746cb1b305ddc8f8d8ca46878552b9c1123628971e13a275183822f209e";
@@ -14957,9 +16056,10 @@ let
   };
 
   TermTable = buildPerlPackage rec {
-    name = "Term-Table-0.013";
+    pname = "Term-Table";
+    version = "0.013";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/EX/EXODIST/${name}.tar.gz";
+      url = mirror://cpan/authors/id/E/EX/EXODIST/Term-Table-0.013.tar.gz;
       sha256 = "ffeb36dcb25c575b9f63657d1591a14af22cd10ba23cc76de9d976b426f4fc40";
     };
     propagatedBuildInputs = [ Importer ];
@@ -14970,7 +16070,8 @@ let
   };
 
   TermUI = buildPerlPackage rec {
-     name = "Term-UI-0.46";
+     pname = "Term-UI";
+     version = "0.46";
      src = fetchurl {
        url = mirror://cpan/authors/id/B/BI/BINGOS/Term-UI-0.46.tar.gz;
        sha256 = "19p92za5cx1v7g57pg993amprcvm1az3pp7y9g5b1aplsy06r54i";
@@ -14983,7 +16084,8 @@ let
   };
 
   TermVT102 = buildPerlPackage {
-    name = "Term-VT102-0.91";
+    pname = "Term-VT102";
+    version = "0.91";
     src = fetchurl {
       url = mirror://cpan/authors/id/A/AJ/AJWOOD/Term-VT102-0.91.tar.gz;
       sha256 = "f954e0310941d45c0fc3eb4a40f5d3a00d68119e277d303a1e6af11ded6fbd94";
@@ -14993,7 +16095,8 @@ let
   };
 
   TermVT102Boundless = buildPerlPackage {
-    name = "Term-VT102-Boundless-0.05";
+    pname = "Term-VT102-Boundless";
+    version = "0.05";
     src = fetchurl {
       url = mirror://cpan/authors/id/F/FB/FBARRIOS/Term-VT102-Boundless-0.05.tar.gz;
       sha256 = "e1ded85ae3d76b59c03b8697f4a6cb01ae31bd62a9354f5bb7d18f9e927b485f";
@@ -15002,9 +16105,10 @@ let
   };
 
   TermAnimation = buildPerlPackage rec {
-    name = "Term-Animation-2.6";
+    pname = "Term-Animation";
+    version = "2.6";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KB/KBAUCOM/${name}.tar.gz";
+      url = mirror://cpan/authors/id/K/KB/KBAUCOM/Term-Animation-2.6.tar.gz;
       sha256 = "7d5c3c2d4f9b657a8b1dce7f5e2cbbe02ada2e97c72f3a0304bf3c99d084b045";
     };
     propagatedBuildInputs = [ Curses ];
@@ -15043,7 +16147,8 @@ let
   };
 
   TestAbortable = buildPerlPackage rec {
-     name = "Test-Abortable-0.002";
+     pname = "Test-Abortable";
+     version = "0.002";
      src = fetchurl {
        url = mirror://cpan/authors/id/R/RJ/RJBS/Test-Abortable-0.002.tar.gz;
        sha256 = "0v97y31j56f4mxw0vxyjbdprq4951h4wcdh4acnfm63np7wvg44p";
@@ -15058,7 +16163,8 @@ let
   };
 
   TestAssert = buildPerlModule {
-    name = "Test-Assert-0.0504";
+    pname = "Test-Assert";
+    version = "0.0504";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DE/DEXTER/Test-Assert-0.0504.tar.gz;
       sha256 = "194bzflmzc0cw5727kznbj1zwzj7gnj7nx1643zk2hshdjlnv8yg";
@@ -15068,7 +16174,8 @@ let
   };
 
   TestAssertions = buildPerlPackage rec {
-    name = "Test-Assertions-1.054";
+    pname = "Test-Assertions";
+    version = "1.054";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BB/BBC/Test-Assertions-1.054.tar.gz;
       sha256 = "10026w4r3yv6k3vc6cby7d61mxddlqh0ls6z39c82f17awfy9p7w";
@@ -15077,9 +16184,10 @@ let
   };
 
   TestAggregate = buildPerlModule rec {
-    name = "Test-Aggregate-0.375";
+    pname = "Test-Aggregate";
+    version = "0.375";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RW/RWSTAUNER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RW/RWSTAUNER/Test-Aggregate-0.375.tar.gz;
       sha256 = "c6cc0abfd0d4fce85371acca93ec245381841d32b4caa2d6475e4bc8130427d1";
     };
     buildInputs = [ TestMost TestNoWarnings TestTrap ];
@@ -15092,9 +16200,10 @@ let
 
 
   TestBase = buildPerlPackage rec {
-    name = "Test-Base-0.89";
+    pname = "Test-Base";
+    version = "0.89";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/I/IN/INGY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/I/IN/INGY/Test-Base-0.89.tar.gz;
       sha256 = "056hibgg3i2b89mwr76vyxi6ayb3hqjqcwicvn3s5lximsma3517";
     };
     propagatedBuildInputs = [ Spiffy ];
@@ -15102,7 +16211,8 @@ let
   };
 
   TestBits = buildPerlPackage {
-    name = "Test-Bits-0.02";
+    pname = "Test-Bits";
+    version = "0.02";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DR/DROLSKY/Test-Bits-0.02.tar.gz;
       sha256 = "1hqbvqlkj3k9ys4zq3f1fl1y6crni8r0ynan673f49rs91b6z0m9";
@@ -15116,9 +16226,10 @@ let
   };
 
   TestCheckDeps = buildPerlPackage rec {
-    name = "Test-CheckDeps-0.010";
+    pname = "Test-CheckDeps";
+    version = "0.010";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LE/LEONT/${name}.tar.gz";
+      url = mirror://cpan/authors/id/L/LE/LEONT/Test-CheckDeps-0.010.tar.gz;
       sha256 = "1vjinlixxdx6gfcw8y1dw2rla8bfhi8nmgcqr3nffc7kqskcrz36";
     };
     propagatedBuildInputs = [ CPANMetaCheck ];
@@ -15129,9 +16240,10 @@ let
   };
 
   TestClass = buildPerlPackage rec {
-    name = "Test-Class-0.50";
+    pname = "Test-Class";
+    version = "0.50";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/E/ET/ETHER/Test-Class-0.50.tar.gz;
       sha256 = "099154ed8caf3ff97c71237fab952264ac1c03d9270737a56071cabe65991350";
     };
     buildInputs = [ TestException ];
@@ -15143,7 +16255,8 @@ let
   };
 
   TestClassMost = buildPerlModule rec {
-     name = "Test-Class-Most-0.08";
+     pname = "Test-Class-Most";
+     version = "0.08";
      src = fetchurl {
        url = mirror://cpan/authors/id/O/OV/OVID/Test-Class-Most-0.08.tar.gz;
        sha256 = "1zvx9hil0mg0pnb8xfa4m0xgjpvh8s5gnbyprq3xwpdsdgcdwk33";
@@ -15156,7 +16269,8 @@ let
   };
 
   TestCleanNamespaces = buildPerlPackage {
-    name = "Test-CleanNamespaces-0.24";
+    pname = "Test-CleanNamespaces";
+    version = "0.24";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/Test-CleanNamespaces-0.24.tar.gz;
       sha256 = "338d5569e8e89a654935f843ec0bc84aaa486fe8dd1898fb9cab3eccecd5327a";
@@ -15171,7 +16285,8 @@ let
   };
 
   TestCmd = buildPerlPackage rec {
-     name = "Test-Cmd-1.09";
+     pname = "Test-Cmd";
+     version = "1.09";
      src = fetchurl {
        url = mirror://cpan/authors/id/N/NE/NEILB/Test-Cmd-1.09.tar.gz;
        sha256 = "114nfafwfxxn7kig265b7lg0znb5ybvc282sjjwf14g7vpn20cyg";
@@ -15185,7 +16300,8 @@ let
   };
 
   TestCommand = buildPerlModule {
-    name = "Test-Command-0.11";
+    pname = "Test-Command";
+    version = "0.11";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DA/DANBOO/Test-Command-0.11.tar.gz;
       sha256 = "0cwm3c4d49mdrbm6vgh78b3x8mk730l0zg8i7xb9z8bkx9pzr8r8";
@@ -15198,7 +16314,8 @@ let
   };
 
   TestCompile = buildPerlModule rec {
-    name = "Test-Compile-1.3.0";
+    pname = "Test-Compile";
+    version = "1.3.0";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/EG/EGILES/Test-Compile-v1.3.0.tar.gz;
       sha256 = "77527e9477ac5260443c756367a7f7bc3d8f6c6ebbc561b0b2fb3f79303bad33";
@@ -15211,7 +16328,8 @@ let
   };
 
   TestCPANMeta = buildPerlPackage {
-    name = "Test-CPAN-Meta-0.25";
+    pname = "Test-CPAN-Meta";
+    version = "0.25";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BA/BARBIE/Test-CPAN-Meta-0.25.tar.gz;
       sha256 = "f55b4f9cf6bc396d0fe8027267685cb2ac4affce897d0967a317fac6db5a8db5";
@@ -15223,7 +16341,8 @@ let
   };
 
   TestCPANMetaJSON = buildPerlPackage rec {
-     name = "Test-CPAN-Meta-JSON-0.16";
+     pname = "Test-CPAN-Meta-JSON";
+     version = "0.16";
      src = fetchurl {
        url = mirror://cpan/authors/id/B/BA/BARBIE/Test-CPAN-Meta-JSON-0.16.tar.gz;
        sha256 = "1jg9ka50ixwq083wd4k12rhdjq87w0ihb34gd8jjn7gvvyd51b37";
@@ -15236,9 +16355,10 @@ let
   };
 
   TestDataSplit = buildPerlModule rec {
-    name = "Test-Data-Split-0.2.1";
+    pname = "Test-Data-Split";
+    version = "0.2.1";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SH/SHLOMIF/Test-Data-Split-0.2.1.tar.gz;
       sha256 = "9ba0c27a9e23c5dd8ede7611a049180485acc512a63783e1d1843b6569db5ae7";
     };
     buildInputs = [ TestDifferences ];
@@ -15250,7 +16370,8 @@ let
   };
 
   TestDeep = buildPerlPackage {
-    name = "Test-Deep-1.128";
+    pname = "Test-Deep";
+    version = "1.128";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RJ/RJBS/Test-Deep-1.128.tar.gz;
       sha256 = "0bq9c0vrxbwhhy1pd2ss06fk06jal98j022mnyq6k0msdy1pwbc5";
@@ -15260,7 +16381,8 @@ let
   };
 
   TestDir = buildPerlPackage {
-    name = "Test-Dir-1.16";
+    pname = "Test-Dir";
+    version = "1.16";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MT/MTHURN/Test-Dir-1.16.tar.gz;
       sha256 = "7332b323913eb6a2684d094755196304b2f8606f70eaab913654ca91f273eac2";
@@ -15272,7 +16394,8 @@ let
   };
 
   TestDifferences = buildPerlPackage {
-    name = "Test-Differences-0.67";
+    pname = "Test-Differences";
+    version = "0.67";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DC/DCANTRELL/Test-Differences-0.67.tar.gz;
       sha256 = "c88dbbb48b934b069284874f33abbaaa438aa31204aa3fa73bfc2f4aeac878da";
@@ -15285,7 +16408,8 @@ let
   };
 
   TestDistManifest = buildPerlModule {
-    name = "Test-DistManifest-1.014";
+    pname = "Test-DistManifest";
+    version = "1.014";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/Test-DistManifest-1.014.tar.gz;
       sha256 = "3d26c20df42628981cbfcfa5b1ca028c6ceadb344c1dcf97a25ad6a88b73d7c5";
@@ -15299,7 +16423,8 @@ let
   };
 
   TestEOL = buildPerlPackage {
-    name = "Test-EOL-2.00";
+    pname = "Test-EOL";
+    version = "2.00";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/Test-EOL-2.00.tar.gz;
       sha256 = "0l3bxpsw0x7j9nclizcp53mnf9wny25dmg2iglfhzgnk0xfpwzwf";
@@ -15311,7 +16436,8 @@ let
   };
 
   TestException = buildPerlPackage rec {
-    name = "Test-Exception-0.43";
+    pname = "Test-Exception";
+    version = "0.43";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/EX/EXODIST/Test-Exception-0.43.tar.gz;
       sha256 = "0cxm7s4bg0xpxa6l6996a6iq3brr4j7p4hssnkc6dxv4fzq16sqm";
@@ -15320,7 +16446,8 @@ let
   };
 
   TestFailWarnings = buildPerlPackage {
-    name = "Test-FailWarnings-0.008";
+    pname = "Test-FailWarnings";
+    version = "0.008";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DA/DAGOLDEN/Test-FailWarnings-0.008.tar.gz;
       sha256 = "0vx9chcp5x8m0chq574p9fnfckh5gl94j7904rh9v17n568fyd6s";
@@ -15333,9 +16460,10 @@ let
   };
 
   TestFatal = buildPerlPackage rec {
-    name = "Test-Fatal-0.014";
+    pname = "Test-Fatal";
+    version = "0.014";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RJ/RJBS/Test-Fatal-0.014.tar.gz;
       sha256 = "bcdcef5c7b2790a187ebca810b0a08221a63256062cfab3c3b98685d91d1cbb0";
     };
     propagatedBuildInputs = [ TryTiny ];
@@ -15347,7 +16475,8 @@ let
   };
 
   TestFile = buildPerlPackage {
-    name = "Test-File-1.443";
+    pname = "Test-File";
+    version = "1.443";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BD/BDFOY/Test-File-1.443.tar.gz;
       sha256 = "61b4a6ab8f617c8c7b5975164cf619468dc304b6baaaea3527829286fa58bcd5";
@@ -15360,7 +16489,8 @@ let
   };
 
   TestFileContents = buildPerlModule {
-    name = "Test-File-Contents-0.23";
+    pname = "Test-File-Contents";
+    version = "0.23";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DW/DWHEELER/Test-File-Contents-0.23.tar.gz;
       sha256 = "cd6fadfb910b34b4b53991ff231dad99929ca8850abec3ad0e2810c4bd7b1f3d";
@@ -15373,7 +16503,8 @@ let
   };
 
   TestFileShareDir = buildPerlPackage {
-    name = "Test-File-ShareDir-1.001002";
+    pname = "Test-File-ShareDir";
+    version = "1.001002";
     src = fetchurl {
       url = mirror://cpan/authors/id/K/KE/KENTNL/Test-File-ShareDir-1.001002.tar.gz;
       sha256 = "b33647cbb4b2f2fcfbde4f8bb4383d0ac95c2f89c4c5770eb691f1643a337aad";
@@ -15388,7 +16519,8 @@ let
   };
 
   TestFork = buildPerlModule rec {
-    name = "Test-Fork-0.02";
+    pname = "Test-Fork";
+    version = "0.02";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MS/MSCHWERN/Test-Fork-0.02.tar.gz;
       sha256 = "0gnh8m81fdrwmzy1fix12grfq7sf7nn0gbf24zlap1gq4kxzpzpw";
@@ -15400,7 +16532,8 @@ let
   };
 
   TestHarnessStraps = buildPerlModule {
-    name = "Test-Harness-Straps-0.30";
+    pname = "Test-Harness-Straps";
+    version = "0.30";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MS/MSCHWERN/Test-Harness-Straps-0.30.tar.gz;
       sha256 = "8b00efaa35723c1a35c8c8f5fa46a99e4bc528dfa520352b54ac418ef6d1cfa8";
@@ -15412,7 +16545,8 @@ let
   };
 
   TestHexDifferences = buildPerlPackage rec {
-     name = "Test-HexDifferences-1.001";
+     pname = "Test-HexDifferences";
+     version = "1.001";
      src = fetchurl {
        url = mirror://cpan/authors/id/S/ST/STEFFENW/Test-HexDifferences-1.001.tar.gz;
        sha256 = "18lh6shpfx567gjikrid4hixydgv1hi3mycl20qzq2j2vpn4afd6";
@@ -15424,7 +16558,8 @@ let
   };
 
   TestHexString = buildPerlModule rec {
-     name = "Test-HexString-0.03";
+     pname = "Test-HexString";
+     version = "0.03";
      src = fetchurl {
        url = mirror://cpan/authors/id/P/PE/PEVANS/Test-HexString-0.03.tar.gz;
        sha256 = "0h1zl2l1ljlcxsn0xvin9dwiymnhyhnfnxgzg3f9899g37f4qk3x";
@@ -15436,7 +16571,8 @@ let
   };
 
   TestHTTPServerSimple = buildPerlPackage {
-    name = "Test-HTTP-Server-Simple-0.11";
+    pname = "Test-HTTP-Server-Simple";
+    version = "0.11";
     src = fetchurl {
       url = mirror://cpan/authors/id/A/AL/ALEXMV/Test-HTTP-Server-Simple-0.11.tar.gz;
       sha256 = "85c97ebd4deb805291b17277032da48807228f24f89b1ce2fb3c09f7a896bb78";
@@ -15448,7 +16584,8 @@ let
   };
 
   TestJSON = buildPerlModule {
-    name = "Test-JSON-0.11";
+    pname = "Test-JSON";
+    version = "0.11";
     src = fetchurl {
       url = mirror://cpan/authors/id/O/OV/OVID/Test-JSON-0.11.tar.gz;
       sha256 = "1cyp46w3q7dg89qkw31ik2h2a6mdx6pzdz2lmp8m0a61zjr8mh07";
@@ -15458,7 +16595,8 @@ let
   };
 
   TestKwalitee = buildPerlPackage rec {
-     name = "Test-Kwalitee-1.28";
+     pname = "Test-Kwalitee";
+     version = "1.28";
      src = fetchurl {
        url = mirror://cpan/authors/id/E/ET/ETHER/Test-Kwalitee-1.28.tar.gz;
        sha256 = "18s3c8qfr3kmmyxmsn5la2zgbdsgpnkmscnl68i7fnavfpfnqlxl";
@@ -15473,7 +16611,8 @@ let
   };
 
   TestLeakTrace = buildPerlPackage rec {
-    name = "Test-LeakTrace-0.16";
+    pname = "Test-LeakTrace";
+    version = "0.16";
     src = fetchurl {
       url = mirror://cpan/authors/id/L/LE/LEEJO/Test-LeakTrace-0.16.tar.gz;
       sha256 = "00z4hcjra5nk700f3fgpy8fs036d7ry7glpn8g3wh7jzj7nrw22z";
@@ -15485,7 +16624,8 @@ let
   };
 
   TestLectroTest = buildPerlPackage {
-    name = "Test-LectroTest-0.5001";
+    pname = "Test-LectroTest";
+    version = "0.5001";
     src = fetchurl {
       url = mirror://cpan/authors/id/T/TM/TMOERTEL/Test-LectroTest-0.5001.tar.gz;
       sha256 = "0dfpkvn06499gczch4gfmdb05fdj82vlqy7cl6hz36l9jl6lyaxc";
@@ -15497,7 +16637,8 @@ let
   };
 
   TestLoadAllModules = buildPerlPackage {
-    name = "Test-LoadAllModules-0.022";
+    pname = "Test-LoadAllModules";
+    version = "0.022";
     src = fetchurl {
       url = mirror://cpan/authors/id/K/KI/KITANO/Test-LoadAllModules-0.022.tar.gz;
       sha256 = "1zjwbqk1ns9m8srrhyj3i5zih976i4d2ibflh5s8lr10a1aiz1hv";
@@ -15510,7 +16651,8 @@ let
   };
 
   TestLongString = buildPerlPackage rec {
-    name = "Test-LongString-0.17";
+    pname = "Test-LongString";
+    version = "0.17";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RG/RGARCIA/Test-LongString-0.17.tar.gz;
       sha256 = "0kwp7rfr1i2amz4ckigkv13ah7jr30q6l5k4wk0vxl84myg39i5b";
@@ -15518,9 +16660,10 @@ let
   };
 
   TestMemoryCycle = buildPerlPackage rec {
-    name = "Test-Memory-Cycle-1.06";
+    pname = "Test-Memory-Cycle";
+    version = "1.06";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PE/PETDANCE/${name}.tar.gz";
+      url = mirror://cpan/authors/id/P/PE/PETDANCE/Test-Memory-Cycle-1.06.tar.gz;
       sha256 = "9d53ddfdc964cd8454cb0da4c695b6a3ae47b45839291c34cb9d8d1cfaab3202";
     };
     propagatedBuildInputs = [ DevelCycle PadWalker ];
@@ -15530,7 +16673,8 @@ let
   };
 
   TestMockClass = buildPerlModule {
-    name = "Test-Mock-Class-0.0303";
+    pname = "Test-Mock-Class";
+    version = "0.0303";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DE/DEXTER/Test-Mock-Class-0.0303.tar.gz;
       sha256 = "00pkfqcz7b34q1mvx15k46sbxs22zcrvrbv15rnbn2na57z54bnd";
@@ -15544,9 +16688,10 @@ let
   };
 
   TestMockGuard = buildPerlModule rec {
-    name = "Test-Mock-Guard-0.10";
+    pname = "Test-Mock-Guard";
+    version = "0.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/X/XA/XAICRON/${name}.tar.gz";
+      url = mirror://cpan/authors/id/X/XA/XAICRON/Test-Mock-Guard-0.10.tar.gz;
       sha256 = "7f228a63f8d6ceb92aa784080a13e85073121b2835eca06d794f9709950dbd3d";
     };
     propagatedBuildInputs = [ ClassLoad ];
@@ -15558,7 +16703,8 @@ let
   };
 
   TestMockModule = buildPerlModule {
-    name = "Test-MockModule-0.170.0";
+    pname = "Test-MockModule";
+    version = "0.170.0";
     src = fetchurl {
       url = mirror://cpan/authors/id/G/GF/GFRANKS/Test-MockModule-v0.170.0.tar.gz;
       sha256 = "0pggwrlqj6k44qayhbpjqkzry1r626iy2vf30zlf2jdhbjbvlycz";
@@ -15568,9 +16714,10 @@ let
   };
 
   SUPER = buildPerlModule rec {
-    name = "SUPER-1.20141117";
+    pname = "SUPER";
+    version = "1.20141117";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CH/CHROMATIC/${name}.tar.gz";
+      url = mirror://cpan/authors/id/C/CH/CHROMATIC/SUPER-1.20141117.tar.gz;
       sha256 = "1a620e7d60aee9b13b1b26a44694c43fdb2bba1755cfff435dae83c7d42cc0b2";
     };
     propagatedBuildInputs = [ SubIdentify ];
@@ -15582,9 +16729,10 @@ let
 
 
   TestMockObject = buildPerlPackage rec {
-    name = "Test-MockObject-1.20180705";
+    pname = "Test-MockObject";
+    version = "1.20180705";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CH/CHROMATIC/${name}.tar.gz";
+      url = mirror://cpan/authors/id/C/CH/CHROMATIC/Test-MockObject-1.20180705.tar.gz;
       sha256 = "4516058d5d511155c1c462dab4027d762d6a474b99f73bf7da20b5ffbd024518";
     };
     buildInputs = [ CGI TestException TestWarn ];
@@ -15596,15 +16744,17 @@ let
   };
 
   TestMockTime = buildPerlPackage rec {
-    name = "Test-MockTime-0.17";
+    pname = "Test-MockTime";
+    version = "0.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DD/DDICK/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DD/DDICK/Test-MockTime-0.17.tar.gz;
       sha256 = "1y820qsq7yf7r6smy5c6f0mpf2cis2q24vwmpim1svv0n8cf2qrk";
     };
   };
 
   TestMockTimeHiRes = buildPerlModule rec {
-     name = "Test-MockTime-HiRes-0.08";
+     pname = "Test-MockTime-HiRes";
+     version = "0.08";
      src = fetchurl {
        url = mirror://cpan/authors/id/T/TA/TARAO/Test-MockTime-HiRes-0.08.tar.gz;
        sha256 = "1hfykcjrls6ywgbd49w29c7apj3nq4wlyx7jzpd2glwmz2pgfjaz";
@@ -15618,7 +16768,8 @@ let
   };
 
   TestMojibake = buildPerlPackage {
-    name = "Test-Mojibake-1.3";
+    pname = "Test-Mojibake";
+    version = "1.3";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SY/SYP/Test-Mojibake-1.3.tar.gz;
       sha256 = "0cqvbwddgh0pfzmh989gkysi9apqj7dp7jkxfa428db9kgzpbzlg";
@@ -15631,7 +16782,8 @@ let
   };
 
   TestMoreUTF8 = buildPerlPackage rec {
-     name = "Test-More-UTF8-0.05";
+     pname = "Test-More-UTF8";
+     version = "0.05";
      src = fetchurl {
        url = mirror://cpan/authors/id/M/MO/MONS/Test-More-UTF8-0.05.tar.gz;
        sha256 = "016fs77lmw8xxrcnapvp6wq4hjwgsdfi3l9ylpxgxkcpdarw9wdr";
@@ -15643,7 +16795,8 @@ let
   };
 
   TestMost = buildPerlPackage {
-    name = "Test-Most-0.35";
+    pname = "Test-Most";
+    version = "0.35";
     src = fetchurl {
       url = mirror://cpan/authors/id/O/OV/OVID/Test-Most-0.35.tar.gz;
       sha256 = "0zv5dyzq55r28plffibcr7wd00abap0h2zh4s4p8snaiszsad5wq";
@@ -15657,9 +16810,10 @@ let
   };
 
   TestNeeds = buildPerlPackage rec {
-    name = "Test-Needs-0.002006";
+    pname = "Test-Needs";
+    version = "0.002006";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HAARG/${name}.tar.gz";
+      url = mirror://cpan/authors/id/H/HA/HAARG/Test-Needs-0.002006.tar.gz;
       sha256 = "77f9fff0c96c5e09f34d0416b3533c3319f7cd0bb1f7fe8f8072ad59f433f0e5";
     };
     meta = {
@@ -15669,7 +16823,8 @@ let
   };
 
   TestNoTabs = buildPerlPackage {
-    name = "Test-NoTabs-2.02";
+    pname = "Test-NoTabs";
+    version = "2.02";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/Test-NoTabs-2.02.tar.gz;
       sha256 = "0c306p9qdpa2ycii3c50hml23mwy6bjxpry126g1dw11hyiwcxgv";
@@ -15681,7 +16836,8 @@ let
   };
 
   TestNoWarnings = buildPerlPackage {
-    name = "Test-NoWarnings-1.04";
+    pname = "Test-NoWarnings";
+    version = "1.04";
     src = fetchurl {
       url = mirror://cpan/authors/id/A/AD/ADAMK/Test-NoWarnings-1.04.tar.gz;
       sha256 = "0v385ch0hzz9naqwdw2az3zdqi15gka76pmiwlgsy6diiijmg2k3";
@@ -15693,7 +16849,8 @@ let
   };
 
   TestObject = buildPerlPackage rec {
-    name = "Test-Object-0.08";
+    pname = "Test-Object";
+    version = "0.08";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/Test-Object-0.08.tar.gz;
       sha256 = "65278964147837313f4108e55b59676e8a364d6edf01b3dc198aee894ab1d0bb";
@@ -15701,7 +16858,8 @@ let
   };
 
   TestOutput = buildPerlPackage rec {
-    name = "Test-Output-1.031";
+    pname = "Test-Output";
+    version = "1.031";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BD/BDFOY/Test-Output-1.031.tar.gz;
       sha256 = "193y1xjvgc1p9pdgdwps2127knvpz9wc1xh6gmr74y3ihmqz7f7q";
@@ -15710,7 +16868,8 @@ let
   };
 
   TestPAUSEPermissions = buildPerlPackage rec {
-     name = "Test-PAUSE-Permissions-0.07";
+     pname = "Test-PAUSE-Permissions";
+     version = "0.07";
      src = fetchurl {
        url = mirror://cpan/authors/id/S/SK/SKAJI/Test-PAUSE-Permissions-0.07.tar.gz;
        sha256 = "0gh7f67g1y30yggmwj1pq6xgrx3cfjibj2378nl3gilvyaxw2w2m";
@@ -15724,7 +16883,8 @@ let
   };
 
   TestPerlCritic = buildPerlModule rec {
-    name = "Test-Perl-Critic-1.04";
+    pname = "Test-Perl-Critic";
+    version = "1.04";
     src = fetchurl {
       url = mirror://cpan/authors/id/P/PE/PETDANCE/Test-Perl-Critic-1.04.tar.gz;
       sha256 = "28f806b5412c7908b56cf1673084b8b44ce1cb54c9417d784d91428e1a04096e";
@@ -15733,7 +16893,8 @@ let
   };
 
   TestPerlTidy = buildPerlModule rec {
-    name = "Test-PerlTidy-20190402";
+    pname = "Test-PerlTidy";
+    version = "20190402";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SH/SHLOMIF/Test-PerlTidy-20190402.tar.gz;
       sha256 = "e9cb9b23ed62e8c6a47a1e18b55328aa3bfa467e05cd93e7e12b2738dd1e025f";
@@ -15746,9 +16907,10 @@ let
   };
 
   TestPod = buildPerlPackage rec {
-    name = "Test-Pod-1.52";
+    pname = "Test-Pod";
+    version = "1.52";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/E/ET/ETHER/Test-Pod-1.52.tar.gz;
       sha256 = "1z75x1pxwp8ajwq9iazlg2c3wd7rdlim08yclpdg32qnc36dpa30";
     };
     meta = {
@@ -15758,7 +16920,8 @@ let
   };
 
   TestPodCoverage = buildPerlPackage rec {
-    name = "Test-Pod-Coverage-1.10";
+    pname = "Test-Pod-Coverage";
+    version = "1.10";
     src = fetchurl {
       url = mirror://cpan/authors/id/N/NE/NEILB/Test-Pod-Coverage-1.10.tar.gz;
       sha256 = "1m203mhgfilz7iqc8mxaw4lw02fz391mni3n25sfx7nryylwrja8";
@@ -15767,9 +16930,10 @@ let
   };
 
   TestPodLinkCheck = buildPerlModule rec {
-    name = "Test-Pod-LinkCheck-0.008";
+    pname = "Test-Pod-LinkCheck";
+    version = "0.008";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AP/APOCAL/${name}.tar.gz";
+      url = mirror://cpan/authors/id/A/AP/APOCAL/Test-Pod-LinkCheck-0.008.tar.gz;
       sha256 = "2bfe771173c38b69eeb089504e3f76511b8e45e6a9e6dac3e616e400ea67bcf0";
     };
     buildInputs = [ ModuleBuildTiny TestPod ];
@@ -15781,7 +16945,8 @@ let
   };
 
   TestPodNo404s = buildPerlModule rec {
-    name = "Test-Pod-No404s-0.02";
+    pname = "Test-Pod-No404s";
+    version = "0.02";
     src = fetchurl {
       url = "mirror://cpan/authors/id/A/AP/APOCAL/Test-Pod-No404s-0.02.tar.gz";
       sha256 = "0ycfghsyl9f31kxdppjwx2g5iajrqh3fyywz0x7d8ayndw2hdihi";
@@ -15795,7 +16960,8 @@ let
   };
 
   TestPortabilityFiles = buildPerlPackage {
-    name = "Test-Portability-Files-0.10";
+    pname = "Test-Portability-Files";
+    version = "0.10";
     src = fetchurl {
       url = mirror://cpan/authors/id/A/AB/ABRAXXA/Test-Portability-Files-0.10.tar.gz;
       sha256 = "08e4b432492dc1b44b55d5db57952eb76379c7f434ee8f16aca64d491f401a16";
@@ -15807,9 +16973,10 @@ let
   };
 
   TestRequires = buildPerlPackage rec {
-    name = "Test-Requires-0.10";
+    pname = "Test-Requires";
+    version = "0.10";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TOKUHIROM/${name}.tar.gz";
+      url = mirror://cpan/authors/id/T/TO/TOKUHIROM/Test-Requires-0.10.tar.gz;
       sha256 = "1d9f481lj12cw1ciil46xq9nq16p6a90nm7yrsalpf8asn8s6s17";
     };
     meta = {
@@ -15819,9 +16986,10 @@ let
   };
 
   TestRequiresGit = buildPerlPackage rec {
-    name = "Test-Requires-Git-1.008";
+    pname = "Test-Requires-Git";
+    version = "1.008";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BO/BOOK/${name}.tar.gz";
+      url = mirror://cpan/authors/id/B/BO/BOOK/Test-Requires-Git-1.008.tar.gz;
       sha256 = "70916210970d84d7491451159ab8b67e15251c8c0dae7c3df6c8d88542ea42a6";
     };
     propagatedBuildInputs = [ GitVersionCompare ];
@@ -15832,7 +17000,8 @@ let
   };
 
   TestRequiresInternet = buildPerlPackage rec {
-     name = "Test-RequiresInternet-0.05";
+     pname = "Test-RequiresInternet";
+     version = "0.05";
      src = fetchurl {
        url = mirror://cpan/authors/id/M/MA/MALLEN/Test-RequiresInternet-0.05.tar.gz;
        sha256 = "0gl33vpj9bb78pzyijp884b66sbw6jkh1ci0xki8rmf03hmb79xv";
@@ -15844,9 +17013,10 @@ let
   };
 
   TestRoo = buildPerlPackage rec {
-    name = "Test-Roo-1.004";
+    pname = "Test-Roo";
+    version = "1.004";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DA/DAGOLDEN/Test-Roo-1.004.tar.gz;
       sha256 = "1mnym49j1lj7gzylma5b6nr4vp75rmgz2v71904v01xmxhy9l4i1";
     };
 
@@ -15855,7 +17025,8 @@ let
   };
 
   TestRoutine = buildPerlPackage {
-    name = "Test-Routine-0.027";
+    pname = "Test-Routine";
+    version = "0.027";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RJ/RJBS/Test-Routine-0.027.tar.gz;
       sha256 = "0n6k310v2py787lkvhzrn8vndws9icdf8mighgl472k0x890xm5s";
@@ -15870,9 +17041,10 @@ let
   };
 
   TestRun = buildPerlModule rec {
-    name = "Test-Run-0.0304";
+    pname = "Test-Run";
+    version = "0.0304";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SH/SHLOMIF/Test-Run-0.0304.tar.gz;
       sha256 = "f3feaf9c4494c0b3a5294228cab27efe93653b7e0bbd7fbb99b94b65b247f323";
     };
     buildInputs = [ TestTrap ];
@@ -15885,9 +17057,10 @@ let
   };
 
   TestRunCmdLine = buildPerlModule rec {
-    name = "Test-Run-CmdLine-0.0131";
+    pname = "Test-Run-CmdLine";
+    version = "0.0131";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SH/SHLOMIF/Test-Run-CmdLine-0.0131.tar.gz;
       sha256 = "cceeeecd3f4b2f1d2929f3ada351c1ade23a8ac73ef0486dc6e9605ebcdaef18";
     };
     buildInputs = [ TestRun TestTrap ];
@@ -15901,9 +17074,10 @@ let
    };
 
   TestRunPluginAlternateInterpreters = buildPerlModule rec {
-    name = "Test-Run-Plugin-AlternateInterpreters-0.0124";
+    pname = "Test-Run-Plugin-AlternateInterpreters";
+    version = "0.0124";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SH/SHLOMIF/Test-Run-Plugin-AlternateInterpreters-0.0124.tar.gz;
       sha256 = "eecb3830d350b5d7853322df4f3090af42ff17e9c31075f8d4f69856c968bff3";
     };
     buildInputs = [ TestRun TestRunCmdLine TestTrap YAMLLibYAML ];
@@ -15916,7 +17090,8 @@ let
   };
 
   TestRunPluginBreakOnFailure = buildPerlModule rec {
-    name = "Test-Run-Plugin-BreakOnFailure-0.0.5";
+    pname = "Test-Run-Plugin-BreakOnFailure";
+    version = "0.0.5";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SH/SHLOMIF/Test-Run-Plugin-BreakOnFailure-v0.0.5.tar.gz;
       sha256 = "e422eb64a2fa6ae59837312e37ab88d68b4945148eb436a3774faed5074f0430";
@@ -15931,9 +17106,10 @@ let
   };
 
   TestRunPluginColorFileVerdicts = buildPerlModule rec {
-    name = "Test-Run-Plugin-ColorFileVerdicts-0.0124";
+    pname = "Test-Run-Plugin-ColorFileVerdicts";
+    version = "0.0124";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SH/SHLOMIF/Test-Run-Plugin-ColorFileVerdicts-0.0124.tar.gz;
       sha256 = "0418f03abe241f5a3c2a2ab3dd2679d11eee42c9e1f5b5a6ea80d9e238374302";
     };
     buildInputs = [ TestRun TestRunCmdLine TestTrap ];
@@ -15948,9 +17124,10 @@ let
   };
 
   TestRunPluginColorSummary = buildPerlModule rec {
-    name = "Test-Run-Plugin-ColorSummary-0.0202";
+    pname = "Test-Run-Plugin-ColorSummary";
+    version = "0.0202";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SH/SHLOMIF/Test-Run-Plugin-ColorSummary-0.0202.tar.gz;
       sha256 = "ea4fb6768c4f6645cedf87d9b7c6baf97364ebc6f4171e4dd5f68939fb2bdd3a";
     };
     buildInputs = [ TestRun TestRunCmdLine TestTrap ];
@@ -15964,9 +17141,10 @@ let
   };
 
   TestRunPluginTrimDisplayedFilenames = buildPerlModule rec {
-    name = "Test-Run-Plugin-TrimDisplayedFilenames-0.0125";
+    pname = "Test-Run-Plugin-TrimDisplayedFilenames";
+    version = "0.0125";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SH/SHLOMIF/Test-Run-Plugin-TrimDisplayedFilenames-0.0125.tar.gz;
       sha256 = "2255bc5cb6ab65ee4dfff3bcdf007fb74785ff3bb439a9cef5052c66d80424a5";
     };
     buildInputs = [ TestRun TestRunCmdLine TestTrap YAMLLibYAML ];
@@ -15994,9 +17172,10 @@ let
   };
 
   TestScript = buildPerlPackage rec {
-    name = "Test-Script-1.25";
+    pname = "Test-Script";
+    version = "1.25";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/${name}.tar.gz";
+      url = mirror://cpan/authors/id/P/PL/PLICEASE/Test-Script-1.25.tar.gz;
       sha256 = "199s78hh77zwwqba6pa1ngzjnzrdj2ka6qv5w0i286aafh93705n";
     };
 
@@ -16006,9 +17185,10 @@ let
   };
 
   TestSharedFork = buildPerlPackage rec {
-    name = "Test-SharedFork-0.35";
+    pname = "Test-SharedFork";
+    version = "0.35";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/EX/EXODIST/${name}.tar.gz";
+      url = mirror://cpan/authors/id/E/EX/EXODIST/Test-SharedFork-0.35.tar.gz;
       sha256 = "17y52j20k1bs9dgf4n6rhh9dn4cfxxbnfn2cfs7pb00fc5jyhci9";
     };
     buildInputs = [ TestRequires ];
@@ -16033,7 +17213,8 @@ let
   };
 
   TestSpec = buildPerlPackage rec {
-    name = "Test-Spec-0.54";
+    pname = "Test-Spec";
+    version = "0.54";
     src = fetchurl {
       url = mirror://cpan/authors/id/A/AK/AKZHAN/Test-Spec-0.54.tar.gz;
       sha256 = "1lk5l69bm6yl1zxzz5v6mizzqfinpdhasmi4qjxr1vnwcl9cyc8a";
@@ -16047,7 +17228,8 @@ let
   };
 
   TestSubCalls = buildPerlPackage rec {
-    name = "Test-SubCalls-1.10";
+    pname = "Test-SubCalls";
+    version = "1.10";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/Test-SubCalls-1.10.tar.gz;
       sha256 = "cbc1e9b35a05e71febc13e5ef547a31c8249899bb6011dbdc9d9ff366ddab6c2";
@@ -16056,9 +17238,10 @@ let
   };
 
   TestSynopsis = buildPerlPackage rec {
-    name = "Test-Synopsis-0.15";
+    pname = "Test-Synopsis";
+    version = "0.15";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Z/ZO/ZOFFIX/${name}.tar.gz";
+      url = mirror://cpan/authors/id/Z/ZO/ZOFFIX/Test-Synopsis-0.15.tar.gz;
       sha256 = "1cxxidhwf8j8n41d423ankvls2wdi7aw755csi3hcv3mj9k67mfi";
     };
     meta = {
@@ -16068,7 +17251,8 @@ let
   };
 
   TestTableDriven = buildPerlPackage {
-    name = "Test-TableDriven-0.02";
+    pname = "Test-TableDriven";
+    version = "0.02";
     src = fetchurl {
       url = mirror://cpan/authors/id/J/JR/JROCKWAY/Test-TableDriven-0.02.tar.gz;
       sha256 = "16l5n6sx3yqdir1rqq21d41znpwzbs8v34gqr93y051arypphn22";
@@ -16080,7 +17264,8 @@ let
   };
 
   TestTempDirTiny = buildPerlPackage rec {
-    name = "Test-TempDir-Tiny-0.018";
+    pname = "Test-TempDir-Tiny";
+    version = "0.018";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DA/DAGOLDEN/Test-TempDir-Tiny-0.018.tar.gz;
       sha256 = "10ay3zbihyxn4nbb1f0fmr4szag8iy8pd27v8j6idq6cgzys3dyp";
@@ -16094,9 +17279,10 @@ let
   };
 
   TestTCP = buildPerlPackage rec {
-    name = "Test-TCP-2.19";
+    pname = "Test-TCP";
+    version = "2.19";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TOKUHIROM/${name}.tar.gz";
+      url = mirror://cpan/authors/id/T/TO/TOKUHIROM/Test-TCP-2.19.tar.gz;
       sha256 = "14ahzklq3xgmwj58p9vdcfgpggrmh3nigq5mzqk4wakbb6fjs0fx";
     };
     meta = {
@@ -16107,9 +17293,10 @@ let
   };
 
   TestTime = buildPerlPackage rec {
-    name = "Test-Time-0.05";
+    pname = "Test-Time";
+    version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SA/SATOH/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SA/SATOH/Test-Time-0.05.tar.gz;
       sha256 = "abef8885a811440114bfe067edc32f08500fbfd624902f8c3a81fc224ac4b410";
     };
     meta = {
@@ -16119,7 +17306,8 @@ let
   };
 
   TestToolbox = buildPerlModule rec {
-     name = "Test-Toolbox-0.4";
+     pname = "Test-Toolbox";
+     version = "0.4";
      src = fetchurl {
        url = mirror://cpan/authors/id/M/MI/MIKO/Test-Toolbox-0.4.tar.gz;
        sha256 = "1hxx9rhvncvn7wvzhzx4sk00w0xq2scgspfhhyqwjnm1yg3va820";
@@ -16131,9 +17319,10 @@ let
   };
 
   TestTrailingSpace = buildPerlModule rec {
-    name = "Test-TrailingSpace-0.0301";
+    pname = "Test-TrailingSpace";
+    version = "0.0301";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SH/SHLOMIF/Test-TrailingSpace-0.0301.tar.gz;
       sha256 = "a28875747adb7a0e7d1ae8a4ffe71869e7ceb3a85d0cb30172959dada7de5970";
     };
     propagatedBuildInputs = [ FileFindObjectRule ];
@@ -16144,7 +17333,8 @@ let
   };
 
   TestUnitLite = buildPerlModule {
-    name = "Test-Unit-Lite-0.1202";
+    pname = "Test-Unit-Lite";
+    version = "0.1202";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DE/DEXTER/Test-Unit-Lite-0.1202.tar.gz;
       sha256 = "1a5jym9hjcpdf0rwyn7gwrzsx4xqzwgzx59rgspqlqiif7p2a79m";
@@ -16156,7 +17346,8 @@ let
   };
 
   TestWarn = buildPerlPackage {
-    name = "Test-Warn-0.36";
+    pname = "Test-Warn";
+    version = "0.36";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BI/BIGJ/Test-Warn-0.36.tar.gz;
       sha256 = "1nkc7jzxff0w4x9axbpsgxrksqdjnf70rb74q39zikkrsd3a7g7c";
@@ -16169,9 +17360,10 @@ let
   };
 
   TestWarnings = buildPerlPackage rec {
-    name = "Test-Warnings-0.026";
+    pname = "Test-Warnings";
+    version = "0.026";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/E/ET/ETHER/Test-Warnings-0.026.tar.gz;
       sha256 = "ae2b68b1b5616704598ce07f5118efe42dc4605834453b7b2be14e26f9cc9a08";
     };
     buildInputs = [ CPANMetaCheck ];
@@ -16183,7 +17375,8 @@ let
   };
 
   TestWithoutModule = buildPerlPackage {
-    name = "Test-Without-Module-0.20";
+    pname = "Test-Without-Module";
+    version = "0.20";
     src = fetchurl {
       url = mirror://cpan/authors/id/C/CO/CORION/Test-Without-Module-0.20.tar.gz;
       sha256 = "8e9aeb7c32a6c6d0b8a93114db2a8c072721273a9d9a2dd4f9ca86cfd28aa524";
@@ -16195,7 +17388,8 @@ let
   };
 
   TestWWWMechanize = buildPerlPackage {
-    name = "Test-WWW-Mechanize-1.52";
+    pname = "Test-WWW-Mechanize";
+    version = "1.52";
     src = fetchurl {
       url = mirror://cpan/authors/id/P/PE/PETDANCE/Test-WWW-Mechanize-1.52.tar.gz;
       sha256 = "1jsywlbxhqw39ij7s8vmgff5vys58vlfaq27072awacnxc65aal4";
@@ -16210,7 +17404,8 @@ let
   };
 
   TestWWWMechanizeCatalyst = buildPerlPackage rec {
-    name = "Test-WWW-Mechanize-Catalyst-0.62";
+    pname = "Test-WWW-Mechanize-Catalyst";
+    version = "0.62";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MS/MSTROUT/Test-WWW-Mechanize-Catalyst-0.62.tar.gz;
       sha256 = "1cdc2q16vs6fb335pzaislz2rx1ph9acaxyp7v5hv9xbwwddwfqq";
@@ -16225,7 +17420,8 @@ let
   };
 
   TestWWWMechanizeCGI = buildPerlPackage {
-    name = "Test-WWW-Mechanize-CGI-0.1";
+    pname = "Test-WWW-Mechanize-CGI";
+    version = "0.1";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MR/MRAMBERG/Test-WWW-Mechanize-CGI-0.1.tar.gz;
       sha256 = "0bwwdk0iai5dlvvfpja971qpgvmf6yq67iag4z4szl9v5sra0xm5";
@@ -16235,7 +17431,8 @@ let
   };
 
   TestWWWMechanizePSGI = buildPerlPackage {
-    name = "Test-WWW-Mechanize-PSGI-0.39";
+    pname = "Test-WWW-Mechanize-PSGI";
+    version = "0.39";
     src = fetchurl {
       url = mirror://cpan/authors/id/O/OA/OALDERS/Test-WWW-Mechanize-PSGI-0.39.tar.gz;
       sha256 = "0n4rhyyags3cwqb0gb1pr6gccd2x3l190j8gd96lwlvxnjrklss7";
@@ -16249,7 +17446,8 @@ let
   };
 
   TestXPath = buildPerlModule {
-    name = "Test-XPath-0.19";
+    pname = "Test-XPath";
+    version = "0.19";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MA/MANWAR/Test-XPath-0.19.tar.gz;
       sha256 = "1wy0488yg15kahfafnlmlhppxik7d0z00wxwj9fszrsq2h6crz6y";
@@ -16258,7 +17456,8 @@ let
   };
 
   TestYAML = buildPerlPackage rec {
-    name = "Test-YAML-1.07";
+    pname = "Test-YAML";
+    version = "1.07";
     src = fetchurl {
       url = mirror://cpan/authors/id/T/TI/TINITA/Test-YAML-1.07.tar.gz;
       sha256 = "0pwrrnwi1qaiy3c5522vy0kzncxc9g02r4b056wqqaa69w1hsc0z";
@@ -16267,9 +17466,10 @@ let
   };
 
   TextAligner = buildPerlModule rec {
-    name = "Text-Aligner-0.13";
+    pname = "Text-Aligner";
+    version = "0.13";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SH/SHLOMIF/Text-Aligner-0.13.tar.gz;
       sha256 = "1vry21jrh91l2pkajnrps83bnr1fn6zshbzi80mcrnggrn9iq776";
     };
     meta = {
@@ -16278,9 +17478,10 @@ let
   };
 
   TextAspell = buildPerlPackage rec {
-    name = "Text-Aspell-0.09";
+    pname = "Text-Aspell";
+    version = "0.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HA/HANK/${name}.tar.gz";
+      url = mirror://cpan/authors/id/H/HA/HANK/Text-Aspell-0.09.tar.gz;
       sha256 = "0r9g31rd55934mp6n45b96g934ck4qns8x9i7qckn9wfy44k5sib";
     };
     propagatedBuildInputs = [ pkgs.aspell ];
@@ -16290,7 +17491,8 @@ let
   };
 
   TextAutoformat = buildPerlPackage {
-    name = "Text-Autoformat-1.74";
+    pname = "Text-Autoformat";
+    version = "1.74";
     src = fetchurl {
       url = mirror://cpan/authors/id/N/NE/NEILB/Text-Autoformat-1.74.tar.gz;
       sha256 = "07eb3c2b3515897340ca6e9377495bbe2e05ec80d7f3f146adab8e534a818d5e";
@@ -16304,7 +17506,8 @@ let
   };
 
   TextBalanced = buildPerlPackage {
-    name = "Text-Balanced-2.03";
+    pname = "Text-Balanced";
+    version = "2.03";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SH/SHAY/Text-Balanced-2.03.tar.gz;
       sha256 = "057753f8f0568b53921f66a60a89c30092b73329bcc61a2c43339ab70c9792c8";
@@ -16341,17 +17544,19 @@ let
   };
 
   TextBrew = buildPerlPackage rec {
-    name = "Text-Brew-0.02";
+    pname = "Text-Brew";
+    version = "0.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KC/KCIVEY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/K/KC/KCIVEY/Text-Brew-0.02.tar.gz;
       sha256 = "0k7nxglbx5pxl693zrj1fsi094sf1a3vqsrn73inzz7r3j28a6xa";
     };
   };
 
   TextCharWidth = buildPerlPackage rec {
-    name = "Text-CharWidth-0.04";
+    pname = "Text-CharWidth";
+    version = "0.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KU/KUBOTA/${name}.tar.gz";
+      url = mirror://cpan/authors/id/K/KU/KUBOTA/Text-CharWidth-0.04.tar.gz;
       sha256 = "abded5f4fdd9338e89fd2f1d8271c44989dae5bf50aece41b6179d8e230704f8";
     };
   };
@@ -16370,9 +17575,10 @@ let
   };
 
   TextCSVEncoded = buildPerlPackage rec {
-    name = "Text-CSV-Encoded-0.25";
+    pname = "Text-CSV-Encoded";
+    version = "0.25";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/Z/ZA/ZARQUON/${name}.tar.gz";
+      url = mirror://cpan/authors/id/Z/ZA/ZARQUON/Text-CSV-Encoded-0.25.tar.gz;
       sha256 = "1l5rwlmnpnhjszb200a94lwvkwslsvyxm24ycf37gm8dla1mk2i4";
     };
     propagatedBuildInputs = [ TextCSV ];
@@ -16383,9 +17589,10 @@ let
   };
 
   TextCSV_XS = buildPerlPackage rec {
-    name = "Text-CSV_XS-1.39";
+    pname = "Text-CSV_XS";
+    version = "1.39";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/H/HM/HMBRAND/${name}.tgz";
+      url = mirror://cpan/authors/id/H/HM/HMBRAND/Text-CSV_XS-1.39.tgz;
       sha256 = "aa4e424eaf68bea0d0e8c16b961c942b64926e6183ce1dbbc6c799eafb0a9ebd";
     };
     meta = {
@@ -16395,9 +17602,10 @@ let
   };
 
   TextDiff = buildPerlPackage rec {
-    name = "Text-Diff-1.45";
+    pname = "Text-Diff";
+    version = "1.45";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/${name}.tar.gz";
+      url = mirror://cpan/authors/id/N/NE/NEILB/Text-Diff-1.45.tar.gz;
       sha256 = "013g13prdghxvrp5754gyc7rmv1syyxrhs33yc5f0lrz3dxs1fp8";
     };
     propagatedBuildInputs = [ AlgorithmDiff ];
@@ -16408,9 +17616,10 @@ let
   };
 
   TextFormat = buildPerlModule rec {
-    name = "Text-Format-0.61";
+    pname = "Text-Format";
+    version = "0.61";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SH/SHLOMIF/Text-Format-0.61.tar.gz;
       sha256 = "bb8a3b8ff515c85101baf553a769337f944a05cde81f111ae78aff416bf4ae2b";
     };
     meta = {
@@ -16422,7 +17631,8 @@ let
   };
 
   TextGerman = buildPerlPackage rec {
-     name = "Text-German-0.06";
+     pname = "Text-German";
+     version = "0.06";
      src = fetchurl {
        url = mirror://cpan/authors/id/U/UL/ULPFR/Text-German-0.06.tar.gz;
        sha256 = "1p87pgap99lw0nv62i3ghvsi7yg90lhn8vsa3yqp75rd04clybcj";
@@ -16432,7 +17642,8 @@ let
   };
 
   TextGlob = buildPerlPackage rec {
-    name = "Text-Glob-0.11";
+    pname = "Text-Glob";
+    version = "0.11";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RC/RCLAMP/Text-Glob-0.11.tar.gz;
       sha256 = "11sj62fynfgwrlgkv5a051cq6yn0pagxqjsz27dxx8phsd4wv706";
@@ -16440,7 +17651,8 @@ let
   };
 
   TextIconv = buildPerlPackage {
-    name = "Text-Iconv-1.7";
+    pname = "Text-Iconv";
+    version = "1.7";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MP/MPIOTR/Text-Iconv-1.7.tar.gz;
       sha256 = "5b80b7d5e709d34393bcba88971864a17b44a5bf0f9e4bcee383d029e7d2d5c3";
@@ -16448,7 +17660,8 @@ let
   };
 
   TestInter = buildPerlPackage {
-    name = "Test-Inter-1.09";
+    pname = "Test-Inter";
+    version = "1.09";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SB/SBECK/Test-Inter-1.09.tar.gz;
       sha256 = "1e9f129cc1a001fb95449d385253b38afabf5b466e3b3bd33e4e430f216e177a";
@@ -16461,7 +17674,8 @@ let
   };
 
   TestManifest = buildPerlPackage {
-    name = "Test-Manifest-2.021";
+    pname = "Test-Manifest";
+    version = "2.021";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BD/BDFOY/Test-Manifest-2.021.tar.gz;
       sha256 = "a47aaad71c580e16e6e63d8c037cdddcd919876754beb2c95d9a88682dd332d9";
@@ -16473,18 +17687,20 @@ let
   };
 
   TextMarkdown = buildPerlPackage rec {
-    name = "Text-Markdown-1.000031";
+    pname = "Text-Markdown";
+    version = "1.000031";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BO/BOBTFISH/${name}.tar.gz";
+      url = mirror://cpan/authors/id/B/BO/BOBTFISH/Text-Markdown-1.000031.tar.gz;
       sha256 = "06y79lla8adkqhrs41xdddqjs81dcrh266b50mfbg37bxkawd4f1";
     };
     buildInputs = [ ListMoreUtils TestDifferences TestException ];
   };
 
   TestMinimumVersion = buildPerlPackage rec {
-    name = "Test-MinimumVersion-0.101082";
+    pname = "Test-MinimumVersion";
+    version = "0.101082";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RJ/RJBS/Test-MinimumVersion-0.101082.tar.gz;
       sha256 = "3fba4e8fcf74806259aa639be7d90e70346ad0e0e4b8b619593490e378241970";
     };
     propagatedBuildInputs = [ PerlMinimumVersion ];
@@ -16496,7 +17712,8 @@ let
   };
 
   TextMicroTemplate = buildPerlPackage {
-    name = "Text-MicroTemplate-0.24";
+    pname = "Text-MicroTemplate";
+    version = "0.24";
     src = fetchurl {
       url = mirror://cpan/authors/id/K/KA/KAZUHO/Text-MicroTemplate-0.24.tar.gz;
       sha256 = "1j5ljx7hs4k29732nr5f2m4kssz4rqjw3kknsnhams2yydqix01j";
@@ -16508,7 +17725,8 @@ let
   };
 
   TestNumberDelta = buildPerlPackage {
-    name = "Test-Number-Delta-1.06";
+    pname = "Test-Number-Delta";
+    version = "1.06";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DA/DAGOLDEN/Test-Number-Delta-1.06.tar.gz;
       sha256 = "535430919e6fdf6ce55ff76e9892afccba3b7d4160db45f3ac43b0f92ffcd049";
@@ -16521,7 +17739,8 @@ let
   };
 
   TextPasswordPronounceable = buildPerlPackage {
-    name = "Text-Password-Pronounceable-0.30";
+    pname = "Text-Password-Pronounceable";
+    version = "0.30";
     src = fetchurl {
       url = mirror://cpan/authors/id/T/TS/TSIBLEY/Text-Password-Pronounceable-0.30.tar.gz;
       sha256 = "c186a50256e0bedfafb17e7ce157e7c52f19503bb79e18ebf06255911f6ead1a";
@@ -16532,7 +17751,8 @@ let
   };
 
   TextPDF = buildPerlPackage rec {
-    name = "Text-PDF-0.31";
+    pname = "Text-PDF";
+    version = "0.31";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BH/BHALLISSY/Text-PDF-0.31.tar.gz;
       sha256 = "0s5cimfr4wwzgv15k30x83ncg1257jwsvmbmb86lp02rw5g537yz";
@@ -16540,7 +17760,8 @@ let
   };
 
   TextQuoted = buildPerlPackage {
-    name = "Text-Quoted-2.10";
+    pname = "Text-Quoted";
+    version = "2.10";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BP/BPS/Text-Quoted-2.10.tar.gz;
       sha256 = "081bf95ec9220af26cec89161e61bf73f9fbcbfeee1d9af15139e5d7b708f445";
@@ -16553,9 +17774,10 @@ let
   };
 
   TextRecordParser = buildPerlPackage rec {
-    name = "Text-RecordParser-1.6.5";
+    pname = "Text-RecordParser";
+    version = "1.6.5";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KC/KCLARK/${name}.tar.gz";
+      url = mirror://cpan/authors/id/K/KC/KCLARK/Text-RecordParser-1.6.5.tar.gz;
       sha256 = "0nn33c058bl957v38xhqig4ld34lifl4arqiilhxky339i0q2fys";
     };
 
@@ -16568,7 +17790,8 @@ let
   };
 
   TextReform = buildPerlModule {
-    name = "Text-Reform-1.20";
+    pname = "Text-Reform";
+    version = "1.20";
     src = fetchurl {
       url = mirror://cpan/authors/id/C/CH/CHORNY/Text-Reform-1.20.tar.gz;
       sha256 = "a8792dd8c1aac97001032337b36a356be96e2d74c4f039ef9a363b641db4ae61";
@@ -16580,7 +17803,8 @@ let
   };
 
   TextRoman = buildPerlPackage rec {
-    name = "Text-Roman-3.5";
+    pname = "Text-Roman";
+    version = "3.5";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SY/SYP/Text-Roman-3.5.tar.gz;
       sha256 = "0sh47svzz0wm993ywfgpn0fvhajl2sj5hcnf5zxjz02in6ihhjnb";
@@ -16592,7 +17816,8 @@ let
   };
 
   TextSimpleTable = buildPerlPackage {
-    name = "Text-SimpleTable-2.07";
+    pname = "Text-SimpleTable";
+    version = "2.07";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MR/MRAMBERG/Text-SimpleTable-2.07.tar.gz;
       sha256 = "1v8r8qpzg283p2pqqr8dqrak2bxray1b2jmib0qk75jffqw3yv95";
@@ -16605,7 +17830,8 @@ let
   };
 
   TextSoundex = buildPerlPackage {
-    name = "Text-Soundex-3.05";
+    pname = "Text-Soundex";
+    version = "3.05";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RJ/RJBS/Text-Soundex-3.05.tar.gz;
       sha256 = "f6dd55b4280b25dea978221839864382560074e1d6933395faee2510c2db60ed";
@@ -16613,9 +17839,10 @@ let
   };
 
   TextSprintfNamed = buildPerlModule rec {
-    name = "Text-Sprintf-Named-0.0403";
+    pname = "Text-Sprintf-Named";
+    version = "0.0403";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SH/SHLOMIF/Text-Sprintf-Named-0.0403.tar.gz;
       sha256 = "8a2f6e52998d1d8adb6ce0f5be85265be2e51ce06cf8ae23b3a0f059ba21b888";
     };
     buildInputs = [ TestWarn ];
@@ -16626,9 +17853,10 @@ let
   };
 
   TextTable = buildPerlModule rec {
-    name = "Text-Table-1.133";
+    pname = "Text-Table";
+    version = "1.133";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SH/SHLOMIF/Text-Table-1.133.tar.gz;
       sha256 = "04kh5x5inq183rdg221wlqaaqi1ipyj588mxsslik6nhc14f17nd";
     };
     propagatedBuildInputs = [ TextAligner ];
@@ -16640,15 +17868,17 @@ let
   };
 
   TextTabularDisplay = buildPerlPackage rec {
-    name = "Text-TabularDisplay-1.38";
+    pname = "Text-TabularDisplay";
+    version = "1.38";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DA/DARREN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DA/DARREN/Text-TabularDisplay-1.38.tar.gz;
       sha256 = "1s46s4pg5mpfllx3icf4vnqz9iadbbdbsr5p7pr6gdjnzbx902gb";
     };
   };
 
   TextTemplate = buildPerlPackage {
-    name = "Text-Template-1.55";
+    pname = "Text-Template";
+    version = "1.55";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MS/MSCHOUT/Text-Template-1.55.tar.gz;
       sha256 = "a4948be945250c17f9f0aaee56cc79b3195dcebcb75215b55d6ed1ca2b02f18b";
@@ -16657,7 +17887,8 @@ let
   };
 
   TestTrap = buildPerlModule rec {
-    name = "Test-Trap-0.3.4";
+    pname = "Test-Trap";
+    version = "0.3.4";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/EB/EBHANSSEN/Test-Trap-v0.3.4.tar.gz;
       sha256 = "1qjs2080kcc66s4d7499br5lw2qmhr9gxky4xsl6vjdn6dpna10b";
@@ -16670,9 +17901,10 @@ let
   };
 
   TestVars = buildPerlModule rec {
-    name = "Test-Vars-0.014";
+    pname = "Test-Vars";
+    version = "0.014";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DR/DROLSKY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/D/DR/DROLSKY/Test-Vars-0.014.tar.gz;
       sha256 = "0qr8q0ksr925ycwbsyxjwgz4p9r7a8vkxpn33vy23zbijwpa3xx7";
     };
 
@@ -16686,9 +17918,10 @@ let
   };
 
   TestVersion = buildPerlPackage rec {
-    name = "Test-Version-2.09";
+    pname = "Test-Version";
+    version = "2.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/${name}.tar.gz";
+      url = mirror://cpan/authors/id/P/PL/PLICEASE/Test-Version-2.09.tar.gz;
       sha256 = "9ce1dd2897a5f30e1b7f8966ec66f57d8d8f280f605f28c7ca221fa79aca38e0";
     };
     buildInputs = [ TestException ];
@@ -16700,7 +17933,8 @@ let
   };
 
   TextTrim = buildPerlModule {
-    name = "Text-Trim-1.02";
+    pname = "Text-Trim";
+    version = "1.02";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MA/MATTLAW/Text-Trim-1.02.tar.gz;
       sha256 = "1bnwjl5n04w8nnrzrm75ljn4pijqbijr9csfkjcs79h4gwn9lwqw";
@@ -16712,7 +17946,8 @@ let
   };
 
   TextUnaccent = buildPerlPackage {
-    name = "Text-Unaccent-1.08";
+    pname = "Text-Unaccent";
+    version = "1.08";
     src = fetchurl {
       url = mirror://cpan/authors/id/L/LD/LDACHARY/Text-Unaccent-1.08.tar.gz;
       sha256 = "0avk50kia78kxryh2whmaj5l18q2wvmkdyqyjsf6kwr4kgy6x3i7";
@@ -16722,7 +17957,8 @@ let
   };
 
   TextUnidecode = buildPerlPackage rec {
-    name = "Text-Unidecode-1.30";
+    pname = "Text-Unidecode";
+    version = "1.30";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SB/SBURKE/Text-Unidecode-1.30.tar.gz;
       sha256 = "1imii0p6wvhrxsr5z2zhazpx5vl4l4ybf1y2c5hy480xvi6z293c";
@@ -16730,7 +17966,8 @@ let
   };
 
   Testutf8 = buildPerlPackage {
-    name = "Test-utf8-1.01";
+    pname = "Test-utf8";
+    version = "1.01";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MA/MARKF/Test-utf8-1.01.tar.gz;
       sha256 = "ef371b1769cd8d36d2d657e8321723d94c8f8d89e7fd7437c6648c5dc6711b7a";
@@ -16743,9 +17980,10 @@ let
   };
 
   TextvFileasData = buildPerlPackage rec {
-    name = "Text-vFile-asData-0.08";
+    pname = "Text-vFile-asData";
+    version = "0.08";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RC/RCLAMP/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RC/RCLAMP/Text-vFile-asData-0.08.tar.gz;
       sha256 = "b291ab5e0f987c5172560a692234711a75e4596d83475f72d01278369532f82a";
     };
     propagatedBuildInputs = [ ClassAccessorChained ];
@@ -16756,7 +17994,8 @@ let
   };
 
   TextWikiFormat = buildPerlModule {
-    name = "Text-WikiFormat-0.81";
+    pname = "Text-WikiFormat";
+    version = "0.81";
     src = fetchurl {
       url = mirror://cpan/authors/id/C/CY/CYCLES/Text-WikiFormat-0.81.tar.gz;
       sha256 = "0cxbgx879bsskmnhjzamgsa5862ddixyx4yr77lafmwimnaxjg74";
@@ -16765,7 +18004,8 @@ let
   };
 
   TextWrapI18N = buildPerlPackage {
-    name = "Text-WrapI18N-0.06";
+    pname = "Text-WrapI18N";
+    version = "0.06";
     src = fetchurl {
       url = mirror://cpan/authors/id/K/KU/KUBOTA/Text-WrapI18N-0.06.tar.gz;
       sha256 = "4bd29a17f0c2c792d12c1005b3c276f2ab0fae39c00859ae1741d7941846a488";
@@ -16783,7 +18023,8 @@ let
   };
 
   TextWrapper = buildPerlPackage {
-    name = "Text-Wrapper-1.05";
+    pname = "Text-Wrapper";
+    version = "1.05";
     src = fetchurl {
       url = mirror://cpan/authors/id/C/CJ/CJM/Text-Wrapper-1.05.tar.gz;
       sha256 = "64268e15983a9df47e1d9199a491f394e89f542e54afb33f4b78f3f318e09ab9";
@@ -16796,9 +18037,10 @@ let
   };
 
   threadsshared = buildPerlPackage rec {
-    name = "threads-shared-1.59";
+    pname = "threads-shared";
+    version = "1.59";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JD/JDHEDDEN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/J/JD/JDHEDDEN/threads-shared-1.59.tar.gz;
       sha256 = "1krz69ks3siz0fhc9waf817nnlmxsgq7rc5rq99xvqg1f1g9iz6i";
     };
     meta = {
@@ -16808,9 +18050,10 @@ let
   };
 
   ThreadQueue = buildPerlPackage rec {
-    name = "Thread-Queue-3.13";
+    pname = "Thread-Queue";
+    version = "3.13";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JD/JDHEDDEN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/J/JD/JDHEDDEN/Thread-Queue-3.13.tar.gz;
       sha256 = "1s6wpxy07mr03krkzjr5r02cswsj18dd38aa5f16dfrgvp6xm8vb";
     };
     meta = {
@@ -16820,9 +18063,10 @@ let
   };
 
   Throwable = buildPerlPackage rec {
-    name = "Throwable-0.200013";
+    pname = "Throwable";
+    version = "0.200013";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RJ/RJBS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RJ/RJBS/Throwable-0.200013.tar.gz;
       sha256 = "184gdcwxqwnkrx5md968v1ny70pq6blzpkihccm3bpdxnpgd11wr";
     };
     propagatedBuildInputs = [ DevelStackTrace Moo ];
@@ -16834,9 +18078,10 @@ let
   };
 
   TieCacheLRU = buildPerlPackage rec {
-    name = "Tie-Cache-LRU-20150301";
+    pname = "Tie-Cache-LRU";
+    version = "20150301";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MS/MSCHWERN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MS/MSCHWERN/Tie-Cache-LRU-20150301.tar.gz;
       sha256 = "1bf740450d3a6d7c12b48c25f7da5964e44e7cc38b28572cfb76ff22464f4469";
     };
     propagatedBuildInputs = [ ClassVirtual enum ];
@@ -16847,9 +18092,10 @@ let
   };
 
   TieCacheLRUExpires = buildPerlPackage rec {
-    name = "Tie-Cache-LRU-Expires-0.55";
+    pname = "Tie-Cache-LRU-Expires";
+    version = "0.55";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/O/OE/OESTERHOL/${name}.tar.gz";
+      url = mirror://cpan/authors/id/O/OE/OESTERHOL/Tie-Cache-LRU-Expires-0.55.tar.gz;
       sha256 = "b316d849acd25f24346d55a9950d281fee0746398767c601234122159573eb9a";
     };
     propagatedBuildInputs = [ TieCacheLRU ];
@@ -16859,9 +18105,10 @@ let
   };
 
   TieCycle = buildPerlPackage rec {
-    name = "Tie-Cycle-1.225";
+    pname = "Tie-Cycle";
+    version = "1.225";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/B/BD/BDFOY/${name}.tar.gz";
+      url = mirror://cpan/authors/id/B/BD/BDFOY/Tie-Cycle-1.225.tar.gz;
       sha256 = "0i9xq2qm50p2ih24265jndp2x8hfq7ap0d88nrlv5yaad4hxhc7k";
     };
     meta = {
@@ -16871,7 +18118,8 @@ let
   };
 
   TieFile = buildPerlPackage {
-    name = "Tie-File-1.00";
+    pname = "Tie-File";
+    version = "1.00";
     src = fetchurl {
       url = mirror://cpan/authors/id/T/TO/TODDR/Tie-File-1.00.tar.gz;
       sha256 = "7ca9c8a957cf743d3a98d0eb5deb767b1e14b4f00bc9d03da83d466fcb76bd44";
@@ -16882,7 +18130,8 @@ let
   };
 
   TieIxHash = buildPerlModule {
-    name = "Tie-IxHash-1.23";
+    pname = "Tie-IxHash";
+    version = "1.23";
     src = fetchurl {
       url = mirror://cpan/authors/id/C/CH/CHORNY/Tie-IxHash-1.23.tar.gz;
       sha256 = "0mmg9iyh42syal3z1p2pn9airq65yrkfs66cnqs9nz76jy60pfzs";
@@ -16894,7 +18143,8 @@ let
   };
 
   TieHashIndexed = buildPerlPackage {
-    name = "Tie-Hash-Indexed-0.05";
+    pname = "Tie-Hash-Indexed";
+    version = "0.05";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MH/MHX/Tie-Hash-Indexed-0.05.tar.gz;
       sha256 = "a8862a4763d58a8c785e34b8b18e5db4ce5c3e36b9b5cf565a3088584eab361e";
@@ -16907,7 +18157,8 @@ let
   };
 
   TieRefHash = buildPerlPackage {
-    name = "Tie-RefHash-1.39";
+    pname = "Tie-RefHash";
+    version = "1.39";
     src = fetchurl {
       url = mirror://cpan/authors/id/F/FL/FLORA/Tie-RefHash-1.39.tar.gz;
       sha256 = "b0b80ef571e7dadb726b8214f7352a932a8fa82af29072895aa1aadc89f48bec";
@@ -16915,9 +18166,10 @@ let
   };
 
   TieRegexpHash = buildPerlPackage rec {
-    name = "Tie-RegexpHash-0.17";
+    pname = "Tie-RegexpHash";
+    version = "0.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AL/ALTREUS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/A/AL/ALTREUS/Tie-RegexpHash-0.17.tar.gz;
       sha256 = "0c207850e77efb16618e0aa015507926a3425b34aad5aa6e3e40d83989a085a3";
     };
     meta = {
@@ -16926,7 +18178,8 @@ let
   };
 
   TieSub = buildPerlPackage rec {
-     name = "Tie-Sub-1.001";
+     pname = "Tie-Sub";
+     version = "1.001";
      src = fetchurl {
        url = mirror://cpan/authors/id/S/ST/STEFFENW/Tie-Sub-1.001.tar.gz;
        sha256 = "1cgiyj85hhw2m4x2iv4zgaj3hzf3fghircpcfqmjndni4r4a0wgg";
@@ -16940,7 +18193,8 @@ let
   };
 
   TieToObject = buildPerlPackage {
-    name = "Tie-ToObject-0.03";
+    pname = "Tie-ToObject";
+    version = "0.03";
     src = fetchurl {
       url = mirror://cpan/authors/id/N/NU/NUFFIN/Tie-ToObject-0.03.tar.gz;
       sha256 = "1x1smn1kw383xc5h9wajxk9dlx92bgrbf7gk4abga57y6120s6m3";
@@ -16948,7 +18202,8 @@ let
   };
 
   TimeDate = buildPerlPackage {
-    name = "TimeDate-2.30";
+    pname = "TimeDate";
+    version = "2.30";
     src = fetchurl {
       url = mirror://cpan/authors/id/G/GB/GBARR/TimeDate-2.30.tar.gz;
       sha256 = "11lf54akr9nbivqkjrhvkmfdgkbhw85sq0q4mak56n6bf542bgbm";
@@ -16984,7 +18239,8 @@ let
   };
 
   TimeLocal = buildPerlPackage {
-    name = "Time-Local-1.28";
+    pname = "Time-Local";
+    version = "1.28";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DR/DROLSKY/Time-Local-1.28.tar.gz;
       sha256 = "9278b9e5cc99dcbb0fd27a43e914828b59685601edae082889b5ee7266afe10e";
@@ -16996,7 +18252,8 @@ let
   };
 
   TimeParseDate = buildPerlPackage {
-    name = "Time-ParseDate-2015.103";
+    pname = "Time-ParseDate";
+    version = "2015.103";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MU/MUIR/modules/Time-ParseDate-2015.103.tar.gz;
       sha256 = "2c1a06235bf811813caac9eaa9daa71af758667cdf7b082cb59863220fcaeed1";
@@ -17008,7 +18265,8 @@ let
   };
 
   TimePeriod = buildPerlPackage {
-    name = "Time-Period-1.25";
+    pname = "Time-Period";
+    version = "1.25";
     src = fetchurl {
       url = "mirror://cpan/authors/id/P/PB/PBOYD/Time-Period-1.25.tar.gz";
       sha256 = "d07fa580529beac6a9c8274c6bf220b4c3aade685df65c1669d53339bf6ef1e8";
@@ -17021,9 +18279,10 @@ let
   };
 
   Tk = buildPerlPackage rec {
-    name = "Tk-804.034";
+    pname = "Tk";
+    version = "804.034";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SR/SREZIC/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SR/SREZIC/Tk-804.034.tar.gz;
       sha256 = "fea6b144c723528a2206c8cd9175844032ee9c14ee37791f0f151e5e5b293fe2";
     };
     makeMakerFlags = "X11INC=${pkgs.xorg.libX11.dev}/include X11LIB=${pkgs.xorg.libX11.out}/lib";
@@ -17035,9 +18294,10 @@ let
   };
 
   TreeDAGNode = buildPerlPackage rec {
-    name = "Tree-DAG_Node-1.31";
+    pname = "Tree-DAG_Node";
+    version = "1.31";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RS/RSAVAGE/${name}.tgz";
+      url = mirror://cpan/authors/id/R/RS/RSAVAGE/Tree-DAG_Node-1.31.tgz;
       sha256 = "016kr76azxzfcpxjkhqp2piyyl6529shjis20mc3g2snfabsd2qw";
     };
     meta = {
@@ -17048,9 +18308,10 @@ let
   };
 
   TreeSimple = buildPerlPackage rec {
-    name = "Tree-Simple-1.33";
+    pname = "Tree-Simple";
+    version = "1.33";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RS/RSAVAGE/${name}.tgz";
+      url = mirror://cpan/authors/id/R/RS/RSAVAGE/Tree-Simple-1.33.tgz;
       sha256 = "1alnwb6c7n4al91m9cyknvcyvdz521lh22dz1hyk4v7c50adffnv";
     };
     buildInputs = [ TestException ];
@@ -17061,7 +18322,8 @@ let
   };
 
   TreeSimpleVisitorFactory = buildPerlPackage {
-    name = "Tree-Simple-VisitorFactory-0.15";
+    pname = "Tree-Simple-VisitorFactory";
+    version = "0.15";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RS/RSAVAGE/Tree-Simple-VisitorFactory-0.15.tgz;
       sha256 = "06y2vazkl307k59hnkp9h5bp3p7711kgmp1qdhb2lgnfwzn84zin";
@@ -17071,7 +18333,8 @@ let
   };
 
   TryTiny = buildPerlPackage {
-    name = "Try-Tiny-0.30";
+    pname = "Try-Tiny";
+    version = "0.30";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/Try-Tiny-0.30.tar.gz;
       sha256 = "da5bd0d5c903519bbf10bb9ba0cb7bcac0563882bcfe4503aee3fb143eddef6b";
@@ -17084,7 +18347,8 @@ let
   };
 
   Twiggy = buildPerlPackage rec {
-     name = "Twiggy-0.1025";
+     pname = "Twiggy";
+     version = "0.1025";
      src = fetchurl {
        url = mirror://cpan/authors/id/M/MI/MIYAGAWA/Twiggy-0.1025.tar.gz;
        sha256 = "1a57knbwync7rlzhsz1kdc0sd380xnaccwgiy1qwj5d87abdynnp";
@@ -17099,7 +18363,8 @@ let
   };
 
   TypeTiny = buildPerlPackage {
-    name = "Type-Tiny-1.004004";
+    pname = "Type-Tiny";
+    version = "1.004004";
     src = fetchurl {
       url = mirror://cpan/authors/id/T/TO/TOBYINK/Type-Tiny-1.004004.tar.gz;
       sha256 = "081281ea004cdd89003d938aa52c1398e24411dd8f7163b14d0977a13f7062be";
@@ -17112,7 +18377,8 @@ let
   };
 
   TypesSerialiser = buildPerlPackage rec {
-     name = "Types-Serialiser-1.0";
+     pname = "Types-Serialiser";
+     version = "1.0";
      src = fetchurl {
        url = mirror://cpan/authors/id/M/ML/MLEHMANN/Types-Serialiser-1.0.tar.gz;
        sha256 = "03bk0hm5ys8k7265dkap825ybn2zmzb1hl0kf1jdm8yq95w39lvs";
@@ -17123,7 +18389,8 @@ let
   };
 
   UNIVERSALcan = buildPerlPackage {
-    name = "UNIVERSAL-can-1.20140328";
+    pname = "UNIVERSAL-can";
+    version = "1.20140328";
     src = fetchurl {
       url = mirror://cpan/authors/id/C/CH/CHROMATIC/UNIVERSAL-can-1.20140328.tar.gz;
       sha256 = "522da9f274786fe2cba99bc77cc1c81d2161947903d7fad10bd62dfb7f11990f";
@@ -17136,7 +18403,8 @@ let
   };
 
   UNIVERSALisa = buildPerlPackage {
-    name = "UNIVERSAL-isa-1.20171012";
+    pname = "UNIVERSAL-isa";
+    version = "1.20171012";
     src = fetchurl {
       url = mirror://cpan/authors/id/E/ET/ETHER/UNIVERSAL-isa-1.20171012.tar.gz;
       sha256 = "0avzv9j32aab6l0rd63n92v0pgliz1p4yabxxjfq275hdh1mcsfi";
@@ -17149,9 +18417,10 @@ let
   };
 
   UNIVERSALrequire = buildPerlPackage rec {
-    name = "UNIVERSAL-require-0.18";
+    pname = "UNIVERSAL-require";
+    version = "0.18";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/${name}.tar.gz";
+      url = mirror://cpan/authors/id/N/NE/NEILB/UNIVERSAL-require-0.18.tar.gz;
       sha256 = "b2a736a87967a143dab58c8a110501d5235bcdd2c8b2a3bfffcd3c0bd06b38ed";
     };
     meta = {
@@ -17161,9 +18430,10 @@ let
   };
 
   UnicodeCaseFold = buildPerlModule rec {
-    name = "Unicode-CaseFold-1.01";
+    pname = "Unicode-CaseFold";
+    version = "1.01";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AR/ARODLAND/${name}.tar.gz";
+      url = mirror://cpan/authors/id/A/AR/ARODLAND/Unicode-CaseFold-1.01.tar.gz;
       sha256 = "418a212808f9d0b8bb330ac905096d2dd364976753d4c71534dab9836a63194d";
     };
     meta = {
@@ -17173,7 +18443,8 @@ let
   };
 
   UnicodeCheckUTF8 = buildPerlPackage {
-    name = "Unicode-CheckUTF8-1.03";
+    pname = "Unicode-CheckUTF8";
+    version = "1.03";
     src = fetchurl {
       url = mirror://cpan/authors/id/B/BR/BRADFITZ/Unicode-CheckUTF8-1.03.tar.gz;
       sha256 = "97f84daf033eb9b49cd8fe31db221fef035a5c2ee1d757f3122c88cf9762414c";
@@ -17181,9 +18452,10 @@ let
   };
 
   UnicodeLineBreak = buildPerlPackage rec {
-    name = "Unicode-LineBreak-2019.001";
+    pname = "Unicode-LineBreak";
+    version = "2019.001";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEZUMI/${name}.tar.gz";
+      url = mirror://cpan/authors/id/N/NE/NEZUMI/Unicode-LineBreak-2019.001.tar.gz;
       sha256 = "12iinva5gqc9g7qzxrvmh45n714z0ad9g7wq2dxwgp6drbj64rs8";
     };
     propagatedBuildInputs = [ MIMECharset ];
@@ -17194,7 +18466,8 @@ let
   };
 
   UnicodeString = buildPerlPackage rec {
-    name = "Unicode-String-2.10";
+    pname = "Unicode-String";
+    version = "2.10";
     src = fetchurl {
       url = mirror://cpan/authors/id/G/GA/GAAS/GAAS/Unicode-String-2.10.tar.gz;
       sha256 = "0s4vp8k7ag7z9lsnnkpa9mnch83kxhp9gh7yiapld5a7rq712jl9";
@@ -17202,7 +18475,8 @@ let
   };
 
   UnixGetrusage = buildPerlPackage {
-    name = "Unix-Getrusage-0.03";
+    pname = "Unix-Getrusage";
+    version = "0.03";
     src = fetchurl {
       url = mirror://cpan/authors/id/T/TA/TAFFY/Unix-Getrusage-0.03.tar.gz;
       sha256 = "76cde1cee2453260b85abbddc27cdc9875f01d2457e176e03dcabf05fb444d12";
@@ -17210,7 +18484,8 @@ let
   };
 
   URI = buildPerlPackage rec {
-    name = "URI-1.76";
+    pname = "URI";
+    version = "1.76";
     src = fetchurl {
       url = mirror://cpan/authors/id/O/OA/OALDERS/URI-1.76.tar.gz;
       sha256 = "b2c98e1d50d6f572483ee538a6f4ccc8d9185f91f0073fd8af7390898254413e";
@@ -17224,7 +18499,8 @@ let
   };
 
   URIdb = buildPerlModule {
-    name = "URI-db-0.19";
+    pname = "URI-db";
+    version = "0.19";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DW/DWHEELER/URI-db-0.19.tar.gz;
       sha256 = "c4999deaf451652216032c8e327ff6e6d655539eac379095bb69b0c369efa658";
@@ -17237,9 +18513,10 @@ let
   };
 
   URIFind = buildPerlModule rec {
-    name = "URI-Find-20160806";
+    pname = "URI-Find";
+    version = "20160806";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MS/MSCHWERN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MS/MSCHWERN/URI-Find-20160806.tar.gz;
       sha256 = "1mk3jv8x0mcq3ajrn9garnxd0jc7sw4pkwqi88r5apqvlljs84z2";
     };
     propagatedBuildInputs = [ URI ];
@@ -17250,7 +18527,8 @@ let
   };
 
   URIFromHash = buildPerlPackage {
-    name = "URI-FromHash-0.05";
+    pname = "URI-FromHash";
+    version = "0.05";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DR/DROLSKY/URI-FromHash-0.05.tar.gz;
       sha256 = "1l3g5ygv83vn9y1zpwjdqq5cs4ip2q058q0gmpcf5wp9rsycbjm7";
@@ -17264,16 +18542,18 @@ let
   };
 
   UriGoogleChart = buildPerlPackage rec {
-    name = "URI-GoogleChart-1.02";
+    pname = "URI-GoogleChart";
+    version = "1.02";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/G/GA/GAAS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/G/GA/GAAS/URI-GoogleChart-1.02.tar.gz;
       sha256 = "00hq5cpsk7sa04n0wg52qhpqf9i2849yyvw2zk83ayh1qqpc50js";
     };
     propagatedBuildInputs = [ URI ];
   };
 
   UserIdentity = buildPerlPackage rec {
-     name = "User-Identity-0.99";
+     pname = "User-Identity";
+     version = "0.99";
      src = fetchurl {
        url = mirror://cpan/authors/id/M/MA/MARKOV/User-Identity-0.99.tar.gz;
        sha256 = "0c2qwxgpqncm4ya3rb5zz2hgiwwf559j1b1a6llyarf9jy43hfzm";
@@ -17285,7 +18565,8 @@ let
   };
 
   URIIMAP = buildPerlPackage {
-    name = "URI-imap-1.01";
+    pname = "URI-imap";
+    version = "1.01";
     src = fetchurl {
       url = mirror://cpan/authors/id/C/CW/CWEST/URI-imap-1.01.tar.gz;
       sha256 = "0bdv6mrdijcq46r3lmz801rscs63f8p9qqliy2safd6fds4rj55v";
@@ -17294,7 +18575,8 @@ let
   };
 
   URINested = buildPerlModule {
-    name = "URI-Nested-0.10";
+    pname = "URI-Nested";
+    version = "0.10";
     src = fetchurl {
       url = mirror://cpan/authors/id/D/DW/DWHEELER/URI-Nested-0.10.tar.gz;
       sha256 = "e1971339a65fbac63ab87142d4b59d3d259d51417753c77cb58ea31a8233efaf";
@@ -17307,9 +18589,10 @@ let
   };
 
   URIws = buildPerlPackage rec {
-    name = "URI-ws-0.03";
+    pname = "URI-ws";
+    version = "0.03";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PL/PLICEASE/${name}.tar.gz";
+      url = mirror://cpan/authors/id/P/PL/PLICEASE/URI-ws-0.03.tar.gz;
       sha256 = "6e6b0e4172acb6a53c222639c000608c2dd61d50848647482ac8600d50e541ef";
     };
     propagatedBuildInputs = [ URI ];
@@ -17321,9 +18604,10 @@ let
   };
 
   UUIDTiny = buildPerlPackage rec {
-    name = "UUID-Tiny-1.04";
+    pname = "UUID-Tiny";
+    version = "1.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CA/CAUGUSTIN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/C/CA/CAUGUSTIN/UUID-Tiny-1.04.tar.gz;
       sha256 = "6dcd92604d64e96cc6c188194ae16a9d3a46556224f77b6f3d1d1312b68f9a3d";
     };
     meta = {
@@ -17333,9 +18617,10 @@ let
   };
 
   VariableMagic = buildPerlPackage rec {
-    name = "Variable-Magic-0.62";
+    pname = "Variable-Magic";
+    version = "0.62";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/V/VP/VPIT/${name}.tar.gz";
+      url = mirror://cpan/authors/id/V/VP/VPIT/Variable-Magic-0.62.tar.gz;
       sha256 = "3f9a18517e33f006a9c2fc4f43f01b54abfe6ff2eae7322424f31069296b615c";
     };
     meta = {
@@ -17345,9 +18630,10 @@ let
   };
 
   version = buildPerlPackage rec {
-    name = "version-0.9924";
+    pname = "version";
+    version = "0.9924";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JP/JPEACOCK/${name}.tar.gz";
+      url = mirror://cpan/authors/id/J/JP/JPEACOCK/version-0.9924.tar.gz;
       sha256 = "81e4485ff3faf9b7813584d57b557f4b34e73b6c2eb696394f6deefacf5ca65b";
     };
     meta = {
@@ -17375,9 +18661,10 @@ let
   };
 
   VMEC2 = buildPerlModule rec {
-    name = "VM-EC2-1.28";
+    pname = "VM-EC2";
+    version = "1.28";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LD/LDS/${name}.tar.gz";
+      url = mirror://cpan/authors/id/L/LD/LDS/VM-EC2-1.28.tar.gz;
       sha256 = "b2b6b31745c57431fca0efb9b9d0b8f168d6081755e048fd9d6c4469bd108acd";
     };
     propagatedBuildInputs = [ AnyEventCacheDNS AnyEventHTTP JSON StringApprox XMLSimple ];
@@ -17388,9 +18675,10 @@ let
   };
 
   VMEC2SecurityCredentialCache = buildPerlPackage rec {
-    name = "VM-EC2-Security-CredentialCache-0.25";
+    pname = "VM-EC2-Security-CredentialCache";
+    version = "0.25";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RC/RCONOVER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RC/RCONOVER/VM-EC2-Security-CredentialCache-0.25.tar.gz;
       sha256 = "fc7e9c152ff2b721ccb221ac40089934775cf58366aedb5cc1693609f840937b";
     };
     propagatedBuildInputs = [ DateTimeFormatISO8601 VMEC2 ];
@@ -17401,9 +18689,10 @@ let
   };
 
   W3CLinkChecker = buildPerlPackage rec {
-    name = "W3C-LinkChecker-4.81";
+    pname = "W3C-LinkChecker";
+    version = "4.81";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SC/SCOP/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SC/SCOP/W3C-LinkChecker-4.81.tar.gz;
       sha256 = "6239f61b20d91dce7b21e4d4f626ab93a8f1e2f207da5015590d508cf6c66a65";
     };
     outputs = [ "out" ];
@@ -17416,9 +18705,10 @@ let
   };
 
   WWWCurl = buildPerlPackage rec {
-    name = "WWW-Curl-4.17";
+    pname = "WWW-Curl";
+    version = "4.17";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SZ/SZBALINT/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SZ/SZBALINT/WWW-Curl-4.17.tar.gz;
       sha256 = "1fmp9aib1kaps9vhs4dwxn7b15kgnlz9f714bxvqsd1j1q8spzsj";
     };
     patches = [ ../development/perl-modules/WWW-Curl-4.17-Skip-preprocessor-symbol-only-CURL_STRICTER.patch ];
@@ -17433,7 +18723,8 @@ let
   };
 
   WWWFormUrlEncoded = buildPerlModule rec {
-     name = "WWW-Form-UrlEncoded-0.25";
+     pname = "WWW-Form-UrlEncoded";
+     version = "0.25";
      src = fetchurl {
        url = mirror://cpan/authors/id/K/KA/KAZEBURO/WWW-Form-UrlEncoded-0.25.tar.gz;
        sha256 = "0kh7qrskhbk4j253pr2q4vpn73q5k6fj517m3lnj8n755z9adxz1";
@@ -17446,7 +18737,8 @@ let
   };
 
   WWWMechanize = buildPerlPackage {
-    name = "WWW-Mechanize-1.91";
+    pname = "WWW-Mechanize";
+    version = "1.91";
     src = fetchurl {
       url = mirror://cpan/authors/id/O/OA/OALDERS/WWW-Mechanize-1.91.tar.gz;
       sha256 = "0cb14m1vhaf0mgn2fqwi5hm72xhfi77hpq2g57swgy0w83x7m27b";
@@ -17462,7 +18754,8 @@ let
   };
 
   WWWMechanizeCGI = buildPerlPackage {
-    name = "WWW-Mechanize-CGI-0.3";
+    pname = "WWW-Mechanize-CGI";
+    version = "0.3";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MR/MRAMBERG/WWW-Mechanize-CGI-0.3.tar.gz;
       sha256 = "046jm18liq7rwkdawdh9520cnalkfrk26yqryp7xgw71y65lvq61";
@@ -17475,7 +18768,8 @@ let
   };
 
   WWWRobotRules = buildPerlPackage {
-    name = "WWW-RobotRules-6.02";
+    pname = "WWW-RobotRules";
+    version = "6.02";
     src = fetchurl {
       url = mirror://cpan/authors/id/G/GA/GAAS/WWW-RobotRules-6.02.tar.gz;
       sha256 = "07m50dp5n5jxv3m93i55qvnd67a6g7cvbvlik115kmc8lbkh5da6";
@@ -17514,17 +18808,19 @@ let
   };
 
   Want = buildPerlPackage rec {
-    name = "Want-0.29";
+    pname = "Want";
+    version = "0.29";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/R/RO/ROBIN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/R/RO/ROBIN/Want-0.29.tar.gz;
       sha256 = "1xsjylbxxcbkjazqms49ipi94j1hd2ykdikk29cq7dscil5p9r5l";
     };
   };
 
   Workflow = buildPerlModule rec {
-    name = "Workflow-1.45";
+    pname = "Workflow";
+    version = "1.45";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JO/JONASBN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/J/JO/JONASBN/Workflow-1.45.tar.gz;
       sha256 = "0w814z4j85gghzqnbxzsr60m8dbqc02yi7137sq58lhbsfshmvhx";
     };
     buildInputs = [ DBDMock ListMoreUtils PodCoverageTrustPod TestException TestKwalitee TestPod TestPodCoverage ];
@@ -17537,9 +18833,10 @@ let
   };
 
   Wx = buildPerlPackage rec {
-    name = "Wx-0.9932";
+    pname = "Wx";
+    version = "0.9932";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MD/MDOOTSON/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MD/MDOOTSON/Wx-0.9932.tar.gz;
       sha256 = "0w0vcpk8bmklh16c0z1vxgipnmvdw7cckcmay7k7cihgb99vdz8w";
     };
     propagatedBuildInputs = [ AlienWxWidgets ];
@@ -17550,9 +18847,10 @@ let
   };
 
   WxGLCanvas = buildPerlPackage rec {
-    name = "Wx-GLCanvas-0.09";
+    pname = "Wx-GLCanvas";
+    version = "0.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MB/MBARBON/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MB/MBARBON/Wx-GLCanvas-0.09.tar.gz;
       sha256 = "1q4gvj4gdx4l8k4mkgiix24p9mdfy1miv7abidf0my3gy2gw5lka";
     };
     propagatedBuildInputs = [ pkgs.libGLU Wx ];
@@ -17560,9 +18858,10 @@ let
   };
 
   X11IdleTime = buildPerlPackage rec {
-    name = "X11-IdleTime-0.09";
+    pname = "X11-IdleTime";
+    version = "0.09";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AW/AWENDT/${name}.tar.gz";
+      url = mirror://cpan/authors/id/A/AW/AWENDT/X11-IdleTime-0.09.tar.gz;
       sha256 = "0j27cb9yy9ymni8cbiyxplbg086b8lv6b330nwqyx0briq3xrzfq";
     };
     buildInputs = [ pkgs.xorg.libXext pkgs.xorg.libXScrnSaver pkgs.xorg.libX11 ];
@@ -17574,9 +18873,10 @@ let
   };
 
   X11Protocol = buildPerlPackage rec {
-    name = "X11-Protocol-0.56";
+    pname = "X11-Protocol";
+    version = "0.56";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SM/SMCCAM/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SM/SMCCAM/X11-Protocol-0.56.tar.gz;
       sha256 = "1dq89bh6fqv7l5mbffqcismcljpq5f869bx7g8lg698zgindv5ny";
     };
     buildInputs = [ pkgs.xlibsWrapper ];
@@ -17585,9 +18885,10 @@ let
   };
 
   X11GUITest = buildPerlPackage rec {
-    name = "X11-GUITest-0.28";
+    pname = "X11-GUITest";
+    version = "0.28";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/C/CT/CTRONDLP/${name}.tar.gz";
+      url = mirror://cpan/authors/id/C/CT/CTRONDLP/X11-GUITest-0.28.tar.gz;
       sha256 = "0jznws68skdzkhgkgcgjlj40qdyh9i75r7fw8bqzy406f19xxvnw";
     };
     buildInputs = [ pkgs.xlibsWrapper pkgs.xorg.libXtst pkgs.xorg.libXi ];
@@ -17596,9 +18897,10 @@ let
   };
 
   X11XCB = buildPerlPackage rec {
-    name = "X11-XCB-0.18";
+    pname = "X11-XCB";
+    version = "0.18";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MS/MSTPLBG/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MS/MSTPLBG/X11-XCB-0.18.tar.gz;
       sha256 = "1cjpghw7cnackw20lbd7yzm222kz5bnrwz52f8ay24d1f4pwrnxf";
     };
     AUTOMATED_TESTING = false;
@@ -17613,9 +18915,10 @@ let
   };
 
   XMLDescent = buildPerlModule rec {
-    name = "XML-Descent-1.04";
+    pname = "XML-Descent";
+    version = "1.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/A/AN/ANDYA/${name}.tar.gz";
+      url = mirror://cpan/authors/id/A/AN/ANDYA/XML-Descent-1.04.tar.gz;
       sha256 = "0l5xmw2hd95ypppz3lyvp4sn02ccsikzjwacli3ydxfdz1bbh4d7";
     };
     buildInputs = [ TestDifferences ];
@@ -17627,18 +18930,20 @@ let
   };
 
   XMLDOM = buildPerlPackage rec {
-    name = "XML-DOM-1.46";
+    pname = "XML-DOM";
+    version = "1.46";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TJ/TJMATHER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/T/TJ/TJMATHER/XML-DOM-1.46.tar.gz;
       sha256 = "0phpkc4li43m2g44hdcvyxzy9pymqwlqhh5hwp2xc0cv8l5lp8lb";
     };
     propagatedBuildInputs = [ XMLRegExp libxml_perl ];
   };
 
   XMLFeedPP = buildPerlPackage rec {
-    name = "XML-FeedPP-0.95";
+    pname = "XML-FeedPP";
+    version = "0.95";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MARKOV/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MA/MARKOV/XML-FeedPP-0.95.tar.gz;
       sha256 = "1x5806xwmbqxr1dkdhalb6d7n31s3ya776klkai7c2x6y6drbhwh";
     };
     propagatedBuildInputs = [ XMLTreePP ];
@@ -17649,7 +18954,8 @@ let
   };
 
   XMLFilterBufferText = buildPerlPackage {
-    name = "XML-Filter-BufferText-1.01";
+    pname = "XML-Filter-BufferText";
+    version = "1.01";
     src = fetchurl {
       url = mirror://cpan/authors/id/R/RB/RBERJON/XML-Filter-BufferText-1.01.tar.gz;
       sha256 = "8fd2126d3beec554df852919f4739e689202cbba6a17506e9b66ea165841a75c";
@@ -17658,7 +18964,8 @@ let
   };
 
   XMLFilterXInclude = buildPerlPackage {
-    name = "XML-Filter-XInclude-1.0";
+    pname = "XML-Filter-XInclude";
+    version = "1.0";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MS/MSERGEANT/XML-Filter-XInclude-1.0.tar.gz;
       sha256 = "98746f3c1f6f049491fec203d455bb8f8c9c6e250f041904dda5d78e21187f93";
@@ -17667,9 +18974,10 @@ let
   };
 
   XMLGrove = buildPerlPackage rec {
-    name = "XML-Grove-0.46alpha";
+    pname = "XML-Grove";
+    version = "0.46alpha";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KM/KMACLEOD/${name}.tar.gz";
+      url = mirror://cpan/authors/id/K/KM/KMACLEOD/XML-Grove-0.46alpha.tar.gz;
       sha256 = "05yis1ms7cgwjh57k57whrmalb3ha0bjr9hyvh7cnadcyiynvdpw";
     };
     buildInputs = [ pkgs.libxml2 ];
@@ -17683,9 +18991,10 @@ let
   };
 
   XMLHandlerYAWriter = buildPerlPackage rec {
-    name = "XML-Handler-YAWriter-0.23";
+    pname = "XML-Handler-YAWriter";
+    version = "0.23";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KR/KRAEHE/${name}.tar.gz";
+      url = mirror://cpan/authors/id/K/KR/KRAEHE/XML-Handler-YAWriter-0.23.tar.gz;
       sha256 = "11d45a1sz862va9rry3p2m77pwvq3kpsvgwhc5ramh9mbszbnk77";
     };
     propagatedBuildInputs = [ libxml_perl ];
@@ -17695,9 +19004,10 @@ let
   };
 
   XMLLibXML = buildPerlPackage rec {
-    name = "XML-LibXML-2.0134";
+    pname = "XML-LibXML";
+    version = "2.0134";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SH/SHLOMIF/XML-LibXML-2.0134.tar.gz;
       sha256 = "1ks69xymv6zkj7hvaymjvb78ch81abri7kg4zrwxhdfsqb8a9g7h";
     };
     SKIP_SAX_INSTALL = 1;
@@ -17711,7 +19021,8 @@ let
   };
 
   XMLLibXMLSimple = buildPerlPackage {
-    name = "XML-LibXML-Simple-0.99";
+    pname = "XML-LibXML-Simple";
+    version = "0.99";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MA/MARKOV/XML-LibXML-Simple-0.99.tar.gz;
       sha256 = "14fe45c9fcb36c1cf14ac922da4439f1f83d451a5e70aa7177cb6edb705c9e44";
@@ -17724,9 +19035,10 @@ let
   };
 
   XMLLibXSLT = buildPerlPackage rec {
-    name = "XML-LibXSLT-1.96";
+    pname = "XML-LibXSLT";
+    version = "1.96";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/${name}.tar.gz";
+      url = mirror://cpan/authors/id/S/SH/SHLOMIF/XML-LibXSLT-1.96.tar.gz;
       sha256 = "0wyl8klgr65j8y8fzgwz9jlvfjwvxazna8j3dg9gksd2v973fpia";
     };
     buildInputs = [ pkgs.zlib pkgs.libxml2 pkgs.libxslt ];
@@ -17734,9 +19046,10 @@ let
   };
 
   XMLMini = buildPerlPackage rec {
-    name = "XML-Mini-1.38";
+    pname = "XML-Mini";
+    version = "1.38";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PD/PDEEGAN/${name}.tar.gz";
+      url = mirror://cpan/authors/id/P/PD/PDEEGAN/XML-Mini-1.38.tar.gz;
       sha256 = "af803d38036a3184e124a682e5466f1bc107f48a89ef35b0c7647e11a073fe2d";
     };
     meta = {
@@ -17745,7 +19058,8 @@ let
   };
 
   XMLNamespaceSupport = buildPerlPackage {
-    name = "XML-NamespaceSupport-1.12";
+    pname = "XML-NamespaceSupport";
+    version = "1.12";
     src = fetchurl {
       url = mirror://cpan/authors/id/P/PE/PERIGRIN/XML-NamespaceSupport-1.12.tar.gz;
       sha256 = "1vz5pbi4lm5fhq2slrs2hlp6bnk29863abgjlcx43l4dky2rbsa7";
@@ -17753,7 +19067,8 @@ let
   };
 
   XMLParser = buildPerlPackage {
-    name = "XML-Parser-2.44";
+    pname = "XML-Parser";
+    version = "2.44";
     src = fetchurl {
       url = mirror://cpan/authors/id/T/TO/TODDR/XML-Parser-2.44.tar.gz;
       sha256 = "05ij0g6bfn27iaggxf8nl5rhlwx6f6p6xmdav6rjcly3x5zd1s8s";
@@ -17768,7 +19083,8 @@ let
   };
 
   XMLParserLite = buildPerlPackage {
-    name = "XML-Parser-Lite-0.722";
+    pname = "XML-Parser-Lite";
+    version = "0.722";
     src = fetchurl {
       url = mirror://cpan/authors/id/P/PH/PHRED/XML-Parser-Lite-0.722.tar.gz;
       sha256 = "1vk3jwh1kfcsmc5kvxzqdnb1cllvf0yf27fg0ra0w6jkw4ks143g";
@@ -17781,9 +19097,10 @@ let
   };
 
   XMLXPath = buildPerlPackage rec {
-    name = "XML-XPath-1.44";
+    pname = "XML-XPath";
+    version = "1.44";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MA/MANWAR/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MA/MANWAR/XML-XPath-1.44.tar.gz;
       sha256 = "1cc9110705165dc09dd09974dd7c0b6709c9351d6b6b1cef5a711055f891dd0f";
     };
     buildInputs = [ PathTiny ];
@@ -17795,7 +19112,8 @@ let
   };
 
   XMLXPathEngine = buildPerlPackage {
-    name = "XML-XPathEngine-0.14";
+    pname = "XML-XPathEngine";
+    version = "0.14";
     src = fetchurl {
       url = mirror://cpan/authors/id/M/MI/MIROD/XML-XPathEngine-0.14.tar.gz;
       sha256 = "0r72na14bmsxfd16s9nlza155amqww0k8wsa9x2a3sqbpp5ppznj";
@@ -17806,7 +19124,8 @@ let
   };
 
   XMLRegExp = buildPerlPackage {
-    name = "XML-RegExp-0.04";
+    pname = "XML-RegExp";
+    version = "0.04";
     src = fetchurl {
       url = mirror://cpan/authors/id/T/TJ/TJMATHER/XML-RegExp-0.04.tar.gz;
       sha256 = "0m7wj00a2kik7wj0azhs1zagwazqh3hlz4255n75q21nc04r06fz";
@@ -17814,7 +19133,8 @@ let
   };
 
   XMLRSS = buildPerlModule {
-    name = "XML-RSS-1.60";
+    pname = "XML-RSS";
+    version = "1.60";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SH/SHLOMIF/XML-RSS-1.60.tar.gz;
       sha256 = "4b3359878bb1a2bc06dae7ed17b00143a2b89c814b8b12f6e2780f35b1528677";
@@ -17828,7 +19148,8 @@ let
   };
 
   XMLSAX = buildPerlPackage {
-    name = "XML-SAX-1.00";
+    pname = "XML-SAX";
+    version = "1.00";
     src = fetchurl {
       url = mirror://cpan/authors/id/G/GR/GRANTM/XML-SAX-1.00.tar.gz;
       sha256 = "1qra9k3wszjxvsgbragl55z3qba4nri0ipmjaxfib4l6xxj6bsj5";
@@ -17840,7 +19161,8 @@ let
   };
 
   XMLSAXBase = buildPerlPackage {
-    name = "XML-SAX-Base-1.09";
+    pname = "XML-SAX-Base";
+    version = "1.09";
     src = fetchurl {
       url = mirror://cpan/authors/id/G/GR/GRANTM/XML-SAX-Base-1.09.tar.gz;
       sha256 = "66cb355ba4ef47c10ca738bd35999723644386ac853abbeb5132841f5e8a2ad0";
@@ -17853,7 +19175,8 @@ let
   };
 
   XMLSAXExpat = buildPerlPackage rec {
-     name = "XML-SAX-Expat-0.51";
+     pname = "XML-SAX-Expat";
+     version = "0.51";
      src = fetchurl {
        url = mirror://cpan/authors/id/B/BJ/BJOERN/XML-SAX-Expat-0.51.tar.gz;
        sha256 = "0gy8h2bvvvlxychwsb99ikdh5cqpk6sqc073jk2b4zffs09n40ac";
@@ -17866,7 +19189,8 @@ let
   };
 
   XMLSAXWriter = buildPerlPackage {
-    name = "XML-SAX-Writer-0.57";
+    pname = "XML-SAX-Writer";
+    version = "0.57";
     src = fetchurl {
       url = mirror://cpan/authors/id/P/PE/PERIGRIN/XML-SAX-Writer-0.57.tar.gz;
       sha256 = "3d61d07ef43b0126f5b4de4f415a256fa859fa88dc4fdabaad70b7be7c682cf0";
@@ -17880,7 +19204,8 @@ let
   };
 
   XMLSemanticDiff = buildPerlModule {
-    name = "XML-SemanticDiff-1.0007";
+    pname = "XML-SemanticDiff";
+    version = "1.0007";
     src = fetchurl {
       url = mirror://cpan/authors/id/P/PE/PERIGRIN/XML-SemanticDiff-1.0007.tar.gz;
       sha256 = "1xd00821y795fy2rag8aizb5wsbbzfxgmdf9qwpvdxn3pgpyzz85";
@@ -17889,7 +19214,8 @@ let
   };
 
   XMLSimple = buildPerlPackage {
-    name = "XML-Simple-2.25";
+    pname = "XML-Simple";
+    version = "2.25";
     src = fetchurl {
       url = mirror://cpan/authors/id/G/GR/GRANTM/XML-Simple-2.25.tar.gz;
       sha256 = "1y6vh328zrh085d40852v4ij2l4g0amxykswxd1nfhd2pspds7sk";
@@ -17898,9 +19224,10 @@ let
   };
 
   XMLTokeParser = buildPerlPackage rec {
-    name = "XML-TokeParser-0.05";
+    pname = "XML-TokeParser";
+    version = "0.05";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/P/PO/PODMASTER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/P/PO/PODMASTER/XML-TokeParser-0.05.tar.gz;
       sha256 = "1hnpwb3lh6cbgwvjjgqzcp6jm4mp612qn6ili38adc9nhkwv8fc5";
     };
     propagatedBuildInputs = [ XMLParser ];
@@ -17911,9 +19238,10 @@ let
   };
 
   XMLTreePP = buildPerlPackage rec {
-    name = "XML-TreePP-0.43";
+    pname = "XML-TreePP";
+    version = "0.43";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/K/KA/KAWASAKI/${name}.tar.gz";
+      url = mirror://cpan/authors/id/K/KA/KAWASAKI/XML-TreePP-0.43.tar.gz;
       sha256 = "7fbe2d6430860059894aeeebf75d4cacf1bf8d7b75294eb87d8e1502f81bd760";
     };
     propagatedBuildInputs = [ LWP ];
@@ -17924,9 +19252,10 @@ let
   };
 
   XMLTwig = buildPerlPackage rec {
-    name = "XML-Twig-3.52";
+    pname = "XML-Twig";
+    version = "3.52";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIROD/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MI/MIROD/XML-Twig-3.52.tar.gz;
       sha256 = "1bc0hrz4jp6199hi29sdxmb9gyy45whla9hd19yqfasgq8k5ixzy";
     };
     propagatedBuildInputs = [ XMLParser ];
@@ -17934,7 +19263,8 @@ let
   };
 
   XMLValidatorSchema = buildPerlPackage {
-    name = "XML-Validator-Schema-1.10";
+    pname = "XML-Validator-Schema";
+    version = "1.10";
     src = fetchurl {
       url = mirror://cpan/authors/id/S/SA/SAMTREGAR/XML-Validator-Schema-1.10.tar.gz;
       sha256 = "6142679580150a891f7d32232b5e31e2b4e5e53e8a6fa9cbeecb5c23814f1422";
@@ -17946,17 +19276,19 @@ let
   };
 
   XMLWriter = buildPerlPackage rec {
-    name = "XML-Writer-0.625";
+    pname = "XML-Writer";
+    version = "0.625";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/J/JO/JOSEPHW/${name}.tar.gz";
+      url = mirror://cpan/authors/id/J/JO/JOSEPHW/XML-Writer-0.625.tar.gz;
       sha256 = "1gjzs570i67ywbv967g8ylb5sg59clwmyrl2yix3jl70dhn55070";
     };
   };
 
   XSObjectMagic = buildPerlPackage rec {
-    name = "XS-Object-Magic-0.04";
+    pname = "XS-Object-Magic";
+    version = "0.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/F/FL/FLORA/${name}.tar.gz";
+      url = mirror://cpan/authors/id/F/FL/FLORA/XS-Object-Magic-0.04.tar.gz;
       sha256 = "03fghj7hq0fiicmfdxhmzfm4mzv7s097pgkd32ji7jnljvhm9six";
     };
     buildInputs = [ ExtUtilsDepends TestFatal ];
@@ -17984,9 +19316,10 @@ let
   };
 
   YAMLSyck = buildPerlPackage rec {
-    name = "YAML-Syck-1.31";
+    pname = "YAML-Syck";
+    version = "1.31";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TODDR/${name}.tar.gz";
+      url = mirror://cpan/authors/id/T/TO/TODDR/YAML-Syck-1.31.tar.gz;
       sha256 = "14420hp7vxhrs0hgsmrfc9s9dassw1bns4jbmdq55b735xrwbbfp";
     };
     meta = {
@@ -17996,15 +19329,17 @@ let
   };
 
   YAMLTiny = buildPerlPackage rec {
-    name = "YAML-Tiny-1.73";
+    pname = "YAML-Tiny";
+    version = "1.73";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/ET/ETHER/${name}.tar.gz";
+      url = mirror://cpan/authors/id/E/ET/ETHER/YAML-Tiny-1.73.tar.gz;
       sha256 = "0i3p4nz8ysrsrs6vlzc6gkjcfpcaf05xjc7lwbjkw7lg5shmycdw";
     };
   };
 
   YAMLLibYAML = buildPerlPackage rec {
-    name = "YAML-LibYAML-0.77";
+    pname = "YAML-LibYAML";
+    version = "0.77";
     src = fetchurl {
       url = mirror://cpan/authors/id/T/TI/TINITA/YAML-LibYAML-0.77.tar.gz;
       sha256 = "04wfa78i3r6gznl47gj3qvsa1ixdas7l7c5c3n5mwm81wi4d9vsi";
@@ -18012,9 +19347,10 @@ let
   };
 
   WebServiceLinode = buildPerlModule rec {
-    name = "WebService-Linode-0.28";
+    pname = "WebService-Linode";
+    version = "0.28";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/M/MI/MIKEGRB/${name}.tar.gz";
+      url = mirror://cpan/authors/id/M/MI/MIKEGRB/WebService-Linode-0.28.tar.gz;
       sha256 = "66a315016999c0d2043caae86e664dad10c6613708f33a2f56aae8030326c509";
     };
     buildInputs = [ ModuleBuildTiny ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -8052,10 +8052,11 @@ let
   };
 
   Inline = buildPerlPackage rec {
-    name = "Inline-0.82";
+    pname = "Inline";
+    version = "0.83";
     src = fetchurl {
-      url = mirror://cpan/authors/id/T/TI/TINITA/Inline-0.82.tar.gz;
-      sha256 = "1af94a8e95e4ba4545592341c47d8d1dc45b01822b877f7d3095a438566e874b";
+      url = mirror://cpan/authors/id/T/TI/TINITA/Inline-0.83.tar.gz;
+      sha256 = "171a8e5f66faf88fe5ef4de7126267cd8fb2503483432eabc3b88ac7d5be4239";
     };
     buildInputs = [ TestWarn ];
     meta = {

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -16934,10 +16934,11 @@ let
   };
 
   TimeDurationParse = buildPerlPackage rec {
-    name = "Time-Duration-Parse-0.14";
+    pname = "Time-Duration-Parse";
+    version = "0.15";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/N/NE/NEILB/${name}.tar.gz";
-      sha256 = "17nh73r50mqqpgxdf3zpgdiqrizmjy0vdk0zd6xi9zcsdijrdhnc";
+      url = mirror://cpan/authors/id/N/NE/NEILB/Time-Duration-Parse-0.15.tar.gz;
+      sha256 = "10g39bbrxkabbsfq4rv7f5b5x7h3jba08j4pg8gwr0b9iqx19n31";
     };
     buildInputs = [ TimeDuration ];
     propagatedBuildInputs = [ ExporterLite ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -13340,10 +13340,11 @@ let
   };
 
   RegexpGrammars = buildPerlModule rec {
-    name = "Regexp-Grammars-1.049";
+    pname = "Regexp-Grammars";
+    version = "1.050";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DC/DCONWAY/${name}.tar.gz";
-      sha256 = "2e642a7051b9ea5dccd05d53e49684ca28e99c43b811bbec37d160d3f81edf68";
+      url = mirror://cpan/authors/id/D/DC/DCONWAY/Regexp-Grammars-1.050.tar.gz;
+      sha256 = "a35e8ddacce25cb66a8816905183b93cae066bbe3977f8c68765da46a4368b86";
     };
     meta = {
       description = "Add grammatical parsing features to Perl 5.10 regexes";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -8371,10 +8371,11 @@ let
   };
 
   LinguaENInflect = buildPerlPackage rec {
-    name = "Lingua-EN-Inflect-1.903";
+    pname = "Lingua-EN-Inflect";
+    version = "1.904";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/D/DC/DCONWAY/${name}.tar.gz";
-      sha256 = "fcef4b67b04cc39e427b2d70e7c5b24195edd0ed88dd705a08ecd5cd830b0d49";
+      url = mirror://cpan/authors/id/D/DC/DCONWAY/Lingua-EN-Inflect-1.904.tar.gz;
+      sha256 = "54d344884ba9b585680975bbd4049ddbf27bf654446fb00c7e1fc538e08c3173";
     };
     meta = {
       description = "Convert singular to plural. Select 'a' or 'an'";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -12914,10 +12914,11 @@ let
   };
 
   PerlPrereqScannerNotQuiteLite = buildPerlPackage {
-    name = "Perl-PrereqScanner-NotQuiteLite-0.9904";
+    pname = "Perl-PrereqScanner-NotQuiteLite";
+    version = "0.9905";
     src = fetchurl {
-      url = mirror://cpan/authors/id/I/IS/ISHIGAKI/Perl-PrereqScanner-NotQuiteLite-0.9904.tar.gz;
-      sha256 = "1qf6x49sjswazh7bicpm7wnwpdnx245ws02s53dvbxcbw2c66hsn";
+      url = mirror://cpan/authors/id/I/IS/ISHIGAKI/Perl-PrereqScanner-NotQuiteLite-0.9905.tar.gz;
+      sha256 = "076hhmrir07c3yzrmwdjlkgsnhfmbsfdylrxi63sikym545r1sv3";
     };
     propagatedBuildInputs = [ DataDump ModuleCPANfile ModuleFind RegexpTrie ];
     buildInputs = [ ExtUtilsMakeMakerCPANfile TestFailWarnings TestUseAllModules ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -15947,10 +15947,11 @@ let
   };
 
   TestRunValgrind = buildPerlModule rec {
-    name = "Test-RunValgrind-0.2.0";
+    pname = "Test-RunValgrind";
+    version = "0.2.1";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/S/SH/SHLOMIF/${name}.tar.gz";
-      sha256 = "70947565ad0be3e5d0cd9aca9e1fd0cb07c873e574310e92e8eca629ec6cd631";
+      url = mirror://cpan/authors/id/S/SH/SHLOMIF/Test-RunValgrind-0.2.1.tar.gz;
+      sha256 = "25a4a8bfcefaed7c40d8b8492e8828e798e6c85ca5f34ce4b9993f9899a7b09c";
     };
     buildInputs = [ TestTrap ];
     propagatedBuildInputs = [ PathTiny ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -14025,10 +14025,11 @@ let
   };
 
   Storable = buildPerlPackage {
-    name = "Storable-3.11";
+    pname = "Storable";
+    version = "3.15";
     src = fetchurl {
-      url = mirror://cpan/authors/id/X/XS/XSAWYERX/Storable-3.11.tar.gz;
-      sha256 = "b2dac116d2f5adaf289e9a8a9bbac35cc2c24a9d2221fea9b6578a33b8ec7d28";
+      url = mirror://cpan/authors/id/X/XS/XSAWYERX/Storable-3.15.tar.gz;
+      sha256 = "fc3dad06cb2e6fc86a2f2abc5b5491d9da328ca3e6b6306559c224521db174da";
     };
     meta = {
       license = with stdenv.lib.licenses; [ artistic1 gpl1Plus ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -1602,12 +1602,12 @@ let
   };
 
   CatalystViewJSON = buildPerlPackage rec {
-    name = "Catalyst-View-JSON-0.36";
+    pname = "Catalyst-View-JSON";
+    version = "0.37";
     src = fetchurl {
-      url = mirror://cpan/authors/id/J/JJ/JJNAPIORK/Catalyst-View-JSON-0.36.tar.gz;
-      sha256 = "0x943j1n2r0zqanyzdrs1xsnn8ayn2wqskn7h144xcqa6v6gcisl";
+      url = mirror://cpan/authors/id/H/HA/HAARG/Catalyst-View-JSON-0.37.tar.gz;
+      sha256 = "1v4xkzazs743sc7cd1kxkbi99cf00a4dadyyancckcbpi9p3znn5";
     };
-    buildInputs = [ YAML ];
     propagatedBuildInputs = [ CatalystRuntime ];
     meta = {
       description = "JSON view for your data";


### PR DESCRIPTION
###### Motivation for this change

- [x] Update ```perlPackages``` to the latest CPAN versions
- [x] change ```buildPerlPackage``` towards using ```pname``` (package name) and ```version``` instead of ```name``` which is useless (it is not consistent neither with CPAN urls not with "${pname}-${version}" pattern - sometimes it is "${pname}-v${version}") and tricky to parse (#61691)

My test build is not yet finished, I make PR to parallel it with ofborg's