### PR TITLE
pythonPackages.applicationinsights: init at 0.11.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2451,6 +2451,11 @@
     github = "joncojonathan";
     name = "Jonathan Haddock";
   };
+  jonringer = {
+    name = "Jon Ringer";
+    email = "jonringer117@gmail.com";
+    github = "jonringer";
+  };
   jorsn = {
     name = "Johannes Rosenberger";
     email = "johannes@jorsn.eu";

--- a/pkgs/development/python-modules/applicationinsights/default.nix
+++ b/pkgs/development/python-modules/applicationinsights/default.nix
@@ -1,0 +1,20 @@
+{ lib, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+   pname = "applicationinsights";
+   version = "0.11.9";
+
+   src = fetchPypi {
+     inherit pname version;
+     sha256 = "1hyjdv6xnswgqvip8y164piwfach9hjkbp7vc2qzhd7amjpim89h";
+   };
+
+  meta = with lib; {
+    homepage = https://github.com/microsoft/ApplicationInsights-Python;
+    description = "This project extends the Application Insights API surface to support Python";
+    platforms = platforms.all;
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+
+ }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -187,6 +187,8 @@ in {
 
   aplpy = callPackage ../development/python-modules/aplpy { };
 
+  applicationinsights = callPackage ../development/python-modules/applicationinsights { };
+
   argon2_cffi = callPackage ../development/python-modules/argon2_cffi { };
 
   asana = callPackage ../development/python-modules/asana { };


### PR DESCRIPTION
###### Motivation for this change
Add more azure support to Nix.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

```
nix path-info -Sh /nix/store/ib84i5id755i296v65faczaf77s02izj-python3.6-applicationinsights-0.11.9
/nix/store/ib84i5id755i296v65faczaf77s02izj-python3.6-applicationinsights-0.11.9          95.4M
```