### PR TITLE
linuxPackages.virtualboxGuestAdditions: don't install VBoxOGL for now

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
@@ -107,11 +107,17 @@ stdenv.mkDerivation {
     wrapProgram $out/bin/VBoxClient-all \
             --prefix PATH : "${which}/bin"
 
-    # Install OpenGL libraries
-    mkdir -p $out/lib
-    cp -v lib/VBoxOGL*.so $out/lib
-    mkdir -p $out/lib/dri
-    ln -s $out/lib/VBoxOGL.so $out/lib/dri/vboxvideo_dri.so
+    # Don't install VBoxOGL for now
+    # It seems to be broken upstream too, and fixing it is far down the priority list:
+    # https://www.virtualbox.org/pipermail/vbox-dev/2017-June/014561.html
+    # Additionally, 3d support seems to rely on VBoxOGL.so being symlinked from
+    # libGL.so (which we can't), and Oracle doesn't plan on supporting libglvnd
+    # either. (#18457)
+    ## Install OpenGL libraries
+    #mkdir -p $out/lib
+    #cp -v lib/VBoxOGL*.so $out/lib
+    #mkdir -p $out/lib/dri
+    #ln -s $out/lib/VBoxOGL.so $out/lib/dri/vboxvideo_dri.so
 
     # Install desktop file
     mkdir -p $out/share/autostart


### PR DESCRIPTION
It seems to be broken upstream too, and fixing it is far down the
priority list:
https://www.virtualbox.org/pipermail/vbox-dev/2017-June/014561.html
Additionally, 3d support seems to rely on VBoxOGL.so being symlinked
from libGL.so (which we can't), and Oracle doesn't plan on supporting
libglvnd either. (#18457)

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
