### PR TITLE
WIP: improve support for crosscompiling to musl32

### DIFF
--- a/pkgs/applications/misc/audio/sox/0001-musl-rewind-pipe-workaround.patch
+++ b/pkgs/applications/misc/audio/sox/0001-musl-rewind-pipe-workaround.patch
@@ -1,0 +1,24 @@
+From e7446c9bcb47674c9d0ee3b5bab129e9b86eb1c9 Mon Sep 17 00:00:00 2001
+From: Walter Franzini <walter.franzini@gmail.com>
+Date: Fri, 7 Jun 2019 17:57:11 +0200
+Subject: [PATCH] musl does not support rewind pipe, make it build anyway
+
+---
+ src/formats.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/src/formats.c b/src/formats.c
+index f3efe764..477bf451 100644
+--- a/src/formats.c
++++ b/src/formats.c
+@@ -424,7 +424,6 @@ static void UNUSED rewind_pipe(FILE * fp)
+   /* To fix this #error, either simply remove the #error line and live without
+    * file-type detection with pipes, or add support for your compiler in the
+    * lines above.  Test with cat monkey.wav | ./sox --info - */
+-  #error FIX NEEDED HERE
+   #define NO_REWIND_PIPE
+   (void)fp;
+ #endif
+-- 
+2.19.2
+

