### PR TITLE
iptables: 1.8.2 -> 1.8.3, libnftnl: 1.1.2 -> 1.1.3

### DIFF
--- a/pkgs/development/libraries/libnftnl/default.nix
+++ b/pkgs/development/libraries/libnftnl/default.nix
@@ -1,12 +1,12 @@
 { stdenv, fetchurl, pkgconfig, libmnl }:
 
 stdenv.mkDerivation rec {
-  version = "1.1.2";
-  name = "libnftnl-${version}";
+  version = "1.1.3";
+  pname = "libnftnl";
 
   src = fetchurl {
-    url = "https://netfilter.org/projects/libnftnl/files/${name}.tar.bz2";
-    sha256 = "0pffmsv41alsn5ac7mwnb9fh3qpwzqk13jrzn6c5i71wq6kbgix5";
+    url = "https://netfilter.org/projects/${pname}/files/${pname}-${version}.tar.bz2";
+    sha256 = "03xszkcpqk3s1rqc6vh7g5j13kh3d3yjnvjhk5scds3an39rgp92";
   };
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/os-specific/linux/iptables/default.nix
+++ b/pkgs/os-specific/linux/iptables/default.nix
@@ -2,41 +2,13 @@
 , libnetfilter_conntrack, libnftnl, libmnl, libpcap }:
 
 stdenv.mkDerivation rec {
-  name = "iptables-${version}";
-  version = "1.8.2";
+  pname = "iptables";
+  version = "1.8.3";
 
   src = fetchurl {
-    url = "https://www.netfilter.org/projects/iptables/files/${name}.tar.bz2";
-    sha256 = "1bqj9hf3szy9r0w14iy23w00ir8448nfhpcprbwmcchsxm88nxx3";
+    url = "https://www.netfilter.org/projects/${pname}/files/${pname}-${version}.tar.bz2";
+    sha256 = "106xkkg5crsscjlinxvqvprva23fwwqfgrzl8m2nn841841sqg52";
   };
-
-  patches = [
-    # Adds missing bits to extensions' libipt_icmp.c and libip6t_icmp6.c that were causing build to fail
-    (fetchpatch {
-      url = "https://git.netfilter.org/iptables/patch/?id=907e429d7548157016cd51aba4adc5d0c7d9f816";
-      sha256 = "0vc7ljcglz5152lc3jx4p44vjfi6ipvxdrgkdb5dmkhlb5v93i2h";
-    })
-    # Build with musl libc fails because of conflicting struct ethhdr definitions
-    (fetchpatch {
-      url = "https://git.netfilter.org/iptables/patch/?id=51d374ba41ae4f1bb851228c06b030b83dd2092f";
-      sha256 = "05fwrq03f9sm0v2bfwshbrg7pi2p978w1460arnmpay3135gj266";
-    })
-    # Extensions: libip6t_mh: fix bogus translation error
-    (fetchpatch {
-      url = "https://git.netfilter.org/iptables/patch/?id=5839d7fe62ff667af7132fc7d589b386951f27b3";
-      sha256 = "0578jn1ip710z9kijwg9g2vjq2kfrbafl03m1rgi4fasz215gvkf";
-    })
-    # Prevent headers collisions between linux and netfilter (in.h and in6.h)
-    # Fixed upstream with two commits
-    (fetchpatch {
-      url = "https://git.netfilter.org/iptables/patch/?id=8d9d7e4b9ef4c6e6abab2cf35c747d7ca36824bd";
-      sha256 = "0q3wcspiqym1r6dg1jhg7h8hpvsjzx1k7cs39z36mzlbmj9lm0zb";
-    })
-    (fetchpatch {
-      url = "https://git.netfilter.org/iptables/patch/?id=2908eda10bf9fc81119d4f3ad672c67918ab5955";
-      sha256 = "1dci4c8b7gcdrf77l2aicrcwlbp320xjz76fhavams0b4kgs6yr3";
-    })
-  ];
 
   nativeBuildInputs = [ bison flex pkgconfig pruneLibtoolFiles ];
 


### PR DESCRIPTION
###### Motivation for this change

Submitting together since iptables bump requires libnftnl update.


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---