### PR TITLE
firejail: 0.9.58.2 -> 0.9.60

### DIFF
--- a/pkgs/os-specific/linux/firejail/default.nix
+++ b/pkgs/os-specific/linux/firejail/default.nix
@@ -3,11 +3,10 @@ let
   s = # Generated upstream information
   rec {
     baseName="firejail";
-    version="0.9.58.2";
+    version="0.9.60";
     name="${baseName}-${version}";
-    hash="0ck40b5g1gr5w25qa1lnamwkqnnnbyl14na5c8bq0za0qpf2f8jx";
-    url="https://vorboss.dl.sourceforge.net/project/firejail/firejail/firejail-0.9.58.2.tar.xz";
-    sha256="0ck40b5g1gr5w25qa1lnamwkqnnnbyl14na5c8bq0za0qpf2f8jx";
+    url="mirror://sourceforge/firejail/firejail/firejail-${version}.tar.xz";
+    sha256="1mw2s040wbxaj4lqfm6033wxrxlnix40mqc2bsfran5sj2gxd3sh";
   };
   buildInputs = [
     which


### PR DESCRIPTION
###### Motivation for this change

https://firejail.wordpress.com/download-2/release-notes/

(link not specific to this version, sorry!)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---