### PR TITLE
exodus: init at 19.5.24

### DIFF
--- a/pkgs/applications/altcoins/exodus/default.nix
+++ b/pkgs/applications/altcoins/exodus/default.nix
@@ -1,0 +1,78 @@
+{ stdenv, lib, makeWrapper, fetchurl, unzip, glib, systemd, nss, nspr, gtk3-x11, gnome2,
+atk, cairo, gdk_pixbuf, xorg, xorg_sys_opengl, utillinux, alsaLib, dbus, at-spi2-atk,
+cups, vivaldi-ffmpeg-codecs, libpulseaudio }:
+
+stdenv.mkDerivation rec {
+  pname = "exodus";
+  version = "19.5.24";
+
+  src = fetchurl {
+    url = "https://exodusbin.azureedge.net/releases/${pname}-linux-x64-${version}.zip";
+    sha256 = "1yx296i525qmpqh8f2vax7igffg826nr8cyq1l0if35374bdsqdw";
+  };
+
+  sourceRoot = ".";
+  unpackCmd = ''
+			${unzip}/bin/unzip "$src" -x "Exodus*/lib*so"
+  '';
+
+  installPhase = ''
+		mkdir -p $out/bin $out/share/applications
+		cd Exodus-linux-x64
+		cp -r . $out
+		ln -s $out/Exodus $out/bin/Exodus
+		ln -s $out/exodus.desktop $out/share/applications
+		substituteInPlace $out/share/applications/exodus.desktop \
+				  --replace 'Exec=bash -c "cd `dirname %k` && ./Exodus"' "Exec=Exodus"
+  '';
+
+  dontPatchELF = true;
+  dontBuild = true;
+
+  preFixup = let
+    libPath = lib.makeLibraryPath [
+			glib
+			nss
+			nspr
+			gtk3-x11
+			gnome2.pango
+			atk
+			cairo
+			gdk_pixbuf
+			xorg.libX11
+			xorg.libxcb
+			xorg.libXcomposite
+			xorg.libXcursor
+			xorg.libXdamage
+			xorg.libXext
+			xorg.libXfixes
+			xorg.libXi
+			xorg.libXrender
+			xorg.libXtst
+			xorg_sys_opengl
+			utillinux
+			xorg.libXrandr
+			xorg.libXScrnSaver
+			alsaLib
+			dbus.lib
+			at-spi2-atk
+			cups.lib
+			libpulseaudio
+			systemd
+			vivaldi-ffmpeg-codecs
+    ];
+  in ''
+    patchelf \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath "${libPath}" \
+      $out/Exodus
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://www.exodus.io/";
+    description = "Top-rated cryptocurrency wallet with Trezor integration and built-in Exchange";
+    license = licenses.unfree;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.mmahut ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2783,6 +2783,8 @@ in
 
   exiftool = perlPackages.ImageExifTool;
 
+  exodus = callPackage ../applications/altcoins/exodus { };
+
   ext4magic = callPackage ../tools/filesystems/ext4magic { };
 
   extract_url = callPackage ../applications/misc/extract_url { };


### PR DESCRIPTION
###### Motivation for this change

Initial packaging of exodus wallet.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
- [X] Tested with Trezor hardware wallet

---
