### PR TITLE
buildah: 1.8.2 -> 1.8.3

### DIFF
--- a/pkgs/development/tools/buildah/default.nix
+++ b/pkgs/development/tools/buildah/default.nix
@@ -3,13 +3,13 @@
 , go-md2man }:
 
 let
-  version = "1.8.2";
+  version = "1.8.3";
 
   src = fetchFromGitHub {
     rev    = "v${version}";
     owner  = "containers";
     repo   = "buildah";
-    sha256 = "1r91ndnc3ysrfdjybsnlnbkw26n25mfwc9i8ys5y3c26fq8ic3zd";
+    sha256 = "12fi67pnp07zrk72zniiciw2nhmzn6lmbkydv5sib08x765izn6s";
   };
 
   goPackagePath = "github.com/containers/buildah";


### PR DESCRIPTION
###### Motivation for this change

Looks like nice update:

https://github.com/containers/buildah/releases/tag/v1.8.3

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---