### PR TITLE
minder: init at 1.5.0

### DIFF
--- a/pkgs/applications/misc/minder/default.nix
+++ b/pkgs/applications/misc/minder/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchFromGitHub
+, pkgconfig, meson, ninja, python3
+, wrapGAppsHook, vala, shared-mime-info
+, cairo, pantheon, glib, gtk3, libxml2, libgee, libarchive
+}:
+
+stdenv.mkDerivation rec {
+  pname = "minder";
+  version = "1.3.1";
+
+  src = fetchFromGitHub {
+    owner = "phase1geo";
+    repo = pname;
+    rev = version;
+    sha256 = "0b9acrdi712f7g08gj6wd9mvdrf11vfgp0rdzlwinl19bsr0zwpm";
+  };
+
+  nativeBuildInputs = [ pkgconfig meson ninja python3 wrapGAppsHook vala shared-mime-info ];
+  buildInputs = [ cairo pantheon.granite glib gtk3 libxml2 libgee libarchive ];
+
+  postPatch = ''
+    chmod +x meson/post_install.py
+    patchShebangs meson/post_install.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Mind-mapping application for Elementary OS";
+    homepage = "https://github.com/phase1geo/Minder";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ dtzWill ];
+  };
+}
+

--- a/pkgs/applications/misc/minder/default.nix
+++ b/pkgs/applications/misc/minder/default.nix
@@ -2,25 +2,32 @@
 , pkgconfig, meson, ninja, python3
 , wrapGAppsHook, vala, shared-mime-info
 , cairo, pantheon, glib, gtk3, libxml2, libgee, libarchive
+, hicolor-icon-theme # for setup-hook
 }:
 
 stdenv.mkDerivation rec {
   pname = "minder";
-  version = "1.3.1";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "phase1geo";
     repo = pname;
     rev = version;
-    sha256 = "0b9acrdi712f7g08gj6wd9mvdrf11vfgp0rdzlwinl19bsr0zwpm";
+    sha256 = "0lhmv3z2jifv4cksxa27jigdfj9n81myjsxg38xp28fx5x3h8bzc";
   };
 
   nativeBuildInputs = [ pkgconfig meson ninja python3 wrapGAppsHook vala shared-mime-info ];
-  buildInputs = [ cairo pantheon.granite glib gtk3 libxml2 libgee libarchive ];
+  buildInputs = [ cairo pantheon.granite glib gtk3 libxml2 libgee libarchive hicolor-icon-theme ];
 
   postPatch = ''
     chmod +x meson/post_install.py
     patchShebangs meson/post_install.py
+  '';
+
+  postFixup = ''
+    for x in $out/bin/*; do
+      ln -vrs $x "$out/bin/''${x##*.}"
+    done
   '';
 
   meta = with stdenv.lib; {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8707,6 +8707,8 @@ in
 
   metamath = callPackage ../development/interpreters/metamath { };
 
+  minder = callPackage ../applications/misc/minder { };
+
   mujs = callPackage ../development/interpreters/mujs { };
 
   nix-exec = callPackage ../development/interpreters/nix-exec {


### PR DESCRIPTION
###### Motivation for this change

Mind-mapping application for Elementary OS!

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---