### PR TITLE
timetrap: restore "t" executable

### DIFF
--- a/pkgs/applications/office/timetrap/default.nix
+++ b/pkgs/applications/office/timetrap/default.nix
@@ -3,7 +3,7 @@
 bundlerApp {
   pname = "timetrap";
   gemdir = ./.;
-  exes = [ "timetrap" ];
+  exes = [ "t" "timetrap" ];
 
   meta = with lib; {
     description = "A simple command line time tracker written in ruby";


### PR DESCRIPTION
###### Motivation for this change

lost in 44a554792d58f8bf1239ab3cd8892ac9f1e693ff

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).