### PR TITLE
uhd: 3.13.0.1 -> 3.14.0.0

### DIFF
--- a/pkgs/applications/radio/uhd/default.nix
+++ b/pkgs/applications/radio/uhd/default.nix
@@ -12,12 +12,12 @@ let
 
   # UHD seems to use three different version number styles: x.y.z, xxx_yyy_zzz
   # and xxx.yyy.zzz. Hrmpf... style keeps changing
-  version = "3.13.0.1";
+  version = "3.14.0.0";
 
   # Firmware images are downloaded (pre-built) from the respective release on Github
   uhdImagesSrc = fetchurl {
     url = "https://github.com/EttusResearch/uhd/releases/download/${uhdVer}/uhd-images_${version}.tar.xz";
-    sha256 = "0y9i93z188ch0hdlkvv0k9m0k7vns7rbxaqsnk35xnlqlxxgqdvj";
+    sha256 = "1fp37wgqkbr14cxg9l7ghfd4r92y2bxwgb7cfjzs96hbpd9s6al0";
   };
 
 in stdenv.mkDerivation {
@@ -27,7 +27,7 @@ in stdenv.mkDerivation {
     owner = "EttusResearch";
     repo = "uhd";
     rev = "${uhdVer}";
-    sha256 = "0si49qk96zhpanmcrzlr3igc5s1y30x4p0z973q60dx9fhqsbb6k";
+    sha256 = "0y1hff4vslfv36vxgvjqajg4862a11d4wgr0vcb0visgh1bi8qgy";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---