### PR TITLE
dedup: 1.0 -> 2.0

### DIFF
--- a/pkgs/tools/backup/dedup/default.nix
+++ b/pkgs/tools/backup/dedup/default.nix
@@ -1,24 +1,29 @@
-{ stdenv, fetchurl, lz4, snappy, openmp }:
+{ stdenv, fetchurl, fetchgit, lz4, snappy, libsodium
+# For testing
+, coreutils, gawk
+}:
 
 stdenv.mkDerivation rec {
   pname = "dedup";
-  version = "1.0";
+  version = "2.0";
 
   src = fetchurl {
     url = "https://dl.2f30.org/releases/${pname}-${version}.tar.gz";
-    sha256 = "0wd4cnzhqk8l7byp1y16slma6r3i1qglwicwmxirhwdy1m7j5ijy";
+    sha256 = "0n5kkni4d6blz3s94y0ddyhijb74lxv7msr2mvdmj8l19k0lrfh1";
   };
 
   makeFlags = [
     "CC:=$(CC)"
     "PREFIX=${placeholder "out"}"
     "MANPREFIX=${placeholder "out"}/share/man"
-    # These are likely wrong on some platforms, please report!
-    "OPENMPCFLAGS=-fopenmp"
-    "OPENMPLDLIBS=-lgomp"
   ];
 
-  buildInputs = [ lz4 snappy openmp ];
+  buildInputs = [ lz4 snappy libsodium ];
+
+  doCheck = true;
+
+  checkInputs = [ coreutils gawk ];
+  checkTarget = "test";
 
   meta = with stdenv.lib; {
     description = "data deduplication program";

--- a/pkgs/tools/backup/dedup/default.nix
+++ b/pkgs/tools/backup/dedup/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   checkTarget = "test";
 
   meta = with stdenv.lib; {
-    description = "data deduplication program";
+    description = "Data deduplication program";
     homepage = https://git.2f30.org/dedup/file/README.html;
     license = with licenses; [ bsd0 isc ];
     maintainers = with maintainers; [ dtzWill ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1362,9 +1362,7 @@ in
 
   ddate = callPackage ../tools/misc/ddate { };
 
-  dedup = callPackage ../tools/backup/dedup {
-    inherit (llvmPackages) openmp;
-  };
+  dedup = callPackage ../tools/backup/dedup { };
 
   dehydrated = callPackage ../tools/admin/dehydrated { };
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update deps, enable tests.

https://git.2f30.org/dedup/file/CHANGELOG.html

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---