### PR TITLE
pythonPackages.neuron: fix for darwin

### DIFF
--- a/pkgs/applications/science/biology/neuron/default.nix
+++ b/pkgs/applications/science/biology/neuron/default.nix
@@ -33,6 +33,12 @@ stdenv.mkDerivation rec {
       --replace 'float abs(float arg);' "" \
       --replace 'short abs(short arg);' "" \
       --replace 'long abs(long arg);' ""
+  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+    # we are darwin, but we don't have all the quirks the source wants to compensate for
+    substituteInPlace src/nrnpython/setup.py.in --replace 'readline="edit"' 'readline="readline"'
+    for f in src/nrnpython/*.[ch] ; do
+      substituteInPlace $f --replace "<Python/Python.h>" "<Python.h>"
+    done
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/applications/science/biology/neuron/default.nix
+++ b/pkgs/applications/science/biology/neuron/default.nix
@@ -80,7 +80,8 @@ stdenv.mkDerivation rec {
     license     = licenses.bsd3;
     homepage    = http://www.neuron.yale.edu/neuron;
     maintainers = [ maintainers.adev ];
-    platforms   = platforms.all;
+    # source claims it's only tested for x86 and powerpc
+    platforms   = platforms.x86_64 ++ platforms.i686;
   };
 }
 


### PR DESCRIPTION
###### Motivation for this change
Fix build on darwin by un-compensating for some of the darwin quirks the neuron source is expecting but we don't have.

Also disable for non-x86 as the source claims `#error "This code has only been tested on x86 and powerpc platforms."`

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [x] macOS
   - [x] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
