### PR TITLE
pythonPackages.flask-swagger-ui: init at 3.20.9

### DIFF
--- a/pkgs/development/python-modules/flask-swagger-ui/default.nix
+++ b/pkgs/development/python-modules/flask-swagger-ui/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, buildPythonPackage, fetchPypi, flask }:
+
+buildPythonPackage rec {
+  pname = "flask-swagger-ui";
+  version = "3.20.9";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "3282c770764c8053360f33b2fc120e1d169ecca2138537d0e6e1135b1f9d4ff2";
+  };
+
+  doCheck = false;  # there are no tests
+
+  propagatedBuildInputs = [
+    flask
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/sveint/flask-swagger-ui";
+    license = licenses.mit;
+    description = "Swagger UI blueprint for Flask";
+    maintainers = with maintainers; [ vanschelven ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2721,6 +2721,8 @@ in {
 
   flask-swagger = callPackage ../development/python-modules/flask-swagger { };
 
+  flask-swagger-ui = callPackage ../development/python-modules/flask-swagger-ui { };
+
   flask_testing = callPackage ../development/python-modules/flask-testing { };
 
   flask_wtf = callPackage ../development/python-modules/flask-wtf { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
