### PR TITLE
hexyl: 0.5.0 -> 0.5.1

### DIFF
--- a/pkgs/tools/misc/hexyl/default.nix
+++ b/pkgs/tools/misc/hexyl/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname   = "hexyl";
-  version = "0.5.0";
+  version = "0.5.1";
 
   src = fetchFromGitHub {
     owner  = "sharkdp";
     repo   = pname;
     rev    = "v${version}";
-    sha256 = "1b5y2lwcv802hjp105h35vda1d6rgysm9qvrm0v96srm0qqh8rq3";
+    sha256 = "0511ikhfc0fa6cfp02n49zlzyqgwf7ymgn911y8fnjlaf6grsh67";
   };
 
-  cargoSha256 = "0z7dg098ivyvf4782hy8hc5c1ddj3qrrnrqhgpwcdbx3xlwn8p8x";
+  cargoSha256 = "126hq802hncji4yvkf7jvaq2njzw8kwzvc7fqw99nrdn4k56xig7";
 
   meta = with stdenv.lib; {
     description = "A command-line hex viewer";


### PR DESCRIPTION
###### Motivation for this change

Update hexyl, a command-line hex viewer (kind of like `hexdump`), to the newest version.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions (Ubuntu 16.04.6)
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).