### PR TITLE
strategies: init at 0.2.3

### DIFF
--- a/pkgs/development/python-modules/strategies/default.nix
+++ b/pkgs/development/python-modules/strategies/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildPythonPackage, fetchPypi
+, multipledispatch, toolz
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "strategies";
+  version = "0.2.3";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "02i4ydrs9k61p8iv2vl2akks8p9gc88rw8031wlwb1zqsyjmb328";
+  };
+
+  propagatedBuildInputs = [ multipledispatch toolz ];
+  checkInputs = [ pytest ];
+
+  meta = {
+    description = "A Python library for control flow programming";
+    homepage    = "https://github.com/logpy/strategies";
+    license     = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ suhr ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4419,6 +4419,8 @@ in {
 
   statsmodels = callPackage ../development/python-modules/statsmodels { };
 
+  strategies = callPackage ../development/python-modules/strategies { };
+
   stravalib = callPackage ../development/python-modules/stravalib { };
 
   streamz = callPackage ../development/python-modules/streamz { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
