### PR TITLE
octoprint: 1.3.10 -> 1.3.11

### DIFF
--- a/nixos/modules/services/misc/octoprint.nix
+++ b/nixos/modules/services/misc/octoprint.nix
@@ -7,7 +7,7 @@ let
   cfg = config.services.octoprint;
 
   baseConfig = {
-    plugins.cura.cura_engine = "${pkgs.curaengine_stable}/bin/CuraEngine";
+    plugins.curalegacy.cura_engine = "${pkgs.curaengine_stable}/bin/CuraEngine";
     server.host = cfg.host;
     server.port = cfg.port;
     webcam.ffmpeg = "${pkgs.ffmpeg.bin}/bin/ffmpeg";

--- a/pkgs/applications/misc/octoprint/default.nix
+++ b/pkgs/applications/misc/octoprint/default.nix
@@ -15,12 +15,8 @@ let
     packageOverrides = lib.foldr lib.composeExtensions (self: super: { }) ([
       (mkOverride "flask"       "0.10.1" "0wrkavjdjndknhp8ya8j850jq7a1cli4g5a93mg8nh1xz2gq50sc")
       (mkOverride "flask_login" "0.2.11" "1rg3rsjs1gwi2pw6vr9jmhaqm9b3vc9c4hfcsvp4y8agbh7g3mc3")
-      (mkOverride "pylru"       "1.0.9"  "0b0pq0l7xv83dfsajsc49jcxzc99kb9jfx1a1dlx22hzcy962dvi")
       (mkOverride "sarge"       "0.1.4"  "08s8896973bz1gg0pkr592w6g4p6v47bkfvws5i91p9xf8b35yar")
       (mkOverride "tornado"     "4.5.3"  "02jzd23l4r6fswmwxaica9ldlyc2p6q8dk6dyff7j58fmdzf853d")
-
-      # https://github.com/NixOS/nixpkgs/pull/58179#issuecomment-478605134
-      (mkOverride "werkzeug"    "0.14.1" "c3fd7a7d41976d9f44db327260e263132466836cef6f91512889ed60ad26557c")
 
       # Octoprint holds back jinja2 to 2.8.1 due to breaking changes.
       # This old version does not have updated test config for pytest 4,
@@ -43,16 +39,15 @@ let
     "Flask-Assets"
     "Flask-Babel"
     "Flask-Principal"
-    "PyYAML"
     "emoji"
     "flask"
     "future"
     "futures"
     "monotonic"
+    "markdown"
     "pkginfo"
     "psutil"
     "pyserial"
-    "python-dateutil"
     "requests"
     "rsa"
     "sarge"
@@ -60,19 +55,19 @@ let
     "semantic_version"
     "watchdog"
     "websocket-client"
-    "werkzeug"
     "wrapt"
+    "sentry-sdk"
   ];
 
 in py.pkgs.buildPythonApplication rec {
   pname = "OctoPrint";
-  version = "1.3.10";
+  version = "1.3.11";
 
   src = fetchFromGitHub {
     owner  = "foosel";
     repo   = "OctoPrint";
     rev    = version;
-    sha256 = "1pvh7ay76zrvfzcsadh3sl48sgf3by9vpiaqlrkscsw02zirx9r7";
+    sha256 = "1102ki1819wsmkfg4riz4i0hjlr3w6nsvk8wrzqq0lc0s5ycf4jx";
   };
 
   propagatedBuildInputs = with py.pkgs; [
@@ -80,8 +75,8 @@ in py.pkgs.buildPythonApplication rec {
     semantic-version flask_principal werkzeug flaskbabel tornado
     psutil pyserial flask_login netaddr markdown sockjs-tornado
     pylru pyyaml sarge feedparser netifaces click websocket_client
-    scandir chainmap future dateutil futures wrapt monotonic emoji
-    frozendict
+    scandir chainmap future futures wrapt monotonic emoji
+    frozendict cachelib sentry-sdk typing
   ] ++ lib.optionals stdenv.isDarwin [ py.pkgs.appdirs ];
 
   checkInputs = with py.pkgs; [ nose mock ddt ];

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -104,6 +104,25 @@ let
       };
     };
 
+    curaenginelegacy = buildPlugin rec {
+      pname = "CuraEngineLegacy";
+      version = "1.0.2";
+
+      src = fetchFromGitHub {
+        owner = "OctoPrint";
+        repo = "OctoPrint-${pname}";
+        rev = version;
+        sha256 = "1cdb276wfyf3wcfj5g3migd6b6aqmkrxncrqjfcfx4j4k3xac965";
+      };
+
+      meta = with stdenv.lib; {
+        description = "Plugin for slicing via Cura Legacy from within OctoPrint";
+        homepage = "https://github.com/OctoPrint/OctoPrint-CuraEngineLegacy";
+        license = licenses.agpl3;
+        maintainers = with maintainers; [ gebner ];
+      };
+    };
+
   };
 
 in self

--- a/pkgs/development/python-modules/cachelib/default.nix
+++ b/pkgs/development/python-modules/cachelib/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, buildPythonPackage, fetchPypi }:
+
+buildPythonPackage rec {
+  pname = "cachelib";
+  version = "0.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "13dfv0a4ahgx0wmpqv8jqhshim4229p9c1c7gcsra81pkm89p24b";
+  };
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/pallets/cachelib";
+    description = "Collection of cache libraries in the same API interface";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ gebner ];
+  };
+}

