### PR TITLE
eudev: use utillinuxMinimal

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15966,7 +15966,7 @@ in
     stdenv = crossLibcStdenv;
   };
 
-  eudev = callPackage ../os-specific/linux/eudev {};
+  eudev = callPackage ../os-specific/linux/eudev { utillinux = utillinuxMinimal; };
 
   libudev0-shim = callPackage ../os-specific/linux/libudev0-shim { };
 


### PR DESCRIPTION
Presumably, the target audience for eudev are people who wish to avoid pulling
in systemd for whatever reason; it makes sense then to make the default build
not pull in systemd via utillinux.
