### PR TITLE
python.pkgs.pyglet: hardcode library paths

### DIFF
--- a/pkgs/development/python-modules/pyglet/default.nix
+++ b/pkgs/development/python-modules/pyglet/default.nix
@@ -1,5 +1,14 @@
-{ stdenv, buildPythonPackage, fetchPypi
-, libGLU_combined, xorg, freetype, fontconfig, future}:
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, libGLU_combined
+, xorg
+, future
+, pytest
+, glibc
+, gtk2-x11
+, gdk_pixbuf
+}:
 
 buildPythonPackage rec {
   version = "1.3.2";
@@ -10,14 +19,49 @@ buildPythonPackage rec {
     sha256 = "b00570e7cdf6971af8953b6ece50d83d13272afa5d1f1197c58c0f478dd17743";
   };
 
+  # find_library doesn't reliably work with nix (https://github.com/NixOS/nixpkgs/issues/7307).
+  # Even naively searching `LD_LIBRARY_PATH` won't work since `libc.so` is a linker script and
+  # ctypes.cdll.LoadLibrary cannot deal with those. Therefore, just hardcode the paths to the
+  # necessary libraries.
   postPatch = let
-    libs = [ libGLU_combined xorg.libX11 freetype fontconfig ];
-    paths = builtins.concatStringsSep "," (map (l: "\"${l}/lib\"") libs);
-  in "sed -i -e 's|directories\.extend.*lib[^]]*|&,${paths}|' pyglet/lib.py";
-
-  doCheck = false;
+    ext = stdenv.hostPlatform.extensions.sharedLibrary;
+  in ''
+    cat > pyglet/lib.py <<EOF
+    import ctypes
+    def load_library(*names, **kwargs):
+        for name in names:
+            path = None
+            if name == 'GL':
+                path = '${libGLU_combined}/lib/libGL${ext}'
+            elif name == 'GLU':
+                path = '${libGLU_combined}/lib/libGLU${ext}'
+            elif name == 'c':
+                path = '${glibc}/lib/libc${ext}.6'
+            elif name == 'X11':
+                path = '${xorg.libX11}/lib/libX11${ext}'
+            elif name == 'gdk-x11-2.0':
+                path = '${gtk2-x11}/lib/libgdk-x11-2.0${ext}'
+            elif name == 'gdk_pixbuf-2.0':
+                path = '${gdk_pixbuf}/lib/libgdk_pixbuf-2.0${ext}'
+            if path is not None:
+                return ctypes.cdll.LoadLibrary(path)
+        raise Exception("Could not load library {}".format(names))
+    EOF
+  '';
 
   propagatedBuildInputs = [ future ];
+
+  # needs an X server. Keep an eye on
+  # https://bitbucket.org/pyglet/pyglet/issues/219/egl-support-headless-rendering
+  doCheck = false;
+
+  checkInputs = [
+    pytest
+  ];
+
+  checkPhase = ''
+    py.test tests/unit tests/integration
+  '';
 
   meta = with stdenv.lib; {
     homepage = "http://www.pyglet.org/";

--- a/pkgs/development/python-modules/roboschool/default.nix
+++ b/pkgs/development/python-modules/roboschool/default.nix
@@ -1,5 +1,6 @@
 { lib
 , buildPythonPackage
+, isPy3k
 , python
 , fetchFromGitHub
 , fetchpatch
@@ -22,6 +23,9 @@ buildPythonPackage rec {
     rev = version;
     sha256 = "1s7rp5bbiglnrfm33wf7x7kqj0ks3b21bqyz18c5g6vx39rxbrmh";
   };
+
+  # fails to find boost_python for some reason
+  disabled = !isPy3k;
 
   propagatedBuildInputs = [
     gym


### PR DESCRIPTION
###### Motivation for this change

The new way to find libraries (basically a switch statement) isn't particularly pretty, but its simple and reliable. The old way failed to load `libc`, since `libc.so` is actually a linker script so we need to directly provide the path to `libc.so.6`. Other libraries were missing completely.

I tried to run the Cartpole example of rl-coach, which failed to render anything before and runs perfectly now.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
