### PR TITLE
Add rusty-tags 3.5.1 release

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1153,6 +1153,11 @@
     github = "danharaj";
     name = "Dan Haraj";
   };
+  danielakhterov = {
+    email = "akhterovd@gamil.com";
+    github = "danielakhterov";
+    name = "Daniel Akhterov";
+  };
   danieldk = {
     email = "me@danieldk.eu";
     github = "danieldk";

--- a/pkgs/development/tools/misc/rusty-tags/default.nix
+++ b/pkgs/development/tools/misc/rusty-tags/default.nix
@@ -1,0 +1,24 @@
+/* { lib, rustPlatform, fetchFromGitHub }: */
+with import <nixpkgs> {};
+
+rustPlatform.buildRustPackage rec {
+  name = "rusty-tags-${version}";
+  version = "3.5.1";
+
+  src = fetchFromGitHub {
+    owner = "dan-t";
+    repo = "rusty-tags";
+    rev = "v${version}";
+    sha256 = "1cv3cxjwlbc4rgkp19f8x28igs1xhjz2y05css19sarxbnzbkf34";
+  };
+
+  cargoSha256 = "1llnlr2i1xncwm55c5sg0h6fyv9991xh8iw8acyfgi5a79ylcpb6";
+
+  meta = with lib; {
+    description = "Create ctags/etags for a cargo project and all of its dependencies";
+    homepage = https://github.com/dan-t/rusty-tags;
+    license = with licenses; [ bsd3 ];
+    maintainers = with maintainers; [ dan-t ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/tools/misc/rusty-tags/default.nix
+++ b/pkgs/development/tools/misc/rusty-tags/default.nix
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage rec {
     description = "Create ctags/etags for a cargo project and all of its dependencies";
     homepage = https://github.com/dan-t/rusty-tags;
     license = with licenses; [ bsd3 ];
-    maintainers = with maintainers; [ dan-t ];
+    maintainers = with maintainers; [ danielakhterov ];
     platforms = platforms.all;
   };
 }

--- a/pkgs/development/tools/misc/rusty-tags/default.nix
+++ b/pkgs/development/tools/misc/rusty-tags/default.nix
@@ -1,5 +1,4 @@
-/* { lib, rustPlatform, fetchFromGitHub }: */
-with import <nixpkgs> {};
+{ lib, rustPlatform, fetchFromGitHub }:
 
 rustPlatform.buildRustPackage rec {
   name = "rusty-tags-${version}";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24155,4 +24155,5 @@ in
 
   bemenu = callPackage ../applications/misc/bemenu { };
 
+  rusty-tags = callPackage ../development/tools/misc/rusty-tags { };
 }


### PR DESCRIPTION
###### Motivation for this change
I wanted to be able to install rusty-tags via nix instead of `cargo install`.

###### Things done
Added myself to  the list of maintainers. Added a simple nix derivation for [rusty-tags](https://github.com/dan-t/rusty-tags) v3.5.1.

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
