### PR TITLE
throttled: fix for Intel CPU throttling issues

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -325,6 +325,7 @@
   ./services/hardware/tcsd.nix
   ./services/hardware/tlp.nix
   ./services/hardware/thinkfan.nix
+  ./services/hardware/throttled.nix
   ./services/hardware/trezord.nix
   ./services/hardware/triggerhappy.nix
   ./services/hardware/u2f.nix

--- a/nixos/modules/services/hardware/throttled.nix
+++ b/nixos/modules/services/hardware/throttled.nix
@@ -1,0 +1,21 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.throttled;
+in {
+  options = {
+    services.throttled = {
+      enable = mkEnableOption "fix for Intel CPU throttling";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.packages = [ pkgs.throttled ];
+    # The upstream package has this in Install, but that's not enough, see the NixOS manual
+    systemd.services."lenovo_fix".wantedBy = [ "multi-user.target" ];
+
+    environment.etc."lenovo_fix.conf".source = "${pkgs.throttled}/etc/lenovo_fix.conf";
+  };
+}

--- a/pkgs/tools/system/throttled/default.nix
+++ b/pkgs/tools/system/throttled/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchFromGitHub, python3Packages }:
+
+stdenv.mkDerivation rec {
+  pname = "throttled";
+  version = "0.6";
+
+  src = fetchFromGitHub {
+    owner = "erpalma";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "1icb2288pj25vbdnd16zvisw9c01hp8vkk25ilkc74gy76xhpcs4";
+  };
+
+  nativeBuildInputs = [ python3Packages.wrapPython ];
+
+  pythonPath = with python3Packages; [ 
+    configparser
+    dbus-python
+    pygobject3
+  ];
+
+  # The upstream unit both assumes the install location, and tries to run in a virtualenv 
+  postPatch = ''sed -e 's|ExecStart=.*|ExecStart=${placeholder "out"}/bin/lenovo_fix.py|' -i systemd/lenovo_fix.service'';
+
+  installPhase = ''
+    runHook preInstall
+    install -D -m755 -t $out/bin lenovo_fix.py
+    install -D -t $out/bin lenovo_fix.py mmio.py
+    install -D -m644 -t $out/etc etc/*
+    install -D -m644 -t $out/lib/systemd/system systemd/*
+    runHook postInstall
+  '';
+
+  postFixup = ''wrapPythonPrograms'';
+
+  meta = with stdenv.lib; {
+    description = "Fix for Intel CPU throttling issues";
+    homepage = https://github.com/erpalma/throttled;
+    license = licenses.mit;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ michaelpj ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23749,6 +23749,8 @@ in
 
   thermald = callPackage ../tools/system/thermald { };
 
+  throttled = callPackage ../tools/system/throttled { };
+
   thinkfan = callPackage ../tools/system/thinkfan { };
 
   tup = callPackage ../development/tools/build-managers/tup { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
`throttled` is a project that fixes some of the Intel CPU throttling issues primarily (but not exclusively) affecting Lenovo machines.

It is a slightly less ad-hoc version of the fix that we have in [`nixos-hardware`](https://github.com/NixOS/nixos-hardware/blob/master/common/pc/laptop/cpu-throttling-bug.nix), and hopefully could replace it. Crucially, it seems to be maintained.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
