### PR TITLE
libpsl: 0.20.2 -> 0.21.0 / publicsuffix-list: init at 2019-05-24

### DIFF
--- a/pkgs/data/misc/publicsuffix-list/default.nix
+++ b/pkgs/data/misc/publicsuffix-list/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchFromGitHub }:
+
+let
+  pname = "publicsuffix-list";
+  version = "2019-05-24";
+in fetchFromGitHub rec {
+  name = "${pname}-${version}";
+  owner = "publicsuffix";
+  repo = "list";
+  rev = "a1db0e898956e126de65be1a5e977fbbbbeebe33";
+  sha256 = "092153w2jr7nx28p9wc9k6b5azi9c39ghnqfnfiwfzv1j8jm3znq";
+
+  postFetch = ''
+    tar xf $downloadedFile --strip=1
+    install -Dm0444 public_suffix_list.dat tests/test_psl.txt -t $out/share/publicsuffix
+  '';
+
+  meta = with lib; {
+    homepage = "https://publicsuffix.org/";
+    description = "Cross-vendor public domain suffix database";
+    platforms = platforms.all;
+    license = licenses.mpl20;
+    maintainers = [ maintainers.c0bw3b ];
+  };
+}

--- a/pkgs/development/libraries/libpsl/default.nix
+++ b/pkgs/development/libraries/libpsl/default.nix
@@ -1,34 +1,22 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, docbook_xsl, docbook_xml_dtd_43, gtk-doc, icu
-, libxslt, pkgconfig, python3 }:
+{ stdenv, fetchurl, autoreconfHook, docbook_xsl, docbook_xml_dtd_43, gtk-doc, lzip
+, libidn2, libunistring, libxslt, pkgconfig, python3, valgrind
+, publicsuffix-list
+}:
 
-let
+stdenv.mkDerivation rec {
+  pname = "libpsl";
+  version = "0.21.0";
 
-  listVersion = "2017-02-03";
-  listSources = fetchFromGitHub {
-    sha256 = "0fhc86pjv50hxj3xf9r4mh0zzvdzqp5lac20caaxq1hlvdzavaa3";
-    rev = "37e30d13801eaad3383b122c11d8091c7ac21040";
-    repo = "list";
-    owner = "publicsuffix";
+  src = fetchurl {
+    url = "https://github.com/rockdaboot/${pname}/releases/download/${pname}-${version}/${pname}-${version}.tar.lz";
+    sha256 = "183hadbira0d2zvv8272lspy31dgm9x26z35c61s5axcd5wd9g9i";
   };
 
-  libVersion = "0.20.2";
-
-in stdenv.mkDerivation rec {
-  name = "libpsl-${version}";
-  version = "${libVersion}-list-${listVersion}";
-
-  src = fetchFromGitHub {
-    sha256 = "0ijingxpnvl5xnna32j93ijagvjsvw2lhj71q39hz9xhzjzrda9b";
-    rev = "libpsl-${libVersion}";
-    repo = "libpsl";
-    owner = "rockdaboot";
-  };
-
-  buildInputs = [ icu libxslt ];
-  nativeBuildInputs = [ autoreconfHook docbook_xsl docbook_xml_dtd_43 gtk-doc pkgconfig python3 ];
+  nativeBuildInputs = [ autoreconfHook docbook_xsl docbook_xml_dtd_43 gtk-doc lzip pkgconfig python3 valgrind ];
+  buildInputs = [ libidn2 libunistring libxslt ];
+  propagatedBuildInputs = [ publicsuffix-list ];
 
   postPatch = ''
-    substituteInPlace src/psl.c --replace bits/stat.h sys/stat.h
     patchShebangs src/psl-make-dafsa
   '';
 
@@ -36,15 +24,14 @@ in stdenv.mkDerivation rec {
     gtkdocize
   '';
 
-  preConfigure = ''
-    # The libpsl check phase requires the list's test scripts (tests/) as well
-    cp -Rv "${listSources}"/* list
-  '';
   configureFlags = [
-    "--disable-builtin"
     "--disable-static"
     "--enable-gtk-doc"
     "--enable-man"
+    "--enable-valgrind-tests"
+    "--with-psl-distfile=${publicsuffix-list}/share/publicsuffix/public_suffix_list.dat"
+    "--with-psl-file=${publicsuffix-list}/share/publicsuffix/public_suffix_list.dat"
+    "--with-psl-testfile=${publicsuffix-list}/share/publicsuffix/test_psl.txt"
   ];
 
   enableParallelBuilding = true;
@@ -60,8 +47,10 @@ in stdenv.mkDerivation rec {
       "supercookies" and "super domain" certificates, for highlighting parts of
       the domain in a user interface or sorting domain lists by site.
     '';
-    homepage = http://rockdaboot.github.io/libpsl/;
+    homepage = "https://rockdaboot.github.io/libpsl/";
+    changelog = "https://raw.githubusercontent.com/rockdaboot/${pname}/${pname}-${version}/NEWS";
     license = licenses.mit;
-    platforms = with platforms; linux ++ darwin;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.c0bw3b ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16461,6 +16461,8 @@ in
 
   public-sans  = callPackage ../data/fonts/public-sans { };
 
+  publicsuffix-list = callPackage ../data/misc/publicsuffix-list { };
+
   qogir-theme = callPackage ../data/themes/qogir { };
 
   redhat-official-fonts = callPackage ../data/fonts/redhat-official { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
- `publicsuffix-list` is now its own data derivation so it can be reused by other ; and it allows semi-automatic update of this dataset (right now we're shipping an outdated list)
- `libpsl` update taking the system-wide PSL as input
- switched from `icu` to `libidn2`+`libunistring` in libpsl because it is upstream default and it reduces overall closure size
- added myslef as maintainer of both derivations

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

```ini
$ /nix/store/57dvdfm90pkckfm7y47kljxsl7szh4rw-libpsl-0.21.0/bin/psl --version
psl 0.21.0 (0x001500)
libpsl 0.21.0 (+libidn2/2.1.1)

Copyright (C) 2014-2018 Tim Ruehsen
License: MIT

$ /nix/store/57dvdfm90pkckfm7y47kljxsl7szh4rw-libpsl-0.21.0/bin/psl --print-info
dist filename: /nix/store/szphjhh0j68yhddyw2zh8ykr00mhd1r2-publicsuffix-list-2019-05-24/share/publicsuffix/public_suffix_list.dat
builtin suffixes: 8753
builtin exceptions: 8
builtin wildcards: 64
builtin filename: /nix/store/szphjhh0j68yhddyw2zh8ykr00mhd1r2-publicsuffix-list-2019-05-24/share/publicsuffix/public_suffix_list.dat
builtin file time: 1 (jeu., 01 janv. 1970 01:00:01 CET)
builtin SHA1 file hash: 82a6723fa5ebb37bbbd0a32f6e2f614be275c932
builtin outdated: 0
```

```ìni
$ nix path-info -sSh /nix/store/k746lpxpvm9h9bjy793k985i6manryr5-libpsl-0.20.2-list-2017-02-03
/nix/store/k746lpxpvm9h9bjy793k985i6manryr5-libpsl-0.20.2-list-2017-02-03        115.8K   64.2M

$ nix path-info -sSh /nix/store/57dvdfm90pkckfm7y47kljxsl7szh4rw-libpsl-0.21.0
/nix/store/57dvdfm90pkckfm7y47kljxsl7szh4rw-libpsl-0.21.0        116.8K   28.9M
```