### PR TITLE
re2: 20140304 -> 20190401

### DIFF
--- a/pkgs/development/libraries/re2/default.nix
+++ b/pkgs/development/libraries/re2/default.nix
@@ -1,24 +1,24 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
   name = "re2-${version}";
-  version = "20140304";
+  version = "20190401";
 
-  src = fetchurl {
-    url = "https://re2.googlecode.com/files/${name}.tgz";
-    sha256 = "19wn0472c9dsxp35d0m98hlwhngx1f2xhxqgr8cb5x72gnjx3zqb";
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "re2";
+    rev = "2019-04-01";
+    sha256 = "018b8z3fgcr02rmhxdz80r363k40938cbgmk1c9b46k6xkc4q0hd";
   };
 
   preConfigure = ''
     substituteInPlace Makefile --replace "/usr/local" "$out"
-  '' + stdenv.lib.optionalString stdenv.isDarwin ''
-    # Fixed in https://github.com/google/re2/commit/b2c9765b4a7afbea8b6be1dae548b6f4d5f39e42
-    substituteInPlace Makefile \
-        --replace '-dynamiclib' '-dynamiclib -Wl,-install_name,$(libdir)/libre2.so.$(SONAME)'
+    # we're using gnu sed, even on darwin
+    substituteInPlace Makefile  --replace "SED_INPLACE=sed -i '''" "SED_INPLACE=sed -i"
   '';
 
   meta = {
-    homepage = https://code.google.com/p/re2/;
+    homepage = https://github.com/google/re2;
     description = "An efficient, principled regular expression library";
     license = stdenv.lib.licenses.bsd3;
     platforms = with stdenv.lib.platforms; all;

--- a/pkgs/development/libraries/re2/default.nix
+++ b/pkgs/development/libraries/re2/default.nix
@@ -17,6 +17,13 @@ stdenv.mkDerivation rec {
     substituteInPlace Makefile  --replace "SED_INPLACE=sed -i '''" "SED_INPLACE=sed -i"
   '';
 
+  preCheck = "patchShebangs runtests";
+  doCheck = true;
+  checkTarget = "test";
+
+  doInstallCheck = true;
+  installCheckTarget = "testinstall";
+
   meta = {
     homepage = https://github.com/google/re2;
     description = "An efficient, principled regular expression library";


### PR DESCRIPTION
###### Motivation for this change
I was surprised this had been left untouched for so long, so am bumping it - in the process enabling both the checks and install-checks.

I haven't tested the _full_ `nox-review` rebuild on linux yet, because it involves building chromium three times, which I don't really have the appetite for. I have tested building _most_ reverse-dependencies though, and all on macos (there being fewer).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
