### PR TITLE
plata-theme: 0.7.6 -> 0.8.0

### DIFF
--- a/pkgs/data/themes/plata/default.nix
+++ b/pkgs/data/themes/plata/default.nix
@@ -8,23 +8,26 @@
 , xfceSupport ? true
 , gtkNextSupport ? false
 , plankSupport ? false
+, steamSupport ? false
 , telegramSupport ? false
-, tweetdeckSupport ? false
+, tweetdeckSupport ? false, zip ? null
 , selectionColor ? null # Primary color for 'selected-items' (Default: #3F51B5 = Indigo500)
 , accentColor ? null # Secondary color for notifications and OSDs (Default: #7986CB = Indigo300)
 , suggestionColor ? null # Secondary color for 'suggested' buttons (Default: #673AB7 = DPurple500)
 , destructionColor ? null # Tertiary color for 'destructive' buttons (Default: #F44336 = Red500)
 }:
 
+assert tweetdeckSupport -> zip != null;
+
 stdenv.mkDerivation rec {
   name = "plata-theme-${version}";
-  version = "0.7.6";
+  version = "0.8.0";
 
   src = fetchFromGitLab {
     owner = "tista500";
     repo = "plata-theme";
     rev = version;
-    sha256 = "1jllsl2h3zdvlp3k2dy3h4jyccrzzymwbqz43jhnm6mxxabxzijg";
+    sha256 = "10xvfrc945zqlgzlx8zjyg0gnkwmq9vfjk0yqjy3gg62i65s8sch";
   };
 
   preferLocalBuild = true;
@@ -37,7 +40,8 @@ stdenv.mkDerivation rec {
     inkscape
     libxml2
     gnome2.glib.dev
-  ];
+  ]
+  ++ stdenv.lib.optional tweetdeckSupport zip;
 
   buildInputs = [
     gdk_pixbuf
@@ -62,6 +66,7 @@ stdenv.mkDerivation rec {
       (enableFeature xfceSupport "xfce")
       (enableFeature gtkNextSupport "gtk_next")
       (enableFeature plankSupport "plank")
+      (enableFeature steamSupport "airforsteam")
       (enableFeature telegramSupport "telegram")
       (enableFeature tweetdeckSupport "tweetdeck")
     ]
@@ -69,6 +74,13 @@ stdenv.mkDerivation rec {
     ++ (withOptional accentColor "accent_color")
     ++ (withOptional suggestionColor "suggestion_color")
     ++ (withOptional destructionColor "destruction_color");
+
+  postInstall = ''
+    for dest in $out/share/gtksourceview-{3.0,4}/styles; do
+      mkdir -p $dest
+      cp $out/share/themes/Plata-{Noir,Lumine}/gtksourceview/*.xml $dest
+    done
+  '';
 
   meta = with stdenv.lib; {
     description = "A Gtk+ theme based on Material Design Refresh";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update `plata-theme` to 0.8.0.

Add flags for parallel and steam support, and fix building with tweetdeck support. 

Add GtkSourceView support (versions 3.0 and 4).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
