### PR TITLE
sd-image: FAT free /boot

### DIFF
--- a/nixos/modules/installer/cd-dvd/sd-image-aarch64.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image-aarch64.nix
@@ -46,7 +46,10 @@ in
         (cd ${pkgs.raspberrypifw}/share/raspberrypi/boot && cp bootcode.bin fixup*.dat start*.elf $NIX_BUILD_TOP/firmware/)
         cp ${pkgs.ubootRaspberryPi3_64bit}/u-boot.bin firmware/u-boot-rpi3.bin
         cp ${configTxt} firmware/config.txt
-        ${extlinux-conf-builder} -t 3 -c ${config.system.build.toplevel} -d ./firmware
       '';
+    populateRootCommands = ''
+      mkdir -p ./files/boot
+      ${extlinux-conf-builder} -t 3 -c ${config.system.build.toplevel} -d ./files/boot
+    '';
   };
 }

--- a/nixos/modules/installer/cd-dvd/sd-image-aarch64.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image-aarch64.nix
@@ -27,7 +27,7 @@ in
   boot.kernelParams = ["cma=32M" "console=ttyS0,115200n8" "console=ttyAMA0,115200n8" "console=tty0"];
 
   sdImage = {
-    populateBootCommands = let
+    populateFirmwareCommands = let
       configTxt = pkgs.writeText "config.txt" ''
         kernel=u-boot-rpi3.bin
 
@@ -43,10 +43,10 @@ in
         avoid_warnings=1
       '';
       in ''
-        (cd ${pkgs.raspberrypifw}/share/raspberrypi/boot && cp bootcode.bin fixup*.dat start*.elf $NIX_BUILD_TOP/boot/)
-        cp ${pkgs.ubootRaspberryPi3_64bit}/u-boot.bin boot/u-boot-rpi3.bin
-        cp ${configTxt} boot/config.txt
-        ${extlinux-conf-builder} -t 3 -c ${config.system.build.toplevel} -d ./boot
+        (cd ${pkgs.raspberrypifw}/share/raspberrypi/boot && cp bootcode.bin fixup*.dat start*.elf $NIX_BUILD_TOP/firmware/)
+        cp ${pkgs.ubootRaspberryPi3_64bit}/u-boot.bin firmware/u-boot-rpi3.bin
+        cp ${configTxt} firmware/config.txt
+        ${extlinux-conf-builder} -t 3 -c ${config.system.build.toplevel} -d ./firmware
       '';
   };
 }

--- a/nixos/modules/installer/cd-dvd/sd-image-armv7l-multiplatform.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image-armv7l-multiplatform.nix
@@ -29,7 +29,7 @@ in
   boot.kernelParams = ["console=ttyS0,115200n8" "console=ttymxc0,115200n8" "console=ttyAMA0,115200n8" "console=ttyO0,115200n8" "console=ttySAC2,115200n8" "console=tty0"];
 
   sdImage = {
-    populateBootCommands = let
+    populateFirmwareCommands = let
       configTxt = pkgs.writeText "config.txt" ''
         # Prevent the firmware from smashing the framebuffer setup done by the mainline kernel
         # when attempting to show low-voltage or overtemperature warnings.
@@ -46,11 +46,11 @@ in
         enable_uart=1
       '';
       in ''
-        (cd ${pkgs.raspberrypifw}/share/raspberrypi/boot && cp bootcode.bin fixup*.dat start*.elf $NIX_BUILD_TOP/boot/)
-        cp ${pkgs.ubootRaspberryPi2}/u-boot.bin boot/u-boot-rpi2.bin
-        cp ${pkgs.ubootRaspberryPi3_32bit}/u-boot.bin boot/u-boot-rpi3.bin
-        cp ${configTxt} boot/config.txt
-        ${extlinux-conf-builder} -t 3 -c ${config.system.build.toplevel} -d ./boot
+        (cd ${pkgs.raspberrypifw}/share/raspberrypi/boot && cp bootcode.bin fixup*.dat start*.elf $NIX_BUILD_TOP/firmware/)
+        cp ${pkgs.ubootRaspberryPi2}/u-boot.bin firmware/u-boot-rpi2.bin
+        cp ${pkgs.ubootRaspberryPi3_32bit}/u-boot.bin firmware/u-boot-rpi3.bin
+        cp ${configTxt} firmware/config.txt
+        ${extlinux-conf-builder} -t 3 -c ${config.system.build.toplevel} -d ./firmware
       '';
   };
 }

