### PR TITLE
[18.09] cups: add patch for CVE-2018-4700

### DIFF
--- a/pkgs/misc/cups/default.nix
+++ b/pkgs/misc/cups/default.nix
@@ -29,6 +29,13 @@ stdenv.mkDerivation rec {
       sha256 = "1ddgdlg9s0l2ph6l8lx1m1lx6k50gyxqi3qiwr44ppq1rxs80ny5";
     })
     ./cups-clean-dirty.patch
+    (fetchpatch {
+      name = "CVE-2018-4700.patch";
+      url = "https://github.com/apple/cups/commit/"
+          + "feb4c62b211bfbd78dc10d737d873439ccdfa58c.patch";
+      sha256 = "1g1626sl4vdwbj9jdzpxmxl8gwyykmxr6i4vr2ba3vn140wnv088";
+      includes = [ "cgi-bin/var.c" ];
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change
Resolves https://github.com/NixOS/nixpkgs/issues/60106

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
