### PR TITLE
iperf3: symlink manpage to iperf & split man output

### DIFF
--- a/pkgs/tools/networking/iperf/2.nix
+++ b/pkgs/tools/networking/iperf/2.nix
@@ -11,10 +11,18 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "format" ];
   configureFlags = [ "--enable-fastsampling" ];
 
+  postInstall = ''
+    mv $out/bin/iperf $out/bin/iperf2
+    ln -s $out/bin/iperf2 $out/bin/iperf
+  '';
+
   meta = with stdenv.lib; {
     homepage = https://sourceforge.net/projects/iperf/;
     description = "Tool to measure IP bandwidth using UDP or TCP";
     platforms = platforms.unix;
     license = licenses.mit;
+
+    # prioritize iperf3
+    priority = 10;
   };
 }

--- a/pkgs/tools/networking/iperf/3.nix
+++ b/pkgs/tools/networking/iperf/3.nix
@@ -10,6 +10,8 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ openssl ];
 
+  outputs = [ "out" "man" ];
+
   patches = stdenv.lib.optionals stdenv.hostPlatform.isMusl [
     (fetchpatch {
       url = "https://git.alpinelinux.org/aports/plain/main/iperf3/remove-pg-flags.patch?id=99ec9e1c84e338629cf1b27b0fdc808bde4d8564";
@@ -19,7 +21,8 @@ stdenv.mkDerivation rec {
   ];
 
   postInstall = ''
-    ln -s iperf3 $out/bin/iperf
+    ln -s $out/bin/iperf3 $out/bin/iperf
+    ln -s $man/share/man/man1/iperf3.1 $man/share/man/man1/iperf.1
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
Closes: https://github.com/NixOS/nixpkgs/issues/62255

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
