### PR TITLE
New znc modules

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2609,6 +2609,15 @@
     github = "kisonecat";
     name = "Jim Fowler";
   };
+  kiwi = {
+    email = "envy1988@gmail.com";
+    github = "Kiwi";
+    name = "Robert Djubek";
+    keys = [{
+      longkeyid = "rsa4096/0x156C88A5B0A04B2A";
+      fingerprint = "8992 44FC D291 5CA2 0A97  802C 156C 88A5 B0A0 4B2A";
+    }];
+  };
   kjuvi = {
     email = "quentin.vaucher@pm.me";
     github = "kjuvi";

--- a/pkgs/applications/networking/znc/modules.nix
+++ b/pkgs/applications/networking/znc/modules.nix
@@ -57,6 +57,26 @@ in rec {
     };
   };
 
+  clientaway = zncDerivation rec {
+    name = "znc-clientaway-${version}";
+    version = "git-2017-04-28";
+    module_name = "clientaway";
+
+    src = fetchFromGitHub {
+      owner = "kylef";
+      repo = "znc-contrib";
+      rev = "f6724a4a3b16b050088adde0cbeed74f189e5044";
+      sha256 = "0ikd3dzjjlr0gs0ikqfk50msm6mij99ln2rjzqavh58iwzr7n5r8";
+    };
+
+    meta = with stdenv.lib; {
+      description = "ZNC clientaway module";
+      homepage = https://github.com/kylef/znc-contrib;
+      license = licenses.gpl2;
+      maintainers = with maintainers; [ kiwi ];
+    };
+  };
+
   fish = zncDerivation rec {
     name = "znc-fish-${version}";
     version = "git-2014-10-10";

--- a/pkgs/applications/networking/znc/modules.nix
+++ b/pkgs/applications/networking/znc/modules.nix
@@ -117,6 +117,26 @@ in rec {
     };
   };
 
+  palaver = zncDerivation rec {
+    name = "znc-palaver-${version}";
+    version = "2018-09-18";
+    module_name = "palaver";
+
+    src = fetchFromGitHub {
+      owner = "cocodelabs";
+      repo = "znc-palaver";
+      rev = "c70e8112686f917d39197d582db36c3ea37a4cb6";
+      sha256 = "1gjr8yqgpkpcc18rf0zfgil3rcd1ihqk0q9f8rwbfvs5381h3c58";
+    };
+
+    meta = with stdenv.lib; {
+      description = "Palaver ZNC module";
+      homepage = "https://github.com/cocodelabs/znc-palaver";
+      license = licenses.mit;
+      maintainers = with maintainers; [ kiwi ];
+    };
+  };
+
   playback = zncDerivation rec {
     name = "znc-playback-${version}";
     version = "git-2015-08-04";

--- a/pkgs/applications/networking/znc/modules.nix
+++ b/pkgs/applications/networking/znc/modules.nix
@@ -97,6 +97,26 @@ in rec {
     };
   };
 
+  ignore = zncDerivation rec {
+    name = "znc-ignore-${version}";
+    version = "git-2017-04-28";
+    module_name = "ignore";
+
+    src = fetchFromGitHub {
+      owner = "kylef";
+      repo = "znc-contrib";
+      rev = "f6724a4a3b16b050088adde0cbeed74f189e5044";
+      sha256 = "0ikd3dzjjlr0gs0ikqfk50msm6mij99ln2rjzqavh58iwzr7n5r8";
+    };
+
+    meta = with stdenv.lib; {
+      description = "ZNC ignore module";
+      homepage = https://github.com/kylef/znc-contrib;
+      license = licenses.gpl2;
+      maintainers = with maintainers; [ kiwi ];
+    };
+  };
+
   playback = zncDerivation rec {
     name = "znc-playback-${version}";
     version = "git-2015-08-04";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Switching a FreeBSD server I use for ZNC to NixOS and there aren't a lot of ZNC modules. I added a few I needed and more.

###### Things done
Added `ignore` and `clientaway` from [znc-contrib](https://github.com/kylef-archive/znc-contrib)
Added [`palaver`](https://github.com/cocodelabs/znc-palaver)

I was going to add more of the znc-contrib but I wasn't able to figure them out (yubikey uses extra C++ libraries and 2 are python; one of which is a rewrite of privmsg, which we already have, so w/e)

I've added them to the modules that load and ZNC still starts so I think that means they're working.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
