### PR TITLE
python: sh: fix (patch a test to be able to install again)

### DIFF
--- a/pkgs/development/python-modules/sh/default.nix
+++ b/pkgs/development/python-modules/sh/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, python, coverage, lsof, glibcLocales }:
+{ stdenv, buildPythonPackage, fetchPypi, fetchpatch, python, coverage, lsof, glibcLocales }:
 
 buildPythonPackage rec {
   pname = "sh";
@@ -9,9 +9,17 @@ buildPythonPackage rec {
     sha256 = "1z2hx357xp3v4cv44xmqp7lli3frndqpyfmpbxf7n76h7s1zaaxm";
   };
 
-  # Disable tests that fail on Darwin
-  # Some of the failures are due to Nix using GNU coreutils
-  patches = [ ./disable-broken-tests-darwin.patch ];
+  patches = [
+    # Disable tests that fail on Darwin
+    # Some of the failures are due to Nix using GNU coreutils
+    ./disable-broken-tests-darwin.patch
+    # Fix tests for Python 3.7. See: https://github.com/amoffat/sh/pull/468
+    (fetchpatch {
+      url = "https://github.com/amoffat/sh/commit/b6202f75706473f02084d819e0765056afa43664.patch";
+      sha256 = "1kzxyxcc88zhgn2kmfg9yrbs4n405b2jq7qykb453l52hy10vi94";
+      excludes = [ ".travis.yml" ];
+    })
+  ];
 
   postPatch = ''
     sed -i 's#/usr/bin/env python#${python.interpreter}#' test.py


### PR DESCRIPTION
###### Motivation for this change
On NixOS 19.03, one test failed because of an extra LC_CTYPE=C.UTF-8
'cruft variable. The test has been patched to remove this variable.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
