### PR TITLE
libblockdev: add gptfdisk as a dependency

### DIFF
--- a/pkgs/development/libraries/libblockdev/default.nix
+++ b/pkgs/development/libraries/libblockdev/default.nix
@@ -1,5 +1,5 @@
-{ stdenv, fetchFromGitHub, autoreconfHook, pkgconfig, gtk-doc, libxslt, docbook_xsl
-, docbook_xml_dtd_43, python3, gobject-introspection, glib, udev, kmod, parted, libyaml
+{ stdenv, fetchFromGitHub, substituteAll, autoreconfHook, pkgconfig, gtk-doc, libxslt, docbook_xsl
+, docbook_xml_dtd_43, python3, gobject-introspection, glib, udev, kmod, parted, gptfdisk, libyaml
 , cryptsetup, lvm2, dmraid, utillinux, libbytesize, libndctl, nss, volume_key
 }:
 
@@ -17,6 +17,13 @@ in stdenv.mkDerivation rec {
 
   outputs = [ "out" "dev" "devdoc" ];
 
+  patches = [
+    (substituteAll {
+      src = ./fix-paths.patch;
+      sgdisk = "${gptfdisk}/bin/sgdisk";
+    })
+  ];
+
   postPatch = ''
     patchShebangs scripts
   '';
@@ -26,7 +33,7 @@ in stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    glib udev kmod parted cryptsetup lvm2 dmraid utillinux libbytesize libndctl nss volume_key libyaml
+    glib udev kmod parted gptfdisk cryptsetup lvm2 dmraid utillinux libbytesize libndctl nss volume_key libyaml
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/development/libraries/libblockdev/fix-paths.patch
+++ b/pkgs/development/libraries/libblockdev/fix-paths.patch
@@ -1,0 +1,47 @@
+--- a/src/plugins/part.c
++++ b/src/plugins/part.c
+@@ -146,7 +146,7 @@ static GMutex deps_check_lock;
+ #define DEPS_LAST 2
+ 
+ static const UtilDep deps[DEPS_LAST] = {
+-    {"sgdisk", "0.8.6", NULL, "GPT fdisk \\(sgdisk\\) version ([\\d\\.]+)"},
++    {"@sgdisk@", "0.8.6", NULL, "GPT fdisk \\(sgdisk\\) version ([\\d\\.]+)"},
+     {"sfdisk", NULL, NULL, NULL},
+ };
+ 
+@@ -355,7 +355,7 @@ gboolean bd_part_create_table (const gchar *disk, BDPartTableType type, gboolean
+ }
+ 
+ static gchar* get_part_type_guid_and_gpt_flags (const gchar *device, int part_num, guint64 *flags, GError **error) {
+-    const gchar *args[4] = {"sgdisk", NULL, device, NULL};
++    const gchar *args[4] = {"@sgdisk@", NULL, device, NULL};
+     gchar *output = NULL;
+     gchar **lines = NULL;
+     gchar **line_p = NULL;
+@@ -1325,7 +1325,7 @@ gboolean bd_part_resize_part (const gchar *disk, const gchar *part, guint64 size
+ 
+ 
+ static gboolean set_gpt_flag (const gchar *device, int part_num, BDPartFlag flag, gboolean state, GError **error) {
+-    const gchar *args[5] = {"sgdisk", "--attributes", NULL, device, NULL};
++    const gchar *args[5] = {"@sgdisk@", "--attributes", NULL, device, NULL};
+     int bit_num = 0;
+     gboolean success = FALSE;
+ 
+@@ -1351,7 +1351,7 @@ static gboolean set_gpt_flag (const gchar *device, int part_num, BDPartFlag flag
+ }
+ 
+ static gboolean set_gpt_flags (const gchar *device, int part_num, guint64 flags, GError **error) {
+-    const gchar *args[5] = {"sgdisk", "--attributes", NULL, device, NULL};
++    const gchar *args[5] = {"@sgdisk@", "--attributes", NULL, device, NULL};
+     guint64 real_flags = 0;
+     gchar *mask_str = NULL;
+     gboolean success = FALSE;
+@@ -1791,7 +1791,7 @@ gboolean bd_part_set_part_name (const gchar *disk, const gchar *part, const gcha
+  * Tech category: %BD_PART_TECH_GPT-%BD_PART_TECH_MODE_MODIFY_PART
+  */
+ gboolean bd_part_set_part_type (const gchar *disk, const gchar *part, const gchar *type_guid, GError **error) {
+-    const gchar *args[5] = {"sgdisk", "--typecode", NULL, disk, NULL};
++    const gchar *args[5] = {"@sgdisk@", "--typecode", NULL, disk, NULL};
+     const gchar *part_num_str = NULL;
+     gboolean success = FALSE;
+     guint64 progress_id = 0;


### PR DESCRIPTION
###### Motivation for this change

Certain udisk2 operations (eg creating luks-encrypted ext4 volumes) require libblockdev to have access to the sgdisk utility. This change adds gptfdisk (which includes sgdisk) to libblockdev.

Fixes #62749.

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [X] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
