### PR TITLE
fakechroot: 2.19 -> 2.20.1, prefer patch and official source over "fork"

### DIFF
--- a/pkgs/tools/system/fakechroot/default.nix
+++ b/pkgs/tools/system/fakechroot/default.nix
@@ -1,16 +1,27 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, perl }:
+{ stdenv, fetchFromGitHub, fetchpatch, autoreconfHook, perl }:
 
 stdenv.mkDerivation rec {
-  name = "fakechroot-${version}";
-  version = "2.19";
+  pname = "fakechroot";
+  version = "2.20.1";
 
-  # TODO: move back to mainline once https://github.com/dex4er/fakechroot/pull/46 is merged
   src = fetchFromGitHub {
-    owner  = "copumpkin";
-    repo   = "fakechroot";
-    rev    = "dcc0cfe3941e328538f9e62b2c0b15430d393ec1";
-    sha256 = "1ls3y97qqfcfd3z0balz94xq1gskfk04pg85x6b7wjw8dm4030qd";
+    owner  = "dex4er";
+    repo   = pname;
+    rev    = version;
+    sha256 = "0xgnwazrmrg4gm30xjxdn6sx3lhqvxahrh6gmy3yfswxc30pmg86";
   };
+
+  # Use patch from https://github.com/dex4er/fakechroot/pull/46 , remove once merged!
+  # Courtesy of one of our own, @copumpkin!
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/dex4er/fakechroot/pull/46/commits/dcc0cfe3941e328538f9e62b2c0b15430d393ec1.patch";
+      sha256 = "1mk8j2njd94s7vf2wggi08xxxzx8dxrvdricl9cbspvkyp715w2m";
+      # Don't bother trying to reconcile conflicts for NEWS entries, as they will continue to occur
+      # and are uninteresting as well as unimportant for our purposes (since NEWS never leaves the build env).
+      excludes = [ "NEWS.md" ];
+    })
+  ];
 
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ perl ];


### PR DESCRIPTION
###### Motivation for this change

The most immediate motivation for the source/patch reworking is to
upgrade the tree without needing to provide an updated version
with the fix and the upgrade as well.

Naturally the patch won't necessarily apply to all future versions,
but that's easy enough to check and happily appears to have no trouble
with this upgrade.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---