### PR TITLE
krita: 4.2.0 -> 4.2.1

### DIFF
--- a/pkgs/applications/graphics/krita/default.nix
+++ b/pkgs/applications/graphics/krita/default.nix
@@ -11,7 +11,7 @@
 let
 
 major = "4.2";
-minor = "0";
+minor = "1";
 patch = null;
 
 in
@@ -22,7 +22,7 @@ mkDerivation rec {
 
   src = fetchurl {
     url = "https://download.kde.org/stable/krita/${major}.${minor}/${name}.tar.gz";
-    sha256 = "1l5bhk4b2f3qdzg9jk2sxz2bq8cqs10nm3wgkrkbqs6vig75rsym";
+    sha256 = "1jm9kj9cq2nhaqg3kvyb193hhkd6al1gh23fkl54dj88x3fpldim";
   };
 
   nativeBuildInputs = [ cmake extra-cmake-modules python3Packages.sip makeWrapper ];


### PR DESCRIPTION
###### Motivation for this change

https://cgit.kde.org/krita.git/log/?h=v4.2.1

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---