### PR TITLE
earlyoom: 1.2 -> 1.3

### DIFF
--- a/pkgs/os-specific/linux/earlyoom/default.nix
+++ b/pkgs/os-specific/linux/earlyoom/default.nix
@@ -3,13 +3,13 @@
 stdenv.mkDerivation rec {
   name = "earlyoom-${VERSION}";
   # This environment variable is read by make to set the build version.
-  VERSION = "1.2";
+  VERSION = "1.3";
 
   src = fetchFromGitHub {
     owner = "rfjakob";
     repo = "earlyoom";
     rev = "v${VERSION}";
-    sha256 = "0bpqlbsjcmcizgw75j1zyw1sp2cgwhaar9y70sibw1km011yqbzd";
+    sha256 = "0fwbx0y80nqgkxrc9kf9j3iwa0wbps2jmqir3pgqbc2cj0wjh0lr";
   };
 
   installPhase = ''


### PR DESCRIPTION
###### Motivation for this change

https://github.com/rfjakob/earlyoom/blob/v1.3/README.md#changelog

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---