### PR TITLE
ruby-zoom: 5.0.1 -> 5.3.0

### DIFF
--- a/pkgs/tools/text/ruby-zoom/Gemfile.lock
+++ b/pkgs/tools/text/ruby-zoom/Gemfile.lock
@@ -1,18 +1,18 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    djinni (2.1.1)
-      fagin (~> 1.0, >= 1.0.0)
-    fagin (1.0.0)
-    hilighter (1.1.0)
-    json_config (0.1.2)
-    ruby-zoom (5.0.1)
-      djinni (~> 2.1, >= 2.1.1)
-      fagin (~> 1.0, >= 1.0.0)
-      hilighter (~> 1.1, >= 1.1.0)
-      json_config (~> 0.1, >= 0.1.2)
-      scoobydoo (~> 0.1, >= 0.1.4)
-    scoobydoo (0.1.4)
+    djinni (2.2.4)
+      fagin (~> 1.2, >= 1.2.1)
+    fagin (1.2.1)
+    hilighter (1.2.3)
+    json_config (1.1.0)
+    ruby-zoom (5.3.0)
+      djinni (~> 2.2, >= 2.2.4)
+      fagin (~> 1.2, >= 1.2.1)
+      hilighter (~> 1.2, >= 1.2.3)
+      json_config (~> 1.0, >= 1.0.0)
+      scoobydoo (~> 1.0, >= 1.0.0)
+    scoobydoo (1.0.0)
 
 PLATFORMS
   ruby
@@ -21,4 +21,4 @@ DEPENDENCIES
   ruby-zoom
 
 BUNDLED WITH
-   1.14.6
+   1.17.2

--- a/pkgs/tools/text/ruby-zoom/gemset.nix
+++ b/pkgs/tools/text/ruby-zoom/gemset.nix
@@ -1,52 +1,64 @@
 {
   djinni = {
     dependencies = ["fagin"];
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "00zfgd7zx2p9xjc64xm4iwdxq2bb6n1z09nw815c2f4lvlaq269f";
+      sha256 = "18zk80jk70xq1bnsvzcgxb13x9fqdb5g4m02b2f6mvqm4cyw26pl";
       type = "gem";
     };
-    version = "2.1.1";
+    version = "2.2.4";
   };
   fagin = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0jryqrgb5jvz0m7p91c2bhn6gdwxn9jfdaq3cfkirc3y7yfzv131";
+      sha256 = "0psyydh4hf2s1kz0r50aiyjf5v2pqhkbmy0gicxzaj5n17q2ga24";
       type = "gem";
     };
-    version = "1.0.0";
+    version = "1.2.1";
   };
   hilighter = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0sy59nfcfk4p1fnrdkipi0mvsj9db17chrx7lb2jg3majbr1wz59";
+      sha256 = "03zm49g96dfpan5fhblcjxrzv7ldwan57sn0jcllkcmrqfd0zlyz";
+      type = "gem";
+    };
+    version = "1.2.3";
+  };
+  json_config = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0slb618n1ipn47j6dsxbfv2j9pl06dxn2i651llix09d529m7zwa";
       type = "gem";
     };
     version = "1.1.0";
   };
-  json_config = {
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "16q3q0j9s8w93lzxa7rrvh5wqk11np7s2nmgmdlrh8gl3w76xcz6";
-      type = "gem";
-    };
-    version = "0.1.2";
-  };
   ruby-zoom = {
     dependencies = ["djinni" "fagin" "hilighter" "json_config" "scoobydoo"];
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0115kbz6l8srzizs77k9l0585lg93x90kg49jjpan7ssm786q05j";
+      sha256 = "0iqxc0rzypsxy4wbxnvgvk98dbcsrcczq3xi9xd4wz4ggwq564l3";
       type = "gem";
     };
-    version = "5.0.1";
+    version = "5.3.0";
   };
   scoobydoo = {
+    groups = ["default"];
+    platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1w83zgip3qvh20pgqgcp9yp0k35ypn7ny0d61xcv1ik0r3ab8ga0";
+      sha256 = "162p75nc9x078kqcpdsrsd7kngs6jc5n4injz3kzpwf0jgbbm8n7";
       type = "gem";
     };
-    version = "0.1.4";
+    version = "1.0.0";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Update package to the latest available version

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
