### PR TITLE
qtikz: unstable-20161122 -> 0.12

### DIFF
--- a/pkgs/applications/graphics/ktikz/default.nix
+++ b/pkgs/applications/graphics/ktikz/default.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation rec {
 
   meta = with stdenv.lib; {
     description = "Editor for the TikZ language";
+    homepage = "https://github.com/fhackenberger/ktikz";
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = [ maintainers.layus ];

--- a/pkgs/applications/graphics/ktikz/default.nix
+++ b/pkgs/applications/graphics/ktikz/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2;
     platforms = platforms.linux;
     maintainers = [ maintainers.layus ];
-    long_description = ''
+    longDescription = ''
       You will also need a working *tex installation in your PATH, containing at least `preview` and `pgf`.
     '';
   };

--- a/pkgs/applications/graphics/ktikz/default.nix
+++ b/pkgs/applications/graphics/ktikz/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, fetchFromGitHub, gettext, poppler, qt5 , pkgconfig }:
+{ stdenv, fetchFromGitHub, fetchurl
+, gettext, poppler, qt5 , pkgconfig }:
 
 # Warning: You will also need a working pdflatex installation containing
 # at least auctex and pgf.
@@ -8,15 +9,20 @@
 # See historical versions of this file for building ktikz with KDE4.
 
 stdenv.mkDerivation rec {
-  version = "unstable-20161122";
+  version = "0.12";
   name = "qtikz-${version}";
 
   src = fetchFromGitHub {
     owner = "fhackenberger";
     repo = "ktikz";
-    rev = "be66c8b1ff7e6b791b65af65e83c4926f307cf5a";
-    sha256 = "15jx53sjlnky4yg3ry1i1c29g28v1jbbvhbz66h7a49pfxa40fj3";
+    rev = version;
+    sha256 = "1s83x8r2yi64wc6ah2iz09dj3qahy0fkxx6cfgpkavjw9x0j0582";
   };
+
+  patches = [ (fetchurl {
+    url = "https://github.com/fhackenberger/ktikz/commit/972685a406517bb85eb561f2c8e26f029eacd7db.patch";
+    sha256 = "16jwsl18marfw5m888vwxdd1h7cqa37rkfqgirzdliacb1cr4f58";
+  })];
 
   meta = with stdenv.lib; {
     description = "Editor for the TikZ language";
@@ -53,17 +59,15 @@ stdenv.mkDerivation rec {
   '';
 
   # 1. Configuration is done by overwriting qtikzconfig.pri
-  # 2. Recent Qt removed QString::fromAscii in favor of QString::fromLatin1
-  patchPhase = ''
+  postPatch = ''
     echo "$conf" | sed "s!@out@!$out!g" > qmake/qtikzconfig.pri
-    find -name "*.cpp" -exec sed -i s/fromAscii/fromLatin1/g "{}" \;
   '';
 
   configurePhase = ''
       qmake PREFIX="$out" ./qtikz.pro
   '';
 
-  nativeBuildInputs = [ pkgconfig ];
+  nativeBuildInputs = [ pkgconfig qt5.qttools ];
   buildInputs = [ gettext qt5.full poppler ];
 
   enableParallelBuilding = true;

--- a/pkgs/applications/graphics/ktikz/default.nix
+++ b/pkgs/applications/graphics/ktikz/default.nix
@@ -1,8 +1,7 @@
-{ stdenv, fetchFromGitHub, fetchurl
+{ stdenv, fetchFromGitHub, fetchpatch
 , pkgconfig, makeWrapper
 , poppler, qt5, gnuplot
 }:
-
 
 # This package only builds ktikz without KDE integration because KDE4 is
 # deprecated and upstream does not (yet ?) support KDE5.
@@ -30,10 +29,12 @@ stdenv.mkDerivation rec {
     sha256 = "1s83x8r2yi64wc6ah2iz09dj3qahy0fkxx6cfgpkavjw9x0j0582";
   };
 
-  patches = [ (fetchurl {
-    url = "https://github.com/fhackenberger/ktikz/commit/972685a406517bb85eb561f2c8e26f029eacd7db.patch";
-    sha256 = "16jwsl18marfw5m888vwxdd1h7cqa37rkfqgirzdliacb1cr4f58";
-  })];
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/fhackenberger/ktikz/commit/972685a406517bb85eb561f2c8e26f029eacd7db.patch";
+      sha256 = "16jwsl18marfw5m888vwxdd1h7cqa37rkfqgirzdliacb1cr4f58";
+    })
+  ];
 
   QT_PLUGIN_PATH = "${qt5.qtbase}/${qt5.qtbase.qtPluginPrefix}";
 

--- a/pkgs/applications/graphics/ktikz/default.nix
+++ b/pkgs/applications/graphics/ktikz/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   patches = [
     (fetchpatch {
       url = "https://github.com/fhackenberger/ktikz/commit/972685a406517bb85eb561f2c8e26f029eacd7db.patch";
-      sha256 = "16jwsl18marfw5m888vwxdd1h7cqa37rkfqgirzdliacb1cr4f58";
+      sha256 = "13z40rcd4m4n088v7z2ns17lnpn0z3rzp31lsamic3qdcwjwa5k8";
     })
   ];
 


### PR DESCRIPTION
###### Motivation for this change

No update in two years, and a broken package ;-)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---