### PR TITLE
pythonPackages.klein: fix build/tests

### DIFF
--- a/pkgs/development/python-modules/klein/default.nix
+++ b/pkgs/development/python-modules/klein/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi
+{ lib, buildPythonPackage, fetchPypi, fetchpatch
 , six, twisted, werkzeug, incremental
 , mock }:
 
@@ -11,9 +11,17 @@ buildPythonPackage rec {
     sha256 = "30aaf0d78a987d5dbfe0968a07367ad0c73e02823cc8eef4c54f80ab848370d0";
   };
 
+  patches = [
+    (fetchpatch {
+      name = "tests-expect-werkzeug-308.patch";
+      url = https://github.com/twisted/klein/commit/e2a5835b83e37a2bc5faefbfe1890c529b18b9c6.patch;
+      sha256 = "03j0bj3l3hnf7f96rb27i4bzy1iih79ll5bcah7gybdi1wpznh8w";
+    })
+  ];
+
   propagatedBuildInputs = [ six twisted werkzeug incremental ];
 
-  checkInputs = [ mock ];
+  checkInputs = [ mock twisted ];
 
   checkPhase = ''
     trial klein


### PR DESCRIPTION
###### Motivation for this change
Guess it broke when `checkInputs` became more strict, the further werkzeug-related breakage sneaking in after that without anyone noticing.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
