### PR TITLE
nodePackages: init openstf

### DIFF
--- a/pkgs/development/node-packages/default-v8.nix
+++ b/pkgs/development/node-packages/default-v8.nix
@@ -20,4 +20,8 @@ nodePackages // {
       done
     '';
   };
+
+  stf = nodePackages.stf.override {
+    nativeBuildInputs = with pkgs; [ yasm czmq protobufc ];
+  };
 }

--- a/pkgs/development/node-packages/node-packages-v8.json
+++ b/pkgs/development/node-packages/node-packages-v8.json
@@ -8,5 +8,6 @@
 , "node-gyp-build"
 , "node-pre-gyp"
 , "pnpm"
+, "stf"
 , "titanium"
 ]


### PR DESCRIPTION
Hello,

This commit introduce npm package for openstf.io.

Node v10 is not yet supported by STF, so it's defined only for node v8.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
