### PR TITLE
adds nodejs_latest packages

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4187,6 +4187,7 @@ in
 
   # Update this when adding the newest nodejs major version!
   nodejs_latest = nodejs-12_x;
+  nodejs-slim_latest = nodejs-slim-12_x;
 
   nodePackages_10_x = dontRecurseIntoAttrs (callPackage ../development/node-packages/default-v10.nix {
     nodejs = pkgs.nodejs-10_x;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4185,6 +4185,9 @@ in
     openssl = openssl_1_1;
   };
 
+  # Update this when adding the newest nodejs major version!
+  nodejs_latest = nodejs-12_x;
+
   nodePackages_10_x = dontRecurseIntoAttrs (callPackage ../development/node-packages/default-v10.nix {
     nodejs = pkgs.nodejs-10_x;
   });


### PR DESCRIPTION
###### Motivation for this change
Well, from what I've understand `nodejs` package is version locked to v8 for compatibility reasons, but this makes it hard for people who want to stay on the latest release. Current latest package is `nodejs-12_x` but after a while v13 will release and we will have a package called `nodejs-13_x` and most people will miss this update. So I propose `nodejs-latest` package definitions.

Thanks to @samueldr, @alexarice , @infinisil from IRC :)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

I've tested these packages with the following:
```
cd into root of project
nix-build -A nodejs-latest
nix-shell -p nodejs-latest -I nixpkgs=.
```
