### PR TITLE
tdm: init at 2.07

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -881,6 +881,11 @@
     github = "ceedubs";
     name = "Cody Allen";
   };
+  cf6b88f = {
+    email = "elmo.todurov@eesti.ee";
+    github = "cf6b88f";
+    name = "Elmo Todurov";
+  };
   cfouche = {
     email = "chaddai.fouche@gmail.com";
     github = "Chaddai";

--- a/pkgs/games/tdm/default.nix
+++ b/pkgs/games/tdm/default.nix
@@ -1,0 +1,102 @@
+{ stdenv, fetchurl, binutils-unwrapped, scons, gnum4, p7zip, glibc_multi, mesa_noglu
+, xorg, libGLU_combined, openal
+, lib, makeWrapper, makeDesktopItem }:
+
+let
+  pname = "tdm";
+  version = "2.07";
+
+  desktop = makeDesktopItem {
+    desktopName = pname;
+    name = pname;
+    exec = "@out@/bin/${pname}";
+    icon = "${pname}";
+    terminal = "False";
+    comment = "The Dark Mod - stealth FPS inspired by the Thief series";
+    type = "Application";
+    categories = "Game;";
+    genericName = pname;
+  };
+in stdenv.mkDerivation {
+  name = "${pname}-${version}";
+  src = fetchurl {
+    url = "http://www.thedarkmod.com/sources/thedarkmod.${version}.src.7z";
+    sha256 = "17wdpip8zvm2njz0xrf7xcxl73hnsc6i83zj18kn8rnjkpy50dd6";
+  };
+  nativeBuildInputs = [
+    p7zip scons gnum4 makeWrapper
+  ];
+  buildInputs = [
+    glibc_multi mesa_noglu.dev xorg.libX11.dev openal
+    xorg.libXext.dev xorg.libXxf86vm.dev
+    libGLU_combined
+  ];
+  unpackPhase = ''
+    7z x $src
+  '';
+
+  # I'm pretty sure there's a better way to build 2 targets than a random hook
+  preBuild = ''
+    pushd tdm_update
+    scons BUILD=release TARGET_ARCH=x64
+    install -Dm755 tdm_update.linux $out/share/libexec/tdm_update.linux
+    popd
+  '';
+
+  # why oh why can it find ld but not strip?
+  postPatch = ''
+    sed -i 's!strip \$!${binutils-unwrapped}/bin/strip $!' SConstruct
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 ${desktop}/share/applications/${pname}.desktop $out/share/applications/${pname}.desktop
+    substituteInPlace $out/share/applications/${pname}.desktop --subst-var out
+    install -Dm755 thedarkmod.x64 $out/share/libexec/tdm
+
+    # The package doesn't install assets, these get installed by running tdm_update.linux
+    # Provide a script that runs tdm_update.linux on first launch
+    install -Dm755 <(cat <<'EOF'
+#!/bin/sh
+set -e
+DIR="$HOME/.local/share/tdm"
+mkdir -p "$DIR"
+cd "$DIR"
+exec "PKGDIR/share/libexec/tdm_update.linux" --noselfupdate
+EOF
+    ) $out/bin/tdm_update
+
+    install -Dm755 <(cat <<'EOF'
+#!/bin/sh
+set -e
+DIR="$HOME/.local/share/tdm"
+if [ ! -d "$DIR" ]; then
+  echo "Please run tdm_update to (re)download game data"
+else
+  cd "$DIR"
+  exec "PKGDIR/share/libexec/tdm"
+fi
+EOF
+    ) $out/bin/tdm
+    sed -i "s!PKGDIR!$out!g" $out/bin/tdm_update
+    sed -i "s!PKGDIR!$out!g" $out/bin/tdm
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/tdm --suffix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libGLU_combined ]}
+  '';
+
+  enableParallelBuilding = true;
+  sconsFlags = [ "BUILD=release" "TARGET_ARCH=x64" ];
+  NIX_CFLAGS_COMPILE = ["-Wno-error=format-security"];
+  meta = with stdenv.lib; {
+    description = "The Dark Mod - stealth FPS inspired by the Thief series";
+    homepage = "http://www.thedarkmod.com";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ cf6b88f ];
+    platforms = with platforms; [ "x86_64-linux" ];  # tdm also supports x86, but I don't have a x86 install at hand to test.
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24049,6 +24049,8 @@ in
     gcc-armhf-embedded = pkgsCross.armhf-embedded.buildPackages.gcc;
   };
 
+  tdm = callPackage ../games/tdm { };
+
   newlib = callPackage ../development/misc/newlib { };
   newlibCross = callPackage ../development/misc/newlib {
     stdenv = crossLibcStdenv;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add The Dark Mod http://www.thedarkmod.com/main/ — a FPS game inspired by the Thief series

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Runs.