### PR TITLE
aliza: 1.36.3 -> 1.48.10

### DIFF
--- a/pkgs/applications/science/medicine/aliza/default.nix
+++ b/pkgs/applications/science/medicine/aliza/default.nix
@@ -2,11 +2,12 @@
 
 with stdenv.lib;
 stdenv.mkDerivation {
-  name = "aliza";
+  pname = "aliza";
+  version = "1.48.10";
   src = fetchurl {
-    # Hosted on muoniurn's google drive
-    url = "https://drive.google.com/uc?export=download&id=1zMYfSUqMaYuvuF41zAFUC5ndR55wD7Ip";
-    sha256 = "0prlmzz8qbqqkr0plk781afq25dvy4pv89vlgccpim79psqlchl3";
+    # See https://www.aliza-dicom-viewer.com/download
+    url = "https://drive.google.com/uc?export=download&id=16WEScARaSrzJpJkyGuOUxDF95eUwGyET";
+    sha256 = "1ls16cwd0fmb5axxmy9lgf8cqrf7g7swm26f0gr2vqp4z9bw6qn3";
     name = "aliza.rpm";
   };
 
@@ -48,5 +49,6 @@ stdenv.mkDerivation {
     homepage = http://www.aliza-dicom-viewer.com;
     license = licenses.unfreeRedistributable;
     maintainers = with maintainers; [ mounium ];
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Currently the aliza package doesn't have a version defined. This results in parsing errors in tools like Repology.
In addition, it is unclear for maintainers to determine which version is in Nixpkgs. I currently have determined the older version by running Aliza and going to Application -> About.

This PR upgrades aliza to 1.48.10. It only defines a RPM package for Linux, so I have specified the platform as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---