### PR TITLE
memtest86-efi: backport to 19.03

### DIFF
--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -33,6 +33,15 @@ initrd {initrd}
 options {kernel_params}
 """
 
+# The boot loader entry for memtest86.
+#
+# TODO: This is hard-coded to use the 64-bit EFI app, but it could probably
+# be updated to use the 32-bit EFI app on 32-bit systems.  The 32-bit EFI
+# app filename is BOOTIA32.efi.
+MEMTEST_BOOT_ENTRY = """title MemTest86
+efi /efi/memtest86/BOOTX64.efi
+"""
+
 def write_loader_conf(profile, generation):
     with open("@efiSysMountPoint@/loader/loader.conf.tmp", 'w') as f:
         if "@timeout@" != "":
@@ -198,6 +207,24 @@ def main():
         write_entry(*gen, machine_id)
         if os.readlink(system_dir(*gen)) == args.default_config:
             write_loader_conf(*gen)
+
+    memtest_entry_file = "@efiSysMountPoint@/loader/entries/memtest86.conf"
+    if os.path.exists(memtest_entry_file):
+        os.unlink(memtest_entry_file)
+    shutil.rmtree("@efiSysMountPoint@/efi/memtest86", ignore_errors=True)
+    if "@memtest86@" != "":
+        mkdir_p("@efiSysMountPoint@/efi/memtest86")
+        for path in glob.iglob("@memtest86@/*"):
+            if os.path.isdir(path):
+                shutil.copytree(path, os.path.join("@efiSysMountPoint@/efi/memtest86", os.path.basename(path)))
+            else:
+                shutil.copy(path, "@efiSysMountPoint@/efi/memtest86/")
+
+        memtest_entry_file = "@efiSysMountPoint@/loader/entries/memtest86.conf"
+        memtest_entry_file_tmp_path = "%s.tmp" % memtest_entry_file
+        with open(memtest_entry_file_tmp_path, 'w') as f:
+            f.write(MEMTEST_BOOT_ENTRY)
+        os.rename(memtest_entry_file_tmp_path, memtest_entry_file)
 
     # Since fat32 provides little recovery facilities after a crash,
     # it can leave the system in an unbootable state, when a crash/outage

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
@@ -25,6 +25,8 @@ let
     inherit (cfg) consoleMode;
 
     inherit (efi) efiSysMountPoint canTouchEfiVariables;
+
+    memtest86 = if cfg.memtest86.enable then pkgs.memtest86-efi else "";
   };
 in {
 
@@ -85,6 +87,19 @@ in {
           </para></listitem>
         </itemizedlist>
       '';
+    };
+
+    memtest86 = {
+      enable = mkOption {
+        default = false;
+        type = types.bool;
+        description = ''
+          Make MemTest86 available from the systemd-boot menu. MemTest86 is a
+          program for testing memory.  MemTest86 is an unfree program, so
+          this requires <literal>allowUnfree</literal> to be set to
+          <literal>true</literal>.
+        '';
+      };
     };
   };
 

--- a/pkgs/tools/misc/memtest86-efi/default.nix
+++ b/pkgs/tools/misc/memtest86-efi/default.nix
@@ -1,0 +1,55 @@
+{ lib, stdenv, fetchurl, unzip, utillinux, libguestfs-with-appliance }:
+
+stdenv.mkDerivation rec {
+  pname = "memtest86-efi";
+  version = "8.0";
+
+  src = fetchurl {
+    # TODO: The latest version of memtest86 is actually 8.1, but apparently the
+    # company has stopped distributing versioned binaries of memtest86:
+    # https://www.passmark.com/forum/memtest86/44494-version-8-1-distribution-file-is-not-versioned?p=44505#post44505
+    # However, it does look like redistribution is okay, so if we had
+    # somewhere to host binaries that we make sure to version, then we could
+    # probably keep up with the latest versions released by the company.
+    url = "https://www.memtest86.com/downloads/memtest86-${version}-usb.zip";
+    sha256 = "147mnd7fnx2wvbzscw7pkg9ljiczhz05nb0cjpmww49a0ms4yknw";
+  };
+
+  nativeBuildInputs = [ libguestfs-with-appliance unzip ];
+
+  unpackPhase = ''
+    unzip -q $src -d .
+  '';
+
+  installPhase = ''
+    mkdir -p $out
+
+    # memtest86 is distributed as a bootable USB image.  It contains the actual
+    # memtest86 EFI app.
+    #
+    # The following command uses libguestfs to extract the actual EFI app from the
+    # usb image so that it can be installed directly on the hard drive.  This creates
+    # the ./BOOT/ directory with the memtest86 EFI app.
+    guestfish --ro --add ./memtest86-usb.img --mount /dev/sda1:/  copy-out /EFI/BOOT .
+
+    cp -r BOOT/* $out/
+  '';
+
+  meta = with lib; {
+    homepage = http://memtest86.com/;
+    downloadPage = "https://www.memtest86.com/download.htm";
+    description = "A tool to detect memory errors, to be run from a bootloader";
+    longDescription = ''
+      A UEFI app that is able to detect errors in RAM.  It can be run from a
+      bootloader.  Released under a proprietary freeware license.
+    '';
+    # The Memtest86 License for the Free Edition states,
+    # "MemTest86 Free Edition is free to download with no restrictions on usage".
+    # However the source code for Memtest86 does not appear to be available.
+    #
+    # https://www.memtest86.com/license.htm
+    license = licenses.unfreeRedistributable;
+    maintainers = with maintainers; [ cdepillabout ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4239,6 +4239,8 @@ in
 
   memtest86 = callPackage ../tools/misc/memtest86 { };
 
+  memtest86-efi = callPackage ../tools/misc/memtest86-efi { };
+
   memtest86plus = callPackage ../tools/misc/memtest86+ { };
 
   meo = callPackage ../tools/security/meo {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11054,6 +11054,8 @@ in
 
   libguestfs-appliance = callPackage ../development/libraries/libguestfs/appliance.nix {};
   libguestfs = callPackage ../development/libraries/libguestfs { };
+  libguestfs-with-appliance = libguestfs.override { appliance = libguestfs-appliance; };
+
 
   libhangul = callPackage ../development/libraries/libhangul { };
 


### PR DESCRIPTION
This PR backports the following PRs to 19.03:

- #60967: memtest86-efi: init at 8.0
- #61036: nixos/systemd-boot: add support for memtest86 EFI app
- #60024: libguestfs-with-appliance: Add package for libguesfs containing libguestfs appliances (this is needed for the memtest86-efi derivation)

These PRs do two big things:

1. Create a memtest86-efi derivation for the newer unfree version of Memtest86 that supports running on UEFI.
2. Add a NixOS option to install the Memtest86 EFI app so it is available from the `systemd-boot` menu.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The above PRs have all been merged into `master`.  I wanted this functionality available in 19.03 as well.

You can try building the memtest86-efi command with the following, as long as you have this PR checked out:

```console
$ nix-build -A memtest86-efi
```

You can test installing the memtest86 EFI app with the following nixos setting:

```nix
{ config, pkgs, ...}:

{
  boot.loader.systemd-boot.memtest86.enable = true;
}
```

Although you need to be using `systemd-boot` for this to work.

Also, you need `allowUnfree` set to `true` for both of these to work.

Pinging @c0bw3b and @JohnAZoidberg since they were nice enough to do reviews for the above PRs.  Also pinging @Lassulus and @matthewbauer since they merged in the above PRs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
