### PR TITLE
dropbox: fix tray menu with StatusNotifierItem trays

### DIFF
--- a/pkgs/applications/networking/dropbox/default.nix
+++ b/pkgs/applications/networking/dropbox/default.nix
@@ -36,7 +36,7 @@ buildFHSUserEnv {
     libICE libSM libX11 libXcomposite libXdamage libXext libXfixes libXrender
     libXxf86vm libxcb xkeyboardconfig
     curl dbus firefox-bin fontconfig freetype gcc glib gnutar libxml2 libxslt
-    procps zlib mesa libxshmfence libpthreadstubs
+    procps zlib mesa libxshmfence libpthreadstubs libappindicator
   ];
 
   extraInstallCommands = ''


### PR DESCRIPTION

###### Motivation for this change

If dropbox can't load libappindicator, it will fallback to using the old
xembed protocol. If you (or your Desktop Environment) are running
something like KDE's XEmbed SNI Proxy, then you'll at least see an icon,
but clicking the icon won't give you menu.

Adding libappindicator to the env allows dropbox to fully integrate with
contemporary status trays, while still falling back to xembed if the
required DBus service is not present.

This should also be backported to (at least) the `nixos-19.03` channel.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
