### PR TITLE
python.pkgs.rl-coach: init at 0.12.0

### DIFF
--- a/pkgs/development/python-modules/annoy/default.nix
+++ b/pkgs/development/python-modules/annoy/default.nix
@@ -1,0 +1,26 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, nose
+}:
+
+buildPythonPackage rec {
+  version = "1.15.2";
+  pname = "annoy";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1i5bkf8mwd1pyrbhfwncir2r8yq8s9qz5j13vv2qz92n9g57sr3m";
+  };
+
+  checkInputs = [
+    nose
+  ];
+
+  meta = with stdenv.lib; {
+    description = "Approximate Nearest Neighbors in C++/Python optimized for memory usage and loading/saving to disk";
+    homepage = https://github.com/spotify/annoy;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ timokau ];
+  };
+}

--- a/pkgs/development/python-modules/rl-coach/default.nix
+++ b/pkgs/development/python-modules/rl-coach/default.nix
@@ -1,0 +1,98 @@
+{ stdenv
+, lib
+, buildPythonPackage
+, pythonOlder
+, fetchPypi
+, tensorflow
+, annoy
+, pillow
+, matplotlib
+, numpy
+, pandas
+, pygame
+, pyopengl
+, scipy
+, scikitimage
+, gym
+, bokeh
+, kubernetes
+, redis
+, minio
+, pytest
+, psutil
+}:
+
+buildPythonPackage rec {
+  version = "0.12.0";
+  pname = "rl-coach";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0kfm699rsy63726hpz3fyppl7zbl0fzf0vk2kkfgg718mcjxmdnh";
+  };
+
+  propagatedBuildInputs = [
+    tensorflow
+    annoy
+    pillow
+    matplotlib
+    numpy
+    pandas
+    pygame
+    pyopengl
+    scipy
+    scikitimage
+    gym
+    bokeh
+    kubernetes
+    redis
+    minio
+    psutil
+  ];
+
+  checkInputs = [
+    pytest
+  ];
+
+  # run only some tests that do not need any optional dependencies
+  # available tests: https://github.com/NervanaSystems/coach/tree/master/rl_coach/tests
+  testsToRun = [
+    # test only the tensorflow backend (not mxnet)
+    "architectures/tensorflow_components"
+    "agents"
+    "exploration_policies"
+    "filters"
+    "memories"
+    "utils"
+  ];
+  checkPhase = let
+    fullTestPaths = map (testfile: "rl_coach/tests/${testfile}") testsToRun;
+    escapedPaths = map lib.escapeShellArg fullTestPaths;
+    pytestArgs = builtins.concatStringsSep " " escapedPaths;
+  in
+  ''
+    pytest ${pytestArgs}
+  '';
+
+  postPatch = ''
+    # pinned to 8.0.1 for unknown reason, at least basic functionallity seems to work without it
+    # https://github.com/NervanaSystems/coach/pull/149#issuecomment-495915804
+    sed -i '/kubernetes/d' requirements.txt
+
+    # this is just an "intel-optimized" version of tensorflow, e.g. an implementation detail
+    sed -i 's/intel-tensorflow/tensorflow/g' setup.py
+
+    # backports of python3 features not needed
+    # https://github.com/NervanaSystems/coach/issues/324
+    sed -i '/futures/d' requirements.txt
+  '';
+
+  disabled = pythonOlder "3.5"; # minimum required version
+
+  meta = with stdenv.lib; {
+    description = "Enables easy experimentation with state of the art Reinforcement Learning algorithms";
+    homepage = "https://nervanasystems.github.io/coach/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ timokau ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5278,6 +5278,8 @@ in {
 
   clize = callPackage ../development/python-modules/clize { };
 
+  rl-coach = callPackage ../development/python-modules/rl-coach { };
+
   zerobin = callPackage ../development/python-modules/zerobin { };
 
   tensorflow-estimator = callPackage ../development/python-modules/tensorflow-estimator { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5274,6 +5274,8 @@ in {
 
   sigtools = callPackage ../development/python-modules/sigtools { };
 
+  annoy = callPackage ../development/python-modules/annoy { };
+
   clize = callPackage ../development/python-modules/clize { };
 
   zerobin = callPackage ../development/python-modules/zerobin { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

I'm tinkering with reinforcement learning, `coach` is a popular RL library, `annoy` one of its dependencies.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
