### PR TITLE
phoronix-test-suite: init at 8.8.1

### DIFF
--- a/pkgs/tools/misc/phoronix-test-suite/default.nix
+++ b/pkgs/tools/misc/phoronix-test-suite/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchurl, php, which, gnused, makeWrapper, gnumake, gcc }:
+
+stdenv.mkDerivation rec {
+  name = "phoronix-test-suite-${version}";
+  version = "8.8.1";
+
+  src = fetchurl {
+    url = "https://phoronix-test-suite.com/releases/${name}.tar.gz";
+    sha256 = "1l5wnj5d652dg02j7iy7n9ab7qrpclmgvyxnh1s6cdnnnspyxznn";
+  };
+
+  buildInputs = [ php ];
+  nativeBuildInputs = [ which gnused makeWrapper ];
+
+  installPhase = ''
+    ./install-sh $out
+    wrapProgram $out/bin/phoronix-test-suite \
+    --set PHP_BIN ${php}/bin/php \
+    --prefix PATH : ${stdenv.lib.makeBinPath [ gnumake gcc ]}
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Open-Source, Automated Benchmarking";
+    homepage = https://www.phoronix-test-suite.com/;
+    maintainers = with maintainers; [ davidak ];
+    license = licenses.gpl3;
+    platforms = with platforms; unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1748,6 +1748,8 @@ in
 
   pev = callPackage ../development/tools/analysis/pev { };
 
+  phoronix-test-suite = callPackage ../tools/misc/phoronix-test-suite { };
+
   photon = callPackage ../tools/networking/photon { };
 
   playerctl = callPackage ../tools/audio/playerctl { };


### PR DESCRIPTION
###### Motivation for this change

I want to use it to benchmark filesystems and NixOS configurations :)

Some tests work, some need additional dependencies. I will extend it later to support more tests.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
