### PR TITLE
ddclient: fix fallout from #62068

### DIFF
--- a/pkgs/tools/networking/ddclient/default.nix
+++ b/pkgs/tools/networking/ddclient/default.nix
@@ -19,10 +19,9 @@ perlPackages.buildPerlPackage rec {
     touch Makefile.PL
     substituteInPlace ddclient \
       --replace 'in the output of ifconfig' 'in the output of ip addr show' \
-      --replace 'ifconfig -a'               '${iproute}/sbin/ip addr show' \
-      --replace 'ifconfig $arg'             '${iproute}/sbin/ip addr show $arg' \
-   # Until we get the patchShebangs fixed (issue #55786) we need to patch this manually
-      --replace '/usr/bin/perl'		    '${perl}/bin/perl'
+      --replace 'ifconfig -a' '${iproute}/sbin/ip addr show' \
+      --replace 'ifconfig $arg' '${iproute}/sbin/ip addr show $arg' \
+      --replace '/usr/bin/perl' '${perl}/bin/perl' # Until we get the patchShebangs fixed (issue #55786) we need to patch this manually
   '';
 
   installPhase = ''


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
https://github.com/NixOS/nixpkgs/issues/62216

@romildo Thanks. I feel pretty silly about that...
@mmahut Sorry. I really should have done a final check on your PR. My bad.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
