### PR TITLE
icr: do not wrap crystal so we can use one from the environment

### DIFF
--- a/pkgs/development/tools/icr/default.nix
+++ b/pkgs/development/tools/icr/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, crystal, shards, which, makeWrapper
+{ stdenv, fetchFromGitHub, crystal, shards, which
 , openssl, readline, libyaml }:
 
 stdenv.mkDerivation rec {
@@ -19,14 +19,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ crystal libyaml openssl readline ];
 
-  nativeBuildInputs = [ makeWrapper shards which ];
+  nativeBuildInputs = [ shards which ];
 
   doCheck = true;
   checkTarget = "test";
-
-  postInstall = ''
-    wrapProgram $out/bin/icr --prefix PATH : "${stdenv.lib.makeBinPath [ crystal ]}"
-  '';
 
   meta = with stdenv.lib; {
     description = "Interactive console for the Crystal programming language";


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Further to #61156, do not wrap ```crystal``` so icr will work with whatever crystal is currently available in the environment.

This means that installing ```icr``` on its own isn't enough to make it work - you need to have crystal available, either in the global environment, the user environment or using something like ```direnv``` (recommended).

Cc: @c0bw3b 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
