### PR TITLE
xcpc: move libdsk and lesstiff as optional

### DIFF
--- a/pkgs/misc/emulators/xcpc/default.nix
+++ b/pkgs/misc/emulators/xcpc/default.nix
@@ -1,20 +1,27 @@
-{ stdenv, fetchurl, libdsk, pkgconfig, glib, libXaw, libX11, libXext, lesstif }:
+{ stdenv, fetchurl, pkgconfig, glib, libXaw, libX11, libXext
+  , libDSKSupport ? true, libdsk
+  , motifSupport ? false, lesstif
+}:
 
+with stdenv.lib;
 stdenv.mkDerivation rec {
   version = "20070122";
-  name = "xcpc-${version}";
+  pname = "xcpc";
 
   src = fetchurl {
-    url = "mirror://sourceforge/xcpc/${name}.tar.gz";
+    url = "mirror://sourceforge/xcpc/${pname}-${version}.tar.gz";
     sha256 = "0hxsbhmyzyyrlidgg0q8izw55q0z40xrynw5a1c3frdnihj9jf7n";
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ glib libdsk libXaw libX11 libXext lesstif ];
 
-  meta = with stdenv.lib; {
+  buildInputs = [ glib libdsk libXaw libX11 libXext ]
+    ++ optional libDSKSupport libdsk
+    ++ optional motifSupport lesstif;
+
+  meta = {
     description = "A portable Amstrad CPC 464/664/6128 emulator written in C";
-    homepage = https://www.xcpc-emulator.net;
+    homepage = "https://www.xcpc-emulator.net";
     license = licenses.gpl2Plus;
     maintainers = [ maintainers.genesis ];
     platforms = platforms.linux;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

optional lesstif should make it works on ARM (tested with pkgsCross.raspberryPi.xcpc )

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
