### PR TITLE
nixos/syncthing: run init only if a devices or folders are set

### DIFF
--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -421,7 +421,9 @@ in {
           '';
         };
       };
-      syncthing-init = {
+      syncthing-init = mkIf (
+        cfg.declarative.devices != {} || cfg.declarative.folders != {}
+      ) {
         after = [ "syncthing.service" ];
         wantedBy = [ "multi-user.target" ];
 


### PR DESCRIPTION
###### Motivation for this change
All Folders/Devices which got added through the webinterface got removed. This fixes that issue