### PR TITLE
zlib: enable check and parallel building

### DIFF
--- a/pkgs/development/libraries/zlib/default.nix
+++ b/pkgs/development/libraries/zlib/default.nix
@@ -63,6 +63,9 @@ stdenv.mkDerivation (rec {
     "LIBRARY_PATH=$(out)/lib"
   ];
 
+  enableParallelBuilding = true;
+  doCheck = true;
+
   makeFlags = [
     "PREFIX=${stdenv.cc.targetPrefix}"
   ] ++ stdenv.lib.optionals (stdenv.hostPlatform.libc == "msvcrt") [
@@ -80,6 +83,7 @@ stdenv.mkDerivation (rec {
     description = "Lossless data-compression library";
     license = licenses.zlib;
     platforms = platforms.all;
+    maintainers = [ ];
   };
 } // stdenv.lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform) {
   preConfigure = ''

--- a/pkgs/development/libraries/zlib/default.nix
+++ b/pkgs/development/libraries/zlib/default.nix
@@ -83,7 +83,6 @@ stdenv.mkDerivation (rec {
     description = "Lossless data-compression library";
     license = licenses.zlib;
     platforms = platforms.all;
-    maintainers = [ ];
   };
 } // stdenv.lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform) {
   preConfigure = ''


### PR DESCRIPTION
###### Motivation for this change
They have unit tests we can run, so we might as well run them; and they support `-j`, so we might as well pass it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
