### PR TITLE
RFC: introduce a patches file in <pkg>/nix-support/

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1158,6 +1158,10 @@ fixupPhase() {
         printWords ${!propagatedInputsSlice} > "${!outputDev}/nix-support/$propagatedInputsFile"
     done
 
+    if [ -n "${patches:-}" ];then
+        mkdir -p "${!outputDev}/nix-support"
+        printWords $patches > "${!outputDev}/nix-support/patches"
+    fi
 
     if [ -n "${setupHook:-}" ]; then
         mkdir -p "${!outputDev}/nix-support"


### PR DESCRIPTION
###### Motivation for this change
This is more of a request for comments than an actual PR, I would like to collect some feedback in order to find ways to scan for vulnerabilities in a live system without the need to have derivations available in the nix store.
Vulnix is a great tool in the Nixpkgs development context but when we want to use it for automating scans of live systems where derivations aren't necessarily available it becomes a bit tricky. An example of such systems is machines that are deployed with NixOps where the derivations are built in a deploy server or machines that rely on a binary cache to substitute paths.

The idea in this PR is to introduce a `patches` file that would be created under `/nix/store/<hash>-<pkg-name>/nix-support/`; in such a file we would dump the list of patches filenames. Afaik, Vulnix already relies on the assumption that CVE patches would have a filename that mentions the CVE id, from the README:
>vulnix will inspect derivations for patches which supposedly fix specific CVEs. When a patch filename contains one or more CVE identifiers, these will not reported anymore. Example Nix code:

>patches = [ ./CVE-2018-6951.patch ];

So we can follow the same approach for Nix store paths and teach Vulnix to look for the patches file under nix-support to auto-detect security fixes

cc: @ckauhaus 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
