### PR TITLE
scalapack: Increase individual test timeout to prevent hydra failures

### DIFF
--- a/pkgs/development/libraries/science/math/scalapack/default.nix
+++ b/pkgs/development/libraries/science/math/scalapack/default.nix
@@ -30,6 +30,10 @@ stdenv.mkDerivation rec {
       )
   '';
 
+  # Increase individual test timeout from 1500s to 10000s because hydra's builds
+  # sometimes fail due to this
+  checkFlagsArray = [ "ARGS=--timeout 10000" ];
+
   preCheck = ''
     # make sure the test starts even if we have less than 4 cores
     export OMPI_MCA_rmaps_base_oversubscribe=1


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Build occasionally failed (see https://hydra.nixos.org/job/nixpkgs/trunk/scalapack.x86_64-linux/all?page=1) due to individual tests timing out:

```
95/96 Test #93: xcheevr ..........................***Timeout 1500.05 sec

[...]

95% tests passed, 5 tests failed out of 96

Total Test time (real) = 4836.54 sec

The following tests FAILED:
         44 - xdllt (Timeout)
         45 - xcllt (Timeout)
         91 - xssyevr (Timeout)
         92 - xdsyevr (Timeout)
         93 - xcheevr (Timeout)
Errors while running CTest
make: *** [Makefile:141: test] Error 8
builder for '/nix/store/kszycfkp7aimpxx8j9kr3lgk3iiwb5sj-scalapack-2.0.2.drv' failed with exit code 2
```

As I found out through http://icl.cs.utk.edu/lapack-forum/viewtopic.php?t=4861, this 1500s timeout is built into cmake itself and can only be overwritten globally by passing `--timeout` to ctest, which is what this PR does with a value of 10000s.

An alternative would be to just disable the tests, which might be desirable, because they take ~1h20 to run, in comparison to the ~10 minutes of the build itself! Honestly this is a huge waste of build power, and I doubt the tests will ever give us a failure anyways.

Ping @costrouc @markuskowa 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
