### PR TITLE
libmatroska: 1.5.0 -> 1.5.2

### DIFF
--- a/pkgs/development/libraries/libmatroska/default.nix
+++ b/pkgs/development/libraries/libmatroska/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libmatroska";
-  version = "1.5.0";
+  version = "1.5.2";
 
   src = fetchFromGitHub {
     owner  = "Matroska-Org";
     repo   = "libmatroska";
     rev    = "release-${version}";
-    sha256 = "01kp48ih9pqkm518ylbxicjmknqvb3njb71il2h2wa37whsaals8";
+    sha256 = "057iib6p62x31g1ikdjsjzmqzjlajqx6p74h7y4r524pzgb27fzy";
   };
 
   nativeBuildInputs = [ cmake pkgconfig ];


### PR DESCRIPTION
###### Motivation for this change

Fixes the build, broken by https://github.com/NixOS/nixpkgs/pull/62459

(libmatroska 1.5.0 expects libebml 1.3.7)

Currently broken on 

```
installing 'libmatroska-1.5.0'
these derivations will be built:
  /nix/store/wyn86b98pya06xs9xw06fkikd5crxp41-libmatroska-1.5.0.drv
building '/nix/store/wyn86b98pya06xs9xw06fkikd5crxp41-libmatroska-1.5.0.drv'...
unpacking sources
unpacking source archive /nix/store/i3wq66dndcvkm5jrkhzcsfx7c6d7sgdi-source
source root is source
patching sources
configuring
fixing cmake files...
cmake flags: -DCMAKE_FIND_PACKAGE_NO_SYSTEM_PACKAGE_REGISTRY=ON -DCMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY=ON -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_SKIP_BUILD_RPATH=ON -DBUILD_TESTING=OFF -DCMAKE_INSTALL_INCLUDEDIR=/nix/store/g7471azh71jvbdz5szm8yd782imh5iqz-libmatroska-1.5.0/include -DCMAKE_INSTALL_LIBDIR=/nix/store/g7471azh71jvbdz5szm8yd782imh5iqz-libmatroska-1.5.0/lib -DCMAKE_INSTALL_NAME_DIR=/nix/store/g7471azh71jvbdz5szm8yd782imh5iqz-libmatroska-1.5.0/lib -DCMAKE_POLICY_DEFAULT_CMP0025=NEW -DCMAKE_OSX_DEPLOYMENT_TARGET= -DCMAKE_OSX_SYSROOT= -DCMAKE_FIND_FRAMEWORK=last -DCMAKE_STRIP=/nix/store/2dfjlvp38xzkyylwpavnh61azi0d168b-binutils-2.31.1/bin/strip -DCMAKE_RANLIB=/nix/store/2dfjlvp38xzkyylwpavnh61azi0d168b-binutils-2.31.1/bin/ranlib -DCMAKE_AR=/nix/store/2dfjlvp38xzkyylwpavnh61azi0d168b-binutils-2.31.1/bin/ar -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_INSTALL_PREFIX=/nix/store/g7471azh71jvbdz5szm8yd782imh5iqz-libmatroska-1.5.0 -DBUILD_SHARED_LIBS=YES
-- The C compiler identification is GNU 7.4.0
-- The CXX compiler identification is GNU 7.4.0
-- Check for working C compiler: /nix/store/ds1prvgw3i3ic8c7axyrw4lwm3d0gqab-gcc-wrapper-7.4.0/bin/gcc
-- Check for working C compiler: /nix/store/ds1prvgw3i3ic8c7axyrw4lwm3d0gqab-gcc-wrapper-7.4.0/bin/gcc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /nix/store/ds1prvgw3i3ic8c7axyrw4lwm3d0gqab-gcc-wrapper-7.4.0/bin/g++
-- Check for working CXX compiler: /nix/store/ds1prvgw3i3ic8c7axyrw4lwm3d0gqab-gcc-wrapper-7.4.0/bin/g++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
CMake Error at CMakeLists.txt:8 (find_package):
  By not providing "FindEbml.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "Ebml", but
  CMake did not find one.

  Could not find a package configuration file provided by "Ebml" (requested
  version 1.3.7) with any of the following names:

    EbmlConfig.cmake
    ebml-config.cmake

  Add the installation prefix of "Ebml" to CMAKE_PREFIX_PATH or set
  "Ebml_DIR" to a directory containing one of the above files.  If "Ebml"
  provides a separate development package or SDK, be sure it has been
  installed.


-- Configuring incomplete, errors occurred!
See also "/build/source/build/CMakeFiles/CMakeOutput.log".
builder for '/nix/store/wyn86b98pya06xs9xw06fkikd5crxp41-libmatroska-1.5.0.drv' failed with exit code 1
error: build of '/nix/store/wyn86b98pya06xs9xw06fkikd5crxp41-libmatroska-1.5.0.drv' failed
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @worldofpeace