### PR TITLE
pythonPackages.accupy: init at 0.1.4

### DIFF
--- a/pkgs/development/python-modules/accupy/default.nix
+++ b/pkgs/development/python-modules/accupy/default.nix
@@ -1,0 +1,62 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, mpmath
+, numpy
+, pipdate
+, pybind11
+, pyfma
+, eigen
+, pytest
+, matplotlib
+, perfplot
+, isPy27
+}:
+
+buildPythonPackage rec {
+  pname = "accupy";
+  version = "0.1.4";
+  disabled = isPy27;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "2a67f2a778b824fb24eb338fed8e0b61c1af93369d57ff8132f5d602d60f0543";
+  };
+
+  buildInputs = [
+    pybind11 eigen
+  ];
+
+  propagatedBuildInputs = [
+    mpmath
+    numpy
+    pipdate
+    pyfma
+  ];
+
+  checkInputs = [
+    pytest
+    matplotlib
+    perfplot
+  ];
+
+  postConfigure = ''
+   substituteInPlace setup.py \
+     --replace "/usr/include/eigen3/" "${eigen}/include/eigen3/"
+  '';
+
+  preBuild = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  checkPhase = ''
+    pytest test
+  '';
+
+  meta = with lib; {
+    description = "Accurate sums and dot products for Python";
+    homepage = https://github.com/nschloe/accupy;
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/perfplot/default.nix
+++ b/pkgs/development/python-modules/perfplot/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, matplotlib
+, numpy
+, pipdate
+, tqdm
+, pytest
+, isPy27
+}:
+
+buildPythonPackage rec {
+  pname = "perfplot";
+  version = "0.5.0";
+  disabled = isPy27;
+
+  src = fetchFromGitHub {
+    owner = "nschloe";
+    repo = "perfplot";
+    rev = "v${version}";
+    sha256 = "16aj5ryjic1k3qn8xhpw6crczvxcs691vs5kv4pvb1zdx69g1xbv";
+  };
+
+  propagatedBuildInputs = [
+    matplotlib
+    numpy
+    pipdate
+    tqdm
+  ];
+
+  checkInputs = [
+    pytest
+  ];
+
+  checkPhase = ''
+   HOME=$(mktemp -d) pytest test/perfplot_test.py
+  '';
+
+  meta = with lib; {
+    description = "Performance plots for Python code snippets";
+    homepage = https://github.com/nschloe/perfplot;
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/pipdate/default.nix
+++ b/pkgs/development/python-modules/pipdate/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, appdirs
+, requests
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "pipdate";
+  version = "0.3.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "a27f64d13269adfd8594582f5a62c9f2151b426e701afdfc3b4f4019527b4121";
+  };
+
+  propagatedBuildInputs = [
+    appdirs
+    requests
+  ];
+
+  checkInputs = [
+    pytest
+  ];
+
+  checkPhase = ''
+    HOME=$(mktemp -d) pytest test/test_pipdate.py
+  '';
+
+  # tests require network access
+  doCheck = false;
+
+  meta = with lib; {
+    description = "pip update helpers";
+    homepage = https://github.com/nschloe/pipdate;
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc ];
+  };
+}

--- a/pkgs/development/python-modules/pyfma/default.nix
+++ b/pkgs/development/python-modules/pyfma/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pybind11
+, numpy
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "pyfma";
+  version = "0.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "79514717f8e632a0fb165e3d61222ed61202bea7b0e082f7b41c91e738f1fbc9";
+  };
+
+  buildInputs = [
+    pybind11
+  ];
+
+  checkInputs = [
+    numpy
+    pytest
+  ];
+
+  preBuild = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  checkPhase = ''
+    pytest test
+  '';
+
+  meta = with lib; {
+    description = "Fused multiply-add for Python";
+    homepage = https://github.com/nschloe/pyfma;
+    license = licenses.mit;
+    maintainers = [ maintainers.costrouc];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -968,6 +968,8 @@ in {
 
   vega = callPackage ../development/python-modules/vega { };
 
+  accupy = callPackage ../development/python-modules/accupy { };
+
   acme = callPackage ../development/python-modules/acme { };
 
   acme-tiny = callPackage ../development/python-modules/acme-tiny { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3876,6 +3876,8 @@ in {
 
   pyfantom = callPackage ../development/python-modules/pyfantom { };
 
+  pyfma = callPackage ../development/python-modules/pyfma { };
+
   pyfftw = callPackage ../development/python-modules/pyfftw { };
 
   pyfiglet = callPackage ../development/python-modules/pyfiglet { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -603,6 +603,8 @@ in {
 
   perf = callPackage ../development/python-modules/perf { };
 
+  perfplot = callPackage ../development/python-modules/perfplot { };
+
   phonopy = callPackage ../development/python-modules/phonopy { };
 
   pims = callPackage ../development/python-modules/pims { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3706,6 +3706,8 @@ in {
     glibcLocales = pkgs.glibcLocales;
   };
 
+  pipdate = callPackage ../development/python-modules/pipdate { };
+
   pika = callPackage ../development/python-modules/pika { };
 
   pika-pool = callPackage ../development/python-modules/pika-pool { };


### PR DESCRIPTION
###### Motivation for this change

Heard a great talk at pycon about accurate floating point math wanted to play with package.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
