### PR TITLE
wireguard: restart on failure\nAs a oneshot service, if the startup f…

### DIFF
--- a/nixos/modules/services/networking/wireguard.nix
+++ b/nixos/modules/services/networking/wireguard.nix
@@ -245,7 +245,9 @@ let
         path = with pkgs; [ kmod iproute wireguard-tools ];
 
         serviceConfig = {
-          Type = "oneshot";
+          Type = "simple";
+          Restart = "on-failure";
+          RestartSec = "5s";
           RemainAfterExit = true;
         };
 


### PR DESCRIPTION
###### Motivation for this change

As a oneshot service, if the startup failed it would never be attempted again. This is problematic when peer's addresses require DNS. DNS may not be reliably available at the time wireguard starts. Converting this to a simple service with Restart and RestartAfter directives allows the service to be reattempted, but at the cost of losing the oneshot semantics.

See issue: https://github.com/NixOS/nixpkgs/issues/30459

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
