### PR TITLE
paperkey: use HTTPS

### DIFF
--- a/pkgs/tools/security/paperkey/default.nix
+++ b/pkgs/tools/security/paperkey/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "1.6";
 
   src = fetchurl {
-    url = "http://www.jabberwocky.com/software/paperkey/${name}.tar.gz";
+    url = "https://www.jabberwocky.com/software/paperkey/${name}.tar.gz";
     sha256 = "1xq5gni6gksjkd5avg0zpd73vsr97appksfx0gx2m38s4w9zsid2";
   };
 
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
       retention qualities - far longer than the magnetic or optical means that
       are generally used to back up computer data.
     '';
-    homepage = http://www.jabberwocky.com/software/paperkey/;
+    homepage = "https://www.jabberwocky.com/software/paperkey/";
     license = licenses.gpl2;
     platforms = platforms.unix;
     maintainers = with maintainers; [ skeidel ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Especially important for a security tool!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
