### PR TITLE
vim/neovim: Backports fix for ACE

### DIFF
--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, cmake, gettext, msgpack, libtermkey, libiconv
+{ stdenv, fetchFromGitHub, fetchpatch, cmake, gettext, msgpack, libtermkey, libiconv
 , libuv, lua, ncurses, pkgconfig
 , unibilium, xsel, gperf
 , libvterm-neovim
@@ -35,6 +35,13 @@ in
       # necessary so that nix can handle `UpdateRemotePlugins` for the plugins
       # it installs. See https://github.com/neovim/neovim/issues/9413.
       ./system_rplugin_manifest.patch
+
+      # Arbitrary code execution fix
+      # https://github.com/numirias/security/blob/cf4f74e0c6c6e4bbd6b59823aa1b85fa913e26eb/doc/2019-06-04_ace-vim-neovim.md
+      (fetchpatch {
+        url = "https://github.com/neovim/neovim/pull/10082.patch";
+        sha256 = "0g4knlpaabbq6acqgqm765b1knqv981nk2gf84fmknqnv4sgbsq2";
+      })
     ];
 
     enableParallelBuilding = true;

--- a/pkgs/applications/editors/vim/0001-source-command-doesnt-check-for-the-sandbox-5357552.patch
+++ b/pkgs/applications/editors/vim/0001-source-command-doesnt-check-for-the-sandbox-5357552.patch
@@ -1,0 +1,31 @@
+From 53575521406739cf20bbe4e384d88e7dca11f040 Mon Sep 17 00:00:00 2001
+From: Bram Moolenaar <Bram@vim.org>
+Date: Wed, 22 May 2019 22:38:25 +0200
+Subject: [PATCH] patch 8.1.1365: source command doesn't check for the sandbox
+
+Problem:    Source command doesn't check for the sandbox. (Armin Razmjou)
+Solution:   Check for the sandbox when sourcing a file.
+---
+ src/getchar.c               | 6 ++++++
+ src/testdir/test_source.vim | 9 +++++++++
+ src/version.c               | 2 ++
+ 3 files changed, 17 insertions(+)
+
+diff --git a/src/getchar.c b/src/getchar.c
+index 9379a6a8d4..debad7efd2 100644
+--- a/src/getchar.c
++++ b/src/getchar.c
+@@ -1407,6 +1407,12 @@ openscript(
+ 	emsg(_(e_nesting));
+ 	return;
+     }
++
++    // Disallow sourcing a file in the sandbox, the commands would be executed
++    // later, possibly outside of the sandbox.
++    if (check_secure())
++	return;
++
+ #ifdef FEAT_EVAL
+     if (ignore_script)
+ 	/* Not reading from script, also don't open one.  Warning message? */
+diff --git a/src/testdir/test_source.vim b/src/testdir/test_source.vim

--- a/pkgs/applications/editors/vim/default.nix
+++ b/pkgs/applications/editors/vim/default.nix
@@ -25,6 +25,12 @@ stdenv.mkDerivation rec {
       cf-private
     ];
 
+  patches = [
+    # Arbitrary code execution fix
+    # https://github.com/numirias/security/blob/cf4f74e0c6c6e4bbd6b59823aa1b85fa913e26eb/doc/2019-06-04_ace-vim-neovim.md
+    ./0001-source-command-doesnt-check-for-the-sandbox-5357552.patch
+  ];
+
   configureFlags = [
     "--enable-multibyte"
     "--enable-nls"


### PR DESCRIPTION
###### Motivation for this change

Details:

 * https://github.com/numirias/security/blob/cf4f74e0c6c6e4bbd6b59823aa1b85fa913e26eb/doc/2019-06-04_ace-vim-neovim.md

The vim patch is the upstream commit, with incompatible changes removed.

The neovim patch is the upstream one directly.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ☑️ Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - ☑️ NixOS
   - 🔲 macOS
   - 🔲 other Linux distributions
- 🔲 Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- 🔲 Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- 🔲 Tested execution of all binary files (usually in `./result/bin/`)
- 🔲 Determined the impact on package closure size (by running `nix path-info -S` before and after)
- ☑️ Assured whether relevant documentation is up to date
- ☑️ Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
