### PR TITLE
reredirect: init at 0.2

### DIFF
--- a/pkgs/tools/misc/reredirect/default.nix
+++ b/pkgs/tools/misc/reredirect/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "reredirect";
+  version = "0.2";
+
+  src = fetchFromGitHub {
+    owner = "jerome-pouiller";
+    repo = "reredirect";
+    rev = "v${version}";
+    sha256 = "0aqzs940kwvw80lhkszx8spcdh9ilsx5ncl9vnp611hwlryfw7kk";
+  };
+
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+
+  postFixup = ''
+    substituteInPlace ${placeholder "out"}/bin/relink \
+      --replace "reredirect" "${placeholder "out"}/bin/reredirect"
+  '';
+
+  meta = with stdenv.lib; {
+    description = "Tool to dynamicly redirect outputs of a running process";
+    homepage = "https://github.com/jerome-pouiller/reredirect";
+    license = licenses.mit;
+    maintainers = [ maintainers.tobim ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5984,6 +5984,8 @@ in
 
   redsocks = callPackage ../tools/networking/redsocks { };
 
+  reredirect = callPackage ../tools/misc/reredirect { };
+
   retext = libsForQt5.callPackage ../applications/editors/retext { };
 
   richgo = callPackage ../development/tools/richgo {  };


### PR DESCRIPTION
###### Motivation for this change
reredirect - A tool to dynamically redirect outputs of a running program

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
