### PR TITLE
gitAndTools.git-standup: init at 2.3.1

### DIFF
--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -113,6 +113,8 @@ let
 
   git-secrets = callPackage ./git-secrets { };
 
+  git-standup = callPackage ./git-standup { };
+
   git-stree = callPackage ./git-stree { };
 
   git-sync = callPackage ./git-sync { };

--- a/pkgs/applications/version-management/git-and-tools/git-standup/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-standup/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, fetchFromGitHub, makeWrapper, git }:
+
+stdenv.mkDerivation rec {
+  pname = "git-standup";
+  version = "2.3.1";
+
+  src = fetchFromGitHub {
+    owner = "kamranahmedse";
+    repo = pname;
+    rev = version;
+    sha256 = "0wx9ypyxhpjbrasl6264jmj9fjrpg3gn93dg00cakabz3r7yxxq3";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    install -Dm755 -t $out/bin git-standup
+
+    wrapProgram $out/bin/git-standup \
+      --prefix PATH : "${stdenv.lib.makeBinPath [ git ]}"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Recall what you did on the last working day";
+    homepage = "https://github.com/kamranahmedse/git-standup";
+    license = licenses.mit;
+    maintainers = [ maintainers.marsam ];
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Add https://github.com/kamranahmedse/git-standup/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
