### PR TITLE
git-quick-stats: init at 2.0.8

### DIFF
--- a/pkgs/development/tools/git-quick-stats/default.nix
+++ b/pkgs/development/tools/git-quick-stats/default.nix
@@ -8,9 +8,7 @@ stdenv.mkDerivation rec {
     rev = "${version}";
     sha256 = "1px1sk7b6mjnbclsr1jn33m9k4wd8wqyw4d6w1rgj0ii29lhzmqi";
   };
-  installPhase = ''
-    PREFIX=$out make install
-  '';
+  PREFIX = builtins.placeholder "out";
   meta = with stdenv.lib; {
     homepage = "https://github.com/arzzen/git-quick-stats";
     description = "A simple and efficient way to access various statistics in git repository";

--- a/pkgs/development/tools/git-quick-stats/default.nix
+++ b/pkgs/development/tools/git-quick-stats/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchFromGitHub }:
+stdenv.mkDerivation rec {
+  name = "git-quick-stats-${version}";
+  version = "2.0.8";
+  src = fetchFromGitHub {
+    repo = "git-quick-stats";
+    owner = "arzzen";
+    rev = "${version}";
+    sha256 = "1px1sk7b6mjnbclsr1jn33m9k4wd8wqyw4d6w1rgj0ii29lhzmqi";
+  };
+  installPhase = ''
+    PREFIX=$out make install
+  '';
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/arzzen/git-quick-stats";
+    description = "A simple and efficient way to access various statistics in git repository";
+    platforms = platforms.all;
+    maintainers = [ maintainers.kmein ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18047,6 +18047,8 @@ in
     python = python27;
   };
 
+  git-quick-stats = callPackage ../development/tools/git-quick-stats {};
+
   git-review = callPackage ../applications/version-management/git-review { };
 
   gitolite = callPackage ../applications/version-management/gitolite { };


### PR DESCRIPTION
###### Motivation for this change
This package was missing from nixpkgs while for example homebrew has it.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---