### PR TITLE
libfilezilla: 0.13.0 -> 0.16.0; filezilla: -> 3.42.1

### DIFF
--- a/pkgs/applications/networking/ftp/filezilla/default.nix
+++ b/pkgs/applications/networking/ftp/filezilla/default.nix
@@ -1,17 +1,18 @@
 { stdenv, fetchurl, dbus, gnutls, wxGTK30, libidn, tinyxml, gettext
 , pkgconfig, xdg_utils, gtk2, sqlite, pugixml, libfilezilla, nettle }:
 
-let version = "3.31.0"; in
+let version = "3.42.1"; in
 stdenv.mkDerivation {
   name = "filezilla-${version}";
 
   src = fetchurl {
-    url = "mirror://sourceforge/project/filezilla/FileZilla_Client/${version}/FileZilla_${version}_src.tar.bz2";
-    sha256 = "1rfysb8dil35a7bzj2kw0mzzkys39d7yn6ipsbk8l6rkwfvnii8l";
+    url = "https://download.filezilla-project.org/client/FileZilla_${version}_src.tar.bz2";
+    sha256 = "083ycsycwy1szhp3mzf998wsqa74hmdxdsy07x6k81vp2cxjxijg";
   };
 
   configureFlags = [
     "--disable-manualupdatecheck"
+    "--disable-autoupdatecheck"
   ];
 
   nativeBuildInputs = [ pkgconfig ];

--- a/pkgs/development/libraries/libfilezilla/default.nix
+++ b/pkgs/development/libraries/libfilezilla/default.nix
@@ -1,13 +1,16 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, pkgconfig, nettle }:
 
 stdenv.mkDerivation rec {
-  name = "libfilezilla-${version}";
-  version = "0.13.0";
+  pname = "libfilezilla";
+  version = "0.16.0";
 
   src = fetchurl {
-    url = "http://download.filezilla-project.org/libfilezilla/${name}.tar.bz2";
-    sha256 = "0sk8kz2zrvf7kp9jrp3l4rpipv4xh0hg8d4h734xyag7vd03rjpz";
+    url = "https://download.filezilla-project.org/${pname}/${pname}-${version}.tar.bz2";
+    sha256 = "1fd71vmllzvljff5l5ka5wnzbdsxx4i54dpxpklydmbsqpilnv1v";
   };
+
+  nativeBuildInputs = [ pkgconfig ];
+  buildInputs = [ nettle ];
 
   meta = with stdenv.lib; {
     homepage = https://lib.filezilla-project.org/;


### PR DESCRIPTION
###### Motivation for this change

Should be bumped together for API reasons I believe,
but might as well since filezilla is only user of it :).


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---