### PR TITLE
pythonPackages.python-redis-lock: init at 3.3.1

### DIFF
--- a/pkgs/development/python-modules/python-redis-lock/default.nix
+++ b/pkgs/development/python-modules/python-redis-lock/default.nix
@@ -1,0 +1,36 @@
+{ stdenv
+, buildPythonPackage
+, fetchPypi
+, redis
+, pytest
+, process-tests
+, pkgs
+, withDjango ? false, django_redis
+}:
+
+buildPythonPackage rec {
+  pname = "python-redis-lock";
+  version = "3.3.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "5316d473ce6ce86a774b9f9c110d84c3a9bd1a2abfda5d99e9c0c8a872a8e6d6";
+  };
+
+  checkInputs = [ pytest process-tests pkgs.redis ];
+
+  checkPhase = ''
+    pytest tests/
+  '';
+
+  propagatedBuildInputs = [ redis ]
+  ++ stdenv.lib.optional withDjango django_redis;
+
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/ionelmc/python-redis-lock";
+    license = licenses.bsd2;
+    description = "Lock context manager implemented via redis SETNX/BLPOP";
+    maintainers = with maintainers; [ vanschelven ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -850,6 +850,8 @@ in {
 
   python-rapidjson = callPackage ../development/python-modules/python-rapidjson { };
 
+  python-redis-lock = callPackage ../development/python-modules/python-redis-lock { };
+
   python-sql = callPackage ../development/python-modules/python-sql { };
 
   python-snappy = callPackage ../development/python-modules/python-snappy {


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
