### PR TITLE
gnuradio: rename plugins gnuradio-* -> gr-*

### DIFF
--- a/pkgs/applications/radio/gnuradio/ais.nix
+++ b/pkgs/applications/radio/gnuradio/ais.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig, boost, gnuradio
-, makeWrapper, cppunit, gnuradio-osmosdr
+, makeWrapper, cppunit, gr-osmosdr
 , pythonSupport ? true, python, swig
 }:
 
 assert pythonSupport -> python != null && swig != null;
 
 stdenv.mkDerivation rec {
-  name = "gnuradio-ais-${version}";
+  name = "gr-ais-${version}";
   version = "2015-12-20";
 
   src = fetchFromGitHub {
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
-    cmake boost gnuradio makeWrapper cppunit gnuradio-osmosdr
+    cmake boost gnuradio makeWrapper cppunit gr-osmosdr
   ] ++ stdenv.lib.optionals pythonSupport [ python swig ];
 
   postInstall = ''

--- a/pkgs/applications/radio/gnuradio/gsm.nix
+++ b/pkgs/applications/radio/gnuradio/gsm.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchFromGitHub, cmake, pkgconfig, boost, gnuradio
-, makeWrapper, cppunit, libosmocore, gnuradio-osmosdr
+, makeWrapper, cppunit, libosmocore, gr-osmosdr
 , pythonSupport ? true, python, swig
 }:
 
 assert pythonSupport -> python != null && swig != null;
 
 stdenv.mkDerivation rec {
-  name = "gnuradio-gsm-${version}";
+  name = "gr-gsm-${version}";
   version = "2016-08-25";
 
   src = fetchFromGitHub {
@@ -18,12 +18,12 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
-    cmake boost gnuradio makeWrapper cppunit libosmocore gnuradio-osmosdr
+    cmake boost gnuradio makeWrapper cppunit libosmocore gr-osmosdr
   ] ++ stdenv.lib.optionals pythonSupport [ python swig ];
 
   postInstall = ''
     for prog in "$out"/bin/*; do
-        wrapProgram "$prog" --set PYTHONPATH $PYTHONPATH:${gnuradio-osmosdr}/lib/${python.libPrefix}/site-packages:$(toPythonPath "$out")
+        wrapProgram "$prog" --set PYTHONPATH $PYTHONPATH:${gr-osmosdr}/lib/${python.libPrefix}/site-packages:$(toPythonPath "$out")
     done
   '';
 

--- a/pkgs/applications/radio/gnuradio/limesdr.nix
+++ b/pkgs/applications/radio/gnuradio/limesdr.nix
@@ -8,7 +8,7 @@ let
   version = "2.0.0";
 
 in stdenv.mkDerivation rec {
-  name = "gnuradio-limesdr-${version}";
+  name = "gr-limesdr-${version}";
 
   src = fetchFromGitHub {
     owner = "myriadrf";

--- a/pkgs/applications/radio/gnuradio/nacl.nix
+++ b/pkgs/applications/radio/gnuradio/nacl.nix
@@ -6,7 +6,7 @@
 assert pythonSupport -> python != null && swig != null;
 
 stdenv.mkDerivation rec {
-  name = "gnuradio-nacl-${version}";
+  name = "gr-nacl-${version}";
   version = "2017-04-10";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/radio/gnuradio/osmosdr.nix
+++ b/pkgs/applications/radio/gnuradio/osmosdr.nix
@@ -13,7 +13,7 @@
 assert pythonSupport -> python != null && swig != null;
 
 stdenv.mkDerivation rec {
-  name = "gnuradio-osmosdr-${version}";
+  name = "gr-osmosdr-${version}";
   version = "2018-08-15";
 
   src = fetchgit {

--- a/pkgs/applications/radio/gnuradio/rds.nix
+++ b/pkgs/applications/radio/gnuradio/rds.nix
@@ -5,7 +5,7 @@
 assert pythonSupport -> python != null && swig != null;
 
 stdenv.mkDerivation rec {
-  name = "gnuradio-rds-${version}";
+  name = "gr-rds-${version}";
   version = "1.1.0";
 
   src = fetchFromGitHub {

--- a/pkgs/applications/radio/gqrx/default.nix
+++ b/pkgs/applications/radio/gqrx/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, qtbase, qtsvg, gnuradio, boost, gnuradio-osmosdr
+{ stdenv, fetchFromGitHub, cmake, qtbase, qtsvg, gnuradio, boost, gr-osmosdr
 # drivers (optional):
 , rtl-sdr, hackrf
 , pulseaudioSupport ? true, libpulseaudio
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [
-    qtbase qtsvg gnuradio boost gnuradio-osmosdr rtl-sdr hackrf
+    qtbase qtsvg gnuradio boost gr-osmosdr rtl-sdr hackrf
   ] ++ stdenv.lib.optionals pulseaudioSupport [ libpulseaudio ];
 
   enableParallelBuilding = true;

--- a/pkgs/applications/radio/qradiolink/default.nix
+++ b/pkgs/applications/radio/qradiolink/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitHub, alsaLib, boost
 , qt4, libpulseaudio, codec2, libconfig
-, gnuradio, gnuradio-osmosdr, gsm
+, gnuradio, gr-osmosdr, gsm
 , libopus, libjpeg, protobuf, qwt, speex
 } :
 
@@ -39,7 +39,7 @@ in stdenv.mkDerivation {
     libconfig
     gsm
     gnuradio
-    gnuradio-osmosdr
+    gr-osmosdr
     libopus
     libjpeg
     protobuf

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -108,6 +108,12 @@ mapAliases ({
   gnome-themes-standard = gnome-themes-extra; # added 2018-03-14
   gnome_doc_utils = gnome-doc-utils; # added 2018-02-25
   gnome_themes_standard = gnome-themes-standard; # added 2018-02-25
+  gnuradio-nacl = gr-nacl; # added 2019-05-27
+  gnuradio-gsm = gr-gsm; # added 2019-05-27
+  gnuradio-ais = gr-ais; # added 2019-05-27
+  gnuradio-limesdr = gr-limesdr; # added 2019-05-27
+  gnuradio-rds = gr-rds; # added 2019-05-27
+  gnuradio-osmosdr = gr-osmosdr; # added 2019-05-27
   gnustep-make = gnustep.make; # added 2016-7-6
   go-pup = pup; # added 2017-12-19
   gobjectIntrospection = gobject-introspection; # added 2018-12-02

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17754,21 +17754,21 @@ in
 
   gnuradio-with-packages = callPackage ../applications/radio/gnuradio/wrapper.nix {
     inherit (python2Packages) python;
-    extraPackages = [ gnuradio-nacl gnuradio-osmosdr gnuradio-ais gnuradio-rds ]
-      ++ lib.optionals stdenv.isLinux [ gnuradio-gsm gnuradio-limesdr ];
+    extraPackages = [ gr-nacl gr-osmosdr gr-ais gr-rds ]
+      ++ lib.optionals stdenv.isLinux [ gr-gsm gr-limesdr ];
   };
 
-  gnuradio-nacl = callPackage ../applications/radio/gnuradio/nacl.nix { };
+  gr-nacl = callPackage ../applications/radio/gnuradio/nacl.nix { };
 
-  gnuradio-gsm = callPackage ../applications/radio/gnuradio/gsm.nix { };
+  gr-gsm = callPackage ../applications/radio/gnuradio/gsm.nix { };
 
-  gnuradio-ais = callPackage ../applications/radio/gnuradio/ais.nix { };
+  gr-ais = callPackage ../applications/radio/gnuradio/ais.nix { };
 
-  gnuradio-limesdr = callPackage ../applications/radio/gnuradio/limesdr.nix { };
+  gr-limesdr = callPackage ../applications/radio/gnuradio/limesdr.nix { };
 
-  gnuradio-rds = callPackage ../applications/radio/gnuradio/rds.nix { };
+  gr-rds = callPackage ../applications/radio/gnuradio/rds.nix { };
 
-  gnuradio-osmosdr = callPackage ../applications/radio/gnuradio/osmosdr.nix { };
+  gr-osmosdr = callPackage ../applications/radio/gnuradio/osmosdr.nix { };
 
   goldendict = libsForQt5.callPackage ../applications/misc/goldendict { };
 


### PR DESCRIPTION
###### Motivation for this change
Harmonize plugin names with repology (see https://github.com/NixOS/nixpkgs/issues/60006). In most cases this is also the official package name of the plugins. This will allow for auto updater to check for updates.


###### Things done
* Globally renamed all plugins to gr-*
* added aliases to maintain backwards compatibility

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
