### PR TITLE
grim: 1.1 -> 1.2.0

### DIFF
--- a/pkgs/tools/graphics/grim/default.nix
+++ b/pkgs/tools/graphics/grim/default.nix
@@ -1,14 +1,14 @@
 { stdenv, fetchFromGitHub, cairo, libjpeg, meson, ninja, wayland, pkgconfig, wayland-protocols }:
 
 stdenv.mkDerivation rec {
-  name = "grim-${version}";
-  version = "1.1";
+  pname = "grim";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "emersion";
-    repo = "grim";
+    repo = pname;
     rev = "v${version}";
-    sha256 = "1bcvkggqszcwy6hg8g4mch3yr25ic0baafbd90af5s5mrhrjxxxz";
+    sha256 = "0brljl4zfbn5mh9hkfrfkvd27c5y9vdkgap9r1hrfy9r1x20sskn";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

https://github.com/emersion/grim/releases/tag/v1.2.0

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---