### PR TITLE
cargo-make: 0.19.2 -> 0.19.3

### DIFF
--- a/pkgs/development/tools/rust/cargo-make/default.nix
+++ b/pkgs/development/tools/rust/cargo-make/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-make";
-  version = "0.19.2";
+  version = "0.19.3";
 
   src =
     let
@@ -10,11 +10,11 @@ rustPlatform.buildRustPackage rec {
         owner = "sagiegurari";
         repo = pname;
         rev = version;
-        sha256 = "175cflcm9k81fpp2pxz4hcaf8v3i7jqc9gcr4flnsqxjrh22vymp";
+        sha256 = "11mkfwvzsr86w9675zpq8gcq5avsfvwffca26h6gkc7ahqcsx3ac";
       };
       cargo-lock = fetchurl {
-        url = "https://gist.githubusercontent.com/xrelkd/e4c9c7738b21f284d97cb7b1d181317d/raw/f1e6360acfbe5ae573f8f31a82a5c881a6f0ed68/cargo-make-Cargo.lock";
-        sha256 = "004dx4gyby5smpvawqv946mambcg59zq6n8h89hz61mxkh7frmh4";
+        url = "https://gist.githubusercontent.com/xrelkd/e4c9c7738b21f284d97cb7b1d181317d/raw/3592410d14443cc6be675553a9c228401114fa5f/cargo-make-Cargo.lock";
+        sha256 = "0m8m2pn8y7n1js1kkva4lxahz5j4d73lj7l45h8dd30lw2w4n3hg";
       };
     in
     runCommand "cargo-make-src" {} ''
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = stdenv.lib.optionals stdenv.isDarwin [ Security ];
 
-  cargoSha256 = "1hmfg3x9p5a2vz2r3v8m5wgyabbybl5lcjvi930b9wi5cnfm756g";
+  cargoSha256 = "00yvx87s8vngb97ldq2amdhdv3nn38liys7nilay73phx0xybx4p";
 
   # Some tests fail because they need network access.
   # However, Travis ensures a proper build.


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update `cargo-make` to the latest release.
https://github.com/sagiegurari/cargo-make/releases/tag/0.19.3

**Note**: `doCheck` is set as `false`. 
 Some tests fail because they need network access. However, Travis-CI ensures a proper build.

https://travis-ci.org/sagiegurari/cargo-make/jobs/537918655
https://travis-ci.org/sagiegurari/cargo-make/jobs/537918656
https://travis-ci.org/sagiegurari/cargo-make/jobs/537918657
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
