### PR TITLE
treewide: update cargoSha256 hashes for cargo-vendor upgrade

### DIFF
--- a/pkgs/applications/altcoins/ethabi.nix
+++ b/pkgs/applications/altcoins/ethabi.nix
@@ -13,7 +13,7 @@ buildRustPackage rec {
     sha256 = "1gqd3vwsvv1wvi659qcdywgmh41swblpwmmxb033k8irw581dwq4";
   };
 
-  cargoSha256 = "0ckj5s5fr7xdqpnn4m9zwa1w71g6wwqqvax6f4xkijxdcx83n6c2";
+  cargoSha256 = "0zkdai31jf8f5syklaxq43ydjvp5xclr8pd6y1q6vkwjz6z49hzm";
 
   cargoBuildFlags = ["--features cli"];
 

--- a/pkgs/applications/altcoins/polkadot/default.nix
+++ b/pkgs/applications/altcoins/polkadot/default.nix
@@ -16,7 +16,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0v7g03rbml2afw0splmyjh9nqpjg0ldjw09hyc0jqd3qlhgxiiyj";
   }; 
 
-  cargoSha256 = "0wwkaxqj2v5zach5xcqfzf6prc0gxy2v47janglp44xbxbx9xk08";
+  cargoSha256 = "19xcxpbkrbygghz9qi52vzviksxg28m7ibvl359vlhqv1cjxmpsq";
 
   buildInputs = [ pkgconfig openssl openssl.dev ];
 

--- a/pkgs/applications/altcoins/zcash/librustzcash/default.nix
+++ b/pkgs/applications/altcoins/zcash/librustzcash/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "02l1f46frpvw1r6k1wfh77mrsnmsdvifqx0vnscxz4xgb9ia9d1c";
   };
 
-  cargoSha256 = "1b0kal53ggcr59hbrsdj8fifjycahrmzwq677n9h3fywv4r237m6";
+  cargoSha256 = "1xlq8vkzfyr5q8gxvzkwi8r1kxg4rg8l1ckdwfdxlkhnw0yscbra";
 
   installPhase = ''
     mkdir -p $out/lib

--- a/pkgs/applications/gis/whitebox-tools/default.nix
+++ b/pkgs/applications/gis/whitebox-tools/default.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = stdenv.lib.optional stdenv.isDarwin Security;
 
-  cargoSha256 = "1gbgirng21ak0kl3fiyr6lxwzrjd5v79gcrbzf941nb8y8rlvz7k";
+  cargoSha256 = "11m13h9b75xz8dfisfcykar53qsl1crrp3l75s73gkkkvczlfd24";
 
   meta = with stdenv.lib; {
     description = "An advanced geospatial data analysis platform";

--- a/pkgs/applications/misc/todiff/default.nix
+++ b/pkgs/applications/misc/todiff/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1y0v8nkaqb8kn61xwarpbyrq019gxx1f5f5p1hzw73nqxadc1rcm";
   };
 
-  cargoSha256 = "1r7l9zbw6kq8yb5cv6h0qgl2gp71bkn9xv7b2n49a5r7by98jjqr";
+  cargoSha256 = "0xn5p71qk0ahd2drklja16xwv7zw0797kkzpiv563kffzvd1p8id";
 
   checkPhase = "cargo test --features=integration_tests";
 

--- a/pkgs/applications/networking/cluster/click/default.nix
+++ b/pkgs/applications/networking/cluster/click/default.nix
@@ -13,7 +13,7 @@ buildRustPackage rec {
     sha256 = "0sbj41kypn637z1w115w2h5v6bxz3y6w5ikgpx3ihsh89lkc19d2";
   };
 
-  cargoSha256 = "05asqp5312a1g26pvf5hgqhc4kj3iw2hdvml2ycvga33sxb7zm7r";
+  cargoSha256 = "1179a17lfr3001vp1a2adbkhdm9677n56af2c0zvkr18jas6b2w7";
 
   patches = [ ./fix_cargo_lock_version.patch ];
 

--- a/pkgs/applications/networking/dyndns/cfdyndns/default.nix
+++ b/pkgs/applications/networking/dyndns/cfdyndns/default.nix
@@ -12,7 +12,7 @@ buildRustPackage rec {
     sha256 = "1mcdjykrgh0jq6k6y664lai8sbgzk6j7k0r944f43vg63d1jql5b";
   };
 
-  cargoSha256 = "0k9d6pxsb4gvkqs00g71c1nnz773iccg4vajgn33qdym6m6qsjwy";
+  cargoSha256 = "1d7jpffkw2m2v37bfdqsl9sqwsl19cgglpa00lwy4ih09kzbc2n9";
 
   buildInputs = [ makeWrapper openssl ];
 

--- a/pkgs/applications/networking/feedreaders/newsboat/default.nix
+++ b/pkgs/applications/networking/feedreaders/newsboat/default.nix
@@ -10,7 +10,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1dqdcp34jmphqf3d8ik0xdhg0s66nd5rky0y8y591nidq29wws6s";
   };
 
-  cargoSha256 = "05pf020jp20ffmvin6d1g8zbwf1zk03bm1cb99b7iqkk4r54g6dn";
+  cargoSha256 = "06r682vvr8m7gl443qx9ncmq8dpmdxcls68f29d0mmf7llddy5sa";
 
   postPatch = ''
     substituteInPlace Makefile --replace "|| true" ""

--- a/pkgs/applications/networking/instant-messengers/fractal/default.nix
+++ b/pkgs/applications/networking/instant-messengers/fractal/default.nix
@@ -31,7 +31,7 @@ rustPlatform.buildRustPackage rec {
   checkPhase = null;
   installPhase = null;
 
-  cargoSha256 = "0hlvdcdzkggc2adggmlxz0yxigwp3320wfav77gddlvfip1f90sw";
+  cargoSha256 = "1ax5dv200v8mfx0418bx8sbwpbp6zj469xg75hp78kqfiv83pn1g";
 
   meta = with stdenv.lib; {
     description = "Matrix group messaging app";

--- a/pkgs/applications/networking/p2p/synapse-bt/default.nix
+++ b/pkgs/applications/networking/p2p/synapse-bt/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1lsfvcsmbsg51v8c2hkpwkx0zg25sdjc3q7x72b5bwwnw9l0iglz";
   };
 
-  cargoSha256 = "1sc8c0w2dbvcdv16idw02y35x0jx5ff6ddzij09pmqjx55zgsjf7";
+  cargoSha256 = "0ay6k52x6lzyvmzmlzrjfyqmify9wz74hxsdh8mhrhlpcvll17h1";
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ openssl ] ++ stdenv.lib.optional stdenv.isDarwin Security;

