### PR TITLE
weechatScripts.wee-slack: 2.2.0 -> 2.3.0

### DIFF
--- a/pkgs/applications/networking/irc/weechat/scripts/wee-slack/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/wee-slack/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "wee-slack-${version}";
-  version = "2.2.0";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     repo = "wee-slack";
     owner = "wee-slack";
     rev = "v${version}";
-    sha256 = "1iy70q630cgs7fvk2151fq9519dwxrlqq862sbrwypzr6na6yqpg";
+    sha256 = "0544j6vqbvb2xshq7ma2a3apx2vvpgfg3jh5prg265wnh4991nsw";
   };
 
   patches = [

--- a/pkgs/applications/networking/irc/weechat/scripts/wee-slack/libpath.patch
+++ b/pkgs/applications/networking/irc/weechat/scripts/wee-slack/libpath.patch
@@ -1,13 +1,13 @@
 diff --git a/wee_slack.py b/wee_slack.py
-index c5c7bc6..23fef2f 100644
+index dbe6446..d1b7546 100644
 --- a/wee_slack.py
 +++ b/wee_slack.py
-@@ -25,6 +25,8 @@ try:
- except:
-     from StringIO import StringIO
+@@ -25,6 +25,8 @@ import random
+ import socket
+ import string
  
 +sys.path.append('@env@')
 +
- from websocket import create_connection, WebSocketConnectionClosedException
+ from websocket import ABNF, create_connection, WebSocketConnectionClosedException
  
- # hack to make tests possible.. better way?
+ try:


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Updates `wee-slack` to the current release.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
