### PR TITLE
pixiecore: initial commit

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5707,4 +5707,9 @@
     github = "zzamboni";
     name = "Diego Zamboni";
   };
+  raunovv = {
+    email = "rauno@oyenetwork.com";
+    github = "raunovv";
+    name = "Rauno Väli";
+  };
 }

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -635,6 +635,7 @@
   ./services/networking/ostinato.nix
   ./services/networking/owamp.nix
   ./services/networking/pdnsd.nix
+  ./services/networking/pixiecore.nix
   ./services/networking/polipo.nix
   ./services/networking/powerdns.nix
   ./services/networking/pdns-recursor.nix

--- a/nixos/modules/services/networking/pixiecore.nix
+++ b/nixos/modules/services/networking/pixiecore.nix
@@ -81,14 +81,6 @@ in
   };
 
   config = mkIf cfg.enable {
-    users.users.pixiecore = {
-      isSystemUser = true;
-      group = "pixiecore";
-      home = "/var/cache/pixiecore";
-      createHome = true;
-    };
-
-    users.groups.pixiecore = {};
 
     systemd.services.pixiecore = {
       description = "Netboot server";
@@ -98,9 +90,10 @@ in
       serviceConfig = {
         Type="simple";
         PIDFile="/run/pixiecore.pid";
+        DynamicUser="yes";
+        AmbientCapabilities = "cap_net_bind_service";
         ExecStart  = "${pkgs.pixiecore}/bin/pixiecore boot ${cfg.kernel} ${cfg.initrd} ${optionalString (cfg.cmdLine != "") "--cmdline=\\\'${cfg.cmdLine}\\\'"} ${optionalString cfg.debug "--debug"} ${optionalString cfg.logTimestamps "--log-timestamps"} ${optionalString cfg.dhcpNoBind "--dhcp-no-bind"} ${optionalString (cfg.listen != "") "--listen-addr ${cfg.listen}"} ${optionalString (cfg.port != 0) "--port ${toString cfg.port}"} ${optionalString (cfg.statusPort!= 0) "--status-port ${toString cfg.statusPort}"}";
-        User = "pixiecore";
-        Group = "pixiecore";
+
       };
     };
 

--- a/nixos/modules/services/networking/pixiecore.nix
+++ b/nixos/modules/services/networking/pixiecore.nix
@@ -14,25 +14,21 @@ in
 
     services.pixiecore = {
 
-      enable = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Whether to run pixiecore netboot server.";
-      };
+      enable = mkEnableOption "Pixiecore";
 
-     debug = mkOption {
+      debug = mkOption {
         type = types.bool;
         default = false;
         description = "Log more things that aren't directly related to booting a recognized client";
       };
 
-     logTimestamps = mkOption {
+      logTimestamps = mkOption {
         type = types.bool;
         default = true;
         description = "Add a timestamp to each log line";
       };
 
-     dhcpNoBind = mkOption {
+      dhcpNoBind = mkOption {
         type = types.bool;
         default = false;
         description = "Handle DHCP traffic without binding to the DHCP server port";
@@ -62,19 +58,19 @@ in
         description = "Kernel commandline arguments";
       };
 
-     listen = mkOption {
+      listen = mkOption {
         type = types.string;
         default = "0.0.0.0";
         description = "IPv4 address to listen on";
       };
 
-     port = mkOption {
+      port = mkOption {
         type = types.int;
         default = 80;
         description = "Port to listen on for HTTP";
       };
 
-     statusPort = mkOption {
+      statusPort = mkOption {
         type = types.int;
         default = 80;
         description = "HTTP port for status information (can be the same as --port)";
@@ -85,27 +81,26 @@ in
   };
 
   config = mkIf cfg.enable {
-#    users.users.pixiecore = {
-#      isSystemUser = true;
-#      group = "pixiecore";
-#      home = "/var/cache/pixiecore";
-#      createHome = true;
-#    };
+    users.users.pixiecore = {
+      isSystemUser = true;
+      group = "pixiecore";
+      home = "/var/cache/pixiecore";
+      createHome = true;
+    };
 
-#    users.groups.pixiecore = {};
+    users.groups.pixiecore = {};
 
     systemd.services.pixiecore = {
       description = "Netboot server";
       after = [ "network.target"];
       wants = [ "network.target"];
       wantedBy = [ "multi-user.target"];
-      preStart = ''
-      '';
       serviceConfig = {
         Type="simple";
         PIDFile="/run/pixiecore.pid";
-        PermissionsStartOnly = true;
         ExecStart  = "${pkgs.pixiecore}/bin/pixiecore boot ${cfg.kernel} ${cfg.initrd} ${optionalString (cfg.cmdLine != "") "--cmdline=\\\'${cfg.cmdLine}\\\'"} ${optionalString cfg.debug "--debug"} ${optionalString cfg.logTimestamps "--log-timestamps"} ${optionalString cfg.dhcpNoBind "--dhcp-no-bind"} ${optionalString (cfg.listen != "") "--listen-addr ${cfg.listen}"} ${optionalString (cfg.port != 0) "--port ${toString cfg.port}"} ${optionalString (cfg.statusPort!= 0) "--status-port ${toString cfg.statusPort}"}";
+        User = "pixiecore";
+        Group = "pixiecore";
       };
     };
 

--- a/nixos/modules/services/networking/pixiecore.nix
+++ b/nixos/modules/services/networking/pixiecore.nix
@@ -1,0 +1,114 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.pixiecore;
+
+in
+
+{
+
+  options = {
+
+    services.pixiecore = {
+
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Whether to run pixiecore netboot server.";
+      };
+
+     debug = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Log more things that aren't directly related to booting a recognized client";
+      };
+
+     logTimestamps = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Add a timestamp to each log line";
+      };
+
+     dhcpNoBind = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Handle DHCP traffic without binding to the DHCP server port";
+      };
+
+      bootMsg = mkOption {
+        type = types.nullOr types.string;
+        default = "";
+        description = "Message to print on machines before booting";
+      };
+
+      kernel = mkOption {
+        type = types.string;
+        default = "";
+        description = "Kernel path";
+      };
+
+      initrd = mkOption {
+        type = types.string;
+        default = "";
+        description = "Initrd path";
+      };
+
+      cmdLine = mkOption {
+        type = types.nullOr types.string;
+        default = "";
+        description = "Kernel commandline arguments";
+      };
+
+     listen = mkOption {
+        type = types.string;
+        default = "0.0.0.0";
+        description = "IPv4 address to listen on";
+      };
+
+     port = mkOption {
+        type = types.int;
+        default = 80;
+        description = "Port to listen on for HTTP";
+      };
+
+     statusPort = mkOption {
+        type = types.int;
+        default = 80;
+        description = "HTTP port for status information (can be the same as --port)";
+      };
+
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+#    users.users.pixiecore = {
+#      isSystemUser = true;
+#      group = "pixiecore";
+#      home = "/var/cache/pixiecore";
+#      createHome = true;
+#    };
+
+#    users.groups.pixiecore = {};
+
+    systemd.services.pixiecore = {
+      description = "Netboot server";
+      after = [ "network.target"];
+      wants = [ "network.target"];
+      wantedBy = [ "multi-user.target"];
+      preStart = ''
+      '';
+      serviceConfig = {
+        Type="simple";
+        PIDFile="/run/pixiecore.pid";
+        PermissionsStartOnly = true;
+        ExecStart  = "${pkgs.pixiecore}/bin/pixiecore boot ${cfg.kernel} ${cfg.initrd} ${optionalString (cfg.cmdLine != "") "--cmdline=\\\'${cfg.cmdLine}\\\'"} ${optionalString cfg.debug "--debug"} ${optionalString cfg.logTimestamps "--log-timestamps"} ${optionalString cfg.dhcpNoBind "--dhcp-no-bind"} ${optionalString (cfg.listen != "") "--listen-addr ${cfg.listen}"} ${optionalString (cfg.port != 0) "--port ${toString cfg.port}"} ${optionalString (cfg.statusPort!= 0) "--status-port ${toString cfg.statusPort}"}";
+      };
+    };
+
+  };
+
+}

--- a/pkgs/tools/networking/pixiecore/default.nix
+++ b/pkgs/tools/networking/pixiecore/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildGoPackage, fetchgit, fetchhg, fetchbzr, fetchsvn }:
+
+buildGoPackage rec {
+  name = "netboot-unstable-${version}";
+  version = "2019-02-14";
+  rev = "01f30467ac8e8f4e3a3c6b6a8642d62a04e97631";
+
+  goPackagePath = "go.universe.tf/netboot";
+
+  src = fetchgit {
+    inherit rev;
+    url = "https://github.com/google/netboot";
+    sha256 = "1ddbp63zx1qwxwm58cx9km2nbccwgy032v143nwa4gq9z4p5mr0z";
+  };
+
+  goDeps = ./deps.nix;
+
+  # TODO: add metadata https://nixos.org/nixpkgs/manual/#sec-standard-meta-attributes
+  meta = {
+    description = "A tool to manage network booting of machines";
+    homepage = "https://github.com/danderson/netboot/tree/master/pixiecore";
+    license =  stdenv.lib.licenses.asl20;
+    maintainers = [ "Rauno Väli rauno@oyenetwork.com" ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/pkgs/tools/networking/pixiecore/default.nix
+++ b/pkgs/tools/networking/pixiecore/default.nix
@@ -1,7 +1,8 @@
 { stdenv, buildGoPackage, fetchgit, fetchhg, fetchbzr, fetchsvn }:
 
 buildGoPackage rec {
-  name = "netboot-unstable-${version}";
+  name = "${pname}-${version}";
+  pname = "netboot";
   version = "2019-02-14";
   rev = "01f30467ac8e8f4e3a3c6b6a8642d62a04e97631";
 
@@ -15,12 +16,11 @@ buildGoPackage rec {
 
   goDeps = ./deps.nix;
 
-  # TODO: add metadata https://nixos.org/nixpkgs/manual/#sec-standard-meta-attributes
   meta = {
     description = "A tool to manage network booting of machines";
     homepage = "https://github.com/danderson/netboot/tree/master/pixiecore";
     license =  stdenv.lib.licenses.asl20;
-    maintainers = [ "Rauno Väli rauno@oyenetwork.com" ];
+    maintainers = with stdenv.lib.maintainers; [ raunovv ];
     platforms = stdenv.lib.platforms.linux;
   };
 }

--- a/pkgs/tools/networking/pixiecore/deps.nix
+++ b/pkgs/tools/networking/pixiecore/deps.nix
@@ -1,0 +1,155 @@
+[
+  {
+    goPackagePath = "github.com/fsnotify/fsnotify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/fsnotify/fsnotify";
+      rev = "1485a34d5d5723fea214f5710708e19a831720e4";
+      sha256 = "0h2g3603z3zsnagxv5dlgzclq1hp2b95wl7c0k4m9ccaif4i8hjf";
+    };
+  }
+  {
+    goPackagePath = "github.com/hashicorp/hcl";
+    fetch = {
+      type = "git";
+      url = "https://github.com/hashicorp/hcl";
+      rev = "99e2f22d1c94b272184d97dd9d252866409100ab";
+      sha256 = "1dypdjw7zmw2dmmkf2hyzsap1j9g9rwdjc3dky66kfhxvixsi66r";
+    };
+  }
+  {
+    goPackagePath = "github.com/magiconair/properties";
+    fetch = {
+      type = "git";
+      url = "https://github.com/magiconair/properties";
+      rev = "de8848e004dd33dc07a2947b3d76f618a7fc7ef1";
+      sha256 = "19zqw1x0w0crh8zc84yy82nkcc5yjz72gviaf2xjgfm5a8np7nyb";
+    };
+  }
+  {
+    goPackagePath = "github.com/mitchellh/mapstructure";
+    fetch = {
+      type = "git";
+      url = "https://github.com/mitchellh/mapstructure";
+      rev = "3536a929edddb9a5b34bd6861dc4a9647cb459fe";
+      sha256 = "03bpv28jz9zhn4947saqwi328ydj7f6g6pf1m2d4m5zdh5jlfkrr";
+    };
+  }
+  {
+    goPackagePath = "github.com/pelletier/go-toml";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pelletier/go-toml";
+      rev = "728039f679cbcd4f6a54e080d2219a4c4928c546";
+      sha256 = "1v76s3vds0i9dxaha4ikd6xjm7vqqfk6sy9l6jc2lsvmj99d5sy6";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/afero";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/afero";
+      rev = "588a75ec4f32903aa5e39a2619ba6a4631e28424";
+      sha256 = "0j9r65qgd58324m85lkl49vk9dgwd62g7dwvkfcm3k6i9dc555a9";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/cast";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/cast";
+      rev = "8c9545af88b134710ab1cd196795e7f2388358d7";
+      sha256 = "0xq1ffqj8y8h7dcnm0m9lfrh0ga7pssnn2c1dnr09chqbpn4bdc5";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/cobra";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/cobra";
+      rev = "67fc4837d267bc9bfd6e47f77783fcc3dffc68de";
+      sha256 = "1k7dq78fjz94lzifsprkmiv93swwzwcbg1vd64v20wvnga8v254b";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/jwalterweatherman";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/jwalterweatherman";
+      rev = "94f6ae3ed3bceceafa716478c5fbf8d29ca601a1";
+      sha256 = "1ywmkwci5zyd88ijym6f30fj5c0k2yayxarkmnazf5ybljv50q7b";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/pflag";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/pflag";
+      rev = "24fa6976df40757dce6aea913e7b81ade90530e1";
+      sha256 = "0rf6prz6gl0l1b3wijzdgq887cdwigvzxvz6gqbm5l8pkq3fx1m9";
+    };
+  }
+  {
+    goPackagePath = "github.com/spf13/viper";
+    fetch = {
+      type = "git";
+      url = "https://github.com/spf13/viper";
+      rev = "7a605a50e69cd1ea431c4a1e6eebe9b287ef6de4";
+      sha256 = "0sfb2nsi8mi90cshzycmigrff055my72q2lz2rm52cqrmdy25a5q";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/crypto";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/crypto";
+      rev = "22d7a77e9e5f409e934ed268692e56707cd169e5";
+      sha256 = "139dmvmnhnn9zsrcmg03jr0fd8y8shjfng9k4l8hdxyqg0glgs4j";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/net";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/net";
+      rev = "f3200d17e092c607f615320ecaad13d87ad9a2b3";
+      sha256 = "1mskh7p80dd8j1ffy16917d3cyy7lfh1gb56n4rq9g1bwckz4lwy";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/sys";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/sys";
+      rev = "0e01d883c5c5e3a1741118a9962f68d71b0a6ed4";
+      sha256 = "1ydpc55b2pl8m6rihr2b0yvi7qn96ldf6wdxca5d6c4z5rmk7dk9";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev = "342b2e1fbaa52c93f31447ad2c6abc048c63e475";
+      sha256 = "0flv9idw0jm5nm8lx25xqanbkqgfiym6619w575p7nrdh0riqwqh";
+    };
+  }
+  {
+    goPackagePath = "gopkg.in/yaml.v2";
+    fetch = {
+      type = "git";
+      url = "https://gopkg.in/yaml.v2";
+      rev = "51d6538a90f86fe93ac480b35f37b2be17fef232";
+      sha256 = "01wj12jzsdqlnidpyjssmj0r4yavlqy7dwrg7adqd8dicjc4ncsa";
+    };
+  }
+  {
+    goPackagePath = "github.com/golang/glog";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/glog";
+      rev = "23def4e6c14b4da8ac2ed8007337bc5eb5007998";
+      sha256 = "0jb2834rw5sykfr937fxi8hxi2zy80sj2bdn9b3jb4b26ksqng30";
+    };
+  }
+]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24181,4 +24181,6 @@ in
 
   dapper = callPackage ../development/tools/dapper { };
 
+  pixiecore = callPackage ../tools/networking/pixiecore {}; 
+
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Initial commit for pixiecore tool: https://github.com/danderson/netboot/tree/master/pixiecore

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
