### PR TITLE
pythonPackages.azure-cli-core: init at 2.0.66 

### DIFF
--- a/pkgs/development/python-modules/antlr4-python2-runtime/default.nix
+++ b/pkgs/development/python-modules/antlr4-python2-runtime/default.nix
@@ -1,0 +1,18 @@
+{ stdenv, fetchPypi, buildPythonPackage, isPy3k }:
+
+buildPythonPackage rec {
+  pname = "antlr4-python2-runtime";
+  version = "4.7.2";
+  disabled = isPy3k;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "04ljic5wnqpizln8q3c78pqrckz6q5nb433if00j1mlyv2yja22q";
+  };
+
+  meta = {
+    description = "Runtime for ANTLR";
+    homepage = "https://www.antlr.org/";
+    license = stdenv.lib.licenses.bsd3;
+  };
+}

--- a/pkgs/development/python-modules/azure-cli-core/default.nix
+++ b/pkgs/development/python-modules/azure-cli-core/default.nix
@@ -1,0 +1,93 @@
+{ stdenv
+, lib
+, python
+, buildPythonPackage
+, fetchPypi
+, adal
+, antlr4-python3-runtime
+, argcomplete
+, azure-cli-telemetry
+, colorama
+, jmespath
+, humanfriendly
+, knack
+, msrest
+, msrestazure
+, paramiko
+, pygments
+, pyjwt
+, pyopenssl
+, pyyaml
+, requests
+, six
+, tabulate
+, azure-mgmt-resource
+, pyperclip
+, psutil
+, enum34
+, futures
+, antlr4-python2-runtime
+, ndg-httpsclient
+, isPy3k
+}:
+
+buildPythonPackage rec {
+  pname = "azure-cli-core";
+  version = "2.0.66";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0fp6b2x1l9bg07pca7asm80rnjlc4kkm061s3nrb55yj6awsnim5";
+  };
+
+  propagatedBuildInputs = [
+    adal
+    argcomplete
+    azure-cli-telemetry
+    colorama
+    jmespath
+    humanfriendly
+    knack
+    msrest
+    msrestazure
+    paramiko
+    pygments
+    pyjwt
+    pyopenssl
+    pyyaml
+    requests
+    six
+    tabulate
+    azure-mgmt-resource
+    pyperclip
+    psutil
+  ]
+  ++ lib.optionals isPy3k [ antlr4-python3-runtime ]
+  ++ lib.optionals (!isPy3k) [ enum34 futures antlr4-python2-runtime ndg-httpsclient ];
+
+  # Remove overly restrictive version contraints and obsolete namespace setup
+  prePatch = ''
+    substituteInPlace setup.py \
+      --replace "wheel==0.30.0" "wheel" \
+      --replace "azure-mgmt-resource==2.1.0" "azure-mgmt-resource"
+    substituteInPlace setup.cfg \
+      --replace "azure-namespace-package = azure-cli-nspkg" ""
+  '';
+
+  # Prevent these __init__'s from violating PEP420, only needed for python2
+  postInstall = lib.optionalString isPy3k ''
+    rm $out/${python.sitePackages}/azure/__init__.py \
+       $out/${python.sitePackages}/azure/cli/__init__.py
+  '';
+
+  # Tests are not included in sdist package
+  doCheck = false;
+
+  meta = with lib; {
+    homepage = https://github.com/Azure/azure-cli;
+    description = "Next generation multi-platform command line experience for Azure";
+    platforms = platforms.all;
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/development/python-modules/azure-cli-telemetry/default.nix
+++ b/pkgs/development/python-modules/azure-cli-telemetry/default.nix
@@ -1,0 +1,50 @@
+{ stdenv
+, lib
+, buildPythonPackage
+, fetchPypi
+, isPy3k
+, python
+, applicationinsights
+, portalocker
+}:
+
+buildPythonPackage rec {
+  pname = "azure-cli-telemetry";
+  version = "1.0.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "14wmxdsrrlnixaj52q37rrvp9wg5b54gf5wn2z1vq68kxpg1s560";
+  };
+
+  propagatedBuildInputs = [
+    applicationinsights
+    portalocker
+  ];
+
+  # tests are not published to pypi
+  doCheck = false;
+
+  # Remove overly restrictive version contraints and obsolete namespace setup
+  prePatch = ''
+    substituteInPlace setup.py \
+      --replace "applicationinsights>=0.11.1,<0.11.8" "applicationinsights" \
+      --replace "portalocker==1.2.1" "portalocker"
+    substituteInPlace setup.cfg \
+      --replace "azure-namespace-package = azure-cli-nspkg" ""
+  '';
+
+  # Prevent these __init__'s from violating PEP420, only needed for python2
+  postInstall = lib.optionalString isPy3k ''
+    rm $out/${python.sitePackages}/azure/__init__.py \
+       $out/${python.sitePackages}/azure/cli/__init__.py
+  '';
+
+  meta = with lib; {
+    homepage = https://github.com/Azure/azure-cli;
+    description = "Next generation multi-platform command line experience for Azure";
+    platforms = platforms.all;
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/development/python-modules/knack/default.nix
+++ b/pkgs/development/python-modules/knack/default.nix
@@ -1,0 +1,55 @@
+{ stdenv
+, lib
+, buildPythonPackage
+, fetchPypi
+, argcomplete
+, colorama
+, jmespath
+, knack
+, pygments
+, pyyaml
+, six
+, tabulate
+, mock
+, vcrpy
+, pytest
+}:
+
+buildPythonPackage rec {
+  pname = "knack";
+  version = "0.6.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1kxxj9m2mvva9rz11m6pgdg0mi712d28faj4633rl23qa53sh7i8";
+  };
+
+  propagatedBuildInputs = [
+    argcomplete
+    colorama
+    jmespath
+    pygments
+    pyyaml
+    six
+    tabulate
+  ];
+
+  checkInputs = [
+    mock
+    vcrpy
+    pytest
+  ];
+
+  # tries to make a '/homeless-shelter' dir
+  checkPhase = ''
+    pytest -k 'not test_cli_exapp1'
+  '';
+
+  meta = with lib; {
+    homepage = https://github.com/microsoft/knack;
+    description = "A Command-Line Interface framework";
+    platforms = platforms.all;
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer ];
+  };
+}

