### PR TITLE
simp_le: 0.9.0 -> 0.14.0

### DIFF
--- a/pkgs/tools/admin/certbot/default.nix
+++ b/pkgs/tools/admin/certbot/default.nix
@@ -2,13 +2,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "certbot";
-  version = "0.31.0";
+  version = "0.34.2";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "0rwjxmkpicyc9a5janvj1lfi430nq6ha94nyfgp11ds9fyydbh1s";
+    sha256 = "0658awigjxih5j0snrs8iwazhviw9ivq6pib7sy0939haigqf32f";
   };
 
   propagatedBuildInputs = with python3Packages; [
@@ -40,7 +40,8 @@ python3Packages.buildPythonApplication rec {
     done
   '';
 
-  doCheck = !stdenv.isDarwin; # On Hydra Darwin tests fail with "Too many open files".
+  checkInputs = with python3Packages; [ pytest pyyaml ];
+  doCheck = false /* integration tests want 'docker', not sure how to disable */;
 
   meta = with stdenv.lib; {
     homepage = src.meta.homepage;

--- a/pkgs/tools/admin/simp_le/default.nix
+++ b/pkgs/tools/admin/simp_le/default.nix
@@ -2,11 +2,11 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "simp_le-client";
-  version = "0.9.0";
+  version = "0.14.0";
 
   src = python3Packages.fetchPypi {
     inherit pname version;
-    sha256 = "1yxfznd78zkg2f657v520zj5w4dvq5n594d0kpm4lra8xnpg4zcv";
+    sha256 = "0kqdgbdb835b74l8y79n2nvwgvbz07ij5k7f3q3hj7w4y49ribr3";
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

https://github.com/zenhack/simp_le#0140

(intermediate versions are listed below)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).


Rudimentary testing only so far, and FWIW using acme 0.34.2, FWIW ( #61203 )

Should confirm NixOS test (and that the test uses this :P),
may confirm on live deployment but no timetable on that.

---