### PR TITLE
radamsa: 0.5 -> 0.6

### DIFF
--- a/pkgs/tools/security/radamsa/default.nix
+++ b/pkgs/tools/security/radamsa/default.nix
@@ -1,26 +1,42 @@
-{ stdenv, fetchurl }:
+{ stdenv, fetchurl, fetchFromGitLab, bash }:
 
+let
+  # Fetch explicitly, otherwise build will try to do so
+  owl = fetchurl {
+    name = "ol.c.gz";
+    url = "https://gitlab.com/owl-lisp/owl/uploads/0d0730b500976348d1e66b4a1756cdc3/ol-0.1.19.c.gz";
+    sha256 = "0kdmzf60nbpvdn8j3l51i9lhcwfi4aw1zj4lhbp4adyg8n8pp4c6";
+  };
+in
 stdenv.mkDerivation rec {
-  name = "radamsa-${version}";
-  version = "0.5";
+  pname = "radamsa";
+  version = "0.6";
 
-  src = fetchurl {
-    url = "https://github.com/aoh/radamsa/releases/download/v${version}/${name}.tar.gz";
-    sha256 = "1d2chp45fbdb2v5zpsx6gh3bv8fhcjv0zijz10clcznadnm8c6p2";
+  src = fetchFromGitLab {
+    owner = "akihe";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0mi1mwvfnlpblrbmp0rcyf5p74m771z6nrbsly6cajyn4mlpmbaq";
   };
 
   patchPhase = ''
     substituteInPlace ./tests/bd.sh  \
       --replace "/bin/echo" echo
-    substituteInPlace ./Makefile \
-      --replace "PREFIX=/usr" "PREFIX=$out" \
-      --replace "BINDIR=/bin" "BINDIR="
+
+    ln -s ${owl} ol.c.gz
+
+    patchShebangs tests
   '';
+
+  makeFlags = [ "PREFIX=${placeholder "out"}" "BINDIR=" ];
+
+  checkInputs = [ bash ];
+  doCheck = true;
   
   meta = {
     description = "A general purpose fuzzer";
     longDescription = "Radamsa is a general purpose data fuzzer. It reads data from given sample files, or standard input if none are given, and outputs modified data. It is usually used to generate malformed data for testing programs.";
-    homepage = https://github.com/aoh/radamsa;
+    homepage =  https://gitlab.com/akihe/radamsa;
     maintainers = [ stdenv.lib.maintainers.markWot ];
     platforms = stdenv.lib.platforms.all;
   };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

* new home (github -> gitlab)
* "modernize" a bit
* run tests!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---