### PR TITLE
cargo-make: 0.19.3 -> 0.19.4

### DIFF
--- a/pkgs/development/tools/rust/cargo-make/default.nix
+++ b/pkgs/development/tools/rust/cargo-make/default.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-make";
-  version = "0.19.3";
+  version = "0.19.4";
 
   src =
     let
@@ -10,11 +10,11 @@ rustPlatform.buildRustPackage rec {
         owner = "sagiegurari";
         repo = pname;
         rev = version;
-        sha256 = "11mkfwvzsr86w9675zpq8gcq5avsfvwffca26h6gkc7ahqcsx3ac";
+        sha256 = "019dn401p4bds144fbvqxbnn8vswcj0lxr8cvgpxb2y22640z60l";
       };
       cargo-lock = fetchurl {
-        url = "https://gist.githubusercontent.com/xrelkd/e4c9c7738b21f284d97cb7b1d181317d/raw/3592410d14443cc6be675553a9c228401114fa5f/cargo-make-Cargo.lock";
-        sha256 = "0m8m2pn8y7n1js1kkva4lxahz5j4d73lj7l45h8dd30lw2w4n3hg";
+        url = "https://gist.githubusercontent.com/xrelkd/e4c9c7738b21f284d97cb7b1d181317d/raw/c5b9fde279a9f6d55d97e0ba4e0b4cd62e0ab2bf/cargo-make-Cargo.lock";
+        sha256 = "1d5md3m8hxwf3pwvx059fsk1b3vvqm17pxbbyiisn9v4psrsmld5";
       };
     in
     runCommand "cargo-make-src" {} ''
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = stdenv.lib.optionals stdenv.isDarwin [ Security ];
 
-  cargoSha256 = "00yvx87s8vngb97ldq2amdhdv3nn38liys7nilay73phx0xybx4p";
+  cargoSha256 = "0wf60ck0w3m9fa19dz99q84kw05sxlj2pp6bd8r1db3cfy8f8h8j";
 
   # Some tests fail because they need network access.
   # However, Travis ensures a proper build.


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update `cargo-make` to the latest release.
https://github.com/sagiegurari/cargo-make/releases/tag/0.19.4

**Note**: `doCheck` is set as `false`.
Some tests fail because they need network access. However, Travis-CI ensures a proper build.
https://travis-ci.org/sagiegurari/cargo-make/jobs/540061851
https://travis-ci.org/sagiegurari/cargo-make/jobs/540061852
https://travis-ci.org/sagiegurari/cargo-make/jobs/540061853

`cargo-make` is a subcommand for `cargo`. You need to invoke `cargo-make` via `cargo` command.
To test the binary files in `./result/bin`, consider the following commands:
```
[john@nixos:~/result/bin] PATH=.:$PATH cargo make --version
cargo-make 0.19.4
[john@nixos:~/result/bin] makers --version
makers 0.19.4
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
