### PR TITLE
gnome3.eog: 3.32.1 -> 3.32.2

### DIFF
--- a/pkgs/desktops/gnome-3/core/eog/default.nix
+++ b/pkgs/desktops/gnome-3/core/eog/default.nix
@@ -4,13 +4,13 @@
 
 let
   pname = "eog";
-  version = "3.32.1";
+  version = "3.32.2";
 in stdenv.mkDerivation rec {
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
-    sha256 = "165axw63c2l5qk5k2xs7g9d97xnxf5a4br0hdb8s3bpv7lf5nw8q";
+    sha256 = "1bcxpqgzlk2cy4wfb3b5h66mhpj2fhrk1rrb5qqcv5xrr62ik5xy";
   };
 
   nativeBuildInputs = [ meson ninja pkgconfig gettext itstool wrapGAppsHook libxml2 gobject-introspection python3 ];


### PR DESCRIPTION
https://gitlab.gnome.org/GNOME/eog/blob/3.32.2/NEWS

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- :heavy_check_mark:  Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - :heavy_check_mark:  NixOS
   - :black_square_button: macOS
   - :black_square_button: other Linux distributions
- :black_square_button:  Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- :black_square_button:  Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- :heavy_check_mark:  Tested execution of all binary files (usually in `./result/bin/`)
- :black_square_button: Determined the impact on package closure size (by running `nix path-info -S` before and after)
- :black_square_button: Assured whether relevant documentation is up to date
- :heavy_check_mark:  Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
