### PR TITLE
kvantum: init at 0.11.1

### DIFF
--- a/pkgs/data/themes/kvantum/default.nix
+++ b/pkgs/data/themes/kvantum/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, cmake, qtbase, qtsvg, qtx11extras, kwindowsystem }:
+
+stdenv.mkDerivation rec {
+  pname = "kvantum";
+  version = "0.11.1";
+
+  src = fetchFromGitHub {
+    owner = "tsujan";
+    repo = pname;
+    rev = "V${version}";
+    sha256 = "14qi8hknx0vyw04rdl4sw5zscjf3cxv80mff32bpvhjc2d1n3ivq";
+  };
+
+  sourceRoot = "source/Kvantum";
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ qtbase qtsvg qtx11extras kwindowsystem ];
+
+  postPatch = ''
+    sed -i -e "s,set(KVANTUM_STYLE_DIR .*/styles/\"),set(KVANTUM_STYLE_DIR \"$qtPluginPrefix/styles/\")," \
+      style/CMakeLists.txt
+  '';
+
+  meta = with stdenv.lib; {
+    description = "SVG-based theme engine for Qt, KDE and LXQt, with an emphasis on elegance, usability and practicality";
+    homepage = https://github.com/tsujan/Kvantum;
+    license = licenses.gpl3;
+    platforms = platforms.unix;
+    maintainers = [ maintainers.romildo ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16296,6 +16296,8 @@ in
 
   kochi-substitute-naga10 = callPackage ../data/fonts/kochi-substitute-naga10 {};
 
+  kvantum = libsForQt5.callPackage ../data/themes/kvantum { };
+
   latinmodern-math = callPackage ../data/fonts/lm-math {};
 
   lato = callPackage ../data/fonts/lato {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Add [`kvantum`](https://github.com/tsujan/Kvantum/tree/master/Kvantum) to nixpkgs.

> Kvantum (by Pedram Pourang, a.k.a. Tsu Jan tsujan2000@gmail.com) is an SVG-based theme engine for Qt, tuned to KDE and LXQt, with an emphasis on elegance, usability and practicality. Its homepage is https://github.com/tsujan/Kvantum.
> 
> Kvantum has a default dark theme, which is inspired by the default theme of Enlightenment. Creation of realistic themes like that for KDE was my first reason to make Kvantum but it goes far beyond its default theme: you could make themes with very different looks and feels for it, whether they be photorealistic or cartoonish, 3D or flat, embellished or minimalistic, or something in between, and Kvantum will let you control almost every aspect of Qt widgets.
> 
> Kvantum also comes with extra themes that are installed as root with Qt5 installation and can be selected and activated by using Kvantum Manager.

![Default](https://user-images.githubusercontent.com/1217934/58519384-afb6b480-8189-11e9-8337-64a4fc52eef7.png)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).