### PR TITLE
thin-provisioning-tools: 0.7.6 -> 0.8.5

### DIFF
--- a/pkgs/tools/misc/thin-provisioning-tools/default.nix
+++ b/pkgs/tools/misc/thin-provisioning-tools/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "thin-provisioning-tools";
-  version = "0.8.2";
+  version = "0.8.5";
 
   src = fetchFromGitHub {
     owner = "jthornber";
     repo = pname;
     rev = "v${version}";
-    sha256 = "0m0vngy619mm6bzmkd4n363yab9lvxan2wsbx1y7g0vaf5s33nhr";
+    sha256 = "0fxmzjbnsb2xjawp9mkix398r0aiqzwdsbmyvxd7fdf4cyvqriis";
   };
 
   nativeBuildInputs = [ autoreconfHook ];

--- a/pkgs/tools/misc/thin-provisioning-tools/default.nix
+++ b/pkgs/tools/misc/thin-provisioning-tools/default.nix
@@ -1,33 +1,19 @@
-{ stdenv, fetchFromGitHub, fetchpatch, autoreconfHook, expat, libaio, boost }:
+{ stdenv, fetchFromGitHub, autoreconfHook, expat, libaio, boost }:
 
 stdenv.mkDerivation rec {
-  name = "thin-provisioning-tools-${version}";
-  version = "0.7.6";
+  pname = "thin-provisioning-tools";
+  version = "0.8.2";
 
   src = fetchFromGitHub {
     owner = "jthornber";
-    repo = "thin-provisioning-tools";
+    repo = pname;
     rev = "v${version}";
-    sha256 = "175mk3krfdmn43cjw378s32hs62gq8fmq549rjmyc651sz6jnj0g";
+    sha256 = "0m0vngy619mm6bzmkd4n363yab9lvxan2wsbx1y7g0vaf5s33nhr";
   };
 
   nativeBuildInputs = [ autoreconfHook ];
 
   buildInputs = [ expat libaio boost ];
-
-  patches = [
-    (fetchpatch {
-      # a) Fix build if limits.h provides definition for PAGE_SIZE, as musl does w/musl per XSI[1] although it's apparently optional [2].
-      #    This value is only provided when it's known to be a constant, to avoid the need to discover the value dynamically.
-      # b) If not using system-provided (kernel headers, or libc headers, or something) use the POSIX approach of querying the value
-      #    dynamically using sysconf(_SC_PAGE_SIZE) instead of hardcoded value that hopefully is correct.
-      # [1] http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/limits.h.html
-      # [2] http://www.openwall.com/lists/musl/2015/09/11/8
-      url = "https://raw.githubusercontent.com/void-linux/void-packages/a0ece13ad7ab2aae760e09e41e0459bd999a3695/srcpkgs/thin-provisioning-tools/patches/musl.patch";
-      sha256 = "1m8r3vhrnsy8drgs0svs3fgpi3mmxzdcqsv6bmvc0j52cvfqvhvy";
-      extraPrefix = ""; # empty means add 'a/' and 'b/'
-    })
-  ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---