### PR TITLE
qarte: 3.10.0+188 -> 4.6.0

### DIFF
--- a/pkgs/applications/video/qarte/default.nix
+++ b/pkgs/applications/video/qarte/default.nix
@@ -3,11 +3,11 @@
 let
   pythonEnv = python3.withPackages (ps: with ps; [ pyqt5 sip ]);
 in stdenv.mkDerivation {
-  name = "qarte-3.10.0+188";
+  name = "qarte-4.6.0";
   src = fetchbzr {
-    url = http://bazaar.launchpad.net/~vincent-vandevyvre/qarte/qarte-3;
-    rev = "188";
-    sha256 = "06xpkjgm5ci5gfkza9f44m8l4jj32gfmr65cqs4x0j2ihrc6b4r9";
+    url = http://bazaar.launchpad.net/~vincent-vandevyvre/qarte/qarte-4;
+    rev = "22";
+    sha256 = "0v4zpj8w67ydvnmanxbl8pwvn0cfv70c0mlw36a1r4n0rvgxffcn";
   };
 
   buildInputs = [ makeWrapper pythonEnv ];


### PR DESCRIPTION
###### Motivation for this change

The version that is currently packaged is unusable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
