### PR TITLE
maintainers/scripts/update.nix: various fixes

### DIFF
--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -709,9 +709,12 @@ passthru.updateScript = writeScript "update-zoom-us" ''
 <programlisting>
 passthru.updateScript = [ ../../update.sh pname "--requested-release=unstable" ];
 </programlisting>
-      Note that the update scripts will be run in parallel by default; you
-      should avoid running <command>git commit</command> or any other commands
-      that cannot handle that.
+     </para>
+     <para>
+      The script will be usually run from the root of the Nixpkgs repository
+      but you should not rely on that. Also note that the update scripts will
+      be run in parallel by default; you should avoid running <command>git
+      commit</command> or any other commands that cannot handle that.
      </para>
      <para>
       For information about how to run the updates, execute

--- a/doc/stdenv.xml
+++ b/doc/stdenv.xml
@@ -715,13 +715,7 @@ passthru.updateScript = [ ../../update.sh pname "--requested-release=unstable" ]
      </para>
      <para>
       For information about how to run the updates, execute
-      <cmdsynopsis>
-       <command>nix-shell</command> 
-       <arg>
-        maintainers/scripts/update.nix
-       </arg>
-      </cmdsynopsis>
-      .
+      <command>nix-shell maintainers/scripts/update.nix</command>.
      </para>
     </listitem>
    </varlistentry>

