### PR TITLE
nixos/zoneminder: font files cannot be found

### DIFF
--- a/nixos/modules/services/misc/zoneminder.nix
+++ b/nixos/modules/services/misc/zoneminder.nix
@@ -229,6 +229,8 @@ in {
               location / {
                 try_files $uri $uri/ /index.php?$args =404;
 
+                rewrite ^/skins/.*/css/fonts/(.*)$ /fonts/$1 permanent;
+
                 location ~ /api/(css|img|ico) {
                   rewrite ^/api(.+)$ /api/app/webroot/$1 break;
                   try_files $uri $uri/ =404;


### PR DESCRIPTION
###### Motivation for this change

ZM's paths to font files are wrong so we need to rewrite them.

The browser will try to access ```/skins/classic/css/fonts/font_file.ttf``` which should just be ```/fonts/font_file.ttf```.

I have no idea how this used to work, but in any case after this it does.

Cc: @amazari @aanderse 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
