### PR TITLE
Ibus: binding fixes

### DIFF
--- a/pkgs/tools/inputmethods/ibus/default.nix
+++ b/pkgs/tools/inputmethods/ibus/default.nix
@@ -1,6 +1,6 @@
 { stdenv, substituteAll, fetchurl, runCommand, fetchFromGitHub, autoreconfHook, gettext, makeWrapper, pkgconfig
 , vala, wrapGAppsHook, dbus, dconf ? null, glib, gdk_pixbuf, gobject-introspection, gtk2
-, gtk3, gtk-doc, isocodes, python3, json-glib, libnotify ? null, enablePythonLibrary ? true
+, gtk3, gtk-doc, isocodes, python3, json-glib, libnotify ? null, enablePython2Library ? false
 , enableUI ? true, withWayland ? false, libxkbcommon ? null, wayland ? null
 , buildPackages, runtimeShell }:
 
@@ -110,7 +110,8 @@ stdenv.mkDerivation rec {
     (enableFeature (dconf != null) "dconf")
     (enableFeature (libnotify != null) "libnotify")
     (enableFeature withWayland "wayland")
-    (enableFeature enablePythonLibrary "python-library")
+    (enableFeature enablePython2Library "python-library")
+    (enableFeature enablePython2Library "python2") # XXX: python2 library does not work anyway
     (enableFeature enableUI "ui")
     "--with-unicode-emoji-dir=${emojiData}"
     "--with-emoji-annotation-dir=${cldrEmojiAnnotation}/share/unicode/cldr/common/annotations"

--- a/pkgs/tools/inputmethods/ibus/default.nix
+++ b/pkgs/tools/inputmethods/ibus/default.nix
@@ -135,6 +135,7 @@ stdenv.mkDerivation rec {
     dconf
     gdk_pixbuf
     gobject-introspection
+    python3.pkgs.pygobject3 # for pygobject overrides
     gtk2
     gtk3
     isocodes

--- a/pkgs/tools/inputmethods/ibus/default.nix
+++ b/pkgs/tools/inputmethods/ibus/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, runCommand, fetchFromGitHub, autoreconfHook, gettext, makeWrapper, pkgconfig
+{ stdenv, substituteAll, fetchurl, runCommand, fetchFromGitHub, autoreconfHook, gettext, makeWrapper, pkgconfig
 , vala, wrapGAppsHook, dbus, dconf ? null, glib, gdk_pixbuf, gobject-introspection, gtk2
 , gtk3, gtk-doc, isocodes, python3, json-glib, libnotify ? null, enablePythonLibrary ? true
 , enableUI ? true, withWayland ? false, libxkbcommon ? null, wayland ? null
@@ -90,10 +90,15 @@ stdenv.mkDerivation rec {
     sha256 = "1npavb896qrp6qbqayb0va4mpsi68wybcnlbjknzgssqyw2ylh9r";
   };
 
+  patches = [
+    (substituteAll {
+      src = ./fix-paths.patch;
+      pythonInterpreter = python3Runtime.interpreter;
+      pythonSitePackages = python3.sitePackages;
+    })
+  ];
+
   postPatch = ''
-    substituteInPlace setup/ibus-setup.in --subst-var-by PYTHON ${python3Runtime.interpreter}
-    substituteInPlace data/dconf/Makefile.am --replace "dconf update" true
-    substituteInPlace configure.ac --replace '$python2dir/ibus' $out/${python3.sitePackages}/ibus
     echo \#!${runtimeShell} > data/dconf/make-dconf-override-db.sh
     cp ${buildPackages.gtk-doc}/share/gtk-doc/data/gtk-doc.make .
   '';

--- a/pkgs/tools/inputmethods/ibus/fix-paths.patch
+++ b/pkgs/tools/inputmethods/ibus/fix-paths.patch
@@ -1,0 +1,31 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -462,7 +462,7 @@
+     PYTHON2_VERSION=`$PYTHON2 -c "import sys; sys.stdout.write(sys.version[[:3]])"`
+     PYTHON2_LIBDIR="$PYTHON2_PREFIX/lib/python$PYTHON2_VERSION"
+     python2dir="$PYTHON2_LIBDIR/site-packages"
+-    pkgpython2dir="$python2dir/ibus"
++    pkgpython2dir="$prefix/@pythonSitePackages@/ibus"
+     AC_SUBST(pkgpython2dir)
+ else
+     enable_python_library="no (disabled, use --enable-python-library to enable)"
+--- a/data/dconf/Makefile.am
++++ b/data/dconf/Makefile.am
+@@ -50,7 +50,7 @@
+ 
+ install-data-hook:
+ 	if test -z "$(DESTDIR)"; then \
+-	    dconf update; \
++	    true; \
+ 	fi
+ 
+ EXTRA_DIST = \
+--- a/setup/ibus-setup.in
++++ b/setup/ibus-setup.in
+@@ -27,5 +27,5 @@
+ export IBUS_DATAROOTDIR=@datarootdir@
+ export IBUS_LOCALEDIR=@localedir@
+ export IBUS_LIBEXECDIR=${libexecdir}
+-exec @PYTHON@ @prefix@/share/ibus/setup/main.py $@
++exec @pythonInterpreter@ @prefix@/share/ibus/setup/main.py $@
+ 

--- a/pkgs/tools/inputmethods/ibus/fix-paths.patch
+++ b/pkgs/tools/inputmethods/ibus/fix-paths.patch
@@ -1,5 +1,19 @@
 --- a/configure.ac
 +++ b/configure.ac
+@@ -429,11 +429,11 @@
+ if test "x$enable_pygobject" = "xyes"; then
+     PKG_CHECK_MODULES(PYTHON, [pygobject-3.0 >= $PYGOBJECT_REQUIRED])
+ 
+-    pyoverridesdir=`$PYTHON -c "import gi; print(gi._overridesdir)"`
++    pyoverridesdir="$prefix/@pythonSitePackages@/gi/overrides"
+     AC_SUBST(pyoverridesdir)
+ 
+     if test x"$enable_python2" = x"yes"; then
+-        py2overridesdir=`$PYTHON2 -c "import gi; print(gi._overridesdir)"`
++        py2overridesdir="$prefix/@pythonSitePackages@/gi/overrides"
+         AC_SUBST(py2overridesdir)
+     fi
+ fi
 @@ -462,7 +462,7 @@
      PYTHON2_VERSION=`$PYTHON2 -c "import sys; sys.stdout.write(sys.version[[:3]])"`
      PYTHON2_LIBDIR="$PYTHON2_PREFIX/lib/python$PYTHON2_VERSION"


### PR DESCRIPTION
###### Motivation for this change
Build gi overrides & stop building Python 2 bindings installed to Python 3 directory.

cc @laMudri 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
