### PR TITLE
nixos/wireguard: add peer service to interface dependencies

### DIFF
--- a/nixos/modules/services/networking/wireguard.nix
+++ b/nixos/modules/services/networking/wireguard.nix
@@ -244,7 +244,7 @@ let
         description = "WireGuard Peer - ${interfaceName} - ${peer.publicKey}";
         requires = [ "wireguard-${interfaceName}.service" ];
         after = [ "wireguard-${interfaceName}.service" ];
-        wantedBy = [ "multi-user.target" ];
+        wantedBy = [ "multi-user.target" "wireguard-${interfaceName}.service" ];
         environment.DEVICE = interfaceName;
         environment.WG_ENDPOINT_RESOLUTION_RETRIES = "infinity";
         path = with pkgs; [ iproute wireguard-tools ];


### PR DESCRIPTION
###### Motivation for this change
Previously each oneshot peer service only ran once and was not
restarted together with the interface unit. Because of this,
defined peers were missing after restarting their corresponding
interface unit.

The issue should be easily reproducible:

```
[root@nixos]# wg show wg0
interface: wg0
  public key: <pubkey>
  private key: (hidden)
  listening port: 12345

peer: <peer-pubkey>
  endpoint: <endpoint>
  allowed ips: <allowed-ips>
  latest handshake: 1 second ago
  transfer: 2.25 KiB received, 708 B sent

[root@nixos]# systemctl stop wireguard-wg0.service

[root@nixos]# systemctl start wireguard-wg0.service

[root@nixos]# wg show wg0
interface: wg0
  public key: <pubkey>
  private key: (hidden)
  listening port: 12345
```

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
/cc @grahamc @fpletz 