### PR TITLE
editline: 1.16.0 -> 1.16.1

### DIFF
--- a/pkgs/development/libraries/editline/default.nix
+++ b/pkgs/development/libraries/editline/default.nix
@@ -2,28 +2,13 @@
 
 stdenv.mkDerivation rec {
   name = "editline-${version}";
-  version = "1.16.0";
+  version = "1.16.1";
   src = fetchFromGitHub {
     owner = "troglobit";
     repo = "editline";
     rev = version;
-    sha256 = "0a751dp34mk9hwv59ss447csknpm5i5cgd607m3fqf24rszyhbf2";
+    sha256 = "192valxbvkxh47dszrnahv7xiccarjw9y84g4zaw5y0lxfc54dir";
   };
-
-  patches = [
-    # will be in 1.17.0
-    (fetchpatch {
-      name = "redisplay-clear-screen.patch";
-      url = "https://github.com/troglobit/editline/commit/a4b67d226829a55bc8501f36708d5e104a52fbe4.patch";
-      sha256 = "0dbgdqxa4x9wgr9kx89ql74np4qq6fzdbph9j9c65ns3gnaanjkw";
-    })
-    # PR24
-    (fetchpatch {
-      name = "fix-narrow-term-crash.patch";
-      url = https://github.com/troglobit/editline/pull/24/commits/8660aef4b795fbd46a86dca804f067a81757c5df.patch;
-      sha256 = "0pcz1f141qv78xbq09yh0zfcjiqyavr66snz1hvxzvi8x0vixc4i";
-    })
-  ];
 
   nativeBuildInputs = [ autoreconfHook ];
 


### PR DESCRIPTION
###### Motivation for this change

https://github.com/troglobit/editline/releases/tag/1.16.1

Incorporates the patches we were applying, some of which we authored!
\o/

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---