### PR TITLE
libtins: 4.0 -> 4.2 / compactor: 0.11.1 -> 0.12.2

### DIFF
--- a/pkgs/development/libraries/libtins/default.nix
+++ b/pkgs/development/libraries/libtins/default.nix
@@ -1,14 +1,14 @@
 { boost, cmake, fetchFromGitHub, gtest, libpcap, openssl, stdenv }:
 
 stdenv.mkDerivation rec {
-  name = "libtins-${version}";
-  version = "4.0";
-  
+  pname = "libtins";
+  version = "4.2";
+
   src = fetchFromGitHub {
     owner = "mfontanini";
-    repo = "libtins";
+    repo = pname;
     rev = "v${version}";
-    sha256 = "13sdqad976j7gq2k1il6g51yxwr8rlqdkzf1kj9mzhihjq8541qs";
+    sha256 = "0gv661gdf018zk1sr6fnvcmd5akqjihs4h6zzxv6881v6yhhglrz";
   };
 
   postPatch = ''
@@ -32,14 +32,15 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
   doCheck = true;
   preCheck = ''
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/lib
-    export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$PWD/lib
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD${placeholder "out"}/lib
+    export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$PWD${placeholder "out"}/lib
   '';
   checkTarget = "tests test";
 
   meta = with stdenv.lib; {
     description = "High-level, multiplatform C++ network packet sniffing and crafting library";
-    homepage = https://libtins.github.io/;
+    homepage = "https://libtins.github.io/";
+    changelog = "https://raw.githubusercontent.com/mfontanini/${pname}/v${version}/CHANGES.md";
     license = stdenv.lib.licenses.bsd2;
     maintainers = with maintainers; [ fdns ];
     platforms = stdenv.lib.platforms.unix;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Version updates
Fix `compactor` builds (currently failing on Hydra)

cc @fdns 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
