### PR TITLE
udocker: 1.1.1 -> 1.1.3

### DIFF
--- a/pkgs/tools/virtualization/udocker/default.nix
+++ b/pkgs/tools/virtualization/udocker/default.nix
@@ -2,14 +2,14 @@
 
 buildPythonApplication rec {
 
-  version = "1.1.1";
+  version = "1.1.3";
   pname = "udocker";
 
   src = fetchFromGitHub rec {
     owner = "indigo-dc";
     repo = "udocker" ;
     rev = "v${version}";
-    sha256 = "134xk7rfj0xki9znryk5qf1nsfa318ahrrsi1k6ia7kipp7i3hb4";
+    sha256 = "1c8y1p3brj987drikwrby8m1hdr40ja4anx0p4xsij3ll2h62w6z";
   };
 
   buildInputs = [ proot patchelf fakechroot runc simplejson pycurl coreutils ];


### PR DESCRIPTION
###### Motivation for this change

Little docker, growing up!

https://github.com/indigo-dc/udocker/releases/tag/v1.1.3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---