### PR TITLE
 lua*Packages TLS updates

### DIFF
--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -324,15 +324,16 @@ with self; {
 
   luaossl = buildLuaPackage rec {
     name = "luaossl-${version}";
-    version = "20170903";
+    version = "20181207";
 
     src = fetchurl {
-      url = "https://www.25thandclement.com/~william/projects/releases/${name}.tgz";
-      sha256 = "10392bvd0lzyibipblgiss09zlqh3a5zgqg1b9lgbybpqb9cv2k3";
+      url = "https://github.com/wahern/luaossl/releases/download/rel-${version}/luaossl-rel-${version}.zip";
+      sha256 = "194r6db80ksh4zh8d2k35q6vci9zbrfvkanjl280y6ij2xyhkvj7";
     };
 
     preConfigure = ''export prefix=$out'';
 
+    nativeBuildInputs = [ unzip ];
     buildInputs = [ openssl ];
 
     meta = with stdenv.lib; {

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -380,13 +380,13 @@ with self; {
   };
 
   luasec = buildLuaPackage rec {
-    name = "sec-0.6";
+    name = "sec-0.8";
 
     src = fetchFromGitHub {
       owner = "brunoos";
       repo = "luasec";
       rev = "lua${name}";
-      sha256 = "0wv8l7f7na7kw5xn8mjik2wpxbizl7zvvp5s7fcwvz9kl5jdpk5b";
+      sha256 = "1cgb7ihnrrfr59a2da4d3chr7lqpid98xpglmzhv3hrpg4x5sksz";
     };
 
     propagatedBuildInputs = [ luasocket ];


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via all NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))  `prosody.x86_64-linux`
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] N/A Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after).  A couple kilobytes added.
- [ ] N/A, I think. Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
I tried generating these, but they wouldn't build, even if I overrode them to depend on openssl.  (I don't know what's wrong.)

So far I've done mainly basic testing around `knot-resolver`, but even https with TLS 1.3 seemed to work when I added the `openssl-1.1` branch locally.