### PR TITLE
clickhouse: enable for darwin

### DIFF
--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -1,6 +1,7 @@
 { stdenv, fetchurl, icu, expat, zlib, bzip2, python, fixDarwinDylibNames, libiconv
 , which
 , buildPackages
+, darwin
 , toolset ? /**/ if stdenv.cc.isClang  then "clang"
             else null
 , enableRelease ? true
@@ -140,7 +141,8 @@ stdenv.mkDerivation {
   enableParallelBuilding = true;
 
   nativeBuildInputs = [ which ];
-  depsBuildBuild = [ buildPackages.stdenv.cc ];
+  depsBuildBuild = [ buildPackages.stdenv.cc ]
+    ++ optional (stdenv.isDarwin && buildPackages.stdenv.cc.isGNU) darwin.cctools;
   buildInputs = [ expat zlib bzip2 libiconv ]
     ++ optional (stdenv.hostPlatform == stdenv.buildPlatform) icu
     ++ optional stdenv.isDarwin fixDarwinDylibNames

--- a/pkgs/development/libraries/cctz/default.nix
+++ b/pkgs/development/libraries/cctz/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub }:
+{ stdenv, fetchFromGitHub, darwin }:
 
 stdenv.mkDerivation rec {
   name = "cctz-${version}";
@@ -13,7 +13,13 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "PREFIX=$(out)" ];
 
+  buildInputs = stdenv.lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Foundation;
+
   installTargets = [ "install_hdrs" "install_shared_lib" ];
+
+  postInstall = stdenv.lib.optionalString stdenv.isDarwin ''
+    install_name_tool -id $out/lib/libcctz.so $out/lib/libcctz.so
+  '';
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/poco/default.nix
+++ b/pkgs/development/libraries/poco/default.nix
@@ -28,6 +28,6 @@ stdenv.mkDerivation rec {
     description = "Cross-platform C++ libraries with a network/internet focus";
     license = licenses.boost;
     maintainers = with maintainers; [ orivej ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/servers/clickhouse/default.nix
+++ b/pkgs/servers/clickhouse/default.nix
@@ -1,10 +1,27 @@
-{ stdenv, fetchFromGitHub, fetchpatch, cmake, libtool
+{ stdenv, fetchFromGitHub, fetchpatch, cmake, libtool, buildPackages
 , boost, capnproto, cctz, clang-unwrapped, double-conversion, gperftools, icu
 , libcpuid, libxml2, lld, llvm, lz4 , mysql, openssl, poco, re2, rdkafka
 , readline, sparsehash, unixODBC, zstd, ninja, jemalloc, brotli, protobuf, xxHash
 }:
 
-stdenv.mkDerivation rec {
+let
+  # can't link c++ libraries built with clang with code built with gcc, so
+  # need to ensure these have been built with same compiler
+  abiCompat = stdenvA: stdenvB: stdenvA.cc.isGNU == stdenvB.cc.isGNU;
+  cctz' = if (abiCompat stdenv cctz.stdenv) then cctz else (cctz.override { inherit stdenv; });
+  poco' = if (abiCompat stdenv poco.stdenv) then poco else (poco.override { inherit stdenv; });
+  re2' = if (abiCompat stdenv re2.stdenv) then re2 else (re2.override { inherit stdenv; });
+  boost' = if (abiCompat stdenv boost.stdenv) then boost else (boost.override {
+    inherit stdenv buildPackages;
+  });
+  # protobuf does a charming double-callPackage, so we wrap the callPackage it
+  # is handed, giving it one that injects our extra args into calls
+  protobuf' = if (abiCompat stdenv protobuf.stdenv) then protobuf else (protobuf.override (oldAttrs: {
+    callPackage = f: cpArgs: oldAttrs.callPackage f (cpArgs // {
+      inherit stdenv buildPackages;
+    });
+  }));
+in stdenv.mkDerivation rec {
   name = "clickhouse-${version}";
   version = "19.6.2.11";
 
@@ -14,12 +31,25 @@ stdenv.mkDerivation rec {
     rev    = "v${version}-stable";
     sha256 = "0bs38a8dm5x43klx4nc5dwkkxpab12lp2chyvc2y47c75j7rn5d7";
   };
+  patches = stdenv.lib.optionals stdenv.isDarwin [
+    (fetchpatch {
+      name = "darwin-build-fix.patch";
+      url = https://github.com/yandex/ClickHouse/commit/10c349e398111b522c20db3852455d067f7d9471.patch;
+      sha256 = "1y2c5zprlnlihi9437w3fn6c5dx2vhxhm6165njv6k3j0zmmad9h";
+    })
+    (fetchpatch {
+      name = "darwin-build-fix-2.patch";
+      url = https://github.com/yandex/ClickHouse/commit/deddb40bf203bc7ef21b3cb29a858a71992c2937.patch;
+      sha256 = "1ax6h46jmb40rc91vh34179c55nh5xj825gdgz4avawpk608y2yw";
+    })
+  ];
 
   nativeBuildInputs = [ cmake libtool ninja ];
   buildInputs = [
-    boost capnproto cctz clang-unwrapped double-conversion gperftools icu
-    libcpuid libxml2 lld llvm lz4 mysql.connector-c openssl poco re2 rdkafka
-    readline sparsehash unixODBC zstd jemalloc brotli protobuf xxHash
+    gperftools icu capnproto clang-unwrapped double-conversion
+    libcpuid libxml2 lld llvm lz4 mysql.connector-c openssl rdkafka
+    readline sparsehash unixODBC zstd jemalloc brotli xxHash
+    cctz' poco' re2' boost' protobuf'
   ];
 
   cmakeFlags = [
@@ -48,6 +78,6 @@ stdenv.mkDerivation rec {
     description = "Column-oriented database management system";
     license = licenses.asl20;
     maintainers = with maintainers; [ orivej ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14133,6 +14133,8 @@ in
   clickhouse = callPackage ../servers/clickhouse {
     # clickhouse doesn't build on llvm8.
     inherit (llvmPackages_7) clang-unwrapped lld llvm;
+    stdenv = gcc8Stdenv;
+    buildPackages = buildPackages // { stdenv = gcc8Stdenv; };
   };
 
   couchdb = callPackage ../servers/http/couchdb {


### PR DESCRIPTION
~A draft, because this sits on top of https://github.com/NixOS/nixpkgs/pull/62335 - direct any attention about the `re2` changes to that PR.~
###### Motivation for this change
With a little effort, `clickhouse` builds and appears to work on darwin.

The main issue is that it wants to be built with gcc (specifically gcc8) rather than clang, and therefore any c++-linked libraries have to be built with gcc too. This is largely achieved through `stdenv`-overriding, but in the case of `boost` requires a minor alteration. I think this is worth it, though - because a gcc-built boost is a valid thing a user might have need of.

The package overrides are only conditionally applied where needed, because I didn't want to cause linux builds to require these packages to be built specifically with gcc *8* rather than the default.

Tested on macos 10.13.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
