### PR TITLE
openimageio2: init at 2.0.8

### DIFF
--- a/pkgs/applications/graphics/openimageio/2.x.nix
+++ b/pkgs/applications/graphics/openimageio/2.x.nix
@@ -1,0 +1,60 @@
+{ stdenv
+, fetchFromGitHub
+, boost
+, cmake
+, ilmbase
+, libjpeg
+, libpng
+, libtiff
+, opencolorio
+, openexr
+, robin-map
+, unzip
+}:
+
+stdenv.mkDerivation rec {
+  pname = "openimageio";
+  version = "2.0.8";
+
+  src = fetchFromGitHub {
+    owner = "OpenImageIO";
+    repo = "oiio";
+    rev = "Release-${version}";
+    sha256 = "0nk72h7q1n664b268zkhibb7a3i7fb3nl2z7fg31ys5r9zlq6mnp";
+  };
+
+  outputs = [ "bin" "out" "dev" "doc" ];
+
+  nativeBuildInputs = [
+    cmake
+    unzip
+  ];
+
+  buildInputs = [
+    boost
+    ilmbase
+    libjpeg
+    libpng
+    libtiff
+    opencolorio
+    openexr
+    robin-map
+  ];
+
+  cmakeFlags = [
+    "-DUSE_PYTHON=OFF"
+    "-DUSE_QT=OFF"
+    # GNUInstallDirs
+    "-DCMAKE_INSTALL_BINDIR=${placeholder "bin"}/bin"
+    "-DCMAKE_INSTALL_INCLUDEDIR=${placeholder "dev"}/include"
+    "-DCMAKE_INSTALL_LIBDIR=lib" # needs relative path for pkgconfig
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = http://www.openimageio.org;
+    description = "A library and tools for reading and writing images";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ goibhniu jtojnar ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/applications/graphics/openimageio/default.nix
+++ b/pkgs/applications/graphics/openimageio/default.nix
@@ -3,7 +3,7 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "openimageio-${version}";
+  pname = "openimageio";
   version = "1.8.16";
 
   src = fetchFromGitHub {
@@ -15,28 +15,25 @@ stdenv.mkDerivation rec {
 
   outputs = [ "bin" "out" "dev" "doc" ];
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake unzip ];
   buildInputs = [
     boost ilmbase libjpeg libpng
     libtiff opencolorio openexr
-    unzip
   ];
 
   cmakeFlags = [
     "-DUSE_PYTHON=OFF"
+    # GNUInstallDirs
+    "-DCMAKE_INSTALL_BINDIR=${placeholder "bin"}/bin"
   ];
 
-  preBuild = ''
-    makeFlags="ILMBASE_HOME=${ilmbase.dev} OPENEXR_HOME=${openexr.dev} USE_PYTHON=0
-      INSTALLDIR=$out dist_dir="
-  '';
-
-  postInstall = ''
-    mkdir -p $bin
-    mv $out/bin $bin/
-  '';
-
-  enableParallelBuilding = true;
+  makeFlags = [
+    "ILMBASE_HOME=${ilmbase.dev}"
+    "OPENEXR_HOME=${openexr.dev}"
+    "USE_PYTHON=0"
+    "INSTALLDIR=${placeholder "out"}"
+    "dist_dir="
+  ];
 
   meta = with stdenv.lib; {
     homepage = http://www.openimageio.org;

--- a/pkgs/development/libraries/robin-map/default.nix
+++ b/pkgs/development/libraries/robin-map/default.nix
@@ -1,0 +1,26 @@
+{ stdenv
+, fetchFromGitHub
+, cmake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "robin-map";
+  version = "0.6.1";
+
+  src = fetchFromGitHub {
+    owner = "Tessil";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0blvvbr14f0drbd6dp0cs8x4ng3ppb5i72dmhk43ylg6yjgh4fhq";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/Tessil/robin-map;
+    description = "C++ implementation of a fast hash map and hash set using robin hood hashing";
+    license = licenses.mit;
+    maintainers = with maintainers; [ goibhniu jtojnar ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23525,6 +23525,8 @@ in
 
   redis-desktop-manager = libsForQt5.callPackage ../applications/misc/redis-desktop-manager { };
 
+  robin-map = callPackage ../development/libraries/robin-map { };
+
   robo3t = callPackage ../applications/misc/robo3t { };
 
   rucksack = callPackage ../development/tools/rucksack { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19391,6 +19391,8 @@ in
     stdenv = overrideCC stdenv gcc6;
   };
 
+  openimageio2 = callPackage ../applications/graphics/openimageio/2.x.nix { };
+
   openjump = callPackage ../applications/misc/openjump { };
 
   openorienteering-mapper = libsForQt5.callPackage ../applications/gis/openorienteering-mapper { };


### PR DESCRIPTION
###### Motivation for this change
We already have an older version which some programs still depend on so I added it as a separate expression.

cc @cillianderoiste 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Diffed the directory tree of `openimage` and there do not appear to be any changes.
- [x] Built app against `openimage2`
- [x] Checked that the `.pc` file in `openimage2` looks correct
- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
