### PR TITLE
atlassian-crowd: 3.4.3 -> 3.4.4

### DIFF
--- a/pkgs/servers/atlassian/crowd.nix
+++ b/pkgs/servers/atlassian/crowd.nix
@@ -3,11 +3,11 @@
 
 stdenv.mkDerivation rec {
   name = "atlassian-crowd-${version}";
-  version = "3.4.3";
+  version = "3.4.4";
 
   src = fetchurl {
     url = "https://www.atlassian.com/software/crowd/downloads/binary/${name}.tar.gz";
-    sha256 = "0swp41lr7n318jxl61w5c09485ygn261zc74p7xaisrwmh9ygyzs";
+    sha256 = "0bs3l2s5f8ymyvvxn6z3wwccbvac42giahmfqiam51m9zkfhf0rk";
   };
 
   phases = [ "unpackPhase" "buildPhase" "installPhase" "fixupPhase" ];


### PR DESCRIPTION
Security update as per [upstream advisory](https://confluence.atlassian.com/crowd/crowd-security-advisory-2019-05-22-970260700.html).

Fixes CVE-2019-11580.

Will backport to 19.03 as well.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
