### PR TITLE
nim: 0.19.4 -> 0.20.0

### DIFF
--- a/pkgs/applications/science/biology/mosdepth/default.nix
+++ b/pkgs/applications/science/biology/mosdepth/default.nix
@@ -4,26 +4,26 @@ let
   hts-nim = fetchFromGitHub {
     owner = "brentp";
     repo = "hts-nim";
-    rev = "v0.2.5";
-    sha256 = "1fma99rjqxgg9dihkd10hm1jjp5amsk5wsxnvq1lk4mcsjix5xqb";
+    rev = "v0.2.14";
+    sha256 = "0d1z4b6mrppmz3hgkxd4wcy79w68icvhi7q7n3m2k17n8f3xbdx3";
   };
 
   docopt = fetchFromGitHub {
     owner = "docopt";
     repo = "docopt.nim";
-    rev = "v0.6.5";
-    sha256 = "0yx79m4jkdcazwlky55nwf39zj5kdhymrrdrjq29mahiwx83x5zr";
+    rev = "v0.6.7";
+    sha256 = "1ga7ckg21fzwwvh26jp2phn2h3pvkn8g8sm13dxif33rp471bv37";
   };
 
 in stdenv.mkDerivation rec {
   name = "mosdepth-${version}";
-  version = "0.2.3";
+  version = "0.2.6";
 
   src = fetchFromGitHub {
     owner = "brentp";
     repo = "mosdepth";
     rev = "v${version}";
-    sha256 = "1b9frrwhcvay3alhn0d02jccc2qlbij1732hzq9nhwnr4kvsvxx7";
+    sha256 = "0i9pl9lsli3y84ygxanrr525gfg8fs9h481944cbzsmqmbldwvgk";
   };
 
   buildInputs = [ nim ];

--- a/pkgs/development/compilers/nim/default.nix
+++ b/pkgs/development/compilers/nim/default.nix
@@ -1,14 +1,15 @@
 # based on https://github.com/nim-lang/Nim/blob/v0.18.0/.travis.yml
 
-{ stdenv, lib, fetchurl, makeWrapper, nodejs-slim-10_x, openssl, pcre, readline, boehmgc, sfml, tzdata, coreutils }:
+{ stdenv, lib, fetchurl, makeWrapper, nodejs-slim-11_x, openssl, pcre, readline,
+  boehmgc, sfml, tzdata, coreutils, sqlite }:
 
 stdenv.mkDerivation rec {
   name = "nim-${version}";
-  version = "0.19.4";
+  version = "0.20.0";
 
   src = fetchurl {
     url = "https://nim-lang.org/download/${name}.tar.xz";
-    sha256 = "0k59dhfsg5wnkc3nxg5a336pjd9jnfxabns63bl9n28iwdg16hgl";
+    sha256 = "144sd7icg2p6qsrr29jdnl11hr34daxq4h16ywwrayz866w7kx2i";
   };
 
   doCheck = !stdenv.isDarwin;
@@ -20,6 +21,7 @@ stdenv.mkDerivation rec {
     "-lpcre"
     "-lreadline"
     "-lgc"
+    "-lsqlite3"
   ];
 
   # 1. nodejs is only needed for tests
@@ -27,19 +29,21 @@ stdenv.mkDerivation rec {
   #    used for bootstrapping, but koch insists on moving the nim compiler around
   #    as part of building it, so it cannot be read-only
 
+  checkInputs = [
+    nodejs-slim-11_x tzdata coreutils
+  ];
+
   nativeBuildInputs = [
-    makeWrapper nodejs-slim-10_x tzdata coreutils
+    makeWrapper
   ];
 
   buildInputs = [
-    openssl pcre readline boehmgc sfml
+    openssl pcre readline boehmgc sfml sqlite
   ];
 
-  phases = [ "unpackPhase" "patchPhase" "buildPhase" "installPhase" "checkPhase" ];
-
   buildPhase = ''
-    # use $CC to trigger the linker since calling ld in build.sh causes an error
-    LD=$CC
+    runHook preBuild
+
     # build.sh wants to write to $HOME/.cache
     HOME=$TMPDIR
     sh build.sh
@@ -48,35 +52,55 @@ stdenv.mkDerivation rec {
                  -d:useGnuReadline \
                  ${lib.optionals (stdenv.isDarwin || stdenv.isLinux) "-d:nativeStacktrace"}
     ./koch tools -d:release
+
+    runHook postBuild
+  '';
+
+  prePatch =
+    let disableTest = ''sed -i '1i discard \"\"\"\n  disabled: true\n\"\"\"\n\n' '';
+        disableStdLibTest = ''sed -i -e '/^when isMainModule/,/^END$/{s/^/#/}' '';
+        disableCompile = ''sed -i -e 's/^/#/' '';
+    in ''
+      substituteInPlace ./tests/osproc/tworkingdir.nim --replace "/usr/bin" "${coreutils}/bin"
+      substituteInPlace ./tests/stdlib/ttimes.nim --replace "/usr/share/zoneinfo" "${tzdata}/share/zoneinfo"
+
+      # reported upstream: https://github.com/nim-lang/Nim/issues/11435
+      ${disableTest} ./tests/misc/tstrace.nim
+
+      # runs out of memory on a machine with 8GB RAM
+      ${disableTest} ./tests/system/t7894.nim
+
+      # requires network access (not available in the build container)
+      ${disableTest} ./tests/stdlib/thttpclient.nim
+    '' + lib.optionalString stdenv.isAarch64 ''
+      # supposedly broken on aarch64
+      ${disableStdLibTest} ./lib/pure/stats.nim
+
+      # reported upstream: https://github.com/nim-lang/Nim/issues/11463
+      ${disableCompile} ./lib/nimhcr.nim
+      ${disableTest} ./tests/dll/nimhcr_unit.nim
+      ${disableTest} ./tests/dll/nimhcr_integration.nim
+    '';
+
+  checkPhase = ''
+    runHook preCheck
+
+    ./koch tests --nim:bin/nim all
+
+    runHook postCheck
   '';
 
   installPhase = ''
+    runHook preInstall
+
     install -Dt $out/bin bin/* koch
     ./koch install $out
     mv $out/nim/bin/* $out/bin/ && rmdir $out/nim/bin
     mv $out/nim/*     $out/     && rmdir $out/nim
     wrapProgram $out/bin/nim \
       --suffix PATH : ${lib.makeBinPath [ stdenv.cc ]}
-  '';
 
-  patchPhase =
-    let disableTest = ''sed -i '1i discard \"\"\"\n  disabled: true\n\"\"\"\n\n' '';
-        disableStdLibTest = ''sed -i -e '/^when isMainModule/,/^END$/{s/^/#/}' '';
-    in ''
-      substituteInPlace ./tests/async/tioselectors.nim --replace "/bin/sleep" "sleep"
-      substituteInPlace ./tests/osproc/tworkingdir.nim --replace "/usr/bin" "${coreutils}/bin"
-      substituteInPlace ./tests/stdlib/ttimes.nim --replace "/usr/share/zoneinfo" "${tzdata}/share/zoneinfo"
-
-      # disable tests requiring network access (not available in the build container)
-      ${disableTest} ./tests/stdlib/thttpclient.nim
-    '' + lib.optionalString stdenv.isAarch64 ''
-      # disable test supposedly broken on aarch64
-      ${disableStdLibTest} ./lib/pure/stats.nim
-    '';
-
-  checkPhase = ''
-    PATH=$PATH:$out/bin
-    ./koch tests
+    runHook postInstall
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
Update to the latest release of Nim.

What I did:
- ~~makeWrapper not needed anymore~~
- link sqlite (needed for the the stdlib sqlite module)
- update nodejs to 11.x
- use default phase order (fixes linker errors during test phase)
- substitution in ./test/async/tioselectors.nim not needed anymore
- two more tests need to be disabled
- LD=$CC workaround not needed anymore
- update mosdepth for it to compile with nim 0.20.0

nrpl compiles with the new version.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
