### PR TITLE
linux_testing (5.2.0-rc1): fix build, include 'cpio' in nativeBuildInputs

### DIFF
--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -1,5 +1,5 @@
 { buildPackages, runCommand, nettools, bc, bison, flex, perl, rsync, gmp, libmpc, mpfr, openssl
-, libelf
+, libelf, cpio
 , utillinux
 , writeTextFile
 }:
@@ -284,10 +284,11 @@ stdenv.mkDerivation ((drvAttrs config stdenv.hostPlatform.platform kernelPatches
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ perl bc nettools openssl rsync gmp libmpc mpfr ]
-      ++ optional (stdenv.hostPlatform.platform.kernelTarget == "uImage") buildPackages.ubootTools
-      ++ optional (stdenv.lib.versionAtLeast version "4.14") libelf
-      ++ optional (stdenv.lib.versionAtLeast version "4.15") utillinux
+      ++ optional  (stdenv.hostPlatform.platform.kernelTarget == "uImage") buildPackages.ubootTools
+      ++ optional  (stdenv.lib.versionAtLeast version "4.14") libelf
+      ++ optional  (stdenv.lib.versionAtLeast version "4.15") utillinux
       ++ optionals (stdenv.lib.versionAtLeast version "4.16") [ bison flex ]
+      ++ optional  (stdenv.lib.versionAtLeast version "5.2")  cpio
       ;
 
   hardeningDisable = [ "bindnow" "format" "fortify" "stackprotector" "pic" "pie" ];


### PR DESCRIPTION
81d4e65891f92e8e72c244da663c83c1e40dc919 automatically bumped `linux_testing` to 5.2.0-rc1, but the 5.2 merge window included a new feature adding compressed headers for compiled kernels into `/proc/kheaders.tar.xz`

See https://github.com/torvalds/linux/commit/43d8ce9d65a54846d378545770991e65838981e0

This feature requires 'cpio' to now be included in nativeBuildInputs since it's used to construct that archive.

This wasn't caught by Hydra since we turn off build of linuxPackages, but ideally we should at least build the kernel in the future (`linux_testing` itself.)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
- [x] Tested execution (booted)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
