### PR TITLE
alacritty: build on aarch64-linux

### DIFF
--- a/pkgs/applications/misc/alacritty/default.nix
+++ b/pkgs/applications/misc/alacritty/default.nix
@@ -119,6 +119,6 @@ in buildRustPackage rec {
     homepage = https://github.com/jwilm/alacritty;
     license = with licenses; [ asl20 ];
     maintainers = with maintainers; [ mic92 ];
-    platforms = [ "x86_64-linux" "x86_64-darwin" ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

AArch64 all the things :)

I want to use alacritty on an aarch64-linux platform. It works just fine.

###### Things done

- ☑️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ☑️ NixOS
   - 🔲 macOS
   - 🔲 other Linux distributions
- 🔲 Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- 🔲 Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- ☑️ Tested execution of all binary files (usually in `./result/bin/`)
- 🔲 Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ☑️ Assured whether relevant documentation is up to date
- ☑️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
