### PR TITLE
postgresqlPackages.pg_auto_failover: init at 1.0.2

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pg_auto_failover.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_auto_failover.nix
@@ -1,0 +1,33 @@
+{ stdenv, fetchFromGitHub, postgresql, openssl }:
+
+if stdenv.lib.versionOlder postgresql.version "10"
+then throw "pg_auto_failover not supported for PostgreSQL ${postgresql.version}"
+else
+stdenv.mkDerivation rec {
+  pname = "pg_auto_failover";
+  version = "1.0.2";
+
+  src = fetchFromGitHub {
+    owner = "citusdata";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1296zk143y9fvmcg2hjbrjdjfhi5rrd0clh16vblkghcvxrzfyvy";
+  };
+
+  buildInputs = [ postgresql openssl ];
+
+  installPhase = ''
+    install -D -t $out/bin src/bin/pg_autoctl/pg_autoctl
+    install -D -t $out/lib src/monitor/pgautofailover.so
+    install -D -t $out/share/extension src/monitor/*.sql
+    install -D -t $out/share/extension src/monitor/pgautofailover.control
+  '';
+
+  meta = with stdenv.lib; {
+    description = "PostgreSQL extension and service for automated failover and high-availability";
+    homepage = "https://github.com/citusdata/pg_auto_failover";
+    maintainers = [ maintainers.marsam ];
+    platforms = postgresql.meta.platforms;
+    license = licenses.postgresql;
+  };
+}

--- a/pkgs/servers/sql/postgresql/packages.nix
+++ b/pkgs/servers/sql/postgresql/packages.nix
@@ -7,6 +7,8 @@ self: super: {
         };
     };
 
+    pg_auto_failover = super.callPackage ./ext/pg_auto_failover.nix { };
+
     pg_repack = super.callPackage ./ext/pg_repack.nix { };
 
     pg_similarity = super.callPackage ./ext/pg_similarity.nix { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add https://github.com/citusdata/pg_auto_failover

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
