### PR TITLE
caja-dropbox: fix python dependency

### DIFF
--- a/pkgs/desktops/mate/caja-dropbox/default.nix
+++ b/pkgs/desktops/mate/caja-dropbox/default.nix
@@ -1,31 +1,49 @@
-{ stdenv, fetchurl, pkgconfig, gtk3, mate, python3Packages }:
+{ stdenv, fetchurl, substituteAll
+, pkgconfig, gobject-introspection, gdk_pixbuf
+, gtk3, mate, python3, dropbox }:
 
+let
+  dropboxd = "${dropbox}/bin/dropbox";
+in
 stdenv.mkDerivation rec {
-  name = "caja-dropbox-${version}";
+  pname = "caja-dropbox";
   version = "1.22.1";
 
   src = fetchurl {
-    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${name}.tar.xz";
+    url = "http://pub.mate-desktop.org/releases/${stdenv.lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "18cnd3yw2ingvl38mhmfbl5k0kfg8pzcf2649j00i6v90cwiril5";
   };
 
+  patches = [
+    (substituteAll {
+      src = ./fix-cli-paths.patch;
+      inherit dropboxd;
+    })
+  ];
+
+  strictDeps = true;
+
   nativeBuildInputs = [
     pkgconfig
+    gobject-introspection
+    gdk_pixbuf
+    (python3.withPackages (ps: with ps; [
+      docutils
+      pygobject3
+    ]))
   ];
 
   buildInputs = [
     gtk3
     mate.caja
-    python3Packages.python
-    python3Packages.pygtk
-    python3Packages.docutils
+    python3
   ];
 
   configureFlags = [ "--with-caja-extension-dir=$$out/lib/caja/extensions-2.0" ];
 
   meta = with stdenv.lib; {
     description = "Dropbox extension for Caja file manager";
-    homepage = https://github.com/mate-desktop/caja-dropbox;
+    homepage = "https://github.com/mate-desktop/caja-dropbox";
     license = with licenses; [ gpl3 cc-by-nd-30 ];
     platforms = platforms.unix;
     maintainers = [ maintainers.romildo ];

--- a/pkgs/desktops/mate/caja-dropbox/fix-cli-paths.patch
+++ b/pkgs/desktops/mate/caja-dropbox/fix-cli-paths.patch
@@ -1,0 +1,11 @@
+--- a/caja-dropbox.in
++++ b/caja-dropbox.in
+@@ -70,7 +70,7 @@ DOWNLOADING = "Downloading Dropbox... %d%%"
+ UNPACKING = "Unpacking Dropbox... %d%%"
+
+ PARENT_DIR = os.path.expanduser("~")
+-DROPBOXD_PATH = "%s/.dropbox-dist/dropboxd" % PARENT_DIR
++DROPBOXD_PATH = "@dropboxd@"
+ DESKTOP_FILE = "@DESKTOP_FILE_DIR@/caja-dropbox.desktop"
+
+ enc = locale.getpreferredencoding()


### PR DESCRIPTION
###### Motivation for this change
Fixes #62612
This seems to fix the issue though I don't know much about python packaging so I don't know if what I have done is correct.

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).