### PR TITLE
weechat: 2.4 -> 2.5

### DIFF
--- a/pkgs/applications/networking/irc/weechat/default.nix
+++ b/pkgs/applications/networking/irc/weechat/default.nix
@@ -28,21 +28,13 @@ let
   in
     assert lib.all (p: p.enabled -> ! (builtins.elem null p.buildInputs)) plugins;
     stdenv.mkDerivation rec {
-      version = "2.4";
+      version = "2.5";
       name = "weechat-${version}";
 
       src = fetchurl {
         url = "https://weechat.org/files/src/weechat-${version}.tar.bz2";
-        sha256 = "1z80y5fbrb56wdcx9njrf203r8282wnn3piw3yffk5lvhklsz9k1";
+        sha256 = "14giv8j1phmpg3i9whx45nmskan501lwcq352ps9z52rkja2qxsc";
       };
-
-      patches = [
-        (fetchpatch {
-          url = https://github.com/weechat/weechat/commit/6a9937f08ad2c14aeb0a847ffb99e652d47d8251.patch;
-          sha256 = "1blhgxwqs65dvpw3ppxszxrsg02rx7qck1w71h61ljinyjzri3bp";
-          excludes = [ "ChangeLog.adoc" ];
-        })
-      ];
 
       outputs = [ "out" "man" ] ++ map (p: p.name) enabledPlugins;
 


### PR DESCRIPTION
###### Motivation for this change

Changelog [1]:

  New features
    - core: use getopt to parse command line arguments
    - core: add option weechat.look.prefix_same_nick_middle
    - core: add option weechat.look.buffer_time_same
    - core: use seconds by default in /repeat interval, allow unit for the interval
    - core: allow text in addition to a command in command /repeat
    - core: add option "addreplace" in command /filter
    - api: return allocated string in hook_info callback and function info_get
    - api: replace argument "keep_eol" by "flags" in function string_split
    - api: add function command_options
    - api: add function string_match_list
    - irc: add bar items "irc_nick", "irc_host" and "irc_nick_host"
    - irc: add variable "host" in server structure
    - relay: add support of UNIX socket
    - relay: add option relay.weechat.commands
    - script: use SHA-512 instead of MD5 for script checksum
    - spell: rename aspell plugin to spell
    - trigger: add hooks "info" and "info_hashtable"
    - xfer: rename option xfer.network.speed_limit to xfer.network.speed_limit_send, add option xfer.network.speed_limit_recv

  Bug fixes
    - core: don’t execute command scheduled by /repeat and /wait if the buffer does not exist any more
    - core: set max length to 4096 for /secure passphrase
    - core: refilter only affected buffers on filter change
    - fset: fix slow refresh of fset buffer during /reload
    - irc: fix parsing of MODE command when there are colons after the first mode argument
    - irc: fix memory leak in infos "irc_server_isupport" and "irc_server_isupport_value"
    - irc: fix length of string for SHA-512, SHA-256 and SHA-1 in help on ssl_fingerprint option
    - irc: display an error with /allchan -current or /allpv -current if the current buffer is not an irc buffer
    - irc: fix update of channels modes with arguments when joining a channel
    - irc: quote NICK command argument sent to the server
    - php: fix memory leak in functions string_eval_expression, string_eval_path_home, key_bind, hook_process_hashtable, hook_hsignal_send, info_get_hashtable, hdata_update
    - relay: fix crash when a weechat relay client reloads the relay plugin with /plugin reload relay
    - spell: fix detection of nick followed by the nick completer
    - trigger: fix split of hook arguments

  Tests
    - unit: add tests on function util_signal_search

  Build
    - core: fix value of libdir in file weechat.pc
    - core: fix generation of man page weechat-headless with autotools
    - core: add CMake option "ENABLE_CODE_COVERAGE" to compile with code coverage options (CMake ≥ 3.0 is now required)
    - core: fix compilation on Mac OS 
    - lua: add detection of Lua 5.3 with autotools
    - ruby: add detection of Ruby 2.6
    - tests: fix compilation of tests on FreeBSD

[1] https://weechat.org/files/changelog/ChangeLog-2.5.html#v2.5

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
