### PR TITLE
python: azure-keyvault: init at 1.1.0

### DIFF
--- a/pkgs/development/python-modules/azure-keyvault/default.nix
+++ b/pkgs/development/python-modules/azure-keyvault/default.nix
@@ -1,0 +1,34 @@
+{ pkgs
+, buildPythonPackage
+, fetchPypi
+, azure-common
+, isPyPy
+, python
+, msrestazure
+}:
+
+# lowPrio to avoid a collision with azure-common's azure/__init__.py file
+pkgs.lib.lowPrio (buildPythonPackage rec {
+  version = "1.1.0";
+  pname = "azure-keyvault";
+  disabled = isPyPy;
+
+  src = fetchPypi {
+    inherit pname version;
+    extension = "zip";
+    sha256 = "0jfxm8lx8dzs3v2b04ljizk8gfckbm5l2v86rm7k0npbfvryba1p";
+  };
+
+  propagatedBuildInputs = [ azure-common msrestazure ];
+
+  postInstall = ''
+    echo "__import__('pkg_resources').declare_namespace(__name__)" >> "$out/lib/${python.libPrefix}"/site-packages/azure/__init__.py
+  '';
+
+  meta = with pkgs.lib; {
+    description = "This is the Microsoft Azure Key Vault Client Library.";
+    homepage = "https://azure.microsoft.com/en-us/develop/python/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ vanschelven ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -249,6 +249,8 @@ in {
 
   azure-common = callPackage ../development/python-modules/azure-common { };
 
+  azure-keyvault = callPackage ../development/python-modules/azure-keyvault { };
+
   azure-mgmt-common = callPackage ../development/python-modules/azure-mgmt-common { };
 
   azure-mgmt-compute = callPackage ../development/python-modules/azure-mgmt-compute { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
