### PR TITLE
dnscrypt-proxy2: 2.0.22 -> 2.0.25

### DIFF
--- a/pkgs/tools/networking/dnscrypt-proxy/2.x/default.nix
+++ b/pkgs/tools/networking/dnscrypt-proxy/2.x/default.nix
@@ -1,8 +1,8 @@
 { stdenv, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
-  name = "dnscrypt-proxy2-${version}";
-  version = "2.0.22";
+  pname = "dnscrypt-proxy2";
+  version = "2.0.25";
 
   goPackagePath = "github.com/jedisct1/dnscrypt-proxy";
 
@@ -10,7 +10,7 @@ buildGoPackage rec {
     owner = "jedisct1";
     repo = "dnscrypt-proxy";
     rev = version;
-    sha256 = "0rmiyqxbbc3gjnfvyggf2lckckliiijq528993gv0n875r7ahkix";
+    sha256 = "1ix76nihzjbiib7n2pjx2ynziz8hrrx3idwdjnkwckxfq11g96y3";
   };
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change

https://github.com/jedisct1/dnscrypt-proxy/releases/tag/2.0.25
https://github.com/jedisct1/dnscrypt-proxy/releases/tag/2.0.24
https://github.com/jedisct1/dnscrypt-proxy/releases/tag/2.0.23

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---