### PR TITLE
hashcat-utils: init at 1.9

### DIFF
--- a/pkgs/tools/security/hashcat-utils/default.nix
+++ b/pkgs/tools/security/hashcat-utils/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "hashcat-utils";
+  version = "1.9";
+
+  src = fetchFromGitHub {
+    owner = "hashcat";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0wgc6wv7i6cs95rgzzx3zqm14xxbjyajvcqylz8w97d8kk4x4wjr";
+  };
+
+  sourceRoot = "source/src";
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm0555 *.bin -t $out/bin
+    install -Dm0555 *.pl -t $out/bin
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Small utilities that are useful in advanced password cracking";
+    homepage = https://github.com/hashcat/hashcat-utils;
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ fadenb ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3503,6 +3503,8 @@ in
 
   hashcat = callPackage ../tools/security/hashcat { };
 
+  hashcat-utils = callPackage ../tools/security/hashcat-utils { };
+
   hash_extender = callPackage ../tools/security/hash_extender { };
 
   hash-slinger = callPackage ../tools/security/hash-slinger { };


### PR DESCRIPTION
###### Motivation for this change
I was lacking a tool in NixOS to convert bettercap output to something hashcat will work with ;)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
