### PR TITLE
coqPackages.ltac2: init at 0.1

### DIFF
--- a/pkgs/development/coq-modules/ltac2/default.nix
+++ b/pkgs/development/coq-modules/ltac2/default.nix
@@ -1,0 +1,49 @@
+{ stdenv, fetchFromGitHub, which, coq }:
+
+let params = {
+  "8.7" = {
+    version = "0.1";
+    rev = "v0.1-8.7";
+    sha256 = "0l6wiwi4cvd0i324fb29i9mdh0ijlxzggw4mrjjy695l2qdnlgg0";
+  };
+  "8.8" = {
+    version = "0.1";
+    rev = "0.1";
+    sha256 = "1zz26cyv99whj7rrpgnhhm9dfqnpmrx5pqizn8ihf8jkq8d4drz7";
+  };
+  "8.9" = {
+    version = "0.1";
+    rev = "a69551a49543b22a7d4e6a2484356b56bd05068e";
+    sha256 = "0xby1kb26r9gcvk5511wqj05fqm9paynwfxlfqkmwkgnfmzk0x73";
+  };
+};
+  param = params."${coq.coq-version}";
+in
+
+stdenv.mkDerivation rec {
+  inherit (param) version;
+  name = "coq${coq.coq-version}-ltac2-${version}";
+
+  src = fetchFromGitHub {
+    owner = "coq";
+    repo = "ltac2";
+    inherit (param) rev sha256;
+  };
+
+  nativeBuildInputs = [ which ];
+  buildInputs = [ coq ] ++ (with coq.ocamlPackages; [ ocaml findlib camlp5 ]);
+
+  installFlags = "COQLIB=$(out)/lib/coq/${coq.coq-version}/";
+
+  meta = {
+    description = "A robust and expressive tactic language for Coq";
+    maintainers = [ stdenv.lib.maintainers.vbgl ];
+    license = stdenv.lib.licenses.lgpl21;
+    inherit (coq.meta) platforms;
+    inherit (src.meta) homepage;
+  };
+
+  passthru = {
+    compatibleCoqVersions = stdenv.lib.flip builtins.hasAttr params;
+  };
+}

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -33,6 +33,7 @@ let
       interval = callPackage ../development/coq-modules/interval {};
       InfSeqExt = callPackage ../development/coq-modules/InfSeqExt {};
       iris = callPackage ../development/coq-modules/iris {};
+      ltac2 = callPackage ../development/coq-modules/ltac2 {};
       math-classes = callPackage ../development/coq-modules/math-classes { };
       inherit (callPackage ../development/coq-modules/mathcomp { })
         mathcompGen mathcompGenSingle mathcompCorePkgs_1_7 mathcompCorePkgs_1_8 mathcompCorePkgs


### PR DESCRIPTION
###### Motivation for this change

Ltac2 is an attempt at providing the Coq users with a tactic language that is more robust and more expressive than the venerable Ltac language.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
