### PR TITLE
swig: use pname and standardize meta

### DIFF
--- a/pkgs/development/tools/misc/swig/2.x.nix
+++ b/pkgs/development/tools/misc/swig/2.x.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, autoconf, automake, libtool, bison, pcre }:
 
 stdenv.mkDerivation rec {
-  name = "swig-${version}";
+  pname = "swig";
   version = "2.0.12";
 
   src = fetchFromGitHub {
@@ -16,8 +16,8 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--without-tcl" ];
 
+  # Disable ccache documentation as it needs yodl
   postPatch = ''
-    # Disable ccache documentation as it need yodl
     sed -i '/man1/d' CCache/Makefile.in
   '';
 
@@ -25,26 +25,11 @@ stdenv.mkDerivation rec {
     ./autogen.sh
   '';
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "SWIG, an interface compiler that connects C/C++ code to higher-level languages";
-
-    longDescription = ''
-       SWIG is an interface compiler that connects programs written in C and
-       C++ with languages such as Perl, Python, Ruby, Scheme, and Tcl.  It
-       works by taking the declarations found in C/C++ header files and using
-       them to generate the wrapper code that scripting languages need to
-       access the underlying C/C++ code.  In addition, SWIG provides a variety
-       of customization features that let you tailor the wrapping process to
-       suit your application.
-    '';
-
     homepage = http://swig.org/;
-
-    # Licensing is a mess: http://www.swig.org/Release/LICENSE .
-    license = "BSD-style";
-
-    platforms = lib.platforms.linux ++ lib.platforms.darwin;
-
-    maintainers = [ ];
+    # Different types of licenses available: http://www.swig.org/Release/LICENSE .
+    license = licenses.gpl3Plus;
+    platforms = with platforms; linux ++ darwin;
   };
 }

--- a/pkgs/development/tools/misc/swig/3.x.nix
+++ b/pkgs/development/tools/misc/swig/3.x.nix
@@ -1,7 +1,7 @@
 { stdenv, fetchFromGitHub, autoconf, automake, libtool, bison, pcre, buildPackages }:
 
 stdenv.mkDerivation rec {
-  name = "swig-${version}";
+  pname = "swig";
   version = "3.0.12";
 
   src = fetchFromGitHub {
@@ -17,8 +17,8 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--without-tcl" ];
 
+  # Disable ccache documentation as it needs yodl
   postPatch = ''
-    # Disable ccache documentation as it need yodl
     sed -i '/man1/d' CCache/Makefile.in
   '';
 

--- a/pkgs/development/tools/misc/swig/default.nix
+++ b/pkgs/development/tools/misc/swig/default.nix
@@ -1,10 +1,11 @@
 { stdenv, fetchurl, boost, tcl }:
 
 stdenv.mkDerivation rec {
-  name = "swig-1.3.40";
+  pname = "swig";
+  version = "1.3.40";
 
   src = fetchurl {
-    url = "mirror://sourceforge/swig/${name}.tar.gz";
+    url = "mirror://sourceforge/swig/${pname}-${version}.tar.gz";
     sha256 = "02dc8g8wy75nd2is1974rl24c6mdl0ai1vszs1xpg9nd7dlv6i8r";
   };
 
@@ -14,26 +15,12 @@ stdenv.mkDerivation rec {
 
   configureFlags = [ "--disable-ccache" ];
 
-  meta = {
-    description = "Interface compiler that connects C/C++ code to higher-level languages";
 
-    longDescription = ''
-       SWIG is an interface compiler that connects programs written in C and
-       C++ with languages such as Perl, Python, Ruby, Scheme, and Tcl.  It
-       works by taking the declarations found in C/C++ header files and using
-       them to generate the wrapper code that scripting languages need to
-       access the underlying C/C++ code.  In addition, SWIG provides a variety
-       of customization features that let you tailor the wrapping process to
-       suit your application.
-    '';
-
+  meta = with stdenv.lib; {
+    description = "SWIG, an interface compiler that connects C/C++ code to higher-level languages";
     homepage = http://swig.org/;
-
-    # Licensing is a mess: http://www.swig.org/Release/LICENSE .
-    license = "BSD-style";
-
-    platforms = stdenv.lib.platforms.all;
-
-    maintainers = [ ];
+    # Different types of licenses available: http://www.swig.org/Release/LICENSE .
+    license = licenses.gpl3Plus;
+    platforms = with platforms; linux ++ darwin;
   };
 }


### PR DESCRIPTION
- pname makes it easier to override the version in an overlay and looks generally cleaner
- Updated the meta sections to match between the various versions

No real functional change, just cleanup.

###### Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
