### PR TITLE
luaPackages.lpeg: 1.0.1 -> 1.0.2

### DIFF
--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -10,6 +10,7 @@ http,,,,,
 inspect,,,,,
 ldoc,,,,,
 lgi,,,,,
+lpeg,,,,,vyp
 lpeg_patterns,,,,,
 lpeglabel,,,,,
 lpty,,,,,

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -239,6 +239,25 @@ lgi = buildLuarocksPackage {
     };
   };
 };
+lpeg = buildLuarocksPackage {
+  pname = "lpeg";
+  version = "1.0.2-1";
+
+  src = fetchurl {
+    url    = https://luarocks.org/lpeg-1.0.2-1.src.rock;
+    sha256 = "1g5zmfh0x7drc6mg2n0vvlga2hdc08cyp3hnb22mh1kzi63xdl70";
+  };
+  disabled = (luaOlder "5.1");
+  propagatedBuildInputs = [ lua ];
+
+  meta = {
+    homepage = "http://www.inf.puc-rio.br/~roberto/lpeg.html";
+    description = "Parsing Expression Grammars For Lua";
+    license = {
+      fullName = "MIT/X11";
+    };
+  };
+};
 lpeg_patterns = buildLuarocksPackage {
   pname = "lpeg_patterns";
   version = "0.5-0";

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -556,35 +556,6 @@ with self; {
     };
   };
 
-  lpeg = buildLuaPackage rec {
-    name = "lpeg-${version}";
-    version = "1.0.1";
-
-    src = fetchurl {
-      url = "http://www.inf.puc-rio.br/~roberto/lpeg/${name}.tar.gz";
-      sha256 = "62d9f7a9ea3c1f215c77e0cadd8534c6ad9af0fb711c3f89188a8891c72f026b";
-    };
-
-    preBuild = ''
-      makeFlagsArray=(CC=$CC);
-    '';
-
-    buildFlags = platformString;
-
-    installPhase = ''
-      mkdir -p $out/lib/lua/${lua.luaversion}
-      install -p lpeg.so $out/lib/lua/${lua.luaversion}
-      install -p re.lua $out/lib/lua/${lua.luaversion}
-    '';
-
-    meta = with stdenv.lib; {
-      description = "Parsing Expression Grammars For Lua";
-      homepage = "http://www.inf.puc-rio.br/~roberto/lpeg/";
-      license = licenses.mit;
-      maintainers = with maintainers; [ vyp ];
-      platforms = platforms.all;
-    };
-  };
 
   vicious = toLuaModule(stdenv.mkDerivation rec {
     name = "vicious-${version}";


### PR DESCRIPTION
and move to generated.

Tested with nix-review.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
