### PR TITLE
pythonPackages.django_silk: fix build, enable tests

### DIFF
--- a/pkgs/development/python-modules/django_silk/default.nix
+++ b/pkgs/development/python-modules/django_silk/default.nix
@@ -56,6 +56,7 @@ buildPythonPackage rec {
     description = "Silky smooth profiling for the Django Framework";
     homepage = https://github.com/mtford90/silk;
     license = licenses.mit;
+    maintainers = with maintainers; [ ris ];
   };
 
 }

--- a/pkgs/development/python-modules/django_silk/default.nix
+++ b/pkgs/development/python-modules/django_silk/default.nix
@@ -12,6 +12,7 @@
 , pytz
 , pillow
 , mock
+, gprof2dot
 }:
 
 buildPythonPackage rec {
@@ -26,7 +27,11 @@ buildPythonPackage rec {
   doCheck = false;
 
   buildInputs = [ mock ];
-  propagatedBuildInputs = [ django pygments simplejson dateutil requests sqlparse jinja2 autopep8 pytz pillow ];
+  propagatedBuildInputs = [
+    django pygments simplejson dateutil requests
+    sqlparse jinja2 autopep8 pytz pillow gprof2dot
+  ];
+
 
   meta = with stdenv.lib; {
     description = "Silky smooth profiling for the Django Framework";

--- a/pkgs/development/python-modules/django_silk/default.nix
+++ b/pkgs/development/python-modules/django_silk/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , buildPythonPackage
-, fetchPypi
+, python
+, fetchFromGitHub
 , django
 , pygments
 , simplejson
@@ -13,18 +14,31 @@
 , pillow
 , mock
 , gprof2dot
+, freezegun
+, contextlib2
+, networkx
+, pydot
+, factory_boy
 }:
 
 buildPythonPackage rec {
   pname = "django-silk";
   version = "3.0.2";
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "8dd5b78531360bd8c3d571384f9f4f82ef03e1764e30dd4621c5638f5c973a1d";
+  # pypi tarball doesn't include test project
+  src = fetchFromGitHub {
+    owner = "jazzband";
+    repo = "django-silk";
+    rev = version;
+    sha256 = "1fbaafc2gx01gscdalp6hj6bz4b0cmq59lgmvsydw7jkds4mps7c";
   };
-
-  doCheck = false;
+  # "test_time_taken" tests aren't suitable for reproducible execution, but django's
+  # test runner doesn't have an easy way to ignore tests - so instead prevent it from picking
+  # them up as tests
+  postPatch = ''
+    substituteInPlace project/tests/test_silky_profiler.py \
+      --replace "def test_time_taken" "def _test_time_taken"
+  '';
 
   buildInputs = [ mock ];
   propagatedBuildInputs = [
@@ -32,6 +46,11 @@ buildPythonPackage rec {
     sqlparse jinja2 autopep8 pytz pillow gprof2dot
   ];
 
+  checkInputs = [ freezegun contextlib2 networkx pydot factory_boy ];
+  checkPhase = ''
+    cd project
+    DB=sqlite3 DB_NAME=db.sqlite3 ${python.interpreter} manage.py test
+  '';
 
   meta = with stdenv.lib; {
     description = "Silky smooth profiling for the Django Framework";

--- a/pkgs/development/python-modules/gprof2dot/default.nix
+++ b/pkgs/development/python-modules/gprof2dot/default.nix
@@ -17,7 +17,6 @@ buildPythonApplication {
     homepage = https://github.com/jrfonseca/gprof2dot;
     description = "Python script to convert the output from many profilers into a dot graph";
     license = licenses.lgpl3Plus;
-    platforms = platforms.linux;
     maintainers = [ maintainers.pmiddend ];
   };
 }

--- a/pkgs/development/python-modules/gprof2dot/default.nix
+++ b/pkgs/development/python-modules/gprof2dot/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, buildPythonApplication }:
+{ lib, fetchFromGitHub, buildPythonApplication, python, graphviz }:
 
 buildPythonApplication {
   name = "gprof2dot-2017-09-19";
@@ -9,6 +9,9 @@ buildPythonApplication {
     rev = "2017.09.19";
     sha256 = "1b5wvjv5ykbhz7aix7l3y7mg1hxi0vgak4a49gr92sdlz8blj51v";
   };
+
+  checkInputs = [ graphviz ];
+  checkPhase = "${python.interpreter} tests/test.py";
 
   meta = with lib; {
     homepage = https://github.com/jrfonseca/gprof2dot;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -445,7 +445,9 @@ in {
 
   grandalf = callPackage ../development/python-modules/grandalf { };
 
-  gprof2dot = callPackage ../development/python-modules/gprof2dot { };
+  gprof2dot = callPackage ../development/python-modules/gprof2dot {
+    inherit (pkgs) graphviz;
+  };
 
   gsd = callPackage ../development/python-modules/gsd { };
 


### PR DESCRIPTION
###### Motivation for this change
Noticed `django-silk` has been broken since its last auto-bump. Fixed that by adding `gprof2dot` to `propagatedBuildInputs`, but this had the side effect of disabling the package for darwin. Fortunately I realized that `gprof2dot` does indeed work on darwin, and to prove this I enabled its tests and removed the linux restriction.

Finally I enabled the tests for `django-silk` and added myself as maintainer in the hopes it doesn't get so neglected again (I think I might have added it in the first place after all...).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
