### PR TITLE
vnote: init at 2.5

### DIFF
--- a/pkgs/applications/office/vnote/default.nix
+++ b/pkgs/applications/office/vnote/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, qmake, qtbase, qtwebengine, hicolor-icon-theme, makeDesktopItem }:
+
+let
+  description = "A note-taking application that knows programmers and Markdown better";
+  desktopItem = makeDesktopItem {
+    name = "VNote";
+    exec = "vnote";
+    icon = "vnote";
+    comment = description;
+    desktopName = "VNote";
+    categories = "Office";
+  };
+in stdenv.mkDerivation rec {
+  version = "2.5";
+  pname = "vnote";
+
+  src = fetchFromGitHub {
+    owner = "tamlok";
+    repo = "vnote";
+    fetchSubmodules = true;
+    rev = "v${version}";
+    sha256 = "17nl4z1k24wfl18f6fxs2chsmxc2526ckn5pddi2ckirbiwqwm60";
+  };
+
+  nativeBuildInputs = [ qmake ];
+  buildInputs = [ qtbase qtwebengine hicolor-icon-theme ];
+
+  meta = with stdenv.lib; {
+    inherit description;
+    homepage = "https://tamlok.github.io/vnote";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.kuznero ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23756,6 +23756,8 @@ in
 
   ib-controller = callPackage ../applications/office/ib/controller { jdk=oraclejdk8; };
 
+  vnote = libsForQt5.callPackage ../applications/office/vnote { };
+
   ssh-audit = callPackage ../tools/security/ssh-audit { };
 
   thermald = callPackage ../tools/system/thermald { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Introduce a note-taking application that knows programmers and Markdown better, [VNote](https://tamlok.github.io/vnote).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
