### PR TITLE
igprof: init at v5.9.16

### DIFF
--- a/pkgs/development/tools/misc/igprof/default.nix
+++ b/pkgs/development/tools/misc/igprof/default.nix
@@ -1,0 +1,43 @@
+{stdenv, fetchFromGitHub, libunwind, cmake, pcre, gdb}:
+
+stdenv.mkDerivation rec {
+  version = "5.9.16";
+  name = "igprof-${version}";
+
+  src = fetchFromGitHub {
+    owner = "igprof";
+    repo = "igprof";
+    rev = "v${version}";
+    sha256 = "0rx3mv8zdh9bmcpfbzkib3d52skzfr8600gh5gv21wcsh50jnifx";
+  };
+
+  postPatch = ''
+    substituteInPlace src/igprof --replace libigprof.so $out/lib/libigprof.so
+    '';
+
+  buildInputs = [libunwind gdb pcre];
+  nativeBuildInputs = [cmake];
+  CXXFLAGS = ["-fPIC" "-O2" "-w" "-fpermissive"];
+
+  meta = {
+    description = "The Ignominous Profiler";
+
+    longDescription = ''
+      IgProf is a fast and light weight profiler. It correctly handles
+      dynamically loaded shared libraries, threads and sub-processes started by
+      the application.  We have used it routinely with large C++ applications
+      consisting of many hundreds of shared libraries and thousands of symbols
+      from millions of source lines of code. It requires no special privileges
+      to run. The performance reports provide full navigable call stacks and
+      can be customised by applying filters. Results from any number of
+      profiling runs can be included. This means you can both dig into the
+      details and see the big picture from combined workloads.
+    '';
+
+    license = stdenv.lib.licenses.gpl2;
+
+    homepage = https://igprof.org/;
+    platforms = stdenv.lib.platforms.linux;
+    maintainers = with stdenv.lib.maintainers; [ ktf ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23224,6 +23224,8 @@ in
 
   igraph = callPackage ../development/libraries/igraph { };
 
+  igprof = callPackage ../development/tools/misc/igprof { };
+
   illum = callPackage ../tools/system/illum { };
 
   image_optim = callPackage ../applications/graphics/image_optim { inherit (nodePackages) svgo; };


### PR DESCRIPTION
###### Motivation for this change

Add IgProf profiler.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---