### PR TITLE
aerc: init at 0.1.0

### DIFF
--- a/pkgs/applications/networking/mailreaders/aerc/default.nix
+++ b/pkgs/applications/networking/mailreaders/aerc/default.nix
@@ -1,0 +1,55 @@
+{ stdenv, buildGoModule, fetchurl
+, go, scdoc
+, python3, perl, w3m, dante
+}:
+
+buildGoModule rec {
+  pname = "aerc";
+  version = "0.1.0";
+
+  src = fetchurl {
+    url = "https://git.sr.ht/~sircmpwn/aerc/archive/${version}.tar.gz";
+    sha256 = "0wx9l097s51ih4khk231f9fs3vw55an8l2jx3q13v7y20522wgnk";
+  };
+
+  nativeBuildInputs = [
+    go
+    scdoc
+    python3.pkgs.wrapPython
+  ];
+
+  pythonPath = [
+    python3.pkgs.colorama
+  ];
+
+  buildInputs = [ python3 perl ];
+
+  buildPhase = "
+    runHook preBuild
+    # we use make instead of go build
+    runHook postBuild
+  ";
+
+  installPhase = ''
+    runHook preInstall
+    make PREFIX=$out install
+    wrapPythonProgramsIn $out/share/aerc/filters "$out $pythonPath"
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/aerc --prefix PATH ":" "$out/share/aerc/filters"
+    wrapProgram $out/share/aerc/filters/html --prefix PATH ":" \
+      ${stdenv.lib.makeBinPath [ w3m dante ]}
+  '';
+
+  modSha256 = "1h0vr01s2y0k3jjigz0h8ngjv1mhk6kw8mdisp5pr017jbhijfsi";
+
+  meta = with stdenv.lib; {
+    description = "aerc is an email client for your terminal";
+    homepage = https://aerc-mail.org/;
+    maintainers = with maintainers; [ tadeokondrak ];
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -466,6 +466,8 @@ in
     wxGTK = wxGTK30;
   } // (config.aegisub or {}));
 
+  aerc = callPackage ../applications/networking/mailreaders/aerc { };
+
   aerospike = callPackage ../servers/nosql/aerospike { };
 
   aespipe = callPackage ../tools/security/aespipe { };


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

#62648

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

Closes #62648.