### PR TITLE
pythonPackages.serverlessrepo: fix pyyaml override

### DIFF
--- a/pkgs/development/python-modules/serverlessrepo/default.nix
+++ b/pkgs/development/python-modules/serverlessrepo/default.nix
@@ -1,23 +1,12 @@
 { lib
-, python
+, buildPythonPackage
+, fetchPypi
+, pytest
+, boto3
+, six
+, pyyaml
+, mock
 }:
-
-let
-  py = python.override {
-    packageOverrides = self: super: {
-      pyyaml = super.pyyaml.overridePythonAttrs (oldAttrs: rec {
-        version = "3.12";
-        src = oldAttrs.src.override {
-          inherit version;
-          sha256 = "592766c6303207a20efc445587778322d7f73b161bd994f227adaa341ba212ab";
-        };
-      });
-    };
-  };
-
-in
-
-with py.pkgs;
 
 buildPythonPackage rec {
   pname = "serverlessrepo";
@@ -38,6 +27,10 @@ buildPythonPackage rec {
 
   checkPhase = ''
     pytest tests/unit
+  '';
+
+  postPatch = ''
+    substituteInPlace setup.py --replace "pyyaml~=3.12" "pyyaml~=5.1"
   '';
 
   meta = with lib; {

--- a/pkgs/development/tools/aws-sam-cli/default.nix
+++ b/pkgs/development/tools/aws-sam-cli/default.nix
@@ -59,6 +59,7 @@ buildPythonApplication rec {
   postPatch = ''
     substituteInPlace requirements/base.txt --replace "requests==2.20.1" "requests==2.21.0"
     substituteInPlace requirements/base.txt --replace "six~=1.11.0" "six~=1.12.0"
+    substituteInPlace requirements/base.txt --replace "PyYAML~=3.12" "PyYAML~=5.1"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
The previous PR https://github.com/NixOS/nixpkgs/pull/62011 botched `pythonPackages.serverlessrepo` by overriding PyYAML, even though `serverlessrepo` is a python module.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
