### PR TITLE
Fix pkgs.biber for Darwin (alt)

### DIFF
--- a/pkgs/development/perl-modules/generic/default.nix
+++ b/pkgs/development/perl-modules/generic/default.nix
@@ -1,6 +1,14 @@
-{ lib, stdenv, perl, buildPerl, toPerlModule }:
+{ lib, stdenv, perl, buildPerl, toPerlModule, makeWrapper }:
 
-{ buildInputs ? [], nativeBuildInputs ? [], name, ... } @ attrs:
+{ buildInputs ? [], nativeBuildInputs ? [], doUseWrapper ? false, name, ... } @ attrs:
+# By default, executables produced by this function use the shebang as a way of injecting
+# dependent module paths. This can go over the shebang character limit which results
+# in the shebang being ignored. On Darwin, the limit appears to be 512 characters.
+#
+# See: https://github.com/boronine/shebang-test
+#
+# Use `doUseWrapper = true` to enable an alternative `makeWrapper` method of injecting
+# dependent module paths.
 
 toPerlModule(stdenv.mkDerivation (
   (
@@ -37,7 +45,8 @@ toPerlModule(stdenv.mkDerivation (
     name = "perl${perl.version}-${name}";
     builder = ./builder.sh;
     buildInputs = buildInputs ++ [ perl ];
-    nativeBuildInputs = nativeBuildInputs ++ [ (perl.dev or perl) ];
+    nativeBuildInputs = nativeBuildInputs ++ [ (perl.dev or perl) makeWrapper ];
     fullperl = buildPerl;
+    inherit doUseWrapper;
   }
 ))

--- a/pkgs/tools/typesetting/biber/default.nix
+++ b/pkgs/tools/typesetting/biber/default.nix
@@ -6,6 +6,7 @@ in
 
 perlPackages.buildPerlModule rec {
   name = "biber-${version}";
+  doUseWrapper = true;
   inherit (biberSource) version;
 
   src = "${biberSource}/source/bibtex/biber/biblatex-biber.tar.gz";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

This PR contains an alternative solution for https://github.com/NixOS/nixpkgs/pull/35477

See comment: https://github.com/NixOS/nixpkgs/pull/35477#issuecomment-496517903

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
