### PR TITLE
pythonPackages.curio: patch tests

### DIFF
--- a/pkgs/development/python-modules/curio/default.nix
+++ b/pkgs/development/python-modules/curio/default.nix
@@ -22,6 +22,8 @@ buildPythonPackage rec {
   # test_aside_basic times out,
   # test_aside_cancel fails because modifies PYTHONPATH and cant find pytest
   checkPhase = ''
+    # __pycache__ was packaged accidentally, https://github.com/dabeaz/curio/issues/301
+    rm -r tests/__pycache__
     pytest --deselect tests/test_task.py::test_aside_basic --deselect tests/test_task.py::test_aside_cancel
   '';
 


### PR DESCRIPTION
###### Motivation for this change
The tests currently will fail with 
```
$ nix-shell -p python36Packages.curio
...
running install tests
ImportError while loading conftest '/build/curio-0.9/tests/conftest.py'.
py._path.local.LocalPath.ImportMismatchError: ('conftest', '/Users/beazley/Desktop/Projects/junk/curio/tests/conftest.py', local('/build/curio-0.9/tests/conftest.py'))
```

The package was distributed with a `tests/__pycache__/`  that is causing it to read invalid information.

[I opened an issue on his repo to fix the pypi distribution](https://github.com/dabeaz/curio/issues/301), this is an temporary fix

@marsam 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
