### PR TITLE
go-tools: 2017.2.2 -> 2019.1.1

### DIFF
--- a/pkgs/development/tools/go-tools/default.nix
+++ b/pkgs/development/tools/go-tools/default.nix
@@ -5,16 +5,16 @@
 
 buildGoPackage rec {
   name = "go-tools-${version}";
-  version = "2017.2.2";
+  version = "2019.1.1";
 
   goPackagePath = "honnef.co/go/tools";
-  excludedPackages = ''\(simple\|ssa\|ssa/ssautil\|lint\|staticcheck\|unused\)/testdata'';
+  excludedPackages = ''\(simple\|ssa\|ssa/ssautil\|lint\|staticcheck\|stylecheck\|unused\)/testdata'';
 
   src = fetchFromGitHub {
     owner = "dominikh";
     repo = "go-tools";
     rev = "${version}";
-    sha256 = "1khl6szjj0skkfqp234p9rf3icik7fw2pk2x0wbj3wa9q3f84hb7";
+    sha256 = "1zwh64x3i32p6f6808q609n63xda3bq888n43wl4alpx1b08spha";
   };
 
   goDeps = ./deps.nix;
@@ -23,7 +23,7 @@ buildGoPackage rec {
     description = "A collection of tools and libraries for working with Go code, including linters and static analysis.";
     homepage = https://staticcheck.io;
     license = licenses.mit;
-    maintainers = with maintainers; [ kalbasit ];
+    maintainers = with maintainers; [ rvolosatovs kalbasit ];
     platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/development/tools/go-tools/deps.nix
+++ b/pkgs/development/tools/go-tools/deps.nix
@@ -1,4 +1,13 @@
 [
+ {
+    goPackagePath = "github.com/BurntSushi/toml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/BurntSushi/toml";
+      rev = "3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005";
+      sha256 = "1fjdwwfzyzllgiwydknf1pwjvy49qxfsczqx5gz3y0izs7as99j6";
+    };
+  }
   {
     goPackagePath = "github.com/kisielk/gotool";
     fetch = {
@@ -13,8 +22,8 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/tools";
-      rev = "96e9e165b75e735822645eff82850b08c377be36";
-      sha256 = "1zj9ck5sg9b0pphxybmvxf64hhcap7v7j37fx3v5aknf18crjjdg";
+      rev = "2c0ae70061356820330c96810d9483beb9a6da8e";
+      sha256 = "1lsi2ssxajclj3bciz2a41v1vjv768ja3v6wnbyhxy8xphwkp4fk";
     };
   }
 ]


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Upstream update

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
