### PR TITLE
purescript: add test that compiles & runs a minimal module

### DIFF
--- a/pkgs/development/compilers/purescript/purescript/default.nix
+++ b/pkgs/development/compilers/purescript/purescript/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, zlib, gmp, ncurses5, lib }:
+{ stdenv, pkgs, fetchurl, zlib, gmp, ncurses5, lib }:
 
 # from justinwoo/easy-purescript-nix
 # https://github.com/justinwoo/easy-purescript-nix/blob/d383972c82620a712ead4033db14110497bc2c9c/purs.nix
@@ -50,6 +50,11 @@ in stdenv.mkDerivation rec {
     mkdir -p $out/etc/bash_completion.d/
     $PURS --bash-completion-script $PURS > $out/etc/bash_completion.d/purs-completion.bash
   '';
+
+  passthru.tests = {
+    minimal-module = pkgs.callPackage ./test-minimal-module {};
+  };
+
   meta = with stdenv.lib; {
     description = "A strongly-typed functional programming language that compiles to JavaScript";
     homepage = http://www.purescript.org/;

--- a/pkgs/development/compilers/purescript/purescript/test-minimal-module/Main.js
+++ b/pkgs/development/compilers/purescript/purescript/test-minimal-module/Main.js
@@ -1,0 +1,8 @@
+"use strict"
+
+exports.log = function (s) {
+    return function () {
+        console.log(s);
+        return {};
+    };
+};

--- a/pkgs/development/compilers/purescript/purescript/test-minimal-module/Main.purs
+++ b/pkgs/development/compilers/purescript/purescript/test-minimal-module/Main.purs
@@ -1,0 +1,9 @@
+module Main where
+
+foreign import data Effect :: Type -> Type
+data Unit = Unit
+
+foreign import log :: String -> Effect Unit
+
+main :: Effect Unit
+main = log "hello world"

--- a/pkgs/development/compilers/purescript/purescript/test-minimal-module/default.nix
+++ b/pkgs/development/compilers/purescript/purescript/test-minimal-module/default.nix
@@ -1,0 +1,11 @@
+{ runCommand, purescript, nodejs }:
+
+runCommand "purescript-test-minimal-module" {} ''
+  ${purescript}/bin/purs compile -o ./output ${./.}/Main.purs
+
+  echo 'require("./output/Main/index.js").main()' > node.js
+
+  ${nodejs}/bin/node node.js | grep "hello world" || echo "did not output hello world"
+
+  touch $out
+''


### PR DESCRIPTION
This ensures the compiler actually works.

`console.log` is wrapped in a purescript function and everything is
run with nodejs.

@GrahamcOfBorg run purescript.tests
