### PR TITLE
national-park-typeface: init at 206464

### DIFF
--- a/pkgs/data/fonts/national-park/default.nix
+++ b/pkgs/data/fonts/national-park/default.nix
@@ -1,0 +1,24 @@
+{ lib, fetchzip }:
+
+let
+  pname = "national-park-typeface";
+  version = "206464";
+in fetchzip {
+  name = "${pname}-${version}";
+  url = "https://files.cargocollective.com/c${version}/NationalPark.zip";
+
+  postFetch = ''
+    mkdir -p $out/share/fonts
+    unzip -j $downloadedFile National\*.otf -d $out/share/fonts/opentype/
+  '';
+
+  sha256 = "044gh4xcasp8i9ny6z4nmns1am2pk5krc4ann2afq35v9bnl2q5d";
+
+  meta = with lib; {
+    description = ''Typeface designed to mimic the national park service
+    signs that are carved using a router bit'';
+    homepage = https://nationalparktypeface.com/;
+    license = licenses.ofl;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16388,6 +16388,8 @@ in
 
   nanum-gothic-coding = callPackage ../data/fonts/nanum-gothic-coding {  };
 
+  national-park-typeface = callPackage ../data/fonts/national-park { };
+
   nordic = callPackage ../data/themes/nordic { };
 
   nordic-polar = callPackage ../data/themes/nordic-polar { };


### PR DESCRIPTION
###### Motivation for this change

Add this unique font :).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---