### PR TITLE
init maintainers/scripts/update-hackage

### DIFF
--- a/maintainers/scripts/update-hackage
+++ b/maintainers/scripts/update-hackage
@@ -1,0 +1,34 @@
+#!/usr/bin/env nix-shell
+#!nix-shell update-hackage-shell.nix -i sh
+
+set -eu -o pipefail
+
+exit_trap()
+{
+  local lc="$BASH_COMMAND" rc=$?
+  test $rc -eq 0 || echo "*** error $rc: $lc"
+}
+
+trap exit_trap EXIT
+
+
+if [ $# -ne 1 ]; then
+	echo "Usage: $0 <HACKAGE_REPO>"
+	echo "You can clone the hackage repository via:"
+	echo "git clone git@github.com:commercialhaskell/all-cabal-hashes.git --branch hackage"
+	exit 1
+fi
+
+HACKAGE_REPO="${1}"
+
+cd  "$HACKAGE_REPO"
+rm -f preferred-versions
+for n in */preferred-versions; do
+  cat >>preferred-versions "$n"
+  echo >>preferred-versions
+done
+cd -
+
+hackage2nix --nixpkgs="$NIXPKGS_ROOT" +RTS -M4G -RTS \
+	--config="pkgs/development/haskell-modules/configuration-hackage2nix.yaml" \
+	--hackage "$HACKAGE_REPO" --preferred-versions "$HACKAGE_REPO/preferred-versions"

--- a/maintainers/scripts/update-hackage-shell.nix
+++ b/maintainers/scripts/update-hackage-shell.nix
@@ -1,0 +1,9 @@
+{ nixpkgs ? import ../.. { }
+}:
+with nixpkgs;
+mkShell {
+  buildInputs = [
+    haskellPackages.cabal2nix
+  ];
+  NIXPKGS_ROOT = toString ../..;
+}


### PR DESCRIPTION
There are 3 scripts to update the haskell infra at https://github.com/NixOS/cabal2nix
This moves the command to regenerate pkgs/development/haskell-modules/hackage-packages.nix
in nixpkgs to ease the process.
The user still needs to download the hackage repo and point the script at it.

As I was dealing with haskell problems, I tried to experiment things but having the scripts in cabal2nix are too integrated for quick experiments (automatically pull repos/commit things). 
I am not sure how much of these scripts should go into nixpkgs but this single script allows to tweak
pkgs/development/haskell-modules/configuration-hackage2nix.yaml and regenerate pkgs/development/haskell-modules/hackage-packages.nix which is good enough as a start
@peti 

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
