### PR TITLE
xournalpp: 1.0.8 -> 1.0.12

### DIFF
--- a/pkgs/applications/graphics/xournalpp/default.nix
+++ b/pkgs/applications/graphics/xournalpp/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , lib
 , fetchFromGitHub
-, fetchpatch
 
 , cmake
 , gettext
@@ -14,6 +13,7 @@
 , hicolor-icon-theme
 , libsndfile
 , libxml2
+, libzip
 , pcre
 , poppler
 , portaudio
@@ -22,30 +22,19 @@
 # Plugins don't appear to be working in this version, so disable them by not
 # building with Lua support by default. In a future version, try switching this
 # to 'true' and seeing if the top-level Plugin menu appears.
-, withLua ? false, lua
+, withLua ? true, lua
 }:
 
 stdenv.mkDerivation rec {
   name = "xournalpp-${version}";
-  version = "1.0.8";
+  version = "1.0.12";
 
   src = fetchFromGitHub {
     owner = "xournalpp";
     repo = "xournalpp";
     rev = version;
-    sha256 = "01q84xjp9z1krna10gjj562km6i3wdq8cg7paxax1k6bh52ryvf6";
+    sha256 = "0yg70hsx58s3wb5kzccivrqa7kvmdapygxmif1j64hddah2rqcn9";
   };
-
-  patches = [
-    # This patch removes the unused 'xopp-recording.sh' file which breaks the
-    # cmake build; this patch isn't in a release yet, and should be removed at
-    # or after 1.0.9 is released.
-    (fetchpatch {
-      name = "remove-xopp-recording.sh.patch";
-      url = "https://github.com/xournalpp/xournalpp/commit/a17a3f2c80c607a22d0fdeb66d38358bea7e4d85.patch";
-      sha256 = "10pcpvklm6kr0lv2xrsbpg2037ni9j6dmxgjf56p466l3gz60iwy";
-    })
-  ];
 
   nativeBuildInputs = [ cmake gettext pkgconfig wrapGAppsHook ];
   buildInputs =
@@ -55,12 +44,15 @@ stdenv.mkDerivation rec {
       hicolor-icon-theme
       libsndfile
       libxml2
+      libzip
       pcre
       poppler
       portaudio
       zlib
     ]
     ++ lib.optional withLua lua;
+
+  hardeningDisable = [ "format" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21007,7 +21007,9 @@ in
     inherit (gnome2) libgnomeprint libgnomeprintui libgnomecanvas;
   };
 
-  xournalpp = callPackage ../applications/graphics/xournalpp { };
+  xournalpp = callPackage ../applications/graphics/xournalpp {
+    lua = lua5_3;
+  };
 
   apvlv = callPackage ../applications/misc/apvlv { };
 


### PR DESCRIPTION
###### Motivation for this change

* revisit plugin support, drop old patch
* use lua5_3 as it seems to expect (require)
* disable format hardening, fix build

https://github.com/xournalpp/xournalpp/releases/tag/1.0.12

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - Runs and minor interactions seem reasonable, tablet/pen input not
    tested since I don't have such devices O:).
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---