### PR TITLE
Adds Citrix workspace app package

### DIFF
--- a/pkgs/applications/networking/remote/citrix-workspace/default.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/default.nix
@@ -1,0 +1,214 @@
+{ stdenv
+, lib
+, fetchurl
+, requireFile
+, makeWrapper
+, libredirect
+, busybox
+, file
+, makeDesktopItem
+, tzdata
+, cacert
+, glib
+, gtk2
+, atk
+, gdk_pixbuf
+, cairo
+, pango
+, gnome3
+, xorg
+, libpng12
+, freetype
+, fontconfig
+, gtk_engines
+, alsaLib
+, libidn
+, zlib
+, version ? "19.3.0"
+}:
+
+let
+  # In 56e1bdc7f9c (libidn: 1.34 -> 1.35), libidn.so.11 became libidn.so.12.
+  # Citrix looks for the former so we build version 1.34 to please the binary
+  libidn_134 = libidn.overrideDerivation (_: rec {
+    name = "libidn-1.34";
+    src = fetchurl {
+      url = "mirror://gnu/libidn/${name}.tar.gz";
+      sha256 = "0g3fzypp0xjcgr90c5cyj57apx1cmy0c6y9lvw2qdcigbyby469p";
+    };
+  });
+
+  versionInfo = let
+    supportedVersions = {
+      "19.3.0" = {
+        major     = "19";
+        minor     = "3";
+        patch     = "0";
+        x64hash   = "0mhpp29ca3dw9hx72i0qawdq35wcc7qzgxwzlx4aicwnm1gbil5c";
+        x86hash   = "1hxgj5lk5ghbpssbqjd404qr84gls967vwrh8ww5hg3pn86kyf8w";
+        x64suffix = "5";
+        x86suffix = "5";
+        homepage  = https://www.citrix.com/downloads/workspace-app/linux/workspace-app-for-linux-latest.html;
+      };
+    };
+
+    # Copied this file largely from the citrix-receiver package
+    # Leaving this here even though there are no deprecations yet
+    # for ease of future maintenance
+    deprecatedVersions = let
+      versions = [ ];
+    in
+      lib.listToAttrs
+        (lib.flip map versions
+          (v: lib.nameValuePair v (throw "Unsupported citrix_workspace version: ${v}")));
+  in
+    deprecatedVersions // supportedVersions;
+
+  citrixWorkspaceForVersion = { major, minor, patch, x64hash, x86hash, x64suffix, x86suffix, homepage }:
+    stdenv.mkDerivation rec {
+      name     = "citrix-workspace-${version}";
+      version  = "${major}.${minor}.${patch}";
+      inherit homepage;
+
+      prefixWithBitness = if stdenv.is64bit then "linuxx64" else "linuxx86";
+
+      src = requireFile rec {
+        name    = if stdenv.is64bit then "${prefixWithBitness}-${version}.${x64suffix}.tar.gz" else "${prefixWithBitness}-${version}.${x86suffix}.tar.gz";
+        sha256  = if stdenv.is64bit then x64hash else x86hash;
+        message = ''
+          In order to use Citrix Workspace, you need to comply with the Citrix EULA and download
+          the ${if stdenv.is64bit then "64-bit" else "32-bit"} binaries, .tar.gz from:
+
+          ${homepage}
+
+          (if you do not find version ${version} there, try at
+          https://www.citrix.com/downloads/workspace-app/
+
+          Once you have downloaded the file, please use the following command and re-run the
+          installation:
+
+          nix-prefetch-url file://\$PWD/${name}
+        '';
+      };
+
+      dontBuild = true;
+
+      sourceRoot = ".";
+
+      buildInputs = [
+        makeWrapper
+        busybox
+        file
+        gtk2
+        gdk_pixbuf
+      ];
+
+      libPath = stdenv.lib.makeLibraryPath [
+        glib
+        gtk2
+        atk
+        gdk_pixbuf
+        cairo
+        pango
+        gnome3.dconf
+        xorg.libX11
+        xorg.libXext
+        xorg.libXrender
+        xorg.libXinerama
+        xorg.libXfixes
+        libpng12
+        libidn_134
+        zlib
+        gtk_engines
+        freetype
+        fontconfig
+        alsaLib
+        stdenv.cc.cc # Fixes: Can not load [..]/opt/citrix-icaclient/lib/ctxh264_fb.so:(null)
+      ];
+
+      desktopItem = makeDesktopItem {
+        name        = "wfica";
+        desktopName = "Citrix Workspace";
+        genericName = "Citrix Workspace";
+        exec        = "wfica";
+        icon        = "wfica";
+        comment     = "Connect to remote Citrix server";
+        categories  = "GTK;GNOME;X-GNOME-NetworkSettings;Network;";
+        mimeType    = "application/x-ica";
+      };
+
+      installPhase = ''
+        runHook preInstall
+
+        export ICAInstDir="$out/opt/citrix-icaclient"
+
+        sed -i \
+          -e 's,^main_install_menu$,install_ICA_client,g' \
+          -e 's,^integrate_ICA_client(),alias integrate_ICA_client=true\nintegrate_ICA_client_old(),g' \
+          -e 's,^ANSWER=""$,ANSWER="$INSTALLER_YES",' \
+          -e 's,/bin/true,true,g' \
+          ./${prefixWithBitness}/hinst
+
+        # Run the installer...
+        bash ./${prefixWithBitness}/hinst CDROM "`pwd`"
+
+        echo "Deleting broken links..."
+        for link in `find $ICAInstDir -type l `
+        do
+          [ -f "$link" ] || rm -v "$link"
+        done
+
+        echo "Expanding certificates..."
+        # As explained in https://wiki.archlinux.org/index.php/Citrix#Security_Certificates
+        pushd "$ICAInstDir/keystore/cacerts"
+        awk 'BEGIN {c=0;} /BEGIN CERT/{c++} { print > "cert." c ".pem"}' < ${cacert}/etc/ssl/certs/ca-bundle.crt
+        popd
+
+        echo "Patching executables..."
+        find $ICAInstDir -type f -exec file {} \; |
+          grep 'ELF.*executable' |
+          cut -f 1 -d : |
+          grep -vi '\(.dll\|.so\)$' | # added as a workaround to https://github.com/NixOS/nixpkgs/issues/41729
+          while read f
+          do
+            echo "Patching ELF intrepreter and rpath for $f"
+            chmod u+w "$f"
+            patchelf \
+              --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+              --set-rpath "$ICAInstDir:$libPath" "$f"
+          done
+
+        echo "Wrapping wfica..."
+        mkdir "$out/bin"
+
+        makeWrapper "$ICAInstDir/wfica" "$out/bin/wfica" \
+          --add-flags "-icaroot $ICAInstDir" \
+          --set ICAROOT "$ICAInstDir" \
+          --set GTK_PATH "${gtk2.out}/lib/gtk-2.0:${gnome3.gnome-themes-extra}/lib/gtk-2.0" \
+          --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE" \
+          --set LD_PRELOAD "${libredirect}/lib/libredirect.so" \
+          --set LD_LIBRARY_PATH "$libPath" \
+          --set NIX_REDIRECTS "/usr/share/zoneinfo=${tzdata}/share/zoneinfo:/etc/zoneinfo=${tzdata}/share/zoneinfo:/etc/timezone=$ICAInstDir/timezone"
+
+        echo "We arbitrarily set the timezone to UTC. No known consequences at this point."
+        echo UTC > "$ICAInstDir/timezone"
+
+        echo "Installing desktop item..."
+        mkdir -p $out/share/applications
+        cp ${desktopItem}/share/applications/* $out/share/applications
+
+        # We introduce a dependency on the source file so that it need not be redownloaded everytime
+        echo $src >> "$out/share/workspace_dependencies.pin"
+
+        runHook postInstall
+      '';
+
+      meta = with stdenv.lib; {
+        license     = stdenv.lib.licenses.unfree;
+        inherit homepage;
+        description = "Citrix Workspace";
+        platforms   = platforms.linux;
+      };
+    };
+
+in citrixWorkspaceForVersion (lib.getAttr version versionInfo)

--- a/pkgs/applications/networking/remote/citrix-workspace/wrapper.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/wrapper.nix
@@ -1,0 +1,19 @@
+{ citrix_workspace, extraCerts ? [], symlinkJoin }:
+
+let
+
+  mkCertCopy = certPath:
+    "cp ${certPath} $out/opt/citrix-icaclient/keystore/cacerts/";
+
+in
+
+if builtins.length extraCerts == 0 then citrix_workspace else symlinkJoin {
+  name = "citrix-with-extra-certs-${citrix_workspace.version}";
+  paths = [ citrix_workspace ];
+
+  postBuild = ''
+    ${builtins.concatStringsSep "\n" (map mkCertCopy extraCerts)}
+
+    sed -i -E "s,-icaroot (.+citrix-icaclient),-icaroot $out/opt/citrix-icaclient," $out/bin/wfica
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2093,6 +2093,16 @@ in
     citrix_receiver = citrix_receiver_unwrapped_13_8_0;
   };
 
+  citrix_workspace_unwrapped = callPackage ../applications/networking/remote/citrix-workspace { };
+  citrix_workspace_unwrapped_19_3_0 = citrix_workspace_unwrapped.override { version = "19.3.0"; };
+
+  citrix_workspace = callPackage ../applications/networking/remote/citrix-workspace/wrapper.nix {
+    citrix_workspace = citrix_workspace_unwrapped;
+  };
+  citrix_workspace_19_3_0 = callPackage ../applications/networking/remote/citrix-workspace/wrapper.nix {
+    citrix_workspace = citrix_workspace_unwrapped_19_3_0;
+  };
+
   citra = libsForQt5.callPackage ../misc/emulators/citra { };
 
   cmst = libsForQt5.callPackage ../tools/networking/cmst { };


### PR DESCRIPTION
Citrix workspace is replacing Citrix receiver as per
https://docs.citrix.com/en-us/citrix-workspace-app.html
Creates Citrix workspace package using the citrix-receiver package as a template.
Built and used locally.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
