### PR TITLE
abbaye-des-morts: init at 2.0.1

### DIFF
--- a/pkgs/games/abbaye-des-morts/default.nix
+++ b/pkgs/games/abbaye-des-morts/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, fetchFromGitHub, SDL2, SDL2_image, SDL2_mixer }:
+
+stdenv.mkDerivation rec {
+  pname = "abbaye-des-morts";
+  version = "2.0.1";
+
+  src = fetchFromGitHub {
+    owner = "nevat";
+    repo = "abbayedesmorts-gpl";
+    rev = "v${version}";
+    sha256 = "1pwqf7r9bqb2p3xrw9i7y8pgr1401fy3mnnqpb1qkhmdl3gqi9hb";
+  };
+
+  buildInputs = [ SDL2 SDL2_image SDL2_mixer ];
+
+  makeFlags = [ "PREFIX=$(out)" "DESTDIR=" ];
+
+  preBuild = stdenv.lib.optionalString stdenv.cc.isClang
+    ''
+      substituteInPlace Makefile \
+        --replace -fpredictive-commoning ""
+    '';
+
+  preInstall = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/applications
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://locomalito.com/abbaye_des_morts.php";
+    description = "A retro arcade video game";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.marius851000 ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21167,6 +21167,8 @@ in
 
   _90secondportraits = callPackage ../games/90secondportraits { love = love_0_10; };
 
+  abbaye-des-morts = callPackage ../games/abbaye-des-morts { };
+
   adom = callPackage ../games/adom { };
 
   airstrike = callPackage ../games/airstrike { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
A fun game I discovered and wanted to play. Packaged it BTW.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
