### PR TITLE
pythonPackages.pyworld: init at 0.2.8

### DIFF
--- a/pkgs/development/python-modules/pyworld/default.nix
+++ b/pkgs/development/python-modules/pyworld/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, lib
+, buildPythonPackage, fetchPypi
+, numpy, cython
+}:
+
+buildPythonPackage rec {
+  pname = "pyworld";
+  version = "0.2.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "b25bc84efb1bfe1fa0e10b19b391ef40b6e1a330a8e31d676befa58614880bb3";
+  };
+
+  nativeBuildInputs = [
+    cython
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+  ];
+
+  # There are not any tests.
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A Python wrapper for the high-quality vocoder \"World\"";
+    homepage = https://github.com/JeremyCCHsu/Python-Wrapper-for-World-Vocoder;
+    license = licenses.mit;
+    maintainers = with maintainers; [ hyphon81 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -860,6 +860,8 @@ in {
 
   PyWebDAV = callPackage ../development/python-modules/pywebdav { };
 
+  pyworld = callPackage ../development/python-modules/pyworld { };
+
   pyxml = disabledIf isPy3k (callPackage ../development/python-modules/pyxml{ });
 
   pyvcd = callPackage ../development/python-modules/pyvcd { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
