### PR TITLE
cryptsetup: enable kernel crypto api support again

### DIFF
--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -438,6 +438,7 @@ in
       default =
         [ "aes" "aes_generic" "blowfish" "twofish"
           "serpent" "cbc" "xts" "lrw" "sha1" "sha256" "sha512"
+          "af_alg" "algif_skcipher"
 
           (if pkgs.stdenv.hostPlatform.system == "x86_64-linux" then "aes_x86_64" else "aes_i586")
         ];

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -273,7 +273,7 @@ let
       };
     };
 
-    makeLuksRootTest = name: luksFormatOpts: makeInstallerTest "luksroot-format2"
+    makeLuksRootTest = name: luksFormatOpts: makeInstallerTest name
       { createPartitions = ''
           $machine->succeed(
             "flock /dev/vda parted --script /dev/vda -- mklabel msdos"

--- a/pkgs/os-specific/linux/cryptsetup/default.nix
+++ b/pkgs/os-specific/linux/cryptsetup/default.nix
@@ -32,7 +32,6 @@ stdenv.mkDerivation rec {
   NIX_LDFLAGS = "-lgcc_s";
 
   configureFlags = [
-    "--disable-kernel_crypto"
     "--enable-cryptsetup-reencrypt"
     "--with-crypto_backend=openssl"
   ] ++ stdenv.lib.optional enablePython "--enable-python";


### PR DESCRIPTION
###### Motivation for this change
This is needed for tcrypt and the benchmark subcommand. If enabled,
it is also used to unlock LUKS2 volumes and therefore the kernel modules
providing this feature need to be available in our initrd.

Fixes #42163. #54019.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

cc @cript0nauta @zarelit @hlandau 
