### PR TITLE
pympress: init at 1.2.0

### DIFF
--- a/pkgs/applications/office/pympress/default.nix
+++ b/pkgs/applications/office/pympress/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, python3Packages
+, wrapGAppsHook
+, xvfb_run
+, gtk3
+, gobject-introspection
+, libcanberra-gtk3
+, dbus
+, poppler_gi
+, python3
+ }:
+
+python3Packages.buildPythonApplication rec {
+  pname = "pympress";
+  version = "1.4.0";
+
+  src = python3Packages.fetchPypi {
+    inherit pname version;
+    sha256 = "101wj6m931bj0ah6niw79i8ywb5zlb2783g7n7dmkhw6ay3jj4vq";
+  };
+
+  nativeBuildInputs = [
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gtk3
+    gobject-introspection
+    libcanberra-gtk3
+    poppler_gi
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    pycairo
+    pygobject3
+    python-vlc
+    watchdog
+  ];
+
+  doCheck = false; # there are no tests
+
+  meta = with lib; {
+    description = "Simple yet powerful PDF reader designed for dual-screen presentations";
+    license = licenses.gpl2Plus;
+    homepage = "https://pympress.xyz/";
+    maintainers = [ maintainers.tbenst ];
+  };
+}

--- a/pkgs/development/python-modules/python-vlc/default.nix
+++ b/pkgs/development/python-modules/python-vlc/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools
+, vlc
+, substituteAll
+}:
+
+buildPythonPackage rec {
+  pname = "python-vlc";
+  version = "3.0.7110";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0ydnqwwgpwq1kz1pjrc7629ljzdd30izymjylsbzzyq8pq6wl6w2";
+  };
+
+  propagatedBuildInputs = [
+    setuptools
+  ];
+
+  patches = [
+    (substituteAll {
+      src = ./vlc-paths.patch;
+      libvlcPath="${vlc}/lib/libvlc.so.5";
+    })
+  ];
+
+  doCheck = false; # no tests
+
+  meta = with lib; {
+    homepage = "https://wiki.videolan.org/PythonBinding";
+    maintainers = with maintainers; [ tbenst ];
+    description = "Python bindings for VLC, the cross-platform multimedia player and framework";
+    license = licenses.lgpl21Plus;
+  };
+}

--- a/pkgs/development/python-modules/python-vlc/vlc-paths.patch
+++ b/pkgs/development/python-modules/python-vlc/vlc-paths.patch
@@ -1,0 +1,13 @@
+diff --git a/vlc.py b/vlc.py
+index e3245a5..cebec09 100644
+--- a/vlc.py
++++ b/vlc.py
+@@ -190,7 +190,7 @@ def find_lib():
+ 
+     else:
+         # All other OSes (linux, freebsd...)
+-        p = find_library('vlc')
++        p = "@libvlcPath@"
+         try:
+             dll = ctypes.CDLL(p)
+         except OSError:  # may fail

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5733,6 +5733,8 @@ in
 
   pygmentex = callPackage ../tools/typesetting/pygmentex { };
 
+  pympress = callPackage ../applications/office/pympress { };
+
   pythonIRClib = pythonPackages.pythonIRClib;
 
   pythonSexy = pythonPackages.libsexy;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5139,6 +5139,8 @@ in {
 
   vsts = callPackage ../development/python-modules/vsts { };
 
+  python-vlc = callPackage ../development/python-modules/python-vlc { };
+
   weasyprint = callPackage ../development/python-modules/weasyprint { };
 
   webassets = callPackage ../development/python-modules/webassets { };


### PR DESCRIPTION
###### Motivation for this change
Pympress is a simple yet powerful PDF reader designed for dual-screen presentations.

###### Things done

Added pympress and dependency python-vlc

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
