### PR TITLE
kronometer: adding homepage and description

### DIFF
--- a/pkgs/tools/misc/kronometer/default.nix
+++ b/pkgs/tools/misc/kronometer/default.nix
@@ -17,6 +17,8 @@ mkDerivation rec {
   };
 
   meta = with lib; {
+    homepage = "https://kde.org/applications/utilities/kronometer/";
+    description = "A stopwatch application";
     license = licenses.gpl2;
     maintainers = with maintainers; [ peterhoeg ];
   };


### PR DESCRIPTION
###### Motivation for this change

Fitting CONTRIBUTING.md. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
