### PR TITLE
rofi-pass: refactor add new optional dependency pass-otp

### DIFF
--- a/pkgs/tools/security/pass/rofi-pass.nix
+++ b/pkgs/tools/security/pass/rofi-pass.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     gnugrep
     gnused
     libnotify
-    pass
+    (pass.withExtensions (ext: [ ext.pass-otp ]))
     pwgen
     rofi
     utillinux


### PR DESCRIPTION
###### Motivation for this change

Rofi-pass as of a year ago added support for OTP passwords. This
dependency is "optional" but extremely nice to have as a default.

https://github.com/carnager/rofi-pass#requirements

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
