### PR TITLE
mirrors: rename sourceforgejp to osdn

### DIFF
--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -21,6 +21,9 @@ rec {
 
   # OSDN (formerly SourceForge.jp).
   osdn = [
+    https://osdn.dl.osdn.jp/
+    https://osdn.mirror.constant.com/
+    https://mirrors.gigenet.com/OSDN/
     https://osdn.dl.sourceforge.jp/
     https://jaist.dl.sourceforge.jp/
   ];

--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -19,8 +19,8 @@ rec {
     https://kent.dl.sourceforge.net/sourceforge/
   ];
 
-  # SourceForge.jp.
-  sourceforgejp = [
+  # OSDN (formerly SourceForge.jp).
+  osdn = [
     https://osdn.dl.sourceforge.jp/
     https://jaist.dl.sourceforge.jp/
   ];

--- a/pkgs/data/fonts/hanazono/default.nix
+++ b/pkgs/data/fonts/hanazono/default.nix
@@ -5,7 +5,7 @@ let
 in fetchzip {
   name = "hanazono-${version}";
 
-  url = "mirror://sourceforgejp/hanazono-font/68253/hanazono-${version}.zip";
+  url = "mirror://osdn/hanazono-font/68253/hanazono-${version}.zip";
 
   postFetch = ''
     mkdir -p $out/share/{doc,fonts}

--- a/pkgs/data/fonts/kochi-substitute-naga10/default.nix
+++ b/pkgs/data/fonts/kochi-substitute-naga10/default.nix
@@ -5,7 +5,7 @@ in
 fetchzip {
   name = "kochi-substitute-naga10-${version}";
 
-  url = "mirror://sourceforgejp/efont/5411/kochi-substitute-${version}.tar.bz2";
+  url = "mirror://osdn/efont/5411/kochi-substitute-${version}.tar.bz2";
 
   postFetch = ''
     tar -xjf $downloadedFile --strip-components=1

--- a/pkgs/data/fonts/kochi-substitute-naga10/default.nix
+++ b/pkgs/data/fonts/kochi-substitute-naga10/default.nix
@@ -25,7 +25,7 @@ fetchzip {
       this font may not be sold commercially. See kochi-substitute for the free
       Debian version.
     '';
-    homepage = http://sourceforge.jp/projects/efont/;
+    homepage = "https://osdn.net/projects/efont/";
     license = lib.licenses.unfreeRedistributable;
     maintainers = [ lib.maintainers.auntie ];
   };

--- a/pkgs/data/fonts/kochi-substitute/default.nix
+++ b/pkgs/data/fonts/kochi-substitute/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation {
       versions of the fonts, which remove some non-free glyphs that were added
       from the naga10 font.
     '';
-    homepage = http://sourceforge.jp/projects/efont/;
+    homepage = "https://osdn.net/projects/efont/";
     license = stdenv.lib.licenses.wadalab;
     maintainers = [ stdenv.lib.maintainers.auntie ];
   };

--- a/pkgs/data/fonts/migmix/default.nix
+++ b/pkgs/data/fonts/migmix/default.nix
@@ -6,19 +6,19 @@ stdenv.mkDerivation rec {
 
   srcs = [
     (fetchzip {
-      url = "mirror://sourceforgejp/mix-mplus-ipa/63544/migmix-1p-${version}.zip";
+      url = "mirror://osdn/mix-mplus-ipa/63544/migmix-1p-${version}.zip";
       sha256 = "0wp44axcalaak04nj3dgpx0vk13nqa3ihx2vjv4acsgv83x8ciph";
     })
     (fetchzip {
-      url = "mirror://sourceforgejp/mix-mplus-ipa/63544/migmix-2p-${version}.zip";
+      url = "mirror://osdn/mix-mplus-ipa/63544/migmix-2p-${version}.zip";
       sha256 = "0y7s3rbxrp5bv56qgihk8b847lqgibfhn2wlkzx7z655fbzdgxw9";
     })
     (fetchzip {
-      url = "mirror://sourceforgejp/mix-mplus-ipa/63544/migmix-1m-${version}.zip";
+      url = "mirror://osdn/mix-mplus-ipa/63544/migmix-1m-${version}.zip";
       sha256 = "1sfym0chy8ilyd9sr3mjc0bf63vc33p05ynpdc11miivxn4qsshx";
     })
     (fetchzip {
-      url = "mirror://sourceforgejp/mix-mplus-ipa/63544/migmix-2m-${version}.zip";
+      url = "mirror://osdn/mix-mplus-ipa/63544/migmix-2m-${version}.zip";
       sha256 = "0hg04rvm39fh4my4akmv4rhfc14s3ipz2aw718h505k9hppkhkch";
     })
   ];

--- a/pkgs/data/fonts/migu/default.nix
+++ b/pkgs/data/fonts/migu/default.nix
@@ -6,19 +6,19 @@ stdenv.mkDerivation rec {
 
   srcs = [
     (fetchzip {
-      url = "mirror://sourceforgejp/mix-mplus-ipa/63545/migu-1p-${version}.zip";
+      url = "mirror://osdn/mix-mplus-ipa/63545/migu-1p-${version}.zip";
       sha256 = "04wpbk5xbbcv2rzac8yzj4ww7sk2hy2rg8zs96yxc5vzj9q7svf6";
     })
     (fetchzip {
-      url = "mirror://sourceforgejp/mix-mplus-ipa/63545/migu-1c-${version}.zip";
+      url = "mirror://osdn/mix-mplus-ipa/63545/migu-1c-${version}.zip";
       sha256 = "1k7ymix14ac5fb44bjvbaaf24784zzpyc1jj2280c0zdnpxksyk6";
     })
     (fetchzip {
-      url = "mirror://sourceforgejp/mix-mplus-ipa/63545/migu-1m-${version}.zip";
+      url = "mirror://osdn/mix-mplus-ipa/63545/migu-1m-${version}.zip";
       sha256 = "07r8id83v92hym21vrqmfsfxb646v8258001pkjhgfnfg1yvw8lm";
     })
     (fetchzip {
-      url = "mirror://sourceforgejp/mix-mplus-ipa/63545/migu-2m-${version}.zip";
+      url = "mirror://osdn/mix-mplus-ipa/63545/migu-2m-${version}.zip";
       sha256 = "1pvzbrawh43589j8rfxk86y1acjbgzzdy5wllvdkpm1qnx28zwc2";
     })
   ];

--- a/pkgs/data/fonts/mplus-outline-fonts/default.nix
+++ b/pkgs/data/fonts/mplus-outline-fonts/default.nix
@@ -17,7 +17,7 @@ in fetchzip rec {
 
   meta = with lib; {
     description = "M+ Outline Fonts";
-    homepage = http://mplus-fonts.sourceforge.jp/mplus-outline-fonts/index-en.html;
+    homepage = "https://mplus-fonts.osdn.jp/about-en.html";
     license = licenses.mit;
     maintainers = with maintainers; [ henrytill ];
     platforms = platforms.all;

--- a/pkgs/data/fonts/mplus-outline-fonts/default.nix
+++ b/pkgs/data/fonts/mplus-outline-fonts/default.nix
@@ -5,7 +5,7 @@ let
 in fetchzip rec {
   name = "mplus-${version}";
 
-  url = "mirror://sourceforgejp/mplus-fonts/62344/mplus-TESTFLIGHT-${version}.tar.xz";
+  url = "mirror://osdn/mplus-fonts/62344/mplus-TESTFLIGHT-${version}.tar.xz";
 
   postFetch = ''
     tar -xJf $downloadedFile --strip-components=1

--- a/pkgs/tools/inputmethods/anthy/default.nix
+++ b/pkgs/tools/inputmethods/anthy/default.nix
@@ -1,18 +1,18 @@
 { stdenv, fetchurl }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   name = "anthy-9100h";
 
   meta = with stdenv.lib; {
     description = "Hiragana text to Kana Kanji mixed text Japanese input method";
-    homepage    = http://sourceforge.jp/projects/anthy/;
+    homepage    = "https://anthy.osdn.jp/";
     license     = licenses.gpl2Plus;
     maintainers = with maintainers; [ ericsagnes ];
     platforms   = platforms.linux;
   };
 
   src = fetchurl {
-    url = "http://dl.sourceforge.jp/anthy/37536/anthy-9100h.tar.gz";
+    url = "mirror://osdn/anthy/37536/${name}.tar.gz";
     sha256 = "0ism4zibcsa5nl77wwi12vdsfjys3waxcphn1p5s7d0qy1sz0mnj";
   };
 }

--- a/pkgs/tools/text/nkf/default.nix
+++ b/pkgs/tools/text/nkf/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "2.1.4";
 
   src = fetchurl {
-    url = "mirror://sourceforgejp/nkf/64158/${name}.tar.gz";
+    url = "mirror://osdn/nkf/64158/${name}.tar.gz";
     sha256 = "b4175070825deb3e98577186502a8408c05921b0c8ff52e772219f9d2ece89cb";
   };
 

--- a/pkgs/tools/text/nkf/default.nix
+++ b/pkgs/tools/text/nkf/default.nix
@@ -1,19 +1,19 @@
 { stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
-  name = "nkf-${version}";
-  version = "2.1.4";
+  pname = "nkf";
+  version = "2.1.5";
 
   src = fetchurl {
-    url = "mirror://osdn/nkf/64158/${name}.tar.gz";
-    sha256 = "b4175070825deb3e98577186502a8408c05921b0c8ff52e772219f9d2ece89cb";
+    url = "mirror://osdn/nkf/70406/${pname}-${version}.tar.gz";
+    sha256 = "0i5dbcb9aipwr8ym4mhvgf1in3frl6y8h8x96cprz9s7b11xz9yi";
   };
 
-  makeFlags = "prefix=\${out}";
+  makeFlags = [ "prefix=$(out)" ];
 
   meta = {
     description = "Tool for converting encoding of Japanese text";
-    homepage = http://sourceforge.jp/projects/nkf/;
+    homepage = "https://nkf.osdn.jp/";
     license = stdenv.lib.licenses.zlib;
     platforms = stdenv.lib.platforms.unix;
     maintainers = [ stdenv.lib.maintainers.auntie ];


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change
SourceForge.jp renamed to OSDN on May 11, 2015. https://osdn.net/projects/sourceforge/news/24923

From [Wikipedia](https://en.wikipedia.org/wiki/OSDN#History):
> On May 11, 2015, the site was renamed from "SourceForge.JP" to "OSDN".[[10](https://osdn.net/projects/sourceforge/news/24923)][[11](http://internet.watch.impress.co.jp/docs/news/20150408_696843.html)] In the same month that OSDN changed the site name, SourceForge caused two controversies: DevShare adware and project hijacking. In contrast, OSDN totally refuses adware bundling and project hijacking.
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [X] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [X] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
