### PR TITLE
[coq] simple-io: 1.0.0 -> 1.2.0; QuickChick: init at 1.1.0 for Coq 8.9

### DIFF
--- a/pkgs/development/coq-modules/QuickChick/default.nix
+++ b/pkgs/development/coq-modules/QuickChick/default.nix
@@ -14,22 +14,22 @@ let params =
       sha256 = "0fri4nih40vfb0fbr82dsi631ydkw48xszinq43lyinpknf54y17";
     };
 
-    "8.7" = {
-      version = "20171212";
-      rev = "195e550a1cf0810497734356437a1720ebb6d744";
-      sha256 = "0zm23y89z0h4iamy74qk9qi2pz2cj3ga6ygav0w79n0qyqwhxcq1";
-    };
     "8.8" = rec {
-      preConfigure = "substituteInPlace Makefile --replace quickChickTool.byte quickChickTool.native";
       version = "20190311";
       rev = "22af9e9a223d0038f05638654422e637e863b355";
       sha256 = "00rnr19lg6lg0haq1sy4ld38p7imzand6fc52fvfq27gblxkp2aq";
-      buildInputs = with coq.ocamlPackages; [ ocamlbuild num ];
-      propagatedBuildInputs = [ coq-ext-lib simple-io ];
+    };
+
+    "8.9" = rec {
+      version = "1.1.0";
+      rev = "v${version}";
+      sha256 = "1c34v1k37rk7v0xk2czv5n79mbjxjrm6nh3llg2mpfmdsqi68wf3";
     };
   };
   param = params."${coq.coq-version}";
 in
+
+let recent = stdenv.lib.versionAtLeast coq.coq-version "8.8"; in
 
 stdenv.mkDerivation rec {
 
@@ -41,15 +41,18 @@ stdenv.mkDerivation rec {
     inherit (param) rev sha256;
   };
 
+  preConfigure = stdenv.lib.optionalString recent
+    "substituteInPlace Makefile --replace quickChickTool.byte quickChickTool.native";
+
   buildInputs = [ coq ]
   ++ (with coq.ocamlPackages; [ ocaml camlp5 findlib ])
-  ++ (param.buildInputs or [])
+  ++ stdenv.lib.optionals recent
+     (with coq.ocamlPackages; [ ocamlbuild num ])
   ;
-  propagatedBuildInputs = [ ssreflect ] ++ (param.propagatedBuildInputs or []);
+  propagatedBuildInputs = [ ssreflect ]
+  ++ stdenv.lib.optionals recent [ coq-ext-lib simple-io ];
 
   enableParallelBuilding = false;
-
-  preConfigure = param.preConfigure or null;
 
   installPhase = ''
     make -f Makefile.coq COQLIB=$out/lib/coq/${coq.coq-version}/ install

--- a/pkgs/development/coq-modules/simple-io/default.nix
+++ b/pkgs/development/coq-modules/simple-io/default.nix
@@ -1,13 +1,13 @@
 { stdenv, fetchFromGitHub, coq, coq-ext-lib }:
 
 stdenv.mkDerivation rec {
-  version = "1.0.0";
+  version = "1.2.0";
   name = "coq${coq.coq-version}-simple-io-${version}";
   src = fetchFromGitHub {
     owner = "Lysxia";
     repo = "coq-simple-io";
     rev = version;
-    sha256 = "06gnbl8chv6ig18rlxnp8gg0np6863kxd7j15h46q0v1cnpx84lp";
+    sha256 = "1im1vwp7l7ha8swnhgbih0qjg187n8yx14i003nf6yy7p0ryxc9m";
   };
 
   buildInputs = [ coq ] ++ (with coq.ocamlPackages; [ ocaml ocamlbuild ]);


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
