### PR TITLE
kvirc: init at 5.0.0

### DIFF
--- a/pkgs/applications/networking/irc/kvirc/default.nix
+++ b/pkgs/applications/networking/irc/kvirc/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub
+, qtbase, qtmultimedia, qtsvg, qtx11extras
+, pkgconfig, cmake, gettext
+}:
+
+stdenv.mkDerivation rec {
+  pname = "kvirc";
+  version = "5.0.0";
+
+  src = fetchFromGitHub {
+    owner = "kvirc";
+    repo = "KVIrc";
+    rev = version;
+    sha256 = "1dq7v6djw0gz56rvghs4r5gfhzx4sfg60rnv6b9zprw0vlvcxbn4";
+  };
+
+  buildInputs = [
+    qtbase qtmultimedia qtsvg qtx11extras
+  ];
+
+  nativeBuildInputs = [
+    pkgconfig cmake gettext
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Advanced IRC Client";
+    homepage = "http://www.kvirc.net/";
+    license = licenses.gpl2;
+    maintainers = [ maintainers.suhr ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18660,6 +18660,8 @@ in
     python3Packages = python36Packages;
   };
 
+  kvirc = libsForQt5.callPackage ../applications/networking/irc/kvirc { };
+
   lame = callPackage ../development/libraries/lame { };
 
   larswm = callPackage ../applications/window-managers/larswm { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
