### PR TITLE
nixos/bepasty: Kind of modernize the module

### DIFF
--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -240,7 +240,7 @@
       xtreemfs = 212;
       calibre-server = 213;
       heapster = 214;
-      bepasty = 215;
+      # bepasty = 215; # unused
       # pumpio = 216; # unused, removed 2018-02-24
       nm-openvpn = 217;
       mathics = 218;
@@ -548,7 +548,7 @@
       #kibana = 211;
       xtreemfs = 212;
       calibre-server = 213;
-      bepasty = 215;
+      # bepasty = 215; # unused
       # pumpio = 216; # unused, removed 2018-02-24
       nm-openvpn = 217;
       mathics = 218;

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -238,6 +238,11 @@ with lib;
     # binfmt
     (mkRenamedOptionModule [ "boot" "binfmtMiscRegistrations" ] [ "boot" "binfmt" "registrations" ])
 
+    # bepasty
+    (mkRemovedOptionModule [ "services" "bepasty" "enable" ] "bepasty will now be enabled when creating a server")
+    (mkRemovedOptionModule [ "services" "bepasty" "dataDir" ] "bepasty dataDir is now hardcoded to /var/lib/bepasty-$name and permissions are managed by systemd.")
+    (mkRemovedOptionModule [ "services" "bepasty" "workDir" ] "bepasty workDir is now hardcoded to /run/bepasty-$name and permissions are managed by systemd.")
+
   ] ++ (flip map [ "blackboxExporter" "collectdExporter" "fritzboxExporter"
                    "jsonExporter" "minioExporter" "nginxExporter" "nodeExporter"
                    "snmpExporter" "unifiExporter" "varnishExporter" ]

--- a/pkgs/tools/misc/bepasty/default.nix
+++ b/pkgs/tools/misc/bepasty/default.nix
@@ -1,4 +1,5 @@
 { python3Packages
+, fetchpatch
 , lib
 }:
 
@@ -10,6 +11,15 @@ with python3Packages;
 buildPythonPackage rec {
   pname = "bepasty";
   version = "0.5.0";
+
+  patches = [
+    # Fix for bytes under Python 3
+    # See https://github.com/bepasty/bepasty-server/issues/200
+    (fetchpatch {
+      url = "https://github.com/bepasty/bepasty-server/commit/4678896d71ae9e217e34e25600494ce5b740d922.patch";
+      sha256 = "031j17l07qg2k31x3dpjjasmampj54izndvd1xlfianbg4v67wcq";
+    })
+  ];
 
   propagatedBuildInputs = [
     flask


### PR DESCRIPTION
- Switch to Python 3 which fixes bepasty not being found (and requires a
patch to work which is already on bepasty master)
- Remove the enable option
- Hardcode directories and let systemd manage permissions
- Sandbox the service using systemd
- Switch to a dynamic user and run nothing as root (except for preStart)
- Allow users to set permissions without adding them to the store
(extraConfigFile)
- Make assertion more clear

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
