### PR TITLE
kubernetes: 1.13.6 -> 1.13.7 (CVE-2019-11245)

### DIFF
--- a/pkgs/applications/networking/cluster/kubernetes/default.nix
+++ b/pkgs/applications/networking/cluster/kubernetes/default.nix
@@ -15,13 +15,13 @@ with lib;
 
 stdenv.mkDerivation rec {
   name = "kubernetes-${version}";
-  version = "1.13.6";
+  version = "1.13.7";
 
   src = fetchFromGitHub {
     owner = "kubernetes";
     repo = "kubernetes";
     rev = "v${version}";
-    sha256 = "02v12x241zkl11qfb8d472kzq3hvsgip1qvg179kf1xwd5cswlxq";
+    sha256 = "013bbnhxzv41hqnz98k5kyrvaxz39gk9ay7sw996sy3v60vwc3z3";
   };
 
   buildInputs = [ removeReferencesTo makeWrapper which go rsync go-bindata ];


### PR DESCRIPTION
###### Motivation for this change
To fix regression introduced in v1.13.6. Also referred to as: CVE-2019-11245
See: kubernetes/kubernetes#78308

relates to #62816

Tests run clean locally:
```
$ nix-build ./nixos/release.nix -A tests.kubernetes.rbac.singlenode -A tests.kubernetes.rbac.multinode -A tests.kubernetes.dns.singlenode -A tests.kubernetes.dns.multinode
/nix/store/g557kf9qgzdy509f8ia50pkvql4g334w-vm-test-run-kubernetes-rbac-singlenode
/nix/store/c6n4966w9cpfsaf1gqn4z9mb09laifiy-vm-test-run-kubernetes-rbac-multinode
/nix/store/ww40jwpp8xdszy0ixcfa532wdjdlabjx-vm-test-run-kubernetes-dns-singlenode
/nix/store/1sx28xlidwr9s86zwmbkz25qnhil1155-vm-test-run-kubernetes-dns-multinode
```

ping @srhb 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [X] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
