### PR TITLE
nixos/undervolt: correct description of numerical input

### DIFF
--- a/nixos/modules/services/hardware/undervolt.nix
+++ b/nixos/modules/services/hardware/undervolt.nix
@@ -35,7 +35,7 @@ in {
       type = types.nullOr types.str;
       default = null;
       description = ''
-        The amount of voltage to offset the CPU cores by. Accepts a floating point number.
+        The amount of voltage to offset the CPU cores by. Accepts a negative integer.
       '';
     };
 
@@ -43,7 +43,7 @@ in {
       type = types.nullOr types.str;
       default = null;
       description = ''
-        The amount of voltage to offset the GPU by. Accepts a floating point number.
+        The amount of voltage to offset the GPU by. Accepts a negative integer.
       '';
     };
 
@@ -51,7 +51,7 @@ in {
       type = types.nullOr types.str;
       default = null;
       description = ''
-        The amount of voltage to offset uncore by. Accepts a floating point number.
+        The amount of voltage to offset uncore by. Accepts a negative integer.
       '';
     };
 
@@ -59,7 +59,7 @@ in {
       type = types.nullOr types.str;
       default = null;
       description = ''
-        The amount of voltage to offset analogio by. Accepts a floating point number.
+        The amount of voltage to offset analogio by. Accepts a negative integer.
       '';
     };
 
@@ -67,7 +67,7 @@ in {
       type = types.nullOr types.str;
       default = null;
       description = ''
-        The temperature target. Accepts a floating point number.
+        The temperature target. Accepts a negative integer.
       '';
     };
 
@@ -75,7 +75,7 @@ in {
       type = types.nullOr types.str;
       default = null;
       description = ''
-        The temperature target on AC power. Accepts a floating point number.
+        The temperature target on AC power. Accepts a negative integer.
       '';
     };
 
@@ -83,7 +83,7 @@ in {
       type = types.nullOr types.str;
       default = null;
       description = ''
-        The temperature target on battery power. Accepts a floating point number.
+        The temperature target on battery power. Accepts a negative integer.
       '';
     };
   };


### PR DESCRIPTION
###### Motivation for this change
Undervolt only accepts negative integers, and crashes if given floating points.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
