### PR TITLE
pythonPackages.spglib: add patch fixing darwin/py27 build

### DIFF
--- a/pkgs/development/python-modules/spglib/default.nix
+++ b/pkgs/development/python-modules/spglib/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, numpy, nose, pyyaml }:
+{ stdenv, buildPythonPackage, fetchPypi, fetchpatch, numpy, nose, pyyaml }:
 
 buildPythonPackage rec {
   pname = "spglib";
@@ -8,6 +8,15 @@ buildPythonPackage rec {
     inherit pname version;
     sha256 = "15b02b74c0f06179bc3650c43a710a5200abbba387c6eda3105bfd9236041443";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "fix-assertions.patch";
+      url = https://github.com/atztogo/spglib/commit/d57070831585a6f02dec0a31d25b375ba347798c.patch;
+      stripLen = 1;
+      sha256 = "0crmkc498rbrawiy9zbl39qis2nmsbfr4s6kk6k3zhdy8z2ppxw7";
+    })
+  ];
 
   propagatedBuildInputs = [ numpy ];
 


### PR DESCRIPTION
###### Motivation for this change
In trying to fix the darwin py27 build for this package, realized it was an upstream problem. Opened upstream issue https://github.com/atztogo/spglib/issues/78, turns out the problem was an incorrect assertion and darwin/py27 was the only combination where its `assert()` wasn't acting as a no-op, so tripping up on this problem.

`pythonPackages.seekpath` reverse-dependency seems broken, so `nox-review` doesn't _quite_ build fully, but this doesn't break anything new. Tested on non-nixos linux x86_64 and macos 10.13.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
