### PR TITLE
txr: 209 -> 216

### DIFF
--- a/pkgs/tools/misc/txr/default.nix
+++ b/pkgs/tools/misc/txr/default.nix
@@ -37,5 +37,6 @@ stdenv.mkDerivation rec {
     license = licenses.bsd2;
     homepage = http://nongnu.org/txr;
     maintainers = with stdenv.lib.maintainers; [ dtzWill ];
+    platforms = platforms.linux; # Darwin fails although it should work AFAIK
   };
 }

--- a/pkgs/tools/misc/txr/default.nix
+++ b/pkgs/tools/misc/txr/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, bison, flex, libffi }:
 
 stdenv.mkDerivation rec {
-  name = "txr-${version}";
-  version = "209";
+  pname = "txr";
+  version = "216";
 
   src = fetchurl {
-    url = "http://www.kylheku.com/cgit/txr/snapshot/${name}.tar.bz2";
-    sha256 = "1g236bk5ygh3car4kki3w6n0pwny8q4awg8p86fh2khj52qz6mdl";
+    url = "http://www.kylheku.com/cgit/txr/snapshot/${pname}-${version}.tar.bz2";
+    sha256 = "07cxdpc9zsqd0c2668g00dqjpd6zc4mfdn74aarr6d2hpzdhh937";
   };
 
   nativeBuildInputs = [ bison flex ];

--- a/pkgs/tools/misc/txr/default.nix
+++ b/pkgs/tools/misc/txr/default.nix
@@ -20,7 +20,17 @@ stdenv.mkDerivation rec {
   # Remove failing test-- mentions 'usr/bin' so probably related :)
   preCheck = "rm -rf tests/017";
 
-  # TODO: install 'tl.vim', make avail when txr is installed or via plugin
+  postInstall = ''
+    d=$out/share/vim-plugins/txr
+    mkdir -p $d/{syntax,ftdetect}
+
+    cp {tl,txr}.vim $d/syntax/
+
+    cat > $d/ftdetect/txr.vim <<EOF
+      au BufRead,BufNewFile *.txr set filetype=txr | set lisp
+      au BufRead,BufNewFile *.tl,*.tlo set filetype=tl | set lisp
+    EOF
+  '';
 
   meta = with stdenv.lib; {
     description = "Programming language for convenient data munging";


### PR DESCRIPTION
###### Motivation for this change

Versions 210-215 crashed during tests,
but this one looks good! Enjoy!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---