### PR TITLE
docear: init at 1.2.0

### DIFF
--- a/pkgs/applications/office/docear/default.nix
+++ b/pkgs/applications/office/docear/default.nix
@@ -1,0 +1,44 @@
+{stdenv, fetchurl, runtimeShell, makeWrapper
+, oraclejre
+, antialiasFont ? true
+}:
+
+stdenv.mkDerivation rec {
+  pname = "docear";
+  version = "1.2";
+
+  src = fetchurl {
+    url = "http://docear.org/downloads/docear_linux.tar.gz";
+    sha256 = "1g5n7r2x4gas6dl2fbyh7v9yxdcb6bzml8n3ldmpzv1rncgjcdp4";
+  };
+
+  buildInputs = [ oraclejre makeWrapper ];
+
+  buildPhase = "";
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share
+    cp -R * $out/share
+    chmod 0755 $out/share/ -R
+
+    # The wrapper ensures oraclejre is used
+    makeWrapper ${runtimeShell} $out/bin/docear \
+      --set _JAVA_OPTIONS "${stdenv.lib.optionalString antialiasFont ''-Dswing.aatext=TRUE -Dawt.useSystemAAFontSettings=on''}" \
+      --set JAVA_HOME ${oraclejre.home} \
+      --add-flags "$out/share/docear.sh"
+
+    chmod 0755 $out/bin/docear
+    '';
+
+  meta = with stdenv.lib; {
+    description = "A unique solution to academic literature management";
+    homepage = "http://www.docear.org/";
+    # Licenses at: http://www.docear.org/software/download/
+    license = with licenses; [
+      gpl2 # for the main software and some dependencies
+      bsd3 # for one of its dependencies
+    ];
+    maintainers = with maintainers; [ unode ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2497,6 +2497,8 @@ in
 
   docbook2mdoc = callPackage ../tools/misc/docbook2mdoc { };
 
+  docear = callPackage ../applications/office/docear { };
+
   dockbarx = callPackage ../applications/misc/dockbarx { };
 
   dog = callPackage ../tools/system/dog { };


### PR DESCRIPTION
###### Motivation for this change

Adding Docear - an academic literature suite

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

As per [terms of service (bottom of page)](http://www.docear.org/software/download/) some **optional** functionality included in the software may fall under `nonfree` license.