### PR TITLE
nixos/cadvisor: expose interval options

### DIFF
--- a/nixos/modules/services/monitoring/cadvisor.nix
+++ b/nixos/modules/services/monitoring/cadvisor.nix
@@ -84,6 +84,39 @@ in {
         type = types.bool;
         description = "Cadvisor storage driver, enable secure communication.";
       };
+
+      globalHousekeepingInterval = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Interval between global housekeepings.
+
+          The value is parsed with <link xlink:href='https://golang.org/pkg/time/#ParseDuration'>time.ParseDuration</link>.
+        '';
+        example = "1m0s";
+      };
+
+      housekeepingInterval = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Interval between container housekeepings.
+
+          The value is parsed with <link xlink:href='https://golang.org/pkg/time/#ParseDuration'>time.ParseDuration</link>.
+        '';
+        example = "1s";
+      };
+
+      maxHousekeepingInterval = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Largest interval to allow between container housekeepings.
+
+          The value is parsed with <link xlink:href='https://golang.org/pkg/time/#ParseDuration'>time.ParseDuration</link>.
+        '';
+        example = "1m0s";
+      };
     };
   };
 
@@ -112,6 +145,12 @@ in {
             -logtostderr=true \
             -listen_ip="${cfg.listenAddress}" \
             -port="${toString cfg.port}" \
+            ${optionalString (cfg.globalHousekeepingInterval != null)
+              "--global_housekeeping_interval=${cfg.globalHousekeepingInterval}"} \
+            ${optionalString (cfg.housekeepingInterval != null)
+              "--housekeeping_interval=${cfg.housekeepingInterval}"} \
+            ${optionalString (cfg.maxHousekeepingInterval != null)
+              "--max_housekeeping_interval=${cfg.maxHousekeepingInterval}"} \
             ${optionalString (cfg.storageDriver != null) ''
               -storage_driver "${cfg.storageDriver}" \
               -storage_driver_user "${cfg.storageDriverHost}" \


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Options are described here: https://github.com/google/cadvisor/blob/master/docs/runtime_options.md

If Prometheus only queries every 10s, there's no point for cadvisor to query the system every second. These options allow to disable that unnecessary work.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
