### PR TITLE
gnss-sdr: 0.0.9 -> 0.0.10 (wip)

### DIFF
--- a/pkgs/applications/radio/gnss-sdr/default.nix
+++ b/pkgs/applications/radio/gnss-sdr/default.nix
@@ -14,14 +14,14 @@
 }:
 
 stdenv.mkDerivation rec {
-  name = "gnss-sdr-${version}";
-  version = "0.0.9";
+  pname = "gnss-sdr";
+  version = "0.0.10";
 
   src = fetchFromGitHub {
-    owner = "gnss-sdr";
-    repo = "gnss-sdr";
+    owner = pname;
+    repo = pname;
     rev = "v${version}";
-    sha256 = "0gis932ly3vk7d5qvznffp54pkmbw3m6v60mxjfdj5dd3r7vf975";
+    sha256 = "0mnvwnns6dnf2g6lmiwmm43i8gzxx4wdmskkfzyjaq4js5x5kvzg";
   };
 
   buildInputs = [

--- a/pkgs/applications/radio/gnss-sdr/default.nix
+++ b/pkgs/applications/radio/gnss-sdr/default.nix
@@ -4,6 +4,9 @@
 , cmake
 , glog
 , gmock
+, log4cpp
+, matio
+, pugixml
 , openssl
 , google-gflags
 , gnuradio
@@ -30,6 +33,9 @@ stdenv.mkDerivation rec {
     cmake
     glog
     gmock
+    log4cpp
+    matio
+    pugixml
     openssl.dev
     google-gflags
     gnuradio


### PR DESCRIPTION
###### Motivation for this change

https://gnss-sdr.org/gnss-sdr-v0010-released/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
     - rebuilding again to be sure, FWIW
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---