### PR TITLE
azimuth: use the builtins install target

### DIFF
--- a/pkgs/games/azimuth/default.nix
+++ b/pkgs/games/azimuth/default.nix
@@ -1,17 +1,21 @@
-{ stdenv, fetchFromGitHub, SDL }:
+{ stdenv, fetchFromGitHub, SDL, which, installTool ? false }:
 
 stdenv.mkDerivation rec {
   pname = "azimuth";
-  version = "1.0.2";
+  version = "1.0.3";
 
   src = fetchFromGitHub {
     owner  = "mdsteele";
     repo   = "azimuth";
     rev    = "v${version}";
-    sha256 = "0yh52i3vfmj5zd7fs1r2xpjy2mknycr5xz6kyixj2qncb25xsm7z";
+    sha256 = "1znfvpmqiixd977jv748glk5zc4cmhw5813zp81waj07r9b0828r";
   };
 
+  nativeBuildInputs = [ which ];
+  buildInputs = [ SDL ];
+
   preConfigure = ''
+    cat Makefile
     substituteInPlace data/azimuth.desktop \
       --replace Exec=azimuth "Exec=$out/bin/azimuth" \
       --replace "Version=%AZ_VERSION_NUMBER" "Version=${version}"
@@ -19,29 +23,11 @@ stdenv.mkDerivation rec {
 
   makeFlags = [
     "BUILDTYPE=release"
-  ];
+    "INSTALLDIR=$(out)"
+  ] ++ (if installTool then ["INSTALLTOOL=true"] else ["INSTALLTOOL=false"]);
 
-  buildInputs = [ SDL ];
 
   enableParallelBuilding = true;
-
-  # the game doesn't have an installation procedure
-  installPhase = ''
-    mkdir -p $out/bin
-    cp out/release/host/bin/azimuth $out/bin/azimuth
-    cp out/release/host/bin/editor $out/bin/azimuth-editor
-    cp out/release/host/bin/muse $out/bin/azimuth-muse
-    cp out/release/host/bin/zfxr $out/bin/azimuth-zfxr
-    mkdir -p $out/share/doc/azimuth
-    cp doc/* README.md LICENSE $out/share/doc/azimuth
-    mkdir -p $out/share/icons/hicolor/128x128/apps $out/share/icons/hicolor/64x64/apps $out/share/icons/hicolor/48x48/apps $out/share/icons/hicolor/32x32/apps
-    cp data/icons/icon_128x128.png $out/share/icons/hicolor/128x128/apps/azimuth.png
-    cp data/icons/icon_64x64.png $out/share/icons/hicolor/64x64/apps/azimuth.png
-    cp data/icons/icon_48x48.png $out/share/icons/hicolor/48x48/apps/azimuth.png
-    cp data/icons/icon_32x32.png $out/share/icons/hicolor/32x32/apps/azimuth.png
-    mkdir -p $out/share/applications
-    cp data/azimuth.desktop $out/share/applications
-  '';
 
   meta = {
     description = "A metroidvania game using only vectorial graphic";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
I've made an install target to the Makefile of azimuth.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
