### PR TITLE
nixos/malloc: add scudo from LLVM compiler-rt

### DIFF
--- a/nixos/modules/config/malloc.nix
+++ b/nixos/modules/config/malloc.nix
@@ -21,6 +21,15 @@ let
         and scalable concurrency support.
       '';
     };
+
+    "scudo" = {
+      libPath = "${pkgs.llvmPackages.compiler-rt}/lib/linux/libclang_rt.scudo-x86_64.so";
+      description = ''
+        A user-mode allocator based on LLVM Sanitizer’s CombinedAllocator,
+        which aims at providing additional mitigations against heap based
+        vulnerabilities, while maintaining good performance.
+      '';
+    };
   };
 
   providerConf = providers."${cfg.provider}";


### PR DESCRIPTION
###### Motivation for this change

The Scudo allocator is a good compromise between security, performance and compatibility. The GrapheneOS allocator which is currently the only "secure" allocator option in NixOS is incompatible with Nix itself (due to coping badly with tons of small allocs) and has a fairly big overhead.

Scudo doesn't go as far in terms of error checking as the Graphene allocator (Graphene is closer to ASAN/MSAN). But being able to run Nix is fairly important :-) It's around a 20% CPU time increase on some test nix evaluations I've done compared to libc malloc.

See:

- https://llvm.org/docs/ScudoHardenedAllocator.html
- https://android-developers.googleblog.com/2019/05/queue-hardening-enhancements.html which mentions Android Q planning to use Scudo for some security critical components.

@joachifm

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
