### PR TITLE
vim_configurable: build against gtk{2,3}-x11 instead of gtk{2,3} to fix builds on darwin

### DIFF
--- a/pkgs/applications/editors/vim/configurable.nix
+++ b/pkgs/applications/editors/vim/configurable.nix
@@ -1,7 +1,7 @@
 # TODO tidy up eg The patchelf code is patching gvim even if you don't build it..
 # but I have gvim with python support now :) - Marc
 { source ? "default", callPackage, fetchurl, stdenv, ncurses, pkgconfig, gettext
-, writeText, config, glib, gtk2, gtk3, lua, python, perl, tcl, ruby
+, writeText, config, glib, gtk2-x11, gtk3-x11, lua, python, perl, tcl, ruby
 , libX11, libXext, libSM, libXpm, libXt, libXaw, libXau, libXmu
 , libICE
 , vimPlugins
@@ -130,8 +130,8 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [ ncurses libX11 libXext libSM libXpm libXt libXaw libXau
     libXmu glib libICE ]
-    ++ stdenv.lib.optional (guiSupport == "gtk2") gtk2
-    ++ stdenv.lib.optional (guiSupport == "gtk3") gtk3
+    ++ stdenv.lib.optional (guiSupport == "gtk2") gtk2-x11
+    ++ stdenv.lib.optional (guiSupport == "gtk3") gtk3-x11
     ++ stdenv.lib.optionals darwinSupport [ CoreServices CoreData Cocoa Foundation libobjc cf-private ]
     ++ stdenv.lib.optional luaSupport lua
     ++ stdenv.lib.optional pythonSupport python


### PR DESCRIPTION
###### Motivation for this change

`vim_configurable` fails to build on macOS. You can reproduce the failure by running `nix-build -A vim_configurable ~/.nix-defexpr/channels/nixpkgs/default.nix` when using the unstable channel.

This commit builds on the work by @smaret from https://github.com/NixOS/nixpkgs/pull/61912 and https://github.com/NixOS/nixpkgs/pull/61942 , by using `gtk{2,3}-x11` dependencies that override `cairo` to work on Darwin.

Related to https://github.com/NixOS/nixpkgs/issues/61891.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
