### PR TITLE
weechatScripts.weechat-otr: init at 1.9.2

### DIFF
--- a/pkgs/applications/networking/irc/weechat/scripts/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/default.nix
@@ -14,4 +14,8 @@
   };
 
   weechat-autosort = callPackage ./weechat-autosort { };
+
+  weechat-otr = callPackage ./weechat-otr {
+    inherit pythonPackages;
+  };
 }

--- a/pkgs/applications/networking/irc/weechat/scripts/weechat-otr/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/weechat-otr/default.nix
@@ -1,0 +1,64 @@
+{ stdenv, substituteAll, buildEnv, fetchgit, fetchFromGitHub, pythonPackages, gmp }:
+
+let
+  # pure-python-otr (potr) requires an older version of pycrypto, which is
+  # not compatible with pycryptodome. Therefore, the latest patched version
+  # of pycrypto will be fetched from the Debian project.
+  # https://security-tracker.debian.org/tracker/source-package/python-crypto
+
+  pycrypto = pythonPackages.buildPythonPackage rec {
+    pname = "pycrypto";
+    version = "2.6.1-10";
+
+    src = fetchgit {
+      url = "https://salsa.debian.org/sramacher/python-crypto.git";
+      rev = "debian/${version}";
+      sha256 = "10rgq8bmjfpiqqa1g1p1hh7pxlxs7x0nawvk6zip0pd6x2vsr661";
+    };
+
+    buildInputs = [ gmp ];
+
+    preConfigure = ''
+      sed -i 's,/usr/include,/no-such-dir,' configure
+      sed -i "s!,'/usr/include/'!!" setup.py
+    '';
+  };
+
+  potr = pythonPackages.potr.overridePythonAttrs (oldAttrs: {
+    propagatedBuildInputs = [ pycrypto ];
+  });
+in stdenv.mkDerivation rec {
+  pname = "weechat-otr";
+  version = "1.9.2";
+
+  src = fetchFromGitHub {
+    repo = pname;
+    owner = "mmb";
+    rev = "v${version}";
+    sha256 = "1lngv98y6883vk8z2628cl4d5y8jxy39w8245gjdvshl8g18k5s2";
+  };
+
+  patches = [
+    (substituteAll {
+      src = ./libpath.patch;
+      env = "${buildEnv {
+        name = "weechat-otr-env";
+        paths = [ potr pycrypto ];
+      }}/${pythonPackages.python.sitePackages}";
+    })
+  ];
+
+  passthru.scripts = [ "weechat_otr.py" ];
+
+  installPhase = ''
+    mkdir -p $out/share
+    cp weechat_otr.py $out/share/weechat_otr.py
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/mmb/weechat-otr";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ geistesk ];
+    description = "WeeChat script for Off-the-Record messaging";
+  };
+}

--- a/pkgs/applications/networking/irc/weechat/scripts/weechat-otr/libpath.patch
+++ b/pkgs/applications/networking/irc/weechat/scripts/weechat-otr/libpath.patch
@@ -1,0 +1,13 @@
+diff --git a/weechat_otr.py b/weechat_otr.py
+index 0ccfb35..c42bebf 100644
+--- a/weechat_otr.py
++++ b/weechat_otr.py
+@@ -41,6 +41,8 @@ import shlex
+ import shutil
+ import sys
+ 
++sys.path.append('@env@')
++
+ import potr
+ import weechat
+ 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
This PR adds the `otr.py` script for WeeChat.

As discussed both in the [NixOS Wiki](https://nixos.wiki/wiki/Weechat) and in [`potr`'s issue tracker](https://github.com/python-otr/pure-python-otr/issues/68) before, `potr` does not work properly with the current version of `pycryptodome` and requires an older version of `pycrpto`. Therefore, the last release of `pycrypto`, with Debian's [security patches](https://security-tracker.debian.org/tracker/source-package/python-crypto) applied, will be used.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
