### PR TITLE
reaverwps-t6x: 1.6.3 -> 1.6.5

### DIFF
--- a/pkgs/tools/networking/reaver-wps-t6x/default.nix
+++ b/pkgs/tools/networking/reaver-wps-t6x/default.nix
@@ -1,25 +1,20 @@
 { stdenv, fetchFromGitHub, libpcap, pixiewps, makeWrapper }:
 
 stdenv.mkDerivation rec {
-  version = "1.6.3";
-  name = "reaver-wps-t6x-${version}";
+  pname = "reaver-wps-t6x";
+  version = "1.6.5";
 
   src = fetchFromGitHub {
     owner = "t6x";
     repo = "reaver-wps-fork-t6x";
     rev = "v${version}";
-    sha256 = "1bccwp67q1q0h5m38gqxn9imq5rb75jbmv7fjr2n38v10jcga2pb";
+    sha256 = "03v5jyb4if74rpg0mcd8700snb120b6w2gnsa3aqdgj5676ic5dn";
   };
 
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ libpcap pixiewps ];
 
-  preConfigure = "cd src";
-
-  installPhase = ''
-    mkdir -p $out/bin
-    cp reaver wash $out/bin/
-  '';
+  sourceRoot = "source/src";
 
   meta = with stdenv.lib; {
     description = "Online and offline brute force attack against WPS";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
https://github.com/t6x/reaver-wps-fork-t6x/releases/tag/v1.6.5
https://github.com/t6x/reaver-wps-fork-t6x/releases/tag/v1.6.4

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
