### PR TITLE
xv: 0.1.0 -> 0.1.1

### DIFF
--- a/pkgs/tools/misc/xv/default.nix
+++ b/pkgs/tools/misc/xv/default.nix
@@ -1,21 +1,33 @@
-{ stdenv, fetchFromGitHub, rustPlatform, ncurses }:
+{ stdenv, lib, fetchFromGitHub, rustPlatform
+, ncurses ? null
+, darwin ? null }:
+
+let useNcurses = !stdenv.hostPlatform.isWindows; in
+
+assert useNcurses -> ncurses != null;
 
 rustPlatform.buildRustPackage rec {
   pname   = "xv";
-  version = "0.1.0";
+  version = "0.1.1";
 
   src = fetchFromGitHub {
     owner  = "chrisvest";
     repo   = pname;
     rev    = "${version}";
-    sha256 = "1cghg3ypxx6afllvwzc6j4z4h7mylapapipqghpdndrfizk7rsxi";
+    sha256 = "0x2yd21sr4wik3z22rknkx1fgb64j119ynjls919za8gd83zk81g";
   };
 
-  cargoSha256 = "0iwx9cxnxlif135s2v2hji8xil38xk5a1h147ryb54v6nabaxvjw";
+  cargoSha256 = "0m69pcmnx3c3q7lgvbhxc8dl6lavv5ch4r6wg2bhdmapcmb4p7jq";
 
-  buildInputs = [ ncurses ];
+  buildInputs = lib.optionals useNcurses [ ncurses ]
+  ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ Security ])
+  ;
 
-  meta = with stdenv.lib; {
+  # I'm picking pancurses for Windows simply because that's the example given in Cursive's
+  # documentation for picking an alternative backend. We could just as easily pick crossterm.
+  cargoBuildFlags = lib.optionals (!useNcurses) [ "--no-default-features" "--features pancurses-backend" ];
+
+  meta = with lib; {
     description = "A visual hex viewer for the terminal";
     longDescription = ''
       XV is a terminal hex viewer with a text user interface, written in 100% safe Rust.


### PR DESCRIPTION
###### Motivation for this change
https://github.com/chrisvest/xv/releases/tag/0.1.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS (with sandbox)
   - [X] macOS (without sandbox)
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

The release notes for xv 0.1.1 talk about exposing other Cursive backends and give an example of Windows. It seems that the Cursive library doesn't support ncurses on Windows. I chose the `pancurses` library instead for Windows, but I don't have any way of actually testing this. I did check and it looks like the `pancurses-rs` crate bundles and compiles PDCurses itself for Windows, so there should be no need for any new build inputs on Windows.