### PR TITLE
ddclient: patch unpure /usr/bin/perl

### DIFF
--- a/pkgs/tools/networking/ddclient/default.nix
+++ b/pkgs/tools/networking/ddclient/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, perlPackages, iproute }:
+{ stdenv, fetchurl, perlPackages, iproute, perl }:
 
 perlPackages.buildPerlPackage rec {
   name = "ddclient-${version}";
@@ -20,7 +20,9 @@ perlPackages.buildPerlPackage rec {
     substituteInPlace ddclient \
       --replace 'in the output of ifconfig' 'in the output of ip addr show' \
       --replace 'ifconfig -a'               '${iproute}/sbin/ip addr show' \
-      --replace 'ifconfig $arg'             '${iproute}/sbin/ip addr show $arg'
+      --replace 'ifconfig $arg'             '${iproute}/sbin/ip addr show $arg' \
+   # Until we get the patchShebangs fixed (issue #55786) we need to patch this manually
+      --replace '/usr/bin/perl'		    '${perl}/bin/perl'
   '';
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

Fixes #62056 as new upstream version is using an unpure path.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
