### PR TITLE
emacs-irony: prebuild irony-server executable

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17600,7 +17600,7 @@ in
       inherit (pythonPackages) elpy;
       inherit
         autoconf automake git libffi libpng pkgconfig poppler rtags w3m zlib
-        substituteAll rustPlatform;
+        substituteAll rustPlatform cmake llvmPackages;
     };
   };
 

--- a/pkgs/top-level/emacs-packages.nix
+++ b/pkgs/top-level/emacs-packages.nix
@@ -288,6 +288,45 @@ let
 
   icicles = callPackage ../applications/editors/emacs-modes/icicles { };
 
+  irony = melpaBuild rec {
+    pname = "irony";
+    ename = "irony";
+    version = "20190516";
+    src = fetchFromGitHub {
+      owner = "Sarcasm";
+      repo = "irony-mode";
+      rev = "c3ae899b61124a747ebafc705086345e460ac08e";
+      sha256 = "06ld83vzyklfmrfi6pp893mvlnhacv9if75c9pbipjvy6nwfb63r";
+    };
+    recipe = fetchurl {
+      url = "https://raw.githubusercontent.com/milkypostman/melpa/3cfa28c7314fa57fa9a3aaaadf9ef83f8ae541a9/recipes/irony";
+      sha256 = "1xcxrdrs7imi31nxpszgpaywq4ivni75hrdl4zzrf103xslqpl8a";
+      name = "recipe";
+    };
+    preConfigure = ''
+      cd server
+    '';
+    preBuild = ''
+      make
+    '';
+    postInstall = ''
+      mkdir -p $out
+      mv $out/share/emacs/site-lisp/elpa/*/server/bin $out
+      rm -rf $out/share/emacs/site-lisp/*/server
+    '';
+    preCheck = ''
+      cd source/server
+    '';
+    dontUseCmakeBuildDir = true;
+    doCheck = true;
+    packageRequires = [ emacs ];
+    nativeBuildInputs = [ external.cmake external.llvmPackages.llvm ];
+    meta = {
+      homepage = "https://melpa.org/#/irony";
+      license = lib.licenses.gpl3;
+    };
+  };
+
   redshank = callPackage ../applications/editors/emacs-modes/redshank { };
 
   rtags = melpaBuild rec {


### PR DESCRIPTION
This has melpaBuild compile the irony-server executable automatically.
This means each user of the irony executable doesn’t have to wait for
it to compile on each new use. This depends on this PR to work
correctly:

https://github.com/Sarcasm/irony-mode/pull/537

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
