### PR TITLE
microwindows: init at unstable-2019-05-20

### DIFF
--- a/pkgs/servers/microwindows/default.nix
+++ b/pkgs/servers/microwindows/default.nix
@@ -1,0 +1,58 @@
+{ stdenv, fetchFromGitHub, automake, gcc, zlib, libpng, libjpeg
+ , freetype, libX11, libXext, buildPackages, yacc, flex }:
+
+with stdenv.lib;
+
+stdenv.mkDerivation rec {
+  version = "unstable-2019-05-20";
+  pname = "microwindows";
+
+  src = fetchFromGitHub {
+    owner = "ghaerr";
+    repo = "microwindows";
+    rev = "ad3164ddd42fb28761a04ec69534e4486a5894f8";
+    sha256 = "0qddkzwax96i0g73ir378s37b3xhihpz2146a3yph4l2p6lcdd8i";
+  };
+
+  sourceRoot = "source/src";
+
+  patchPhase = ''
+    cp Configs/config.linux-X11 config
+    # canceled failing demo
+    substituteInPlace demos/nuklear/Makefile --replace "all:" "#all:"
+  '';
+
+  nativeBuildInputs = [ gcc ];
+  depsBuildBuild = [ automake yacc flex buildPackages.stdenv.cc ];
+  buildInputs = [ libpng libjpeg freetype libX11 libXext zlib ];
+
+  makeFlags = [
+    "HOSTCC=gcc"
+    "LEX=flex"
+    "HAVE_JPEG_SUPPORT=Y"
+    "INSTALL_PREFIX=${placeholder "out"}"
+    "INSTALL_OWNER1= INSTALL_OWNER2="
+  ];
+
+  # copy missing binaries
+  postInstall = ''
+    cp bin/* $out/bin
+  '';
+
+  postFixup =
+  ''
+      find "$out/bin" -executable -exec \
+      patchelf \
+      --replace-needed /build/source/src/lib/libnano-X.so "$out/lib/libnano-X.so" \
+      --replace-needed /build/source/src/lib/libmwin.so "$out/lib/libmwin.so" \
+      {} \;
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A small graphical windowing system";
+    homepage = "http://microwindows.org";
+    license = licenses.mpl11;
+    maintainers = [ maintainers.genesis ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15174,6 +15174,7 @@ in
   meteor = callPackage ../servers/meteor { };
 
   micronaut = callPackage ../development/tools/micronaut {};
+  microwindows = callPackage ../servers/microwindows { };
 
   minio = callPackage ../servers/minio { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
