### PR TITLE
nixos: Make 'nesting.clone' work in NixOS tests

### DIFF
--- a/nixos/lib/build-vms.nix
+++ b/nixos/lib/build-vms.nix
@@ -32,14 +32,14 @@ rec {
 
     import ./eval-config.nix {
       inherit system;
-      modules = configurations ++
+      modules = configurations ++ extraConfigurations;
+      baseModules =  (import ../modules/module-list.nix) ++
         [ ../modules/virtualisation/qemu-vm.nix
           ../modules/testing/test-instrumentation.nix # !!! should only get added for automated test runs
           { key = "no-manual"; documentation.nixos.enable = false; }
           { key = "qemu"; system.build.qemu = qemu; }
           { key = "nodes"; _module.args.nodes = nodes; }
-        ] ++ optional minimal ../modules/testing/minimal-kernel.nix
-          ++ extraConfigurations;
+        ] ++ optional minimal ../modules/testing/minimal-kernel.nix;
     };
 
 

--- a/nixos/lib/build-vms.nix
+++ b/nixos/lib/build-vms.nix
@@ -37,9 +37,9 @@ rec {
           ../modules/testing/test-instrumentation.nix # !!! should only get added for automated test runs
           { key = "no-manual"; documentation.nixos.enable = false; }
           { key = "qemu"; system.build.qemu = qemu; }
+          { key = "nodes"; _module.args.nodes = nodes; }
         ] ++ optional minimal ../modules/testing/minimal-kernel.nix
           ++ extraConfigurations;
-      extraArgs = { inherit nodes; };
     };
 
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -161,6 +161,7 @@ in
   nat.standalone = handleTest ./nat.nix { withFirewall = false; };
   ndppd = handleTest ./ndppd.nix {};
   neo4j = handleTest ./neo4j.nix {};
+  nesting = handleTest ./nesting.nix {};
   netdata = handleTest ./netdata.nix {};
   networking.networkd = handleTest ./networking.nix { networkd = true; };
   networking.scripted = handleTest ./networking.nix { networkd = false; };

--- a/nixos/tests/nesting.nix
+++ b/nixos/tests/nesting.nix
@@ -1,22 +1,42 @@
 import ./make-test.nix {
   name = "nesting";
-  machine = { pkgs, ... }: {
-    environment.systemPackages = [ pkgs.cowsay ];
-    nesting.clone = [
-      ({ pkgs, ... }: {
-        environment.systemPackages = [ pkgs.hello ];
-      })
-    ];
+  nodes =  {
+    clone = { pkgs, ... }: {
+      environment.systemPackages = [ pkgs.cowsay ];
+      nesting.clone = [
+        ({ pkgs, ... }: {
+          environment.systemPackages = [ pkgs.hello ];
+        })
+      ];
+    };
+    children = { pkgs, ... }: {
+      environment.systemPackages = [ pkgs.cowsay ];
+      nesting.children = [
+        ({ pkgs, ... }: {
+          environment.systemPackages = [ pkgs.hello ];
+        })
+      ];
+    };
   };
   testScript = ''
-    $machine->waitForUnit("default.target");
-    $machine->succeed("cowsay hey");
-    $machine->fail("hello");
+    $clone->waitForUnit("default.target");
+    $clone->succeed("cowsay hey");
+    $clone->fail("hello");
 
     # Nested clones do inherit from parent
-    $machine->succeed("/run/current-system/fine-tune/child-1/bin/switch-to-configuration test");
-    $machine->succeed("cowsay hey");
-    $machine->succeed("hello");
+    $clone->succeed("/run/current-system/fine-tune/child-1/bin/switch-to-configuration test");
+    $clone->succeed("cowsay hey");
+    $clone->succeed("hello");
+    
+
+    $children->waitForUnit("default.target");
+    $children->succeed("cowsay hey");
+    $children->fail("hello");
+
+    # Nested children do not inherit from parent
+    $children->succeed("/run/current-system/fine-tune/child-1/bin/switch-to-configuration test");
+    $children->fail("cowsay hey");
+    $children->succeed("hello");
 
   '';
 }

--- a/nixos/tests/nesting.nix
+++ b/nixos/tests/nesting.nix
@@ -1,0 +1,22 @@
+import ./make-test.nix {
+  name = "nesting";
+  machine = { pkgs, ... }: {
+    environment.systemPackages = [ pkgs.cowsay ];
+    nesting.clone = [
+      ({ pkgs, ... }: {
+        environment.systemPackages = [ pkgs.hello ];
+      })
+    ];
+  };
+  testScript = ''
+    $machine->waitForUnit("default.target");
+    $machine->succeed("cowsay hey");
+    $machine->fail("hello");
+
+    # Nested clones do inherit from parent
+    $machine->succeed("/run/current-system/fine-tune/child-1/bin/switch-to-configuration test");
+    $machine->succeed("cowsay hey");
+    $machine->succeed("hello");
+
+  '';
+}


### PR DESCRIPTION
Because nesting.clone calls 'eval-config.nix' manually,
without the 'extraArgs' argument that provides the 'nodes'
argument to nixos modules in nixos tests, evaluating
of 'nesting.clone' definitions would fail with the following error

while evaluating the module argument `nodes' in "<redacted>"
while evaluating the attribute '_module.args.nodes' at undefined position:
attribute 'nodes' missing, at <redacted./nixpkgs/lib/modules.nix:163:28

by not using 'extraArgs' but a nixos module instead, the nodes parameter
gets propagated to the 'eval-config.nix' call that  'nesting.clone'
makes too -  getting rid of the error.

See  https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/system/activation/top-level.nix#L13-L23
See  https://github.com/NixOS/nixpkgs/blob/master/nixos/lib/build-vms.nix#L27
See  https://github.com/NixOS/nixpkgs/issues/20886#issuecomment-495952149

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
