### PR TITLE
intel-ocl: fix source URL

### DIFF
--- a/pkgs/os-specific/linux/intel-ocl/default.nix
+++ b/pkgs/os-specific/linux/intel-ocl/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "5.0-63503";
 
   src = fetchzip {
-    url = "http://registrationcenter-download.intel.com/akdlm/irc_nas/11396/SRB5.0_linux64.zip";
+    url = "https://registrationcenter-download.intel.com/akdlm/irc_nas/11396/SRB5.0_linux64.zip";
     sha256 = "0qbp63l74s0i80ysh9ya8x7r79xkddbbz4378nms9i7a0kprg9p2";
     stripRoot = false;
   };


### PR DESCRIPTION
###### Motivation for this change
Current source download fails with 404.
File seems to be available via http**s**.

This should probably be backported to 19.03?

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
