### PR TITLE
wasabiwallet: init at 1.1.5

### DIFF
--- a/pkgs/applications/altcoins/wasabiwallet/default.nix
+++ b/pkgs/applications/altcoins/wasabiwallet/default.nix
@@ -1,0 +1,44 @@
+{ stdenv, fetchurl, makeDesktopItem, openssl_1_1, xorg, curl, fontconfig, krb5, zlib, dotnet-sdk }:
+
+stdenv.mkDerivation rec {
+  pname = "wasabiwallet";
+  version = "1.1.5";
+
+	src = fetchurl {
+		url = "https://github.com/zkSNACKs/WalletWasabi/releases/download/v${version}/WasabiLinux-${version}.tar.gz";
+		sha256 = "1iq7qkpq073yq1bz8pam4cbm2myznhpjr3g9afblvmxwgbdjxak0";
+	};
+
+	dontBuild = true;
+	dontPatchELF = true;
+
+	desktopItem = makeDesktopItem {
+		name = "wasabi";
+		exec = "wasabiwallet";
+		desktopName = "Wasabi";
+		genericName = "Bitcoin wallet";
+		comment = meta.description;
+		categories = "Application;Network;Utility;";
+	};
+
+  installPhase = ''
+		mkdir -p $out/opt/${pname} $out/bin $out/share/applications
+		cp -Rv . $out/opt/${pname}
+		cd $out/opt/${pname}
+		for i in $(find . -type f -name '*.so') wassabee
+			do
+				patchelf --set-rpath ${stdenv.lib.makeLibraryPath [ openssl_1_1 stdenv.cc.cc.lib xorg.libX11 curl fontconfig.lib krb5 zlib dotnet-sdk ]} $i
+			done
+		patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" wassabee
+		ln -s $out/opt/${pname}/wassabee $out/bin/${pname}
+		cp -v $desktopItem/share/applications/* $out/share/applications
+	'';
+
+  meta = with stdenv.lib; {
+    description = "Privacy focused Bitcoin wallet";
+    homepage = "https://wasabiwallet.io/";
+    license = licenses.mit;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ mmahut ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6503,6 +6503,8 @@ in
 
   wal_e = callPackage ../tools/backup/wal-e { };
 
+  wasabiwallet = callPackage ../applications/altcoins/wasabiwallet { };
+
   watchexec = callPackage ../tools/misc/watchexec {
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };


### PR DESCRIPTION
###### Motivation for this change

Init at 1.1.5

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
