### PR TITLE
colorls: init at 1.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2938,6 +2938,11 @@
     github = "lukeadams";
     name = "Luke Adams";
   };
+  lukebfox = {
+    email = "lbentley-fox1@sheffield.ac.uk";
+    github = "lukebfox";
+    name = "Luke Bentley-Fox";
+  };
   lukego = {
     email = "luke@snabb.co";
     github = "lukego";

--- a/pkgs/tools/system/colorls/Gemfile
+++ b/pkgs/tools/system/colorls/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'colorls'

--- a/pkgs/tools/system/colorls/Gemfile.lock
+++ b/pkgs/tools/system/colorls/Gemfile.lock
@@ -1,0 +1,21 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    clocale (0.0.4)
+    colorls (1.2.0)
+      clocale (~> 0)
+      filesize (~> 0)
+      manpages (~> 0)
+      rainbow (>= 2.2, < 4.0)
+    filesize (0.2.0)
+    manpages (0.6.1)
+    rainbow (3.0.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  colorls
+
+BUNDLED WITH
+   1.17.2

--- a/pkgs/tools/system/colorls/default.nix
+++ b/pkgs/tools/system/colorls/default.nix
@@ -1,0 +1,16 @@
+{ lib, bundlerApp, ruby, ... }:
+
+bundlerApp rec {
+  pname = "colorls";
+
+  gemdir = ./.;
+  exes = [ "colorls" ];
+
+  meta = with lib; {
+    description = "Prettified LS";
+    homepage    = https://github.com/athityakumar/colorls;
+    license     = with licenses; mit;
+    maintainers = with maintainers; [ lukebfox ];
+    platforms   = ruby.meta.platforms;
+  };
+}

--- a/pkgs/tools/system/colorls/gemset.nix
+++ b/pkgs/tools/system/colorls/gemset.nix
@@ -1,0 +1,53 @@
+{
+  clocale = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "065pb7hzmd6zndbln4ag94bjpw3hsm71jagsgiqskpxhgrbq03jz";
+      type = "gem";
+    };
+    version = "0.0.4";
+  };
+  colorls = {
+    dependencies = ["clocale" "filesize" "manpages" "rainbow"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0bcrig88ipzj43lnkrb5qmimdrml4lx15rcrhr6m2hxb0pks8932";
+      type = "gem";
+    };
+    version = "1.2.0";
+  };
+  filesize = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "17p7rf1x7h3ivaznb4n4kmxnnzj25zaviryqgn2n12v2kmibhp8g";
+      type = "gem";
+    };
+    version = "0.2.0";
+  };
+  manpages = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "11p6ilnfda6af15ks3xiz2pr0hkvdvadnk1xm4ahqlf84dld3fnd";
+      type = "gem";
+    };
+    version = "0.6.1";
+  };
+  rainbow = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0bb2fpjspydr6x0s8pn1pqkzmxszvkfapv0p4627mywl7ky4zkhk";
+      type = "gem";
+    };
+    version = "3.0.0";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1320,6 +1320,8 @@ in
     xcbuildHook = xcbuild6Hook;
   };
 
+  colorls = callPackage ../tools/system/colorls { };
+
   compsize = callPackage ../os-specific/linux/compsize { };
 
   coturn = callPackage ../servers/coturn { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

`colorls` is a tool which beautifies the terminal's ls command, with color and icons.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
