### PR TITLE
pythonPackages.scikit-build: fix by bumping pytest-virtualenv, -shutil, -fixture-config, -server-fixtures

### DIFF
--- a/pkgs/development/python-modules/pytest-fixture-config/default.nix
+++ b/pkgs/development/python-modules/pytest-fixture-config/default.nix
@@ -1,18 +1,18 @@
 { stdenv, buildPythonPackage, fetchPypi
-, setuptools-git, pytest_3 }:
+, setuptools-git, pytest }:
 
 buildPythonPackage rec {
   pname = "pytest-fixture-config";
-  version = "1.4.0";
+  version = "1.7.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "839d70343c87d6dda5bca88e3ab06e7b2027998dc1ec452c14d50be5725180a3";
+    sha256 = "13i1qpz22w3x4dmw8vih5jdnbqfqvl7jiqs0dg764s0zf8bp98a1";
   };
 
   nativeBuildInputs = [ setuptools-git ];
 
-  buildInputs = [ pytest_3 ];
+  buildInputs = [ pytest ];
 
   doCheck = false;
 

--- a/pkgs/development/python-modules/pytest-server-fixtures/default.nix
+++ b/pkgs/development/python-modules/pytest-server-fixtures/default.nix
@@ -1,17 +1,17 @@
 { stdenv, buildPythonPackage, fetchPypi
-, pytest_3, pytest-shutil, pytest-fixture-config, psutil
+, pytest, pytest-shutil, pytest-fixture-config, psutil
 , requests, future, retry }:
 
 buildPythonPackage rec {
   pname = "pytest-server-fixtures";
-  version = "1.6.2";
+  version = "1.7.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "c89f9532f62cf851489082ece1ec692b6ed5b0f88f20823bea25e2a963ebee8f";
+    sha256 = "07vdv3y89qzv89ws0y48h92yplqsx208b9cizx80w644dazb398g";
   };
 
-  buildInputs = [ pytest_3 ];
+  buildInputs = [ pytest ];
   propagatedBuildInputs = [ pytest-shutil pytest-fixture-config psutil requests future retry ];
 
   # RuntimeError: Unable to find a free server number to start Xvfb

--- a/pkgs/development/python-modules/pytest-shutil/default.nix
+++ b/pkgs/development/python-modules/pytest-shutil/default.nix
@@ -1,19 +1,19 @@
 { stdenv, lib, isPyPy, buildPythonPackage, fetchPypi
-, pytest_3, cmdline, pytestcov, coverage, setuptools-git, mock, pathpy, execnet
+, pytest, cmdline, pytestcov, coverage, setuptools-git, mock, pathpy, execnet
 , contextlib2, termcolor }:
 
 buildPythonPackage rec {
   pname = "pytest-shutil";
-  version = "1.6.0";
+  version = "1.7.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "efe615b7709637ec8828abebee7fc2ad033ae0f1fc54145f769a8b5e8cc3b4ca";
+    sha256 = "0q8j0ayzmnvlraml6i977ybdq4xi096djhf30n2m1rvnvrhm45nq";
   };
 
-  checkInputs = [ cmdline pytest_3 ];
+  checkInputs = [ cmdline pytest ];
   propagatedBuildInputs = [ pytestcov coverage setuptools-git mock pathpy execnet contextlib2 termcolor ];
-  nativeBuildInputs = [ pytest_3 ];
+  nativeBuildInputs = [ pytest ];
 
   checkPhase = ''
     py.test ${lib.optionalString isPyPy "-k'not (test_run or test_run_integration)'"}

--- a/pkgs/development/python-modules/pytest-virtualenv/default.nix
+++ b/pkgs/development/python-modules/pytest-virtualenv/default.nix
@@ -1,20 +1,20 @@
 { stdenv, buildPythonPackage, fetchPypi
-, pytest_3, pytestcov, mock, cmdline, pytest-fixture-config, pytest-shutil }:
+, pytest, pytestcov, mock, cmdline, pytest-fixture-config, pytest-shutil, virtualenv }:
 
 buildPythonPackage rec {
   pname = "pytest-virtualenv";
-  version = "1.6.0";
+  version = "1.7.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "d281725d10848773cb2b495d1255dd0a42fc9179e34a274c22e1c35837721f19";
+    sha256 = "03w2zz3crblj1p6i8nq17946hbn3zqp9z7cfnifw47hi4a4fww12";
   };
 
-  checkInputs = [ pytest_3 pytestcov mock cmdline ];
-  propagatedBuildInputs = [ pytest-fixture-config pytest-shutil ];
+  checkInputs = [ pytest pytestcov mock cmdline ];
+  propagatedBuildInputs = [ pytest-fixture-config pytest-shutil virtualenv ];
   checkPhase = '' py.test tests/unit '';
 
-  nativeBuildInputs = [ pytest_3 ];
+  nativeBuildInputs = [ pytest ];
 
   meta = with stdenv.lib; {
     description = "Create a Python virtual environment in your test that cleans up on teardown. The fixture has utility methods to install packages and list what’s installed.";

--- a/pkgs/development/python-modules/scikit-build/default.nix
+++ b/pkgs/development/python-modules/scikit-build/default.nix
@@ -17,13 +17,14 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ wheel setuptools packaging ];
   checkInputs = [ 
-    cmake ninja cython codecov coverage six virtualenv pathpy
+    cmake ninja cython codecov coverage six pathpy
     pytest pytestcov pytest-mock pytest-virtualenv pytestrunner
     requests flake8
   ];
 
   disabledTests = lib.concatMapStringsSep " and " (s: "not " + s) ([
     "test_hello_develop" # tries setuptools develop install
+    "test_source_distribution" # pip has no way to install missing dependencies
     "test_wheel" # pip has no way to install missing dependencies
     "test_fortran_compiler" # passes if gfortran is available
     "test_install_command" # tries to alter out path


### PR DESCRIPTION
###### Motivation for this change
`scikit-build` appears to have broken when `pytest` was bumped to 4.x. However the only thing complaining about the presence of pytest4 was one of its dependencies, `pytest-virtualenv`. So what I did instead was bump that _along with_ `pytest-shutil`, `pytest-fixture-config` and `pytest-server-fixtures` because they all actually come from the same "master package" https://github.com/manahl/pytest-plugins and all have a recent 1.7.0 release which makes them compatible with pytest4 and allows me to remove any `pytest_3` requirement for them.

Finally I had to disable `test_source_distribution` in `scikit-build` to get its tests to pass. Previously I think it had actually been auto-skipping this test so I don't think I'm _actually_ net disabling anything.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
