### PR TITLE
 thunderbird,  thunderbird-bin: 60.6.0 -> 60.7.0 

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/release_sources.nix
@@ -1,585 +1,585 @@
 {
-  version = "60.6.0";
+  version = "60.7.0";
   sources = [
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/ar/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/ar/thunderbird-60.7.0.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha512 = "ba14ed80e0b18cc3b40a1bf1810eb67a246f6e995d527e625432eb24dce46bde85dd0dbcac5590d74b8bbb7be900f266b72055349f9b0ea6839fb8d5779aa54d";
+      sha512 = "07f3c9310e46fb43bab84c892c06aae11a33f0b7cf14730a92c9292d3e51bce9a1d37707ee819c8ba9fb8b9e78bf2089772684405a8276ac32676b2585c7bc32";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/ast/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/ast/thunderbird-60.7.0.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha512 = "b6ab87d344c3e806a2316022a6c8632dcd9548c745766e136ca9aa70f54fe744587849372fc7426173a91996ff4709aee85f8e5de2565add3bbac58d370e7a96";
+      sha512 = "75967b7e98bd7d3b1d1ddb01aa5950d3d7bda77001bc0d8eb5d30a9bf617eb4fd36d6870c774943c41de9ba784f969fa0ffcfe5787331f3b721a1adbabee4e27";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/be/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/be/thunderbird-60.7.0.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha512 = "2d5f88efb2f6e3be552cb503bfe184a3ad6b395da3139c6c97585f490d9a02c5ce391c0f6b3b1be0505b63f0b8af70da9eca8820b5baefc3dc043a60abb47d5a";
+      sha512 = "78d8a8052bdebce1680d7a68ad3c0a0f8f4e3a0aa789ebc3874e58aa4eaa177feace8874b0bf7ad9d846673fb43e2356e7deefaa0a93dcf7db9c8d393ffc4508";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/bg/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/bg/thunderbird-60.7.0.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha512 = "16b7b8d54e200b9156a346a0e4b80cb5c91a0297222a3f4a227770344d6453fea679d7c8a512eb9d879abe262ce34c2dab654cbe60aab13d0cc7919757dcae8d";
+      sha512 = "228182664420439f0847746db29764a50f85607589600d48e79c4f9ba63912750ebda16c24c31a8b8f11dd0f02c0f493d6c2ca3a56dfc2cd8f2c0621b809092d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/br/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/br/thunderbird-60.7.0.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha512 = "d20854f75f09f95489a1d647bbdeed9062a553dcede68f48672d0a0a82001e283a7d24162a6110ce3efa1a1bdd846ca7fe036c37a20f63bf8dcd54d80a767084";
+      sha512 = "7eed1bee8424f0d6cb26636fffe16da398406902e791c3e346c74a405feff23f158df8a0790064022977469605001aac2ea484e93e803134f8c063da40e9b2ae";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/ca/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/ca/thunderbird-60.7.0.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha512 = "8477742f367c2e4206ba61afcef372d39163aeba5e781ea9a089b0d3cf9ef44be8ce6bd3417490616a51aff3152a52eb3599b2acf66e0186e696c9df29b9732b";
+      sha512 = "e9071b7f54db240cfdf91b64aec9170a94b2b753d7b7b04dedfa1335f41829db09e6623d6b44186d552b85aedbfe57cacacd7bf68605a488ed8a5d667769c3d2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/cs/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/cs/thunderbird-60.7.0.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha512 = "b434e8763a93df511dcc9c032d11c0a26c7583f7ce01980be63ea453f8d503e703cddca5e5a67db619cb1b9690d0256c91eec8166fff30733186e429d3c513a8";
+      sha512 = "2366449d58ab72cc59b0abd5bd4c279e3d1e95668b834b4d49a606338206197434f78ec911b6c69301916754f813c137a89ae7fabf1bbfba1273bf4ead1ba1a3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/cy/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/cy/thunderbird-60.7.0.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha512 = "71a6a2642dfce4505ed3b6b551ffdd5c469f1261191b73d3bd09bdf98788297536b3b94dd52327d263d4b1256080ff0317d8e10e09b53871ab805b426892e9a0";
+      sha512 = "dcc268a8bb5fe9be6a3ddcb4cd25cf341db58e9ad2837d15ec949dc737edfeda3fdb17368237b58a33ffe1b41ede2496ad06c1fee46f9d59468138e3bd2292d1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/da/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/da/thunderbird-60.7.0.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha512 = "e24c19e5caafd4b4c5081acf700fb175e07c1702da0af111122cf793e4791d38c49902e1b9574ab9606482c539677e6caad2b9f8f655ac0fb24f1b0c8454c456";
+      sha512 = "1d027329c79b9fe335fa9243e6aefd9f5a8f15e8280db3ab449478dd435bdec6d4020c03e22c124a3505aca4908bf35f8b3203a637a508b747f83e4d0fb24de6";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/de/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/de/thunderbird-60.7.0.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha512 = "e9ec916a00bfd50745c95ed42976eeb0b9cc314165b6401e24e1433a68fa5591c3020397a0c35566072784e423b42132d4e55dc307a47d34c693d5fe9e3e6380";
+      sha512 = "51436c4e59dbda6eff921800f65d9181983e3fdc86def4f0d358ff616f646a58c84581376e37a4db180a80535d71da6c75be790419e66fb6b9c949a52f8973c9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/dsb/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/dsb/thunderbird-60.7.0.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha512 = "4fd72e0ba6982c0aeba4911a626aa7dea2d6678502aec9523efb5e89b613b20b471d50a2667df000541279ff961fc3323ebaa16d3482c2bebcaa33ec849a05d3";
+      sha512 = "6316491fc7cc1160456adf586679939ce52f12321b260c137808e7ea4d52ce4251e373d65e8e9bb0462282735a45e557c2e800a3fc0cff7b91a0dbee4b8ecd96";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/el/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/el/thunderbird-60.7.0.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha512 = "bd86c6855ce42bf52ca6822e6fd3cfd7e09c9fd2577407c666b46d84afcf43655f30dc0e3546ae41b84eb5ca7e681072fae90a08de9dd017c3594dea4e5b9bb8";
+      sha512 = "1185db88183bf22d788639ae8b57ae348a54f2ab20562d9f9ad3990ca64d989f7009387a02ebe5bc8121ce2aa8bb5f6eb2d1ff5ecf8cd7bc76af14f02c8fd365";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/en-GB/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/en-GB/thunderbird-60.7.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha512 = "47009db4f18cad43a9d4ba20a4edbfbb07cc5222cb65121dfe45eb3c9120fd18277d5601309f9f3f21eebe10fd70201a9d15815fd35ef6f9d3f95360d939a0ec";
+      sha512 = "085d55a9333d147829f15b7452b59dee2743999270b79f56957ab813d10a8e36242215eedb8db34a2fa8b213c58b4c8bb503c7251dc144fa4ea20c5417dbedad";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/en-US/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/en-US/thunderbird-60.7.0.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha512 = "86bfb05041e347430c424652f8fcb102aa44c0bb68bf1b7a55ce888fcefa2ac08f55bb4bcbe7a558aaf3214ae694b97a6805f14de2ce575968fa2a1988e281ba";
+      sha512 = "0bf5bbbaf76c1dd304eda6ad175f3fdc4fbe9f56ed11bac4b6855f13c2cbd5ddd635c364d8f9660542a20d4bf8d3a8b18b4398280d15ad47afc4fa88d321d5bb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/es-AR/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/es-AR/thunderbird-60.7.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha512 = "87a5caeb7d8f8846c52b9a7344260e480efce156239559a890bf5e167939cd35e2223ef4ad2429b196a87ca164b02eb7df3dd03ed1f52f95bf30d75afec40fd8";
+      sha512 = "e1212f10b58d13d3376f72df61e1609fba269adc698e55bc3f19624a5004286b417d3181708dc80806a02d910167cd4f63e5d4adb3b2f7cdedcfdd140ed482d4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/es-ES/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/es-ES/thunderbird-60.7.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha512 = "ec6a17263d696b2fa4195349fd3badaf7ac7dbdf93ee7247a77d27aa13daf5de06db8c2df3449b06e6d28fc032e9c4eeb897be8b1a798e9fb7b68f3c8509d6d8";
+      sha512 = "136859c06b23f07fad831925f3a990b1bbfe955083f96b767482d496bb054b63d31eaab3361e5edc1d226a1a38296599cdaa1980839b3d0feadfb93c511aa10b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/et/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/et/thunderbird-60.7.0.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha512 = "d4591fdc97c5c1654f59116670e8516c12b53311e6f76f13711c04c86cfbf4cbd893a2f5f657b27fc44ad9919e3c0b5192ae98b26281ef4df6863fc522d50a7b";
+      sha512 = "4562561e5a317ce632e9323096c4ba83c9ac5183e6e42cbcd9475965166392390ece9a370f6f9fe46d3d19fd0d65596bee6519e4060b49bdcac01996c47e0a18";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/eu/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/eu/thunderbird-60.7.0.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha512 = "316b4d9d515b23476d29c0136c9981d281f7a3628aacd18f912640a2b6e1d5b53d66d42e9300af6b2cb78e4ada7458d0002c3d4a5ac7f5129db3dd66f4358341";
+      sha512 = "4601b91b694f76654ea5ea3c932b3bb56f99096144a2c4e6dd5ab369ba0c9bf30044fe7490d67f50c9308b1223cd887e22f8cbbd1f35ba3e769d2b2e1e230b67";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/fi/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/fi/thunderbird-60.7.0.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha512 = "944742e4331c7ccbc27d887d9d5702ced9807d743d57e8a14b18f4dd6b2148ed24b295eb498c09d1d54f2f1110abfd9e2acbad83a882189d0d7e5403dbe650b4";
+      sha512 = "39f949f4d71f8ad64ccaaef6b61797f1b8da5fd2e3bd80ec6110bc994806413e4617ba375c973a47819d2c8ae774f01941c5fc9698585b276d805c525bd91abf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/fr/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/fr/thunderbird-60.7.0.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha512 = "1dfeaeb5e6985ebd820188721377589ebf4b993337a4231f6d036ae05173e8fb33c17bae76a3982e34a98da934d584d0efec4e01d6045b24345ea66299ecfe19";
+      sha512 = "ab281a68685555afbcfad63f6ea55aee413696b50cfba1563de7767a824fc22d00e39dcae04b6383e3b7da57ae23ffb09d49739ac78c69a59d2becd9ce22dd23";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/fy-NL/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/fy-NL/thunderbird-60.7.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha512 = "6e61fc74b45e75170157806c8f358b5236e5de79e1d07db4f7834bebf2b9822d90377334ec1f2cf44a838c52c7135711b5a7036a0336813fe79c7dc3aa43e25e";
+      sha512 = "042ea959bf071f7f5b62ffdccd13739c4c0defdf9de3bfd19bec695e89b18aca35f4bbb4938de424834309dbb2a0d3f45c32461b6e517f7c9c4740f38f2d02b7";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/ga-IE/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/ga-IE/thunderbird-60.7.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha512 = "7de19973a7e9770cfdd9ff944e9bea8e6755a81e2fd41ce27ff0d16bfe948534294c18f2f7ca05092aa574bea6fadd5a90bb08ca6472c27e7b0cdc6c15d25341";
+      sha512 = "1da90daff6d3eb7473dd44e7878cfacc807e495a0028802b04adf61992134179cf7afdc8c1c3fb9336120639efed2969cf197cc29a41591598b486aec20b9a9b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/gd/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/gd/thunderbird-60.7.0.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha512 = "1d5309b6eb47b16b49142ba18de96b285fc0f91a7eb3be5cac576683da37143c1e91318dff4f039119668679acf3c2643bdde9a26788f0bb240cebaa5f907389";
+      sha512 = "21197c08e9f27bcc30b4f579c1005caf458f0e1cbcc564ca270885c215aac18e17eae485dd5d2ab756013fea24af36b919e65d100d88db43570ab690be7e2679";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/gl/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/gl/thunderbird-60.7.0.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha512 = "ecb09d7d8e6b5705d4c71d306a1556a74f78617520e59f041e3b63a0116f0472717c5f3bb055fda3c5c9fd72b198d997704292f64bc60349ec29efe057c46d52";
+      sha512 = "12db9c89338c80f063408167b2d91a8361236b220cdddec141d7dcf6518f8ef39105c32dada76f3a326d09e1dca7e4ea134827154546840cbfb8ac18e9bec351";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/he/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/he/thunderbird-60.7.0.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha512 = "7ced9d95c40376ee1334e5c5cb2bb9fd6e5cefcc26dc134fb5ef71bc20b6476b263ee742d3e0634517ca399c61c776bd7347b58c2c9bd0c395949756d1d0f5af";
+      sha512 = "be5eef2e90af44623554359960ae0f9da3c54484643ab8ceaa72c0b000c7cb17693be8e865a6964ad3b356906c1872fc2315a601531faf16ebd7c356ac3f8110";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/hr/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/hr/thunderbird-60.7.0.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha512 = "c9cb6cd5b3d7f1091f55b74af73825d2d0e8b763ffc102a1d49e58b2ac9e6fe2fdd81c1bcf7effd53d86c1ba8f662e3ae0b413ef80bafcb6e2ae64d34c7f3311";
+      sha512 = "48f8d55811632b650a1be62125ba3b56b144e422c0b410a2ad5ee4ff1a779c0a6c8d6f8d6c754bfa907a9c7aa22f0a5484cbc624247db89ef7ffe624d9a939cc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/hsb/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/hsb/thunderbird-60.7.0.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha512 = "e4f8092eb72e8311459a9232dc55342c2ff61b232d0b3a1be04acde78d7c06f14108f68378de200cadbe58125cddf46fddd421f76ac0d046e1a796fc5277278e";
+      sha512 = "bd38e36a1de618e692298ebd0d8593bddd2f80d36420af091a44974187042d47eb5cb8d1ea908855e5ce832b305e156470f0ad13ab6cf60acb066a4e3fa209d5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/hu/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/hu/thunderbird-60.7.0.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha512 = "ba1ca73de9b3b0137e38c10bbf29cd28310a7e2e58804de75247da098401f4b609d414e55a25b9646c16dae353db9d6fd193e437e42b7659d66f0ec9117e8629";
+      sha512 = "40e992503afd3c10fccda0b2892194e97df0f165b808d953293cc6c5d9c472af45dcf4aacf65eab9bcd052282d46bb1fd6d108f057c7ce8e5e22b902baa56d53";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/hy-AM/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/hy-AM/thunderbird-60.7.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha512 = "d5fbb20b9a75be427f1fb2a3c3674397b04793469dc3f493ec9bbf631e83a52573700540832cfe7faf71c16908ee0bc7bcd84b3cbd6e10fde950d477b27bc6dc";
+      sha512 = "18213aaf5bf8d761209c325305722bbbf8355c09856ce95d6b613c51cf824d6c53881355391ccca8cdf6f02e8f1e0c486219e1eb832124d313cc3115adea4927";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/id/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/id/thunderbird-60.7.0.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha512 = "35b1d1db2dc6c38b8d2fce2652857d9251e287acad125ab19c5e20487ac5ee6d4ad01d8f6d6cfc1ed9618cb8a47666d9c64e725b2d1f11894741e8cf99a887f8";
+      sha512 = "31790666d7cbf9571d32f6d372a3026fc7295004c14282557bf809ac1601242caac511d20ee8bdd04d8d63f864c300179b6d1a79cb8cc3aabfefb8088c88768c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/is/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/is/thunderbird-60.7.0.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha512 = "548170e5b1c2d7c09d4792f012064e5bbb201236768ba92fa318821b83101a395f3a4cd06560db89c23561eda20078921902aaa9b7ecbb201c356149af3d55cc";
+      sha512 = "a790b49f9bc055ab302e369bf69f8353354d1ee1ae50a8666a1c6ebd48d500275cfeef16eadc0330710865dc3b5e4ec8577c973b80e581f03a2dd2f05f299663";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/it/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/it/thunderbird-60.7.0.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha512 = "026fc8d2b61eaff1f34ce7726923697ba5c7563b65fbb9bbd700e88998d198eee595348cc47135c5dc8589201fcf0d75141acd5d1e49980ccc5c544b545bb424";
+      sha512 = "1ba1218036387f697420000b80ed33276a0535e3914ad10d993ec0f2aa9efd312b13027a77816eba129c59303d2dbe80e48b523313d3f1dfced8dd20f23e3f95";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/ja/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/ja/thunderbird-60.7.0.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha512 = "deb6e23d8c3c700d7de3f433862040ae5db610012cfd4a8faaf239a6429662d625d8a40c583f22797e34afbeec7dd6888a1558155e0878f4a84ea71694cc97ef";
+      sha512 = "a627ec7cac46179cb77e9b234de657cc6817a05adb55632b52a5d316be0fbee6a7475bc06a06b691650088376de4da1e7c2754de0cea3c7d21d47a4298c1f6be";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/kab/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/kab/thunderbird-60.7.0.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha512 = "e6c1dba878c8bfcd4031123f0578512b0cfad675ddfd89859d5ea25b2c112195f788cb1d3e0deec12ca1f052c2c0bfdeda2527402cf0d51f54e781029a6e3b47";
+      sha512 = "51282592eefdfc6249d48409c4210ded53306474c238785cf1fed7e55681b165e99493c5d3e4c1261c4bdeb5071f4a7d6fc32f0f243c41c749e67859449e6f55";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/kk/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/kk/thunderbird-60.7.0.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha512 = "70dd97b4d5db05463deff785fbd9dbdb649c00ec79d8f1cf009ab54961efafc45f12da654367b0df58211a8fe57597cba7743b7557dc121bbf1d838aa692809a";
+      sha512 = "1ab662dc20156e6f1d90a73528e904b9361eea1d89f3b55ef67541c29f4620244b1e3dd61c795663f109452a98aebf436af4a8aa376b6a751f9a046d0e9d5ab2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/ko/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/ko/thunderbird-60.7.0.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha512 = "8faf4d44bb882107805c663462170e96593f10e7218fa3a1e244937ee3965901d712c89edf9cbc4fefba85c91662c1a7e2811cf1bc3390377cd8ea3f3c8e29e0";
+      sha512 = "b3135bf41e32d4a431bb385b5e473c94810a65c8703810352a32bc6ae2665427636cb70c4c0c29bd3c85d68a89af1d9c5edef290d35c8b4f0adcd196d4e97084";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/lt/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/lt/thunderbird-60.7.0.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha512 = "604b8283cce3cddd90ae65be0d32ce7051bbe360fb772e47be60fa3312330d38b46d240b9e61eed3134fadef90aca9ac930ae6512dfdc1343104edff928be54c";
+      sha512 = "acf6fe072deeb711480c571506ea96b96bbb2c0fdf85ed66bf03a800e1305682cb34daa2e44530c1c57ef59664e13c01584816453449486f595e38610956c15c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/ms/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/ms/thunderbird-60.7.0.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha512 = "b4af3085260ece6e30b482e9e8335a75298335b0b551a8219bbc04521d41d0088d483134df8801a529934320ab5d51b99b388177b9432b7fdcbd7391ac11b22d";
+      sha512 = "8a74dfba38c2228e00ba3503fa6a05a0b4e4aba68c034e0711bc8f68c00efdeec816e0de6e6aea325427f8b6f790eb2b157df795a0d67e800beacd6fa572fe38";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/nb-NO/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/nb-NO/thunderbird-60.7.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha512 = "75022e5524379f4683d6e85bfc057480dcc003d421ec256ade11ba9f4eb60b74c65a7131f07987cecd5a13d8e61dbf2c71446e4c2cbfd9efa65a1c86939e82aa";
+      sha512 = "49116d9ac9f9fe322b56a5908e1727c53ca5351f60ba9b7ec1f453580e0be85efa84cc467e901aa269fe266d39860b313173a36f08ac6c6420032b3fec11a823";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/nl/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/nl/thunderbird-60.7.0.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha512 = "301dfe0a9ce8743703c1f4968bb9bd7b9881a7b70ce1760c12e9a9b2ffe386e8c85406a2b3121981676e4ba2f9ae5a32782857a168965f1fd93530cb22dc3ddd";
+      sha512 = "091e81383130fab108de72f71794fbf9eeb08106367f64c5b0fd9ba48dd2363890c2dbfe2c0aec4d44feaad6b55cdaad8844c4291cb1d9d12f2ba0341c259ad9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/nn-NO/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/nn-NO/thunderbird-60.7.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha512 = "67704f6dc56fb2d396cd5154d32648464cbf331890dfbe30c6870f63d8f26d8f46322c2b2c40cec86fdbd7b93eeacae2551b0e699428749c89acb715bf8d00b2";
+      sha512 = "1384adc5a57fb5d4fb4fff055c94b81fa5430872f687ad339a76120604e4898cc9621ba21f366498f79323e8f3b7b0d1d2c44bcb35894019ee4797fe4b563976";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/pl/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/pl/thunderbird-60.7.0.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha512 = "6477cf8274f38d3922edf51e0a419936d2ac494906c06fcf78c99ae95847c2fd4530e03d1574f7ba4b5d1221e98a71bb1a7e3810a1ebcd72c4e412f0e85c3c31";
+      sha512 = "088e52c4fed03ccd663f6942c41203adf33e39272f3b6be5e4884e417586620f4eb732d861dfd6325ca63ee11c2e7412bf8eae1a7eec841237fd966f0422d377";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/pt-BR/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/pt-BR/thunderbird-60.7.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha512 = "775ccbd6e8adda7318a5ff9d364d6d8b3d8af39208a349f61123550a149c728f7d6248c27b3b4561c8445c1c7c53300579f073b47ba31a52b68a8570515e6329";
+      sha512 = "d0a45e4b826d19d25f703dbf37a718dadb1fd2ec61e25457e306e08ba1f066fdbc48d2032b395c62ebde82280db0e9c519157e8e4b12bc28bf5cf49087760f0a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/pt-PT/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/pt-PT/thunderbird-60.7.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha512 = "057a2b690dfd529be26ddc225f6f760190315721ef69ab0d9974788b7c00617704af82ec56cbb502a3854945b624896ceb800ba1a31080fe9984fe12af4d301f";
+      sha512 = "7a4f314d5dbd09ba3b7908d57dfb4719ec1a63ff5ff7edd0cb00e1f0bd96009c2870b0c18ca973210c57cce7d8fc76d4d8dc54b7235652e8f33f468dd58b5026";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/rm/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/rm/thunderbird-60.7.0.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha512 = "10c4edf026d5b924d5105201179f8f5f6ecf5917e99efb60c663325ef98e5ba63f965954c93e3962af454111656687abd2be65e0c552617f8fc7eb6ee3b339bf";
+      sha512 = "239c248c11b3f3a8c1d95ea9e3c973d965b2dfd8fd0790ee5aa85947db1295374e56b9cd1379e54e139fbac7b8c51e201b592d7b371ed72181011ae78f49b275";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/ro/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/ro/thunderbird-60.7.0.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha512 = "d6a4fe46346b6699d570e316c7e97b530100923771d4ab76878dbea959dcd1c34e694c3a968eb786d19be96e0b7757952d47a87bc52f99d078eefc9a2483dd7f";
+      sha512 = "5be62fbf84bd4e5f4eb24edd620269288aa09e0a65836c0dfdaee28d90a68375dab44d1e5c988704fc82efeab6d060e343b623b01de28e967b91390c54aedb91";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/ru/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/ru/thunderbird-60.7.0.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha512 = "14b79c2751306b7e66cc3049c0338c16042c60fd707275f25775692b09c28fbd30b46886fdb2c8205de342e29cc0519887f8f92efd369e92a0a94ab33a5cba3a";
+      sha512 = "da9da528081d70ac504f61ae7668150e1a33acd159bf2f984805b7e76fd3e556cc6982b2d9596c621c533817c2cdd5e5ef28b42f362137908df1af097ae54f88";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/si/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/si/thunderbird-60.7.0.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha512 = "a8781bfe6bf9ceac67bab6e2f2957d61bb5d27292a15ea24776bdd8dda4b7828a350ec8caaae40a894db85b9d9fe4d457172f8dcedd681fa58912eef74ade60a";
+      sha512 = "1ec7e7b376b8d1ad9d25b753f785c05fcfd8f46d50b8f9ef8a73600726ba056411d4e2cbca5cef3e8eb7fa9531be7828af30aecd10842ef0d46b7ffd09b6c95d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/sk/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/sk/thunderbird-60.7.0.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha512 = "b22ef7083b344f8dec27b09631468c1263cb436479cfffc82b95ec78fc05ef66ec9b133d612dd097f9c24096b9c4e538efde6a88150816268a3a5a2d81a8e1fb";
+      sha512 = "598a8eca2a14a9c76b098355bc735c641763762dde312e5a47e8448bf0ae5fe2c78061c727a7e097073fd0d05e121fa1f4fcecbafdf02adb5c9c18a92e5ada47";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/sl/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/sl/thunderbird-60.7.0.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha512 = "b3a295b4f1a27a75634bae5dbf033973849659bf9dc9fdecf33b90618aa919bf644e2211c789ceefa495cc72e6586ed1db1683658ca88f0fe4cb3ed7a909a208";
+      sha512 = "724cae2a2437e337ca5142916e6072e43a5f329100ae3e72c258cf7efabeafbcd10c8c6ae0fe1e507afdfda23492e5d8a4f54f373bfef9025e5663b8bae291ee";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/sq/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/sq/thunderbird-60.7.0.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha512 = "5f990f0f257d7b096f4310de22a0ea26f27b18e5f7566f3eed45bed66ff89e384f55b7932fd5ce65039077ff902631db3feffce69d2e6a8e13893586759d14b3";
+      sha512 = "317b776ea77f7232327e7bab54f27b2e47ada0f6ea7df42c42ef89ce2df0d9c3a24b752c08e46a8c246df5a44b7e34c7591e01bd63ec3cde7f537083dc1f8304";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/sr/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/sr/thunderbird-60.7.0.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha512 = "71623636dca3b89af58feeb1b998b9bf16c8f8c7ff7c8f273aafc0500ce4b5d4bfae3e997d8669e3075c6586b631df0a613ba062fc4d74cf281f686aa7b18109";
+      sha512 = "768f31cc6ef0adc40253f60c312cdd8033e1fe5515f007ac18db6e37da79d2ef70ff208786cc738e31ed1ca75d5745b9de845f22eeb4bd3b4c8f7f7aff074af5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/sv-SE/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/sv-SE/thunderbird-60.7.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha512 = "2e0f6115a0e1b538288594ff47b92b1eb688a26e5f67bb7b83b5c01fe781efe414fc8a9e2c289fd7312026fa1b9bc56588a0c0b25172c35d1e224269a779e40b";
+      sha512 = "93951ffef37d547bb13143863c417f3717a4a6d54498852bcbd729f20a422d5a05233161d6970bce20f6992dfa07032d779160659b21e9e858505649ee2b3b6b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/tr/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/tr/thunderbird-60.7.0.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha512 = "fa3aa0c732a4e2feda079d283f6d0f98eb721a88e98a7df70681acb50d525e48af273deb19e6d2e5f41d20fc5daddf0c89c3e6d9ced74ccc34bd75fc12ebf26b";
+      sha512 = "c4a5510ecd6a2c98ef335b2862ec8b5123fcc1c88e3be72788f5863219abd20a639d7843faa19331ecdda6dab0365f21abb927e8fcdaf42ee4f36aaa37577fe5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/uk/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/uk/thunderbird-60.7.0.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha512 = "535fff2ee782b9818f3953314b084f5d63af4457310e8236b5dbe0fb7d0db5ef3c1aa0efbb992ef32ad89cd1df3ad50acae26fc116eae474b6b6970cb1172772";
+      sha512 = "54854f5b2c237b0545e062bfce142d9ac5f0353f0e2ce066faadb77e40bf62b1468c537852d486fee610096886d1ffc815948037a8a7fe911133f15ab1e47a70";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/vi/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/vi/thunderbird-60.7.0.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha512 = "54bfad80adc5f4a97e5dbb098e4330a7248b650178e9a9f49b2252fe1a15afb7e247f9af29253f59c7ff43e8af67a96f1cf069f3919ecd53ce0ff953e6cb42de";
+      sha512 = "85203efbb6e8f19135e61a4f297e7556592783d8e254f63c12687b77224af75b5c4d9a0aedd1c50dfd178a0cae865d980d958a8ef6c01b6932322c60ea052a4e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/zh-CN/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/zh-CN/thunderbird-60.7.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha512 = "7452bdee386e1e85967d7b88c6f935cb89ba7dece1f39d3b20f24cdd04a99793d3a11c333b76d107fe88d8c4c3eb69947be11792af7f8657515c48eda655d237";
+      sha512 = "536759160596e2c893114a7f5dc094325b695fec33543d32feb5b92e244079e9c64a22635b84b5587a7bb34c613041664ad7303fc39b8d25a510bd248d38d124";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-x86_64/zh-TW/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-x86_64/zh-TW/thunderbird-60.7.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha512 = "0c1a7048f250bb0f3248ed92ad2e45d3bb01b308eaa6115cde9050253d960b6538467ea6c5754c6f5458035fe31bd2fc529ab423f6ca9da179dfb7f51ef1f612";
+      sha512 = "b63e819eae2b5aa71ac13fc875dce504effadd7e00bc46eb6b5c539c34d569d33da4895caa37a424b79d082a8b3693ba41908bd49d4914937c2d2a123a2feea2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/ar/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/ar/thunderbird-60.7.0.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha512 = "c04863a1693b2e0567eda646f6364b58cbf959c61045ba1948aebe9f30f63351888cca4a70de4a1655b48ee0407e0c665691c6ffcc2638c18b70046eb04cb02c";
+      sha512 = "57acb34987d0d098bf8dcb43d44460f2ebf29a88d4b5377cf889681a50a71195fa81c4920d7fd69c76295a7c41fadc94790e858de53182e5257260817318f49c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/ast/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/ast/thunderbird-60.7.0.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha512 = "ed4c86716aa7ca675577f577f62bf11f025ba96a061e0c89952a99ad5e3ba3e3edb01dd8d428cd0884fdc78127453dcfde0e81ecb4ba3e11e650022f6df07102";
+      sha512 = "f538b3fdff93c7d19962c76e5fb7dba635fb8d2b14b760e39b024e04d878d475cc9f5dd317931f69a92cf8e79e62b32f9d1230d7876b4a5647233111f256d522";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/be/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/be/thunderbird-60.7.0.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha512 = "fff19d979335f90004f35646edf2c4ca7f1243a013d79c246db6a0139f787573bd2db2636adf503366a94d44cf8b932d2141ff1df2faced750ac6c604116d6da";
+      sha512 = "a2e97e6393f9aa24e7d99d8f200019279bd7535982670cc7841411d9f8eedce1b0b7a17c272792097053d50974f8ea092019c1a2a86dfc781ad13f49166c35a9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/bg/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/bg/thunderbird-60.7.0.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha512 = "afcbb510382a811af5afadf306ce66915f472a3cac62ec2e2ab5930c795fd443600c02743be29db3bbbccf3c9d8507bf54ad0452bd580de4f9db52d5438aa596";
+      sha512 = "5936686f7e62aff1475e6ef7600112b83316befa54a9befb34edadc5a2a03e5a4dbf2fb92b3b86b2a4c56296fbad50ab60922006638ccbd705225f6737231ecb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/br/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/br/thunderbird-60.7.0.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha512 = "3ca375f94f1f5795b2676d1e8774fc17e3eb0824ceeef6b4598b99f35265806a017e0dfbf2b07f275eae92b68fa975b05cf2d66c6adfd1147399ee7be3df94eb";
+      sha512 = "58153a303b6a76da23621f9503acb1ae7afcbc8fe68b4dd7d02a8cfcb95e3e5f86e8b3f6f6dd2812ae9781831d6b311c111e0a129d22a7bf83b7e15ebb44cf88";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/ca/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/ca/thunderbird-60.7.0.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha512 = "75d31ded8c44d8429c58f8c6bc1b5104a4b62a3d0899ac81ba9deb277204290d7ae079e6baf4b243188db7e1050b4a0b9046dd26ca8fa546083fdfbbf724bd01";
+      sha512 = "fd3f289257574191c25e0ae5adc099f95c8c757dc881e8b85404d2df91069f09e6e8e1edbc7326824b55c8d7e10356e2e95f8d27fd741b0ce650cf32120d423b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/cs/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/cs/thunderbird-60.7.0.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha512 = "0ead8f9276a6dcfaf39c1d400c892f95d431cee960c94857cd3e95e6f148571ed946325e6518bcea5821aaeb0e8f8f5dbbdd3970aad9cda549dbfc07eb2392ff";
+      sha512 = "3d9f97fc839a33ead139e47aebd248dd947ee80c217c065c6714198f3438f5675611d27bfe26e52537bcf595a3e4dbabedd95ec3fac98cdd541da7af05cd82dc";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/cy/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/cy/thunderbird-60.7.0.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha512 = "fb9d58efc4b0a72a1bbe09624d38b83227c94a2584b4a852b95753d83481b64194e6d14578fe24210581feaf5b8ccf55c530cb3bae606ea6acd39a456a91dcc4";
+      sha512 = "08b3a7ca0b49cdcc347f04cab508cb037c603eb255074c3c32ee06caa9f15f64038aaea2f96837beb414bafbc8b41e699edf4811eb7ef823c481b37c275d46a1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/da/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/da/thunderbird-60.7.0.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha512 = "1bf483526e7e52626b6298c93c6586d1973cdd9c3aec660b31550b4658690e8454622276d2bac3b096acceb8e9b41fbf7db735ed8a2c185ee968e489a62ae329";
+      sha512 = "6b9c8d18358d771b039e4d2dba999c18d7b8ef70ed74cd4be50325d3506015ba9f3795e9b489f0e99169a02db8daf5a91481aab0c43412f4ad6db93e03fa0ca8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/de/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/de/thunderbird-60.7.0.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha512 = "1bdaf4b2a5ce2b1824250b4fd35695ce9c3be306b8c21d9002995e142f6a655166df15d3f68f80dc0f5963f31e87d01b00ee8c4463c6002df0eb536fc3eb2bfb";
+      sha512 = "55c741a9b849a2b7a8df800967c6ed17cdc805d7827137099fda1466c4677eb630fbeac9e28d1b92eee82521352f43bb77412f896e5d9ef21d9bf16e35a55898";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/dsb/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/dsb/thunderbird-60.7.0.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha512 = "0b6f71ec6d02f06dde3509fd1fb771a341b12a7a44681d05244aa7ea61726f8f8792ff12a72b0700196162047b23b7a9741a3522519935813b075d617c79490c";
+      sha512 = "bc96d4452f5b4aba09e30f65bd9298b267fc5b6982ea126d31bb3af22cd55bc9f29040b08d8580000f15b17f4fdc5b160f109145a458d5fdd8b7b6120ae6873f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/el/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/el/thunderbird-60.7.0.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha512 = "bec935b6e469400f7d88fee26dab49c8159dd8a74bd34827122d23276e6b5e837dbedb8281b0a2c1b87e90d2897e2dc15a475ac53bf911f15887280630ef82fa";
+      sha512 = "c448c0fd389e9fb6a7ac1771ba2481c69af6c5549044e958bac258ee71d3e0a80a1ad60fd80e33fd7d96ee0e5921338b067d7d87281f354950db2816f185477b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/en-GB/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/en-GB/thunderbird-60.7.0.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha512 = "4e28d8bbc384c98767825e16111d24a96ad2291f40b1eb7b295ab2b7103482a9aa11c00ae5e455ea7e5a7e5d077a4d7c45e6f8890c69e7c7c237909c332bad75";
+      sha512 = "29c181d15234088c4e823f9681f8205a910190a493779733e587f0ce5eb304dad367b72b635541d509f2f5ab1bf7cbcaaccdf70047f372ea9f15c33605078778";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/en-US/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/en-US/thunderbird-60.7.0.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha512 = "6b5619c5a03a4d585b030682fc41069c3ebe3c783578853c3c36c9055fe03c78c782f2621c12a454b4968e5416e01312639ef48047b407558dd6ad85fd81befd";
+      sha512 = "631d84e772069bfe192f7db3fde5113595201b56340b8284fbd3c26c58ce67e93c2e52bdbe95c8378fa1b99f6d26d4ba6d2cc5851321251dc84c5d375773824c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/es-AR/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/es-AR/thunderbird-60.7.0.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha512 = "9b6828c7c646f0483b758902d2cfd7897649acfc1622d1a338320d0f9a9f52b38dc8734ace3816fd4a116883ff7c9ffdfbae6b93e5070697a108a7df207de1d1";
+      sha512 = "b1af2b1a40167ba7a75f833b64f0d27f9be48ec91880884ef33f931fa439084f6ebd77eaeaff19140d50c4da256325fca17385de032a05ebf0b1d0716ac80ea4";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/es-ES/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/es-ES/thunderbird-60.7.0.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha512 = "e0a8d2e68602cb5a9c0bca574ff8ed797c0e71a2bd86519e7d7de1ca8fc54316bead8ccc35e7f8dbc26cb11ab76e59076c09e69edb8175947c7c0dfab5758e3f";
+      sha512 = "1f0452f271eb218d9370f627a7e1ca0b392e8979f26cc4396c159adde26a6f70779851e6d91787c5274a401402f1b924f72bb1add5b6d90c5442d32e86cf8c1e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/et/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/et/thunderbird-60.7.0.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha512 = "c597b215fb574f948ed3cd169f7fd814a9f23e5c797da8457d9c810097f71b26751b386280cbba2fbf0224d07665c2fa33c3cb19c0fc54bbb0146fa271b25442";
+      sha512 = "1dac4826026c051fa38a96287c5a5d5849679681994b584e08ce4143b229503d2912db520c6ddebd081e4d3a799fd692935436cb6816c1ff6a61bf40240d904b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/eu/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/eu/thunderbird-60.7.0.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha512 = "9c1dfdeb74e6882689c036995d20ea7d0cbe9f3b406ec15b7a71d1f890cd209d3e7b03f6ce35d778adfcad2dfcfeb20ad55b9888dd222ffdb429166c8ad3a905";
+      sha512 = "3417239cb9b16b49a97df31008c7768e9fdc3d6197cc84d8bf360e2ff64c7d81f11e52e530b65d54e3a1ef4a1253c6c53c9baec8ffc915a4ae4d33e9abfd6d7f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/fi/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/fi/thunderbird-60.7.0.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha512 = "fa24033927751c7b1cffbd3e165507d8cc0ef7ac7755f08afe102b9b9a339d0a31b8f738d1bb71bc0a8876f51a1411b4840b033a3716306e5e8a17eb4d7f0382";
+      sha512 = "3e31ccddca9537a2ddef98e4444a85eeb37227ef5da301d6aecc3abe714cd84aba33b926a7fdc8e5d6c3b72082d9457c0f2362aa5775d7cf354e2fc6600fcd2a";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/fr/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/fr/thunderbird-60.7.0.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha512 = "37daee1b1c0f1757a0098806d41bcd71c0dfd700bce2f7da58ec670c58d2b5fefcef2fde102bed7fa6daa62b59404716c26547de54a00eaed6201616c681b5ac";
+      sha512 = "813887a9db572f588b769c91061886547e813e8fb9761df26294d27af6eab75d1befc1950b890c3eb0a166b6e46d36bc55a2baecc96a4d33ae1a670c28cea0f3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/fy-NL/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/fy-NL/thunderbird-60.7.0.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha512 = "85b2a6fa843d5364eaaacbc3399ad4a05169a7c988640f3a120fabe994bca31b0c22019a8537d598a14d33dc75f2037cda5504cb7d72149fec1ff040e1f962bd";
+      sha512 = "ee9621ddc0eb0195fa5a4ca0b982eb9805fe470a098e81e0a0620169ef13081654200573943d429cb2a9ed8de61aa361e5fbc6ae35498bfee8de31192d8a9944";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/ga-IE/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/ga-IE/thunderbird-60.7.0.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha512 = "475b766786a50d461ec6896b72c4eef83231f903672d275513c632eb8f4e7e1dd24bc635c18c066fdada4616b99116b3757d59d2718bc8bf21bfa495abea9a5f";
+      sha512 = "2e017ce8473ed99b573546aee5ec901c29243a9b4412ea594ce94f244c41edbc614eb902859289ce61d9e25edf0eb534c9bef1c00f3dd67c9515ff24caf6eeaa";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/gd/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/gd/thunderbird-60.7.0.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha512 = "d5ee56fd14c4abbf9d3335cd75e284d6c00ed28db74ffd2a726a19dbed21a74e2d97e9dcb63d63bca31f3637380a29f3bdd1280c670e446850ba8d4e98971395";
+      sha512 = "e49cd177caa27b072b08f71e7127a67e96ccc5960c6900e6f43cf47c0e78000f7f03e543243ca316834dc7c887fa0dc5675fa5f304430b0a8435c3be4cb95e92";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/gl/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/gl/thunderbird-60.7.0.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha512 = "262b36a73483dc3a379d416862f6f5c6d685a366f25a2599ba527d28fe0a17da9f3d377c38559a0688cfc5e5927001d3db7db0693fdbae44ba5596ac92c1a72f";
+      sha512 = "23aa10200e5e96b969db0d1e5c82b3cd78504d2742ebb09fb5910f0d68aef08f09d278954c3612bc980bd820a290b28184de65b229c3edc228db8c6b77d335d1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/he/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/he/thunderbird-60.7.0.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha512 = "404838f4defcb0da984532ba32740c9919ebf57c9e68137e43b1e40263a4f553a573028bc96c9f056141e405b4528e060ead4e30dcdc365e87069393b0056a5f";
+      sha512 = "ff21a536979886895db1e18bde93baf13447f240cf1d64a6018941b22cfdc206b0afaf7e02fa76f778e44d1ab333351bfcfdee475d24f37ea270a5eb500b099b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/hr/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/hr/thunderbird-60.7.0.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha512 = "9793e03d4b01c90af721a0197e20ea61c30e09e602321e214674a85ba5366a4eb4a394d0a2347af2a3f8c7f40da2eff50bb25c935db7b59cf573b8e6033469e1";
+      sha512 = "9e9f91262e633b6bd51cd349450c2078bfcb49e10c1bb63bdd0ce71cb63ba7aa35481547030638f5e2ad810959217887a69ffd99453cae03e20763ed71e66263";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/hsb/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/hsb/thunderbird-60.7.0.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha512 = "bd5be5e781edef1d410ed85552d72449e94b13c28a9943cc64ea4bf8092ed477ad61a39eb956b3ed008168a62206a0684ae8b38f370ac88a3c67df78ed57720d";
+      sha512 = "3205a0d1d96cf0f6dd1cafc08e3ff4f9fe14ed2917dee0209e1088a8aeddd74c59bb413d1ac32650e9829890ccf5b860b3a71f9dd92d35be7b26f201bcadc1a5";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/hu/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/hu/thunderbird-60.7.0.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha512 = "a5f7e309efb45715dd67b4fb5ee1a88ac4c6ae54d5755c2476cff246d93abca6725116817173c72e701cfd570329f1d84f7732e3eaf3e7fd96e238512298c595";
+      sha512 = "03fb2b6cf147af43ef8621201c75e35767378d72b67d9e3460818ee38a78a35d62ac404685ed0a212da055632f6787402663e5c87f4cc2e827ad23fdd7c54793";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/hy-AM/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/hy-AM/thunderbird-60.7.0.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha512 = "145e562fdf0ea143d0c1e9f4581f2b2fc58bf085aa227e4486e780f7da54e7e0b1cce53cfe9dad1ac47aca50beee5e554f3494c7df2e2c240a3a9b350d5f46b8";
+      sha512 = "20d87f045b7969783c44c82701dbdcdf29fec9a2fa905ed0e00d824174c38425044983ac8b0507e5c8e5ce6c2489528ab0da880e06b85ae45f78be9a4a48c5d8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/id/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/id/thunderbird-60.7.0.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha512 = "6f865a97783fe0269547981367717de6577780b24eeab33e26a19fc716cd4733cca28b7fab8cb8156b6a04b09e09b75cfca8b43c07aa99088cfe98a96a716361";
+      sha512 = "24a68981c39b12c50a2b7454624d548196bdcc0979367169978e782a7f83121f8bb097dd117173a8d3a75cce79c5d40c607048547687240f0e8408525ee66101";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/is/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/is/thunderbird-60.7.0.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha512 = "756301497644e2656a383f0c76a7723b1ce9ab49f760e08cc6f0159c898634664dcf5f92952310c408ecf8818939a25b3b181fd50836d32d017dc4c45b67dc25";
+      sha512 = "4f7dba2a9a04ded46d8812983368631bf9528def3dc03dd06804394c20c6760ca268c8638ae1813558dfe48220ce680a2a6a177817ae81e5719f34d310830b30";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/it/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/it/thunderbird-60.7.0.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha512 = "4ebfd6d2dd79e238594286412516729b66fa26d99ed3d6a399428bca87f63bd3f329877f70702d1d43229755268b0e9c951c753ce110250e805cdcdf576e0eb1";
+      sha512 = "af3cf72dd486d6bdc585d06cc4f32438c7868f378e3ce2910da08c58f20f4e7d4c9012231f73cd95a2df22e1badfc23070b9cae5694889c562285c6587fafc91";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/ja/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/ja/thunderbird-60.7.0.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha512 = "0cbdd253afec94716c0a4ce4131e8260cf7e42d9a7df48210875524ca33d42fc7c011b3b9724b29054844b159896cf9a03fd817af4cfbae9b718777d4f4b278d";
+      sha512 = "20169d2f4887ba49d41f2fd608d4842ad076705910bf720009bd2408d386ebac7ede2c0d52392f49e9c0f4b7403806716ba7dd150ad142a1649005a6d51a5da8";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/kab/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/kab/thunderbird-60.7.0.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha512 = "cf363a3e2177d2ac629713674bd22da270887882f21dccefbd6ca30c71f535c5b69fe1c05554fbed95920d4ebc4acc1649a05be1594b1cad5f4b17a7652f3e74";
+      sha512 = "6be43761a03541cb8c8fc61513745abe9263e9cf2b47dff191742bb1fb6fc6001b7d60ce80e1af85daf6016810064ce532be11f82cfe8ef352ecd0722cc983b1";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/kk/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/kk/thunderbird-60.7.0.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha512 = "77555e556b3d04ebc07390633e4ba3a3fda8c7ca9c8e7a61f522633a20378c857522598a3ad1b3b55e03bff181df615186183947c7770a3afc3df6c18d58446c";
+      sha512 = "31386ac56cf93b3f9aaea18973b5629f8afc1ed44f7fce3ae09ea9dd11a344ba4ada59422f8501984325ddf7906d2f70d69cbd5c6ddc8a768797d22232524423";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/ko/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/ko/thunderbird-60.7.0.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha512 = "634c0ba3322494670df3c7d14b8866d55f185588d1fe6dde706da86a66481f98deefed6739561f3c0c73ca005e1581d541da773c5d3d7caddd5b49510d9f138e";
+      sha512 = "a241269e84ca52dbd00e073e8227f108028f2bef27f083d3d4c1fe76b4cb05231598bcb88726406b61168ca855ea995e13858fd7c193b8e346e8e6c7bd2b4fc3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/lt/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/lt/thunderbird-60.7.0.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha512 = "9646f54ebabca5e8503d44b099871bfb6345cd4a3fe04ab0211aa8f019800b48faae93eb5565428818c4cf25b8b1e536614f23e4fcac76791c06482aa9fd7396";
+      sha512 = "1f222a2ad3c583020957eab49ec2a6f3230880e8cf5b38be19b7e29b9eb593606f6b3a3a162d47c809ff3da1c7000f599e5ba0fd921340a442bd262f9c02cde3";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/ms/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/ms/thunderbird-60.7.0.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha512 = "ecec0bac0770bd3cad75881266aea00a9ae3c8506a64e000ffb118cc18cb28a3968b9ece10e11bbc4628612065345ab1f58df0df130a2e497809a244049c1774";
+      sha512 = "faa2fb605a446e79b3f0c75d5c695de56c5404aa3921bd6684c6e385cb97089c43f33db7611d824173d4df9bf98001a76495a68324d87d52e8b4de58eb701a5c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/nb-NO/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/nb-NO/thunderbird-60.7.0.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha512 = "271be3b2bf2424bb149e7f1a1c11564e9b9d849e043a95489a8215a3ce757d032cfce2ff5df1b666fec5cad00b7a540b437d6d0ef33ccec485a0b5b96f61e8bd";
+      sha512 = "e1b6d917391561dfac0b36f9a305135659dd96e52cfc9a1080beb3c671a00f37cccbb39de02e790a87f0efef86ec8a8c0b8351184d44c5cbff5c5ba9862ac03d";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/nl/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/nl/thunderbird-60.7.0.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha512 = "a80e354c855d51fc278fc46e83ad41de079f1aff1fb7d0329eba377c07ecf67621f9c11e2c51760b23aeea4547eacc7916f3092e61009b162283a8f4458b5573";
+      sha512 = "957caacf6a84c9d4454fe7b708c5b798c32296ccf2a1aaebcb02645065fb10a2f6f098a0f14661ccd4f9ae665e7ffe62fba40df7aa3d00e63606ff2d97a00c45";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/nn-NO/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/nn-NO/thunderbird-60.7.0.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha512 = "312414bf118a808ad663807dfab5f69bca61a8f20087cfeac78883a869cd43eb03d5c7dd511a32350c0f59b0e28de7bc1992ce3ba48d8e1b5fe3c2abc09441af";
+      sha512 = "5d0017b8485e7236ce23c64d1b8aa30d3c8f0d938bf6d98a4413b0abecf6bfb05c2a0975410432702f967e7261b028dbd89c4580d661f438c7c0f9a3181b7845";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/pl/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/pl/thunderbird-60.7.0.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha512 = "4abf25e59400c038e9719200459903e3e113302592bf65d024c1dd05852d51e2969f3f53a33dd55f9d131bcd1405571f713a6dc3165d8af1147616574f4aa5c4";
+      sha512 = "22231f71381381c358bfabbf62970b8ba69d6f72d0d3a13ac1bd04f870cea53cca9d937b28e8f456f5aee80b3967af5d13fea40177d8715008fb4ce84aa90f3f";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/pt-BR/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/pt-BR/thunderbird-60.7.0.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha512 = "ca38fec5178dfc2f841dea0d30490df8be3e4424a2d94bda1a3cf1cbb1908df90c29adafe3f844ec13f2bf87606fcf20066d3789b29440b55762a9c83ff5bfb9";
+      sha512 = "53110bc399a63da962617e11f209aad895fa5254be955d70ac70d3bd70676dee695e7ff485255edc2107928ed169118fc50c149966b475fcdd5868a453710db2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/pt-PT/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/pt-PT/thunderbird-60.7.0.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha512 = "f8c25a0d9d6a4ca582c7d3593c8a74c1931fdd4a85ca9ac2af0b37efb877ac0232e9188af5cb5985f1a865aabb252b58197cace1f6cff3ce4551b5f4678eea56";
+      sha512 = "05935c86b294444e296befb13803dec0b4b848e08324346dbd43a1c22e66cda226d0db5317a2c857cc799e6d9d0433c29594a529ba8a7ce3c371729bfdc7651e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/rm/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/rm/thunderbird-60.7.0.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha512 = "ab74f4fa6729d6f7c2f0fb1f99c457ccd65a81be9bb5d7519beef4ec1ddf58c9f51370e7e3fbf71f2a8781f2669b50d20e65e687794b7dfeccb7da99865bd614";
+      sha512 = "4567ae5e584f65946209d5ebfad07db68c11211737e446d96ecb3eed2ae55902600eaf1dab7d870b7ea00c38d87045ef45ebe3e78a416070b93206f0ce9a18cf";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/ro/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/ro/thunderbird-60.7.0.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha512 = "cb086a6ce3446ee8437c762040b03ee58a3cebd1a0cf473197e7da19d81704bd1ae7cda5d3329e17e76d1f7e682674a12bda3e964fa934fd271d80cfcb5da907";
+      sha512 = "fc323ca7ab5fb0d259a941ba4f1c49f998fbdacf9679185bc4f17665d092aede662d2ac7793a451b81ab24e968c8ea7a0ea391ee69b1d646831927fcc35af833";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/ru/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/ru/thunderbird-60.7.0.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha512 = "2334973a52a5e954b082be0bc9921a6034532edf558a2ffc2b1ffaad7d1d8777832cfe21e005290c65f4ed906816243dc3c1a35a5e078f005ebe84f3769cbad0";
+      sha512 = "0f656f500decb22f1e84f1f92d8e5faa4a702ec3858a759dcc303ed0caec50dcf3711da15803dd7c5cac2111653e49276f8935f99d7b75e385dbb0cf9512003c";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/si/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/si/thunderbird-60.7.0.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha512 = "aa7a52b410a507571551430d538fe4b84efbc57bad8eb89631c2c79f8bd23399a60e8ba8018e9b086d6562ef4e0e96b5f6b912952838ef38507a6eb41e776fe6";
+      sha512 = "768c011614527977ab446e0e9ac42f90f1bb91d2d1e3ee5e5e91a31e6085e12dbd37542080b964724e4c65a1cad25be7998137740f2bc6cd82cc2d1b9056fd75";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/sk/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/sk/thunderbird-60.7.0.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha512 = "4cef3b0059d27313ff35610fc273b7c02faaeb21996a5b62be6cefd0c4b76162fd8a54bae3e2f6527135bfc97ed8133cde34e51505d8abb25d90a03716427370";
+      sha512 = "d648a5a20a1c0e4d6f50368fb57000e99b7868b1c4bab8861b2bea73e8b0ec2b9912f41e16ee272d49a6ced36c1e61ba267ba41b136255e3c5aacc15952fa3a2";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/sl/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/sl/thunderbird-60.7.0.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha512 = "6e4e2771a18bf7af347fff15eb5b5c312b7373d2fa86474317154ed8ae48e996028cda78ad9ac5ad09839af9844039334a25349df2c45c30095606f684b849b4";
+      sha512 = "ab9923acfcbc5c327a6f7cadbacbf680f1db10a27bbae270824b7ff4673805b20ff76c3fc694acfdf1ac2e537bf4f08d9599b1bdb4a2824eb98d264ca8a9bfeb";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/sq/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/sq/thunderbird-60.7.0.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha512 = "eb1d190808ad33b2eecfd8979c3ae669f44c3426bc247781b11698818f1804ba1b28851b7c7f507b676c87d86d89b7f537d378a130997dc21cd8870e070dedcf";
+      sha512 = "fd6b788ea87a04185162d8bad64c5ac4d649e1c9a89b1eaf1e9cba704827a0d8e70e29cef4e18dd3f63307cde959561ff9cee880650cc9476b31f2f8c0ebe450";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/sr/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/sr/thunderbird-60.7.0.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha512 = "bd46e690c9969d65563075996581c9ff13576143425985764a1fef4d2d6d4bf55cecd1e52b3e7a237b187a9144c928578879737f16c4b59be29120b67b18526d";
+      sha512 = "1edaea6e10b22ad82eca06a5c6f69a9a4cc515c32cde425735e7da371046ecdb6fec3be63212fe7747cda54661874a41dc1f7579ca0ccf8991fc459e3f813b2e";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/sv-SE/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/sv-SE/thunderbird-60.7.0.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha512 = "19e859d0f94de0b4cd82fb35a63a32cc9dfe09c74429380c90f749748e17123f161398a465b53aa333c50863a256be99df4029f45d08f80a7695b45883c94799";
+      sha512 = "3d895759ce8005718d3348058e6b9146d2cbab42ea9bab63446c0f91177ab1d52a84199fe4c0ef4cb5da4994db7239d97b7befddcf5155cd4a53b5fd91b250ad";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/tr/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/tr/thunderbird-60.7.0.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha512 = "964a16f7836a1dcfda273db6c65ea22d516722e410ceb961ee8212540837911ba3b156d5c365a7c1a79c7d2239b0df03dc1176a266d09b075c1e5b870a833352";
+      sha512 = "36d5dd40de1824b97615353b002febcfcacceefd4af189313920292229511ef83049839fbe5fa18a3ae87b922c750da774f69f8cde79b77c57d4aabd14053229";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/uk/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/uk/thunderbird-60.7.0.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha512 = "aee1e5a933bcb5238263ebc6ea57e9d3fe851c19c5c017e1e15bbb9e5cf1e9f39edf75b1b908caa4da688e14e41e4318a7fca0c41d045355cdc91b9ef48ba957";
+      sha512 = "ddceab3f336e9f0edf36a057e1805f41eba3308fe7ad06a135a7cc1a27d59229d9481535eda33aeb2db23c5b074d6bb83e02233645570f8ef4afef697210fa02";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/vi/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/vi/thunderbird-60.7.0.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha512 = "dd667bf5db90586bb29c97c8dd3bd0d50c5f4c5f5cbebdfc908dda4a54e72575edcf5d5b8bed97b1b6aa7350ea79c767115137aa6500b263bd5ae80d61efdbc1";
+      sha512 = "b660eee5eabfd65602d110168c81b6ba99d45f1ffb02e8a037bde6d47513f90b88f160b4125fbd91d3057bd35e1e9b743a715385b796aa2873f4906e3e44321b";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/zh-CN/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/zh-CN/thunderbird-60.7.0.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha512 = "f791ad02b1a67ac2906602a3c90238e5e8062fedea5851a790196eb1da0e19174543a7dc00e53460d40a0c39089c109125875fbec458fd65a650ab7d438cafdf";
+      sha512 = "4d4e4d032623835297ca5e43bcd9a058794c3568f4918a6c984c39b8f0998a1f9b412fbb96047c1f5e9bc7bd69253f4636bea81fb6e61031c66ba4e5f229f5e9";
     }
-    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.6.0/linux-i686/zh-TW/thunderbird-60.6.0.tar.bz2";
+    { url = "http://archive.mozilla.org/pub/thunderbird/releases/60.7.0/linux-i686/zh-TW/thunderbird-60.7.0.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha512 = "83cec9f663cd4e02d921f2f96a7dab791cdb015756f63148833491a263abb297bed5ee64101b4ae86ea4a3ed09b75d668bcf36a12563885f3eb164655b3348bd";
+      sha512 = "0bdd9c9bd11544abb6230fc94bfa49e2f1ffccf8a5684a5326a7b38880870e847841e0c81dcc33b969fe4327c6a2d51ba3313306842cb8ecc084222444f2ac4b";
     }
     ];
 }

--- a/pkgs/applications/networking/mailreaders/thunderbird/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/default.nix
@@ -24,11 +24,11 @@ let
   gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
 in stdenv.mkDerivation rec {
   name = "thunderbird-${version}";
-  version = "60.6.0";
+  version = "60.7.0";
 
   src = fetchurl {
     url = "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
-    sha512 = "2s8h6z3rkylrclng1cpmj5dvsbhqymrdwvjy3g2s8rq66xca13wkyswdhgh8671d0dw9bmminikk53d2xqg7lqvvd1rdsminwscln4z";
+    sha512 = "0l773bl9kkrz905rm4ipsic5ykkrw2lmg3i9c5vxpc0j1qgmz3p3x5db1kbk2yy2i5hx9lkn5szhgjf71d7dgvf7935z67d5djqnhk0";
   };
 
   # from firefox, but without sound libraries


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

- Critical security fix
- Attachment pane of Write window no longer focussed when attaching files using a keyboard shortcut

https://www.thunderbird.net/en-US/thunderbird/60.7.0/releasenotes/
https://www.mozilla.org/en-US/security/advisories/mfsa2019-15/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Both `thunderbird-bin` and `thunderbird` are tested.

---
