### PR TITLE
vulkan-loader: Always include /run/opengl-driver(-32)/share in search path.

### DIFF
--- a/pkgs/development/libraries/vulkan-loader/default.nix
+++ b/pkgs/development/libraries/vulkan-loader/default.nix
@@ -21,8 +21,10 @@ stdenv.mkDerivation rec {
   buildInputs = [ cmake python3 xlibsWrapper libxcb libXrandr libXext wayland ];
   enableParallelBuilding = true;
 
+  patches = [ ./system-search-path.patch ];
+
   cmakeFlags = [
-    "-DFALLBACK_DATA_DIRS=${addOpenGLRunpath.driverLink}/share:/usr/local/share:/usr/share"
+    "-DSYSTEM_SEARCH_PATH=${addOpenGLRunpath.driverLink}/share"
     "-DVULKAN_HEADERS_INSTALL_DIR=${vulkan-headers}"
   ];
 

--- a/pkgs/development/libraries/vulkan-loader/system-search-path.patch
+++ b/pkgs/development/libraries/vulkan-loader/system-search-path.patch
@@ -1,0 +1,45 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9ac5ce835..cbdb0ff56 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -88,6 +88,12 @@ if(UNIX)
+             STRING
+             "Search path to use when XDG_DATA_DIRS is unset or empty or the current process is SUID/SGID. Default is freedesktop compliant."
+         )
++    set(
++        SYSTEM_SEARCH_PATH ""
++        CACHE
++            STRING
++            "Search path to always use, after all other search paths."
++    )
+ endif()
+ 
+ if(UNIX AND NOT APPLE) # i.e.: Linux
+@@ -184,6 +190,7 @@ if(UNIX)
+     add_definitions(-DFALLBACK_CONFIG_DIRS="${FALLBACK_CONFIG_DIRS}")
+     add_definitions(-DFALLBACK_DATA_DIRS="${FALLBACK_DATA_DIRS}")
+     add_definitions(-DSYSCONFDIR="${CMAKE_INSTALL_FULL_SYSCONFDIR}")
++    add_definitions(-DSYSTEM_SEARCH_PATH="${SYSTEM_SEARCH_PATH}")
+ 
+     # Make sure /etc is searched by the loader
+     if(NOT (CMAKE_INSTALL_FULL_SYSCONFDIR STREQUAL "/etc"))
+diff --git a/loader/loader.c b/loader/loader.c
+index 0d3b5a947..abe357004 100644
+--- a/loader/loader.c
++++ b/loader/loader.c
+@@ -3688,6 +3688,7 @@ static VkResult ReadDataFilesInSearchPaths(const struct loader_instance *inst, e
+                 search_path_size += DetermineDataFilePathSize(xdgdatahome, rel_size);
+                 search_path_size += DetermineDataFilePathSize(home_root, rel_size);
+             }
++            search_path_size += DetermineDataFilePathSize(SYSTEM_SEARCH_PATH, rel_size);
+ #endif
+         }
+     }
+@@ -3737,6 +3738,7 @@ static VkResult ReadDataFilesInSearchPaths(const struct loader_instance *inst, e
+                 CopyDataFilePath(xdgdatahome, relative_location, rel_size, &cur_path_ptr);
+                 CopyDataFilePath(home_root, relative_location, rel_size, &cur_path_ptr);
+             }
++            CopyDataFilePath(SYSTEM_SEARCH_PATH, relative_location, rel_size, &cur_path_ptr);
+         }
+ 
+         // Remove the last path separator


### PR DESCRIPTION
Even though FALLBACK_DATA_DIRS is set to include this, it only applies when XDG_DATA_DIRS is not defined, so the NixOS opengl.nix module still had to include these in the search path. Use a simple patch to force a default search path, consulted after all other search paths.

Note that FALLBACK_DATA_DIRS is no longer set, and the default (/usr/local/share:/usr/share) applies.

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

Allow getting rid of adding these driver paths to `XDG_DATA_DIRS`. That will be a separate PR. Adding these paths to `XDG_DATA_DIRS` may be hurting application startup time due to every application checking them.

###### Things done

Tested that `vulkaninfo` and `vkcube` work without `/run/opengl-driver(-32)/share` in `XDG_DATA_DIRS` (did not work before, unless `XDG_DATA_DIRS` was not set at all), also 32-bit binary on 64-bit system.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
