### PR TITLE
spyder: 3.3.3 -> 3.3.4, convert to python modules

### DIFF
--- a/pkgs/development/python-modules/spyder-kernels/default.nix
+++ b/pkgs/development/python-modules/spyder-kernels/default.nix
@@ -1,0 +1,27 @@
+{ stdenv, buildPythonPackage, fetchPypi, cloudpickle, ipykernel, wurlitzer }:
+
+buildPythonPackage rec {
+  pname = "spyder-kernels";
+  version = "0.4.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "a13cefb569ef9f63814cb5fcf3d0db66e09d2d7e6cc68c703d5118b2d7ba062b";
+  };
+
+  propagatedBuildInputs = [
+    cloudpickle
+    ipykernel
+    wurlitzer
+  ];
+
+  # No tests
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Jupyter kernels for Spyder's console";
+    homepage = "https://github.com/spyder-ide/spyder-kernels";
+    license = licenses.mit;
+    maintainers = with maintainers; [ gebner ];
+  };
+}

--- a/pkgs/development/python-modules/spyder-kernels/default.nix
+++ b/pkgs/development/python-modules/spyder-kernels/default.nix
@@ -1,18 +1,21 @@
-{ stdenv, buildPythonPackage, fetchPypi, cloudpickle, ipykernel, wurlitzer }:
+{ stdenv, buildPythonPackage, fetchPypi, cloudpickle, ipykernel, wurlitzer,
+  jupyter_client, pyzmq }:
 
 buildPythonPackage rec {
   pname = "spyder-kernels";
-  version = "0.4.2";
+  version = "0.4.4";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "a13cefb569ef9f63814cb5fcf3d0db66e09d2d7e6cc68c703d5118b2d7ba062b";
+    sha256 = "0g3754s71cnh7kygps6gbzrhs5gb47p3pblr7hcvxk1mzl3xw94r";
   };
 
   propagatedBuildInputs = [
     cloudpickle
     ipykernel
     wurlitzer
+    jupyter_client
+    pyzmq
   ];
 
   # No tests

--- a/pkgs/development/python-modules/spyder/default.nix
+++ b/pkgs/development/python-modules/spyder/default.nix
@@ -1,42 +1,18 @@
-{ stdenv, python3, makeDesktopItem }:
+{ stdenv, buildPythonPackage, fetchPypi, makeDesktopItem, jedi, pycodestyle,
+  psutil, pyflakes, rope, numpy, scipy, matplotlib, pylint, keyring, numpydoc,
+  qtconsole, qtawesome, nbconvert, mccabe, pyopengl, cloudpickle,
+  spyder-kernels }:
 
-let
-
-  spyder-kernels = with python3.pkgs; buildPythonPackage rec {
-    pname = "spyder-kernels";
-    version = "0.4.2";
-
-    src = fetchPypi {
-      inherit pname version;
-      sha256 = "a13cefb569ef9f63814cb5fcf3d0db66e09d2d7e6cc68c703d5118b2d7ba062b";
-    };
-
-    propagatedBuildInputs = [
-      cloudpickle
-      ipykernel
-      wurlitzer
-    ];
-
-    # No tests
-    doCheck = false;
-
-    meta = {
-      description = "Jupyter kernels for Spyder's console";
-      homepage = https://github.com/spyder-ide/spyder-kernels;
-      license = stdenv.lib.licenses.mit;
-    };
-  };
-
-in python3.pkgs.buildPythonApplication rec {
+buildPythonPackage rec {
   pname = "spyder";
   version = "3.3.3";
 
-  src = python3.pkgs.fetchPypi {
+  src = fetchPypi {
     inherit pname version;
     sha256 = "ef31de03cf6f149077e64ed5736b8797dbd278e3c925e43f0bfc31bb55f6e5ba";
   };
 
-  propagatedBuildInputs = with python3.pkgs; [
+  propagatedBuildInputs = [
     jedi pycodestyle psutil pyflakes rope numpy scipy matplotlib pylint keyring
     numpydoc qtconsole qtawesome nbconvert mccabe pyopengl cloudpickle spyder-kernels
   ];
@@ -68,8 +44,9 @@ in python3.pkgs.buildPythonApplication rec {
       environment for the Python language with advanced editing, interactive
       testing, debugging and introspection features.
     '';
-    homepage = https://github.com/spyder-ide/spyder/;
+    homepage = "https://github.com/spyder-ide/spyder/";
     license = licenses.mit;
     platforms = platforms.linux;
+    maintainers = with maintainers; [ gebner ];
   };
 }

--- a/pkgs/development/python-modules/spyder/default.nix
+++ b/pkgs/development/python-modules/spyder/default.nix
@@ -1,20 +1,21 @@
 { stdenv, buildPythonPackage, fetchPypi, makeDesktopItem, jedi, pycodestyle,
   psutil, pyflakes, rope, numpy, scipy, matplotlib, pylint, keyring, numpydoc,
-  qtconsole, qtawesome, nbconvert, mccabe, pyopengl, cloudpickle,
-  spyder-kernels }:
+  qtconsole, qtawesome, nbconvert, mccabe, pyopengl, cloudpickle, pygments,
+  spyder-kernels, qtpy, pyzmq, chardet }:
 
 buildPythonPackage rec {
   pname = "spyder";
-  version = "3.3.3";
+  version = "3.3.4";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "ef31de03cf6f149077e64ed5736b8797dbd278e3c925e43f0bfc31bb55f6e5ba";
+    sha256 = "1fa5yhw0sjk5qydydp76scyxd8lvyciknq0vajnq0mxhhvfig3ra";
   };
 
   propagatedBuildInputs = [
     jedi pycodestyle psutil pyflakes rope numpy scipy matplotlib pylint keyring
     numpydoc qtconsole qtawesome nbconvert mccabe pyopengl cloudpickle spyder-kernels
+    pygments qtpy pyzmq chardet
   ];
 
   # There is no test for spyder
@@ -29,6 +30,12 @@ buildPythonPackage rec {
     genericName = "Python IDE";
     categories = "Application;Development;Editor;IDE;";
   };
+
+  postPatch = ''
+    # remove dependency on pyqtwebengine
+    # this is still part of the pyqt 5.11 version we have in nixpkgs
+    sed -i /pyqtwebengine/d setup.py
+  '';
 
   # Create desktop item
   postInstall = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22869,7 +22869,7 @@ in
 
   simgrid = callPackage ../applications/science/misc/simgrid { };
 
-  spyder = callPackage ../applications/science/spyder { };
+  spyder = with python3.pkgs; toPythonApplication spyder;
 
   openspace = callPackage ../applications/science/astronomy/openspace { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -932,6 +932,9 @@ in {
 
   sniffio = callPackage ../development/python-modules/sniffio { };
 
+  spyder-kernels = callPackage ../development/python-modules/spyder-kernels {};
+  spyder = callPackage ../development/python-modules/spyder {};
+
   tenacity = callPackage ../development/python-modules/tenacity { };
 
   tokenserver = callPackage ../development/python-modules/tokenserver {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I want to package [CQ-editor](https://github.com/CadQuery/CQ-editor), which has spyder as a dependency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