--- a/pkgs/applications/science/logic/elan/default.nix
+++ b/pkgs/applications/science/logic/elan/default.nix
@@ -4,7 +4,7 @@ rustPlatform.buildRustPackage rec {
   name = "elan-${version}";
   version = "0.7.5";
 
-  cargoSha256 = "0vv7kr7rc3lvas7ngp5dp99ajjd5v8k5937ish7zqz1k4970q2f1";
+  cargoSha256 = "0lc320m3vw76d6pa5wp6c9jblac6lmyf9qqnxmsnkn4ixdhnghsd";
 
   src = fetchFromGitHub {
     owner = "kha";

--- a/pkgs/applications/science/misc/rink/default.nix
+++ b/pkgs/applications/science/misc/rink/default.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
   };
   cargoPatches = [ ./cargo-lock.patch ];
 
-  cargoSha256 = "0xmmxm7zwmq7w0pspx17glg4mjgh9l61w0h2k7n97x6p35i198d1";
+  cargoSha256 = "1ijfvfhgjgzlpi1hjhy435m7vq568grh84bmkdlj3m83jxjcz874";
 
   buildInputs = [ pkgconfig ];
   propagatedBuildInputs = [ openssl gmp ncurses ];

--- a/pkgs/applications/version-management/git-and-tools/git-absorb/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-absorb/default.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = stdenv.lib.optionals stdenv.isDarwin [ libiconv Security ];
 
-  cargoSha256 = "0fvxs09b9x38vp0psvlvbj09myxrhabp95pp3nz7nxsgr7fxflrr";
+  cargoSha256 = "0q40qcki49dw23n3brgdz5plvigmsf61jm0kfy48j89mijih8zy7";
 
   meta = with stdenv.lib; {
     inherit (src.meta) homepage;

--- a/pkgs/applications/version-management/git-and-tools/git-codeowners/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-codeowners/default.nix
@@ -10,7 +10,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0bzq4ridzb4l1zqrj1r0vlzkjpgfaqwky5jf49cwjhz4ybwrfpkq";
   };
 
-  cargoSha256 = "0rdmv9s86xba1zkl2j5rgix6k7pkkxqmpar03sak2fjrd7mh8iz0";
+  cargoSha256 = "1k5gxbjv4a8l5y9rm0n4vwzlwp4hk1rb59v0wvcirmj0p7hpw9x9";
 
   meta = with lib; {
     homepage = "https://github.com/softprops/git-codeowners";

--- a/pkgs/applications/version-management/git-and-tools/git-dit/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-dit/default.nix
@@ -26,7 +26,7 @@ buildRustPackage rec {
     sha256 = "1sx6sc2dj3l61gbiqz8vfyhw5w4xjdyfzn1ixz0y8ipm579yc7a2";
   };
 
-  cargoSha256 = "08zbvjwjdpv2sbj6mh73py82inhs18jvmh8m9k4l94fcz6ykgqwr";
+  cargoSha256 = "10852131aizfw9j1yl4gz180h4gd8y5ymx3wmf5v9cmqiqxy8bgy";
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/applications/version-management/git-and-tools/git-ignore/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-ignore/default.nix
@@ -13,7 +13,7 @@ buildRustPackage rec {
     sha256 = "0krz50pw9bkyzl78bvppk6skbpjp8ga7bd34jya4ha1xfmd8p89c";
   };
 
-  cargoSha256 = "0r6whz8vghhjyc5vrr0n172nghmi61zj96lk26qm0bgxqyzll1kj";
+  cargoSha256 = "1ccipxifnm38315qigaq28hlzam2wr8q2p2dbcq96kar6pq377vf";
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ openssl ]

--- a/pkgs/applications/version-management/sit/default.nix
+++ b/pkgs/applications/version-management/sit/default.nix
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage rec {
     export HOME=$(mktemp -d)
   '';
 
-  cargoSha256 = "023anmnprxbsvqww1b1bdyfhbhjh1ah2kc67cdihvdvi4lqdmbia";
+  cargoSha256 = "0kijx7s7zh6yisrsjz213h9x5jx43ixr44vy5rb3wwbn9dgsr528";
 
   meta = with stdenv.lib; {
     description = "Serverless Information Tracker";

--- a/pkgs/applications/virtualization/cntr/default.nix
+++ b/pkgs/applications/virtualization/cntr/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0lmbsnjia44h4rskqkv9yc7xb6f3qjgbg8kcr9zqnr7ivr5fjcxg";
   };
 
-  cargoSha256 = "0gainr5gfy0bbhr6078zvgx0kzp53slxjp37d3da091ikgzgfn51";
+  cargoSha256 = "0xkwza9fx61pvlsm0s3dxc9i09mqp6c9df8w63fyiq7174vjxryx";
 
   meta = with stdenv.lib; {
     description = "A container debugging tool based on FUSE";

--- a/pkgs/applications/virtualization/railcar/default.nix
+++ b/pkgs/applications/virtualization/railcar/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "09zn160qxd7760ii6rs5nhr00qmaz49x1plclscznxh9hinyjyh9";
   };
 
-  cargoSha256 = "16f3ys0zzha8l5jdklmrqivl8hmrb9qgqgzcm3jn06v45hls9lan";
+  cargoSha256 = "1k4y37x783fsd8li17k56vlx5ziwmrz167a0w5mcb9sgyd2kc19a";
 
   buildInputs = [ libseccomp ];
 

--- a/pkgs/applications/window-managers/dwm/dwm-status.nix
+++ b/pkgs/applications/window-managers/dwm/dwm-status.nix
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [ makeWrapper pkgconfig ];
   buildInputs = [ dbus gdk_pixbuf libnotify xorg.libX11 ];
 
-  cargoSha256 = "1khknf1bjs80cc2n4jnpilf8cc15crykhhyvvff6q4ay40353gr6";
+  cargoSha256 = "1r2wczfkdpvjc7iylwajkminraaz1ix6n724in0dvv5klfcdxlxb";
 
   postInstall = lib.optionalString (bins != [])  ''
     wrapProgram $out/bin/dwm-status --prefix "PATH" : "${stdenv.lib.makeBinPath bins}"

--- a/pkgs/applications/window-managers/i3/wmfocus.nix
+++ b/pkgs/applications/window-managers/i3/wmfocus.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0jx0h2zyghs3bp4sg8f3vk5rkyprz2dqfqs0v72vmkp3cvgzxbvs";
   };
 
-  cargoSha256 = "01ifrk6whvckys1kbj65cdwh976yn7dy9vpf4jybnlqripknab43";
+  cargoSha256 = "1xmc28ns59jcmnv17102s2084baxqdvi0ibbyqwb108385qnixzf";
 
   nativeBuildInputs = [ python3 pkgconfig ];
   buildInputs = [ cairo libxkbcommon xorg.xcbutilkeysyms ];

--- a/pkgs/applications/window-managers/wtftw/default.nix
+++ b/pkgs/applications/window-managers/wtftw/default.nix
@@ -9,7 +9,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1r74nhcwiy2rmifzjhdal3jcqz4jz48nfvhdyw4gasa6nxp3msdl";
   };
 
-  cargoSha256 = "0z92ml84b5652zgwzn08a8vvxksaa54jql66sfpdz1mvjwhgdmvn";
+  cargoSha256 = "18lb24k71sndklbwwhbv8jglj2d4y9mdk07l60wsvn5m2jbnpckk";
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ libXinerama libX11 ];

--- a/pkgs/development/interpreters/wasm-gc/default.nix
+++ b/pkgs/development/interpreters/wasm-gc/default.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoPatches = [ ./fix-build.patch ]; # Cargo.lock is not up-to-date
 
