### PR TITLE
pythonPackages.pysptk: init at 0.1.16

### DIFF
--- a/pkgs/development/python-modules/pysptk/default.nix
+++ b/pkgs/development/python-modules/pysptk/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage, fetchPypi
+, numpy, scipy, cython, six, decorator
+}:
+
+buildPythonPackage rec {
+  pname = "pysptk";
+  version = "0.1.17";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "aa8bd2ae84bfe72e9015ccb69eb3b687bc64fad6139ae0b327fe07918e1e28ff";
+  };
+
+  PYSPTK_BUILD_VERSION = 0;
+
+  nativeBuildInputs = [
+    cython
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+    scipy
+    six
+    decorator
+  ];
+
+  # No tests in the PyPI tarball
+  doCheck = false;
+
+  meta = with lib; {
+    description = "A python wrapper for Speech Signal Processing Toolkit (SPTK)";
+    homepage = https://pysptk.readthedocs.io/en/latest/;
+    license = licenses.mit;
+    maintainers = with maintainers; [ hyphon81 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2340,6 +2340,8 @@ in {
 
   pyspf = callPackage ../development/python-modules/pyspf { };
 
+  pysptk = callPackage ../development/python-modules/pysptk { };
+
   pysrim = callPackage ../development/python-modules/pysrim { };
 
   pysrt = callPackage ../development/python-modules/pysrt { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
