### PR TITLE
multipath-tools: 0.6.2 -> 0.8.1 (cont. https://github.com/NixOS/nixpkgs/pull/61824)

### DIFF
--- a/pkgs/os-specific/linux/multipath-tools/default.nix
+++ b/pkgs/os-specific/linux/multipath-tools/default.nix
@@ -10,15 +10,9 @@ stdenv.mkDerivation rec {
     sha256 = "159hxvbk9kh1qay9x04w0gsqzg0hkl5yghfc1wi9kv2n5pcwbkpm";
   };
 
-  postPatch = ''
-    sed -i -re '
-      s,^( *#define +DEFAULT_MULTIPATHDIR\>).*,\1 "'"$out/lib/multipath"'",
-    ' libmultipath/defaults.h
-    sed -i -e 's,\$(DESTDIR)/\(usr/\)\?,$(prefix)/,g' \
-      kpartx/Makefile libmpathpersist/Makefile
-    sed -i -e "s,GZIP = .*, GZIP = gzip -9n -c," \
-      Makefile.inc
-  '';
+  patches = [
+    ./fix-paths.patch
+  ];
 
   nativeBuildInputs = [ gzip ];
   buildInputs = [ systemd lvm2 libaio readline liburcu ];

--- a/pkgs/os-specific/linux/multipath-tools/default.nix
+++ b/pkgs/os-specific/linux/multipath-tools/default.nix
@@ -1,21 +1,38 @@
-{ stdenv, fetchurl, lvm2, libaio, gzip, readline, systemd, liburcu }:
+{ stdenv
+, fetchurl
+, substituteAll
+, gzip
+, json_c
+, libaio
+, liburcu
+, linuxHeaders
+, lvm2
+, perl
+, pkg-config
+, readline
+, systemd
+}:
 
 stdenv.mkDerivation rec {
   name = "multipath-tools-${version}";
-  version = "0.6.2";
+  version = "0.8.1";
 
   src = fetchurl {
     name = "${name}.tar.gz";
     url = "https://git.opensvc.com/?p=multipath-tools/.git;a=snapshot;h=${version};sf=tgz";
-    sha256 = "159hxvbk9kh1qay9x04w0gsqzg0hkl5yghfc1wi9kv2n5pcwbkpm";
+    sha256 = "14q620g0wdflzk1pajqv35zkq4j95rhki9h78q1m9kwmghyx8d6c";
   };
 
   patches = [
-    ./fix-paths.patch
+    (substituteAll {
+      src = ./fix-paths.patch;
+      inherit linuxHeaders lvm2;
+      systemd = systemd.dev;
+    })
   ];
 
-  nativeBuildInputs = [ gzip ];
-  buildInputs = [ systemd lvm2 libaio readline liburcu ];
+  nativeBuildInputs = [ gzip perl pkg-config ];
+  buildInputs = [ systemd lvm2 libaio readline liburcu json_c ];
 
   makeFlags = [
     "LIB=lib"

--- a/pkgs/os-specific/linux/multipath-tools/fix-paths.patch
+++ b/pkgs/os-specific/linux/multipath-tools/fix-paths.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile.inc b/Makefile.inc
+index 3e8635ff..73e278d4 100644
+--- a/Makefile.inc
++++ b/Makefile.inc
+@@ -63,7 +63,7 @@ INSTALL_PROGRAM = install
+ OPTFLAGS     = -Wunused -Wstrict-prototypes -O2 -g -pipe -Wformat-security -Wall \
+ 		-Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector --param=ssp-buffer-size=4
+ 
+-CFLAGS	     = $(OPTFLAGS) -fPIC -DLIB_STRING=\"${LIB}\" -DRUN_DIR=\"${RUN}\"
++CFLAGS	     = $(OPTFLAGS) -fPIC -DLIB_STRING=\"${syslibdir}\" -DRUN_DIR=\"${RUN}\"
+ SHARED_FLAGS = -shared
+ 
+ %.o:	%.c

--- a/pkgs/os-specific/linux/multipath-tools/fix-paths.patch
+++ b/pkgs/os-specific/linux/multipath-tools/fix-paths.patch
@@ -1,13 +1,67 @@
 diff --git a/Makefile.inc b/Makefile.inc
-index 3e8635ff..73e278d4 100644
+index 56c3eda0..2530a150 100644
 --- a/Makefile.inc
 +++ b/Makefile.inc
-@@ -63,7 +63,7 @@ INSTALL_PROGRAM = install
- OPTFLAGS     = -Wunused -Wstrict-prototypes -O2 -g -pipe -Wformat-security -Wall \
- 		-Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector --param=ssp-buffer-size=4
+@@ -98,7 +98,7 @@ OPTFLAGS	= -O2 -g -pipe -Wall -Wextra -Wformat=2 -Werror=implicit-int \
+ 		  -Wp,-D_FORTIFY_SOURCE=2 $(STACKPROT) \
+ 		  --param=ssp-buffer-size=4
  
--CFLAGS	     = $(OPTFLAGS) -fPIC -DLIB_STRING=\"${LIB}\" -DRUN_DIR=\"${RUN}\"
-+CFLAGS	     = $(OPTFLAGS) -fPIC -DLIB_STRING=\"${syslibdir}\" -DRUN_DIR=\"${RUN}\"
- SHARED_FLAGS = -shared
+-CFLAGS		:= $(OPTFLAGS) -DBIN_DIR=\"$(bindir)\" -DLIB_STRING=\"${LIB}\" -DRUN_DIR=\"${RUN}\" \
++CFLAGS		:= $(OPTFLAGS) -DBIN_DIR=\"$(bindir)\" -DLIB_STRING=\"${syslibdir}\" -DRUN_DIR=\"${RUN}\" \
+ 		   -MMD -MP $(CFLAGS)
+ BIN_CFLAGS	= -fPIE -DPIE
+ LIB_CFLAGS	= -fPIC
+diff --git a/kpartx/Makefile b/kpartx/Makefile
+index 7eb467ee..bfec5d3b 100644
+--- a/kpartx/Makefile
++++ b/kpartx/Makefile
+@@ -8,7 +8,7 @@ LDFLAGS += $(BIN_LDFLAGS)
  
- %.o:	%.c
+ LIBDEPS += -ldevmapper
+ 
+-ifneq ($(call check_func,dm_task_set_cookie,/usr/include/libdevmapper.h),0)
++ifneq ($(call check_func,dm_task_set_cookie,@lvm2@/include/libdevmapper.h),0)
+ 	CFLAGS += -DLIBDM_API_COOKIE
+ endif
+ 
+diff --git a/libmultipath/Makefile b/libmultipath/Makefile
+index a2be42ea..00d82dd4 100644
+--- a/libmultipath/Makefile
++++ b/libmultipath/Makefile
+@@ -20,19 +20,19 @@ ifdef SYSTEMD
+ 	endif
+ endif
+ 
+-ifneq ($(call check_func,dm_task_no_flush,/usr/include/libdevmapper.h),0)
++ifneq ($(call check_func,dm_task_no_flush,@lvm2@/include/libdevmapper.h),0)
+ 	CFLAGS += -DLIBDM_API_FLUSH -D_GNU_SOURCE
+ endif
+ 
+-ifneq ($(call check_func,dm_task_set_cookie,/usr/include/libdevmapper.h),0)
++ifneq ($(call check_func,dm_task_set_cookie,@lvm2@/include/libdevmapper.h),0)
+ 	CFLAGS += -DLIBDM_API_COOKIE
+ endif
+ 
+-ifneq ($(call check_func,udev_monitor_set_receive_buffer_size,/usr/include/libudev.h),0)
++ifneq ($(call check_func,udev_monitor_set_receive_buffer_size,@systemd@/include/libudev.h),0)
+ 	CFLAGS += -DLIBUDEV_API_RECVBUF
+ endif
+ 
+-ifneq ($(call check_func,dm_task_deferred_remove,/usr/include/libdevmapper.h),0)
++ifneq ($(call check_func,dm_task_deferred_remove,@lvm2@/include/libdevmapper.h),0)
+ 	CFLAGS += -DLIBDM_API_DEFERRED
+ endif
+ 
+diff --git a/libmultipath/prioritizers/Makefile b/libmultipath/prioritizers/Makefile
+index 9d0fe03c..3851837b 100644
+--- a/libmultipath/prioritizers/Makefile
++++ b/libmultipath/prioritizers/Makefile
+@@ -21,7 +21,7 @@ LIBS = \
+ 	libpriopath_latency.so \
+ 	libpriosysfs.so
+ 
+-ifneq ($(call check_file,/usr/include/linux/nvme_ioctl.h),0)
++ifneq ($(call check_file,@linuxHeaders@/include/linux/nvme_ioctl.h),0)
+ 	LIBS += libprioana.so
+ 	CFLAGS += -I../nvme
+ endif


### PR DESCRIPTION
Depends on https://github.com/NixOS/nixpkgs/pull/61824. I am not sure if this PR would be mergaable as is so I have split in two.

###### Motivation for this change
Also fixing library detection in Makefile. In the previous and the current
version `/usr/include` was hardcoded in Makefile. I have tested that all
optional features are found during build. Excerpt from build output:

    Checking for dm_task_no_flush in /nix/store/d2x72ihg707mdjvbjz3n4s9v02syr86y-lvm2-2.03.01/include/libdevmapper.h ... yes
    Checking for dm_task_set_cookie in /nix/store/d2x72ihg707mdjvbjz3n4s9v02syr86y-lvm2-2.03.01/include/libdevmapper.h ... yes
    Checking for udev_monitor_set_receive_buffer_size in /nix/store/jvm37ymza8h2l74p0j0l3hxwwsnrha1l-systemd-239.20190219-dev/include/libudev.h ... yes
    Checking for dm_task_deferred_remove in /nix/store/d2x72ihg707mdjvbjz3n4s9v02syr86y-lvm2-2.03.01/include/libdevmapper.h ... yes
    Checking if /nix/store/rz560c4bc3czwzzlli1z2az7hxp8axlh-linux-headers-4.19.16/include/linux/nvme_ioctl.h exists ... yes

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
