### PR TITLE
gtk-gnutella: 1.1.9 -> 1.1.14

### DIFF
--- a/pkgs/tools/networking/p2p/gtk-gnutella/default.nix
+++ b/pkgs/tools/networking/p2p/gtk-gnutella/default.nix
@@ -1,29 +1,51 @@
-{ stdenv, fetchurl, bison, pkgconfig
-, glib, gtk2, libxml2, gettext, zlib, binutils, gnutls }:
+{ stdenv, fetchurl, fetchpatch, bison, pkgconfig, gettext, desktop-file-utils
+, glib, gtk2, libxml2, libbfd, zlib, binutils, gnutls
+}:
 
-let
-  name = "gtk-gnutella";
-  version = "1.1.9";
-in
-stdenv.mkDerivation {
-  name = "${name}-${version}";
+stdenv.mkDerivation rec {
+  pname = "gtk-gnutella";
+  version = "1.1.14";
 
   src = fetchurl {
-    url = "mirror://sourceforge/${name}/${name}-${version}.tar.bz2";
-    sha256 = "1zvadgsskmpm82id9mbj24a2lyq38qv768ixv7nmfjl3d4wr2biv";
+    url = "mirror://sourceforge/${pname}/${version}/${pname}-${version}.tar.xz";
+    sha256 = "0sljjha4anfz1r1xq1c6qnnkjv62ld56p7xgj4bsi6lqmq1azvii";
   };
 
-  nativeBuildInputs = [ bison gettext pkgconfig ];
-  buildInputs = [ binutils glib gnutls gtk2 libxml2 zlib ];
+  patches = [
+    (fetchpatch {
+      # Avoid namespace conflict with glibc 2.28 'statx' struct / remove after v1.1.14
+      url = "https://github.com/gtk-gnutella/gtk-gnutella/commit/e4205a082eb32161e28de81f5cba8095eea8ecc7.patch";
+      sha256 = "0ffkw2cw2b2yhydii8jm40vd40p4xl224l8jvhimg02lgs3zfbca";
+    })
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/gtk-gnutella/raw/f30/f/gtk-gnutella-1.1.14-endian.patch";
+      sha256 = "19q4lq8msknfz4mkbjdqmmgld16p30j2yx371p8spmr19q5i0sfn";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace Makefile.SH --replace "@exit 0" "@echo done"
+  '';
+
+  nativeBuildInputs = [ bison desktop-file-utils gettext pkgconfig ];
+  buildInputs = [ binutils glib gnutls gtk2 libbfd libxml2 zlib ];
+
+  configureScript = "./build.sh";
+  configureFlags = [ "--configure-only" ];
 
   hardeningDisable = [ "bindnow" "fortify" "pic" "relro" ];
 
-  configureScript = "./build.sh --configure-only";
+  enableParallelBuilding = true;
+
+  postInstall = ''
+    install -Dm0444 src/${pname}.man $out/share/man/man1/${pname}.1
+  '';
 
   meta = with stdenv.lib; {
-    homepage = http://gtk-gnutella.sourceforge.net/;
-    description = "Server/client for Gnutella";
-    license = licenses.gpl2;
+    description = "A GTK+ Gnutella client, optimized for speed and scalability";
+    homepage = "http://gtk-gnutella.sourceforge.net/"; # Code: https://github.com/gtk-gnutella/gtk-gnutella
+    changelog = "https://raw.githubusercontent.com/gtk-gnutella/gtk-gnutella/v${version}/ChangeLog";
+    license = licenses.gpl2Plus;
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Package refresh
and fix its build since it is currently failing on Hydra

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
