### PR TITLE
pythonPackages.apprise: init at 0.7.6

### DIFF
--- a/pkgs/development/python-modules/apprise/default.nix
+++ b/pkgs/development/python-modules/apprise/default.nix
@@ -1,0 +1,31 @@
+{ lib, buildPythonPackage, fetchPypi
+, Babel, decorator, requests, requests_oauthlib, oauthlib, urllib3, six, click, markdown, pyyaml
+, pytestrunner, coverage, flake8, mock, pytest, pytestcov, tox
+}:
+
+buildPythonPackage rec {
+  pname = "apprise";
+  version = "0.7.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "c3c7922f7b80107620f541a6c16435485e7045771b3ecfb998deacee0eb90753";
+  };
+
+  nativeBuildInputs = [ Babel ];
+
+  propagatedBuildInputs = [
+    decorator requests requests_oauthlib oauthlib urllib3 six click markdown pyyaml
+  ];
+
+  checkInputs = [
+    pytestrunner coverage flake8 mock pytest pytestcov tox
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/caronc/apprise";
+    description = "Push Notifications that work with just about every platform!";
+    license = licenses.mit;
+    maintainers = [ maintainers.marsam ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -187,6 +187,8 @@ in {
 
   aplpy = callPackage ../development/python-modules/aplpy { };
 
+  apprise = callPackage ../development/python-modules/apprise { };
+
   argon2_cffi = callPackage ../development/python-modules/argon2_cffi { };
 
   asana = callPackage ../development/python-modules/asana { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add https://github.com/caronc/apprise

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
