### PR TITLE
tmatrix: init at 1.0

### DIFF
--- a/pkgs/applications/misc/tmatrix/default.nix
+++ b/pkgs/applications/misc/tmatrix/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, lib, fetchFromGitHub, cmake, ncurses }:
+
+stdenv.mkDerivation rec {
+  pname = "tmatrix";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "M4444";
+    repo = "TMatrix";
+    rev = "v${version}";
+    sha256 = "1g0gn4p02vjc6l8lc78wlx4xkd74ha7ybx9fvvdr6mizk0cyjili";
+  };
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ ncurses ];
+
+  postInstall = ''
+    mkdir -p $out/share/man/man6
+    install -m 0644 ../tmatrix.6 $out/share/man/man6
+  '';
+
+  meta = with lib; {
+    description = "Terminal based replica of the digital rain from The Matrix";
+    longDescription = ''
+      TMatrix is a program that simulates the digital rain form The Matrix.
+      It's focused on being the most accurate replica of the digital rain effect
+      achievable on a typical terminal, while also being customizable and
+      performant.
+    '';
+    homepage = "https://github.com/M4444/TMatrix";
+    license = licenses.gpl2;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ infinisil ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20364,6 +20364,8 @@ in
     inherit (linuxPackages) x86_energy_perf_policy;
   };
 
+  tmatrix = callPackage ../applications/misc/tmatrix { };
+
   tnef = callPackage ../applications/misc/tnef { };
 
   todiff = callPackage ../applications/misc/todiff { };


### PR DESCRIPTION
###### Motivation for this change
Because it's really cool. Nice package, @M4444!

![test](https://raw.githubusercontent.com/M4444/TMatrix/v1.0/assets/img/TMatrix.gif)

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested execution of all binary files (usually in `./result/bin/`)
---
