### PR TITLE
linux_{5_1,testing}: fix bug null pointer dereference

### DIFF
--- a/pkgs/os-specific/linux/kernel/bug-null-pointer-dereference.patch
+++ b/pkgs/os-specific/linux/kernel/bug-null-pointer-dereference.patch
@@ -1,0 +1,15 @@
+diff --git a/mm/compaction.c b/mm/compaction.c
+# From: Suzuki K Poulose <suzuki.poulose@arm.com>
+# https://lore.kernel.org/lkml/1558711908-15688-1-git-send-email-suzuki.poulose@arm.com/raw
+index 444029da4..368445cc7 100644
+--- a/mm/compaction.c
++++ b/mm/compaction.c
+@@ -1397,7 +1397,7 @@ fast_isolate_freepages(struct compact_control *cc)
+ 				page = pfn_to_page(highest);
+ 				cc->free_pfn = highest;
+ 			} else {
+-				if (cc->direct_compaction) {
++				if (cc->direct_compaction && pfn_valid(min_pfn)) {
+ 					page = pfn_to_page(min_pfn);
+ 					cc->free_pfn = min_pfn;
+ 				}

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -62,4 +62,9 @@ rec {
     name = "export_kernel_fpu_functions";
     patch = ./export_kernel_fpu_functions.patch;
   };
+
+  bug-null-pointer-dereference = {
+    name = "bug-null-pointer-dereference";
+    patch = ./bug-null-pointer-dereference.patch;
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15265,6 +15265,7 @@ in
       [ kernelPatches.bridge_stp_helper
         kernelPatches.modinst_arg_list_too_long
         kernelPatches.export_kernel_fpu_functions
+        kernelPatches.bug-null-pointer-dereference
       ];
   };
 
@@ -15273,6 +15274,7 @@ in
       kernelPatches.bridge_stp_helper
       kernelPatches.modinst_arg_list_too_long
       kernelPatches.export_kernel_fpu_functions
+      kernelPatches.bug-null-pointer-dereference
     ];
   };
 


### PR DESCRIPTION
###### Motivation for this change
Fix this issue https://github.com/NixOS/nixpkgs/issues/61909

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