--- a/nixos/modules/installer/cd-dvd/sd-image-armv7l-multiplatform.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image-armv7l-multiplatform.nix
@@ -50,7 +50,10 @@ in
         cp ${pkgs.ubootRaspberryPi2}/u-boot.bin firmware/u-boot-rpi2.bin
         cp ${pkgs.ubootRaspberryPi3_32bit}/u-boot.bin firmware/u-boot-rpi3.bin
         cp ${configTxt} firmware/config.txt
-        ${extlinux-conf-builder} -t 3 -c ${config.system.build.toplevel} -d ./firmware
       '';
+    populateRootCommands = ''
+      mkdir -p ./files/boot
+      ${extlinux-conf-builder} -t 3 -c ${config.system.build.toplevel} -d ./files/boot
+    '';
   };
 }

--- a/nixos/modules/installer/cd-dvd/sd-image-raspberrypi.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image-raspberrypi.nix
@@ -35,11 +35,11 @@ in
         kernel=u-boot-rpi1.bin
       '';
       in ''
-        (cd ${pkgs.raspberrypifw}/share/raspberrypi/boot && cp bootcode.bin fixup*.dat start*.elf $NIX_BUILD_TOP/boot/)
-        cp ${pkgs.ubootRaspberryPiZero}/u-boot.bin boot/u-boot-rpi0.bin
-        cp ${pkgs.ubootRaspberryPi}/u-boot.bin boot/u-boot-rpi1.bin
-        cp ${configTxt} boot/config.txt
-        ${extlinux-conf-builder} -t 3 -c ${config.system.build.toplevel} -d ./boot
+        (cd ${pkgs.raspberrypifw}/share/raspberrypi/boot && cp bootcode.bin fixup*.dat start*.elf $NIX_BUILD_TOP/firmware/)
+        cp ${pkgs.ubootRaspberryPiZero}/u-boot.bin firmware/u-boot-rpi0.bin
+        cp ${pkgs.ubootRaspberryPi}/u-boot.bin firmware/u-boot-rpi1.bin
+        cp ${configTxt} firmware/config.txt
+        ${extlinux-conf-builder} -t 3 -c ${config.system.build.toplevel} -d ./firmware
       '';
   };
 }

--- a/nixos/modules/installer/cd-dvd/sd-image-raspberrypi.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image-raspberrypi.nix
@@ -39,7 +39,10 @@ in
         cp ${pkgs.ubootRaspberryPiZero}/u-boot.bin firmware/u-boot-rpi0.bin
         cp ${pkgs.ubootRaspberryPi}/u-boot.bin firmware/u-boot-rpi1.bin
         cp ${configTxt} firmware/config.txt
-        ${extlinux-conf-builder} -t 3 -c ${config.system.build.toplevel} -d ./firmware
       '';
+    populateRootCommands = ''
+      mkdir -p ./files/boot
+      ${extlinux-conf-builder} -t 3 -c ${config.system.build.toplevel} -d ./files/boot
+    '';
   };
 }

