### PR TITLE
libtool2: enable parallel builds

### DIFF
--- a/pkgs/development/tools/misc/libtool/libtool2.nix
+++ b/pkgs/development/tools/misc/libtool/libtool2.nix
@@ -2,10 +2,11 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "libtool-2.4.6";
+  pname = "libtool";
+  version = "2.4.6";
 
   src = fetchurl {
-    url = "mirror://gnu/libtool/${name}.tar.gz";
+    url = "mirror://gnu/libtool/${pname}-${version}.tar.gz";
     sha256 = "1qq61k6lp1fp75xs398yzi6wvbx232l7xbyn3p13cnh27mflvgg3";
   };
 
@@ -23,13 +24,14 @@ stdenv.mkDerivation rec {
   doCheck = false;
   doInstallCheck = false;
 
+  enableParallelBuilding = true;
+
   # Don't run the native `strip' when cross-compiling.  This breaks at least
   # with `.a' files for MinGW.
   dontStrip = stdenv.hostPlatform != stdenv.buildPlatform;
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "GNU Libtool, a generic library support script";
-
     longDescription = ''
       GNU libtool is a generic library support script.  Libtool hides
       the complexity of using shared libraries behind a consistent,
@@ -39,12 +41,9 @@ stdenv.mkDerivation rec {
       your Makefile, Makefile.in, or Makefile.am.  See the
       documentation for details.
     '';
-
     homepage = https://www.gnu.org/software/libtool/;
-
-    license = stdenv.lib.licenses.gpl2Plus;
-
+    license = licenses.gpl2Plus;
     maintainers = [ ];
-    platforms = stdenv.lib.platforms.unix;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
