### PR TITLE
git-quick-stats: init at 2.0.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -250,6 +250,11 @@
     github = "akru";
     name = "Alexander Krupenkin ";
   };
+  alex3rd = {
+    email = "aaermolov@gmail.com";
+    github = "wiedzmin";
+    name = "Alex Ermolov";
+  };
   alexchapman = {
     email = "alex@farfromthere.net";
     github = "AJChapman";

--- a/pkgs/applications/version-management/git-and-tools/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/default.nix
@@ -99,6 +99,8 @@ let
 
   git-open = callPackage ./git-open { };
 
+  git-quick-stats = callPackage ./git-quick-stats { };
+
   git-radar = callPackage ./git-radar { };
 
   git-recent = callPackage ./git-recent {

--- a/pkgs/applications/version-management/git-and-tools/git-quick-stats/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-quick-stats/default.nix
@@ -1,0 +1,39 @@
+{ stdenv, fetchFromGitHub, makeWrapper, coreutils, git, gnugrep, gnused }:
+
+stdenv.mkDerivation rec {
+    pname = "git-quick-stats";
+    version = "2.0.8";
+
+    src = fetchFromGitHub {
+        owner = "arzzen";
+        repo = pname;
+        rev = "c11bce17bdb1c7f1272c556605b48770646bf807";
+        sha256 = "1px1sk7b6mjnbclsr1jn33m9k4wd8wqyw4d6w1rgj0ii29lhzmqi";
+    };
+
+    buildInputs = [ makeWrapper ];
+
+    dontBuild = true;
+
+    makeFlags = [ "PREFIX=${placeholder "out"}" ];
+
+    wrapperPath = with stdenv.lib; makeBinPath [
+        coreutils
+        git
+        gnugrep
+        gnused
+    ];
+
+    postFixup = ''
+        patchShebangs $out/bin
+
+        wrapProgram $out/bin/git-quick-stats --prefix PATH : "${wrapperPath}"
+    '';
+
+    meta = with stdenv.lib; {
+        description = "Simple and efficient tool to access various statistics in git repository";
+        homepage = "https://github.com/arzzen/git-quick-stats";
+        license = licenses.mit;
+        platforms = platforms.unix;
+    };
+}

--- a/pkgs/applications/version-management/git-and-tools/git-quick-stats/default.nix
+++ b/pkgs/applications/version-management/git-and-tools/git-quick-stats/default.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation rec {
     meta = with stdenv.lib; {
         description = "Simple and efficient tool to access various statistics in git repository";
         homepage = "https://github.com/arzzen/git-quick-stats";
+        maintainers = [ maintainers.alex3rd ];
         license = licenses.mit;
         platforms = platforms.unix;
     };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
