### PR TITLE
gitAndTools.lab: 0.15.3 -> 0.16.0

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/lab/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/lab/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "lab";
-  version = "0.15.3";
+  version = "0.16.0";
 
   src = fetchFromGitHub {
     owner = "zaquestion";
     repo = "lab";
     rev = "v${version}";
-    sha256 = "00c0ljyvcqrzzcsdb3r37lxd4z2wvwp80ggs8jvp7y32p1b61bsg";
+    sha256 = "0f1gi4mlcxjvz2sgh0hzzsqxg5gfvq2ay7xjd0y1kz3pp8kxja7i";
   };
 
   subPackages = [ "." ];
@@ -16,15 +16,16 @@ buildGoModule rec {
   modSha256 = "0bw47dd1b46ywsian2b957a4ipm77ncidipzri9ra39paqlv7abb";
 
   postInstall = ''
-    mkdir -p $out/share/zsh/site-functions
-    LAB_CORE_HOST=a LAB_CORE_USER=b LAB_CORE_TOKEN=c \
+    mkdir -p "$out/share/bash-completion/completions" "$out/share/zsh/site-functions"
+    export LAB_CORE_HOST=a LAB_CORE_USER=b LAB_CORE_TOKEN=c
+    $out/bin/lab completion bash > $out/share/bash-completion/completions/lab
     $out/bin/lab completion zsh > $out/share/zsh/site-functions/_lab
   '';
 
   meta = with stdenv.lib; {
     description = "Lab wraps Git or Hub, making it simple to clone, fork, and interact with repositories on GitLab";
     homepage = https://zaquestion.github.io/lab;
-    license = licenses.unlicense;
+    license = licenses.cc0;
     maintainers = with maintainers; [ marsam dtzWill ];
     platforms = platforms.all;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Changelog: https://github.com/zaquestion/lab/releases/tag/v0.16.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
