### PR TITLE
pythonPackages.rfc3987: init at 1.3.8

### DIFF
--- a/pkgs/development/python-modules/rfc3987/default.nix
+++ b/pkgs/development/python-modules/rfc3987/default.nix
@@ -1,0 +1,19 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "rfc3987";
+  version = "1.3.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "d3c4d257a560d544e9826b38bc81db676890c79ab9d7ac92b39c7a253d5ca733";
+  };
+
+  doCheck = false;
+  meta = with stdenv.lib; {
+    homepage = "https://pypi.python.org/pypi/rfc3987";
+    license = licenses.gpl3Plus;
+    description = "Parsing and validation of URIs (RFC 3986) and IRIs (RFC 3987)";
+    maintainers = with maintainers; [ vanschelven ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2739,6 +2739,8 @@ in {
 
   pyRFC3339 = callPackage ../development/python-modules/pyrfc3339 { };
 
+  rfc3987 = callPackage ../development/python-modules/rfc3987 { };
+
   ConfigArgParse = callPackage ../development/python-modules/configargparse { };
 
   jsonschema = callPackage ../development/python-modules/jsonschema { };


### PR DESCRIPTION
###### Motivation for this change

Add a useful python-package; this package is also a dependency of the `jsonschema` pythonpackage that will be added in a separate PR.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nfix-review wip"` (there are no such packages)
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
