### PR TITLE
pstree: re-init at 2.39 (reverts #60994)

### DIFF
--- a/pkgs/applications/misc/pstree/default.nix
+++ b/pkgs/applications/misc/pstree/default.nix
@@ -1,0 +1,25 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "pstree-2.39";
+
+  src = fetchurl {
+    urls = [
+      "http://www.sfr-fresh.com/unix/misc/${name}.tar.gz"
+      "https://distfiles.macports.org/pstree/${name}.tar.gz"
+    ];
+    sha256 = "17s7v15c4gryjpi11y1xq75022nkg4ggzvjlq2dkmyg67ssc76vw";
+  };
+
+  unpackPhase = "unpackFile \$src; sourceRoot=.";
+
+  buildPhase = "pwd; $CC -o pstree pstree.c";
+  installPhase = "mkdir -p \$out/bin; cp pstree \$out/bin";
+
+  meta = {
+    description = "Show the set of running processes as a tree";
+    license = "GPL";
+    maintainers = [ ];
+    platforms = stdenv.lib.platforms.unix;
+  };
+}

--- a/pkgs/applications/misc/pstree/default.nix
+++ b/pkgs/applications/misc/pstree/default.nix
@@ -1,25 +1,38 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "pstree-2.39";
+  pname = "pstree";
+  version = "2.39";
 
   src = fetchurl {
     urls = [
-      "http://www.sfr-fresh.com/unix/misc/${name}.tar.gz"
-      "https://distfiles.macports.org/pstree/${name}.tar.gz"
+      "https://distfiles.macports.org/${pname}/${pname}-${version}.tar.gz"
+      "https://fossies.org/linux/misc/${pname}-${version}.tar.gz"
+      "ftp://ftp.thp.uni-duisburg.de/pub/source/${pname}-${version}.tar.gz"
     ];
     sha256 = "17s7v15c4gryjpi11y1xq75022nkg4ggzvjlq2dkmyg67ssc76vw";
   };
 
-  unpackPhase = "unpackFile \$src; sourceRoot=.";
+  sourceRoot = ".";
+  buildPhase = ''
+    runHook preBuild
+    $CC $NIX_CFLAGS -o pstree pstree.c
+    runHook postBuild
+  '';
 
-  buildPhase = "pwd; $CC -o pstree pstree.c";
-  installPhase = "mkdir -p \$out/bin; cp pstree \$out/bin";
+  installPhase = ''
+    runHook preInstall
+    install -Dm0555 ${pname} -t $out/bin
+    install -Dm0444 ${pname}.1 -t $out/share/man/man1
+    runHook postInstall
+  '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "Show the set of running processes as a tree";
-    license = "GPL";
-    maintainers = [ ];
-    platforms = stdenv.lib.platforms.unix;
+    homepage = "http://www.thp.uni-duisburg.de/pstree/";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.c0bw3b ];
+    platforms = platforms.unix;
+    priority = 5; # Lower than psmisc also providing pstree on Linux platforms
   };
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -256,7 +256,6 @@ mapAliases ({
   # end
   ppl-address-book = throw "deprecated in 2019-05-02: abandoned by upstream.";
   procps-ng = procps; # added 2018-06-08
-  pstree = psmisc; # added 2019-05-05
   pulseaudioLight = pulseaudio; # added 2018-04-25
   qca-qt5 = libsForQt5.qca-qt5;  # added 2015-12-19
   qt_gstreamer = qt-gstreamer;  # added 2017-02

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19572,6 +19572,8 @@ in
 
   psol = callPackage ../development/libraries/psol { };
 
+  pstree = callPackage ../applications/misc/pstree { };
+
   ptask = callPackage ../applications/misc/ptask { };
 
   pulseaudio-ctl = callPackage ../applications/audio/pulseaudio-ctl { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Closes #61725 and reverts #60994
`pstree` runs on all Unixes whereas `psmisc` is Linux-only (and BSD) but not Darwin-compatible

cc @lilyball @thefloweringash 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
