### PR TITLE
vokoscreen: 2.5.0 -> 2.5.8-beta

### DIFF
--- a/pkgs/applications/video/vokoscreen/default.nix
+++ b/pkgs/applications/video/vokoscreen/default.nix
@@ -1,14 +1,18 @@
-{ stdenv, fetchgit
-, pkgconfig, qtbase, qttools, qmake, qtx11extras, alsaLib, libv4l, libXrandr
+{ stdenv, fetchFromGitHub
+, pkgconfig, qtbase, qttools, qmake, qtmultimedia, qtx11extras, alsaLib, libv4l, libXrandr
 , ffmpeg
 }:
 
-stdenv.mkDerivation {
-  name = "vokoscreen-2.5.0";
-  src = fetchgit {
-    url = "https://github.com/vkohaupt/vokoscreen.git";
-    rev = "8325c8658d6e777d34d2e6b8c8bc03f8da9b3d2f";
-    sha256 = "1hvw7xz1mj16ishbaip73wddbmgibsz0pad4y586zbarpynss25z";
+stdenv.mkDerivation rec {
+
+  pname = "vokoscreen";
+  version = "2.5.8-beta";
+
+  src = fetchFromGitHub {
+    owner   = "vkohaupt";
+    repo    = "vokoscreen";
+    rev     = version;
+    sha256  = "1a85vbsi53mhzva49smqwcs61c51wv3ic410nvb9is9nlsbifwan";
   };
 
   nativeBuildInputs = [ pkgconfig qmake ];
@@ -16,6 +20,7 @@ stdenv.mkDerivation {
     alsaLib
     libv4l
     qtbase
+    qtmultimedia
     qttools
     qtx11extras
     libXrandr
@@ -35,14 +40,14 @@ stdenv.mkDerivation {
 
   meta = with stdenv.lib; {
     description = "Simple GUI screencast recorder, using ffmpeg";
-    homepage = http://linuxecke.volkoh.de/vokoscreen/vokoscreen.html;
+    homepage = "http://linuxecke.volkoh.de/vokoscreen/vokoscreen.html";
     longDescription = ''
       vokoscreen is an easy to use screencast creator to record
       educational videos, live recordings of browser, installation,
       videoconferences, etc.
     '';
     license = licenses.gpl2Plus;
-    maintainers = [maintainers.league];
+    maintainers = [ maintainers.league ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/video/vokoscreen/ffmpeg-out-of-box.patch
+++ b/pkgs/applications/video/vokoscreen/ffmpeg-out-of-box.patch
@@ -1,20 +1,20 @@
 diff --git a/settings/QvkSettings.cpp b/settings/QvkSettings.cpp
-index bbf2abf..187efad 100644
+index 3008e62..07485bd 100644
 --- a/settings/QvkSettings.cpp
 +++ b/settings/QvkSettings.cpp
-@@ -56,17 +56,8 @@ void QvkSettings::readAll()
-       GIFPlayer = settings.value( "GIFplayer" ).toString();
+@@ -66,17 +66,8 @@ void QvkSettings::readAll()
        Minimized = settings.value( "Minimized", 0 ).toUInt();
+       MinimizedByStart = settings.value( "MinimizedByStart", 0 ).toUInt();
        Countdown = settings.value( "Countdown", 0 ).toUInt();
 -      QFile file;
 -      if ( file.exists( qApp->applicationDirPath().append( "/bin/ffmpeg" ) ) == true )
 -      {
--	vokoscreenWithLibs = true;
+-        vokoscreenWithLibs = true;
 -        Recorder = qApp->applicationDirPath().append( "/bin/ffmpeg" );
 -      }
 -      else
 -      {
--	vokoscreenWithLibs = false;
+-        vokoscreenWithLibs = false;
 -        Recorder = settings.value( "Recorder", "ffmpeg" ).toString();
 -      }
 +      vokoscreenWithLibs = true;
@@ -22,10 +22,3 @@ index bbf2abf..187efad 100644
      settings.endGroup();
      
      settings.beginGroup( "Videooptions" );
-@@ -398,4 +389,4 @@ double QvkSettings::getShowClickTime()
- int QvkSettings::getShowKeyOnOff()
- {
-   return showKeyOnOff; 
--}
-\ No newline at end of file
-+}


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update ancient version of vokoscreen to current beta. See discussion in #61053. The beta seems to very stable (tested it multiple times).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
