### PR TITLE
bazel: 0.24.0 -> 0.26.0

### DIFF
--- a/pkgs/development/tools/build-managers/bazel/bash-tools-test.nix
+++ b/pkgs/development/tools/build-managers/bazel/bash-tools-test.nix
@@ -1,4 +1,4 @@
-{ stdenv, writeText, runCommandCC, bazel }:
+{ stdenv, writeText, runCommandCC, bazel, runLocal, bazelTest }:
 
 # Tests that certain executables are available in bazel-executed bash shells.
 
@@ -22,21 +22,22 @@ let
     )
   '';
 
-  runLocal = name: script: runCommandCC name { preferLocalBuild = true; } script;
-
-  workspaceDir = runLocal "our_workspace" ''
+  workspaceDir = runLocal "our_workspace" {} ''
     mkdir $out
     cp ${WORKSPACE} $out/WORKSPACE
     cp ${fileIn} $out/input.txt
     cp ${fileBUILD} $out/BUILD
   '';
 
-  testBazel = runLocal "bazel-test-bash-tools" ''
-    export HOME=$(mktemp -d)
-    cp -r ${workspaceDir} wd && chmod +w wd && cd wd
-    ${bazel}/bin/bazel build :tool_usage
-    cp bazel-genfiles/output.txt $out
-    echo "Testing content" && [ "$(cat $out | wc -l)" == "2" ] && echo "OK"
-  '';
+  testBazel = bazelTest {
+    name = "bazel-test-bash-tools";
+    inherit workspaceDir;
+
+    bazelScript = ''
+      ${bazel}/bin/bazel build :tool_usage
+      cp bazel-genfiles/output.txt $out
+      echo "Testing content" && [ "$(cat $out | wc -l)" == "2" ] && echo "OK"
+    '';
+  };
 
 in testBazel

--- a/pkgs/development/tools/build-managers/bazel/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/default.nix
@@ -93,6 +93,8 @@ let
   # Java toolchain used for the build and tests
   javaToolchain = "@bazel_tools//tools/jdk:toolchain_host${buildJdkName}";
 
+  platforms = lib.platforms.linux ++ lib.platforms.darwin;
+
 in
 stdenv.mkDerivation rec {
 
@@ -103,7 +105,7 @@ stdenv.mkDerivation rec {
     description = "Build tool that builds code quickly and reliably";
     license = licenses.asl20;
     maintainers = [ maintainers.mboes ];
-    platforms = platforms.linux ++ platforms.darwin;
+    inherit platforms;
   };
 
   # Additional tests that check bazel’s functionality. Execute
@@ -115,6 +117,7 @@ stdenv.mkDerivation rec {
     let
       runLocal = name: attrs: script: runCommandCC name ({
         preferLocalBuild = true;
+        meta.platforms = platforms;
       } // attrs) script;
 
       # bazel wants to extract itself into $install_dir/install every time it runs,

--- a/pkgs/development/tools/build-managers/bazel/python-bin-path-test.nix
+++ b/pkgs/development/tools/build-managers/bazel/python-bin-path-test.nix
@@ -22,7 +22,7 @@ let
       srcs = [ "lib.py" ],
     )
 
-    py_test(
+    py_binary(
       name = "bin",
       srcs = [ "bin.py" ],
       deps = [ ":lib" ],
@@ -46,10 +46,9 @@ let
     # about why to create a subdir for the workspace.
     cp -r ${workspaceDir} wd && chmod u+w wd && cd wd
     ${bazel}/bin/bazel \
-      test \
-        --test_output=errors \
+      run \
         --host_javabase='@local_jdk//:jdk' \
-        //...
+        //python:bin
 
     touch $out
   '';

--- a/pkgs/tools/system/xe/default.nix
+++ b/pkgs/tools/system/xe/default.nix
@@ -3,7 +3,7 @@
 stdenv.mkDerivation rec {
   name = "xe-${version}";
   version = "0.11";
-  
+
   src = fetchFromGitHub {
     owner = "chneukirchen";
     repo = "xe";
@@ -12,12 +12,12 @@ stdenv.mkDerivation rec {
   };
 
   makeFlags = "PREFIX=$(out)";
-  
+
   meta = with lib; {
     description = "Simple xargs and apply replacement";
     homepage = https://github.com/chneukirchen/xe;
     license = licenses.publicDomain;
-    platforms = platforms.linux;
+    platforms = platforms.all;
     maintainers = with maintainers; [ cstrahan ndowens ];
   };
 }


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
A few new versions of Bazel have been released. This bumps to 0.26.1 to stay recent.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
