### PR TITLE
pythonPackages.strict-rfc3339: init at 0.7

### DIFF
--- a/pkgs/development/python-modules/strict-rfc3339/default.nix
+++ b/pkgs/development/python-modules/strict-rfc3339/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "strict-rfc3339";
+  version = "0.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "5cad17bedfc3af57b399db0fed32771f18fc54bbd917e85546088607ac5e1277";
+  };
+doCheck = false;
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/danielrichman/strict-rfc3339";
+    license = licenses.gpl3;
+    description = "Strict, simple, lightweight RFC3339 functions";
+    maintainers = with maintainers; [ vanschelven ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5425,6 +5425,8 @@ in {
 
   stripe = callPackage ../development/python-modules/stripe { };
 
+  strict-rfc3339 = callPackage ../development/python-modules/strict-rfc3339 { };
+
   twilio = callPackage ../development/python-modules/twilio { };
 
   uranium = callPackage ../development/python-modules/uranium { };


### PR DESCRIPTION
###### Motivation for this change

Adds a useful python package (that also happens to be a dependency of the `jsonschema` package, for which a separate PR will be openend soon

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"` there are no such packages yet
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
