### PR TITLE
 lib/make-ext4: bump fudge factor to 96 MiB

### DIFF
--- a/nixos/lib/make-ext4-fs.nix
+++ b/nixos/lib/make-ext4-fs.nix
@@ -23,6 +23,8 @@ pkgs.stdenv.mkDerivation {
 
   buildCommand =
     ''
+      export EXT2FS_NO_MTAB_OK=yes
+
       # Add the closures of the top-level store objects.
       storePaths=$(cat ${sdClosureInfo}/store-paths)
 
@@ -67,7 +69,7 @@ pkgs.stdenv.mkDerivation {
         size=$(( blocks - ''${free##*:} + fudge ))
 
         echo "Resizing from $blocks blocks to $size blocks. (~ $((size*blocksize/1024/1024))MiB)"
-        EXT2FS_NO_MTAB_OK=yes resize2fs $out -f $size
+        resize2fs $out -f $size
       )
 
       # And a final fsck, because of the previous truncating.

--- a/nixos/lib/make-ext4-fs.nix
+++ b/nixos/lib/make-ext4-fs.nix
@@ -59,14 +59,15 @@ pkgs.stdenv.mkDerivation {
       (
         # Resizes **snugly** to its actual limits (or closer to)
         free=$(dumpe2fs $out | grep '^Free blocks:')
+        free=$((''${free##*:})) # format the number
         blocksize=$(dumpe2fs $out | grep '^Block size:')
+        blocksize=$((''${blocksize##*:})) # format the number
         blocks=$(dumpe2fs $out | grep '^Block count:')
-        blocks=$((''${blocks##*:})) # format the number.
-        blocksize=$((''${blocksize##*:})) # format the number.
         # System can't boot with 0 blocks free.
         # Add 16MiB of free space
         fudge=$(( 16 * 1024 * 1024 / blocksize ))
-        size=$(( blocks - ''${free##*:} + fudge ))
+        blocks=$((''${blocks##*:})) # format the number
+        size=$(( blocks - free + fudge ))
 
         echo "Resizing from $blocks blocks to $size blocks. (~ $((size*blocksize/1024/1024))MiB)"
         resize2fs $out -f $size

--- a/nixos/lib/make-ext4-fs.nix
+++ b/nixos/lib/make-ext4-fs.nix
@@ -63,14 +63,12 @@ pkgs.stdenv.mkDerivation {
         blocksize=$(dumpe2fs $out | grep '^Block size:')
         blocksize=$((''${blocksize##*:})) # format the number
         blocks=$(dumpe2fs $out | grep '^Block count:')
-        # System can't boot with 0 blocks free.
-        # Add 16MiB of free space
-        fudge=$(( 16 * 1024 * 1024 / blocksize ))
         blocks=$((''${blocks##*:})) # format the number
+        # System can't boot with 0 blocks free. Also, Aarch64 build of resize2fs
+        # will sometimes complain about "No space left on device" unless there
+        # is some fudge factor (likely an upstream bug). Add 128 MiB of free space.
+        fudge=$(( 128 * 1024 * 1024 / blocksize ))
         size=$(( blocks - free + fudge ))
-
-        echo "Resizing from $blocks blocks to $size blocks. (~ $((size*blocksize/1024/1024))MiB)"
-        resize2fs $out -f $size
       )
 
       # And a final fsck, because of the previous truncating.


### PR DESCRIPTION
###### Motivation for this change

`resize2fs` seems to have a block miscalculation bug that requires fudge factor increase from 16 MiB all the way up to ~96 MiB~ 128 MiB.

I'm pretty sure miscalculation bug is specific to Aarch64, since I can build ext4 images that are only 20-30 blocks away on x86-64 just fine, however I'm not entirely sure since I haven't tested it with exact same filesystems.

Issue can be reproduced by running `nix-build https://github.com/transumption/holoportos/archive/6b6497c1fde9c143be16be83948d950670f27d11.tar.gz -A artifacts.installers.holoport-nano`. I can create minimal repro if necessary: that said, the only variable that should affect this behavior is the closure size.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS (both Aarch64 and x86-64)
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
