### PR TITLE
uefi-firmware-parser: init at 1.8

### DIFF
--- a/pkgs/development/tools/analysis/uefi-firmware-parser/default.nix
+++ b/pkgs/development/tools/analysis/uefi-firmware-parser/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, python3, fetchFromGitHub }:
+
+with python3.pkgs;
+
+buildPythonApplication rec {
+  pname = "uefi-firmware-parser";
+  version = "1.8";
+
+  # Version 1.8 is not published on pypi
+  src = fetchFromGitHub {
+    owner = "theopolis";
+    repo = "uefi-firmware-parser";
+    rev = "v${version}";
+    sha256 = "1yn9vi91j1yxkn0icdnjhgl0qrqqkzyhccj39af4f19q1gdw995l";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/theopolis/uefi-firmware-parser/";
+    description = "Parse BIOS/Intel ME/UEFI firmware related structures: Volumes, FileSystems, Files, etc";
+    # MIT + license headers in some files
+    license = with licenses; [
+      mit
+      zlib         # uefi_firmware/me.py
+      bsd2         # uefi_firmware/compression/Tiano/**/*
+      publicDomain # uefi_firmware/compression/LZMA/SDK/C/*
+    ];
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
+    maintainers = [ maintainers.samueldr ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9692,6 +9692,8 @@ in
     inherit (darwin.apple_sdk.frameworks) CoreFoundation;
   };
 
+  uefi-firmware-parser = callPackage ../development/tools/analysis/uefi-firmware-parser { };
+
   uhd = callPackage ../applications/radio/uhd { };
 
   uisp = callPackage ../development/tools/misc/uisp { };


### PR DESCRIPTION
###### Motivation for this change

Sometimes you have to dig deep into the rabbit hole when debugging stuff. This makes proprietary UEFI more transparent by slicing and dicing them into more usable parts.

###### Things done

Tested by actually using the thing against an UEFI binary. It worked as expected.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ☑️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ☑️ NixOS
   - 🔲 macOS
   - 🔲 other Linux distributions
- 🔲 Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ☑️ Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- ☑️ Tested execution of all binary files (usually in `./result/bin/`)
- 🔲 Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ☑️ Assured whether relevant documentation is up to date
- ☑️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
