### PR TITLE
mpssh: init at 1.3.3

### DIFF
--- a/pkgs/tools/networking/mpssh/default.nix
+++ b/pkgs/tools/networking/mpssh/default.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     sha256 = "0iibzb9qrwf9wsmp2b8j76qw66ql8fw5jx02x82a22fsaznb5dng";
-    rev = "${version}";
+    rev = version;
     repo = pname;
     owner = "ndenev";
   };

--- a/pkgs/tools/networking/mpssh/default.nix
+++ b/pkgs/tools/networking/mpssh/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchFromGitHub, openssh }:
+
+stdenv.mkDerivation rec {
+  pname = "mpssh";
+  version = "1.3.3";
+
+  src = fetchFromGitHub {
+    sha256 = "0iibzb9qrwf9wsmp2b8j76qw66ql8fw5jx02x82a22fsaznb5dng";
+    rev = "${version}";
+    repo = pname;
+    owner = "ndenev";
+  };
+
+  buildInputs = [ openssh ];
+
+  postPatch = ''
+    substituteInPlace Makefile --replace /usr/local $out
+    substituteInPlace Makefile --replace "-o root" ""
+    '';
+
+  makeFlags = "CC=cc LD=cc BIN=$(out)/bin SSHPATH=${openssh}/bin/ssh SCPPATH=${openssh}/bin/scp";
+
+  meta = {
+    homepage = "https://github.com/ndenev/mpssh";
+    description = "Mass Parallel SSH";
+    license = stdenv.lib.licenses.bsd3;
+
+    longDescription = ''
+      mpssh is a parallel ssh tool. What it does is connecting to a number of hosts
+      specified in the hosts file and execute the same command on all of them,
+      showing a nicely formatted output with each line prepended with the hostname
+      that produced the line. It is also possible to specify a script on the local filesystem
+      that will be first scp copied to the remote host and then executed.
+    '';
+
+    platforms = stdenv.lib.platforms.unix;
+    maintainers = [ stdenv.lib.maintainers.ktf ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4627,6 +4627,8 @@ in
 
   mpw = callPackage ../tools/security/mpw { };
 
+  mpssh = callPackage ../tools/networking/mpssh { };
+
   mr = callPackage ../applications/version-management/mr { };
 
   mrtg = callPackage ../tools/misc/mrtg { };


### PR DESCRIPTION
###### Motivation for this change

New package.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
