### PR TITLE
pythonPackages.pytest-flask: init at 0.15.0

### DIFF
--- a/pkgs/development/python-modules/pytest-flask/default.nix
+++ b/pkgs/development/python-modules/pytest-flask/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, buildPythonPackage, fetchPypi, pytest, flask, werkzeug, setuptools_scm }:
+
+buildPythonPackage rec {
+  pname = "pytest-flask";
+  version = "0.15.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0jdzrib94vwfpl8524h34aqzqndh3h4xn706v32xh412c8dphx6q";
+  };
+
+  doCheck = false;
+
+  buildInputs = [
+     pytest
+  ];
+
+  propagatedBuildInputs = [
+    flask
+    werkzeug
+  ];
+
+  nativeBuildInputs = [ setuptools_scm ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/pytest-dev/pytest-flask/";
+    license = licenses.mit;
+    description = "A set of py.test fixtures to test Flask applications";
+    maintainers = with maintainers; [ vanschelven ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -808,6 +808,8 @@ in {
 
   pytest-env = callPackage ../development/python-modules/pytest-env { };
 
+  pytest-flask = callPackage ../development/python-modules/pytest-flask { };
+
   pytest-mypy = callPackage ../development/python-modules/pytest-mypy { };
 
   pytest-pylint = callPackage ../development/python-modules/pytest-pylint { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
