### PR TITLE
purescript: 0.12.5 -> 0.13.0

### DIFF
--- a/pkgs/development/compilers/purescript/purescript/default.nix
+++ b/pkgs/development/compilers/purescript/purescript/default.nix
@@ -46,7 +46,7 @@ in stdenv.mkDerivation rec {
     description = "A strongly-typed functional programming language that compiles to JavaScript";
     homepage = http://www.purescript.org/;
     license = licenses.bsd3;
-    maintainers = [ maintainers.justinwoo ];
+    maintainers = with maintainers; [ justinwoo srghma ];
     platforms = [ "x86_64-linux" "x86_64-darwin" ];
   };
 }

--- a/pkgs/development/compilers/purescript/purescript/default.nix
+++ b/pkgs/development/compilers/purescript/purescript/default.nix
@@ -16,23 +16,15 @@ let
           chmod u-w $PURS
         '';
 
+  revisions = builtins.fromJSON (builtins.readFile ./revision.json);
 in stdenv.mkDerivation rec {
   pname = "purescript";
-  version = "0.12.5";
 
-  src =
-    if stdenv.isDarwin
-    then
-    fetchurl {
-      url = "https://github.com/${pname}/${pname}/releases/download/v${version}/macos.tar.gz";
-      sha256 = "15j9lkrl15dicx37bmh0199b3qdixig7w24wvdzi20jqbacz8nkn";
-    }
-    else
-    fetchurl {
-      url = "https://github.com/${pname}/${pname}/releases/download/v${version}/linux64.tar.gz";
-      sha256 = "07dva5gxq77g787krscv4dsz5088fzkvpmm9fwxw9a59jszzs7kq";
-    };
+  version = revisions.version;
 
+  src = if stdenv.isDarwin
+    then fetchurl { inherit (revisions.mac) url sha256; }
+    else fetchurl { inherit (revisions.linux) url sha256; };
 
   buildInputs = [ zlib
                   gmp

--- a/pkgs/development/compilers/purescript/purescript/revision.json
+++ b/pkgs/development/compilers/purescript/purescript/revision.json
@@ -1,0 +1,11 @@
+{
+  "version": "v0.13.0",
+  "linux": {
+    "url": "https://github.com/purescript/purescript/releases/download/v0.13.0/linux64.tar.gz",
+    "sha256": "06g5q69yv6c3alq9vr8zjqqzamlii7xf6vj9j52akjq5lww214ba"
+  },
+  "mac": {
+    "url": "https://github.com/purescript/purescript/releases/download/v0.13.0/macos.tar.gz",
+    "sha256": "0xpisy38gj6fgyyzm6fdl0v819dhjmil4634xxangvhvs7jf5il0"
+  }
+}

--- a/pkgs/development/compilers/purescript/purescript/update.sh
+++ b/pkgs/development/compilers/purescript/purescript/update.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix curl jq
+
+# prelude
+script_dir=$(dirname "$(readlink -f "$BASH_SOURCE")")
+
+# config
+owner="purescript"
+repo="purescript"
+
+last_release_version=$(curl -s https://api.github.com/repos/$owner/$repo/releases/latest | jq --raw-output .tag_name)
+
+linux_url="https://github.com/$owner/$repo/releases/download/$last_release_version/linux64.tar.gz"
+echo "linux_url=$linux_url"
+mac_url="https://github.com/$owner/$repo/releases/download/$last_release_version/macos.tar.gz"
+echo "mac_url=$mac_url"
+
+cat > "$script_dir/revision.json" <<EOF
+{
+  "version": "$last_release_version",
+  "linux": {
+    "url": "$linux_url",
+    "sha256": "$(nix-prefetch-url --quiet $linux_url)"
+  },
+  "mac": {
+    "url": "$mac_url",
+    "sha256": "$(nix-prefetch-url --quiet $mac_url)"
+  }
+}
+EOF


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
