### PR TITLE
sigrok suite: enable for darwin

### DIFF
--- a/pkgs/development/libraries/librevisa/default.nix
+++ b/pkgs/development/libraries/librevisa/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = http://www.librevisa.org/;
     license = licenses.gpl3Plus;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = [ maintainers.bjornfor ];
   };
 }

--- a/pkgs/development/libraries/libserialport/default.nix
+++ b/pkgs/development/libraries/libserialport/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, udev }:
+{ stdenv, fetchurl, pkgconfig, udev, darwin }:
 
 stdenv.mkDerivation rec {
   name = "libserialport-0.1.1";
@@ -9,14 +9,14 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkgconfig ];
-  buildInputs = [ udev ];
+  buildInputs = stdenv.lib.optional stdenv.isLinux udev
+    ++ stdenv.lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.IOKit;
 
   meta = with stdenv.lib; {
     description = "Cross-platform shared library for serial port access";
     homepage = https://sigrok.org/;
     license = licenses.gpl3Plus;
-    # macOS, Windows and Android is also supported (according to upstream).
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = [ maintainers.bjornfor ];
   };
 }

--- a/pkgs/development/tools/libsigrok/default.nix
+++ b/pkgs/development/tools/libsigrok/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     description = "Core library of the sigrok signal analysis software suite";
     homepage = https://sigrok.org/;
     license = licenses.gpl3Plus;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = [ maintainers.bjornfor ];
   };
 }

--- a/pkgs/development/tools/libsigrokdecode/default.nix
+++ b/pkgs/development/tools/libsigrokdecode/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     description = "Protocol decoding library for the sigrok signal analysis software suite";
     homepage = https://sigrok.org/;
     license = licenses.gpl3Plus;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = [ maintainers.bjornfor ];
   };
 }

--- a/pkgs/development/tools/sigrok-cli/default.nix
+++ b/pkgs/development/tools/sigrok-cli/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     description = "Command-line frontend for the sigrok signal analysis software suite";
     homepage = https://sigrok.org/;
     license = licenses.gpl3Plus;
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = [ maintainers.bjornfor ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change
Out of curiosity I decided to see if the sigrok suite worked on darwin, and it does appear to from basic inspection.

Now, I don't actually have any sigrok-compatible hardware on me, so obviously wasn't able to test the full functionality, but the cli is able to find the "dummy" devices and find all its protocol decoders.

Tested on macos 10.13.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
