### PR TITLE
ledger-live-desktop: init at 1.12.0

### DIFF
--- a/pkgs/applications/altcoins/ledger-live-desktop/default.nix
+++ b/pkgs/applications/altcoins/ledger-live-desktop/default.nix
@@ -2,11 +2,11 @@
 
 stdenv.mkDerivation rec {
   pname = "ledger-live-desktop";
-  version = "1.9.1";
+  version = "1.12.0";
 
   src = fetchurl {
     url = "https://github.com/LedgerHQ/${pname}/releases/download/v${version}/${pname}-${version}-linux-x86_64.AppImage";
-    sha256 = "0b919ilvv3zi17fnzngnnmg28dxqlq0dvj3fdvb50kh3ibrhdcfz";
+    sha256 = "0sn0ri8kqvy36d6vjwsb0mh54nwic58416m6q5drl1schsn6wyvj";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/applications/altcoins/ledger-live-desktop/default.nix
+++ b/pkgs/applications/altcoins/ledger-live-desktop/default.nix
@@ -1,0 +1,44 @@
+{
+ stdenv,
+ appimage-run,
+ fetchurl,
+ runtimeShell,
+}:
+
+stdenv.mkDerivation rec {
+  github-user = "LedgerHQ";
+  pname = "ledger-live-desktop";
+  version = "1.9.1";
+
+  src = fetchurl {
+    url = "https://github.com/${github-user}/${pname}/releases/download/v${version}/${pname}-${version}-linux-x86_64.AppImage";
+    sha256 = "0b919ilvv3zi17fnzngnnmg28dxqlq0dvj3fdvb50kh3ibrhdcfz";
+  };
+
+  buildInputs = [ appimage-run ];
+
+  unpackPhase = ":";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,share}
+    cp $src $out/share/${pname}
+    echo "#!${runtimeShell}" > $out/bin/${pname}
+    echo "${appimage-run}/bin/appimage-run $out/share/${pname}" >> $out/bin/${pname}
+    chmod +x $out/bin/${pname} $out/share/${pname}
+
+    runHook postInstall
+  '';
+
+  meta = with stdenv.lib; {
+    description = ''
+    The companion to your Ledger hardware wallet
+    Easily set up and manage your Ledger device
+    '';
+    homepage = https://www.ledger.com/live;
+    license = licenses.mit;
+    maintainers = with maintainers; [ thedavidmeister ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4385,6 +4385,8 @@ in
 
   leatherman = callPackage ../development/libraries/leatherman { };
 
+  ledger-live-desktop = callPackage ../applications/altcoins/ledger-live-desktop { };
+
   ledmon = callPackage ../tools/system/ledmon { };
 
   leela = callPackage ../tools/graphics/leela { };


### PR DESCRIPTION
###### Motivation for this change

Adds ledger live desktop, the app that manages ledger S/X/blue

https://www.ledger.com/

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
