### PR TITLE
inter: 3.5 -> 3.6

### DIFF
--- a/pkgs/data/fonts/inter/default.nix
+++ b/pkgs/data/fonts/inter/default.nix
@@ -1,7 +1,7 @@
 { lib, fetchzip }:
 
 let
-  version = "3.5";
+  version = "3.6";
 in fetchzip {
   name = "inter-${version}";
 
@@ -12,14 +12,14 @@ in fetchzip {
     unzip -j $downloadedFile \*.otf -d $out/share/fonts/opentype
   '';
 
-  sha256 = "0zqixzzbb3n1j4jvpjm0hlxc32j53hgq4j078gihjkhgvjhsklf2";
+  sha256 = "0m0psphc4npxfn6cpvyx5xs54grwn3mjbj9yyipm0lbihq4mih7q";
 
   meta = with lib; {
     homepage = https://rsms.me/inter/;
     description = "A typeface specially designed for user interfaces";
     license = licenses.ofl;
     platforms = platforms.all;
-    maintainers = with maintainers; [ demize ];
+    maintainers = with maintainers; [ demize dtzWill ];
   };
 }
 


### PR DESCRIPTION
###### Motivation for this change

https://github.com/rsms/inter/releases/tag/v3.6

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---