### PR TITLE
matrix-synapse: 0.95.5 -> 0.95.5.1

### DIFF
--- a/pkgs/servers/matrix-synapse/default.nix
+++ b/pkgs/servers/matrix-synapse/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, python3
-, enableSystemd ? true
+, enableSystemd ? stdenv.isLinux
 }:
 
 with python3.pkgs;
@@ -23,11 +23,11 @@ let
 
 in buildPythonApplication rec {
   pname = "matrix-synapse";
-  version = "0.99.5";
+  version = "0.99.5.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "0f50nfddrd4zxyv27wn9k5fxhqqa9kgvk2ijby0pgf61b054dhfn";
+    sha256 = "17iyy6hq6m0mcb5r8zwzw90qqfn6w4b9l87snlfrry8gzwjjwncz";
   };
 
   patches = [


### PR DESCRIPTION
###### Motivation for this change

This version is needed for compatibility with 1.0.0 and the new v4 rooms.

Also, enable systemd support based on host OS.

https://matrix.org/blog/2019/05/21/synapse-0-99-5-1-released

I will deploy this tonight to test it out.

Cc:  @ralith @roblabla @ekleog @pacien 


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
