### PR TITLE
spidermonkey_60: 60.4.0 -> 60.7.0

### DIFF
--- a/pkgs/development/interpreters/spidermonkey/60.nix
+++ b/pkgs/development/interpreters/spidermonkey/60.nix
@@ -1,14 +1,13 @@
 { stdenv, fetchurl, fetchpatch, autoconf213, pkgconfig, perl, python2, zip
 , which, readline, zlib, icu }:
 
-let
-  version = "60.4.0";
-in stdenv.mkDerivation rec {
-  name = "spidermonkey-${version}";
+stdenv.mkDerivation rec {
+  pname = "spidermonkey";
+  version = "60.7.0";
 
   src = fetchurl {
     url = "mirror://mozilla/firefox/releases/${version}esr/source/firefox-${version}esr.source.tar.xz";
-    sha256 = "11gzxd82grc3kg1ha4yni6ag6b97n46qycvv6x15s91ziia5hli0";
+    sha256 = "08x0nijh0ja5jza95a8y030ibk756bn7zlw3a3c4750yilfhqpqa";
   };
 
   buildInputs = [ readline zlib icu ];


### PR DESCRIPTION
###### Motivation for this change

(This should generally track firefox-esr's version, right?)


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---