### PR TITLE
libimagequant: 2.12.2 -> 2.12.3

### DIFF
--- a/pkgs/development/libraries/libimagequant/default.nix
+++ b/pkgs/development/libraries/libimagequant/default.nix
@@ -1,29 +1,26 @@
-{ stdenv, fetchFromGitHub, unzip }:
+{ stdenv, fetchFromGitHub }:
 
-with stdenv;
+stdenv.mkDerivation rec {
+  pname = "libimagequant";
+  version = "2.12.3";
 
-let
-  version = "2.12.2";
-in
-  mkDerivation {
-    name = "libimagequant-${version}";
-    src = fetchFromGitHub {
-      owner = "ImageOptim";
-      repo = "libimagequant";
-      rev = "${version}";
-      sha256 = "1k61ifcjbp2lcrwqidflj99inkyhpbrw0hl1nzq1rjp5dnw2y5lw";
-    };
+  src = fetchFromGitHub {
+    owner = "ImageOptim";
+    repo = pname;
+    rev = version;
+    sha256 = "0qsfq1kv1m5jzn9v9iz0bac66k4clcis1c9877qabnwzwmwma5v0";
+  };
 
-    preConfigure = ''
-      patchShebangs ./configure
-    '';
+  preConfigure = ''
+    patchShebangs ./configure
+  '';
 
-    meta = {
-      homepage = https://pngquant.org/lib/;
-      description = "Image quantization library";
-      longDescription = "Small, portable C library for high-quality conversion of RGBA images to 8-bit indexed-color (palette) images.";
-      license = lib.licenses.gpl3Plus;
-      platforms = lib.platforms.unix;
-      maintainers = with lib.maintainers; [ ma9e ];
-    };
-  }
+  meta = with stdenv.lib; {
+    homepage = "https://pngquant.org/lib/";
+    description = "Image quantization library";
+    longDescription = "Small, portable C library for high-quality conversion of RGBA images to 8-bit indexed-color (palette) images.";
+    license = licenses.gpl3Plus;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ ma9e marsam ];
+  };
+}


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Changes: https://github.com/ImageOptim/libimagequant/compare/2.12.2...2.12.3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
