### PR TITLE
pybind11: Fix build

### DIFF
--- a/pkgs/development/libraries/pybind11/default.nix
+++ b/pkgs/development/libraries/pybind11/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, catch, python, eigen }:
+{ stdenv, fetchurl, fetchFromGitHub, cmake, catch, python, eigen }:
 
 stdenv.mkDerivation rec {
   name = "pybind-${version}";
@@ -16,7 +16,14 @@ stdenv.mkDerivation rec {
 
   # Disable test_cmake_build test, as it fails in sandbox
   # https://github.com/pybind/pybind11/issues/1355
-  patches = [ ./no_test_cmake_build.patch ];
+  patches = [
+    ./no_test_cmake_build.patch
+    (fetchurl { # Remove on bump to v2.2.5
+      name = "pytest_namespace_to_configure.patch";
+      url = "https://github.com/pybind/pybind11/commit/e7ef34f23f194cfa40bdbf967c6d34712261a4ee.patch";
+      sha256 = "1dhv6p0b5fxzxc8j3sfy8kvfmdshczk22xfxh6bk0cfnfdy9iqrq";
+    })
+  ];
 
   doCheck = true;
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Fix the pybind11 build.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
