### PR TITLE
mno16: init at 1.0

### DIFF
--- a/pkgs/data/fonts/mno16/default.nix
+++ b/pkgs/data/fonts/mno16/default.nix
@@ -1,0 +1,21 @@
+{ lib, fetchzip }:
+
+let
+  pname = "mno16";
+  version = "1.0";
+in fetchzip rec {
+  name = "${pname}-${version}";
+  url = "https://github.com/sevmeyer/${pname}/releases/download/${version}/${name}.zip";
+  sha256 = "1x06nl281fcjk6g1p4cgrgxakmwcci6vvasskaygsqlzxd8ig87w";
+
+  postFetch = ''
+    mkdir -p $out/share/fonts/truetype
+    unzip -j $downloadedFile \*.ttf -d $out/share/fonts/truetype/
+  '';
+
+  meta = with lib; {
+    description = "minimalist monospaced font";
+    homepage = https://sev.dev/fonts/mno16; 
+    license = licenses.cc0;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16376,6 +16376,8 @@ in
 
   medio = callPackage ../data/fonts/medio { };
 
+  mno16 = callPackage ../data/fonts/mno16 { };
+
   mnist = callPackage ../data/machine-learning/mnist { };
 
   mobile-broadband-provider-info = callPackage ../data/misc/mobile-broadband-provider-info { };


### PR DESCRIPTION
###### Motivation for this change

tiny monospaced font :D

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---