### PR TITLE
build-support/writers: actually run checks

### DIFF
--- a/pkgs/build-support/writers/default.nix
+++ b/pkgs/build-support/writers/default.nix
@@ -24,6 +24,9 @@ rec {
     }) ''
       echo "#! $interpreter" > $out
       cat "$contentPath" >> $out
+      ${optionalString (check != "") ''
+        ${check} $out
+      ''}
       chmod +x $out
       ${optionalString (types.path.check nameOrPath) ''
         mv $out tmp


### PR DESCRIPTION
###### Motivation for this change
actually run the check phase of the nix-writers. This is currently only implemented for writePython{2,3}