### PR TITLE
liburing: 1.0.0pre92 -> 1.0.0pre116

### DIFF
--- a/pkgs/development/libraries/liburing/default.nix
+++ b/pkgs/development/libraries/liburing/default.nix
@@ -3,12 +3,12 @@
 
 stdenv.mkDerivation rec {
   name = "liburing-${version}";
-  version = "1.0.0pre92_${builtins.substring 0 7 src.rev}";
+  version = "1.0.0pre116_${builtins.substring 0 7 src.rev}";
 
   src = fetchgit {
     url    = "http://git.kernel.dk/liburing";
-    rev    = "7b989f34191302011b5b49bf5b26b36862d54056";
-    sha256 = "12kfqvwzxksmsm8667a1g4vxr6xsaq63cz9wrfhwq6hrsv3ynydc";
+    rev    = "ffe3e090cd41d0977ca74fafcb452838f76ceea1";
+    sha256 = "1nmg89jgz1kbv7lv1drkkb4x0pank51sijagflxmnmvqgrk53gxd";
   };
 
   enableParallelBuilding = true;
@@ -26,6 +26,7 @@ stdenv.mkDerivation rec {
   postInstall = ''
     mkdir -p $out/bin
     cp ./examples/io_uring-cp examples/io_uring-test $out/bin
+    cp ./examples/link-cp $out/bin/io_uring-link-cp
   '';
 
   meta = with stdenv.lib; {
@@ -34,6 +35,5 @@ stdenv.mkDerivation rec {
     license     = licenses.lgpl21;
     platforms   = platforms.linux;
     maintainers = with maintainers; [ thoughtpolice ];
-    badPlatforms = [ "aarch64-linux" ];
   };
 }


### PR DESCRIPTION
Notably, this includes non-x86 platform support, eventfd registration
for completion events, "drained" events that must have all outstanding
prior events/further events drained (e.g. for fsync), and linked CQEs
that can express completion ordering dependencies.

Most of these require 5.2-rc1, and linked CQEs require custom patches
from Jens' linux-block tree (that didn't hit the 5.2 merge window,
apparently.)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).