### PR TITLE
briss: Use makeWrapper so it can take command-line args

### DIFF
--- a/pkgs/tools/graphics/briss/default.nix
+++ b/pkgs/tools/graphics/briss/default.nix
@@ -1,6 +1,6 @@
 # The releases of this project are apparently precompiled to .jar files.
 
-{ stdenv, fetchurl, jre, runtimeShell }:
+{ stdenv, fetchurl, jre, makeWrapper }:
 
 let
 
@@ -14,13 +14,13 @@ in stdenv.mkDerivation {
     inherit sha256;
   };
 
+  nativeBuildInputs = [makeWrapper];
+
   installPhase = ''
     mkdir -p "$out/bin";
     mkdir -p "$out/share";
     install -D -m444 -t "$out/share" *.jar
-    echo "#!${runtimeShell}" > "$out/bin/briss"
-    echo "${jre}/bin/java -Xms128m -Xmx1024m -cp \"$out/share/\" -jar \"$out/share/briss-${version}.jar\"" >> "$out/bin/briss"
-    chmod +x "$out/bin/briss"
+    makeWrapper "${jre}/bin/java" "$out/bin/briss" --add-flags "-Xms128m -Xmx1024m -cp \"$out/share/\" -jar \"$out/share/briss-${version}.jar\""
   '';
 
   meta = {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Briss is a GUI application for chopping up PDFs. With previous packaging, you could open the app from the command-line, but couldn't specify a filename as an argument. This change uses makeWrapper instead of a custom script, so it can pass through command-line arguments.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
