### PR TITLE
castxml: 20180403 -> 0.2.0

### DIFF
--- a/pkgs/development/python-modules/pybindgen/default.nix
+++ b/pkgs/development/python-modules/pybindgen/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchPypi, buildPythonPackage, setuptools_scm, pygccxml }:
+{ stdenv, fetchPypi, buildPythonPackage, isPy3k, setuptools_scm, pygccxml }:
 buildPythonPackage rec {
   pname = "PyBindGen";
   version = "0.19.0";
@@ -11,6 +11,7 @@ buildPythonPackage rec {
   buildInputs = [ setuptools_scm ];
 
   checkInputs = [ pygccxml ];
+  doCheck = (!isPy3k); # Fails to import module 'cxxfilt' from pygccxml on Py3k
 
   meta = with stdenv.lib; {
     homepage = https://github.com/gjcarneiro/pybindgen;
@@ -19,5 +20,3 @@ buildPythonPackage rec {
     maintainers = with maintainers; [ teto ];
   };
 }
-
-

--- a/pkgs/development/tools/castxml/default.nix
+++ b/pkgs/development/tools/castxml/default.nix
@@ -2,20 +2,22 @@
 , pythonPackages
 , cmake
 , llvmPackages
+, libffi, libxml2, zlib
 , withMan ? true
 }:
 stdenv.mkDerivation rec {
 
-  name    = "${pname}-${version}";
   pname   = "CastXML";
-  version = "20180403";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
-    owner  = "CastXML";
-    repo   = "CastXML";
-    rev    = "c2a44d06d9379718292b696f4e13a2725ff9d95e";
-    sha256 = "1hjh8ihjyp1m2jb5yypp5c45bpbz8k004f4p1cjw4gc7pxhjacdj";
+    owner  = pname;
+    repo   = pname;
+    rev    = "v${version}";
+    sha256 = "1qpgr5hyb692h7l5igmq53m6a6vi4d9qp8ks893cflfx9955h3ip";
   };
+
+  nativeBuildInputs = [ cmake ] ++ stdenv.lib.optionals withMan [ pythonPackages.sphinx ];
 
   cmakeFlags = [
     "-DCLANG_RESOURCE_DIR=${llvmPackages.clang-unwrapped}"
@@ -23,16 +25,16 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    cmake
     llvmPackages.clang-unwrapped
     llvmPackages.llvm
-  ] ++ stdenv.lib.optionals withMan [ pythonPackages.sphinx ];
+    libffi libxml2 zlib
+  ];
 
-  propagatedbuildInputs = [ llvmPackages.libclang ];
+  propagatedBuildInputs = [ llvmPackages.libclang ];
 
-  # 97% tests passed, 96 tests failed out of 2866
+  # 97% tests passed, 97 tests failed out of 2881
   # mostly because it checks command line and nix append -isystem and all
-  doCheck=false;
+  doCheck = false;
   checkPhase = ''
     # -E exclude 4 tests based on names
     # see https://github.com/CastXML/CastXML/issues/90
@@ -40,7 +42,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with stdenv.lib; {
-    homepage = https://www.kitware.com;
+    homepage = "https://github.com/CastXML/CastXML";
     license = licenses.asl20;
     description = "Abstract syntax tree XML output tool";
     platforms = platforms.unix;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fix its build on Hydra
v0.2.0 is the first tagged release from upstream
Published 2019-04-18

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
