### PR TITLE
pythonPackages.matchpy: 0.4.6 -> 0.5.1, fix build

### DIFF
--- a/pkgs/development/python-modules/matchpy/default.nix
+++ b/pkgs/development/python-modules/matchpy/default.nix
@@ -3,7 +3,7 @@
 , fetchPypi
 , hopcroftkarp
 , multiset
-, pytest
+, pytest_3
 , pytestrunner
 , hypothesis
 , setuptools_scm
@@ -12,16 +12,20 @@
 
 buildPythonPackage rec {
   pname = "matchpy";
-  version = "0.4.6";
+  version = "0.5.1";
   disabled = isPy27;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "eefa1e50a10e1255db61bc2522a6768ad0701f8854859f293ebaa442286faadd";
+    sha256 = "1vvf1cd9kw5z1mzvypc9f030nd18lgvvjc8j56b1s9b7dyslli2r";
   };
 
+  postPatch = ''
+    substituteInPlace setup.cfg --replace "hypothesis>=3.6,<4.0" "hypothesis"
+  '';
+
   buildInputs = [ setuptools_scm pytestrunner ];
-  checkInputs = [ pytest hypothesis ];
+  checkInputs = [ pytest_3 hypothesis ];
   propagatedBuildInputs = [ hopcroftkarp multiset ];
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
Was trying to fix `matchpy`, realized it was also a bit out of date. This bumps it and also fixes the tests - it really does seem to want `pytest_3` for now (though it looks like it's ok with us tricking it over the hypothesis version)

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
