### PR TITLE
Restart declarative containers when their host environment configuration changes

### DIFF
--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -689,7 +689,7 @@ in
       [{ name = "container@"; value = unit; }]
       # declarative containers
       ++ (mapAttrsToList (name: cfg: nameValuePair "container@${name}" (let
-          config = cfg // (
+          containerConfig = cfg // (
           if cfg.enableTun then
             {
               allowedDevices = cfg.allowedDevices
@@ -700,17 +700,17 @@ in
           else {});
         in
           unit // {
-            preStart = preStartScript config;
-            script = startScript config;
-            postStart = postStartScript config;
-            serviceConfig = serviceDirectives config;
+            preStart = preStartScript containerConfig;
+            script = startScript containerConfig;
+            postStart = postStartScript containerConfig;
+            serviceConfig = serviceDirectives containerConfig;
           } // (
-          if config.autoStart then
+          if containerConfig.autoStart then
             {
               wantedBy = [ "machines.target" ];
               wants = [ "network.target" ];
               after = [ "network.target" ];
-              restartTriggers = [ config.path ];
+              restartTriggers = [ containerConfig.path ];
               reloadIfChanged = true;
             }
           else {})

--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -710,8 +710,11 @@ in
               wantedBy = [ "machines.target" ];
               wants = [ "network.target" ];
               after = [ "network.target" ];
-              restartTriggers = [ containerConfig.path ];
-              reloadIfChanged = true;
+              restartTriggers = [
+                containerConfig.path
+                config.environment.etc."containers/${name}.conf".source
+              ];
+              restartIfChanged = true;
             }
           else {})
       )) config.containers)


### PR DESCRIPTION
###### Motivation for this change

Changing network interfaces or bind mounts on NixOS containers requires a full restart of the container. However, with the prior version, this relationship was not properly represented and only a `reload` would occur:

```
ogden.......> reloading the following units: container@buildkite-builder-grahamc-1.service, container@buildkite-builder-grahamc-10.service, container@buildkite-builder-grahamc-2.service, container@buildkite-builder-grahamc-3.service, container@buildkite-builder-grahamc-4.service, container@buildkite-builder-grahamc-5.service, container@buildkite-builder-grahamc-6.service, container@buildkite-builder-grahamc-7.service, container@buildkite-builder-grahamc-8.service, container@buildkite-builder-grahamc-9.service, dbus.service
```

This is not sufficient and doesn't completely update the container.

After this change, it properly starts and stops the container when the bind mounts change:

```
ogden.......> updating GRUB 2 menu...
ogden.......> stopping the following units: container@buildkite-builder-grahamc-1.service, container@buildkite-builder-grahamc-10.service, container@buildkite-builder-grahamc-2.service, container@buildkite-builder-grahamc-3.service, container@buildkite-builder-grahamc-4.service, container@buildkite-builder-grahamc-5.service, container@buildkite-builder-grahamc-6.service, container@buildkite-builder-grahamc-7.service, container@buildkite-builder-grahamc-8.service, container@buildkite-builder-grahamc-9.service
ogden.......> activating the configuration...
ogden.......> setting up /etc...
ogden.......> reloading user units for root...
ogden.......> reloading user units for grahamc...
ogden.......> setting up tmpfiles
ogden.......> starting the following units: container@buildkite-builder-grahamc-1.service, container@buildkite-builder-grahamc-10.service, container@buildkite-builder-grahamc-2.service, container@buildkite-builder-grahamc-3.service, container@buildkite-builder-grahamc-4.service, container@buildkite-builder-grahamc-5.service, container@buildkite-builder-grahamc-6.service, container@buildkite-builder-grahamc-7.service, container@buildkite-builder-grahamc-8.service, container@buildkite-builder-grahamc-9.service
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Test results:

```
$ nix-build ./nixos/tests/containers*; echo $?
/nix/store/rkjnxm7qkd8yx7drjprl5hc4bbipkqzp-vm-test-run-containers-bridge
/nix/store/y4q6ffsf21gi452wv90a713ac8khmfcf-vm-test-run-containers-bridge
/nix/store/3kf7f6574dk4d6ph2pzgv0i4090h0vjq-vm-test-run-containers-hosts
/nix/store/mcxwmk3na4mjw2a4a54f63jfkfxwh9dx-vm-test-run-containers-imperative
/nix/store/y738p0y84v98qm49l6pi90z8fj87i47z-vm-test-run-containers-ipv4
/nix/store/ishfl5njzdpxkql11dvs8ha904wlcz3f-vm-test-run-containers-ipv6
/nix/store/hfwdd79brbdp0w449lhy44ibxlh9brhz-vm-test-run-containers-macvlans
/nix/store/yigbf08mza360l668ambakmx6lndlnnk-vm-test-run-containers-physical_interfaces
/nix/store/fwy1mdh0sfkh0887pc2q3bh92f6k8n1b-vm-test-run-containers-portforward
/nix/store/aaiv2vzsiz6bpvrg1n53ngj4x224pz8d-vm-test-run-cotnainers-reloadable
/nix/store/ak44x378g17z6v19a8maph77qqwi9mqh-vm-test-run-containers-restart_networking
/nix/store/c8g5v6j335mkjiygch1f8i281wmqhxnh-vm-test-run-containers-tmpfs
```