### PR TITLE
Fixes meson for systemd-boot AArch64 cross-build

### DIFF
--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -72,6 +72,8 @@ python3Packages.buildPythonApplication rec {
     ar = '${targetPackages.stdenv.cc.bintools.targetPrefix}ar'
     strip = '${targetPackages.stdenv.cc.bintools.targetPrefix}strip'
     pkgconfig = 'pkg-config'
+    ld = '${targetPackages.stdenv.cc.targetPrefix}ld'
+    objcopy = '${targetPackages.stdenv.cc.targetPrefix}objcopy'
 
     [properties]
     needs_exe_wrapper = true

--- a/pkgs/development/tools/build-managers/meson/default.nix
+++ b/pkgs/development/tools/build-managers/meson/default.nix
@@ -1,5 +1,15 @@
 { lib, python3Packages, stdenv, writeTextDir, substituteAll, targetPackages }:
 
+let
+  # See https://mesonbuild.com/Reference-tables.html#cpu-families
+  cpuFamilies = {
+    "aarch64" = "aarch64";
+    "armv6l"  = "arm";
+    "armv7l"  = "arm";
+    "i686"    = "x86";
+    "x86_64"  = "x86_64";
+  };
+in
 python3Packages.buildPythonApplication rec {
   version = "0.49.2";
   pname = "meson";
@@ -68,7 +78,7 @@ python3Packages.buildPythonApplication rec {
 
     [host_machine]
     system = '${targetPackages.stdenv.targetPlatform.parsed.kernel.name}'
-    cpu_family = '${targetPackages.stdenv.targetPlatform.parsed.cpu.family}'
+    cpu_family = '${cpuFamilies.${targetPackages.stdenv.targetPlatform.parsed.cpu.name}}'
     cpu = '${targetPackages.stdenv.targetPlatform.parsed.cpu.name}'
     endian = ${if targetPackages.stdenv.targetPlatform.isLittleEndian then "'little'" else "'big'"}
   '';

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -96,7 +96,7 @@ in stdenv.mkDerivation rec {
     "-Dsystem-gid-max=499"
     # "-Dtime-epoch=1"
 
-    (if stdenv.isAarch32 || stdenv.isAarch64 || !stdenv.hostPlatform.isEfi then "-Dgnu-efi=false" else "-Dgnu-efi=true")
+    (if !stdenv.hostPlatform.isEfi then "-Dgnu-efi=false" else "-Dgnu-efi=true")
     "-Defi-libdir=${toString gnu-efi}/lib"
     "-Defi-includedir=${toString gnu-efi}/include/efi"
     "-Defi-ldsdir=${toString gnu-efi}/lib"


### PR DESCRIPTION
Note about `cpu_family`:

As documented, it should be `aarch64` for AArch64.

 * https://mesonbuild.com/Reference-tables.html#cpu-families

```
 $ nix eval '((import <nixpkgs> {}).pkgsCross.aarch64-multiplatform.stdenv.targetPlatform.parsed.cpu.family)'
"arm"
```

This explains the new conditional. `family` seems fine for at least
~`x86_64`~, `i686` and `armv7`.

* * *

This should be merged together with #61321; dropping the systemd AArch64 change on one of the PRs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

**This was tested when rebased on nixos-unstable. In the current state of staging, something (glib) doesn't build for at-leat cross-compilation, it looks like.**

- ☑️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ☑️ NixOS
   - 🔲 other Linux distributions
- 🔲 Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- 🔲 Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- 🔲 Tested execution of all binary files (usually in `./result/bin/`)
- 🔲 Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ☑️ Assured whether relevant documentation is up to date
- ☑️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @andir 