### PR TITLE
python3Packages.pywebpush: init at 1.9.4

### DIFF
--- a/pkgs/development/python-modules/http-ece/default.nix
+++ b/pkgs/development/python-modules/http-ece/default.nix
@@ -1,0 +1,24 @@
+{ lib, fetchPypi, buildPythonPackage
+, coverage, flake8, mock, nose
+, cryptography }:
+
+buildPythonPackage rec {
+  pname = "http_ece";
+  version = "1.1.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1y5ln09ji4dwpzhxr77cggk02kghq7lql60a6969a5n2lwpvqblk";
+  };
+
+  propagatedBuildInputs = [ cryptography ];
+
+  checkInputs = [ coverage flake8 mock nose ];
+
+  meta = with lib; {
+    description = "Encipher HTTP Messages";
+    homepage = https://github.com/martinthomson/encrypted-content-encoding;
+    license = licenses.mit;
+    maintainers = with maintainers; [ peterhoeg ];
+  };
+}

--- a/pkgs/development/python-modules/py-vapid/default.nix
+++ b/pkgs/development/python-modules/py-vapid/default.nix
@@ -1,0 +1,24 @@
+{ lib, buildPythonPackage, fetchPypi
+, flake8, mock, nose, pytest
+, cryptography
+}:
+
+buildPythonPackage rec {
+  pname = "py-vapid";
+  version = "1.5.0";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1b3g4ljkpi6ka5n63bl5y47r3qhxjmr6qfamqwxnmna2567b5las";
+  };
+
+  propagatedBuildInputs = [ cryptography ];
+
+  checkInputs = [ flake8 mock nose pytest ];
+
+  meta = with lib; {
+    description = "VAPID is a voluntary standard for WebPush subscription providers";
+    homepage = https://github.com/mozilla-services/vapid;
+    license = licenses.mpl20;
+  };
+}

--- a/pkgs/development/python-modules/pywebpush/default.nix
+++ b/pkgs/development/python-modules/pywebpush/default.nix
@@ -1,0 +1,28 @@
+{ lib, fetchPypi, buildPythonPackage
+, coverage, flake8, mock, nose
+, http-ece, py-vapid, requests }:
+
+buildPythonPackage rec {
+  pname = "pywebpush";
+  version = "1.9.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "03qkijz56fx7p8405sknw2wji4pfj5knajk2lmj9y58mjxydbpp3";
+  };
+
+  propagatedBuildInputs = [
+    http-ece py-vapid requests
+  ];
+
+  checkInputs = [
+    coverage flake8 mock nose
+  ];
+
+  meta = with lib; {
+    description = "Webpush Data encryption library for Python";
+    homepage = https://github.com/web-push-libs/pywebpush;
+    license = licenses.mpl20;
+    maintainers = with maintainers; [ peterhoeg ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -302,7 +302,7 @@
     "hook" = ps: with ps; [  ];
     "horizon" = ps: with ps; [  ];
     "hp_ilo" = ps: with ps; [  ];
-    "html5" = ps: with ps; [ aiohttp-cors ];
+    "html5" = ps: with ps; [ aiohttp-cors pywebpush ];
     "http" = ps: with ps; [ aiohttp-cors ];
     "htu21d" = ps: with ps; [  ];
     "huawei_lte" = ps: with ps; [  ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -868,6 +868,8 @@ in {
 
   PyWebDAV = callPackage ../development/python-modules/pywebdav { };
 
+  pywebpush = callPackage ../development/python-modules/pywebpush { };
+
   pyxml = disabledIf isPy3k (callPackage ../development/python-modules/pyxml{ });
 
   pyvcd = callPackage ../development/python-modules/pyvcd { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -862,6 +862,8 @@ in {
 
   pytricia =  callPackage ../development/python-modules/pytricia { };
 
+  py-vapid = callPackage ../development/python-modules/py-vapid { };
+
   PyWebDAV = callPackage ../development/python-modules/pywebdav { };
 
   pyxml = disabledIf isPy3k (callPackage ../development/python-modules/pyxml{ });

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -481,6 +481,8 @@ in {
 
   hopcroftkarp = callPackage ../development/python-modules/hopcroftkarp { };
 
+  http-ece = callPackage ../development/python-modules/http-ece { };
+
   httpsig = callPackage ../development/python-modules/httpsig { };
 
   httptools = callPackage ../development/python-modules/httptools { };


### PR DESCRIPTION
###### Motivation for this change

These 3 packages were needed for html5 notifications to work in HA.

Needs proper testing.

Cc: @dotlambda 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
