### PR TITLE
pythonPackages.bjoern: fix test result checking

### DIFF
--- a/pkgs/development/python-modules/bjoern/default.nix
+++ b/pkgs/development/python-modules/bjoern/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, libev, python }:
+{ stdenv, buildPythonPackage, fetchPypi, libev, python, isPy3k }:
 
 buildPythonPackage rec {
   pname = "bjoern";
@@ -13,7 +13,8 @@ buildPythonPackage rec {
 
   checkPhase = ''
     ${python.interpreter} tests/keep-alive-behaviour.py 2>/dev/null
-    ${python.interpreter} tests/test_wsgi_compliance.py
+  '' + stdenv.lib.optionalString isPy3k ''
+    ${python.interpreter} tests/test_wsgi_compliance.py | (! grep -i "fail")
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
When testing https://github.com/NixOS/nixpkgs/pull/61887 noticed `test_wsgi_compliance.py` returns a zero exit status unconditionally - to check for a failure we need to grep the stdout. It also appears this test is broken upstream for py27 - I should open an issue with them...

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
