### PR TITLE
public-sans: 1.004 -> 1.005

### DIFF
--- a/pkgs/data/fonts/public-sans/default.nix
+++ b/pkgs/data/fonts/public-sans/default.nix
@@ -1,7 +1,7 @@
 { lib, fetchzip }:
 
 let
-  version = "1.004";
+  version = "1.005";
 in fetchzip rec {
   name = "public-sans-${version}";
 
@@ -12,7 +12,7 @@ in fetchzip rec {
     unzip $downloadedFile fonts/{otf,variable}/\*.\[ot\]tf -d $out/share/
   '';
 
-  sha256 = "1d9ll6gvvlmlykv868lq7xmwldlfjp94k0rjqifipg3q1qv051lg";
+  sha256 = "0s0zgszpi12wanl031gi3j24ci9pkbkhvsxc30skx8s1mj99cd7i";
 
   meta = with lib; {
     description = "A strong, neutral, principles-driven, open source typeface for text or display";


### PR DESCRIPTION
###### Motivation for this change

https://github.com/uswds/public-sans/releases/tag/v1.005

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---