### PR TITLE
Use cross build packages in extlinux builder when hostPlafrom differs from buildPlatform

### DIFF
--- a/nixos/modules/system/boot/loader/generic-extlinux-compatible/default.nix
+++ b/nixos/modules/system/boot/loader/generic-extlinux-compatible/default.nix
@@ -8,7 +8,8 @@ let
 
   timeoutStr = if blCfg.timeout == null then "-1" else toString blCfg.timeout;
 
-  builder = import ./extlinux-conf-builder.nix { pkgs = pkgs.buildPackages; };
+  builderPkgs = if (pkgs.stdenv.hostPlatform != pkgs.stdenv.buildPlatform) then pkgs else pkgs.buildPackages;
+  builder = import ./extlinux-conf-builder.nix { pkgs = builderPkgs; };
 in
 {
   options = {

--- a/nixos/modules/system/boot/loader/generic-extlinux-compatible/extlinux-conf-builder.nix
+++ b/nixos/modules/system/boot/loader/generic-extlinux-compatible/extlinux-conf-builder.nix
@@ -1,8 +1,10 @@
 { pkgs }:
 
-pkgs.substituteAll {
+let
+  builderPkgs = if (pkgs.stdenv.hostPlatform != pkgs.stdenv.buildPlatform) then pkgs else pkgs.buildPackages;
+in pkgs.substituteAll {
   src = ./extlinux-conf-builder.sh;
   isExecutable = true;
-  path = [pkgs.buildPackages.coreutils pkgs.buildPackages.gnused pkgs.buildPackages.gnugrep];
-  inherit (pkgs.buildPackages) bash;
+  path = [builderPkgs.coreutils builderPkgs.gnused builderPkgs.gnugrep];
+  inherit (builderPkgs) bash;
 }


### PR DESCRIPTION
###### Motivation for this change

When cross building a system configuration using NixOps and `nixpkgs.crossSystem`, the builder for extlinux is run on the target host and not the build system.
The current abstraction places the buildPkgs into the builders path, making the builder fail with unsupported execution formats for things like coreutils.

This change attemts to correct this.
As I am not very experienced with the Nix cross-build setup as a hole, I am not very confident about this change as I don't know the full implications of it.
I apologize in advance for the extra strain this puts on the reviews, I hope we can come to a propper solution in the end.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
