### PR TITLE
rtl_433: enable soapysdr backend support

### DIFF
--- a/pkgs/applications/radio/rtl_433/default.nix
+++ b/pkgs/applications/radio/rtl_433/default.nix
@@ -1,4 +1,7 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, libusb1, rtl-sdr }:
+{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig
+, libusb1, rtl-sdr, soapysdr-with-plugins
+}:
+
 stdenv.mkDerivation rec {
 
   version = "18.12";
@@ -13,7 +16,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
 
-  buildInputs = [ libusb1 rtl-sdr ];
+  buildInputs = [ libusb1 rtl-sdr soapysdr-with-plugins ];
 
   meta = with stdenv.lib; {
     description = "Decode traffic from devices that broadcast on 433.9 MHz";


### PR DESCRIPTION
###### Motivation for this change
soapy support was added in 18.12. This allows to use more SDR devices.

###### Things done
Tested with a rtl-sdr via the soapy backend and a LimeSDR-mini
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
