### PR TITLE
vscod{e,ium}: 1.33.1 -> 1.34.0

### DIFF
--- a/pkgs/applications/editors/vscode/vscode.nix
+++ b/pkgs/applications/editors/vscode/vscode.nix
@@ -12,14 +12,14 @@ let
   archive_fmt = if system == "x86_64-darwin" then "zip" else "tar.gz";
 
   sha256 = {
-    "i686-linux" = "0n2k134yx0zirddi5xig4zihn73s8xiga11pwk90f01wp1i0hygg";
-    "x86_64-linux" = "0ljijcqfyrfck5imldis3hx9d9iacnspgnm58kvlziam8y0imwzv";
-    "x86_64-darwin" = "00fg106rggsbng90k1jjp1c6nmnwni5s0fgmbz6k45shfa3iqamc";
+    "i686-linux" = "1xl8bk1m7d930dp7nw4770vk14cppci0ag079y8d39xqnvs24mr0";
+    "x86_64-linux" = "0mq6gzz7338h4ragiar55xxby0x7whcd9nvnfk46bri162bacjbg";
+    "x86_64-darwin" = "0pgj515k2bkpz953shmnalfw6yz8sg07jsxqk1rni9s3khrrd25h";
   }.${system};
 in
   callPackage ./generic.nix rec {
 
-    version = "1.33.1";
+    version = "1.34.0";
     pname = "vscode";
 
     executableName = "code" + lib.optionalString isInsiders "-insiders";

--- a/pkgs/applications/editors/vscode/vscodium.nix
+++ b/pkgs/applications/editors/vscode/vscodium.nix
@@ -12,14 +12,14 @@ let
   archive_fmt = if system == "x86_64-darwin" then "zip" else "tar.gz";
 
   sha256 = {
-    "i686-linux" = "c45be9ff32a5acef91befc85d545402daac5cef627fe8f17fea40ae387b35b22";
-    "x86_64-linux" = "7a87f19bc48cbe017321c72da244d879a7da364b92b3a89b742d437ffcd585d3";
-    "x86_64-darwin" = "e393be5dd82ea1900e3a0597b6cb2e4c924b6acda4297d9d3eff5abcc857f32c";
+    "i686-linux" = "1vr3mblg5223k56yqi9fqwa7yg8qi4r3nkw6ssf87gs8jwfxa47l";
+    "x86_64-linux" = "1vqq365zw44ll22i06bxxviyywv1v2f71c2mricrz3faz25c3lvm";
+    "x86_64-darwin" = "0pa5cz8kq45q375b74kaa8qn1h0r1mp9amh5gsprg3hx89xzvhxi";
   }.${system};
 in
   callPackage ./generic.nix rec {
 
-    version = "1.33.1";
+    version = "1.34.0";
     pname = "vscodium";
 
     executableName = "vscodium";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
