### PR TITLE
cargo-web: 0.6.23 -> 0.6.25

### DIFF
--- a/pkgs/development/tools/cargo-web/default.nix
+++ b/pkgs/development/tools/cargo-web/default.nix
@@ -1,29 +1,32 @@
 { stdenv, fetchFromGitHub, openssl, perl, pkgconfig, rustPlatform
-, CoreServices, Security
+, CoreServices, Security, cf-private
 }:
 
 rustPlatform.buildRustPackage rec {
-  name = "cargo-web-${version}";
-  version = "0.6.23";
+  pname = "cargo-web";
+  version = "0.6.25";
 
   src = fetchFromGitHub {
     owner = "koute";
-    repo = "cargo-web";
+    repo = pname;
     rev = version;
-    sha256 = "1qbi3z4x39il07xlhfvq5ckzjqrf0yf6p8qidf24fp92gb940zxr";
+    sha256 = "0q77bryc7ap8gb4rzp9xk8ngqwxh106qn7899g30lwxycnyii0mf";
   };
 
-  cargoSha256 = "1ysp8y0s0ha5gffwkra2vd1qh5wmfy1678k9hsfals0ww2f79wii";
+  cargoSha256 = "1f4sj260q4rlzbajwimya1yhh90hmmbhr47yfg9i8xcv5cg0cqjn";
 
   nativeBuildInputs = [ openssl perl pkgconfig ];
-  buildInputs = stdenv.lib.optionals stdenv.isDarwin [ CoreServices Security ];
+  buildInputs = stdenv.lib.optionals stdenv.isDarwin [
+    CoreServices Security
+    # Needed for CFURLResourceIsReachable symbols.
+    cf-private
+  ];
 
   meta = with stdenv.lib; {
     description = "A Cargo subcommand for the client-side Web";
     homepage = https://github.com/koute/cargo-web;
-    license = with licenses; [asl20 /* or */ mit];
+    license = with licenses; [ asl20 /* or */ mit ];
     maintainers = [ maintainers.kevincox ];
-    broken = stdenv.isDarwin;  # test with CoreFoundation 10.11
     platforms = platforms.all;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7966,6 +7966,7 @@ in
 
   cargo-web = callPackage ../development/tools/cargo-web {
     inherit (darwin.apple_sdk.frameworks) CoreServices Security;
+    inherit (darwin) cf-private;
   };
 
   carnix = (callPackage ../build-support/rust/carnix.nix { }).carnix { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

[changelog](https://github.com/koute/cargo-web#changelog)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
