### PR TITLE
boehm-gc: remove libatomic_ops, guile: 2.2.3 -> 2.2.4

### DIFF
--- a/pkgs/development/interpreters/guile/default.nix
+++ b/pkgs/development/interpreters/guile/default.nix
@@ -12,11 +12,11 @@
 
 (rec {
   name = "guile-${version}";
-  version = "2.2.3";
+  version = "2.2.4";
 
   src = fetchurl {
     url = "mirror://gnu/guile/${name}.tar.xz";
-    sha256 = "11j01agvnci2cx32wwpqs9078856yxmvs15gcsz7ganpkj2ahlw3";
+    sha256 = "07p3g0v2ba2vlfbfidqzlgbhnzdx46wh2rgc5gszq1mjyx5bks6r";
   };
 
   outputs = [ "out" "dev" "info" ];
@@ -42,7 +42,6 @@
 
   patches = [
     ./eai_system.patch
-    ./riscv.patch
   ] ++ stdenv.lib.optional (coverageAnalysis != null) ./gcov-file-name.patch
     ++ stdenv.lib.optional stdenv.isDarwin (fetchpatch {
       url = "https://gitlab.gnome.org/GNOME/gtk-osx/raw/52898977f165777ad9ef169f7d4818f2d4c9b731/patches/guile-clocktime.patch";

--- a/pkgs/development/libraries/boehm-gc/default.nix
+++ b/pkgs/development/libraries/boehm-gc/default.nix
@@ -40,9 +40,6 @@ stdenv.mkDerivation rec {
 
   doCheck = true; # not cross;
 
-  # Don't run the native `strip' when cross-compiling.
-  dontStrip = stdenv.hostPlatform != stdenv.buildPlatform;
-
   enableParallelBuilding = true;
 
   meta = {

--- a/pkgs/development/libraries/boehm-gc/default.nix
+++ b/pkgs/development/libraries/boehm-gc/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, fetchpatch, pkgconfig, libatomic_ops
+{ lib, stdenv, fetchurl, fetchpatch
 , enableLargeConfig ? false # doc: https://github.com/ivmai/bdwgc/blob/v7.6.6/doc/README.macros#L179
 }:
 
@@ -14,9 +14,6 @@ stdenv.mkDerivation rec {
     sha256 = "1798rp3mcfkgs38ynkbg2p47bq59pisrc6mn0l20pb5iczf0ssj3";
   };
 
-  buildInputs = [ libatomic_ops ];
-  nativeBuildInputs = [ pkgconfig ];
-
   outputs = [ "out" "dev" "doc" ];
   separateDebugInfo = stdenv.isLinux;
 
@@ -29,14 +26,9 @@ stdenv.mkDerivation rec {
     lib.optional stdenv.hostPlatform.isRiscV ./riscv.patch;
 
   configureFlags =
-    [ "--enable-cplusplus" ]
+    [ "--enable-cplusplus" "--with-libatomic-ops=none" ]
     ++ lib.optional enableLargeConfig "--enable-large-config"
-    ++ lib.optional (stdenv.hostPlatform.libc == "musl") "--disable-static"
-    # Configure script can't detect whether C11 atomic intrinsics are available
-    # when cross-compiling, so it links to libatomic_ops, which has to be
-    # propagated to all dependencies. To avoid this, assume that the intrinsics
-    # are available.
-    ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "--with-libatomic-ops=none";
+    ++ lib.optional (stdenv.hostPlatform.libc == "musl") "--disable-static";
 
   doCheck = true; # not cross;
 


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Follow up of #54402 for staging. This completely removes the `libatomic_ops` dependency of `boehm-gc` and removes the no longer needed `dontStrip` attribute.

`libatomic_ops` is not known to be needed on any platform supported by Nix, and if any platform did need it, it would still not work correctly because boehm-gc requires that all dependents link to `libatomic_ops` as well, if `boehm-gc` is linked with `libatomic_ops`. This is not currently done, so any package that uses `boehm-gc` would currently fail to compile on such a hypothetical platform. See #54402 for more details.

I also updated guile to 2.2.4.

cc @dtzWill because you reviewed #54402

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
