### PR TITLE
kubernetes: 1.14.2 -> 1.14.3 (CVE-2019-11245)

### DIFF
--- a/pkgs/applications/networking/cluster/kubernetes/default.nix
+++ b/pkgs/applications/networking/cluster/kubernetes/default.nix
@@ -15,13 +15,13 @@ with lib;
 
 stdenv.mkDerivation rec {
   name = "kubernetes-${version}";
-  version = "1.14.2";
+  version = "1.14.3";
 
   src = fetchFromGitHub {
     owner = "kubernetes";
     repo = "kubernetes";
     rev = "v${version}";
-    sha256 = "17jb05c5i9y725jf5ad2ki99wyi2dv2jdhfgcxrki9fzjsx967g2";
+    sha256 = "1r31ssf8bdbz8fdsprhkc34jqhz5rcs3ixlf0mbjcbq0xr7y651z";
   };
 
   buildInputs = [ removeReferencesTo makeWrapper which go rsync go-bindata ];


### PR DESCRIPTION
###### Motivation for this change
To fix regression introduced in v1.14.2. Also referred to as: CVE-2019-11245
See: https://github.com/kubernetes/kubernetes/issues/78308

Tests run clean locally:
```
$ nix-build ./nixos/release.nix -A tests.kubernetes.rbac.singlenode -A tests.kubernetes.rbac.multinode -A tests.kubernetes.dns.singlenode -A tests.kubernetes.dns.multinode
/nix/store/6ggrc2r43xbymxn424x0acmqvg467zh1-vm-test-run-kubernetes-rbac-singlenode
/nix/store/qibnbw26dyvap65dxih84bgd0fbn7nw7-vm-test-run-kubernetes-rbac-multinode
/nix/store/f5q27sqqkfxgnyzwgc2h2kdz83445yxp-vm-test-run-kubernetes-dns-singlenode
/nix/store/a7zkprxpprjga8salr6bpjypaz827j99-vm-test-run-kubernetes-dns-multinode
```

ping @srhb 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
