### PR TITLE
teeworlds: fetchSubmodules

### DIFF
--- a/pkgs/games/teeworlds/default.nix
+++ b/pkgs/games/teeworlds/default.nix
@@ -10,7 +10,8 @@ stdenv.mkDerivation rec {
     owner = "teeworlds";
     repo = "teeworlds";
     rev = version;
-    sha256 = "05qj6gdw167pan1gwq82ffz03nmlhhzrv1sslpfm8w81nq4b5c72";
+    sha256 = "1hfj22xxswqnm1s74ln3dwl63rs4mk9g4yvpf75plswbxd0020la";
+    fetchSubmodules = true;
   };
 
   postPatch = ''


### PR DESCRIPTION
###### Motivation for this change

The languages and maps directories are submodules, and are not included in tarballs downloaded from GitHub. This results in an English-only game that can't run a server.

An alternative approach would have been to use an official release tarball, which is hosted on GitHub as a release artifact.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
