### PR TITLE
 ubootRock64, ubootRockPro64: update

### DIFF
--- a/pkgs/misc/uboot/rock64.nix
+++ b/pkgs/misc/uboot/rock64.nix
@@ -2,8 +2,8 @@
   rkbin = fetchFromGitHub {
     owner = "ayufan-rock64";
     repo = "rkbin";
-    rev = "af17d09dee19b41f4f01e1722eaf6911fb296245";
-    sha256 = "189f7h6wj2yrcc5ga103jnyysykf9j3j9p1vcy7791bxwxqxnggf";
+    rev = "f79a708978232a2b6b06c2e4173c5314559e0d3a";
+    sha256 = "0h7xm4ck3p3380c6bqm5ixrkxwcx6z5vysqdwvfa7gcqx5d6x5zz";
   };
 in buildUBoot rec {
   version = "2017.09";
@@ -11,11 +11,11 @@ in buildUBoot rec {
   src = fetchFromGitHub {
     owner = "ayufan-rock64";
     repo = "linux-u-boot";
-    rev = "d646df03ace3bd191e24361944ce1c7ef3c8744c";
-    sha256 = "0gclcd034qfhfbabrdqmky08i0hlwmn63n0zg6mndplms5qpcx75";
+    rev = "56bd9582537a70c30387de3ce9038a56d2c77bfe";
+    sha256 = "1m0k8ivzhmg9y4x0k7fz7y71pgblzxy81m6x32iivz5kjnxdnv4i";
   };
 
-  patches = [ ./rock64-fdt-dtc-compatibility.patch ];
+  extraPatches = [ ./rock64-fdt-dtc-compatibility.patch ];
 
   extraMakeFlags = [ "BL31=${armTrustedFirmwareRK3328}/bl31.elf" "u-boot.itb" "all" ];
 

--- a/pkgs/misc/uboot/rockpro64.nix
+++ b/pkgs/misc/uboot/rockpro64.nix
@@ -2,8 +2,8 @@
   rkbin = fetchFromGitHub {
     owner = "ayufan-rock64";
     repo = "rkbin";
-    rev = "af17d09dee19b41f4f01e1722eaf6911fb296245";
-    sha256 = "189f7h6wj2yrcc5ga103jnyysykf9j3j9p1vcy7791bxwxqxnggf";
+    rev = "f79a708978232a2b6b06c2e4173c5314559e0d3a";
+    sha256 = "0h7xm4ck3p3380c6bqm5ixrkxwcx6z5vysqdwvfa7gcqx5d6x5zz";
   };
 in buildUBoot rec {
   version = "2017.09";
@@ -11,17 +11,17 @@ in buildUBoot rec {
   src = fetchFromGitHub {
     owner = "ayufan-rock64";
     repo = "linux-u-boot";
-    rev = "d646df03ace3bd191e24361944ce1c7ef3c8744c";
-    sha256 = "0gclcd034qfhfbabrdqmky08i0hlwmn63n0zg6mndplms5qpcx75";
+    rev = "56bd9582537a70c30387de3ce9038a56d2c77bfe";
+    sha256 = "1m0k8ivzhmg9y4x0k7fz7y71pgblzxy81m6x32iivz5kjnxdnv4i";
   };
 
-  patches = [ ./rock64-fdt-dtc-compatibility.patch ];
+  extraPatches = [ ./rock64-fdt-dtc-compatibility.patch ];
 
   # Upstream ATF hangs in SPL
-  extraMakeFlags = [ "BL31=${rkbin}/rk33/rk3399_bl31_v1.17.elf" "u-boot.itb" "all" ];
+  extraMakeFlags = [ "BL31=${rkbin}/rk33/rk3399_bl31_v1.25.elf" "u-boot.itb" "all" ];
 
   postBuild = ''
-    ./tools/mkimage -n rk3399 -T rksd -d ${rkbin}/rk33/rk3399_ddr_933MHz_v1.13.bin idbloader.img
+    ./tools/mkimage -n rk3399 -T rksd -d ${rkbin}/rk33/rk3399_ddr_933MHz_v1.19.bin idbloader.img
     cat spl/u-boot-spl.bin >> idbloader.img
     dd if=u-boot.itb of=idbloader.img seek=448 conv=notrunc
   '';


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->

This PR updates the Rock64 and RockPro64 U-Boot to the latest commit in ayufan's repo, which fixes some minor issues. I also updated the binary blobs from rkbin. Lastly, I used `extraPatches` instead of `patches` to avoid overriding the patches specified in `buildUBoot`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
