### PR TITLE
zathura: pass gsettings schemas

### DIFF
--- a/pkgs/applications/misc/zathura/core/default.nix
+++ b/pkgs/applications/misc/zathura/core/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, meson, ninja, makeWrapper, pkgconfig
+{ stdenv, fetchurl, meson, ninja, wrapGAppsHook, pkgconfig
 , appstream-glib, desktop-file-utils, python3
 , gtk, girara, gettext, libxml2
 , sqlite, glib, texlive, libintl, libseccomp
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     meson ninja pkgconfig desktop-file-utils python3.pkgs.sphinx
-    gettext makeWrapper libxml2
+    gettext wrapGAppsHook libxml2
   ] ++ optional stdenv.isLinux appstream-glib;
 
   buildInputs = [


### PR DESCRIPTION
File chooser dialogue in print dialogue requires GTK’s GSettings schemas or it will trigger a trap.

Closes: https://github.com/NixOS/nixpkgs/issues/16287