### PR TITLE
[r19.03] libheif: add patch for CVE-2019-11471

### DIFF
--- a/pkgs/development/libraries/libheif/1.3.2-CVE-2019-11471.patch
+++ b/pkgs/development/libraries/libheif/1.3.2-CVE-2019-11471.patch
@@ -1,0 +1,15 @@
+Adapted from upstream commit 995a4283d8ed2d0d2c1ceb1a577b993df2f0e014
+--- a/libheif/heif_context.cc
++++ b/libheif/heif_context.cc
+@@ -566,6 +566,11 @@
+           image->set_is_alpha_channel_of(refs[0]);
+ 
+           auto master_iter = m_all_images.find(refs[0]);
++          if (master_iter == m_all_images.end()) {
++            return Error(heif_error_Invalid_input,
++                         heif_suberror_Nonexisting_item_referenced,
++                         "Non-existing alpha image referenced");
++          }
+           master_iter->second->set_alpha_channel(image);
+         }
+

--- a/pkgs/development/libraries/libheif/default.nix
+++ b/pkgs/development/libraries/libheif/default.nix
@@ -11,6 +11,8 @@ stdenv.mkDerivation rec {
     sha256 = "0hk8mzig2kp5f94j4jwqxzjrm7ffk16ffvxl92rf0afsh6vgnz7w";
   };
 
+  patches = [ ./1.3.2-CVE-2019-11471.patch ];
+
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
   buildInputs = [ libde265 x265 libpng libjpeg ];
 


### PR DESCRIPTION
###### Motivation for this change
Backport of CVE-2019-11471 fix (see https://github.com/NixOS/nixpkgs/pull/61919) to 19.03. Required a bit of patch alteration.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
