### PR TITLE
stdmanpages: Use correct fdl12Plus license

### DIFF
--- a/pkgs/data/documentation/std-man-pages/default.nix
+++ b/pkgs/data/documentation/std-man-pages/default.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchurl}:
+{ stdenv, lib, fetchurl }:
 
 stdenv.mkDerivation rec {
   name = "std-man-pages-4.4.0";
@@ -15,10 +15,10 @@ stdenv.mkDerivation rec {
     cp -R * $out/share/man
   '';
 
-  meta = {
-    description = "C++ STD manual pages";
-    homepage = https://gcc.gnu.org/;
-    license = "GPL/LGPL";
-    platforms = stdenv.lib.platforms.unix;
+  meta = with lib; {
+    description = "GCC C++ STD manual pages";
+    homepage = "https://gcc.gnu.org/";
+    license = with licenses; [ fdl12Plus ];
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
###### Motivation for this change
The source code is (L)GPL licensed but not the documentation.

See: https://gcc.gnu.org/onlinedocs/libstdc++/

###### Things done
- [x] Doesn't change build product
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
