### PR TITLE
add python3.pkgs.gtts-token for home-assistant

### DIFF
--- a/pkgs/development/python-modules/gtts-token/default.nix
+++ b/pkgs/development/python-modules/gtts-token/default.nix
@@ -1,0 +1,31 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "gtts-token";
+  version = "1.1.3";
+
+  src = fetchPypi {
+    pname = "gTTS-token";
+    inherit version;
+    sha256 = "9d6819a85b813f235397ef931ad4b680f03d843c9b2a9e74dd95175a4bc012c5";
+  };
+
+  propagatedBuildInputs = [
+    requests
+  ];
+
+  # Tests only in github repo, require working internet connection
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Calculates a token to run the Google Translate text to speech";
+    homepage = https://github.com/boudewijn26/gTTS-token;
+    license = licenses.mit;
+    maintainers = [ maintainers.makefu ];
+  };
+}
+

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -259,7 +259,7 @@
     "google_domains" = ps: with ps; [  ];
     "google_maps" = ps: with ps; [  ];
     "google_pubsub" = ps: with ps; [ google_cloud_pubsub ];
-    "google_translate" = ps: with ps; [  ];
+    "google_translate" = ps: with ps; [ gtts-token ];
     "google_travel_time" = ps: with ps; [  ];
     "google_wifi" = ps: with ps; [  ];
     "googlehome" = ps: with ps; [  ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2951,6 +2951,8 @@ in {
 
   gspread = callPackage ../development/python-modules/gspread { };
 
+  gtts-token = callPackage ../development/python-modules/gtts-token { };
+
   gym = callPackage ../development/python-modules/gym { };
 
   gyp = callPackage ../development/python-modules/gyp { };


### PR DESCRIPTION
###### Motivation for this change

adds `gtts-token` package to nixpkgs. This package is required for `google_translate` tts service of `home-assistant`

###### Things done


- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [NA] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
