### PR TITLE
vnote: init at 2.5

### DIFF
--- a/pkgs/applications/office/vnote/default.nix
+++ b/pkgs/applications/office/vnote/default.nix
@@ -1,0 +1,63 @@
+{ stdenv, fetchFromGitHub, qt5, makeDesktopItem }:
+
+let
+  description = "A note-taking application that knows programmers and Markdown better";
+  desktopItem = makeDesktopItem {
+    name = "VNote";
+    exec = "vnote";
+    icon = "vnote";
+    comment = description;
+    desktopName = "VNote";
+    categories = "Office";
+  };
+in stdenv.mkDerivation rec {
+  version = "2.5";
+  name = "vnote-${version}";
+
+  src = fetchFromGitHub {
+    owner = "tamlok";
+    repo = "vnote";
+    fetchSubmodules = true;
+    rev = "8d780bd5898464139e252623ffaccd966e093ff1";
+    sha256 = "17nl4z1k24wfl18f6fxs2chsmxc2526ckn5pddi2ckirbiwqwm60";
+  };
+
+  configurePhase = ''
+    mkdir build
+    cd build
+    qmake ../VNote.pro
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ./src/VNote $out/bin/vnote
+
+    mkdir -p $out/share/applications
+    cp ${desktopItem}/share/applications/* $out/share/applications
+
+    mkdir -p $out/share/icons/hicolor/scalable/apps
+    cp ../src/resources/icons/vnote.svg $out/share/icons/hicolor/scalable/apps/vnote.svg
+    mkdir -p $out/share/icons/hicolor/16x16/apps
+    cp ../src/resources/icons/16x16/vnote.png $out/share/icons/hicolor/16x16/apps/vnote.png
+    mkdir -p $out/share/icons/hicolor/32x32/apps
+    cp ../src/resources/icons/32x32/vnote.png $out/share/icons/hicolor/32x32/apps/vnote.png
+    mkdir -p $out/share/icons/hicolor/48x48/apps
+    cp ../src/resources/icons/48x48/vnote.png $out/share/icons/hicolor/48x48/apps/vnote.png
+    mkdir -p $out/share/icons/hicolor/64x64/apps
+    cp ../src/resources/icons/64x64/vnote.png $out/share/icons/hicolor/64x64/apps/vnote.png
+    mkdir -p $out/share/icons/hicolor/128x128/apps
+    cp ../src/resources/icons/128x128/vnote.png $out/share/icons/hicolor/128x128/apps/vnote.png
+    mkdir -p $out/share/icons/hicolor/256x256/apps
+    cp ../src/resources/icons/256x256/vnote.png $out/share/icons/hicolor/256x256/apps/vnote.png
+  '';
+
+  buildInputs = [ qt5.full ];
+
+  meta = with stdenv.lib; {
+    inherit description;
+    homepage = https://tamlok.github.io/vnote;
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.kuznero ];
+  };
+}

--- a/pkgs/development/python-modules/flask-babelex/default.nix
+++ b/pkgs/development/python-modules/flask-babelex/default.nix
@@ -1,0 +1,42 @@
+{ stdenv
+, buildPythonPackage
+, python
+, fetchPypi
+, flask
+, Babel
+, jinja2
+, pytz
+, speaklater
+}:
+
+buildPythonPackage rec {
+  pname = "Flask-BabelEx";
+  version = "0.9.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1d2lnw2dwhv23x0w4fvsy26ppng9b7hb0dh129k031nfnpnwsyfg";
+  };
+
+  propagatedBuildInputs = [
+    flask
+    Babel
+    jinja2
+    pytz
+    speaklater
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Adds i18n/l10n support to Flask applications";
+    longDescription = ''
+      This is fork of official Flask-Babel extension with following features:
+
+      1. It is possible to use multiple language catalogs in one Flask application;
+      2. Localization domains: your extension can package localization file(s) and use them if necessary;
+      3. Does not reload localizations for each request.
+    '';
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ kuznero ];
+    homepage = https://github.com/mrjoes/flask-babelex;
+  };
+}

--- a/pkgs/development/python-modules/flask-gravatar/default.nix
+++ b/pkgs/development/python-modules/flask-gravatar/default.nix
@@ -1,0 +1,46 @@
+{ stdenv
+, buildPythonPackage
+, python
+, fetchPypi
+, flask
+, pytest
+, pytest-runner
+, pytestcov
+, pytestpep8
+, pydocstyle
+, isort
+, check-manifest
+}:
+
+buildPythonPackage rec {
+  pname = "Flask-Gravatar";
+  version = "0.5.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1qb2ylirjajdqsmldhwfdhf8i86k7vlh3y4gnqfqj4n6q8qmyrk0";
+  };
+
+  buildInputs = [
+    pytest
+    pytest-runner
+    pytestcov
+    pytestpep8
+    pydocstyle
+    isort
+    check-manifest
+  ];
+
+  doCheck = false;
+
+  propagatedBuildInputs = [
+    flask
+  ];
+
+  meta = with stdenv.lib; {
+    description = "This is small and simple integration gravatar into flask";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ kuznero ];
+    homepage = https://github.com/zzzsochi/Flask-Gravatar;
+  };
+}

--- a/pkgs/development/python-modules/flask-migrate/default.nix
+++ b/pkgs/development/python-modules/flask-migrate/default.nix
@@ -11,6 +11,8 @@ buildPythonPackage rec {
     sha256 = "1awlb4q1l9iv794qjjxxyhcv4i69j77kh7nsg17a6kb909mglml3";
   };
 
+  doCheck = false;
+
   checkInputs = optional isPy3k glibcLocales;
   propagatedBuildInputs = [ flask flask_sqlalchemy flask_script alembic ];
 

--- a/pkgs/development/python-modules/flask-mongoengine/default.nix
+++ b/pkgs/development/python-modules/flask-mongoengine/default.nix
@@ -1,0 +1,42 @@
+{ stdenv
+, buildPythonPackage
+, python
+, fetchPypi
+, flask
+, flask_wtf
+, rednose
+, six
+, mongoengine
+}:
+
+buildPythonPackage rec {
+  pname = "flask-mongoengine";
+  version = "0.9.5";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1hcg2kz88ih2350pmfdkqjpvf4nh09fqn3sckdzc7qjbzkm6lhhg";
+  };
+
+  buildInputs = [
+    flask
+    flask_wtf
+    rednose
+    six
+    mongoengine
+  ];
+
+  doCheck = false;
+
+  propagatedBuildInputs = [
+    flask
+    mongoengine
+  ];
+
+  meta = with stdenv.lib; {
+    description = "A Flask extension that provides integration with MongoEngine";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ kuznero ];
+    homepage = https://github.com/mongoengine/flask-mongoengine;
+  };
+}

--- a/pkgs/development/python-modules/flask-paranoid/default.nix
+++ b/pkgs/development/python-modules/flask-paranoid/default.nix
@@ -1,0 +1,38 @@
+{ stdenv
+, buildPythonPackage
+, python
+, fetchPypi
+, flask
+}:
+
+buildPythonPackage rec {
+  pname = "Flask-Paranoid";
+  version = "0.2.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0jf7f31pwiqd6dwhiyhwcix1c9d7l5aam93q2pqm80ifcibr5vm2";
+  };
+
+  propagatedBuildInputs = [
+    flask
+  ];
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "Simple user session protection";
+    longDescription = ''
+      When a client connects to an application, a "paranoid" token will be
+      generated according to the IP address and user agent. In all subsequent
+      requests, the token will be recalculated and checked against the one
+      computed for the first request. If the session cookie is stolen and the
+      attacker tries to use it from another location, the generated token will
+      be different, and in that case the extension will clear the session and
+      block the request.
+    '';
+    license = licenses.mit;
+    maintainers = with maintainers; [ kuznero ];
+    homepage = https://github.com/miguelgrinberg/flask-paranoid;
+  };
+}

--- a/pkgs/development/python-modules/flask-peewee/default.nix
+++ b/pkgs/development/python-modules/flask-peewee/default.nix
@@ -1,0 +1,35 @@
+{ stdenv
+, buildPythonPackage
+, python
+, fetchPypi
+, flask
+, wtf-peewee
+}:
+
+buildPythonPackage rec {
+  pname = "flask-peewee";
+  version = "3.0.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0z9v068367jd72mbr1m87xpdlsc9hwxq5shkrw9sjswpqhx4h29c";
+  };
+
+  buildInputs = [
+    wtf-peewee
+  ];
+
+  doCheck = false;
+
+  propagatedBuildInputs = [
+    flask
+    wtf-peewee
+  ];
+
+  meta = with stdenv.lib; {
+    description = "flask integration for peewee, including admin, authentication, rest api and more";
+    license = licenses.mit;
+    maintainers = with maintainers; [ kuznero ];
+    homepage = https://github.com/coleifer/flask-peewee;
+  };
+}

--- a/pkgs/development/python-modules/flask-security/default.nix
+++ b/pkgs/development/python-modules/flask-security/default.nix
@@ -1,0 +1,88 @@
+{ stdenv
+, buildPythonPackage
+, python
+, fetchPypi
+, flask
+, flask-babelex
+, flask_login
+, flask_mail
+, flask-mongoengine
+, flask-peewee
+, flask_principal
+, flask_sqlalchemy
+, flask_wtf
+, pydocstyle
+, pytest
+, pytest-runner
+, pytest-translations
+, pytest-flakes
+, pytestcov
+, pytestpep8
+, passlib
+, pony
+, mongoengine
+, mock
+, isort
+, check-manifest
+}:
+
+buildPythonPackage rec {
+  pname = "Flask-Security";
+  version = "3.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0ck4ybpppka56cqv0s26h1jjq6sqvwmqfm85ylq9zy28b9gsl7fn";
+  };
+
+  buildInputs = [
+    pydocstyle
+    pytest
+    pytest-runner
+    pytest-translations
+    pytest-flakes
+    pytestcov
+    pytestpep8
+    flask-babelex
+    flask_login
+    flask-mongoengine
+    flask_mail
+    flask-peewee
+    flask_principal
+    flask_sqlalchemy
+    flask_wtf
+    passlib
+    pony
+    mongoengine
+    mock
+    isort
+    check-manifest
+  ];
+
+  doCheck = false;
+
+  propagatedBuildInputs = [
+    flask
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Quick and simple security for Flask applications";
+    longDescription = ''
+      Flask-Security allows you to quickly add common security mechanisms to your Flask application. They include:
+
+      1.  Session based authentication
+      2.  Role management
+      3.  Password hashing
+      4.  Basic HTTP authentication
+      5.  Token based authentication
+      6.  Token based account activation (optional)
+      7.  Token based password recovery / resetting (optional)
+      8.  User registration (optional)
+      9.  Login tracking (optional)
+      10. JSON/Ajax Support
+    '';
+    license = licenses.mit;
+    maintainers = with maintainers; [ kuznero ];
+    homepage = https://github.com/mattupstate/flask-security;
+  };
+}

--- a/pkgs/development/python-modules/mongoengine/default.nix
+++ b/pkgs/development/python-modules/mongoengine/default.nix
@@ -24,6 +24,10 @@ buildPythonPackage rec {
     blinker
   ];
 
+  propagatedBuildInputs = [
+    pymongo
+  ];
+
   doCheck = false;
 
   meta = with stdenv.lib; {

--- a/pkgs/development/python-modules/mongoengine/default.nix
+++ b/pkgs/development/python-modules/mongoengine/default.nix
@@ -1,0 +1,38 @@
+{ stdenv
+, buildPythonPackage
+, python
+, fetchPypi
+, pymongo
+, six
+, pillow
+, blinker
+}:
+
+buildPythonPackage rec {
+  pname = "mongoengine";
+  version = "0.17.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0947qk3yiyzixyd7pm74kzfbqi17q23a0ny7sdyfc9ypqzd9894c";
+  };
+
+  buildInputs = [
+    pymongo
+    six
+    pillow
+    blinker
+  ];
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "MongoEngine is an ORM-like layer on top of PyMongo";
+    longDescription = ''
+      MongoEngine is a Python Object-Document Mapper for working with MongoDB.
+    '';
+    license = licenses.mit;
+    maintainers = with maintainers; [ kuznero ];
+    homepage = https://github.com/MongoEngine/mongoengine;
+  };
+}

--- a/pkgs/development/python-modules/pony/default.nix
+++ b/pkgs/development/python-modules/pony/default.nix
@@ -1,0 +1,31 @@
+{ stdenv
+, buildPythonPackage
+, python
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "pony";
+  version = "0.7.10";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "127yhqc3vjayl7070qvyvcsm08kj1sbq98n7pcmqr782296rvfsm";
+  };
+
+  # propagatedBuildInputs = [];
+
+  meta = with stdenv.lib; {
+    description = "Pony ORM is easy to use and powerful object-relational mapper";
+    longDescription = ''
+      Using Pony, developers can create and maintain database-oriented software
+      applications faster and with less effort. One of the most interesting
+      features of Pony is its ability to write queries to the database using
+      generator expressions. Pony then analyzes the abstract syntax tree of a
+      generator and translates it to its SQL equivalent.
+    '';
+    license = licenses.asl20;
+    maintainers = with maintainers; [ kuznero ];
+    homepage = https://github.com/ponyorm/pony;
+  };
+}

--- a/pkgs/development/python-modules/pytest-runner/default.nix
+++ b/pkgs/development/python-modules/pytest-runner/default.nix
@@ -1,0 +1,24 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, pytest
+, setuptools_scm
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-runner";
+  version = "4.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1x0d9n40lsiphblbs61rdc0d5r31f6vh0vcahqdv0mffakbnrb80";
+  };
+
+  buildInputs = [ pytest setuptools_scm ];
+
+  meta = with stdenv.lib; {
+    license = licenses.mit;
+    homepage = https://github.com/pytest-dev/pytest-runner;
+    description = "Setup scripts can use pytest-runner to add setup.py test support for pytest runner";
+  };
+}

--- a/pkgs/development/python-modules/pytest-translations/default.nix
+++ b/pkgs/development/python-modules/pytest-translations/default.nix
@@ -1,0 +1,31 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, pytest
+, pbr
+, pyenchant
+, polib
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-translations";
+  version = "2.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "025wh3rqlv82w7j5632wng6524np9w4a4vj803jcbk26hzlsanlg";
+  };
+
+  buildInputs = [
+    pytest
+    pbr
+    pyenchant
+    polib
+  ];
+
+  meta = with stdenv.lib; {
+    license = licenses.asl20;
+    homepage = https://github.com/Thermondo/pytest-translations;
+    description = "Tests translation files with pytest";
+  };
+}

--- a/pkgs/development/python-modules/sshtunnel/default.nix
+++ b/pkgs/development/python-modules/sshtunnel/default.nix
@@ -1,0 +1,29 @@
+{ stdenv
+, buildPythonPackage
+, python
+, fetchPypi
+, paramiko
+}:
+
+buildPythonPackage rec {
+  pname = "sshtunnel";
+  version = "0.1.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0xhdqj8ych976xi847k4m7llnvlnwbn9n0iik97adbyk3cdf96pj";
+  };
+
+  buildInputs = [
+    paramiko
+  ];
+
+  doCheck = false;
+
+  meta = with stdenv.lib; {
+    description = "SSH tunnels to remote server";
+    license = licenses.mit;
+    maintainers = with maintainers; [ kuznero ];
+    homepage = https://github.com/pahaz/sshtunnel;
+  };
+}

--- a/pkgs/development/python-modules/wtf-peewee/default.nix
+++ b/pkgs/development/python-modules/wtf-peewee/default.nix
@@ -1,0 +1,32 @@
+{ stdenv
+, buildPythonPackage
+, python
+, fetchPypi
+, flask
+, peewee
+, wtforms
+}:
+
+buildPythonPackage rec {
+  pname = "wtf-peewee";
+  version = "3.0.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "10qjhyhcfvvfwhsx4ldc58gyrp2zm1pigygw4wrxm5c5dh9mvl5c";
+  };
+
+  buildInputs = [ peewee wtforms ];
+
+  propagatedBuildInputs = [
+    peewee
+    wtforms
+  ];
+
+  meta = with stdenv.lib; {
+    description = "WTForms integration for peewee";
+    license = licenses.mit;
+    maintainers = with maintainers; [ kuznero ];
+    homepage = https://github.com/coleifer/wtf-peewee;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23704,6 +23704,8 @@ in
 
   ib-controller = callPackage ../applications/office/ib/controller { jdk=oraclejdk8; };
 
+  vnote = callPackage ../applications/office/vnote { };
+
   ssh-audit = callPackage ../tools/security/ssh-audit { };
 
   thermald = callPackage ../tools/system/thermald { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -804,6 +804,8 @@ in {
 
   pytest-pylint = callPackage ../development/python-modules/pytest-pylint { };
 
+  pytest-runner = callPackage ../development/python-modules/pytest-runner { };
+
   pytest-tornado = callPackage ../development/python-modules/pytest-tornado { };
 
   python-binance = callPackage ../development/python-modules/python-binance { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2663,6 +2663,8 @@ in {
 
   flask-babelex = callPackage ../development/python-modules/flask-babelex { };
 
+  flask-gravatar = callPackage ../development/python-modules/flask-gravatar { };
+
   flask-peewee = callPackage ../development/python-modules/flask-peewee { };
 
   flask-mongoengine = callPackage ../development/python-modules/flask-mongoengine { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2655,6 +2655,8 @@ in {
 
   flask-babel = callPackage ../development/python-modules/flask-babel { };
 
+  flask-babelex = callPackage ../development/python-modules/flask-babelex { };
+
   flask-bootstrap = callPackage ../development/python-modules/flask-bootstrap { };
 
   flask-caching = callPackage ../development/python-modules/flask-caching { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2717,6 +2717,8 @@ in {
 
   flask_wtf = callPackage ../development/python-modules/flask-wtf { };
 
+  wtf-peewee = callPackage ../development/python-modules/wtf-peewee { };
+
   wtforms = callPackage ../development/python-modules/wtforms { };
 
   graph-tool = callPackage ../development/python-modules/graph-tool/2.x.x.nix {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2663,6 +2663,8 @@ in {
 
   flask-peewee = callPackage ../development/python-modules/flask-peewee { };
 
+  flask-mongoengine = callPackage ../development/python-modules/flask-mongoengine { };
+
   pony = callPackage ../development/python-modules/pony { };
 
   mongoengine = callPackage ../development/python-modules/mongoengine { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2709,6 +2709,8 @@ in {
 
   flask-restplus = callPackage ../development/python-modules/flask-restplus { };
 
+  flask-security = callPackage ../development/python-modules/flask-security { };
+
   flask_script = callPackage ../development/python-modules/flask-script { };
 
   flask-silk = callPackage ../development/python-modules/flask-silk { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2687,6 +2687,8 @@ in {
 
   flask-paginate = callPackage ../development/python-modules/flask-paginate { };
 
+  flask-paranoid = callPackage ../development/python-modules/flask-paranoid { };
+
   flask_principal = callPackage ../development/python-modules/flask-principal { };
 
   flask-pymongo = callPackage ../development/python-modules/Flask-PyMongo { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2661,6 +2661,8 @@ in {
 
   flask-babelex = callPackage ../development/python-modules/flask-babelex { };
 
+  pony = callPackage ../development/python-modules/pony { };
+
   flask-bootstrap = callPackage ../development/python-modules/flask-bootstrap { };
 
   flask-caching = callPackage ../development/python-modules/flask-caching { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2663,6 +2663,8 @@ in {
 
   pony = callPackage ../development/python-modules/pony { };
 
+  mongoengine = callPackage ../development/python-modules/mongoengine { };
+
   flask-bootstrap = callPackage ../development/python-modules/flask-bootstrap { };
 
   flask-caching = callPackage ../development/python-modules/flask-caching { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1082,6 +1082,8 @@ in {
 
   asyncssh = callPackage ../development/python-modules/asyncssh { };
 
+  sshtunnel = callPackage ../development/python-modules/sshtunnel { };
+
   python-fontconfig = callPackage ../development/python-modules/python-fontconfig { };
 
   funcsigs = callPackage ../development/python-modules/funcsigs { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2661,6 +2661,8 @@ in {
 
   flask-babelex = callPackage ../development/python-modules/flask-babelex { };
 
+  flask-peewee = callPackage ../development/python-modules/flask-peewee { };
+
   pony = callPackage ../development/python-modules/pony { };
 
   mongoengine = callPackage ../development/python-modules/mongoengine { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -808,6 +808,8 @@ in {
 
   pytest-tornado = callPackage ../development/python-modules/pytest-tornado { };
 
+  pytest-translations = callPackage ../development/python-modules/pytest-translations { };
+
   python-binance = callPackage ../development/python-modules/python-binance { };
 
   python-dbusmock = callPackage ../development/python-modules/python-dbusmock { };


### PR DESCRIPTION
###### Motivation for this change

Introduce a note-taking application that knows programmers and Markdown better, [VNote](https://tamlok.github.io/vnote).

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
