### PR TITLE
nrfutil: init at 5.2.0

### DIFF
--- a/pkgs/development/python-modules/intelhex/default.nix
+++ b/pkgs/development/python-modules/intelhex/default.nix
@@ -1,22 +1,24 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, fetchpatch
 , fetchurl
 }:
 
 buildPythonPackage rec {
   pname = "intelhex";
-  version = "2.1";
+  version = "2.2.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0k5l1mn3gv1vb0jd24ygxksx8xqr57y1ivgyj37jsrwpzrp167kw";
+    sha256 = "0ckqjbxd8gwcg98gfzpn4vq1qxzfvq3rdbrr1hikj1nmw08qb780";
   };
 
   patches = [
-    (fetchurl {
-      url = https://github.com/bialix/intelhex/commit/f251aef214daa2116e15ff7f7dcec1639eb12d5b.patch;
-      sha256 = "02i15qjmcz7mwbwvyj3agl5y7098rag2iwypdilkaadhbslsl9b9";
+    # patch the tests to check for the correct version string (2.2.1)
+    (fetchpatch {
+      url = "https://patch-diff.githubusercontent.com/raw/bialix/intelhex/pull/26.patch";
+      sha256 = "1f3f2cyf9ipb9zdifmjs8rqhg028dhy91vabxxn3l7br657s8r2l";
     })
   ];
 

--- a/pkgs/development/python-modules/pc-ble-driver-py/default.nix
+++ b/pkgs/development/python-modules/pc-ble-driver-py/default.nix
@@ -1,0 +1,51 @@
+{ stdenv, buildPythonPackage, fetchpatch, fetchFromGitHub,
+  python, cmake, git, swig, boost, udev,
+  setuptools, enum34, wrapt, future }:
+
+buildPythonPackage rec {
+  pname = "pc-ble-driver-py";
+  version = "0.11.4";
+  disabled = python.isPy3k;
+
+  src = fetchFromGitHub {
+    owner = "NordicSemiconductor";
+    repo = "pc-ble-driver-py";
+    rev = "v${version}";
+    fetchSubmodules = true;
+    sha256 = "0lgmcnrlcivmawmlcwnn4pdp6afdbnf3fyfgq22xzs6v72m9gp81";
+  };
+
+  nativeBuildInputs = [ cmake swig git setuptools ];
+  buildInputs = [ boost udev ];
+  propagatedBuildInputs = [ enum34 wrapt future ];
+
+  patches = [
+    # build system expects case-insensitive file system
+    (fetchpatch {
+      url = "https://patch-diff.githubusercontent.com/raw/NordicSemiconductor/pc-ble-driver-py/pull/84.patch";
+      sha256 = "0ibx5g2bndr5h9sfnx51bk9b62q4jvpdwhxadbnj3da8kvcz13cy";
+    })
+  ];
+
+  postPatch = ''
+    # do not force static linking of boost
+    sed -i /Boost_USE_STATIC_LIBS/d pc-ble-driver/cmake/*.cmake
+
+    cd python
+  '';
+
+  preBuild = ''
+    pushd ../build
+    cmake ..
+    make -j $NIX_BUILD_CORES
+    popd
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Bluetooth Low Energy nRF5 SoftDevice serialization";
+    homepage = "https://github.com/NordicSemiconductor/pc-ble-driver-py";
+    license = licenses.unfreeRedistributable;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ gebner ];
+  };
+}

--- a/pkgs/development/python-modules/piccata/default.nix
+++ b/pkgs/development/python-modules/piccata/default.nix
@@ -1,0 +1,19 @@
+{ buildPythonPackage, fetchPypi, lib, ipaddress }:
+
+buildPythonPackage rec {
+  pname = "piccata";
+  version = "1.0.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "45f6c98c2ea809d445040888117f99bc3ee843490d86fecc5805ff5ea41508f7";
+  };
+
+  propagatedBuildInputs = [ ipaddress ];
+
+  meta = {
+    description = "Simple CoAP (RFC7252) toolkit";
+    homepage = "https://github.com/NordicSemiconductor/piccata";
+    maintainers = with lib.maintainers; [ gebner ];
+  };
+}

--- a/pkgs/development/python-modules/pyspinel/default.nix
+++ b/pkgs/development/python-modules/pyspinel/default.nix
@@ -1,0 +1,21 @@
+{ buildPythonPackage, fetchPypi, lib, future, pyserial, ipaddress }:
+
+buildPythonPackage rec {
+  pname = "pyspinel";
+  version = "1.0.0a3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0914a662d57a14bce9df21f22711b5c9b2fef37cf461be54ed35c6e229060fd4";
+  };
+
+  propagatedBuildInputs = [ pyserial ipaddress future ];
+
+  doCheck = false;
+
+  meta = {
+    description = "Interface to the OpenThread Network Co-Processor (NCP)";
+    homepage = "https://github.com/openthread/pyspinel";
+    maintainers = with lib.maintainers; [ gebner ];
+  };
+}

--- a/pkgs/development/tools/misc/nrfutil/default.nix
+++ b/pkgs/development/tools/misc/nrfutil/default.nix
@@ -1,0 +1,33 @@
+{ stdenv, python2Packages, fetchFromGitHub }:
+
+with python2Packages; buildPythonApplication rec {
+  pname = "nrfutil";
+  version = "5.2.0";
+
+  src = fetchFromGitHub {
+    owner = "NordicSemiconductor";
+    repo = "pc-nrfutil";
+    rev = "v${version}";
+    sha256 = "1hajjgz8r4fjbwqr22p5dvb6k83dpxf8k7mhx20gkbrrx9ivqh79";
+  };
+
+  propagatedBuildInputs = [ pc-ble-driver-py six pyserial enum34 click ecdsa
+    protobuf tqdm piccata pyspinel intelhex pyyaml crcmod libusb1 ipaddress ];
+
+  checkInputs = [ nose behave ];
+
+  postPatch = ''
+    # remove version bound on pyyaml
+    sed -i /pyyaml/d requirements.txt
+
+    mkdir test-reports
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Device Firmware Update tool for nRF chips";
+    homepage = "https://github.com/NordicSemiconductor/pc-nrfutil";
+    license = licenses.unfreeRedistributable;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ gebner ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9397,6 +9397,8 @@ in
   noweb = callPackage ../development/tools/literate-programming/noweb { };
   nuweb = callPackage ../development/tools/literate-programming/nuweb { tex = texlive.combined.scheme-small; };
 
+  nrfutil = callPackage ../development/tools/misc/nrfutil { };
+
   obelisk = callPackage ../development/tools/ocaml/obelisk { };
 
   obuild = callPackage ../development/tools/ocaml/obuild { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -780,6 +780,8 @@ in {
     slurm = pkgs.slurm;
   };
 
+  pyspinel = callPackage ../development/python-modules/pyspinel {};
+
   pyssim = callPackage ../development/python-modules/pyssim { };
 
   pystache = callPackage ../development/python-modules/pystache { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -593,6 +593,8 @@ in {
 
   pathlib = callPackage ../development/python-modules/pathlib { };
 
+  pc-ble-driver-py = toPythonModule (callPackage ../development/python-modules/pc-ble-driver-py { });
+
   pdf2image = callPackage ../development/python-modules/pdf2image { };
 
   pdfminer = callPackage ../development/python-modules/pdfminer_six { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -605,6 +605,8 @@ in {
 
   phonopy = callPackage ../development/python-modules/phonopy { };
 
+  piccata = callPackage ../development/python-modules/piccata {};
+
   pims = callPackage ../development/python-modules/pims { };
 
   plantuml = callPackage ../tools/misc/plantuml { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

[nrfutil](https://github.com/NordicSemiconductor/pc-nrfutil) is a firmware flash utility for nRF microcontrollers.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
