### PR TITLE
pythonPackages.swagger-spec-validator: init at 2.4.3

### DIFF
--- a/pkgs/development/python-modules/swagger-spec-validator/default.nix
+++ b/pkgs/development/python-modules/swagger-spec-validator/default.nix
@@ -1,0 +1,37 @@
+{ lib, buildPythonPackage, fetchFromGitHub, pyyaml, jsonschema, six, pytest, mock }:
+
+buildPythonPackage rec {
+  pname = "swagger-spec-validator";
+  version = "2.4.3";
+
+  src = fetchFromGitHub {
+    owner = "Yelp";
+    repo = "swagger_spec_validator";
+    rev = "v" + version;
+    sha256 = "02f8amc6iq2clxxmrz8hirbb57sizaxijp0higqy16shk63ibalw";
+  };
+
+  checkInputs = [
+    pytest
+    mock
+  ];
+
+  checkPhase = ''
+    pytest tests
+  '';
+
+  propagatedBuildInputs = [
+    pyyaml
+    jsonschema
+    six
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/Yelp/swagger_spec_validator";
+    license = licenses.asl20;
+    description = "Validation of Swagger specifications";
+    maintainers = with maintainers; [ vanschelven ];
+  };
+}
+
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4898,6 +4898,8 @@ in {
 
   svgwrite = callPackage ../development/python-modules/svgwrite { };
 
+  swagger-spec-validator = callPackage ../development/python-modules/swagger-spec-validator { };
+
   freezegun = callPackage ../development/python-modules/freezegun { };
 
   taskw = callPackage ../development/python-modules/taskw { };


### PR DESCRIPTION

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