--- a/pkgs/development/python-modules/psutil/default.nix
+++ b/pkgs/development/python-modules/psutil/default.nix
@@ -6,11 +6,11 @@
 
 buildPythonPackage rec {
   pname = "psutil";
-  version = "5.5.1";
+  version = "5.6.2";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "045qaqvn6k90bj5bcy259yrwcd2afgznaav3sfhphy9b8ambzkkj";
+    sha256 = "1v95vb5385qscfdvphv8l2w22bmir3d7yhpi02n58v3mlqy1r3l2";
   };
 
   # No tests in archive

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -247,6 +247,8 @@ in {
 
   azure-nspkg = callPackage ../development/python-modules/azure-nspkg { };
 
+  azure-cli-telemetry = callPackage ../development/python-modules/azure-cli-telemetry { };
+
   azure-common = callPackage ../development/python-modules/azure-common { };
 
   azure-mgmt-common = callPackage ../development/python-modules/azure-mgmt-common { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3131,6 +3131,8 @@ in {
 
   kitchen = callPackage ../development/python-modules/kitchen { };
 
+  knack = callPackage ../development/python-modules/knack { };
+
   kubernetes = callPackage ../development/python-modules/kubernetes { };
 
   pylast = callPackage ../development/python-modules/pylast { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1069,6 +1069,8 @@ in {
 
   amqplib = callPackage ../development/python-modules/amqplib {};
 
+  antlr4-python2-runtime = callPackage ../development/python-modules/antlr4-python2-runtime {};
+
   antlr4-python3-runtime = callPackage ../development/python-modules/antlr4-python3-runtime {};
 
   apipkg = callPackage ../development/python-modules/apipkg {};

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -247,6 +247,8 @@ in {
 
   azure-nspkg = callPackage ../development/python-modules/azure-nspkg { };
 
+  azure-cli-core = callPackage ../development/python-modules/azure-cli-core { };
+
   azure-cli-telemetry = callPackage ../development/python-modules/azure-cli-telemetry { };
 
   azure-common = callPackage ../development/python-modules/azure-common { };


### PR DESCRIPTION
###### Motivation for this change
Lay the groundwork for [azure-cli repo](https://github.com/Azure/azure-cli), which is the "new azure cli standard". Also know as "azure cli 2.0".

The azure-cli package will have to wait for #60435 to be merged. And then nix will have modern support for azure :) (at least cli, nixops will be later)

Separate from #60435 

Works with python2, python3.6 and python3.7. Unfortunately contextvars is needed for one of the dependencies (msrest) so it's broken on python3.5.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
$ nix path-info -Sh /nix/store/fsdvfxzz6bwgdvzdhnziw5rjnpjjr896-python3.6-azure-cli-core-2.0.66
/nix/store/fsdvfxzz6bwgdvzdhnziw5rjnpjjr896-python3.6-azure-cli-core-2.0.66      135.5M