### PR TITLE
llvm_7: skip failing X86 test cases on armv7l

### DIFF
--- a/pkgs/development/compilers/llvm/7/llvm.nix
+++ b/pkgs/development/compilers/llvm/7/llvm.nix
@@ -89,6 +89,14 @@ in stdenv.mkDerivation (rec {
     substituteInPlace unittests/Support/CMakeLists.txt \
       --replace "add_subdirectory(DynamicLibrary)" ""
     rm unittests/Support/DynamicLibrary/DynamicLibraryTest.cpp
+  '' + optionalString stdenv.hostPlatform.isAarch32 ''
+    # skip failing X86 test cases on armv7l
+    rm test/DebugInfo/X86/debug_addr.ll
+    rm test/tools/llvm-dwarfdump/X86/debug_addr.s
+    rm test/tools/llvm-dwarfdump/X86/debug_addr_address_size_mismatch.s
+    rm test/tools/llvm-dwarfdump/X86/debug_addr_dwarf4.s
+    rm test/tools/llvm-dwarfdump/X86/debug_addr_unsupported_version.s
+    rm test/tools/llvm-dwarfdump/X86/debug_addr_version_mismatch.s
   '' + ''
     patchShebangs test/BugPoint/compile-custom.ll.py
   '';


### PR DESCRIPTION
fixes #57472

###### Things done
tested OK on armv7l

- [X] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [X] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).