### PR TITLE
lbdb: fix build for 0.48.1

### DIFF
--- a/pkgs/tools/misc/lbdb/default.nix
+++ b/pkgs/tools/misc/lbdb/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perl, perlPackages, finger_bsd, makeWrapper
+{ stdenv, fetchurl, fetchpatch, perl, perlPackages, finger_bsd, makeWrapper
 , abook ? null
 , gnupg ? null
 , goobook ? null
@@ -32,7 +32,14 @@ stdenv.mkDerivation {
     ++ optional   (khard != null) "--with-khard"
     ++ optional      (mu != null) "--with-mu";
 
-  patches = [ ./add-methods-to-rc.patch ];
+  patches = [ ./add-methods-to-rc.patch
+    # fix undefined exec_prefix. Remove with the next release
+    (fetchpatch {
+      url = "https://github.com/RolandRosenfeld/lbdb/commit/60b7bae255011f59212d96adfbded459d6a27129.patch";
+      sha256 = "129zg086glmlalrg395jq8ljcp787dl3rxjf9v7apsd8mqfdkl2v";
+      excludes = [ "debian/changelog" ];
+    })
+  ];
   postFixup = "wrapProgram $out/lib/mutt_ldap_query --prefix PERL5LIB : "
     + "${AuthenSASL}/${perl.libPrefix}"
     + ":${ConvertASN1}/${perl.libPrefix}"
@@ -43,6 +50,6 @@ stdenv.mkDerivation {
     license = licenses.gpl2;
     platforms = platforms.all;
     description = "The Little Brother's Database";
-    maintainers = [ maintainers.kaiha ];
+    maintainers = [ maintainers.kaiha maintainers.bfortz ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

Incorporates an upstream bux fix for the broken 0.48.1 release (undefined exec_prefix).

Should be backported to 19.03 (or 19.03 should revert to 0.48). 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
