### PR TITLE
nixos/malloc: apply allocator settings to systemd units

### DIFF
--- a/nixos/modules/config/malloc.nix
+++ b/nixos/modules/config/malloc.nix
@@ -91,5 +91,7 @@ in
 
   config = mkIf (cfg.provider != "libc") {
     environment.variables.LD_PRELOAD = providerLibPath;
+    systemd.extraConfig = "DefaultEnvironment=\"LD_PRELOAD=${providerLibPath}\"";
+    systemd.user.extraConfig = "DefaultEnvironment=\"LD_PRELOAD=${providerLibPath}\"";
   };
 }


### PR DESCRIPTION
###### Motivation for this change

#62236 

This PR uses systemd's system.conf/user.conf "DefaultEnvironment" feature to set the allocator's LD_PRELOAD near-globally.

I've only tested this with Scudo, not with Graphene, so no idea if it's going to break Graphene allocator systems further than they are already. With this PR, I see almost all processes on my system using the configured allocator. The only exceptions are:

- chromium (but that's expected, they have their own allocator I imagine)
- sddm-helper and 1-2 /bin/sh processes it spawns. Haven't looked into what's going on there, but I don't particularly care much either.

@GrahamcOfBorg test hardened

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
