### PR TITLE
jgmenu: 1.1 -> 3.0

### DIFF
--- a/pkgs/applications/misc/jgmenu/default.nix
+++ b/pkgs/applications/misc/jgmenu/default.nix
@@ -1,18 +1,19 @@
-{ stdenv, fetchFromGitHub, pkgconfig, python3Packages, pango, librsvg, libxml2, menu-cache, xorg }:
+{ stdenv, fetchFromGitHub, pkgconfig, python3Packages, pango, librsvg, libxml2, menu-cache, xorg, makeWrapper }:
 
 stdenv.mkDerivation rec {
-  name = "jgmenu-${version}";
-  version = "1.1";
+  pname = "jgmenu";
+  version = "3.0";
 
   src = fetchFromGitHub {
     owner = "johanmalm";
-    repo = "jgmenu";
+    repo = pname;
     rev = "v${version}";
-    sha256 = "0hnxzy5mm5z6r9gaimfsf7kbpr23khck2fhh3j8bk2lkp53420fz";
+    sha256 = "01r92nili4v4pdmw4g5z0rsg1q7m7q3a5hjc47mnchgibdiissvl";
   };
 
   nativeBuildInputs = [
     pkgconfig
+    makeWrapper
     python3Packages.wrapPython
   ];
 
@@ -22,12 +23,17 @@ stdenv.mkDerivation rec {
     libxml2
     menu-cache
     xorg.libXinerama
+    xorg.libXrandr
+    python3Packages.python
   ];
 
-  makeFlags = [ "prefix=$(out)" ];
+  makeFlags = [ "prefix=${placeholder "out"}" ];
 
   postFixup = ''
     wrapPythonProgramsIn "$out/lib/jgmenu"
+    for f in $out/bin/jgmenu{,_run}; do
+      wrapProgram $f --prefix PATH : $out/bin
+    done
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Update to [3.0](https://github.com/johanmalm/jgmenu/releases).


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).