--- a/maintainers/scripts/update.nix
+++ b/maintainers/scripts/update.nix
@@ -122,7 +122,7 @@ let
   packageData = package: {
     name = package.name;
     pname = (builtins.parseDrvName package.name).name;
-    updateScript = pkgs.lib.toList package.updateScript;
+    updateScript = map builtins.toString (pkgs.lib.toList package.updateScript);
   };
 
 in pkgs.stdenv.mkDerivation {

--- a/maintainers/scripts/update.nix
+++ b/maintainers/scripts/update.nix
@@ -20,7 +20,9 @@ let
       in
         [x] ++ nubOn f xs;
 
-  pkgs = import ./../../default.nix { };
+  pkgs = import ./../../default.nix {
+    overlays = [];
+  };
 
   packagesWith = cond: return: set:
     nubOn (pkg: pkg.updateScript)

--- a/maintainers/scripts/update.nix
+++ b/maintainers/scripts/update.nix
@@ -69,9 +69,12 @@ let
     let
       attrSet = pkgs.lib.attrByPath (pkgs.lib.splitString "." path) null pkgs;
     in
-      packagesWith (name: pkg: builtins.hasAttr "updateScript" pkg)
-                     (name: pkg: pkg)
-                     attrSet;
+      if attrSet == null then
+        builtins.throw "Attribute path `${path}` does not exists."
+      else
+        packagesWith (name: pkg: builtins.hasAttr "updateScript" pkg)
+                       (name: pkg: pkg)
+                       attrSet;
 
   packageByName = name:
     let

--- a/pkgs/common-updater/scripts/update-source-version
+++ b/pkgs/common-updater/scripts/update-source-version
@@ -109,13 +109,13 @@ if [ "$oldVersion" = "$newVersion" ]; then
 fi
 
 # Escape regex metacharacter that are allowed in store path names
-oldVersion=$(echo "$oldVersion" | sed -re 's|[.+]|\\&|g')
-oldUrl=$(echo "$oldUrl" | sed -re 's|[${}.+]|\\&|g')
+oldVersionEscaped=$(echo "$oldVersion" | sed -re 's|[.+]|\\&|g')
+oldUrlEscaped=$(echo "$oldUrl" | sed -re 's|[${}.+]|\\&|g')
 
-if [ $(grep -c -E "^\s*(let\b)?\s*$versionKey\s*=\s*\"$oldVersion\"" "$nixFile") = 1 ]; then
-    pattern="/\b$versionKey\b\s*=/ s|\"$oldVersion\"|\"$newVersion\"|"
-elif [ $(grep -c -E "^\s*(let\b)?\s*name\s*=\s*\"[^\"]+-$oldVersion\"" "$nixFile") = 1 ]; then
-    pattern="/\bname\b\s*=/ s|-$oldVersion\"|-$newVersion\"|"
+if [ $(grep -c -E "^\s*(let\b)?\s*$versionKey\s*=\s*\"$oldVersionEscaped\"" "$nixFile") = 1 ]; then
+    pattern="/\b$versionKey\b\s*=/ s|\"$oldVersionEscaped\"|\"$newVersion\"|"
+elif [ $(grep -c -E "^\s*(let\b)?\s*name\s*=\s*\"[^\"]+-$oldVersionEscaped\"" "$nixFile") = 1 ]; then
+    pattern="/\bname\b\s*=/ s|-$oldVersionEscaped\"|-$newVersion\"|"
 else
     die "Couldn't figure out where out where to patch in new version in '$attr'!"
 fi
@@ -128,7 +128,7 @@ fi
 
 # Replace new URL
 if [ -n "$newUrl" ]; then
-    sed -i "$nixFile" -re "s|\"$oldUrl\"|\"$newUrl\"|"
+    sed -i "$nixFile" -re "s|\"$oldUrlEscaped\"|\"$newUrl\"|"
 
     if cmp -s "$nixFile" "$nixFile.bak"; then
         die "Failed to replace source URL '$oldUrl' to '$newUrl' in '$attr'!"

--- a/pkgs/common-updater/scripts/update-source-version
+++ b/pkgs/common-updater/scripts/update-source-version
@@ -86,14 +86,10 @@ if [ $(grep -c "$oldHash" "$nixFile") != 1 ]; then
     die "Couldn't locate old source hash '$oldHash' (or it appeared more than once) in '$nixFile'!"
 fi
 
-oldUrl=$(nix-instantiate $systemArg --eval -E "with import ./. {}; builtins.elemAt $attr.src.drvAttrs.urls 0" | tr -d '"')
+oldUrl=$(nix-instantiate $systemArg --eval -E "with import ./. {}; builtins.elemAt ($attr.src.drvAttrs.urls or [ $attr.src.url ]) 0" | tr -d '"')
 
 if [ -z "$oldUrl" ]; then
-    oldUrl=$(nix-instantiate $systemArg --eval -E "with import ./. {}; $attr.src.url" | tr -d '"')
-
-    if [ -z "$oldUrl" ]; then
-      die "Couldn't evaluate source url from '$attr.src'!"
-    fi
+    die "Couldn't evaluate source url from '$attr.src'!"
 fi
 
 drvName=$(nix-instantiate $systemArg --eval -E "with import ./. {}; (builtins.parseDrvName $attr.name).name" | tr -d '"')

--- a/pkgs/desktops/gnome-3/update.nix
+++ b/pkgs/desktops/gnome-3/update.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, writeScript, python3, common-updater-scripts, coreutils, gnugrep, gnused }:
+{ stdenv, lib, writeScript, python3, common-updater-scripts }:
 { packageName, attrPath ? packageName, versionPolicy ? "odd-unstable" }:
 
 let
@@ -9,7 +9,7 @@ let
     package_name="$1"
     attr_path="$2"
     version_policy="$3"
-    PATH=${lib.makeBinPath [ common-updater-scripts coreutils gnugrep gnused python ]}
+    PATH=${lib.makeBinPath [ common-updater-scripts python ]}
     latest_tag=$(python "${./find-latest-version.py}" "$package_name" "$version_policy" "stable")
     update-source-version "$attr_path" "$latest_tag"
   '';


### PR DESCRIPTION
###### Motivation for this change
For update script parallelization, we have started calling `builtins.toJSON` on `updateScript`s, which triggers evaluation of paths and therefore their copying
to Nix store. This breaks update scripts that assume that they exist in `nixpkgs`
like `dwarf-fortress`.

#61935

Let’s stringify the paths before JSONification to prevent the evaluation.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
