### PR TITLE
python.pkgs.pip: 19.0.3 -> 19.1.1

### DIFF
--- a/pkgs/development/python-modules/pip/default.nix
+++ b/pkgs/development/python-modules/pip/default.nix
@@ -10,11 +10,11 @@
 
 buildPythonPackage rec {
   pname = "pip";
-  version = "19.0.3";
+  version = "19.1.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "6e6f197a1abfb45118dbb878b5c859a0edbdd33fd250100bc015b67fded4b9f2";
+    sha256 = "0n09vnyn8q3vf31prb050s2nfx4gvwy1gwazgrfbc7hasg9xgls4";
   };
 
   # pip detects that we already have bootstrapped_pip "installed", so we need


### PR DESCRIPTION
###### Motivation for this change
Remove pip version warning when installing packages. I know this will cause a lot of rebuilds, sorry.

Building tensorflow from scratch, and haven't hit any issues.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
```
$ nix path-info -Sh /nix/store/vcdwhk6w6syjx3hwb4ifkqcrsp4w7h3j-python3.5-pip-19.1.1
/nix/store/vcdwhk6w6syjx3hwb4ifkqcrsp4w7h3j-python3.5-pip-19.1.1         102.0M
```