### PR TITLE
luaPackages.luadbi: 0.7.1 -> 0.7.2

### DIFF
--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -29,6 +29,7 @@ lua-zlib,,,,,koral
 luabitop,,,,,
 luaevent,,,,,
 luacheck,,,,,
+luadbi,,,,
 luaffi,,http://luarocks.org/dev,,,
 luaposix,,,,,vyp lblasc
 luazip,,,,,

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -595,6 +595,25 @@ luabitop = buildLuarocksPackage {
     };
   };
 };
+luadbi = buildLuarocksPackage {
+  pname = "luadbi";
+  version = "0.7.2-1";
+
+  src = fetchurl {
+    url    = https://luarocks.org/luadbi-0.7.2-1.src.rock;
+    sha256 = "0mj9ggyb05l03gs38ds508620mqaw4fkrzz9861n4j0zxbsbmfwy";
+  };
+  disabled = (luaOlder "5.1") || (luaAtLeast "5.4");
+  propagatedBuildInputs = [ lua ];
+
+  meta = {
+    homepage = "https://github.com/mwild1/luadbi";
+    description = "Database abstraction layer";
+    license = {
+      fullName = "MIT/X11";
+    };
+  };
+};
 luaevent = buildLuarocksPackage {
   pname = "luaevent";
   version = "0.4.6-1";

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -256,42 +256,6 @@ with self; {
     };
   };
 
-  luadbi = buildLuaPackage rec {
-    name = "luadbi-${version}";
-    version = "0.7.1";
-
-    src = fetchFromGitHub {
-      owner = "mwild1";
-      repo = "luadbi";
-      rev = "v${version}";
-      sha256 = "01i8018zb7w2bhaqglm7cnvbiirgd95b9d07irgz3sci91p08cwp";
-    };
-
-    MYSQL_INC="-I${mysql.connector-c}/include/mysql";
-
-    buildInputs = [ mysql.client mysql.connector-c postgresql sqlite ];
-
-    preConfigure = stdenv.lib.optionalString stdenv.isDarwin ''
-      substituteInPlace Makefile \
-        --replace '-shared' '-bundle -undefined dynamic_lookup -all_load'
-    '';
-
-    installFlags = [
-      "LUA_CDIR=$(out)/lib/lua/${lua.luaversion}"
-      "LUA_LDIR=$(out)/share/lua/${lua.luaversion}"
-    ];
-
-    installTargets = [
-      "install_lua" "install_mysql" "install_psql" "install_sqlite3"
-    ];
-
-    meta = with stdenv.lib; {
-      homepage = https://github.com/mwild1/luadbi;
-      license = licenses.mit;
-      platforms = stdenv.lib.platforms.unix;
-    };
-  };
-
   luafilesystem = buildLuaPackage rec {
     version = "1.7.0";
     name = "filesystem-${version}";


### PR DESCRIPTION
move to generated.
I ran a nix-review on it with success (built prosody fine) and tried to start prosody but it does nothing, not sure how to properly test it.

 /cc @sshisk  

related PR https://github.com/NixOS/nixpkgs/pull/62298

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