--- a/pkgs/applications/misc/audio/sox/default.nix
+++ b/pkgs/applications/misc/audio/sox/default.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation rec {
   # configure.ac uses pkg-config only to locate libopusfile
   nativeBuildInputs = optional enableOpusfile pkgconfig;
 
+  patches = [ ./0001-musl-rewind-pipe-workaround.patch ];
+
   buildInputs =
     optional (enableAlsa && stdenv.isLinux) alsaLib ++
     optional enableLibao libao ++

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -343,7 +343,9 @@ stdenv.mkDerivation {
       hardening_unsupported_flags+=" stackprotector pic"
     '' + optionalString (targetPlatform.libc == "newlib") ''
       hardening_unsupported_flags+=" stackprotector fortify pie pic"
-    '' + optionalString targetPlatform.isNetBSD ''
+      '' + optionalString (targetPlatform.libc == "musl" && targetPlatform.isi686) ''
+      hardening_unsupported_flags+=" stackprotector"
+      '' + optionalString targetPlatform.isNetBSD ''
       hardening_unsupported_flags+=" stackprotector fortify"
     ''
 

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -343,9 +343,9 @@ stdenv.mkDerivation {
       hardening_unsupported_flags+=" stackprotector pic"
     '' + optionalString (targetPlatform.libc == "newlib") ''
       hardening_unsupported_flags+=" stackprotector fortify pie pic"
-      '' + optionalString (targetPlatform.libc == "musl" && targetPlatform.isi686) ''
+    '' + optionalString (targetPlatform.libc == "musl" && targetPlatform.isx86_32) ''
       hardening_unsupported_flags+=" stackprotector"
-      '' + optionalString targetPlatform.isNetBSD ''
+    '' + optionalString targetPlatform.isNetBSD ''
       hardening_unsupported_flags+=" stackprotector fortify"
     ''
 

--- a/pkgs/development/compilers/gcc/6/default.nix
+++ b/pkgs/development/compilers/gcc/6/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, targetPackages, fetchurl, noSysDirs
+{ stdenv, targetPackages, fetchurl, fetchpatch, noSysDirs
 , langC ? true, langCC ? true, langFortran ? false
 , langObjC ? stdenv.targetPlatform.isDarwin
 , langObjCpp ? stdenv.targetPlatform.isDarwin
@@ -58,6 +58,10 @@ let version = "6.5.0";
       ++ optional noSysDirs ../no-sys-dirs.patch
       ++ optional langFortran ../gfortran-driving.patch
       ++ optional (targetPlatform.libc == "musl") ../libgomp-dont-force-initial-exec.patch
+      ++ optional (targetPlatform.libc == "musl" && targetPlatform.isx86_32) (fetchpatch {
+        url = "https://git.alpinelinux.org/aports/plain/main/gcc/gcc-6.1-musl-libssp.patch";
+        sha256 = "1jf1ciz4gr49lwyh8knfhw6l5gvfkwzjy90m7qiwkcbsf4a3fqn2";
+      })
       ;
 
     javaEcj = fetchurl {

--- a/pkgs/development/compilers/gcc/7/default.nix
+++ b/pkgs/development/compilers/gcc/7/default.nix
@@ -58,6 +58,10 @@ let version = "7.4.0";
       })
       ++ optional langFortran ../gfortran-driving.patch
       ++ optional (targetPlatform.libc == "musl" && targetPlatform.isPower) ../ppc-musl.patch
+      ++ optional (targetPlatform.libc == "musl" && targetPlatform.isx86_32) (fetchpatch {
+        url = "https://git.alpinelinux.org/aports/plain/main/gcc/gcc-6.1-musl-libssp.patch";
+        sha256 = "1jf1ciz4gr49lwyh8knfhw6l5gvfkwzjy90m7qiwkcbsf4a3fqn2";
+      })
       ++ optional (targetPlatform.libc == "musl") ../libgomp-dont-force-initial-exec.patch;
 
     /* Cross-gcc settings (build == host != target) */

--- a/pkgs/development/libraries/libexecinfo/30-linux-makefile.patch
+++ b/pkgs/development/libraries/libexecinfo/30-linux-makefile.patch
@@ -1,0 +1,44 @@
+--- Makefile.orig
++++ Makefile
+@@ -23,24 +23,25 @@
+ # SUCH DAMAGE.
+ #
+ # $Id: Makefile,v 1.3 2004/07/19 05:19:55 sobomax Exp $
++#
++# Linux Makefile by Matt Smith <mcs@darkregion.net>, 2011/01/04
+ 
+-LIB=	execinfo
++CC=cc
++AR=ar
++EXECINFO_CFLAGS=$(CFLAGS) -O2 -pipe -fno-strict-aliasing -std=gnu99 -c
++EXECINFO_LDFLAGS=$(LDFLAGS)
+ 
+-SRCS=	stacktraverse.c stacktraverse.h execinfo.c execinfo.h
++all: static dynamic
+ 
+-INCS=	execinfo.h
++static:
++	$(CC) $(EXECINFO_CFLAGS) $(EXECINFO_LDFLAGS) stacktraverse.c
++	$(CC) $(EXECINFO_CFLAGS) $(EXECINFO_LDFLAGS) execinfo.c
++	$(AR) rcs libexecinfo.a stacktraverse.o execinfo.o
+ 
+-SHLIB_MAJOR=	1
+-SHLIB_MINOR=	0
++dynamic:
++	$(CC) -fpic -DPIC $(EXECINFO_CFLAGS) $(EXECINFO_LDFLAGS) stacktraverse.c -o stacktraverse.So
++	$(CC) -fpic -DPIC $(EXECINFO_CFLAGS) $(EXECINFO_LDFLAGS) execinfo.c -o execinfo.So
++	$(CC) -shared -Wl,-soname,libexecinfo.so.1 -o libexecinfo.so.1 stacktraverse.So execinfo.So
+ 
+-NOPROFILE=	yes
+-
+-DPADD=		${LIBM}
+-LDADD=		-lm
+-
+-#WARNS?=	4
+-
+-#stacktraverse.c: gen.py
+-#	./gen.py > stacktraverse.c
+-
+-.include <bsd.lib.mk>
++clean:
++	rm -rf *.o *.So *.a *.so

--- a/pkgs/development/libraries/libexecinfo/default.nix
+++ b/pkgs/development/libraries/libexecinfo/default.nix
@@ -20,14 +20,11 @@ stdenv.mkDerivation rec {
       url = https://git.alpinelinux.org/cgit/aports/plain/main/libexecinfo/20-define-gnu-source.patch?id=730cdcef6901750f4029d4c3b8639ce02ee3ead1;
       sha256 = "1mp8mc639b0h2s69m5z6s2h3q3n1zl298j9j0plzj7f979j76302";
     })
-    (fetchpatch {
-      name = "30-linux-makefile.patch";
-      url = https://git.alpinelinux.org/cgit/aports/plain/main/libexecinfo/30-linux-makefile.patch?id=730cdcef6901750f4029d4c3b8639ce02ee3ead1;
-      sha256 = "1jwjz22z5cjy5h2bfghn62yl9ar8jiqhdvbwrcfavv17ihbhwcaf";
-    })
+    ./30-linux-makefile.patch
   ];
 
   makeFlags = [ "CC:=$(CC)" "AR:=$(AR)" ];
+  hardeningEnable = [ "stackprotector" ];
 
   patchFlags = "-p0";
 

--- a/pkgs/development/libraries/libsodium/default.nix
+++ b/pkgs/development/libraries/libsodium/default.nix
@@ -12,6 +12,11 @@ stdenv.mkDerivation rec {
   separateDebugInfo = stdenv.isLinux;
 
   enableParallelBuilding = true;
+  hardeningDisable = stdenv.lib.optional (stdenv.targetPlatform.isMusl && stdenv.targetPlatform.isi686) "stackprotector";
+
+  # FIXME: the hardeingDisable attr above does not seems effective, so
+  # the need to disable stackprotector via configureFlags
+  configureFlags = stdenv.lib.optional (stdenv.targetPlatform.isMusl && stdenv.targetPlatform.isi686) "--disable-ssp";
 
   doCheck = true;
 

--- a/pkgs/development/libraries/libsodium/default.nix
+++ b/pkgs/development/libraries/libsodium/default.nix
@@ -12,11 +12,11 @@ stdenv.mkDerivation rec {
   separateDebugInfo = stdenv.isLinux;
 
   enableParallelBuilding = true;
-  hardeningDisable = stdenv.lib.optional (stdenv.targetPlatform.isMusl && stdenv.targetPlatform.isi686) "stackprotector";
+  hardeningDisable = stdenv.lib.optional (stdenv.targetPlatform.isMusl && stdenv.targetPlatform.isx86_32) "stackprotector";
 
   # FIXME: the hardeingDisable attr above does not seems effective, so
   # the need to disable stackprotector via configureFlags
-  configureFlags = stdenv.lib.optional (stdenv.targetPlatform.isMusl && stdenv.targetPlatform.isi686) "--disable-ssp";
+  configureFlags = stdenv.lib.optional (stdenv.targetPlatform.isMusl && stdenv.targetPlatform.isx86_32) "--disable-ssp";
 
   doCheck = true;
 

--- a/pkgs/development/tools/parsing/bison/2.x.nix
+++ b/pkgs/development/tools/parsing/bison/2.x.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     sha256 = "0c9li3iaslzzr3zig6m3zlmb4r8i0wfvkcrvdyiqxasb09mjkqh8";
   };
 
-  nativeBuildInputs = [ m4 ];
+  nativeBuildInputs = [ perl m4 ];
   propagatedBuildInputs = [ m4 ];
   checkInputs = [ perl ];
 

--- a/pkgs/os-specific/linux/audit/audit-strndupa-rawmemchr-compat.patch
+++ b/pkgs/os-specific/linux/audit/audit-strndupa-rawmemchr-compat.patch
@@ -1,0 +1,141 @@
+From d579a08bb1cde71f939c13ac6b2261052ae9f77e Mon Sep 17 00:00:00 2001
+From: Steve Grubb <sgrubb@redhat.com>
+Date: Tue, 26 Feb 2019 18:33:33 -0500
+Subject: [PATCH] Add substitue functions for strndupa & rawmemchr
+
+---
+ ChangeLog           |  1 +
+ auparse/auparse.c   | 12 +++++++++++-
+ auparse/interpret.c | 11 +++++++++--
+ configure.ac        | 14 +++++++++++++-
+ src/ausearch-lol.c  | 12 +++++++++++-
+ 5 files changed, 45 insertions(+), 5 deletions(-)
+
+diff --git a/ChangeLog b/ChangeLog
+index 253c63b..14ee2d0 100644
+--- a/ChangeLog
++++ b/ChangeLog
+@@ -62,6 +62,7 @@
+ - Allow exclude and user filter by executable name (Ondrej Mosnacek)
+ - Fix auditd regression where keep_logs is limited by rotate_logs 2 file test
+ - In ausearch/report fix --end to use midnight time instead of now (#1671338)
++- Add substitue functions for strndupa & rawmemchr
+ 
+ 2.8.3
+ - Correct msg function name in LRU debug code
+diff --git a/auparse/auparse.c b/auparse/auparse.c
+index 69127b7..042ea2b 100644
+--- a/auparse/auparse.c
++++ b/auparse/auparse.c
+@@ -1,5 +1,5 @@
+ /* auparse.c --
+- * Copyright 2006-08,2012-17 Red Hat Inc., Durham, North Carolina.
++ * Copyright 2006-08,2012-19 Red Hat Inc., Durham, North Carolina.
+  * All Rights Reserved.
+  *
+  * This library is free software; you can redistribute it and/or
+@@ -1119,6 +1119,16 @@ static int str2event(char *s, au_event_t *e)
+ 	return 0;
+ }
+ 
++#ifndef HAVE_STRNDUPA
++static inline char *strndupa(const char *old, size_t n)
++{
++	size_t len = strnlen(old, n);
++	char *tmp = alloca(len + 1);
++	tmp[len] = 0;
++	return memcpy(tmp, old, len);
++}
++#endif
++
+ /* Returns 0 on success and 1 on error */
+ static int extract_timestamp(const char *b, au_event_t *e)
+ {
+diff --git a/auparse/interpret.c b/auparse/interpret.c
+index 88523c6..f19ee85 100644
+--- a/auparse/interpret.c
++++ b/auparse/interpret.c
+@@ -855,6 +855,13 @@ static const char *print_escaped_ext(const idata *id)
+ 		return print_escaped(id->val);
+ }
+ 
++// rawmemchr is faster. Let's use it if we have it.
++#ifdef HAVE_RAWMEMCHR
++#define STRCHR rawmemchr
++#else
++#define STRCHR strchr
++#endif
++
+ static const char *print_proctitle(const char *val)
+ {
+ 	char *out = (char *)print_escaped(val);
+@@ -865,7 +872,7 @@ static const char *print_proctitle(const char *val)
+ 		// Proctitle has arguments separated by NUL bytes
+ 		// We need to write over the NUL bytes with a space
+ 		// so that we can see the arguments
+-		while ((ptr  = rawmemchr(ptr, '\0'))) {
++		while ((ptr  = STRCHR(ptr, '\0'))) {
+ 			if (ptr >= end)
+ 				break;
+ 			*ptr = ' ';
+diff --git a/configure.ac b/configure.ac
+index acd6d61..00658d4 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1,7 +1,7 @@
+ dnl
+ define([AC_INIT_NOTICE],
+ [### Generated automatically using autoconf version] AC_ACVERSION [
+-### Copyright 2005-18 Steve Grubb <sgrubb@redhat.com>
++### Copyright 2005-19 Steve Grubb <sgrubb@redhat.com>
+ ###
+ ### Permission is hereby granted, free of charge, to any person obtaining a
+ ### copy of this software and associated documentation files (the "Software"),
+@@ -72,6 +72,18 @@ dnl; posix_fallocate is used in audisp-remote
+ AC_CHECK_FUNCS([posix_fallocate])
+ dnl; signalfd is needed for libev
+ AC_CHECK_FUNC([signalfd], [], [ AC_MSG_ERROR([The signalfd system call is necessary for auditd]) ])
++dnl; check if rawmemchr is available
++AC_CHECK_FUNCS([rawmemchr])
++dnl; check if strndupa is available
++AC_LINK_IFELSE(
++  [AC_LANG_SOURCE(
++    [[
++      #define _GNU_SOURCE
++      #include <string.h>
++      int main() { (void) strndupa("test", 10); return 0; }]])],
++ [AC_DEFINE(HAVE_STRNDUPA, 1, [Let us know if we have it or not])],
++ []
++)
+ 
+ ALLWARNS=""
+ ALLDEBUG="-g"
+diff --git a/src/ausearch-lol.c b/src/ausearch-lol.c
+index bebbcf4..0babd51 100644
+--- a/src/ausearch-lol.c
++++ b/src/ausearch-lol.c
+@@ -1,6 +1,6 @@
+ /*
+ * ausearch-lol.c - linked list of linked lists library
+-* Copyright (c) 2008,2010,2014,2016 Red Hat Inc., Durham, North Carolina.
++* Copyright (c) 2008,2010,2014,2016,2019 Red Hat Inc., Durham, North Carolina.
+ * All Rights Reserved. 
+ *
+ * This software may be freely redistributed and/or modified under the
+@@ -152,6 +152,16 @@ static int compare_event_time(event *e1, event *e2)
+ 	return 0;
+ }
+ 
++#ifndef HAVE_STRNDUPA
++static inline char *strndupa(const char *old, size_t n)
++{
++	size_t len = strnlen(old, n);
++	char *tmp = alloca(len + 1);
++	tmp[len] = 0;
++	return memcpy(tmp, old, len);
++}
++#endif
++
+ /*
+  * This function will look at the line and pick out pieces of it.
+  */

--- a/pkgs/os-specific/linux/audit/default.nix
+++ b/pkgs/os-specific/linux/audit/default.nix
@@ -1,5 +1,6 @@
 {
   stdenv, buildPackages, fetchurl, fetchpatch,
+  autoreconfHook,
   enablePython ? false, python ? null,
 }:
 
@@ -16,6 +17,7 @@ stdenv.mkDerivation rec {
   outputs = [ "bin" "dev" "out" "man" ];
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
+  nativeBuildInputs = [ autoreconfHook ];
   buildInputs = stdenv.lib.optional enablePython python;
 
   configureFlags = [
@@ -29,18 +31,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  patches = stdenv.lib.optional stdenv.hostPlatform.isMusl [
-    (fetchpatch {
-      url = "https://git.alpinelinux.org/cgit/aports/plain/main/audit/0002-auparse-remove-use-of-rawmemchr.patch?id=3e57180fdf3f90c30a25aea44f57846efc93a696";
-      name = "0002-auparse-remove-use-of-rawmemchr.patch";
-      sha256 = "1caaqbfgb2rq3ria5bz4n8x30ihgihln6w9w9a46k62ba0wh9rkz";
-    })
-    (fetchpatch {
-      url = "https://git.alpinelinux.org/cgit/aports/plain/main/audit/0003-all-get-rid-of-strndupa.patch?id=3e57180fdf3f90c30a25aea44f57846efc93a696";
-      name = "0003-all-get-rid-of-strndupa.patch";
-      sha256 = "1ddrm6a0ijrf7caw1wpw2kkbjp2lkxkmc16v51j5j7dvdalc6591";
-    })
-  ];
+  patches = [ ./audit-strndupa-rawmemchr-compat.patch ];
 
   prePatch = ''
     sed -i 's,#include <sys/poll.h>,#include <poll.h>\n#include <limits.h>,' audisp/audispd.c

--- a/pkgs/os-specific/linux/musl/default.nix
+++ b/pkgs/os-specific/linux/musl/default.nix
@@ -16,6 +16,11 @@ let
     sha256 = "14igk6k00bnpfw660qhswagyhvr0gfqg4q55dxvaaq7ikfkrir71";
   };
 
+  stack_chk_fail_local_c = fetchurl {
+    url = "https://git.alpinelinux.org/aports/plain/main/musl/__stack_chk_fail_local.c?h=3.10-stable";
+    sha256 = "1nhkzzy9pklgjcq2yg89d3l18jif331srd3z3vhy5qwxl1spv6i9";
+  };
+
   # iconv tool, implemented by musl author.
   # Original: http://git.etalabs.net/cgit/noxcuse/plain/src/iconv.c?id=02d288d89683e99fd18fe9f54d4e731a6c474a4f
   # We use copy from Alpine which fixes error messages, see:
@@ -75,6 +80,16 @@ stdenv.mkDerivation rec {
 
   NIX_DONT_SET_RPATH = true;
 
+  preBuild = ''
+    ${if (stdenv.targetPlatform.libc == "musl" && stdenv.targetPlatform.isx86_32) then
+    "# the -x c flag is required since the file extension confuses gcc
+    # that detect the file as a linker script.
+    $CC -x c -c ${stack_chk_fail_local_c} -o __stack_chk_fail_local.o
+    $AR r libssp_nonshared.a __stack_chk_fail_local.o"
+      else ""
+    }
+  '';
+
   postInstall = ''
     # Not sure why, but link in all but scsi directory as that's what uclibc/glibc do.
     # Apparently glibc provides scsi itself?
@@ -83,6 +98,13 @@ stdenv.mkDerivation rec {
     # Strip debug out of the static library
     $STRIP -S $out/lib/libc.a
     mkdir -p $out/bin
+
+
+    ${if (stdenv.targetPlatform.libc == "musl" && stdenv.targetPlatform.isx86_32) then
+      "install -D libssp_nonshared.a $out/lib/libssp_nonshared.a
+      $STRIP -S $out/lib/libssp_nonshared.a"
+      else ""
+    }
 
     # Create 'ldd' symlink, builtin
     ln -rs $out/lib/libc.so $out/bin/ldd


### PR DESCRIPTION
###### Motivation for this change

Crosscompiling packages to musl32 lead to compilation errors due to the missing `__stack_chk_fail_local` symbol.  Even building nix fails. This PR disable stackprotector for musl32.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
