### PR TITLE
[r18.09] exim: add patch for CVE-2019-10149

### DIFF
--- a/pkgs/servers/mail/exim/default.nix
+++ b/pkgs/servers/mail/exim/default.nix
@@ -1,4 +1,4 @@
-{ coreutils, db, fetchurl, openssl, pcre, perl, pkgconfig, stdenv
+{ coreutils, db, fetchurl, openssl, pcre, perl, pkgconfig, stdenv, fetchpatch
 , enableLDAP ? false, openldap
 , enableMySQL ? false, mysql, zlib
 , enableAuthDovecot ? false, dovecot
@@ -12,6 +12,16 @@ stdenv.mkDerivation rec {
     url = "https://ftp.exim.org/pub/exim/exim4/${name}.tar.xz";
     sha256 = "066ip7a5lqfn9rcr14j4nm0kqysw6mzvbbb0ip50lmfm0fqsqmzc";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2019-10149.patch";
+      url = https://git.exim.org/exim.git/patch/d740d2111f189760593a303124ff6b9b1f83453d;
+      stripLen = 1;
+      includes = ["src/deliver.c"];
+      sha256 = "0va872q2d3nizr001hfs1yaa4w5lffppk4hkim2ywcpq8ap5kxfk";
+    })
+  ];
 
   nativeBuildInputs = [ pkgconfig ];
   buildInputs = [ coreutils db openssl perl pcre ]


### PR DESCRIPTION
###### Motivation for this change
https://nvd.nist.gov/vuln/detail/CVE-2019-10149

Other releases and master are safe.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
