### PR TITLE
datadog-agent: fix sha256 sum

### DIFF
--- a/pkgs/tools/networking/dd-agent/datadog-agent.nix
+++ b/pkgs/tools/networking/dd-agent/datadog-agent.nix
@@ -13,7 +13,7 @@ in buildGoPackage rec {
   src = fetchFromGitHub {
     inherit owner repo;
     rev    = "${version}";
-    sha256 = "194ml6sh4i3gszcy1rcffcaw0419imlgbnzvgihydlh7pwc3sl83";
+    sha256 = "1dwdiaf357l9c6b2cps5mdyfma3c1mp96zzxg1826fvz3x8ix68z";
   };
 
   subPackages = [


### PR DESCRIPTION
###### Motivation for this change
Fix sha256 sum in datadog agent v6.11.2

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
