### PR TITLE
ndstool: init at 2.1.2

### DIFF
--- a/pkgs/tools/archivers/ndstool/default.nix
+++ b/pkgs/tools/archivers/ndstool/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, autoconf, automake }:
+
+stdenv.mkDerivation rec {
+  pname = "ndstool";
+  version = "2.1.2";
+
+  src = fetchFromGitHub {
+    owner = "devkitPro";
+    repo = "ndstool";
+    rev = "v${version}";
+    sha256 = "0isnm0is5k6dgi2n2c3mysyr5hpwikp5g0s3ix7ms928z04l8ccm";
+  };
+
+  nativeBuildInputs = [ autoconf automake ];
+
+  preConfigure = "./autogen.sh";
+
+  meta = {
+    homepage = https://github.com/devkitPro/ndstool;
+    description = "A tool to unpack and repack nds rom";
+    maintainers = [ stdenv.lib.maintainers.marius851000 ];
+    license = stdenv.lib.licenses.gpl3;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4696,6 +4696,8 @@ in
 
   nextcloud-news-updater = callPackage ../servers/nextcloud/news-updater.nix { };
 
+  ndstool = callPackage ../tools/archivers/ndstool { };
+
   ngrep = callPackage ../tools/networking/ngrep { };
 
   ngrok = ngrok-2;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
use this in one of my program

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
