### PR TITLE
add libcoap

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2638,6 +2638,12 @@
     github = "Kmeakin";
   };
 
+  kmein = {
+    email = "kieran.meinhardt@gmail.com";
+    name = "Kierán Meinhardt";
+    github = "kmein";
+  };
+
   knedlsepp = {
     email = "josef.kemetmueller@gmail.com";
     github = "knedlsepp";

--- a/pkgs/applications/networking/libcoap/default.nix
+++ b/pkgs/applications/networking/libcoap/default.nix
@@ -1,0 +1,31 @@
+{ fetchFromGitHub, automake, autoconf, which, pkgconfig, libtool, stdenv }:
+stdenv.mkDerivation rec {
+  pname = "libcoap";
+  version = "4.2.0";
+  src = fetchFromGitHub {
+    repo = "libcoap";
+    owner = "obgm";
+    rev = "v${version}";
+    fetchSubmodules = true;
+    sha256 = "0mmvkq72i4rda6b7g93qrwg2nwh2rvkq4xw70yppj51hsdrnpfl7";
+  };
+  nativeBuildInputs = [
+    automake
+    autoconf
+    which
+    libtool
+    pkgconfig
+  ];
+  preConfigure = "./autogen.sh";
+  configureFlags = [
+    "--disable-documentation"
+    "--disable-shared"
+  ];
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/obgm/libcoap";
+    description = "A CoAP (RFC 7252) implementation in C";
+    platforms = platforms.linux;
+    license = licenses.bsd2;
+    maintainers = [ maintainers.kmein ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4021,6 +4021,8 @@ in
 
   libcloudproviders = callPackage ../development/libraries/libcloudproviders { };
 
+  libcoap = callPackage ../applications/networking/libcoap {};
+
   libcroco = callPackage ../development/libraries/libcroco { };
 
   libcryptui = callPackage ../development/libraries/libcryptui { };


### PR DESCRIPTION
###### Motivation for this change
libcoap was missing

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---