### PR TITLE
w3m-nox: fix build

### DIFF
--- a/pkgs/applications/networking/browsers/w3m/no-x11.patch
+++ b/pkgs/applications/networking/browsers/w3m/no-x11.patch
@@ -1,14 +1,13 @@
 Forget about X11 in fb module.
 This breaks w3mimgdisplay under X11, but removes X11 dependency it in pure fb.
 diff --git a/w3mimg/fb/fb_imlib2.c b/w3mimg/fb/fb_imlib2.c
-index ea36637..d3d7bc3 100644
+index 1a5151c..d3d7bc3 100644
 --- a/w3mimg/fb/fb_imlib2.c
 +++ b/w3mimg/fb/fb_imlib2.c
-@@ -3,7 +3,7 @@
+@@ -3,6 +3,7 @@
                  fb_imlib2.c 0.3 Copyright (C) 2002, hito
   **************************************************************************/
  
--#include <X11/Xlib.h>
 +#define X_DISPLAY_MISSING
  #include <Imlib2.h>
  #include "fb.h"


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

In the latest version (0.5.3+git20190105), `<X11/xlib.h>` isn't directly
included in `fb_imlib2.c` anymore, however it's used by `<Imlib.h>`
which broke our patch which disables X11 here.

Hydra build failure: https://hydra.nixos.org/build/93730733
See also https://github.com/tats/w3m/commit/2266d1bd988daed273992e7b26fbeba030002b82

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
