### PR TITLE
xarchiver: 0.5.4.12 -> 0.5.4.14

### DIFF
--- a/pkgs/tools/archivers/xarchiver/default.nix
+++ b/pkgs/tools/archivers/xarchiver/default.nix
@@ -1,23 +1,15 @@
-{ stdenv, fetchFromGitHub, fetchpatch, gtk3, pkgconfig, intltool, libxslt, hicolor-icon-theme }:
+{ stdenv, fetchFromGitHub, gtk3, pkgconfig, intltool, libxslt, hicolor-icon-theme }:
 
 stdenv.mkDerivation rec {
-  version = "0.5.4.12";
+  version = "0.5.4.14";
   name = "xarchiver-${version}";
 
   src = fetchFromGitHub {
     owner = "ib";
     repo = "xarchiver";
     rev = "${version}";
-    sha256 = "13d8slcx3frz0dhl1w4llj7001n57cjjb8r7dlaw5qacaas3xfwi";
+    sha256 = "1iklwgykgymrwcc5p1cdbh91v0ih1m58s3w9ndl5kyd44bwlb7px";
   };
-
-  patches = [
-    # Fixes darwin build, remove with next update.
-    (fetchpatch {
-      url = https://github.com/ib/xarchiver/commit/8c69d066a827419feafd0bd047d19207ceadc7df.patch;
-      sha256 = "1ch1409hx1ynkm0mz93zy8h7wvcrsn56sz7lczsf6hznc8yzl0qg";
-    })
-  ];
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ gtk3 intltool libxslt hicolor-icon-theme ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Changelog seems only at the level of 5.4.x:

https://github.com/ib/xarchiver/blob/0.5.4.14/ChangeLog

Commits from 0.5.4.12 to 0.5.4.14:

https://github.com/ib/xarchiver/compare/0.5.4.12...0.5.4.14


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---