### PR TITLE
xf86_video_nested: 2012-06-15 -> 2017-06-12

### DIFF
--- a/pkgs/os-specific/linux/xf86-video-nested/default.nix
+++ b/pkgs/os-specific/linux/xf86-video-nested/default.nix
@@ -3,12 +3,12 @@
 }:
 
 stdenv.mkDerivation {
-  name = "xf86-video-nested-2012-06-15";
+  name = "xf86-video-nested-2017-06-12";
 
   src = fetchgit {
     url = git://anongit.freedesktop.org/xorg/driver/xf86-video-nested;
-    rev = "ad48dc6eb98776a8a886f26f31c0110352fa1da4";
-    sha256 = "0r5k9rk8mq4j51a310qvvfmhhz8a0cmcwr8pl8mkwfsgcpwxbpfg";
+    rev = "6a48b385c41ea89354d0b2ee7f4649a1d1d9ec70";
+    sha256 = "133rd2kvr2q2wmwpx82bb93qbi8wm8qp1vlmbhgc7aslz0j4cqqv";
   };
 
   buildInputs =


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fix the xf86_video_nested build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
