### PR TITLE
perlPackages.ack: 2.28 -> v3.0.0

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -86,12 +86,12 @@ let
   makeFullPerlPath = deps: makePerlPath (stdenv.lib.misc.closePropagation deps);
 
 
-  ack = buildPerlPackage {
+  ack = buildPerlPackage rec {
     pname = "ack";
-    version = "2.28";
+    version = "3.0.0";
     src = fetchurl {
-      url = mirror://cpan/authors/id/P/PE/PETDANCE/ack-2.28.tar.gz;
-      sha256 = "16zgn96v1qkibpj5lic571zjl07y8x55v5xql3x7bvlsmgqcnvla";
+      url = "mirror://cpan/authors/id/P/PE/PETDANCE/${pname}-v${version}.tar.gz";
+      sha256 = "1vadghcvkghrwjjbgph0scd6a7nkpx5cxfca5x9wvcr6a8idpbcd";
     };
     outputs = ["out" "man"];
     # use gnused so that the preCheck command passes


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---