### PR TITLE
pythonPackages.mypy: 0.700 -> 0.701

### DIFF
--- a/pkgs/development/python-modules/mypy/default.nix
+++ b/pkgs/development/python-modules/mypy/default.nix
@@ -1,21 +1,21 @@
-{ stdenv, fetchPypi, buildPythonPackage, lxml, typed-ast, psutil, isPy3k
+{ stdenv, fetchPypi, buildPythonPackage, typed-ast, psutil, isPy3k
 ,mypy_extensions }:
 
 buildPythonPackage rec {
   pname = "mypy";
-  version = "0.700";
+  version = "0.701";
 
   # Tests not included in pip package.
   doCheck = false;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1zxfi5s9hxrz0hbaj4n513az17l44pxl80r62ipjc0bsmbcic2xi";
+    sha256 = "05479r3gbq17r22hyhxjg49smx5q864pgx8ayy23rsdj4w6z2r2p";
   };
 
   disabled = !isPy3k;
 
-  propagatedBuildInputs = [ lxml typed-ast psutil mypy_extensions ];
+  propagatedBuildInputs = [ typed-ast psutil mypy_extensions ];
 
   meta = with stdenv.lib; {
     description = "Optional static typing for Python";


### PR DESCRIPTION
###### Motivation for this change

Update package to latest

removed lxml as it isn't needed by the package according to the setup.py https://github.com/python/mypy/blob/master/setup.py#L181 and was moved to a test dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Closure size: 
```
nix path-info -Sh /nix/store/9hcdyp60xyjsdqqsxghsn88kmf63w3j4-python3.5-mypy-0.700
/nix/store/9hcdyp60xyjsdqqsxghsn88kmf63w3j4-python3.5-mypy-0.700         111.4M
nix path-info -Sh /nix/store/4dcm8c8hfl3h0zmfnkl8xa47wwjdvzi9-python3.5-mypy-0.701
/nix/store/4dcm8c8hfl3h0zmfnkl8xa47wwjdvzi9-python3.5-mypy-0.701         104.5M
```