### PR TITLE
srandrd: init at v0.6.0

### DIFF
--- a/pkgs/tools/X11/srandrd/default.nix
+++ b/pkgs/tools/X11/srandrd/default.nix
@@ -1,0 +1,31 @@
+{ stdenv
+, fetchFromGitHub
+, libX11
+, libXrandr
+, libXinerama
+}:
+
+stdenv.mkDerivation rec {
+  pname = "srandrd";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "jceb";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "07r1ck2ijj30n19ylndgw75ly9k3815kj9inpxblfnjpwbbw6ic0";
+  };
+
+  buildInputs = [ libX11 libXrandr libXinerama ];
+
+  makeFlags = "PREFIX=$(out)";
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/jceb/srandrd";
+    description = "Simple randr daemon";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.utdemir ];
+  };
+
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8690,6 +8690,8 @@ in
   pharo-spur64 = assert stdenv.is64bit; pharo-vms.spur64;
   pharo-launcher = callPackage ../development/pharo/launcher { };
 
+  srandrd = callPackage ../tools/X11/srandrd { };
+
   srecord = callPackage ../development/tools/misc/srecord { };
 
   srelay = callPackage ../tools/networking/srelay { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

srandrd is a handy utility to run a command when display configuration changes.

It's a simple c script without many dependencies, and I tested that it works on my NixOS machine.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---