### PR TITLE
opengl: provide swrast as fallback when no GL drivers are found

### DIFF
--- a/pkgs/build-support/add-opengl-runpath/default.nix
+++ b/pkgs/build-support/add-opengl-runpath/default.nix
@@ -1,9 +1,10 @@
-{ lib, stdenv }:
+{ lib, stdenv, mesa }:
 
 stdenv.mkDerivation {
   name = "add-opengl-runpath";
 
   driverLink = "/run/opengl-driver" + lib.optionalString stdenv.isi686 "-32";
+  swrast = if mesa ? swrast then mesa.swrast else null;
 
   buildCommand = ''
     mkdir -p $out/nix-support

--- a/pkgs/build-support/add-opengl-runpath/setup-hook.sh
+++ b/pkgs/build-support/add-opengl-runpath/setup-hook.sh
@@ -5,6 +5,11 @@
 # actually sets RUNPATH not RPATH, which applies only to dependencies of the binary
 # it set on (including for dlopen), so the RUNPATH must indeed be set on these
 # libraries and would not work if set only on executables.
+
+# When no installed OpenGL drivers are available, we can fall back to
+# the vendor-neutral mesa swrast driver. This is about 1MB, but it’s
+# very important to have a fallback if we can’t find any drivers
+# installed.
 addOpenGLRunpath() {
     local forceRpath=
 
@@ -23,7 +28,6 @@ addOpenGLRunpath() {
     for file in "$@"; do
         if ! isELF "$file"; then continue; fi
         local origRpath="$(patchelf --print-rpath "$file")"
-        patchelf --set-rpath "@driverLink@/lib:$origRpath" ${forceRpath:+--force-rpath} "$file"
+        patchelf --set-rpath "@driverLink@/lib:$origRpath:@swrast@/lib" ${forceRpath:+--force-rpath} "$file"
     done
 }
-

--- a/pkgs/development/libraries/libglvnd/default.nix
+++ b/pkgs/development/libraries/libglvnd/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, lib, fetchFromGitHub, fetchpatch, autoreconfHook, python2, pkgconfig, libX11, libXext, xorgproto, addOpenGLRunpath }:
+{ stdenv, lib, fetchFromGitHub, fetchpatch, autoreconfHook, python2, pkgconfig, libX11, libXext, xorgproto
+, addOpenGLRunpath }:
 
 stdenv.mkDerivation rec {
   name = "libglvnd-${version}";
@@ -11,7 +12,7 @@ stdenv.mkDerivation rec {
     sha256 = "1a126lzhd2f04zr3rvdl6814lfl0j077spi5dsf2alghgykn5iif";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkgconfig python2 addOpenGLRunpath ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig python2 ];
   buildInputs = [ libX11 libXext xorgproto ];
 
   postPatch = lib.optionalString stdenv.isDarwin ''
@@ -36,18 +37,15 @@ stdenv.mkDerivation rec {
       url = "https://github.com/NVIDIA/libglvnd/commit/0177ade40262e31a80608a8e8e52d3da7163dccf.patch";
       sha256 = "1rnz5jw2gvx4i1lcp0k85jz9xgr3dgzsd583m2dlxkaf2a09j89d";
     })
+
+    # Fallback to mesa when no other drivers are found.
+    ./mesa-fallback.patch
   ] ++ stdenv.lib.optional stdenv.isDarwin
     (fetchpatch {
       url = "https://github.com/NVIDIA/libglvnd/commit/294ccb2f49107432567e116e13efac586580a4cc.patch";
       sha256 = "01339wg27cypv93221rhk3885vxbsg8kvbfyia77jmjdcnwrdwm2";
     });
   outputs = [ "out" "dev" ];
-
-  # Set RUNPATH so that driver libraries in /run/opengl-driver(-32)/lib can be found.
-  # See the explanation in addOpenGLRunpath.
-  postFixup = ''
-    addOpenGLRunpath $out/lib/libGLX.so $out/lib/libEGL.so
-  '';
 
   passthru = { inherit (addOpenGLRunpath) driverLink; };
 

--- a/pkgs/development/libraries/libglvnd/mesa-fallback.patch
+++ b/pkgs/development/libraries/libglvnd/mesa-fallback.patch
@@ -1,0 +1,19 @@
+Fallback to mesa when no drivers are found.
+
+diff --git a/src/GLX/libglxmapping.c b/src/GLX/libglxmapping.c
+index be384f8..a8d751f 100644
+--- a/src/GLX/libglxmapping.c
++++ b/src/GLX/libglxmapping.c
+@@ -429,6 +429,12 @@ __GLXvendorInfo *__glXLookupVendorByName(const char *vendorName)
+             if (filename) {
+                 vendor->dlhandle = dlopen(filename, RTLD_LAZY);
+             }
++
++            if (vendor->dlhandle == NULL) {
++                // Try the bundled vendor name if the above fails
++                filename = ConstructVendorLibraryFilename("mesa");
++                vendor->dlhandle = dlopen(filename, RTLD_LAZY);
++            }
+             free(filename);
+             if (vendor->dlhandle == NULL) {
+                 goto fail;

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -96,7 +96,7 @@ let self = stdenv.mkDerivation {
   ];
 
   outputs = [ "out" "dev" "drivers" ]
-            ++ lib.optional (elem "swrast" galliumDrivers) "osmesa";
+            ++ lib.optionals (elem "swrast" galliumDrivers) [ "swrast" "osmesa" ];
 
   # TODO: Figure out how to enable opencl without having a runtime dependency on clang
   configureFlags = [
@@ -198,6 +198,13 @@ let self = stdenv.mkDerivation {
 
     # move vendor files
     mv $out/share/ $drivers/
+
+    # move swrast to its own output
+    if [ -n "$swrast" ]; then
+      mkdir -p $swrast/lib
+      mv $drivers/lib/lib*_mesa* $swrast/lib
+      ln -s $swrast/lib $drivers/lib
+    fi
 
     # Update search path used by glvnd
     for js in $drivers/share/glvnd/egl_vendor.d/*.json; do


### PR DESCRIPTION
When no libGL drivers are found, we will fall back to “libGLX_mesa.so”
which corresponds to the mesa “swrast” driver. This uses some X11 apis
for rendering, and is suitable for many use cases of . This is still
not as good as having the hardware drivers. Adding libGLX_mesa.so to
the closures ends up adding about 1MB, which is signifcant but still
acceptable.

Fixes #62032
Fixes #62169
Fixes #9415

/cc @ambrop72 @edahlgren

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
