### PR TITLE
sngrep: init at 1.4.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2505,6 +2505,11 @@
     github = "jonringer";
     name = "Jonathan Ringer";
   };
+  jorise = {
+    email = "info@jorisengbers.nl";
+    github = "JorisE";
+    name = "Joris Engbers";
+  };
   jorsn = {
     name = "Johannes Rosenberger";
     email = "johannes@jorsn.eu";

--- a/pkgs/applications/networking/sniffers/sngrep/default.nix
+++ b/pkgs/applications/networking/sniffers/sngrep/default.nix
@@ -1,0 +1,38 @@
+{ stdenv, autoconf, automake, fetchFromGitHub, libpcap, ncurses, openssl, pcre }:
+
+stdenv.mkDerivation rec {
+  pname = "sngrep";
+  version = "1.4.6";
+
+  src = fetchFromGitHub {
+    owner = "irontec";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "0fj13pim5bfm3a2nr05apspraf29klpmcnhmycklfmrlncq5xqdf";
+  };
+
+  buildInputs = [
+    libpcap ncurses pcre openssl ncurses
+  ];
+
+  nativeBuildInputs = [
+    autoconf automake
+  ];
+
+  configureFlags = [
+    "--with-pcre"
+    "--enable-unicode"
+    "--enable-ipv6"
+    "--enable-eep"
+  ];
+
+  preConfigure = "./bootstrap.sh";
+
+  meta = with stdenv.lib; {
+    description = "A tool for displaying SIP calls message flows from terminal";
+    homepage = "https://github.com/irontec/sngrep";
+    license = licenses.gpl3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ jorise ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18047,6 +18047,8 @@ in
   wireshark-gtk = throw "Not supported anymore. Use wireshark-qt or wireshark-cli instead.";
   wireshark-cli = wireshark.override { withQt = false; };
 
+  sngrep = callPackage ../applications/networking/sniffers/sngrep {};
+
   termshark = callPackage ../tools/networking/termshark { };
 
   fbida = callPackage ../applications/graphics/fbida { };


### PR DESCRIPTION
Sngrep is used to inspect SIP traffic.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
