### PR TITLE
pwsafe: 1.07 -> 1.08.1

### DIFF
--- a/pkgs/applications/misc/pwsafe/default.nix
+++ b/pkgs/applications/misc/pwsafe/default.nix
@@ -6,17 +6,17 @@
 
 stdenv.mkDerivation rec {
   pname = "pwsafe";
-  version = "1.07";
+  version = "1.08.1";
 
   src = fetchFromGitHub {
-    owner = "${pname}";
-    repo = "${pname}";
+    owner = pname;
+    repo = pname;
     rev = "${version}BETA";
-    sha256 = "0syxmliybgvm9j6d426l7j12ryrl42azy80m66jc56fv9nkqwaya";
+    sha256 = "0x89pn056h8b4yvxbd6l3qwrghslxc7vlxnblmcmsx7xx4i041ng";
   };
 
   nativeBuildInputs = [ 
-  	cmake gettext perl pkgconfig zip
+    cmake gettext perl pkgconfig zip
   ];
   buildInputs = [
     libXext libXi libXt libXtst wxGTK31
@@ -49,11 +49,10 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  installFlags = [ "PREFIX=$(out)" ];
+  installFlags = [ "PREFIX=${placeholder "out"}" ];
 
   meta = with stdenv.lib; {
     description = "A password database utility";
-
     longDescription = ''
       Password Safe is a password database utility. Like many other
       such products, commercial and otherwise, it stores your
@@ -61,8 +60,7 @@ stdenv.mkDerivation rec {
       one password (the "safe combination"), instead of all the
       username/password combinations that you use.
     '';
-
-    homepage = https://pwsafe.org/;
+    homepage = "https://pwsafe.org/";
     maintainers = with maintainers; [ c0bw3b pjones ];
     platforms = platforms.linux;
     license = licenses.artistic2;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Version bump
\+ now ships 'pwsafe-cli' in addition to wx GUI

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
