### PR TITLE
pythonPackages.bjoern: 2.2.3 -> 3.0.1

### DIFF
--- a/pkgs/development/python-modules/bjoern/default.nix
+++ b/pkgs/development/python-modules/bjoern/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "bjoern";
-  version = "2.2.3";
+  version = "3.0.1";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1lbwqmqrl32jlfzhffxsb1fm7xbbjgbhjr21imk656agvpib2wx2";
+    sha256 = "1ajmmfzr6fm8h8s7m69f2ffx0wk6snjvdx527hhj00bzn7zybnmn";
   };
 
   buildInputs = [ libev ];


### PR DESCRIPTION
###### Motivation for this change
Upstream has addressed issues noted in https://github.com/NixOS/nixpkgs/pull/62055 and made a new release. This should supersede https://github.com/NixOS/nixpkgs/pull/62055 and https://github.com/NixOS/nixpkgs/pull/61887.

Test execution seems a little unusual/hit-and-miss for me on macos (tested 10.13), but the exact same problem appears to exist with 2.2.3.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
