### PR TITLE
python2Packages.cmd2_8: 0.8.0 -> 0.8.9, fix build

### DIFF
--- a/pkgs/development/python-modules/cmd2/old.nix
+++ b/pkgs/development/python-modules/cmd2/old.nix
@@ -2,17 +2,17 @@
 , pyperclip, six, pyparsing, vim
 , contextlib2 ? null, subprocess32 ? null
 , pytest, mock, which, fetchFromGitHub, glibcLocales
-, runtimeShell
+, runtimeShell, wcwidth, enum34
 }:
 buildPythonPackage rec {
   pname = "cmd2";
-  version = "0.8.0";
+  version = "0.8.9";
 
   src = fetchFromGitHub {
     owner = "python-cmd2";
     repo = "cmd2";
     rev = version;
-    sha256 = "0nw2b7n7zg51bc3glxw0l9fn91mwjnjshklhmxhyvjbsg7khf64z";
+    sha256 = "1zil4z4qgvs8pxmz09g4352mxxir5j17k86r1qmwwv7fv93a80f9";
   };
 
   LC_ALL="en_US.UTF-8";
@@ -27,16 +27,15 @@ buildPythonPackage rec {
   '';
 
   checkInputs= [ pytest mock which vim glibcLocales ];
-  checkPhase = ''
-    # test_path_completion_user_expansion might be fixed in the next release
-    py.test -k 'not test_path_completion_user_expansion'
-  '';
+  checkPhase = "py.test";
   doCheck = !stdenv.isDarwin;
 
   propagatedBuildInputs = [
     pyperclip
     six
     pyparsing
+    wcwidth
+    enum34
   ]
   ++ stdenv.lib.optional (pythonOlder "3.5") contextlib2
   ++ stdenv.lib.optional (pythonOlder "3.0") subprocess32


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

I haven't tried to build it on darwin

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
