### PR TITLE
genymotion: refactor src from requireFile to fetchurl 

### DIFF
--- a/pkgs/development/mobile/genymotion/default.nix
+++ b/pkgs/development/mobile/genymotion/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, requireFile, makeWrapper, which, zlib, libGL, glib, xorg, libxkbcommon
+{ stdenv, fetchurl, makeWrapper, which, zlib, libGL, glib, xorg, libxkbcommon
 , xdg_utils
 # For glewinfo
 , libXmu, libXi, libXext }:
@@ -10,10 +10,10 @@ let
   libPath = "${stdenv.lib.makeLibraryPath packages}";
 in
 stdenv.mkDerivation rec {
-  name = "genymotion-${version}";
+  pname = "genymotion";
   version = "2.8.0";
-  src = requireFile {
-    url = https://www.genymotion.com/download/;
+  src = fetchurl {
+    url = "https://dl.genymotion.com/releases/genymotion-${version}/genymotion-${version}-linux_x64.bin";
     name = "genymotion-${version}-linux_x64.bin";
     sha256 = "0lvfdlpmmsyq2i9gs4mf6a8fxkfimdr4rhyihqnfhjij3fzxz4lk";
   };
@@ -24,12 +24,12 @@ stdenv.mkDerivation rec {
     mkdir -p phony-home $out/share/applications
     export HOME=$TMP/phony-home
 
-    mkdir ${name}
-    echo "y" | sh $src -d ${name}
-    sourceRoot=${name}
+    mkdir ${pname}
+    echo "y" | sh $src -d ${pname}
+    sourceRoot=${pname}
 
     substitute phony-home/.local/share/applications/genymobile-genymotion.desktop \
-      $out/share/applications/genymobile-genymotion.desktop --replace "$TMP/${name}" "$out/libexec"
+      $out/share/applications/genymobile-genymotion.desktop --replace "$TMP/${pname}" "$out/libexec"
   '';
 
   installPhase = ''


### PR DESCRIPTION
The old src url was updated by the host, making the required file inaccessible. The new url links directly to the required file.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
The old src URL was updated by the host, making the required file inaccessible.

###### Things done
The old URL was to an html page which shows the most recent version of genymotion.
There was recently a major version update (2.8.0 -> 3.0.2) which now occupies the old URL.
I tried updating our nix expression to the latest package, but ran into issues linking `xcb`.
Next I tried finding the old file but could not locate it through genymotion's webpage, or various search engines.
Next I looked at the download URL associated with the newest version. I swapped out the version numbers of the URL, and luckily the file was still available at it's direct path.
I am updating the Nix expression to include this direct path so that it will provide a more helpful message to users.
I am hoping to save future users from the trouble of tracking the file down.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
