### PR TITLE
ocaml-ng.ocamlPackages_4_08.ocaml: 4.08.0+rc1 -> 4.08.0+rc2

### DIFF
--- a/pkgs/development/compilers/ocaml/4.08.nix
+++ b/pkgs/development/compilers/ocaml/4.08.nix
@@ -1,8 +1,8 @@
 import ./generic.nix {
   major_version = "4";
   minor_version = "08";
-  patch_version = "0+rc1";
-  sha256 = "014yincnkfg0j2jy0cn30l5hb1y4sf2qf1gy9ix9ghgn32iw5ndk";
+  patch_version = "0+rc2";
+  sha256 = "09wp2iig6v5pivkjcnibdvkg5mchcj3q4zms6ij67039xczm8qrg";
 
   # If the executable is stripped it does not work
   dontStrip = true;


### PR DESCRIPTION
###### Motivation for this change

Announcement: https://inbox.ocaml.org/caml-list/45D5CD8A-1E96-41C9-8116-CAFD1F7F233B@inria.fr/T/#u

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@GrahamcOfBorg build ocaml-ng.ocamlPackages_4_08.ocaml