### PR TITLE
iamy: 2.1.1 -> 2.3.2

### DIFF
--- a/pkgs/tools/admin/iamy/default.nix
+++ b/pkgs/tools/admin/iamy/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, buildGoPackage, fetchFromGitHub }:
+{ stdenv, buildGoModule, fetchFromGitHub }:
 
-buildGoPackage rec {
+buildGoModule rec {
   name = "iamy-${version}";
-  version = "2.1.1";
+  version = "2.3.2";
 
   goPackagePath = "github.com/99designs/iamy";
 
@@ -10,8 +10,14 @@ buildGoPackage rec {
     owner = "99designs";
     repo = "iamy";
     rev = "v${version}";
-    sha256 = "0b55hxcvgil8rl6zh2kyndfi7s5nzclawjb0sby14wpys3v08bjf";
+    sha256 = "1fypc6yjnhlpk7zhb2lvah2ikh2zji9sll55rqjbr3i4j02h484z";
   };
+
+  modSha256 = "0akak573zvz3xg5d7vf0ch2mrmj1jkzcdc29v3kn43f7944c2wcl";
+
+  buildFlagsArray = [''-ldflags=
+    -X main.Version=v${version} -s -w
+  ''];
 
   meta = with stdenv.lib; {
     description = "A cli tool for importing and exporting AWS IAM configuration to YAML files";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
