### PR TITLE
pythonPackages.flask-swagger: init at 0.2.14

### DIFF
--- a/pkgs/development/python-modules/flask-swagger/default.nix
+++ b/pkgs/development/python-modules/flask-swagger/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, buildPythonPackage, fetchPypi
+, flask, pyyaml }:
+
+buildPythonPackage rec {
+  version = "0.2.14";
+  pname = "flask-swagger";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "b4085f5bc36df4c20b6548cd1413adc9cf35719b0f0695367cd542065145294d";
+  };
+
+  doCheck = true;
+
+  propagatedBuildInputs = [
+    flask
+    pyyaml
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/gangverk/flask-swagger";
+    license = licenses.mit;
+    description = "Extract swagger specs from your flask project";
+    maintainers = with maintainers; [ vanschelven ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2719,6 +2719,8 @@ in {
 
   flask_sqlalchemy = callPackage ../development/python-modules/flask-sqlalchemy { };
 
+  flask-swagger = callPackage ../development/python-modules/flask-swagger { };
+
   flask_testing = callPackage ../development/python-modules/flask-testing { };
 
   flask_wtf = callPackage ../development/python-modules/flask-wtf { };


### PR DESCRIPTION

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
