### PR TITLE
bro: 2.5.5 -> 2.6.2

### DIFF
--- a/pkgs/applications/networking/ids/bro/default.nix
+++ b/pkgs/applications/networking/ids/bro/default.nix
@@ -2,15 +2,19 @@
 , geoip, gperftools, python, swig }:
 
 stdenv.mkDerivation rec {
-  name = "bro-2.5.5";
+  name = "bro-2.6.2";
 
   src = fetchurl {
     url = "https://www.bro.org/downloads/${name}.tar.gz";
-    sha256 = "1kvkiq8jjsqryry9jd4vw45pbfb46jly988mq62mv4sd1fqsxwhq";
+    sha256 = "19n0xai1mndx2i28q9cnszam57r6p6zqhprxxfpxh7bv7xpqgxkd";
   };
 
   nativeBuildInputs = [ cmake flex bison file ];
   buildInputs = [ openssl libpcap perl zlib curl geoip gperftools python swig ];
+
+  # Indicate where to install the python bits, since it can't put them in the "usual"
+  # locations as those paths are read-only.
+  cmakeFlags = [ "-DPY_MOD_INSTALL_DIR=${placeholder "out"}/${python.sitePackages}" ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Security fix release mentioned at top of notes, FWIW:

https://raw.githubusercontent.com/zeek/zeek/bb979702cf9a2fa67b8d1a1c7f88d0b56c6af104/NEWS

----

Seems reasonable but if anyone actually familiar can test or otherwise
review that'd be appreciated!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---