### PR TITLE
Datadog: update packages

### DIFF
--- a/pkgs/tools/networking/dd-agent/datadog-agent.nix
+++ b/pkgs/tools/networking/dd-agent/datadog-agent.nix
@@ -6,14 +6,14 @@ let
 
 in buildGoPackage rec {
   name = "datadog-agent-${version}";
-  version = "6.11.0";
+  version = "6.11.2";
   owner   = "DataDog";
   repo    = "datadog-agent";
 
   src = fetchFromGitHub {
     inherit owner repo;
     rev    = "${version}";
-    sha256 = "1gvawsrm3qlrciahnqa9793hwm586jiccmnz1pp0z889508wbg07";
+    sha256 = "194ml6sh4i3gszcy1rcffcaw0419imlgbnzvgihydlh7pwc3sl83";
   };
 
   subPackages = [

--- a/pkgs/tools/networking/dd-agent/datadog-process-agent.nix
+++ b/pkgs/tools/networking/dd-agent/datadog-process-agent.nix
@@ -2,14 +2,14 @@
 
 buildGoPackage rec {
   name = "datadog-process-agent-${version}";
-  version = "6.11.0";
+  version = "6.11.1";
   owner   = "DataDog";
   repo    = "datadog-process-agent";
 
   src = fetchFromGitHub {
     inherit owner repo;
     rev    = "${version}";
-    sha256 = "1max3gp1isb30fjy55bkp9dsd8al31a968pmnr1h8wg2pycvgyif";
+    sha256 = "0fc2flm0pa44mjxvn4fan0mkvg9yyg27w68xdgrnpdifj99kxxjf";
   };
 
   goDeps = ./datadog-process-agent-deps.nix;


### PR DESCRIPTION
###### Motivation for this change
Update datadog packages:
- datadog agent to 6.11.0;
- datadog process agent to 6.11.0;

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
