### PR TITLE
wireguard-tools, wireguard-go: add update scripts, wireguard-go: 0.0.20181222 -> 0.0.20190517

### DIFF
--- a/pkgs/tools/networking/wireguard-go/default.nix
+++ b/pkgs/tools/networking/wireguard-go/default.nix
@@ -2,13 +2,13 @@
 
 buildGoPackage rec {
   name = "wireguard-go-${version}";
-  version = "0.0.20181222";
+  version = "0.0.20190517";
 
   goPackagePath = "git.zx2c4.com/wireguard-go";
 
   src = fetchzip {
     url = "https://git.zx2c4.com/wireguard-go/snapshot/wireguard-go-${version}.tar.xz";
-    sha256 = "00m1r97qrr4l21s5jk5m3xfpiybqbzgxp9failsy1nmx27wrdiky";
+    sha256 = "0ir3dp13vkkqr76q0jvw610qw40053ngk51psqhqxfaw3jicdqgr";
   };
 
   goDeps = ./deps.nix;

--- a/pkgs/tools/networking/wireguard-go/default.nix
+++ b/pkgs/tools/networking/wireguard-go/default.nix
@@ -13,6 +13,8 @@ buildGoPackage rec {
 
   goDeps = ./deps.nix;
 
+  passthru.updateScript = ./update.sh;
+
   meta = with stdenv.lib; {
     description = "Userspace Go implementation of WireGuard";
     homepage = https://git.zx2c4.com/wireguard-go/about/;

--- a/pkgs/tools/networking/wireguard-go/deps.nix
+++ b/pkgs/tools/networking/wireguard-go/deps.nix
@@ -1,12 +1,30 @@
 # file generated from go.mod using vgo2nix (https://github.com/adisbladis/vgo2nix)
 [
   {
+    goPackagePath = "github.com/Microsoft/go-winio";
+    fetch = {
+      type = "git";
+      url = "https://github.com/Microsoft/go-winio";
+      rev = "v0.4.12";
+      sha256 = "10v2f1xaw2cc97mjqnxzgs9ydpqv71f0ynp1spcywqw97la56zqw";
+    };
+  }
+  {
+    goPackagePath = "github.com/pkg/errors";
+    fetch = {
+      type = "git";
+      url = "https://github.com/pkg/errors";
+      rev = "v0.8.1";
+      sha256 = "0g5qcb4d4fd96midz0zdk8b9kz8xkzwfa8kr1cliqbg8sxsy5vd1";
+    };
+  }
+  {
     goPackagePath = "golang.org/x/crypto";
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/crypto";
-      rev = "505ab145d0a9";
-      sha256 = "1vbsvcvmjz6c00p5vf8ls533p52fx2y3gy6v4k5qrdlzl4wf0i5s";
+      rev = "a29dc8fdc734";
+      sha256 = "07f0jj4haqs0ywc1akk1qjwn5msl2j0pry1rxjkkbfcq4r6ihc1p";
     };
   }
   {
@@ -14,8 +32,8 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/net";
-      rev = "610586996380";
-      sha256 = "1sqwmvf70rq1j65lv5jzyiy7gd53l37dxlnjf2xj6p2i4fcwkk4z";
+      rev = "7f726cade0ab";
+      sha256 = "0zv5var5agbhd2mcn7lciwip0j49gxka73f0csvh3hvb1di068gn";
     };
   }
   {
@@ -23,8 +41,17 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/sys";
-      rev = "2a47403f2ae5";
-      sha256 = "0ww1iz1zcw995957h32289yascl37pkvfj3qcvyghvnzf7xg9v6z";
+      rev = "a43fa875dd82";
+      sha256 = "0xvwwaqcj02a9n8izs4zrlg8vvz7wffli955i93nc34m1f0w8vyg";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/text";
+      rev = "v0.3.0";
+      sha256 = "0r6x6zjzhr8ksqlpiwm5gdd7s209kwk5p4lw54xjvz10cs3qlq19";
     };
   }
 ]

--- a/pkgs/tools/networking/wireguard-go/update.sh
+++ b/pkgs/tools/networking/wireguard-go/update.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnused common-updater-scripts vgo2nix
+
+set -eu -o pipefail
+
+basedir="$(git rev-parse --show-toplevel)"
+version="$(curl -sL https://build.wireguard.com/distros.txt | sed -n 's/^upstream\tgo\t\([^\t]\+\)\t.*/\1/p')"
+update-source-version wireguard-go "$version"
+
+vgo2nix -dir $(nix-build -A wireguard-go.src) -outfile "$basedir/pkgs/tools/networking/wireguard-go/deps.nix"
+
+if [[ -f "$basedir/wireguard-go.log" ]];then
+    rm "$basedir/wireguard-go.log"
+fi

--- a/pkgs/tools/networking/wireguard-tools/default.nix
+++ b/pkgs/tools/networking/wireguard-tools/default.nix
@@ -37,6 +37,8 @@ stdenv.mkDerivation rec {
     done
   '';
 
+  passthru.updateScript = ./update.sh;
+
   meta = with stdenv.lib; {
     description = "Tools for the WireGuard secure network tunnel";
     downloadPage = https://git.zx2c4.com/WireGuard/refs/;

--- a/pkgs/tools/networking/wireguard-tools/update.sh
+++ b/pkgs/tools/networking/wireguard-tools/update.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnused common-updater-scripts
+
+set -eu -o pipefail
+
+version="$(curl -sL https://build.wireguard.com/distros.txt | sed -n 's/^upstream\tkmodtools\t\([^\t]\+\)\t.*/\1/p')"
+update-source-version wireguard-tools "$version"


### PR DESCRIPTION
###### Motivation for this change
This adds updateScripts for both wireguard-tools and wireguard-go. As the kernel uses the src from wireguard-tools, this also applies to wireguard kernel modules.

I verified both scripts by updating to the latest version. `wireguard-tools` was already up to date, so I manually reverted the bump. `wireguard-go` was outdated, so I added a commit that updates the package.

I didn't build wireguard-go, will let @GrahamcOfBorg handle that.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @zx2c4 