### PR TITLE
dapper: init at v0.4.1

### DIFF
--- a/pkgs/development/tools/dapper/default.nix
+++ b/pkgs/development/tools/dapper/default.nix
@@ -1,0 +1,31 @@
+{ buildGoPackage
+, lib
+, fetchFromGitHub
+, fetchpatch
+}:
+
+buildGoPackage rec {
+  pname = "dapper";
+  version = "0.4.1";
+
+  goPackagePath = "github.com/rancher/dapper";
+
+  src = fetchFromGitHub {
+    owner = "rancher";
+    repo = "dapper";
+    rev = "v${version}";
+    sha256 = "03rmkmlvhmfwcln5v1rqww1kirxm0d1p58h6pj8f5fnhk9spb162";
+  };
+   patchPhase = ''
+     substituteInPlace main.go --replace 0.0.0 ${version}
+   '';
+
+  meta = with lib; {
+    description = "Docker Build Wrapper";
+    homepage = "https://github.com/rancher/dapper";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ kuznero ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24146,4 +24146,6 @@ in
 
   bemenu = callPackage ../applications/misc/bemenu { };
 
+  dapper = callPackage ../development/tools/dapper { };
+
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add the dapper (https://github.com/rancher/dapper) tool. 
The dapper tool wraps docker and eases building of software (such as k3s) inside of docker containers for consistency.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

