### PR TITLE
python.pkgs.applicationinsights: init at 0.11.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2461,6 +2461,11 @@
     github = "joncojonathan";
     name = "Jonathan Haddock";
   };
+  jonringer = {
+    email = "jonringer117@gmail.com";
+    github = "jonringer";
+    name = "Jonathan Ringer";
+  };
   jorsn = {
     name = "Johannes Rosenberger";
     email = "johannes@jorsn.eu";

--- a/pkgs/development/python-modules/applicationinsights/default.nix
+++ b/pkgs/development/python-modules/applicationinsights/default.nix
@@ -1,0 +1,24 @@
+{ buildPythonPackage
+, lib
+, fetchPypi
+, portalocker
+}:
+
+buildPythonPackage rec {
+  version = "0.11.9";
+  pname = "applicationinsights";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1hyjdv6xnswgqvip8y164piwfach9hjkbp7vc2qzhd7amjpim89h";
+  };
+
+  propagatedBuildInputs = [ portalocker ];
+
+  meta = with lib; {
+    description = "This project extends the Application Insights API surface to support Python";
+    homepage = https://github.com/Microsoft/ApplicationInsights-Python;
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/development/python-modules/portalocker/default.nix
+++ b/pkgs/development/python-modules/portalocker/default.nix
@@ -1,0 +1,37 @@
+{ buildPythonPackage
+, fetchPypi
+, lib
+, sphinx
+, flake8
+, pytest
+, pytestcov
+, pytest-flakes
+, pytestpep8
+}:
+
+buildPythonPackage rec {
+  version = "1.4.0";
+  pname = "portalocker";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0gwjnalfwl1mb9a04m9h3hrds75xmc9na666aiz2cgz0m545dcrz";
+  };
+
+  checkInputs = [
+    sphinx
+    flake8
+    pytest
+    pytestcov
+    pytest-flakes
+    pytestpep8
+  ];
+
+  meta = with lib; {
+    description = "A library to provide an easy API to file locking";
+    homepage = https://github.com/WoLpH/portalocker;
+    license = licenses.psfl;
+    maintainers = with maintainers; [ jonringer ];
+    platforms = platforms.unix; # Windows has a dependency on pypiwin32
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1068,6 +1068,8 @@ in {
 
   application = callPackage ../development/python-modules/application { };
 
+  applicationinsights = callPackage ../development/python-modules/applicationinsights { };
+
   appnope = callPackage ../development/python-modules/appnope { };
 
   approvaltests = callPackage ../development/python-modules/approvaltests { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1611,6 +1611,8 @@ in {
 
   parsy = callPackage ../development/python-modules/parsy { };
 
+  portalocker = callPackage ../development/python-modules/portalocker { };
+
   portpicker = callPackage ../development/python-modules/portpicker { };
 
   pkginfo = callPackage ../development/python-modules/pkginfo { };


### PR DESCRIPTION
###### Motivation for this change
Add more Azure support into Nixos packages.

Not related to #60435 (separate pypi package and repo)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [X] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
$ nix path-info -Sh result/
/nix/store/hgyfrsfw3my1p14lbsmdz02ynmqz7cc0-python3.5-applicationinsights-0.11.9          95.0M
