### PR TITLE
vimPlugins.SpaceCamp: init at 2019-06-05

### DIFF
--- a/pkgs/misc/vim-plugins/generated.nix
+++ b/pkgs/misc/vim-plugins/generated.nix
@@ -1651,6 +1651,17 @@ let
     };
   };
 
+  SpaceCamp = buildVimPluginFrom2Nix {
+    pname = "SpaceCamp";
+    version = "2019-06-05";
+    src = fetchFromGitHub {
+      owner = "jaredgorski";
+      repo = "SpaceCamp";
+      rev = "de431dc161f8f839a47c6f1cb277e7318ddba6f5";
+      sha256 = "032i1isc558rz2hmh3dfxnwgbqn7wdlhzz1c05v6bd7yyv0k5g23";
+    };
+  };
+
   Spacegray-vim = buildVimPluginFrom2Nix {
     pname = "Spacegray-vim";
     version = "2019-02-23";

--- a/pkgs/misc/vim-plugins/vim-plugin-names
+++ b/pkgs/misc/vim-plugins/vim-plugin-names
@@ -105,6 +105,7 @@ itchyny/vim-gitbranch
 ivanov/vim-ipython
 jacoborus/tender.vim
 janko-m/vim-test
+jaredgorski/SpaceCamp
 JazzCore/ctrlp-cmatcher
 jceb/vim-hier
 jceb/vim-orgmode


### PR DESCRIPTION
###### Motivation for this change
Add another colorscheme. :)

###### Things done

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [X] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
$ nix path-info -Sh /nix/store/ssiq01sv58fg8fps341n3fw7hn29vcr1-vimplugin-SpaceCamp-2019-06-05
/nix/store/ssiq01sv58fg8fps341n3fw7hn29vcr1-vimplugin-SpaceCamp-2019-06-05         1.1M