### PR TITLE
Change handle from c0dehero to pyrolagus

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -820,10 +820,6 @@
     github = "c0deaddict";
     name = "Jos van Bakel";
   };
-  c0dehero = {
-    email = "codehero@nerdpol.ch";
-    name = "CodeHero";
-  };
   calbrecht = {
     email = "christian.albrecht@mayflower.de";
     github = "calbrecht";
@@ -4094,6 +4090,11 @@
   pxc = {
     email = "patrick.callahan@latitudeengineering.com";
     name = "Patrick Callahan";
+  };
+  pyrolagus = {
+    email = "pyrolagus@gmail.com";
+    github = "PyroLagus";
+    name = "Danny Bautista";
   };
   q3k = {
     email = "q3k@q3k.org";

--- a/pkgs/games/minetest/default.nix
+++ b/pkgs/games/minetest/default.nix
@@ -61,7 +61,7 @@ let
       description = "Infinite-world block sandbox game";
       license = licenses.lgpl21Plus;
       platforms = platforms.linux;
-      maintainers = with maintainers; [ c0dehero fpletz ];
+      maintainers = with maintainers; [ pyrolagus fpletz ];
     };
   };
 

--- a/pkgs/games/super-tux-kart/default.nix
+++ b/pkgs/games/super-tux-kart/default.nix
@@ -51,7 +51,7 @@ in stdenv.mkDerivation rec {
     '';
     homepage = https://supertuxkart.net/;
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ c0dehero fuuzetsu peterhoeg ];
+    maintainers = with maintainers; [ pyrolagus fuuzetsu peterhoeg ];
     platforms = with platforms; linux;
   };
 }

--- a/pkgs/games/voxelands/default.nix
+++ b/pkgs/games/voxelands/default.nix
@@ -26,6 +26,6 @@ stdenv.mkDerivation rec {
     description = "Infinite-world block sandbox game based on Minetest";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ c0dehero ];
+    maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
###### Motivation for this change

I changed my username on GitHub from c0dehero to pyrolagus. This is where I first added my handle to maintainers.nix: https://github.com/NixOS/nixpkgs/pull/7862

I didn't change [voxelands.nix](https://github.com/NixOS/nixpkgs/blob/6eb186990215d1af5cd37a5898fc0d429531df69/pkgs/games/voxelands/default.nix) because that package is probably better off being deleted; the project looks dead and the URL just redirects to some spam/referral website. Should I open up an issue suggesting deletion, or what is the protocol for package removal?