### PR TITLE
qbe: init at unstable-2019-05-15

### DIFF
--- a/pkgs/development/compilers/qbe/default.nix
+++ b/pkgs/development/compilers/qbe/default.nix
@@ -1,0 +1,22 @@
+{ stdenv, fetchgit }:
+
+stdenv.mkDerivation {
+  pname = "qbe";
+  version = "unstable-2019-05-15";
+
+  src = fetchgit {
+    url = "git://c9x.me/qbe.git";
+    rev = "acc3af47330fd6610cf0fbdb28e9fbd05160888f";
+    sha256 = "1c8ynqbakgz3hfdcyhwdmz7i1hnyd9m25f9y47sc21bvxwfrbzpi";
+  };
+
+  makeFlags = [ "PREFIX=$(out)" ];
+  meta = with stdenv.lib; {
+    homepage = "https://c9x.me/compile/";
+    description = "A small compiler backend written in C";
+    maintainers = with maintainers; [ fgaz ];
+    license = licenses.mit;
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7925,6 +7925,8 @@ in
 
   pony-stable = callPackage ../development/compilers/ponyc/pony-stable.nix { };
 
+  qbe = callPackage ../development/compilers/qbe { };
+
   rgbds = callPackage ../development/compilers/rgbds { };
 
   rtags = callPackage ../development/tools/rtags {


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
