### PR TITLE
p11-kit: 0.23.15 -> 0.23.16.1

### DIFF
--- a/pkgs/development/libraries/p11-kit/default.nix
+++ b/pkgs/development/libraries/p11-kit/default.nix
@@ -4,27 +4,14 @@
 
 stdenv.mkDerivation rec {
   pname = "p11-kit";
-  version = "0.23.15";
+  version = "0.23.16.1";
 
   src = fetchFromGitHub {
     owner = "p11-glue";
     repo = pname;
     rev = version;
-    sha256 = "0kf7zz2cvd6j09qkff3rl3wfisva82ia1z9h8bmy4ifwkv4yl9fv";
+    sha256 = "0jr62qkbqxp3iawgksk1qc3gp8p6x09sg5v7xac80ghyfxil15wy";
   };
-
-  patches = [
-    (fetchpatch {
-      # https://github.com/p11-glue/p11-kit/issues/212
-      url = "https://github.com/p11-glue/p11-kit/commit/2a474e1fe8f4bd8b4ed7622e5cf3b2718a202562.patch";
-      sha256 = "13wi32hpzilvzxn57crn79h88q38jm2fzd5zxj4wnhv9dhwqr6lg";
-    })
-    (fetchpatch {
-      # https://github.com/p11-glue/p11-kit/issues/220
-      url = "https://github.com/p11-glue/p11-kit/commit/e2170b295992cb7fdf115227a78028ac3780619f.patch";
-      sha256 = "0433d8drfxaabsxwkkl4kr0jx8jr2l3a9ar11szipd9jwvrqnyr7";
-    })
-  ];
 
   outputs = [ "out" "dev"];
   outputBin = "dev";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

https://github.com/p11-glue/p11-kit/releases/tag/0.23.16.1
https://github.com/p11-glue/p11-kit/releases/tag/0.23.16

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---