### PR TITLE
riemann-tools: 0.2.13 -> 0.2.14, add more config options

### DIFF
--- a/nixos/modules/services/monitoring/riemann-tools.nix
+++ b/nixos/modules/services/monitoring/riemann-tools.nix
@@ -11,7 +11,7 @@ let
 
   healthLauncher = writeScriptBin "riemann-health" ''
     #!/bin/sh
-    exec ${pkgs.riemann-tools}/bin/riemann-health --host ${riemannHost}
+    exec ${pkgs.riemann-tools}/bin/riemann-health ${builtins.concatStringsSep " " cfg.extraArgs} --host ${riemannHost}
   '';
 
 
@@ -34,8 +34,16 @@ in {
           Address of the host riemann node. Defaults to localhost.
         '';
       };
+      extraArgs = mkOption {
+        type = types.listOf types.string;
+        default = [];
+        description = ''
+          A list of commandline-switches forwarded to a riemann-tool.
+          See for example `riemann-health --help` for available options.
+        '';
+        example = ["-p 5555" "--timeout=30" "--attribute=myattribute=42"];
+      };
     };
-
   };
 
   config = mkIf cfg.enableHealth {

--- a/pkgs/tools/misc/riemann-tools/Gemfile
+++ b/pkgs/tools/misc/riemann-tools/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem "riemann-tools", "0.2.13"
+gem "riemann-tools", "0.2.14"

--- a/pkgs/tools/misc/riemann-tools/Gemfile.lock
+++ b/pkgs/tools/misc/riemann-tools/Gemfile.lock
@@ -4,21 +4,22 @@ GEM
     beefcake (1.0.0)
     json (1.8.6)
     mtrc (0.0.4)
+    optimist (3.0.0)
     riemann-client (0.2.6)
       beefcake (>= 0.3.5, <= 1.0.0)
       mtrc (>= 0.0.4)
       trollop (>= 1.16.2)
-    riemann-tools (0.2.13)
+    riemann-tools (0.2.14)
       json (~> 1.8)
-      riemann-client (>= 0.2.6)
-      trollop (>= 1.16.2)
+      optimist (~> 3.0, >= 3.0.0)
+      riemann-client (~> 0.2, >= 0.2.6)
     trollop (2.9.9)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  riemann-tools (= 0.2.13)
+  riemann-tools (= 0.2.14)
 
 BUNDLED WITH
    1.17.2

--- a/pkgs/tools/misc/riemann-tools/gemset.nix
+++ b/pkgs/tools/misc/riemann-tools/gemset.nix
@@ -29,6 +29,16 @@
     };
     version = "0.0.4";
   };
+  optimist = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "05jxrp3nbn5iilc1k7ir90mfnwc5abc9h78s5rpm3qafwqxvcj4j";
+      type = "gem";
+    };
+    version = "3.0.0";
+  };
   riemann-client = {
     dependencies = ["beefcake" "mtrc" "trollop"];
     groups = ["default"];
@@ -41,15 +51,15 @@
     version = "0.2.6";
   };
   riemann-tools = {
-    dependencies = ["json" "riemann-client" "trollop"];
+    dependencies = ["json" "optimist" "riemann-client"];
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0brf44cq4xz0nqhs189zlg76527bfv3jr453yc00410qdzz8fpxa";
+      sha256 = "07w9x3iw32zwpzsm9l63vn0nv1778qls1blqysr45m7l7x6n5wjx";
       type = "gem";
     };
-    version = "0.2.13";
+    version = "0.2.14";
   };
   trollop = {
     groups = ["default"];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update riemann-tools (minor version).
Add more NixOS config options (attributes and commandSwitches) to be able to customize the monitoring client.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