--- a/nixos/modules/installer/cd-dvd/sd-image.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image.nix
@@ -64,7 +64,8 @@ in
 
     firmwareSize = mkOption {
       type = types.int;
-      default = 120;
+      # As of 2019-05-31 the Raspberry pi firmware + u-bot takes ~13MiB
+      default = 20;
       description = ''
         Size of the /boot/firmware partition, in megabytes.
       '';

--- a/nixos/modules/installer/cd-dvd/sd-image.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image.nix
@@ -14,6 +14,7 @@ with lib;
 let
   rootfsImage = pkgs.callPackage ../../../lib/make-ext4-fs.nix ({
     inherit (config.sdImage) storePaths;
+    populateImageCommands = config.sdImage.populateRootCommands;
     volumeLabel = "NIXOS_SD";
   } // optionalAttrs (config.sdImage.rootPartitionUUID != null) {
     uuid = config.sdImage.rootPartitionUUID;
@@ -77,6 +78,16 @@ in
         /boot/firmware partition on the SD image.
       '';
     };
+
+    populateRootCommands = mkOption {
+      example = literalExample "''\${extlinux-conf-builder} -t 3 -c \${config.system.build.toplevel} -d ./files/boot''";
+      description = ''
+        Shell commands to populate the ./files directory.
+        All files in that directory are copied to the
+        root (/) partition on the SD image. Use this to
+        populate the ./files/boot (/boot) directory.
+      '';
+    };
   };
 
   config = {
@@ -117,8 +128,8 @@ in
             label: dos
             label-id: ${config.sdImage.firmwarePartitionID}
 
-            start=8M, size=$firmwareSizeBlocks, type=b, bootable
-            start=${toString (8 + config.sdImage.firmwareSize)}M, type=83
+            start=8M, size=$firmwareSizeBlocks, type=b
+            start=${toString (8 + config.sdImage.firmwareSize)}M, type=83, bootable
         EOF
 
         # Copy the rootfs into the SD image

--- a/nixos/modules/installer/cd-dvd/sd-image.nix
+++ b/nixos/modules/installer/cd-dvd/sd-image.nix
@@ -25,6 +25,11 @@ let
   });
 in
 {
+  imports = [
+    (mkRemovedOptionModule [ "sdImage" "bootPartitionID" ] "The FAT partition for SD image now only holds the Raspberry Pi firmware files. Use firmwarePartitionID to configure that partition's ID.")
+    (mkRemovedOptionModule [ "sdImage" "bootSize" ] "The boot files for SD image have been moved to the main ext4 partition. The FAT partition now only holds the Raspberry Pi firmware files. Changing its size may not be required.")
+  ];
+
   options.sdImage = {
     imageName = mkOption {
       default = "${config.sdImage.imageBaseName}-${config.system.nixos.label}-${pkgs.stdenv.hostPlatform.system}.img";


### PR DESCRIPTION
### Motivation for this change

#### A. Booting from ext4

*Fixes #51924*

This fixes one annoyance and allows recovering a bit of space.

The annoyance is that there is about 100MiB free for the generations on the
`/boot` partition in the current state of the SD images. This is not much when
playing around with kernels and this limit is often hit.

By using the FAT32 partition as a "firmware-only" partition for the Raspberry
Pi, we can reduce its size to a minimum required to hold the firmware-esque
bits required for boot. This allows us to cut ~100MiB of space.

#### B. Review "firmware" setup

By treating the FAT32 partition exactly as if it was a firmware bit, we can:

 1. Skip mounting it in the installed system.

This is not entirely *useful*, but this makes it easier to allow bigger firmwares
to be *fused* to the SD image as a user only has to remove the FAT32
partition to gain more space if needed (e.g. with some Rockchip firmwares).

> The initial PR also removed the 8MiB gap and assumed a user would
> remove the FAT32 partition before *fusing* a firmware to the SD image,
> but this is way too inconvenient compared to just dumping the data to
> the right location on the disk. 8MiB is not a significant enough size to
> warrant the headaches.

### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ☑️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ☑️ NixOS
   - 🔲 other Linux distributions
- 🔲 Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- ☑️ Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- ☑️ Tested on hardware
- ☑️ Determined the impact on package closure size (by running ~~`nix path-info -S`~~ `nix path-info -s` before and after)
- 🔲 Assured whether relevant documentation is up to date
- ☑️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

Here's the diff of the size of the image; the closure itself doesn't really change more.

```
[samueldr@aarch64:~/nixpkgs]$ nix path-info -s ./fat-free
/nix/store/pl1nvnm7g71j0hvbhjhd9xjxfy3ry7kg-nixos-sd-image-19.09pre130979.gfedcba-aarch64-linux.img      2007622888

[samueldr@aarch64:~/nixpkgs]$ nix path-info -s ./image--nixos-unstable
/nix/store/vlkb2zv9cyw95zhqpfz0cxxg1ibbr77j-nixos-sd-image-19.09pre130979.gfedcba-aarch64-linux.img      2081703144
```

All commits in the series should be independently good and able to build and boot. I verified boot at each step.

This was verified on:

 * Raspberry Pi 3B (the usual sd card boot, firmware from FAT32 partition as-built)
 * Pine A64-LTS (firmware from SPI nor flash, FAT32 partition still on)
 * Orange Pi Zero Plus 2 H5 (FAT32 partition deleted, no partition added, firmware fused as usual with dd)

---

**fusing**: I am using "fusing" as the term for the usual `sudo dd if=u-boot-sunxi-with-spl.bin of=/dev/sdX bs=1024 seek=8` for SoCs that read the firmware off the storage at a specific offset.