### PR TITLE
[WIP] gmic_krita_qt: 2.3.6 -> 2.6.4

### DIFF
--- a/pkgs/tools/graphics/gmic_krita_qt/default.nix
+++ b/pkgs/tools/graphics/gmic_krita_qt/default.nix
@@ -62,16 +62,11 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkgconfig ];
 
   buildInputs = [
-    qtbase qttools fftw fftw.dev zlib libjpeg libtiff libpng
+    qtbase qttools fftw zlib libjpeg libtiff libpng
     opencv openexr graphicsmagick curl krita
   ];
 
-  NIX_CFLAGS = [ "-L${fftw}/lib" ];
-
-  cmakeFlags = [
-    "-DGMIC_QT_HOST=krita"
-    "-DFFTW3_INCLUDE_DIR=${fftw.dev}/include"
-    ];
+  cmakeFlags = [ "-DGMIC_QT_HOST=krita" ];
 
   installPhase = ''
     mkdir -p $out/bin;

--- a/pkgs/tools/graphics/gmic_krita_qt/default.nix
+++ b/pkgs/tools/graphics/gmic_krita_qt/default.nix
@@ -4,7 +4,7 @@
 , fetchgit }:
 
 let
-  version = "2.3.6";
+  version = "2.6.4";
 
 in stdenv.mkDerivation rec {
   name = "gmic_krita_qt-${version}";
@@ -12,35 +12,35 @@ in stdenv.mkDerivation rec {
   gmic-community = fetchFromGitHub {
     owner = "dtschump";
     repo = "gmic-community";
-    rev = "3fd528f20a2a7d651e96078c205ff21efb9cdd1a";
-    sha256 = "08d37b49qgh5d4rds7hvr5wjj4p1y8cnbidz1cyqsibq0555pwq2";
+    rev = "011f7ec229c279d820f332eb1f64b913e152aff2";
+    sha256 = "0gya9kk36jrbs99s5qhrwziifhkvwv31zr8x9gzfmahbb753bj9r";
   };
 
   CImg = fetchgit {
     url = "https://framagit.org/dtschump/CImg";
-    rev = "90f5657d8eab7b549ef945103ef680e747385805";
-    sha256 = "1af3dwqq18dkw0lz2gvnlw8y0kc1cw01hnc72rf3pg2wyjcp0pvc";
+    rev = "v.${version}";
+    sha256 = "100lh85l3rh0w3dmy2qmfwlmx85h18xzr11znnx571nqf2zdmbmk";
   };
 
   gmic_stdlib = fetchurl {
     name = "gmic_stdlib.h";
-    # Version should e in sync with gmic. Basically the version string without dots
-    url = "http://gmic.eu/gmic_stdlib236.h";
-    sha256 = "0q5g87dsn9byd2qqsa9xrsggfb9qv055s3l2gc0jrcvpx2qbza4q";
+    # Version should be in sync with gmic. Basically the version string without dots
+    url = "http://gmic.eu/gmic_stdlib${builtins.replaceStrings [ "." ] [ "" ] version}.h";
+    sha256 = "1i2jm4bih0mvvah7rj6a0rk6hdw0cmdmdzkbvj67qbplyin5k2kf";
   };
 
   gmic = fetchFromGitHub {
     owner = "dtschump";
     repo = "gmic";
     rev = "v.${version}";
-    sha256 = "1yg9ri3n07drv8gz4x0mn39ryi801ibl26jaza47m19ma893m8fi";
+    sha256 = "0rcg9h1wig02263yh5gp77gdp97fr4hvf8nd71x43yzwnq47zma9";
   };
 
   gmic_qt = fetchFromGitHub {
     owner = "c-koi";
     repo = "gmic-qt";
     rev = "v.${version}";
-    sha256= "0j9wqlq67dwzir36yg58xy5lbblwizvgcvlmzcv9d6l901d5ayf3";
+    sha256= "1lffypx1d77vylgh6r0v6wf5d9jmfx0szbzd510i44fzkdismpdl";
   };
 
   unpackPhase = ''
@@ -62,11 +62,16 @@ in stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkgconfig ];
 
   buildInputs = [
-    qtbase qttools fftw zlib libjpeg libtiff libpng
+    qtbase qttools fftw fftw.dev zlib libjpeg libtiff libpng
     opencv openexr graphicsmagick curl krita
   ];
 
-  cmakeFlags = [ "-DGMIC_QT_HOST=krita" ];
+  NIX_CFLAGS = [ "-L${fftw}/lib" ];
+
+  cmakeFlags = [
+    "-DGMIC_QT_HOST=krita"
+    "-DFFTW3_INCLUDE_DIR=${fftw.dev}/include"
+    ];
 
   installPhase = ''
     mkdir -p $out/bin;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update Krita's gmic "plugin"

###### Things done
Update version number and checksums.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
###### Things to do
- [ ] gmic_krita_qt fails to link against fftw.
If anyone has some time I would be happy about a few hints.

### Relevant Information:
**Error Message:**
```
/nix/store/2dfjlvp38xzkyylwpavnh61azi0d168b-binutils-2.31.1/bin/ld: CMakeFiles/gmic_krita_qt.dir/build/gmic/src/gmic.cpp.o: in function `_GLOBAL__sub_I_gmic.cpp':
gmic.cpp:(.text.startup+0x2): undefined reference to `fftw_init_threads'
/nix/store/2dfjlvp38xzkyylwpavnh61azi0d168b-binutils-2.31.1/bin/ld: CMakeFiles/gmic_krita_qt.dir/src/FilterSelector/FiltersModelReader.cpp.o: in function `_GLOBAL__sub_I_FiltersModelReader.cpp':
FiltersModelReader.cpp:(.text.startup+0x2f): undefined reference to `fftw_init_threads'
/nix/store/2dfjlvp38xzkyylwpavnh61azi0d168b-binutils-2.31.1/bin/ld: CMakeFiles/gmic_krita_qt.dir/src/CroppedImageListProxy.cpp.o: in function `_GLOBAL__sub_I_CroppedImageListProxy.cpp':
CroppedImageListProxy.cpp:(.text.startup+0x2b): undefined reference to `fftw_init_threads'
/nix/store/2dfjlvp38xzkyylwpavnh61azi0d168b-binutils-2.31.1/bin/ld: CMakeFiles/gmic_krita_qt.dir/src/CroppedActiveLayerProxy.cpp.o: in function `_GLOBAL__sub_I_CroppedActiveLayerProxy.cpp':
CroppedActiveLayerProxy.cpp:(.text.startup+0x2b): undefined reference to `fftw_init_threads'
/nix/store/2dfjlvp38xzkyylwpavnh61azi0d168b-binutils-2.31.1/bin/ld: CMakeFiles/gmic_krita_qt.dir/src/FilterSyncRunner.cpp.o: in function `_GLOBAL__sub_I_FilterSyncRunner.cpp':
FilterSyncRunner.cpp:(.text.startup+0x2f): undefined reference to `fftw_init_threads'
/nix/store/2dfjlvp38xzkyylwpavnh61azi0d168b-binutils-2.31.1/bin/ld: CMakeFiles/gmic_krita_qt.dir/src/FilterThread.cpp.o:FilterThread.cpp:(.text.startup+0x2f): more undefined references to `fftw_init_threads' follow
collect2: error: ld returned 1 exit status
```

This is quite weird as the previous version was also linked against this library as well.
**CMakeLists.txt file diff:**
```
  message(FATAL_ERROR "\nVersion numbers of files 'gmic.h' (" |	  message(FATAL_ERROR "\nVersion numbers of files 'gmic.h' ("
    add_definitions(-Dgmic_prelease=${PRERELEASE_DATE})	      |	    add_definitions(-Dgmic_prerelease="${PRERELEASE_DATE}")
add_definitions(-Dcimg_use_rng)				      <
							      >	SET(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
							      >	SET(CMAKE_INSTALL_RPATH "$ORIGIN/")
							      >
							      >	    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -s"
							      >	    if (WIN32)
							      >	        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}
							      >	    endif()
# qt5_create_translation(				      |	set(gmic_translation_files
#     qmic_qt_QM					      <
#     ${CMAKE_SOURCE_DIR}/translations			      <
#     ${gmic_qt_SRCS}					      <
#     translations/cs.ts				      <
#     translations/de.ts				      <
#     translations/es.ts				      <
#     translations/fr.ts				      <
#     translations/id.ts				      <
#     translations/it.ts				      <
#     translations/nl.ts				      <
#     translations/pl.ts				      <
#     translations/pt.ts				      <
#     translations/ru.ts				      <
#     translations/ua.ts				      <
#     translations/ja.ts				      <
#     translations/zh.ts				      <
# )							      <
qt5_add_translation(gmic_qt_QM				      <
							      >	)
							      >
							      >	set_source_files_properties(${gmic_translation_files} PROPERT
							      >
							      >	# qt5_create_translation(
							      >	#     qmic_qt_QM
							      >	#     ${CMAKE_SOURCE_DIR}/translations
							      >	#     ${gmic_qt_SRCS}
							      >	#     ${gmic_translation_files}
							      >	# )
							      >
							      >	qt5_add_translation(gmic_qt_QM
							      >	    ${gmic_translation_files}
							      >	    install(TARGETS gmic_gimp_qt RUNTIME DESTINATION bin)
							      >	    install(TARGETS gmic_krita_qt RUNTIME DESTINATION bin)
							      >	    install(TARGETS gmic_qt RUNTIME DESTINATION bin)
							      >
							      >	elseif (${GMIC_QT_HOST} STREQUAL "paintdotnet")
							      >
							      >	    set (gmic_qt_SRCS ${gmic_qt_SRCS} src/Host/PaintDotNet/ho
							      >	    add_definitions(-DGMIC_HOST=paintdotnet)
							      >	    add_executable(gmic_paintdotnet_qt ${gmic_qt_SRCS} ${gmic
							      >	    target_link_libraries(
							      >	      gmic_paintdotnet_qt
							      >	      PRIVATE
							      >	      ${gmic_qt_LIBRARIES}
							      >	      )
    message(FATAL_ERROR "GMIC_QT_HOST is not defined as gimp, |	    message(FATAL_ERROR "GMIC_QT_HOST is not defined as gimp,
```
The following two issues also apply to the previous version (so it's unlikely that they are relevant)
FFTW3 is found but there is no path or version number?
```
-- Found ZLIB: /nix/store/ynykygggqw7l6wy5cp45565c0phxh8kv-zlib-1.2.11/lib/libz.so (found version "1.2.11")
-- Found PNG: /nix/store/phv46yv3c6jraiv2aq6i1dgs9pjr3l8q-libpng-apng-1.6.37/lib/libpng.so (found version "1.6.37")
-- Found PkgConfig: /nix/store/cnxbsf7l63nzy1bssrllxc39lm9wys28-pkg-config-0.29.2/bin/pkg-config (found version "0.29.2")
-- Found FFTW3
-- FFTW Found Version:
-- Found CURL: /nix/store/kzrl9md38ms37pay33kdi97rpcb099v1-curl-7.64.1/lib/libcurl.so (found version "7.64.1")
-- Found OpenMP_C: -fopenmp (found version "4.5")
-- Found OpenMP_CXX: -fopenmp (found version "4.5")
-- Found OpenMP: TRUE (found version "4.5")
```

Also `fftw` has the required libraries in it's lib folder and `fftw.dev` has the required header files.