### PR TITLE
nv-codec-headers: 8.2.15.6 -> 9.0.18.1

### DIFF
--- a/pkgs/development/libraries/nv-codec-headers/default.nix
+++ b/pkgs/development/libraries/nv-codec-headers/default.nix
@@ -1,20 +1,20 @@
 { stdenv, fetchgit }:
 
 stdenv.mkDerivation rec {
-  name = "nv-codec-headers-${version}";
-  version = "8.2.15.6";
+  pname = "nv-codec-headers";
+  version = "9.0.18.1";
 
   src = fetchgit {
     url = "https://git.videolan.org/git/ffmpeg/nv-codec-headers.git";
     rev = "n${version}";
-    sha256 = "0216ww8byjxz639kagyw0mr9vxxwj89xdnj448d579vjr54jychv";
+    sha256 = "0354fivb92ix341jds7a7qn3mgwimrnxbganhlhr4vayj25c3hw5";
   };
 
   makeFlags = [ "PREFIX=$(out)" ];
 
   meta = {
     description = "FFmpeg version of headers for NVENC";
-    homepage = http://ffmpeg.org/;
+    homepage = "https://ffmpeg.org/";
     license = stdenv.lib.licenses.mit;
     maintainers = [ stdenv.lib.maintainers.MP2E ];
     platforms = stdenv.lib.platforms.all;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
