### PR TITLE
agave: 009 -> v10

### DIFF
--- a/pkgs/data/fonts/agave/default.nix
+++ b/pkgs/data/fonts/agave/default.nix
@@ -2,7 +2,7 @@
 
 let
   pname = "agave";
-  version = "009";
+  version = "10";
 in fetchurl {
   name = "${pname}-${version}";
   url = "https://github.com/agarick/agave/releases/download/v${version}/agave-r.ttf";
@@ -13,7 +13,7 @@ in fetchurl {
     install -D $downloadedFile $out/share/fonts/truetype/agave-r.ttf
   '';
 
-  sha256 = "16qvz3zpwiq2nw0gxygva5pssswcia5xp0q6ir5jfkackvqf3fql";
+  sha256 = "1mfj6a9sp00mjz7420yyrbbs5bqks3fz2slwgcppklxnz0890r9f";
 
   meta = with lib; {
     description = "truetype monospaced typeface designed for X environments";


### PR DESCRIPTION
###### Motivation for this change

https://github.com/agarick/agave/releases/tag/v10

Powerline glyphs and other goodness!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---