### PR TITLE
pythonPackages.salmon-mail: fix build

### DIFF
--- a/pkgs/development/python-modules/salmon-mail/default.nix
+++ b/pkgs/development/python-modules/salmon-mail/default.nix
@@ -10,6 +10,18 @@ buildPythonPackage rec {
     sha256 = "cb2f9c3bf2b9f8509453ca8bc06f504350e19488eb9d3d6a4b9e4b8c160b527d";
   };
 
+  # Salmon mail has some issues with python-daemon which is why they set an
+  # upper bound for the version. See:
+  # https://github.com/moggers87/salmon/issues/90
+  # https://github.com/moggers87/salmon/blob/3.1.0/setup.py#L10
+  #
+  # Anyway, those issues seem to be related to installation only, as far as I
+  # understand, so let's just remove the version upper bound.
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace "python-daemon<2.2.0" "python-daemon"
+  '';
+
   checkInputs = [ nose jinja2 mock ];
   propagatedBuildInputs = [ chardet dnspython lmtpd python-daemon six ];
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Python package `salmon-mail` failed to build because it had set an upper bound for a dependency and nixpkgs contains too new version of that dependency. This upper bound seems to be just some installation convenience thing, not a compatibility issue, so I just removed the upper bound.

For more information:

- https://github.com/moggers87/salmon/issues/90
- https://github.com/moggers87/salmon/blob/3.1.0/setup.py#L10

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
