### PR TITLE
sway: 1.0 -> 1.1.1

### DIFF
--- a/pkgs/applications/window-managers/sway/default.nix
+++ b/pkgs/applications/window-managers/sway/default.nix
@@ -1,35 +1,28 @@
-{ stdenv, fetchFromGitHub, fetchpatch
+{ stdenv, fetchFromGitHub, makeWrapper
 , meson, ninja
 , pkgconfig, scdoc
 , wayland, libxkbcommon, pcre, json_c, dbus, libevdev
 , pango, cairo, libinput, libcap, pam, gdk_pixbuf
-, wlroots, wayland-protocols
+, wlroots, wayland-protocols, swaybg
 }:
 
 stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
   pname = "sway";
-  version = "1.0";
+  version = "1.1.1";
 
   src = fetchFromGitHub {
     owner = "swaywm";
     repo = "sway";
     rev = version;
-    sha256 = "09cndc2nl39d3l7g5634xp0pxcz60pvc5277mfw89r22mh0j78rx";
+    sha256 = "0yhn9zdg9mzfhn97c440lk3pw6122nrhx0is5sqmvgr6p814f776";
   };
 
   patches = [
-    # Fix for a compiler warning that causes a build failure
-    # (see https://github.com/swaywm/sway/issues/3862):
-    (fetchpatch {
-      url = "https://github.com/swaywm/sway/commit/bcde298a719f60b9913133dbd2a169dedbc8dd7d.patch";
-      sha256 = "0r583nmqvq43ib93yv6flw8pj833v32lbs0q0xld56s3rnzvvdcp";
-    })
     ./sway-config-no-nix-store-references.patch
     ./load-configuration-from-etc.patch
   ];
 
-  nativeBuildInputs = [ pkgconfig meson ninja scdoc ];
+  nativeBuildInputs = [ pkgconfig meson ninja scdoc makeWrapper ];
 
   buildInputs = [
     wayland libxkbcommon pcre json_c dbus libevdev
@@ -43,6 +36,10 @@ stdenv.mkDerivation rec {
     "-Ddefault-wallpaper=false" "-Dxwayland=enabled" "-Dgdk-pixbuf=enabled"
     "-Dtray=enabled" "-Dman-pages=enabled"
   ];
+
+  postInstall = ''
+    wrapProgram $out/bin/sway --prefix PATH : "${swaybg}/bin"
+  '';
 
   meta = with stdenv.lib; {
     description = "i3-compatible tiling Wayland compositor";

--- a/pkgs/applications/window-managers/sway/default.nix
+++ b/pkgs/applications/window-managers/sway/default.nix
@@ -41,6 +41,10 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/sway --prefix PATH : "${swaybg}/bin"
   '';
 
+  postPatch = ''
+    sed -i "s/version: '1.0'/version: '${version}'/" meson.build
+  '';
+
   meta = with stdenv.lib; {
     description = "i3-compatible tiling Wayland compositor";
     homepage    = https://swaywm.org;

--- a/pkgs/development/libraries/wlroots/default.nix
+++ b/pkgs/development/libraries/wlroots/default.nix
@@ -4,17 +4,15 @@
 , libpng, ffmpeg_4
 }:
 
-let
+stdenv.mkDerivation rec {
   pname = "wlroots";
-  version = "0.5.0";
-in stdenv.mkDerivation rec {
-  name = "${pname}-${version}";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "swaywm";
     repo = "wlroots";
     rev = version;
-    sha256 = "1phiidyddzgaxy4gbqwmykxn0y8za6y5mp66l9dpd9i6fml153yq";
+    sha256 = "1rdcmll5b8w242n6yfjpsaprq280ck2jmbz46dxndhignxgda7k4";
   };
 
   # $out for the library, $bin for rootston, and $examples for the example


### PR DESCRIPTION
Should be ready for merge!

~~Compiles now, thanks to a new upstream release. Still waiting for a resolution of #60434.~~

~~Currently does't compile, still investigating that.~~

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
  - [x] Runs from within another sway session (in windowed mode)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
