### PR TITLE
x265: 2.9 -> 3.0

### DIFF
--- a/pkgs/development/libraries/x265/default.nix
+++ b/pkgs/development/libraries/x265/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchurl, fetchpatch, cmake, yasm
+{ stdenv, fetchurl, fetchpatch, cmake, nasm, numactl
+, numaSupport ? stdenv.hostPlatform.isLinux && (stdenv.hostPlatform.isx86 || stdenv.hostPlatform.isAarch64)  # Enabled by default on NUMA platforms
 , debugSupport ? false # Run-time sanity checks (debugging)
 , highbitdepthSupport ? false # false=8bits per channel, true=10/12bits per channel
 , werrorSupport ? false # Warnings as errors
@@ -16,26 +17,20 @@ in
 
 stdenv.mkDerivation rec {
   name = "x265-${version}";
-  version = "2.9";
+  version = "3.0";
 
   src = fetchurl {
     urls = [
       "https://get.videolan.org/x265/x265_${version}.tar.gz"
       "ftp://ftp.videolan.org/pub/videolan/x265/x265_${version}.tar.gz"
     ];
-    sha256 = "090hp4216isis8q5gb7bwzia8rfyzni54z21jnwm97x3hiy6ibpb";
+    sha256 = "0qh65wdpasrspkm1y0dlfa123myax568yi0sas0lmg5b1hkgrff5";
   };
 
   enableParallelBuilding = true;
 
   patches = [
-    # Fix issue #442 (linking issue on non-x86 platforms)
-    # Applies on v2.9 only, this should be removed at next update
-    (fetchpatch {
-      url = "https://bitbucket.org/multicoreware/x265/commits/471726d3a0462739ff8e3518eb1a1e8a01de4e8d/raw";
-      sha256 = "0mj8lb8ng8lrhzjavap06vjhqf6j0r3sn76c6rhs3012f86lv928";
-    })
-    # Fix build on ARM (#406) 
+    # Fix build on ARM (#406)
     (fetchpatch {
       url = "https://bitbucket.org/multicoreware/x265/issues/attachments/406/multicoreware/x265/1527562952.26/406/X265-2.8-asm-primitives.patch";
       sha256 = "1vf8bpl37gbd9dcbassgkq9i0rp24qm3bl6hx9zv325174bn402v";
@@ -67,7 +62,7 @@ stdenv.mkDerivation rec {
     rm $out/lib/*.a
   '';
 
-  nativeBuildInputs = [ cmake yasm ];
+  nativeBuildInputs = [ cmake nasm ] ++ stdenv.lib.optional numaSupport numactl;
 
   meta = with stdenv.lib; {
     description = "Library for encoding h.265/HEVC video streams";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update to 3.0

Also, since version 2.6, x265 it's using `nasm` instead of `yasm`, see https://bitbucket.org/multicoreware/x265/src/feec4bdf98663ac4a2561b63e1ccec423c7d26a4/build/README.txt#lines-37
That means that the x265 version from nix, wasn't using any of the CPU optimizations

I also compiled with NUMA support by default. Not 100% sure, but it seems that NUMA systems will get a big performance win, while for non NUMA systems this change should be un-noticeable. For more info see:
https://bitbucket.org/multicoreware/x265/commits/62b8fe990df5e560834e9b567a913238d8dd398e
https://bitbucket.org/multicoreware/x265/issues/108/numa-pools

I compressed a short video (~1 minute) with the same options, and the performance change was huge, it went down from 22 to 8 minutes

###### Things done


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Note: Original PR was #61103