### PR TITLE
filezilla: add wrapper to set necessary FZ_DATADIR

### DIFF
--- a/pkgs/applications/networking/ftp/filezilla/default.nix
+++ b/pkgs/applications/networking/ftp/filezilla/default.nix
@@ -1,5 +1,7 @@
 { stdenv, fetchurl, dbus, gnutls, wxGTK30, libidn, tinyxml, gettext
-, pkgconfig, xdg_utils, gtk2, sqlite, pugixml, libfilezilla, nettle }:
+, pkgconfig, xdg_utils, gtk2, sqlite, pugixml, libfilezilla, nettle
+, makeWrapper
+}:
 
 let version = "3.31.0"; in
 stdenv.mkDerivation {
@@ -17,7 +19,11 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [
     dbus gnutls wxGTK30 libidn tinyxml gettext xdg_utils gtk2 sqlite
-    pugixml libfilezilla nettle ];
+    pugixml libfilezilla nettle makeWrapper ];
+
+  postInstall = ''
+    wrapProgram $out/bin/filezilla --set FZ_DATADIR $out
+  '';
 
   meta = with stdenv.lib; {
     homepage = https://filezilla-project.org/;


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Filezilla fails to start currently, with the following message being
shown in a lone dialog before the program exits:

> Could not find the resource files for FileZilla, closing FileZilla.
> You can set the data directory of FileZilla using the '--datadir
> <custompath>' commandline option or by setting the FZ_DATADIR
> environment variable.

This commit adds a wrapper for the filezilla binary to set the
environment variable to the package root, which fixes the issue.

This commit also sets enableParallelBuilding = true.  It greatly
reduces build time, and the build isn't deterministic anyway.

(This affects master, but I would also like to request that this change be pushed to release-19.03, since Filezilla is also broken there.  How can I go about doing that?  Thanks.)

CC maintainer @pSub.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - `/nix/store/sw1qk0z4k7lzlmv5lcc1gkmnqyzkax2z-filezilla-3.31.0      194782168`
    `/nix/store/a3kvy3cp6ylhlhiwq4algf03h96dgh06-filezilla-3.31.0      194782688`
- [X] Assured whether relevant documentation is up to date
  - _No documentation found in doc/._
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
