### PR TITLE
ocamlPackages.{camlpdf,cpdf}: fix build

### DIFF
--- a/pkgs/development/ocaml-modules/camlpdf/default.nix
+++ b/pkgs/development/ocaml-modules/camlpdf/default.nix
@@ -21,6 +21,12 @@ stdenv.mkDerivation rec {
     EOF
   '';
 
+  makeFlags = with stdenv.lib;
+  optionals (versionAtLeast ocaml.version "4.06") [
+    "OCAMLBCFLAGS+=-unsafe-string"
+    "OCAMLNCFLAGS+=-unsafe-string"
+  ];
+
   createFindlibDestdir = true;
 
   meta = with stdenv.lib; {

--- a/pkgs/development/ocaml-modules/cpdf/default.nix
+++ b/pkgs/development/ocaml-modules/cpdf/default.nix
@@ -14,6 +14,12 @@ stdenv.mkDerivation {
   buildInputs = [ ocaml findlib ncurses ];
   propagatedBuildInputs = [ camlpdf ];
 
+  makeFlags = with stdenv.lib;
+  optionals (versionAtLeast ocaml.version "4.06") [
+    "OCAMLBCFLAGS+=-unsafe-string"
+    "OCAMLNCFLAGS+=-unsafe-string"
+  ];
+
   createFindlibDestdir = true;
 
   postInstall = ''


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Fix build of `ocamlPackages.{camlpdf,cpdf`}, which are currently broken.
See https://github.com/ocaml/opam-repository/pull/11844 for details.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
