### PR TITLE
Tifffile

### DIFF
--- a/pkgs/development/python-modules/tifffile/default.nix
+++ b/pkgs/development/python-modules/tifffile/default.nix
@@ -1,6 +1,7 @@
-{ lib, fetchPypi, buildPythonPackage, isPy27
+{ lib, fetchPypi, buildPythonPackage, isPy27, isPy3k
 , numpy, enum34, futures, pathlib
 , pytest
+, imagecodecs-lite
 }:
 
 buildPythonPackage rec {
@@ -23,11 +24,12 @@ buildPythonPackage rec {
   '';
 
   propagatedBuildInputs = [ numpy ]
-    ++ lib.optional isPy27 [ futures enum34 pathlib ];
+    ++ lib.optional isPy27 [ futures enum34 pathlib ]
+    ++ lib.optional isPy3k [ imagecodecs-lite ];
 
   meta = with lib; {
     description = "Read and write image data from and to TIFF files.";
-    homepage = https://www.lfd.uci.edu/~gohlke/;
+    homepage = "https://www.lfd.uci.edu/~gohlke/";
     maintainers = [ maintainers.lebastr ];
     license = licenses.bsd3;
   };


### PR DESCRIPTION
###### Motivation for this change
Add missing dependency to `tifffile`. Note: do not merge until https://github.com/NixOS/nixpkgs/pull/62754 is merged

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
