### PR TITLE
plata-theme: 0.7.6 -> 0.8.1

### DIFF
--- a/pkgs/data/themes/plata/default.nix
+++ b/pkgs/data/themes/plata/default.nix
@@ -1,9 +1,8 @@
-{ stdenv, fetchFromGitLab, autoreconfHook, pkgconfig, parallel
+{ stdenv, fetchFromGitLab, autoreconfHook, pkgconfig, parallel, zip
 , sassc, inkscape, libxml2, gnome2, gdk_pixbuf, librsvg, gtk-engine-murrine
 , cinnamonSupport ? true
 , gnomeFlashbackSupport ? true
 , gnomeShellSupport ? true
-, mateSupport ? true
 , openboxSupport ? true
 , xfceSupport ? true
 , gtkNextSupport ? false
@@ -17,14 +16,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "plata-theme-${version}";
-  version = "0.7.6";
+  pname = "plata-theme";
+  version = "0.8.1";
 
   src = fetchFromGitLab {
     owner = "tista500";
     repo = "plata-theme";
     rev = version;
-    sha256 = "1jllsl2h3zdvlp3k2dy3h4jyccrzzymwbqz43jhnm6mxxabxzijg";
+    sha256 = "0nq1c12ldaz9750dcb1vz0ff10s4171pjsd21sih1sz89z64q2hy";
   };
 
   preferLocalBuild = true;
@@ -37,7 +36,8 @@ stdenv.mkDerivation rec {
     inkscape
     libxml2
     gnome2.glib.dev
-  ];
+  ]
+  ++ (stdenv.lib.optional (telegramSupport != null) zip);
 
   buildInputs = [
     gdk_pixbuf
@@ -57,7 +57,6 @@ stdenv.mkDerivation rec {
       (enableFeature cinnamonSupport "cinnamon")
       (enableFeature gnomeFlashbackSupport "flashback")
       (enableFeature gnomeShellSupport "gnome")
-      (enableFeature mateSupport "mate")
       (enableFeature openboxSupport "openbox")
       (enableFeature xfceSupport "xfce")
       (enableFeature gtkNextSupport "gtk_next")


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

- Update to version [0.8.1](https://gitlab.com/tista500/plata-theme/releases)
- Use pname instead of of name
- Dropped Mate desktop support (since 0.7.0)
- Requires zip as build dependency for telegram (since 0.7.7)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).