### PR TITLE
hotspot: 1.0.0 -> 1.2.0

### DIFF
--- a/pkgs/development/tools/analysis/hotspot/default.nix
+++ b/pkgs/development/tools/analysis/hotspot/default.nix
@@ -5,24 +5,24 @@
   fetchFromGitHub,
   kconfigwidgets,
   ki18n,
+  kio,
   kitemmodels,
   kitemviews,
+  kwindowsystem,
   libelf,
   qtbase,
   threadweaver,
 }:
 
 stdenv.mkDerivation rec {
-  name = "hotspot-${version}";
-  version = "1.0.0"; # don't forget to bump `rev` below when you change this
+  pname = "hotspot";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "KDAB";
     repo = "hotspot";
-    # TODO: For some reason, `fetchSubmodules` doesn't work when using `rev = "v${version}";`,
-    #       so using an explicit commit instead. See #15559
-    rev = "352687bf620529e9887616651f123f922cb421a4";
-    sha256 = "09ly15yafpk31p3w7h2xixf1xdmx803w9fyb2aq7mhmc7pcxqjsx";
+    rev = "v${version}";
+    sha256 = "05rkzrvak93z8mzcpm4mcjxb933l8pjsxr9a595wfn1gn2ihmada";
     fetchSubmodules = true;
   };
 
@@ -32,8 +32,10 @@ stdenv.mkDerivation rec {
     extra-cmake-modules
     kconfigwidgets
     ki18n
+    kio
     kitemmodels
     kitemviews
+    kwindowsystem
     libelf
     qtbase
     threadweaver


### PR DESCRIPTION
###### Motivation for this change

Latest version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I need somebody to test this for me on NixOS, as on Ubuntu the GUI fails to start with `qt.qpa.plugin: Coul dnot find the Qt platform plugin "xcb" in ""`. (This was already the case with hotspot 1.0.0.)