### PR TITLE
boost: run build and install hooks

### DIFF
--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -97,9 +97,9 @@ let
 in
 
 stdenv.mkDerivation {
-  name = "boost-${version}";
+  pname = "boost";
 
-  inherit src;
+  inherit src version;
 
   patchFlags = "";
 
@@ -112,11 +112,10 @@ stdenv.mkDerivation {
   meta = {
     homepage = http://boost.org/;
     description = "Collection of C++ libraries";
-    license = stdenv.lib.licenses.boost;
-
+    license = licenses.boost;
     platforms = platforms.unix ++ platforms.windows;
-    badPlatforms = stdenv.lib.optional (versionOlder version "1.59") "aarch64-linux"
-                 ++ stdenv.lib.optional ((versionOlder version "1.57") || version == "1.58") "x86_64-darwin";
+    badPlatforms = optional (versionOlder version "1.59") "aarch64-linux"
+                 ++ optional ((versionOlder version "1.57") || version == "1.58") "x86_64-darwin";
     maintainers = with maintainers; [ peti ];
   };
 
@@ -158,16 +157,22 @@ stdenv.mkDerivation {
     ++ optional (toolset != null) "--with-toolset=${toolset}";
 
   buildPhase = ''
+    runHook preBuild
     ./b2 ${b2Args}
+    runHook postBuild
   '';
 
   installPhase = ''
+    runHook preInstall
+
     # boostbook is needed by some applications
     mkdir -p $dev/share/boostbook
     cp -a tools/boostbook/{xsl,dtd} $dev/share/boostbook/
 
     # Let boost install everything else
     ./b2 ${b2Args} install
+
+    runHook postInstall
   '';
 
   postFixup = ''


### PR DESCRIPTION
###### Motivation for this change
Users who want to patch boost may put a postInstall hook in an overlay, which
requires that that expression runs them on the buildPhase and installPhase.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
