### PR TITLE
krita: 4.1.8 -> 4.2.0

### DIFF
--- a/pkgs/applications/graphics/krita/default.nix
+++ b/pkgs/applications/graphics/krita/default.nix
@@ -4,14 +4,14 @@
 , kio, kcrash
 , boost, libraw, fftw, eigen, exiv2, libheif, lcms2, gsl, openexr, giflib
 , openjpeg, opencolorio, vc, poppler, curl, ilmbase
-, qtmultimedia, qtx11extras
+, qtmultimedia, qtx11extras, quazip
 , python3Packages
 }:
 
 let
 
-major = "4.1";
-minor = "8";
+major = "4.2";
+minor = "0";
 patch = null;
 
 in
@@ -22,7 +22,7 @@ mkDerivation rec {
 
   src = fetchurl {
     url = "https://download.kde.org/stable/krita/${major}.${minor}/${name}.tar.gz";
-    sha256 = "0h2rplc76r82b8smk61zci1ijj9xkjmf20pdqa8fc2lz4zicjxh4";
+    sha256 = "1l5bhk4b2f3qdzg9jk2sxz2bq8cqs10nm3wgkrkbqs6vig75rsym";
   };
 
   nativeBuildInputs = [ cmake extra-cmake-modules python3Packages.sip makeWrapper ];
@@ -32,13 +32,15 @@ mkDerivation rec {
     ki18n kitemmodels kitemviews kwindowsystem kio kcrash
     boost libraw fftw eigen exiv2 lcms2 gsl openexr libheif giflib
     openjpeg opencolorio poppler curl ilmbase
-    qtmultimedia qtx11extras
+    qtmultimedia qtx11extras quazip
     python3Packages.pyqt5
   ] ++ lib.optional (stdenv.hostPlatform.isi686 || stdenv.hostPlatform.isx86_64) vc;
 
   NIX_CFLAGS_COMPILE = [ "-I${ilmbase.dev}/include/OpenEXR" ];
 
   cmakeFlags = [
+    "-DQUAZIP_INCLUDE_DIR=${quazip}/include/quazip"
+    "-DQUAZIP_LIBRARIES=${quazip}/lib/libquazip.so"
     "-DPYQT5_SIP_DIR=${python3Packages.pyqt5}/share/sip/PyQt5"
     "-DPYQT_SIP_DIR_OVERRIDE=${python3Packages.pyqt5}/share/sip/PyQt5"
     "-DCMAKE_BUILD_TYPE=RelWithDebInfo"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18661,6 +18661,7 @@ in
 
   krita = libsForQt5.callPackage ../applications/graphics/krita {
     openjpeg = openjpeg_1;
+    inherit (libsForQt5) quazip;
   };
 
   krusader = libsForQt5.callPackage ../applications/misc/krusader { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Krita 4.2.0 has been [released](https://krita.org/en/krita-4-2-release-notes/).

###### Things done
- Updated version number and checksum
- Added new dependency [quazip](https://krita.org/en/item/new-test-builds-changes-to-flow-and-saving-loading/)

###### Things to do
- [ ] we may need to update qt5, are [these changes](https://phabricator.kde.org/T10838) already in nixpkgs? 
- [ ] update [gmic_krita_qt](https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/graphics/gmic_krita_qt/default.nix), I should probably make a [separate PR](https://github.com/NixOS/nixpkgs/pull/62270) for that. (haven't used this so far, ?the current version seems to work with Krita 4.2.0 though?)
- [x] **DONE:** I'm not really familiar with CMake magic, I've set `QUAZIP_INCLUDE_DIR` and `QUAZIP_LIBRARIES` as environment variables but they are still not found during build...  the relevant CMake files can be found [here](https://github.com/KDE/krita/blob/v4.2.0/CMakeLists.txt#L778) and [here](https://github.com/KDE/krita/blob/v4.2.0/libs/store/CMakeLists.txt).
- [x] **DONE:** It now fails bceause ~~there are ?missing functions? in quazip~~ I'm an idiot - `QUAZIP_LIBRARIES` does not expect a directory.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
