### PR TITLE
 nixos/pam: safe defaults for pam_ssh_agent_auth

### DIFF
--- a/nixos/doc/manual/release-notes/rl-1909.xml
+++ b/nixos/doc/manual/release-notes/rl-1909.xml
@@ -119,6 +119,19 @@
       and <option>services.limesurvey.virtualHost</option> options.
     </para>
    </listitem>
+   <listitem>
+     <para>
+       The <option>security.pam.enableSSHAgentAuth</option> module has been
+       removed because it allowed a privilege escalation from any program running as the user.
+       The options replacing it don't have the same default and may lock you out of your
+       system, be extremly careful when migrating!
+       <option>security.pam.sshAgentAuth.enable</option> and
+       <option>security.pam.sshAgentAuth.authorizedKeys</option> are replacing it but the
+       default authorized key files is now <literal>/etc/ssh/authorized_keys.d/%u</literal>
+       instead of
+       <literal>/.ssh/authorized_keys:~/.ssh/authorized_keys2:/etc/ssh/authorized_keys.d/%u</literal>.
+     </para>
+   </listitem>
   </itemizedlist>
  </section>
 

--- a/pkgs/os-specific/linux/pam_ssh_agent_auth/default.nix
+++ b/pkgs/os-specific/linux/pam_ssh_agent_auth/default.nix
@@ -16,12 +16,15 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ pam openssl perl ];
 
+  configureFlags = [ "--with-mantype=man" ];
+
   enableParallelBuilding = true;
 
-  meta = {
+  meta = with stdenv.lib; {
     homepage = http://pamsshagentauth.sourceforge.net/;
     description = "PAM module for authentication through the SSH agent";
-    maintainers = [ stdenv.lib.maintainers.eelco ];
-    platforms = stdenv.lib.platforms.linux;
+    maintainers = with maintainers; [ eelco ];
+    license = licenses.openssl;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fixes https://github.com/NixOS/nixpkgs/issues/31611, replace https://github.com/NixOS/nixpkgs/pull/32178 and advance https://github.com/NixOS/nixpkgs/issues/43716.

###### Things done
**BREAKING CHANGES**
1. Replaces option `security.pam.enableSSHAgentAuth` with `security.pam.sshAgentAuth.{enable,authorizedKeys}` defaulting to safe defaults.
2. Add license to `pam_ssh_agent_auth`
3. `sudo` don't preserve `SSH_AUTH_SOCK` anymore

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
