### PR TITLE
Update packet python

### DIFF
--- a/pkgs/development/python-modules/packet-python/default.nix
+++ b/pkgs/development/python-modules/packet-python/default.nix
@@ -3,28 +3,24 @@
 , fetchPypi
 , requests
 , python
-, fetchpatch
+
+# For tests/setup.py
+, pytestrunner
 }:
 
 buildPythonPackage rec {
   pname = "packet-python";
-  version = "1.37.1";
+  version = "1.38.2";
   src = fetchPypi {
     inherit pname version;
-    sha256 = "316941d2473c0f42ac17ac89e9aa63a023bb96f35cf8eafe9e091ea424892778";
+    sha256 = "1lh97la51fa3nxjl4ngsanrxw6qq5jwwn0dxj2f0946m043200xl";
   };
+  nativeBuildInputs = [ pytestrunner ];
   propagatedBuildInputs = [ requests ];
 
   checkPhase = ''
     ${python.interpreter} -m unittest discover -s test
   '';
-
-  patches = [
-    (fetchpatch {
-      url = https://github.com/packethost/packet-python/commit/361ad0c60d0bfce2a992eefd17e917f9dcf36400.patch;
-      sha256 = "1cmzyq0302y4cqmim6arnvn8n620qysq458g2w5aq4zj1vz1q9g1";
-    })
-  ];
 
   # Not all test files are included in archive
   doCheck = false;

--- a/pkgs/development/python-modules/packet-python/default.nix
+++ b/pkgs/development/python-modules/packet-python/default.nix
@@ -5,7 +5,9 @@
 , python
 
 # For tests/setup.py
+, pytest
 , pytestrunner
+, requests-mock
 }:
 
 buildPythonPackage rec {
@@ -17,13 +19,15 @@ buildPythonPackage rec {
   };
   nativeBuildInputs = [ pytestrunner ];
   propagatedBuildInputs = [ requests ];
+  checkInputs = [
+    pytest
+    pytestrunner
+    requests-mock
+  ];
 
   checkPhase = ''
-    ${python.interpreter} -m unittest discover -s test
+    ${python.interpreter} setup.py test
   '';
-
-  # Not all test files are included in archive
-  doCheck = false;
 
   meta = {
     description = "A Python client for the Packet API.";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
New release of packet-python that brings in a few small features and also allows for testing from the sdist.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
