### PR TITLE
Backport terraform-0.12 and 0.11.14 to release-19.03

### DIFF
--- a/pkgs/applications/networking/cluster/terraform/default.nix
+++ b/pkgs/applications/networking/cluster/terraform/default.nix
@@ -97,8 +97,8 @@ in rec {
   terraform_0_11-full = terraform_0_11.full;
 
   terraform_0_12 = pluggable (generic {
-    version = "0.12.0-beta1";
-    sha256 = "0djakf2agbhpfqis4x0lf2i8s1ahvrdyfkcgr6lzp0nsks652rcm";
+    version = "0.12.0-rc1";
+    sha256 = "1ap1q5bixkzshnwy8xyfh768qwg3y4pcjzaiajzn2icjf4ay5nqm";
     patches = [ ./provider-path.patch ];
     passthru = { inherit plugins; };
   });

--- a/pkgs/applications/networking/cluster/terraform/default.nix
+++ b/pkgs/applications/networking/cluster/terraform/default.nix
@@ -97,8 +97,8 @@ in rec {
   terraform_0_11-full = terraform_0_11.full;
 
   terraform_0_12 = pluggable (generic {
-    version = "0.12.0-alpha4";
-    sha256 = "16cwqxxb19m91d7rx7awri1awz7d8cfnrv0rbql9rbg5qjyqxcp9";
+    version = "0.12.0-beta1";
+    sha256 = "0djakf2agbhpfqis4x0lf2i8s1ahvrdyfkcgr6lzp0nsks652rcm";
     patches = [ ./provider-path.patch ];
     passthru = { inherit plugins; };
   });

--- a/pkgs/applications/networking/cluster/terraform/default.nix
+++ b/pkgs/applications/networking/cluster/terraform/default.nix
@@ -97,8 +97,8 @@ in rec {
   terraform_0_11-full = terraform_0_11.full;
 
   terraform_0_12 = pluggable (generic {
-    version = "0.12.0-rc1";
-    sha256 = "1ap1q5bixkzshnwy8xyfh768qwg3y4pcjzaiajzn2icjf4ay5nqm";
+    version = "0.12.0";
+    sha256 = "1lycy789wzh1fcg7qcl540546bgw4b9kjlbh2j4hnm0bs9696b2a";
     patches = [ ./provider-path.patch ];
     passthru = { inherit plugins; };
   });

--- a/pkgs/applications/networking/cluster/terraform/default.nix
+++ b/pkgs/applications/networking/cluster/terraform/default.nix
@@ -88,8 +88,8 @@ let
   plugins = removeAttrs terraform-providers ["override" "overrideDerivation" "recurseForDerivations"];
 in rec {
   terraform_0_11 = pluggable (generic {
-    version = "0.11.13";
-    sha256 = "014d2ibmbp5yc1802ckdcpwqbm5v70xmjdyh5nadn02dfynaylna";
+    version = "0.11.14";
+    sha256 = "1bzz5wy13gh8j47mxxp6ij6yh20xmxd9n5lidaln3mf1bil19dmc";
     patches = [ ./provider-path.patch ];
     passthru = { inherit plugins; };
   });


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This backports https://github.com/NixOS/nixpkgs/pull/61939 to `release-19.03`.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
