### PR TITLE
hackertyper: update to 2.1

### DIFF
--- a/pkgs/tools/misc/hackertyper/default.nix
+++ b/pkgs/tools/misc/hackertyper/default.nix
@@ -2,25 +2,17 @@
 
 stdenv.mkDerivation rec {
   pname = "hackertyper";
-  version = "20190226";
+  version = "2.1";
 
   src = fetchFromGitHub {
     owner  = "Hurricane996";
     repo   = "Hackertyper";
-    rev    = "dc017270777f12086271bb5a1162d0f3613903c4";
-    sha256 = "0szkkkxspmfq1z2n4nldj2c9jn6jgiqik085rx1wkks0zgcdcgy1";
+    rev    = "8d08e3200c65817bd8c5bd0baa5032919315853b";
+    sha256 = "0shri0srihw9fk027k61qkxr9ikwkn28aaamrhps6lg0vpbqpx2w";
   };
-
 
   makeFlags = [ "PREFIX=$(out)" ];
   buildInputs = [ ncurses ];
-
-  preInstall = ''
-    mkdir -p $out/bin
-    mkdir -p $out/share/man/man1
-  '';
-
-
 
   doInstallCheck = true;
   installCheckPhase = ''


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
update were avalaible upstream

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
