### PR TITLE
lutris: add hicolor theme

### DIFF
--- a/pkgs/applications/misc/lutris/default.nix
+++ b/pkgs/applications/misc/lutris/default.nix
@@ -31,7 +31,7 @@ let
     graphite2 gtk2 gtk3 udev ncurses wayland libglvnd vulkan-loader
 
     # Lutris
-    gobjectIntrospection gdk_pixbuf pango openssl sqlite xterm libnotify procps
+    gobject-introspection gdk_pixbuf hicolor-icon-theme pango openssl sqlite xterm libnotify procps
 
     # Adventure Game Studio
     allegro dumb
@@ -47,7 +47,7 @@ let
 
     # DOSBox
     SDL_net SDL_sound
- 
+
     # GOG
     glib-networking
 


### PR DESCRIPTION
###### Motivation for this change
Upon start of the application, you get greeted with:
```
(.lutris-0.5.2.1-wrapped:18904): Gtk-WARNING **: 11:21:17.422: Could not find the icon 'lutris'. The 'hicolor' theme
was not found either, perhaps you need to install it.
You can get a copy from:
        http://icon-theme.freedesktop.org/releases
```
This is to remove the warning and help with some of the icons.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
before:
```
$ nix path-info -S /nix/store/jrn1fjjaxfg6ksj28irgjjdmssn6xviz-lutris
/nix/store/jrn1fjjaxfg6ksj28irgjjdmssn6xviz-lutris       6312348432
```

after:
```
$ nix path-info -S ./result
/nix/store/n7ns10bscarg5nlsxvdfy9nwwm8nvdsb-lutris       6312477224
```
