### PR TITLE
cocoapods: define updateScript

### DIFF
--- a/pkgs/development/mobile/cocoapods/default.nix
+++ b/pkgs/development/mobile/cocoapods/default.nix
@@ -9,6 +9,9 @@ bundlerApp rec {
   gemset = if beta then ./gemset-beta.nix else ./gemset.nix;
   exes = [ "pod" ];
 
+  # toString prevents the update script from being copied into the nix store
+  passthru.updateScript = toString ./update;
+
   meta = with lib; {
     description     = "CocoaPods manages dependencies for your Xcode projects.";
     homepage        = https://github.com/CocoaPods/CocoaPods;

--- a/pkgs/development/mobile/cocoapods/update
+++ b/pkgs/development/mobile/cocoapods/update
@@ -3,6 +3,8 @@
 
 set -e
 
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
 rm -f Gemfile.lock Gemfile-beta.lock
 bundler lock
 BUNDLE_GEMFILE=Gemfile-beta bundler lock --lockfile=Gemfile-beta.lock


### PR DESCRIPTION
###### Motivation for this change
This means `nix-shell maintainers/scripts/update.nix --argstr maintainer lilyball` will update `cocoapods`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
