### PR TITLE
adrdox: init at v1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -948,6 +948,11 @@
     github = "chiiruno";
     name = "Okina Matara";
   };
+  chloekek = {
+    email = "rightfold+ck@gmail.com";
+    github = "chloekek";
+    name = "Chloé Kekoa";
+  };
   choochootrain = {
     email = "hurshal@imap.cc";
     github = "choochootrain";

--- a/pkgs/development/tools/documentation/adrdox/cross-platform.patch
+++ b/pkgs/development/tools/documentation/adrdox/cross-platform.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index f54da14..912896e 100644
+--- a/Makefile
++++ b/Makefile
+@@ -2,7 +2,7 @@ LIBDPARSE=Dscanner/libdparse/src/dparse/ast.d Dscanner/libdparse/src/dparse/form
+ 
+ all:
+ 	#dmd diff.d terminal.d $(LIBDPARSE)
+-	dmd -m64 doc2.d latex.d cgi.d comment.d stemmer.d dom.d script.d jsvar.d html.d color.d -J. $(LIBDPARSE) -g # -version=std_parser_verbose 
++	dmd doc2.d latex.d cgi.d comment.d stemmer.d dom.d script.d jsvar.d html.d color.d -J. $(LIBDPARSE) -g # -version=std_parser_verbose 
+ 	#dmd -of/var/www/dpldocs.info/locate locate.d  dom.d stemmer.d  cgi -J. -version=fastcgi -m64 -debug
+ locate:
+ 	dmd -of/var/www/dpldocs.info/locate locate.d  dom.d stemmer.d  cgi -J. -version=fastcgi -m64 -debug postgres.d database.d -L-L/usr/local/pgsql/lib

--- a/pkgs/development/tools/documentation/adrdox/default.nix
+++ b/pkgs/development/tools/documentation/adrdox/default.nix
@@ -1,0 +1,43 @@
+{ stdenv, fetchFromGitHub, dmd }:
+
+stdenv.mkDerivation rec {
+  pname = "adrdox";
+  version = "v1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "adamdruppe";
+    repo = "adrdox";
+    rev = version;
+    sha256 = "1w0y158ab36385jhg6q9xjlb8cilfwimlh43q86n40l10vhn4bk9";
+  };
+
+  buildInputs = [ dmd ];
+
+  patches = [
+    # Allow building on non-64-bit systems. adrdox works fine on those
+    # platforms.
+    ./cross-platform.patch
+  ];
+
+  # We need a custom install phase because the makefile lacks an install
+  # target. If a future version of adrdox gets an install target, the custom
+  # install phase may be removed.
+  installPhase = ''
+    runHook preInstall
+
+    install -d $out/bin
+    install doc2 $out/bin
+    # doc2 expects the asset files to be in the same directory as the binary.
+    install skeleton-default.html script.js search-docs.js style.css $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Documentation generator for D";
+    homepage = "https://github.com/adamdruppe/adrdox";
+    license = licenses.boost;
+    maintainers = [ maintainers.chloekek ];
+    platforms = dmd.meta.platforms;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8712,6 +8712,8 @@ in
 
   adtool = callPackage ../tools/admin/adtool { };
 
+  adrdox = callPackage ../development/tools/documentation/adrdox { };
+
   inherit (callPackage ../development/tools/alloy { })
     alloy4
     alloy5


### PR DESCRIPTION
Adding a package for the adrdox documentation generator for D.

###### Motivation for this change

I like this tool and it wasn't in Nixpkgs so I added it to Nixpkgs. It is used by several D projects for generating HTML documentation from source code.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
