### PR TITLE
Expose makeLinuxHeaders function from nixos/kernel-headers

### DIFF
--- a/pkgs/os-specific/linux/kernel-headers/default.nix
+++ b/pkgs/os-specific/linux/kernel-headers/default.nix
@@ -4,13 +4,10 @@
 }:
 
 let
-  common = { version, sha256, patches ? [] }: stdenvNoCC.mkDerivation {
-    name = "linux-headers-${version}";
+  makeLinuxHeaders = { src, version, patches ? [] }: stdenvNoCC.mkDerivation {
+    inherit src;
 
-    src = fetchurl {
-      url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
-      inherit sha256;
-    };
+    name = "linux-headers-${version}";
 
     ARCH = stdenvNoCC.hostPlatform.platform.kernelArch or stdenvNoCC.hostPlatform.kernelArch;
 
@@ -73,13 +70,18 @@ let
     };
   };
 in {
+  inherit makeLinuxHeaders;
 
-  linuxHeaders = common {
-    version = "4.19.16";
-    sha256 = "1pqvn6dsh0xhdpawz4ag27vkw1abvb6sn3869i4fbrz33ww8i86q";
-    patches = [
-       ./no-relocs.patch # for building x86 kernel headers on non-ELF platforms
-       ./no-dynamic-cc-version-check.patch # so we can use `stdenvNoCC`, see `makeFlags` above
-    ];
-  };
+  linuxHeaders = let version = "4.19.16"; in
+    makeLinuxHeaders {
+      inherit version;
+      src = fetchurl {
+        url = "mirror://kernel/linux/kernel/v4.x/linux-${version}.tar.xz";
+        sha256 = "1pqvn6dsh0xhdpawz4ag27vkw1abvb6sn3869i4fbrz33ww8i86q";
+      };
+      patches = [
+         ./no-relocs.patch # for building x86 kernel headers on non-ELF platforms
+         ./no-dynamic-cc-version-check.patch # so we can use `stdenvNoCC`, see `makeFlags` above
+      ];
+    };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

While it is easy to switch the kernel or make a custom kernel by applying `kernelPatches` it is not so easy to get the corresponding headers; the derivation for `linuxHeaders` uses a hard-coded version.

This PR exposes a function that takes care of that. It is just a minor refactor of the (not exported) function `common` already present in `kernel-headers/default.nix`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---