### PR TITLE
pythonPackages.fire: fix python 3.7 build

### DIFF
--- a/pkgs/development/python-modules/fire/default.nix
+++ b/pkgs/development/python-modules/fire/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchFromGitHub, six, hypothesis, mock
+{ stdenv, buildPythonPackage, fetchFromGitHub, fetchpatch, six, hypothesis, mock
 , python-Levenshtein, pytest }:
 
 buildPythonPackage rec {
@@ -20,6 +20,13 @@ buildPythonPackage rec {
     py.test
   '';
 
+  patches = [
+    # Add Python 3.7 support. Remove with the next release
+    (fetchpatch {
+      url = "https://github.com/google/python-fire/commit/668007ae41391f5964870b4597e41493a936a11e.patch";
+      sha256 = "0rf7yzv9qx66zfmdggfz478z37fi4rwx4hlh3dk1065sx5rfksi0";
+    })
+  ];
 
   meta = with stdenv.lib; {
     description = "A library for automatically generating command line interfaces";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fixes https://github.com/NixOS/nixpkgs/issues/61770
cc: @abathur

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
