### PR TITLE
imagecodecs-lite: init at 2019.4.20

### DIFF
--- a/pkgs/development/python-modules/imagecodecs-lite/default.nix
+++ b/pkgs/development/python-modules/imagecodecs-lite/default.nix
@@ -1,0 +1,25 @@
+{ lib, fetchPypi, buildPythonPackage
+, pytest
+, numpy
+, cython
+}:
+
+buildPythonPackage rec {
+  pname = "imagecodecs-lite";
+  version = "2019.4.20";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1cp88g7g91gdhjhaz6gvb4jzvi5ad817id9f2bnc5r95ag93bqb0";
+  };
+
+  checkInputs = [ pytest ];
+  propagatedBuildInputs = [ numpy cython ];
+
+  meta = with lib; {
+    description = "Block-oriented, in-memory buffer transformation, compression, and decompression functions";
+    homepage = "https://www.lfd.uci.edu/~gohlke/";
+    maintainers = [ maintainers.tbenst ];
+    license = licenses.bsd3;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2094,6 +2094,8 @@ in {
 
   ijson = callPackage ../development/python-modules/ijson {};
 
+  imagecodecs-lite = disabledIf (!isPy3k) (callPackage ../development/python-modules/imagecodecs-lite { });
+
   imagesize = callPackage ../development/python-modules/imagesize { };
 
   image-match = callPackage ../development/python-modules/image-match { };


### PR DESCRIPTION

###### Motivation for this change
Block-oriented, in-memory buffer transformation, compression, and decompression functions. Needed for `tifffile`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
