### PR TITLE
wxGTK31: 3.1.0 -> 3.1.2

### DIFF
--- a/pkgs/development/libraries/wxwidgets/3.1/default.nix
+++ b/pkgs/development/libraries/wxwidgets/3.1/default.nix
@@ -1,16 +1,91 @@
-{ stdenv, fetchFromGitHub
-, wxGTK30
+{ stdenv, fetchFromGitHub, fetchurl, fetchpatch, pkgconfig
+, gtk2, gtk3, libXinerama, libSM, libXxf86vm
+, xorgproto, gstreamer, gst-plugins-base, GConf, setfile
+, libGLSupported
+, withMesa ? libGLSupported, libGLU ? null, libGL ? null
+, compat24 ? false, compat26 ? true, unicode ? true
+, withGtk2 ? true
+, withWebKit ? false, webkitgtk24x-gtk2 ? null, webkitgtk ? null
+, AGL ? null, Carbon ? null, Cocoa ? null, Kernel ? null, QTKit ? null
 }:
+
+assert withMesa -> libGLU != null && libGL != null;
+assert withWebKit -> (if withGtk2 then webkitgtk24x-gtk2 else webkitgtk) != null;
 
 with stdenv.lib;
 
-wxGTK30.overrideAttrs (oldAttrs : rec {
-    name = "wxwidgets-${version}";
-    version = "3.1.0";
-    src = fetchFromGitHub {
-        owner = "wxWidgets";
-        repo = "wxWidgets";
-        rev = "v${version}";
-        sha256 = "14kl1rsngm70v3mbyv1mal15iz2b18k97avjx8jn7s81znha1c7f";
-    };
-})
+stdenv.mkDerivation rec {
+  version = "3.1.2";
+  name = "wxwidgets-${version}";
+
+  src = fetchFromGitHub {
+    owner = "wxWidgets";
+    repo = "wxWidgets";
+    rev = "v${version}";
+    sha256 = "0gfdhb7xq5vzasm7s1di39nchv42zsp0dmn4v6knzb7mgsb107wb";
+  };
+
+  buildInputs =
+    [ (if withGtk2 then gtk2 else gtk3) libXinerama libSM libXxf86vm xorgproto gstreamer
+      gst-plugins-base GConf ]
+    ++ optional withMesa libGLU
+    ++ optional withWebKit (if withGtk2 then webkitgtk24x-gtk2 else webkitgtk)
+    ++ optionals stdenv.isDarwin [ setfile Carbon Cocoa Kernel QTKit ];
+
+  nativeBuildInputs = [ pkgconfig ];
+
+  propagatedBuildInputs = optional stdenv.isDarwin AGL;
+
+  patches = [
+    (fetchurl { # https://trac.wxwidgets.org/ticket/17942
+      url = "https://trac.wxwidgets.org/raw-attachment/ticket/17942/"
+          + "fix_assertion_using_hide_in_destroy.diff";
+      sha256 = "009y3dav79wiig789vkkc07g1qdqprg1544lih79199kb1h64lvy";
+    })
+  ];
+
+  configureFlags =
+    [ "--disable-precomp-headers" "--enable-mediactrl" ]
+    ++ optional unicode "--enable-unicode"
+    ++ optional withMesa "--with-opengl"
+    ++ optionals stdenv.isDarwin
+      # allow building on 64-bit
+      [ "--with-cocoa" "--enable-universal-binaries" "--with-macosx-version-min=10.7" ]
+    ++ optionals withWebKit
+      ["--enable-webview" "--enable-webview-webkit"];
+
+  SEARCH_LIB = "${libGLU.out}/lib ${libGL.out}/lib ";
+
+  preConfigure = "
+    substituteInPlace configure --replace 'SEARCH_INCLUDE=' 'DUMMY_SEARCH_INCLUDE='
+    substituteInPlace configure --replace 'SEARCH_LIB=' 'DUMMY_SEARCH_LIB='
+    substituteInPlace configure --replace /usr /no-such-path
+  " + optionalString stdenv.isDarwin ''
+    substituteInPlace configure --replace \
+      'ac_cv_prog_SETFILE="/Developer/Tools/SetFile"' \
+      'ac_cv_prog_SETFILE="${setfile}/bin/SetFile"'
+    substituteInPlace configure --replace \
+      "-framework System" \
+      -lSystem
+  '';
+
+  postInstall = "
+    (cd $out/include && ln -s wx-*/* .)
+  ";
+
+  passthru = {
+    inherit compat24 compat26 unicode;
+    gtk = if withGtk2 then gtk2 else gtk3;
+  };
+
+  enableParallelBuilding = true;
+
+  meta = {
+    platforms = with platforms; darwin ++ linux;
+    license = licenses.wxWindows;
+    homepage = https://www.wxwidgets.org/;
+    description = "a C++ library that lets developers create applications for Windows, macOS, Linux and other platforms with a single code base";
+    longDescription = "wxWidgets gives you a single, easy-to-use API for writing GUI applications on multiple platforms that still utilize the native platform's controls and utilities. Link with the appropriate library for your platform and compiler, and your application will adopt the look and feel appropriate to that platform. On top of great GUI functionality, wxWidgets gives you: online help, network programming, streams, clipboard and drag and drop, multithreading, image loading and saving in a variety of popular formats, database support, HTML viewing and printing, and much more.";
+    badPlatforms = [ "x86_64-darwin" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13642,7 +13642,11 @@ in
     inherit (darwin.apple_sdk.frameworks) AGL Carbon Cocoa Kernel QTKit;
   };
 
-  wxGTK31 = callPackage ../development/libraries/wxwidgets/3.1 {};
+  wxGTK31 = callPackage ../development/libraries/wxwidgets/3.1 {
+    inherit (gnome2) GConf;
+    inherit (darwin.stubs) setfile;
+    inherit (darwin.apple_sdk.frameworks) AGL Carbon Cocoa Kernel QTKit;
+  };
 
   wxmac = callPackage ../development/libraries/wxwidgets/3.0/mac.nix {
     inherit (darwin.apple_sdk.frameworks) AGL Cocoa Kernel;


### PR DESCRIPTION
###### Motivation for this change
In #55475 a crash bug was introduced in Prusa Slicer. After some investigation, this seemed to be a bug in wxWidgets 3.1.0 that was no longer present in 3.1.2. As 3.1.2 has been out for a while, it seemed like a good idea to upgrade the package.

3.1.2 no longer accepts the `compat2[46]` options, which is why I copied the old file over and removed those configure flags. They seemed to be passed downstream however, so I did not remove the arguments entirely.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
