### PR TITLE
insomnia: 6.3.2 -> 6.5.3

### DIFF
--- a/pkgs/development/web/insomnia/default.nix
+++ b/pkgs/development/web/insomnia/default.nix
@@ -18,11 +18,11 @@ let
   ];
 in stdenv.mkDerivation rec {
   name = "insomnia-${version}";
-  version = "6.3.2";
+  version = "6.5.3";
 
   src = fetchurl {
     url = "https://github.com/getinsomnia/insomnia/releases/download/v${version}/insomnia_${version}_amd64.deb";
-    sha256 = "15zf5nmsmz3ajb4xmhm3gynn36qp0ark0gah8qd0hqq76n9jmjnp";
+    sha256 = "0km7anw5xpcfr6j7pwqhv26pk7nxv1jywqlz0lpvgj6w85aafcm3";
   };
 
   nativeBuildInputs = [ 

--- a/pkgs/development/web/insomnia/default.nix
+++ b/pkgs/development/web/insomnia/default.nix
@@ -1,6 +1,7 @@
 { stdenv, makeWrapper, fetchurl, dpkg
 , alsaLib, atk, cairo, cups, dbus, expat, fontconfig, freetype
-, gdk_pixbuf, glib, gnome2, nspr, nss, gtk3, gtk2, at-spi2-atk 
+, gdk_pixbuf, glib, gnome2, nspr, nss, gtk3, gtk2, at-spi2-atk
+, gsettings-desktop-schemas, gobject-introspection, wrapGAppsHook
 , libX11, libXScrnSaver, libXcomposite, libXcursor, libXdamage, libXext
 , libXfixes, libXi, libXrandr, libXrender, libXtst, libxcb, nghttp2
 , libudev0-shim, glibc, curl, openssl, autoPatchelfHook
@@ -28,6 +29,7 @@ in stdenv.mkDerivation rec {
     autoPatchelfHook
     dpkg
     makeWrapper
+    gobject-introspection wrapGAppsHook
   ];
   
   buildInputs = [
@@ -46,6 +48,7 @@ in stdenv.mkDerivation rec {
     gnome2.pango
     gtk2
     gtk3
+    gsettings-desktop-schemas
     libX11
     libXScrnSaver
     libXcomposite


### PR DESCRIPTION
###### Motivation for this change
Insomnia is a bit outdated. Exported data format changed and old versions can not import data with confusing "No importers found for file" error.

Also I have fixed crash while opening GTK file chooser.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
