### PR TITLE
quaternion: 0.0.9.4 -> 0.0.9.4c

### DIFF
--- a/pkgs/applications/networking/instant-messengers/quaternion/default.nix
+++ b/pkgs/applications/networking/instant-messengers/quaternion/default.nix
@@ -37,6 +37,7 @@ let
   };
 
 in rec {
-  quaternion     = generic "0.0.9.4"     "12mkwiqqbi4774kwl7gha72jyf0jf547acy6rw8ry249zl4lja54" "" libqmatrixclient_0_5;
+  quaternion     = generic "0.0.9.4c"     "12mkwiqqbi4774kwl7gha72jyf0jf547acy6rw8ry249zl4lja54" "" libqmatrixclient_0_5;
+
   quaternion-git = quaternion;
 }

--- a/pkgs/development/libraries/libqmatrixclient/default.nix
+++ b/pkgs/development/libraries/libqmatrixclient/default.nix
@@ -12,6 +12,10 @@ let
       inherit sha256;
     };
 
+    postPatch = ''
+      sed -i -e '/example/Id' CMakeLists.txt
+    '';
+
     buildInputs = [ qtbase qtmultimedia ];
 
     nativeBuildInputs = [ cmake ];
@@ -27,6 +31,7 @@ let
 
 in rec {
   libqmatrixclient_0_4 = generic "0.4.2.1" "056hvp2m74wx72yd8vai18siddj9l8bhrvrkc4ia4cwjsqw02kid" "v";
-  libqmatrixclient_0_5 = generic "0.5.1.2" "0vvpm1vlqfvhgfvavifrj4998g8v33hp5xjf0n8zfsmg4lxlnfg1" "";
+  libqmatrixclient_0_5 = generic "0.5.2"   "1bhlqfs7251fss4icx794ka614npr6zyrpp4qwc4q5408ykfm7lr" "";
+
   libqmatrixclient = libqmatrixclient_0_4;
 }


### PR DESCRIPTION
###### Motivation for this change

The libqmatrixclient change is needed to fix a bug with direct chats being marked unread incorrectly and the quaternion change is technically not needed as the changes only relate to appstream packaging but as we are rebuilding it anyway due to libqmatrixclient changing, we might as well.

Will test it out tonight.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
