### PR TITLE
haskellPackages: Don't ignore old overrides

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7491,9 +7491,7 @@ in
 
   haskell = callPackage ./haskell-packages.nix { };
 
-  haskellPackages = dontRecurseIntoAttrs (haskell.packages.ghc865.override {
-    overrides = haskell.packageOverrides;
-  });
+  haskellPackages = dontRecurseIntoAttrs haskell.packages.ghc865;
 
   inherit (haskellPackages) ghc;
 


### PR DESCRIPTION
This prevented `pkgs.haskell.packages.${compiler}` overlays from propagating
to `pkgs.haskellPackages`

E.g. if you use this overlay:
```nix
self: super: {
  haskell = super.haskell // {
    packages = super.haskell.packages // {
      ghc865 = super.haskell.packages.ghc865.override (old: {
        overrides = super.lib.composeExtensions (old.overrides or (hself: hsuper: {})) (hself: hsuper: {
          foobarbaz = "foobarbaz";
        });
      });
    };
  };
}
```

You now have access to `foobarbaz` through `pkgs.haskellPackages.foobarbaz` in addition to `pkgs.haskell.packages.ghc865.foobarbaz`.

Pinging @peti @r-ryantm @basvandijk @domenkozar