--- a/pkgs/development/python-modules/markdown/default.nix
+++ b/pkgs/development/python-modules/markdown/default.nix
@@ -7,22 +7,18 @@
 
 buildPythonPackage rec {
   pname = "Markdown";
-  version = "2.6.10";
+  version = "3.1.1";
 
   src = fetchPypi {
-    extension = "zip";
     inherit pname version;
-    sha256 = "cfa536d1ee8984007fcecc5a38a493ff05c174cb74cb2341dafd175e6bc30851";
+    sha256 = "2e50876bcdd74517e7b71f3e7a76102050edec255b3983403f1a63e7c8a41e7a";
   };
-
-  # error: invalid command 'test'
-#   doCheck = false;
 
   checkInputs = [ nose pyyaml ];
 
   meta = {
-    description = "A Python implementation of John Gruber’s Markdown with Extension support";
-    homepage = https://github.com/Python-Markdown/markdown;
+    description = "A Python implementation of John Gruber's Markdown with Extension support";
+    homepage = "https://github.com/Python-Markdown/markdown";
     license = lib.licenses.bsd3;
   };
 }

--- a/pkgs/development/python-modules/pylru/default.nix
+++ b/pkgs/development/python-modules/pylru/default.nix
@@ -2,15 +2,15 @@
 
 buildPythonPackage rec {
   pname = "pylru";
-  version = "1.1.0";
+  version = "1.2.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "e03a3d354eb8fdfa11638698e8a1f06cd3b3a214ebc0a120c603a79290d9ebec";
+    sha256 = "492f934bb98dc6c8b2370c02c95c65516ddc08c8f64d27f70087eb038621d297";
   };
 
   meta = with lib; {
-    homepage = https://github.com/jlhutch/pylru;
+    homepage = "https://github.com/jlhutch/pylru";
     description = "A least recently used (LRU) cache implementation";
     license = licenses.gpl2;
     maintainers = with maintainers; [ abbradar ];

--- a/pkgs/development/python-modules/sentry-sdk/default.nix
+++ b/pkgs/development/python-modules/sentry-sdk/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, buildPythonPackage, fetchPypi, urllib3, certifi }:
+
+buildPythonPackage rec {
+  pname = "sentry-sdk";
+  version = "0.8.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "f5819df450d7b0696be69a0c6d70a09e4890a3844ee8ccb7a461794135bd5965";
+  };
+
+  propagatedBuildInputs = [ urllib3 certifi ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/getsentry/sentry-python";
+    description = "New Python SDK for Sentry.io";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ gebner ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -319,6 +319,8 @@ in {
 
   cachecontrol = callPackage ../development/python-modules/cachecontrol { };
 
+  cachelib = callPackage ../development/python-modules/cachelib { };
+
   cachy = callPackage ../development/python-modules/cachy { };
 
   cdecimal = callPackage ../development/python-modules/cdecimal { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -890,6 +890,8 @@ in {
 
   selectors2 = callPackage ../development/python-modules/selectors2 { };
 
+  sentry-sdk = callPackage ../development/python-modules/sentry-sdk {};
+
   sepaxml = callPackage ../development/python-modules/sepaxml { };
 
   serversyncstorage = callPackage ../development/python-modules/serversyncstorage {};


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

The cura slicer plugin is now no longer bundled, you need to add it manually to `services.octoprint.plugins`.

Tested on aarch64, prints fine.

cc maintainer @abbradar 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
