### PR TITLE
caja-with-extensions: init

### DIFF
--- a/pkgs/desktops/mate/caja-with-extensions/default.nix
+++ b/pkgs/desktops/mate/caja-with-extensions/default.nix
@@ -1,0 +1,20 @@
+{ stdenv, lib, makeWrapper, caja-extensions, caja, extensions ? [ caja-extensions ] }:
+
+stdenv.mkDerivation {
+  pname = "${caja.pname}-with-extensions";
+  version = caja.version;
+
+  phases = [ "installPhase" ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  inherit caja;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    makeWrapper $caja/bin/caja $out/bin/caja \
+    --set CAJA_EXTENSION_DIRS ${lib.concatMapStringsSep ":" (x: "${x.outPath}/lib/caja/extensions-2.0") extensions}
+  '';
+
+  inherit (caja.meta);
+}

--- a/pkgs/desktops/mate/caja/default.nix
+++ b/pkgs/desktops/mate/caja/default.nix
@@ -1,11 +1,11 @@
 { stdenv, fetchurl, pkgconfig, intltool, gtk3, libnotify, libxml2, libexif, exempi, mate, hicolor-icon-theme, wrapGAppsHook }:
 
 stdenv.mkDerivation rec {
-  name = "caja-${version}";
+  pname = "caja";
   version = "1.22.1";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "10b7yjimblymp1fpsrl4jb2k7kbhla2izsj3njfmg2n6fv9fy9iv";
   };
 

--- a/pkgs/desktops/mate/default.nix
+++ b/pkgs/desktops/mate/default.nix
@@ -4,11 +4,12 @@ let
   callPackage = newScope self;
 
   self = rec {
-  
+
     atril = callPackage ./atril { };
     caja = callPackage ./caja { };
     caja-dropbox = callPackage ./caja-dropbox { };
     caja-extensions = callPackage ./caja-extensions { };
+    caja-with-extensions = callPackage ./caja-with-extensions { };
     engrampa = callPackage ./engrampa { };
     eom = callPackage ./eom { };
     libmatekbd = callPackage ./libmatekbd { };
@@ -86,7 +87,7 @@ let
       mozo
       pluma
     ];
-  
+
   };
 
 in self


### PR DESCRIPTION
###### Motivation for this change
The standalone caja package does not find extensions. These are all configured in the mate desktop environment. This package builds a wrapper round caja which sets the extension directory correctly.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