-  cargoSha256 = "1jvk9n324p3x3j6q6x0p5diig3b5c683k74cfflff25i7gsmmvc7";
+  cargoSha256 = "073dnn80sl4adh7vi6q9sx2vkmy27gxy7ysxz17iz12p7pfcagm2";
 
   meta = with stdenv.lib; {
     description = "gc-sections for wasm";

--- a/pkgs/development/misc/loc/default.nix
+++ b/pkgs/development/misc/loc/default.nix
@@ -13,7 +13,7 @@ buildRustPackage rec {
     sha256 = "0086asrx48qlmc484pjz5r5znli85q6qgpfbd81gjlzylj7f57gg";
   };
 
-  cargoSha256 = "0y2ww48vh667kkyg9pyjwcbh7fxi41bjnkhwp749crjqn2abimrk";
+  cargoSha256 = "06iqzpg5jz1xd2amajvlf7yaz9kr3q2ipbhx71whvv9mwplmxmbi";
 
   meta = with stdenv.lib; {
     homepage = https://github.com/cgag/loc;

--- a/pkgs/development/tools/analysis/panopticon/default.nix
+++ b/pkgs/development/tools/analysis/panopticon/default.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage rec {
      git
   ];
 
-  cargoSha256 = "02k21mh0jyc6vz52jx1qijsfk07pkdv1g2hqx7gyvmm4v10vbfna";
+  cargoSha256 = "1fsxd7yzb38h1d52yyz7kj1v0riycjydb1b1bn1zkhgwm5sm2kbs";
   doCheck = false;
 
   postInstall = ''

--- a/pkgs/development/tools/cargo-web/default.nix
+++ b/pkgs/development/tools/cargo-web/default.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1qbi3z4x39il07xlhfvq5ckzjqrf0yf6p8qidf24fp92gb940zxr";
   };
 
-  cargoSha256 = "16wzgyn3k0yn70y0ciliyx1sjgppmkv9b4bn9p4x0qi6l0ah7fdp";
+  cargoSha256 = "1ysp8y0s0ha5gffwkra2vd1qh5wmfy1678k9hsfals0ww2f79wii";
 
   nativeBuildInputs = [ openssl perl pkgconfig ];
   buildInputs = stdenv.lib.optionals stdenv.isDarwin [ CoreServices Security ];

--- a/pkgs/development/tools/clog-cli/default.nix
+++ b/pkgs/development/tools/clog-cli/default.nix
@@ -13,7 +13,7 @@ buildRustPackage rec {
     sha256 = "1wxglc4n1dar5qphhj5pab7ps34cjr7jy611fwn72lz0f6c7jp3z";
   };
 
-  cargoSha256 = "1pi8fh6vz6m5hr38wm0v0hxp1yxm1ma8yzish3b78zkv8f90kmv0";
+  cargoSha256 = "1i1aq7bwkx8sqrlpxq24ldh908j72lwi2r3sg9zaz5p8xq1xgq6p";
 
   meta = {
     description = "Generate changelogs from local git metadata";

--- a/pkgs/development/tools/documentation/mdsh/default.nix
+++ b/pkgs/development/tools/documentation/mdsh/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "17pd090wpnx7i8q9pp9rhps35ahm1xn4h6pm1cfsafm072qd7rff";
   };
 
-  cargoSha256 = "1hsnz4sj8kff9azcbw9pkr2ipxlymz4zcm4vhfwydfkdlvdncpxm";
+  cargoSha256 = "0a2d2qnb0wkxcs2l839p7jsr99ng2frahsfi2viy9fjynsjpvzlm";
 
   meta = with stdenv.lib; {
     description = "Markdown shell pre-processor";

--- a/pkgs/development/tools/geckodriver/default.nix
+++ b/pkgs/development/tools/geckodriver/default.nix
@@ -20,7 +20,7 @@ buildRustPackage rec {
 
   buildInputs = lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ];
 
-  cargoSha256 = "1a8idl6falz0n9irh1p8hv5w2pmiknzsfnxl70k1psnznrpk2y8n";
+  cargoSha256 = "1pwg35kgn5z2zrlj1dwcbbdmkgmnvfxpxv4klzsxxg4m9xr1pfy4";
 
   meta = with lib; {
     description = "Proxy for using W3C WebDriver-compatible clients to interact with Gecko-based browsers";

--- a/pkgs/development/tools/git-series/default.nix
+++ b/pkgs/development/tools/git-series/default.nix
@@ -13,7 +13,7 @@ buildRustPackage rec {
     sha256 = "07mgq5h6r1gf3jflbv2khcz32bdazw7z1s8xcsafdarnm13ps014";
   };
 
-  cargoSha256 = "06w864f73kijq24xzljfaf47d97aqyg4md3crzbq8hns157m3sv2";
+  cargoSha256 = "07b25pcndhwvpwa5khdh8y1fl44hdv6ff2pfj1mjc0wchbspqm6q";
 
   cargoDepsHook = ''
     (

--- a/pkgs/development/tools/misc/tokei/default.nix
+++ b/pkgs/development/tools/misc/tokei/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0gz8m5j9p7hwylyl7cdxbli9rpy1p6lsrbym4zk647819pg4k1jp";
   };
 
-  cargoSha256 = "1xai3jxvs8r3s3v5d5w40miw6nihnj9gzlzzdrwphmgrkywr88c4";
+  cargoSha256 = "19h0ybi9qq5shvr7zix0gb24a29lqkvyfc5xbgps8wqgfrhx4nqa";
 
   buildInputs = [ libiconv ];
 

--- a/pkgs/development/tools/pax-rs/default.nix
+++ b/pkgs/development/tools/pax-rs/default.nix
@@ -36,5 +36,5 @@ buildRustPackage rec {
       cp ${cargo-lock} $out/Cargo.lock
     '';
 
-  cargoSha256 = "0sdk090sp89vgwz5a71f481a5sk13kcqb29cx1dslfq59sp4j6y7";
+  cargoSha256 = "132a9vnlyp78zxiw5xrazadvx0scs7h2vbm5wz612dmh436mwnxg";
 }

--- a/pkgs/development/tools/rq/default.nix
+++ b/pkgs/development/tools/rq/default.nix
@@ -13,7 +13,7 @@ buildRustPackage rec {
     sha256 = "066f6sdy0vrp113wlg18q9p0clyrg9iqbj17ly0yn8dxr5iar002";
   };
 
-  cargoSha256 = "0c4awm1d87b396d3g3mp1md5p92i5a64a9jdawpr8mwjd0bly05m";
+  cargoSha256 = "1n92d82l9wqrpsbkqiir6zsgf12xp4xb6bxq2nywg4lmwrnyapbh";
 
   buildInputs = [ llvmPackages.clang-unwrapped v8 ];
 

--- a/pkgs/development/tools/rust/cargo-fuzz/default.nix
+++ b/pkgs/development/tools/rust/cargo-fuzz/default.nix
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage rec {
       cp ${cargo-lock} $out/Cargo.lock
     '';
 
-  cargoSha256 = "0ajm8qp8hi7kn7199ywv26cmjv13phxv72lz8kcq97hxg17x0dkk";
+  cargoSha256 = "19kldw2sx0jd89q5q9cwmdcaan148s45fxlb2m0vdxwb69crb7yp";
 
   meta = with stdenv.lib; {
     description = "Command line helpers for fuzzing";

--- a/pkgs/development/tools/rust/pyo3-pack/default.nix
+++ b/pkgs/development/tools/rust/pyo3-pack/default.nix
@@ -14,7 +14,7 @@ in rustPlatform.buildRustPackage rec {
     sha256 = "0577v8nqjbb7l7fqvac706bg9zrcp8fbh9ca1mkj44db12v02kgb";
   };
 
-  cargoSha256 = "1xrzz8c2pfb70i7ynv5lw0d89r284kvhkgjh8z8pgyk1j79ixv2v";
+  cargoSha256 = "1prwgkgvg11cbpx086irrafg59mfvnykadagcp3qgyry6d82blsv";
 
   nativeBuildInputs = [ pkgconfig ];
 

--- a/pkgs/development/tools/rust/racer/default.nix
+++ b/pkgs/development/tools/rust/racer/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0kgax74qa09axq7b175ph3psprgidwgsml83wm1qwdq16gpxiaif";
   };
 
-  cargoSha256 = "1j3fviimdxn6xa75z0l9wkgdnznp8q20jjs42mql6ql782dga5lk";
+  cargoSha256 = "119xfkglpfq26bz411rjj31i088vr0847p571cxph5v3dfxbgz4y";
 
   buildInputs = [ makeWrapper ];
 

--- a/pkgs/development/tools/rust/racerd/default.nix
+++ b/pkgs/development/tools/rust/racerd/default.nix
@@ -14,7 +14,7 @@ buildRustPackage rec {
 
   doCheck = false;
 
-  cargoSha256 = "00gxj98zdkbrc5cxd4w5hk7iwv9a1kwa535hhspx9xd02r4d8rzl";
+  cargoSha256 = "0rxr8l5fhryxqf141sb2j4bjxdikj2hd7bnhbicgm35c9f6cir4m";
 
   buildInputs = [ makeWrapper ];
 

--- a/pkgs/development/tools/rust/rainicorn/default.nix
+++ b/pkgs/development/tools/rust/rainicorn/default.nix
@@ -13,7 +13,7 @@ buildRustPackage rec {
     sha256 = "07vh4g120sx569wkzclq91blkkd7q7z582pl8vz0li1l9ij8md01";
   };
 
-  cargoSha256 = "14kd25mw6m20blqcr221cclcqxw0j229zxq8hsaay6q7jgv0c7a0";
+  cargoSha256 = "07zsj12g4ff0cdb9pwz302vxvajr8g6nl3bpz4vdyi84csfvmahz";
 
   meta = with stdenv.lib; {
     broken = true;

--- a/pkgs/development/tools/rust/svd2rust/default.nix
+++ b/pkgs/development/tools/rust/svd2rust/default.nix
@@ -14,7 +14,7 @@ buildRustPackage rec {
   };
   cargoPatches = [ ./cargo-lock.patch ];
 
-  cargoSha256 = "0wsiaa6q9hr9x1cbg6sc8ajg846jjci5qwhdga4d408fmqav72ih";
+  cargoSha256 = "03rfb8swxbcc9qm4mhxz5nm4b1gw7g7389wrdc91abxl4mw733ac";
 
   # doc tests fail due to missing dependency
   doCheck = false;

--- a/pkgs/games/ja2-stracciatella/default.nix
+++ b/pkgs/games/ja2-stracciatella/default.nix
@@ -22,7 +22,7 @@ let
     name = "libstracciatella-${version}";
     inherit version;
     src = libstracciatellaSrc;
-    cargoSha256 = "0gxp5ps1lzmrg19h6k31fgxjdnjl6amry2vmb612scxcwklxryhm";
+    cargoSha256 = "0a1pc8wyvgmna0a5cbpv3mh0h4nzjxlm887ymcq00cy1ciq5nmj4";
     doCheck = false;
   };
 in

--- a/pkgs/misc/tw-rs/default.nix
+++ b/pkgs/misc/tw-rs/default.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [ perl zlib openssl ]
     ++ stdenv.lib.optional stdenv.isDarwin curl;
 
-  cargoSha256 = "0c3324b7z77kiwc6whbppfmrli254fr1nyd0vpsxvpc0av3279jg";
+  cargoSha256 = "00v0b2vjal1dar4kwqk246k44mjyi1zp18hyj15dsww2972bm3b7";
 
   meta = with stdenv.lib; {
     description = "Twitter command-line interface written in rust";

--- a/pkgs/servers/webmetro/default.nix
+++ b/pkgs/servers/webmetro/default.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1n2c7ygs8qsd5zgii6fqqcwg427bsij082bg4ijnzkq5630dx651";
   };
 
-  cargoSha256 = "0drf331qic1gf58j7izwp0q2l4w0dyrhr19rd2y5k43cw4m1nq59";
+  cargoSha256 = "07c8rrm70idmpvijvgkbgw5vswcyrghlrzv1km054xds5qxi2ldq";
 
   meta = with stdenv.lib; {
     description = "Simple relay server for broadcasting a WebM stream";

--- a/pkgs/shells/ion/default.nix
+++ b/pkgs/shells/ion/default.nix
@@ -13,7 +13,7 @@ buildRustPackage rec {
     sha256 = "0i0acl5nw254mw8dbfmb4792rr71is98a5wg32yylfnlrk7zlf8z";
   };
 
-  cargoSha256 = "0ffp6r5jqyf9j8jd77vbvc6l3xm09ipbraj6av6iciw1sxskib33";
+  cargoSha256 = "1hs01b1rhbpafxlhw661k907rznqhcgyng85njkb99bg4lxwxaap";
 
   meta = with stdenv.lib; {
     description = "Modern system shell with simple (and powerful) syntax";

--- a/pkgs/tools/X11/xidlehook/default.nix
+++ b/pkgs/tools/X11/xidlehook/default.nix
@@ -16,7 +16,7 @@ rustPlatform.buildRustPackage rec {
   };
 
   cargoBuildFlags = lib.optionals (!stdenv.isLinux) ["--no-default-features" "--features" "pulse"];
-  cargoSha256 = "148p7r9xmc0nc0d4qyxhh29xqcb5axwqwcxcrkgd41f32c3g44dc";
+  cargoSha256 = "0xnz2s8vh5njqs4a1qm98ydh8pywxvnnpym0z94fsifyfdjlsfm4";
 
   buildInputs = [ xlibsWrapper xorg.libXScrnSaver libpulseaudio ] ++ lib.optional stdenv.isDarwin Security;
   nativeBuildInputs = [ pkgconfig patchelf ];

--- a/pkgs/tools/admin/intecture/agent.nix
+++ b/pkgs/tools/admin/intecture/agent.nix
@@ -14,7 +14,7 @@ buildRustPackage rec {
     sha256 = "0j27qdgyxybaixggh7k57mpm6rifimn4z2vydk463msc8b3kgywj";
   };
 
-  cargoSha256 = "1fcl2nnplcic729cmvall2k7wf3jdm7dspvlbxji99bn813ackig";
+  cargoSha256 = "093ipd8lg2ngnln55x5j40g2n8f3y8aysgz9rjn95a4npxrg4yxw";
 
   buildInputs = [ openssl zeromq czmq zlib ];
 

--- a/pkgs/tools/admin/intecture/auth.nix
+++ b/pkgs/tools/admin/intecture/auth.nix
@@ -14,7 +14,7 @@ buildRustPackage rec {
     sha256 = "0c7ar3pc7n59lzfy74lwz51p09s2bglc870rfr4c0vmc91jl0pj2";
   };
 
-  cargoSha256 = "0q3mrcvl1yyrx4a88kanjlfcx6slf7r79i0dh4w81sj6gp07sssm";
+  cargoSha256 = "1rnhhb4mpf1j7c7a2pz4741hzbf2s2wb0bm25j049n64j49j3jq8";
 
   buildInputs = [ openssl zeromq czmq zlib ];
 

--- a/pkgs/tools/admin/intecture/cli.nix
+++ b/pkgs/tools/admin/intecture/cli.nix
@@ -14,7 +14,7 @@ buildRustPackage rec {
     sha256 = "16a5fkpyqkf8w20k3ircc1d0qmif7nygkzxj6mzk9609dlb0dmxq";
   };
 
-  cargoSha256 = "0qwbgwxrjc0dvjbpqa59jixy5nq7lng2c1z91rw48qc91v7fa664";
+  cargoSha256 = "0dhrx6njfbd8w27ifk13g6s3ick579bhc4ijf54rfb9g6n8abafx";
 
   buildInputs = [ openssl zeromq czmq zlib ];
 

--- a/pkgs/tools/backup/rdedup/default.nix
+++ b/pkgs/tools/backup/rdedup/default.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0y34a3mpghdmcb2rx4z62q0s351bfmy1287d75mm07ryfgglgsd7";
   };
 
-  cargoSha256 = "0p19qcz2ph6axfccjwc6z72hrlb48l7sf1n0hc1gfq8hj2s3k2s1";
+  cargoSha256 = "19j1xscchnckqq1nddx9nr9wxxv124ab40l4mdalqbkli4zd748j";
 
   patches = [
     ./v3.1.1-fix-Cargo.lock.patch

--- a/pkgs/tools/filesystems/btrfs-dedupe/default.nix
+++ b/pkgs/tools/filesystems/btrfs-dedupe/default.nix
@@ -12,7 +12,7 @@ buildRustPackage rec {
     sha256 = "0qy1g4crhfgs2f5cmrsjv6qscg3r66gb8n6sxhimm9ksivhjyyjp";
   };
 
-  cargoSha256 = "0dmn9bccicxhqcj9zrsxxp0vb5ma12a1hs9brpc22n4g1qy4yzcn";
+  cargoSha256 = "1sz3fswb76rnk7x4kpl1rnj2yxbhpx6q8kv8xxiqdr7qyphpi98r";
 
   buildInputs = [ lzo zlib ];
 

--- a/pkgs/tools/graphics/gifski/default.nix
+++ b/pkgs/tools/graphics/gifski/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0x41gyc5jk45jlx0hcq80j5gj1f66lcmbclqyx70l43ggslsi26f";
   };
 
-  cargoSha256 = "0rgcm9kj9wapn8y3ymcm1n713r0a9bvgm339y302f5gy76gbgzrk";
+  cargoSha256 = "1pik6jcxg3amb5widpxn8j9szghbrhl0wsxjisizas3033xzrhcf";
 
   nativeBuildInputs = [ pkgconfig ];
 

--- a/pkgs/tools/graphics/oxipng/default.nix
+++ b/pkgs/tools/graphics/oxipng/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1r195x3wdkshjwy23fpqsyyrw7iaj7yb39nhcnx9d4nhgq8w0pcl";
   };
 
-  cargoSha256 = "08mw937s61r4fj9bqrg492ss13zkik9557n9yk90r97a81972zbn";
+  cargoSha256 = "1mjqkjrnh5gw39qjni574qh7k4p891xbb4ip2q69cm177ffbghiz";
 
   # https://crates.io/crates/cloudflare-zlib#arm-vs-nightly-rust
   cargoBuildFlags = [ "--features=cloudflare-zlib/arm-always" ];

--- a/pkgs/tools/graphics/svgcleaner/default.nix
+++ b/pkgs/tools/graphics/svgcleaner/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1jpnqsln37kkxz98vj7gly3c2170v6zamd876nc9nfl9vns41s0f";
   };
 
-  cargoSha256 = "0d5jlq301s55xgdg9mv26hbj75pkjkyxfny7vbiqp9igj128lza3";
+  cargoSha256 = "0kzrklw5nrzgvrfzq1mlnri06s19p4f3w38v39247baz2xd6j1n2";
 
   meta = with stdenv.lib; {
     description = "A tool for tidying and optimizing SVGs";

--- a/pkgs/tools/misc/broot/default.nix
+++ b/pkgs/tools/misc/broot/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1pwbz4ac2zb40g6q6ykzhzfbn0jr5xarkvgw9wxv455mbi67rd6y";
   };
 
-  cargoSha256 = "0cq78im3hg7wns260gwvajikj80l7kjbg3zycy3nvdx34llgv0n5";
+  cargoSha256 = "0yph5mwxn6arfbxbvri5qa7wzwj1q0s675j6vblia9akn02fyqd9";
 
   meta = with stdenv.lib; {
     description = "An interactive tree view, a fuzzy search, a balanced BFS descent and customizable commands";

--- a/pkgs/tools/misc/diskus/default.nix
+++ b/pkgs/tools/misc/diskus/default.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = stdenv.lib.optionals stdenv.isDarwin [ Security ];
 
-  cargoSha256 = "1syrmm5qpz7d1h17xpw1wa3d2snaz9n7d1avsjp7xz8s2qcx1wdc";
+  cargoSha256 = "13d4h6f3idwj2bxafqrjihgwwr8v3k158r7b569jp7q2v1msqqx1";
 
   meta = with stdenv.lib; {
     description = "A minimal, fast alternative to 'du -sh'";

--- a/pkgs/tools/misc/dust/default.nix
+++ b/pkgs/tools/misc/dust/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1l8z1daiq2x92449p2ciblcwl0ddgr3vqj2dsd3z8jj3y0z8j51s";
   };
 
-  cargoSha256 = "0x3ay440vbc64y3pd8zhd119sw8fih0njmkzpr7r8wdw3k48v96m";
+  cargoSha256 = "1bby08ijpwb8676pgm87k80s0n0fqsxc3wmz0v8p9s85yzkflnx5";
 
   doCheck = false;
 

--- a/pkgs/tools/misc/exa/default.nix
+++ b/pkgs/tools/misc/exa/default.nix
@@ -8,7 +8,7 @@ buildRustPackage rec {
   name = "exa-${version}";
   version = "0.8.0";
 
-  cargoSha256 = "08zzn3a32xfjkmpawcjppn1mr26ws3iv40cckiz8ldz4qc8y9gdh";
+  cargoSha256 = "0kaldln4fb9n53190m2r130mcblkjx32glzj9rk8hrz6dd6yhfb0";
 
   src = fetchFromGitHub {
     owner = "ogham";

--- a/pkgs/tools/misc/fd/default.nix
+++ b/pkgs/tools/misc/fd/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0y4657w1pi4x9nmbv551dj00dyiv935m8ph7jlv00chwy3hrb3yi";
   };
 
-  cargoSha256 = "0dfv6nia3v3f3rwbjh2h3zdqd48vw8gwilhq0z4n6xvjzk7qydj5";
+  cargoSha256 = "1qqlii9693ih7pxl80v515a13jar3yayr5v7pa57x14i9syir10c";
 
   preFixup = ''
     install -Dm644 "$src/doc/fd.1" "$out/man/man1/fd.1"

--- a/pkgs/tools/misc/heatseeker/default.nix
+++ b/pkgs/tools/misc/heatseeker/default.nix
@@ -13,7 +13,7 @@ buildRustPackage rec {
     sha256 = "1fcrbjwnhcz71i70ppy0rcgk5crwwmbkm9nrk1kapvks33pv0az7";
   };
 
-  cargoSha256 = "0kqkzjd90v19qvl3iv1vv2fi8h0z75b0yn0z5jq8w4m94fvh0p95";
+  cargoSha256 = "0m3sxbz1iii31s30cnv1970i1mwfhl6gm19k8wv0n7zji30ayx07";
 
   # some tests require a tty, this variable turns them off for Travis CI,
   # which we can also make use of

--- a/pkgs/tools/misc/hexyl/default.nix
+++ b/pkgs/tools/misc/hexyl/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1b5y2lwcv802hjp105h35vda1d6rgysm9qvrm0v96srm0qqh8rq3";
   };
 
-  cargoSha256 = "0lnwkp9jxz7c0jp7w8z2kpl2qkpd1np3s83nim8s6srl6aapc94c";
+  cargoSha256 = "0z7dg098ivyvf4782hy8hc5c1ddj3qrrnrqhgpwcdbx3xlwn8p8x";
 
   meta = with stdenv.lib; {
     description = "A command-line hex viewer";

--- a/pkgs/tools/misc/hyperfine/default.nix
+++ b/pkgs/tools/misc/hyperfine/default.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1mn5nv3zljj2wz40imf62gknv84f7igslsf59gg1qvhgvgsd98sp";
   };
 
-  cargoSha256 = "1kyx1fhz8l5m8dhwd7j3hic86xx71216775m9bslmm2z4csl7r1s";
+  cargoSha256 = "138m29nl65rg3gx2wkx0jj7p8i2csh9kq03v4arp3mnbglp4802y";
 
   buildInputs = stdenv.lib.optional stdenv.isDarwin Security;
 

--- a/pkgs/tools/misc/journaldriver/default.nix
+++ b/pkgs/tools/misc/journaldriver/default.nix
@@ -3,7 +3,7 @@
 rustPlatform.buildRustPackage rec {
   name        = "journaldriver-${version}";
   version     = "1.1.0";
-  cargoSha256 = "03rq96hzv97wh2gbzi8sz796bqgh6pbpvdn0zy6zgq2f2sgkavsl";
+  cargoSha256 = "0wmr0r54ar7gvhvhv76a49ap74lx8hl79bf73vc4f4xlj7hj303g";
 
   src = fetchFromGitHub {
     owner  = "tazjin";

--- a/pkgs/tools/misc/kanshi/default.nix
+++ b/pkgs/tools/misc/kanshi/default.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage
 
   buildInputs = [ pkgconfig udev ];
 
-  cargoSha256 = "sha256:0lf1zfmq9ypxk86ma0n4nczbklmjs631wdzfx4wd3cvhghyr8nkq";
+  cargoSha256 = "0pvkrdjrg9y38vsrqkrvsknzp78sknpmq14rskvij450a9mpihii";
 
   meta = {
     description = "Dynamic display configuration tool";

--- a/pkgs/tools/misc/loop/default.nix
+++ b/pkgs/tools/misc/loop/default.nix
@@ -10,7 +10,7 @@ rustPlatform.buildRustPackage {
     sha256 = "0f33sc1slg97q1aisdrb465c3p7fgdh2swv8k3yphpnja37f5nl4";
   };
 
-  cargoSha256 = "1ccf8dkswwdbwf9diy0l4vc4i2g05ynhi3w1jg3b2ldrvj0j9m9s";
+  cargoSha256 = "19x8n39yaa924naldw6fv7mq9qb500arkhwj9jz2fsbhz5nz607r";
 
   meta = with stdenv.lib; {
     description = "UNIX's missing `loop` command";

--- a/pkgs/tools/misc/mcfly/default.nix
+++ b/pkgs/tools/misc/mcfly/default.nix
@@ -18,7 +18,7 @@ rustPlatform.buildRustPackage rec {
     chmod +x $out/share/mcfly/mcfly.bash
   '';
 
-  cargoSha256 = "0asldrf6s23f9aylk9f8zimmaskgqv3vkdhfnrd26zl9axm0a0ap";
+  cargoSha256 = "1bf65kagvhsi6lg8187ihi5j45hkq9d8v6j7rzmmfhngdzvcfr69";
 
   meta = with stdenv.lib; {
     homepage = https://github.com/cantino/mcfly;

--- a/pkgs/tools/misc/miniserve/default.nix
+++ b/pkgs/tools/misc/miniserve/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1g8ggqs4fyscb1r98qj22f61jgkqnr4vdyps0drrvydl9lafdmpl";
   };
 
-  cargoSha256 = "18wyr0q5pkxds5hrl4g3mqmk46mr0nvs0id94aiw87729ly4vi8c";
+  cargoSha256 = "055mbrzg7v8a65awn1051b4b9ngxq25wy31gjq8kc93qsb7k0f2k";
 
   nativeBuildInputs = [ cmake pkgconfig zlib ];
 

--- a/pkgs/tools/misc/parallel-rust/default.nix
+++ b/pkgs/tools/misc/parallel-rust/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1bb1m3ckkrxlnw9w24ig70bd1zwyrbaw914q3xz5yv43c0l6pn9c";
   };
 
-  cargoSha256 = "0p3wpjz3jrqjasi39zq6q54dhpymc5jp0mfsnzbq6dvz18s8m588";
+  cargoSha256 = "0ssawp06fidsppvfzk0balf4fink2vym9688r7k7x7pb2z7cvyqc";
 
   patches = [ ./fix_cargo_lock_version.patch ];
 

--- a/pkgs/tools/misc/pazi/default.nix
+++ b/pkgs/tools/misc/pazi/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "12z2vyzmyxfq1krbbrjar7c2gvyq1969v16pb2pm7f4g4k24g0c8";
   };
 
-  cargoSha256 = "0mgjl5vazk5z1859lb2va9af9yivz47jw4b01rjr4mq67v9jfld1";
+  cargoSha256 = "1w97jvlamxlxkqpim5iyayhbsqvg3rqds2nxq1fk5imj4hbi3681";
 
   cargoPatches = [ ./cargo-lock.patch ];
 

--- a/pkgs/tools/misc/powerline-rs/default.nix
+++ b/pkgs/tools/misc/powerline-rs/default.nix
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1mxkw6ydnqjyplbki2j9pbnlhxmkw9qqw54443a3cjmn2g08jyzp";
   };
 
-  cargoSha256 = "1sr9vbfk5bb3n0lv93y19in1clyvbj0w3p1gmp4sbw8lx84zwxhc";
+  cargoSha256 = "1d0f1c1vp1r9r3ic921xkcr59f4a45y2xbxm4gl6grhb9z6p5k7l";
 
   nativeBuildInputs = [ pkgconfig file perl cmake curl ];
   buildInputs = [ openssl libssh2 libgit2 libzip ] ++ lib.optional stdenv.isDarwin Security;

--- a/pkgs/tools/misc/skim/default.nix
+++ b/pkgs/tools/misc/skim/default.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage rec {
 
   outputs = [ "out" "vim" ];
 
-  cargoSha256 = "0vxyi7f5p9blv1isngvad8jrgpwmmv3dkr39qsb2i217jx3mzj2i";
+  cargoSha256 = "1rwb0yvqpxp1pikdw6345n035krx0qcx4f5di89841fhr123zv0w";
 
   patchPhase = ''
     sed -i -e "s|expand('<sfile>:h:h')|'$out'|" plugin/skim.vim

--- a/pkgs/tools/misc/tealdeer/default.nix
+++ b/pkgs/tools/misc/tealdeer/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "055pjxgiy31j69spq66w80ig469yi075dk8ad38z6rlvjmf74k71";
   };
 
-  cargoSha256 = "1jxwz2b6p82byvfjx77ba265j6sjr7bjqi2yik8x2i7lrz8v8z1g";
+  cargoSha256 = "0yrz2pq4zdv6hzc8qc1zskpkq556mzpwvzl7qzbfzx8b6g31ak19";
 
   buildInputs = [ openssl cacert curl ];
 

--- a/pkgs/tools/misc/termplay/default.nix
+++ b/pkgs/tools/misc/termplay/default.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
   };
 
   cargoBuildFlags = ["--features" "bin"];
-  cargoSha256 = "1ghvp4n6mvckamvn3hk672wh29jlrwmhrd4hv3mh98li1x9ssbmf";
+  cargoSha256 = "06vf2lhdsp7vsln8007zd1xcswn5akk9gnhh7582x1siiijksmn7";
 
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [

--- a/pkgs/tools/misc/vdirsyncer/default.nix
+++ b/pkgs/tools/misc/vdirsyncer/default.nix
@@ -18,7 +18,7 @@ python3Packages.buildPythonApplication rec {
     name = "${name}-native";
     inherit src;
     sourceRoot = "source/rust";
-    cargoSha256 = "02fxxw4vr6rpdbslrc9c1zhzs704bw7i40akrmh5cxl26rsffdgk";
+    cargoSha256 = "1qziwlf6nlkpxb1hamb7qsipqg9ibp871rimgpwil38vqmyd570s";
     buildInputs = [ pkgconfig openssl ] ++ stdenv.lib.optional stdenv.isDarwin Security;
   };
 

--- a/pkgs/tools/misc/vivid/default.nix
+++ b/pkgs/tools/misc/vivid/default.nix
@@ -16,7 +16,7 @@ rustPlatform.buildRustPackage rec {
     substituteInPlace src/main.rs --replace /usr/share $out/share
   '';
 
-  cargoSha256 = "156wapa2ds7ij1jhrpa8mm6dicwq934qxl56sqw3bgz6pfa8fldz";
+  cargoSha256 = "125392a7x0h9jgcqc4wcaky0494xmr82iacxwl883kf0g227rv2y";
 
   postInstall = ''
     mkdir -p $out/share/${pname}

--- a/pkgs/tools/misc/void/default.nix
+++ b/pkgs/tools/misc/void/default.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage rec {
   # The tests are long-running and not that useful
   doCheck = false;
 
-  cargoSha256 = "1rq947s82icl7gdkjynjwz426bpmd96dip2dv2y7p8rg7yz29x0m";
+  cargoSha256 = "03g7155jpg8k1ymk95m8rlhlszkxyq0rv32966n4gk5yziijvk4k";
 
   meta = with stdenv.lib; {
     description = "Terminal-based personal organizer";

--- a/pkgs/tools/misc/watchexec/default.nix
+++ b/pkgs/tools/misc/watchexec/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0azfnqx5v1shsd7jdxzn41awh9dbjykv8h1isrambc86ygr1c1cy";
   };
 
-  cargoSha256 = "1xlcfr2q2pw47sav9iryjva7w9chv90g18hszq8s0q0w71sccv6j";
+  cargoSha256 = "0rc1p5q3ihcak7vlmzwawdbgcp1kvj5qjr7p4r1zk9fnhijmrjg9";
 
   buildInputs = stdenv.lib.optionals stdenv.isDarwin [
     CoreServices

--- a/pkgs/tools/misc/websocat/default.nix
+++ b/pkgs/tools/misc/websocat/default.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1gf2snr12vnx2mhsrwkb5274r1pvdrf8m3bybrqbh8s9wd83nrh6";
   };
 
-  cargoSha256 = "0vkb3jmyb3zg3xiig5vlxhh74m27rvqbkgrwdqzprifn9vcj17ir";
+  cargoSha256 = "1zqfvbihf8xwgh092n9wzm3mdgbv0n99gjsfk9przqj2vh7wfvh2";
 
   buildInputs = stdenv.lib.optional stdenv.isDarwin Security;
 

--- a/pkgs/tools/networking/boringtun/default.nix
+++ b/pkgs/tools/networking/boringtun/default.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "04i53dvxld2a0xzr0gfl895rcwfvisj1rfs7rl0444gml8s8xyb3";
   };
 
-  cargoSha256 = "0mqgd5r3rdzaw3vkmz0rswn3cwq9b4im6g4rrq7wr7pgrzq96xwm";
+  cargoSha256 = "1gvmshwg9b486933vfgkg2r8nn6w6dyz42hqjy74p785fcg0v5hs";
 
   # To prevent configuration phase error that is caused by
   # lacking a new line in file ".cargo/config",

--- a/pkgs/tools/networking/bukubrow/default.nix
+++ b/pkgs/tools/networking/bukubrow/default.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
   };
   sourceRoot = "source/binary";
 
-  cargoSha256 = "19d1pgk8nm5jsfd696bqayi5s8ivv9gi6jdb00d10ddjxz234gs7";
+  cargoSha256 = "0553awiba24a3a8xwjhlwf8yzbs44lnirjvcxnvsgah7dc44r0gj";
 
   buildInputs = [ sqlite ];
 

--- a/pkgs/tools/networking/gnirehtet/default.nix
+++ b/pkgs/tools/networking/gnirehtet/default.nix
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage rec {
       sha256 = "118ig42qzr2xyra7r8zfxq38xidaxfc98ja9836jwnn9fgbigczr";
   };
   sourceRoot = "source/relay-rust";
-  cargoSha256 = "0370jbllahcdhs132szbxb2yr675s5smm74sx58qi8jhykbb5qs7";
+  cargoSha256 = "1500lfwbfnc0k2hn7r1n629fq11zfqm3fg13dddmhchq4i3sqkfb";
 
   patchFlags = [ "-p2" ];
   patches = [

--- a/pkgs/tools/networking/shadowsocks-rust/default.nix
+++ b/pkgs/tools/networking/shadowsocks-rust/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0mqjm54mp6c9mfdl3gf01v9vm2rjll8fw63n6j4qgv01y4hrsm4f";
   };
 
-  cargoSha256 = "1m0p40z6qx6s0r1x6apz56n2s4ppn8b2cff476xrfhp6s1j046q7";
+  cargoSha256 = "19wx19sbal2q5ndniv6vllayjjy5fzi8fw7fn1d23jb9l91ak7ab";
 
   buildInputs = [ openssl libsodium ]
     ++ stdenv.lib.optionals stdenv.isDarwin [ Security ];

--- a/pkgs/tools/networking/tox-node/default.nix
+++ b/pkgs/tools/networking/tox-node/default.nix
@@ -31,7 +31,7 @@ buildRustPackage rec {
 
   doCheck = false;
 
-  cargoSha256 = "18w1ycvj2q4q8lj81wn5lfljh5wa7b230ahqdz30w20pv1cazsv2";
+  cargoSha256 = "0z47wmqx417y9r0l5lfm310d4vyfjzinrwpax1zni8pm444q1y42";
 
   meta = with stdenv.lib; {
     description = "A server application to run tox node written in pure Rust";

--- a/pkgs/tools/nix/nixdoc/default.nix
+++ b/pkgs/tools/nix/nixdoc/default.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs =  stdenv.lib.optional stdenv.isDarwin [ darwin.Security ];
 
-  cargoSha256 = "1bfn1x1jhpyidai4cjwip5r1ibkqp26ivmqq3vjm71l00m6avb94";
+  cargoSha256 = "1hy8w73fir4wnqx7zfvfqh7s24w95x9nkw55kmizvrwf0glw9m4n";
 
   meta = with stdenv.lib; {
     description = "Generate documentation for Nix functions";

--- a/pkgs/tools/package-management/cargo-edit/default.nix
+++ b/pkgs/tools/package-management/cargo-edit/default.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0g3dikwk6n48dmhx9qchmzyrhcr40242lhvlcyk1nqbpvs3b51fm";
   };
 
-  cargoSha256 = "1bq0mjn44f0sn94nb9wqal4swhkzn7f3vbk5jyay4v3wqfz1gb7r";
+  cargoSha256 = "1i7l21j8x2sm7m1mcyvqnggg6csf893h0gfrgyd8xyfiphl30jvj";
 
   nativeBuildInputs = lib.optional (!stdenv.isDarwin) pkgconfig;
   buildInputs = lib.optional (!stdenv.isDarwin) openssl;

--- a/pkgs/tools/package-management/cargo-release/default.nix
+++ b/pkgs/tools/package-management/cargo-release/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "14l5znr1nl69v2v3mdrlas85krq9jn280ssflmd0dz7i4fxiaflc";
   };
 
-  cargoSha256 = "1f0wgggsjpmcijq07abm3yw06z2ahsdr9iwn4izljvkc1nkqk6jq";
+  cargoSha256 = "1l1rvd3i3d7jn3crwc194i5qm3f0jaw7ksb4bvqn3v8rf44chmrs";
 
   buildInputs = stdenv.lib.optional stdenv.isDarwin Security;
 

--- a/pkgs/tools/package-management/cargo-tree/default.nix
+++ b/pkgs/tools/package-management/cargo-tree/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "12z0sa7g79x46q2ybpy6i9rf1x4cnwajw8dsjzra2qhssyp8rp9c";
   };
 
-  cargoSha256 = "10nfa0pd4zhz36f9yx80qd0bbsmqdjk8r6656jyzh92ydncry1as";
+  cargoSha256 = "0ibmgyiqa53m9xfvl726w1sq37lbdp7vzyc76gwcp1zvzkcv2860";
 
   nativeBuildInputs = [ pkgconfig cmake ];
   buildInputs = [ curl ] ++ lib.optionals stdenv.isDarwin [ libiconv darwin.apple_sdk.frameworks.Security ];

--- a/pkgs/tools/package-management/nix-du/default.nix
+++ b/pkgs/tools/package-management/nix-du/default.nix
@@ -9,7 +9,7 @@ rustPlatform.buildRustPackage rec {
     rev = "v${version}";
     sha256 = "1x6qpivxbn94034jfdxb97xi97fhcdv2z7llq2ccfc80mgd0gz8l";
   };
-  cargoSha256 = "0sva4lnhccm6ly7pa6m99s3fqkmh1dzv7r2727nsg2f55prd4kxc";
+  cargoSha256 = "071gbhxbvnwi7n3zpy7bmlprzir0sl0f0pb191xg2ynw678prd7v";
 
   doCheck = true;
   checkInputs = [ graphviz ];

--- a/pkgs/tools/package-management/nix-index/default.nix
+++ b/pkgs/tools/package-management/nix-index/default.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
     rev = "v${version}";
     sha256 = "05fqfwz34n4ijw7ydw2n6bh4bv64rhks85cn720sy5r7bmhfmfa8";
   };
-  cargoSha256 = "045qm7cyg3sdvf22i8b9cz8gsvggs5bn9xz8k1pvn5gxb7zj24cx";
+  cargoSha256 = "0h8a5bnv32rkvywn8xdbny38m24bi6p9scwljgdk8k067pn3qk34";
   nativeBuildInputs = [ pkgconfig makeWrapper ];
   buildInputs = [ openssl curl ]
     ++ stdenv.lib.optional stdenv.isDarwin Security;

--- a/pkgs/tools/system/mq-cli/default.nix
+++ b/pkgs/tools/system/mq-cli/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "02z85waj5jc312biv2qhbgplsggxgjmfmyv9v8b1ky0iq1mpxjw7";
   };
 
-  cargoSha256 = "0kpv52474bp3k2wmz8xykca8iz46dwnjmly2nivblnaap49w2zsz";
+  cargoSha256 = "03ab6jbcgmbgg9hn7ihk8814sjwdmrr9p4xlll6nfdad4a7gq3yn";
 
   meta = with lib; {
     description      = "CLI tool to manage POSIX message queues";

--- a/pkgs/tools/text/mdbook/default.nix
+++ b/pkgs/tools/text/mdbook/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1xmw4v19ff6mvimwk5l437wslzw5npy60zdb8r4319bjf32pw9pn";
   };
 
-  cargoSha256 = "0kcc0b2644qbalz7dnqwxsjdmw1h57k0rjrvwqh8apj2sgl64gyv";
+  cargoSha256 = "1xpsc4qff2lrq15mz1gvmw6n5vl88sfwpjbsnp5ja5k1im156lam";
 
   buildInputs = stdenv.lib.optionals stdenv.isDarwin [
     CoreServices

--- a/pkgs/tools/text/ripgrep/default.nix
+++ b/pkgs/tools/text/ripgrep/default.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0vak82d4vyw0w8agswbyxa6g3zs2h9mxm2xjw0xs9qccvmi7whbb";
   };
 
-  cargoSha256 = "0i31d0m145dsjfix589p5pfp83qp3a5wvz1v9sp4bxn3rggmw734";
+  cargoSha256 = "1k1wg27p7w8b3cgygnkr6yhsc4hpnvrpa227s612vy2zfcmgb1kx";
 
   cargoBuildFlags = stdenv.lib.optional withPCRE2 "--features pcre2";
 

--- a/pkgs/tools/text/staccato/default.nix
+++ b/pkgs/tools/text/staccato/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1zbd1gx0ik2r7bavcid776j37g6rzd3f6cs94kq1qar4gyf1gqjm";
   };
 
-  cargoSha256 = "074mfyanwdykg6wci2ia63wcnnyik741g8n624pac215sg4i95h7";
+  cargoSha256 = "0h1822hba6lpv14y6hgn8qgh7p812b3kkf592ggr6yjlhqfh37n7";
 
   meta = {
     broken = true;

--- a/pkgs/tools/text/xsv/default.nix
+++ b/pkgs/tools/text/xsv/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "17v1nw36mrarrd5yv4xd3mpc1d7lvhd5786mqkzyyraf78pjg045";
   };
 
-  cargoSha256 = "1qk5wkjm3d4dz5fldlq7rjlm602v0l04hxrbar2j6vhcz9w2r4n6";
+  cargoSha256 = "1xlbszr9ccv924ww45lnc0qqb7nxj2cnc41480xbpvsdqsdrgbhs";
 
   buildInputs = stdenv.lib.optional stdenv.isDarwin Security;
 

--- a/pkgs/tools/typesetting/tectonic/default.nix
+++ b/pkgs/tools/typesetting/tectonic/default.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1j98qxlq74vs8nf2jsn2xw9iyrf8kih4v0hrvznkhcab6bpibp2x";
   };
 
-  cargoSha256 = "1zgav5zxfvdnrr7himykj5ha20cb5ldxpcpl8y6d19dirxvcmpc6";
+  cargoSha256 = "0hsm5a40lc3gy1zrfrchp7zby17xjv5a4llqr4xmka07y7sk08fn";
 
   nativeBuildInputs = [ pkgconfig ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

A recent upgrade of cargo-vendor changed its output slightly, which broke all `cargoSha256` hashes in nixpkgs. See #60668 for more information.

Since then, a few hashes have been fixed in master by hand, but there were a lot still to do, so I did all of the ones left over with some scripts I wrote. Once this is merged, I can run the same scripts on the release branch that the cargo-vendor upgrade has made it into.

I’ve tested that this doesn’t break any builds on *master*. The actual target of the PR is staging, though, because of the number of rebuilds. The one hash I wasn’t able to update was `habitat`’s, because it’s currently broken and the build doesn’t get far enough to produce a hash anyway.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
