### PR TITLE
aws-sam-cli: 0.14.2 -> 0.16.1

### DIFF
--- a/pkgs/development/python-modules/aws-lambda-builders/default.nix
+++ b/pkgs/development/python-modules/aws-lambda-builders/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage rec {
   pname = "aws-lambda-builders";
-  version = "0.2.1";
+  version = "0.3.0";
 
   # No tests available in PyPI tarball
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "aws-lambda-builders";
     rev = "v${version}";
-    sha256 = "1pbi6572q1nqs2wd7jx9d5vgf3rqdsqlaz4v8fqvl23wfb2c4vpd";
+    sha256 = "1c3r3iz29s68mlmdsxbl65x5zqx25b89d40rir6729ck4gll4dyd";
   };
 
   # Package is not compatible with Python 3.5

--- a/pkgs/development/python-modules/serverlessrepo/default.nix
+++ b/pkgs/development/python-modules/serverlessrepo/default.nix
@@ -1,12 +1,23 @@
 { lib
-, buildPythonPackage
-, fetchPypi
-, pytest
-, boto3
-, six
-, pyyaml
-, mock
+, python
 }:
+
+let
+  py = python.override {
+    packageOverrides = self: super: {
+      pyyaml = super.pyyaml.overridePythonAttrs (oldAttrs: rec {
+        version = "3.12";
+        src = oldAttrs.src.override {
+          inherit version;
+          sha256 = "592766c6303207a20efc445587778322d7f73b161bd994f227adaa341ba212ab";
+        };
+      });
+    };
+  };
+
+in
+
+with py.pkgs;
 
 buildPythonPackage rec {
   pname = "serverlessrepo";

--- a/pkgs/development/tools/aws-sam-cli/default.nix
+++ b/pkgs/development/tools/aws-sam-cli/default.nix
@@ -1,5 +1,6 @@
 { lib
 , python
+, fetchFromGitHub
 }:
 
 let
@@ -13,27 +14,11 @@ let
         };
       });
 
-      requests = super.requests.overridePythonAttrs (oldAttrs: rec {
-        version = "2.20.1";
+      aws-sam-translator = super.aws-sam-translator.overridePythonAttrs (oldAttrs: rec {
+        version = "1.10.0";
         src = oldAttrs.src.override {
           inherit version;
-          sha256 = "ea881206e59f41dbd0bd445437d792e43906703fff75ca8ff43ccdb11f33f263";
-        };
-      });
-
-      idna = super.idna.overridePythonAttrs (oldAttrs: rec {
-        version = "2.7";
-        src = oldAttrs.src.override {
-          inherit version;
-          sha256 = "684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16";
-        };
-      });
-
-      six = super.six.overridePythonAttrs (oldAttrs: rec {
-        version = "1.11";
-        src = oldAttrs.src.override {
-          inherit version;
-          sha256 = "70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9";
+          sha256 = "0e1fa094c6791b233f5e73f2f0803ec6e0622f2320ec5a969f0986855221b92b";
         };
       });
     };
@@ -45,11 +30,11 @@ with py.pkgs;
 
 buildPythonApplication rec {
   pname = "aws-sam-cli";
-  version = "0.14.2";
+  version = "0.16.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "b7f80838d57c1096a9a03ed703a91a8a5775a6ead33df8f31765ecf39b3a956f";
+    sha256 = "2dd68800723c76f52980141ba704e105d77469b6ba465781fbc9120e8121e76c";
   };
 
   # Tests are not included in the PyPI package
@@ -70,6 +55,11 @@ buildPythonApplication rec {
     serverlessrepo
     six
   ];
+
+  postPatch = ''
+    substituteInPlace requirements/base.txt --replace "requests==2.20.1" "requests==2.21.0"
+    substituteInPlace requirements/base.txt --replace "six~=1.11.0" "six~=1.12.0"
+  '';
 
   meta = with lib; {
     homepage = https://github.com/awslabs/aws-sam-cli;


### PR DESCRIPTION
###### Motivation for this change
To bring aws-sam-cli up-to-date and fix `pythonPackages.serverlessrepo`, which was made broken by pyyaml being updated to a newer version ni nixpkgs.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
