### PR TITLE
spdlog: 1.2.1 -> 1.3.1 ; waybar: 0.6.5 -> 0.6.6

### DIFF
--- a/pkgs/applications/misc/waybar/default.nix
+++ b/pkgs/applications/misc/waybar/default.nix
@@ -1,5 +1,5 @@
 { stdenv, fetchFromGitHub, meson, pkgconfig, ninja
-, wayland, wlroots, gtkmm3, libinput, libsigcxx, jsoncpp, fmt
+, wayland, wlroots, gtkmm3, libinput, libsigcxx, jsoncpp, fmt, spdlog
 , traySupport  ? true,  libdbusmenu-gtk3
 , pulseSupport ? false, libpulseaudio
 , nlSupport    ? true,  libnl
@@ -9,13 +9,13 @@
 }:
   stdenv.mkDerivation rec {
     name = "waybar-${version}";
-    version = "0.6.5";
+    version = "0.6.6";
 
     src = fetchFromGitHub {
       owner = "Alexays";
       repo = "Waybar";
       rev = version;
-      sha256 = "1k3ynx5ssq7ji0nlx0n7zrgrshxv5abj8fa8c5lcyxr2wxffna9z";
+      sha256 = "0wxd03lkgssz0vsib9qc040vfg1i6nrg7ac2c6qwficx62j2zlm1";
     };
 
     nativeBuildInputs = [
@@ -23,7 +23,7 @@
     ];
 
     buildInputs = with stdenv.lib;
-      [ wayland wlroots gtkmm3 libinput libsigcxx jsoncpp fmt ]
+      [ wayland wlroots gtkmm3 libinput libsigcxx jsoncpp fmt spdlog ]
       ++ optional  traySupport  libdbusmenu-gtk3
       ++ optional  pulseSupport libpulseaudio
       ++ optional  nlSupport    libnl

--- a/pkgs/development/libraries/spdlog/default.nix
+++ b/pkgs/development/libraries/spdlog/default.nix
@@ -15,7 +15,7 @@ let
 
       nativeBuildInputs = [ cmake ];
 
-      cmakeFlags = [ "-DSPDLOG_BUILD_EXAMPLES=OFF" ];
+      cmakeFlags = [ "-DSPDLOG_BUILD_EXAMPLES=OFF" "-DSPDLOG_BUILD_BENCH=OFF" ];
 
       outputs = [ "out" "doc" ];
 
@@ -35,8 +35,8 @@ let
 in
 {
   spdlog_1 = generic {
-    version = "1.2.1";
-    sha256 = "0gdj8arfz4r9419zbcxk9y9nv47qr7kyjjzw9m3ijgmn2pmxk88n";
+    version = "1.3.1";
+    sha256 = "1rd4zmrlkcdjx0m0wpmjm1g9srj7jak6ai08qkhbn2lsn0niifzd";
   };
 
   spdlog_0 = generic {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Spdlog 1.3.1 was needed for Waybar 0.6.6. Tested with `nix-review wip`

Spdlog changelogs:

- https://github.com/gabime/spdlog/releases/tag/v1.3.0
- https://github.com/gabime/spdlog/releases/tag/v1.3.1

Waybar changelog:

- https://github.com/Alexays/Waybar/releases/tag/0.6.6

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).