### PR TITLE
 wireguard: 0.0.20190406 -> 0.0.20190531 and Change peers without tearing down the interface, handle DNS failures better

### DIFF
--- a/nixos/modules/services/networking/wireguard.nix
+++ b/nixos/modules/services/networking/wireguard.nix
@@ -246,6 +246,7 @@ let
         after = [ "wireguard-${interfaceName}.service" ];
         wantedBy = [ "multi-user.target" ];
         environment.DEVICE = interfaceName;
+        environment.WG_ENDPOINT_RESOLUTION_RETRIES = "infinity";
         path = with pkgs; [ iproute wireguard-tools ];
 
         serviceConfig = {

--- a/pkgs/tools/networking/wireguard-tools/default.nix
+++ b/pkgs/tools/networking/wireguard-tools/default.nix
@@ -4,11 +4,11 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   name = "wireguard-tools-${version}";
-  version = "0.0.20190406";
+  version = "0.0.20190531";
 
   src = fetchzip {
     url = "https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${version}.tar.xz";
-    sha256 = "1rqyyyx7j41vpp4jigagqs2qdyfngh15y48ghdqfrkv7v93vwdak";
+    sha256 = "0caw6kc0lqsvzvdjpdbdn3r9ff93vdl46616pwlig0rsdjrqnklj";
   };
 
   sourceRoot = "source/src/tools";


### PR DESCRIPTION
###### Motivation for this change

In #30459 @sjau reported a problem with starting up a system with WireGuard where peers used DNS. On boot, the system would start the WireGuard interface, and attempt to add a peer by hostname. This would fail because the system wasn't able to resolve domains yet.

In #61971 sjau fixed this bug by having the wg startup unit restart until it worked, but this caused @zx2c4 great heartache.

Relatedly, having the entire interface and all peers disappear because one peer failed to resolve is not a nice or acceptable failure mode. This is related to  another problem: changing a single peer causes the interface to go away and be restarted from scratch. This isn't necessary, either :)

 - Commit 1 changes the unit to create a systemd unit per peer
 - Commit 2 updates wireguard from  0.0.20190406 -> 0.0.20190531 which adds a flag to fix the original bug  report -- by letting resolution retry forever
 - Commit 3 takes advantage of that flag

cc @Mic92 

 - Closes #62288
 - Makes @zx2c4 happier

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
