### PR TITLE
ocamlPackages.opium: init at 0.17.1

### DIFF
--- a/pkgs/development/ocaml-modules/hmap/default.nix
+++ b/pkgs/development/ocaml-modules/hmap/default.nix
@@ -1,0 +1,41 @@
+{ stdenv
+, lib
+, fetchurl
+, findlib
+, ocaml
+, ocamlbuild
+, topkg
+}:
+
+let
+  minimumSupportedOcamlVersion = "4.02.0";
+in
+assert lib.versionOlder minimumSupportedOcamlVersion ocaml.version;
+
+stdenv.mkDerivation rec {
+	pname = "hmap";
+  version = "0.8.1";
+  name = "ocaml${ocaml.version}-${pname}-${version}";
+
+  src = fetchurl {
+    url = "http://erratique.ch/software/hmap/releases/${pname}-${version}.tbz";
+    sha256 = "10xyjy4ab87z7jnghy0wnla9wrmazgyhdwhr4hdmxxdn28dxn03a";
+  };
+
+	buildInputs = [ ocaml ocamlbuild findlib topkg ];
+
+  inherit (topkg) installPhase;
+
+  buildPhase = "${topkg.run} build --tests true";
+
+  doCheck = true;
+
+  checkPhase = "${topkg.run} test";
+
+  meta = {
+		description = "Heterogeneous value maps for OCaml";
+    homepage = "https://erratique.ch/software/hmap";
+		license = lib.licenses.isc;
+		maintainers = [ lib.maintainers.pmahoney ];
+  };
+}

--- a/pkgs/development/ocaml-modules/opium/default.nix
+++ b/pkgs/development/ocaml-modules/opium/default.nix
@@ -1,0 +1,30 @@
+{ buildDunePackage
+
+, ppx_sexp_conv
+, ppx_fields_conv
+
+, cmdliner
+, cohttp-lwt-unix
+, logs
+, magic-mime
+, opium_kernel
+, stringext
+
+, alcotest
+}:
+
+buildDunePackage rec {
+	pname = "opium";
+	inherit (opium_kernel) version src meta minimumOCamlVersion;
+
+  doCheck = true;
+
+	buildInputs = [
+    ppx_sexp_conv ppx_fields_conv
+    alcotest
+  ];
+
+	propagatedBuildInputs = [
+    opium_kernel cmdliner cohttp-lwt-unix magic-mime logs stringext
+  ];
+}

--- a/pkgs/development/ocaml-modules/opium_kernel/default.nix
+++ b/pkgs/development/ocaml-modules/opium_kernel/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildDunePackage
+, fetchFromGitHub
+
+, ppx_fields_conv
+, ppx_sexp_conv
+
+, cohttp-lwt
+, ezjsonm
+, hmap
+}:
+
+buildDunePackage rec {
+	pname = "opium_kernel";
+  version = "0.17.1";
+
+  minimumOCamlVersion = "4.04.1";
+  
+	src = fetchFromGitHub {
+		owner = "rgrinberg";
+		repo = "opium";
+		rev = "v${version}";
+		sha256 = "03xzh0ik6k3c0yn1w1avph667vdagwclzimwwrlf9qdxnzxvcnp3";
+	};
+
+  doCheck = true;
+
+	buildInputs = [
+    ppx_sexp_conv ppx_fields_conv
+  ];
+
+	propagatedBuildInputs = [
+    hmap cohttp-lwt ezjsonm
+  ];
+
+  meta = {
+		description = "Sinatra like web toolkit for OCaml based on cohttp & lwt";
+    homepage = "https://github.com/rgrinberg/opium";
+		license = lib.licenses.mit;
+		maintainers = [ lib.maintainers.pmahoney ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -551,6 +551,10 @@ let
 
     opam-file-format = callPackage ../development/ocaml-modules/opam-file-format { };
 
+    opium = callPackage ../development/ocaml-modules/opium { };
+
+    opium_kernel = callPackage ../development/ocaml-modules/opium_kernel { };
+
     opti = callPackage ../development/ocaml-modules/opti { };
 
     optint = callPackage ../development/ocaml-modules/optint { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -271,6 +271,8 @@ let
 
     higlo = callPackage ../development/ocaml-modules/higlo { };
 
+    hmap = callPackage ../development/ocaml-modules/hmap { };
+
     imagelib = callPackage ../development/ocaml-modules/imagelib { };
 
     inotify = callPackage ../development/ocaml-modules/inotify { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

To use opium ocaml library (and hmap, a dependency of opium)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
